### PR TITLE
feat: Add join cardinality sampling

### DIFF
--- a/optimizer/CMakeLists.txt
+++ b/optimizer/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library(
   PlanUtils.cpp
   RelationOp.cpp
   ToVelox.cpp
-  VeloxHistory.cpp)
+  VeloxHistory.cpp
+  JoinSample.cpp)
 
 add_dependencies(velox_verax velox_hive_connector)
 

--- a/optimizer/JoinSample.cpp
+++ b/optimizer/JoinSample.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/Plan.h" //@manual
+#include "optimizer/connectors/ConnectorSplitSource.h" //@manual
+#include "velox/common/base/AsyncSource.h"
+#include "velox/runner/LocalRunner.h"
+
+namespace facebook::velox::optimizer {
+
+namespace {
+// Counter for making unique query ids for sampling.
+int64_t sampleQueryCounter;
+
+Value bigintValue() {
+  return Value(toType(BIGINT()), 1);
+}
+
+Value intValue() {
+  return Value(toType(INTEGER()), 1);
+}
+
+ExprCP bigintLit(int64_t n) {
+  return make<Literal>(
+      bigintValue(), queryCtx()->registerVariant(std::make_unique<variant>(n)));
+}
+
+ExprCP intLit(int32_t n) {
+  return make<Literal>(
+      intValue(), queryCtx()->registerVariant(std::make_unique<variant>(n)));
+}
+
+// Returns an int64 hash with low 28 bits set.
+ExprCP makeHash(ExprCP expr) {
+  switch (expr->value().type->kind()) {
+    case TypeKind::BIGINT:
+      break;
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+      expr = make<Call>(
+          toName("cast"), bigintValue(), ExprVector{expr}, FunctionSet());
+      break;
+    default: {
+      ExprVector castArgs;
+      castArgs.push_back(make<Call>(
+          toName("cast"),
+          Value(toType(VARCHAR()), 1),
+          castArgs,
+          FunctionSet()));
+
+      ExprVector args;
+      args.push_back(make<Call>(
+          toName("cast"),
+          Value(toType(VARBINARY()), 1),
+          castArgs,
+          FunctionSet()));
+      ExprVector final;
+      final.push_back(make<Call>(
+          toName("crc32"), Value(toType(INTEGER()), 1), args, FunctionSet()));
+      expr = make<Call>(toName("cast"), bigintValue(), final, FunctionSet());
+    }
+  }
+
+  ExprVector andArgs;
+  andArgs.push_back(expr);
+  andArgs.push_back(bigintLit(0x7fffffff));
+  return make<Call>(
+      toName("bitwise_and"), bigintValue(), andArgs, FunctionSet());
+}
+
+ExprCP scaleTo32(ExprCP value) {
+  ExprVector andArgs;
+  andArgs.push_back(value);
+  andArgs.push_back(bigintLit(0x7fffffff));
+  return make<Call>(
+      toName("bitwise_and"), bigintValue(), andArgs, FunctionSet());
+}
+
+ExprCP mul(ExprCP a, int64_t b) {
+  return scaleTo32(make<Call>(
+      toName("multiply"),
+      bigintValue(),
+      ExprVector{a, bigintLit(b)},
+      FunctionSet()));
+}
+
+ExprCP rightShift(ExprCP a, int32_t s) {
+  return make<Call>(
+      toName("bitwise_right_shift"),
+      bigintValue(),
+      ExprVector{a, intLit(s)},
+      FunctionSet());
+}
+
+ExprCP xor64(ExprCP a, ExprCP b) {
+  return make<Call>(
+      toName("bitwise_xor"), bigintValue(), ExprVector{a, b}, FunctionSet());
+}
+
+std::shared_ptr<core::QueryCtx> sampleQueryCtx(
+    std::shared_ptr<core::QueryCtx> original) {
+  std::unordered_map<std::string, std::string> empty;
+  return core::QueryCtx::create(
+      original->executor(),
+      core::QueryConfig(std::move(empty)),
+      original->connectorSessionProperties(),
+      original->cache(),
+      original->pool()->shared_from_this(),
+      nullptr,
+      fmt::format("sample:{}", ++sampleQueryCounter));
+}
+
+using KeyFreq = folly::F14FastMap<uint32_t, uint32_t>;
+
+std::shared_ptr<runner::Runner> prepareSampleRunner(
+    SchemaTableCP table,
+    const ExprVector& keys,
+    int64_t mod,
+    int64_t lim) {
+  auto base = make<BaseTable>();
+  base->schemaTable = table;
+  PlanObjectSet sampleColumns;
+  for (auto& e : keys) {
+    sampleColumns.unionSet(e->columns());
+  }
+  ColumnVector columns;
+  sampleColumns.forEach(
+      [&](PlanObjectCP c) { columns.push_back(c->as<Column>()); });
+  auto index = chooseLeafIndex(base)[0];
+  auto* scan = make<TableScan>(
+      nullptr,
+      TableScan::outputDistribution(base, index, columns),
+      base,
+      index,
+      index->distribution().cardinality,
+      columns);
+  ExprCP hash = makeHash(keys[0]);
+  if (keys.size() == 1) {
+    hash = mul(hash, 1815531889);
+  } else {
+    auto kMul = 0xeb382d69ULL;
+
+    for (auto i = 1; i < keys.size(); ++i) {
+      auto other = makeHash(keys[i]);
+      auto a = mul(xor64(hash, other), kMul);
+      a = xor64(a, rightShift(a, 15));
+      auto b = mul(xor64(other, a), kMul);
+      b = xor64(b, rightShift(b, 13));
+      hash = mul(b, kMul);
+    }
+  }
+  ColumnCP hashCol =
+      make<Column>(toName("hash"), nullptr, bigintValue(), nullptr);
+  RelationOpPtr proj =
+      make<Project>(scan, ExprVector{hash}, ColumnVector{hashCol});
+  ExprCP hashMod = make<Call>(
+      toName("mod"),
+      bigintValue(),
+      ExprVector{hashCol, bigintLit(mod)},
+      FunctionSet());
+  ExprCP filterExpr = make<Call>(
+      toName("lt"),
+      Value(toType(BOOLEAN()), 1),
+      ExprVector{hashMod, bigintLit(lim)},
+      FunctionSet());
+  RelationOpPtr filter = make<Filter>(proj, ExprVector{filterExpr});
+
+  runner::MultiFragmentPlan::Options& options =
+      queryCtx()->optimization()->options();
+  auto plan = queryCtx()->optimization()->toVeloxPlan(filter, options);
+  return std::make_shared<runner::LocalRunner>(
+      plan.plan,
+      sampleQueryCtx(queryCtx()->optimization()->queryCtxShared()),
+      std::make_shared<connector::ConnectorSplitSourceFactory>());
+}
+
+std::unique_ptr<KeyFreq> runJoinSample(runner::Runner& runner) {
+  auto result = std::make_unique<folly::F14FastMap<uint32_t, uint32_t>>();
+  while (auto rows = runner.next()) {
+    auto h = rows->childAt(0)->as<FlatVector<int64_t>>();
+    for (auto i = 0; i < h->size(); ++i) {
+      if (!h->isNullAt(i)) {
+        ++(*result)[static_cast<uint32_t>(h->valueAt(i))];
+      }
+    }
+  }
+  runner.waitForCompletion(1000000);
+  return result;
+}
+
+float freqs(KeyFreq& l, KeyFreq& r) {
+  if (l.empty()) {
+    return 0;
+  }
+  float hits = 0;
+  for (auto& pair : l) {
+    auto it = r.find(pair.first);
+    if (it != r.end()) {
+      hits += it->second;
+    }
+  }
+  return hits / l.size();
+}
+
+float keyCardinality(const ExprVector& keys) {
+  float card = 1;
+  for (auto& key : keys) {
+    card *= key->value().cardinality;
+  }
+  return card;
+}
+} // namespace
+
+std::pair<float, float> sampleJoin(
+    SchemaTableCP left,
+    const ExprVector& leftKeys,
+    SchemaTableCP right,
+    const ExprVector& rightKeys) {
+  uint64_t leftRows = left->numRows();
+  uint64_t rightRows = right->numRows();
+  auto leftCard = keyCardinality(leftKeys);
+  auto rightCard = keyCardinality(rightKeys);
+  int32_t fraction = 10000;
+  if (leftRows < 10000 && rightRows < 10000) {
+    // sample all.
+  } else if (leftCard > 10000 && rightCard > 10000) {
+    // Keys have many values, sample a fraction.
+    auto smaller = std::min(leftRows, rightRows);
+    float ratio = smaller / 10000.0;
+    fraction = std::max<int32_t>(2, 10000 / ratio);
+  } else {
+    return std::make_pair(0, 0);
+  }
+
+  auto leftRunner = prepareSampleRunner(left, leftKeys, 10000, fraction);
+  auto rightRunner = prepareSampleRunner(right, rightKeys, 10000, fraction);
+  auto leftRun = std::make_shared<AsyncSource<KeyFreq>>(
+      [leftRunner]() { return runJoinSample(*leftRunner); });
+  auto rightRun = std::make_shared<AsyncSource<KeyFreq>>(
+      [rightRunner]() { return runJoinSample(*rightRunner); });
+  auto executor = queryCtx()->optimization()->queryCtxShared()->executor();
+  if (executor) {
+    executor->add([leftRun]() { leftRun->prepare(); });
+    executor->add([rightRun]() { rightRun->prepare(); });
+  }
+
+  auto leftFreq = leftRun->move();
+  auto rightFreq = rightRun->move();
+  return std::make_pair(
+      freqs(*rightFreq, *leftFreq), freqs(*leftFreq, *rightFreq));
+}
+
+} // namespace facebook::velox::optimizer

