### PR TITLE
Support map as struct and pushdown of subfields

### DIFF
--- a/optimizer/BitSet.h
+++ b/optimizer/BitSet.h
@@ -70,7 +70,7 @@ class BitSet {
   }
 
   template <typename Func>
-  void forEach(Func f) {
+  void forEach(Func f) const {
     bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, f);
   }
 

--- a/optimizer/Cost.h
+++ b/optimizer/Cost.h
@@ -44,7 +44,9 @@ class History {
   /// columns extracted. This is used first for coming up with join orders. The
   /// plan candidates are then made and findCost() is used to access historical
   /// cost and plan cardinality.
-  virtual bool setLeafSelectivity(BaseTable& baseTable) = 0;
+  virtual bool setLeafSelectivity(
+      BaseTable& baseTable,
+      RowTypePtr scanType) = 0;
 
   virtual void recordLeafSelectivity(
       const std::string& handle,

--- a/optimizer/FunctionRegistry.cpp
+++ b/optimizer/FunctionRegistry.cpp
@@ -38,17 +38,36 @@ FunctionRegistry* FunctionRegistry::instance() {
   return registry.get();
 }
 
-bool declareBuiltin() {
-  auto metadata = std::make_unique<FunctionMetadata>();
-  LambdaInfo info;
-  info.ordinal = 1;
-  info.lambdaArg = {LambdaArg::kKey, LambdaArg::kValue};
-  info.argOrdinal = {0, 0};
-  metadata->lambdas.push_back(std::move(info));
-  metadata->subfieldArg = 0;
-  FunctionRegistry::instance()->registerFunction(
-      "transform_values", std::move(metadata));
+bool declareBuiltIn() {
+  {
+    auto metadata = std::make_unique<FunctionMetadata>();
+    LambdaInfo info;
+    info.ordinal = 1;
+    info.lambdaArg = {LambdaArg::kKey, LambdaArg::kValue};
+    info.argOrdinal = {0, 0};
+    metadata->lambdas.push_back(std::move(info));
+    metadata->subfieldArg = 0;
+    metadata->cost = 40;
+    FunctionRegistry::instance()->registerFunction(
+        "transform_values", std::move(metadata));
+  }
+  {
+    auto metadata = std::make_unique<FunctionMetadata>();
+    LambdaInfo info;
+    info.ordinal = 1;
+    info.lambdaArg = {LambdaArg::kElement};
+    info.argOrdinal = {0};
+    metadata->lambdas.push_back(std::move(info));
+    metadata->subfieldArg = 0;
+    metadata->cost = 20;
+    FunctionRegistry::instance()->registerFunction(
+        "transform", std::move(metadata));
+  }
   return true;
+}
+
+namespace {
+bool temp = declareBuiltIn();
 }
 
 } // namespace facebook::velox::optimizer

--- a/optimizer/QueryGraph.cpp
+++ b/optimizer/QueryGraph.cpp
@@ -274,12 +274,22 @@ PlanObjectSet allTables(CPSpan<Expr> exprs) {
   return all;
 }
 
-Column::Column(Name name, PlanObjectP relation, const Value& value)
-    : Expr(PlanType::kColumn, value), name_(name), relation_(relation) {
+Column::Column(
+    Name name,
+    PlanObjectP relation,
+    const Value& value,
+    ColumnCP top,
+    PathCP path)
+    : Expr(PlanType::kColumn, value),
+      name_(name),
+      relation_(relation),
+      topColumn_(top),
+      path_(path) {
   columns_.add(this);
   subexpressions_.add(this);
   if (relation_ && relation_->type() == PlanType::kTable) {
-    schemaColumn_ = relation->as<BaseTable>()->schemaTable->findColumn(name_);
+    schemaColumn_ = relation->as<BaseTable>()->schemaTable->findColumn(
+        topColumn_ ? topColumn_->name() : name_);
     VELOX_CHECK(schemaColumn_);
   }
 }

--- a/optimizer/QueryGraphContext.cpp
+++ b/optimizer/QueryGraphContext.cpp
@@ -79,6 +79,12 @@ TypePtr QueryGraphContext::dedupType(const TypePtr& type) {
     case TypeKind::MAP:
       newType = MAP(children[0], children[1]);
       break;
+    case TypeKind::FUNCTION: {
+      auto args = children;
+      args.pop_back();
+      newType =
+          std::make_shared<FunctionType>(std::move(args), children.back());
+    } break;
     default:
       VELOX_FAIL("Type has size > 0 and is not row/array/map");
   }

--- a/optimizer/VeloxHistory.cpp
+++ b/optimizer/VeloxHistory.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::optimizer {
 using namespace facebook::velox::exec;
 using namespace facebook::velox::runner;
 
-bool VeloxHistory::setLeafSelectivity(BaseTable& table) {
+bool VeloxHistory::setLeafSelectivity(BaseTable& table, RowTypePtr scanType) {
   auto optimization = queryCtx()->optimization();
   auto handlePair = optimization->leafHandle(table.id());
   auto handle = handlePair.first;
@@ -47,8 +47,8 @@ bool VeloxHistory::setLeafSelectivity(BaseTable& table) {
     return false;
   }
 
-  auto sample =
-      runnerTable->layouts()[0]->sample(handlePair.first, 1, handlePair.second);
+  auto sample = runnerTable->layouts()[0]->sample(
+      handlePair.first, 1, handlePair.second, scanType);
   table.filterSelectivity =
       static_cast<float>(sample.second) / (sample.first + 1);
   recordLeafSelectivity(string, table.filterSelectivity, false);

--- a/optimizer/VeloxHistory.h
+++ b/optimizer/VeloxHistory.h
@@ -34,7 +34,7 @@ class VeloxHistory : public History {
 
   /// Sets the filter selectivity of a table scan. Returns true if there is data
   /// to back the estimate and false if this is a pure guess.
-  bool setLeafSelectivity(BaseTable& table) override;
+  bool setLeafSelectivity(BaseTable& table, RowTypePtr scanType) override;
 
   /// Stores observed costs and cardinalities from a query execution. If 'op' is
   /// non-null, non-leaf costs from non-leaf levels are recorded. Otherwise only

--- a/optimizer/connectors/ConnectorMetadata.h
+++ b/optimizer/connectors/ConnectorMetadata.h
@@ -255,10 +255,13 @@ class TableLayout {
   /// to look at a subset of all accessed columns, so we specify these instead
   /// of defaulting to the columns in 'handle'.  'allocator' is used for
   /// temporary memory in gathering statistics.
+  /// 'outputType' can specify a cast from map to struct. Filter expressions see
+  /// the 'outputType' and 'subfields' are relative to that.
   virtual std::pair<int64_t, int64_t> sample(
       const connector::ConnectorTableHandlePtr& handle,
       float pct,
       std::vector<core::TypedExprPtr> extraFilters,
+      RowTypePtr outputType = nullptr,
       const std::vector<common::Subfield>& fields = {},
       HashStringAllocator* allocator = nullptr,
       std::vector<ColumnStatistics>* statistics = nullptr) const {
@@ -481,13 +484,16 @@ class ConnectorMetadata {
   /// have to be applied to the data returned by the
   /// DataSource. 'rejectedFilters' may or may not be a subset of
   /// 'filters' or subexpressions thereof. If 'lookupKeys' is present,
-  /// these must match the lookupKeys() in 'layout'.
+  /// these must match the lookupKeys() in 'layout'. If 'dataColumns' is given,
+  /// it must have all the existing columns and may additionally specify casting
+  /// from maps to structs by giving a struct in the place of a map.
   virtual ConnectorTableHandlePtr createTableHandle(
       const TableLayout& layout,
       std::vector<ColumnHandlePtr> columnHandles,
       core::ExpressionEvaluator& evaluator,
       std::vector<core::TypedExprPtr> filters,
       std::vector<core::TypedExprPtr>& rejectedFilters,
+      RowTypePtr dataColumns = nullptr,
       std::optional<LookupKeys> = std::nullopt) {
     VELOX_UNSUPPORTED();
   }

--- a/optimizer/connectors/hive/HiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/HiveConnectorMetadata.h
@@ -111,6 +111,7 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       core::ExpressionEvaluator& evaluator,
       std::vector<core::TypedExprPtr> filters,
       std::vector<core::TypedExprPtr>& rejectedFilters,
+      RowTypePtr dataColumns = nullptr,
       std::optional<LookupKeys> lookupKeys = std::nullopt) override;
 
  protected:

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -200,12 +200,13 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
     const connector::ConnectorTableHandlePtr& handle,
     float pct,
     std::vector<core::TypedExprPtr> extraFilters,
+    RowTypePtr scanType,
     const std::vector<common::Subfield>& fields,
     HashStringAllocator* allocator,
     std::vector<ColumnStatistics>* statistics) const {
   std::vector<std::unique_ptr<velox::dwrf::StatisticsBuilder>> builders;
   VELOX_CHECK(extraFilters.empty());
-  auto result = sample(handle, pct, fields, allocator, &builders);
+  auto result = sample(handle, pct, scanType, fields, allocator, &builders);
   if (!statistics) {
     return result;
   }
@@ -229,6 +230,7 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
 std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
     const connector::ConnectorTableHandlePtr& tableHandle,
     float pct,
+    RowTypePtr scanType,
     const std::vector<common::Subfield>& fields,
     HashStringAllocator* /*allocator*/,
     std::vector<std::unique_ptr<velox::dwrf::StatisticsBuilder>>* statsBuilders)
@@ -500,7 +502,7 @@ void LocalTable::sampleNumDistincts(float samplePct, memory::MemoryPool* pool) {
   auto* localLayout = dynamic_cast<LocalHiveTableLayout*>(layout);
   VELOX_CHECK_NOT_NULL(localLayout, "Expecting a local hive layout");
   auto [sampled, passed] = localLayout->sample(
-      handle, samplePct, fields, allocator.get(), &statsBuilders);
+      handle, samplePct, type_, fields, allocator.get(), &statsBuilders);
   numSampledRows_ = sampled;
   for (auto i = 0; i < statsBuilders.size(); ++i) {
     if (statsBuilders[i]) {

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -98,7 +98,8 @@ class LocalHiveTableLayout : public HiveTableLayout {
       const connector::ConnectorTableHandlePtr& handle,
       float pct,
       std::vector<core::TypedExprPtr> extraFilters,
-      const std::vector<common::Subfield>& fields,
+      RowTypePtr outputType = nullptr,
+      const std::vector<common::Subfield>& fields = {},
       HashStringAllocator* allocator = nullptr,
       std::vector<ColumnStatistics>* statistics = nullptr) const override;
 
@@ -114,6 +115,7 @@ class LocalHiveTableLayout : public HiveTableLayout {
   std::pair<int64_t, int64_t> sample(
       const connector::ConnectorTableHandlePtr& handle,
       float pct,
+      RowTypePtr scanType,
       const std::vector<common::Subfield>& fields,
       HashStringAllocator* allocator,
       std::vector<std::unique_ptr<dwrf::StatisticsBuilder>>* statsBuilders)

--- a/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -91,7 +91,8 @@ TEST_F(HiveConnectorMetadataTest, basic) {
   auto c0 = common::Subfield::create("c0");
   fields.push_back(std::move(*c0));
   HashStringAllocator allocator(pool_.get());
-  auto pair = layout->sample(tableHandle, 100, {}, fields, &allocator, &stats);
+  auto pair = layout->sample(
+      tableHandle, 100, {}, layout->rowType(), fields, &allocator, &stats);
   EXPECT_EQ(250'000, pair.first);
   EXPECT_EQ(250'000, pair.second);
 }

--- a/optimizer/tests/FeatureGen.h
+++ b/optimizer/tests/FeatureGen.h
@@ -26,12 +26,18 @@ struct FeatureOptions {
   int32_t idListMinCard{10};
   int32_t idListMaxDistinct{1000};
   int32_t numIdScoreList{5};
+
+  /// Structs for use in reading the features. One field for each
+  /// key. Filled in by makeFeatures().
+  RowTypePtr floatStruct;
+  RowTypePtr idListStruct;
+  RowTypePtr idScoreListStruct;
 };
 
 std::vector<RowVectorPtr> makeFeatures(
     int32_t numBatches,
     int32_t batchSize,
-    const FeatureOptions& opts,
+    FeatureOptions& opts,
     memory::MemoryPool* pool);
 
 } // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<exec::test::TempDirectoryPath> ParquetTpchTest::tempDirectory_;
 std::shared_ptr<exec::test::TpchQueryBuilder> ParquetTpchTest::tpchBuilder_;
 
 //  static
-void ParquetTpchTest::SetUpTestSuite() {
+void ParquetTpchTest::SetUpTestCase() {
   memory::MemoryManager::testingSetInstance({});
 
   duckDb_ = std::make_shared<DuckDbQueryRunner>();
@@ -89,7 +89,7 @@ void ParquetTpchTest::SetUpTestSuite() {
 }
 
 //  static
-void ParquetTpchTest::TearDownTestSuite() {
+void ParquetTpchTest::TearDownTestCase() {
   connector::unregisterConnectorFactory(
       connector::hive::HiveConnectorFactory::kHiveConnectorName);
   connector::unregisterConnectorFactory(

--- a/optimizer/tests/ParquetTpchTest.h
+++ b/optimizer/tests/ParquetTpchTest.h
@@ -36,11 +36,11 @@ DECLARE_bool(create_dataset);
 
 namespace facebook::velox::optimizer::test {
 
-class ParquetTpchTest : public testing::Test {
+class ParquetTpchTest : public virtual testing::Test {
  protected:
-  static void SetUpTestSuite();
+  static void SetUpTestCase();
 
-  static void TearDownTestSuite();
+  static void TearDownTestCase();
 
   static void saveTpchTablesAsParquet();
 

--- a/optimizer/tests/QueryTestBase.h
+++ b/optimizer/tests/QueryTestBase.h
@@ -26,6 +26,26 @@
 
 namespace facebook::velox::optimizer::test {
 
+struct TestResult {
+  /// Runner that produced the results. Owns results.
+  std::shared_ptr<runner::LocalRunner> runner;
+
+  /// Results. Declare after runner because results are from a pool in the
+  /// runner's cursor, so runner must destruct last.
+  std::vector<RowVectorPtr> results;
+
+  /// Human readable Velox plan.
+  std::string veloxString;
+
+  /// Human readable Verax  output.
+  std::string planString;
+
+  /// Error message.
+  std::string errorString;
+
+  std::vector<exec::TaskStats> stats;
+};
+
 class QueryTestBase : public exec::test::LocalRunnerTestBase {
  protected:
   void SetUp() override;
@@ -41,12 +61,11 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
       const RowTypePtr& rowType,
       const std::vector<std::string>& columnNames);
 
-  std::shared_ptr<runner::LocalRunner> runSql(
-      const std::string& sql,
-      std::vector<RowVectorPtr>* resultVector = nullptr,
-      std::string* planString = nullptr,
-      std::string* errorString = nullptr,
-      std::vector<exec::TaskStats>* statsReturn = nullptr);
+  TestResult runSql(const std::string& sql);
+
+  TestResult runVelox(const core::PlanNodePtr& plan);
+
+  TestResult runFragmentedPlan(runner::MultiFragmentPlanPtr plan);
 
   runner::MultiFragmentPlanPtr planSql(
       const std::string& sql,
@@ -67,6 +86,7 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner);
 
+  OptimizerOptions optimizerOptions_;
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> optimizerPool_;
   std::shared_ptr<memory::MemoryPool> schemaPool_;

--- a/optimizer/tests/VeloxSql.cpp
+++ b/optimizer/tests/VeloxSql.cpp
@@ -487,8 +487,10 @@ class VeloxRunner {
     try {
       facebook::velox::optimizer::Schema veraxSchema(
           "test", schema_.get(), &locus);
-      facebook::velox::optimizer::Optimization opt(
-          *plan, veraxSchema, *history_, evaluator, FLAGS_optimizer_trace);
+      optimizer::OptimizerOptions optimizerOpts = {
+          .traceFlags = FLAGS_optimizer_trace};
+      optimizer::Optimization opt(
+          *plan, veraxSchema, *history_, evaluator, optimizerOpts);
       auto best = opt.bestPlan();
       if (planString) {
         *planString = best->op->toString(true, false);


### PR DESCRIPTION
Allows specifying a set of columns that are expected to be flat maps and will be accessed as structs s long as the whole map is not accessed.

Extracts column skylines and groups all projections to extract single subfields inside or near the leaf table scan if subfield projection is enabled.

Adds a an extra argument for output type to sampling so that map as struct can be supported.  The dataColumns must be the type in the file and the output types can specify a struct instead of a map.