### PR TITLE
fix: add TableWrite support for Velox optimizer

### DIFF
--- a/frontend/optimizer/Plan.cpp
+++ b/frontend/optimizer/Plan.cpp
@@ -92,7 +92,7 @@ Optimization::Optimization(
   for (auto& join : root_->joins) {
     join->guessFanout();
   }
-  setDerivedTableOutput(root_, inputPlan_);
+  setDerivedTableOutput(root_, *inputPlanWithoutWrite_);
 }
 
 void Optimization::trace(

--- a/frontend/optimizer/connectors/CMakeLists.txt
+++ b/frontend/optimizer/connectors/CMakeLists.txt
@@ -19,6 +19,7 @@ velox_link_libraries(velox_connector_metadata velox_common_base velox_memory
                      velox_connector velox_dwio_dwrf_writer)
 
 add_subdirectory(hive)
+add_subdirectory(tests)
 
 velox_add_library(velox_connector_split_source ConnectorSplitSource.cpp)
 

--- a/frontend/optimizer/connectors/tests/CMakeLists.txt
+++ b/frontend/optimizer/connectors/tests/CMakeLists.txt
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_fe_logical_plan_tests
-               PlanPrinterTest.cpp NameAllocatorTest.cpp NameMappingsTest.cpp)
+velox_add_library(velox_test_connector_metadata TestConnector.cpp)
 
-add_test(velox_fe_logical_plan_tests velox_fe_logical_plan_tests)
-
-target_link_libraries(velox_fe_logical_plan_tests
-                      velox_fe_logical_plan_builder
-                      velox_test_connector_metadata
-                      GTest::gtest
-                      GTest::gtest_main
-                      GTest::gmock)
+velox_link_libraries(velox_test_connector_metadata velox_common_base
+                     velox_memory velox_connector)