--- a/optimizer/QueryGraph.h
+++ b/optimizer/QueryGraph.h
@@ -537,6 +537,10 @@ class JoinEdge {
     return lrFanout_;
   }
 
+  float rlFanout() const {
+    return rlFanout_;
+  }
+
   bool leftOptional() const {
     return leftOptional_;
   }
@@ -545,7 +549,7 @@ class JoinEdge {
     return rightOptional_;
   }
 
-  void addEquality(ExprCP left, ExprCP right);
+  void addEquality(ExprCP left, ExprCP right, bool update = false);
 
   /// True if inner join.
   bool isInner() const {
@@ -596,6 +600,11 @@ class JoinEdge {
   // True if a hash join build can be broadcastable. Used when building on the
   // right. None of the right hash join variants is broadcastable.
   bool isBroadcastableType() const;
+
+  /// Returns a key string for recording a join cardinality sample. The string
+  /// is empty if not applicable. The bool is true if the key has right table
+  /// before left.
+  std::pair<std::string, bool> sampleKey() const;
 
  private:
   // Leading left side join keys.

--- a/optimizer/RelationOp.cpp
+++ b/optimizer/RelationOp.cpp
@@ -18,6 +18,7 @@
 #include "optimizer/PlanUtils.h" //@manual
 #include "optimizer/QueryGraph.h" //@manual
 #include "velox/common/base/SuccinctPrinter.h"
+#include "velox/expression/ScopedVarSetter.h"
 
 namespace facebook::velox::optimizer {
 
@@ -139,6 +140,33 @@ const char* joinTypeLabel(velox::core::JoinType type) {
   }
 }
 
+const std::string& TableScan::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::stringstream out;
+  out << "{scan " << baseTable->schemaTable->name << "(";
+  auto* opt = queryCtx()->optimization();
+  ScopedVarSetter cnames(&opt->cnamesInExpr(), false);
+  for (auto& key : keys) {
+    out << "lookup " << key->toString() << ", ";
+  }
+  std::vector<std::string> filters;
+  for (auto& f : baseTable->columnFilters) {
+    filters.push_back(f->toString());
+  }
+  for (auto& f : baseTable->filter) {
+    filters.push_back(f->toString());
+  }
+  std::sort(filters.begin(), filters.end());
+  for (auto& f : filters) {
+    out << "f: " << f << ", ";
+  }
+  out << ")";
+  key_ = out.str();
+  return key_;
+}
+
 std::string TableScan::toString(bool /*recursive*/, bool detail) const {
   std::stringstream out;
   if (input()) {
@@ -153,6 +181,49 @@ std::string TableScan::toString(bool /*recursive*/, bool detail) const {
     }
   }
   return out.str();
+}
+
+std::pair<std::string, std::string> joinKeysString(
+    const ExprVector& left,
+    const ExprVector& right) {
+  std::vector<int32_t> indices(left.size());
+  std::iota(indices.begin(), indices.end(), 0);
+  auto* opt = queryCtx()->optimization();
+  ScopedVarSetter cname(&opt->cnamesInExpr(), false);
+  std::vector<std::string> strings;
+  for (auto& k : left) {
+    strings.push_back(k->toString());
+  }
+  std::sort(indices.begin(), indices.end(), [&](int32_t l, int32_t r) {
+    return strings[l] < strings[r];
+  });
+  std::stringstream leftStream;
+  std::stringstream rightStream;
+  for (auto i : indices) {
+    leftStream << left[i]->toString() << ", ";
+    rightStream << right[i]->toString() << ", ";
+  }
+  return std::make_pair(leftStream.str(), rightStream.str());
+}
+
+const std::string& Join::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  auto& leftTree = input_->historyKey();
+  auto& rightTree = right->historyKey();
+  std::stringstream out;
+  auto [leftText, rightText] = joinKeysString(leftKeys, rightKeys);
+  if (leftTree < rightTree || joinType != core::JoinType::kInner) {
+    out << "join " << joinTypeLabel(joinType) << "(" << leftTree << " keys "
+        << leftText << " = " << rightText << rightTree << ")";
+  } else {
+    out << "join " << joinTypeLabel(reverseJoinType(joinType)) << "("
+        << rightTree << " keys " << rightText << " = " << leftText << leftTree
+        << ")";
+  }
+  key_ = out.str();
+  return key_;
 }
 
 std::string Join::toString(bool recursive, bool detail) const {
@@ -209,6 +280,32 @@ Aggregation::Aggregation(
   }
 }
 
