### PR TITLE
Extract NameMappings and NameAllocator into a separate build target

### DIFF
--- a/axiom/logical_plan/NameAllocator.cpp
+++ b/axiom/logical_plan/NameAllocator.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/logical_plan/NameAllocator.h"
+#include <velox/common/base/Exceptions.h>
+
+namespace facebook::velox::logical_plan {
+
+namespace {
+
+bool isAllDigits(std::string_view str) {
+  for (auto c : str) {
+    if (!isdigit(c)) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
+
+std::string NameAllocator::newName(const std::string& hint) {
+  VELOX_CHECK(!hint.empty(), "Hint cannot be empty");
+
+  // Strip suffix past '_' if all digits.
+  std::string prefix = hint;
+
+  auto pos = prefix.rfind('_');
+  if (pos != std::string::npos &&
+      isAllDigits(
+          std::string_view(prefix.data() + pos + 1, prefix.size() - pos - 1))) {
+    prefix = prefix.substr(0, pos);
+  }
+
+  std::string name = prefix;
+  do {
+    if (names_.insert(name).second) {
+      return name;
+    }
+    name = fmt::format("{}_{}", prefix, nextId_++);
+  } while (true);
+}
+
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/NameAllocator.h
+++ b/axiom/logical_plan/NameAllocator.h
@@ -13,25 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
-#include <gtest/gtest.h>
-
-#include "axiom/logical_plan/NameAllocator.h"
+#include <string>
+#include <unordered_set>
 
 namespace facebook::velox::logical_plan {
 
-TEST(NameAllocatorTest, basic) {
-  NameAllocator allocator;
-  EXPECT_EQ(allocator.newName("foo"), "foo");
-  EXPECT_EQ(allocator.newName("foo"), "foo_0");
+/// Generate unique names based on user-provided hints.
+class NameAllocator {
+ public:
+  /// Returns 'hint' as is it is unique. Otherwise, return 'hint_N' where N is a
+  /// numeric suffix appended to ensure uniqueness. If 'hint' already has a
+  /// suffix and is not unique, the suffix is replaced with a new one.
+  ///
+  /// Example:
+  ///
+  ///   newName("a") -> "a"
+  ///   newName("a") -> "a_0"
+  ///   newName("a") -> "a_1"
+  ///   newName("a_0") -> "a_2"
+  std::string newName(const std::string& hint);
 
-  EXPECT_EQ(allocator.newName("bar"), "bar");
-  EXPECT_EQ(allocator.newName("bar"), "bar_1");
+  void reset() {
+    names_.clear();
+    nextId_ = 0;
+  }
 
-  EXPECT_EQ(allocator.newName("foo_0"), "foo_2");
-
-  EXPECT_EQ(allocator.newName("foo_bar"), "foo_bar");
-  EXPECT_EQ(allocator.newName("foo_bar"), "foo_bar_3");
-}
+ private:
+  std::unordered_set<std::string> names_;
+  int32_t nextId_{0};
+};
 
 } // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/logical_plan/NameMappings.h"
+#include <velox/common/base/Exceptions.h>
+
+namespace facebook::velox::logical_plan {
+
+std::string NameMappings::QualifiedName::toString() const {
+  if (alias.has_value()) {
+    return fmt::format("{}.{}", alias.value(), name);
+  }
+
+  return name;
+}
+
+void NameMappings::add(const QualifiedName& name, const std::string& id) {
+  bool ok = mappings_.emplace(name, id).second;
+  VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
+}
+
+void NameMappings::add(const std::string& name, const std::string& id) {
+  bool ok =
+      mappings_.emplace(QualifiedName{.alias = {}, .name = name}, id).second;
+  VELOX_CHECK(ok, "Duplicate name: {}", name);
+}
+
+std::optional<std::string> NameMappings::lookup(const std::string& name) const {
+  auto it = mappings_.find(QualifiedName{.alias = {}, .name = name});
+  if (it != mappings_.end()) {
+    return it->second;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<std::string> NameMappings::lookup(
+    const std::string& alias,
+    const std::string& name) const {
+  auto it = mappings_.find(QualifiedName{.alias = alias, .name = name});
+  if (it != mappings_.end()) {
+    return it->second;
+  }
+
+  return std::nullopt;
+}
+
+std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
+    const std::string& id) const {
+  std::vector<QualifiedName> names;
+  for (const auto& [key, value] : mappings_) {
+    if (value == id) {
+      names.push_back(key);
+    }
+  }
+
+  VELOX_CHECK_LE(names.size(), 2);
+  if (names.size() == 2) {
+    VELOX_CHECK_EQ(names[0].name, names[1].name);
+    VELOX_CHECK_NE(names[0].alias.has_value(), names[1].alias.has_value());
+  }
+
+  return names;
+}
+
+void NameMappings::setAlias(const std::string& alias) {
+  std::vector<std::pair<std::string, std::string>> names;
+  for (auto it = mappings_.begin(); it != mappings_.end();) {
+    if (it->first.alias.has_value()) {
+      it = mappings_.erase(it);
+    } else {
+      names.emplace_back(it->first.name, it->second);
+      ++it;
+    }
+  }
+
+  for (auto& [name, id] : names) {
+    mappings_.emplace(
+        QualifiedName{.alias = alias, .name = std::move(name)}, std::move(id));
+  }
+}
+
+void NameMappings::merge(const NameMappings& other) {
+  for (const auto& [name, id] : other.mappings_) {
+    if (mappings_.count(name)) {
+      VELOX_CHECK(!name.alias.has_value());
+      mappings_.erase(name);
+    } else {
+      mappings_.emplace(name, id);
+    }
+  }
+}
+
+std::unordered_map<std::string, std::string> NameMappings::uniqueNames() const {
+  std::unordered_map<std::string, std::string> names;
+  for (const auto& [name, id] : mappings_) {
+    if (!name.alias.has_value()) {
+      names.emplace(id, name.name);
+    }
+  }
+  return names;
+}
+
+std::string NameMappings::toString() const {
+  bool first = true;
+  std::stringstream out;
+  for (const auto& [name, id] : mappings_) {
+    if (!first) {
+      out << ", ";
+    } else {
+      first = false;
+    }
+    out << name.toString() << " -> " << id;
+  }
+  return out.str();
+}
+
+size_t NameMappings::QualifiedNameHasher::operator()(
+    const QualifiedName& value) const {
+  size_t h1 = 0;
+  if (value.alias.has_value()) {
+    h1 = std::hash<std::string>()(value.alias.value());
+  }
+
+  size_t h2 = std::hash<std::string>()(value.name);
+
+  return h1 ^ (h2 << 1);
+}
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace facebook::velox::logical_plan {
+
+/// Maintains a mapping from user-visible names to auto-generated IDs.
+/// Unique names may be accessed by name alone. Non-unique names must be
+/// disambiguated using an alias.
+class NameMappings {
+ public:
+  struct QualifiedName {
+    std::optional<std::string> alias;
+    std::string name;
+
+    bool operator==(const QualifiedName& other) const {
+      return alias == other.alias && name == other.name;
+    }
+
+    std::string toString() const;
+  };
+
+  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  void add(const QualifiedName& name, const std::string& id);
+
+  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  void add(const std::string& name, const std::string& id);
+
+  /// Returns ID for the specified 'name' if exists.
+  std::optional<std::string> lookup(const std::string& name) const;
+
+  /// Returns ID for the specified 'name' if exists.
+  std::optional<std::string> lookup(
+      const std::string& alias,
+      const std::string& name) const;
+
+  /// Returns all names for the specified ID. There can be up to 2 names: w/ and
+  /// w/o alias.
+  std::vector<QualifiedName> reverseLookup(const std::string& id) const;
+
+  /// Sets new alias for the names. Unique names will be accessible both with
+  /// the new alias and without. Ambiguous names will no longer be accessible.
+  ///
+  /// Used in PlanBuilder::as() API.
+  void setAlias(const std::string& alias);
+
+  /// Merges mappings from 'other' into this. Removes unqualified access to
+  /// non-unique names.
+  ///
+  /// @pre IDs are unique across 'this' and 'other'. This expectation is not
+  /// verified explicitly. Violations would lead to undefined behavior.
+  ///
+  /// Used in PlanBuilder::join() API.
+  void merge(const NameMappings& other);
+
+  /// Returns a mapping from IDs to unaliased names for a subset of columns with
+  /// unique names.
+  ///
+  /// Used to produce final output.
+  std::unordered_map<std::string, std::string> uniqueNames() const;
+  std::string toString() const;
+
+  void reset() {
+    mappings_.clear();
+  }
+
+ private:
+  struct QualifiedNameHasher {
+    size_t operator()(const QualifiedName& value) const;
+  };
+
+  // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
+  // alias.
+  std::unordered_map<QualifiedName, std::string, QualifiedNameHasher> mappings_;
+};
+
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -16,12 +16,12 @@
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/logical_plan/NameAllocator.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 
 namespace facebook::velox::logical_plan {
 
-class NameAllocator;
 class NameMappings;
 
 class PlanBuilder {
@@ -120,114 +120,6 @@ class PlanBuilder {
 
   // Mapping from user-provided to auto-generated output column names.
   std::shared_ptr<NameMappings> outputMapping_;
-};
-
-/// Generate unique names based on user-provided hints.
-class NameAllocator {
- public:
-  /// Returns 'hint' as is it is unique. Otherwise, return 'hint_N' where N is a
-  /// numeric suffix appended to ensure uniqueness. If 'hint' already has a
-  /// suffix and is not unique, the suffix is replaced with a new one.
-  ///
-  /// Example:
-  ///
-  ///   newName("a") -> "a"
-  ///   newName("a") -> "a_0"
-  ///   newName("a") -> "a_1"
-  ///   newName("a_0") -> "a_2"
-  std::string newName(const std::string& hint);
-
-  void reset() {
-    names_.clear();
-    nextId_ = 0;
-  }
-
- private:
-  std::unordered_set<std::string> names_;
-  int32_t nextId_{0};
-};
-
-/// Maintains a mapping from user-visible names to auto-generated IDs.
-/// Unique names may be accessed by name alone. Non-unique names must be
-/// disambiguated using an alias.
-class NameMappings {
- public:
-  struct QualifiedName {
-    std::optional<std::string> alias;
-    std::string name;
-
-    bool operator==(const QualifiedName& other) const {
-      return alias == other.alias && name == other.name;
-    }
-
-    std::string toString() const {
-      if (alias.has_value()) {
-        return fmt::format("{}.{}", alias.value(), name);
-      }
-
-      return name;
-    }
-  };
-
-  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
-  void add(const QualifiedName& name, const std::string& id) {
-    bool ok = mappings_.emplace(name, id).second;
-    VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
-  }
-
-  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
-  void add(const std::string& name, const std::string& id) {
-    bool ok =
-        mappings_.emplace(QualifiedName{.alias = {}, .name = name}, id).second;
-    VELOX_CHECK(ok, "Duplicate name: {}", name);
-  }
-
-  /// Returns ID for the specified 'name' if exists.
-  std::optional<std::string> lookup(const std::string& name) const;
-
-  /// Returns ID for the specified 'name' if exists.
-  std::optional<std::string> lookup(
-      const std::string& alias,
-      const std::string& name) const;
-
-  /// Returns all names for the specified ID. There can be up to 2 names: w/ and
-  /// w/o alias.
-  std::vector<QualifiedName> reverseLookup(const std::string& id) const;
-
-  /// Sets new alias for the names. Unique names will be accessible both with
-  /// the new alias and without. Ambiguous names will no longer be accessible.
-  ///
-  /// Used in PlanBuilder::as() API.
-  void setAlias(const std::string& alias);
-
-  /// Merges mappings from 'other' into this. Removes unqualified access to
-  /// non-unique names.
-  ///
-  /// @pre IDs are unique across 'this' and 'other'. This expectation is not
-  /// verified explicitly. Violations would lead to undefined behavior.
-  ///
-  /// Used in PlanBuilder::join() API.
-  void merge(const NameMappings& other);
-
-  /// Returns a mapping from IDs to unaliased names for a subset of columns with
-  /// unique names.
-  ///
-  /// Used to produce final output.
-  std::unordered_map<std::string, std::string> uniqueNames() const;
-  std::string toString() const;
-
-  void reset() {
-    mappings_.clear();
-  }
-
- private:
-  struct QualifiedNameHasher {
-    size_t operator()(const QualifiedName& value) const;
-  };
-
-  // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
-  // alias.
-  std::unordered_map<QualifiedName, std::string, QualifiedNameHasher> mappings_;
 };
 
 } // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/tests/NameMappingsTest.cpp
+++ b/axiom/logical_plan/tests/NameMappingsTest.cpp
@@ -17,7 +17,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/logical_plan/NameAllocator.h"
+#include "axiom/logical_plan/NameMappings.h"
 
 namespace facebook::velox::logical_plan {
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -514,6 +514,8 @@ struct OptimizerOptions {
   /// the whole map is accessed as a map.
   std::unordered_map<std::string, std::vector<std::string>> mapAsStruct;
 
+  bool sampleJoins{true};
+
   /// Produce trace of plan candidates.
   int32_t traceFlags{0};
 };

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -76,7 +76,7 @@ ColumnCP SchemaTable::column(const std::string& name, const Value& value) {
 
 ColumnCP SchemaTable::findColumn(const std::string& name) const {
   auto it = columns.find(toName(name));
-  VELOX_CHECK(it != columns.end());
+  VELOX_CHECK(it != columns.end(), "Column not found: {}", name);
   return it->second;
 }
 

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -36,6 +36,10 @@ void VeloxHistory::recordJoinSample(
     float rl) {}
 
 std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
+  if (!queryCtx()->optimization()->opts().sampleJoins) {
+    return {0, 0};
+  }
+
   auto keyPair = edge->sampleKey();
 
   if (keyPair.first.empty()) {
@@ -73,7 +77,7 @@ std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
     joinSamples_[keyPair.first] = pair;
   }
   if (trace) {
-    std::cout << "Sample join " << keyPair.first << ": " << pair.first << " : "
+    std::cout << "Sample join " << keyPair.first << ": " << pair.first << " :"
               << pair.second
               << " time=" << succinctMicros(getCurrentTimeMicro() - start)
               << std::endl;


### PR DESCRIPTION
Summary: Also, add an option to disable sampling for joins.

Differential Revision: D78991007


