### PR TITLE
feat: Accept logical plans as optimizer input

### DIFF
--- a/frontend/optimizer/CMakeLists.txt
+++ b/frontend/optimizer/CMakeLists.txt
@@ -19,7 +19,9 @@ add_subdirectory(connectors)
 add_library(
   velox_verax
   ToGraph.cpp
+  LogicalPlanToGraph.cpp
   Subfields.cpp
+  LogicalPlanSubfields.cpp
   Plan.cpp
   BitSet.cpp
   ParallelExpr.cpp
@@ -41,5 +43,6 @@ add_library(
 
 add_dependencies(velox_verax velox_hive_connector)
 
-target_link_libraries(velox_verax velox_core velox_connector_metadata
-                      velox_multifragment_plan velox_connector)
+target_link_libraries(
+  velox_verax velox_core velox_connector_metadata velox_fe_logical_plan
+  velox_multifragment_plan velox_connector)

--- a/frontend/optimizer/LogicalPlanSubfields.cpp
+++ b/frontend/optimizer/LogicalPlanSubfields.cpp
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/Plan.h" //@manual
+#include "optimizer/PlanUtils.h" //@manual
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/ConstantExpr.h"
+
+namespace facebook::velox::optimizer {
+
+using namespace facebook::velox;
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace {
+
+RowTypePtr lambdaArgType(const lp::Expr* expr) {
+  auto* l = dynamic_cast<const lp::LambdaExpr*>(expr);
+  VELOX_CHECK_NOT_NULL(l);
+  return l->signature();
+}
+} // namespace
+
+PathCP stepsToPath(const std::vector<Step>& steps) {
+  std::vector<Step> reverse;
+  for (int32_t i = steps.size() - 1; i >= 0; --i) {
+    reverse.push_back(steps[i]);
+  }
+  return queryCtx()->toPath(make<Path>(std::move(reverse)));
+}
+
+void Optimization::markFieldAccessed(
+    const LogicalContextSource& source,
+    int32_t ordinal,
+    std::vector<Step>& steps,
+    bool isControl,
+    const std::vector<const RowType*>& context,
+    const std::vector<LogicalContextSource>& sources) {
+  auto fields =
+      isControl ? &logicalControlSubfields_ : &logicalPayloadSubfields_;
+  if (source.planNode) {
+    auto kind = source.planNode->kind();
+    auto path = stepsToPath(steps);
+    fields->nodeFields[source.planNode].resultPaths[ordinal].add(path->id());
+    if (kind == lp::NodeKind::kProject) {
+      auto* project = reinterpret_cast<const lp::ProjectNode*>(source.planNode);
+      markSubfields(
+          project->expressions()[ordinal].get(),
+          steps,
+          isControl,
+          std::vector<const RowType*>{project->inputs()[0]->outputType().get()},
+          std::vector<LogicalContextSource>{
+              LogicalContextSource{.planNode = project->inputs()[0].get()}});
+      return;
+    }
+    if (kind == lp::NodeKind::kAggregate) {
+      auto* agg = reinterpret_cast<const lp::AggregateNode*>(source.planNode);
+      std::vector<const RowType*> inputContext = {
+          agg->inputs()[0]->outputType().get()};
+      std::vector<LogicalContextSource> inputSources = {
+          LogicalContextSource{.planNode = agg->inputs()[0].get()}};
+      auto& keys = agg->groupingKeys();
+      std::vector<Step> empty;
+      if (ordinal < keys.size()) {
+        markSubfields(
+            keys[ordinal].get(), empty, isControl, inputContext, inputSources);
+        return;
+      }
+      auto& aggregate = agg->aggregates()[ordinal - keys.size()];
+      for (auto& in : aggregate->inputs()) {
+        markSubfields(in.get(), empty, isControl, inputContext, inputSources);
+      }
+      if (aggregate->filter()) {
+        markSubfields(
+            aggregate->filter().get(),
+            empty,
+            isControl,
+            inputContext,
+            inputSources);
+      }
+      for (auto& field : aggregate->ordering()) {
+        markSubfields(
+            field.expression.get(),
+            empty,
+            isControl,
+            inputContext,
+            inputSources);
+      }
+      return;
+    }
+    auto& sourceInputs = source.planNode->inputs();
+    if (sourceInputs.empty()) {
+      return;
+    }
+    auto fieldName = source.planNode->outputType()->nameOf(ordinal);
+    for (auto i = 0; i < sourceInputs.size(); ++i) {
+      auto& type = sourceInputs[i]->outputType();
+      auto maybeIdx = type->getChildIdxIfExists(fieldName);
+      if (maybeIdx.has_value()) {
+        LogicalContextSource s{.planNode = sourceInputs[i].get()};
+        markFieldAccessed(
+            s, maybeIdx.value(), steps, isControl, context, sources);
+        return;
+      }
+    }
+    VELOX_FAIL("Should have found source for expr {}", fieldName);
+  }
+  // The source is a lambda arg. We apply the path to the corresponding
+  // container arg of the 2nd order function call that has the lambda.
+  auto* md =
+      FunctionRegistry::instance()->metadata(toName(source.call->name()));
+  auto* lInfo = md->lambdaInfo(source.lambdaOrdinal);
+  auto nth = lInfo->argOrdinal[ordinal];
+  auto callContext = context;
+  callContext.erase(callContext.begin());
+  auto callSources = sources;
+  callSources.erase(callSources.begin());
+  markSubfields(
+      source.call->inputs()[nth].get(),
+      steps,
+      isControl,
+      callContext,
+      callSources);
+}
+
+std::optional<int32_t> Optimization::stepToArg(
+    const Step& step,
+    const FunctionMetadata* metadata) {
+  auto it = std::find(
+      metadata->fieldIndexForArg.begin(),
+      metadata->fieldIndexForArg.end(),
+      step.id);
+  if (it != metadata->fieldIndexForArg.end()) {
+    // The arg corresponding to the step is accessed.
+    return metadata->argOrdinal[it - metadata->fieldIndexForArg.begin()];
+  }
+  return std::nullopt;
+}
+
+bool looksConstant(const lp::ExprPtr& expr) {
+  if (expr->isConstant()) {
+    return true;
+  }
+  if (expr->isInputReference()) {
+    return false;
+  }
+  for (auto& in : expr->inputs()) {
+    if (!looksConstant(in)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const lp::ConstantExprPtr Optimization::maybeFoldLogicalConstant(
+    const lp::ExprPtr expr) {
+  if (expr->isConstant()) {
+    return std::static_pointer_cast<const lp::ConstantExpr>(expr);
+  }
+  if (looksConstant(expr)) {
+    auto literal = translateExpr(expr);
+    if (literal->type() == PlanType::kLiteral) {
+      return std::make_shared<lp::ConstantExpr>(
+          toTypePtr(literal->value().type), literal->as<Literal>()->literal());
+    }
+  }
+  return nullptr;
+}
+
+void Optimization::markSubfields(
+    const lp::Expr* expr,
+    std::vector<Step>& steps,
+    bool isControl,
+    const std::vector<const RowType*> context,
+    const std::vector<LogicalContextSource>& sources) {
+  if (expr->isInputReference()) {
+    auto& name = expr->asUnchecked<lp::InputReferenceExpr>()->name();
+    for (auto i = 0; i < sources.size(); ++i) {
+      auto maybeIdx = context[i]->getChildIdxIfExists(name);
+      if (maybeIdx.has_value()) {
+        auto source = sources[i];
+        markFieldAccessed(
+            source, maybeIdx.value(), steps, isControl, context, sources);
+        return;
+      }
+    }
+    VELOX_FAIL("Field not found {}", name);
+  }
+
+  if (isSpecialForm(expr, lp::SpecialForm::kDereference)) {
+    VELOX_CHECK(expr->inputAt(1)->isConstant());
+    auto* field = expr->inputAt(1)->asUnchecked<lp::ConstantExpr>();
+    auto* input = expr->inputAt(0).get();
+    Name name = nullptr;
+    auto fieldIndex = maybeIntegerLiteral(field);
+    // Always fill both index and name for a struct getter.
+    if (fieldIndex.has_value()) {
+      name =
+          toName(input->type()->as<TypeKind::ROW>().nameOf(fieldIndex.value()));
+    } else {
+      name = toName(field->value().value<TypeKind::VARCHAR>());
+      fieldIndex = input->type()->as<TypeKind::ROW>().getChildIdx(
+          field->value().value<TypeKind::VARCHAR>());
+    }
+    steps.push_back(Step{
+        .kind = StepKind::kField,
+        .field = (name == nullptr || strlen(name) == 0) ? nullptr : name,
+        .id = fieldIndex.has_value() ? fieldIndex.value() : 0});
+    markSubfields(input, steps, isControl, context, sources);
+    steps.pop_back();
+    return;
+  }
+  if (expr->isCall()) {
+    auto& name = expr->asUnchecked<lp::CallExpr>()->name();
+    if (name == "cardinality") {
+      steps.push_back(Step{.kind = StepKind::kCardinality});
+      markSubfields(expr->inputAt(0).get(), steps, isControl, context, sources);
+      steps.pop_back();
+      return;
+    }
+    if (name == "subscript" || name == "element_at") {
+      auto constant = maybeFoldLogicalConstant(expr->inputAt(1));
+      if (!constant) {
+        std::vector<Step> subSteps;
+        markSubfields(
+            expr->inputAt(1).get(), subSteps, isControl, context, sources);
+        steps.push_back(Step{.kind = StepKind::kSubscript, .allFields = true});
+        markSubfields(
+            expr->inputs()[0].get(), steps, isControl, context, sources);
+        steps.pop_back();
+        return;
+      }
+      auto& value = constant->value();
+      if (value.kind() == TypeKind::VARCHAR) {
+        std::string str = value.value<TypeKind::VARCHAR>();
+        steps.push_back(
+            Step{.kind = StepKind::kSubscript, .field = toName(str)});
+        markSubfields(
+            expr->inputs()[0].get(), steps, isControl, context, sources);
+        steps.pop_back();
+        return;
+      }
+      auto id = integerValue(&value);
+      steps.push_back(Step{.kind = StepKind::kSubscript, .id = id});
+      markSubfields(
+          expr->inputs()[0].get(), steps, isControl, context, sources);
+      steps.pop_back();
+      return;
+    }
+    auto* metadata = FunctionRegistry::instance()->metadata(toName(name));
+    if (!metadata || !metadata->processSubfields()) {
+      for (auto i = 0; i < expr->inputs().size(); ++i) {
+        std::vector<Step> steps;
+        markSubfields(
+            expr->inputs()[i].get(), steps, isControl, context, sources);
+      }
+      return;
+    }
+    // The function has non-default metadata. Record subfields.
+    auto* call = reinterpret_cast<const lp::CallExpr*>(expr);
+    auto* fields =
+        isControl ? &logicalControlSubfields_ : &logicalPayloadSubfields_;
+    auto path = stepsToPath(steps);
+    fields->argFields[call].resultPaths[ResultAccess::kSelf].add(path->id());
+    for (auto i = 0; i < expr->inputs().size(); ++i) {
+      if (metadata->subfieldArg.has_value() &&
+          i == metadata->subfieldArg.value()) {
+        // A subfield of func is a subfield of one arg.
+        markSubfields(
+            expr->inputs()[metadata->subfieldArg.value()].get(),
+            steps,
+            isControl,
+            context,
+            sources);
+        continue;
+      }
+      if (!steps.empty() && steps.back().kind == StepKind::kField) {
+        auto maybeNth = stepToArg(steps.back(), metadata);
+        if (maybeNth.has_value() && maybeNth.value() == i) {
+          auto newSteps = steps;
+          auto argPath = stepsToPath(newSteps);
+          fields->argFields[expr].resultPaths[maybeNth.value()].add(
+              argPath->id());
+          newSteps.pop_back();
+          markSubfields(
+              expr->inputs()[maybeNth.value()].get(),
+              newSteps,
+              isControl,
+              context,
+              sources);
+          continue;
+        } else if (
+            std::find(
+                metadata->fieldIndexForArg.begin(),
+                metadata->fieldIndexForArg.end(),
+                i) != metadata->fieldIndexForArg.end()) {
+          // The ith argument corresponds to some subfield field index
+          // other than the one in path, so this argument is not
+          // referenced.
+          continue;
+        }
+      }
+      if (auto* lambda = metadata->lambdaInfo(i)) {
+        auto argType = lambdaArgType(expr->inputs()[i].get());
+        std::vector<const RowType*> newContext = {argType.get()};
+        newContext.insert(newContext.end(), context.begin(), context.end());
+        std::vector<LogicalContextSource> newSources = {LogicalContextSource{
+            .call = expr->asUnchecked<lp::CallExpr>(), .lambdaOrdinal = i}};
+        newSources.insert(newSources.end(), sources.begin(), sources.end());
+
+        auto* l = expr->inputAt(i)->asUnchecked<lp::LambdaExpr>();
+        std::vector<Step> empty;
+        markSubfields(
+            l->body().get(), empty, isControl, newContext, newSources);
+        continue;
+        markSubfields(
+            expr->inputs()[i].get(), empty, isControl, context, sources);
+        continue;
+      }
+      // The argument is not special, just mark through without path.
+      std::vector<Step> empty;
+      markSubfields(
+          expr->inputs()[i].get(), empty, isControl, context, sources);
+    }
+    return;
+  }
+  if (expr->isConstant()) {
+    return;
+  }
+  if (expr->isSpecialForm()) {
+    for (auto i = 0; i < expr->inputs().size(); ++i) {
+      std::vector<Step> steps;
+      markSubfields(
+          expr->inputs()[i].get(), steps, isControl, context, sources);
+    }
+    return;
+  }
+  VELOX_UNREACHABLE("Unhandled expr: {}", lp::ExprPrinter::toText(*expr));
+}
+
+void Optimization::markColumnSubfields(
+    const lp::LogicalPlanNode* node,
+    const std::vector<logical_plan::ExprPtr>& columns,
+    int32_t source) {
+  std::vector<const RowType*> context = {
+      node->inputs()[source]->outputType().get()};
+  std::vector<LogicalContextSource> sources = {
+      {.planNode = node->inputs()[source].get()}};
+  for (auto i = 0; i < columns.size(); ++i) {
+    std::vector<Step> steps;
+    markSubfields(columns[i].get(), steps, true, context, sources);
+  }
+}
+
+void Optimization::markControl(const lp::LogicalPlanNode* node) {
+  auto kind = node->kind();
+  if (kind == lp::NodeKind::kJoin) {
+    auto* join = reinterpret_cast<const lp::JoinNode*>(node);
+    if (auto* filter = join->condition().get()) {
+      std::vector<const RowType*> context = {
+          join->left()->outputType().get(), join->right()->outputType().get()};
+      std::vector<LogicalContextSource> sources = {
+          {.planNode = join->left().get()}, {.planNode = join->right().get()}};
+      std::vector<Step> steps;
+      markSubfields(filter, steps, true, context, sources);
+    }
+  } else if (kind == lp::NodeKind::kFilter) {
+    std::vector<const RowType*> context = {
+        node->inputAt(0)->outputType().get()};
+    std::vector<LogicalContextSource> sources = {
+        {.planNode = node->inputAt(0).get()}};
+    std::vector<Step> steps;
+    markSubfields(
+        reinterpret_cast<const lp::FilterNode*>(node)->predicate().get(),
+        steps,
+        true,
+        context,
+        sources);
+  } else if (kind == lp::NodeKind::kAggregate) {
+    auto* agg = dynamic_cast<const lp::AggregateNode*>(node);
+    markColumnSubfields(node, agg->groupingKeys(), 0);
+  } else if (kind == lp::NodeKind::kSort) {
+    auto* order = dynamic_cast<const lp::SortNode*>(node);
+    std::vector<lp::ExprPtr> keys;
+    for (auto& k : order->ordering()) {
+      keys.push_back(k.expression);
+    }
+    markColumnSubfields(node, keys, 0);
+  }
+  for (auto& source : node->inputs()) {
+    markControl(source.get());
+  }
+}
+
+void Optimization::markAllSubfields(
+    const RowType* type,
+    const lp::LogicalPlanNode* node) {
+  markControl(node);
+  LogicalContextSource source = {.planNode = node};
+  std::vector<const RowType*> context;
+  std::vector<LogicalContextSource> sources;
+  for (auto i = 0; i < type->size(); ++i) {
+    std::vector<Step> steps;
+    markFieldAccessed(source, i, steps, false, context, sources);
+  }
+}
+
+std::vector<int32_t> Optimization::usedChannels(
+    const lp::LogicalPlanNode* node) {
+  auto& control = logicalControlSubfields_.nodeFields[node];
+  auto& payload = logicalPayloadSubfields_.nodeFields[node];
+  BitSet unique;
+  std::vector<int32_t> result;
+  for (auto& pair : control.resultPaths) {
+    result.push_back(pair.first);
+    unique.add(pair.first);
+  }
+  for (auto& pair : payload.resultPaths) {
+    if (!unique.contains(pair.first)) {
+      result.push_back(pair.first);
+    }
+  }
+  return result;
+}
+
+namespace {
+
+template <typename T>
+lp::ExprPtr makeKey(const TypePtr& type, T v) {
+  return std::make_shared<lp::ConstantExpr>(type, variant(v));
+}
+} // namespace
+
+lp::ExprPtr stepToLogicalPlanGetter(Step step, lp::ExprPtr arg) {
+  switch (step.kind) {
+    case StepKind::kField: {
+      if (step.field) {
+        auto& type = arg->type()->childAt(
+            arg->type()->as<TypeKind::ROW>().getChildIdx(step.field));
+        return std::make_shared<lp::SpecialFormExpr>(
+            type,
+            lp::SpecialForm::kDereference,
+            std::vector<lp::ExprPtr>{
+                arg,
+                std::make_shared<lp::ConstantExpr>(
+                    VARCHAR(), variant(step.field))});
+      } else {
+        auto& type = arg->type()->childAt(step.id);
+        return std::make_shared<lp::SpecialFormExpr>(
+            type,
+            lp::SpecialForm::kDereference,
+            std::vector<lp::ExprPtr>{
+                arg,
+                std::make_shared<lp::ConstantExpr>(
+                    BIGINT(), variant(step.id))});
+      }
+    }
+    case StepKind::kSubscript: {
+      auto& type = arg->type();
+      if (type->kind() == TypeKind::MAP) {
+        lp::ExprPtr key;
+        switch (type->as<TypeKind::MAP>().childAt(0)->kind()) {
+          case TypeKind::VARCHAR:
+            key = makeKey(VARCHAR(), step.field);
+            break;
+          case TypeKind::BIGINT:
+            key = makeKey<int64_t>(BIGINT(), step.id);
+            break;
+          case TypeKind::INTEGER:
+            key = makeKey<int32_t>(INTEGER(), step.id);
+            break;
+          case TypeKind::SMALLINT:
+            key = makeKey<int16_t>(SMALLINT(), step.id);
+            break;
+          case TypeKind::TINYINT:
+            key = makeKey<int8_t>(TINYINT(), step.id);
+            break;
+          default:
+            VELOX_FAIL("Unsupported key type");
+        }
+
+        return std::make_shared<lp::CallExpr>(
+            type->as<TypeKind::MAP>().childAt(1),
+            "subscript",
+            std::vector<lp::ExprPtr>{arg, key});
+      }
+      return std::make_shared<lp::CallExpr>(
+          type->childAt(0),
+          "subscript",
+          std::vector<lp::ExprPtr>{arg, makeKey<int32_t>(INTEGER(), step.id)});
+    }
+
+    default:
+      VELOX_NYI();
+  }
+}
+
+std::string LogicalPlanSubfields::toString() const {
+  std::stringstream out;
+  out << "Nodes:";
+  for (auto& pair : nodeFields) {
+    out << "Node " << pair.first->id() << " = {";
+    for (auto& s : pair.second.resultPaths) {
+      out << s.first << " -> {";
+      s.second.forEach(
+          [&](auto i) { out << queryCtx()->pathById(i)->toString(); });
+      out << "}\n";
+    }
+  }
+  if (!argFields.empty()) {
+    out << "Functions:";
+    for (auto& pair : argFields) {
+      out << "Func " << lp::ExprPrinter::toText(*pair.first) << " = {";
+      for (auto& s : pair.second.resultPaths) {
+        out << s.first << " -> {";
+        s.second.forEach(
+            [&](auto i) { out << queryCtx()->pathById(i)->toString(); });
+        out << "}\n";
+      }
+    }
+  }
+  return out.str();
+}
+
+} // namespace facebook::velox::optimizer

--- a/frontend/optimizer/LogicalPlanToGraph.cpp
+++ b/frontend/optimizer/LogicalPlanToGraph.cpp
@@ -26,13 +26,11 @@ namespace facebook::velox::optimizer {
 
 using namespace facebook::velox;
 
-std::string veloxToString(const core::PlanNode* plan) {
-  return plan->toString(true, true);
-}
+namespace lp = facebook::velox::logical_plan;
 
 void Optimization::setDerivedTableOutput(
     DerivedTableP dt,
-    const velox::core::PlanNode& planNode) {
+    const velox::logical_plan::LogicalPlanNode& planNode) {
   auto& outputType = planNode.outputType();
   for (auto i = 0; i < outputType->size(); ++i) {
     auto fieldType = outputType->childAt(i);
@@ -46,41 +44,30 @@ void Optimization::setDerivedTableOutput(
   }
 }
 
-DerivedTableP Optimization::makeQueryGraph() {
-  markAllSubfields(inputPlan_->outputType().get(), inputPlan_);
+DerivedTableP Optimization::makeQueryGraphFromLogical() {
+  markAllSubfields(logicalPlan_->outputType().get(), logicalPlan_);
   auto* root = make<DerivedTable>();
   root_ = root;
   currentSelect_ = root_;
   root->cname = toName(fmt::format("dt{}", ++nameCounter_));
-  makeQueryGraph(*inputPlan_, kAllAllowedInDt);
+  makeQueryGraph(*logicalPlan_, kAllAllowedInDt);
   return root_;
 }
 
-const std::string* columnName(const core::TypedExprPtr& expr) {
-  if (auto column =
-          dynamic_cast<const core::FieldAccessTypedExpr*>(expr.get())) {
-    if (column->inputs().empty() ||
-        dynamic_cast<const core::InputTypedExpr*>(column->inputs()[0].get())) {
-      return &column->name();
-    }
+const std::string* columnName(const lp::Expr& expr) {
+  if (expr.isInputReference()) {
+    return &expr.asUnchecked<lp::InputReferenceExpr>()->name();
   }
   return nullptr;
 }
 
-bool isCall(const core::TypedExprPtr& expr, const std::string& name) {
-  if (auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
-    return exec::sanitizeName(call->name()) == name;
-  }
-  return false;
-}
-
 void Optimization::translateConjuncts(
-    const core::TypedExprPtr& input,
+    const lp::ExprPtr& input,
     ExprVector& flat) {
   if (!input) {
     return;
   }
-  if (isCall(input, "and")) {
+  if (isSpecialForm(input.get(), lp::SpecialForm::kAnd)) {
     for (auto& child : input->inputs()) {
       translateConjuncts(child, flat);
     }
@@ -99,9 +86,20 @@ const variant* toVariant(BaseVector& constantVector) {
   VELOX_FAIL("Literal not of foldable type");
 }
 
+std::shared_ptr<const exec::ConstantExpr> Optimization::foldConstant(
+    const core::TypedExprPtr& typedExpr) {
+  auto exprSet = evaluator_.compile(typedExpr);
+  auto first = exprSet->exprs().front().get();
+  if (dynamic_cast<const exec::ConstantExpr*>(first)) {
+    return std::dynamic_pointer_cast<exec::ConstantExpr>(
+        exprSet->exprs().front());
+  }
+  return nullptr;
+}
+
 ExprCP Optimization::tryFoldConstant(
-    const core::CallTypedExpr* call,
-    const core::CastTypedExpr* cast,
+    const lp::CallExpr* call,
+    const lp::SpecialFormExpr* cast,
     const ExprVector& literals) {
   try {
     Value value(call ? toType(call->type()) : toType(cast->type()), 1);
@@ -115,26 +113,25 @@ ExprCP Optimization::tryFoldConstant(
     auto exprSet = evaluator_.compile(typedExpr);
     auto first = exprSet->exprs().front().get();
     if (auto constantExpr = dynamic_cast<const exec::ConstantExpr*>(first)) {
-      core::ConstantTypedExprPtr typed;
+      lp::ConstantExprPtr typed;
       auto kind = constantExpr->type()->kind();
       switch (kind) {
         case TypeKind::ARRAY:
         case TypeKind::ROW:
         case TypeKind::MAP:
-          typed =
-              std::make_shared<core::ConstantTypedExpr>(constantExpr->value());
+          VELOX_NYI("Need complex type to variant conversion");
           break;
         default: {
           auto* variantLiteral = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
               toVariant,
               constantExpr->value()->typeKind(),
               *constantExpr->value());
-          typed = std::make_shared<core::ConstantTypedExpr>(
-              constantExpr->value()->type(), *variantLiteral);
+          typed = std::make_shared<lp::ConstantExpr>(
+              constantExpr->type(), *variantLiteral);
           break;
         }
       }
-      return makeConstant(typed);
+      return makeConstant(*typed);
     }
     return nullptr;
   } catch (const std::exception&) {
@@ -143,37 +140,33 @@ ExprCP Optimization::tryFoldConstant(
 }
 
 bool Optimization::isSubfield(
-    const core::ITypedExpr* expr,
+    const lp::Expr* expr,
     Step& step,
-    core::TypedExprPtr& input) {
-  if (auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(expr)) {
-    input = field->inputs().empty() ? nullptr : field->inputs()[0];
-    if (!input || dynamic_cast<const core::InputTypedExpr*>(input.get())) {
-      return false;
-    }
+    lp::ExprPtr& input) {
+  if (isSpecialForm(expr, lp::SpecialForm::kDereference)) {
     step.kind = StepKind::kField;
-    step.field = toName(field->name());
-    return true;
-  }
-  if (auto deref = dynamic_cast<const core::DereferenceTypedExpr*>(expr)) {
-    step = {.kind = StepKind::kField, .id = deref->index()};
-    input = deref->inputs()[0];
-    auto& type = input->type();
-    VELOX_CHECK_EQ(type->kind(), TypeKind::ROW);
-    auto& name = type->as<TypeKind::ROW>().nameOf(step.id);
-    // There can be field index-only field accesses over functions
-    // that hav row values without field names. These are not suitable
-    // for subfield pruning in columns though, so fill in the name if
-    // there is one.
-    if (!name.empty()) {
-      step.field = toName(name);
+    auto maybeIndex =
+        maybeIntegerLiteral(expr->inputAt(1)->asUnchecked<lp::ConstantExpr>());
+    Name name = nullptr;
+    int64_t id = 0;
+    auto& rowType = expr->inputAt(0)->type()->as<TypeKind::ROW>();
+    if (maybeIndex.has_value()) {
+      id = maybeIndex.value();
+      name = toName(rowType.nameOf(maybeIndex.value()));
+    } else {
+      auto& field = expr->inputAt(1)->asUnchecked<lp::ConstantExpr>()->value();
+      name = toName(field.value<TypeKind::VARCHAR>());
+      id = rowType.getChildIdx(name);
     }
+    step.field = name;
+    step.id = id;
+    input = expr->inputAt(0);
     return true;
   }
-  if (auto* call = dynamic_cast<const core::CallTypedExpr*>(expr)) {
+  if (auto* call = dynamic_cast<const lp::CallExpr*>(expr)) {
     auto name = call->name();
     if (name == "subscript" || name == "element_at") {
-      auto subscript = translateExpr(call->inputs()[1]);
+      auto subscript = translateExpr(call->inputAt(1));
       if (subscript->type() == PlanType::kLiteral) {
         step.kind = StepKind::kSubscript;
         auto& literal = subscript->as<Literal>()->literal();
@@ -182,28 +175,22 @@ bool Optimization::isSubfield(
             step.field = toName(literal.value<TypeKind::VARCHAR>());
             break;
           case TypeKind::BIGINT:
-            step.id = literal.value<TypeKind::BIGINT>();
-            break;
           case TypeKind::INTEGER:
-            step.id = literal.value<TypeKind::INTEGER>();
-            break;
           case TypeKind::SMALLINT:
-            step.id = literal.value<TypeKind::SMALLINT>();
-            break;
           case TypeKind::TINYINT:
-            step.id = literal.value<TypeKind::TINYINT>();
+            step.id = integerValue(&literal);
             break;
           default:
             VELOX_UNREACHABLE();
         }
-        input = expr->inputs()[0];
+        input = expr->inputAt(0);
         return true;
       }
       return false;
     }
     if (name == "cardinality") {
       step.kind = StepKind::kCardinality;
-      input = expr->inputs()[0];
+      input = expr->inputAt(0);
       return true;
     }
   }
@@ -211,43 +198,55 @@ bool Optimization::isSubfield(
 }
 
 void Optimization::getExprForField(
-    const core::FieldAccessTypedExpr* field,
-    core::TypedExprPtr& resultExpr,
+    const lp::Expr* field,
+    lp::ExprPtr& resultExpr,
     ColumnCP& resultColumn,
-    const core::PlanNode*& context) {
+    const lp::LogicalPlanNode*& context) {
   for (;;) {
-    auto& name = field->name();
+    auto& name = field->asUnchecked<lp::InputReferenceExpr>()->name();
     auto row = context->outputType();
     auto ordinal = row->getChildIdx(name);
-    if (auto* project = dynamic_cast<const core::ProjectNode*>(context)) {
-      auto& def = project->projections()[ordinal];
+    if (auto* project = dynamic_cast<const lp::ProjectNode*>(context)) {
+      auto& def = project->expressions()[ordinal];
       if (auto* innerField =
-              dynamic_cast<const core::FieldAccessTypedExpr*>(def.get())) {
-        context = context->sources()[0].get();
+              dynamic_cast<const lp::InputReferenceExpr*>(def.get())) {
+        context = context->inputAt(0).get();
         field = innerField;
         continue;
       }
       resultExpr = def;
-      context = project->sources()[0].get();
+      context = project->inputAt(0).get();
       return;
     }
-    auto& sources = context->sources();
+    auto& sources = context->inputs();
     if (sources.empty()) {
       auto leaf = findLeaf(context);
-      auto internedName = toName(name);
+      auto it = renames_.find(name);
+      VELOX_CHECK(it != renames_.end());
+      auto maybeColumn = it->second;
+      VELOX_CHECK(maybeColumn->type() == PlanType::kColumn);
+      resultColumn = maybeColumn->as<Column>();
       resultExpr = nullptr;
+      context = nullptr;
+#if 0
+      auto internedName = toName(name);
       if (auto* table = dynamic_cast<BaseTableCP>(leaf)) {
-        for (auto i = 0; i < table->columns.size(); ++i) {
+	for (auto i = 0; i < table->columns.size(); ++i) {
           if (table->columns[i]->name() == internedName) {
             resultColumn = table->columns[i];
             break;
           }
         }
-        context = nullptr;
-        return;
-      } else {
+    } else {
         VELOX_NYI("Leaf node is not a table");
       }
+#else
+      VELOX_CHECK_NOT_NULL(resultColumn->relation());
+      if (resultColumn->relation()->type() == PlanType::kTable) {
+        VELOX_CHECK(leaf == resultColumn->relation());
+      }
+#endif
+      return;
     }
     for (auto i = 0; i < sources.size(); ++i) {
       auto& row = sources[i]->outputType();
@@ -260,23 +259,13 @@ void Optimization::getExprForField(
   }
 }
 
-bool isLeafField(const core::ITypedExpr* expr) {
-  if (auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(expr)) {
-    if (field->inputs().empty() ||
-        dynamic_cast<const core::InputTypedExpr*>(field->inputs()[0].get())) {
-      return true;
-    }
-  }
-  return false;
-}
-
 std::optional<ExprCP> Optimization::translateSubfield(
-    const core::TypedExprPtr& inputExpr) {
+    const lp::ExprPtr& inputExpr) {
   std::vector<Step> steps;
-  auto* source = exprSource_;
+  auto* source = logicalExprSource_;
   auto expr = inputExpr;
   for (;;) {
-    core::TypedExprPtr input;
+    lp::ExprPtr input;
     Step step;
     VELOX_CHECK_NOT_NULL(expr);
     bool isStep = isSubfield(expr.get(), step, input);
@@ -286,15 +275,11 @@ std::optional<ExprCP> Optimization::translateSubfield(
       }
       // if this is a field we follow to the expr assigning the field if any.
       Step ignore;
-      core::TypedExprPtr ignore2;
+      lp::ExprPtr ignore2;
       if (!isSubfield(expr.get(), ignore, ignore2)) {
         ColumnCP column = nullptr;
-        if (isLeafField(expr.get())) {
-          getExprForField(
-              reinterpret_cast<const core::FieldAccessTypedExpr*>(expr.get()),
-              expr,
-              column,
-              source);
+        if (expr->isInputReference()) {
+          getExprForField(expr.get(), expr, column, source);
           if (expr) {
             continue;
           }
@@ -307,8 +292,9 @@ std::optional<ExprCP> Optimization::translateSubfield(
           }
         } else {
           ensureFunctionSubfields(expr);
-          auto it = functionSubfields_.find(expr.get());
-          if (it != functionSubfields_.end()) {
+          auto call = expr->asUnchecked<lp::CallExpr>();
+          auto it = logicalFunctionSubfields_.find(call);
+          if (it != logicalFunctionSubfields_.end()) {
             skyline = &it->second;
           }
         }
@@ -329,6 +315,7 @@ std::optional<ExprCP> Optimization::translateSubfield(
   }
 }
 
+namespace {
 PathCP innerPath(const std::vector<Step>& steps, int32_t last) {
   std::vector<Step> reverse;
   for (int32_t i = steps.size() - 1; i >= last; --i) {
@@ -336,11 +323,35 @@ PathCP innerPath(const std::vector<Step>& steps, int32_t last) {
   }
   return toPath(std::move(reverse));
 }
+} // namespace
+
+variant* subscriptLiteral(TypeKind kind, const Step& step) {
+  auto* ctx = queryCtx();
+  switch (kind) {
+    case TypeKind::VARCHAR:
+      return ctx->registerVariant(
+          std::make_unique<variant>(std::string(step.field)));
+    case TypeKind::BIGINT:
+      return ctx->registerVariant(
+          std::make_unique<variant>(static_cast<int64_t>(step.id)));
+    case TypeKind::INTEGER:
+      return ctx->registerVariant(
+          std::make_unique<variant>(static_cast<int32_t>(step.id)));
+    case TypeKind::SMALLINT:
+      return ctx->registerVariant(
+          std::make_unique<variant>(static_cast<int16_t>(step.id)));
+    case TypeKind::TINYINT:
+      return ctx->registerVariant(
+          std::make_unique<variant>(static_cast<int8_t>(step.id)));
+    default:
+      VELOX_FAIL("Unsupported key type");
+  }
+}
 
 ExprCP Optimization::makeGettersOverSkyline(
     const std::vector<Step>& steps,
     const SubfieldProjections* skyline,
-    const core::TypedExprPtr& base,
+    const lp::ExprPtr& base,
     ColumnCP column) {
   int32_t last = steps.size() - 1;
   ExprCP expr = nullptr;
@@ -420,8 +431,8 @@ ExprCP Optimization::makeGettersOverSkyline(
 }
 
 std::optional<BitSet> findSubfields(
-    const PlanSubfields& fields,
-    const core::CallTypedExpr* call) {
+    const LogicalPlanSubfields& fields,
+    const lp::CallExpr* call) {
   auto it = fields.argFields.find(call);
   if (it == fields.argFields.end()) {
     return std::nullopt;
@@ -435,18 +446,18 @@ std::optional<BitSet> findSubfields(
 }
 
 BitSet Optimization::functionSubfields(
-    const core::CallTypedExpr* call,
+    const lp::CallExpr* call,
     bool controlOnly,
     bool payloadOnly) {
   BitSet subfields;
   if (!controlOnly) {
-    auto maybe = findSubfields(payloadSubfields_, call);
+    auto maybe = findSubfields(logicalPayloadSubfields_, call);
     if (maybe.has_value()) {
       subfields = maybe.value();
     }
   }
   if (!payloadOnly) {
-    auto maybe = findSubfields(controlSubfields_, call);
+    auto maybe = findSubfields(logicalControlSubfields_, call);
     if (maybe.has_value()) {
       subfields.unionSet(maybe.value());
     }
@@ -455,54 +466,146 @@ BitSet Optimization::functionSubfields(
   return subfields;
 }
 
-void Optimization::ensureFunctionSubfields(const core::TypedExprPtr& expr) {
-  if (auto* call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
+void Optimization::ensureFunctionSubfields(const lp::ExprPtr& expr) {
+  if (auto* call = dynamic_cast<const lp::CallExpr*>(expr.get())) {
     auto metadata = FunctionRegistry::instance()->metadata(
         exec::sanitizeName(call->name()));
     if (!metadata) {
       return;
     }
-    if (!translatedSubfieldFuncs_.count(call)) {
+    if (!logicalTranslatedSubfieldFuncs_.count(call)) {
       translateExpr(expr);
     }
   }
 }
 
-ExprCP Optimization::makeConstant(const core::ConstantTypedExprPtr& constant) {
-  auto it = exprDedup_.find(constant.get());
-  if (it != exprDedup_.end()) {
+BuiltinNames::BuiltinNames()
+    : eq(toName("eq")),
+      lt(toName("lt")),
+      lte(toName("lte")),
+      gt(toName("gt")),
+      gte(toName("gte")),
+      plus(toName("plus")),
+      multiply(toName("multiply")),
+      _and(toName("and")),
+      _or(toName("or")) {
+  canonicalizable.insert(eq);
+  canonicalizable.insert(lt);
+  canonicalizable.insert(lte);
+  canonicalizable.insert(gt);
+  canonicalizable.insert(gte);
+  canonicalizable.insert(plus);
+  canonicalizable.insert(multiply);
+  canonicalizable.insert(_and);
+  canonicalizable.insert(_or);
+}
+
+Name BuiltinNames::reverse(Name name) const {
+  if (name == lt) {
+    return gt;
+  }
+  if (name == lte) {
+    return gte;
+  }
+  if (name == gt) {
+    return lt;
+  }
+  if (name == gte) {
+    return lte;
+  }
+  return name;
+}
+
+BuiltinNames& Optimization::builtinNames() {
+  if (!builtinNames_) {
+    builtinNames_ = std::make_unique<BuiltinNames>();
+  }
+  return *builtinNames_;
+}
+
+void Optimization::canonicalizeCall(Name& name, ExprVector& args) {
+  auto& names = builtinNames();
+  if (!names.isCanonicalizable(name)) {
+    return;
+  }
+  VELOX_CHECK_EQ(args.size(), 2, "Expecting binary op {}", name);
+  if ((args[0]->type() == PlanType::kLiteral &&
+       args[1]->type() != PlanType::kLiteral) ||
+      args[0]->id() > args[1]->id()) {
+    std::swap(args[0], args[1]);
+    name = names.reverse(name);
+  }
+}
+
+ExprCP Optimization::deduppedCall(
+    Name name,
+    Value value,
+    ExprVector args,
+    FunctionSet flags) {
+  if (args.size() == 2) {
+    canonicalizeCall(name, args);
+  }
+  ExprDedupKey key = {name, &args};
+  auto it = functionDedup_.find(key);
+  if (it != functionDedup_.end()) {
     return it->second;
   }
-
-  Literal* literal;
-  if (constant->hasValueVector()) {
-    auto dedupped = queryCtx()->toVector(constant->valueVector());
-    literal = make<Literal>(Value(toType(constant->type()), 1), dedupped);
-  } else {
-    literal = make<Literal>(
-        Value(toType(constant->type()), 1),
-        queryCtx()->registerVariant(
-            std::make_unique<variant>(constant->value())));
+  auto* call =
+      make<Call>(name, std::move(value), std::move(args), std::move(flags));
+  if (!call->containsFunction(FunctionSet::kNondeterministic)) {
+    key.args = &call->args();
+    functionDedup_[key] = call;
   }
-  // Keep the key live for the optimization duration.
-  tempExprs_.push_back(constant);
-  exprDedup_[constant.get()] = literal;
+  return call;
+}
+
+ExprCP Optimization::makeConstant(const lp::ConstantExpr& constant) {
+  auto temp = constant.valueShared();
+  auto it = constantDedup_.find(temp);
+  if (it != constantDedup_.end()) {
+    return it->second;
+  }
+  auto* literal = make<Literal>(Value(toType(constant.type()), 1), temp.get());
+  // The variant will stay live for the optimization duration.
+  reverseConstantDedup_[literal] = temp;
+  constantDedup_[std::move(temp)] = literal;
   return literal;
 }
 
-ExprCP Optimization::translateExpr(const core::TypedExprPtr& expr) {
-  if (auto name = columnName(expr)) {
+const char* specialFormCallName(const lp::SpecialFormExpr* form) {
+  switch (form->form()) {
+    case lp::SpecialForm::kAnd:
+      return "and";
+    case lp::SpecialForm::kOr:
+      return "or";
+    case lp::SpecialForm::kCast:
+      return "cast";
+    case lp::SpecialForm::kTryCast:
+      return "trycast";
+    case lp::SpecialForm::kCoalesce:
+      return "coalesce";
+    case lp::SpecialForm::kIf:
+      return "if";
+    case lp::SpecialForm::kSwitch:
+      return "switch";
+    default:
+      VELOX_UNREACHABLE(
+          "Bad special form {}", static_cast<int32_t>(form->form()));
+  }
+}
+
+ExprCP Optimization::translateExpr(const lp::ExprPtr& expr) {
+  if (auto name = columnName(*expr)) {
     return translateColumn(*name);
   }
-  if (auto constant =
-          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr)) {
-    return makeConstant(constant);
+  if (expr->isConstant()) {
+    return makeConstant(*expr->asUnchecked<lp::ConstantExpr>());
   }
   auto path = translateSubfield(expr);
   if (path.has_value()) {
     return path.value();
   }
-  auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get());
+  auto call = dynamic_cast<const lp::CallExpr*>(expr.get());
   std::string callName;
   if (call) {
     callName = exec::sanitizeName(call->name());
@@ -514,10 +617,12 @@ ExprCP Optimization::translateExpr(const core::TypedExprPtr& expr) {
       }
     }
   }
-  auto cast = dynamic_cast<const core::CastTypedExpr*>(expr.get());
-  if (!cast && !call) {
-    if (auto* lambda = dynamic_cast<const core::LambdaTypedExpr*>(expr.get())) {
-      return translateLambda(lambda);
+  auto isCast = isSpecialForm(expr.get(), lp::SpecialForm::kCast);
+  const lp::SpecialFormExpr* cast =
+      isCast ? expr->asUnchecked<lp::SpecialFormExpr>() : nullptr;
+  if (!isCast && !call) {
+    if (expr->isLambda()) {
+      return translateLambda(expr->asUnchecked<lp::LambdaExpr>());
     }
   }
   ExprVector args{expr->inputs().size()};
@@ -542,11 +647,13 @@ ExprCP Optimization::translateExpr(const core::TypedExprPtr& expr) {
       return literal;
     }
   }
-  if (call) {
-    auto name = toName(callName);
+  if (call || expr->isSpecialForm()) {
+    auto name = call
+        ? toName(callName)
+        : toName(specialFormCallName(expr->asUnchecked<lp::SpecialFormExpr>()));
     funcs = funcs | functionBits(name);
     auto* callExpr = deduppedCall(
-        name, Value(toType(call->type()), cardinality), std::move(args), funcs);
+        name, Value(toType(expr->type()), cardinality), std::move(args), funcs);
     return callExpr;
   }
   if (cast) {
@@ -562,7 +669,7 @@ ExprCP Optimization::translateExpr(const core::TypedExprPtr& expr) {
   return nullptr;
 }
 
-ExprCP Optimization::translateLambda(const core::LambdaTypedExpr* lambda) {
+ExprCP Optimization::translateLambda(const lp::LambdaExpr* lambda) {
   auto savedRenames = renames_;
   auto row = lambda->signature();
   toType(row);
@@ -580,9 +687,9 @@ ExprCP Optimization::translateLambda(const core::LambdaTypedExpr* lambda) {
 }
 
 std::optional<ExprCP> Optimization::translateSubfieldFunction(
-    const core::CallTypedExpr* call,
+    const lp::CallExpr* call,
     const FunctionMetadata* metadata) {
-  translatedSubfieldFuncs_.insert(call);
+  logicalTranslatedSubfieldFuncs_.insert(call);
   auto subfields = functionSubfields(call, false, false);
   if (subfields.empty()) {
     // The function is accessed as a whole.
@@ -632,211 +739,159 @@ std::optional<ExprCP> Optimization::translateSubfieldFunction(
   }
   auto* name = toName(exec::sanitizeName(call->name()));
   funcs = funcs | functionBits(name);
-  if (metadata->explode) {
-    auto map = metadata->explode(call, paths);
+  if (metadata->logicalExplode) {
+    auto map = metadata->logicalExplode(call, paths);
     std::unordered_map<PathCP, ExprCP> translated;
     for (auto& pair : map) {
       translated[pair.first] = translateExpr(pair.second);
     }
     if (!translated.empty()) {
-      functionSubfields_[call] =
+      logicalFunctionSubfields_[call] =
           SubfieldProjections{.pathToExpr = std::move(translated)};
       return nullptr;
     }
   }
   auto* callExpr =
       make<Call>(name, Value(toType(call->type()), cardinality), args, funcs);
-  exprDedup_[call] = callExpr;
   return callExpr;
 }
 
+ExprCP Optimization::translateColumn(const std::string& name) {
+  auto column = renames_.find(name);
+  if (column != renames_.end()) {
+    return column->second;
+  }
+  VELOX_FAIL("could not resolve name {}", name);
+}
+
 ExprVector Optimization::translateColumns(
-    const std::vector<core::FieldAccessTypedExprPtr>& source) {
+    const std::vector<lp::ExprPtr>& source) {
   ExprVector result{source.size()};
   for (auto i = 0; i < source.size(); ++i) {
-    result[i] = translateColumn(source[i]->name()); // NOLINT
+    result[i] = translateExpr(source[i]); // NOLINT
   }
   return result;
 }
 
-TypePtr intermediateType(const core::CallTypedExprPtr& call) {
-  std::vector<TypePtr> types;
-  for (auto& arg : call->inputs()) {
-    types.push_back(arg->type());
-  }
-  return exec::Aggregate::intermediateType(
-      exec::sanitizeName(call->name()), types);
-}
-
-TypePtr finalType(const core::CallTypedExprPtr& call) {
-  std::vector<TypePtr> types;
-  for (auto& arg : call->inputs()) {
-    types.push_back(arg->type());
-  }
-  return exec::Aggregate::finalType(exec::sanitizeName(call->name()), types);
-}
-
 AggregationP Optimization::translateAggregation(
-    const core::AggregationNode& source) {
-  using velox::core::AggregationNode;
-  if (source.step() == AggregationNode::Step::kPartial ||
-      source.step() == AggregationNode::Step::kSingle) {
-    auto* aggregation =
-        make<Aggregation>(nullptr, translateColumns(source.groupingKeys()));
-    std::unordered_map<std::string, ExprCP> keyRenames;
+    const lp::AggregateNode& source) {
+  auto* aggregation =
+      make<Aggregation>(nullptr, translateColumns(source.groupingKeys()));
+  std::unordered_map<std::string, ExprCP> keyRenames;
 
-    for (auto i = 0; i < source.groupingKeys().size(); ++i) {
-      if (aggregation->grouping[i]->type() == PlanType::kColumn) {
-        aggregation->mutableColumns().push_back(
-            aggregation->grouping[i]->as<Column>());
-      } else {
-        auto name = toName(source.outputType()->nameOf(i));
-        toType(source.outputType()->childAt(i));
+  for (auto i = 0; i < source.groupingKeys().size(); ++i) {
+    if (aggregation->grouping[i]->type() == PlanType::kColumn) {
+      aggregation->mutableColumns().push_back(
+          aggregation->grouping[i]->as<Column>());
+    } else {
+      auto name = toName(source.outputType()->nameOf(i));
+      toType(source.outputType()->childAt(i));
 
-        auto* column = make<Column>(
-            name, currentSelect_, aggregation->grouping[i]->value());
-        aggregation->mutableColumns().push_back(column);
-        keyRenames[name] = column;
-      }
-    }
-    // The keys for intermediate are the same as for final.
-    aggregation->intermediateColumns = aggregation->columns();
-    for (auto channel : usedChannels(&source)) {
-      if (channel < source.groupingKeys().size()) {
-        continue;
-      }
-      auto i = channel - source.groupingKeys().size();
-      auto rawFunc = translateExpr(source.aggregates()[i].call)->as<Call>();
-      ExprCP condition = nullptr;
-      if (source.aggregates()[i].mask) {
-        condition = translateExpr(source.aggregates()[i].mask);
-      }
-      VELOX_CHECK(source.aggregates()[i].sortingKeys.empty());
-      // rawFunc is either a single or a partial aggregation. We need
-      // both final and intermediate types. The type of rawFunc itself
-      // is one or the other so resolve the types using the registered
-      // signatures.
-      auto accumulatorType =
-          toType(intermediateType(source.aggregates()[i].call));
-      Value finalValue = rawFunc->value();
-      finalValue.type = toType(finalType(source.aggregates()[i].call));
-      auto* agg = make<Aggregate>(
-          rawFunc->name(),
-          finalValue,
-          rawFunc->args(),
-          rawFunc->functions(),
-          false,
-          condition,
-          false,
-          accumulatorType);
-      auto name = toName(source.aggregateNames()[i]);
-      auto* column = make<Column>(name, currentSelect_, agg->value());
+      auto* column =
+          make<Column>(name, currentSelect_, aggregation->grouping[i]->value());
       aggregation->mutableColumns().push_back(column);
-      auto intermediateValue = agg->value();
-      intermediateValue.type = accumulatorType;
-      auto* intermediateColumn =
-          make<Column>(name, currentSelect_, intermediateValue);
-      aggregation->intermediateColumns.push_back(intermediateColumn);
-      auto dedupped = queryCtx()->dedup(agg);
-      aggregation->aggregates.push_back(dedupped->as<Aggregate>());
-      auto resultName = toName(source.aggregateNames()[i]);
-      renames_[resultName] = aggregation->columns().back();
+      keyRenames[name] = column;
     }
-    for (auto& pair : keyRenames) {
-      renames_[pair.first] = pair.second;
-    }
-    return aggregation;
   }
-  return nullptr;
+  // The keys for intermediate are the same as for final.
+  aggregation->intermediateColumns = aggregation->columns();
+  for (auto channel : usedChannels(&source)) {
+    if (channel < source.groupingKeys().size()) {
+      continue;
+    }
+    auto i = channel - source.groupingKeys().size();
+    auto aggregate = source.aggregates()[i];
+    ExprVector args = translateColumns(aggregate->inputs());
+    FunctionSet funcs;
+    std::vector<TypePtr> argTypes;
+    for (auto& arg : args) {
+      funcs = funcs | arg->functions();
+      argTypes.push_back(toTypePtr(arg->value().type));
+    }
+    ExprCP condition = nullptr;
+    if (aggregate->filter()) {
+      condition = translateExpr(aggregate->filter());
+    }
+    VELOX_CHECK(aggregate->ordering().empty());
+    Name aggName = toName(aggregate->name());
+
+    auto accumulatorType =
+        toType(exec::Aggregate::intermediateType(aggregate->name(), argTypes));
+    Value finalValue = Value(toType(aggregate->type()), 1);
+    auto* agg = make<Aggregate>(
+        aggName,
+        finalValue,
+        args,
+        funcs,
+        false,
+        condition,
+        false,
+        accumulatorType);
+    auto name = toName(source.outputNames()[channel]);
+    auto* column = make<Column>(name, currentSelect_, agg->value());
+    aggregation->mutableColumns().push_back(column);
+    auto intermediateValue = agg->value();
+    intermediateValue.type = accumulatorType;
+    auto* intermediateColumn =
+        make<Column>(name, currentSelect_, intermediateValue);
+    aggregation->intermediateColumns.push_back(intermediateColumn);
+    auto dedupped = queryCtx()->dedup(agg);
+    aggregation->aggregates.push_back(dedupped->as<Aggregate>());
+    auto resultName = toName(source.outputNames()[i]);
+    renames_[resultName] = aggregation->columns().back();
+  }
+  for (auto& pair : keyRenames) {
+    renames_[pair.first] = pair.second;
+  }
+  return aggregation;
 }
 
-OrderByP Optimization::translateOrderBy(const core::OrderByNode& order) {
+OrderByP Optimization::translateOrderBy(const lp::SortNode& order) {
   OrderTypeVector orderType;
-  for (auto& sort : order.sortingOrders()) {
+  ExprVector keys;
+  for (auto& field : order.ordering()) {
+    auto sort = field.order;
     orderType.push_back(
         sort.isAscending() ? (sort.isNullsFirst() ? OrderType::kAscNullsFirst
                                                   : OrderType::kAscNullsLast)
                            : (sort.isNullsFirst() ? OrderType::kDescNullsFirst
                                                   : OrderType::kDescNullsLast));
+
+    keys.push_back(translateExpr(field.expression));
   }
-  auto keys = translateColumns(order.sortingKeys());
   auto* orderBy = QGC_MAKE_IN_ARENA(OrderBy)(nullptr, keys, orderType, {});
   return orderBy;
 }
 
-ColumnCP Optimization::makeMark(const core::AbstractJoinNode& join) {
-  auto type = join.outputType();
-  auto name = toName(type->nameOf(type->size() - 1));
-  Value value(toType(type->childAt(type->size() - 1)), 2);
-  auto* column = make<Column>(name, currentSelect_, value);
-  return column;
-}
+void Optimization::translateJoin(const lp::JoinNode& join) {
+  auto joinLeft = join.left();
+  auto joinRight = join.right();
 
-void Optimization::translateJoin(const core::AbstractJoinNode& join) {
-  bool isInner = join.isInnerJoin();
-  auto joinLeft = join.sources()[0];
-  auto joinLeftKeys = join.leftKeys();
-  auto joinRight = join.sources()[1];
-  auto joinRightKeys = join.rightKeys();
   auto joinType = join.joinType();
-  // Normalize right exists to left exists swapping the sides.
-  if (joinType == core::JoinType::kRightSemiFilter ||
-      joinType == core::JoinType::kRightSemiProject) {
-    std::swap(joinLeft, joinRight);
-    std::swap(joinLeftKeys, joinRightKeys);
-    joinType = joinType == core::JoinType::kRightSemiFilter
-        ? core::JoinType::kLeftSemiFilter
-        : core::JoinType::kLeftSemiProject;
-  }
+  bool isInner = joinType == lp::JoinType::kInner;
   makeQueryGraph(*joinLeft, allow(PlanType::kJoin));
-  auto leftKeys = translateColumns(joinLeftKeys);
   // For an inner join a join tree on the right can be flattened, for all other
   // kinds it must be kept together in its own dt.
   makeQueryGraph(*joinRight, isInner ? allow(PlanType::kJoin) : 0);
-  auto rightKeys = translateColumns(joinRightKeys);
   ExprVector conjuncts;
-  translateConjuncts(join.filter(), conjuncts);
+  translateConjuncts(join.condition(), conjuncts);
+
   if (isInner) {
-    // Every column to column equality adds to an equivalence class and is an
-    // independent bidirectional join edge.
-    for (auto i = 0; i < leftKeys.size(); ++i) {
-      auto l = leftKeys[i];
-      auto r = rightKeys.at(i);
-      if (l->type() == PlanType::kColumn && r->type() == PlanType::kColumn) {
-        l->as<Column>()->equals(r->as<Column>());
-        currentSelect_->addJoinEquality(l, r, {}, false, false, false, false);
-      } else {
-        currentSelect_->addJoinEquality(l, r, {}, false, false, false, false);
-      }
-    }
     currentSelect_->conjuncts.insert(
         currentSelect_->conjuncts.end(), conjuncts.begin(), conjuncts.end());
   } else {
     bool leftOptional =
-        joinType == core::JoinType::kRight || joinType == core::JoinType::kFull;
+        joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
     bool rightOptional =
-        joinType == core::JoinType::kLeft || joinType == core::JoinType::kFull;
-    bool rightExists = joinType == core::JoinType::kLeftSemiFilter;
-    bool rightNotExists = joinType == core::JoinType::kAnti;
-    ColumnCP markColumn =
-        joinType == core::JoinType::kLeftSemiProject ? makeMark(join) : nullptr;
-    ;
-
+        joinType == lp::JoinType::kLeft || joinType == lp::JoinType::kFull;
+    ExprVector leftKeys;
+    ExprVector rightKeys;
     PlanObjectSet leftTables;
-    PlanObjectCP rightTable = nullptr;
-
-    for (auto i = 0; i < leftKeys.size(); ++i) {
-      auto l = leftKeys[i];
-      leftTables.unionSet(l->allTables());
-      auto r = rightKeys.at(i);
-      auto rightKeyTable = r->singleTable();
-      if (rightTable) {
-        VELOX_CHECK(rightKeyTable == rightTable);
-      } else {
-        rightTable = rightKeyTable;
-      }
-    }
-    VELOX_CHECK(rightTable, "No right side in join");
+    // If non-inner, and many tables on the right they are one dt. If a single
+    // table then this too is the last in 'tables'.
+    auto rightTable = currentSelect_->tables.back();
+    extractNonInnerJoinEqualities(
+        conjuncts, rightTable, leftKeys, rightKeys, leftTables);
     std::vector<PlanObjectCP> leftTableVector;
     leftTables.forEach(
         [&](PlanObjectCP table) { leftTableVector.push_back(table); });
@@ -846,12 +901,8 @@ void Optimization::translateJoin(const core::AbstractJoinNode& join) {
         conjuncts,
         leftOptional,
         rightOptional,
-        rightExists,
-        rightNotExists,
-        markColumn);
-    if (markColumn) {
-      renames_[markColumn->name()] = markColumn;
-    }
+        false,
+        false);
     currentSelect_->joins.push_back(edge);
     for (auto i = 0; i < leftKeys.size(); ++i) {
       edge->addEquality(leftKeys[i], rightKeys[i]);
@@ -859,60 +910,23 @@ void Optimization::translateJoin(const core::AbstractJoinNode& join) {
   }
 }
 
-void Optimization::translateNonEqualityJoin(
-    const core::NestedLoopJoinNode& join) {
-  auto joinType = join.joinType();
-  bool isInner = joinType == core::JoinType::kInner;
-  makeQueryGraph(*join.sources()[0], allow(PlanType::kJoin));
-  // For an inner join a join tree on the right can be flattened, for all other
-  // kinds it must be kept together in its own dt.
-  makeQueryGraph(*join.sources()[1], isInner ? allow(PlanType::kJoin) : 0);
-  ExprVector conjuncts;
-  translateConjuncts(join.joinCondition(), conjuncts);
-  if (conjuncts.empty()) {
-    // Inner cross product. Join conditions may be added from
-    // conjuncts of the enclosing DerivedTable.
-    return;
-  }
-  PlanObjectSet tables;
-  for (auto& conjunct : conjuncts) {
-    tables.unionColumns(conjunct);
-  }
-  std::vector<PlanObjectCP> tableVector;
-  tables.forEach([&](PlanObjectCP table) { tableVector.push_back(table); });
-  if (tableVector.size() == 2) {
-    auto* edge = make<JoinEdge>(
-        tableVector[0], tableVector[1], conjuncts, false, false, false, false);
-    edge->guessFanout();
-    currentSelect_->joins.push_back(edge);
-
-  } else {
-    VELOX_NYI("Multiway non-equality join not supported");
-    currentSelect_->conjuncts.insert(
-        currentSelect_->conjuncts.end(), conjuncts.begin(), conjuncts.end());
-  }
-}
-
-bool isJoin(const core::PlanNode& node) {
-  auto name = node.name();
-  if (name == "HashJoin" || name == "MergeJoin" || name == "NestedLoopJoin") {
+bool isJoin(const lp::LogicalPlanNode& node) {
+  auto kind = node.kind();
+  if (kind == lp::NodeKind::kJoin) {
     return true;
   }
-  if (name == "Project" || name == "Filter") {
-    return isJoin(*node.sources()[0]);
+  if (kind == lp::NodeKind::kFilter || kind == lp::NodeKind::kProject) {
+    return isJoin(*node.inputAt(0));
   }
   return false;
 }
 
-bool isDirectOver(const core::PlanNode& node, const std::string& name) {
-  auto source = node.sources()[0];
-  if (source && source->name() == name) {
-    return true;
-  }
-  return false;
+bool isDirectOver(const lp::LogicalPlanNode& node, lp::NodeKind kind) {
+  auto source = node.inputAt(0);
+  return source && source->kind() == kind;
 }
 
-PlanObjectP Optimization::wrapInDt(const core::PlanNode& node) {
+PlanObjectP Optimization::wrapInDt(const lp::LogicalPlanNode& node) {
   DerivedTableP previousDt = currentSelect_;
   auto* newDt = make<DerivedTable>();
   auto cname = toName(fmt::format("dt{}", ++nameCounter_));
@@ -937,40 +951,40 @@ PlanObjectP Optimization::wrapInDt(const core::PlanNode& node) {
   return newDt;
 }
 
-PlanObjectP Optimization::makeBaseTable(const core::TableScanNode* tableScan) {
-  auto tableHandle = tableScan->tableHandle().get();
-  auto assignments = tableScan->assignments();
-  auto schemaTable = schema_.findTable(tableHandle->name());
+PlanObjectP Optimization::makeBaseTable(const lp::TableScanNode* tableScan) {
+  auto schemaTable = schema_.findTable(tableScan->tableName());
   auto cname = fmt::format("t{}", ++nameCounter_);
 
   auto* baseTable = make<BaseTable>();
   baseTable->cname = toName(cname);
   baseTable->schemaTable = schemaTable;
-  planLeaves_[tableScan] = baseTable;
+  logicalPlanLeaves_[tableScan] = baseTable;
   auto channels = usedChannels(tableScan);
-
-  for (auto& pair : assignments) {
-    auto idx = tableScan->outputType()->getChildIdx(pair.second->name());
-    if (std::find(channels.begin(), channels.end(), idx) == channels.end()) {
+  auto type = tableScan->outputType();
+  auto& names = tableScan->columnNames();
+  for (auto i = 0; i < type->size(); ++i) {
+    if (std::find(channels.begin(), channels.end(), i) == channels.end()) {
       continue;
     }
-    auto schemaColumn = schemaTable->findColumn(pair.second->name());
+    auto schemaColumn = schemaTable->findColumn(names[i]);
     auto value = schemaColumn->value();
-    auto* column = make<Column>(toName(pair.second->name()), baseTable, value);
+    auto* column =
+        make<Column>(toName(names[i]), baseTable, value, schemaColumn->name());
     baseTable->columns.push_back(column);
     auto kind = column->value().type->kind();
     if (kind == TypeKind::ARRAY || kind == TypeKind::ROW ||
         kind == TypeKind::MAP) {
       BitSet allPaths;
-      if (controlSubfields_.hasColumn(tableScan, idx)) {
+      if (logicalControlSubfields_.hasColumn(tableScan, i)) {
         baseTable->controlSubfields.ids.push_back(column->id());
-        allPaths = controlSubfields_.nodeFields[tableScan].resultPaths[idx];
+        allPaths =
+            logicalControlSubfields_.nodeFields[tableScan].resultPaths[i];
         baseTable->controlSubfields.subfields.push_back(allPaths);
       }
-      if (payloadSubfields_.hasColumn(tableScan, idx)) {
+      if (logicalPayloadSubfields_.hasColumn(tableScan, i)) {
         baseTable->payloadSubfields.ids.push_back(column->id());
         auto payloadPaths =
-            payloadSubfields_.nodeFields[tableScan].resultPaths[idx];
+            logicalPayloadSubfields_.nodeFields[tableScan].resultPaths[i];
         baseTable->payloadSubfields.subfields.push_back(payloadPaths);
         allPaths.unionSet(payloadPaths);
       }
@@ -981,7 +995,7 @@ PlanObjectP Optimization::makeBaseTable(const core::TableScanNode* tableScan) {
         }
       }
     }
-    renames_[pair.first] = column;
+    renames_[type->nameOf(i)] = column;
   }
 
   ColumnVector top;
@@ -995,18 +1009,60 @@ PlanObjectP Optimization::makeBaseTable(const core::TableScanNode* tableScan) {
   return baseTable;
 }
 
-const Type* pathType(const Type* type, PathCP path);
+const Type* pathType(const Type* type, PathCP path) {
+  for (auto& step : path->steps()) {
+    switch (step.kind) {
+      case StepKind::kField:
+        if (step.field) {
+          type =
+              type->childAt(type->as<TypeKind::ROW>().getChildIdx(step.field))
+                  .get();
+          break;
+        }
+        type = type->childAt(step.id).get();
+        break;
+      case StepKind::kSubscript:
+        type = type->childAt(type->kind() == TypeKind::ARRAY ? 0 : 1).get();
+        break;
+      default:
+        VELOX_NYI();
+    }
+  }
+  return type;
+}
 
-void Optimization::addProjection(const core::ProjectNode* project) {
-  exprSource_ = project->sources()[0].get();
+void Optimization::makeSubfieldColumns(
+    BaseTable* baseTable,
+    ColumnCP column,
+    const BitSet& paths) {
+  SubfieldProjections projections;
+  auto* ctx = queryCtx();
+  float card =
+      baseTable->schemaTable->columnGroups[0]->distribution().cardinality *
+      baseTable->filterSelectivity;
+  paths.forEach([&](auto id) {
+    auto* path = ctx->pathById(id);
+    auto type = pathType(column->value().type, path);
+    Value value(type, card);
+    auto name = fmt::format("{}.{}", column->name(), path->toString());
+    auto* subcolumn =
+        make<Column>(toName(name), baseTable, value, nullptr, column, path);
+    baseTable->columns.push_back(subcolumn);
+    projections.pathToExpr[path] = subcolumn;
+  });
+  allColumnSubfields_[column] = std::move(projections);
+}
+
+void Optimization::addProjection(const lp::ProjectNode* project) {
+  logicalExprSource_ = project->inputAt(0).get();
   auto names = project->names();
-  auto exprs = project->projections();
+  auto exprs = project->expressions();
   for (auto i : usedChannels(project)) {
-    if (auto field = dynamic_cast<const core::FieldAccessTypedExpr*>(
-            exprs.at(i).get())) {
+    if (exprs[i]->isInputReference()) {
+      auto name = exprs[i]->asUnchecked<lp::InputReferenceExpr>()->name();
       // A variable projected to itself adds no renames. Inputs contain this
       // all the time.
-      if (field->name() == names[i]) {
+      if (name == names[i]) {
         continue;
       }
     }
@@ -1015,11 +1071,11 @@ void Optimization::addProjection(const core::ProjectNode* project) {
   }
 }
 
-void Optimization::addFilter(const core::FilterNode* filter) {
-  exprSource_ = filter->sources()[0].get();
+void Optimization::addFilter(const lp::FilterNode* filter) {
+  logicalExprSource_ = filter->inputAt(0).get();
   ExprVector flat;
-  translateConjuncts(filter->filter(), flat);
-  if (isDirectOver(*filter, "Aggregation")) {
+  translateConjuncts(filter->predicate(), flat);
+  if (isDirectOver(*filter, lp::NodeKind::kAggregate)) {
     VELOX_CHECK(
         currentSelect_->having.empty(),
         "Must have aall of HAVING in one filter");
@@ -1031,35 +1087,25 @@ void Optimization::addFilter(const core::FilterNode* filter) {
 }
 
 PlanObjectP Optimization::addAggregation(
-    const core::AggregationNode& aggNode,
+    const lp::AggregateNode& aggNode,
     uint64_t allowedInDt) {
-  using AggregationNode = velox::core::AggregationNode;
-  if (aggNode.step() == AggregationNode::Step::kPartial ||
-      aggNode.step() == AggregationNode::Step::kSingle) {
-    if (!contains(allowedInDt, PlanType::kAggregation)) {
-      return wrapInDt(aggNode);
-    }
-    if (aggNode.step() == AggregationNode::Step::kSingle) {
-      aggFinalType_ = aggNode.outputType();
-    }
-    makeQueryGraph(
-        *aggNode.sources()[0], makeDtIf(allowedInDt, PlanType::kAggregation));
-    auto agg = translateAggregation(aggNode);
-    if (agg) {
-      auto* aggPlan = make<AggregationPlan>(agg);
-      currentSelect_->aggregation = aggPlan;
-    }
-  } else {
-    if (aggNode.step() == AggregationNode::Step::kFinal) {
-      aggFinalType_ = aggNode.outputType();
-    }
-    makeQueryGraph(*aggNode.sources()[0], allowedInDt);
+  using AggregateNode = lp::AggregateNode;
+  if (!contains(allowedInDt, PlanType::kAggregation)) {
+    return wrapInDt(aggNode);
+  }
+  aggFinalType_ = aggNode.outputType();
+  makeQueryGraph(
+      *aggNode.inputAt(0), makeDtIf(allowedInDt, PlanType::kAggregation));
+  auto agg = translateAggregation(aggNode);
+  if (agg) {
+    auto* aggPlan = make<AggregationPlan>(agg);
+    currentSelect_->aggregation = aggPlan;
   }
   return currentSelect_;
 }
 
-bool hasNondeterministic(const core::TypedExprPtr& expr) {
-  if (auto* call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
+bool hasNondeterministic(const lp::ExprPtr& expr) {
+  if (auto* call = dynamic_cast<const lp::CallExpr*>(expr.get())) {
     if (functionBits(toName(call->name()))
             .contains(FunctionSet::kNondeterministic)) {
       return true;
@@ -1074,82 +1120,78 @@ bool hasNondeterministic(const core::TypedExprPtr& expr) {
 }
 
 PlanObjectP Optimization::makeQueryGraph(
-    const core::PlanNode& node,
+    const lp::LogicalPlanNode& node,
     uint64_t allowedInDt) {
-  auto name = node.name();
-  if (name == "Filter" && !contains(allowedInDt, PlanType::kFilter)) {
+  auto kind = node.kind();
+  if (kind == lp::NodeKind::kFilter &&
+      !contains(allowedInDt, PlanType::kFilter)) {
     return wrapInDt(node);
   }
 
-  if (isJoin(node) && !contains(allowedInDt, PlanType::kJoin)) {
+  if (kind == lp::NodeKind::kJoin && !contains(allowedInDt, PlanType::kJoin)) {
     return wrapInDt(node);
   }
-  if (name == "TableScan") {
-    return makeBaseTable(reinterpret_cast<const core::TableScanNode*>(&node));
+  if (kind == lp::NodeKind::kTableScan) {
+    return makeBaseTable(reinterpret_cast<const lp::TableScanNode*>(&node));
   }
-  if (name == "Project") {
-    makeQueryGraph(*node.sources()[0], allowedInDt);
-    addProjection(reinterpret_cast<const core::ProjectNode*>(&node));
+  if (kind == lp::NodeKind::kProject) {
+    makeQueryGraph(*node.inputAt(0), allowedInDt);
+    addProjection(reinterpret_cast<const lp::ProjectNode*>(&node));
     return currentSelect_;
   }
-  if (name == "Filter") {
-    auto filter = reinterpret_cast<const core::FilterNode*>(&node);
-    if (!isNondeterministicWrap_ && hasNondeterministic(filter->filter())) {
+  if (kind == lp::NodeKind::kFilter) {
+    auto filter = reinterpret_cast<const lp::FilterNode*>(&node);
+    if (!isNondeterministicWrap_ && hasNondeterministic(filter->predicate())) {
       // Force wrap the filter and its input inside a dt so the filter
       // does not get mixed with parrent nodes.
       isNondeterministicWrap_ = true;
       return makeQueryGraph(node, 0);
     }
     isNondeterministicWrap_ = false;
-    makeQueryGraph(*node.sources()[0], allowedInDt);
+    makeQueryGraph(*node.inputAt(0), allowedInDt);
     addFilter(filter);
     return currentSelect_;
   }
-  if (name == "HashJoin" || name == "MergeJoin") {
+  if (kind == lp::NodeKind::kJoin) {
     if (!contains(allowedInDt, PlanType::kJoin)) {
       return wrapInDt(node);
     }
-    translateJoin(*reinterpret_cast<const core::AbstractJoinNode*>(&node));
+    translateJoin(*reinterpret_cast<const lp::JoinNode*>(&node));
     return currentSelect_;
   }
-  if (name == "NestedLoopJoin") {
-    if (!contains(allowedInDt, PlanType::kJoin)) {
-      return wrapInDt(node);
-    }
-    translateNonEqualityJoin(
-        *reinterpret_cast<const core::NestedLoopJoinNode*>(&node));
-    return currentSelect_;
-  }
-  if (name == "LocalPartition") {
-    makeQueryGraph(*node.sources()[0], allowedInDt);
-    return currentSelect_;
-  }
-  if (name == "Aggregation") {
+  if (kind == lp::NodeKind::kAggregate) {
     return addAggregation(
-        *reinterpret_cast<const core::AggregationNode*>(&node), allowedInDt);
+        *reinterpret_cast<const lp::AggregateNode*>(&node), allowedInDt);
   }
-  if (name == "OrderBy") {
+  if (kind == lp::NodeKind::kSort) {
     if (!contains(allowedInDt, PlanType::kOrderBy)) {
       return wrapInDt(node);
     }
-    makeQueryGraph(
-        *node.sources()[0], makeDtIf(allowedInDt, PlanType::kOrderBy));
+    makeQueryGraph(*node.inputAt(0), makeDtIf(allowedInDt, PlanType::kOrderBy));
     currentSelect_->orderBy =
-        translateOrderBy(*reinterpret_cast<const core::OrderByNode*>(&node));
+        translateOrderBy(*reinterpret_cast<const lp::SortNode*>(&node));
     return currentSelect_;
   }
-  if (name == "Limit") {
+  if (kind == lp::NodeKind::kLimit) {
     if (!contains(allowedInDt, PlanType::kLimit)) {
       return wrapInDt(node);
     }
-    makeQueryGraph(*node.sources()[0], makeDtIf(allowedInDt, PlanType::kLimit));
-    auto limit = reinterpret_cast<const core::LimitNode*>(&node);
+    makeQueryGraph(*node.inputAt(0), makeDtIf(allowedInDt, PlanType::kLimit));
+    auto limit = reinterpret_cast<const lp::LimitNode*>(&node);
     currentSelect_->limit = limit->count();
     currentSelect_->offset = limit->offset();
   } else {
-    VELOX_NYI("Unsupported PlanNode {}", name);
+    VELOX_NYI("Unsupported PlanNode {}", static_cast<int32_t>(kind));
   }
   return currentSelect_;
+}
+
+std::string leString(const lp::Expr* e) {
+  return lp::ExprPrinter::toText(*e);
+}
+
+std::string pString(const lp::LogicalPlanNode* p) {
+  return lp::PlanPrinter::toText(*p);
 }
 
 } // namespace facebook::velox::optimizer

--- a/frontend/optimizer/Plan.h
+++ b/frontend/optimizer/Plan.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "logical_plan/LogicalPlanNode.h" //@manual
 #include "optimizer/Cost.h" //@manual
 #include "optimizer/RelationOp.h" //@manual
 #include "velox/connectors/Connector.h"
@@ -25,6 +26,13 @@
 /// Planning-time data structures. Represent the state of the planning process
 /// plus utilities.
 namespace facebook::velox::optimizer {
+
+inline bool isSpecialForm(
+    const logical_plan::Expr* expr,
+    logical_plan::SpecialForm form) {
+  return expr->isSpecialForm() &&
+      expr->asUnchecked<logical_plan::SpecialFormExpr>()->form() == form;
+}
 
 /// Represents a path over an Expr of complex type. Used as a key
 /// for a map from unique step+optionl subscript expr pairs to the
@@ -92,6 +100,20 @@ struct ExprDedupHasher {
 using FunctionDedupMap =
     std::unordered_map<ExprDedupKey, ExprCP, ExprDedupHasher>;
 
+struct VariantPtrHasher {
+  size_t operator()(const std::shared_ptr<const variant>& value) const {
+    return value->hash();
+  }
+};
+
+struct VariantPtrComparer {
+  bool operator()(
+      const std::shared_ptr<const variant>& left,
+      const std::shared_ptr<const variant>& right) const {
+    return *left == *right;
+  }
+};
+
 /// Set of accessed subfields given ordinal of output column or function
 /// argument.
 struct ResultAccess {
@@ -117,6 +139,24 @@ struct PlanSubfields {
   std::string toString() const;
 };
 
+/// PlanNode output columns and function arguments with accessed subfields.
+struct LogicalPlanSubfields {
+  std::unordered_map<const logical_plan::LogicalPlanNode*, ResultAccess>
+      nodeFields;
+  std::unordered_map<const velox::logical_plan::Expr*, ResultAccess> argFields;
+
+  bool hasColumn(const logical_plan::LogicalPlanNode* node, int32_t ordinal)
+      const {
+    auto it = nodeFields.find(node);
+    if (it == nodeFields.end()) {
+      return false;
+    }
+    return it->second.resultPaths.count(ordinal) != 0;
+  }
+
+  std::string toString() const;
+};
+
 /// Struct for resolving which PlanNode or Lambda defines which
 /// FieldAccessTypedExpr for column and subfield tracking.
 struct ContextSource {
@@ -125,8 +165,19 @@ struct ContextSource {
   int32_t lambdaOrdinal{-1};
 };
 
+/// Struct for resolving which logical PlanNode or Lambda defines which
+/// field for column and subfield tracking.
+struct LogicalContextSource {
+  const logical_plan::LogicalPlanNode* planNode;
+  const logical_plan::CallExpr* call;
+  int32_t lambdaOrdinal{-1};
+};
+
 /// Utility for making a getter from a Step.
 core::TypedExprPtr stepToGetter(Step, core::TypedExprPtr arg);
+
+logical_plan::ExprPtr stepToLogicalPlanGetter(Step, logical_plan::ExprPtr arg);
+
 /// Lists the subfield paths physically produced by a source. The
 /// source can be a column or a complex type function. This is empty
 /// if the whole object corresponding to the type of the column or
@@ -523,6 +574,20 @@ class Optimization {
       runner::MultiFragmentPlan::Options options =
           runner::MultiFragmentPlan::Options{.numWorkers = 5, .numDrivers = 5});
 
+  Optimization(
+      const logical_plan::LogicalPlanNode& plan,
+      const Schema& schema,
+      History& history,
+      std::shared_ptr<core::QueryCtx> queryCtx,
+      velox::core::ExpressionEvaluator& evaluator,
+      OptimizerOptions opts = OptimizerOptions(),
+      runner::MultiFragmentPlan::Options options =
+          runner::MultiFragmentPlan::Options{.numWorkers = 5, .numDrivers = 5});
+
+  Optimization(const Optimization& other) = delete;
+
+  void operator==(Optimization& other) = delete;
+
   /// Returns the optimized RelationOp plan for 'plan' given at construction.
   PlanPtr bestPlan();
 
@@ -688,9 +753,13 @@ class Optimization {
     return mask & ~(1UL << static_cast<int32_t>(op));
   }
 
+  void initialize();
+
   // Initializes a tree of DerivedTables with JoinEdges from 'plan' given at
   // construction. Sets 'root_' to the root DerivedTable.
   DerivedTableP makeQueryGraph();
+
+  DerivedTableP makeQueryGraphFromLogical();
 
   // Converts 'plan' to PlanObjects and records join edges into
   // 'currentSelect_'. If 'node' does not match  allowedInDt, wraps 'node' in a
@@ -699,8 +768,14 @@ class Optimization {
       const velox::core::PlanNode& node,
       uint64_t allowedInDt);
 
+  PlanObjectP makeQueryGraph(
+      const logical_plan::LogicalPlanNode& node,
+      uint64_t allowedInDt);
+
   // Converts a table scan into a BaseTable wen building a DerivedTable.
   PlanObjectP makeBaseTable(const core::TableScanNode* tableScan);
+
+  PlanObjectP makeBaseTable(const logical_plan::TableScanNode* tableScan);
 
   // Decomposes complex type columns into parts projected out as top
   // level if subfield pushdown is on.
@@ -713,14 +788,22 @@ class Optimization {
   // being assembled.
   void addProjection(const core::ProjectNode* project);
 
+  void addProjection(const logical_plan::ProjectNode* project);
+
   // Interprets a Filter node and adds its information into the DerivedTable
   // being assembled.
   void addFilter(const core::FilterNode* Filter);
+
+  void addFilter(const logical_plan::FilterNode* Filter);
 
   // Interprets an AggregationNode and adds its information to the DerivedTable
   // being assembled.
   PlanObjectP addAggregation(
       const core::AggregationNode& aggNode,
+      uint64_t allowedInDt);
+
+  PlanObjectP addAggregation(
+      const logical_plan::AggregateNode& aggNode,
       uint64_t allowedInDt);
 
   // Sets the columns to project out from the root DerivedTable  based on
@@ -729,12 +812,28 @@ class Optimization {
       DerivedTableP dt,
       const velox::core::PlanNode& planNode);
 
+  void setDerivedTableOutput(
+      DerivedTableP dt,
+      const velox::logical_plan::LogicalPlanNode& planNode);
+
   // Returns a literal from applying 'call' or 'cast' to 'literals'. nullptr if
   // not successful.
   ExprCP tryFoldConstant(
       const velox::core::CallTypedExpr* call,
       const velox::core::CastTypedExpr* cast,
       const ExprVector& literals);
+
+  ExprCP tryFoldConstant(
+      const logical_plan::CallExpr* call,
+      const logical_plan::SpecialFormExpr* cast,
+      const ExprVector& literals);
+
+  // Folds a logical expr to a constant if can. Should be called only if 'expr'
+  // only depends on constants. Identifier scope will may not be not set at time
+  // of call. This is before regular constant folding because subscript
+  // expressions must be folded for subfield resolution.
+  const logical_plan::ConstantExprPtr maybeFoldLogicalConstant(
+      const logical_plan::ExprPtr expr);
 
   // Returns a constant expression if 'typedExprcan be folded, nullptr
   // otherwise.
@@ -744,9 +843,13 @@ class Optimization {
   // Returns the ordinal positions of actually referenced outputs of 'node'.
   std::vector<int32_t> usedChannels(const core::PlanNode* node);
 
+  std::vector<int32_t> usedChannels(const logical_plan::LogicalPlanNode* node);
+
   // Returns the ordinal position of used arguments for a function call that
   // produces a complex type.
   std::vector<int32_t> usedArgs(const core::ITypedExpr* call);
+
+  std::vector<int32_t> usedArgs(const logical_plan::Expr* call);
 
   void markFieldAccessed(
       const ContextSource& source,
@@ -756,6 +859,14 @@ class Optimization {
       const std::vector<const RowType*>& context,
       const std::vector<ContextSource>& sources);
 
+  void markFieldAccessed(
+      const LogicalContextSource& source,
+      int32_t ordinal,
+      std::vector<Step>& steps,
+      bool isControl,
+      const std::vector<const RowType*>& context,
+      const std::vector<LogicalContextSource>& sources);
+
   void markSubfields(
       const core::ITypedExpr* expr,
       std::vector<Step>& steps,
@@ -763,19 +874,41 @@ class Optimization {
       const std::vector<const RowType*> context,
       const std::vector<ContextSource>& sources);
 
+  void markSubfields(
+      const logical_plan::Expr* expr,
+      std::vector<Step>& steps,
+      bool isControl,
+      const std::vector<const RowType*> context,
+      const std::vector<LogicalContextSource>& sources);
+
   void markAllSubfields(const RowType* type, const core::PlanNode* node);
+  void markAllSubfields(
+      const RowType* type,
+      const logical_plan::LogicalPlanNode* node);
 
   void markControl(const core::PlanNode* node);
+
+  void markControl(const logical_plan::LogicalPlanNode* node);
 
   void markColumnSubfields(
       const core::PlanNode* node,
       const std::vector<core::FieldAccessTypedExprPtr>& columns,
       int32_t source);
 
+  void markColumnSubfields(
+      const logical_plan::LogicalPlanNode* node,
+      const std::vector<logical_plan::ExprPtr>& columns,
+      int32_t source);
+
   bool isSubfield(
       const core::ITypedExpr* expr,
       Step& step,
       core::TypedExprPtr& input);
+
+  bool isSubfield(
+      const logical_plan::Expr* expr,
+      Step& step,
+      logical_plan::ExprPtr& input);
 
   // if 'step' applied to result of the function of 'metadata'
   // corresponds to an argument, returns the ordinal of the argument/
@@ -788,8 +921,15 @@ class Optimization {
       bool controlOnly,
       bool payloadOnly);
 
+  BitSet functionSubfields(
+      const logical_plan::CallExpr* call,
+      bool controlOnly,
+      bool payloadOnly);
+
   // Makes a deduplicated Expr tree from 'expr'.
   ExprCP translateExpr(const velox::core::TypedExprPtr& expr);
+
+  ExprCP translateExpr(const logical_plan::ExprPtr& expr);
 
   // For comparisons, swaps the args to have a canonical form for
   // deduplication. E.g column op constant, and Smaller plan object id
@@ -804,7 +944,11 @@ class Optimization {
   // Returns a deduplicated Literal from the value in 'constant'.
   ExprCP makeConstant(const core::ConstantTypedExprPtr& constant);
 
+  ExprCP makeConstant(const logical_plan::ConstantExpr& constant);
+
   ExprCP translateLambda(const velox::core::LambdaTypedExpr* lambda);
+
+  ExprCP translateLambda(const logical_plan::LambdaExpr* lambda);
 
   // If 'expr' is not a subfield path, returns std::nullopt. If 'expr'
   // is a subfield path that is subsumed by a projected subfield,
@@ -816,11 +960,19 @@ class Optimization {
   // resolves to xx[1]. If no subfield projections, c[1][1] is c[1][1] etc.
   std::optional<ExprCP> translateSubfield(const core::TypedExprPtr& expr);
 
+  std::optional<ExprCP> translateSubfield(const logical_plan::ExprPtr& expr);
+
   void getExprForField(
       const core::FieldAccessTypedExpr* expr,
       core::TypedExprPtr& resultExpr,
       ColumnCP& resultColumn,
       const core::PlanNode*& context);
+
+  void getExprForField(
+      const logical_plan::Expr* expr,
+      logical_plan::ExprPtr& resultExpr,
+      ColumnCP& resultColumn,
+      const logical_plan::LogicalPlanNode*& context);
 
   // Translates a complex type function where the generated Exprs  depend on the
   // accessed subfields.
@@ -828,8 +980,14 @@ class Optimization {
       const core::CallTypedExpr* call,
       const FunctionMetadata* metadata);
 
+  std::optional<ExprCP> translateSubfieldFunction(
+      const logical_plan::CallExpr* call,
+      const FunctionMetadata* metadata);
+
   // Calls translateSubfieldFunction() if not already called.
   void ensureFunctionSubfields(const core::TypedExprPtr& expr);
+
+  void ensureFunctionSubfields(const logical_plan::ExprPtr& expr);
 
   // Makes dedupped getters for 'steps'. if steps is below skyline,
   // nullptr. If 'steps' intersects 'skyline' returns skyline wrapped
@@ -842,11 +1000,19 @@ class Optimization {
       const core::TypedExprPtr& base,
       ColumnCP column);
 
+  ExprCP makeGettersOverSkyline(
+      const std::vector<Step>& steps,
+      const SubfieldProjections* skyline,
+      const logical_plan::ExprPtr& base,
+      ColumnCP column);
+
   // Adds conjuncts combined by any number of enclosing ands from 'input' to
   // 'flat'.
   void translateConjuncts(
       const velox::core::TypedExprPtr& input,
       ExprVector& flat);
+
+  void translateConjuncts(const logical_plan::ExprPtr& input, ExprVector& flat);
 
   // Converts 'name' to a deduplicated ExprCP. If 'name' is assigned to an
   // expression in a projection, returns the deduplicated ExprPtr of the
@@ -857,8 +1023,12 @@ class Optimization {
   ExprVector translateColumns(
       const std::vector<velox::core::FieldAccessTypedExprPtr>& source);
 
+  ExprVector translateColumns(const std::vector<logical_plan::ExprPtr>& source);
+
   // Adds a JoinEdge corresponding to 'join' to the enclosing DerivedTable.
   void translateJoin(const velox::core::AbstractJoinNode& join);
+
+  void translateJoin(const logical_plan::JoinNode& join);
 
   // Makes an extra column for existence flag.
   ColumnCP makeMark(const velox::core::AbstractJoinNode& join);
@@ -869,15 +1039,22 @@ class Optimization {
   // Adds order by information to the enclosing DerivedTable.
   OrderByP translateOrderBy(const velox::core::OrderByNode& order);
 
+  OrderByP translateOrderBy(const logical_plan::SortNode& order);
+
   // Adds aggregation information to the enclosing DerivedTable.
   AggregationP translateAggregation(
       const velox::core::AggregationNode& aggregation);
+
+  AggregationP translateAggregation(
+      const logical_plan::AggregateNode& aggregation);
 
   // Adds 'node' and descendants to query graph wrapped inside a
   // DerivedTable. Done for joins to the right of non-inner joins,
   // group bys as non-top operators, whenever descendents of 'node'
   // are not freely reorderable with its parents' descendents.
   PlanObjectP wrapInDt(const velox::core::PlanNode& node);
+
+  PlanObjectP wrapInDt(const logical_plan::LogicalPlanNode& node);
 
   /// Retrieves or makes a plan from 'key'. 'key' specifies a set of
   /// top level joined tables or a hash join build side table or
@@ -1050,12 +1227,20 @@ class Optimization {
     return leaf;
   }
 
+  PlanObjectCP findLeaf(const logical_plan::LogicalPlanNode* node) {
+    auto* leaf = logicalPlanLeaves_[node];
+    VELOX_CHECK_NOT_NULL(leaf);
+    return leaf;
+  }
+
   const Schema& schema_;
 
   OptimizerOptions opts_;
 
+  const logical_plan::LogicalPlanNode* logicalPlan_{nullptr};
+
   // Top level plan to optimize.
-  const velox::core::PlanNode& inputPlan_;
+  const velox::core::PlanNode* inputPlan_{nullptr};
 
   // Source of historical cost/cardinality information.
   History& history_;
@@ -1070,6 +1255,8 @@ class Optimization {
   // Source PlanNode when inside addProjection() or 'addFilter().
   const core::PlanNode* exprSource_{nullptr};
 
+  const logical_plan::LogicalPlanNode* logicalExprSource_{nullptr};
+
   // Maps names in project noes of 'inputPlan_' to deduplicated Exprs.
   std::unordered_map<std::string, ExprCP> renames_;
 
@@ -1081,7 +1268,19 @@ class Optimization {
   // for leaves, e.g. constants.
   ExprDedupMap exprDedup_;
 
-  // Dedup map from name+ExprVector to corresponding Call Expr.
+  std::unordered_map<
+      std::shared_ptr<const variant>,
+      ExprCP,
+      VariantPtrHasher,
+      VariantPtrComparer>
+      constantDedup_;
+
+  // Reverse map from dedupped literal to the shared_ptr. We put the
+  // shared ptr back into the result plan so the variant never gets
+  // copied.
+  std::map<ExprCP, std::shared_ptr<const variant>> reverseConstantDedup_;
+
+  // Dedup map fr om name+ExprVector to corresponding Call Expr.
   FunctionDedupMap functionDedup_;
 
   // Counter for generating unique correlation names for BaseTables and
@@ -1112,10 +1311,20 @@ class Optimization {
   // Column and subfield info for items that only affect column values.
   PlanSubfields payloadSubfields_;
 
+  // Column and subfield access info for filters, joins, grouping and other
+  // things affecting result row selection.
+  LogicalPlanSubfields logicalControlSubfields_;
+
+  // Column and subfield info for items that only affect column values.
+  LogicalPlanSubfields logicalPayloadSubfields_;
+
   /// Expressions corresponding to skyline paths over a subfield decomposable
   /// function.
   std::unordered_map<const core::ITypedExpr*, SubfieldProjections>
       functionSubfields_;
+
+  std::unordered_map<const logical_plan::CallExpr*, SubfieldProjections>
+      logicalFunctionSubfields_;
 
   // Every unique path step, expr pair. For paths c.f1.f2 and c.f1.f3 there are
   // 3 entries: c.f1 and c.f1.f2 and c1.f1.f3, where the two last share the same
@@ -1125,6 +1334,9 @@ class Optimization {
   // Complex type functions that have been checke for explode and
   // 'functionSubfields_'.
   std::unordered_set<const core::CallTypedExpr*> translatedSubfieldFuncs_;
+
+  std::unordered_set<const logical_plan::CallExpr*>
+      logicalTranslatedSubfieldFuncs_;
 
   /// If subfield extraction is pushed down, then these give the skyline
   /// subfields for a column for control and payload situations. The same column
@@ -1149,6 +1361,8 @@ class Optimization {
 
   // Map from leaf PlanNode to corresponding PlanObject
   std::unordered_map<const core::PlanNode*, PlanObjectCP> planLeaves_;
+  std::unordered_map<const logical_plan::LogicalPlanNode*, PlanObjectCP>
+      logicalPlanLeaves_;
 
   // Map from plan object id to pair of handle with pushdown filters and list of
   // filters to eval on the result from the handle.
@@ -1236,5 +1450,8 @@ RowTypePtr skylineStruct(BaseTableCP baseTable, ColumnCP column);
 
 /// Returns  the inverse join type, e.g. right outer from left outr.
 core::JoinType reverseJoinType(core::JoinType joinType);
+
+PathCP stepsToPath(const std::vector<Step>& steps);
+variant* subscriptLiteral(TypeKind kind, const Step& step);
 
 } // namespace facebook::velox::optimizer

--- a/frontend/optimizer/PlanUtils.cpp
+++ b/frontend/optimizer/PlanUtils.cpp
@@ -59,4 +59,39 @@ std::string succinctNumber(double value, int32_t precision) {
       precision);
 }
 
+namespace {
+template <typename T>
+int64_t integerValueInner(const variant* variant) {
+  return variant->value<T>();
+}
+} // namespace
+
+int64_t integerValue(const variant* variant) {
+  switch (variant->kind()) {
+    case TypeKind::TINYINT:
+      return integerValueInner<int8_t>(variant);
+    case TypeKind::SMALLINT:
+      return integerValueInner<int16_t>(variant);
+    case TypeKind::INTEGER:
+      return integerValueInner<int32_t>(variant);
+    case TypeKind::BIGINT:
+      return integerValueInner<int64_t>(variant);
+    default:
+      VELOX_FAIL();
+  }
+}
+
+std::optional<int64_t> maybeIntegerLiteral(
+    const logical_plan::ConstantExpr* expr) {
+  switch (expr->typeKind()) {
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+      return integerValue(&expr->value());
+    default:
+      return std::nullopt;
+  }
+}
+
 } // namespace facebook::velox::optimizer

--- a/frontend/optimizer/PlanUtils.h
+++ b/frontend/optimizer/PlanUtils.h
@@ -118,4 +118,12 @@ Target transform(const V& set, Func func) {
   return result;
 }
 
+/// Returns the integer value of 'variant'. Throws if this is not an integer.
+int64_t integerValue(const variant* variant);
+
+/// Returns the integer value of 'expr' if the type is an integer,
+/// std::nullopt otherwise.
+std::optional<int64_t> maybeIntegerLiteral(
+    const logical_plan::ConstantExpr* expr);
+
 } // namespace facebook::velox::optimizer

--- a/frontend/optimizer/QueryGraph.h
+++ b/frontend/optimizer/QueryGraph.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
+#include "logical_plan/ExprPrinter.h" //@manual
+#include "logical_plan/LogicalPlanNode.h" //@manual
+#include "logical_plan/PlanPrinter.h" //@manual
 #include "optimizer/Schema.h" //@manual
-
 #include "velox/core/PlanNode.h"
 
 /// Defines subclasses of PlanObject for describing the logical
@@ -164,6 +166,7 @@ class Column : public Expr {
       Name _name,
       PlanObjectP _relation,
       const Value& value,
+      Name nameInTable = nullptr,
       ColumnCP topColumn = nullptr,
       PathCP path = nullptr);
 
@@ -358,6 +361,11 @@ struct FunctionMetadata {
       const core::CallTypedExpr* call,
       std::vector<PathCP>& paths)>
       explode;
+
+  std::function<std::unordered_map<PathCP, logical_plan::ExprPtr>(
+      const logical_plan::CallExpr* call,
+      std::vector<PathCP>& paths)>
+      logicalExplode;
 };
 
 const FunctionMetadata* functionMetadata(Name name);
@@ -432,6 +440,9 @@ class Call : public Expr {
 };
 
 using CallCP = const Call*;
+
+/// True if 'expr' is a call to function 'name'.
+bool isCallExpr(ExprCP expr, Name name);
 
 /// Represents a lambda. May occur as an immediate argument of selected
 /// functions.
@@ -989,6 +1000,20 @@ float tableCardinality(PlanObjectCP table);
 
 /// Returns all distinct tables 'exprs' depend on.
 PlanObjectSet allTables(CPSpan<Expr> exprs);
+
+/// Fills 'leftKeys' and 'rightKeys's from 'conjuncts' so that
+/// equalities with one side only depending on 'right' go to
+/// 'rightKeys' and the other side not depending on 'right' goes to
+/// 'leftKeys'. The left side may depend on more than one table. The
+/// tables 'leftKeys' depend on are returned in 'allLeft'. The
+/// conjuncts that are not equalities or have both sides depending
+/// on right and something else are left in 'conjuncts'.
+void extractNonInnerJoinEqualities(
+    ExprVector& conjuncts,
+    PlanObjectCP right,
+    ExprVector& leftKeys,
+    ExprVector& rightKeys,
+    PlanObjectSet& allLeft);
 
 /// Appends the string representation of 'exprs' to 'out'.
 void exprsToString(const ExprVector& exprs, std::stringstream& out);

--- a/frontend/optimizer/tests/CMakeLists.txt
+++ b/frontend/optimizer/tests/CMakeLists.txt
@@ -13,14 +13,22 @@
 # limitations under the License.
 
 add_executable(
-  velox_plan_test PlanTest.cpp Tpch.cpp ParquetTpchTest.cpp QueryTestBase.cpp
-                  SubfieldTest.cpp FeatureGen.cpp)
+  velox_plan_test
+  PlanTest.cpp
+  Tpch.cpp
+  ParquetTpchTest.cpp
+  QueryTestBase.cpp
+  SubfieldTest.cpp
+  LogicalSubFieldTest.cpp
+  FeatureGen.cpp
+  Genies.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 
 target_link_libraries(
   velox_plan_test
   velox_verax
+  velox_fe_logical_plan_builder
   velox_tpch_gen
   velox_connector_split_source
   velox_hive_connector_metadata

--- a/frontend/optimizer/tests/FeatureGen.cpp
+++ b/frontend/optimizer/tests/FeatureGen.cpp
@@ -18,6 +18,7 @@
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::optimizer::test {
+namespace lp = facebook::velox::logical_plan;
 
 RowTypePtr makeRowType(
     const std::vector<RowVectorPtr>& vectors,
@@ -250,6 +251,113 @@ void makeExprs(
     names.push_back("floats");
     exprs.push_back(std::make_shared<core::CallTypedExpr>(
         ROW(std::move(floatTypes)), std::move(floatExprs), "row_constructor"));
+  }
+}
+
+namespace lpe {
+
+lp::ExprPtr floatFeatures() {
+  return std::make_shared<lp::InputReferenceExpr>(
+      MAP(INTEGER(), REAL()), "float_features");
+}
+
+lp::ExprPtr intLiteral(int32_t i) {
+  return std::make_shared<lp::ConstantExpr>(INTEGER(), variant(i));
+}
+
+lp::ExprPtr floatLiteral(float i) {
+  return std::make_shared<lp::ConstantExpr>(REAL(), variant(i));
+}
+
+lp::ExprPtr rand() {
+  lp::ExprPtr r = std::make_shared<lp::CallExpr>(
+      INTEGER(), "rand", std::vector<lp::ExprPtr>{intLiteral(5)});
+  return std::make_shared<lp::SpecialFormExpr>(
+      REAL(), lp::SpecialForm::kCast, std::vector<lp::ExprPtr>{r});
+}
+
+lp::ExprPtr plus(lp::ExprPtr x, lp::ExprPtr y) {
+  return std::make_shared<lp::CallExpr>(
+      REAL(), "plus", std::vector<lp::ExprPtr>{x, y});
+}
+
+lp::ExprPtr floatFeature(const FeatureOptions& opts) {
+  int32_t id = atoi(
+      opts.floatStruct
+          ->nameOf(folly::Random::rand32(opts.rng) % opts.floatStruct->size())
+          .c_str());
+  std::vector<lp::ExprPtr> args{floatFeatures(), intLiteral(id)};
+
+  return std::make_shared<lp::CallExpr>(REAL(), "subscript", std::move(args));
+}
+
+lp::ExprPtr plusOne(lp::ExprPtr expr) {
+  std::vector<lp::ExprPtr> args{expr, floatLiteral(1)};
+  return std::make_shared<lp::CallExpr>(REAL(), "plus", std::move(args));
+}
+lp::ExprPtr uid() {
+  return std::make_shared<lp::InputReferenceExpr>(BIGINT(), "uid");
+}
+
+lp::ExprPtr bigintMod(lp::ExprPtr x, int64_t y) {
+  lp::ExprPtr lit = std::make_shared<lp::ConstantExpr>(BIGINT(), variant(y));
+  return std::make_shared<lp::CallExpr>(
+      BIGINT(), "mod", std::vector<lp::ExprPtr>{x, lit});
+}
+
+lp::ExprPtr bigintEq(lp::ExprPtr x, int64_t y) {
+  lp::ExprPtr lit = std::make_shared<lp::ConstantExpr>(BIGINT(), variant(y));
+  return std::make_shared<lp::CallExpr>(
+      BOOLEAN(), "eq", std::vector<lp::ExprPtr>{x, lit});
+}
+
+lp::ExprPtr uidCond(lp::ExprPtr f) {
+  auto cond = bigintEq(bigintMod(uid(), 10), 0);
+  return std::make_shared<lp::SpecialFormExpr>(
+      REAL(),
+      lp::SpecialForm::kIf,
+      std::vector<lp::ExprPtr>{cond, f, plusOne(f)});
+}
+
+lp::ExprPtr makeFloatExpr(const FeatureOptions& opts) {
+  auto f = lpe::floatFeature(opts);
+  if (opts.coinToss(opts.plusOnePct)) {
+    f = plusOne(f);
+  }
+  if (opts.coinToss(opts.randomPct)) {
+    f = plus(f, rand());
+  }
+  if (opts.coinToss(opts.multiColumnPct)) {
+    auto g = lpe::floatFeature(opts);
+    if (opts.coinToss(opts.plusOnePct)) {
+      g = plusOne(g);
+    }
+    f = plus(f, g);
+  }
+  if (opts.coinToss(opts.uidPct)) {
+    f = uidCond(f);
+  }
+  return f;
+}
+} // namespace lpe
+
+void makeLogicalExprs(
+    const FeatureOptions& opts,
+    std::vector<std::string>& names,
+    std::vector<lp::ExprPtr>& exprs) {
+  names = {"uid"};
+  exprs = {lpe::uid()};
+  auto numFloatExprs = (opts.floatStruct->size() * opts.floatExprsPct) / 100.0;
+  std::vector<lp::ExprPtr> floatExprs;
+  std::vector<TypePtr> floatTypes;
+  for (auto cnt = 0; cnt < numFloatExprs; ++cnt) {
+    floatExprs.push_back(lpe::makeFloatExpr(opts));
+    floatTypes.push_back(REAL());
+  }
+  if (!floatExprs.empty()) {
+    names.push_back("floats");
+    exprs.push_back(std::make_shared<lp::CallExpr>(
+        ROW(std::move(floatTypes)), "row_constructor", std::move(floatExprs)));
   }
 }
 

--- a/frontend/optimizer/tests/FeatureGen.h
+++ b/frontend/optimizer/tests/FeatureGen.h
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <folly/Random.h>
+#include "logical_plan/LogicalPlanNode.h" //@manual
 #include "velox/core/Expressions.h"
 #include "velox/vector/ComplexVector.h"
+
+#pragma once
 
 namespace facebook::velox::optimizer::test {
 
@@ -70,5 +74,10 @@ void makeExprs(
     const FeatureOptions& opts,
     std::vector<std::string>& names,
     std::vector<core::TypedExprPtr>& exprs);
+
+void makeLogicalExprs(
+    const FeatureOptions& opts,
+    std::vector<std::string>& names,
+    std::vector<logical_plan::ExprPtr>& exprs);
 
 } // namespace facebook::velox::optimizer::test

--- a/frontend/optimizer/tests/Genies.cpp
+++ b/frontend/optimizer/tests/Genies.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/tests/FeatureGen.h" //@manual
+#include "optimizer/tests/QueryTestBase.h" //@manual
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::velox::optimizer::test {
+using namespace facebook::velox;
+using namespace facebook::velox::optimizer;
+using namespace facebook::velox::optimizer::test;
+using namespace facebook::velox::exec::test;
+
+TypePtr makeGenieType() {
+  return ROW(
+      {"uid", "ff", "idlf", "idslf"},
+      {BIGINT(),
+       MAP(INTEGER(), REAL()),
+       MAP(INTEGER(), ARRAY(BIGINT())),
+       MAP(INTEGER(), MAP(BIGINT(), REAL()))});
+}
+
+class GenieFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_UNREACHABLE();
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    auto type = makeGenieType();
+    return {
+        exec::FunctionSignatureBuilder()
+            .returnType(
+                "row(userid bigint, ff map(integer, real), idlf map(integer, array(bigint)), idsf map(integer, map(bigint, real)))")
+            .argumentType("bigint")
+            .argumentType("map(integer, real)")
+            .argumentType("map(integer, array(bigint))")
+            .argumentType("map(integer, map(bigint, real))")
+            .build()};
+  }
+};
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+    udf_genie,
+    GenieFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
+    std::make_unique<GenieFunction>());
+
+void registerGenieUdfs() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "genie");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "exploding_genie");
+}
+
+} // namespace facebook::velox::optimizer::test

--- a/frontend/optimizer/tests/Genies.h
+++ b/frontend/optimizer/tests/Genies.h
@@ -14,21 +14,13 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/tests/FeatureGen.h" //@manual
 
-#include "logical_plan/PlanBuilder.h" //@manual
+#include "optimizer/tests/QueryTestBase.h" //@manual
+#include "velox/common/base/tests/GTestUtils.h"
 
-namespace facebook::velox::logical_plan {
-
-TEST(NameAllocatorTest, basic) {
-  NameAllocator allocator;
-  EXPECT_EQ(allocator.newName("f_oo"), "f_oo");
-  EXPECT_EQ(allocator.newName("f_oo"), "f_oo_0");
-
-  EXPECT_EQ(allocator.newName("bar"), "bar");
-  EXPECT_EQ(allocator.newName("bar"), "bar_1");
-
-  EXPECT_EQ(allocator.newName("f_oo_0"), "f_oo_2");
-}
-
-} // namespace facebook::velox::logical_plan
+namespace facebook::velox::optimizer::test {
+TypePtr makeGenieType();
+void registerGenieUdfs();
+} // namespace facebook::velox::optimizer::test

--- a/frontend/optimizer/tests/LogicalSubFieldTest.cpp
+++ b/frontend/optimizer/tests/LogicalSubFieldTest.cpp
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "logical_plan/PlanBuilder.h" //@manual
+#include "optimizer/FunctionRegistry.h" //@manual
+#include "optimizer/tests/FeatureGen.h" //@manual
+#include "optimizer/tests/Genies.h" //@manual
+#include "optimizer/tests/QueryTestBase.h" //@manual
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+DEFINE_string(subfield_data_path, "", "Data directory for subfield test data");
+
+using namespace facebook::velox;
+using namespace facebook::velox::optimizer;
+using namespace facebook::velox::optimizer::test;
+using namespace facebook::velox::exec::test;
+namespace lp = facebook::velox::logical_plan;
+
+class LogicalSubfieldTest : public QueryTestBase,
+                            public testing::WithParamInterface<int32_t> {
+ protected:
+  static void SetUpTestCase() {
+    testDataPath_ = FLAGS_subfield_data_path;
+    LocalRunnerTestBase::localFileFormat_ = "dwrf";
+    LocalRunnerTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    LocalRunnerTestBase::TearDownTestCase();
+  }
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    lp::PlanBuilder::setFieldAccessHook(fieldIndexHook);
+    switch (GetParam()) {
+      case 1:
+        optimizerOptions_ = OptimizerOptions();
+        break;
+      case 2:
+        optimizerOptions_ = OptimizerOptions{.pushdownSubfields = true};
+        break;
+      case 3:
+        optimizerOptions_ = OptimizerOptions{.pushdownSubfields = true};
+        optimizerOptions_.mapAsStruct["features"] = {
+            "float_features", "id_list_features", "id_score_list_features"};
+        break;
+      default:
+        FAIL();
+        break;
+    }
+  }
+
+  void TearDown() override {
+    QueryTestBase::TearDown();
+    lp::PlanBuilder::setFieldAccessHook(nullptr);
+  }
+
+  // Converts names like __[nn to DereferenceTypedExpr with index nn. Other
+  // cases are unchanged.
+  static lp::SpecialFormExprPtr fieldIndexHook(
+      const core::FieldAccessExpr* fae,
+      lp::ExprPtr input) {
+    auto name = fae->name();
+    if (name.size() < 3 || name[0] != '_' || name[1] != '_') {
+      return nullptr;
+    }
+    int32_t idx = -1;
+    if (1 != sscanf(name.c_str() + 2, "%d", &idx)) {
+      return nullptr;
+    }
+    VELOX_CHECK_GE(idx, 0);
+    VELOX_CHECK_LT(idx, input->type()->size());
+    return std::make_shared<lp::SpecialFormExpr>(
+        input->type()->as<TypeKind::ROW>().childAt(idx),
+        lp::SpecialForm::kDereference,
+        std::vector<lp::ExprPtr>{
+            input,
+            std::make_shared<lp::ConstantExpr>(INTEGER(), variant(idx))});
+  }
+
+  void declareGenies() {
+    TypePtr genieType = makeGenieType();
+    std::vector<TypePtr> genieArgs = {
+        genieType->childAt(0),
+        genieType->childAt(1),
+        genieType->childAt(2),
+        genieType->childAt(3)};
+    planner_->registerScalarFunction("genie", genieArgs, genieType);
+    planner_->registerScalarFunction("exploding_genie", genieArgs, genieType);
+    registerGenieUdfs();
+
+    auto metadata = std::make_unique<FunctionMetadata>();
+    metadata->fieldIndexForArg = {1, 2, 3};
+    metadata->argOrdinal = {1, 2, 3};
+    auto* instance = FunctionRegistry::instance();
+    auto explodingMetadata = std::make_unique<FunctionMetadata>(*metadata);
+    instance->registerFunction("genie", std::move(metadata));
+
+    explodingMetadata->logicalExplode = logicalExplodeGenie;
+    instance->registerFunction("exploding_genie", std::move(explodingMetadata));
+  }
+
+  static std::unordered_map<PathCP, lp::ExprPtr> logicalExplodeGenie(
+      const lp::CallExpr* call,
+      std::vector<PathCP>& paths) {
+    // This function understands paths like .__1[cc], .__2[cc],
+    // .__3[cc] where __x is an ordinal field reference and cc is an integer
+    // constant. If there is an empty path or a path with just one step, this
+    // returns empty, meaning nothing is exploded. If the paths are longer, e.g.
+    // idslf[11][1], then the trailing part is ignored. The returned map will
+    // have the expression for each distinct path that begins with one of .__1,
+    // .__2, .__3 followed by an integer subscript.
+    std::unordered_map<PathCP, lp::ExprPtr> result;
+    for (auto& path : paths) {
+      auto& steps = path->steps();
+      if (steps.size() < 2) {
+        return {};
+      }
+
+      std::vector<Step> prefixSteps = {steps[0], steps[1]};
+      auto prefixPath = toPath(std::move(prefixSteps));
+      if (result.count(prefixPath)) {
+        // There already is an expression for this path.
+        continue;
+      }
+      VELOX_CHECK(steps.front().kind == StepKind::kField);
+      auto nth = steps.front().id;
+      VELOX_CHECK_LE(nth, 3);
+      auto args = call->inputs();
+
+      // Here, for the sake of example, we make every odd key return identity.
+      if (steps[1].id % 2 == 1) {
+        result[prefixPath] = stepToLogicalPlanGetter(steps[1], args[nth]);
+        continue;
+      }
+
+      // For changed float_features, we add the feature id to the value.
+      if (nth == 1) {
+        result[prefixPath] = std::make_shared<lp::CallExpr>(
+            REAL(),
+            "plus",
+            std::vector<lp::ExprPtr>{
+                stepToLogicalPlanGetter(steps[1], args[nth]),
+                std::make_shared<lp::ConstantExpr>(
+                    REAL(), variant(static_cast<float>(steps[1].id)))});
+        continue;
+      }
+
+      // For changed id list features, we do array_distinct on the list.
+      if (nth == 2) {
+        result[prefixPath] = std::make_shared<lp::CallExpr>(
+            ARRAY(BIGINT()),
+            "array_distinct",
+            std::vector<lp::ExprPtr>{
+                stepToLogicalPlanGetter(steps[1], args[nth])});
+        continue;
+      }
+
+      // Access to idslf. Identity.
+      result[prefixPath] = stepToLogicalPlanGetter(steps[1], args[nth]);
+    }
+    return result;
+  }
+
+  std::vector<RowVectorPtr> extractAndIncrementIdList(
+      const std::vector<RowVectorPtr>& vectors,
+      int32_t key) {
+    std::vector<RowVectorPtr> result;
+    facebook::velox::test::VectorMaker vectorMaker(pool_.get());
+
+    for (auto& row : vectors) {
+      auto* idList = row->childAt(3)->as<MapVector>();
+      auto* keys = idList->mapKeys()->as<FlatVector<int32_t>>();
+      auto* values = idList->mapValues()->as<ArrayVector>();
+      auto idsShared =
+          BaseVector::create(values->type(), row->size(), values->pool());
+      auto* ids = idsShared->as<ArrayVector>();
+      for (auto i = 0; i < idList->size(); ++i) {
+        bool found = false;
+        for (auto k = idList->offsetAt(i);
+             k < idList->offsetAt(i) + idList->sizeAt(i);
+             ++k) {
+          if (keys->valueAt(k) == key) {
+            ids->copy(values, i, k, 1);
+            auto* elt = ids->elements()->as<FlatVector<int64_t>>();
+            for (auto e = ids->offsetAt(i);
+                 e < ids->offsetAt(i) + ids->sizeAt(i);
+                 ++e) {
+              elt->set(e, elt->valueAt(e) + 1);
+            }
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          ids->setNull(i, true);
+        }
+      }
+      result.push_back(vectorMaker.rowVector({idsShared}));
+    }
+
+    return result;
+  }
+
+  std::vector<std::string> fieldNames(const RowTypePtr& type) {
+    std::vector<std::string> result;
+    for (auto i = 0; i < type->size(); ++i) {
+      result.push_back(type->nameOf(i));
+    }
+    return result;
+  }
+
+  void testParallelExpr(FeatureOptions& opts, const RowTypePtr& rowType) {
+    core::PlanNodePtr veloxPlan;
+    // No randoms in test expr, different runs must come out the same.
+    opts.randomPct = 0;
+
+    {
+      std::vector<std::string> names;
+      std::vector<core::TypedExprPtr> exprs;
+
+      opts.rng.seed(1);
+      makeExprs(opts, names, exprs);
+
+      auto builder = PlanBuilder()
+                         .tableScan("features", rowType)
+                         .addNode([&](std::string id, auto node) {
+                           return std::make_shared<core::ProjectNode>(
+                               id, std::move(names), std::move(exprs), node);
+                         });
+      veloxPlan = builder.planNode();
+    }
+
+    std::vector<std::string> names;
+    std::vector<lp::ExprPtr> exprs;
+
+    opts.rng.seed(1);
+    makeLogicalExprs(opts, names, exprs);
+    lp::PlanBuilder::Context ctx;
+    auto builder = lp::PlanBuilder(ctx).tableScan(
+        kHiveConnectorId, "features", fieldNames(rowType));
+    lp::LogicalPlanNodePtr logicalPlan = std::make_shared<lp::ProjectNode>(
+        ctx.planNodeIdGenerator->next(),
+        builder.build(),
+        std::move(names),
+        std::move(exprs));
+
+    optimizerOptions_.parallelProjectWidth = 8;
+    auto fragmentedPlan = planVelox(logicalPlan);
+    auto plan = veloxString(fragmentedPlan.plan);
+
+    expectRegexp(plan, "ParallelProject");
+    std::cout << plan;
+    assertSame(veloxPlan, fragmentedPlan);
+  }
+};
+
+TEST_P(LogicalSubfieldTest, structs) {
+  auto structType =
+      ROW({"s1", "s2", "s3"},
+          {BIGINT(), ROW({"s2s1"}, {BIGINT()}), ARRAY(BIGINT())});
+  auto rowType = ROW({"s", "i"}, {structType, BIGINT()});
+  auto vectors = makeVectors(rowType, 10, 10);
+  auto fs = filesystems::getFileSystem(testDataPath_, {});
+  fs->mkdir(testDataPath_ + "/structs");
+  auto filePath = testDataPath_ + "/structs/structs.dwrf";
+  writeToFile(filePath, vectors);
+  tablesCreated();
+
+  auto builder =
+      lp::PlanBuilder()
+          .tableScan(kHiveConnectorId, "structs", fieldNames(rowType))
+          .project({"s.s1 as a", "s.s3[0] as arr0"});
+
+  auto plan = veloxString(planVelox(builder.build()).plan);
+  expectRegexp(plan, "s.*Subfields.*s.s3\\[0\\]");
+  expectRegexp(plan, "s.*Subfields.*s.s1");
+}
+
+TEST_P(LogicalSubfieldTest, maps) {
+  FeatureOptions opts;
+  opts.rng.seed(1);
+  auto vectors = makeFeatures(1, 100, opts, pool_.get());
+  auto rowType = std::dynamic_pointer_cast<const RowType>(vectors[0]->type());
+  auto fields = fieldNames(rowType);
+  auto fs = filesystems::getFileSystem(testDataPath_, {});
+  fs->mkdir(testDataPath_ + "/features");
+  auto filePath = testDataPath_ + "/features/features.dwrf";
+  auto config = std::make_shared<dwrf::Config>();
+  config->set(dwrf::Config::FLATTEN_MAP, true);
+  config->set<const std::vector<uint32_t>>(
+      dwrf::Config::MAP_FLAT_COLS, {2, 3, 4});
+
+  writeToFile(filePath, vectors, config);
+  tablesCreated();
+  std::string plan;
+
+  {
+    lp::PlanBuilder::Context ctx;
+    auto builder =
+        lp::PlanBuilder(ctx)
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project({"uid", "float_features as ff"})
+            .join(
+                lp::PlanBuilder(ctx)
+                    .tableScan(kHiveConnectorId, "features", fields)
+                    .filter(
+                        "uid % 2 = 1 and cast(float_features[10300::INTEGER] as integer) % 2::INTEGER = 0::INTEGER")
+                    .project({"uid as opt_uid", "float_features as opt_ff"}),
+                "uid = opt_uid",
+                lp::JoinType::kLeft)
+            .project(
+                {"uid",
+                 "opt_uid",
+                 "ff[10100::INTEGER] as f10",
+                 "ff[10200::INTEGER] as f20",
+                 "opt_ff[10100::INTEGER] as o10",
+                 "opt_ff[10200::INTEGER] as o20"});
+
+    plan = veloxString(planVelox(builder.build()).plan);
+    std::cout << plan << std::endl;
+  }
+  {
+    auto builder =
+        lp::PlanBuilder()
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project(
+                {"float_features[10100::INTEGER] as f1",
+                 "float_features[10200::INTEGER] as f2",
+                 "id_score_list_features[200800::INTEGER][100000::BIGINT]"});
+    plan = veloxString(planVelox(builder.build()).plan);
+    expectRegexp(plan, "float_features.*Subfields.*float_features.10100.");
+    expectRegexp(plan, "float_features.*Subfields.*float_features.10200.");
+    expectRegexp(
+        plan,
+        "id_score_list_features.*Subfields.* id_score_list_features.200800.*\\[100000\\]");
+    expectRegexp(plan, "ubfield.*id_list", false);
+  }
+  {
+    auto builder = lp::PlanBuilder()
+                       .tableScan(kHiveConnectorId, "features", fields)
+                       .project(
+                           {"float_features[10000::INTEGER] as ff",
+                            "id_score_list_features[200800::INTEGER] as sc1",
+                            "id_list_features as idlf"})
+                       .project({"sc1[1::BIGINT] + 1::REAL as score"});
+    plan = veloxString(planVelox(builder.build()).plan);
+    expectRegexp(
+        plan,
+        "id_score_list_features.*Subfields:.*\\[ id_score_list_features.200800.*\\[1\\]");
+    expectRegexp(plan, "ubfield.*id_list", false);
+    expectRegexp(plan, "ubfield.*float_f", false);
+  }
+  {
+    auto builder = lp::PlanBuilder()
+                       .tableScan(kHiveConnectorId, "features", fields)
+                       .project(
+                           {"float_features[10100::INTEGER] as ff",
+                            "id_score_list_features[200800::INTEGER] as sc1",
+                            "id_list_features as idlf",
+                            "uid"})
+                       .project(
+                           {"sc1[1::BIGINT] + 1::REAL as score",
+                            "idlf[cast(uid % 100 as INTEGER)] as any"});
+    plan = veloxString(planVelox(builder.build()).plan);
+    expectRegexp(
+        plan, "id_list_features.*Subfields:.* id_list_features\\[\\*\\]");
+  }
+  declareGenies();
+
+  // Selected fields of genie are accessed. The uid and idslf args are not
+  // accessed and should not be in the table scan.
+  {
+    auto builder =
+        lp::PlanBuilder()
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project(
+                {"genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+            // Access some fields of the genie by name, others by index.
+            .project(
+                {"g.ff[10200::INTEGER] as f2",
+                 "g.__1[10100::INTEGER] as f11",
+                 "g.__1[10200::INTEGER] + 22::REAL  as f2b",
+                 "g.idlf[201600::INTEGER] as idl100"});
+
+    plan = veloxString(planVelox(builder.build()).plan);
+    expectRegexp(plan, "float_features.*Subfield.*float_features.10200");
+    expectRegexp(plan, "id_list_features.*Subfields.*id_list_features.201600");
+  }
+  // All of genie is returned.
+  {
+    auto builder =
+        lp::PlanBuilder()
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project(
+                {"genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+            .project(
+                {"g",
+                 "g.__1[10100::INTEGER] as f10",
+                 "g.__1[10200::INTEGER] as f2",
+                 "g.__2[200600::INTEGER] as idl100"});
+
+    plan = veloxString(planVelox(builder.build()).plan);
+    std::cout << plan << std::endl;
+  }
+
+  // We expect the genie to explode and the filters to be first.
+  {
+    auto builder =
+        lp::PlanBuilder()
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project(
+                {"exploding_genie(uid, float_features, id_list_features, id_score_list_features) as g"})
+            .project({"g.__1 as ff", "g as gg"})
+            .project(
+                {"ff[10100::INTEGER] as f10",
+                 "ff[10100::INTEGER] as f11",
+                 "ff[10200::INTEGER] as f2",
+                 "gg.__1[10200::INTEGER] + 22::REAL as f2b",
+                 "gg.__2[200600::INTEGER] as idl100"})
+            .filter("f10 < 10::REAL and f11 < 10::REAL");
+
+    plan = veloxString(planVelox(builder.build()).plan);
+    std::cout << plan << std::endl;
+  }
+  {
+    auto builder =
+        lp::PlanBuilder()
+            .tableScan(kHiveConnectorId, "features", fields)
+            .project(
+                {"transform(id_list_features[201800::INTEGER], x -> x + 1) as ids"});
+
+    auto result = runVelox(builder.build());
+    auto expected = extractAndIncrementIdList(vectors, 201800);
+    assertEqualResults(expected, result.results);
+  }
+
+  testParallelExpr(opts, rowType);
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    LogicalSubfieldTests,
+    LogicalSubfieldTest,
+    testing::ValuesIn(std::vector<int32_t>{1, 2, 3}));

--- a/frontend/optimizer/tests/QueryTestBase.h
+++ b/frontend/optimizer/tests/QueryTestBase.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gflags/gflags.h>
 #include "optimizer/SchemaResolver.h" //@manual
@@ -67,6 +69,8 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   TestResult runVelox(const core::PlanNodePtr& plan);
 
+  TestResult runVelox(const logical_plan::LogicalPlanNodePtr& plan);
+
   TestResult runFragmentedPlan(optimizer::PlanAndStats& plan);
 
   /// Checks that 'reference' and 'experiment' produce the same result.
@@ -84,6 +88,17 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
       const core::PlanNodePtr& plan,
       std::string* planString = nullptr,
       std::string* errorString = nullptr);
+
+  optimizer::PlanAndStats planVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      std::string* planString = nullptr,
+      std::string* errorString = nullptr);
+
+  template <typename PlanPtr>
+  optimizer::PlanAndStats planFromTree(
+      const PlanPtr& plan,
+      std::string* planString,
+      std::string* errorString);
 
   std::string veloxString(const std::string& sql);
 

--- a/frontend/optimizer/tests/SubfieldTest.cpp
+++ b/frontend/optimizer/tests/SubfieldTest.cpp
@@ -16,58 +16,20 @@
 
 #include "optimizer/FunctionRegistry.h" //@manual
 #include "optimizer/tests/FeatureGen.h" //@manual
+#include "optimizer/tests/Genies.h" //@manual
 #include "optimizer/tests/QueryTestBase.h" //@manual
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/parse/Expressions.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
-DEFINE_string(subfield_data_path, "", "Data directory for subfield test data");
+DECLARE_string(subfield_data_path);
 
 using namespace facebook::velox;
 using namespace facebook::velox::optimizer;
 using namespace facebook::velox::optimizer::test;
 using namespace facebook::velox::exec::test;
-
-TypePtr makeGenieType() {
-  return ROW(
-      {"uid", "ff", "idlf", "idslf"},
-      {BIGINT(),
-       MAP(INTEGER(), REAL()),
-       MAP(INTEGER(), ARRAY(BIGINT())),
-       MAP(INTEGER(), MAP(BIGINT(), REAL()))});
-}
-
-class GenieFunction : public exec::VectorFunction {
- public:
-  void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      const TypePtr& outputType,
-      exec::EvalCtx& context,
-      VectorPtr& result) const override {
-    VELOX_UNREACHABLE();
-  }
-
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    auto type = makeGenieType();
-    return {
-        exec::FunctionSignatureBuilder()
-            .returnType(
-                "row(userid bigint, ff map(integer, real), idlf map(integer, array(bigint)), idsf map(integer, map(bigint, real)))")
-            .argumentType("bigint")
-            .argumentType("map(integer, real)")
-            .argumentType("map(integer, array(bigint))")
-            .argumentType("map(integer, map(bigint, real))")
-            .build()};
-  }
-};
-
-VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
-    udf_genie,
-    GenieFunction::signatures(),
-    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
-    std::make_unique<GenieFunction>());
 
 class SubfieldTest : public QueryTestBase,
                      public testing::WithParamInterface<int32_t> {
@@ -139,9 +101,7 @@ class SubfieldTest : public QueryTestBase,
         genieType->childAt(3)};
     planner_->registerScalarFunction("genie", genieArgs, genieType);
     planner_->registerScalarFunction("exploding_genie", genieArgs, genieType);
-    VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "genie");
-    VELOX_REGISTER_VECTOR_FUNCTION(udf_genie, "exploding_genie");
-
+    registerGenieUdfs();
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->fieldIndexForArg = {1, 2, 3};
     metadata->argOrdinal = {1, 2, 3};


### PR DESCRIPTION
- Adds a parallel implementation to subfield pruning and conversion to query graph that takes logical_plan::LogicalPlanNode inputs instead of core::PlanNode.

- Adds a a logical plan version of the SubfieldTest.cpp

The Velox PlanNode input support will be removed aftr tests and uses have been migrated.

- Fix name generation in PlanBuilder. Only cut the tail after last _ if it is all digits. TableScan outputType() reflects the renames, not the table column names.

- Allow an integer field index in kDereference special form for anonymous rows returned by functions.

- Add support for lambdas to PlanBuilder. Misc.fixes to LambdaExpr.