### PR TITLE
feat: Parallelize wide expressions

### DIFF
--- a/optimizer/CMakeLists.txt
+++ b/optimizer/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(
   Subfields.cpp
   Plan.cpp
   BitSet.cpp
+  ParallelExpr.cpp
+  ParallelProject.cpp
   PlanObject.cpp
   Schema.cpp
   SchemaResolver.cpp

--- a/optimizer/Cost.h
+++ b/optimizer/Cost.h
@@ -73,4 +73,11 @@ float shuffleCost(const ColumnVector& columns);
 
 float shuffleCost(const ExprVector& columns);
 
+/// Returns cost of 'expr' for one row, excluding cost of subexpressions.
+float selfCost(ExprCP expr);
+
+/// Returns the per row cost of 'expr' and its subexpressions, excluding
+/// 'notCounting', which represents already computed subtrees of 'expr'.
+float costWithChildren(ExprCP expr, const PlanObjectSet& notCounting);
+
 } // namespace facebook::velox::optimizer

--- a/optimizer/FunctionRegistry.cpp
+++ b/optimizer/FunctionRegistry.cpp
@@ -37,6 +37,9 @@ FunctionRegistry* FunctionRegistry::instance() {
   static auto registry = std::make_unique<FunctionRegistry>();
   return registry.get();
 }