--- a/frontend/optimizer/connectors/tests/TestConnector.cpp
+++ b/frontend/optimizer/connectors/tests/TestConnector.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "velox/frontend/optimizer/connectors/tests/TestConnector.h"
+
+namespace facebook::velox::connector {
+
+std::pair<int64_t, int64_t> TestTableLayout::sample(
+    const connector::ConnectorTableHandlePtr&,
+    float,
+    std::vector<core::TypedExprPtr>,
+    RowTypePtr,
+    const std::vector<common::Subfield>&,
+    HashStringAllocator*,
+    std::vector<ColumnStatistics>*) const {
+  return {1000, 1000};
+}
+
+TestTable::TestTable(
+    const std::string& name,
+    const RowTypePtr& schema,
+    TestConnector* connector,
+    uint64_t rows)
+    : Table(name), connector_(connector), rows_(rows) {
+  type_ = schema;
+  for (auto i = 0; i < schema->size(); ++i) {
+    auto columnName = schema->nameOf(i);
+    auto columnType = schema->childAt(i);
+    auto column = std::make_unique<TestColumn>(columnName, columnType);
+    columns_[columnName] = column.get();
+    exportedColumns_.push_back(std::move(column));
+  }
+  auto layout = std::make_unique<TestTableLayout>(
+      name_, this, connector_, getColumnVector());
+  layouts_.push_back(layout.get());
+  exportedLayouts_.push_back(std::move(layout));
+}
+
+std::vector<const Column*> TestTable::getColumnVector() const {
+  std::vector<const Column*> result;
+  result.reserve(columns_.size());
+  for (const auto& [name, column] : columns_) {
+    result.push_back(column);
+  }
+  return result;
+}
+
+std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {
+  if (currentPartition_ >= partitions_.size()) {
+    return {};
+  }
+  std::vector<SplitAndGroup> result;
+  result.push_back(
+      {std::make_shared<TestSplit>(connectorId_), kUngroupedGroupId});
+  currentPartition_++;
+  return result;
+}
+
+std::vector<std::shared_ptr<const PartitionHandle>>
+TestSplitManager::listPartitions(const ConnectorTableHandlePtr&) {
+  return {std::make_shared<PartitionHandle>()};
+}
+
+std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
+    const ConnectorTableHandlePtr& tableHandle,
+    std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+    SplitOptions) {
+  return std::make_shared<TestSplitSource>(
+      tableHandle->connectorId(), std::move(partitions));
+}
+
+const Table* TestConnectorMetadata::findTable(const std::string& name) {
+  auto it = tables_.find(name);
+  VELOX_USER_CHECK(it != tables_.end(), "Test table not found: {}", name);
+  return it->second.get();
+}
+
+ColumnHandlePtr TestConnectorMetadata::createColumnHandle(
+    const TableLayout& layout,
+    const std::string& columnName,
+    std::vector<common::Subfield>,
+    std::optional<TypePtr> castToType,
+    SubfieldMapping) {
+  auto column = layout.findColumn(columnName);
+  VELOX_CHECK_NOT_NULL(
+      column, "Column {} not found in layout {}", columnName, layout.name());
+  return std::make_shared<TestColumnHandle>(
+      columnName, castToType.value_or(column->type()));
+}
+
+ConnectorTableHandlePtr TestConnectorMetadata::createTableHandle(
+    const TableLayout& layout,
+    std::vector<ColumnHandlePtr> columnHandles,
+    core::ExpressionEvaluator&,
+    std::vector<core::TypedExprPtr> filters,
+    std::vector<core::TypedExprPtr>&,
+    RowTypePtr,
+    std::optional<LookupKeys>) {
+  return std::make_shared<TestTableHandle>(
+      layout, std::move(columnHandles), std::move(filters));
+}
+
+void TestConnectorMetadata::addTable(
+    const std::string& name,
+    const RowTypePtr& schema,
+    TestConnector* connector,
+    uint64_t rows) {
+  auto table = std::make_unique<TestTable>(name, schema, connector, rows);
+  tables_.emplace(name, std::move(table));
+}
+
+TestDataSource::TestDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle)
+    : outputType_(outputType), tableHandle_(tableHandle) {
+  pool_ =
+      memory::memoryManager()->addLeafPool(tableHandle_->name() + "_source");
+  std::vector<VectorPtr> children;
+  for (auto i = 0; i < outputType->size(); ++i) {
+    auto type = outputType->childAt(i);
+    children.push_back(BaseVector::createNullConstant(type, 1, pool_.get()));
+  }
+  data_ = std::make_shared<RowVector>(
+      pool_.get(), outputType, BufferPtr(nullptr), 1, std::move(children));
+}
+
+void TestDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  split_ = std::move(split);
+  hasData_ = true;
+}
+
+std::optional<RowVectorPtr> TestDataSource::next(
+    uint64_t,
+    velox::ContinueFuture&) {
+  if (!hasData_) {
+    return std::nullopt;
+  }
+  hasData_ = false;
+  return data_;
+}
+
+void TestDataSource::addDynamicFilter(
+    column_index_t,
+    const std::shared_ptr<common::Filter>&) {}
+
+memory::MemoryPool* TestDataSource::pool() const {
+  return pool_.get();
+}
+
+std::unique_ptr<DataSource> TestConnector::createDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap&,
+    ConnectorQueryCtx*) {
+  return std::make_unique<TestDataSource>(outputType, tableHandle);
+}
+
+std::unique_ptr<DataSink> TestConnector::createDataSink(
+    RowTypePtr,
+    ConnectorInsertTableHandlePtr,
+    ConnectorQueryCtx*,
+    CommitStrategy) {
+  return std::make_unique<TestDataSink>();
+}
+
+void TestConnector::addTable(
+    const std::string& name,
+    const RowTypePtr& schema,
+    uint64_t rows) {
+  metadata_->addTable(name, schema, this, rows);
+}
+
+void TestConnector::addTable(
+    const std::string& name,
+    const RowTypePtr& schema) {
+  metadata_->addTable(name, schema, this, /*rows=*/1000);
+}
+
+void TestConnector::addTable(const std::string& name) {
+  metadata_->addTable(name, /*schema=*/ROW({}, {}), this, /*rows=*/1000);
+}
+
+} // namespace facebook::velox::connector

