### PR TITLE
feat: Introduce Logical Plan (#30)

### DIFF
--- a/frontend/logical_plan/CMakeLists.txt
+++ b/frontend/logical_plan/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(velox_fe_logical_plan Expr.cpp
+                  ExprPrinter.cpp LogicalPlanNode.cpp PlanPrinter.cpp)
+
+velox_link_libraries(velox_fe_logical_plan velox_type)
+
+velox_add_library(velox_fe_logical_plan_builder PlanBuilder.cpp)
+
+velox_link_libraries(
+  velox_fe_logical_plan_builder
+  velox_fe_logical_plan
+  velox_connector_metadata
+  velox_exec)
+
+add_subdirectory(tests)

--- a/frontend/logical_plan/Expr.cpp
+++ b/frontend/logical_plan/Expr.cpp
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/Expr.h"
+#include <boost/algorithm/string.hpp>
+#include "velox/frontend/logical_plan/ExprVisitor.h"
+#include "velox/frontend/logical_plan/LogicalPlanNode.h"
+
+namespace facebook::velox::logical_plan {
+
+void InputReferenceExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void ConstantExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void CallExpr::accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+    const {
+  visitor.visit(*this, context);
+}
+
+void SpecialFormExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void AggregateExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void WindowExpr::accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+    const {
+  visitor.visit(*this, context);
+}
+
+void LambdaExpr::accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+    const {
+  visitor.visit(*this, context);
+}
+
+void SubqueryExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+// static
+const SortOrder SortOrder::kAscNullsFirst{true, true};
+
+// static
+const SortOrder SortOrder::kAscNullsLast{true, false};
+
+// static
+const SortOrder SortOrder::kDescNullsFirst{false, true};
+
+// static
+const SortOrder SortOrder::kDescNullsLast{false, false};
+
+namespace {
+folly::F14FastMap<SpecialForm, std::string> specialFormNames() {
+  return {
+      {SpecialForm::kAnd, "AND"},
+      {SpecialForm::kOr, "OR"},
+      {SpecialForm::kCast, "CAST"},
+      {SpecialForm::kTryCast, "TRY_CAST"},
+      {SpecialForm::kTry, "TRY"},
+      {SpecialForm::kDereference, "DEREFERENCE"},
+      {SpecialForm::kCoalesce, "COALESCE"},
+      {SpecialForm::kIf, "IF"},
+      {SpecialForm::kSwitch, "SWITCH"},
+  };
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(SpecialForm, specialFormNames)
+
+namespace {
+void validateDereferenceInputs(
+    const TypePtr& type,
+    const std::vector<ExprPtr>& inputs) {
+  VELOX_USER_CHECK_EQ(
+      inputs.size(), 2, "DEREFERENCE must have exactly two inputs");
+
+  VELOX_USER_CHECK_EQ(
+      inputs.at(1)->type()->kind(),
+      TypeKind::VARCHAR,
+      "Second input to DEREFERENCE must be a constant string");
+
+  VELOX_USER_CHECK(
+      inputs.at(1)->isConstant(),
+      "Second input to DEREFERENCE must be a constant string");
+
+  const auto* fieldNameExpr = inputs.at(1)->asUnchecked<ConstantExpr>();
+  VELOX_USER_CHECK(
+      !fieldNameExpr->isNull(), "Second input to DEREFERENCE must not be null");
+
+  const auto& fieldName = fieldNameExpr->value().value<TypeKind::VARCHAR>();
+  VELOX_USER_CHECK(
+      !fieldName.empty(),
+      "Second input to DEREFERENCE must not be emtpy string");
+
+  VELOX_USER_CHECK(
+      inputs.at(0)->type()->isRow(),
+      "First input to DEREFERENCE must not be a struct");
+
+  const auto& rowType = inputs.at(0)->type()->asRow();
+  const auto index = rowType.getChildIdxIfExists(fieldName);
+  VELOX_USER_CHECK(
+      index.has_value(),
+      "Field name specified in DEREFERENCE is not found in the struct: {} not in {}",
+      fieldName,
+      folly::join(", ", rowType.names()));
+
+  VELOX_USER_CHECK(
+      type->equivalent(*rowType.childAt(index.value())),
+      "Result type of DEREFERENCE must be the same as the type of the field: {} vs {}",
+      type->toString(),
+      rowType.childAt(index.value())->toString());
+}
+
+void validateIfInputs(const TypePtr& type, const std::vector<ExprPtr>& inputs) {
+  VELOX_USER_CHECK_GE(
+      inputs.size(), 2, "IF must have exactly either two or three inputs");
+  VELOX_USER_CHECK_LE(
+      inputs.size(), 3, "IF must have exactly either two or three inputs");
+
+  VELOX_USER_CHECK_EQ(
+      inputs.at(0)->type()->kind(),
+      TypeKind::BOOLEAN,
+      "First input to IF must be boolean");
+
+  const auto& thenType = inputs.at(1)->type();
+  VELOX_USER_CHECK(
+      type->equivalent(*thenType),
+      "Second input to IF must have the same type as the result of the expression: {} vs {}",
+      type->toString(),
+      thenType->toString());
+
+  if (inputs.size() == 3) {
+    const auto& elseType = inputs.at(2)->type();
+    VELOX_USER_CHECK(
+        type->equivalent(*elseType),
+        "Third input to IF must have the same type as the result of the expression: {} vs {}",
+        type->toString(),
+        elseType->toString());
+  }
+}
+
+void validateSwitchInputs(
+    const TypePtr& type,
+    const std::vector<ExprPtr>& inputs) {
+  VELOX_USER_CHECK_GE(inputs.size(), 2, "SWITCH must have at least two inputs");
+
+  const auto numCases = inputs.size() / 2;
+
+  for (auto i = 0; i < numCases; ++i) {
+    const auto& condition = inputs.at(2 * i);
+    VELOX_USER_CHECK_EQ(
+        condition->type()->kind(),
+        TypeKind::BOOLEAN,
+        "SWITCH conditions must be boolean");
+
+    const auto& thenClause = inputs.at(2 * i + 1);
+
+    VELOX_USER_CHECK(
+        type->equivalent(*thenClause->type()),
+        "Then clauses in SWITCH must have the same type as the output of the SWITCH: {} vs. {}",
+        type->toString(),
+        thenClause->type()->toString());
+  }
+
+  if (inputs.size() % 2 == 1) {
+    const auto& elseClause = inputs.back();
+    VELOX_USER_CHECK(
+        type->equivalent(*elseClause->type()),
+        "Else clause in SWITCH must have the same type as the output of the SWITCH: {} vs. {}",
+        type->toString(),
+        elseClause->type()->toString());
+  }
+}
+} // namespace
+
+SpecialFormExpr::SpecialFormExpr(
+    const TypePtr& type,
+    SpecialForm form,
+    const std::vector<ExprPtr>& inputs)
+    : Expr(ExprKind::kSpecialForm, type, inputs), form_{form} {
+  switch (form) {
+    case SpecialForm::kAnd:
+    case SpecialForm::kOr:
+      VELOX_USER_CHECK_GE(
+          inputs.size(),
+          2,
+          "{} must have at least two inputs",
+          SpecialFormName::toName(form));
+
+      for (auto& input : inputs) {
+        VELOX_USER_CHECK_EQ(
+            input->type()->kind(),
+            TypeKind::BOOLEAN,
+            "All inputs to AND and OR must be boolean");
+      }
+      break;
+    case SpecialForm::kCast:
+    case SpecialForm::kTryCast:
+    case SpecialForm::kTry:
+      VELOX_USER_CHECK_EQ(
+          inputs.size(),
+          1,
+          "{} must have exactly one input",
+          SpecialFormName::toName(form));
+      break;
+    case SpecialForm::kDereference:
+      validateDereferenceInputs(type, inputs);
+      break;
+    case SpecialForm::kCoalesce: {
+      VELOX_USER_CHECK_GE(
+          inputs.size(), 2, "COALESCE must have at least two inputs");
+
+      const auto& firstType = inputs.at(0)->type();
+      for (auto& input : inputs) {
+        VELOX_USER_CHECK(
+            firstType->equivalent(*input->type()),
+            "All inputs to COALESCE must have the same type: {} vs {}",
+            firstType->toString(),
+            input->type()->toString());
+      }
+      break;
+    }
+    case SpecialForm::kIf:
+      validateIfInputs(type, inputs);
+      break;
+    case SpecialForm::kSwitch:
+      validateSwitchInputs(type, inputs);
+      break;
+  }
+}
+
+CallExpr::CallExpr(
+    const TypePtr& type,
+    const std::string& name,
+    const std::vector<ExprPtr>& inputs)
+    : Expr(ExprKind::kCall, type, inputs), name_{name} {
+  VELOX_USER_CHECK(!name.empty());
+
+  static const auto kReservedNames = Enums::invertMap(specialFormNames());
+
+  VELOX_USER_CHECK(
+      !kReservedNames.contains(boost::algorithm::to_upper_copy(name)),
+      "Function name cannot match special for name: {}",
+      name);
+}
+
+namespace {
+folly::F14FastMap<WindowExpr::WindowType, std::string> windowTypeNames() {
+  return {
+      {WindowExpr::WindowType::kRows, "ROWS"},
+      {WindowExpr::WindowType::kRange, "RANGE"},
+  };
+}
+} // namespace
+
+VELOX_DEFINE_EMBEDDED_ENUM_NAME(WindowExpr, WindowType, windowTypeNames)
+
+namespace {
+folly::F14FastMap<WindowExpr::BoundType, std::string> boundTypeNames() {
+  return {
+      {WindowExpr::BoundType::kCurrentRow, "CURRENT ROW"},
+      {WindowExpr::BoundType::kPreceding, "PRECEDING"},
+      {WindowExpr::BoundType::kFollowing, "FOLLOWING"},
+      {WindowExpr::BoundType::kUnboundedPreceding, "UNBOUNDED PRECEDING"},
+      {WindowExpr::BoundType::kUnboundedFollowing, "UNBOUNDED FOLLOWING"},
+  };
+}
+} // namespace
+
+VELOX_DEFINE_EMBEDDED_ENUM_NAME(WindowExpr, BoundType, boundTypeNames)
+
+SubqueryExpr::SubqueryExpr(const LogicalPlanNodePtr& subquery)
+    : Expr(ExprKind::kSubquery, subquery->outputType()->childAt(0), {}),
+      subquery_{subquery} {
+  VELOX_USER_CHECK_EQ(
+      1,
+      subquery->outputType()->size(),
+      "Scalar subquery must produce exactly one column");
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/Expr.h
+++ b/frontend/logical_plan/Expr.h
@@ -1,0 +1,636 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/Enums.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::logical_plan {
+
+enum class ExprKind {
+  kInputReference = 0,
+  kConstant = 1,
+  kCall = 2,
+  kSpecialForm = 3,
+  kAggregate = 4,
+  kWindow = 5,
+  kLambda = 6,
+  kSubquery = 7,
+};
+
+class Expr;
+using ExprPtr = std::shared_ptr<const Expr>;
+
+class ExprVisitor;
+class ExprVisitorContext;
+
+/// Base class for all expressions. Every expression has a return type and zero
+/// or more inputs. Leaf nodes like Constant and InputReference have no inputs.
+/// Call may have many inputs.
+class Expr {
+ public:
+  Expr(ExprKind kind, const TypePtr& type, const std::vector<ExprPtr>& inputs)
+      : kind_{kind}, type_{type}, inputs_{inputs} {
+    VELOX_USER_CHECK_NOT_NULL(type);
+    for (const auto& input : inputs) {
+      VELOX_USER_CHECK_NOT_NULL(input);
+    }
+  }
+
+  virtual ~Expr() = default;
+
+  ExprKind kind() const {
+    return kind_;
+  }
+
+  const TypePtr& type() const {
+    return type_;
+  }
+
+  /// Convenience getter for the type kind. A shortcut for type()->kind().
+  TypeKind typeKind() const {
+    return type_->kind();
+  }
+
+  const std::vector<ExprPtr>& inputs() const {
+    return inputs_;
+  }
+
+  /// Convenience getter for the input at the specified index. A shortcut for
+  /// inputs().at(index).
+  const ExprPtr& inputAt(int32_t index) const {
+    VELOX_USER_CHECK_GE(index, 0);
+    VELOX_USER_CHECK_LT(index, inputs_.size());
+    return inputs_.at(index);
+  }
+
+  bool isInputReference() const {
+    return kind_ == ExprKind::kInputReference;
+  }
+
+  bool isConstant() const {
+    return kind_ == ExprKind::kConstant;
+  }
+
+  bool isCall() const {
+    return kind_ == ExprKind::kCall;
+  }
+
+  bool isSpecialForm() const {
+    return kind_ == ExprKind::kSpecialForm;
+  }
+
+  bool isAggregate() const {
+    return kind_ == ExprKind::kAggregate;
+  }
+
+  bool isWindow() const {
+    return kind_ == ExprKind::kWindow;
+  }
+
+  bool isLambda() const {
+    return kind_ == ExprKind::kLambda;
+  }
+
+  bool isSubquery() const {
+    return kind_ == ExprKind::kSubquery;
+  }
+
+  template <typename T>
+  const T* asUnchecked() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  virtual void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const = 0;
+
+ private:
+  const ExprKind kind_;
+  const TypePtr type_;
+  const std::vector<ExprPtr> inputs_;
+};
+
+/// Reference to an input column.
+class InputReferenceExpr : public Expr {
+ public:
+  /// @param type Type of the referenced column.
+  /// @param name Name of the referenced column. All names in the plan tree must
+  /// be unique. Columns that are being passed through without modifications can
+  /// keep their names. Two columns with the same name must represent the same
+  /// data. Names cannot be empty.
+  InputReferenceExpr(const TypePtr& type, const std::string& name)
+      : Expr(ExprKind::kInputReference, type, {}), name_{name} {}
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const std::string name_;
+};
+
+using InputReferenceExprPtr = std::shared_ptr<const InputReferenceExpr>;
+
+/// Literal value.
+class ConstantExpr : public Expr {
+ public:
+  ConstantExpr(const TypePtr& type, Variant value)
+      : Expr(ExprKind::kConstant, type, {}), value_{std::move(value)} {
+    if (!isNull()) {
+      VELOX_USER_CHECK(type->kindEquals(value_.inferType()));
+    }
+  }
+
+  const Variant& value() const {
+    return value_;
+  }
+
+  bool isNull() const {
+    return value_.isNull();
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const Variant value_;
+};
+
+using ConstantExprPtr = std::shared_ptr<const ConstantExpr>;
+
+/// Scalar function call.
+class CallExpr : public Expr {
+ public:
+  /// @param type Return type of the call.
+  /// @param name Name of the scalar function. Cannot be any of the special
+  /// forms.
+  /// @param inputs Zero or more inputs / arguments.
+  CallExpr(
+      const TypePtr& type,
+      const std::string& name,
+      const std::vector<ExprPtr>& inputs);
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const std::string name_;
+};
+
+using CallExprPtr = std::shared_ptr<const CallExpr>;
+
+enum class SpecialForm {
+  /// Logical AND. Requires two or more boolean inputs. Commutative. The result
+  /// doesn’t depend on the order of inputs.
+  ///
+  /// AND(false, <anything>) => false
+  /// AND(true, true) => true
+  /// AND(true, NULL) => NULL
+  /// AND(true, throws) => throws
+  /// AND(NULL, throws) => throws
+  ///
+  /// Returns true only if all inputs evaluate to true.
+  ///
+  /// Returns false if at least one input evaluates to false even if some inputs
+  /// return null or throw.
+  ///
+  /// Propagates the exception if an input throws and no other input returns
+  /// false.
+  ///
+  /// Returns NULL if at least one input is NULL and no other input evaluates to
+  /// false or throws.
+  ///
+  /// Stops evaluating inputs once the result is determined (e.g. an input
+  /// evaluates to false).
+  ///
+  /// Doesn't guarantee the order in which inputs are evaluated.
+  kAnd = 0,
+
+  /// Logical OR. Requires two or more boolean inputs. Commutative. The result
+  /// doesn’t depend on the order of inputs.
+  ///
+  /// AND(true, <anything>) => true
+  /// AND(false, true) => false
+  /// AND(false, NULL) => NULL
+  /// AND(false, throws) => throws
+  /// AND(NULL, throws) => throws
+  ///
+  /// Returns false only if all inputs evaluate to false.
+  ///
+  /// Returns true if at least one input evaluates to true even if some inputs
+  /// return null or throw.
+  ///
+  /// Propagates the exception if an input throws and no other input returns
+  /// true.
+  ///
+  /// Returns NULL if at least one input is NULL and no other input evaluates to
+  /// true or throws.
+  ///
+  /// Stops evaluating inputs once the result is determined (e.g. an input
+  /// evaluates to true).
+  ///
+  /// Doesn't guarantee the order in which inputs are evaluated.
+  kOr = 1,
+
+  /// Converts value of one type into another. Requires exactly one input. The
+  /// input type is the source (from) type. The output type is the target (to)
+  /// type.
+  ///
+  /// Redundant casts are not allowed. The “from" type must be different from
+  /// the “to" type.
+  ///
+  /// The exact semantics including the set of supported conversions are
+  /// implementation specific and differ between applications.
+  kCast = 2,
+
+  /// Like CAST, but returns NULL if conversion fails. Requires exactly one
+  /// input.
+  ///
+  /// Unlike TRY(CAST(x)), suppresses conversion failures, but propagates
+  /// failures from evaluating cast input.
+  ///
+  /// Example:
+  ///
+  ///   cast(‘foo’ as integer) => Cannot cast 'foo' to INTEGER
+  ///   try_cast(‘foo’ as integer) => NULL
+  ///
+  ///   cast(10 / 0 as double) => Division by zero
+  ///   try_cast(10 / 0 as double) => Division by zero
+  ///   try(cast(10 / 0 as double)) => NULL
+  kTryCast = 3,
+
+  /// Returns the value of the input expression or NULL if input throws.
+  /// Requires exactly one input.
+  ///
+  /// Example:
+  ///
+  ///   10 / 0 => Division by zero
+  ///   try(10 / 0) => NULL
+  kTry = 4,
+
+  /// Returns the value of the struct field. Requires two inputs: an expression
+  /// that returns a struct (ROW type) and a constant name of the field.
+  kDereference = 5,
+
+  /// Returns the first non-null value or NULL if all inputs are NULL. Requires
+  /// two or more arguments. All arguments must be of the same type. Doesn’t
+  /// evaluate arguments past the first non-NULL.
+  kCoalesce = 6,
+
+  /// IF is a special case of SWITCH.
+  ///
+  /// IF(condition, then)
+  /// IF(condition, then, else)
+  ///
+  /// Takes 2 or 3 inputs: boolean condition, “then" clause, optional “else"
+  /// clause. Returns the results of evaluating the "then" clause if the
+  /// condition evaluates to true. Otherwise, returns the results of evaluating
+  /// the "else" clause or NULL if "else" clause is not specified.
+  ///
+  /// The types of “then" and “else" clauses must be the same and match the
+  /// output type of IF.
+  ///
+  /// Evaluates “then" expression only on rows that pass “condition". Evaluates
+  /// “else" expression only on rows that do not pass “condition".
+  kIf = 7,
+
+  /// case
+  ///   when condition then result
+  ///   [when ...]
+  ///   [else result]
+  /// end
+  ///
+  /// Takes two or more inputs: condition1, then1, condition2, then2,.. else.
+  ///
+  /// Condition inputs must be boolean expressions. Else clause is optional.
+  /// Types of all the then clauses and the else clause must be the same and
+  /// match the output of SWITCH.
+  ///
+  /// Evaluates each boolean condition from left to right until one is true and
+  /// returns the result of evaluating the corresponding then clause. If no
+  /// conditions are true, returns the result of evaluating the else clause or
+  /// NULL if the else clause is not specified.
+  kSwitch = 8,
+
+  // TODO Add IN and EXISTS.
+};
+
+VELOX_DECLARE_ENUM_NAME(SpecialForm)
+
+/// SpecialFormExpr is similar to CallExpr, but has different semantics.
+/// CallExpr represents a function call. It is executed by evaluating all
+/// arguments first, then evaluating the function. Special form may have short
+/// circuit behavior where not all arguments are evaluated all the time.
+/// Special form may produce a result even if some arguments raised an error
+/// during evaluation. Each special form has its own special semantic, hence,
+/// they are special and are not represented using CallExpr.
+class SpecialFormExpr : public Expr {
+ public:
+  SpecialFormExpr(
+      const TypePtr& type,
+      SpecialForm form,
+      const std::vector<ExprPtr>& inputs);
+
+  SpecialForm form() const {
+    return form_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const SpecialForm form_;
+};
+
+using SpecialFormExprPtr = std::shared_ptr<const SpecialFormExpr>;
+
+class SortOrder {
+ public:
+  static const SortOrder kAscNullsFirst;
+  static const SortOrder kAscNullsLast;
+  static const SortOrder kDescNullsFirst;
+  static const SortOrder kDescNullsLast;
+
+  SortOrder(bool ascending, bool nullsFirst)
+      : ascending_(ascending), nullsFirst_(nullsFirst) {}
+
+  bool isAscending() const {
+    return ascending_;
+  }
+
+  bool isNullsFirst() const {
+    return nullsFirst_;
+  }
+
+  bool operator==(const SortOrder& other) const {
+    return std::tie(ascending_, nullsFirst_) ==
+        std::tie(other.ascending_, other.nullsFirst_);
+  }
+
+  bool operator!=(const SortOrder& other) const {
+    return !(*this == other);
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "{} NULLS {}",
+        (ascending_ ? "ASC" : "DESC"),
+        (nullsFirst_ ? "FIRST" : "LAST"));
+  }
+
+ private:
+  bool ascending_;
+  bool nullsFirst_;
+};
+
+struct SortingField {
+  ExprPtr expression;
+  SortOrder order;
+};
+
+/// Aggregate function call. To be used in AggregateNode.
+///
+/// Examples:
+///
+///   sum(x)
+///   sum(x * y)
+///   sum(x) filter (where x > 10)
+///   array_agg(x order by y)
+///   array_agg(distinct x)
+///
+class AggregateExpr : public Expr {
+ public:
+  /// @param type Return type.
+  /// @param name Name of the aggregate function.
+  /// @param inputs Zero or more inputs / arguments. These may contain arbitrary
+  /// trees of scalar expressions. Cannot include AggregateExpr or WindowExpr.
+  /// @param filter Optional predicate. If specified, only rows that satisfy
+  /// the predicate are passed to the aggregate function.
+  /// @param ordering Optional sorting order. If specified, the input rows are
+  /// sorted before passing to the aggregate function.
+  /// @param distinct Whether to deduplicate input rows before passing to the
+  /// aggregate function.
+  AggregateExpr(
+      const TypePtr& type,
+      const std::string& name,
+      const std::vector<ExprPtr>& inputs,
+      const ExprPtr& filter = nullptr,
+      const std::vector<SortingField>& ordering = {},
+      bool distinct = false)
+      : Expr(ExprKind::kAggregate, type, inputs),
+        name_{name},
+        filter_{filter},
+        ordering_{ordering},
+        distinct_{distinct} {
+    VELOX_USER_CHECK(!name.empty());
+
+    if (filter != nullptr) {
+      VELOX_USER_CHECK_EQ(filter->typeKind(), TypeKind::BOOLEAN);
+    }
+
+    if (distinct) {
+      VELOX_USER_CHECK_GT(inputs.size(), 0);
+    }
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const ExprPtr& filter() const {
+    return filter_;
+  }
+
+  const std::vector<SortingField>& ordering() const {
+    return ordering_;
+  }
+
+  bool isDistinct() const {
+    return distinct_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const std::string name_;
+  const ExprPtr filter_;
+  const std::vector<SortingField> ordering_;
+  const bool distinct_;
+};
+
+using AggregateExprPtr = std::shared_ptr<const AggregateExpr>;
+
+// Represents a window function call. Can be used in ProjectNode.
+// TODO Adapt documentation from
+// https://prestodb.io/docs/current/functions/window.html
+class WindowExpr : public Expr {
+ public:
+  enum class WindowType { kRange, kRows, kGroups };
+  VELOX_DECLARE_EMBEDDED_ENUM_NAME(WindowType)
+
+  enum class BoundType {
+    kUnboundedPreceding,
+    kPreceding,
+    kCurrentRow,
+    kFollowing,
+    kUnboundedFollowing
+  };
+  VELOX_DECLARE_EMBEDDED_ENUM_NAME(BoundType)
+
+  /// A sliding window of rows to be processed by the function for a given
+  /// input row. A frame can be ROWS type, RANGE type or GROUPS type, and it
+  /// runs from start to end.
+  struct Frame {
+    WindowType type;
+    BoundType startType;
+    ExprPtr startValue;
+    BoundType endType;
+    ExprPtr endValue;
+  };
+
+  /// @param name Name of a window or aggregate function.
+  /// @param partitionKeys Optional keys to break up the input rows into
+  /// separate partitions, over which the window function is independently
+  /// evaluated.
+  /// @param ordering Determines the order within a partition in which input
+  /// rows are processed by the window function.
+  /// @param frame The window frame within the current partition that
+  /// determines what to include in the window.
+  WindowExpr(
+      const TypePtr& type,
+      const std::string& name,
+      const std::vector<ExprPtr>& inputs,
+      const std::vector<ExprPtr>& partitionKeys,
+      const std::vector<SortingField>& ordering,
+      const Frame& frame,
+      bool ignoreNulls)
+      : Expr(ExprKind::kWindow, type, inputs),
+        name_{name},
+        partitionKeys_{partitionKeys},
+        ordering_{ordering},
+        frame_{frame},
+        ignoreNulls_{ignoreNulls} {}
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const std::vector<ExprPtr>& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const std::vector<SortingField>& ordering() const {
+    return ordering_;
+  }
+
+  const Frame& frame() const {
+    return frame_;
+  }
+
+  bool ignoreNulls() const {
+    return ignoreNulls_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const std::string name_;
+  const std::vector<ExprPtr> partitionKeys_;
+  const std::vector<SortingField> ordering_;
+  const Frame frame_;
+  const bool ignoreNulls_;
+};
+
+using WindowExprPtr = std::shared_ptr<const WindowExpr>;
+
+/// Lambda expression used an argument of a lambda function.
+/// Example:
+///
+///   filter(array, x -> x > 10)
+///
+/// This expression is represented as a CallExpr("filter",...) with 2 inputs:
+/// an expression that produces an array and a LambdaExpr that represents x ->
+/// x > 10.
+///
+/// Lambda expression consists of two parts: signature and body. Signature is
+/// a list of names and types of the arguments (x). Body is the expression: x
+/// > 10.
+///
+/// Lambda body may reference columns that are not part of the signature.
+/// These are called captures. Any columns visible to enclosing CallExpr are
+/// also visible to LambdaExpr.
+class LambdaExpr : public Expr {
+ public:
+  LambdaExpr(const RowTypePtr& signature, const ExprPtr& body)
+      : Expr(
+            ExprKind::kLambda,
+            std::make_shared<FunctionType>(
+                std::vector<TypePtr>(signature->children()),
+                body->type()),
+            {}) {
+    VELOX_USER_CHECK_GT(signature->size(), 0);
+  }
+
+  const RowTypePtr& signature() const {
+    return signature_;
+  }
+
+  const ExprPtr& body() const {
+    return body_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const RowTypePtr signature_;
+  const ExprPtr body_;
+};
+
+using LambdaExprPtr = std::shared_ptr<const LambdaExpr>;
+
+class LogicalPlanNode;
+using LogicalPlanNodePtr = std::shared_ptr<const LogicalPlanNode>;
+
+/// Scalar subquery that returns exactly one row and one column. Can be used
+/// anywhere a scalar function call can be used.
+class SubqueryExpr : public Expr {
+ public:
+  explicit SubqueryExpr(const LogicalPlanNodePtr& subquery);
+
+  const LogicalPlanNodePtr& subquery() const {
+    return subquery_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+ private:
+  const LogicalPlanNodePtr subquery_;
+};
+
+using SubqueryExprPtr = std::shared_ptr<const SubqueryExpr>;
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/ExprPrinter.cpp
+++ b/frontend/logical_plan/ExprPrinter.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/ExprPrinter.h"
+
+namespace facebook::velox::logical_plan {
+
+namespace {
+
+struct ToTextVisitorContext : public ExprVisitorContext {
+  std::stringstream out;
+};
+
+class ToTextVisitor : public ExprVisitor {
+ public:
+  void visit(const InputReferenceExpr& expr, ExprVisitorContext& context)
+      const override {
+    toOut(context) << expr.name();
+  }
+
+  void visit(const CallExpr& expr, ExprVisitorContext& context) const override {
+    auto& out = toOut(context);
+
+    out << expr.name();
+    appendInputs(expr, out, context);
+  }
+
+  void visit(const SpecialFormExpr& expr, ExprVisitorContext& context)
+      const override {
+    auto& out = toOut(context);
+
+    out << SpecialFormName::toName(expr.form());
+
+    if (expr.form() == SpecialForm::kCast ||
+        expr.form() == SpecialForm::kTryCast) {
+      out << "(";
+      expr.inputAt(0)->accept(*this, context);
+      out << " AS " << expr.type()->toString() << ")";
+    } else {
+      appendInputs(expr, out, context);
+    }
+  }
+
+  void visit(const AggregateExpr& expr, ExprVisitorContext& context)
+      const override {
+    auto& out = toOut(context);
+
+    out << expr.name();
+    appendInputs(expr, out, context);
+
+    // TODO Add filter, order by and distinct.
+  }
+
+  void visit(const WindowExpr& expr, ExprVisitorContext& context)
+      const override {
+    auto& out = toOut(context);
+
+    out << expr.name();
+    appendInputs(expr, out, context);
+
+    // TODO Add partitionKeys, ordering, frame, ignoreNulls.
+  }
+
+  void visit(const ConstantExpr& expr, ExprVisitorContext& context)
+      const override {
+    // TODO Avoid using Variant::toString as we do not control its output.
+    toOut(context) << expr.value().toString(expr.type());
+  }
+
+  void visit(const LambdaExpr& expr, ExprVisitorContext& context)
+      const override {
+    auto& out = toOut(context);
+
+    const auto numArgs = expr.signature()->size();
+    for (auto i = 0; i < numArgs; ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+
+      out << expr.signature()->nameOf(i);
+    }
+
+    out << " -> ";
+
+    expr.body()->accept(*this, context);
+  }
+
+  void visit(const SubqueryExpr& /* expr */, ExprVisitorContext& /* context */)
+      const override {
+    // TODO Implement.
+    VELOX_NYI();
+  }
+
+ private:
+  static std::stringstream& toOut(ExprVisitorContext& context) {
+    auto& myContext = static_cast<ToTextVisitorContext&>(context);
+    return myContext.out;
+  }
+
+  void appendInputs(
+      const Expr& expr,
+      std::stringstream& out,
+      ExprVisitorContext& context) const {
+    out << "(";
+    const auto numInputs = expr.inputs().size();
+    for (auto i = 0; i < numInputs; ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+
+      expr.inputAt(i)->accept(*this, context);
+    }
+    out << ")";
+  }
+};
+
+} // namespace
+
+// static
+std::string ExprPrinter::toText(const Expr& root) {
+  ToTextVisitorContext context;
+  ToTextVisitor visitor;
+  root.accept(visitor, context);
+  return context.out.str();
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/ExprPrinter.h
+++ b/frontend/logical_plan/ExprPrinter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/frontend/logical_plan/ExprVisitor.h"
+
+namespace facebook::velox::logical_plan {
+
+class ExprPrinter {
+ public:
+  static std::string toText(const Expr& root);
+};
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/ExprVisitor.h
+++ b/frontend/logical_plan/ExprVisitor.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/frontend/logical_plan/Expr.h"
+
+namespace facebook::velox::logical_plan {
+
+class ExprVisitorContext {
+ public:
+  virtual ~ExprVisitorContext() = default;
+};
+
+class ExprVisitor {
+ public:
+  virtual ~ExprVisitor() = default;
+
+  virtual void visit(
+      const InputReferenceExpr& expr,
+      ExprVisitorContext& context) const = 0;
+
+  virtual void visit(const CallExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const SpecialFormExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const AggregateExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const WindowExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const ConstantExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const LambdaExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const SubqueryExpr& expr, ExprVisitorContext& context)
+      const = 0;
+
+ protected:
+  void visitInputs(const Expr& expr, ExprVisitorContext& ctx) const {
+    for (const auto& input : expr.inputs()) {
+      input->accept(*this, ctx);
+    }
+  }
+};
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/LogicalPlanNode.cpp
+++ b/frontend/logical_plan/LogicalPlanNode.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/LogicalPlanNode.h"
+#include "velox/frontend/logical_plan/PlanNodeVisitor.h"
+
+namespace facebook::velox::logical_plan {
+namespace {
+
+class UniqueNameChecker {
+ public:
+  const std::string& add(const std::string& name) {
+    VELOX_USER_CHECK(!name.empty(), "Name must not be empty");
+    VELOX_USER_CHECK(names_.insert(name).second, "Duplicate name: {}", name);
+    return name;
+  }
+
+  void addAll(const std::vector<std::string>& names) {
+    for (const auto& name : names) {
+      add(name);
+    }
+  }
+
+  static void check(const std::vector<std::string>& names) {
+    UniqueNameChecker{}.addAll(names);
+  }
+
+ private:
+  std::unordered_set<std::string> names_;
+};
+
+} // namespace
+
+ValuesNode::ValuesNode(
+    const std::string& id,
+    const RowTypePtr& rowType,
+    std::vector<Variant> rows)
+    : LogicalPlanNode(NodeKind::kValues, id, {}, rowType),
+      rows_{std::move(rows)} {
+  if (rows_.empty()) {
+    VELOX_USER_CHECK_EQ(0, rowType->size());
+  }
+
+  UniqueNameChecker::check(rowType->names());
+
+  for (const auto& row : rows_) {
+    VELOX_USER_CHECK(
+        rowType->equivalent(*row.inferType()),
+        "Incompatible types: {} vs. {}",
+        rowType->toString(),
+        row.inferType()->toString());
+  }
+}
+
+void ValuesNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void TableScanNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void FilterNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+// static
+RowTypePtr ProjectNode::makeOutputType(
+    const std::vector<std::string>& names,
+    const std::vector<ExprPtr>& expressions) {
+  VELOX_USER_CHECK_EQ(names.size(), expressions.size());
+
+  UniqueNameChecker::check(names);
+
+  std::vector<TypePtr> types;
+  types.reserve(names.size());
+  for (const auto& expression : expressions) {
+    VELOX_USER_CHECK_NOT_NULL(expression);
+    types.push_back(expression->type());
+  }
+
+  return ROW(names, std::move(types));
+}
+
+void ProjectNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+// static
+RowTypePtr AggregateNode::makeOutputType(
+    const std::vector<ExprPtr>& groupingKeys,
+    const std::vector<GroupingSet>& groupingSets,
+    const std::vector<AggregateExprPtr>& aggregates,
+    const std::vector<std::string>& outputNames) {
+  const auto size =
+      groupingKeys.size() + aggregates.size() + (groupingSets.empty() ? 0 : 1);
+
+  VELOX_USER_CHECK_EQ(outputNames.size(), size);
+
+  std::vector<std::string> names = outputNames;
+  std::vector<TypePtr> types;
+  types.reserve(size);
+
+  for (const auto& groupingKey : groupingKeys) {
+    types.push_back(groupingKey->type());
+  }
+
+  for (const auto& aggregate : aggregates) {
+    types.push_back(aggregate->type());
+  }
+
+  if (!groupingSets.empty()) {
+    types.push_back(BIGINT());
+  }
+
+  UniqueNameChecker::check(names);
+
+  return ROW(std::move(names), std::move(types));
+}
+
+void AggregateNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+namespace {
+folly::F14FastMap<JoinType, std::string> joinTypeNames() {
+  return {
+      {JoinType::kInner, "INNER"},
+      {JoinType::kLeft, "LEFT"},
+      {JoinType::kRight, "RIGHT"},
+      {JoinType::kFull, "FULL"},
+  };
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(JoinType, joinTypeNames)
+
+// static
+RowTypePtr JoinNode::makeOutputType(
+    const LogicalPlanNodePtr& left,
+    const LogicalPlanNodePtr& right) {
+  auto type = left->outputType()->unionWith(right->outputType());
+
+  UniqueNameChecker::check(type->names());
+
+  return type;
+}
+
+void JoinNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void SortNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+void LimitNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+namespace {
+folly::F14FastMap<SetOperation, std::string> setOperationNames() {
+  return {
+      {SetOperation::kUnion, "UNION"},
+      {SetOperation::kUnionAll, "UNION ALL"},
+      {SetOperation::kIntersect, "INTERSECT"},
+      {SetOperation::kExcept, "EXCEPT"},
+  };
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(SetOperation, setOperationNames)
+
+void SetNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+// static
+RowTypePtr UnnestNode::makeOutputType(
+    const LogicalPlanNodePtr& input,
+    const std::vector<ExprPtr>& unnestExpressions,
+    const std::vector<std::vector<std::string>>& unnestedNames,
+    const std::optional<std::string>& ordinalityName,
+    bool flattenArrayOfRows) {
+  VELOX_USER_CHECK_EQ(unnestedNames.size(), unnestExpressions.size());
+  VELOX_USER_CHECK_GT(
+      unnestedNames.size(),
+      0,
+      "Unnest requires at least one ARRAY or MAP to expand");
+
+  auto size = input->outputType()->size();
+  for (const auto& names : unnestedNames) {
+    size += names.size();
+  }
+
+  std::vector<std::string> names;
+  names.reserve(size);
+
+  std::vector<TypePtr> types;
+  types.reserve(size);
+
+  names = input->outputType()->names();
+  types = input->outputType()->children();
+
+  const auto numUnnest = unnestExpressions.size();
+  for (auto i = 0; i < numUnnest; ++i) {
+    const auto& type = unnestExpressions.at(i)->type();
+
+    VELOX_USER_CHECK(
+        type->isArray() || type->isMap(),
+        "A column to unnest must be an ARRAY or a MAP: {}",
+        type->toString());
+
+    const auto& outputNames = unnestedNames.at(i);
+    const auto& numOutput = outputNames.size();
+
+    if (flattenArrayOfRows && type->isArray() && type->childAt(0)->isRow()) {
+      const auto& rowType = type->childAt(0);
+      VELOX_USER_CHECK_EQ(numOutput, rowType->size());
+
+      for (auto j = 0; j < numOutput; ++j) {
+        names.push_back(outputNames.at(j));
+        types.push_back(rowType->childAt(j));
+      }
+    } else {
+      VELOX_USER_CHECK_EQ(numOutput, type->size());
+      for (auto j = 0; j < numOutput; ++j) {
+        names.push_back(outputNames.at(j));
+        types.push_back(type->childAt(j));
+      }
+    }
+  }
+
+  if (ordinalityName.has_value()) {
+    names.push_back(ordinalityName.value());
+    types.push_back(BIGINT());
+  }
+
+  UniqueNameChecker::check(names);
+
+  return ROW(std::move(names), std::move(types));
+}
+
+void UnnestNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/LogicalPlanNode.h
+++ b/frontend/logical_plan/LogicalPlanNode.h
@@ -1,0 +1,642 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/Enums.h"
+#include "velox/frontend/logical_plan/Expr.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::logical_plan {
+
+enum class NodeKind {
+  kValues = 0,
+  kTableScan = 1,
+  kFilter = 2,
+  kProject = 3,
+  kAggregate = 4,
+  kJoin = 5,
+  kSort = 6,
+  kLimit = 7,
+  kSet = 8,
+  kUnnest = 9,
+};
+
+class LogicalPlanNode;
+using LogicalPlanNodePtr = std::shared_ptr<const LogicalPlanNode>;
+
+class PlanNodeVisitor;
+class PlanNodeVisitorContext;
+
+/// Base class for all logical plan nodes. Every plan node has a unique ID and
+/// zero or more inputs. Leaf nodes like Scan and Values have no inputs. Joins
+/// have two inputs. Union may have many inputs. Most other nodes have just
+/// one input. Every plan node has an output schema (list of names and types
+/// of output columns) expressed as a RowType.
+class LogicalPlanNode {
+ public:
+  LogicalPlanNode(
+      NodeKind kind,
+      const std::string& id,
+      const std::vector<LogicalPlanNodePtr>& inputs,
+      const RowTypePtr& outputType)
+      : kind_{kind}, id_{id}, inputs_{inputs}, outputType_{outputType} {
+    VELOX_USER_CHECK_NOT_NULL(outputType);
+    for (const auto& input : inputs_) {
+      VELOX_USER_CHECK_NOT_NULL(input);
+    }
+  }
+
+  virtual ~LogicalPlanNode() = default;
+
+  NodeKind kind() const {
+    return kind_;
+  }
+
+  const std::string& id() const {
+    return id_;
+  }
+
+  const std::vector<LogicalPlanNodePtr>& inputs() const {
+    return inputs_;
+  }
+
+  /// Returns the only input. Throws if there are zero or more than one inputs.
+  const LogicalPlanNodePtr& onlyInput() const {
+    VELOX_USER_CHECK_EQ(1, inputs_.size());
+    return inputs_.at(0);
+  }
+
+  /// Convenience getter for the input at the specified index. A shortcut for
+  /// inputs().at(index).
+  const LogicalPlanNodePtr& inputAt(size_t index) const {
+    VELOX_USER_CHECK_LT(index, inputs_.size());
+    return inputs_.at(index);
+  }
+
+  const RowTypePtr& outputType() const {
+    return outputType_;
+  }
+
+  virtual void accept(
+      const PlanNodeVisitor& visitor,
+      PlanNodeVisitorContext& context) const = 0;
+
+ private:
+  const NodeKind kind_;
+  const std::string id_;
+  const std::vector<LogicalPlanNodePtr> inputs_;
+  const RowTypePtr outputType_;
+};
+
+/// A table whose content is embedded in the plan.
+class ValuesNode : public LogicalPlanNode {
+ public:
+  /// @param rowType Output schema. A list of column names and types. All names
+  /// must be non-empty and unique.
+  /// @param rows A list of rows. Each row is a list of values, one per column.
+  /// The number, order and types of columns must match 'rowType'.
+  ValuesNode(
+      const std::string& id,
+      const RowTypePtr& rowType,
+      std::vector<Variant> rows);
+
+  const std::vector<Variant>& rows() const {
+    return rows_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::vector<Variant> rows_;
+};
+
+using ValuesNodePtr = std::shared_ptr<const ValuesNode>;
+
+/// A table accessible through a connector.
+class TableScanNode : public LogicalPlanNode {
+ public:
+  /// @param id Unique ID of the plan node.
+  /// @param outputType Output schema. A list of column names and types.
+  /// @param connectorId ID of the connector to use to access the table.
+  /// @param tableName Table name.
+  /// @param columnNames A list of column names. Must align with 'outputType',
+  /// which may expose columns under different names.
+  TableScanNode(
+      const std::string& id,
+      const RowTypePtr& outputType,
+      const std::string& connectorId,
+      const std::string& tableName,
+      const std::vector<std::string>& columnNames)
+      : LogicalPlanNode(NodeKind::kTableScan, id, {}, outputType),
+        connectorId_{connectorId},
+        tableName_(tableName),
+        columnNames_(columnNames) {
+    VELOX_USER_CHECK_EQ(outputType->size(), columnNames.size());
+
+    const auto numColumns = outputType->size();
+    for (auto i = 0; i < numColumns; ++i) {
+      VELOX_USER_CHECK(!outputType->nameOf(i).empty());
+      VELOX_USER_CHECK(!columnNames.at(i).empty());
+    }
+  }
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const std::string& tableName() const {
+    return tableName_;
+  }
+
+  const std::vector<std::string>& columnNames() const {
+    return columnNames_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::string connectorId_;
+  const std::string tableName_;
+  const std::vector<std::string> columnNames_;
+};
+
+using TableScanNodePtr = std::shared_ptr<const TableScanNode>;
+
+/// Eliminates zero or more rows from the input based on a boolean expression.
+/// The output schema is the same as the input schema. This node may reduce the
+/// cardinality of the dataset, but it cannot increase it.
+class FilterNode : public LogicalPlanNode {
+ public:
+  FilterNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const ExprPtr& predicate)
+      : LogicalPlanNode(NodeKind::kFilter, id, {input}, input->outputType()),
+        predicate_{predicate} {
+    VELOX_USER_CHECK_NOT_NULL(predicate);
+    VELOX_USER_CHECK_EQ(predicate->type()->kind(), TypeKind::BOOLEAN);
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+  const ExprPtr& predicate() const {
+    return predicate_;
+  }
+
+ private:
+  const ExprPtr predicate_;
+};
+
+using FilterNodePtr = std::shared_ptr<const FilterNode>;
+
+/// Produces one or more columns using specified expressions. The output
+/// schema matches the list of names and expressions. This not doesn't change
+/// the cardinality of the dataset.
+class ProjectNode : public LogicalPlanNode {
+ public:
+  /// @param names List of output column names. Names must be non-empty and
+  /// unique.
+  /// @param expressions List of expressions aligned with 'names'. Expressions
+  /// may be scalar or window function calls. For any give expression, only
+  /// the root expression can be a window function call. Scalar expressions
+  /// over window function calls are not supported.
+  ProjectNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const std::vector<std::string>& names,
+      const std::vector<ExprPtr>& expressions)
+      : LogicalPlanNode(
+            NodeKind::kProject,
+            id,
+            {input},
+            makeOutputType(names, expressions)),
+        names_{names},
+        expressions_{expressions} {}
+
+  const std::vector<std::string>& names() const {
+    return names_;
+  }
+
+  const std::vector<ExprPtr>& expressions() const {
+    return expressions_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static RowTypePtr makeOutputType(
+      const std::vector<std::string>& names,
+      const std::vector<ExprPtr>& expressions);
+
+  const std::vector<std::string> names_;
+  const std::vector<ExprPtr> expressions_;
+};
+
+using ProjectNodePtr = std::shared_ptr<const ProjectNode>;
+
+/// Groups input data on one or more sets of grouping keys, calculating each
+/// measure for each combination of the grouping keys. The order of columns in
+/// the output schema is: grouping keys, followed by aggregations, optionally
+/// followed by a grouping set index. This node may decrease the cardinality of
+/// the dataset. Unless there are multiple grouping sets, this node cannot
+/// increase the cardinality.
+class AggregateNode : public LogicalPlanNode {
+ public:
+  using GroupingSet = std::vector<int32_t>;
+
+  /// @param groupingKeys Zero or more grouping keys. If empty, at least one
+  /// aggregate must be specified.
+  /// @param groupingSets Zero of more grouping sets. Each set is a list of
+  /// grouping keys specified by an index into 'groupingKeys' array.
+  /// @param aggregates Zero or more aggregates. Must be aligned with
+  /// 'aggregateNames'. If empty, at least one grouping key must be specified.
+  /// Each aggregate is a call to an aggregate function. Each aggregate may
+  /// specify (1) a filter to apply to the input rows; (2) a sorting order to
+  /// apply to input rows; (2) whether to deduplicate input rows. Used to
+  /// support agg(DISTINCT x ORDER BY y) FILTER (WHERE f(z)) SQL syntax.
+  /// @param outputNames List of names of the output columns: one name for each
+  /// grouping key, followed by one name for each aggregate, followed
+  /// by the name of a column that contains grouping set index if 'groupingSets'
+  /// is not empty. Names must be unique.
+  AggregateNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const std::vector<ExprPtr>& groupingKeys,
+      const std::vector<GroupingSet>& groupingSets,
+      const std::vector<AggregateExprPtr>& aggregates,
+      const std::vector<std::string>& outputNames)
+      : LogicalPlanNode(
+            NodeKind::kAggregate,
+            id,
+            {input},
+            makeOutputType(
+                groupingKeys,
+                groupingSets,
+                aggregates,
+                outputNames)),
+        groupingKeys_{groupingKeys},
+        groupingSets_{groupingSets},
+        aggregates_{aggregates},
+        outputNames_{outputNames} {
+    if (groupingKeys.empty()) {
+      VELOX_USER_CHECK(
+          !aggregates.empty(),
+          "Aggregation node must specify at least one aggregate or grouping key");
+    }
+
+    if (aggregates.empty()) {
+      VELOX_USER_CHECK(
+          !groupingKeys.empty(),
+          "Aggregation node must specify at least one aggregate or grouping key");
+    }
+
+    for (const auto& groupingSet : groupingSets) {
+      for (const auto& key : groupingSet) {
+        VELOX_USER_CHECK_LT(key, groupingKeys.size());
+      }
+    }
+  }
+
+  const std::vector<ExprPtr>& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const std::vector<GroupingSet>& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const std::vector<std::string>& outputNames() const {
+    return outputNames_;
+    ;
+  }
+
+  const std::vector<AggregateExprPtr>& aggregates() const {
+    return aggregates_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static RowTypePtr makeOutputType(
+      const std::vector<ExprPtr>& groupingKeys,
+      const std::vector<GroupingSet>& groupingSets,
+      const std::vector<AggregateExprPtr>& aggregates,
+      const std::vector<std::string>& outputNames);
+
+  const std::vector<ExprPtr> groupingKeys_;
+  const std::vector<GroupingSet> groupingSets_;
+  const std::vector<AggregateExprPtr> aggregates_;
+  const std::vector<std::string> outputNames_;
+};
+
+using AggregateNodePtr = std::shared_ptr<const AggregateNode>;
+
+enum class JoinType {
+  /// For each row on the left, find all matching rows on the right and return
+  /// all combinations.
+  kInner = 0,
+
+  /// For each row on the left, find all matching rows on the right and return
+  /// all combinations. In addition, return all rows from the left that have no
+  /// match on the right with right-side columns filled with nulls.
+  kLeft = 1,
+
+  /// Opposite of kLeft. For each row on the right, find all matching rows on
+  /// the left and return all combinations. In addition, return all rows from
+  /// the
+  /// right that have no match on the left with left-side columns filled with
+  /// nulls.
+  kRight = 2,
+
+  /// A "union" of kLeft and kRight. For each row on the left, find all
+  /// matching rows on the right and return all combinations. In addition,
+  /// return all rows from the left that have no match on the right with
+  /// right-side columns filled with nulls. Also, return
+  /// all rows from the right that have no match on the left with left-side
+  /// columns filled with nulls.
+  kFull = 3,
+};
+
+VELOX_DECLARE_ENUM_NAME(JoinType)
+
+/// Combines two separate inputs into a single output, based on a boolean join
+/// condition. The output schema contains all columns from the left input
+/// followed by all columns from the right input.
+class JoinNode : public LogicalPlanNode {
+ public:
+  /// @param condition Optional join condition. If nullptr, the output is a
+  /// cross product of the inputs.
+  JoinNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& left,
+      const LogicalPlanNodePtr& right,
+      JoinType joinType,
+      const ExprPtr& condition)
+      : LogicalPlanNode(
+            NodeKind::kJoin,
+            id,
+            {left, right},
+            makeOutputType(left, right)),
+        joinType_{joinType},
+        condition_{condition} {
+    if (condition != nullptr) {
+      VELOX_USER_CHECK_EQ(condition->typeKind(), TypeKind::BOOLEAN);
+    }
+  }
+
+  const LogicalPlanNodePtr& left() const {
+    return inputAt(0);
+  }
+
+  const LogicalPlanNodePtr& right() const {
+    return inputAt(1);
+  }
+
+  JoinType joinType() const {
+    return joinType_;
+  }
+
+  const ExprPtr& condition() const {
+    return condition_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static RowTypePtr makeOutputType(
+      const LogicalPlanNodePtr& left,
+      const LogicalPlanNodePtr& right);
+
+  const JoinType joinType_;
+  const ExprPtr condition_;
+};
+
+using JoinNodePtr = std::shared_ptr<const JoinNode>;
+
+/// Sort rows based on one or more sort fields. The output schema for this node
+/// matches the input. This node doesn't change the cardinality of the dataset.
+class SortNode : public LogicalPlanNode {
+ public:
+  SortNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const std::vector<SortingField>& ordering)
+      : LogicalPlanNode(NodeKind::kSort, id, {input}, input->outputType()),
+        ordering_{ordering} {
+    VELOX_USER_CHECK(!ordering.empty());
+  }
+
+  const std::vector<SortingField> ordering() const {
+    return ordering_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::vector<SortingField> ordering_;
+};
+
+using SortNodePtr = std::shared_ptr<const SortNode>;
+
+/// Eliminates rows outside of the desired window. Returns up to 'count' rows
+/// starting from 'offset'. The output schema of this node matches the input.
+class LimitNode : public LogicalPlanNode {
+ public:
+  /// @param offset Zero-based index of the first row to return. Must be >= 0.
+  /// @param count Maximum number of rows to return. Must be >= 0. If zero, the
+  /// node produces empty dataset.
+  LimitNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      int64_t offset,
+      int64_t count)
+      : LogicalPlanNode(NodeKind::kLimit, id, {input}, input->outputType()),
+        offset_{offset},
+        count_{count} {
+    VELOX_USER_CHECK_GE(offset, 0);
+    VELOX_USER_CHECK_GE(count, 0);
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using LimitNodePtr = std::shared_ptr<const LimitNode>;
+
+enum class SetOperation {
+  /// Returns all rows from all inputs after removing duplicates.
+  kUnion = 0,
+
+  /// Returns all rows from all inputs.
+  kUnionAll = 1,
+
+  /// Returns a subset of rows that are present in all inputs.
+  kIntersect = 2,
+
+  /// Returns a subset of rows in the first input that are not found in any
+  /// other input.
+  kExcept = 3,
+};
+
+VELOX_DECLARE_ENUM_NAME(SetOperation)
+
+/// Set-level operation that supports combining datasets, possibly excluding
+/// rows based on various types of row level matching.
+class SetNode : public LogicalPlanNode {
+ public:
+  SetNode(
+      const std::string& id,
+      const std::vector<LogicalPlanNodePtr>& inputs,
+      SetOperation operation)
+      : LogicalPlanNode(NodeKind::kSet, id, inputs, inputs.at(0)->outputType()),
+        operation_{operation} {
+    VELOX_USER_CHECK_GE(
+        inputs.size(), 2, "Set operation requires at least 2 inputs");
+    for (const auto& input : inputs) {
+      VELOX_USER_CHECK(
+          *input->outputType() == *outputType(),
+          "Output schemas of all inputs to a Set operation must match");
+    }
+  }
+
+  SetOperation operation() const {
+    return operation_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  const SetOperation operation_;
+};
+
+using SetNodePtr = std::shared_ptr<const SetNode>;
+
+/// Used to expand an ARRAY or MAP into a relation. Arrays are expanded into a
+/// single column, and maps are expanded into two columns (key, value). Can also
+/// be used to expand multiple arrays and maps, in which case they are expanded
+/// into multiple columns, with as many rows as the highest cardinality array or
+/// map (the other columns are padded with nulls). Can optionally request to
+/// produce an ordinality column.
+///
+/// If 'flattenArrayOfRows' is true, ARRAY(ROW) is expanded into multiple
+/// columns, one per struct field.
+///
+/// Duplicates each input row by combining it with every row in the relation
+/// produced by expanding the unnest expressions.
+///
+/// Rows with empty arrays or map do not appear in the output.
+///
+/// This operation typically increases the cardinality of the dataset. However,
+/// it may also reduce the cardinality if there are many rows with empty arrays
+/// and maps.
+///
+/// The output schema contains all columns from the input, followed by columns
+/// in the relation produced by expanding the unnest expressions, followed by an
+/// optional ordinality column of type BIGINT.
+class UnnestNode : public LogicalPlanNode {
+ public:
+  UnnestNode(
+      /// @param unnestExpressions One or more expressions that produce ARRAYs
+      /// or MAPs.
+      /// @param unnestedNames Names to use for expanded relations. Must align
+      /// with 'unnestExpressions'. Each ARRAY requires one name. Each MAP
+      /// requires two maps. If 'flattenArrayOfRows' is true, each ARRAY(ROW)
+      /// requires as many names as there are fields in the ROW.
+      /// @param ordinalityName Optional name for the ordinality output column.
+      /// If not specified, ordinality column is not added. Ordinality is
+      /// 1-based.
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const std::vector<ExprPtr>& unnestExpressions,
+      const std::vector<std::vector<std::string>>& unnestedNames,
+      const std::optional<std::string>& ordinalityName,
+      bool flattenArrayOfRows = false)
+      : LogicalPlanNode(
+            NodeKind::kUnnest,
+            id,
+            {input},
+            makeOutputType(
+                input,
+                unnestExpressions,
+                unnestedNames,
+                ordinalityName,
+                flattenArrayOfRows)),
+        unnestExpressions_(unnestExpressions),
+        unnestedNames_(unnestedNames),
+        ordinalityName_{ordinalityName},
+        flattenArrayOfRows_{flattenArrayOfRows} {
+    if (ordinalityName.has_value()) {
+      VELOX_USER_CHECK(
+          !ordinalityName->empty(), "Ordinality column name must be not empty");
+    }
+  }
+
+  const std::vector<ExprPtr>& unnestExpressions() const {
+    return unnestExpressions_;
+  }
+
+  const std::vector<std::vector<std::string>>& unnestedNames() const {
+    return unnestedNames_;
+  }
+
+  const std::optional<std::string>& ordinalityName() const {
+    return ordinalityName_;
+  }
+
+  bool flattenArrayOfRows() const {
+    return flattenArrayOfRows_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static RowTypePtr makeOutputType(
+      const LogicalPlanNodePtr& input,
+      const std::vector<ExprPtr>& unnestExpressions,
+      const std::vector<std::vector<std::string>>& unnestedNames,
+      const std::optional<std::string>& ordinalityName,
+      bool flattenArrayOfRows);
+
+  const std::vector<ExprPtr> unnestExpressions_;
+  const std::vector<std::vector<std::string>> unnestedNames_;
+  const std::optional<std::string> ordinalityName_;
+  const bool flattenArrayOfRows_;
+};
+
+using UnnestNodePtr = std::shared_ptr<const UnnestNode>;
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/PlanBuilder.cpp
+++ b/frontend/logical_plan/PlanBuilder.cpp
@@ -1,0 +1,730 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/PlanBuilder.h"
+#include "velox/connectors/Connector.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/frontend/optimizer/connectors/ConnectorMetadata.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::logical_plan {
+
+PlanBuilder& PlanBuilder::values(
+    const RowTypePtr& rowType,
+    std::vector<Variant> rows) {
+  VELOX_USER_CHECK_NULL(node_, "Values node must be the leaf node");
+
+  outputMapping_ = std::make_shared<NameMappings>();
+
+  const auto numColumns = rowType->size();
+  std::vector<std::string> outputNames;
+  outputNames.reserve(numColumns);
+  for (const auto& name : rowType->names()) {
+    outputNames.push_back(newName(name));
+    outputMapping_->add(name, outputNames.back());
+  }
+
+  node_ = std::make_shared<ValuesNode>(
+      nextId(), ROW(outputNames, rowType->children()), std::move(rows));
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::tableScan(
+    const std::string& connectorId,
+    const std::string& tableName,
+    const std::vector<std::string>& columnNames) {
+  VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
+
+  auto* metadata = connector::getConnector(connectorId)->metadata();
+  auto* table = metadata->findTable(tableName);
+  const auto& schema = table->rowType();
+
+  const auto numColumns = columnNames.size();
+
+  std::vector<TypePtr> columnTypes;
+  columnTypes.reserve(numColumns);
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(numColumns);
+
+  outputMapping_ = std::make_shared<NameMappings>();
+
+  for (const auto& name : columnNames) {
+    columnTypes.push_back(schema->findChild(name));
+
+    outputNames.push_back(newName(name));
+    outputMapping_->add(name, outputNames.back());
+  }
+
+  node_ = std::make_shared<TableScanNode>(
+      nextId(),
+      ROW(columnNames, columnTypes),
+      connectorId,
+      tableName,
+      outputNames);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::filter(const std::string& predicate) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Filter node cannot be a leaf node");
+
+  auto untypedExpr = parse::parseExpr(predicate, parseOptions_);
+  auto expr = resolveScalarTypes(untypedExpr);
+
+  node_ = std::make_shared<FilterNode>(nextId(), node_, expr);
+
+  return *this;
+}
+
+namespace {
+std::optional<std::string> tryGetRootName(const core::ExprPtr& expr) {
+  if (const auto* fieldAccess =
+          dynamic_cast<const core::FieldAccessExpr*>(expr.get())) {
+    if (fieldAccess->isRootColumn()) {
+      return fieldAccess->name();
+    }
+  }
+
+  return std::nullopt;
+}
+} // namespace
+
+void PlanBuilder::resolveProjections(
+    const std::vector<std::string>& projections,
+    std::vector<std::string>& outputNames,
+    std::vector<ExprPtr>& exprs,
+    NameMappings& mappings) {
+  for (const auto& sql : projections) {
+    auto untypedExpr = parse::parseExpr(sql, parseOptions_);
+    auto expr = resolveScalarTypes(untypedExpr);
+
+    if (untypedExpr->alias().has_value()) {
+      const auto& alias = untypedExpr->alias().value();
+      outputNames.push_back(newName(alias));
+      mappings.add(alias, outputNames.back());
+    } else if (expr->isInputReference()) {
+      // Identity projection
+      const auto& id = expr->asUnchecked<InputReferenceExpr>()->name();
+      outputNames.push_back(id);
+
+      const auto names = outputMapping_->reverseLookup(id);
+      VELOX_USER_CHECK(!names.empty());
+
+      for (const auto& name : names) {
+        mappings.add(name, id);
+      }
+    } else {
+      outputNames.push_back(newName("expr"));
+    }
+
+    exprs.push_back(expr);
+  }
+}
+
+PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Project node cannot be a leaf node");
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(projections.size());
+
+  std::vector<ExprPtr> exprs;
+  exprs.reserve(projections.size());
+
+  auto newOutputMapping = std::make_shared<NameMappings>();
+
+  resolveProjections(projections, outputNames, exprs, *newOutputMapping);
+
+  node_ = std::make_shared<ProjectNode>(nextId(), node_, outputNames, exprs);
+  outputMapping_ = newOutputMapping;
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::with(const std::vector<std::string>& projections) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Project node cannot be a leaf node");
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(projections.size());
+
+  std::vector<ExprPtr> exprs;
+  exprs.reserve(projections.size());
+
+  auto newOutputMapping = std::make_shared<NameMappings>();
+
+  const auto& inputType = node_->outputType();
+
+  for (auto i = 0; i < inputType->size(); i++) {
+    const auto& id = inputType->nameOf(i);
+
+    outputNames.push_back(id);
+
+    const auto names = outputMapping_->reverseLookup(id);
+    for (const auto& name : names) {
+      newOutputMapping->add(name, id);
+    }
+
+    exprs.push_back(
+        std::make_shared<InputReferenceExpr>(inputType->childAt(i), id));
+  }
+
+  resolveProjections(projections, outputNames, exprs, *newOutputMapping);
+
+  node_ = std::make_shared<ProjectNode>(nextId(), node_, outputNames, exprs);
+  outputMapping_ = newOutputMapping;
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Aggregate node cannot be a leaf node");
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(groupingKeys.size() + aggregates.size());
+
+  std::vector<ExprPtr> keyExprs;
+  keyExprs.reserve(groupingKeys.size());
+
+  auto newOutputMapping = std::make_shared<NameMappings>();
+
+  resolveProjections(groupingKeys, outputNames, keyExprs, *newOutputMapping);
+
+  std::vector<AggregateExprPtr> exprs;
+  exprs.reserve(aggregates.size());
+
+  for (const auto& sql : aggregates) {
+    auto untypedExpr = parse::parseExpr(sql, parseOptions_);
+    auto expr = resolveAggregateTypes(untypedExpr);
+
+    if (untypedExpr->alias().has_value()) {
+      const auto& alias = untypedExpr->alias().value();
+      outputNames.push_back(newName(alias));
+      newOutputMapping->add(alias, outputNames.back());
+    } else {
+      outputNames.push_back(newName(expr->name()));
+    }
+
+    exprs.push_back(expr);
+  }
+
+  node_ = std::make_shared<AggregateNode>(
+      nextId(),
+      node_,
+      keyExprs,
+      std::vector<AggregateNode::GroupingSet>{},
+      exprs,
+      outputNames);
+
+  outputMapping_ = newOutputMapping;
+
+  return *this;
+}
+
+namespace {
+
+ExprPtr resolveJoinInputName(
+    const std::optional<std::string>& alias,
+    const std::string& name,
+    const NameMappings& mapping,
+    const RowTypePtr& inputRowType) {
+  if (alias.has_value()) {
+    if (auto id = mapping.lookup(alias.value(), name)) {
+      return std::make_shared<InputReferenceExpr>(
+          inputRowType->findChild(id.value()), id.value());
+    }
+
+    return nullptr;
+  }
+
+  if (auto id = mapping.lookup(name)) {
+    return std::make_shared<InputReferenceExpr>(
+        inputRowType->findChild(id.value()), id.value());
+  }
+
+  VELOX_USER_FAIL(
+      "Cannot resolve column in join input: {} not found in [{}]",
+      NameMappings::QualifiedName{alias, name}.toString(),
+      mapping.toString());
+}
+
+std::string toString(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes) {
+  std::ostringstream signature;
+  signature << functionName << "(";
+  for (auto i = 0; i < argTypes.size(); i++) {
+    if (i > 0) {
+      signature << ", ";
+    }
+    signature << argTypes[i]->toString();
+  }
+  signature << ")";
+  return signature.str();
+}
+
+std::string toString(
+    const std::vector<const exec::FunctionSignature*>& signatures) {
+  std::stringstream out;
+  for (auto i = 0; i < signatures.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << signatures[i]->toString();
+  }
+  return out.str();
+}
+
+TypePtr resolveScalarFunction(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes) {
+  if (auto type = resolveFunction(name, argTypes)) {
+    return type;
+  }
+
+  auto allSignatures = getFunctionSignatures();
+  auto it = allSignatures.find(name);
+  if (it == allSignatures.end()) {
+    VELOX_USER_FAIL("Scalar function doesn't exist: {}.", name);
+  } else {
+    const auto& functionSignatures = it->second;
+    VELOX_USER_FAIL(
+        "Scalar function signature is not supported: {}. Supported signatures: {}.",
+        toString(name, argTypes),
+        toString(functionSignatures));
+  }
+}
+
+ExprPtr tryResolveSpecialForm(
+    const std::string& name,
+    const std::vector<ExprPtr>& resolvedInputs) {
+  if (name == "and") {
+    return std::make_shared<SpecialFormExpr>(
+        BOOLEAN(), SpecialForm::kAnd, resolvedInputs);
+  }
+
+  if (name == "or") {
+    return std::make_shared<SpecialFormExpr>(
+        BOOLEAN(), SpecialForm::kOr, resolvedInputs);
+  }
+
+  if (name == "try") {
+    VELOX_USER_CHECK_EQ(resolvedInputs.size(), 1, "TRY must have one argument");
+    return std::make_shared<SpecialFormExpr>(
+        resolvedInputs.at(0)->type(), SpecialForm::kTry, resolvedInputs);
+  }
+
+  if (name == "coalesce") {
+    VELOX_USER_CHECK_GE(
+        resolvedInputs.size(), 2, "COALESCE must have at least two arguments");
+    return std::make_shared<SpecialFormExpr>(
+        resolvedInputs.at(0)->type(), SpecialForm::kCoalesce, resolvedInputs);
+  }
+
+  if (name == "if") {
+    VELOX_USER_CHECK_GE(
+        resolvedInputs.size(), 2, "IF must have at least two arguments");
+    return std::make_shared<SpecialFormExpr>(
+        resolvedInputs.at(1)->type(), SpecialForm::kIf, resolvedInputs);
+  }
+
+  if (name == "switch") {
+    VELOX_USER_CHECK_GE(
+        resolvedInputs.size(), 2, "SWITCH must have at least two arguments");
+    return std::make_shared<SpecialFormExpr>(
+        resolvedInputs.at(1)->type(), SpecialForm::kSwitch, resolvedInputs);
+  }
+
+  return nullptr;
+}
+
+ExprPtr resolveScalarTypesImpl(
+    const core::ExprPtr& expr,
+    const std::function<ExprPtr(
+        const std::optional<std::string>& alias,
+        const std::string& fieldName)>& inputNameResolver) {
+  if (const auto* fieldAccess =
+          dynamic_cast<const core::FieldAccessExpr*>(expr.get())) {
+    const auto& name = fieldAccess->name();
+
+    if (fieldAccess->isRootColumn()) {
+      return inputNameResolver(std::nullopt, name);
+    }
+
+    if (auto rootName = tryGetRootName(fieldAccess->input())) {
+      if (auto resolved = inputNameResolver(rootName, name)) {
+        return resolved;
+      }
+    }
+
+    auto input =
+        resolveScalarTypesImpl(fieldAccess->input(), inputNameResolver);
+
+    return std::make_shared<SpecialFormExpr>(
+        input->type()->asRow().findChild(name),
+        SpecialForm::kDereference,
+        std::vector<ExprPtr>{
+            input, std::make_shared<ConstantExpr>(VARCHAR(), name)});
+  }
+
+  if (const auto& constant =
+          dynamic_cast<const core::ConstantExpr*>(expr.get())) {
+    return std::make_shared<ConstantExpr>(constant->type(), constant->value());
+  }
+
+  std::vector<ExprPtr> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& input : expr->inputs()) {
+    inputs.push_back(resolveScalarTypesImpl(input, inputNameResolver));
+  }
+
+  if (const auto* call = dynamic_cast<const core::CallExpr*>(expr.get())) {
+    const auto& name = call->name();
+
+    if (auto specialForm = tryResolveSpecialForm(name, inputs)) {
+      return specialForm;
+    }
+
+    std::vector<TypePtr> inputTypes;
+    inputTypes.reserve(inputs.size());
+    for (const auto& input : inputs) {
+      inputTypes.push_back(input->type());
+    }
+
+    auto type = resolveScalarFunction(name, inputTypes);
+
+    return std::make_shared<CallExpr>(type, name, inputs);
+  }
+
+  if (const auto* cast = dynamic_cast<const core::CastExpr*>(expr.get())) {
+    return std::make_shared<SpecialFormExpr>(
+        cast->type(),
+        cast->isTryCast() ? SpecialForm::kTryCast : SpecialForm::kCast,
+        inputs);
+  }
+
+  VELOX_NYI("Can't resolve {}", expr->toString());
+}
+
+AggregateExprPtr resolveAggregateTypesImpl(
+    const core::ExprPtr& expr,
+    const std::function<ExprPtr(
+        const std::optional<std::string>& alias,
+        const std::string& fieldName)>& inputNameResolver) {
+  const auto* call = dynamic_cast<const core::CallExpr*>(expr.get());
+  VELOX_USER_CHECK_NOT_NULL(call, "Aggregate must be a call expression");
+
+  const auto& name = call->name();
+
+  std::vector<ExprPtr> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& input : expr->inputs()) {
+    inputs.push_back(resolveScalarTypesImpl(input, inputNameResolver));
+  }
+
+  std::vector<TypePtr> inputTypes;
+  inputTypes.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    inputTypes.push_back(input->type());
+  }
+
+  if (auto type = exec::resolveAggregateFunction(name, inputTypes).first) {
+    return std::make_shared<AggregateExpr>(type, name, inputs);
+  }
+
+  auto allSignatures = exec::getAggregateFunctionSignatures();
+  auto it = allSignatures.find(name);
+  if (it == allSignatures.end()) {
+    VELOX_USER_FAIL("Aggregate function doesn't exist: {}.", name);
+  } else {
+    const auto& functionSignatures = it->second;
+    VELOX_USER_FAIL(
+        "Aggregate function signature is not supported: {}. Supported signatures: {}.",
+        toString(name, inputTypes),
+        toString(functionSignatures));
+  }
+}
+
+} // namespace
+
+PlanBuilder& PlanBuilder::join(
+    const PlanBuilder& right,
+    const std::string& condition,
+    JoinType joinType) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Join node cannot be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(right.node_);
+
+  // User-facing column names may have duplicates between left and right side.
+  // Columns that are unique can be referenced as is. Columns that are not
+  // unique must be referenced using an alias.
+  outputMapping_->merge(*right.outputMapping_);
+
+  auto inputRowType = node_->outputType()->unionWith(right.node_->outputType());
+
+  auto untypedExpr = parse::parseExpr(condition, parseOptions_);
+  auto expr = resolveScalarTypesImpl(
+      untypedExpr, [&](const auto& alias, const auto& name) {
+        return resolveJoinInputName(alias, name, *outputMapping_, inputRowType);
+      });
+
+  node_ =
+      std::make_shared<JoinNode>(nextId(), node_, right.node_, joinType, expr);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Sort node cannot be a leaf node");
+
+  std::vector<SortingField> sortingFields;
+  sortingFields.reserve(sortingKeys.size());
+
+  for (const auto& key : sortingKeys) {
+    auto orderBy = parse::parseOrderByExpr(key);
+    auto expr = resolveScalarTypes(orderBy.expr);
+
+    sortingFields.push_back(
+        SortingField(expr, {orderBy.ascending, orderBy.nullsFirst}));
+  }
+
+  node_ = std::make_shared<SortNode>(nextId(), node_, sortingFields);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::limit(int32_t offset, int32_t count) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Limit node cannot be a leaf node");
+
+  node_ = std::make_shared<LimitNode>(nextId(), node_, offset, count);
+
+  return *this;
+}
+
+ExprPtr PlanBuilder::resolveInputName(
+    const std::optional<std::string>& alias,
+    const std::string& name) const {
+  if (alias.has_value()) {
+    if (auto id = outputMapping_->lookup(alias.value(), name)) {
+      return std::make_shared<InputReferenceExpr>(
+          node_->outputType()->findChild(id.value()), id.value());
+    }
+
+    return nullptr;
+  }
+
+  if (auto id = outputMapping_->lookup(name)) {
+    return std::make_shared<InputReferenceExpr>(
+        node_->outputType()->findChild(id.value()), id.value());
+  }
+
+  VELOX_USER_FAIL(
+      "Cannot resolve column: {} not in [{}]",
+      NameMappings::QualifiedName{alias, name}.toString(),
+      outputMapping_->toString());
+}
+
+ExprPtr PlanBuilder::resolveScalarTypes(const core::ExprPtr& expr) const {
+  return resolveScalarTypesImpl(expr, [&](const auto& alias, const auto& name) {
+    return resolveInputName(alias, name);
+  });
+}
+
+AggregateExprPtr PlanBuilder::resolveAggregateTypes(
+    const core::ExprPtr& expr) const {
+  return resolveAggregateTypesImpl(
+      expr, [&](const auto& alias, const auto& name) {
+        return resolveInputName(alias, name);
+      });
+}
+
+PlanBuilder& PlanBuilder::as(const std::string& alias) {
+  outputMapping_->setAlias(alias);
+  return *this;
+}
+
+std::string PlanBuilder::newName(const std::string& hint) {
+  return nameAllocator_->newName(hint);
+}
+
+LogicalPlanNodePtr PlanBuilder::build() {
+  VELOX_USER_CHECK_NOT_NULL(node_);
+
+  // Use user-specified names for the output. Should we add an OutputNode?
+
+  const auto names = outputMapping_->uniqueNames();
+
+  bool needRename = false;
+
+  const auto& rowType = node_->outputType();
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(rowType->size());
+
+  std::vector<ExprPtr> exprs;
+  exprs.reserve(rowType->size());
+
+  for (auto i = 0; i < rowType->size(); i++) {
+    const auto& id = rowType->nameOf(i);
+
+    auto it = names.find(id);
+    if (it != names.end()) {
+      outputNames.push_back(it->second);
+    } else {
+      outputNames.push_back(id);
+    }
+
+    if (id != outputNames.back()) {
+      needRename = true;
+    }
+
+    exprs.push_back(
+        std::make_shared<InputReferenceExpr>(rowType->childAt(i), id));
+  }
+
+  if (needRename) {
+    return std::make_shared<ProjectNode>(nextId(), node_, outputNames, exprs);
+  }
+
+  return node_;
+}
+
+std::string NameAllocator::newName(const std::string& hint) {
+  VELOX_CHECK(!hint.empty(), "Hint cannot be empty");
+
+  // Strip suffix past '_'.
+  std::string prefix = hint;
+
+  auto pos = prefix.rfind('_');
+  if (pos != std::string::npos) {
+    prefix = prefix.substr(0, pos);
+  }
+
+  std::string name = prefix;
+  do {
+    if (names_.insert(name).second) {
+      return name;
+    }
+    name = fmt::format("{}_{}", prefix, nextId_++);
+  } while (true);
+}
+
+std::optional<std::string> NameMappings::lookup(const std::string& name) const {
+  auto it = mappings_.find(QualifiedName{.alias = {}, .name = name});
+  if (it != mappings_.end()) {
+    return it->second;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<std::string> NameMappings::lookup(
+    const std::string& alias,
+    const std::string& name) const {
+  auto it = mappings_.find(QualifiedName{.alias = alias, .name = name});
+  if (it != mappings_.end()) {
+    return it->second;
+  }
+
+  return std::nullopt;
+}
+
+std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
+    const std::string& id) const {
+  std::vector<QualifiedName> names;
+  for (const auto& [key, value] : mappings_) {
+    if (value == id) {
+      names.push_back(key);
+    }
+  }
+
+  VELOX_CHECK_LE(names.size(), 2);
+  if (names.size() == 2) {
+    VELOX_CHECK_EQ(names[0].name, names[1].name);
+    VELOX_CHECK_NE(names[0].alias.has_value(), names[1].alias.has_value());
+  }
+
+  return names;
+}
+
+void NameMappings::setAlias(const std::string& alias) {
+  std::vector<std::pair<std::string, std::string>> names;
+  for (auto it = mappings_.begin(); it != mappings_.end();) {
+    if (it->first.alias.has_value()) {
+      it = mappings_.erase(it);
+    } else {
+      names.emplace_back(it->first.name, it->second);
+      ++it;
+    }
+  }
+
+  for (auto& [name, id] : names) {
+    mappings_.emplace(
+        QualifiedName{.alias = alias, .name = std::move(name)}, std::move(id));
+  }
+}
+
+void NameMappings::merge(const NameMappings& other) {
+  for (const auto& [name, id] : other.mappings_) {
+    if (mappings_.contains(name)) {
+      VELOX_CHECK(!name.alias.has_value());
+      mappings_.erase(name);
+    } else {
+      mappings_.emplace(name, id);
+    }
+  }
+}
+
+std::unordered_map<std::string, std::string> NameMappings::uniqueNames() const {
+  std::unordered_map<std::string, std::string> names;
+  for (const auto& [name, id] : mappings_) {
+    if (!name.alias.has_value()) {
+      names.emplace(id, name.name);
+    }
+  }
+  return names;
+}
+
+std::string NameMappings::toString() const {
+  bool first = true;
+  std::stringstream out;
+  for (const auto& [name, id] : mappings_) {
+    if (!first) {
+      out << ", ";
+    } else {
+      first = false;
+    }
+    out << name.toString() << " -> " << id;
+  }
+  return out.str();
+}
+
+size_t NameMappings::QualifiedNameHasher::operator()(
+    const QualifiedName& value) const {
+  size_t h1 = 0;
+  if (value.alias.has_value()) {
+    h1 = std::hash<std::string>()(value.alias.value());
+  }
+
+  size_t h2 = std::hash<std::string>()(value.name);
+
+  return h1 ^ (h2 << 1);
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/PlanBuilder.h
+++ b/frontend/logical_plan/PlanBuilder.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/frontend/logical_plan/LogicalPlanNode.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/PlanNodeIdGenerator.h"
+
+namespace facebook::velox::logical_plan {
+
+class NameAllocator;
+class NameMappings;
+
+class PlanBuilder {
+ public:
+  struct Context {
+    std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator;
+    std::shared_ptr<NameAllocator> nameAllocator;
+
+    Context()
+        : planNodeIdGenerator{std::make_shared<core::PlanNodeIdGenerator>()},
+          nameAllocator{std::make_shared<NameAllocator>()} {}
+  };
+
+  PlanBuilder()
+      : planNodeIdGenerator_(std::make_shared<core::PlanNodeIdGenerator>()),
+        nameAllocator_(std::make_shared<NameAllocator>()) {}
+
+  explicit PlanBuilder(const Context& context)
+      : planNodeIdGenerator_{context.planNodeIdGenerator},
+        nameAllocator_{context.nameAllocator} {
+    VELOX_CHECK_NOT_NULL(planNodeIdGenerator_);
+    VELOX_CHECK_NOT_NULL(nameAllocator_);
+  }
+
+  PlanBuilder& values(const RowTypePtr& rowType, std::vector<Variant> rows);
+
+  PlanBuilder& tableScan(
+      const std::string& connectorId,
+      const std::string& tableName,
+      const std::vector<std::string>& columnNames);
+
+  PlanBuilder& filter(const std::string& predicate);
+
+  PlanBuilder& project(const std::vector<std::string>& projections);
+
+  /// An alias for 'project'.
+  PlanBuilder& map(const std::vector<std::string>& projections) {
+    return project(projections);
+  }
+
+  /// Similar to 'project', but appends 'projections' to the existing columns.
+  PlanBuilder& with(const std::vector<std::string>& projections);
+
+  PlanBuilder& aggregate(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates);
+
+  PlanBuilder& join(
+      const PlanBuilder& right,
+      const std::string& condition,
+      JoinType joinType);
+
+  PlanBuilder& sort(const std::vector<std::string>& sortingKeys);
+
+  /// An alias for 'sort'.
+  PlanBuilder& orderBy(const std::vector<std::string>& sortingKeys) {
+    return sort(sortingKeys);
+  }
+
+  PlanBuilder& limit(int32_t count) {
+    return limit(0, count);
+  }
+
+  PlanBuilder& limit(int32_t offset, int32_t count);
+
+  PlanBuilder& as(const std::string& alias);
+
+  LogicalPlanNodePtr build();
+
+ private:
+  std::string nextId() {
+    return planNodeIdGenerator_->next();
+  }
+
+  std::string newName(const std::string& hint);
+
+  ExprPtr resolveInputName(
+      const std::optional<std::string>& alias,
+      const std::string& name) const;
+
+  ExprPtr resolveScalarTypes(const core::ExprPtr& expr) const;
+
+  AggregateExprPtr resolveAggregateTypes(const core::ExprPtr& expr) const;
+
+  void resolveProjections(
+      const std::vector<std::string>& projections,
+      std::vector<std::string>& outputNames,
+      std::vector<ExprPtr>& exprs,
+      NameMappings& mappings);
+
+  const std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
+  const std::shared_ptr<NameAllocator> nameAllocator_;
+  const parse::ParseOptions parseOptions_;
+
+  LogicalPlanNodePtr node_;
+
+  // Mapping from user-provided to auto-generated output column names.
+  std::shared_ptr<NameMappings> outputMapping_;
+};
+
+/// Generate unique names based on user-provided hints.
+class NameAllocator {
+ public:
+  /// Returns 'hint' as is it is unique. Otherwise, return 'hint_N' where N is a
+  /// numeric suffix appended to ensure uniqueness. If 'hint' already has a
+  /// suffix and is not unique, the suffix is replaced with a new one.
+  ///
+  /// Example:
+  ///
+  ///   newName("a") -> "a"
+  ///   newName("a") -> "a_0"
+  ///   newName("a") -> "a_1"
+  ///   newName("a_0") -> "a_2"
+  std::string newName(const std::string& hint);
+
+  void reset() {
+    names_.clear();
+    nextId_ = 0;
+  }
+
+ private:
+  std::unordered_set<std::string> names_;
+  int32_t nextId_{0};
+};
+
+/// Maintains a mapping from user-visible names to auto-generated IDs.
+/// Unique names may be accessed by name alone. Non-unique names must be
+/// disambiguated using an alias.
+class NameMappings {
+ public:
+  struct QualifiedName {
+    std::optional<std::string> alias;
+    std::string name;
+
+    bool operator==(const QualifiedName& other) const {
+      return alias == other.alias && name == other.name;
+    }
+
+    std::string toString() const {
+      if (alias.has_value()) {
+        return fmt::format("{}.{}", alias.value(), name);
+      }
+
+      return name;
+    }
+  };
+
+  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  void add(const QualifiedName& name, const std::string& id) {
+    bool ok = mappings_.emplace(name, id).second;
+    VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
+  }
+
+  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  void add(const std::string& name, const std::string& id) {
+    bool ok =
+        mappings_.emplace(QualifiedName{.alias = {}, .name = name}, id).second;
+    VELOX_CHECK(ok, "Duplicate name: {}", name);
+  }
+
+  /// Returns ID for the specified 'name' if exists.
+  std::optional<std::string> lookup(const std::string& name) const;
+
+  /// Returns ID for the specified 'name' if exists.
+  std::optional<std::string> lookup(
+      const std::string& alias,
+      const std::string& name) const;
+
+  /// Returns all names for the specified ID. There can be up to 2 names: w/ and
+  /// w/o alias.
+  std::vector<QualifiedName> reverseLookup(const std::string& id) const;
+
+  /// Sets new alias for the names. Unique names will be accessible both with
+  /// the new alias and without. Ambiguous names will no longer be accessible.
+  ///
+  /// Used in PlanBuilder::as() API.
+  void setAlias(const std::string& alias);
+
+  /// Merges mappings from 'other' into this. Removes unqualified access to
+  /// non-unique names.
+  ///
+  /// @pre IDs are unique across 'this' and 'other'. This expectation is not
+  /// verified explicitly. Violations would lead to undefined behavior.
+  ///
+  /// Used in PlanBuilder::join() API.
+  void merge(const NameMappings& other);
+
+  /// Returns a mapping from IDs to unaliased names for a subset of columns with
+  /// unique names.
+  ///
+  /// Used to produce final output.
+  std::unordered_map<std::string, std::string> uniqueNames() const;
+  std::string toString() const;
+
+  void reset() {
+    mappings_.clear();
+  }
+
+ private:
+  struct QualifiedNameHasher {
+    size_t operator()(const QualifiedName& value) const;
+  };
+
+  // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
+  // alias.
+  std::unordered_map<QualifiedName, std::string, QualifiedNameHasher> mappings_;
+};
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/PlanNodeVisitor.h
+++ b/frontend/logical_plan/PlanNodeVisitor.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/frontend/logical_plan/LogicalPlanNode.h"
+
+namespace facebook::velox::logical_plan {
+
+class PlanNodeVisitorContext {
+ public:
+  virtual ~PlanNodeVisitorContext() = default;
+};
+
+class PlanNodeVisitor {
+ public:
+  virtual ~PlanNodeVisitor() = default;
+
+  virtual void visit(const ValuesNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const TableScanNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const FilterNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const ProjectNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const AggregateNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const JoinNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const SortNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const LimitNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const SetNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
+ protected:
+  void visitInputs(const LogicalPlanNode& node, PlanNodeVisitorContext& ctx)
+      const {
+    for (const auto& input : node.inputs()) {
+      input->accept(*this, ctx);
+    }
+  }
+};
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/PlanPrinter.cpp
+++ b/frontend/logical_plan/PlanPrinter.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/PlanPrinter.h"
+#include "velox/frontend/logical_plan/ExprPrinter.h"
+
+namespace facebook::velox::logical_plan {
+
+namespace {
+
+struct ToTextVisitorContext : public PlanNodeVisitorContext {
+  std::stringstream out;
+  int32_t indent{0};
+};
+
+class ToTextVisitor : public PlanNodeVisitor {
+ public:
+  void visit(const ValuesNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(
+        "Values", node, fmt::format("{} rows", node.rows().size()), context);
+  }
+
+  void visit(const TableScanNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(
+        "TableScan",
+        node,
+        fmt::format("{}.{}", node.connectorId(), node.tableName()),
+        context);
+  }
+
+  void visit(const FilterNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode("Filter", node, ExprPrinter::toText(*node.predicate()), context);
+  }
+
+  void visit(const ProjectNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<ToTextVisitorContext&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- Project:";
+
+    appendOutputType(node, myContext);
+
+    myContext.out << std::endl;
+
+    const auto size = node.names().size();
+
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (auto i = 0; i < size; ++i) {
+      myContext.out << indent << node.names().at(i)
+                    << " := " << ExprPrinter::toText(*node.expressions().at(i))
+                    << std::endl;
+    }
+
+    appendInputs(node, myContext);
+  }
+
+  void visit(const AggregateNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<ToTextVisitorContext&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- Aggregate(";
+
+    const auto numKeys = node.groupingKeys().size();
+    for (auto i = 0; i < numKeys; ++i) {
+      if (i > 0) {
+        myContext.out << ", ";
+      }
+      myContext.out << ExprPrinter::toText(*node.groupingKeys().at(i));
+    }
+
+    appendOutputType(node, myContext);
+
+    myContext.out << std::endl;
+
+    const auto size = node.aggregates().size();
+
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (auto i = 0; i < size; ++i) {
+      myContext.out << indent << node.outputNames().at(numKeys + i)
+                    << " := " << ExprPrinter::toText(*node.aggregates().at(i))
+                    << std::endl;
+    }
+
+    appendInputs(node, myContext);
+  }
+
+  void visit(const JoinNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(
+        fmt::format("Join {}", JoinTypeName::toName(node.joinType())),
+        node,
+        ExprPrinter::toText(*node.condition()),
+        context);
+  }
+
+  void visit(const SortNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<ToTextVisitorContext&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- Sort: ";
+
+    const auto size = node.ordering().size();
+    for (auto i = 0; i < size; ++i) {
+      if (i > 0) {
+        myContext.out << ", ";
+      }
+      myContext.out << ExprPrinter::toText(*node.ordering().at(i).expression)
+                    << " " << node.ordering().at(i).order.toString();
+    }
+
+    appendOutputType(node, myContext);
+    myContext.out << std::endl;
+    appendInputs(node, myContext);
+  }
+
+  void visit(const LimitNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(
+        "Limit",
+        node,
+        node.offset() > 0
+            ? fmt::format("{} (offset: {})", node.count(), node.offset())
+            : fmt::format("{}", node.count()),
+        context);
+  }
+
+  void visit(const SetNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode("Set", node, context);
+  }
+
+  void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode("Unnest", node, context);
+  }
+
+ private:
+  static std::string makeIndent(int32_t size) {
+    return std::string(size * 2, ' ');
+  }
+
+  void appendNode(
+      const std::string& name,
+      const LogicalPlanNode& node,
+      const std::optional<std::string>& details,
+      PlanNodeVisitorContext& context) const {
+    auto& myContext = static_cast<ToTextVisitorContext&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- " << name << ":";
+
+    if (details.has_value()) {
+      myContext.out << " " << details.value();
+    }
+
+    appendOutputType(node, myContext);
+
+    myContext.out << std::endl;
+
+    appendInputs(node, myContext);
+  }
+
+  void appendNode(
+      const std::string& name,
+      const LogicalPlanNode& node,
+      PlanNodeVisitorContext& context) const {
+    appendNode(name, node, std::nullopt, context);
+  }
+
+  void appendOutputType(
+      const LogicalPlanNode& node,
+      ToTextVisitorContext& context) const {
+    context.out << " -> " << node.outputType()->toString();
+  }
+
+  void appendInputs(const LogicalPlanNode& node, ToTextVisitorContext& context)
+      const {
+    context.indent++;
+    PlanNodeVisitor::visitInputs(node, context);
+    context.indent--;
+  }
+};
+
+} // namespace
+
+// static
+std::string PlanPrinter::toText(const LogicalPlanNode& root) {
+  ToTextVisitorContext context;
+  ToTextVisitor visitor;
+  root.accept(visitor, context);
+  return context.out.str();
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/PlanPrinter.h
+++ b/frontend/logical_plan/PlanPrinter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/frontend/logical_plan/PlanNodeVisitor.h"
+
+namespace facebook::velox::logical_plan {
+
+class PlanPrinter {
+ public:
+  static std::string toText(const LogicalPlanNode& root);
+};
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/tests/CMakeLists.txt
+++ b/frontend/logical_plan/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(
+  velox_fe_logical_plan_tests PlanPrinterTest.cpp)
+
+add_test(velox_fe_logical_plan_tests velox_fe_logical_plan_tests)
+
+target_link_libraries(
+  velox_fe_logical_plan_tests
+  velox_fe_logical_plan_builder
+  gtest
+  gtest_main)

--- a/frontend/logical_plan/tests/NameAllocatorTest.cpp
+++ b/frontend/logical_plan/tests/NameAllocatorTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/frontend/logical_plan/PlanBuilder.h"
+
+namespace facebook::velox::logical_plan {
+
+TEST(NameAllocatorTest, basic) {
+  NameAllocator allocator;
+  EXPECT_EQ(allocator.newName("foo"), "foo");
+  EXPECT_EQ(allocator.newName("foo"), "foo_0");
+
+  EXPECT_EQ(allocator.newName("bar"), "bar");
+  EXPECT_EQ(allocator.newName("bar"), "bar_1");
+
+  EXPECT_EQ(allocator.newName("foo_0"), "foo_2");
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/tests/NameMappingsTest.cpp
+++ b/frontend/logical_plan/tests/NameMappingsTest.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/frontend/logical_plan/PlanBuilder.h"
+
+namespace facebook::velox::logical_plan {
+
+TEST(NameMappingsTest, basic) {
+  NameAllocator allocator;
+
+  auto newName = [&](const std::string& name) {
+    return allocator.newName(name);
+  };
+
+  NameMappings mappings;
+
+  auto reverseLookup = [&](const std::string& id) {
+    auto names = mappings.reverseLookup(id);
+
+    std::vector<std::string> strings;
+    strings.reserve(names.size());
+    for (auto& name : names) {
+      strings.push_back(name.toString());
+    }
+
+    return strings;
+  };
+
+  auto makeNamesEq = [&](std::initializer_list<std::string> names) {
+    return testing::UnorderedElementsAreArray(names);
+  };
+
+  {
+    mappings.add("a", newName("a"));
+    mappings.add("b", newName("b"));
+    mappings.add("c", newName("c"));
+
+    EXPECT_EQ(mappings.lookup("a"), "a");
+    EXPECT_EQ(mappings.lookup("b"), "b");
+    EXPECT_EQ(mappings.lookup("c"), "c");
+
+    mappings.setAlias("t");
+
+    EXPECT_EQ(mappings.lookup("t", "a"), "a");
+    EXPECT_EQ(mappings.lookup("t", "b"), "b");
+    EXPECT_EQ(mappings.lookup("t", "c"), "c");
+
+    EXPECT_THAT(reverseLookup("a"), makeNamesEq({"a", "t.a"}));
+    EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
+    EXPECT_THAT(reverseLookup("c"), makeNamesEq({"c", "t.c"}));
+
+    NameMappings other;
+    other.add("a", newName("a"));
+    other.add("c", newName("c"));
+    other.add("e", newName("e"));
+
+    mappings.merge(other);
+
+    // "a" and "c" are no longer accessible w/o the alias. "a" from other is not
+    // accessible at all.
+
+    EXPECT_EQ(mappings.lookup("a"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("t", "a"), "a");
+
+    EXPECT_EQ(mappings.lookup("b"), "b");
+    EXPECT_EQ(mappings.lookup("t", "b"), "b");
+
+    EXPECT_EQ(mappings.lookup("c"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("t", "c"), "c");
+
+    EXPECT_EQ(mappings.lookup("e"), "e");
+
+    EXPECT_THAT(reverseLookup("a"), makeNamesEq({"t.a"}));
+    EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
+    EXPECT_THAT(reverseLookup("c"), makeNamesEq({"t.c"}));
+    EXPECT_THAT(reverseLookup("e"), makeNamesEq({"e"}));
+  }
+
+  {
+    allocator.reset();
+    mappings.reset();
+
+    mappings.add("a", newName("a"));
+    mappings.add("b", newName("b"));
+    mappings.add("c", newName("c"));
+    mappings.setAlias("t");
+
+    NameMappings other;
+    other.add("a", newName("a"));
+    other.add("c", newName("c"));
+    other.add("e", newName("e"));
+    other.setAlias("u");
+    mappings.merge(other);
+
+    // "a" and "c" are no longer accessible w/o the alias.
+
+    EXPECT_EQ(mappings.lookup("a"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("t", "a"), "a");
+    EXPECT_EQ(mappings.lookup("u", "a"), "a_0");
+
+    EXPECT_EQ(mappings.lookup("b"), "b");
+    EXPECT_EQ(mappings.lookup("t", "b"), "b");
+    EXPECT_EQ(mappings.lookup("u", "b"), std::nullopt);
+
+    EXPECT_EQ(mappings.lookup("c"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("t", "c"), "c");
+    EXPECT_EQ(mappings.lookup("u", "c"), "c_1");
+
+    EXPECT_EQ(mappings.lookup("e"), "e");
+    EXPECT_EQ(mappings.lookup("t", "e"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("u", "e"), "e");
+
+    EXPECT_THAT(reverseLookup("a"), makeNamesEq({"t.a"}));
+    EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
+    EXPECT_THAT(reverseLookup("c"), makeNamesEq({"t.c"}));
+
+    EXPECT_THAT(reverseLookup("a_0"), makeNamesEq({"u.a"}));
+    EXPECT_THAT(reverseLookup("c_1"), makeNamesEq({"u.c"}));
+    EXPECT_THAT(reverseLookup("e"), makeNamesEq({"e", "u.e"}));
+
+    mappings.setAlias("v");
+
+    // Only b and e are still accessible.
+
+    EXPECT_EQ(mappings.lookup("a"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("b"), "b");
+    EXPECT_EQ(mappings.lookup("v", "b"), "b");
+    EXPECT_EQ(mappings.lookup("c"), std::nullopt);
+    EXPECT_EQ(mappings.lookup("v", "e"), "e");
+
+    EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "v.b"}));
+    EXPECT_THAT(reverseLookup("e"), makeNamesEq({"e", "v.e"}));
+  }
+}
+
+} // namespace facebook::velox::logical_plan

--- a/frontend/logical_plan/tests/PlanPrinterTest.cpp
+++ b/frontend/logical_plan/tests/PlanPrinterTest.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/frontend/logical_plan/PlanPrinter.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "velox/frontend/logical_plan/PlanBuilder.h"
+#include "velox/frontend/optimizer/connectors/ConnectorMetadata.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::logical_plan {
+namespace {
+
+class TestTable : public connector::Table {
+ public:
+  TestTable(const std::string& name, const RowTypePtr& schema)
+      : connector::Table(name) {
+    type_ = schema;
+  }
+
+  const std::unordered_map<std::string, const connector::Column*>& columnMap()
+      const override {
+    VELOX_NYI();
+  }
+
+  const std::vector<const connector::TableLayout*>& layouts() const override {
+    VELOX_NYI();
+  }
+
+  uint64_t numRows() const override {
+    VELOX_NYI();
+  }
+};
+
+class TestMetadata : public connector::ConnectorMetadata {
+ public:
+  void initialize() override {
+    addTable("test", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
+  }
+
+  const connector::Table* findTable(const std::string& name) override {
+    auto it = tables_.find(name);
+    VELOX_USER_CHECK(it != tables_.end(), "Test table not found: {}", name);
+
+    return it->second.get();
+  }
+
+  connector::ConnectorSplitManager* splitManager() override {
+    VELOX_NYI();
+  }
+
+ private:
+  void addTable(const std::string& name, const RowTypePtr& schema) {
+    tables_.emplace(name, std::make_unique<TestTable>(name, schema));
+  }
+
+  std::unordered_map<std::string, std::unique_ptr<TestTable>> tables_;
+};
+
+class TestConnector : public connector::Connector {
+ public:
+  explicit TestConnector(const std::string& id)
+      : connector::Connector(id), metadata_{std::make_unique<TestMetadata>()} {
+    metadata_->initialize();
+  }
+
+  connector::ConnectorMetadata* metadata() const override {
+    return metadata_.get();
+  }
+
+  std::unique_ptr<connector::DataSource> createDataSource(
+      const RowTypePtr& /* outputType */,
+      const connector::ConnectorTableHandlePtr& /* tableHandle */,
+      const connector::ColumnHandleMap& /* columnHandles */,
+      connector::ConnectorQueryCtx* /* connectorQueryCtx */) override {
+    VELOX_NYI();
+  }
+
+  std::unique_ptr<connector::DataSink> createDataSink(
+      RowTypePtr /* inputType */,
+      connector::ConnectorInsertTableHandlePtr /* connectorInsertTableHandle */,
+      connector::ConnectorQueryCtx* /* connectorQueryCtx */,
+      connector::CommitStrategy /* commitStrategy */) override {
+    VELOX_NYI();
+  }
+
+ private:
+  const std::unique_ptr<TestMetadata> metadata_;
+};
+
+class PlanPrinterTest : public testing::Test {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    connector::registerConnector(
+        std::make_shared<TestConnector>(kTestConnectorId));
+  }
+
+  static std::vector<std::string> toLines(const LogicalPlanNodePtr& plan) {
+    auto text = PlanPrinter::toText(*plan);
+
+    LOG(INFO) << std::endl << text;
+
+    std::vector<std::string> lines;
+    folly::split("\n", text, lines);
+
+    return lines;
+  }
+};
+
+TEST_F(PlanPrinterTest, values) {
+  auto plan = PlanBuilder()
+                  .values(
+                      ROW({"a"}, {BIGINT()}),
+                      std::vector<Variant>{Variant::row({123LL})})
+                  .filter("a > 10")
+                  .with({"a + 2 as b"})
+                  .project({"a + b as c"})
+                  .sort({"c DESC"})
+                  .limit(5)
+                  .build();
+
+  const auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Limit"),
+          testing::StartsWith("  - Sort"),
+          testing::StartsWith("    - Project"),
+          testing::StartsWith("        c := plus(a, b)"),
+          testing::StartsWith("      - Project"),
+          testing::StartsWith("          a := a"),
+          testing::StartsWith("          b := plus(a, 2)"),
+          testing::StartsWith("        - Filter: gt(a, 10)"),
+          testing::StartsWith("          - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, tableScan) {
+  auto plan = PlanBuilder()
+                  .tableScan(kTestConnectorId, "test", {"a", "b"})
+                  .with({"cast(a as double) * b as c"})
+                  .build();
+
+  const auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Project"),
+          testing::StartsWith("    a := a"),
+          testing::StartsWith("    b := b"),
+          testing::StartsWith("    c := multiply(CAST(a AS DOUBLE), b)"),
+          testing::StartsWith("  - TableScan"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, aggregate) {
+  auto rowType = ROW({"a", "b"}, {INTEGER(), INTEGER()});
+  std::vector<Variant> data{
+      Variant::row({1, 10}),
+      Variant::row({2, 20}),
+      Variant::row({2, 21}),
+      Variant::row({3, 30}),
+  };
+
+  auto plan =
+      PlanBuilder()
+          .values(rowType, data)
+          .aggregate(
+              {"a"}, {"sum(b) as total", "avg(b) as mean", "min(b + 1::int)"})
+          .with({"total + 1", "mean * 0.3"})
+          .build();
+
+  const auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Project"),
+          testing::StartsWith("    a := a"),
+          testing::StartsWith("    total := total"),
+          testing::StartsWith("    mean := mean"),
+          testing::StartsWith("    min := min"),
+          testing::StartsWith("    expr := plus(total, 1)"),
+          testing::StartsWith("    expr_0 := multiply(mean, 0.3)"),
+          testing::StartsWith("  - Aggregate"),
+          testing::StartsWith("      total := sum(b)"),
+          testing::StartsWith("      mean := avg(b)"),
+          testing::StartsWith("      min := min(plus(b, "),
+          testing::StartsWith("    - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, join) {
+  auto leftType = ROW({"key", "v"}, {INTEGER(), INTEGER()});
+  std::vector<Variant> leftData{
+      Variant::row({1, 10}),
+      Variant::row({2, 20}),
+      Variant::row({2, 21}),
+      Variant::row({3, 30}),
+  };
+
+  auto rightType = ROW({"key", "w"}, {INTEGER(), INTEGER()});
+  std::vector<Variant> rightData{
+      Variant::row({1, 11}),
+      Variant::row({2, 22}),
+  };
+
+  auto context = PlanBuilder::Context();
+  auto plan = PlanBuilder(context)
+                  .values(leftType, leftData)
+                  .as("l")
+                  .join(
+                      PlanBuilder(context).values(rightType, rightData).as("r"),
+                      "l.key = r.key",
+                      JoinType::kLeft)
+                  .with({"l.v + r.w as z"})
+                  .build();
+
+  const auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Project"),
+          testing::StartsWith("    key := key"),
+          testing::StartsWith("    v := v"),
+          testing::StartsWith("    key_0 := key_0"),
+          testing::StartsWith("    w := w"),
+          testing::StartsWith("    z := plus(v, w)"),
+          testing::StartsWith("  - Join LEFT: eq(key, key_0)"),
+          testing::StartsWith("    - Values: 4 rows"),
+          testing::StartsWith("    - Values: 2 rows"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, specialForms) {
+  auto rowType =
+      ROW({"a", "b", "c"},
+          {INTEGER(), INTEGER(), ROW({"x", "y"}, {BOOLEAN(), REAL()})});
+  std::vector<Variant> data{
+      Variant::row({1, 10, Variant::row({true, 0.1f})}),
+      Variant::row({2, 20, Variant::row({true, 0.2f})}),
+      Variant::row({2, 21, Variant::row({true, 0.21f})}),
+      Variant::row({3, 30, Variant::row({true, 0.3f})}),
+  };
+
+  auto plan =
+      PlanBuilder()
+          .values(rowType, data)
+          .map({
+              "a > b AND b > 10::int as a",
+              "a < b OR b > 0::int as b",
+              "cast(a as double) * 1.2",
+              "try_cast(a / b as varchar)",
+              "try(a / b)",
+              "c.x",
+              "coalesce(a, b, 33::int) as c",
+              "if(a > b, a, b)",
+              "case a when 1::int then 'a' when 2::int then 'b' else 'c' end",
+          })
+          .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Project"),
+          testing::StartsWith("    a := a_0"),
+          testing::StartsWith("    b := b_1"),
+          testing::StartsWith("    expr "),
+          testing::StartsWith("    expr_2 "),
+          testing::StartsWith("    expr_3 "),
+          testing::StartsWith("    expr_4 "),
+          testing::StartsWith("    c := c_5"),
+          testing::StartsWith("    expr_6 "),
+          testing::StartsWith("    expr_7 "),
+          testing::StartsWith("  - Project"),
+          testing::StartsWith("      a_0 := AND"),
+          testing::StartsWith("      b_1 := OR"),
+          testing::StartsWith("      expr := multiply(CAST("),
+          testing::StartsWith("      expr_2 := TRY_CAST"),
+          testing::StartsWith("      expr_3 := TRY"),
+          testing::StartsWith("      expr_4 := DEREFERENCE"),
+          testing::StartsWith("      c_5 := COALESCE"),
+          testing::StartsWith("      expr_6 := IF"),
+          testing::StartsWith("      expr_7 := SWITCH"),
+          testing::StartsWith("    - Values: 4 rows"),
+          testing::Eq("")));
+}
+
+} // namespace
+} // namespace facebook::velox::logical_plan


### PR DESCRIPTION
Summary:

Define expressions:
- InputReferenceExpr
- CallExpr
- SpecialFormExpr
- AggregateExpr
- WindowExpr
- ConstantExpr
- LambdaExpr
- SubqueryExpr

Define plan nodes:
- ValuesNode
- TableScanNode
- FilterNode
- ProjectNode
- AggregateNode
- JoinNode
- SortNode
- LimitNode
- SetNode (includes UNION)
- UnnestNode

Add visitors and printers for expressions and plan nodes. 

Add PlanBuilder (dataframe-style API).

```
  auto context = PlanBuilder::Context();
  auto plan = PlanBuilder(context)
                  .values(leftType, leftData)
                  .as("l")
                  .join(
                      PlanBuilder(context).values(rightType, rightData).as("r"),
                      "l.key = r.key",
                      JoinType::kLeft)
                  .with({"l.v + r.w as z"})
                  .build();

- Project: -> ROW<key:INTEGER,v:INTEGER,key_0:INTEGER,w:INTEGER,z:INTEGER>
    key := key
    v := v
    key_0 := key_0
    w := w
    z := plus(v, w)
  - Join LEFT: eq(key, key_0) -> ROW<key:INTEGER,v:INTEGER,key_0:INTEGER,w:INTEGER>
    - Values: 4 rows -> ROW<key:INTEGER,v:INTEGER>
    - Values: 2 rows -> ROW<key_0:INTEGER,w:INTEGER>

```

Follow-ups:

- Add special forms IN, EXISTS, array/map/row constructors.
- Document that Lambda and Subquery need to be handled specially as expressions contained in these nodes are not visible in the tree hierarchy.
- Add serde, toString.

Reviewed By: pedroerp, oerling

Differential Revision: D77602697