+const std::string& Aggregation::historyKey() const {
+  using velox::core::AggregationNode;
+  if (step == AggregationNode::Step::kPartial ||
+      step == AggregationNode::Step::kIntermediate) {
+    return RelationOp::historyKey();
+  }
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::stringstream out;
+  out << input_->historyKey();
+  out << " group by ";
+  auto* opt = queryCtx()->optimization();
+  ScopedVarSetter cnames(&opt->cnamesInExpr(), false);
+  std::vector<std::string> strings;
+  for (auto& key : grouping) {
+    strings.push_back(key->toString());
+  }
+  std::sort(strings.begin(), strings.end());
+  for (auto& s : strings) {
+    out << s << ", ";
+  }
+  key_ = out.str();
+  return key_;
+}
+
 std::string Aggregation::toString(bool recursive, bool detail) const {
   std::stringstream out;
   if (recursive) {
@@ -227,6 +324,27 @@ std::string HashBuild::toString(bool recursive, bool detail) const {
   out << " Build ";
   printCost(detail, out);
   return out.str();
+}
+
+const std::string& Filter::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::stringstream out;
+  auto* opt = queryCtx()->optimization();
+  ScopedVarSetter cname(&opt->cnamesInExpr(), false);
+  out << input_->historyKey() << " filter " << "(";
+  std::vector<std::string> strings;
+  for (auto& e : exprs_) {
+    strings.push_back(e->toString());
+  }
+  std::sort(strings.begin(), strings.end());
+  for (auto& s : strings) {
+    out << s << ", ";
+  }
+  out << ")";
+  key_ = out.str();
+  return key_;
 }
 
 std::string Filter::toString(bool recursive, bool detail) const {

--- a/optimizer/RelationOp.h
+++ b/optimizer/RelationOp.h
@@ -119,6 +119,16 @@ class RelationOp : public Relation {
   /// each subclass.
   virtual void setCost(const PlanState& input);
 
+  /// Returns a key for retrieving/storing a historical record of execution for
+  /// future costing. Empty string if not applicable.
+  virtual const std::string& historyKey() const {
+    if (input_) {
+      return input_->historyKey();
+    }
+    static std::string empty;
+    return empty;
+  }
+
   /// Returns human redable string for 'this' and inputs if 'recursive' is true.
   /// If 'detail' is true, includes cost and other details.
   virtual std::string toString(bool recursive, bool detail) const;
@@ -132,6 +142,9 @@ class RelationOp : public Relation {
   boost::intrusive_ptr<class RelationOp> input_;
 
   Cost cost_;
+
+  // Cache of history lookup key.
+  mutable std::string key_;
 
  private:
   // thread local reference count. PlanObjects are freed when the
@@ -195,6 +208,8 @@ struct TableScan : public RelationOp {
 
   void setCost(const PlanState& input) override;
 
+  const std::string& historyKey() const override;
+
   std::string toString(bool recursive, bool detail) const override;
 
   // The base table reference. May occur in multiple scans if the base
@@ -257,6 +272,9 @@ class Filter : public RelationOp {
   }
 
   void setCost(const PlanState& input) override;
+
+  const std::string& historyKey() const override;
+
   std::string toString(bool recursive, bool detail) const override;
 
  private:
@@ -325,6 +343,9 @@ struct Join : public RelationOp {
   Cost buildCost;
 
   void setCost(const PlanState& input) override;
+
+  const std::string& historyKey() const override;
+
   std::string toString(bool recursive, bool detail) const override;
 };
 
@@ -390,6 +411,9 @@ struct Aggregation : public RelationOp {
   ColumnVector intermediateColumns;
 
   void setCost(const PlanState& input) override;
+
+  const std::string& historyKey() const override;
+
   std::string toString(bool recursive, bool detail) const override;
 };
 

--- a/optimizer/Schema.h
+++ b/optimizer/Schema.h
@@ -399,6 +399,10 @@ struct SchemaTable {
 
   ColumnCP findColumn(const std::string& name) const;
 
+  int64_t numRows() const {
+    return columnGroups[0]->layout->table()->numRows();
+  }
+
   /// True if 'columns' match no more than one row.
   bool isUnique(CPSpan<Column> columns) const;
 

--- a/optimizer/Subfields.cpp
+++ b/optimizer/Subfields.cpp
@@ -383,6 +383,9 @@ void Optimization::markControl(const core::PlanNode* node) {
   } else if (name == "Aggregation") {
     auto* agg = dynamic_cast<const core::AggregationNode*>(node);
     markColumnSubfields(node, agg->groupingKeys(), 0);
+  } else if (name == "OrderBy") {
+    auto* order = dynamic_cast<const core::OrderByNode*>(node);
+    markColumnSubfields(node, order->sortingKeys(), 0);
   }
   for (auto& source : node->sources()) {
     markControl(source.get());

--- a/optimizer/VeloxHistory.h
+++ b/optimizer/VeloxHistory.h
@@ -26,6 +26,15 @@ namespace facebook::velox::optimizer {
 /// handles and execution stats.
 class VeloxHistory : public History {
  public:
+  void recordJoinSample(const std::string& key, float lr, float rl) override;
+
+  std::pair<float, float> sampleJoin(JoinEdge* edge) override;
+
+  NodePrediction* getHistory(const std::string key) override;
+
+  virtual void setHistory(const std::string& key, NodePrediction history)
+      override;
+
   virtual std::optional<Cost> findCost(RelationOp& op) override {
     return std::nullopt;
   }
@@ -40,9 +49,12 @@ class VeloxHistory : public History {
   /// non-null, non-leaf costs from non-leaf levels are recorded. Otherwise only
   /// leaf scan selectivities  are recorded.
   virtual void recordVeloxExecution(
-      const RelationOp* op,
-      const std::vector<velox::runner::ExecutableFragment>& plan,
+      const PlanAndStats& plan,
       const std::vector<velox::exec::TaskStats>& stats);
+
+ private:
+  std::unordered_map<std::string, std::pair<float, float>> joinSamples_;
+  std::unordered_map<std::string, NodePrediction> planHistory_;
 };
 
 } // namespace facebook::velox::optimizer

--- a/optimizer/connectors/ConnectorMetadata.h
+++ b/optimizer/connectors/ConnectorMetadata.h
@@ -17,6 +17,7 @@
 
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/Connector.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
@@ -550,6 +551,11 @@ class ConnectorMetadata {
   /// Returns a SplitManager for split enumeration for TableLayouts accessed
   /// through 'this'.
   virtual ConnectorSplitManager* splitManager() = 0;
+
+  virtual std::shared_ptr<core::QueryCtx> makeQueryCtx(
+      const std::string& queryId) {
+    VELOX_UNSUPPORTED();
+  }
 };
 
 } // namespace facebook::velox::connector

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -128,21 +128,26 @@ void LocalHiveConnectorMetadata::ensureInitialized() const {
   initialized_ = true;
 }
 
-void LocalHiveConnectorMetadata::makeQueryCtx() {
+std::shared_ptr<core::QueryCtx> LocalHiveConnectorMetadata::makeQueryCtx(
+    const std::string& queryId) {
   std::unordered_map<std::string, std::string> config;
   std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
       connectorConfigs;
   connectorConfigs[hiveConnector_->connectorId()] =
       std::const_pointer_cast<config::ConfigBase>(hiveConfig_->config());
 
-  queryCtx_ = core::QueryCtx::create(
+  return core::QueryCtx::create(
       hiveConnector_->executor(),
       core::QueryConfig(config),
       std::move(connectorConfigs),
       cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
       nullptr,
-      "local_hive_metadata");
+      queryId);
+}
+
+void LocalHiveConnectorMetadata::makeQueryCtx() {
+  queryCtx_ = makeQueryCtx("local_hive_metadata");
 }
 
 void LocalHiveConnectorMetadata::makeConnectorQueryCtx() {

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -217,6 +217,9 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
     return tables_;
   }
 
+  std::shared_ptr<core::QueryCtx> makeQueryCtx(
+      const std::string& queryId) override;
+
  private:
   void ensureInitialized() const;
   void makeQueryCtx();

--- a/optimizer/tests/QueryTestBase.h
+++ b/optimizer/tests/QueryTestBase.h
@@ -65,19 +65,20 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   TestResult runVelox(const core::PlanNodePtr& plan);
 
-  TestResult runFragmentedPlan(runner::MultiFragmentPlanPtr plan);
+  TestResult runFragmentedPlan(optimizer::PlanAndStats& plan);
 
   /// Checks that 'reference' and 'experiment' produce the same result.
   void assertSame(
       const core::PlanNodePtr& reference,
-      runner::MultiFragmentPlanPtr experiment);
+      optimizer::PlanAndStats& experiment,
+      TestResult* referenceReturn = nullptr);
 
-  runner::MultiFragmentPlanPtr planSql(
+  optimizer::PlanAndStats planSql(
       const std::string& sql,
       std::string* planString = nullptr,
       std::string* errorString = nullptr);
 
-  runner::MultiFragmentPlanPtr planVelox(
+  optimizer::PlanAndStats planVelox(
       const core::PlanNodePtr& plan,
       std::string* planString = nullptr,
       std::string* errorString = nullptr);

--- a/optimizer/tests/SubfieldTest.cpp
+++ b/optimizer/tests/SubfieldTest.cpp
@@ -270,7 +270,7 @@ class SubfieldTest : public QueryTestBase,
                              id, std::move(names), std::move(exprs), node);
                        });
     auto fragmentedPlan = planVelox(builder.planNode());
-    auto plan = veloxString(fragmentedPlan);
+    auto plan = veloxString(fragmentedPlan.plan);
     expectRegexp(plan, "ParallelProject");
     std::cout << plan;
     assertSame(builder.planNode(), fragmentedPlan);
@@ -293,7 +293,7 @@ TEST_P(SubfieldTest, structs) {
                      .tableScan("structs", rowType)
                      .project({"s.s1 as a", "s.s3[0] as arr0"});
 
-  auto plan = veloxString(planVelox(builder.planNode()));
+  auto plan = veloxString(planVelox(builder.planNode()).plan);
   expectRegexp(plan, "s.*Subfields.*s.s3\\[0\\]");
   expectRegexp(plan, "s.*Subfields.*s.s1");
 }
@@ -340,7 +340,7 @@ TEST_P(SubfieldTest, maps) {
                "opt_ff[10100::INTEGER] as o10",
                "opt_ff[10200::INTEGER] as o20"});
 
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   std::cout << plan << std::endl;
 
   builder =
@@ -350,7 +350,7 @@ TEST_P(SubfieldTest, maps) {
               {"float_features[10100::INTEGER] as f1",
                "float_features[10200::INTEGER] as f2",
                "id_score_list_features[200800::INTEGER][100000::INTEGER]"});
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   expectRegexp(plan, "float_features.*Subfields.*float_features.10100.");
   expectRegexp(plan, "float_features.*Subfields.*float_features.10200.");
   expectRegexp(
@@ -365,7 +365,7 @@ TEST_P(SubfieldTest, maps) {
                      "id_score_list_features[200800::INTEGER] as sc1",
                      "id_list_features as idlf"})
                 .project({"sc1[1::INTEGER] + 1::REAL as score"});
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   expectRegexp(
       plan,
       "id_score_list_features.*Subfields:.*\\[ id_score_list_features.200800.*\\[1\\]");
@@ -382,7 +382,7 @@ TEST_P(SubfieldTest, maps) {
                 .project(
                     {"sc1[1::INTEGER] + 1::REAL as score",
                      "idlf[cast(uid % 100 as INTEGER)] as any"});
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   expectRegexp(
       plan, "id_list_features.*Subfields:.* id_list_features\\[\\*\\]");
 
@@ -401,7 +401,7 @@ TEST_P(SubfieldTest, maps) {
                "g.__1[10200::INTEGER] + 22::REAL  as f2b",
                "g.__2[201600::INTEGER] as idl100"});
 
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   expectRegexp(plan, "float_features.*Subfield.*float_features.10200");
   expectRegexp(plan, "id_list_features.*Subfields.*id_list_features.201600");
 
@@ -417,7 +417,7 @@ TEST_P(SubfieldTest, maps) {
                "g.__1[10200::INTEGER] as f2",
                "g.__2[200600::INTEGER] as idl100"});
 
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   std::cout << plan << std::endl;
 
   // We expect the genie to explode and the filters to be first.
@@ -435,7 +435,7 @@ TEST_P(SubfieldTest, maps) {
                "gg.__2[200600::INTEGER] as idl100"})
           .filter("f10 < 10::REAL and f11 < 10::REAL");
 
-  plan = veloxString(planVelox(builder.planNode()));
+  plan = veloxString(planVelox(builder.planNode()).plan);
   std::cout << plan << std::endl;
 
   builder =


### PR DESCRIPTION
Adds a sampling for join hit rates and reference to history for cardinalities.

Does not generate shuffles if the plan is for a snigle worker.

Makes optimization output contain cardinality estimates as well as keys for persisting the actual cardinalities after execution.