### PR TITLE
fix: TableScanNode's ctor and Connector::createDataSource/Sink APIs

### DIFF
--- a/optimizer/ToVelox.cpp
+++ b/optimizer/ToVelox.cpp
@@ -870,8 +870,7 @@ core::PlanNodePtr Optimization::makeFragment(
       }
       ColumnVector scanColumns;
       auto outputType = scanOutputType(scan, scanColumns, columnAlteredTypes_);
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          assignments;
+      connector::ColumnHandleMap assignments;
       for (auto column : scanColumns) {
         // TODO: Make assignments have a ConnectorTableHandlePtr instead of
         // non-const shared_ptr.
@@ -887,11 +886,7 @@ core::PlanNodePtr Optimization::makeFragment(
                 *scan->index->layout, column->name(), std::move(subfields)));
       }
       auto scanNode = std::make_shared<core::TableScanNode>(
-          nextId(*op),
-          outputType,
-          std::const_pointer_cast<connector::ConnectorTableHandle>(
-              handlePair.first),
-          assignments);
+          nextId(*op), outputType, handlePair.first, assignments);
       VELOX_CHECK(handlePair.second.empty(), "Expecting no rejected filters");
       makePredictionAndHistory(scanNode->id(), scan);
       fragment.scans.push_back(scanNode);

--- a/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -226,10 +226,7 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
       .maxStringLength = 100, .countDistincts = true, .allocator = allocator};
   std::vector<std::unique_ptr<StatisticsBuilder>> builders;
 
-  std::unordered_map<
-      std::string,
-      std::shared_ptr<velox::connector::ColumnHandle>>
-      columnHandles;
+  velox::connector::ColumnHandleMap columnHandles;
   std::vector<std::string> names;
   std::vector<TypePtr> types;
   for (auto& field : fields) {
@@ -253,15 +250,11 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
   int64_t passingRows = 0;
   int64_t scannedRows = 0;
   for (auto& file : files_) {
-    // TODO: make createDataSource take a ConnectorTableHandlePtr instead of a
-    // shared_ptr to mutable handle.
-    auto handleCopy =
-        std::const_pointer_cast<connector::ConnectorTableHandle>(tableHandle);
     auto connectorQueryCtx =
         reinterpret_cast<LocalHiveConnectorMetadata*>(connector()->metadata())
             ->connectorQueryCtx();
     auto dataSource = connector()->createDataSource(
-        outputType, handleCopy, columnHandles, connectorQueryCtx.get());
+        outputType, tableHandle, columnHandles, connectorQueryCtx.get());
 
     auto split = connector::hive::HiveConnectorSplitBuilder(file)
                      .fileFormat(fileFormat_)

--- a/optimizer/tests/ParquetTpchTest.cpp
+++ b/optimizer/tests/ParquetTpchTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "optimizer/tests/ParquetTpchTest.h" //@manual
+#include "velox/connectors/hive/HiveConnector.h"
 
 DEFINE_string(
     data_path,

--- a/optimizer/tests/QueryTestBase.cpp
+++ b/optimizer/tests/QueryTestBase.cpp
@@ -148,8 +148,7 @@ core::PlanNodePtr QueryTestBase::toTableScan(
       true,
       common::SubfieldFilters{},
       nullptr);
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
 
   auto table = connector_->metadata()->findTable(name);
   for (auto i = 0; i < rowType->size(); ++i) {

--- a/optimizer/tests/VeloxSql.cpp
+++ b/optimizer/tests/VeloxSql.cpp
@@ -327,8 +327,7 @@ class VeloxRunner {
     using namespace connector::hive;
     auto handle = std::make_shared<HiveTableHandle>(
         kHiveConnectorId, name, true, common::SubfieldFilters{}, nullptr);
-    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-        assignments;
+    connector::ColumnHandleMap assignments;
 
     auto table = connector_->metadata()->findTable(name);
     for (auto i = 0; i < rowType->size(); ++i) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/13920

TableScanNode, Connector::createDataSource, createIndexSource and createDataSink APIs used to take table and column handles as non-const forcing calling code to use std::const_pointer_cast, which is an anti-pattern.

Differential Revision: D77490731


