### PR TITLE
Add projections and dereferences to plan summary

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -244,6 +244,11 @@ class ProjectNode : public LogicalPlanNode {
     return expressions_;
   }
 
+  const ExprPtr& expressionAt(size_t index) const {
+    VELOX_USER_CHECK_LT(index, expressions_.size());
+    return expressions_.at(index);
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 


### PR DESCRIPTION
Summary: Add logic to include up to specified number of non-trivial projections and dereferences in the summary of the Project node.

Differential Revision: D79241696


