### PR TITLE
Add subquery support to logical plan

### DIFF
--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -338,7 +338,9 @@ enum class SpecialForm {
 
   kStar = 9,
 
-  // TODO Add IN and EXISTS.
+  kIn = 10,
+
+  kExists = 11,
 };
 
 VELOX_DECLARE_ENUM_NAME(SpecialForm)
@@ -622,14 +624,25 @@ using LambdaExprPtr = std::shared_ptr<const LambdaExpr>;
 class LogicalPlanNode;
 using LogicalPlanNodePtr = std::shared_ptr<const LogicalPlanNode>;
 
-/// Scalar subquery that returns exactly one row and one column. Can be used
-/// anywhere a scalar function call can be used.
+/// Enum representing the type of subquery.
+enum class SubqueryType {
+  SCALAR, // Scalar subquery that returns exactly one row and one column
+  IN, // IN subquery used in expressions like "x IN (subquery)"
+  EXISTS // EXISTS subquery used to check if subquery returns any rows
+};
+
+/// Subquery expression that can be used in various contexts depending on its
+/// type.
 class SubqueryExpr : public Expr {
  public:
-  explicit SubqueryExpr(const LogicalPlanNodePtr& subquery);
+  explicit SubqueryExpr(const LogicalPlanNodePtr subquery, SubqueryType type);
 
   const LogicalPlanNodePtr& subquery() const {
     return subquery_;
+  }
+
+  SubqueryType subqueryType() const {
+    return subqueryType_;
   }
 
   void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
@@ -637,6 +650,7 @@ class SubqueryExpr : public Expr {
 
  private:
   const LogicalPlanNodePtr subquery_;
+  const SubqueryType subqueryType_;
 };
 
 using SubqueryExprPtr = std::shared_ptr<const SubqueryExpr>;

--- a/axiom/logical_plan/ExprPrinter.cpp
+++ b/axiom/logical_plan/ExprPrinter.cpp
@@ -16,6 +16,14 @@
 
 #include "axiom/logical_plan/ExprPrinter.h"
 
+// Forward declaration to avoid circular dependency
+namespace facebook::velox::logical_plan {
+class PlanPrinter {
+ public:
+  static std::string toText(const LogicalPlanNode& root);
+};
+} // namespace facebook::velox::logical_plan
+
 namespace facebook::velox::logical_plan {
 
 namespace {
@@ -98,10 +106,16 @@ class ToTextVisitor : public ExprVisitor {
     expr.body()->accept(*this, context);
   }
 
-  void visit(const SubqueryExpr& /* expr */, ExprVisitorContext& /* context */)
+  void visit(const SubqueryExpr& expr, ExprVisitorContext& context)
       const override {
-    // TODO Implement.
-    VELOX_NYI();
+    auto& out = toOut(context);
+    out << std::endl;
+    out << "Subquery";
+    out << std::endl;
+    out << "(";
+    out << PlanPrinter::toText(*(expr.subquery()));
+    out << ")";
+    out << std::endl;
   }
 
  private:

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "velox/type/Type.h"
 
 namespace facebook::velox::logical_plan {
 
@@ -38,17 +39,31 @@ class NameMappings {
     std::string toString() const;
   };
 
-  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
-  void add(const QualifiedName& name, const std::string& id);
+  struct IdAndType {
+    std::string id;
+    TypePtr type;
+
+    bool operator==(const IdAndType& other) const {
+      return id == other.id && type == other.type;
+    }
+
+    std::string toString() const {
+      return fmt::format("{}:{}", id, type->toString());
+    }
+  };
 
   /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
-  void add(const std::string& name, const std::string& id);
+  void
+  add(const QualifiedName& name, const std::string& id, const TypePtr type);
+
+  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  void add(const std::string& name, const std::string& id, const TypePtr type);
 
   /// Returns ID for the specified 'name' if exists.
-  std::optional<std::string> lookup(const std::string& name) const;
+  std::optional<IdAndType> lookup(const std::string& name) const;
 
   /// Returns ID for the specified 'name' if exists.
-  std::optional<std::string> lookup(
+  std::optional<IdAndType> lookup(
       const std::string& alias,
       const std::string& name) const;
 
@@ -89,7 +104,7 @@ class NameMappings {
 
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.
-  std::unordered_map<QualifiedName, std::string, QualifiedNameHasher> mappings_;
+  std::unordered_map<QualifiedName, IdAndType, QualifiedNameHasher> mappings_;
 };
 
 } // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/tests/NameMappingsTest.cpp
+++ b/axiom/logical_plan/tests/NameMappingsTest.cpp
@@ -48,28 +48,40 @@ TEST(NameMappingsTest, basic) {
   };
 
   {
-    mappings.add("a", newName("a"));
-    mappings.add("b", newName("b"));
-    mappings.add("c", newName("c"));
+    mappings.add("a", newName("a"), BOOLEAN());
+    mappings.add("b", newName("b"), BOOLEAN());
+    mappings.add("c", newName("c"), BOOLEAN());
 
-    EXPECT_EQ(mappings.lookup("a"), "a");
-    EXPECT_EQ(mappings.lookup("b"), "b");
-    EXPECT_EQ(mappings.lookup("c"), "c");
+    EXPECT_EQ(
+        mappings.lookup("a"),
+        (NameMappings::IdAndType{.id = "a", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("c"),
+        (NameMappings::IdAndType{.id = "c", .type = BOOLEAN()}));
 
     mappings.setAlias("t");
 
-    EXPECT_EQ(mappings.lookup("t", "a"), "a");
-    EXPECT_EQ(mappings.lookup("t", "b"), "b");
-    EXPECT_EQ(mappings.lookup("t", "c"), "c");
+    EXPECT_EQ(
+        mappings.lookup("t", "a"),
+        (NameMappings::IdAndType{.id = "a", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("t", "b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("t", "c"),
+        (NameMappings::IdAndType{.id = "c", .type = BOOLEAN()}));
 
     EXPECT_THAT(reverseLookup("a"), makeNamesEq({"a", "t.a"}));
     EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
     EXPECT_THAT(reverseLookup("c"), makeNamesEq({"c", "t.c"}));
 
     NameMappings other;
-    other.add("a", newName("a"));
-    other.add("c", newName("c"));
-    other.add("e", newName("e"));
+    other.add("a", newName("a"), BOOLEAN());
+    other.add("c", newName("c"), BOOLEAN());
+    other.add("e", newName("e"), BOOLEAN());
 
     mappings.merge(other);
 
@@ -77,15 +89,25 @@ TEST(NameMappingsTest, basic) {
     // accessible at all.
 
     EXPECT_EQ(mappings.lookup("a"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("t", "a"), "a");
+    EXPECT_EQ(
+        mappings.lookup("t", "a"),
+        (NameMappings::IdAndType{.id = "a", .type = BOOLEAN()}));
 
-    EXPECT_EQ(mappings.lookup("b"), "b");
-    EXPECT_EQ(mappings.lookup("t", "b"), "b");
+    EXPECT_EQ(
+        mappings.lookup("b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("t", "b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
 
     EXPECT_EQ(mappings.lookup("c"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("t", "c"), "c");
+    EXPECT_EQ(
+        mappings.lookup("t", "c"),
+        (NameMappings::IdAndType{.id = "c", .type = BOOLEAN()}));
 
-    EXPECT_EQ(mappings.lookup("e"), "e");
+    EXPECT_EQ(
+        mappings.lookup("e"),
+        (NameMappings::IdAndType{.id = "e", .type = BOOLEAN()}));
 
     EXPECT_THAT(reverseLookup("a"), makeNamesEq({"t.a"}));
     EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
@@ -97,35 +119,51 @@ TEST(NameMappingsTest, basic) {
     allocator.reset();
     mappings.reset();
 
-    mappings.add("a", newName("a"));
-    mappings.add("b", newName("b"));
-    mappings.add("c", newName("c"));
+    mappings.add("a", newName("a"), BOOLEAN());
+    mappings.add("b", newName("b"), BOOLEAN());
+    mappings.add("c", newName("c"), BOOLEAN());
     mappings.setAlias("t");
 
     NameMappings other;
-    other.add("a", newName("a"));
-    other.add("c", newName("c"));
-    other.add("e", newName("e"));
+    other.add("a", newName("a"), BOOLEAN());
+    other.add("c", newName("c"), BOOLEAN());
+    other.add("e", newName("e"), BOOLEAN());
     other.setAlias("u");
     mappings.merge(other);
 
     // "a" and "c" are no longer accessible w/o the alias.
 
     EXPECT_EQ(mappings.lookup("a"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("t", "a"), "a");
-    EXPECT_EQ(mappings.lookup("u", "a"), "a_0");
+    EXPECT_EQ(
+        mappings.lookup("t", "a"),
+        (NameMappings::IdAndType{.id = "a", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("u", "a"),
+        (NameMappings::IdAndType{.id = "a_0", .type = BOOLEAN()}));
 
-    EXPECT_EQ(mappings.lookup("b"), "b");
-    EXPECT_EQ(mappings.lookup("t", "b"), "b");
+    EXPECT_EQ(
+        mappings.lookup("b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("t", "b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
     EXPECT_EQ(mappings.lookup("u", "b"), std::nullopt);
 
     EXPECT_EQ(mappings.lookup("c"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("t", "c"), "c");
-    EXPECT_EQ(mappings.lookup("u", "c"), "c_1");
+    EXPECT_EQ(
+        mappings.lookup("t", "c"),
+        (NameMappings::IdAndType{.id = "c", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("u", "c"),
+        (NameMappings::IdAndType{.id = "c_1", .type = BOOLEAN()}));
 
-    EXPECT_EQ(mappings.lookup("e"), "e");
+    EXPECT_EQ(
+        mappings.lookup("e"),
+        (NameMappings::IdAndType{.id = "e", .type = BOOLEAN()}));
     EXPECT_EQ(mappings.lookup("t", "e"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("u", "e"), "e");
+    EXPECT_EQ(
+        mappings.lookup("u", "e"),
+        (NameMappings::IdAndType{.id = "e", .type = BOOLEAN()}));
 
     EXPECT_THAT(reverseLookup("a"), makeNamesEq({"t.a"}));
     EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "t.b"}));
@@ -140,10 +178,16 @@ TEST(NameMappingsTest, basic) {
     // Only b and e are still accessible.
 
     EXPECT_EQ(mappings.lookup("a"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("b"), "b");
-    EXPECT_EQ(mappings.lookup("v", "b"), "b");
+    EXPECT_EQ(
+        mappings.lookup("b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
+    EXPECT_EQ(
+        mappings.lookup("v", "b"),
+        (NameMappings::IdAndType{.id = "b", .type = BOOLEAN()}));
     EXPECT_EQ(mappings.lookup("c"), std::nullopt);
-    EXPECT_EQ(mappings.lookup("v", "e"), "e");
+    EXPECT_EQ(
+        mappings.lookup("v", "e"),
+        (NameMappings::IdAndType{.id = "e", .type = BOOLEAN()}));
 
     EXPECT_THAT(reverseLookup("b"), makeNamesEq({"b", "v.b"}));
     EXPECT_THAT(reverseLookup("e"), makeNamesEq({"e", "v.e"}));


### PR DESCRIPTION
The user can call `subqueryBuilder()` function to get a PlanBuilder which can be used to build subqueries.

The PR provides three util functions, `withInSubquery`, `withExistsSubquery`, `withScalarSubquery` correspondingly for In subquery, Exists subquery and Scalar subquery. This is because for exists subquery and in subquery, the usage of subquery is tied with its usage environment. For example, for scalar subqueries, we can first map the subquery to a variable, e.g. `subquery_value`, then use it in SQL expression, like `value > subquery_value`. But for exists query, if we map the subquery to a variable, e.g. `subquery_value`, the expression `exists(subquery_value)` will not compile as it's not a valid syntax. So we need to directly construct the EXISTS special expression within the util functions.

Now let me show an example of how to construct simple subqueries.
In the following example queries, the table schema is:
L(key:integer, v:integer)
R(key:integer, w:integer)
* SQL query: SELECT * FROM L WHERE key IN (SELECT key FROM R)
PlanBuilder code snippet:
```
  PlanBuilder planBuilder;
  auto plan = planBuilder.values(leftType, leftData)
                  .as("l")
                  .withInSubquery(
                      "in_subquery_value",
                      planBuilder.subqueryBuilder()
                          .values(rightType, rightData)
                          .as("r")
                          .project({"key"})
                          .build(),
                      "key")
                  .filter("in_subquery_value")
                  .build();
```
Plan printer output:
```
- Filter: in_subquery_value -> ROW<key:INTEGER,v:INTEGER,in_subquery_value:BOOLEAN>
  - Project: -> ROW<key:INTEGER,v:INTEGER,in_subquery_value:BOOLEAN>
      key := key
      v := v
      in_subquery_value := IN(key, 
Subquery
(- Project: -> ROW<key:INTEGER>
    key := key_0
  - Project: -> ROW<key_0:INTEGER>
      key_0 := key_0
    - Values: 2 rows -> ROW<key_0:INTEGER,w:INTEGER>
)
)
    - Values: 4 rows -> ROW<key:INTEGER,v:INTEGER>
```
* SQL query: SELECT * FROM L WHERE EXISTS (SELECT key FORM r WHERE key=L.key)
PlanBuilder code snippet:
```
  PlanBuilder planBuilder;
  auto plan = planBuilder.values(leftType, leftData)
                  .as("l")
                  .withExistsSubquery(
                      "exist_subquery_value",
                      planBuilder.subqueryBuilder()
                          .values(rightType, rightData)
                          .as("r")
                          .filter("key = l.key")
                          .project({"key"})
                          .build())
                  .filter("exist_subquery_value")
                  .build();
```
Plan printer output:
```
- Filter: exist_subquery_value -> ROW<key:INTEGER,v:INTEGER,exist_subquery_value:BOOLEAN>
  - Project: -> ROW<key:INTEGER,v:INTEGER,exist_subquery_value:BOOLEAN>
      key := key
      v := v
      exist_subquery_value := EXISTS(
Subquery
(- Project: -> ROW<key:INTEGER>
    key := key_0
  - Project: -> ROW<key_0:INTEGER>
      key_0 := key_0
    - Filter: eq(key_0, key) -> ROW<key_0:INTEGER,w:INTEGER>
      - Values: 2 rows -> ROW<key_0:INTEGER,w:INTEGER>
)
)
    - Values: 4 rows -> ROW<key:INTEGER,v:INTEGER>
```
* SQL QUERY: SELECT * FROM L WHERE v > (SELECT MIN(w) FROM R)
PlanBuilder code snippet:
```
  auto plan = planBuilder.values(leftType, leftData)
                  .as("l")
                  .withScalarSubquery(
                      "scalar_subquery_value",
                      planBuilder.subqueryBuilder()
                          .values(rightType, rightData)
                          .as("r")
                          .aggregate({}, {"min(w) as min_w"})
                          .build())
                  .filter("v > scalar_subquery_value")
                  .build();
```
Plan printer output:
```
- Filter: gt(v, scalar_subquery_value) -> ROW<key:INTEGER,v:INTEGER,scalar_subquery_value:INTEGER>
  - Project: -> ROW<key:INTEGER,v:INTEGER,scalar_subquery_value:INTEGER>
      key := key
      v := v
      scalar_subquery_value := 
Subquery
(- Aggregate( -> ROW<min_w:INTEGER>
    min_w := min(w)
  - Values: 2 rows -> ROW<key_0:INTEGER,w:INTEGER>
)

    - Values: 4 rows -> ROW<key:INTEGER,v:INTEGER>
```

--------------
Summary:
Add subquery support to logical plan node.
For subqueries:
* subqueries can reference columns in outer query
* columns in subquery can have the same name as columns in outer query
* Resolution of columns will try to match the current query first, and try outer queries from inner to outer until it finds a match.

To achieve this, we make the following changes to the PlanBuilder.
* Instead of having one single `NameMapping outputMapping_`, now we have a list of `NampeMapping outputMapping_`. Here the NameMapping in the front represents the outer most query, while the NameMapping in the back represents the current query the PlanBuilder is working on.
  * When we are building a query, the plan builder tries to resolve the input by iterating the list of NampeMapping from back to front, and return the first match it finds
* Another change is to make the NampeMapping not only remember the unique ID assigned to a input expression , but also the type of the input expression. This is because currently we rely on the current node to resolve the type of an input, but with subquery, the current node may not be the node which holds this input expression. Directly remember both name and type make it easy to get the type.
* Since we will use the same name allocator for the whole query plan build, all expressions have unique name so we do not need to attach scope to the cross referenced input in the output plan.

Differential Revision: D78953518