--- a/frontend/optimizer/connectors/tests/TestConnector.h
+++ b/frontend/optimizer/connectors/tests/TestConnector.h
@@ -9,57 +9,255 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
-
 #pragma once
 
 #include "velox/frontend/optimizer/connectors/ConnectorMetadata.h"
 
 namespace facebook::velox::connector {
 
+// Forward declarations
+class TestConnector;
+
+class TestColumn : public Column {
+ public:
+  TestColumn(const std::string& name, const TypePtr& type)
+      : Column(name, type) {}
+};
+
+class TestTableLayout : public TableLayout {
+ public:
+  TestTableLayout(
+      const std::string& name,
+      const Table* table,
+      connector::Connector* connector,
+      std::vector<const Column*> columns)
+      : TableLayout(
+            name,
+            table,
+            connector,
+            std::move(columns),
+            {}, // partitionColumns
+            {}, // orderColumns
+            {}, // sortOrder
+            {}, // lookupKeys
+            true) {} // supportsScan
+
+  const std::vector<const Column*>& columns() const {
+    return TableLayout::columns();
+  }
+
+  std::pair<int64_t, int64_t> sample(
+      const connector::ConnectorTableHandlePtr& handle,
+      float pct,
+      std::vector<core::TypedExprPtr> extraFilters,
+      RowTypePtr outputType = nullptr,
+      const std::vector<common::Subfield>& fields = {},
+      HashStringAllocator* allocator = nullptr,
+      std::vector<ColumnStatistics>* statistics = nullptr) const override;
+};
+
 class TestTable : public Table {
  public:
-  TestTable(const std::string& name, const RowTypePtr& schema) : Table(name) {
-    type_ = schema;
-  }
+  TestTable(
+      const std::string& name,
+      const RowTypePtr& schema,
+      TestConnector* connector,
+      uint64_t rows);
 
   const std::unordered_map<std::string, const Column*>& columnMap()
       const override {
-    VELOX_NYI();
+    return columns_;
   }
 
   const std::vector<const TableLayout*>& layouts() const override {
-    VELOX_NYI();
+    return layouts_;
   }
 
   uint64_t numRows() const override {
-    VELOX_NYI();
+    return rows_;
   }
+
+ private:
+  std::vector<const Column*> getColumnVector() const;
+
+  connector::Connector* connector_;
+  uint64_t rows_;
+  std::unordered_map<std::string, const Column*> columns_;
+  std::vector<std::unique_ptr<Column>> exportedColumns_;
+  std::vector<const TableLayout*> layouts_;
+  std::vector<std::unique_ptr<TableLayout>> exportedLayouts_;
+};
+
+class TestSplit : public ConnectorSplit {
+ public:
+  explicit TestSplit(const std::string& connectorId)
+      : ConnectorSplit(connectorId) {}
+};
+
+class TestSplitSource : public SplitSource {
+ public:
+  TestSplitSource(
+      const std::string& connectorId,
+      const std::vector<std::shared_ptr<const PartitionHandle>>& partitions)
+      : connectorId_(connectorId),
+        partitions_(partitions),
+        currentPartition_(0) {}
+
+  std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) override;
+
+ private:
+  std::string connectorId_;
+  std::vector<std::shared_ptr<const PartitionHandle>> partitions_;
+  size_t currentPartition_;
+};
+
+class TestSplitManager : public ConnectorSplitManager {
+ public:
+  std::vector<std::shared_ptr<const PartitionHandle>> listPartitions(
+      const ConnectorTableHandlePtr& tableHandle) override;
+
+  std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorTableHandlePtr& tableHandle,
+      std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+      SplitOptions options = {}) override;
+};
+
+class TestColumnHandle : public ColumnHandle {
+ public:
+  TestColumnHandle(const std::string& name, TypePtr type)
+      : name_(name), type_(std::move(type)) {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+  const TypePtr& type() const {
+    return type_;
+  }
+
+ private:
+  std::string name_;
+  TypePtr type_;
+};
+
+class TestTableHandle : public ConnectorTableHandle {
+ public:
+  TestTableHandle(
+      const TableLayout& layout,
+      std::vector<ColumnHandlePtr> columnHandles,
+      std::vector<core::TypedExprPtr> filters = {})
+      : ConnectorTableHandle(layout.connector()->connectorId()),
+        layout_(layout),
+        columnHandles_(std::move(columnHandles)),
+        filters_(std::move(filters)) {}
+
+  const std::string& name() const override {
+    return layout_.table()->name();
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  const TableLayout& layout() const {
+    return layout_;
+  }
+
+  const std::vector<core::TypedExprPtr>& filters() const {
+    return filters_;
+  }
+
+  const std::vector<ColumnHandlePtr>& columnHandles() const {
+    return columnHandles_;
+  }
+
+ private:
+  const TableLayout& layout_;
+  std::vector<ColumnHandlePtr> columnHandles_;
+  std::vector<core::TypedExprPtr> filters_;
 };
 
 class TestConnectorMetadata : public ConnectorMetadata {
  public:
+  TestConnectorMetadata()
+      : splitManager_(std::make_unique<TestSplitManager>()) {}
+
   void initialize() override {}
 
-  const Table* findTable(const std::string& name) override {
-    auto it = tables_.find(name);
-    VELOX_USER_CHECK(it != tables_.end(), "Test table not found: {}", name);
-    return it->second.get();
-  }
+  const Table* findTable(const std::string& name) override;
 
   ConnectorSplitManager* splitManager() override {
-    VELOX_NYI();
+    return splitManager_.get();
   }
 
-  void addTable(const std::string& name, const RowTypePtr& schema) {
-    tables_.emplace(name, std::make_unique<TestTable>(name, schema));
-  }
+  ColumnHandlePtr createColumnHandle(
+      const TableLayout& layout,
+      const std::string& columnName,
+      std::vector<common::Subfield> subfields = {},
+      std::optional<TypePtr> castToType = std::nullopt,
+      SubfieldMapping subfieldMapping = {}) override;
+
+  ConnectorTableHandlePtr createTableHandle(
+      const TableLayout& layout,
+      std::vector<ColumnHandlePtr> columnHandles,
+      core::ExpressionEvaluator& evaluator,
+      std::vector<core::TypedExprPtr> filters,
+      std::vector<core::TypedExprPtr>& rejectedFilters,
+      RowTypePtr dataColumns = nullptr,
+      std::optional<LookupKeys> = std::nullopt) override;
+
+  void addTable(
+      const std::string& name,
+      const RowTypePtr& schema,
+      TestConnector* connector,
+      uint64_t rows);
 
  private:
   std::unordered_map<std::string, std::unique_ptr<TestTable>> tables_;
+  std::unique_ptr<TestSplitManager> splitManager_;
+};
+
+class TestDataSource : public DataSource {
+ public:
+  TestDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle);
+
+  void addSplit(std::shared_ptr<ConnectorSplit> split) override;
+
+  std::optional<RowVectorPtr> next(uint64_t size, velox::ContinueFuture& future)
+      override;
+
+  void addDynamicFilter(
+      column_index_t outputChannel,
+      const std::shared_ptr<common::Filter>& filter) override;
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return 0;
+  }
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+    return {};
+  }
+
+ private:
+  memory::MemoryPool* pool() const;
+
+ private:
+  RowTypePtr outputType_;
+  ConnectorTableHandlePtr tableHandle_;
+  std::shared_ptr<ConnectorSplit> split_;
+  RowVectorPtr data_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  bool hasData_{false};
 };
 
 class TestConnector : public Connector {
@@ -71,32 +269,50 @@ class TestConnector : public Connector {
     return metadata_.get();
   }
 
-  std::unique_ptr<DataSource> createDataSource(
-      const RowTypePtr& /* outputType */,
-      const ConnectorTableHandlePtr& /* tableHandle */,
-      const ColumnHandleMap& /* columnHandles */,
-      ConnectorQueryCtx* /* connectorQueryCtx */) override {
-    VELOX_NYI();
+  bool supportsSplitPreload() override {
+    return true;
   }
+
+  bool canAddDynamicFilter() const override {
+    return true;
+  }
+
+  std::unique_ptr<DataSource> createDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& columnHandles,
+      ConnectorQueryCtx* connectorQueryCtx) override;
 
   std::unique_ptr<DataSink> createDataSink(
-      RowTypePtr /* inputType */,
-      ConnectorInsertTableHandlePtr /* connectorInsertTableHandle */,
-      ConnectorQueryCtx* /* connectorQueryCtx */,
-      CommitStrategy /* commitStrategy */) override {
-    VELOX_NYI();
-  }
+      RowTypePtr inputType,
+      ConnectorInsertTableHandlePtr connectorInsertTableHandle,
+      ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy) override;
 
