### PR TITLE
refactor: Modernize code in velox/parse

### DIFF
--- a/optimizer/tests/SubfieldTest.cpp
+++ b/optimizer/tests/SubfieldTest.cpp
@@ -113,7 +113,7 @@ class SubfieldTest : public QueryTestBase,
   static core::TypedExprPtr fieldIndexHook(
       std::shared_ptr<const core::FieldAccessExpr> fae,
       std::vector<core::TypedExprPtr>& children) {
-    auto name = fae->getFieldName();
+    auto name = fae->name();
     if (name.size() < 3 || name[0] != '_' || name[1] != '_') {
       return nullptr;
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14027

- replace std::shared_ptr<IExpr> with ExprPtr
- move 'inputs' from derives classes to the base IExpr class
- rename getters to match coding style (getInputs -> inputs)
- cleanup includes

Differential Revision: D77863302


