### PR TITLE
feat: Add union/intersect/except support

### DIFF
--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -17,7 +17,8 @@ velox_add_library(velox_fe_logical_plan Expr.cpp ExprPrinter.cpp
 
 velox_link_libraries(velox_fe_logical_plan velox_type)
 
-velox_add_library(velox_fe_logical_plan_builder PlanBuilder.cpp)
+velox_add_library(velox_fe_logical_plan_builder PlanBuilder.cpp
+                  NameAllocator.cpp NameMappings.cpp)
 
 velox_link_libraries(
   velox_fe_logical_plan_builder

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -730,6 +730,45 @@ PlanBuilder& PlanBuilder::unionAll(const PlanBuilder& other) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::intersect(const PlanBuilder& other) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Intersect node cannot be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(other.node_);
+
+  node_ = std::make_shared<SetNode>(
+      nextId(),
+      std::vector<LogicalPlanNodePtr>{node_, other.node_},
+      SetOperation::kIntersect);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::except(const PlanBuilder& other) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Intersect node cannot be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(other.node_);
+
+  node_ = std::make_shared<SetNode>(
+      nextId(),
+      std::vector<LogicalPlanNodePtr>{node_, other.node_},
+      SetOperation::kExcept);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::setOperation(
+    SetOperation op,
+    const std::vector<PlanBuilder>& inputs) {
+  VELOX_USER_CHECK_NULL(node_, "setOperation must be a leaf");
+  outputMapping_ = inputs.front().outputMapping_;
+  std::vector<LogicalPlanNodePtr> nodes;
+  nodes.reserve(inputs.size());
+  for (auto& builder : inputs) {
+    VELOX_CHECK_NOT_NULL(builder.node_);
+    nodes.push_back(builder.node_);
+  }
+  node_ = std::make_shared<SetNode>(nextId(), std::move(nodes), op);
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Sort node cannot be a leaf node");
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -76,6 +76,14 @@ class PlanBuilder {
 
   PlanBuilder& unionAll(const PlanBuilder& other);
 
+  PlanBuilder& intersect(const PlanBuilder& other);
+
+  PlanBuilder& except(const PlanBuilder& other);
+
+  PlanBuilder& setOperation(
+      SetOperation op,
+      const std::vector<PlanBuilder>& inputs);
+
   PlanBuilder& sort(const std::vector<std::string>& sortingKeys);
 
   /// An alias for 'sort'.

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -16,10 +16,7 @@ add_subdirectory(tests)
 
 add_subdirectory(connectors)
 
-add_library(
-  velox_schema_resolver
-  SchemaResolver.cpp
-  SchemaUtils.cpp)
+add_library(velox_schema_resolver SchemaResolver.cpp SchemaUtils.cpp)
 
 target_link_libraries(velox_schema_resolver velox_connector_metadata
                       velox_exception velox_vector)
@@ -33,7 +30,6 @@ add_library(
   Plan.cpp
   BitSet.cpp
   ParallelExpr.cpp
-  ParallelProject.cpp
   PlanObject.cpp
   Schema.cpp
   QueryGraph.cpp
@@ -50,6 +46,10 @@ add_library(
 add_dependencies(velox_verax velox_hive_connector)
 
 target_link_libraries(
-  velox_verax velox_core velox_connector_metadata velox_fe_logical_plan
-  velox_multifragment_plan velox_connector
-                      velox_schema_resolver)
+  velox_verax
+  velox_core
+  velox_connector_metadata
+  velox_fe_logical_plan
+  velox_multifragment_plan
+  velox_connector
+  velox_schema_resolver)

--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -194,6 +194,12 @@ void Filter::setCost(const PlanState& /*input*/) {
   cost_.fanout = pow(0.8, exprs_.size());
 }
 
+void UnionAll::setCost(const PlanState& input) {
+  for (auto& in : inputs) {
+    cost_.inputCardinality += in->cost().inputCardinality * in->cost().fanout;
+  }
+}
+
 float selfCost(ExprCP expr) {
   switch (expr->type()) {
     case PlanType::kColumn: {

--- a/axiom/optimizer/LogicalPlanToGraph.cpp
+++ b/axiom/optimizer/LogicalPlanToGraph.cpp
@@ -1043,7 +1043,8 @@ PlanObjectP Optimization::addProjection(const lp::ProjectNode* project) {
   const auto& exprs = project->expressions();
   for (auto i : usedChannels(project)) {
     if (exprs[i]->isInputReference()) {
-      auto name = exprs[i]->asUnchecked<lp::InputReferenceExpr>()->name();
+      const auto& name =
+          exprs[i]->asUnchecked<lp::InputReferenceExpr>()->name();
       // A variable projected to itself adds no renames. Inputs contain this
       // all the time.
       if (name == names[i]) {
@@ -1107,6 +1108,189 @@ bool hasNondeterministic(const lp::ExprPtr& expr) {
   return false;
 }
 } // namespace
+
+DerivedTableP Optimization::translateSetJoin(
+    const lp::SetNode& set,
+    DerivedTableP setDt) {
+  auto previousDt = currentSelect_;
+  currentSelect_ = setDt;
+  for (auto& input : set.inputs()) {
+    wrapInDt(*input);
+  }
+
+  const bool exists = set.operation() == lp::SetOperation::kIntersect;
+  const bool anti = set.operation() == lp::SetOperation::kExcept;
+
+  const auto* left = setDt->tables[0]->as<DerivedTable>();
+
+  for (auto i = 1; i < setDt->tables.size(); ++i) {
+    const auto* right = setDt->tables[i]->as<DerivedTable>();
+
+    auto* joinEdge =
+        make<JoinEdge>(left, right, ExprVector{}, false, false, exists, anti);
+    for (auto i = 0; i < left->columns.size(); ++i) {
+      joinEdge->addEquality(left->columns[i], right->columns[i]);
+    }
+
+    setDt->joins.push_back(joinEdge);
+  }
+
+  const auto& type = set.outputType();
+  ExprVector exprs;
+  ColumnVector columns;
+  for (auto i = 0; i < type->size(); ++i) {
+    exprs.push_back(left->columns[i]);
+    columns.push_back(
+        make<Column>(toName(type->nameOf(i)), setDt, exprs.back()->value()));
+    renames_[type->nameOf(i)] = columns.back();
+  }
+
+  auto agg = make<Aggregation>(nullptr, exprs);
+  agg->mutableColumns() = columns;
+  agg->intermediateColumns = columns;
+
+  setDt->aggregation = make<AggregationPlan>(agg);
+  for (auto& c : columns) {
+    setDt->exprs.push_back(c);
+  }
+  setDt->columns = columns;
+  setDt->makeInitialPlan();
+  currentSelect_ = previousDt;
+  return setDt;
+}
+
+void Optimization::makeUnionDistributionAndStats(
+    DerivedTableP setDt,
+    DerivedTableP innerDt) {
+  if (setDt->distribution == nullptr) {
+    DistributionType empty;
+    setDt->distribution = make<Distribution>(empty, 0, ExprVector{});
+  }
+  if (innerDt == nullptr) {
+    innerDt = setDt;
+  }
+  if (innerDt->children.empty()) {
+    VELOX_CHECK_EQ(
+        innerDt->columns.size(),
+        setDt->columns.size(),
+        "Union inputs must have same arity also after pruning");
+
+    MemoKey key;
+    key.firstTable = innerDt;
+    key.tables.add(innerDt);
+    for (auto& column : innerDt->columns) {
+      key.columns.add(column);
+    }
+
+    auto it = memo_.find(key);
+    VELOX_CHECK(it != memo_.end(), "Expecting to find a plan for union branch");
+
+    bool ignore;
+    Distribution emptyDistribution;
+    auto plan = it->second.best(emptyDistribution, ignore)->op;
+    setDt->distribution->cardinality += plan->distribution().cardinality;
+    for (auto i = 0; i < setDt->columns.size(); ++i) {
+      // The Column is created in setDt before all branches are planned so the
+      // value is mutated here.
+      auto mutableValue =
+          const_cast<float*>(&setDt->columns[i]->value().cardinality);
+      *mutableValue += plan->columns()[i]->value().cardinality;
+    }
+  } else {
+    for (auto& child : innerDt->children) {
+      makeUnionDistributionAndStats(setDt, child);
+    }
+  }
+}
+
+DerivedTableP Optimization::translateUnion(
+    const lp::SetNode& set,
+    DerivedTableP setDt,
+    bool isTopLevel,
+    bool& isLeftLeaf) {
+  auto initialRenames = renames_;
+  std::vector<DerivedTableP, QGAllocator<DerivedTable*>> children;
+  bool isFirst = true;
+  DerivedTableP previousDt = currentSelect_;
+  for (auto& input : set.inputs()) {
+    if (!isFirst) {
+      renames_ = initialRenames;
+    } else {
+      isFirst = false;
+    }
+
+    currentSelect_ = newDt();
+
+    auto& newDt = currentSelect_;
+
+    auto isUnionLike =
+        [](const lp::LogicalPlanNode& node) -> const lp::SetNode* {
+      if (node.kind() == lp::NodeKind::kSet) {
+        const auto* set = node.asUnchecked<lp::SetNode>();
+        if (set->operation() == lp::SetOperation::kUnion ||
+            set->operation() == lp::SetOperation::kUnionAll) {
+          return set;
+        }
+      }
+
+      return nullptr;
+    };
+
+    if (auto* setNode = isUnionLike(*input)) {
+      auto inner = translateUnion(*setNode, setDt, false, isLeftLeaf);
+      children.push_back(inner);
+    } else {
+      makeQueryGraph(*input, kAllAllowedInDt);
+
+      const auto& type = input->outputType();
+
+      if (isLeftLeaf) {
+        // This is the left leaf of a union tree.
+        for (auto i : usedChannels(input.get())) {
+          const auto& name = type->nameOf(i);
+
+          ExprCP inner = translateColumn(name);
+          newDt->exprs.push_back(inner);
+
+          // The top dt has the same columns as all the unioned dts.
+          auto* outer = make<Column>(toName(name), setDt, inner->value());
+          setDt->columns.push_back(outer);
+          newDt->columns.push_back(outer);
+        }
+        isLeftLeaf = false;
+      } else {
+        for (auto i : usedChannels(input.get())) {
+          ExprCP inner = translateColumn(type->nameOf(i));
+          newDt->exprs.push_back(inner);
+        }
+
+        // Same outward facing columns as the top dt of union.
+        newDt->columns = setDt->columns;
+      }
+
+      newDt->makeInitialPlan();
+      children.push_back(newDt);
+    }
+  }
+
+  currentSelect_ = previousDt;
+  if (isTopLevel) {
+    setDt->children = std::move(children);
+    setDt->setOp = set.operation();
+
+    makeUnionDistributionAndStats(setDt);
+
+    renames_ = initialRenames;
+    for (const auto* column : setDt->columns) {
+      renames_[column->name()] = column;
+    }
+  } else {
+    setDt = newDt();
+    setDt->children = std::move(children);
+    setDt->setOp = set.operation();
+  }
+  return setDt;
+}
 
 PlanObjectP Optimization::makeQueryGraph(
     const lp::LogicalPlanNode& node,
@@ -1179,8 +1363,21 @@ PlanObjectP Optimization::makeQueryGraph(
       return addLimit(*node.asUnchecked<lp::LimitNode>());
     }
 
-    case lp::NodeKind::kSet:
-      [[fallthrough]];
+    case lp::NodeKind::kSet: {
+      auto* setDt = newDt();
+
+      auto* set = node.asUnchecked<lp::SetNode>();
+      if (set->operation() == lp::SetOperation::kUnion ||
+          set->operation() == lp::SetOperation::kUnionAll) {
+        bool isLeftLeaf = true;
+        translateUnion(*set, setDt, true, isLeftLeaf);
+      } else {
+        translateSetJoin(*set, setDt);
+      }
+      currentSelect_->tables.push_back(setDt);
+      currentSelect_->tableSet.add(setDt);
+      return currentSelect_;
+    }
     case lp::NodeKind::kUnnest:
       VELOX_NYI(
           "Unsupported PlanNode {}",

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -1691,7 +1691,168 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   }
 }
 
+namespace {
+RelationOpPtr makeDistinct(const RelationOpPtr& input) {
+  ExprVector exprs;
+  for (auto& c : input->columns()) {
+    exprs.push_back(c);
+  }
+  auto agg = make<Aggregation>(input, exprs);
+  agg->mutableColumns() = input->columns();
+  agg->intermediateColumns = input->columns();
+  return agg;
+}
+
+Distribution somePartition(const RelationOpPtrVector& inputs) {
+  float card = 1;
+
+  // A simple type and many values is a good partitioning key.
+  auto score = [&](ColumnCP column) {
+    const auto& value = column->value();
+    const auto card = value.cardinality;
+    return value.type->kind() >= TypeKind::ARRAY ? card / 10000 : card;
+  };
+
+  const auto& firstInput = inputs[0];
+  auto inputColumns = firstInput->columns();
+  std::sort(
+      inputColumns.begin(),
+      inputColumns.end(),
+      [&](ColumnCP left, ColumnCP right) {
+        return score(left) > score(right);
+      });
+
+  ExprVector columns;
+  for (const auto* column : inputColumns) {
+    card *= column->value().cardinality;
+    columns.push_back(column);
+    if (card > 100'000) {
+      break;
+    }
+  }
+
+  DistributionType distributionType;
+  distributionType.numPartitions =
+      queryCtx()->optimization()->options().numWorkers;
+  distributionType.locus = firstInput->distribution().distributionType.locus;
+
+  Distribution result;
+  result.partition = columns;
+  result.distributionType = distributionType;
+  return result;
+}
+
+// Adds the costs in the input states to the first state and if 'distinct' is
+// not null adds the cost of that to the first state.
+PlanPtr unionPlan(
+    std::vector<PlanState>& states,
+    const std::vector<PlanPtr>& inputPlans,
+    const RelationOpPtr& result,
+    Aggregation* distinct) {
+  auto& firstState = states[0];
+
+  PlanObjectSet fullyImported = inputPlans[0]->fullyImported;
+  for (auto i = 1; i < states.size(); ++i) {
+    const auto& otherCost = states[i].cost;
+    fullyImported.intersect(inputPlans[i]->fullyImported);
+    firstState.cost.add(otherCost);
+    // The input cardinality is not additive, the fanout and other metrics are.
+    firstState.cost.inputCardinality -= otherCost.inputCardinality;
+  }
+  if (distinct) {
+    firstState.addCost(*distinct);
+  }
+  auto plan = make<Plan>(result, states[0]);
+  plan->fullyImported = fullyImported;
+  return plan;
+}
+} // namespace
+
 PlanPtr Optimization::makePlan(
+    const MemoKey& key,
+    const Distribution& distribution,
+    const PlanObjectSet& boundColumns,
+    float existsFanout,
+    PlanState& state,
+    bool& needsShuffle) {
+  if (key.firstTable->type() == PlanType::kDerivedTable &&
+      key.firstTable->as<DerivedTable>()->setOp.has_value()) {
+    const auto* setDt = key.firstTable->as<DerivedTable>();
+
+    RelationOpPtrVector inputs;
+    std::vector<PlanPtr> inputPlans;
+    std::vector<PlanState> inputStates;
+    std::vector<bool> inputNeedsShuffle;
+
+    for (auto* inputDt : setDt->children) {
+      MemoKey inputKey = key;
+      inputKey.firstTable = inputDt;
+      inputKey.tables.erase(key.firstTable);
+      inputKey.tables.add(inputDt);
+
+      bool inputShuffle = false;
+      auto inputPlan = makePlan(
+          inputKey,
+          distribution,
+          boundColumns,
+          existsFanout,
+          state,
+          inputShuffle);
+      inputPlans.push_back(inputPlan);
+      inputStates.emplace_back(*this, setDt, inputPlans.back());
+      inputs.push_back(inputPlan->op);
+      inputNeedsShuffle.push_back(inputShuffle);
+    }
+
+    const bool isDistinct =
+        setDt->setOp.value() == logical_plan::SetOperation::kUnion;
+    if (isSingle_) {
+      RelationOpPtr result = make<UnionAll>(inputs);
+      Aggregation* distinct = nullptr;
+      if (isDistinct) {
+        result = makeDistinct(result);
+        distinct = result->as<Aggregation>();
+      }
+      return unionPlan(inputStates, inputPlans, result, distinct);
+    }
+
+    if (distribution.partition.empty()) {
+      if (isDistinct) {
+        // Pick some partitioning key and shuffle on that and make distinct.
+        Distribution someDistribution = somePartition(inputs);
+        for (auto i = 0; i < inputs.size(); ++i) {
+          inputs[i] = make<Repartition>(
+              inputs[i], someDistribution, inputs[i]->columns());
+          inputStates[i].addCost(*inputs[i]);
+        }
+      }
+    } else {
+      // Some need a shuffle. Add the shuffles, add an optional distinct and
+      // return with no shuffle needed.
+      for (auto i = 0; i < inputs.size(); ++i) {
+        if (inputNeedsShuffle[i]) {
+          inputs[i] =
+              make<Repartition>(inputs[i], distribution, inputs[i]->columns());
+          inputStates[i].addCost(*inputs[i]);
+        }
+      }
+    }
+    needsShuffle = false;
+
+    RelationOpPtr result = make<UnionAll>(inputs);
+    Aggregation* distinct = nullptr;
+    if (isDistinct) {
+      result = makeDistinct(result);
+      distinct = result->as<Aggregation>();
+    }
+    return unionPlan(inputStates, inputPlans, result, distinct);
+  } else {
+    return makeDtPlan(
+        key, distribution, boundColumns, existsFanout, state, needsShuffle);
+  }
+}
+
+PlanPtr Optimization::makeDtPlan(
     const MemoKey& key,
     const Distribution& distribution,
     const PlanObjectSet& /*boundColumns*/,

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/Schema.h"
 #include "velox/core/PlanNode.h"
 
@@ -865,6 +865,12 @@ struct DerivedTable : public PlanObject {
   // side. In this case joins that refer to tables not in 'tableSet' are not
   // considered.
   PlanObjectSet tableSet;
+
+  // Set if this is a set operation. If set, 'children' has the operands.
+  std::optional<logical_plan::SetOperation> setOp;
+
+  /// Operands if 'this' is a set operation, e.g. union.
+  std::vector<DerivedTable*, QGAllocator<DerivedTable*>> children;
 
   // Single row tables from non-correlated scalar subqueries.
   PlanObjectSet singleRowDts;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -429,4 +429,23 @@ std::string Project::toString(bool recursive, bool detail) const {
   return out.str();
 }
 
+std::string UnionAll::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  out << "(";
+  for (auto i = 0; i < inputs.size(); ++i) {
+    out << inputs[i]->toString(recursive, detail);
+    if (i < inputs.size() - 1) {
+      if (detail) {
+        out << std::endl;
+      }
+      out << " union all ";
+      if (detail) {
+        out << std::endl;
+      }
+    }
+  }
+  out << ")";
+  return out.str();
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -453,4 +453,21 @@ struct OrderBy : public RelationOp {
   PlanObjectSet dependentKeys;
 };
 
+/// Represents a union all.
+struct UnionAll : public RelationOp {
+  UnionAll(RelationOpPtrVector inputs)
+      : RelationOp(
+            RelType::kUnionAll,
+            nullptr,
+            inputs[0]->distribution(),
+            inputs[0]->columns()),
+        inputs(std::move(inputs)) {}
+
+  void setCost(const PlanState& input) override;
+
+  std::string toString(bool recursive, bool detail) const override;
+
+  const RelationOpPtrVector inputs;
+};
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -258,7 +258,8 @@ enum class RelType {
   kJoin,
   kHashBuild,
   kAggregation,
-  kOrderBy
+  kOrderBy,
+  kUnionAll
 };
 
 /// Represents a relation (table) that is either physically stored or is the

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -25,10 +25,6 @@ namespace facebook::velox::optimizer {
 using namespace facebook::velox;
 
 namespace {
-std::string veloxToString(const core::PlanNode* plan) {
-  return plan->toString(true, true);
-}
-
 const std::string* columnName(const core::TypedExprPtr& expr) {
   if (auto column =
           dynamic_cast<const core::FieldAccessTypedExpr*>(expr.get())) {

--- a/axiom/optimizer/connectors/CMakeLists.txt
+++ b/axiom/optimizer/connectors/CMakeLists.txt
@@ -20,6 +20,8 @@ velox_link_libraries(velox_connector_metadata velox_common_base velox_memory
 
 add_subdirectory(hive)
 
+add_subdirectory(tests)
+
 velox_add_library(velox_connector_split_source ConnectorSplitSource.cpp)
 
 velox_link_libraries(

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ add_executable(
   SubfieldTest.cpp
   LogicalSubfieldTest.cpp
   FeatureGen.cpp
-  Genies.cpp)
+  Genies.cpp
+  SchemaResolverTest.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 
@@ -29,6 +30,7 @@ target_link_libraries(
   velox_plan_test
   velox_verax
   velox_fe_logical_plan_builder
+  velox_test_connector
   velox_schema_resolver
   velox_tpch_gen
   velox_connector_split_source
@@ -37,6 +39,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader
+  GTest::gmock
   gtest
   gtest_main)
 

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -31,6 +31,8 @@ DECLARE_int32(optimizer_trace);
 DECLARE_int32(num_workers);
 DECLARE_string(history_save_path);
 
+namespace lp = facebook::velox::logical_plan;
+
 namespace facebook::velox::optimizer {
 namespace {
 std::string nodeString(core::PlanNode* node) {
@@ -118,11 +120,32 @@ class PlanTest : public virtual test::ParquetTpchTest,
 
     const auto numWorkers = FLAGS_num_workers;
     if (numWorkers != 1) {
+      gflags::FlagSaver saver;
       FLAGS_num_workers = 1;
-      SCOPE_EXIT {
-        FLAGS_num_workers = numWorkers;
-      };
 
+      auto singlePlan = planVelox(planNode, planString);
+      ASSERT_TRUE(singlePlan.plan != nullptr);
+      auto singleResult = runFragmentedPlan(singlePlan);
+      exec::test::assertEqualResults(
+          referenceResult.results, singleResult.results);
+    }
+  }
+
+  void checkSame(
+      const lp::LogicalPlanNodePtr& planNode,
+      core::PlanNodePtr referencePlan,
+      std::string* planString = nullptr,
+      std::string* veloxPlan = nullptr) {
+    auto fragmentedPlan = planVelox(planNode, planString);
+    if (veloxPlan) {
+      *veloxPlan = veloxString(fragmentedPlan.plan);
+    }
+    optimizer::test::TestResult referenceResult;
+    assertSame(referencePlan, fragmentedPlan, &referenceResult);
+    auto numWorkers = FLAGS_num_workers;
+    if (numWorkers != 1) {
+      gflags::FlagSaver saver;
+      FLAGS_num_workers = 1;
       auto singlePlan = planVelox(planNode, planString);
       ASSERT_TRUE(singlePlan.plan != nullptr);
       auto singleResult = runFragmentedPlan(singlePlan);
@@ -194,12 +217,9 @@ class PlanTest : public virtual test::ParquetTpchTest,
   }
 
   runner::MultiFragmentPlanPtr toSingleNodePlan(
-      const velox::logical_plan::LogicalPlanNodePtr& logicalPlan) {
-    const auto numWorkers = FLAGS_num_workers;
+      const lp::LogicalPlanNodePtr& logicalPlan) {
+    gflags::FlagSaver saver;
     FLAGS_num_workers = 1;
-    SCOPE_EXIT {
-      FLAGS_num_workers = numWorkers;
-    };
 
     schema_ =
         std::make_shared<velox::optimizer::SchemaResolver>(testConnector_, "");
@@ -272,7 +292,7 @@ TEST_F(PlanTest, agg) {
   testConnector_->addTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
 
-  auto logicalPlan = logical_plan::PlanBuilder()
+  auto logicalPlan = lp::PlanBuilder()
                          .tableScan(kTestConnectorId, "numbers", {"a", "b"})
                          .aggregate({"a"}, {"sum(b)"})
                          .build();
@@ -301,7 +321,7 @@ TEST_F(PlanTest, rejectedFilters) {
   testConnector_->addTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
 
-  auto logicalPlan = logical_plan::PlanBuilder()
+  auto logicalPlan = lp::PlanBuilder()
                          .tableScan(kTestConnectorId, "numbers", {"a", "b"})
                          .filter("a > 10")
                          .map({"a + 2"})
@@ -546,6 +566,161 @@ TEST_F(PlanTest, filterBreakup) {
       veloxString,
       "lineitem,.*range.*l_shipinstruct,.*l_shipmode.*remaining.*l_quantity.*l_quantity.*l_quantity");
   expectRegexp(veloxString, "part.*p_size.*p_container");
+}
+
+TEST_F(PlanTest, unions) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+  auto veloxPlan = exec::test::PlanBuilder(pool_.get())
+                       .tableScan("nation", nationType)
+                       .filter("n_nationkey < 11 or n_nationkey > 13")
+                       .project({"n_regionkey + 1 as rk"})
+                       .filter("rk in (1, 2, 4, 5)")
+                       .planNode();
+
+  lp::PlanBuilder::Context ctx;
+  auto t1 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "nation",
+                    {"n_nationkey", "n_regionkey", "n_name", "n_comment"})
+                .filter("n_nationkey < 11");
+  auto t2 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "nation",
+                    {"n_nationkey", "n_regionkey", "n_name", "n_comment"})
+                .filter("n_nationkey > 13");
+
+  auto unionPlan = t1.unionAll(t2)
+                       .project({"n_regionkey + 1 as rk"})
+                       .filter("cast(rk as integer) in (1, 2, 4, 5)")
+                       .build();
+
+  // Skip distributed run. Problem with local exchange source with
+  // multiple inputs.
+  gflags::FlagSaver saver;
+  FLAGS_num_workers = 1;
+
+  checkSame(unionPlan, veloxPlan);
+}
+
+TEST_F(PlanTest, unionJoin) {
+  auto partType = ROW({"p_partkey", "p_retailprice"}, {BIGINT(), DOUBLE()});
+  auto partSuppType = ROW({"ps_partkey", "ps_availqty"}, {BIGINT(), INTEGER()});
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto veloxPlan =
+      exec::test::PlanBuilder(idGenerator)
+          .tableScan("partsupp", partSuppType)
+          .filter(
+              "ps_availqty < 1000::INTEGER or ps_availqty > 2000::INTEGER or ps_availqty between 1200::INTEGER and 1400::INTEGER")
+          .hashJoin(
+              {"ps_partkey"},
+              {"p_partkey"},
+              exec::test::PlanBuilder(idGenerator)
+                  .tableScan("part", partType)
+                  .filter(
+                      "p_retailprice < 1100::DOUBLE or p_retailprice > 1200::DOUBLE")
+                  .planNode(),
+              "",
+              {"p_partkey"})
+          .project({"p_partkey"})
+          .localPartition({})
+          .singleAggregation({}, {"sum(1)"})
+          .planNode();
+
+  lp::PlanBuilder::Context ctx;
+  auto ps1 = lp::PlanBuilder(ctx)
+                 .tableScan(
+                     exec::test::kHiveConnectorId,
+                     "partsupp",
+                     {"ps_partkey", "ps_availqty"})
+                 .filter("ps_availqty < 1000::INTEGER")
+                 .project({"ps_partkey"});
+
+  auto ps2 = lp::PlanBuilder(ctx)
+                 .tableScan(
+                     exec::test::kHiveConnectorId,
+                     "partsupp",
+                     {"ps_partkey", "ps_availqty"})
+                 .filter("ps_availqty  > 2000::INTEGER")
+                 .project({"ps_partkey"});
+
+  auto ps3 =
+      lp::PlanBuilder(ctx)
+          .tableScan(
+              exec::test::kHiveConnectorId,
+              "partsupp",
+              {"ps_partkey", "ps_availqty"})
+          .filter("ps_availqty  between  1200::INTEGER and 1400::INTEGER")
+          .project({"ps_partkey"});
+
+  // The shape of the partsupp union is ps1 union all (ps2 union all
+  // ps3). We verify that a stack of multiple set ops works.
+  auto psu2 = ps2.unionAll(ps3);
+
+  auto p1 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "part",
+                    {"p_partkey", "p_retailprice"})
+                .filter("p_retailprice < 1100::DOUBLE");
+
+  auto p2 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "part",
+                    {"p_partkey", "p_retailprice"})
+                .filter("p_retailprice  > 1200::DOUBLE");
+
+  auto unionPlan =
+      ps1.unionAll(psu2)
+          .join(p1.unionAll(p2), "ps_partkey = p_partkey", lp::JoinType::kInner)
+          .aggregate({}, {"sum(1)"})
+          .build();
+
+  // Skip distributed run. Problem with local exchange source with
+  // multiple inputs.
+  gflags::FlagSaver saver;
+  FLAGS_num_workers = 1;
+
+  checkSame(unionPlan, veloxPlan);
+}
+
+TEST_F(PlanTest, intersect) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+  auto veloxPlan = exec::test::PlanBuilder(pool_.get())
+                       .tableScan("nation", nationType)
+                       .filter("n_nationkey > 11 and n_nationkey < 21")
+                       .project({"n_regionkey + 1 as rk"})
+                       .filter("rk in (1, 2, 4, 5)")
+                       .planNode();
+
+  lp::PlanBuilder::Context ctx;
+  auto t1 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "nation",
+                    {"n_nationkey", "n_regionkey", "n_name", "n_comment"})
+                .filter("n_nationkey < 21")
+                .project({"n_nationkey", "n_regionkey"});
+  auto t2 = lp::PlanBuilder(ctx)
+                .tableScan(
+                    exec::test::kHiveConnectorId,
+                    "nation",
+                    {"n_nationkey", "n_regionkey", "n_name", "n_comment"})
+                .filter(" n_nationkey > 11 ")
+                .project({"n_nationkey", "n_regionkey"});
+
+  auto intersectPlan = t1.intersect(t2)
+                           .project({"n_regionkey + 1 as rk"})
+                           .filter("cast(rk as integer) in (1, 2, 4, 5)")
+                           .build();
+
+  checkSame(intersectPlan, veloxPlan);
 }
 
 } // namespace

--- a/axiom/optimizer/tests/SchemaResolverTest.cpp
+++ b/axiom/optimizer/tests/SchemaResolverTest.cpp
@@ -34,6 +34,11 @@ class SchemaResolverTest : public ::testing::Test {
         baseCatalog_.connector, baseCatalog_.schema);
   }
 
+  void TearDown() override {
+    connector::unregisterConnector("base");
+    connector::unregisterConnector("other");
+  }
+
   struct Catalog {
     std::string id;
     std::string schema;


### PR DESCRIPTION
- Adds PlanBuilder support for Set SetNode.

- Adds a union all relation op.

- Adds conversion to query graph from SetNode: Left leaf gives the types, all other leaf derived tables produce the identical output.

- Support unions in makePlan: The non-union derived tables are cached. The union or union all is generated from the best pick for each leaf dt with an optional shuffle. A distinct is added if needed. The costs are added up across the union inputs. The derived table that stands for the union has no a priori partitioning and its cardinality and column cardinalities are added up froim the inputs.

- Velox executable Unions are generated as local exchanges or as a single remote exchange with many input fragments.

- Intersect and except are generated as semijoins or antijoins with a distinct on the columns of the leftmost input.

- In Velox plan generation, a column to column rename in TempProjection is added. This is needed for renaming columns from an inner derivec table to an outer one when the dt ends with aggregation. A column to column projection is not elided if the column name and the target name differ.

- Miscellaneous cmake build fixes and fixes to tests to make them run sequentially, e.g. adding cleanups of registration.