### PR TITLE
fix: Added type validation for intermediate and output vectors

### DIFF
--- a/optimizer/ToGraph.cpp
+++ b/optimizer/ToGraph.cpp
@@ -717,31 +717,6 @@ ExprVector Optimization::translateColumns(
   return result;
 }
 
-TypePtr aggregateFinalType(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes) {
-  auto signatures = exec::getAggregateFunctionSignatures(name);
-  if (!signatures.has_value()) {
-    VELOX_USER_FAIL("Aggregate function not registered: {}", name);
-  }
-  for (auto& signature : signatures.value()) {
-    exec::SignatureBinder binder(*signature, argTypes);
-    if (binder.tryBind()) {
-      auto type = binder.tryResolveType(signature->returnType());
-      VELOX_USER_CHECK(
-          type,
-          "Cannot resolve intermediate type for aggregate function {}",
-          exec::toString(name, argTypes));
-      return type;
-    }
-  }
-
-  std::stringstream error;
-  error << "Aggregate function signature is not supported: " << name
-        << ". Supported signatures: " << toString(signatures.value()) << ".";
-  VELOX_USER_FAIL(error.str());
-}
-
 TypePtr intermediateType(const core::CallTypedExprPtr& call) {
   std::vector<TypePtr> types;
   for (auto& arg : call->inputs()) {
@@ -755,7 +730,7 @@ TypePtr finalType(const core::CallTypedExprPtr& call) {
   for (auto& arg : call->inputs()) {
     types.push_back(arg->type());
   }
-  return aggregateFinalType(call->name(), types);
+  return exec::Aggregate::finalType(call->name(), types);
 }
 
 AggregationP Optimization::translateAggregation(


### PR DESCRIPTION
Summary:
Fixed a crash in D74199165. Adding validation to Velox to simplify future debugging.

TL;DR We don't validate output types in aggregate functions.
For example, if intermediateType in Coordinator is `Row<int>` and in Velox it's `Row<double>`, no validation will occur. Dynamic cast for FlatVectors doesn't catch this mismatch either, because `RowVector` isn't a template. Without validation we can write by wrong offset in the result vector.

Differential Revision: D74435817
Velox PR: https://github.com/facebookincubator/velox/pull/13322