-  void addTable(const std::string& name, const RowTypePtr& schema) {
-    metadata_->addTable(name, schema);
-  }
+  void
+  addTable(const std::string& name, const RowTypePtr& schema, uint64_t rows);
 
-  void addTable(const std::string& name) {
-    metadata_->addTable(name, ROW({}, {}));
-  }
+  void addTable(const std::string& name, const RowTypePtr& schema);
+
+  void addTable(const std::string& name);
 
  private:
   const std::unique_ptr<TestConnectorMetadata> metadata_;
+};
+
+class TestDataSink : public DataSink {
+ public:
+  void appendData(RowVectorPtr) override {}
+  bool finish() override {
+    return true;
+  }
+  std::vector<std::string> close() override {
+    return {};
+  }
+  void abort() override {}
+  Stats stats() const override {
+    return {};
+  }
 };
 
 } // namespace facebook::velox::connector

--- a/frontend/optimizer/tests/CMakeLists.txt
+++ b/frontend/optimizer/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_executable(
   velox_plan_test PlanTest.cpp Tpch.cpp ParquetTpchTest.cpp QueryTestBase.cpp
-                  SubfieldTest.cpp FeatureGen.cpp)
+                  SubfieldTest.cpp FeatureGen.cpp OptimizerTest.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 
@@ -26,6 +26,7 @@ target_link_libraries(
   velox_hive_connector_metadata
   velox_exec_runner_test_util
   velox_exec_test_lib
+  velox_test_connector_metadata
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader
   gtest

--- a/frontend/optimizer/tests/OptimizerTest.cpp
+++ b/frontend/optimizer/tests/OptimizerTest.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/expression/Expr.h"
+#include "velox/frontend/optimizer/Plan.h"
+#include "velox/frontend/optimizer/SchemaResolver.h"
+#include "velox/frontend/optimizer/VeloxHistory.h"
+#include "velox/frontend/optimizer/connectors/tests/TestConnector.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+
+namespace facebook::velox::optimizer::test {
+namespace {
+
+class OptimizerTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+    rootPool_ = velox::memory::memoryManager()->addRootPool("optimizer_test");
+    optimizerPool_ = rootPool_->addLeafChild("optimizer");
+
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    parse::registerTypeResolver();
+
+    connector_ = std::make_shared<connector::TestConnector>("test");
+    connector_->addTable(
+        "orders",
+        ROW(
+            {{"o_orderkey", BIGINT()},
+             {"o_custkey", BIGINT()},
+             {"o_orderstatus", VARCHAR()},
+             {"o_totalprice", DOUBLE()},
+             {"o_orderdate", VARCHAR()},
+             {"o_orderpriority", VARCHAR()},
+             {"o_clerk", VARCHAR()},
+             {"o_shippriority", INTEGER()},
+             {"o_comment", VARCHAR()}}),
+        50 * 1000);
+    connector_->addTable(
+        "customer",
+        ROW(
+            {{"c_custkey", BIGINT()},
+             {"c_name", VARCHAR()},
+             {"c_address", VARCHAR()},
+             {"c_nationkey", BIGINT()},
+             {"c_phone", VARCHAR()},
+             {"c_acctbal", DOUBLE()},
+             {"c_mktsegment", VARCHAR()},
+             {"c_comment", VARCHAR()}}),
+        1000);
+
+    schema_ = std::make_shared<SchemaResolver>(connector_, "");
+    history_ = std::make_unique<VeloxHistory>();
+
+    queryCtx_ = core::QueryCtx::create();
+    evaluator_ = std::make_unique<exec::SimpleExpressionEvaluator>(
+        queryCtx_.get(), optimizerPool_.get());
+
+    allocator_ = std::make_unique<HashStringAllocator>(optimizerPool_.get());
+    context_ = std::make_unique<QueryGraphContext>(*allocator_);
+    queryCtx() = context_.get();
+  }
+
+ protected:
+  PlanAndStats optimize(core::PlanNodePtr plan) {
+    runner::MultiFragmentPlan::Options opts;
+    opts.numWorkers = 1;
+    opts.numDrivers = 1;
+    opts.queryId = "test";
+
+    Locus locus(connector_->connectorId().c_str(), connector_.get());
+    Schema schema("test", schema_.get(), &locus);
+
+    OptimizerOptions optimizerOpts;
+    Optimization opt(
+        *plan, schema, *history_, queryCtx_, *evaluator_, optimizerOpts, opts);
+    return opt.toVeloxPlan(std::move(opt.bestPlan()->op), opts);
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> optimizerPool_;
+  std::shared_ptr<connector::TestConnector> connector_;
+  std::shared_ptr<SchemaResolver> schema_;
+  std::unique_ptr<VeloxHistory> history_;
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::unique_ptr<exec::SimpleExpressionEvaluator> evaluator_;
+  std::unique_ptr<HashStringAllocator> allocator_;
+  std::unique_ptr<QueryGraphContext> context_;
+};
+
+TEST_F(OptimizerTest, select) {
+  auto orderType = ROW(
+      {{"o_orderkey", BIGINT()},
+       {"o_custkey", BIGINT()},
+       {"o_totalprice", DOUBLE()}});
+  auto plan = exec::test::PlanBuilder()
+                  .tableScan("orders", orderType)
+                  .filter("o_custkey < 100")
+                  .project({"o_orderkey", "o_custkey", "o_totalprice"})
+                  .planNode();
+
+  auto optimizedPlan = optimize(plan);
+  ASSERT_TRUE(optimizedPlan.plan != nullptr);
+  auto fragments = optimizedPlan.plan->fragments();
+  ASSERT_EQ(fragments.size(), 1);
+  auto node = fragments[0].fragment.planNode;
+
+  // Expect plan structured like the following:
+  // Project[1][expressions:
+  //        (dt1.o_orderkey:BIGINT, "t2.o_orderkey"),
+  //        (dt1.o_custkey:BIGINT, "t2.o_custkey"),
+  //        (dt1.o_totalprice:DOUBLE, "t2.o_totalprice")]
+  //   TableScan[0][orders]
+  ASSERT_EQ(node->name(), "Project");
+  auto projectNode = std::dynamic_pointer_cast<const core::ProjectNode>(node);
+  ASSERT_TRUE(projectNode != nullptr);
+
+  auto scanNode = projectNode->sources()[0];
+  ASSERT_EQ(scanNode->name(), "TableScan");
+  auto tableScanNode =
+      std::dynamic_pointer_cast<const core::TableScanNode>(scanNode);
+  ASSERT_TRUE(tableScanNode != nullptr);
+  ASSERT_EQ(tableScanNode->tableHandle()->name(), "orders");
+
+  auto handle = std::dynamic_pointer_cast<const connector::TestTableHandle>(
+      tableScanNode->tableHandle());
+  ASSERT_TRUE(handle != nullptr);
+  // these filters were created via filter pushdown
+  const auto& filters = handle->filters();
+  ASSERT_EQ(filters.size(), 1);
+  ASSERT_EQ(filters[0]->toString(), "lt(\"o_custkey\",100)");
+}
+
+TEST_F(OptimizerTest, join) {
+  auto orderType = ROW(
+      {{"o_orderkey", BIGINT()},
+       {"o_custkey", BIGINT()},
+       {"o_totalprice", DOUBLE()}});
+  auto customerType = ROW(
+      {{"c_custkey", BIGINT()},
+       {"c_name", VARCHAR()},
+       {"c_acctbal", DOUBLE()}});
+
+  auto plan =
+      exec::test::PlanBuilder()
+          .tableScan("orders", orderType)
+          .hashJoin(
+              {"o_custkey"},
+              {"c_custkey"},
+              exec::test::PlanBuilder()
+                  .tableScan("customer", customerType)
+                  .planNode(),
+              "",
+              {"o_orderkey", "o_totalprice", "c_name", "c_acctbal"},
+              core::JoinType::kInner)
+          .project({"o_orderkey", "o_totalprice", "c_name", "c_acctbal"})
+          .planNode();
+
+  auto optimizedPlan = optimize(plan);
+  ASSERT_TRUE(optimizedPlan.plan != nullptr);
+  auto fragments = optimizedPlan.plan->fragments();
+  ASSERT_EQ(fragments.size(), 1);
+  auto node = fragments[0].fragment.planNode;
+
+  // Expect plan structured like the following:
+  // Project[3][expressions:
+  //        (dt1.o_orderkey:BIGINT, "t2.o_orderkey"),
+  //        (dt1.o_totalprice:DOUBLE, "t2.o_totalprice"),
+  //        (dt1.c_name:VARCHAR, "t3.c_name"),
+  //        (dt1.c_acctbal:DOUBLE, "t3.c_acctbal")]
+  //   HashJoin[2][INNER t3.c_custkey=t2.o_custkey]
+  //     TableScan[0][customer]
+  //     TableScan[1][orders]
+  ASSERT_EQ(node->name(), "Project");
+  auto projectNode = std::dynamic_pointer_cast<const core::ProjectNode>(node);
+  ASSERT_TRUE(projectNode != nullptr);
+
+  auto joinNode = projectNode->sources()[0];
+  ASSERT_EQ(joinNode->name(), "HashJoin");
+  auto hashJoinNode =
+      std::dynamic_pointer_cast<const core::HashJoinNode>(joinNode);
+  ASSERT_TRUE(hashJoinNode != nullptr);
+  ASSERT_EQ(hashJoinNode->joinType(), core::JoinType::kInner);
+
+  auto inputNode1 = hashJoinNode->sources()[0];
+  ASSERT_EQ(inputNode1->name(), "TableScan");
+  auto scanNode1 =
+      std::dynamic_pointer_cast<const core::TableScanNode>(inputNode1);
+  ASSERT_TRUE(scanNode1 != nullptr);
+  ASSERT_EQ(scanNode1->tableHandle()->name(), "customer");
+
+  auto inputNode2 = hashJoinNode->sources()[1];
+  ASSERT_EQ(inputNode2->name(), "TableScan");
+  auto scanNode2 =
+      std::dynamic_pointer_cast<const core::TableScanNode>(inputNode2);
+  ASSERT_TRUE(scanNode2 != nullptr);
+  ASSERT_EQ(scanNode2->tableHandle()->name(), "orders");
+}
+
+TEST_F(OptimizerTest, aggregation) {
+  auto orderType = ROW(
+      {{"o_orderkey", BIGINT()},
+       {"o_custkey", BIGINT()},
+       {"o_totalprice", DOUBLE()}});
+  auto plan = exec::test::PlanBuilder()
+                  .tableScan("orders", orderType)
+                  .filter("o_totalprice > 1000.0")
+                  .aggregation(
+                      {"o_custkey"},
+                      {},
+                      {"sum(o_totalprice) AS total_price",
+                       "count(o_orderkey) AS order_count"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+
+  auto optimizedPlan = optimize(plan);
+  ASSERT_TRUE(optimizedPlan.plan != nullptr);
+  auto fragments = optimizedPlan.plan->fragments();
+  ASSERT_EQ(fragments.size(), 1);
+  auto node = fragments[0].fragment.planNode;
+
+  // Expect plan structured like the following:
+  // Project[3][expressions:
+  //    (dt1.o_custkey:BIGINT, "t2.o_custkey"),
+  //    (dt1.total_price:DOUBLE, "dt1.total_price"),
+  //    (dt1.order_count:BIGINT, "dt1.order_count")]
+  //   Aggregation[2][FINAL [t2.o_custkey]]
+  //     Aggregation[1][PARTIAL [t2.o_custkey]]
+  //       TableScan[0][orders]
+  ASSERT_EQ(node->name(), "Project");
+  auto projectNode = std::dynamic_pointer_cast<const core::ProjectNode>(node);
+  ASSERT_TRUE(projectNode != nullptr);
+
+  auto finalAggNode = projectNode->sources()[0];
+  ASSERT_EQ(finalAggNode->name(), "Aggregation");
+  auto finalAggregationNode =
+      std::dynamic_pointer_cast<const core::AggregationNode>(finalAggNode);
+  ASSERT_TRUE(finalAggregationNode != nullptr);
+  ASSERT_EQ(finalAggregationNode->step(), core::AggregationNode::Step::kFinal);
+
+  auto partialAggNode = finalAggregationNode->sources()[0];
+  ASSERT_EQ(partialAggNode->name(), "Aggregation");
+  auto partialAggregationNode =
+      std::dynamic_pointer_cast<const core::AggregationNode>(partialAggNode);
+  ASSERT_TRUE(partialAggregationNode != nullptr);
+  ASSERT_EQ(
+      partialAggregationNode->step(), core::AggregationNode::Step::kPartial);
+
+  auto scanNode = partialAggregationNode->sources()[0];
+  ASSERT_EQ(scanNode->name(), "TableScan");
+  auto tableScanNode =
+      std::dynamic_pointer_cast<const core::TableScanNode>(scanNode);
+  ASSERT_TRUE(tableScanNode != nullptr);
+  ASSERT_EQ(tableScanNode->tableHandle()->name(), "orders");
+
+  auto handle = std::dynamic_pointer_cast<const connector::TestTableHandle>(
+      tableScanNode->tableHandle());
+  ASSERT_TRUE(handle != nullptr);
+  // these filters were created via filter pushdown
+  const auto& filters = handle->filters();
+  ASSERT_EQ(filters.size(), 1);
+  ASSERT_EQ(filters[0]->toString(), "gt(\"o_totalprice\",1000)");
+}
+
+} // namespace
+} // namespace facebook::velox::optimizer::test


### PR DESCRIPTION
Summary:
In this change adding support for processing plans which contain TableWrite nodes in Verax

This is actually a very simple case for two reasons:

1. there can be only one TableWrite node per plan
2. TableWrites are always leaf nodes, which means it's very easy to extract from the plan immediately and hold until it's time to construct the output Velox plan

The details of the table write are stored in an intermediate representation TableWriteIR which just holds some fields for input type, input column names, the table handle, and a couple others. At the time we move from the relational plan back to a Velox plan, this intermediate representation is validated against the optimized plan and recreated

Things would get more complicated if we permitted this table write to be bucketed. It would involve some additional exchanges and holding additional information to construct the output plan. But (1) this is complicated and (2) we don't have an immediate use for it, since the first Axiom use-case is the single node Impulse deployment (non-distributed)

This will need revisiting once we adopt logical plans

Differential Revision: D78389886


