### PR TITLE
feat(functions): Support named rows as return type

### DIFF
--- a/optimizer/tests/SubfieldTest.cpp
+++ b/optimizer/tests/SubfieldTest.cpp
@@ -54,7 +54,7 @@ class GenieFunction : public exec::VectorFunction {
     return {
         exec::FunctionSignatureBuilder()
             .returnType(
-                "row(uid bigint, ff map(integer, real), idlf map(integer, array(bigint)), idslf map(integer, map(bigint, real)))")
+                "row(bigint, map(integer, real), map(integer, array(bigint)), map(integer, map(bigint, real)))")
             .argumentType("bigint")
             .argumentType("map(integer, real)")
             .argumentType("map(integer, array(bigint))")


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/13423

Changing signature binder to carry the name of row children while
binding types, so that users can use functions that return rows with named
children, e.g `row(id bigint)`.

Reviewed By: Yuhta

Differential Revision: D75146919


