### PR TITLE
fix: Check some TPC H queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ velox_resolve_dependency(folly)
 # Use xxhash and xsimd from Velox for now.
 include_directories(.)
 include_directories(${CMAKE_BINARY_DIR})
+include_directories(${CMAKE_BINARY_DIR}/velox)
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/velox/external/xxhash)
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)

--- a/optimizer/Cost.cpp
+++ b/optimizer/Cost.cpp
@@ -150,7 +150,7 @@ void Repartition::setCost(const PlanState& input) {
   RelationOp::setCost(input);
   auto pair = shuffleCostV(columns_);
   cost_.unitCost = pair.second;
-  cost_.totalBytes = cost_.inputCardinality * pair.first;
+  cost_.transferBytes = cost_.inputCardinality * pair.first;
 }
 
 void HashBuild::setCost(const PlanState& input) {

--- a/optimizer/PlanObject.cpp
+++ b/optimizer/PlanObject.cpp
@@ -95,4 +95,8 @@ std::string PlanObjectSet::toString(bool names) const {
   return out.str();
 }
 
+std::string planObjectString(PlanObject* o) {
+  return o->toString();
+}
+
 } // namespace facebook::velox::optimizer

--- a/optimizer/QueryGraph.cpp
+++ b/optimizer/QueryGraph.cpp
@@ -134,6 +134,7 @@ const JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
         rightKeys_,
         lrFanout_,
         rightOptional_,
+        leftOptional_,
         rightExists_,
         rightNotExists_,
         markColumn_,
@@ -144,6 +145,7 @@ const JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
       leftKeys_,
       rlFanout_,
       leftOptional_,
+      rightOptional_,
       false,
       false,
       nullptr,
@@ -174,6 +176,8 @@ std::string JoinEdge::toString() const {
     out << " exists ";
   } else if (rightNotExists_) {
     out << " not exists ";
+  } else if (leftOptional_) {
+    out << "right";
   } else {
     out << " inner ";
   }

