### PR TITLE
Add TpchConnectorMetadata class

### DIFF
--- a/frontend/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/frontend/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
@@ -1,0 +1,253 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "optimizer/connectors/tpch/TpchConnectorMetadata.h" //@manual
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/connectors/tpch/TpchConnectorSplit.h"
+#include "velox/expression/Expr.h"
+#include "velox/tpch/gen/TpchGen.h"
+
+namespace facebook::velox::connector::tpch {
+
+std::vector<std::shared_ptr<const PartitionHandle>>
+TpchSplitManager::listPartitions(const ConnectorTableHandlePtr& tableHandle) {
+  // All TPCH tables are unpartitioned.
+  return {std::make_shared<connector::PartitionHandle>()};
+}
+
+std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
+    const ConnectorTableHandlePtr& tableHandle,
+    std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+    SplitOptions options) {
+  auto* tpchTableHandle =
+      dynamic_cast<const TpchTableHandle*>(tableHandle.get());
+  VELOX_CHECK_NOT_NULL(
+      tpchTableHandle, "Expected TpchTableHandle for TPCH connector");
+
+  return std::make_shared<TpchSplitSource>(
+      tpchTableHandle->getTable(),
+      tpchTableHandle->getScaleFactor(),
+      tpchTableHandle->connectorId(),
+      options);
+}
+
+std::vector<SplitSource::SplitAndGroup> TpchSplitSource::getSplits(
+    uint64_t targetBytes) {
+  std::vector<SplitAndGroup> result;
+
+  if (splits_.empty()) {
+    // Generate splits if not already done
+    auto rowType = velox::tpch::getTableSchema(table_);
+    size_t rowSize = 0;
+    for (auto i = 0; i < rowType->children().size(); i++) {
+      // TODO: use actual size
+      rowSize += 10;
+    }
+    const auto totalRows = velox::tpch::getRowCount(table_, scaleFactor_);
+    const auto rowsPerSplit = options_.fileBytesPerSplit / rowSize;
+    const auto numSplits = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
+
+    // TODO: adjust numSplits based on options_.targetSplitCount
+    for (int64_t i = 0; i < numSplits; ++i) {
+      splits_.push_back(
+          std::make_shared<TpchConnectorSplit>(connectorId_, numSplits, i));
+    }
+  }
+
+  if (currentSplit_ >= splits_.size()) {
+    result.push_back(kNoMoreSplits);
+    return result;
+  }
+
+  uint64_t bytes = 0;
+  while (currentSplit_ < splits_.size()) {
+    auto split = splits_[currentSplit_++];
+    result.emplace_back(SplitAndGroup{split, 0});
+
+    // TODO: use a more accurate size for the split
+    bytes += options_.fileBytesPerSplit;
+
+    if (bytes > targetBytes) {
+      break;
+    }
+  }
+
+  if (result.empty()) {
+    result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
+  }
+
+  return result;
+}
+
+TpchConnectorMetadata::TpchConnectorMetadata(
+    TpchConnector* tpchConnector,
+    double scaleFactor)
+    : tpchConnector_(tpchConnector),
+      scaleFactor_(scaleFactor),
+      splitManager_(this) {}
+
+void TpchConnectorMetadata::reinitialize(double newScaleFactor) {
+  std::lock_guard<std::mutex> l(mutex_);
+  scaleFactor_ = newScaleFactor;
+  tables_.clear();
+  initialize();
+  initialized_ = true;
+}
+
+void TpchConnectorMetadata::initialize() {
+  makeQueryCtx();
+  initializeTables();
+}
+
+void TpchConnectorMetadata::ensureInitialized() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (initialized_) {
+    return;
+  }
+  const_cast<TpchConnectorMetadata*>(this)->initialize();
+  initialized_ = true;
+}
+
+void TpchConnectorMetadata::makeQueryCtx() {
+  queryCtx_ = makeQueryCtx("tpch_metadata");
+}
+
+std::shared_ptr<core::QueryCtx> TpchConnectorMetadata::makeQueryCtx(
+    const std::string& queryId) {
+  std::unordered_map<std::string, std::string> config;
+  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
+      connectorConfigs;
+
+  return core::QueryCtx::create(
+      tpchConnector_->executor(),
+      core::QueryConfig(config),
+      std::move(connectorConfigs),
+      cache::AsyncDataCache::getInstance(),
+      rootPool_->shared_from_this(),
+      nullptr,
+      queryId);
+}
+
+ColumnHandlePtr TpchConnectorMetadata::createColumnHandle(
+    const TableLayout& layoutData,
+    const std::string& columnName,
+    std::vector<common::Subfield> subfields,
+    std::optional<TypePtr> castToType,
+    SubfieldMapping subfieldMapping) {
+  return std::make_shared<connector::tpch::TpchColumnHandle>(columnName);
+}
+
+ConnectorTableHandlePtr TpchConnectorMetadata::createTableHandle(
+    const TableLayout& layout,
+    std::vector<ColumnHandlePtr> columnHandles,
+    core::ExpressionEvaluator& /* evaluator */,
+    std::vector<core::TypedExprPtr> /* filters */,
+    std::vector<core::TypedExprPtr>& /* rejectedFilters */,
+    RowTypePtr /* dataColumns */,
+    std::optional<LookupKeys> /* lookupKeys */) {
+  // TODO: support filters
+  auto* tpchLayout = dynamic_cast<const TpchTableLayout*>(&layout);
+  return std::make_shared<TpchTableHandle>(
+      tpchConnector_->connectorId(),
+      tpchLayout->getTpchTable(),
+      tpchLayout->getScaleFactor());
+}
+
+void TpchConnectorMetadata::initializeTables() {
+  for (auto tpchTable : velox::tpch::tables) {
+    loadTable(tpchTable);
+  }
+}
+
+void TpchConnectorMetadata::loadTable(velox::tpch::Table tpchTable) {
+  const auto tableName = std::string(velox::tpch::toTableName(tpchTable));
+  const auto tableType = velox::tpch::getTableSchema(tpchTable);
+  const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor_);
+
+  auto table = std::make_unique<TpchTable>(tableName, tpchTable, scaleFactor_);
+  table->numRows_ = numRows;
+
+  // Create columns
+  for (auto i = 0; i < tableType->size(); ++i) {
+    const auto columnName = tableType->nameOf(i);
+    const auto columnType = tableType->childAt(i);
+    table->columns()[columnName] =
+        std::make_unique<Column>(columnName, columnType);
+  }
+
+  table->setType(tableType);
+  table->makeDefaultLayout(*this);
+
+  tables_[tableName] = std::move(table);
+}
+
+std::pair<int64_t, int64_t> TpchTableLayout::sample(
+    const connector::ConnectorTableHandlePtr& handle,
+    float pct,
+    std::vector<core::TypedExprPtr> /* extraFilters */,
+    RowTypePtr /* outputType */,
+    const std::vector<common::Subfield>& /* fields */,
+    HashStringAllocator* /* allocator */,
+    std::vector<ColumnStatistics>* /* statistics */) const {
+  const auto totalRows = velox::tpch::getRowCount(tpchTable_, scaleFactor_);
+  const auto sampleRows = static_cast<int64_t>(totalRows * (pct / 100.0));
+  return std::pair(sampleRows, sampleRows);
+}
+
+void TpchTable::makeDefaultLayout(TpchConnectorMetadata& metadata) {
+  std::vector<const Column*> columns;
+  for (auto i = 0; i < type_->size(); ++i) {
+    auto name = type_->nameOf(i);
+    columns.push_back(columns_[name].get());
+  }
+  auto* connector = metadata.tpchConnector();
+  std::vector<const Column*> empty;
+  auto layout = std::make_unique<TpchTableLayout>(
+      name_,
+      this,
+      connector,
+      std::move(columns),
+      empty,
+      empty,
+      std::vector<SortOrder>{},
+      empty,
+      tpchTable_,
+      scaleFactor_);
+  exportedLayouts_.push_back(layout.get());
+  layouts_.push_back(std::move(layout));
+}
+
+const std::unordered_map<std::string, const Column*>& TpchTable::columnMap()
+    const {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (columns_.empty()) {
+    return exportedColumns_;
+  }
+  for (auto& pair : columns_) {
+    exportedColumns_[pair.first] = pair.second.get();
+  }
+  return exportedColumns_;
+}
+
+const Table* TpchConnectorMetadata::findTable(const std::string& name) {
+  ensureInitialized();
+  auto it = tables_.find(name);
+  if (it == tables_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+namespace {
+class LocalTpchConnectorMetadataFactory : public TpchConnectorMetadataFactory {
+ public:
+  std::shared_ptr<ConnectorMetadata> create(TpchConnector* connector) override {
+    return std::make_shared<TpchConnectorMetadata>(connector);
+  }
+};
+
+bool dummy = registerTpchConnectorMetadataFactory(
+    std::make_unique<LocalTpchConnectorMetadataFactory>());
+} // namespace
+
+} // namespace facebook::velox::connector::tpch

--- a/frontend/optimizer/connectors/tpch/TpchConnectorMetadata.h
+++ b/frontend/optimizer/connectors/tpch/TpchConnectorMetadata.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "optimizer/connectors/ConnectorMetadata.h" //@manual
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/tpch/gen/TpchGen.h"
+
+namespace facebook::velox::connector::tpch {
+
+static const SplitSource::SplitAndGroup kNoMoreSplits{nullptr, 0};
+
+class TpchConnectorMetadata;
+
+class TpchSplitSource : public SplitSource {
+ public:
+  TpchSplitSource(
+      velox::tpch::Table table,
+      double scaleFactor,
+      const std::string& connectorId,
+      SplitOptions options)
+      : options_(options),
+        table_(table),
+        scaleFactor_(scaleFactor),
+        connectorId_(connectorId) {}
+
+  std::vector<SplitSource::SplitAndGroup> getSplits(
+      uint64_t targetBytes) override;
+
+ private:
+  const SplitOptions options_;
+  const velox::tpch::Table table_;
+  const double scaleFactor_;
+  const std::string connectorId_;
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits_;
+  int32_t currentSplit_{0};
+};
+
+class TpchSplitManager : public ConnectorSplitManager {
+ public:
+  TpchSplitManager(TpchConnectorMetadata* /* metadata */) {}
+
+  std::vector<std::shared_ptr<const PartitionHandle>> listPartitions(
+      const ConnectorTableHandlePtr& tableHandle) override;
+
+  std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorTableHandlePtr& tableHandle,
+      std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+      SplitOptions options = {}) override;
+};
+
+/// A TableLayout for TPCH tables. Implements sampling by generating TPCH data.
+class TpchTableLayout : public TableLayout {
+ public:
+  TpchTableLayout(
+      const std::string& name,
+      const Table* table,
+      connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::vector<const Column*> partitioning,
+      std::vector<const Column*> orderColumns,
+      std::vector<SortOrder> sortOrder,
+      std::vector<const Column*> lookupKeys,
+      velox::tpch::Table tpchTable,
+      double scaleFactor)
+      : TableLayout(
+            name,
+            table,
+            connector,
+            std::move(columns),
+            std::move(partitioning),
+            std::move(orderColumns),
+            std::move(sortOrder),
+            std::move(lookupKeys),
+            true),
+        tpchTable_(tpchTable),
+        scaleFactor_(scaleFactor) {}
+
+  velox::tpch::Table getTpchTable() const {
+    return tpchTable_;
+  }
+
+  double getScaleFactor() const {
+    return scaleFactor_;
+  }
+
+  std::pair<int64_t, int64_t> sample(
+      const connector::ConnectorTableHandlePtr& handle,
+      float pct,
+      std::vector<core::TypedExprPtr> extraFilters,
+      RowTypePtr outputType = nullptr,
+      const std::vector<common::Subfield>& fields = {},
+      HashStringAllocator* allocator = nullptr,
+      std::vector<ColumnStatistics>* statistics = nullptr) const override;
+
+ private:
+  const velox::tpch::Table tpchTable_;
+  const double scaleFactor_;
+};
+
+class TpchTable : public Table {
+ public:
+  TpchTable(
+      const std::string& name,
+      velox::tpch::Table tpchTable,
+      double scaleFactor)
+      : Table(name), tpchTable_(tpchTable), scaleFactor_(scaleFactor) {}
+
+  std::unordered_map<std::string, std::unique_ptr<Column>>& columns() {
+    return columns_;
+  }
+
+  const std::vector<const TableLayout*>& layouts() const override {
+    return exportedLayouts_;
+  }
+
+  const std::unordered_map<std::string, const Column*>& columnMap()
+      const override;
+
+  void setType(const RowTypePtr& type) {
+    type_ = type;
+  }
+
+  void makeDefaultLayout(TpchConnectorMetadata& metadata);
+
+  uint64_t numRows() const override {
+    return numRows_;
+  }
+
+  velox::tpch::Table getTpchTable() const {
+    return tpchTable_;
+  }
+
+  double getScaleFactor() const {
+    return scaleFactor_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+
+  std::unordered_map<std::string, std::unique_ptr<Column>> columns_;
+
+  mutable std::unordered_map<std::string, const Column*> exportedColumns_;
+
+  std::vector<std::unique_ptr<TableLayout>> layouts_;
+
+  std::vector<const TableLayout*> exportedLayouts_;
+
+  const velox::tpch::Table tpchTable_;
+
+  const double scaleFactor_;
+
+  int64_t numRows_{0};
+
+  friend class TpchConnectorMetadata;
+};
+
+class TpchConnectorMetadata : public ConnectorMetadata {
+ public:
+  TpchConnectorMetadata(
+      TpchConnector* tpchConnector,
+      double scaleFactor = 0.01);
+
+  void initialize() override;
+
+  const Table* findTable(const std::string& name) override;
+
+  ConnectorSplitManager* splitManager() override {
+    ensureInitialized();
+    return &splitManager_;
+  }
+
+  std::shared_ptr<core::QueryCtx> makeQueryCtx(
+      const std::string& queryId) override;
+
+  ColumnHandlePtr createColumnHandle(
+      const TableLayout& layoutData,
+      const std::string& columnName,
+      std::vector<common::Subfield> subfields = {},
+      std::optional<TypePtr> castToType = std::nullopt,
+      SubfieldMapping subfieldMapping = {}) override;
+
+  ConnectorTableHandlePtr createTableHandle(
+      const TableLayout& layout,
+      std::vector<ColumnHandlePtr> columnHandles,
+      core::ExpressionEvaluator& evaluator,
+      std::vector<core::TypedExprPtr> filters,
+      std::vector<core::TypedExprPtr>& rejectedFilters,
+      RowTypePtr dataColumns = nullptr,
+      std::optional<LookupKeys> = std::nullopt) override;
+
+  TpchConnector* tpchConnector() const {
+    return tpchConnector_;
+  }
+
+  double getScaleFactor() const {
+    return scaleFactor_;
+  }
+
+  /// Reinitializes the metadata with a new scale factor.
+  void reinitialize(double newScaleFactor = 0.01);
+
+  const std::unordered_map<std::string, std::unique_ptr<TpchTable>>& tables()
+      const {
+    ensureInitialized();
+    return tables_;
+  }
+
+ private:
+  void ensureInitialized() const;
+  void makeQueryCtx();
+  void initializeTables();
+  void loadTable(velox::tpch::Table tpchTable);
+
+  mutable std::mutex mutex_;
+  mutable bool initialized_{false};
+  TpchConnector* tpchConnector_;
+  double scaleFactor_;
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::unordered_map<std::string, std::unique_ptr<TpchTable>> tables_;
+  TpchSplitManager splitManager_;
+};
+
+} // namespace facebook::velox::connector::tpch

--- a/frontend/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/frontend/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/connectors/tpch/TpchConnectorMetadata.h" //@manual
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include "velox/connectors/tpch/TpchConnector.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::tpch;
+
+class TpchConnectorMetadataTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto config = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{});
+    tpchConnector_ =
+        std::make_shared<TpchConnector>("test-tpch", config, nullptr);
+
+    metadata_ =
+        std::make_unique<TpchConnectorMetadata>(tpchConnector_.get(), 0.01);
+  }
+
+  void TearDown() override {
+    metadata_.reset();
+    tpchConnector_.reset();
+  }
+
+  std::shared_ptr<TpchConnector> tpchConnector_;
+  std::unique_ptr<TpchConnectorMetadata> metadata_;
+};
+
+TEST_F(TpchConnectorMetadataTest, FindAllTables) {
+  metadata_->initialize();
+
+  // Test finding all TPC-H tables
+  std::vector<std::string> expectedTables = {
+      "lineitem",
+      "orders",
+      "customer",
+      "nation",
+      "region",
+      "part",
+      "supplier",
+      "partsupp"};
+
+  for (const auto& tableName : expectedTables) {
+    auto table = metadata_->findTable(tableName);
+    ASSERT_NE(table, nullptr) << "Table " << tableName << " should exist";
+    EXPECT_EQ(table->name(), tableName);
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  facebook::velox::memory::MemoryManagerOptions options;
+  facebook::velox::memory::initializeMemoryManager(options);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary: This diff implements an initial version of TpchConnectorMetadata class and relvant tpch classes that are required to run tpchMetadata correctly. The implementation follows the existing implementation of HiveConnectorMetadata-related classes. The upper layer classes can fetch table and layout information from metadata of TpchConnector.

Reviewed By: kewang1024

Differential Revision: D77706613


