### PR TITLE
refactor: Consolidate subfield filter definitions

### DIFF
--- a/verax/connectors/hive/HiveConnectorMetadata.cpp
+++ b/verax/connectors/hive/HiveConnectorMetadata.cpp
@@ -77,7 +77,7 @@ ConnectorTableHandlePtr HiveConnectorMetadata::createTableHandle(
   }
   auto dataColumns = ROW(std::move(names), std::move(types));
   std::vector<core::TypedExprPtr> remainingConjuncts;
-  SubfieldFilters subfieldFilters;
+  common::SubfieldFilters subfieldFilters;
   for (auto& typedExpr : filters) {
     try {
       auto pair = velox::exec::toSubfieldFilter(typedExpr, &evaluator);

--- a/verax/tests/VeloxSql.cpp
+++ b/verax/tests/VeloxSql.cpp
@@ -302,7 +302,7 @@ class VeloxRunner {
       const std::vector<std::string>& columnNames) {
     using namespace connector::hive;
     auto handle = std::make_shared<HiveTableHandle>(
-        kHiveConnectorId, name, true, SubfieldFilters{}, nullptr);
+        kHiveConnectorId, name, true, common::SubfieldFilters{}, nullptr);
     std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
         assignments;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/12184

There are multiple definitions of subfield filters in velox and consolidate them in Filter.h

Reviewed By: Yuhta

Differential Revision: D68719054


