### PR TITLE
feat: Add special form for '*'

### DIFF
--- a/frontend/logical_plan/Expr.cpp
+++ b/frontend/logical_plan/Expr.cpp
@@ -90,6 +90,7 @@ folly::F14FastMap<SpecialForm, std::string> specialFormNames() {
       {SpecialForm::kCoalesce, "COALESCE"},
       {SpecialForm::kIf, "IF"},
       {SpecialForm::kSwitch, "SWITCH"},
+      {SpecialForm::kStar, "STAR"},
   };
 }
 } // namespace
@@ -255,6 +256,10 @@ SpecialFormExpr::SpecialFormExpr(
     case SpecialForm::kSwitch:
       validateSwitchInputs(type, inputs);
       break;
+    case SpecialForm::kStar:
+      VELOX_USER_CHECK_GE(
+          inputs.size(), 0, "'*' expression cannot not have any inputs");
+      break;
   }
 }
 
@@ -269,7 +274,7 @@ CallExpr::CallExpr(
 
   VELOX_USER_CHECK(
       !kReservedNames.contains(boost::algorithm::to_upper_copy(name)),
-      "Function name cannot match special for name: {}",
+      "Function name cannot match special form name: {}",
       name);
 }
 

--- a/frontend/logical_plan/Expr.h
+++ b/frontend/logical_plan/Expr.h
@@ -152,9 +152,11 @@ class ConstantExpr : public Expr {
  public:
   ConstantExpr(const TypePtr& type, Variant value)
       : Expr(ExprKind::kConstant, type, {}), value_{std::move(value)} {
-    if (!isNull()) {
-      VELOX_USER_CHECK(type->kindEquals(value_.inferType()));
-    }
+    VELOX_USER_CHECK(
+        value_.isTypeCompatible(type),
+        "Constant value doesn't match its type: {} vs. {}",
+        type->toString(),
+        value_.inferType()->toString());
   }
 
   const Variant& value() const {
@@ -331,6 +333,8 @@ enum class SpecialForm {
   /// conditions are true, returns the result of evaluating the else clause or
   /// NULL if the else clause is not specified.
   kSwitch = 8,
+
+  kStar = 9,
 
   // TODO Add IN and EXISTS.
 };

--- a/frontend/logical_plan/PlanBuilder.cpp
+++ b/frontend/logical_plan/PlanBuilder.cpp
@@ -326,28 +326,21 @@ ExprPtr tryResolveSpecialForm(
   }
 
   if (name == "try") {
-    VELOX_USER_CHECK_EQ(resolvedInputs.size(), 1, "TRY must have one argument");
     return std::make_shared<SpecialFormExpr>(
         resolvedInputs.at(0)->type(), SpecialForm::kTry, resolvedInputs);
   }
 
   if (name == "coalesce") {
-    VELOX_USER_CHECK_GE(
-        resolvedInputs.size(), 2, "COALESCE must have at least two arguments");
     return std::make_shared<SpecialFormExpr>(
         resolvedInputs.at(0)->type(), SpecialForm::kCoalesce, resolvedInputs);
   }
 
   if (name == "if") {
-    VELOX_USER_CHECK_GE(
-        resolvedInputs.size(), 2, "IF must have at least two arguments");
     return std::make_shared<SpecialFormExpr>(
         resolvedInputs.at(1)->type(), SpecialForm::kIf, resolvedInputs);
   }
 
   if (name == "switch") {
-    VELOX_USER_CHECK_GE(
-        resolvedInputs.size(), 2, "SWITCH must have at least two arguments");
     return std::make_shared<SpecialFormExpr>(
         resolvedInputs.at(1)->type(), SpecialForm::kSwitch, resolvedInputs);
   }


### PR DESCRIPTION
Summary:
- Use Variant::isTypeCompatible for sanity check in ConstantExpr.
- Add SpecialForm::kStar enum value to represent '*' function argument: foo(*). It is used to request that all columns in the input are wrapped in a struct and passed as an argument.
- Remove unnecessary checks from PlanBuilder.cpp. These checks duplicate checks in SpecialFormExpr's ctor.

Differential Revision: D78486271


