### PR TITLE
Do not require all connectors to support filter pushdown

### DIFF
--- a/axiom/optimizer/LogicalPlanToGraph.cpp
+++ b/axiom/optimizer/LogicalPlanToGraph.cpp
@@ -949,6 +949,9 @@ PlanObjectP Optimization::wrapInDt(const lp::LogicalPlanNode& node) {
 
 PlanObjectP Optimization::makeBaseTable(const lp::TableScanNode* tableScan) {
   auto schemaTable = schema_.findTable(tableScan->tableName());
+  VELOX_CHECK_NOT_NULL(
+      schemaTable, "Table not found: {}", tableScan->tableName());
+
   auto cname = fmt::format("t{}", ++nameCounter_);
 
   auto* baseTable = make<BaseTable>();

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -555,7 +555,7 @@ struct BuiltinNames {
   folly::F14FastSet<Name> canonicalizable;
 };
 
-/// Instance of query optimization. Comverts a plan and schema into an
+/// Instance of query optimization. Converts a plan and schema into an
 /// optimized plan. Depends on QueryGraphContext being set on the
 /// calling thread. There is one instance per query to plan. The
 /// instance must stay live as long as a returned plan is live.

--- a/axiom/optimizer/SchemaResolver.cpp
+++ b/axiom/optimizer/SchemaResolver.cpp
@@ -21,13 +21,14 @@ namespace facebook::velox::optimizer {
 
 const connector::Table* SchemaResolver::findTable(const std::string& name) {
   TableNameParser parser(name);
-  if (!parser.valid()) {
-    VELOX_USER_FAIL("Invalid table name: '{}'", name);
-  }
+  VELOX_USER_CHECK(parser.valid(), "Invalid table name: '{}'", name);
 
   connector::Connector* connector = parser.catalog().has_value()
       ? connector::getConnector(parser.catalog().value()).get()
       : defaultConnector_.get();
+
+  VELOX_USER_CHECK_NOT_NULL(
+      connector, "Connector not found for table: {}", name);
 
   std::string lookupName;
   if (parser.schema().has_value()) {

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -59,9 +59,6 @@ void Optimization::markFieldAccessed(
   auto fields = isControl ? &controlSubfields_ : &payloadSubfields_;
   if (source.planNode) {
     auto name = source.planNode->name();
-    if (name == "TableScan") {
-      LOG(INFO) << "ff";
-    }
     auto path = stepsToPath(steps);
     fields->nodeFields[source.planNode].resultPaths[ordinal].add(path->id());
     if (name == "Project") {

--- a/axiom/optimizer/connectors/tests/TestConnector.cpp
+++ b/axiom/optimizer/connectors/tests/TestConnector.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/connectors/tests/TestConnector.h"
+
+namespace facebook::velox::connector {
+
+ConnectorTableHandlePtr TestConnectorMetadata::createTableHandle(
+    const TableLayout& /* layout */,
+    std::vector<ColumnHandlePtr> /* columnHandles */,
+    core::ExpressionEvaluator& /* evaluator */,
+    std::vector<core::TypedExprPtr> filters,
+    std::vector<core::TypedExprPtr>& rejectedFilters,
+    RowTypePtr /* dataColumns */,
+    std::optional<LookupKeys>) {
+  rejectedFilters = std::move(filters);
+  return std::make_shared<TestTableHandle>(connector_->connectorId());
+}
+
+} // namespace facebook::velox::connector

--- a/axiom/optimizer/connectors/tests/TestConnector.h
+++ b/axiom/optimizer/connectors/tests/TestConnector.h
@@ -20,28 +20,113 @@
 
 namespace facebook::velox::connector {
 
+class TestConnector;
+
+class TestTableLayout : public TableLayout {
+ public:
+  TestTableLayout(
+      const std::string& name,
+      const Table* table,
+      connector::Connector* connector,
+      std::vector<const Column*> columns)
+      : TableLayout(
+            name,
+            table,
+            connector,
+            std::move(columns),
+            std::vector<const Column*>{},
+            std::vector<const Column*>{},
+            std::vector<SortOrder>{},
+            std::vector<const Column*>{},
+            true) {}
+
+  std::pair<int64_t, int64_t> sample(
+      const connector::ConnectorTableHandlePtr& /* handle */,
+      float /* pct */,
+      std::vector<core::TypedExprPtr> /* extraFilters */,
+      RowTypePtr /* outputType */ = nullptr,
+      const std::vector<common::Subfield>& /* fields */ = {},
+      HashStringAllocator* /* allocator */ = nullptr,
+      std::vector<ColumnStatistics>* /* statistics */ = nullptr) const {
+    return std::make_pair(1'000, 1'000);
+  }
+};
+
 class TestTable : public Table {
  public:
-  TestTable(const std::string& name, const RowTypePtr& schema) : Table(name) {
+  TestTable(
+      const std::string& name,
+      const RowTypePtr& schema,
+      TestConnector* connector)
+      : Table(name), connector_{connector} {
     type_ = schema;
+
+    columns_.reserve(schema->size());
+
+    std::vector<const Column*> columnPtrs;
+    columnPtrs.reserve(schema->size());
+
+    for (auto i = 0; i < schema->size(); ++i) {
+      auto column =
+          std::make_shared<Column>(schema->nameOf(i), schema->childAt(i));
+      columns_.emplace_back(column);
+      columnPtrMap_.emplace(column->name(), column.get());
+      columnPtrs.emplace_back(column.get());
+    }
+
+    layout_ =
+        std::make_shared<TestTableLayout>(name, this, connector, columnPtrs);
+    layoutPtrs_.emplace_back(layout_.get());
   }
 
   const std::unordered_map<std::string, const Column*>& columnMap()
       const override {
-    VELOX_NYI();
+    return columnPtrMap_;
   }
 
   const std::vector<const TableLayout*>& layouts() const override {
-    VELOX_NYI();
+    return layoutPtrs_;
   }
 
   uint64_t numRows() const override {
-    VELOX_NYI();
+    return 100;
+  }
+
+ private:
+  TestConnector* connector_;
+  std::vector<std::shared_ptr<const Column>> columns_;
+  std::unordered_map<std::string, const Column*> columnPtrMap_;
+  std::shared_ptr<const TableLayout> layout_;
+  std::vector<const TableLayout*> layoutPtrs_;
+};
+
+class TestColumnHandle : public ColumnHandle {
+ public:
+  explicit TestColumnHandle(const std::string& name) : name_{name} {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+ private:
+  const std::string name_;
+};
+
+class TestTableHandle : public ConnectorTableHandle {
+ public:
+  explicit TestTableHandle(const std::string& connectorId)
+      : ConnectorTableHandle{connectorId} {}
+
+  std::string toString() const override {
+    return "TestTableHandle";
   }
 };
 
 class TestConnectorMetadata : public ConnectorMetadata {
  public:
+  explicit TestConnectorMetadata(TestConnector* connector)
+      : connector_{connector} {}
+
   void initialize() override {}
 
   const Table* findTable(const std::string& name) override {
@@ -55,17 +140,38 @@ class TestConnectorMetadata : public ConnectorMetadata {
   }
 
   void addTable(const std::string& name, const RowTypePtr& schema) {
-    tables_.emplace(name, std::make_unique<TestTable>(name, schema));
+    tables_.emplace(
+        name, std::make_unique<TestTable>(name, schema, connector_));
   }
 
+  ColumnHandlePtr createColumnHandle(
+      const TableLayout& /* layoutData */,
+      const std::string& columnName,
+      std::vector<common::Subfield> /* subfields */,
+      std::optional<TypePtr> /* castToType */,
+      SubfieldMapping /* subfieldMapping */) override {
+    return std::make_shared<TestColumnHandle>(columnName);
+  }
+
+  ConnectorTableHandlePtr createTableHandle(
+      const TableLayout& layout,
+      std::vector<ColumnHandlePtr> columnHandles,
+      core::ExpressionEvaluator& evaluator,
+      std::vector<core::TypedExprPtr> filters,
+      std::vector<core::TypedExprPtr>& rejectedFilters,
+      RowTypePtr dataColumns,
+      std::optional<LookupKeys>) override;
+
  private:
+  TestConnector* connector_;
   std::unordered_map<std::string, std::unique_ptr<TestTable>> tables_;
 };
 
 class TestConnector : public Connector {
  public:
   explicit TestConnector(const std::string& id)
-      : Connector(id), metadata_{std::make_unique<TestConnectorMetadata>()} {}
+      : Connector(id),
+        metadata_{std::make_unique<TestConnectorMetadata>(this)} {}
 
   ConnectorMetadata* metadata() const override {
     return metadata_.get();


### PR DESCRIPTION
Summary: Fix Verax optimizer to not require all connectors to support filter pushdown. Koski connectors do not support that yet.

Differential Revision: D78794959