+const FunctionMetadata* functionMetadata(Name name) {
+  return FunctionRegistry::instance()->metadata(name);
+}
 
 bool declareBuiltIn() {
   {

--- a/optimizer/ParallelExpr.cpp
+++ b/optimizer/ParallelExpr.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/ParallelProject.h" //@manual
+#include "optimizer/Plan.h" //@manual
+#include "optimizer/PlanUtils.h" //@manual
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::optimizer {
+
+struct LevelData {
+  int32_t exprCount{0};
+  float levelCost{0};
+  PlanObjectSet exprs;
+};
+
+int32_t definitionLevel(std::vector<LevelData>& levels, ExprCP expr) {
+  for (auto i = 0; i < levels.size(); ++i) {
+    if (levels[i].exprs.contains(expr)) {
+      return i;
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+void makeExprLevels(
+    PlanObjectSet exprs,
+    std::vector<LevelData>& levelData,
+    std::unordered_map<ExprCP, int32_t>& refCount) {
+  PlanObjectSet counted;
+  for (;;) {
+    PlanObjectSet inputs;
+    levelData.emplace_back();
+    int32_t levelIdx = levelData.size() - 1;
+    exprs.forEach([&](PlanObjectCP o) {
+      auto* expr = o->as<Expr>();
+      float self = selfCost(expr);
+      if (counted.contains(expr)) {
+        auto i = definitionLevel(levelData, expr);
+        levelData[i].exprs.erase(expr);
+        levelData[i].levelCost -= self;
+      }
+      levelData[levelIdx].exprs.add(expr);
+      levelData[levelIdx].levelCost += self;
+      counted.add(expr);
+      if (expr->type() == PlanType::kCall) {
+        for (auto& input : expr->as<Call>()->args()) {
+          if (input->type() == PlanType::kLiteral) {
+            continue;
+          }
+          ++refCount[input];
+          inputs.add(input);
+        }
+      }
+    });
+    if (inputs.empty()) {
+      return;
+    }
+    exprs = std::move(inputs);
+  }
+}
+
+PlanObjectSet makeCseBorder(
+    std::vector<LevelData> levelData,
+    PlanObjectSet& placed,
+    std::unordered_map<ExprCP, int32_t>& refCount) {
+  PlanObjectSet border;
+  for (int32_t leafLevel = levelData.size() - 1; leafLevel >= 0; --leafLevel) {
+    levelData[leafLevel].exprs.forEach([&](PlanObjectCP o) {
+      ExprCP expr = o->as<const Expr>();
+      if (placed.contains(expr)) {
+        return;
+      }
+      if (refCount[expr] > 1) {
+        auto subexprs = expr->subexpressions();
+        subexprs.intersect(border);
+        if (!subexprs.empty()) {
+          // Is a multiply refd over another multiply refd in the same border.
+          // Not a member.
+          return;
+        }
+        border.add(expr);
+      }
+    });
+  }
+  return border;
+}
+
+core::PlanNodePtr Optimization::makeParallelProject(
+    core::PlanNodePtr input,
+    const PlanObjectSet& topExprs,
+    const PlanObjectSet& placed,
+    const PlanObjectSet& extraColumns) {
+  std::vector<std::string> names;
+  std::vector<int32_t> indices;
+  std::vector<float> costs;
+  std::vector<ExprCP> exprs;
+  float totalCost = 0;
+  topExprs.forEach([&](PlanObjectCP o) {
+    exprs.push_back(o->as<Expr>());
+    indices.push_back(indices.size());
+    costs.push_back(costWithChildren(o->as<Expr>(), placed));
+    totalCost += costs.back();
+  });
+  std::sort(indices.begin(), indices.end(), [&](int32_t l, int32_t r) {
+    return costs[l] < costs[r];
+  });
+
+  // Sorted lowest cost first. Make even size groups.
+  float targetCost = totalCost / opts_.parallelProjectWidth;
+  float groupCost = 0;
+  std::vector<std::vector<core::TypedExprPtr>> groups;
+  groups.emplace_back();
+  for (auto nth = 0; nth < indices.size(); ++nth) {
+    auto i = indices[nth];
+    groupCost += costs[i];
+    groups.back().push_back(toTypedExpr(exprs[i]));
+    names.push_back(fmt::format("__temp{}", exprs[i]->id()));
+    auto fieldAccess = std::make_shared<core::FieldAccessTypedExpr>(
+        groups.back().back()->type(), names.back());
+    projectedExprs_[exprs[i]] = fieldAccess;
+    if (groupCost > targetCost) {
+      if (nth == indices.size() - 1) {
+        break;
+      }
+      // Start new group after placing target cost worth.
+      groups.emplace_back();
+      groupCost = 0;
+    }
+  }
+
+  std::vector<std::string> extra;
+  extraColumns.forEach([&](PlanObjectCP o) {
+    auto e = toTypedExpr(o->as<Expr>());
+    if (auto* field =
+            dynamic_cast<const core::FieldAccessTypedExpr*>(e.get())) {
+      extra.push_back(field->name());
+    } else {
+      VELOX_UNREACHABLE();
+    }
+  });
+  return std::make_shared<exec::ParallelProjectNode>(
+      idGenerator().next(),
+      std::move(names),
+      std::move(groups),
+      std::move(extra),
+      input);
+}
+
+// Returns the columns used by Exprs in 'top', excluding columns only referenced
+// from 'placed'.
+void columnBorder(
+    ExprCP expr,
+    const PlanObjectSet& placed,
+    PlanObjectSet& result) {
+  if (placed.contains(expr)) {
+    result.add(expr);
+    return;
+  }
+  switch (expr->type()) {
+    case PlanType::kColumn:
+      result.add(expr);
+      return;
+    case PlanType::kCall: {
+      for (auto& in : expr->as<Call>()->args()) {
+        columnBorder(in, placed, result);
+      }
+      return;
+    }
+    case PlanType::kAggregate:
+      VELOX_UNREACHABLE();
+    default:
+      return;
+  }
+}
+
+PlanObjectSet columnBorder(
+    const PlanObjectSet& top,
+    const PlanObjectSet& placed) {
+  PlanObjectSet result;
+  top.forEach(
+      [&](PlanObjectCP o) { columnBorder(o->as<Expr>(), placed, result); });
+
+  return result;
+}
+
+float parallelBorder(
+    ExprCP expr,
+    const PlanObjectSet& placed,
+    PlanObjectSet& result) {
+  // Cost returned for a subexpressoin that is parallelized. Siblings of these
+  // that are themselves not split should b members of the border.
+  constexpr float kSplit = -1;
+  constexpr float kTargetCost = 50;
+  if (placed.contains(expr)) {
+    return 0;
+  }
+  switch (expr->type()) {
+    case PlanType::kColumn:
+      return selfCost(expr);
+    case PlanType::kCall: {
+      float cost = selfCost(expr);
+      auto call = expr->as<Call>();
+      BitSet splitArgs;
+      auto args = call->args();
+      float allArgsCost = 0;
+      float highestArgCost = 0;
+      for (auto i = 0; i < args.size(); ++i) {
+        auto arg = args[i];
+        auto argCost = parallelBorder(arg, placed, result);
+        if (argCost > highestArgCost) {
+          highestArgCost = argCost;
+        }
+        if (argCost == kSplit) {
+          splitArgs.add(i);
+        }
+        allArgsCost += argCost;
+      }
+      if (!splitArgs.empty()) {
+        // If some arg produced parallel pieces, the non-parallelized siblings
+        // are added to the border.
+        for (auto i = 0; i < args.size(); ++i) {
+          if (!splitArgs.contains(i)) {
+            result.add(args[i]);
+          }
+        }
+        return kSplit;
+      }
+      if (allArgsCost > kTargetCost && highestArgCost < allArgsCost / 2) {
+        // The args are above the target and the biggest is less than half the
+        // total. Add the args to the border.
+        for (auto i = 0; i < args.size(); ++i) {
+          result.add(args[i]);
+        }
+        return kSplit;
+      }
+      return cost + allArgsCost;
+    }
+
+    case PlanType::kAggregate:
+      VELOX_UNREACHABLE();
+    default:
+      return 0;
+  }
+}
+
+core::PlanNodePtr Optimization::maybeParallelProject(
+    Project* project,
+    core::PlanNodePtr input) {
+  PlanObjectSet top;
+  PlanObjectSet allColumns;
+  PlanObjectSet placed;
+  auto& exprs = project->exprs();
+  auto& columns = project->columns();
+  for (auto e : exprs) {
+    allColumns.unionSet(e->columns());
+    top.add(e);
+  }
+  std::vector<LevelData> levelData;
+  std::unordered_map<ExprCP, int32_t> refCount;
+  makeExprLevels(top, levelData, refCount);
+
+  for (;;) {
+    auto cses = makeCseBorder(levelData, placed, refCount);
+    if (cses.empty()) {
+      break;
+    }
+    auto previousPlaced = placed;
+    cses.forEach([&](PlanObjectCP o) {
+      placed.unionSet(o->as<Expr>()->subexpressions());
+    });
+    placed.unionSet(cses);
+    auto extraColumns = columnBorder(top, placed);
+    extraColumns.except(cses);
+    input = makeParallelProject(input, cses, previousPlaced, extraColumns);
+  }
+
+  // Common prerequisites are placed, the expressions that are left  are a tree
+  // with no order
+  PlanObjectSet parallel;
+  top.forEach(
+      [&](PlanObjectCP o) { parallelBorder(o->as<Expr>(), placed, parallel); });
+  auto previousPlaced = placed;
+  parallel.forEach([&](PlanObjectCP o) {
+    placed.unionSet(o->as<Expr>()->subexpressions());
+  });
+  placed.unionSet(parallel);
+  auto extra = columnBorder(top, placed);
+  // The projected through columns are loaded here, so these go into the
+  // parallel exprs and not in the 'noLoadIdentities'.
+  parallel.unionSet(extra);
+  PlanObjectSet empty;
+  input = makeParallelProject(input, parallel, previousPlaced, empty);
+  // one final project for the renames and final functions.
+  std::vector<std::string> names;
+  std::vector<core::TypedExprPtr> finalExprs;
+  for (auto i = 0; i < exprs.size(); ++i) {
+    names.push_back(columns[i]->toString());
+    finalExprs.push_back(toTypedExpr(exprs[i]));
+  }
+  return std::make_shared<core::ProjectNode>(
+      idGenerator().next(), std::move(names), std::move(finalExprs), input);
+}
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/ParallelProject.cpp
+++ b/optimizer/ParallelProject.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/ParallelProject.h" //@manual
+#include "velox/common/base/AsyncSource.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+std::vector<std::string> ParallelProjectNode::allNames(
+    const std::vector<std::string>& names,
+    const std::vector<std::string>& moreNames) {
+  auto result = names;
+  result.insert(result.end(), moreNames.begin(), moreNames.end());
+  return result;
+}
+
+std::vector<core::TypedExprPtr> ParallelProjectNode::flatExprs(
+    std::vector<std::vector<core::TypedExprPtr>>& exprs,
+    const std::vector<std::string> moreNames,
+    const core::PlanNodePtr& input) {
+  std::vector<core::TypedExprPtr> result;
+  for (auto& group : exprs) {
+    result.insert(result.end(), group.begin(), group.end());
+  }
+  auto sourceType = input->outputType();
+  for (auto& name : moreNames) {
+    auto idx = sourceType->getChildIdx(name);
+    result.push_back(std::make_shared<core::FieldAccessTypedExpr>(
+        sourceType->childAt(idx), name));
+  }
+  return result;
+}
+
+void ParallelProjectNode::addDetails(std::stringstream& stream) const {
+  AbstractProjectNode::addDetails(stream);
+  stream << " Parallel expr groups: ";
+  int32_t start = 0;
+  for (auto i = 0; i < exprs_.size(); ++i) {
+    stream << fmt::format("[{}-{}]", start, start + exprs_[i].size() - 1)
+           << (i < exprs_.size() - 1 ? ", " : "");
+    start += exprs_[i].size();
+  }
+  stream << std::endl;
+}
+
+ParallelProject::ParallelProject(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const ParallelProjectNode>& node)
+    : Operator(
+          driverCtx,
+          node->outputType(),
+          operatorId,
+          node->id(),
+          "ParallelProject"),
+      node_(std::move(node)) {}
+
+namespace {
+bool checkAddIdentityProjection(
+    const core::TypedExprPtr& projection,
+    const RowTypePtr& inputType,
+    column_index_t outputChannel,
+    std::vector<IdentityProjection>& identityProjections) {
+  if (auto field = core::TypedExprs::asFieldAccess(projection)) {
+    const auto& inputs = field->inputs();
+    if (inputs.empty() ||
+        (inputs.size() == 1 &&
+         dynamic_cast<const core::InputTypedExpr*>(inputs[0].get()))) {
+      const auto inputChannel = inputType->getChildIdx(field->name());
+      identityProjections.emplace_back(inputChannel, outputChannel);
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace
+
+void ParallelProject::initialize() {
+  Operator::initialize();
+  std::vector<core::TypedExprPtr> allExprs;
+
+  const auto& inputType = node_->sources()[0]->outputType();
+  auto& exprs = node_->exprs();
+  int32_t unitIdx = 0;
+  int32_t exprIdx = 0;
+  int32_t unitSize = exprs[unitIdx].size();
+  work_.emplace_back();
+  work_.back().execCtx = std::make_unique<core::ExecCtx>(
+      operatorCtx_->pool(), operatorCtx_->driverCtx()->task->queryCtx().get());
+
+  std::vector<core::TypedExprPtr> unitExprs;
+  for (column_index_t i = 0; i < node_->exprNames().size(); i++) {
+    auto& projection = exprs[unitIdx][exprIdx];
+    bool identityProjection = checkAddIdentityProjection(
+        projection, inputType, i, identityProjections_);
+    if (!identityProjection) {
+      unitExprs.push_back(projection);
+      work_.back().resultProjections.emplace_back(unitExprs.size() - 1, i);
+    } else {
+      work_.back().loadOnly.push_back(identityProjections_.back().inputChannel);
+    }
+    ++exprIdx;
+    if (exprIdx == unitSize) {
+      // It may be that the only work is loading lazies.
+      auto tempExprs =
+          makeExprSetFromFlag(std::move(unitExprs), operatorCtx_->execCtx());
+      std::shared_ptr<ExprSet> shared(tempExprs.release());
+      work_.back().exprSet = std::move(shared);
+      ++unitIdx;
+      exprIdx = 0;
+      if (unitIdx == exprs.size()) {
+        break;
+      }
+      unitSize = exprs[unitIdx].size();
+      work_.emplace_back();
+      work_.back().execCtx = std::make_unique<core::ExecCtx>(
+          operatorCtx_->pool(),
+          operatorCtx_->driverCtx()->task->queryCtx().get());
+    }
+  }
+
+  int32_t outputIdx = node_->exprNames().size();
+  auto sourceType = node_->sources()[0]->outputType();
+  for (auto& name : node_->noLoadIdentities()) {
+    auto idx = sourceType->getChildIdx(name);
+    identityProjections_.emplace_back(idx, outputIdx++);
+  }
+}
+
+void ParallelProject::addInput(RowVectorPtr input) {
+  input_ = std::move(input);
+  numProcessedInputRows_ = 0;
+}
+
+bool ParallelProject::allInputProcessed() {
+  if (!input_) {
+    return true;
+  }
+  if (numProcessedInputRows_ == input_->size()) {
+    input_ = nullptr;
+    return true;
+  }
+  return false;
+}
+
+bool ParallelProject::isFinished() {
+  return noMoreInput_ && allInputProcessed();
+}
+
+RowVectorPtr ParallelProject::getOutput() {
+  if (allInputProcessed()) {
+    return nullptr;
+  }
+
+  vector_size_t size = input_->size();
+  allRows_.resize(size);
+  allRows_.setAll();
+  std::vector<std::shared_ptr<AsyncSource<WorkResult>>> pending;
+  std::vector<VectorPtr> results(outputType_->size());
+
+  for (auto i = 0; i < work_.size(); ++i) {
+    pending.push_back(std::make_shared<AsyncSource<WorkResult>>(
+        [i, &results, this]() { return doWork(i, results); }));
+    auto item = pending.back();
+    operatorCtx_->task()->queryCtx()->executor()->add(
+        [item]() { item->prepare(); });
+  }
+  std::exception_ptr error;
+  for (auto i = 0; i < pending.size(); ++i) {
+    auto result = pending[i]->move();
+    stats_.wlock()->getOutputTiming.add(pending[i]->prepareTiming());
+    if (!error && result->error) {
+      error = result->error;
+    }
+  }
+  if (error) {
+    std::rethrow_exception(error);
+  }
+
+  for (auto& projection : identityProjections_) {
+    results[projection.outputChannel] =
+        input_->childAt(projection.inputChannel);
+  }
+  numProcessedInputRows_ = size;
+  input_.reset();
+  return std::make_shared<RowVector>(
+      operatorCtx_->pool(), outputType_, nullptr, size, std::move(results));
+}
+
+std::unique_ptr<ParallelProject::WorkResult> ParallelProject::doWork(
+    int32_t workIdx,
+    std::vector<VectorPtr>& results) {
+  auto& work = work_[workIdx];
+  EvalCtx evalCtx(work.execCtx.get(), work.exprSet.get(), input_.get());
+  try {
+    for (auto channel : work.loadOnly) {
+      evalCtx.ensureFieldLoaded(channel, allRows_);
+    }
+
+    std::vector<VectorPtr> localResults;
+    work.exprSet->eval(
+        0, work.exprSet->exprs().size(), true, allRows_, evalCtx, localResults);
+    for (auto& projection : work.resultProjections) {
+      results[projection.outputChannel] =
+          std::move(localResults[projection.inputChannel]);
+    }
+  } catch (const std::exception& e) {
+    return std::make_unique<WorkResult>(std::current_exception());
+  }
+  return std::make_unique<WorkResult>(nullptr);
+}
+
+namespace {
+class ParallelProjectFactory : public Operator::PlanNodeTranslator {
+ public:
+  ParallelProjectFactory() = default;
+
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto project =
+            std::dynamic_pointer_cast<const ParallelProjectNode>(node)) {
+      return std::make_unique<ParallelProject>(id, ctx, project);
+    }
+    return nullptr;
+  }
+};
+
+bool registerParallelProject() {
+  Operator::registerOperator(std::make_unique<ParallelProjectFactory>());
+  return true;
+}
+
+bool temp = registerParallelProject();
+} // namespace
+
+} // namespace facebook::velox::exec

--- a/optimizer/ParallelProject.h
+++ b/optimizer/ParallelProject.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <velox/exec/Driver.h>
+#include <velox/exec/Operator.h>
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::exec {
+
+/// Variant of ProjectNode that computes projections in
+/// parallel. The exprs are given in groups, so that all exprs in
+/// one group run together and all groups run in parallel. If lazies
+/// are loaded, each lazy must be loaded by exactly one group. If
+/// there are identity projections in the groups, possible lazies
+/// are loaded as part of processing the group. One can additionally
+/// specify 'noLoadIdentities' which are identity projected through
+/// without loading. This last set must be disjoint from all columns
+/// accessed by the exprs. The output type has 'names' first and
+/// then 'noLoadIdentities'. The ith name corresponds to the ith
+/// expr when exprs is flattened. Inherits core::ProjectNode in order to reuse
+/// the summary functions.
+class ParallelProjectNode : public core::AbstractProjectNode {
+ public:
+  ParallelProjectNode(
+      const core::PlanNodeId& id,
+      std::vector<std::string> names,
+      std::vector<std::vector<core::TypedExprPtr>> exprs,
+      std::vector<std::string> noLoadIdentities,
+      core::PlanNodePtr input)
+      : AbstractProjectNode(
+            id,
+            allNames(names, noLoadIdentities),
+            flatExprs(exprs, noLoadIdentities, input),
+            input),
+        exprNames_(std::move(names)),
+        exprs_(std::move(exprs)),
+        noLoadIdentities_(std::move(noLoadIdentities)) {}
+
+  std::string_view name() const override {
+    return "ParallelProject";
+  }
+
+  const std::vector<std::string>& exprNames() const {
+    return exprNames_;
+  }
+
+  const std::vector<std::vector<core::TypedExprPtr>>& exprs() const {
+    return exprs_;
+  }
+
+  const std::vector<std::string> noLoadIdentities() const {
+    return noLoadIdentities_;
+  }
+
+ private:
+  // makes a list of all names for use in the ProjectNode.
+  static std::vector<std::string> allNames(
+      const std::vector<std::string>& names,
+      const std::vector<std::string>& moreNames);
+
+  // Flattens out projection exprs and adds dummy  exprs for noLoadIdentities.
+  // Used to fill in ProjectNode members for use in the summary functions.
+  static std::vector<core::TypedExprPtr> flatExprs(
+      std::vector<std::vector<core::TypedExprPtr>>& exprs,
+      const std::vector<std::string> moreNames,
+      const core::PlanNodePtr& input);
+
+  void addDetails(std::stringstream& stream) const override;
+
+  std::vector<std::string> exprNames_;
+  std::vector<std::vector<core::TypedExprPtr>> exprs_;
+  std::vector<std::string> noLoadIdentities_;
+};
+
+class ParallelProject : public Operator {
+ public:
+  ParallelProject(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const ParallelProjectNode>& node);
+
+  bool isFilter() const override {
+    return false;
+  }
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return !input_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /* unused */) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+  void close() override {
+    Operator::close();
+    for (auto& work : work_) {
+      if (work.exprSet) {
+        work.exprSet->clear();
+      }
+    }
+  }
+
+  void initialize() override;
+
+ private:
+  struct WorkUnit {
+    // Maps from result channel of exprSet to channel in the node's output type.
+    std::vector<IdentityProjection> resultProjections;
+    // Positions in input which are to be loaded by this group.
+    std::vector<column_index_t> loadOnly;
+    std::unique_ptr<core::ExecCtx> execCtx;
+    std::shared_ptr<ExprSet> exprSet;
+  };
+
+  struct WorkResult {
+    WorkResult(std::exception_ptr e) : error(std::move(e)) {}
+    std::exception_ptr error;
+  };
+
+  // Tests if 'numProcessedRows_' equals to the length of input_ and clears
+  // outstanding references to input_ if done. Returns true if getOutput
+  // should return nullptr.
+  bool allInputProcessed();
+
+  std::unique_ptr<WorkResult> doWork(
+      int32_t workIdx,
+      std::vector<VectorPtr>& result);
+
+  // Cached Parallelproject node for lazy initialization. After
+  // initialization, they will be reset, and initialized_ will be set to true.
+  std::shared_ptr<const ParallelProjectNode> node_;
+
+  bool initialized_{false};
+
+  std::vector<WorkUnit> work_;
+  SelectivityVector allRows_;
+  int32_t numProcessedInputRows_{0};
+};
+
+} // namespace facebook::velox::exec

--- a/optimizer/Plan.cpp
+++ b/optimizer/Plan.cpp
@@ -74,6 +74,9 @@ std::unordered_map<std::string, float>& baseSelectivities() {
 }
 
 FunctionSet functionBits(Name name) {
+  if (auto* md = functionMetadata(name)) {
+    return md->functionSet;
+  }
   auto deterministic = isDeterministic(name);
   if (deterministic.has_value() && !deterministic.value()) {
     return FunctionSet(FunctionSet::kNondeterministic);

--- a/optimizer/QueryGraph.cpp
+++ b/optimizer/QueryGraph.cpp
@@ -59,7 +59,7 @@ std::string Column::toString() const {
 
 std::string Literal::toString() const {
   std::stringstream out;
-  out << literal_;
+  out << *literal_;
   return out.str();
 }
 

--- a/optimizer/tests/FeatureGen.h
+++ b/optimizer/tests/FeatureGen.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <folly/Random.h>
+#include "velox/core/Expressions.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::optimizer::test {
@@ -32,6 +34,30 @@ struct FeatureOptions {
   RowTypePtr floatStruct;
   RowTypePtr idListStruct;
   RowTypePtr idScoreListStruct;
+
+  // Parameters for generating test exprs.
+  /// Number of projections for float one feature.
+  int32_t floatExprsPct{130};
+  int32_t idListExprPct{0};
+  int32_t idScoreListExprPct{0};
+
+  /// Percentage of projections that depend on multiple features.
+  float multiColumnPct{20};
+
+  /// Percentage of exprs with a rand.
+  int32_t randomPct{20};
+
+  /// Percentage of uid dependent exprs.
+  int32_t uidPct{20};
+
+  /// percentage of extra  + 1's.
+  int32_t plusOnePct{20};
+
+  mutable folly::Random::DefaultGenerator rng;
+
+  bool coinToss(int32_t pct) const {
+    return folly::Random::rand32(rng) % 100u < pct;
+  }
 };
 
 std::vector<RowVectorPtr> makeFeatures(
@@ -39,5 +65,10 @@ std::vector<RowVectorPtr> makeFeatures(
     int32_t batchSize,
     FeatureOptions& opts,
     memory::MemoryPool* pool);
+
+void makeExprs(
+    const FeatureOptions& opts,
+    std::vector<std::string>& names,
+    std::vector<core::TypedExprPtr>& exprs);
 
 } // namespace facebook::velox::optimizer::test

--- a/optimizer/tests/QueryTestBase.h
+++ b/optimizer/tests/QueryTestBase.h
@@ -67,6 +67,11 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   TestResult runFragmentedPlan(runner::MultiFragmentPlanPtr plan);
 
+  /// Checks that 'reference' and 'experiment' produce the same result.
+  void assertSame(
+      const core::PlanNodePtr& reference,
+      runner::MultiFragmentPlanPtr experiment);
+
   runner::MultiFragmentPlanPtr planSql(
       const std::string& sql,
       std::string* planString = nullptr,


### PR DESCRIPTION
Adds an options for parallelizing data independent projections.

Adds a ParallelProject Operator using operator extensibility .

Verax can have a target parallelism for projections. If so, we divide a set of projection expressions into levels using a depth first traversal. If we encounter a multiply referenced Expr, we place it below the lowest referencing level.

After this, we detect one or more multiply referenced (common subexpression) borders. the border is the set of leafmost multiply referenced Exprs such that these do not contain unplaced multiply referenced exprs.

the first border is placed in a projection node. The constituent Exprs are marked placed. We repeat until there are no more multiply referenced Exprs.

At this point we detect a parallelizable border. This border consists of Exprs whose cost including children is over a target threshold. After this, we have top level Exprs, like constructors left but the bulk of the workk is below the parallel border.

We place the expressions in te parallel border. Then we make a finall single threaded projection to stitch the results together. This consists of the Exprs above the parallel border.

All but the last projection are parallel and guarantee non-overlapping Expr trees.

A parallel projection has groups of Exprs that are evaluated together. Each such group is independently schedulable. Additionally it has identity projected columns that are not subject to lazy loading.

When we place the parallel border, we also load all lazies so that lazy loading does columns independently. These are passed through the common subexpression levels because these are typically less wide. We place the bulk f lazy loads and projections into one large reorderable project to expose maximum parallelism.

The ParallelProject operator is like FilterProject without the filter and just runs independent groups of expressions using AsyncSource.

The test adds a facility for making sythetic pseudorandom projection expressions. This can be used for testing and benchmarking parallel projection.