### PR TITLE
Fix zero row support in ValuesNode

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -50,18 +50,14 @@ ValuesNode::ValuesNode(
     std::vector<Variant> rows)
     : LogicalPlanNode(NodeKind::kValues, id, {}, rowType),
       rows_{std::move(rows)} {
-  if (rows_.empty()) {
-    VELOX_USER_CHECK_EQ(0, rowType->size());
-  }
-
   UniqueNameChecker::check(rowType->names());
 
   for (const auto& row : rows_) {
     VELOX_USER_CHECK(
-        rowType->equivalent(*row.inferType()),
+        row.isTypeCompatible(rowType),
         "Incompatible types: {} vs. {}",
-        rowType->toString(),
-        row.inferType()->toString());
+        row.inferType()->toString(),
+        rowType->toString());
   }
 }
 

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -68,7 +68,7 @@ TEST_F(PlanPrinterTest, values) {
                   .limit(5)
                   .build();
 
-  const auto lines = toLines(plan);
+  auto lines = toLines(plan);
 
   EXPECT_THAT(
       lines,
@@ -82,6 +82,19 @@ TEST_F(PlanPrinterTest, values) {
           testing::StartsWith("          b := plus(a, 2)"),
           testing::StartsWith("        - Filter: gt(a, 10)"),
           testing::StartsWith("          - Values"),
+          testing::Eq("")));
+
+  // Empty variant vector - zero rows:
+  plan =
+      PlanBuilder()
+          .values(ROW({"a", "b"}, {BIGINT(), REAL()}), std::vector<Variant>{})
+          .build();
+  lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Values: 0 rows -> ROW<a:BIGINT,b:REAL>"),
           testing::Eq("")));
 }
 


### PR DESCRIPTION
Summary:
When there are zero rows in the ValuesNode, the variant vector will be
empty. That is a legit case.

Differential Revision: D78850942


