### PR TITLE
Add support for subqueries to PlanBuilder

### DIFF
--- a/axiom/logical_plan/ExprApi.cpp
+++ b/axiom/logical_plan/ExprApi.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+
+namespace facebook::velox::logical_plan {
+
+namespace {
+constexpr auto kNoAlias = std::nullopt;
+}
+
+namespace detail {
+
+core::ExprPtr
+BinaryCall(std::string name, core::ExprPtr left, core::ExprPtr right) {
+  return std::make_shared<const core::CallExpr>(
+      std::move(name),
+      std::vector<core::ExprPtr>{std::move(left), std::move(right)},
+      kNoAlias);
+}
+
+} // namespace detail
+
+ExprApi ExprApi::operator+(const Variant& value) const {
+  return Plus(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator-(const Variant& value) const {
+  return Minus(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator*(const Variant& value) const {
+  return Multiply(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator/(const Variant& value) const {
+  return Divide(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator%(const Variant& value) const {
+  return Modulus(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator<(const Variant& value) const {
+  return Lt(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator<=(const Variant& value) const {
+  return Lte(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator>(const Variant& value) const {
+  return Gt(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator>=(const Variant& value) const {
+  return Gte(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator&&(const Variant& value) const {
+  return And(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator||(const Variant& value) const {
+  return Or(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator==(const Variant& value) const {
+  return Eq(expr_, Val(value).expr());
+}
+
+ExprApi ExprApi::operator!=(const Variant& value) const {
+  return NEq(expr_, Val(value).expr());
+}
+
+ExprApi Col(std::string name) {
+  return ExprApi{
+      std::make_shared<const core::FieldAccessExpr>(name, kNoAlias),
+      std::move(name)};
+}
+
+ExprApi Col(std::string name, const ExprApi& input) {
+  std::vector<core::ExprPtr> inputs{input.expr()};
+  return ExprApi{
+      std::make_shared<const core::FieldAccessExpr>(
+          name, kNoAlias, std::move(inputs)),
+      std::move(name)};
+}
+
+ExprApi Cast(velox::TypePtr type, const ExprApi& input) {
+  return ExprApi{std::make_shared<const core::CastExpr>(
+      type, input.expr(), /* isTryCat */ false, kNoAlias)};
+}
+
+ExprApi Val(Variant&& val) {
+  auto type = val.inferType();
+  return ExprApi{std::make_shared<const core::ConstantExpr>(
+      std::move(type), std::move(val), kNoAlias)};
+}
+
+ExprApi Val(Variant&& val, velox::TypePtr type) {
+  return ExprApi{std::make_shared<const core::ConstantExpr>(
+      std::move(type), std::move(val), kNoAlias)};
+}
+
+ExprApi Val(const Variant& val) {
+  auto type = val.inferType();
+  return ExprApi{std::make_shared<const core::ConstantExpr>(
+      std::move(type), val, kNoAlias)};
+}
+
+ExprApi Val(const Variant& val, TypePtr type) {
+  return ExprApi{std::make_shared<const core::ConstantExpr>(
+      std::move(type), val, kNoAlias)};
+}
+
+ExprApi Call(std::string name, const std::vector<ExprApi>& args) {
+  std::vector<core::ExprPtr> argExpr;
+  argExpr.reserve(args.size());
+  for (auto& arg : args) {
+    argExpr.push_back(arg.expr());
+  }
+  return ExprApi{std::make_shared<const core::CallExpr>(
+      std::move(name), std::move(argExpr), kNoAlias)};
+}
+
+ExprApi Lambda(std::vector<std::string> names, const ExprApi& body) {
+  return ExprApi{
+      std::make_shared<core::LambdaExpr>(std::move(names), body.expr())};
+}
+
+ExprApi Subquery(std::shared_ptr<const LogicalPlanNode> subquery) {
+  VELOX_CHECK_NOT_NULL(subquery);
+  VELOX_CHECK_EQ(1, subquery->outputType()->size());
+
+  const auto& name = subquery->outputType()->nameOf(0);
+  const auto expr = std::make_shared<core::SubqueryExpr>(std::move(subquery));
+  if (name.empty()) {
+    return ExprApi(expr);
+  } else {
+    return ExprApi(expr, name);
+  }
+}
+
+ExprApi Sql(const std::string& sql) {
+  return ExprApi{parse::parseExpr(sql, {})};
+}
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/parse/IExpr.h"
+#include "velox/type/Variant.h"
+
+/// Convenient API for building expression trees "by hand".
+///
+/// - Col(<name>) - column reference
+/// - Val(<value>) - literal value
+/// - Call(<name>, arg1, arg2,...) - function call; supports zero or more
+/// argumnts
+/// - Cast(<type>, arg) - cast expression
+/// - Lambda({<args>}, <body>) - lambda expression
+/// - Subquery(<plan>) - correlated (or not) subquery expression
+///
+/// The API supports basic arithmetic and comparison operations:
+/// - Col("a") + Col("b")
+/// - Col("a") * 10
+/// - Col("a") < 0
+
+namespace facebook::velox::logical_plan {
+class LogicalPlanNode;
+using LogicalPlanNodePtr = std::shared_ptr<const LogicalPlanNode>;
+} // namespace facebook::velox::logical_plan
+
+namespace facebook::velox::core {
+
+// A scalar, possibly correlated, subquery expression.
+class SubqueryExpr : public core::IExpr {
+ public:
+  // @param subquery A plan tree that produces a single column.
+  explicit SubqueryExpr(logical_plan::LogicalPlanNodePtr subquery)
+      : IExpr({}), subquery_(std::move(subquery)) {}
+
+  const logical_plan::LogicalPlanNodePtr& subquery() const {
+    return subquery_;
+  }
+
+  std::string toString() const override {
+    return "<subquery>";
+  }
+
+ private:
+  const logical_plan::LogicalPlanNodePtr subquery_;
+};
+
+} // namespace facebook::velox::core
+
+namespace facebook::velox::logical_plan {
+
+namespace detail {
+core::ExprPtr
+BinaryCall(std::string name, core::ExprPtr left, core::ExprPtr right);
+} // namespace detail
+
+#define VELOX_MAKE_BINARY_CALLER(OutName, InName)                         \
+  inline core::ExprPtr OutName(core::ExprPtr left, core::ExprPtr right) { \
+    return detail::BinaryCall(InName, std::move(left), std::move(right)); \
+  }
+
+VELOX_MAKE_BINARY_CALLER(Plus, "plus")
+VELOX_MAKE_BINARY_CALLER(Minus, "minus")
+VELOX_MAKE_BINARY_CALLER(Multiply, "multiply")
+VELOX_MAKE_BINARY_CALLER(Divide, "divide")
+VELOX_MAKE_BINARY_CALLER(Modulus, "modulus")
+VELOX_MAKE_BINARY_CALLER(Lt, "lt")
+VELOX_MAKE_BINARY_CALLER(Gt, "gt")
+VELOX_MAKE_BINARY_CALLER(Lte, "lte")
+VELOX_MAKE_BINARY_CALLER(Gte, "gte")
+VELOX_MAKE_BINARY_CALLER(Eq, "eq")
+VELOX_MAKE_BINARY_CALLER(NEq, "neq")
+VELOX_MAKE_BINARY_CALLER(And, "and")
+VELOX_MAKE_BINARY_CALLER(Or, "or")
+
+#undef VELOX_MAKE_BINARY_CALLER
+
+class ExprApi {
+ public:
+  /* implicit */ ExprApi(core::ExprPtr expr)
+      : expr_{std::move(expr)}, name_{expr_->alias().value_or("")} {}
+
+  ExprApi(core::ExprPtr expr, std::string name)
+      : expr_{std::move(expr)}, name_{std::move(name)} {}
+
+  ExprApi(const ExprApi& other) = default;
+
+  ExprApi(ExprApi&& other) = default;
+
+  ExprApi& operator=(const ExprApi& other) = default;
+
+  ExprApi& operator=(ExprApi&& other) = default;
+
+  const core::ExprPtr& expr() const {
+    return expr_;
+  }
+
+  ExprApi operator+(const ExprApi& other) const {
+    return Plus(expr_, other.expr_);
+  }
+
+  ExprApi operator+(const Variant& value) const;
+
+  ExprApi operator-(const ExprApi& other) const {
+    return Minus(expr_, other.expr_);
+  }
+
+  ExprApi operator-(const Variant& value) const;
+
+  ExprApi operator*(const ExprApi& other) const {
+    return Multiply(expr_, other.expr_);
+  }
+
+  ExprApi operator*(const Variant& value) const;
+
+  ExprApi operator/(const ExprApi& other) const {
+    return Divide(expr_, other.expr_);
+  }
+
+  ExprApi operator/(const Variant& value) const;
+
+  ExprApi operator%(const ExprApi& other) const {
+    return Modulus(expr_, other.expr_);
+  }
+
+  ExprApi operator%(const Variant& value) const;
+
+  ExprApi operator<(const ExprApi& other) const {
+    return Lt(expr_, other.expr_);
+  }
+
+  ExprApi operator<(const Variant& value) const;
+
+  ExprApi operator<=(const ExprApi& other) const {
+    return Lte(expr_, other.expr_);
+  }
+
+  ExprApi operator<=(const Variant& value) const;
+
+  ExprApi operator>(const ExprApi& other) const {
+    return Gt(expr_, other.expr_);
+  }
+
+  ExprApi operator>(const Variant& value) const;
+
+  ExprApi operator>=(const ExprApi& other) const {
+    return Gte(expr_, other.expr_);
+  }
+
+  ExprApi operator>=(const Variant& value) const;
+
+  ExprApi operator&&(const ExprApi& other) const {
+    return And(expr_, other.expr_);
+  }
+
+  ExprApi operator&&(const Variant& value) const;
+
+  ExprApi operator||(const ExprApi& other) const {
+    return Or(expr_, other.expr_);
+  }
+
+  ExprApi operator||(const Variant& value) const;
+
+  ExprApi operator==(const ExprApi& other) const {
+    return Eq(expr_, other.expr_);
+  }
+
+  ExprApi operator==(const Variant& value) const;
+
+  ExprApi operator!=(const ExprApi& other) const {
+    return NEq(expr_, other.expr_);
+  }
+
+  ExprApi operator!=(const Variant& value) const;
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  ExprApi as(std::string name) const {
+    return ExprApi(expr_, std::move(name));
+  }
+
+ private:
+  core::ExprPtr expr_;
+  std::string name_;
+};
+
+ExprApi Val(Variant&& val);
+
+ExprApi Val(Variant&& val, TypePtr type);
+
+ExprApi Val(const Variant& val);
+
+ExprApi Val(const Variant& val, TypePtr type);
+
+template <typename T>
+inline ExprApi Val(T&& val) {
+  return Val(Variant(std::forward<T>(val)));
+}
+
+ExprApi Col(std::string name);
+
+ExprApi Col(std::string name, const ExprApi& input);
+
+ExprApi Call(std::string name, const std::vector<ExprApi>& args);
+
+template <typename... T>
+ExprApi Call(std::string name, T... args) {
+  return Call(std::move(name), std::vector<ExprApi>{std::forward<T>(args)...});
+}
+
+ExprApi Cast(TypePtr type, const ExprApi& input);
+
+inline ExprApi Cast(TypePtr type, const Variant& value) {
+  return Cast(std::move(type), Val(value));
+}
+
+ExprApi Lambda(std::vector<std::string> names, const ExprApi& body);
+
+ExprApi Subquery(std::shared_ptr<const LogicalPlanNode> subquery);
+
+ExprApi Sql(const std::string& sql);
+
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/ExprPrinter.cpp
+++ b/axiom/logical_plan/ExprPrinter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/logical_plan/ExprPrinter.h"
+#include "axiom/logical_plan/PlanPrinter.h"
 
 namespace facebook::velox::logical_plan {
 
@@ -98,10 +99,15 @@ class ToTextVisitor : public ExprVisitor {
     expr.body()->accept(*this, context);
   }
 
-  void visit(const SubqueryExpr& /* expr */, ExprVisitorContext& /* context */)
+  void visit(const SubqueryExpr& expr, ExprVisitorContext& context)
       const override {
-    // TODO Implement.
-    VELOX_NYI();
+    auto& out = toOut(context);
+
+    // TODO Produce a single-line subquery text: Aggregate(keys, aggs) ->
+    // Filter(condition) -> TableScan(t).
+    auto text = PlanPrinter::toText(*expr.subquery());
+    std::replace(text.begin(), text.end(), '\n', ' ');
+    out << "subquery(" << text << ")";
   }
 
  private:

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -288,7 +288,10 @@ class SummarizeExprVisitor : public ExprVisitor {
   }
 
   void visit(const SubqueryExpr& expr, ExprVisitorContext& ctx) const override {
-    VELOX_NYI();
+    auto& myCtx = static_cast<Context&>(ctx);
+    myCtx.expressionCounts()["subquery"]++;
+
+    // TODO Collect expression stats from the subquery.
   }
 };
 

--- a/axiom/logical_plan/tests/ExprApiTest.cpp
+++ b/axiom/logical_plan/tests/ExprApiTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/ExprApi.h"
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+namespace facebook::velox::logical_plan {
+namespace {
+
+class ExprApiTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    aggregate::prestosql::registerAllAggregateFunctions();
+  }
+
+  std::string toString(const ExprApi& expr) {
+    return expr.expr()->toString();
+  }
+};
+
+TEST_F(ExprApiTest, arithmetic) {
+  EXPECT_EQ(toString(Col("a") + 1), toString(Sql("a + 1")));
+  EXPECT_EQ(toString(Col("a") - Val(10)), toString(Sql("a - 10")));
+  EXPECT_EQ(toString(Col("a") * Col("b")), toString(Sql("a * b")));
+  EXPECT_EQ(toString(Col("a") / 1.2), toString(Sql("a / 1.2")));
+
+  EXPECT_EQ(toString(Call("mod", {Col("a"), Val(3)})), toString(Sql("a % 3")));
+  EXPECT_EQ(toString(Call("plus", Col("a"), Val(10))), toString(Sql("a + 10")));
+}
+
+TEST_F(ExprApiTest, call) {
+  EXPECT_EQ(toString(Call("rand")), toString(Sql("rand()")));
+  EXPECT_EQ(toString(Call("abs", Col("a"))), toString(Sql("abs(a)")));
+  EXPECT_EQ(
+      toString(Call("gt", Col("a"), Sql("b * c"))), toString(Sql("a > b * c")));
+}
+
+TEST_F(ExprApiTest, cast) {
+  EXPECT_EQ(
+      toString(Cast(BIGINT(), Col("a"))), toString(Sql("cast(a as bigint)")));
+  EXPECT_EQ(toString(Cast(DOUBLE(), 1)), toString(Sql("1::double")));
+}
+
+TEST_F(ExprApiTest, lambda) {
+  EXPECT_EQ(
+      toString(Call("filter", Col("a"), Lambda({"x"}, Col("x") > 0))),
+      toString(Sql("filter(a, x -> x > 0)")));
+
+  EXPECT_EQ(
+      toString(Call(
+          "transform_values", Col("m"), Lambda({"k", "v"}, Col("k") + 10))),
+      toString(Sql("transform_values(m, (k, v) -> k + 10)")));
+}
+
+TEST_F(ExprApiTest, subquery) {
+  auto subquery = Subquery(PlanBuilder()
+                               .values(
+                                   ROW({"a"}, {BIGINT()}),
+                                   std::vector<Variant>{Variant::row({123LL})})
+                               .aggregate({}, {"sum(a) as x"})
+                               .build());
+
+  EXPECT_EQ(toString(Col("a") < subquery), "lt(\"a\",<subquery>)");
+  EXPECT_EQ(subquery.name(), "x");
+  EXPECT_EQ(subquery.as("y").name(), "y");
+}
+
+TEST_F(ExprApiTest, alias) {
+  EXPECT_EQ(Col("a").name(), "a");
+  EXPECT_EQ(Col("a").as("b").name(), "b");
+
+  EXPECT_EQ(Val(1).name(), "");
+
+  EXPECT_EQ((Col("a") + 1).as("b").name(), "b");
+  EXPECT_EQ((Col("a") + 1).name(), "");
+}
+
+} // namespace
+} // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -102,31 +102,32 @@ TEST_F(PlanPrinterTest, values) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- LIMIT [5]: 1 fields: c BIGINT"),
-          Eq("      limit: 5"),
-          Eq("  - SORT [4]: 1 fields: c BIGINT"),
-          Eq("    - PROJECT [3]: 1 fields: c BIGINT"),
-          Eq("          expressions: call: 1, field: 2"),
-          Eq("          functions: plus: 1"),
-          Eq("          projections: 1 out of 1"),
-          Eq("      - PROJECT [2]: 2 fields: a BIGINT, b BIGINT"),
-          Eq("            expressions: call: 1, constant: 1, field: 2"),
-          Eq("            functions: plus: 1"),
-          Eq("            constants: BIGINT: 1"),
-          Eq("            projections: 1 out of 2"),
-          Eq("        - FILTER [1]: 1 fields: a BIGINT"),
-          Eq("              predicate: gt(a, 10)"),
-          Eq("              expressions: call: 1, constant: 1, field: 1"),
-          Eq("              functions: gt: 1"),
-          Eq("              constants: BIGINT: 1"),
-          Eq("          - VALUES [0]: 1 fields: a BIGINT"),
-          Eq("                rows: 1"),
-          Eq("")));
+          testing::Eq("- LIMIT [5]: 1 fields: c BIGINT"),
+          testing::Eq("      limit: 5"),
+          testing::Eq("  - SORT [4]: 1 fields: c BIGINT"),
+          testing::Eq("    - PROJECT [3]: 1 fields: c BIGINT"),
+          testing::Eq("          expressions: call: 1, field: 2"),
+          testing::Eq("          functions: plus: 1"),
+          testing::Eq("          projections: 1 out of 1"),
+          testing::Eq("      - PROJECT [2]: 2 fields: a BIGINT, b BIGINT"),
+          testing::Eq( "            expressions: call: 1, constant: 1, field: 2"),
+          testing::Eq("            functions: plus: 1"),
+          testing::Eq("            constants: BIGINT: 1"),
+          testing::Eq("            projections: 1 out of 2"),
+          testing::Eq("        - FILTER [1]: 1 fields: a BIGINT"),
+          testing::Eq("              predicate: gt(a, 10)"),
+          testing::Eq("              expressions: call: 1, constant: 1, field: 1"),
+          testing::Eq("              functions: gt: 1"),
+          testing::Eq("              constants: BIGINT: 1"),
+          testing::Eq("          - VALUES [0]: 1 fields: a BIGINT"),
+          testing::Eq("                rows: 1"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -250,20 +251,21 @@ TEST_F(PlanPrinterTest, aggregate) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [2]: 6 fields: a INTEGER, total BIGINT, mean DOUBLE, min INTEGER, expr BIGINT, ..."),
-          Eq("      expressions: call: 2, constant: 2, field: 6"),
-          Eq("      functions: multiply: 1, plus: 1"),
-          Eq("      constants: BIGINT: 1, DOUBLE: 1"),
-          Eq("      projections: 2 out of 6"),
-          Eq("  - AGGREGATE [1]: 4 fields: a INTEGER, total BIGINT, mean DOUBLE, min INTEGER"),
-          Eq("    - VALUES [0]: 2 fields: a INTEGER, b INTEGER"),
-          Eq("          rows: 4"),
-          Eq("")));
+          testing::Eq("- PROJECT [2]: 6 fields: a INTEGER, total BIGINT, mean DOUBLE, min INTEGER, expr BIGINT, ..."),
+          testing::Eq("      expressions: call: 2, constant: 2, field: 6"),
+          testing::Eq("      functions: multiply: 1, plus: 1"),
+          testing::Eq("      constants: BIGINT: 1, DOUBLE: 1"),
+          testing::Eq("      projections: 2 out of 6"),
+          testing::Eq("  - AGGREGATE [1]: 4 fields: a INTEGER, total BIGINT, mean DOUBLE, min INTEGER"),
+          testing::Eq("    - VALUES [0]: 2 fields: a INTEGER, b INTEGER"),
+          testing::Eq("          rows: 4"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -311,21 +313,22 @@ TEST_F(PlanPrinterTest, union) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [3]: 3 fields: a INTEGER, b DOUBLE, expr DOUBLE"),
-          Eq("      expressions: CAST: 1, call: 1, field: 4"),
-          Eq("      functions: plus: 1"),
-          Eq("      projections: 1 out of 3"),
-          Eq("  - UNION ALL [2]: 2 fields: a INTEGER, b DOUBLE"),
-          Eq("    - VALUES [0]: 2 fields: a INTEGER, b DOUBLE"),
-          Eq("          rows: 2"),
-          Eq("    - VALUES [1]: 2 fields: a_0 INTEGER, b_1 DOUBLE"),
-          Eq("          rows: 2"),
-          Eq("")));
+          testing::Eq("- PROJECT [3]: 3 fields: a INTEGER, b DOUBLE, expr DOUBLE"),
+          testing::Eq("      expressions: CAST: 1, call: 1, field: 4"),
+          testing::Eq("      functions: plus: 1"),
+          testing::Eq("      projections: 1 out of 3"),
+          testing::Eq("  - UNION ALL [2]: 2 fields: a INTEGER, b DOUBLE"),
+          testing::Eq("    - VALUES [0]: 2 fields: a INTEGER, b DOUBLE"),
+          testing::Eq("          rows: 2"),
+          testing::Eq("    - VALUES [1]: 2 fields: a_0 INTEGER, b_1 DOUBLE"),
+          testing::Eq("          rows: 2"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -335,6 +338,134 @@ TEST_F(PlanPrinterTest, union) {
           testing::Eq("- UNION ALL [2]: 2 fields"),
           testing::Eq("  - VALUES [0]: 2 fields"),
           testing::Eq("  - VALUES [1]: 2 fields"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, subquery) {
+  std::vector<Variant> data{
+      Variant::row({1}),
+      Variant::row({2}),
+      Variant::row({3}),
+  };
+
+  std::vector<Variant> lookup{
+      Variant::row({1, 10}),
+      Variant::row({2, 20}),
+  };
+
+  auto context = PlanBuilder::Context();
+
+  // Subquery in a project.
+  PlanBuilder::Scope scope;
+  auto plan =
+      PlanBuilder(context)
+          .values(ROW({"a"}, {INTEGER()}), data)
+          .as("l")
+          .captureScope(scope)
+          .with({
+              Col("a") + 1,
+              Subquery(
+                  PlanBuilder(context, scope)
+                      .values(ROW({"a", "b"}, {INTEGER(), INTEGER()}), lookup)
+                      .as("r")
+                      .filter("l.a = r.a")
+                      .aggregate({}, {"sum(b)"})
+                      .build()),
+          })
+          .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Project:"),
+          testing::StartsWith("    a := a"),
+          testing::StartsWith("    expr := expr"),
+          testing::StartsWith("    sum := sum_1"),
+          testing::StartsWith("  - Project:"),
+          testing::StartsWith("      a := a"),
+          testing::StartsWith("      expr := plus(a, 1)"),
+          testing::StartsWith("      sum_1 := subquery"),
+          testing::StartsWith("    - Values: 3 rows"),
+          testing::Eq("")));
+
+  lines = toSummaryLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      // clang-format off
+      testing::ElementsAre(
+          testing::Eq("- PROJECT [5]: 3 fields: a INTEGER, expr INTEGER, sum BIGINT"),
+          testing::Eq("      expressions: field: 3"),
+          testing::Eq("  - PROJECT [4]: 3 fields: a INTEGER, expr INTEGER, sum_1 BIGINT"),
+          testing::Eq("        expressions: call: 1, constant: 1, field: 2, subquery: 1"),
+          testing::Eq("        functions: plus: 1"),
+          testing::Eq("        constants: INTEGER: 1"),
+          testing::Eq("        projections: 2 out of 3"),
+          testing::Eq("    - VALUES [0]: 1 fields: a INTEGER"),
+          testing::Eq("          rows: 3"),
+          testing::Eq(""))
+      // clang-format on
+  );
+
+  lines = toSkeletonLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::Eq("- VALUES [0]: 1 fields"), testing::Eq("")));
+
+  // Subquery in a filter.
+  context = PlanBuilder::Context();
+  plan =
+      PlanBuilder(context)
+          .values(ROW({"a"}, {INTEGER()}), data)
+          .as("l")
+          .captureScope(scope)
+          .filter(
+              Col("a") >
+              Subquery(
+                  PlanBuilder(context, scope)
+                      .values(ROW({"a", "b"}, {INTEGER(), INTEGER()}), lookup)
+                      .as("r")
+                      .filter("l.a = r.a")
+                      .aggregate({}, {"max(b)"})
+                      .build()))
+          .build();
+
+  lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Filter: gt(a, subquery"),
+          testing::StartsWith("  - Values: 3 rows"),
+          testing::Eq("")));
+
+  lines = toSummaryLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      // clang-format off
+      testing::ElementsAre(
+          testing::Eq("- FILTER [4]: 1 fields: a INTEGER"),
+          testing::Eq("      predicate: gt(a, subquery(- Aggregate() -> ROW<max:INTEGER>  ..."),
+          testing::Eq("      expressions: call: 1, field: 1, subquery: 1"),
+          testing::Eq("      functions: gt: 1"),
+          testing::Eq("  - VALUES [0]: 1 fields: a INTEGER"),
+          testing::Eq("        rows: 3"),
+          testing::Eq(""))
+      // clang-format on
+  );
+
+  lines = toSkeletonLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::Eq("- FILTER [4]: 1 fields"),
+          testing::Eq("  - VALUES [0]: 1 fields"),
           testing::Eq("")));
 }
 
@@ -382,22 +513,23 @@ TEST_F(PlanPrinterTest, join) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [3]: 5 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER, z INTEGER"),
-          Eq("      expressions: call: 1, field: 6"),
-          Eq("      functions: plus: 1"),
-          Eq("      projections: 1 out of 5"),
-          Eq("  - JOIN LEFT [2]: 4 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER"),
-          Eq("        condition: eq(key, key_0)"),
-          Eq("    - VALUES [0]: 2 fields: key INTEGER, v INTEGER"),
-          Eq("          rows: 4"),
-          Eq("    - VALUES [1]: 2 fields: key_0 INTEGER, w INTEGER"),
-          Eq("          rows: 2"),
-          Eq("")));
+          testing::Eq("- PROJECT [3]: 5 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER, z INTEGER"),
+          testing::Eq("      expressions: call: 1, field: 6"),
+          testing::Eq("      functions: plus: 1"),
+          testing::Eq("      projections: 1 out of 5"),
+          testing::Eq("  - JOIN LEFT [2]: 4 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER"),
+          testing::Eq("        condition: eq(key, key_0)"),
+          testing::Eq("    - VALUES [0]: 2 fields: key INTEGER, v INTEGER"),
+          testing::Eq("          rows: 4"),
+          testing::Eq("    - VALUES [1]: 2 fields: key_0 INTEGER, w INTEGER"),
+          testing::Eq("          rows: 2"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -453,21 +585,22 @@ TEST_F(PlanPrinterTest, crossJoin) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [3]: 5 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER, z INTEGER"),
-          Eq("      expressions: call: 1, field: 6"),
-          Eq("      functions: plus: 1"),
-          Eq("      projections: 1 out of 5"),
-          Eq("  - JOIN INNER [2]: 4 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER"),
-          Eq("    - VALUES [0]: 2 fields: key INTEGER, v INTEGER"),
-          Eq("          rows: 3"),
-          Eq("    - VALUES [1]: 2 fields: key_0 INTEGER, w INTEGER"),
-          Eq("          rows: 2"),
-          Eq("")));
+          testing::Eq("- PROJECT [3]: 5 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER, z INTEGER"),
+          testing::Eq("      expressions: call: 1, field: 6"),
+          testing::Eq("      functions: plus: 1"),
+          testing::Eq("      projections: 1 out of 5"),
+          testing::Eq("  - JOIN INNER [2]: 4 fields: key INTEGER, v INTEGER, key_0 INTEGER, w INTEGER"),
+          testing::Eq("    - VALUES [0]: 2 fields: key INTEGER, v INTEGER"),
+          testing::Eq("          rows: 3"),
+          testing::Eq("    - VALUES [1]: 2 fields: key_0 INTEGER, w INTEGER"),
+          testing::Eq("          rows: 2"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -540,46 +673,50 @@ TEST_F(PlanPrinterTest, specialForms) {
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          Eq("      expressions: field: 10"),
-          Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
-          Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
-          Eq("        constants: BIGINT: 5, DOUBLE: 1, INTEGER: 1, VARCHAR: 4"),
-          Eq("        projections: 8 out of 10"),
-          Eq("        dereferences: 2 out of 10"),
-          Eq("    - VALUES [0]: 3 fields: a INTEGER, b INTEGER, c ROW(2)"),
-          Eq("          rows: 4"),
-          Eq("")));
+          testing::Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
+          testing::Eq("      expressions: field: 10"),
+          testing::Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
+          testing::Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
+          testing::Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
+          testing::Eq("        constants: BIGINT: 5, DOUBLE: 1, INTEGER: 1, VARCHAR: 4"),
+          testing::Eq("        projections: 8 out of 10"),
+          testing::Eq("        dereferences: 2 out of 10"),
+          testing::Eq("    - VALUES [0]: 3 fields: a INTEGER, b INTEGER, c ROW(2)"),
+          testing::Eq("          rows: 4"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSummaryLines(
       plan, {.project = {.maxProjections = 3, .maxDereferences = 1}});
 
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          Eq("      expressions: field: 10"),
-          Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
-          Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
-          Eq("        constants: BIGINT: 5, DOUBLE: 1, INTEGER: 1, VARCHAR: 4"),
-          Eq("        projections: 8 out of 10"),
-          Eq("          a_0: AND(gt(a, b), gt(b, CAST(10 AS INTEGER)))"),
-          Eq("          b_1: OR(lt(a, b), gt(b, CAST(0 AS INTEGER)))"),
-          Eq("          expr: multiply(CAST(a AS DOUBLE), 1.2)"),
-          Eq("          ... 5 more"),
-          Eq("        dereferences: 2 out of 10"),
-          Eq("          expr_4: DEREFERENCE(c, x)"),
-          Eq("          ... 1 more"),
-          Eq("    - VALUES [0]: 3 fields: a INTEGER, b INTEGER, c ROW(2)"),
-          Eq("          rows: 4"),
-          Eq("")));
+          testing::Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
+          testing::Eq("      expressions: field: 10"),
+          testing::Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
+          testing::Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
+          testing::Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
+          testing::Eq("        constants: BIGINT: 5, DOUBLE: 1, INTEGER: 1, VARCHAR: 4"),
+          testing::Eq("        projections: 8 out of 10"),
+          testing::Eq( "          a_0: AND(gt(a, b), gt(b, CAST(10 AS INTEGER)))"),
+          testing::Eq("          b_1: OR(lt(a, b), gt(b, CAST(0 AS INTEGER)))"),
+          testing::Eq("          expr: multiply(CAST(a AS DOUBLE), 1.2)"),
+          testing::Eq("          ... 5 more"),
+          testing::Eq("        dereferences: 2 out of 10"),
+          testing::Eq("          expr_4: DEREFERENCE(c, x)"),
+          testing::Eq("          ... 1 more"),
+          testing::Eq("    - VALUES [0]: 3 fields: a INTEGER, b INTEGER, c ROW(2)"),
+          testing::Eq("          rows: 4"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 
@@ -605,28 +742,31 @@ TEST_F(PlanPrinterTest, lambda) {
 
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
           testing::StartsWith("- Project"),
-          testing::StartsWith(
-              "    expr := filter(sequence(CAST(1 AS BIGINT), a), x -> gt(x, b))"),
+          testing::StartsWith("    expr := filter(sequence(CAST(1 AS BIGINT), a), x -> gt(x, b))"),
           testing::StartsWith("  - Values"),
-          testing::Eq("")));
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSummaryLines(plan);
 
-  using namespace testing;
-
   EXPECT_THAT(
       lines,
+      // clang-format off
       testing::ElementsAre(
-          Eq("- PROJECT [1]: 1 fields: expr ARRAY"),
-          Eq("      expressions: CAST: 1, call: 3, constant: 1, field: 3, lambda: 1"),
-          Eq("      functions: filter: 1, gt: 1, sequence: 1"),
-          Eq("      constants: BIGINT: 1"),
-          Eq("      projections: 1 out of 1"),
-          Eq("  - VALUES [0]: 2 fields: a BIGINT, b BIGINT"),
-          Eq("        rows: 2"),
-          Eq("")));
+          testing::Eq("- PROJECT [1]: 1 fields: expr ARRAY"),
+          testing::Eq("      expressions: CAST: 1, call: 3, constant: 1, field: 3, lambda: 1"),
+          testing::Eq("      functions: filter: 1, gt: 1, sequence: 1"),
+          testing::Eq("      constants: BIGINT: 1"),
+          testing::Eq("      projections: 1 out of 1"),
+          testing::Eq("  - VALUES [0]: 2 fields: a BIGINT, b BIGINT"),
+          testing::Eq("        rows: 2"),
+          testing::Eq(""))
+      // clang-format on
+  );
 
   lines = toSkeletonLines(plan);
 


### PR DESCRIPTION
Summary:
Example of a query equivalent to 

> SELECT a, (SELECT sum(b) FROM u WHERE u.a = t.a) FROM t 

```
  auto context = PlanBuilder::Context();
  PlanBuilder::Scope scope;
  auto plan =
      PlanBuilder(context)
          .values(ROW({"a"}, {INTEGER()}), data)
          .as("l")
          .captureScope(scope)
          .with({
              Col("a") + 1,
              Subquery(
                  PlanBuilder(context, scope)
                      .values(ROW({"a", "b"}, {INTEGER(), INTEGER()}), lookup)
                      .as("r")
                      .filter("l.a = r.a")
                      .aggregate({}, {"sum(b)"})
                      .build()),
          })
          .build();
```

Rollback Plan:

Differential Revision: D79296510


