### PR TITLE
feat: Add union/intersect/except support (#86)

### DIFF
--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -17,7 +17,8 @@ velox_add_library(velox_fe_logical_plan Expr.cpp ExprPrinter.cpp
 
 velox_link_libraries(velox_fe_logical_plan velox_type)
 
-velox_add_library(velox_fe_logical_plan_builder PlanBuilder.cpp)
+velox_add_library(velox_fe_logical_plan_builder PlanBuilder.cpp
+                  NameAllocator.cpp NameMappings.cpp)
 
 velox_link_libraries(
   velox_fe_logical_plan_builder

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -119,6 +119,14 @@ class PlanBuilder {
 
   PlanBuilder& unionAll(const PlanBuilder& other);
 
+  PlanBuilder& intersect(const PlanBuilder& other);
+
+  PlanBuilder& except(const PlanBuilder& other);
+
+  PlanBuilder& setOperation(
+      SetOperation op,
+      const std::vector<PlanBuilder>& inputs);
+
   PlanBuilder& sort(const std::vector<std::string>& sortingKeys);
 
   /// An alias for 'sort'.

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -16,10 +16,7 @@ add_subdirectory(tests)
 
 add_subdirectory(connectors)
 
-add_library(
-  velox_schema_resolver
-  SchemaResolver.cpp
-  SchemaUtils.cpp)
+add_library(velox_schema_resolver SchemaResolver.cpp SchemaUtils.cpp)
 
 target_link_libraries(velox_schema_resolver velox_connector_metadata
                       velox_exception velox_vector)
@@ -33,7 +30,6 @@ add_library(
   Plan.cpp
   BitSet.cpp
   ParallelExpr.cpp
-  ParallelProject.cpp
   PlanObject.cpp
   Schema.cpp
   QueryGraph.cpp
@@ -50,6 +46,10 @@ add_library(
 add_dependencies(velox_verax velox_hive_connector)
 
 target_link_libraries(
-  velox_verax velox_core velox_connector_metadata velox_fe_logical_plan
-  velox_multifragment_plan velox_connector
-                      velox_schema_resolver)
+  velox_verax
+  velox_core
+  velox_connector_metadata
+  velox_fe_logical_plan
+  velox_multifragment_plan
+  velox_connector
+  velox_schema_resolver)

--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -194,6 +194,12 @@ void Filter::setCost(const PlanState& /*input*/) {
   cost_.fanout = pow(0.8, exprs_.size());
 }
 
+void UnionAll::setCost(const PlanState& input) {
+  for (auto& in : inputs) {
+    cost_.inputCardinality += in->cost().inputCardinality * in->cost().fanout;
+  }
+}
+
 float selfCost(ExprCP expr) {
   switch (expr->type()) {
     case PlanType::kColumn: {

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -429,4 +429,42 @@ std::string Project::toString(bool recursive, bool detail) const {
   return out.str();
 }
 
+const QGstring& UnionAll::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::vector<QGstring> keys;
+  for (auto in : inputs) {
+    keys.push_back(in->historyKey());
+  }
+  std::sort(keys.begin(), keys.end());
+  std::stringstream out;
+  out << "unionall(";
+  for (const auto& key : keys) {
+    out << key << ", ";
+  }
+  out << ")";
+  key_ = sanitizeHistoryKey(out.str());
+  return key_;
+}
+
+std::string UnionAll::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  out << "(";
+  for (auto i = 0; i < inputs.size(); ++i) {
+    out << inputs[i]->toString(recursive, detail);
+    if (i < inputs.size() - 1) {
+      if (detail) {
+        out << std::endl;
+      }
+      out << " union all ";
+      if (detail) {
+        out << std::endl;
+      }
+    }
+  }
+  out << ")";
+  return out.str();
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -258,7 +258,8 @@ enum class RelType {
   kJoin,
   kHashBuild,
   kAggregation,
-  kOrderBy
+  kOrderBy,
+  kUnionAll
 };
 
 /// Represents a relation (table) that is either physically stored or is the

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -25,10 +25,6 @@ namespace facebook::velox::optimizer {
 using namespace facebook::velox;
 
 namespace {
-std::string veloxToString(const core::PlanNode* plan) {
-  return plan->toString(true, true);
-}
-
 const std::string* columnName(const core::TypedExprPtr& expr) {
   if (auto column =
           dynamic_cast<const core::FieldAccessTypedExpr*>(expr.get())) {

--- a/axiom/optimizer/connectors/CMakeLists.txt
+++ b/axiom/optimizer/connectors/CMakeLists.txt
@@ -20,6 +20,8 @@ velox_link_libraries(velox_connector_metadata velox_common_base velox_memory
 
 add_subdirectory(hive)
 
+add_subdirectory(tests)
+
 velox_add_library(velox_connector_split_source ConnectorSplitSource.cpp)
 
 velox_link_libraries(

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ add_executable(
   SubfieldTest.cpp
   LogicalSubfieldTest.cpp
   FeatureGen.cpp
-  Genies.cpp)
+  Genies.cpp
+  SchemaResolverTest.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 
@@ -29,6 +30,7 @@ target_link_libraries(
   velox_plan_test
   velox_verax
   velox_fe_logical_plan_builder
+  velox_test_connector
   velox_schema_resolver
   velox_tpch_gen
   velox_connector_split_source
@@ -37,6 +39,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader
+  GTest::gmock
   gtest
   gtest_main)
 

--- a/axiom/optimizer/tests/SchemaResolverTest.cpp
+++ b/axiom/optimizer/tests/SchemaResolverTest.cpp
@@ -34,6 +34,11 @@ class SchemaResolverTest : public ::testing::Test {
         baseCatalog_.connector, baseCatalog_.schema);
   }
 
+  void TearDown() override {
+    connector::unregisterConnector("base");
+    connector::unregisterConnector("other");
+  }
+
   struct Catalog {
     std::string id;
     std::string schema;


### PR DESCRIPTION
Summary:
- Adds PlanBuilder support for SetNode.

- Adds a union all relation op.

- Adds conversion to query graph from SetNode: Left leaf gives the types, all other leaf derived tables produce the identical output.

- Support unions in makePlan: The non-union derived tables are cached. The union or union all is generated from the best pick for each leaf dt with an optional shuffle. A distinct is added if needed. The costs are added up across the union inputs. The derived table that stands for the union has no a priori partitioning and its cardinality and column cardinalities are added up from the inputs.

- Velox executable Unions are generated as local exchanges or as a single remote exchange with many input fragments.

- Intersect and except are generated as semijoins or antijoins with a distinct on the columns of the leftmost input.

- In Velox plan generation, a column to column rename in TempProjection is added. This is needed for renaming columns from an inner derived table to an outer one when the dt ends with aggregation. A column to column projection is not elided if the column name and the target name differ.

- Miscellaneous cmake build fixes and fixes to tests to make them run sequentially, e.g. adding cleanups of registration.

- Fixes pushdown of aggregation key filters when there is a rename in aggregation or a non-column aggregation key.

- Fixes check of applicability of non-inner joins, i.e. the left key columns must be a subset of the placed  and not the other way around. This would work with single tables since subset is commutative if the sets are the same.
 


Reviewed By: mbasmanova

Differential Revision: D79229260

Pulled By: oerling