--- a/optimizer/QueryGraph.h
+++ b/optimizer/QueryGraph.h
@@ -445,6 +445,7 @@ struct JoinSide {
   const ExprVector& keys;
   float fanout;
   const bool isOptional;
+  const bool isNonOptionalOfOuter;
   const bool isExists;
   const bool isNotExists;
   ColumnCP markColumn;
@@ -461,6 +462,10 @@ struct JoinSide {
     if (isOptional) {
       return velox::core::JoinType::kLeft;
     }
+    if (isNonOptionalOfOuter) {
+      return velox::core::JoinType::kRight;
+    }
+
     if (markColumn) {
       return velox::core::JoinType::kLeftSemiProject;
     }

--- a/optimizer/RelationOp.cpp
+++ b/optimizer/RelationOp.cpp
@@ -97,7 +97,10 @@ std::string Cost::toString(bool /*detail*/, bool isUnit) const {
     out << ", setup " << succinctNumber(setupCost) << "CU";
   }
   if (static_cast<bool>(totalBytes)) {
-    out << " " << velox::succinctBytes(totalBytes);
+    out << " build= " << velox::succinctBytes(totalBytes);
+  }
+  if (static_cast<bool>(transferBytes)) {
+    out << " network= " << velox::succinctBytes(transferBytes);
   }
   return out.str();
 }
@@ -160,6 +163,9 @@ std::string Join::toString(bool recursive, bool detail) const {
   out << "*" << (method == JoinMethod::kHash ? "H" : "M") << " "
       << joinTypeLabel(joinType);
   printCost(detail, out);
+  if (detail && buildCost.unitCost > 0) {
+    out << "{ build=" << buildCost.toString(detail, true) << "}";
+  }
   if (recursive) {
     out << " (" << right->toString(true, detail) << ")";
     if (detail) {

--- a/optimizer/RelationOp.h
+++ b/optimizer/RelationOp.h
@@ -62,6 +62,9 @@ struct Cost {
   // operation is streaming or spills.
   float totalBytes{0};
 
+  /// Shuffle data volume
+  float transferBytes{0};
+
   // Maximum memory occupancy. If the operation is blocking, e.g. group by, the
   // amount of spill is 'totalBytes' - 'peakResidentBytes'.
   float peakResidentBytes{0};
@@ -317,6 +320,9 @@ struct Join : public RelationOp {
   ExprVector leftKeys;
   ExprVector rightKeys;
   ExprVector filter;
+
+  // Total cost of build side plan. For documentation.
+  Cost buildCost;
 
   void setCost(const PlanState& input) override;
   std::string toString(bool recursive, bool detail) const override;

--- a/optimizer/connectors/CMakeLists.txt
+++ b/optimizer/connectors/CMakeLists.txt
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_connector_metadata ConnectorMetadata.cpp)
+velox_add_library(velox_connector_metadata ConnectorMetadata.cpp
+                  StatisticsBuilder.cpp)
 
-velox_link_libraries(
-  velox_connector_metadata
-  velox_common_base velox_memory velox_connector)
+velox_link_libraries(velox_connector_metadata velox_common_base velox_memory
+                     velox_connector velox_dwio_dwrf_writer)
 
 add_subdirectory(hive)
 

--- a/optimizer/connectors/ConnectorMetadata.h
+++ b/optimizer/connectors/ConnectorMetadata.h
@@ -67,11 +67,20 @@ struct ColumnStatistics {
   /// characters/bytes/elements/key-value pairs.
   std::optional<int32_t> maxLength;
 
+  /// Percentage of values where the next row is > the previous. 50 for a random
+  /// distribution, 0 for descending, 100 for ascending.
+  std::optional<float> ascendingPct;
+
+  std::optional<float> descendingPct;
+
   /// Average count of characters/bytes/elements/key-value pairs.
   std::optional<int32_t> avgLength;
 
   /// Estimated number of distinct values. Not specified for complex types.
   std::optional<int64_t> numDistinct;
+
+  /// Count of non-nulls.
+  int64_t numValues{0};
 
   /// For complex type columns, statistics of children. For array, contains one
   /// element describing the array elements. For struct, has one element for
@@ -79,6 +88,44 @@ struct ColumnStatistics {
   /// map, may have one element for each key. In all cases, stats may be
   /// missing.
   std::vector<ColumnStatistics> children;
+};
+
+/// Options for StatisticsBuilder.
+struct StatisticsBuilderOptions {
+  int32_t maxStringLength{100};
+  int32_t initialSize{0};
+  bool countDistincts{false};
+  HashStringAllocator* allocator{nullptr};
+};
+
+/// Abstract class for building statistics from samples.
+class StatisticsBuilder {
+ public:
+  virtual ~StatisticsBuilder() = default;
+
+  static std::unique_ptr<StatisticsBuilder> create(
+      const TypePtr& type,
+      const StatisticsBuilderOptions& opts);
+
+  virtual TypePtr type() const = 0;
+
+  /// Accumulates elements of 'vector' into stats.
+  virtual void add(VectorPtr& data) = 0;
+
+  /// Merges the statistics of 'other' into 'this'.
+  virtual void merge(const StatisticsBuilder& other) = 0;
+
+  /// Fills 'result' with the accumulated stats. Scales up counts by
+  /// 'sampleFraction', e.g. 0.1 means 10x.
+  virtual void build(ColumnStatistics& result, float sampleFraction = 1) = 0;
+
+  static void updateStatsBuilders(
+      const RowVectorPtr& data,
+      std::vector<std::unique_ptr<StatisticsBuilder>>& builders);
+
+  virtual int64_t numAsc() const = 0;
+  virtual int64_t numRepeat() const = 0;
+  virtual int64_t numDesc() const = 0;
 };
 
 /// Base class for column. The column's name and type are immutable but the

--- a/optimizer/connectors/StatisticsBuilder.cpp
+++ b/optimizer/connectors/StatisticsBuilder.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
+#include "optimizer/connectors/ConnectorMetadata.h" //@manual
+
+namespace facebook::velox::connector {
+
+/// StatisticsBuilder using dwrf::StaticsBuilder
+class StatisticsBuilderImpl : public StatisticsBuilder {
+ public:
+  StatisticsBuilderImpl(
+      const TypePtr& type,
+      std::unique_ptr<dwrf::StatisticsBuilder> builder)
+      : type_(type), builder_(std::move(builder)) {}
+
+  TypePtr type() const override {
+    return type_;
+  }
+
+  void add(VectorPtr& data) override;
+
+  void merge(const StatisticsBuilder& other) override;
+  int64_t numAsc() const override {
+    return numAsc_;
+  }
+
+  void build(ColumnStatistics& result, float sampleFraction = 1) override;
+
+  int64_t numRepeat() const override {
+    return numRepeat_;
+  }
+  int64_t numDesc() const override {
+    return numDesc_;
+  }
+
+ private:
+  template <typename Builder, typename T>
+  void addStats(
+      velox::dwrf::StatisticsBuilder* builder,
+      const BaseVector& vector);
+
+  TypePtr type_;
+  std::unique_ptr<dwrf::StatisticsBuilder> builder_;
+  int64_t numAsc_{0};
+  int64_t numRepeat_{0};
+  int64_t numDesc_{0};
+  int64_t numRows_{0};
+};
+
+std::unique_ptr<StatisticsBuilder> StatisticsBuilder::create(
+    const TypePtr& type,
+    const StatisticsBuilderOptions& options) {
+  dwrf::StatisticsBuilderOptions dwrfOptions(
+      options.maxStringLength,
+      options.initialSize,
+      options.countDistincts,
+      options.allocator);
+  switch (type->kind()) {
+    case TypeKind::BIGINT:
+    case TypeKind::INTEGER:
+    case TypeKind::SMALLINT:
+      return std::make_unique<StatisticsBuilderImpl>(
+          type, std::make_unique<dwrf::IntegerStatisticsBuilder>(dwrfOptions));
+
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+      return std::make_unique<StatisticsBuilderImpl>(
+          type, std::make_unique<dwrf::DoubleStatisticsBuilder>(dwrfOptions));
+
+    case TypeKind::VARCHAR:
+      return std::make_unique<StatisticsBuilderImpl>(
+          type, std::make_unique<dwrf::StringStatisticsBuilder>(dwrfOptions));
+
+    default:
+      return nullptr;
+  }
+}
+
+template <typename Builder, typename T>
+void StatisticsBuilderImpl::addStats(
+    velox::dwrf::StatisticsBuilder* builder,
+    const BaseVector& vector) {
+  auto* typedVector = vector.asUnchecked<SimpleVector<T>>();
+  T previous{};
+  bool hasPrevious = false;
+  for (auto i = 0; i < typedVector->size(); ++i) {
+    if (!typedVector->isNullAt(i)) {
+      auto value = typedVector->valueAt(i);
+      if (hasPrevious) {
+        if (value == previous) {
+          ++numRepeat_;
+        } else if (value > previous) {
+          ++numAsc_;
+        } else {
+          ++numDesc_;
+        }
+      } else {
+        previous = value;
+      }
+
+      reinterpret_cast<Builder*>(builder)->addValues(value);
+      previous = value;
+      hasPrevious = true;
+    }
+    ++numRows_;
+  }
+}
+
+void StatisticsBuilderImpl::add(VectorPtr& data) {
+  auto loadChild = [](VectorPtr& data) {
+    data = BaseVector::loadedVectorShared(data);
+  };
+  switch (type_->kind()) {
+    case TypeKind::SMALLINT:
+      loadChild(data);
+      addStats<dwrf::IntegerStatisticsBuilder, short>(builder_.get(), *data);
+      break;
+    case TypeKind::INTEGER:
+      loadChild(data);
+      addStats<dwrf::IntegerStatisticsBuilder, int32_t>(builder_.get(), *data);
+      break;
+    case TypeKind::BIGINT:
+      loadChild(data);
+      addStats<dwrf::IntegerStatisticsBuilder, int64_t>(builder_.get(), *data);
+      break;
+    case TypeKind::REAL:
+      loadChild(data);
+      addStats<dwrf::DoubleStatisticsBuilder, float>(builder_.get(), *data);
+      break;
+    case TypeKind::DOUBLE:
+      loadChild(data);
+      addStats<dwrf::DoubleStatisticsBuilder, double>(builder_.get(), *data);
+      break;
+    case TypeKind::VARCHAR:
+      loadChild(data);
+      addStats<dwrf::StringStatisticsBuilder, StringView>(
+          builder_.get(), *data);
+      break;
+
+    default:
+      break;
+  }
+}
+
+void StatisticsBuilder::updateStatsBuilders(
+    const RowVectorPtr& row,
+    std::vector<std::unique_ptr<StatisticsBuilder>>& builders) {
+  for (auto column = 0; column < builders.size(); ++column) {
+    if (!builders[column]) {
+      continue;
+    }
+    auto* builder = builders[column].get();
+    VectorPtr data = row->childAt(column);
+    builder->add(data);
+  }
+}
+
+void StatisticsBuilderImpl::merge(const StatisticsBuilder& in) {
+  auto* other = dynamic_cast<const StatisticsBuilderImpl*>(&in);
+  builder_->merge(*other->builder_);
+  numAsc_ += other->numAsc_;
+  numRepeat_ += other->numRepeat_;
+  numDesc_ += other->numDesc_;
+  numRows_ += other->numRows_;
+}
+
+void StatisticsBuilderImpl::build(
+    ColumnStatistics& result,
+    float sampleFraction) {
+  auto stats = builder_->build();
+  auto optNumValues = stats->getNumberOfValues();
+  auto numValues = optNumValues.has_value() ? optNumValues.value() : 0;
+  if (auto ints =
+          dynamic_cast<dwio::common::IntegerColumnStatistics*>(stats.get())) {
+    auto min = ints->getMinimum();
+    auto max = ints->getMaximum();
+    if (min.has_value() && max.has_value()) {
+      result.min = variant(min.value());
+      result.max = variant(max.value());
+    }
+  } else if (
+      auto* dbl =
+          dynamic_cast<dwio::common::DoubleColumnStatistics*>(stats.get())) {
+    auto min = dbl->getMinimum();
+    auto max = dbl->getMaximum();
+    if (min.has_value() && max.has_value()) {
+      result.min = variant(min.value());
+      result.max = variant(max.value());
+    }
+  } else if (
+      auto* str =
+          dynamic_cast<dwio::common::StringColumnStatistics*>(stats.get())) {
+    auto min = str->getMinimum();
+    auto max = str->getMaximum();
+    if (min.has_value() && max.has_value()) {
+      result.min = variant(min.value());
+      result.max = variant(max.value());
+    }
+    if (numValues) {
+      result.avgLength = str->getTotalLength().value() / numValues;
+    }
+  }
+  if (numRows_) {
+    result.nullPct =
+        100 * (numRows_ - numValues) / static_cast<float>(numRows_);
+  }
+  result.numDistinct = stats->numDistinct();
+}
+
+} // namespace facebook::velox::connector

--- a/optimizer/connectors/hive/CMakeLists.txt
+++ b/optimizer/connectors/hive/CMakeLists.txt
@@ -12,30 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(
-  velox_hive_connector_metadata
-  OBJECT
-  HiveConnectorMetadata.cpp
-  LocalHiveConnectorMetadata.cpp)
+velox_add_library(velox_hive_connector_metadata OBJECT
+                  HiveConnectorMetadata.cpp LocalHiveConnectorMetadata.cpp)
 
 velox_link_libraries(
   velox_hive_connector_metadata
-    velox_hive_connector
-    velox_dwio_catalog_fbhive
-    velox_dwio_dwrf_reader
-    velox_dwio_dwrf_writer
-    velox_dwio_orc_reader
-    velox_dwio_parquet_reader
-    velox_dwio_parquet_writer
-    velox_file
-    velox_hive_partition_function
-    velox_type_tz
-    velox_s3fs
-    velox_hdfs
-    velox_gcs
-    velox_abfs)
-
-
+  velox_connector_metadata
+  velox_hive_connector
+  velox_dwio_catalog_fbhive
+  velox_dwio_dwrf_reader
+  velox_dwio_dwrf_writer
+  velox_dwio_orc_reader
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_file
+  velox_hive_partition_function
+  velox_type_tz
+  velox_s3fs
+  velox_hdfs
+  velox_gcs
+  velox_abfs)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/optimizer/connectors/hive/HiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/HiveConnectorMetadata.h
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -91,6 +92,12 @@ class HiveTableLayout : public TableLayout {
   const dwio::common::FileFormat fileFormat_;
   const std::vector<const Column*> hivePartitionColumns_;
   std::optional<int32_t> numBuckets_;
+
+  // Feeds 'data' into 'builders'. Builders and children of 'data' correspond
+  // pairwise. 'builders' may have a nullptr for some columns.
+  void updateStatsBuilders(
+      const RowVectorPtr& data,
+      std::vector<std::unique_ptr<dwrf::StatisticsBuilder>>& builders);
 };
 
 class HiveConnectorMetadata : public ConnectorMetadata {

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -23,7 +23,6 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/dwio/common/Options.h"
-#include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -118,8 +117,7 @@ class LocalHiveTableLayout : public HiveTableLayout {
       RowTypePtr scanType,
       const std::vector<common::Subfield>& fields,
       HashStringAllocator* allocator,
-      std::vector<std::unique_ptr<dwrf::StatisticsBuilder>>* statsBuilders)
-      const;
+      std::vector<std::unique_ptr<StatisticsBuilder>>* statsBuilders) const;
 
  private:
   std::vector<std::string> files_;

--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -21,6 +21,7 @@ DEFINE_string(
     "",
     "Path to TPCH data directory. If empty, the test creates a temp directory and deletes it on exit");
 DEFINE_bool(create_dataset, true, "Creates the TPCH tables");
+DEFINE_double(tpch_scale, 0.01, "Scale factor");
 
 namespace facebook::velox::optimizer::test {
 using namespace facebook::velox::exec;
@@ -110,9 +111,10 @@ void ParquetTpchTest::saveTpchTablesAsParquet() {
     auto tableDirectory = fmt::format("{}/{}", createPath_, tableName);
     auto tableSchema = tpch::getTableSchema(table);
     auto columnNames = tableSchema->names();
-    auto plan = PlanBuilder()
-                    .tpchTableScan(table, std::move(columnNames), 0.01)
-                    .planNode();
+    auto plan =
+        PlanBuilder()
+            .tpchTableScan(table, std::move(columnNames), FLAGS_tpch_scale)
+            .planNode();
     auto split =
         exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(
             kTpchConnectorId, 1, 0));


### PR DESCRIPTION
Fixes generation of partial/final accumulator types. Adds support of project semijoin to subfields pass.

Adds comparison of optimized/non-optimized TTPC H plan executions.

Adds network volume as separate from build size. Fixes details of accumulating setup cost vs streaming cost.