### PR TITLE
fix: Fix join graph diamonds

### DIFF
--- a/optimizer/ParallelExpr.cpp
+++ b/optimizer/ParallelExpr.cpp
@@ -48,6 +48,9 @@ void makeExprLevels(
     int32_t levelIdx = levelData.size() - 1;
     exprs.forEach([&](PlanObjectCP o) {
       auto* expr = o->as<Expr>();
+      if (expr->type() == PlanType::kLiteral) {
+        return;
+      }
       float self = selfCost(expr);
       if (counted.contains(expr)) {
         auto i = definitionLevel(levelData, expr);
@@ -167,6 +170,9 @@ void columnBorder(
     ExprCP expr,
     const PlanObjectSet& placed,
     PlanObjectSet& result) {
+  if (expr->type() == PlanType::kLiteral) {
+    return;
+  }
   if (placed.contains(expr)) {
     result.add(expr);
     return;

--- a/optimizer/QueryGraph.h
+++ b/optimizer/QueryGraph.h
@@ -489,7 +489,8 @@ class JoinEdge {
       bool rightOptional,
       bool rightExists,
       bool rightNotExists,
-      ColumnCP markColumn = nullptr)
+      ColumnCP markColumn = nullptr,
+      bool directed = false)
       : leftTable_(leftTable),
         rightTable_(rightTable),
         filter_(std::move(filter)),
@@ -497,7 +498,8 @@ class JoinEdge {
         rightOptional_(rightOptional),
         rightExists_(rightExists),
         rightNotExists_(rightNotExists),
-        markColumn_(markColumn) {
+        markColumn_(markColumn),
+        directed_(directed) {
     if (isInner()) {
       VELOX_CHECK(filter_.empty());
     }
@@ -547,7 +549,7 @@ class JoinEdge {
       return false;
     }
     return !leftTable_ || rightOptional_ || leftOptional_ || rightExists_ ||
-        rightNotExists_ || markColumn_;
+        rightNotExists_ || markColumn_ || directed_;
   }
   // Returns the join side info for 'table'. If 'other' is set, returns the
   // other side.
@@ -629,6 +631,10 @@ class JoinEdge {
 
   // Flag to set if right side has a match.
   const ColumnCP markColumn_;
+
+  // If directed non-outer edge. For example unnest or inner dependent on
+  // optional of outer.
+  bool directed_;
 };
 
 using JoinEdgeP = JoinEdge*;

--- a/optimizer/tests/PlanTest.cpp
+++ b/optimizer/tests/PlanTest.cpp
@@ -234,8 +234,6 @@ TEST_F(PlanTest, q4) {
 }
 
 TEST_F(PlanTest, q5) {
-  // Fix diamond pattern
-  GTEST_SKIP();
   checkTpch(5);
 }
 
@@ -254,10 +252,8 @@ TEST_F(PlanTest, q8) {
 }
 
 TEST_F(PlanTest, q9) {
-  GTEST_SKIP();
   // Plan does not minimize build size. To adjust build cost and check that
-  // import of existences to build side does not affect join cardinality. Good
-  // for SF1, bad for 0.1 and 0.01.
+  // import of existences to build side does not affect join cardinality.
   checkTpch(9);
 }
 
@@ -266,8 +262,6 @@ TEST_F(PlanTest, q10) {
 }
 
 TEST_F(PlanTest, q11) {
-  // Fix
-  GTEST_SKIP();
   checkTpch(11);
 }
 


### PR DESCRIPTION
In Q9 and Q5 there are diamonds where a table is added to a plan through one join edge.  There are more join edges between the added table and the plan made so far. Therefore, make a new composite edge combining all the inner joins between the new table and the already placed tables.

There are cases (Q11) where expr deduplication is not correct because n_name = xx occurs twice and refers to different nation tables in each case. The dedup map must be from func + ExprCP... to ExprCP and not from TypedExprPtr to ExprCP. Like this the args of the function call to dedup are correctly scoped.

Also, dedupping literals so that the same literal has the same ExprCP so that x + 1 and x + 1 dedup. They would not if the literal where not physically the same.