### PR TITLE
feat: Introduce task barrier

### DIFF
--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -139,7 +139,8 @@ std::shared_ptr<Task> ParquetTpchTest::assertQuery(
   bool noMoreSplits = false;
   constexpr int kNumSplits = 10;
   constexpr int kNumDrivers = 4;
-  auto addSplits = [&](Task* task) {
+  auto addSplits = [&](TaskCursor* taskCursor) {
+    auto& task = taskCursor->task();
     if (!noMoreSplits) {
       for (const auto& entry : tpchPlan.dataFiles) {
         for (const auto& path : entry.second) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/13087

Meta's internal AI data loading application requires deterministic execution and the ability to restart from an arbitrary checkpoint. When recovering from a partially executed split, the application must drop previously produced rows to prevent duplicates and ensure model accuracy.

A checkpoint state contains the last partially executed split ID and the number of produced task output rows (N). When recovering from a split, the application drops the first N rows of output. The application can tolerate some missing rows, but it cannot allow for duplicated rows, as it would compromise model quality.

To support this use case, we use sequential Velox task execution mode, creating a new Velox task for each new split. This ensures that all output is produced at the end of each split, regardless of whether the Velox task pipelines contain stateful operators like streaming aggregation or sort-merge join. The AI loading application itself guarantees no data dependence across splits.

However, repeatedly creating new Velox tasks for different splits incurs non-trivial task initialization costs. To optimize, we introduce task barrier support in Velox, enabling task reuse across different splits. This feature allows the task to drain all output from stateful operators at the split boundary.

The new Task::requestBarrier API requests the task to finish processing all splits and drain all buffered data from stateful operators. The API returns a Future to track process, allowing the application to add more splits and resume processing after the Future completes.

Here is a pseudo code illustrating this workflow:
```
// AI data loading main loop.

// Gets splits from AI data loading runtime one at a time and send to
// velox task. If all the splits have been processed, it sends no more
// split signal to velox task and returns false.
bool addSplits();

for (;;) {
 // The split data processing loop.
 while (true) {
   ContinueFuture dataFuture = ContinueFuture::makeEmpty();
   auto data = veloxTask->next(&dataFuture));
   if (data != nullptr) {
     // Consume data and fetch the next batch.
     VELOX_CHECK(!dataFuture.valid());
     continue;
   }
   if (!dataFuture.valid()) {
     // Gets a new split after reaching the task barrier.
     if (getSplits()) {
       continue;
     }
     // All splits have been processed and finished the execution.
     return;
   }
 }
}

// Get splits from AI data loading runtime and feed into Velox task.
bool getSplits() {
 auto splitSet = nextSplitSet();
 // Add the splits to the Velox task.
 for (auto& [op, planNode] : veloxPlan.leafNodes) {
   const auto& id = planNode->id();
   if (splitSet.has_value()) {
     veloxTask->addSplit(id, splitSet.at(id));
   } else {
     // All splits have been processed and send no more splits so the task can
     // transition to finished state.
     veloxTask->noMoreSplits(id);
   }
 }
 return splitSet.has_value();
}
```

The current implementation of the task barrier is only available in serial execution mode and when all plan nodes support the barrier functionality. All stateless operators support barriers. A subset of stateful operators - LocalExchange, LocalPartition and MergeJoin - also support the barrier. We do not support barriers for HashJoin due to potential significant changes and lack of immediate need for AI data load applications. AI data loading applications only use streaming operators.

A follow-up PR will provide barrier support for  StreamingAggregation and IndexLookupJoin operators.

The task barrier works as follows.

Upon receiving a barrier request, the task adds a special barrier split to each source operator and starts the barrier processing for each driver. In case the task has already received the no-more-split signal for any of the source nodes, the barrier request fails. Note the special barrier split is excluded in task split processing count.

Each driver must drain output from all stateful operators. For the MergeJoin operator, it is also desirable to optimize to skip processing input for one side of the join if the other side has been fully processed and there is no possibility of identifying further matches. To achieve this, each driver maintains a BarrierState that contains two operator indexes:

drainingOpId - the operator that’s currently flushing output;
dropInputOpId - the operator that doesn’t need any further input from the upstream operators

The draining operation starts at the leaf drivers, then proceeds to the dependent drivers.

For each leaf driver, the draining operation starts at the source operator when it receives the special barrier split, and propagates the draining signal to downstream operators by advancing the draining operator index in the driver’s barrier state. When the last operator in the leaf driver pipeline is reached, the barrier processing for the leaf driver is complete. The last operator (sink) passes the draining signal to the downstream driver pipeline through the connecting queue.

For a non-leaf driver, the draining operation starts when it receives the draining signal from the upstream driver. The draining proceeds the same as for a leaf driver. When all drivers have finished the barrier processing, the barrier future is fulfilled. At this point, Task::next() returns null without a valid future to indicate that the task has reached the barrier. To resume data processing, the caller must either add new splits with a new barrier request or send a no-more-split signal to complete task processing.

In the case of MergeJoin, when either side receives the draining signal and determines that it doesn’t need the input from the other side to finish draining, the operator requests to drop output from all upstream operators and drivers by setting the dropInputOpId in the barrier state.

Reviewed By: Yuhta

Differential Revision: D71925671
