### PR TITLE
feat: Support complex type constants

### DIFF
--- a/optimizer/Plan.h
+++ b/optimizer/Plan.h
@@ -716,6 +716,9 @@ class Optimization {
   ExprCP
   deduppedCall(Name name, Value value, ExprVector args, FunctionSet flags);
 
+  // Returns a deduplicated Literal from the value in 'constant'.
+  ExprCP makeConstant(const core::ConstantTypedExprPtr& constant);
+
   ExprCP translateLambda(const velox::core::LambdaTypedExpr* lambda);
 
   // If 'expr' is not a subfield path, returns std::nullopt. If 'expr'
@@ -981,6 +984,10 @@ class Optimization {
 
   // Maps names in project noes of 'inputPlan_' to deduplicated Exprs.
   std::unordered_map<std::string, ExprCP> renames_;
+
+  // Holds transient ConstantTypedExprs etc. Must be after 'exprDedup_' in
+  // destruction order.
+  std::vector<core::TypedExprPtr> tempExprs_;
 
   // Maps unique core::TypedExprs from 'inputPlan_' to deduplicated Exps. Use
   // for leaves, e.g. constants.

--- a/optimizer/QueryGraph.cpp
+++ b/optimizer/QueryGraph.cpp
@@ -59,7 +59,11 @@ std::string Column::toString() const {
 
 std::string Literal::toString() const {
   std::stringstream out;
-  out << *literal_;
+  if (vector_) {
+    out << vector_->toString(0);
+  } else {
+    out << *literal_;
+  }
   return out.str();
 }
 

--- a/optimizer/QueryGraph.h
+++ b/optimizer/QueryGraph.h
@@ -98,16 +98,28 @@ using EquivalenceP = Equivalence*;
 class Literal : public Expr {
  public:
   Literal(const Value& value, const velox::variant* literal)
-      : Expr(PlanType::kLiteral, value), literal_(literal) {}
+      : Expr(PlanType::kLiteral, value), literal_(literal), vector_(nullptr) {}
+
+  Literal(const Value& value, const BaseVector* vector)
+      : Expr(PlanType::kLiteral, value), literal_{}, vector_(vector) {}
 
   const velox::variant& literal() const {
     return *literal_;
+  }
+
+  bool hasVector() const {
+    return vector_ != nullptr;
+  }
+
+  const BaseVector* vector() const {
+    return vector_;
   }
 
   std::string toString() const override;
 
  private:
   const velox::variant* const literal_;
+  const BaseVector* const vector_;
 };
 
 /// Represents a column. A column is always defined by a relation, whether table

--- a/optimizer/QueryGraphContext.cpp
+++ b/optimizer/QueryGraphContext.cpp
@@ -109,6 +109,21 @@ const TypePtr& toTypePtr(const Type* type) {
   return queryCtx()->toTypePtr(type);
 }
 
+const BaseVector* QueryGraphContext::toVector(const VectorPtr& vector) {
+  auto it = deduppedVectors_.find(vector.get());
+  if (it != deduppedVectors_.end()) {
+    return it->second.get();
+  }
+  deduppedVectors_[vector.get()] = vector;
+  return vector.get();
+}
+
+VectorPtr QueryGraphContext::toVectorPtr(const BaseVector* vector) {
+  auto it = deduppedVectors_.find(vector);
+  VELOX_CHECK(it != deduppedVectors_.end());
+  return it->second;
+}
+
 bool Step::operator==(const Step& other) const {
   return kind == other.kind && field == other.field && id == other.id;
 }

--- a/optimizer/ToVelox.cpp
+++ b/optimizer/ToVelox.cpp
@@ -354,6 +354,10 @@ core::TypedExprPtr Optimization::toTypedExpr(ExprCP expr) {
     }
     case PlanType::kLiteral: {
       auto literal = expr->as<Literal>();
+      if (literal->vector()) {
+        return std::make_shared<core::ConstantTypedExpr>(
+            queryCtx()->toVectorPtr(literal->vector()));
+      }
       return std::make_shared<core::ConstantTypedExpr>(
           toTypePtr(literal->value().type), literal->literal());
     }

--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<exec::test::TpchQueryBuilder> ParquetTpchTest::tpchBuilder_;
 
 //  static
 void ParquetTpchTest::SetUpTestCase() {
-  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
 
   duckDb_ = std::make_shared<DuckDbQueryRunner>();
   if (FLAGS_data_path.empty()) {

--- a/optimizer/tests/PlanTest.cpp
+++ b/optimizer/tests/PlanTest.cpp
@@ -267,7 +267,6 @@ TEST_F(PlanTest, q11) {
 
 TEST_F(PlanTest, q12) {
   // Fix string in filter
-  GTEST_SKIP();
   checkTpch(12);
 }
 

--- a/optimizer/tests/VeloxSql.cpp
+++ b/optimizer/tests/VeloxSql.cpp
@@ -176,7 +176,7 @@ class VeloxRunner {
  public:
   void initialize() {
     if (FLAGS_cache_gb) {
-      memory::MemoryManager::Options options;
+      memory::MemoryManagerOptions options;
       int64_t memoryBytes = FLAGS_cache_gb * (1LL << 30);
       options.useMmapAllocator = true;
       options.allocatorCapacity = memoryBytes;
@@ -201,8 +201,7 @@ class VeloxRunner {
           memory::memoryManager()->allocator(), std::move(ssdCache));
       cache::AsyncDataCache::setInstance(cache_.get());
     } else {
-      memory::MemoryManager::testingSetInstance(
-          memory::MemoryManager::Options{});
+      memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
     }
 
     rootPool_ = memory::memoryManager()->addRootPool("velox_sql");


### PR DESCRIPTION
Adds support of registering VectorPtrs in QueryGraphContext. This happens for example in the context of IN predicates (Q12).  Folded constants are also deduplicated, so that a constant folding result can dedup with a literal. This enables more common subexpression deduplication.