### PR TITLE
refactor: Consolidate resolve-aggregate-function APIs

### DIFF
--- a/axiom/optimizer/LogicalPlanToGraph.cpp
+++ b/axiom/optimizer/LogicalPlanToGraph.cpp
@@ -19,7 +19,7 @@
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
-#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/FunctionSignature.h"
 
@@ -808,8 +808,8 @@ AggregationP Optimization::translateAggregation(
     VELOX_CHECK(aggregate->ordering().empty());
     Name aggName = toName(aggregate->name());
 
-    auto accumulatorType =
-        toType(exec::Aggregate::intermediateType(aggregate->name(), argTypes));
+    auto accumulatorType = toType(
+        exec::resolveAggregateFunction(aggregate->name(), argTypes).second);
     Value finalValue = Value(toType(aggregate->type()), 1);
     auto* agg = make<Aggregate>(
         aggName,


### PR DESCRIPTION
Summary:
exec::resolveAggregateFunction API duplicates a pair of exec::Aggregate::{intermediateType, finalType) APIs.

Remove exec::Aggregate::xxxType APIs and update the callers to use exec::resolveAggregateFunction.

Differential Revision: D78893595


