### PR TITLE
Fix type check in SetNode

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -514,22 +514,19 @@ VELOX_DECLARE_ENUM_NAME(SetOperation)
 
 /// Set-level operation that supports combining datasets, possibly excluding
 /// rows based on various types of row level matching.
+///
+/// All inputs must have compatible types. Number and types of columns must be
+/// the same. Columns names being unique will be different. The output schema of
+/// the Set node is the schema of the first input. Column names in the output of
+/// the Set match column names in the first input.
+///
+/// Set operation must specify at least 2 inputs.
 class SetNode : public LogicalPlanNode {
  public:
   SetNode(
       const std::string& id,
       const std::vector<LogicalPlanNodePtr>& inputs,
-      SetOperation operation)
-      : LogicalPlanNode(NodeKind::kSet, id, inputs, inputs.at(0)->outputType()),
-        operation_{operation} {
-    VELOX_USER_CHECK_GE(
-        inputs.size(), 2, "Set operation requires at least 2 inputs");
-    for (const auto& input : inputs) {
-      VELOX_USER_CHECK(
-          *input->outputType() == *outputType(),
-          "Output schemas of all inputs to a Set operation must match");
-    }
-  }
+      SetOperation operation);
 
   SetOperation operation() const {
     return operation_;

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -718,6 +718,18 @@ PlanBuilder& PlanBuilder::join(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::unionAll(const PlanBuilder& other) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "UnionAll node cannot be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(other.node_);
+
+  node_ = std::make_shared<SetNode>(
+      nextId(),
+      std::vector<LogicalPlanNodePtr>{node_, other.node_},
+      SetOperation::kUnionAll);
+
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Sort node cannot be a leaf node");
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -74,6 +74,8 @@ class PlanBuilder {
       const std::string& condition,
       JoinType joinType);
 
+  PlanBuilder& unionAll(const PlanBuilder& other);
+
   PlanBuilder& sort(const std::vector<std::string>& sortingKeys);
 
   /// An alias for 'sort'.

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -142,7 +142,7 @@ class ToTextVisitor : public PlanNodeVisitor {
 
   void visit(const SetNode& node, PlanNodeVisitorContext& context)
       const override {
-    appendNode("Set", node, context);
+    appendNode(SetOperationName::toName(node.operation()), node, context);
   }
 
   void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
@@ -156,7 +156,7 @@ class ToTextVisitor : public PlanNodeVisitor {
   }
 
   void appendNode(
-      const std::string& name,
+      std::string_view name,
       const LogicalPlanNode& node,
       const std::optional<std::string>& details,
       PlanNodeVisitorContext& context) const {
@@ -175,7 +175,7 @@ class ToTextVisitor : public PlanNodeVisitor {
   }
 
   void appendNode(
-      const std::string& name,
+      std::string_view name,
       const LogicalPlanNode& node,
       PlanNodeVisitorContext& context) const {
     appendNode(name, node, std::nullopt, context);


### PR DESCRIPTION
Summary:
SetNode used to check that all output types of all inputs are the same. However, this is not possible because we require all symbol names in the plan to be unique.

Relax the check to allow different column names, but same types.

Differential Revision: D79019019


