### PR TITLE
Add Duck-based SQL query parser

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -45,12 +45,23 @@ velox_link_libraries(
   gtest
   gtest_main)
 
+velox_add_library(velox_optimizer_tests_query_sql_parser QuerySqlParser.cpp)
+
+velox_link_libraries(
+  velox_optimizer_tests_query_sql_parser
+  velox_fe_logical_plan_builder
+  velox_parse_parser
+  velox_vector)
+
 add_executable(velox_optimizer_tests_tpch_plan TpchPlanTest.cpp)
 
 add_test(velox_optimizer_tests_tpch_plan velox_optimizer_tests_tpch_plan)
 
 target_link_libraries(
-  velox_optimizer_tests_tpch_plan velox_optimizer_tests_parquet_tpch
+  velox_optimizer_tests_tpch_plan
+  velox_dwio_common_test_utils
+  velox_optimizer_tests_parquet_tpch
+  velox_optimizer_tests_query_sql_parser
   velox_optimizer_tests_query_test_base)
 
 add_executable(
@@ -89,6 +100,7 @@ target_link_libraries(
   velox_schema_resolver
   velox_connector_split_source
   velox_hive_connector_metadata
+  velox_optimizer_tests_query_sql_parser
   velox_query_benchmark
   velox_exec_test_lib
   velox_dwio_common

--- a/axiom/optimizer/tests/QuerySqlParser.cpp
+++ b/axiom/optimizer/tests/QuerySqlParser.cpp
@@ -1,0 +1,733 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/QuerySqlParser.h"
+#include "velox/duckdb/conversion/DuckConversion.h"
+#include "velox/parse/DuckLogicalOperator.h"
+#include "velox/parse/PlanNodeIdGenerator.h"
+
+#include <duckdb.hpp> // @manual
+#include <duckdb/main/connection.hpp> // @manual
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp> // @manual
+#include <duckdb/planner/expression/bound_cast_expression.hpp> // @manual
+#include <duckdb/planner/expression/bound_comparison_expression.hpp> // @manual
+#include <duckdb/planner/expression/bound_constant_expression.hpp> // @manual
+#include <duckdb/planner/expression/bound_function_expression.hpp> // @manual
+#include <duckdb/planner/expression/bound_reference_expression.hpp> // @manual
+#include <duckdb/planner/operator/logical_dummy_scan.hpp> // @manual
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace facebook::velox::optimizer::test {
+
+namespace {
+
+class ColumnNameGenerator {
+ public:
+  std::string next(const std::string& prefix = "_c") {
+    if (names_.count(prefix)) {
+      auto name = fmt::format("{}{}", prefix, nextId_++);
+      names_.insert(name);
+      return name;
+    }
+
+    names_.insert(prefix);
+    return prefix;
+  }
+
+ private:
+  std::unordered_set<std::string> names_;
+  int nextId_{0};
+};
+
+struct QueryContext {
+  const std::string connectorId;
+  core::PlanNodeIdGenerator planNodeIdGenerator;
+  ColumnNameGenerator columnNameGenerator;
+
+  explicit QueryContext(const std::string& _connectorId)
+      : connectorId(_connectorId) {}
+
+  std::string nextNodeId() {
+    return planNodeIdGenerator.next();
+  }
+
+  std::string nextColumnName() {
+    return columnNameGenerator.next();
+  }
+
+  std::string nextColumnName(const std::string& prefix) {
+    return columnNameGenerator.next(prefix);
+  }
+};
+
+std::optional<int64_t> extractInteger(const lp::ConstantExpr& constant) {
+  const auto& value = *constant.value();
+  if (value.isNull()) {
+    return std::nullopt;
+  }
+
+  const auto typeKind = value.kind();
+
+  switch (typeKind) {
+    case TypeKind::BIGINT:
+      return value.value<int64_t>();
+    case TypeKind::INTEGER:
+      return value.value<int32_t>();
+    case TypeKind::VARCHAR:
+      try {
+        return std::stol(value.value<std::string>());
+      } catch (...) {
+        return std::nullopt;
+      }
+    default:
+      return std::nullopt;
+  }
+}
+
+lp::ConstantExprPtr tryParseInterval(
+    const std::string& functionName,
+    const lp::ExprPtr& input) {
+  std::optional<int64_t> value;
+
+  if (const auto* constant = input->asUnchecked<lp::ConstantExpr>()) {
+    value = extractInteger(*constant);
+  } else if (
+      const auto* specialForm = input->asUnchecked<lp::SpecialFormExpr>()) {
+    if (specialForm->form() == lp::SpecialForm::kCast) {
+      if (auto constant =
+              specialForm->inputAt(0)->asUnchecked<lp::ConstantExpr>()) {
+        value = extractInteger(*constant);
+      }
+    }
+  }
+
+  if (!value.has_value()) {
+    return nullptr;
+  }
+
+  int64_t multiplier;
+
+  if (functionName == "to_days") {
+    multiplier = 24 * 60 * 60 * 1'000;
+  } else if (functionName == "to_hours") {
+    multiplier = 60 * 60 * 1'000;
+  } else if (functionName == "to_minutes") {
+    multiplier = 60 * 1'000;
+  } else if (functionName == "to_seconds") {
+    multiplier = 1'000;
+  } else if (functionName == "to_milliseconds") {
+    multiplier = 1;
+  }
+  // The other two options are years and months. They are expressed in terms of
+  // number of months, and return a different type (INTERVAL_YEAR_MONTH).
+  else {
+    if (functionName == "to_years") {
+      multiplier = 12;
+    } else if (functionName == "to_months") {
+      multiplier = 1;
+    } else {
+      return nullptr;
+    }
+
+    return std::make_shared<lp::ConstantExpr>(
+        INTERVAL_YEAR_MONTH(),
+        std::make_shared<Variant>((int32_t)(value.value() * multiplier)));
+  }
+
+  return std::make_shared<lp::ConstantExpr>(
+      INTERVAL_DAY_TIME(),
+      std::make_shared<Variant>(value.value() * multiplier));
+}
+
+std::string mapScalarFunctionName(const std::string& name) {
+  static const std::unordered_map<std::string, std::string> kMapping = {
+      {"+", "plus"},
+      {"-", "minus"},
+      {"*", "multiply"},
+      {"/", "divide"},
+      {"%", "mod"},
+      {"~~", "like"},
+      {"!~~", "not_like"},
+      {"list_value", "array_constructor"},
+  };
+
+  auto it = kMapping.find(name);
+  if (it != kMapping.end()) {
+    return it->second;
+  }
+
+  return name;
+}
+
+std::string mapAggregateFunctionName(const std::string& name) {
+  static const std::unordered_map<std::string, std::string> kMapping = {
+      {"count_star", "count"},
+  };
+
+  auto it = kMapping.find(name);
+  if (it != kMapping.end()) {
+    return it->second;
+  }
+
+  return name;
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalDummyScan& logicalDummyScan,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < logicalDummyScan.types.size(); ++i) {
+    names.push_back(queryContext.nextColumnName());
+    types.push_back(duckdb::toVeloxType(logicalDummyScan.types[i]));
+  }
+
+  auto rowType = ROW(std::move(names), std::move(types));
+
+  std::vector<RowVectorPtr> vectors = {std::make_shared<RowVector>(
+      pool, rowType, nullptr, 1, std::vector<VectorPtr>{})};
+
+  return std::make_shared<lp::ValuesNode>(
+      queryContext.nextNodeId(),
+      rowType,
+      std::vector<Variant>{Variant::null(TypeKind::ROW)});
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalGet& logicalGet,
+    memory::MemoryPool* pool,
+    const std::vector<lp::LogicalPlanNodePtr>& sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(logicalGet.function.name, "seq_scan");
+  VELOX_CHECK_EQ(0, sources.size());
+
+  std::vector<std::string> columnNames;
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  constexpr uint64_t kNone = ~0UL;
+
+  const auto& columnIds = logicalGet.column_ids;
+  for (auto i = 0; i < columnIds.size(); ++i) {
+    if (columnIds[i] == kNone) {
+      continue;
+    }
+    names.push_back(
+        queryContext.nextColumnName(logicalGet.names[columnIds[i]]));
+    types.push_back(
+        duckdb::toVeloxType(logicalGet.returned_types[columnIds[i]]));
+    columnNames.push_back(logicalGet.names[columnIds[i]]);
+  }
+
+  auto rowType = ROW(std::move(names), std::move(types));
+
+  auto tableName = logicalGet.function.to_string(logicalGet.bind_data.get());
+
+  return std::make_shared<lp::TableScanNode>(
+      queryContext.nextNodeId(),
+      rowType,
+      queryContext.connectorId,
+      tableName,
+      columnNames);
+}
+
+lp::ExprPtr toExpr(::duckdb::Expression& expression, const TypePtr& inputType);
+
+std::vector<lp::ExprPtr> toExprs(
+    const ::duckdb::vector<::duckdb::unique_ptr<::duckdb::Expression>>&
+        duckExprs,
+    const TypePtr& inputType) {
+  std::vector<lp::ExprPtr> exprs;
+  exprs.reserve(duckExprs.size());
+  for (const auto& duckExpr : duckExprs) {
+    exprs.push_back(toExpr(*duckExpr, inputType));
+  }
+
+  return exprs;
+}
+
+lp::ExprPtr toLogicalComparisonExpression(
+    const std::string& name,
+    ::duckdb::Expression& expression,
+    const TypePtr& inputType) {
+  auto* comparison =
+      dynamic_cast<::duckdb::BoundComparisonExpression*>(&expression);
+
+  return std::make_shared<lp::CallExpr>(
+      BOOLEAN(),
+      name,
+      toExpr(*comparison->left, inputType),
+      toExpr(*comparison->right, inputType));
+}
+
+lp::ExprPtr toExpr(::duckdb::Expression& expression, const TypePtr& inputType) {
+  switch (expression.type) {
+    case ::duckdb::ExpressionType::VALUE_CONSTANT: {
+      auto* constant =
+          dynamic_cast<::duckdb::BoundConstantExpression*>(&expression);
+      return std::make_shared<lp::ConstantExpr>(
+          duckdb::toVeloxType(constant->return_type),
+          std::make_shared<Variant>(
+              duckdb::duckValueToVariant(constant->value)));
+    }
+    case ::duckdb::ExpressionType::COMPARE_EQUAL:
+      return toLogicalComparisonExpression("eq", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_NOTEQUAL:
+      return toLogicalComparisonExpression("neq", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_GREATERTHAN:
+      return toLogicalComparisonExpression("gt", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return toLogicalComparisonExpression("gte", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_LESSTHAN:
+      return toLogicalComparisonExpression("lt", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+      return toLogicalComparisonExpression("lte", expression, inputType);
+
+    case ::duckdb::ExpressionType::OPERATOR_CAST: {
+      auto* cast = dynamic_cast<::duckdb::BoundCastExpression*>(&expression);
+      const auto form =
+          cast->try_cast ? lp::SpecialForm::kTryCast : lp::SpecialForm::kCast;
+      return std::make_shared<lp::SpecialFormExpr>(
+          duckdb::toVeloxType(cast->return_type),
+          form,
+          std::vector<lp::ExprPtr>{toExpr(*cast->child, inputType)});
+    }
+    case ::duckdb::ExpressionType::BOUND_FUNCTION: {
+      auto* func =
+          dynamic_cast<::duckdb::BoundFunctionExpression*>(&expression);
+
+      const auto inputs = toExprs(func->children, inputType);
+
+      auto name = mapScalarFunctionName(func->function.name);
+
+      if (inputs.size() == 1) {
+        if (auto interval = tryParseInterval(name, inputs[0])) {
+          return interval;
+        }
+      }
+
+      bool negate = false;
+      if (name == "not_like") {
+        name = "like";
+        negate = true;
+      }
+      auto call = std::make_shared<lp::CallExpr>(
+          duckdb::toVeloxType(func->function.return_type), name, inputs);
+      if (negate) {
+        return std::make_shared<lp::CallExpr>(
+            BOOLEAN(), "not", std::vector<lp::ExprPtr>{call});
+      }
+      return call;
+    }
+    case ::duckdb::ExpressionType::BOUND_REF: {
+      auto* ref =
+          dynamic_cast<::duckdb::BoundReferenceExpression*>(&expression);
+      return std::make_shared<lp::InputReferenceExpr>(
+          duckdb::toVeloxType(ref->return_type),
+          inputType->asRow().nameOf(ref->index));
+    }
+    case ::duckdb::ExpressionType::BOUND_AGGREGATE: {
+      auto* agg =
+          dynamic_cast<::duckdb::BoundAggregateExpression*>(&expression);
+
+      const auto inputs = toExprs(agg->children, inputType);
+
+      return std::make_shared<lp::CallExpr>(
+          duckdb::toVeloxType(agg->return_type),
+          mapAggregateFunctionName(agg->function.name),
+          inputs);
+    }
+    default:
+      VELOX_NYI(
+          "Expression type {} is not supported yet: {}",
+          ::duckdb::ExpressionTypeToString(expression.type),
+          expression.ToString());
+  }
+}
+
+lp::ExprPtr makeAnd(const lp::ExprPtr& left, const lp::ExprPtr& right) {
+  return std::make_shared<lp::SpecialFormExpr>(
+      BOOLEAN(), lp::SpecialForm::kAnd, left, right);
+}
+
+lp::ExprPtr combineConjuncts(
+    const ::duckdb::vector<::duckdb::unique_ptr<::duckdb::Expression>>&
+        conjuncts,
+    const RowTypePtr& inputRowType) {
+  lp::ExprPtr combined;
+  for (const auto& conjunct : conjuncts) {
+    auto expr = toExpr(*conjunct, inputRowType);
+    if (!combined) {
+      combined = expr;
+    } else {
+      combined = makeAnd(combined, expr);
+    }
+  }
+
+  return combined;
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalFilter& duckFilter,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  auto predicate =
+      combineConjuncts(duckFilter.expressions, sources[0]->outputType());
+
+  return std::make_shared<lp::FilterNode>(
+      queryContext.nextNodeId(), sources[0], predicate);
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalProjection& logicalProjection,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  const auto projections =
+      toExprs(logicalProjection.expressions, sources[0]->outputType());
+
+  std::vector<std::string> names;
+  names.reserve(projections.size());
+  for (auto i = 0; i < projections.size(); ++i) {
+    names.push_back(queryContext.nextColumnName("_p"));
+  }
+  return std::make_shared<lp::ProjectNode>(
+      queryContext.nextNodeId(), sources[0], names, projections);
+}
+
+namespace {
+std::string translateAggregateName(const std::string& name) {
+  // first(x) is used to get one element of a set. The closes Velox
+  // counterpart is arbitrary, which usually returns the first value it sees.
+  if (name == "first") {
+    return "arbitrary";
+  }
+  return name;
+}
+} // namespace
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalAggregate& logicalAggregate,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  std::vector<std::string> outputNames;
+  outputNames.reserve(
+      logicalAggregate.groups.size() + logicalAggregate.expressions.size());
+
+  auto groupingKeys =
+      toExprs(logicalAggregate.groups, sources[0]->outputType());
+
+  for (const auto& key : groupingKeys) {
+    if (auto* inputReference = key->asUnchecked<lp::InputReferenceExpr>()) {
+      outputNames.push_back(inputReference->name());
+    } else {
+      queryContext.nextColumnName("_gk");
+    }
+  }
+
+  std::vector<lp::AggregateExprPtr> aggregates;
+  for (auto& expression : logicalAggregate.expressions) {
+    const auto expr = toExpr(*expression, sources[0]->outputType());
+    const auto* call = expr->asUnchecked<lp::CallExpr>();
+
+    auto type = call->type();
+    if (expression->return_type.InternalType() ==
+        ::duckdb::PhysicalType::INT128) {
+      type = BIGINT();
+    }
+
+    const auto aggName = translateAggregateName(call->name());
+    aggregates.push_back(
+        std::make_shared<lp::AggregateExpr>(type, aggName, call->inputs()));
+
+    outputNames.push_back(queryContext.nextColumnName("_a"));
+  }
+
+  return std::make_shared<lp::AggregateNode>(
+      queryContext.nextNodeId(),
+      sources[0],
+      groupingKeys,
+      std::vector<lp::AggregateNode::GroupingSet>{},
+      aggregates,
+      outputNames);
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalOrder& logicalOrder,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  const auto& source = sources[0];
+
+  std::vector<lp::SortingField> ordering;
+  for (const auto& order : logicalOrder.orders) {
+    const bool ascending = order.type == ::duckdb::OrderType::ASCENDING ||
+        order.type == ::duckdb::OrderType::ORDER_DEFAULT;
+
+    const bool nullsFirst =
+        order.null_order == ::duckdb::OrderByNullType::NULLS_FIRST ||
+        order.null_order == ::duckdb::OrderByNullType::ORDER_DEFAULT;
+
+    ordering.push_back(
+        {toExpr(*order.expression, source->outputType()),
+         lp::SortOrder{ascending, nullsFirst}});
+  }
+
+  return std::make_shared<lp::SortNode>(
+      queryContext.nextNodeId(), source, ordering);
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalCrossProduct& logicalCrossProduct,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(2, sources.size());
+
+  return std::make_shared<lp::JoinNode>(
+      queryContext.nextNodeId(),
+      sources[0],
+      sources[1],
+      lp::JoinType::kInner,
+      /* condition */ nullptr);
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalComparisonJoin& join,
+    memory::MemoryPool* pool,
+    std::vector<lp::LogicalPlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(2, sources.size());
+
+  lp::JoinType joinType = lp::JoinType::kInner;
+  switch (join.join_type) {
+    case ::duckdb::JoinType::INNER:
+    case ::duckdb::JoinType::SINGLE:
+      joinType = lp::JoinType::kInner;
+      break;
+    case ::duckdb::JoinType::LEFT:
+      joinType = lp::JoinType::kLeft;
+      break;
+    case ::duckdb::JoinType::RIGHT:
+      joinType = lp::JoinType::kRight;
+      break;
+    case ::duckdb::JoinType::OUTER:
+      joinType = lp::JoinType::kFull;
+      break;
+    default:
+      VELOX_NYI(
+          "Unsupported Duck join type: {}",
+          static_cast<int32_t>(join.join_type));
+  }
+
+  const auto joinInputType =
+      sources[0]->outputType()->unionWith(sources[1]->outputType());
+
+  lp::ExprPtr filter;
+  for (auto& condition : join.conditions) {
+    auto expr = ::duckdb::JoinCondition::CreateExpression(std::move(condition));
+    auto conjunct = toExpr(*expr, joinInputType);
+
+    if (!filter) {
+      filter = conjunct;
+    } else {
+      filter = makeAnd(filter, conjunct);
+    }
+  }
+
+  return std::make_shared<lp::JoinNode>(
+      queryContext.nextNodeId(), sources[0], sources[1], joinType, filter);
+}
+
+lp::LogicalPlanNodePtr toPlanNode(
+    ::duckdb::LogicalOperator& plan,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  std::vector<lp::LogicalPlanNodePtr> sources;
+  for (auto& child : plan.children) {
+    sources.push_back(toPlanNode(*child, pool, queryContext));
+    VELOX_CHECK_NOT_NULL(
+        sources.back(), "Null plan for: {}", child->ToString());
+  }
+
+  switch (plan.type) {
+    case ::duckdb::LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalDummyScan&>(plan), pool, queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_GET:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalGet&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_FILTER:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalFilter&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_PROJECTION:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalProjection&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalAggregate&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalCrossProduct&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_ORDER_BY: {
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalOrder&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    }
+    case ::duckdb::LogicalOperatorType::LOGICAL_LIMIT: {
+      auto& limit = dynamic_cast<const ::duckdb::LogicalLimit&>(plan);
+      return std::make_shared<lp::LimitNode>(
+          queryContext.nextNodeId(),
+          sources[0],
+          limit.offset_val,
+          limit.limit_val);
+    }
+    case ::duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+      return toPlanNode(
+          dynamic_cast<::duckdb::LogicalComparisonJoin&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    default:
+      VELOX_NYI(
+          "Plan node is not supported yet: {}",
+          ::duckdb::LogicalOperatorToString(plan.type));
+  }
+}
+
+static void customScalarFunction(
+    ::duckdb::DataChunk& args,
+    ::duckdb::ExpressionState& state,
+    ::duckdb::Vector& result) {
+  VELOX_UNREACHABLE();
+}
+
+static ::duckdb::idx_t customAggregateState() {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateInitialize(::duckdb::data_ptr_t) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateUpdate(
+    ::duckdb::Vector inputs[],
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::idx_t input_count,
+    ::duckdb::Vector& state,
+    ::duckdb::idx_t count) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateCombine(
+    ::duckdb::Vector& state,
+    ::duckdb::Vector& combined,
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::idx_t count) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateFinalize(
+    ::duckdb::Vector& state,
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::Vector& result,
+    ::duckdb::idx_t count,
+    ::duckdb::idx_t offset) {
+  VELOX_UNREACHABLE();
+}
+
+} // namespace
+
+void QuerySqlParser::registerTable(
+    const std::string& name,
+    const RowTypePtr& type) {
+  VELOX_CHECK_EQ(
+      tables_.count(name), 0, "Table is already registered: {}", name);
+
+  auto createTableSql = duckdb::makeCreateTableSql(name, *type);
+  auto res = conn_.Query(createTableSql);
+}
+
+void QuerySqlParser::registerScalarFunction(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& returnType) {
+  ::duckdb::vector<::duckdb::LogicalType> argDuckTypes;
+  for (auto& type : argTypes) {
+    argDuckTypes.push_back(duckdb::fromVeloxType(type));
+  }
+
+  conn_.CreateVectorizedFunction(
+      name,
+      argDuckTypes,
+      duckdb::fromVeloxType(returnType),
+      customScalarFunction);
+}
+
+void QuerySqlParser::registerAggregateFunction(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& returnType) {
+  ::duckdb::vector<::duckdb::LogicalType> argDuckTypes;
+  for (auto& type : argTypes) {
+    argDuckTypes.push_back(duckdb::fromVeloxType(type));
+  }
+
+  conn_.CreateAggregateFunction(
+      name,
+      argDuckTypes,
+      duckdb::fromVeloxType(returnType),
+      customAggregateState,
+      customAggregateInitialize,
+      customAggregateUpdate,
+      customAggregateCombine,
+      customAggregateFinalize);
+}
+
+lp::LogicalPlanNodePtr QuerySqlParser::parse(const std::string& sql) {
+  // Disable the optimizer. Otherwise, the filter over table scan gets pushdown
+  // as a callback that is impossible to recover.
+  conn_.Query("PRAGMA disable_optimizer");
+
+  auto plan = conn_.ExtractPlan(sql);
+
+  QueryContext queryContext{connectorId_};
+  return toPlanNode(*plan, pool_, queryContext);
+}
+
+} // namespace facebook::velox::optimizer::test

--- a/axiom/optimizer/tests/QuerySqlParser.h
+++ b/axiom/optimizer/tests/QuerySqlParser.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/vector/ComplexVector.h"
+
+#include <duckdb.hpp> // @manual
+
+namespace facebook::velox::optimizer::test {
+
+class QuerySqlParser {
+ public:
+  /// TODO Add support for queries that use tables from multiple connectors.
+  ///
+  /// @param connectorId The ID of the connector that can read all tables in the
+  /// query.
+  QuerySqlParser(const std::string& connectorId, memory::MemoryPool* pool)
+      : connectorId_{connectorId}, pool_{pool} {}
+
+  void registerTable(const std::string& name, const RowTypePtr& type);
+
+  void registerScalarFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& returnType);
+
+  // TODO Allow replacing built-in DuckDB functions. Currently, replacing "sum"
+  // causes a crash (a bug in DuckDB). Replacing existing functions is useful
+  // when signatures don't match.
+  void registerAggregateFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& returnType);
+
+  logical_plan::LogicalPlanNodePtr parse(const std::string& sql);
+
+ private:
+  const std::string connectorId_;
+  ::duckdb::DuckDB db_;
+  ::duckdb::Connection conn_{db_};
+  memory::MemoryPool* pool_;
+  std::unordered_map<std::string, std::vector<RowVectorPtr>> tables_;
+};
+
+} // namespace facebook::velox::optimizer::test

--- a/axiom/optimizer/tests/tpch.queries/q1.sql
+++ b/axiom/optimizer/tests/tpch.queries/q1.sql
@@ -1,0 +1,25 @@
+-- TPC-H/TPC-R Pricing Summary Report Query (Q1)
+-- Functional Query Definition
+-- Approved February 1998
+select
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) as sum_qty,
+	sum(l_extendedprice) as sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+	avg(l_quantity) as avg_qty,
+	avg(l_extendedprice) as avg_price,
+	avg(l_discount) as avg_disc,
+	count(*) as count_order
+from
+	lineitem
+where
+    -- TODO Fix this predicate to match the official TPC-H specification.
+    l_shipdate < '1998-09-03'::date
+group by
+	l_returnflag,
+	l_linestatus
+order by
+	l_returnflag,
+	l_linestatus;

--- a/axiom/optimizer/tests/tpch.queries/q3.sql
+++ b/axiom/optimizer/tests/tpch.queries/q3.sql
@@ -1,0 +1,26 @@
+-- TPC-H/TPC-R Shipping Priority Query (Q3)
+-- Functional Query Definition
+-- Approved February 1998
+select
+	l_orderkey,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	o_orderdate,
+	o_shippriority
+from
+	customer as c,
+	orders as o,
+	lineitem as l
+where
+	c_mktsegment = 'BUILDING'
+	and c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate < '1995-03-15'
+	and l_shipdate > '1995-03-15'
+group by
+	l_orderkey,
+	o_orderdate,
+	o_shippriority
+order by
+	revenue desc,
+	o_orderdate
+limit 10;

--- a/axiom/optimizer/tests/tpch.queries/q5.sql
+++ b/axiom/optimizer/tests/tpch.queries/q5.sql
@@ -1,0 +1,27 @@
+-- TPC-H/TPC-R Local Supplier Volume Query (Q5)
+-- Functional Query Definition
+-- Approved February 1998
+select
+	n_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+	customer as c,
+	orders as o,
+	lineitem as l,
+	supplier as s,
+	nation as n,
+	region as r
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and l_suppkey = s_suppkey
+	and c_nationkey = s_nationkey
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'ASIA'
+        and o_orderdate >= '1994-01-01'
+        and cast(o_orderdate as date) < date '1994-01-01' + interval '1' year
+group by
+	n_name
+order by
+	revenue desc;


### PR DESCRIPTION
Summary:

Make a copy of velox/parse/QueryPlanner.* and change it to produce velox::logical_plan::LogicalPlanNode instead of velox::core::PlanNode.

Update VeloxSql.cpp to use that.

Create optimizer/tests/tpch.queries and add q##.sql files that contain SQL texts for q1, q3, and q5. Update TpchPlanTest.cpp to read q##.sql files, parse, optimize, run and verify results.

Follow-up: Add SQL files for all remaining TPC-H queries - https://github.com/facebookexperimental/verax/issues/133

Differential Revision: D79817859
