### PR TITLE
Fix plan printer for cross join

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -701,11 +701,15 @@ PlanBuilder& PlanBuilder::join(
 
   auto inputRowType = node_->outputType()->unionWith(right.node_->outputType());
 
-  auto untypedExpr = parse::parseExpr(condition, parseOptions_);
-  auto expr = resolveScalarTypesImpl(
-      untypedExpr, [&](const auto& alias, const auto& name) {
-        return resolveJoinInputName(alias, name, *outputMapping_, inputRowType);
-      });
+  ExprPtr expr;
+  if (!condition.empty()) {
+    auto untypedExpr = parse::parseExpr(condition, parseOptions_);
+    expr = resolveScalarTypesImpl(
+        untypedExpr, [&](const auto& alias, const auto& name) {
+          return resolveJoinInputName(
+              alias, name, *outputMapping_, inputRowType);
+        });
+  }
 
   node_ =
       std::make_shared<JoinNode>(nextId(), node_, right.node_, joinType, expr);

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -105,7 +105,8 @@ class ToTextVisitor : public PlanNodeVisitor {
     appendNode(
         fmt::format("Join {}", JoinTypeName::toName(node.joinType())),
         node,
-        ExprPrinter::toText(*node.condition()),
+        node.condition() != nullptr ? ExprPrinter::toText(*node.condition())
+                                    : "",
         context);
   }
 


### PR DESCRIPTION
Summary: Current plan printer fail for cross join where condition is nullptr

Reviewed By: mbasmanova

Differential Revision: D78717187


