### PR TITLE
Rewrite non-tpch tests in PlanTest.cpp to use logical plan

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -117,6 +117,10 @@ class PlanBuilder {
       const std::string& condition,
       JoinType joinType);
 
+  PlanBuilder& crossJoin(const PlanBuilder& right) {
+    return join(right, /* condition */ "", JoinType::kInner);
+  }
+
   PlanBuilder& unionAll(const PlanBuilder& other);
 
   PlanBuilder& intersect(const PlanBuilder& other);


### PR DESCRIPTION
Summary:
Fix PlanTest.q2 to use query 2, not 1. The test fails after the fix, hence, added GTEST_SKIP.

Next step is to extract tpch tests into its own TpchPlanTest.cpp.

Differential Revision: D79599469
