### PR TITLE
feat: Add subfield pruning and complex type function decomposition

### DIFF
--- a/optimizer/ArenaCache.h
+++ b/optimizer/ArenaCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/BitSet.cpp
+++ b/optimizer/BitSet.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/BitSet.h" //@manual
+
+namespace facebook::velox::optimizer {
+
+namespace {
+template <typename V>
+bool isZero(const V& bits, size_t begin, size_t end) {
+  for (size_t i = begin; i < end; ++i) {
+    if (bits[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
+
+bool BitSet::operator==(const BitSet& other) const {
+  // The sets are equal if they have the same bits set. Trailing words of zeros
+  // do not count.
+  auto l1 = bits_.size();
+  auto l2 = other.bits_.size();
+  for (unsigned i = 0; i < l1 && i < l2; ++i) {
+    if (bits_[i] != other.bits_[i]) {
+      return false;
+    }
+  }
+  if (l1 < l2) {
+    return isZero(other.bits_, l1, l2);
+  }
+  if (l2 < l1) {
+    return isZero(bits_, l2, l1);
+  }
+  return true;
+}
+
+bool BitSet::isSubset(const BitSet& super) const {
+  auto l1 = bits_.size();
+  auto l2 = super.bits_.size();
+  for (unsigned i = 0; i < l1 && i < l2; ++i) {
+    if (bits_[i] & ~super.bits_[i]) {
+      return false;
+    }
+  }
+  if (l2 < l1) {
+    return isZero(bits_, l2, l1);
+  }
+  return true;
+}
+
+size_t BitSet::hash() const {
+  // The hash is a mix of the hashes of all non-zero words.
+  size_t hash = 123;
+  for (unsigned i = 0; i < bits_.size(); ++i) {
+    hash = velox::simd::crc32U64(hash, bits_[i]);
+  }
+  return hash * hash;
+}
+
+void BitSet::unionSet(const BitSet& other) {
+  ensureWords(other.bits_.size());
+  for (auto i = 0; i < other.bits_.size(); ++i) {
+    bits_[i] |= other.bits_[i];
+  }
+}
+
+void BitSet::intersect(const BitSet& other) {
+  bits_.resize(std::min(bits_.size(), other.bits_.size()));
+  for (auto i = 0; i < bits_.size(); ++i) {
+    assert(!other.bits_.empty());
+    bits_[i] &= other.bits_[i];
+  }
+}
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/BitSet.h
+++ b/optimizer/BitSet.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "optimizer/QueryGraphContext.h" //@manual
+
+namespace facebook::velox::optimizer {
+
+class BitSet {
+ public:
+  bool contains(int32_t id) const {
+    return id < bits_.size() * 64 && velox::bits::isBitSet(bits_.data(), id);
+  }
+
+  void add(int32_t id) {
+    ensureSize(id);
+    velox::bits::setBit(bits_.data(), id);
+  }
+
+  void erase(int32_t id) {
+    if (id < bits_.size() * 64) {
+      velox::bits::clearBit(bits_.data(), id);
+    }
+  }
+
+  bool operator==(const BitSet& other) const;
+
+  size_t hash() const;
+
+  // True if no members.
+  bool empty() const {
+    for (auto word : bits_) {
+      if (word) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns true if 'this' is a subset of 'super'.
+  bool isSubset(const BitSet& super) const;
+
+  /// Erases all ids not in 'other'.
+  void intersect(const BitSet& other);
+
+  /// Adds all ids in 'other'.
+  void unionSet(const BitSet& other);
+
+  void except(const BitSet& other) {
+    velox::bits::forEachSetBit(
+        other.bits_.data(), 0, other.bits_.size() * 64, [&](auto id) {
+          if (id < bits_.size() * 64) {
+            velox::bits::clearBit(bits_.data(), id);
+          }
+        });
+  }
+
+  template <typename Func>
+  void forEach(Func f) {
+    bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, f);
+  }
+
+ protected:
+  void ensureSize(int32_t id) {
+    ensureWords(velox::bits::nwords(id + 1));
+  }
+
+  void ensureWords(int32_t size) {
+    if (bits_.size() < size) {
+      bits_.resize(size);
+    }
+  }
+
+  // A one bit corresponds to the id of each member.
+  std::vector<uint64_t, QGAllocator<uint64_t>> bits_;
+};
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/CMakeLists.txt
+++ b/optimizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ add_subdirectory(connectors)
 add_library(
   velox_verax
   ToGraph.cpp
+  Subfields.cpp
   Plan.cpp
+  BitSet.cpp
   PlanObject.cpp
   Schema.cpp
   SchemaResolver.cpp
@@ -27,6 +29,7 @@ add_library(
   QueryGraphContext.cpp
   Filters.cpp
   Cost.cpp
+  FunctionRegistry.cpp
   PlanUtils.cpp
   RelationOp.cpp
   ToVelox.cpp

--- a/optimizer/Cost.cpp
+++ b/optimizer/Cost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/Cost.h
+++ b/optimizer/Cost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/Filters.cpp
+++ b/optimizer/Filters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/Filters.h
+++ b/optimizer/Filters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/FunctionRegistry.cpp
+++ b/optimizer/FunctionRegistry.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+
+namespace facebook::velox::optimizer {
+
+FunctionMetadata* FunctionRegistry::metadata(const std::string& name) {
+  auto it = metadata_.find(name);
+  if (it == metadata_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+void FunctionRegistry::registerFunction(
+    const std::string& name,
+    std::unique_ptr<FunctionMetadata> metadata) {
+  metadata_[name] = std::move(metadata);
+}
+
+// static
+FunctionRegistry* FunctionRegistry::instance() {
+  static auto registry = std::make_unique<FunctionRegistry>();
+  return registry.get();
+}
+
+bool declareBuiltin() {
+  auto metadata = std::make_unique<FunctionMetadata>();
+  LambdaInfo info;
+  info.ordinal = 1;
+  info.lambdaArg = {LambdaArg::kKey, LambdaArg::kValue};
+  info.argOrdinal = {0, 0};
+  metadata->lambdas.push_back(std::move(info));
+  metadata->subfieldArg = 0;
+  FunctionRegistry::instance()->registerFunction(
+      "transform_values", std::move(metadata));
+  return true;
+}
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/FunctionRegistry.h
+++ b/optimizer/FunctionRegistry.h
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
 #include "optimizer/QueryGraph.h" //@manual
 
 namespace facebook::velox::optimizer {
 
-SchemaP
-tpchSchema(int32_t scale, bool partitioned, bool ordered, bool secondary);
+class FunctionRegistry {
+ public:
+  FunctionMetadata* metadata(const std::string& name);
 
-}
+  void registerFunction(
+      const std::string& function,
+      std::unique_ptr<FunctionMetadata> metadata);
+
+  static FunctionRegistry* instance();
+
+ private:
+  std::unordered_map<std::string, std::unique_ptr<FunctionMetadata>> metadata_;
+};
+} // namespace facebook::velox::optimizer

--- a/optimizer/Plan.cpp
+++ b/optimizer/Plan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/PlanUtils.cpp
+++ b/optimizer/PlanUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/PlanUtils.h
+++ b/optimizer/PlanUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/RelationOp.cpp
+++ b/optimizer/RelationOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/RelationOp.h
+++ b/optimizer/RelationOp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/Schema.cpp
+++ b/optimizer/Schema.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ SchemaTableCP Schema::findTable(std::string_view name) const {
   for (auto& pair : table->columnMap()) {
     auto& tableColumn = *pair.second;
     float cardinality = tableColumn.approxNumDistinct(table->numRows());
-    Value value(tableColumn.type().get(), cardinality);
+    Value value(toType(tableColumn.type()), cardinality);
     auto columnName = toName(pair.first);
     auto* column = make<Column>(columnName, nullptr, value);
     schemaTable->columns[columnName] = column;

--- a/optimizer/Schema.h
+++ b/optimizer/Schema.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -380,7 +380,7 @@ float baseSelectivity(PlanObjectCP object);
 /// (aka indices) need to contain all columns.
 struct SchemaTable {
   SchemaTable(Name _name, const velox::RowTypePtr& _type)
-      : name(_name), type(_type) {}
+      : name(_name), type(reinterpret_cast<const RowType*>(toType(_type))) {}
 
   /// Adds an index. The arguments set the corresponding members of a
   /// Distribution.
@@ -412,7 +412,7 @@ struct SchemaTable {
 
   std::vector<ColumnCP> toColumns(const std::vector<std::string>& names);
   Name name;
-  const velox::RowTypePtr& type;
+  const RowType* type;
 
   // Lookup from name to column.
   NameMap<ColumnCP> columns;

--- a/optimizer/SchemaResolver.cpp
+++ b/optimizer/SchemaResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/SchemaResolver.h
+++ b/optimizer/SchemaResolver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/Subfields.cpp
+++ b/optimizer/Subfields.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/Plan.h" //@manual
+#include "optimizer/PlanUtils.h" //@manual
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/ConstantExpr.h"
+
+namespace facebook::velox::optimizer {
+
+using namespace facebook::velox;
+
+using NodeSubfieldFunc = std::function<void(
+    Optimization*,
+    core::PlanNode* node,
+    const std::vector<const RowType*>& context,
+    const std::vector<ContextSource>& sources,
+    bool isControl)>;
+
+namespace {
+template <typename T>
+int64_t integerValueInner(const BaseVector* vector) {
+  return vector->as<ConstantVector<T>>()->valueAt(0);
+}
+
+int64_t integerValue(const BaseVector* vector) {
+  switch (vector->typeKind()) {
+    case TypeKind::TINYINT:
+      return integerValueInner<int8_t>(vector);
+    case TypeKind::SMALLINT:
+      return integerValueInner<int16_t>(vector);
+    case TypeKind::INTEGER:
+      return integerValueInner<int32_t>(vector);
+    case TypeKind::BIGINT:
+      return integerValueInner<int64_t>(vector);
+    default:
+      VELOX_FAIL();
+  }
+}
+
+PathCP stepsToPath(const std::vector<Step>& steps) {
+  std::vector<Step> reverse;
+  for (int32_t i = steps.size() - 1; i >= 0; --i) {
+    reverse.push_back(steps[i]);
+  }
+  return queryCtx()->toPath(make<Path>(std::move(reverse)));
+}
+
+RowTypePtr lambdaArgType(const core::ITypedExpr* expr) {
+  auto* l = dynamic_cast<const core::LambdaTypedExpr*>(expr);
+  VELOX_CHECK_NOT_NULL(l);
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < l->type()->size() - 1; ++i) {
+    names.push_back(l->type()->as<TypeKind::ROW>().nameOf(i));
+    types.push_back(l->type()->childAt(i));
+  }
+  return ROW(std::move(names), std::move(types));
+}
+} // namespace
+
+void Optimization::markFieldAccessed(
+    const ContextSource& source,
+    int32_t ordinal,
+    std::vector<Step>& steps,
+    bool isControl,
+    const std::vector<const RowType*>& context,
+    const std::vector<ContextSource>& sources) {
+  auto fields = isControl ? &controlSubfields_ : &payloadSubfields_;
+  if (source.planNode) {
+    auto name = source.planNode->name();
+    auto path = stepsToPath(steps);
+    fields->nodeFields[source.planNode].resultPaths[ordinal].add(path->id());
+    if (name == "Project") {
+      auto* project =
+          reinterpret_cast<const core::ProjectNode*>(source.planNode);
+      markSubfields(
+          project->projections()[ordinal].get(),
+          steps,
+          isControl,
+          std::vector<const RowType*>{
+              project->sources()[0]->outputType().get()},
+          std::vector<ContextSource>{
+              ContextSource{.planNode = project->sources()[0].get()}});
+      return;
+    }
+    if (name == "Aggregation") {
+      auto* agg =
+          reinterpret_cast<const core::AggregationNode*>(source.planNode);
+      std::vector<const RowType*> inputContext = {
+          agg->sources()[0]->outputType().get()};
+      std::vector<ContextSource> inputSources = {
+          ContextSource{.planNode = agg->sources()[0].get()}};
+      auto& keys = agg->groupingKeys();
+      std::vector<Step> empty;
+      if (ordinal < keys.size()) {
+        markSubfields(
+            keys[ordinal].get(), empty, isControl, inputContext, inputSources);
+        return;
+      }
+      auto& aggregate = agg->aggregates()[ordinal - keys.size()];
+      markSubfields(
+          aggregate.call.get(), empty, isControl, inputContext, inputSources);
+      if (aggregate.mask) {
+        markSubfields(
+            aggregate.mask.get(), empty, isControl, inputContext, inputSources);
+      }
+      markColumnSubfields(agg, aggregate.sortingKeys, 0);
+      return;
+    }
+    auto& sourceInputs = source.planNode->sources();
+    if (sourceInputs.empty()) {
+      return;
+    }
+    auto fieldName = source.planNode->outputType()->nameOf(ordinal);
+    for (auto i = 0; i < sourceInputs.size(); ++i) {
+      auto& type = sourceInputs[i]->outputType();
+      auto maybeIdx = type->getChildIdxIfExists(fieldName);
+      if (maybeIdx.has_value()) {
+        ContextSource s{.planNode = sourceInputs[i].get()};
+        markFieldAccessed(
+            s, maybeIdx.value(), steps, isControl, context, sources);
+        return;
+      }
+    }
+    VELOX_FAIL("Should have found source for expr");
+  }
+  // The source is a lambda arg. We apply the path to the corresponding
+  // container arg of the 2nd order function call that has the lambda.
+  auto* md =
+      FunctionRegistry::instance()->metadata(toName(source.call->name()));
+  auto* lInfo = md->lambdaInfo(source.lambdaOrdinal);
+  auto nth = lInfo->argOrdinal[ordinal];
+  auto callContext = context;
+  callContext.erase(callContext.begin());
+  auto callSources = sources;
+  callSources.erase(callSources.begin());
+  markSubfields(
+      source.call->inputs()[nth].get(),
+      steps,
+      isControl,
+      callContext,
+      callSources);
+}
+
+std::optional<int32_t> Optimization::stepToArg(
+    const Step& step,
+    const FunctionMetadata* metadata) {
+  auto it = std::find(
+      metadata->fieldIndexForArg.begin(),
+      metadata->fieldIndexForArg.end(),
+      step.id);
+  if (it != metadata->fieldIndexForArg.end()) {
+    // The arg corresponding to the step is accessed.
+    return metadata->argOrdinal[it - metadata->fieldIndexForArg.begin()];
+  }
+  return std::nullopt;
+}
+
+void Optimization::markSubfields(
+    const core::ITypedExpr* expr,
+    std::vector<Step>& steps,
+    bool isControl,
+    const std::vector<const RowType*> context,
+    const std::vector<ContextSource>& sources) {
+  if (auto* field = dynamic_cast<const core::DereferenceTypedExpr*>(expr)) {
+    auto* input = field->inputs()[0].get();
+    auto& name = input->type()->as<TypeKind::ROW>().nameOf(field->index());
+    steps.push_back(Step{
+        .kind = StepKind::kField,
+        .field = (name.empty() ? nullptr : toName(name)),
+        .id = field->index()});
+    markSubfields(input, steps, isControl, context, sources);
+    steps.pop_back();
+    return;
+  }
+  if (auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(expr)) {
+    auto* input = field->inputs().empty() ? nullptr : field->inputs()[0].get();
+    bool isLeaf =
+        !input || dynamic_cast<const core::InputTypedExpr*>(input) != nullptr;
+    if (isLeaf) {
+      for (auto i = 0; i < sources.size(); ++i) {
+        auto maybeIdx = context[i]->getChildIdxIfExists(field->name());
+        if (maybeIdx.has_value()) {
+          auto source = sources[i];
+          markFieldAccessed(
+              source, maybeIdx.value(), steps, isControl, context, sources);
+          return;
+        }
+      }
+      VELOX_FAIL("Field not found {}", field->name());
+    }
+    steps.push_back(
+        Step{.kind = StepKind::kField, .field = toName(field->name())});
+    markSubfields(input, steps, isControl, context, sources);
+    steps.pop_back();
+    return;
+  }
+  if (auto* call = dynamic_cast<const core::CallTypedExpr*>(expr)) {
+    auto& name = call->name();
+    if (name == "cardinality") {
+      steps.push_back(Step{.kind = StepKind::kCardinality});
+      markSubfields(
+          call->inputs()[0].get(), steps, isControl, context, sources);
+      steps.pop_back();
+      return;
+    }
+    if (name == "subscript" || name == "element_at") {
+      auto constant = foldConstant(call->inputs()[1]);
+      if (!constant) {
+        std::vector<Step> subSteps;
+        markSubfields(
+            call->inputs()[1].get(), subSteps, isControl, context, sources);
+        steps.push_back(Step{.kind = StepKind::kSubscript, .allFields = true});
+        markSubfields(
+            call->inputs()[0].get(), steps, isControl, context, sources);
+        steps.pop_back();
+        return;
+      }
+      auto value = constant->value();
+      if (value->type()->kind() == TypeKind::VARCHAR) {
+        std::string str = value->as<ConstantVector<StringView>>()->valueAt(0);
+        steps.push_back(
+            Step{.kind = StepKind::kSubscript, .field = toName(str)});
+        markSubfields(
+            call->inputs()[0].get(), steps, isControl, context, sources);
+        steps.pop_back();
+        return;
+      }
+      auto id = integerValue(constant->value().get());
+      steps.push_back(Step{.kind = StepKind::kSubscript, .id = id});
+      markSubfields(
+          call->inputs()[0].get(), steps, isControl, context, sources);
+      steps.pop_back();
+      return;
+    }
+    auto* metadata = FunctionRegistry::instance()->metadata(toName(name));
+    if (!metadata) {
+      for (auto i = 0; i < call->inputs().size(); ++i) {
+        std::vector<Step> steps;
+        markSubfields(
+            call->inputs()[i].get(), steps, isControl, context, sources);
+      }
+      return;
+    }
+    // The function has non-default metadata. Record subfields.
+    auto* fields = isControl ? &controlSubfields_ : &payloadSubfields_;
+    auto path = stepsToPath(steps);
+    fields->argFields[call].resultPaths[ResultAccess::kSelf].add(path->id());
+    for (auto i = 0; i < call->inputs().size(); ++i) {
+      if (metadata->subfieldArg.has_value() &&
+          i == metadata->subfieldArg.value()) {
+        // A subfield of func is a subfield of one arg.
+        markSubfields(
+            call->inputs()[metadata->subfieldArg.value()].get(),
+            steps,
+            isControl,
+            context,
+            sources);
+        continue;
+      }
+      if (!steps.empty() && steps.back().kind == StepKind::kField) {
+        auto maybeNth = stepToArg(steps.back(), metadata);
+        if (maybeNth.has_value() && maybeNth.value() == i) {
+          auto newSteps = steps;
+          auto argPath = stepsToPath(newSteps);
+          fields->argFields[call].resultPaths[maybeNth.value()].add(
+              argPath->id());
+          newSteps.pop_back();
+          markSubfields(
+              call->inputs()[maybeNth.value()].get(),
+              newSteps,
+              isControl,
+              context,
+              sources);
+          continue;
+        } else if (
+            std::find(
+                metadata->fieldIndexForArg.begin(),
+                metadata->fieldIndexForArg.end(),
+                i) != metadata->fieldIndexForArg.end()) {
+          // The ith argument corresponds to some subfield field index
+          // other than the one in path, so this argument is not
+          // referenced.
+          continue;
+        }
+      }
+      if (auto* lambda = metadata->lambdaInfo(i)) {
+        auto argType = lambdaArgType(call->inputs()[lambda->ordinal].get());
+        std::vector<const RowType*> newContext = {argType.get()};
+        newContext.insert(newContext.end(), context.begin(), context.end());
+        std::vector<ContextSource> newSources = {
+            ContextSource{.call = call, .lambdaOrdinal = i}};
+        newSources.insert(newSources.end(), sources.begin(), sources.end());
+        auto* l = reinterpret_cast<const core::LambdaTypedExpr*>(
+            call->inputs()[i].get());
+        std::vector<Step> empty;
+        markSubfields(
+            l->body().get(), empty, isControl, newContext, newSources);
+        continue;
+        markSubfields(
+            call->inputs()[i].get(), empty, isControl, context, sources);
+        continue;
+      }
+      // The argument is not special, just mark through without path.
+      std::vector<Step> empty;
+      markSubfields(
+          call->inputs()[i].get(), empty, isControl, context, sources);
+    }
+    return;
+  }
+  if (dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
+    return;
+  }
+  if (auto* castExpr = dynamic_cast<const core::CastTypedExpr*>(expr)) {
+    std::vector<Step> steps;
+    markSubfields(
+        castExpr->inputs()[0].get(), steps, isControl, context, sources);
+    return;
+  }
+  VELOX_UNREACHABLE("Unhandled expr: {}", expr->toString());
+}
+
+void Optimization::markColumnSubfields(
+    const core::PlanNode* node,
+    const std::vector<core::FieldAccessTypedExprPtr>& columns,
+    int32_t source) {
+  std::vector<const RowType*> context = {
+      node->sources()[source]->outputType().get()};
+  std::vector<ContextSource> sources = {
+      {.planNode = node->sources()[source].get()}};
+  for (auto i = 0; i < columns.size(); ++i) {
+    std::vector<Step> steps;
+    markSubfields(columns[i].get(), steps, true, context, sources);
+  }
+}
+
+void Optimization::markControl(const core::PlanNode* node) {
+  auto name = node->name();
+  if (auto* join = dynamic_cast<const core::AbstractJoinNode*>(node)) {
+    markColumnSubfields(node, join->leftKeys(), 0);
+    markColumnSubfields(node, join->rightKeys(), 1);
+    if (auto* filter = join->filter().get()) {
+      std::vector<const RowType*> context = {
+          join->sources()[0]->outputType().get(),
+          join->sources()[1]->outputType().get()};
+      std::vector<ContextSource> sources = {
+          {.planNode = join->sources()[0].get()},
+          {.planNode = join->sources()[1].get()}};
+      std::vector<Step> steps;
+      markSubfields(filter, steps, true, context, sources);
+    }
+  } else if (name == "Filter") {
+    std::vector<const RowType*> context = {
+        node->sources()[0]->outputType().get()};
+    std::vector<ContextSource> sources = {
+        {.planNode = node->sources()[0].get()}};
+    std::vector<Step> steps;
+    markSubfields(
+        reinterpret_cast<const core::FilterNode*>(node)->filter().get(),
+        steps,
+        true,
+        context,
+        sources);
+  } else if (name == "Aggregation") {
+    auto* agg = dynamic_cast<const core::AggregationNode*>(node);
+    markColumnSubfields(node, agg->groupingKeys(), 0);
+  }
+  for (auto& source : node->sources()) {
+    markControl(source.get());
+  }
+}
+
+void Optimization::markAllSubfields(
+    const RowType* type,
+    const core::PlanNode* node) {
+  markControl(node);
+  ContextSource source = {.planNode = node};
+  std::vector<const RowType*> context;
+  std::vector<ContextSource> sources;
+  for (auto i = 0; i < type->size(); ++i) {
+    std::vector<Step> steps;
+    markFieldAccessed(source, i, steps, false, context, sources);
+  }
+}
+
+std::vector<int32_t> Optimization::usedChannels(const core::PlanNode* node) {
+  auto& control = controlSubfields_.nodeFields[node];
+  auto& payload = payloadSubfields_.nodeFields[node];
+  BitSet unique;
+  std::vector<int32_t> result;
+  for (auto& pair : control.resultPaths) {
+    result.push_back(pair.first);
+    unique.add(pair.first);
+  }
+  for (auto& pair : payload.resultPaths) {
+    if (!unique.contains(pair.first)) {
+      result.push_back(pair.first);
+    }
+  }
+  return result;
+}
+
+namespace {
+
+template <typename T>
+core::TypedExprPtr makeKey(const TypePtr& type, T v) {
+  return std::make_shared<core::ConstantTypedExpr>(type, variant(v));
+}
+} // namespace
+
+core::TypedExprPtr stepToGetter(Step step, core::TypedExprPtr arg) {
+  switch (step.kind) {
+    case StepKind::kField: {
+      if (step.field) {
+        auto& type = arg->type()->childAt(
+            arg->type()->as<TypeKind::ROW>().getChildIdx(step.field));
+        return std::make_shared<core::FieldAccessTypedExpr>(
+            type, arg, step.field);
+      } else {
+        auto& type = arg->type()->childAt(step.id);
+        return std::make_shared<core::DereferenceTypedExpr>(type, arg, step.id);
+      }
+    }
+    case StepKind::kSubscript: {
+      auto& type = arg->type();
+      if (type->kind() == TypeKind::MAP) {
+        core::TypedExprPtr key;
+        switch (type->as<TypeKind::MAP>().childAt(0)->kind()) {
+          case TypeKind::VARCHAR:
+            key = makeKey(VARCHAR(), step.field);
+            break;
+          case TypeKind::BIGINT:
+            key = makeKey<int64_t>(BIGINT(), step.id);
+            break;
+          case TypeKind::INTEGER:
+            key = makeKey<int32_t>(INTEGER(), step.id);
+            break;
+          case TypeKind::SMALLINT:
+            key = makeKey<int16_t>(SMALLINT(), step.id);
+            break;
+          case TypeKind::TINYINT:
+            key = makeKey<int8_t>(TINYINT(), step.id);
+            break;
+          default:
+            VELOX_FAIL("Unsupported key type");
+        }
+
+        return std::make_shared<core::CallTypedExpr>(
+            type->as<TypeKind::MAP>().childAt(0),
+            std::vector<core::TypedExprPtr>{arg, key},
+            "subscript");
+      }
+      return std::make_shared<core::CallTypedExpr>(
+          type->childAt(0),
+          std::vector<core::TypedExprPtr>{
+              arg, makeKey<int32_t>(INTEGER(), step.id)},
+          "subscript");
+    }
+
+    default:
+      VELOX_NYI();
+  }
+}
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/VeloxHistory.cpp
+++ b/optimizer/VeloxHistory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/VeloxHistory.h
+++ b/optimizer/VeloxHistory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/CMakeLists.txt
+++ b/optimizer/connectors/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optimizer/connectors/ConnectorMetadata.cpp
+++ b/optimizer/connectors/ConnectorMetadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/ConnectorMetadata.h
+++ b/optimizer/connectors/ConnectorMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/ConnectorSplitSource.cpp
+++ b/optimizer/connectors/ConnectorSplitSource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/ConnectorSplitSource.h
+++ b/optimizer/connectors/ConnectorSplitSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/hive/CMakeLists.txt
+++ b/optimizer/connectors/hive/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optimizer/connectors/hive/HiveConnectorMetadata.cpp
+++ b/optimizer/connectors/hive/HiveConnectorMetadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ ConnectorTableHandlePtr HiveConnectorMetadata::createTableHandle(
           true,
           std::move(subfieldFilters),
           remainingFilter,
-          std::move(dataColumns)));
+          layout.rowType()));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/optimizer/connectors/hive/HiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/HiveConnectorMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,10 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   HiveConnector* hiveConnector() const {
     return hiveConnector_;
   }
+
+  /// Rereads the contents of the data path and re-creates the tables
+  /// and stats. This is used in tests after adding tables.
+  void reinitialize();
 
   /// returns the set of known tables. This is not part of the
   /// ConnectorMetadata API. This This is only needed for running the

--- a/optimizer/connectors/hive/tests/CMakeLists.txt
+++ b/optimizer/connectors/hive/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/tests/CMakeLists.txt
+++ b/optimizer/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_plan_test PlanTest.cpp Tpch.cpp ParquetTpchTest.cpp)
+add_executable(
+  velox_plan_test PlanTest.cpp Tpch.cpp ParquetTpchTest.cpp QueryTestBase.cpp
+                  SubfieldTest.cpp FeatureGen.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 
@@ -20,6 +22,9 @@ target_link_libraries(
   velox_plan_test
   velox_verax
   velox_tpch_gen
+  velox_connector_split_source
+  velox_hive_connector_metadata
+  velox_exec_runner_test_util
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader

--- a/optimizer/tests/FeatureGen.cpp
+++ b/optimizer/tests/FeatureGen.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/tests/FeatureGen.h" //@manual
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::velox::optimizer::test {
+
+BufferPtr evenOffsets(int32_t numRows, int32_t step, memory::MemoryPool* pool) {
+  auto buffer = AlignedBuffer::allocate<int32_t>(numRows, pool);
+  for (auto i = 0; i < numRows; ++i) {
+    buffer->asMutable<int32_t>()[i] = i * step;
+  }
+  return buffer;
+}
+
+BufferPtr evenSizes(int32_t numRows, int32_t step, memory::MemoryPool* pool) {
+  auto buffer = AlignedBuffer::allocate<int32_t>(numRows, pool);
+  for (auto i = 0; i < numRows; ++i) {
+    buffer->asMutable<int32_t>()[i] = step;
+  }
+  return buffer;
+}
+
+std::vector<RowVectorPtr> makeFeatures(
+    int32_t numBatches,
+    int32_t batchSize,
+    const FeatureOptions& opts,
+    memory::MemoryPool* pool) {
+  std::vector<RowVectorPtr> result;
+  velox::test::VectorMaker vectorMaker(pool);
+
+  for (auto batchIdx = 0; batchIdx < numBatches; ++batchIdx) {
+    auto uids = vectorMaker.flatVector<int64_t>(
+        batchSize, [&](auto row) { return row + batchIdx * batchSize; });
+    auto tss = vectorMaker.flatVector<int64_t>(batchSize, [&](auto row) {
+      return 100 * (row + batchIdx * batchSize);
+    });
+    auto floatKeys = vectorMaker.flatVector<int32_t>(
+        batchSize * opts.numFloat,
+        [&](int32_t row) { return (row % opts.numFloat) * 100 + 10000; });
+    auto floats = vectorMaker.flatVector<float>(
+        batchSize * opts.numFloat,
+        [&](int32_t row) { return (row % 123) / 100.0; });
+
+    auto floatFeatures = std::make_shared<MapVector>(
+        pool,
+        MAP(INTEGER(), REAL()),
+        nullptr,
+        batchSize,
+        evenOffsets(batchSize, opts.numFloat, pool),
+        evenSizes(batchSize, opts.numFloat, pool),
+        floatKeys,
+        floats);
+
+    std::vector<int32_t> idListSize(opts.numIdList);
+    for (auto i = 0; i < opts.numIdList; ++i) {
+      idListSize[i] = opts.idListMinCard +
+          i * ((opts.idListMaxCard - opts.idListMinCard) / opts.numIdList);
+    }
+
+    auto idLists = vectorMaker.arrayVector<int64_t>(
+        batchSize * opts.numIdList,
+        [&](auto row) { return idListSize[row % idListSize.size()]; },
+        [&](auto row) { return row * 100 + 1; });
+    auto idListKeys = vectorMaker.flatVector<int32_t>(
+        batchSize * opts.numIdList,
+        [&](auto row) { return (row % opts.numIdList) * 200 + 200000; });
+    auto idListFeatures = std::make_shared<MapVector>(
+        pool,
+        MAP(INTEGER(), ARRAY(BIGINT())),
+        nullptr,
+        batchSize,
+        evenOffsets(batchSize, opts.numIdList, pool),
+        evenSizes(batchSize, opts.numIdList, pool),
+        idListKeys,
+        idLists);
+    auto scoreKeys = vectorMaker.flatVector<int32_t>(
+        batchSize * opts.numIdScoreList,
+        [&](auto row) { return (row % opts.numIdScoreList) * 200 + 200000; });
+
+    auto scores = vectorMaker.mapVector<int64_t, float>(
+        batchSize * opts.numIdScoreList,
+        [&](auto row) { return idListSize[row % opts.numIdScoreList]; },
+        [&](int32_t row, int32_t idx) {
+          auto nthArray = (row / opts.numIdScoreList) * opts.numIdList;
+          return idLists->elements()->as<SimpleVector<int64_t>>()->valueAt(
+              idLists->offsetAt(nthArray) + idx);
+        },
+        [&](int32_t row, int32_t idx) { return 1.2 * row / idx; });
+    auto scoreListFeatures = std::make_shared<MapVector>(
+        pool,
+        MAP(INTEGER(), MAP(BIGINT(), REAL())),
+        nullptr,
+        batchSize,
+        evenOffsets(batchSize, opts.numIdScoreList, pool),
+        evenSizes(batchSize, opts.numIdScoreList, pool),
+        scoreKeys,
+        scores);
+    auto row = vectorMaker.rowVector(
+        {"uid",
+         "ts",
+         "float_features",
+         "id_list_features",
+         "id_score_list_features"},
+        {uids, tss, floatFeatures, idListFeatures, scoreListFeatures});
+    result.push_back(std::move(row));
+  }
+  return result;
+}
+
+} // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/FeatureGen.h
+++ b/optimizer/tests/FeatureGen.h
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "velox/vector/ComplexVector.h"
 
-#include "optimizer/QueryGraph.h" //@manual
+namespace facebook::velox::optimizer::test {
 
-namespace facebook::velox::optimizer {
+struct FeatureOptions {
+  int32_t numFloat{10};
+  int32_t numInt{10};
+  int32_t numIdList{10};
+  int32_t idListMaxCard{1000};
+  int32_t idListMinCard{10};
+  int32_t idListMaxDistinct{1000};
+  int32_t numIdScoreList{5};
+};
 
-SchemaP
-tpchSchema(int32_t scale, bool partitioned, bool ordered, bool secondary);
+std::vector<RowVectorPtr> makeFeatures(
+    int32_t numBatches,
+    int32_t batchSize,
+    const FeatureOptions& opts,
+    memory::MemoryPool* pool);
 
-}
+} // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/tests/ParquetTpchTest.h
+++ b/optimizer/tests/ParquetTpchTest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/tests/PlanTest.cpp
+++ b/optimizer/tests/PlanTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,6 +148,21 @@ TEST_F(PlanTest, queryGraph) {
 
   // Identical child types with different names get equal pointers.
   EXPECT_EQ(dedupRow1->childAt(0).get(), dedupDifferentNames->childAt(0).get());
+
+  auto* path = make<Path>()
+                   ->subscript("field")
+                   ->subscript(123)
+                   ->field("f1")
+                   ->cardinality();
+  auto interned = queryCtx()->toPath(path);
+  EXPECT_EQ(interned, path);
+  auto* path2 = make<Path>()
+                    ->subscript("field")
+                    ->subscript(123)
+                    ->field("f1")
+                    ->cardinality();
+  auto interned2 = queryCtx()->toPath(path2);
+  EXPECT_EQ(interned2, interned);
 }
 
 TEST_F(PlanTest, q3) {

--- a/optimizer/tests/QueryTestBase.cpp
+++ b/optimizer/tests/QueryTestBase.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/tests/QueryTestBase.h" //@manual
+
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/exec/Exchange.h"
+
+#include "optimizer/Plan.h" //@manual
+#include "optimizer/SchemaResolver.h" //@manual
+#include "optimizer/VeloxHistory.h" //@manual
+#include "optimizer/connectors/ConnectorSplitSource.h" //@manual
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/expression/Expr.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+DECLARE_string(data_path);
+
+DEFINE_int32(optimizer_trace, 0, "Optimizer trace level");
+
+DEFINE_bool(print_plan, false, "Print optimizer results");
+
+DEFINE_int32(num_drivers, 4, "Number of drivers");
+DEFINE_int32(num_workers, 4, "Number of in-process workers");
+
+DEFINE_string(data_format, "parquet", "Data format");
+
+namespace facebook::velox::optimizer::test {
+using namespace facebook::velox::exec;
+
+void QueryTestBase::SetUp() {
+  exec::test::LocalRunnerTestBase::SetUp();
+  connector_ = connector::getConnector(exec::test::kHiveConnectorId);
+  rootPool_ = memory::memoryManager()->addRootPool("velox_sql");
+  optimizerPool_ = rootPool_->addLeafChild("optimizer");
+  schemaPool_ = rootPool_->addLeafChild("schema");
+
+  parquet::registerParquetReaderFactory();
+  dwrf::registerDwrfReaderFactory();
+  exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);
+  if (!isRegisteredVectorSerde()) {
+    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
+      connectorConfigs;
+  auto copy = hiveConfig_;
+  connectorConfigs[exec::test::kHiveConnectorId] =
+      std::make_shared<config::ConfigBase>(std::move(copy));
+
+  schemaQueryCtx_ = core::QueryCtx::create(
+      driverExecutor_.get(),
+      core::QueryConfig(config_),
+      std::move(connectorConfigs),
+      cache::AsyncDataCache::getInstance(),
+      rootPool_->shared_from_this(),
+      nullptr,
+      "schema");
+  common::SpillConfig spillConfig;
+  common::PrefixSortConfig prefixSortConfig;
+
+  schemaRootPool_ = rootPool_->addAggregateChild("schemaRoot");
+  connectorQueryCtx_ = std::make_shared<connector::ConnectorQueryCtx>(
+      schemaPool_.get(),
+      schemaRootPool_.get(),
+      schemaQueryCtx_->connectorSessionProperties(exec::test::kHiveConnectorId),
+      &spillConfig,
+      prefixSortConfig,
+      std::make_unique<exec::SimpleExpressionEvaluator>(
+          schemaQueryCtx_.get(), schemaPool_.get()),
+      schemaQueryCtx_->cache(),
+      "scan_for_schema",
+      "schema",
+      "N/a",
+      0,
+      schemaQueryCtx_->queryConfig().sessionTimezone());
+
+  schema_ = std::make_shared<facebook::velox::optimizer::SchemaResolver>(
+      connector_, "");
+}
+
+void QueryTestBase::TearDown() {
+  queryCtx_.reset();
+  connector::unregisterConnector(exec::test::kHiveConnectorId);
+  connector_.reset();
+  optimizerPool_.reset();
+  schema_.reset();
+  schemaQueryCtx_.reset();
+  schemaPool_.reset();
+  schemaRootPool_.reset();
+  connectorQueryCtx_.reset();
+  rootPool_.reset();
+  LocalRunnerTestBase::TearDown();
+}
+
+void QueryTestBase::tablesCreated() {
+  auto metadata = dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(
+      connector_->metadata());
+  VELOX_CHECK_NOT_NULL(metadata);
+  metadata->reinitialize();
+  planner_ = std::make_unique<core::DuckDbQueryPlanner>(optimizerPool_.get());
+  auto& tables = metadata->tables();
+  for (auto& pair : tables) {
+    planner_->registerTable(pair.first, pair.second->rowType());
+  }
+  planner_->registerTableScan([this](
+                                  const std::string& id,
+                                  const std::string& name,
+                                  const RowTypePtr& rowType,
+                                  const std::vector<std::string>& columnNames) {
+    return toTableScan(id, name, rowType, columnNames);
+  });
+  history_ = std::make_unique<facebook::velox::optimizer::VeloxHistory>();
+}
+
+core::PlanNodePtr QueryTestBase::toTableScan(
+    const std::string& id,
+    const std::string& name,
+    const RowTypePtr& rowType,
+    const std::vector<std::string>& columnNames) {
+  using namespace connector::hive;
+  auto handle = std::make_shared<HiveTableHandle>(
+      exec::test::kHiveConnectorId,
+      name,
+      true,
+      common::SubfieldFilters{},
+      nullptr);
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      assignments;
+
+  auto table = connector_->metadata()->findTable(name);
+  for (auto i = 0; i < rowType->size(); ++i) {
+    auto projectedName = rowType->nameOf(i);
+    auto& columnName = columnNames[i];
+    VELOX_CHECK(
+        table->columnMap().find(columnName) != table->columnMap().end(),
+        "No column {} in {}",
+        columnName,
+        name);
+    assignments[projectedName] = std::make_shared<HiveColumnHandle>(
+        columnName,
+        HiveColumnHandle::ColumnType::kRegular,
+        rowType->childAt(i),
+        rowType->childAt(i));
+  }
+  return std::make_shared<core::TableScanNode>(
+      id, rowType, handle, assignments);
+}
+
+std::shared_ptr<runner::LocalRunner> QueryTestBase::runSql(
+    const std::string& sql,
+    std::vector<RowVectorPtr>* resultVector,
+    std::string* planString,
+    std::string* errorString,
+    std::vector<exec::TaskStats>* statsReturn) {
+  std::shared_ptr<runner::LocalRunner> runner;
+  auto fragmentedPlan = planSql(sql, planString, errorString);
+  if (!fragmentedPlan) {
+    return nullptr;
+  }
+  try {
+    runner = std::make_shared<runner::LocalRunner>(
+        fragmentedPlan,
+        queryCtx_,
+        std::make_shared<connector::ConnectorSplitSourceFactory>());
+    std::vector<RowVectorPtr> results;
+    while (auto rows = runner->next()) {
+      results.push_back(rows);
+    }
+    if (resultVector) {
+      *resultVector = results;
+    }
+    auto stats = runner->stats();
+    if (statsReturn) {
+      *statsReturn = stats;
+    }
+    auto& fragments = fragmentedPlan->fragments();
+    history_->recordVeloxExecution(nullptr, fragments, stats);
+  } catch (const std::exception& e) {
+    std::cerr << "Query terminated with: " << e.what() << std::endl;
+    if (errorString) {
+      *errorString = fmt::format("Runtime error: {}", e.what());
+    }
+    waitForCompletion(runner);
+    return nullptr;
+  }
+  waitForCompletion(runner);
+  return runner;
+}
+
+runner::MultiFragmentPlanPtr QueryTestBase::planSql(
+    const std::string& sql,
+    std::string* planString,
+    std::string* errorString) {
+  core::PlanNodePtr plan;
+  try {
+    plan = planner_->plan(sql);
+  } catch (std::exception& e) {
+    std::cerr << "parse error: " << e.what() << std::endl;
+    if (errorString) {
+      *errorString = fmt::format("Parse error: {}", e.what());
+    }
+    return nullptr;
+  }
+  return planVelox(plan, planString, errorString);
+}
+
+runner::MultiFragmentPlanPtr QueryTestBase::planVelox(
+    const core::PlanNodePtr& plan,
+    std::string* planString,
+    std::string* errorString) {
+  ++queryCounter_;
+  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
+      connectorConfigs;
+  auto copy = hiveConfig_;
+  connectorConfigs[exec::test::kHiveConnectorId] =
+      std::make_shared<config::ConfigBase>(std::move(copy));
+  queryCtx_ = core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig(config_),
+      std::move(connectorConfigs),
+      cache::AsyncDataCache::getInstance(),
+      rootPool_->shared_from_this(),
+      spillExecutor_.get(),
+      fmt::format("query_{}", queryCounter_));
+
+  // The default Locus for planning is the system and data of 'connector_'.
+  optimizer::Locus locus(connector_->connectorId().c_str(), connector_.get());
+  facebook::velox::optimizer::Optimization::PlanCostMap estimates;
+  runner::MultiFragmentPlan::Options opts;
+  opts.numWorkers = FLAGS_num_workers;
+  opts.numDrivers = FLAGS_num_drivers;
+  auto allocator = std::make_unique<HashStringAllocator>(optimizerPool_.get());
+  auto context =
+      std::make_unique<facebook::velox::optimizer::QueryGraphContext>(
+          *allocator);
+  facebook::velox::optimizer::queryCtx() = context.get();
+  exec::SimpleExpressionEvaluator evaluator(
+      queryCtx_.get(), optimizerPool_.get());
+  runner::MultiFragmentPlanPtr fragmentedPlan;
+  try {
+    facebook::velox::optimizer::Schema veraxSchema(
+        "test", schema_.get(), &locus);
+    facebook::velox::optimizer::Optimization opt(
+        *plan, veraxSchema, *history_, evaluator, FLAGS_optimizer_trace);
+    auto best = opt.bestPlan();
+    if (planString) {
+      *planString = best->op->toString(true, false);
+    }
+    fragmentedPlan = opt.toVeloxPlan(best->op, opts);
+  } catch (const std::exception& e) {
+    facebook::velox::optimizer::queryCtx() = nullptr;
+    std::cerr << "optimizer error: " << e.what() << std::endl;
+    if (errorString) {
+      *errorString = fmt::format("optimizer error: {}", e.what());
+    }
+    return nullptr;
+  }
+  facebook::velox::optimizer::queryCtx() = nullptr;
+  return fragmentedPlan;
+}
+
+void QueryTestBase::waitForCompletion(
+    const std::shared_ptr<runner::LocalRunner>& runner) {
+  if (runner) {
+    try {
+      runner->waitForCompletion(50000);
+    } catch (const std::exception& /*ignore*/) {
+    }
+  }
+}
+
+std::string QueryTestBase::veloxString(const std::string& sql) {
+  auto plan = planSql(sql);
+  VELOX_CHECK_NOT_NULL(plan);
+  return veloxString(plan);
+}
+
+std::string QueryTestBase::veloxString(
+    const runner::MultiFragmentPlanPtr& plan) {
+  std::stringstream out;
+  for (auto i = 0; i < plan->fragments().size(); ++i) {
+    auto& fragment = plan->fragments()[i];
+    out << "Fragment " << i << ":\n";
+    auto* fragmentRoot = fragment.fragment.planNode.get();
+    auto planNodeDetails = [&](const core::PlanNodeId& planNodeId,
+                               const std::string& indentation,
+                               std::stringstream& stream) {
+      auto node = core::PlanNode::findFirstNode(
+          fragmentRoot, [&](auto* node) { return node->id() == planNodeId; });
+      if (!node) {
+        return;
+      }
+      if (auto* scan = dynamic_cast<const core::TableScanNode*>(node)) {
+        stream << std::endl;
+        for (auto& pair : scan->assignments()) {
+          auto* hiveColumn =
+              dynamic_cast<const connector::hive::HiveColumnHandle*>(
+                  pair.second.get());
+          if (!hiveColumn) {
+            continue;
+          }
+          stream << indentation << pair.first << " = " << hiveColumn->toString()
+                 << std::endl;
+        }
+      }
+    };
+
+    out << fragment.fragment.planNode->toString(true, true, planNodeDetails)
+        << std::endl;
+  }
+  out << std::endl;
+  return out.str();
+}
+
+void QueryTestBase::expectRegexp(
+    std::string& text,
+    const std::string regexp,
+    bool expect) {
+  std::istringstream iss(text);
+  std::string line;
+  bool found = false;
+  for (; std::getline(iss, line);) {
+    if (RE2::PartialMatch(line, regexp)) {
+      found = true;
+      break;
+    }
+  }
+  if (found != expect) {
+    FAIL() << "Expected " << (expect == false ? " no " : "") << regexp << " in "
+           << text;
+  }
+}
+
+} // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/QueryTestBase.h
+++ b/optimizer/tests/QueryTestBase.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gflags/gflags.h>
+#include "optimizer/SchemaResolver.h" //@manual
+#include "optimizer/VeloxHistory.h" //@manual
+#include "optimizer/connectors/hive/LocalHiveConnectorMetadata.h" //@manual
+#include "optimizer/tests/ParquetTpchTest.h" //@manual
+#include "velox/exec/tests/utils/LocalRunnerTestBase.h"
+#include "velox/parse/QueryPlanner.h"
+#include "velox/runner/LocalRunner.h"
+
+namespace facebook::velox::optimizer::test {
+
+class QueryTestBase : public exec::test::LocalRunnerTestBase {
+ protected:
+  void SetUp() override;
+
+  void TearDown() override;
+
+  // reads the data directory and picks up new tables.
+  void tablesCreated();
+
+  core::PlanNodePtr toTableScan(
+      const std::string& id,
+      const std::string& name,
+      const RowTypePtr& rowType,
+      const std::vector<std::string>& columnNames);
+
+  std::shared_ptr<runner::LocalRunner> runSql(
+      const std::string& sql,
+      std::vector<RowVectorPtr>* resultVector = nullptr,
+      std::string* planString = nullptr,
+      std::string* errorString = nullptr,
+      std::vector<exec::TaskStats>* statsReturn = nullptr);
+
+  runner::MultiFragmentPlanPtr planSql(
+      const std::string& sql,
+      std::string* planString = nullptr,
+      std::string* errorString = nullptr);
+
+  runner::MultiFragmentPlanPtr planVelox(
+      const core::PlanNodePtr& plan,
+      std::string* planString = nullptr,
+      std::string* errorString = nullptr);
+
+  std::string veloxString(const std::string& sql);
+
+  std::string veloxString(const runner::MultiFragmentPlanPtr& plan);
+
+  void
+  expectRegexp(std::string& text, const std::string regexp, bool expect = true);
+
+  void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner);
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> optimizerPool_;
+  std::shared_ptr<memory::MemoryPool> schemaPool_;
+  std::shared_ptr<memory::MemoryPool> schemaRootPool_;
+  std::shared_ptr<core::QueryCtx> schemaQueryCtx_;
+
+  // A QueryCtx created for each compiled query.
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
+  std::shared_ptr<connector::Connector> connector_;
+  std::shared_ptr<optimizer::SchemaResolver> schema_;
+  std::unique_ptr<facebook::velox::optimizer::VeloxHistory> history_;
+  std::unique_ptr<core::DuckDbQueryPlanner> planner_;
+  inline static int32_t queryCounter_{0};
+};
+} // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/SubfieldTest.cpp
+++ b/optimizer/tests/SubfieldTest.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/tests/FeatureGen.h" //@manual
+#include "optimizer/tests/QueryTestBase.h" //@manual
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::optimizer;
+using namespace facebook::velox::optimizer::test;
+using namespace facebook::velox::exec::test;
+
+TypePtr makeGenieType() {
+  return ROW(
+      {"uid", "ff", "idlf", "idslf"},
+      {BIGINT(),
+       MAP(INTEGER(), REAL()),
+       MAP(INTEGER(), ARRAY(BIGINT())),
+       MAP(INTEGER(), MAP(BIGINT(), REAL()))});
+}
+
+class GenieFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_UNREACHABLE();
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    auto type = makeGenieType();
+    return {
+        exec::FunctionSignatureBuilder()
+            .returnType(
+                "row(uid bigint, ff map(integer, real), idlf map(integer, array(bigint)), idslf map(integer, map(bigint, real)))")
+            .argumentType("bigint")
+            .argumentType("map(integer, real)")
+            .argumentType("map(integer, array(bigint))")
+            .argumentType("map(integer, map(bigint, real))")
+            .build()};
+  }
+};
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+    udf_genie,
+    GenieFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
+    std::make_unique<GenieFunction>());
+
+class SubfieldTest : public QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    core::Expressions::setFieldAccessHook(fieldIndexHook);
+  }
+
+  void TearDown() override {
+    QueryTestBase::TearDown();
+    core::Expressions::setFieldAccessHook(nullptr);
+  }
+
+  // Converts names like __[nn to DereferenceTypedExpr with index nn. Other
+  // cases are unchanged.
+  static core::TypedExprPtr fieldIndexHook(
+      std::shared_ptr<const core::FieldAccessExpr> fae,
+      std::vector<core::TypedExprPtr>& children) {
+    auto name = fae->getFieldName();
+    if (name.size() < 3 || name[0] != '_' || name[1] != '_') {
+      return nullptr;
+    }
+    int32_t idx = -1;
+    if (1 != sscanf(name.c_str() + 2, "%d", &idx)) {
+      return nullptr;
+    }
+    VELOX_CHECK_EQ(children.size(), 1);
+    VELOX_CHECK_GE(idx, 0);
+    VELOX_CHECK_LT(idx, children[0]->type()->size());
+    return std::make_shared<core::DereferenceTypedExpr>(
+        children[0]->type()->as<TypeKind::ROW>().childAt(idx),
+        children[0],
+        idx);
+  }
+
+  void declareGenies() {
+    TypePtr genieType = makeGenieType();
+    std::vector<TypePtr> genieArgs = {
+        genieType->childAt(0),
+        genieType->childAt(1),
+        genieType->childAt(2),
+        genieType->childAt(3)};
+    planner_->registerScalarFunction("genie", genieArgs, genieType);
+    planner_->registerScalarFunction("exploding_genie", genieArgs, genieType);
+    VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "genie");
+    VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "exploding_genie");
+
+    auto metadata = std::make_unique<FunctionMetadata>();
+    metadata->fieldIndexForArg = {1, 2, 3};
+    metadata->argOrdinal = {1, 2, 3};
+    auto* instance = FunctionRegistry::instance();
+    auto explodingMetadata = std::make_unique<FunctionMetadata>(*metadata);
+    instance->registerFunction("genie", std::move(metadata));
+
+    explodingMetadata->explode = explodeGenie;
+    instance->registerFunction("exploding_genie", std::move(explodingMetadata));
+  }
+
+  static std::unordered_map<PathCP, core::TypedExprPtr> explodeGenie(
+      const core::CallTypedExpr* call,
+      std::vector<PathCP>& paths) {
+    // This function understands paths like .__1[cc], .__2[cc],
+    // .__3[cc] where __x is an ordinal field reference and cc is an integer
+    // constant. If there is an empty path or a path with just one step, this
+    // returns empty, meaning nothing is exploded. If the paths are longer, e.g.
+    // idslf[11][1], then the trailing part is ignored. The returned map will
+    // have the expression for each distinct path that begins with one of .__1,
+    // .__2, .__3 followed by an integer subscript.
+    std::unordered_map<PathCP, core::TypedExprPtr> result;
+    for (auto& path : paths) {
+      auto& steps = path->steps();
+      if (steps.size() < 2) {
+        return {};
+      }
+
+      std::vector<Step> prefixSteps = {steps[0], steps[1]};
+      auto prefixPath = toPath(std::move(prefixSteps));
+      if (result.count(prefixPath)) {
+        // There already is an expression for this path.
+        continue;
+      }
+      VELOX_CHECK(steps.front().kind == StepKind::kField);
+      auto nth = steps.front().id;
+      VELOX_CHECK_LE(nth, 3);
+      auto args = call->inputs();
+
+      // Here, for the sake of example, we make every odd key return identity.
+      if (steps[1].id % 2 == 1) {
+        result[prefixPath] = stepToGetter(steps[1], args[nth]);
+        continue;
+      }
+
+      // For changed float_features, we add the feature id to the value.
+      if (nth == 1) {
+        result[prefixPath] = std::make_shared<core::CallTypedExpr>(
+            REAL(),
+            std::vector<core::TypedExprPtr>{
+                stepToGetter(steps[1], args[nth]),
+                std::make_shared<core::ConstantTypedExpr>(
+                    REAL(), variant(static_cast<float>(steps[1].id)))},
+            "plus");
+        continue;
+      }
+
+      // For changed id list features, we do array_distinct on the list.
+      if (nth == 2) {
+        result[prefixPath] = std::make_shared<core::CallTypedExpr>(
+            ARRAY(BIGINT()),
+            std::vector<core::TypedExprPtr>{stepToGetter(steps[1], args[nth])},
+            "array_distinct");
+        continue;
+      }
+
+      // Access to idslf. Identity.
+      result[prefixPath] = stepToGetter(steps[1], args[nth]);
+    }
+    return result;
+  }
+};
+
+TEST_F(SubfieldTest, structs) {
+  auto structType =
+      ROW({"s1", "s2", "s3"},
+          {BIGINT(), ROW({"s2s1"}, {BIGINT()}), ARRAY(BIGINT())});
+  auto rowType = ROW({"s", "i"}, {structType, BIGINT()});
+  auto vectors = makeVectors(rowType, 10, 10);
+  auto fs = filesystems::getFileSystem(files_->getPath(), {});
+  fs->mkdir(files_->getPath() + "/structs");
+  auto filePath = files_->getPath() + "/structs/structs.dwrf";
+  writeToFile(filePath, vectors);
+  tablesCreated();
+
+  auto builder = PlanBuilder()
+                     .tableScan("structs", rowType)
+                     .project({"s.s1 as a", "s.s3[0] as arr0"});
+
+  auto plan = veloxString(planVelox(builder.planNode()));
+  expectRegexp(plan, "s.*Subfields.*s.s3\\[0\\]");
+  expectRegexp(plan, "s.*Subfields.*s.s1");
+}
+
+TEST_F(SubfieldTest, maps) {
+  FeatureOptions opts;
+  auto vectors = makeFeatures(5, 100, opts, pool_.get());
+  auto rowType = std::dynamic_pointer_cast<const RowType>(vectors[0]->type());
+  auto fs = filesystems::getFileSystem(files_->getPath(), {});
+  fs->mkdir(files_->getPath() + "/features");
+  auto filePath = files_->getPath() + "/features/features.dwrf";
+  writeToFile(filePath, vectors);
+  tablesCreated();
+  std::vector<RowVectorPtr> results;
+  std::string plan;
+  auto builder =
+      PlanBuilder()
+          .tableScan("features", rowType)
+          .project(
+              {"float_features[10::INTEGER] as f1",
+               "float_features[20::INTEGER] as f2",
+               "id_score_list_features[10000::INTEGER][100000::INTEGER]"});
+  plan = veloxString(planVelox(builder.planNode()));
+  expectRegexp(plan, "float_features.*Subfields.*float_features\\[10\\]");
+  expectRegexp(plan, "float_features.*Subfields.*float_features\\[20\\]");
+  expectRegexp(
+      plan,
+      "id_score_list_features.*Subfields.* id_score_list_features\\[10000\\]\\[100000\\]");
+  expectRegexp(plan, "id_list", false);
+
+  builder = PlanBuilder()
+                .tableScan("features", rowType)
+                .project(
+                    {"float_features[10000::INTEGER] as ff",
+                     "id_score_list_features[10000::INTEGER] as sc1",
+                     "id_list_features as idlf"})
+                .project({"sc1[1::INTEGER] + 1::REAL as score"});
+  plan = veloxString(planVelox(builder.planNode()));
+  expectRegexp(
+      plan,
+      "id_score_list_features.*Subfields:.*\\[ id_score_list_features\\[10000\\]\\[1\\]");
+  expectRegexp(plan, "id_list", false);
+  expectRegexp(plan, "float_f", false);
+
+  builder = PlanBuilder()
+                .tableScan("features", rowType)
+                .project(
+                    {"float_features[10000::INTEGER] as ff",
+                     "id_score_list_features[10000::INTEGER] as sc1",
+                     "id_list_features as idlf",
+                     "uid"})
+                .project(
+                    {"sc1[1::INTEGER] + 1::REAL as score",
+                     "idlf[cast(uid % 100 as INTEGER)] as any"});
+  plan = veloxString(planVelox(builder.planNode()));
+  expectRegexp(
+      plan, "id_list_features.*Subfields:.* id_list_features\\[\\*\\]");
+
+  declareGenies();
+
+  // Selected fields of genie are accessed. The uid and idslf args are not
+  // accessed and should not be in the table scan.
+  builder =
+      PlanBuilder()
+          .tableScan("features", rowType)
+          .project(
+              {"genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+          .project(
+              {"g.__1[2::INTEGER] as f2",
+               "g.__1[11::INTEGER] as f11",
+               "g.__1[2::INTEGER] + 22::REAL  as f2b",
+               "g.__2[100::INTEGER] as idl100"});
+
+  plan = veloxString(planVelox(builder.planNode()));
+  expectRegexp(plan, "float_features.*Subfield.*float_features\\[2\\]");
+  expectRegexp(plan, "id_list_features.*Subfields.*id_list_features\\[100\\]");
+
+  // All of genie is returned.
+  builder =
+      PlanBuilder()
+          .tableScan("features", rowType)
+          .project(
+              {"genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+          .project(
+              {"g",
+               "g.__1[10::INTEGER] as f10",
+               "g.__1[2::INTEGER] as f2",
+               "g.__2[100::INTEGER] as idl100"});
+
+  plan = veloxString(planVelox(builder.planNode()));
+  std::cout << plan << std::endl;
+
+  // We expect the genie to explode and the filters to be first.
+  builder =
+      PlanBuilder()
+          .tableScan("features", rowType)
+          .project(
+              {"exploding_genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+          .project({"g.__1 as ff", "g as gg"})
+          .project(
+              {"ff[10::INTEGER] as f10",
+               "ff[11::INTEGER] as f11",
+               "ff[2::INTEGER] as f2",
+               "gg.__1[2::INTEGER] + 22::REAL as f2b",
+               "gg.__2[100::INTEGER] as idl100"})
+          .filter("f10 < 10::REAL and f11 < 10::REAL");
+
+  plan = veloxString(planVelox(builder.planNode()));
+  std::cout << plan << std::endl;
+}

--- a/optimizer/tests/Tpch.cpp
+++ b/optimizer/tests/Tpch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optimizer/tests/VeloxSql.cpp
+++ b/optimizer/tests/VeloxSql.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Performs a pass on the input PlanNode tree to determine which subfields of complex type columns and intermediate results are accessed. This fills in maps from PlanNode to column, subfield set pairs for control columns and payload columns. Control columns affect selection of rows, payload columns are along for the ride and are candidates for late materialization.

Control columns are filter inputs, join keys and grouping keys.

We annotate PlanNodes and TypedExprs with the subfield information. the TypedExpr case is relevant for functions that return complex types.

We implement a optimizer::FunctionRegistry for subfield and second order function metadata. When a function that returns complex types is used inside a subfield path, the subfield paths can serve to determine which subfields of the function's input are accessed. This is the case for functions like transform and transform_values.

Additionally, genie functions (DPP functions that operate on all/most columns of the row and return another isomorphic row can be made decomposable. Specifying an explode function does this as follows: The function gets the complete set of subfields that are accessed in the return value. The explode function then looks at the starts of the paths and for each distinct start it understands, it produces an expression. This expression is then substituted for the path where the path is referenced.

For example, select genie(id_list_features).id_list_features[11] from features applies the path id_list_features[11] to the genie. The genie exploder sees this and can return an expression. Also, we automatically know that only [11] is accessed in id_list_features in features. This last fact is inferred based on a mapping from produced subfields to corresponding input arguments of the genie. See FunctionMetadata.

A side effect of this analysis is that we automatically prune unreferenced columns from projections and aggregates. Previously this was not explicitly done.

To implement subfield support, we add a Path object. This is a deduplicated RAII set of distinct paths, each with its id. as with Exprs, comparison is by pointer identity. We add a Path::skyline function which removes all paths that are occluded by a shorter path sharing a common prefix with the longer one.

Additionally, this diff refactors BitSet as separate from PlanObjectSet and fixes lifetimes of velox::variant.