### PR TITLE
verax(fix): pushdown filters in Tpch and allow dynamic scale factor

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -17,6 +17,14 @@ add_subdirectory(tests)
 add_subdirectory(connectors)
 
 add_library(
+  velox_schema_resolver
+  SchemaResolver.cpp
+  SchemaUtils.cpp)
+
+target_link_libraries(velox_schema_resolver velox_connector_metadata
+                      velox_exception velox_vector)
+
+add_library(
   velox_verax
   ToGraph.cpp
   LogicalPlanToGraph.cpp
@@ -28,8 +36,6 @@ add_library(
   ParallelProject.cpp
   PlanObject.cpp
   Schema.cpp
-  SchemaResolver.cpp
-  SchemaUtils.cpp
   QueryGraph.cpp
   QueryGraphContext.cpp
   Filters.cpp
@@ -45,4 +51,5 @@ add_dependencies(velox_verax velox_hive_connector)
 
 target_link_libraries(
   velox_verax velox_core velox_connector_metadata velox_fe_logical_plan
-  velox_multifragment_plan velox_connector)
+  velox_multifragment_plan velox_connector
+                      velox_schema_resolver)

--- a/axiom/optimizer/connectors/tpch/CMakeLists.txt
+++ b/axiom/optimizer/connectors/tpch/CMakeLists.txt
@@ -18,6 +18,7 @@ velox_add_library(velox_tpch_connector_metadata OBJECT
 velox_link_libraries(
   velox_tpch_connector_metadata
   velox_connector_metadata
+  velox_schema_resolver
   velox_tpch_connector
   velox_tpch_gen)
 

--- a/axiom/optimizer/connectors/tpch/tests/CMakeLists.txt
+++ b/axiom/optimizer/connectors/tpch/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
   velox_exec_runner_test_util
   velox_vector_fuzzer
   velox_vector_test_lib
+  velox_schema_resolver
   velox_exec
   velox_exec_test_lib
   GTest::gtest

--- a/axiom/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -17,37 +17,30 @@
 #include "axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h"
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
-#include "velox/connectors/tpch/TpchConnector.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::connector;
-using namespace facebook::velox::connector::tpch;
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::tpch {
+namespace {
 
 class TpchConnectorMetadataTest : public ::testing::Test {
  protected:
   void SetUp() override {
     auto config = std::make_shared<config::ConfigBase>(
         std::unordered_map<std::string, std::string>{});
-    tpchConnector_ =
-        std::make_shared<TpchConnector>("test-tpch", config, nullptr);
-
-    metadata_ =
-        std::make_unique<TpchConnectorMetadata>(tpchConnector_.get(), 0.01);
+    connector_ = std::make_unique<TpchConnector>(
+        connector::tpch::TpchConnectorFactory::kTpchConnectorName,
+        config,
+        nullptr);
+    metadata_ = std::make_unique<TpchConnectorMetadata>(connector_.get());
   }
 
-  void TearDown() override {
-    metadata_.reset();
-    tpchConnector_.reset();
-  }
-
-  std::shared_ptr<TpchConnector> tpchConnector_;
+  std::unique_ptr<TpchConnector> connector_;
   std::unique_ptr<TpchConnectorMetadata> metadata_;
 };
 
-TEST_F(TpchConnectorMetadataTest, FindAllTables) {
-  metadata_->initialize();
-
-  // Test finding all TPC-H tables
+TEST_F(TpchConnectorMetadataTest, findAllTables) {
   std::vector<std::string> expectedTables = {
       "lineitem",
       "orders",
@@ -57,13 +50,132 @@ TEST_F(TpchConnectorMetadataTest, FindAllTables) {
       "part",
       "supplier",
       "partsupp"};
-
   for (const auto& tableName : expectedTables) {
     auto table = metadata_->findTable(tableName);
-    ASSERT_NE(table, nullptr) << "Table " << tableName << " should exist";
-    EXPECT_EQ(table->name(), tableName);
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table->name(), fmt::format("tiny.{}", tableName));
   }
 }
+
+TEST_F(TpchConnectorMetadataTest, findAllScaleFactors) {
+  std::vector<int> scaleFactors = {
+      1, 100, 1000, 10000, 100000, 300, 3000, 30000};
+  auto tableName = "customer";
+  for (const auto& scaleFactor : scaleFactors) {
+    auto qualifiedName = fmt::format("sf{}.{}", scaleFactor, tableName);
+    auto table = metadata_->findTable(qualifiedName);
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table->name(), qualifiedName);
+    auto* tpchTable =
+        dynamic_cast<const facebook::velox::connector::tpch::TpchTable*>(table);
+    ASSERT_NE(tpchTable, nullptr);
+    EXPECT_DOUBLE_EQ(tpchTable->getScaleFactor(), scaleFactor);
+  }
+}
+
+TEST_F(TpchConnectorMetadataTest, invalidLookups) {
+  auto table = metadata_->findTable("invalidtable");
+  EXPECT_EQ(table, nullptr);
+  table = metadata_->findTable("invalidschema.lineitem");
+  EXPECT_EQ(table, nullptr);
+}
+
+TEST_F(TpchConnectorMetadataTest, verifyTpchSchema) {
+  std::vector<std::string> tableNames = {
+      "lineitem",
+      "orders",
+      "customer",
+      "nation",
+      "region",
+      "part",
+      "supplier",
+      "partsupp"};
+  for (const auto& tableName : tableNames) {
+    auto table = metadata_->findTable(tableName);
+    ASSERT_NE(table, nullptr);
+    auto idx = velox::tpch::fromTableName(tableName);
+    auto schema = velox::tpch::getTableSchema(idx);
+
+    const auto& columnMap = table->columnMap();
+    for (const auto& column : columnMap) {
+      ASSERT_NE(schema->findChild(column.first), nullptr);
+    }
+  }
+}
+
+TEST_F(TpchConnectorMetadataTest, createColumnHandle) {
+  auto table = metadata_->findTable("lineitem");
+  ASSERT_NE(table, nullptr);
+
+  const auto& layouts = table->layouts();
+  ASSERT_FALSE(layouts.empty());
+
+  auto columnHandle = metadata_->createColumnHandle(*layouts[0], "orderkey");
+  ASSERT_NE(columnHandle, nullptr);
+
+  auto* tpchColumnHandle =
+      dynamic_cast<const facebook::velox::connector::tpch::TpchColumnHandle*>(
+          columnHandle.get());
+  ASSERT_NE(tpchColumnHandle, nullptr);
+  EXPECT_EQ(tpchColumnHandle->name(), "orderkey");
+}
+
+TEST_F(TpchConnectorMetadataTest, createTableHandle) {
+  metadata_->initialize();
+  auto table = metadata_->findTable("lineitem");
+  ASSERT_NE(table, nullptr);
+  const auto& layouts = table->layouts();
+  ASSERT_EQ(layouts.size(), 1);
+  auto* tpchLayout =
+      dynamic_cast<const facebook::velox::connector::tpch::TpchTableLayout*>(
+          layouts[0]);
+
+  std::vector<facebook::velox::connector::ColumnHandlePtr> columnHandles;
+  std::vector<facebook::velox::core::TypedExprPtr> empty;
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  auto tableHandle = metadata_->createTableHandle(
+      *layouts[0], columnHandles, *evaluator, empty, empty);
+  ASSERT_NE(tableHandle, nullptr);
+
+  auto* tpchTableHandle =
+      dynamic_cast<const facebook::velox::connector::tpch::TpchTableHandle*>(
+          tableHandle.get());
+  ASSERT_NE(tpchTableHandle, nullptr);
+
+  EXPECT_EQ(tpchTableHandle->getTable(), tpchLayout->getTpchTable());
+  EXPECT_DOUBLE_EQ(
+      tpchTableHandle->getScaleFactor(), tpchLayout->getScaleFactor());
+}
+
+TEST_F(TpchConnectorMetadataTest, splitGeneration) {
+  auto table = metadata_->findTable("lineitem");
+  ASSERT_NE(table, nullptr);
+
+  const auto& layouts = table->layouts();
+  ASSERT_FALSE(layouts.empty());
+
+  auto splitManager = metadata_->splitManager();
+  ASSERT_NE(splitManager, nullptr);
+
+  std::vector<facebook::velox::connector::ColumnHandlePtr> columnHandles;
+  std::vector<facebook::velox::core::TypedExprPtr> empty;
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  auto tableHandle = metadata_->createTableHandle(
+      *layouts[0], columnHandles, *evaluator, empty, empty);
+  ASSERT_NE(tableHandle, nullptr);
+
+  auto partitions = splitManager->listPartitions(tableHandle);
+  ASSERT_EQ(partitions.size(), 1);
+
+  auto splitSource = splitManager->getSplitSource(tableHandle, partitions);
+  ASSERT_NE(splitSource, nullptr);
+  auto splits = splitSource->getSplits(1024 * 1024); // 1MB target
+  ASSERT_FALSE(splits.empty());
+}
+} // namespace
+} // namespace facebook::velox::connector::tpch
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   velox_plan_test
   velox_verax
   velox_fe_logical_plan_builder
+  velox_schema_resolver
   velox_tpch_gen
   velox_connector_split_source
   velox_hive_connector_metadata
@@ -45,6 +46,7 @@ target_link_libraries(
   velox_sql
   velox_local_runner
   velox_verax
+  velox_schema_resolver
   velox_connector_split_source
   velox_hive_connector_metadata
   velox_query_benchmark


### PR DESCRIPTION
Summary:
the current implementation of TpchConnectorMetadata sets a static scale factor for the process. Instead, following the TPC-H convention, we will initialize tables of each scale factor (tiny, 1, 100, etc.) which can be indexed by providing a schema-qualified table name

I'm also modifying the way we register metadata factories in the following two ways:

1. export the definition of TpchMetadataFactory so that external callers can register it
2. don't register a MetadataFactory by default

Also adding the ability to pushdown filters into TpchTableHandles. Previously we were dropping filters entirely, which makes Tpch unsuitable as a testbed for optimizer tests.

In a future change, I will convert existing Verax automation to use this TpchConnector rather than the hacked together Hive-Tpch hybrid

Differential Revision: D78605272


