### PR TITLE
fix: unbreak logical plan optimization for multi-connector queries

### DIFF
--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -29,13 +29,17 @@ class PlanPrinterTest : public testing::Test {
  protected:
   static constexpr auto kTestConnectorId = "test";
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
 
     auto connector =
         std::make_shared<connector::TestConnector>(kTestConnectorId);
-    connector->addTable(
+    connector->createTable(
         "test", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
     connector::registerConnector(connector);
   }

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -95,14 +95,16 @@ Schema::Schema(
 Schema::Schema(const char* _name, SchemaResolver* source, LocusCP locus)
     : name_(_name), source_(source), defaultLocus_(locus) {}
 
-SchemaTableCP Schema::findTable(std::string_view name) const {
+SchemaTableCP Schema::findTable(
+    std::string_view connectorId,
+    std::string_view name) const {
   auto internedName = toName(name);
   auto it = tables_.find(internedName);
   if (it != tables_.end()) {
     return it->second;
   }
   VELOX_CHECK_NOT_NULL(source_);
-  auto* table = source_->findTable(std::string(name));
+  auto* table = source_->findTable(std::string(connectorId), std::string(name));
   if (!table) {
     return nullptr;
   }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -449,8 +449,11 @@ class Schema {
   /// Constructs a Schema for producing executable plans, backed by 'source'.
   Schema(Name _name, SchemaResolver* source, LocusCP locus);
 
-  /// Returns the table with 'name' or nullptr if not found.
-  SchemaTableCP findTable(std::string_view name) const;
+  /// Returns the table with 'name' or nullptr if not found, using
+  /// the connector specified by connectorId to perform table lookups.
+  /// An error is thrown if no connector with the specified ID exists.
+  SchemaTableCP findTable(std::string_view connectorId, std::string_view name)
+      const;
 
   Name name() const {
     return name_;

--- a/axiom/optimizer/SchemaResolver.h
+++ b/axiom/optimizer/SchemaResolver.h
@@ -24,25 +24,25 @@ namespace facebook::velox::optimizer {
 
 class SchemaResolver {
  public:
-  SchemaResolver(
-      const std::shared_ptr<connector::Connector>& defaultConnector,
-      const std::string& defaultSchema)
-      : defaultConnector_(defaultConnector), defaultSchema_(defaultSchema) {}
+  SchemaResolver(const std::string& defaultSchema = "")
+      : defaultSchema_(defaultSchema) {}
 
   virtual ~SchemaResolver() = default;
 
   // Converts a table name to a resolved Table, or nullptr if the table doesn't
-  // exist. Input can be any of the following formats:
+  // exist. If a connector for the specified catalog doesn't exist, an error
+  // will be returned. Input table name can be any of the following formats:
   //   - "tablename"
   //   - "schema.tablename"
   //   - "catalog.schema.tablename"
-  // If catalog is omitted, defaultConnector will be used for the table lookup.
   // If schema is omitted, defaultSchema will be prepended prior to lookup.
-  virtual const connector::Table* findTable(const std::string& name);
+  // If the table name specifies a different catalog than the one specified
+  // as a parameter, an error will be thrown.
+  virtual const connector::Table* findTable(
+      const std::string& catalog,
+      const std::string& name);
 
  private:
-  // Connector to use if name does not specify a catalog.
-  const std::shared_ptr<connector::Connector> defaultConnector_;
   const std::string defaultSchema_;
 };
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1085,9 +1085,13 @@ void ToGraph::finalizeDt(
 }
 
 PlanObjectP ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
-  const auto* schemaTable = schema_.findTable(tableScan.tableName());
+  const auto* schemaTable =
+      schema_.findTable(tableScan.connectorId(), tableScan.tableName());
   VELOX_CHECK_NOT_NULL(
-      schemaTable, "Table not found: {}", tableScan.tableName());
+      schemaTable,
+      "Table not found: {} via connector {}",
+      tableScan.tableName(),
+      tableScan.connectorId());
 
   auto* baseTable = make<BaseTable>();
   baseTable->cname = newCName("t");

--- a/axiom/optimizer/connectors/ConnectorMetadata.h
+++ b/axiom/optimizer/connectors/ConnectorMetadata.h
@@ -390,6 +390,8 @@ class PartitionHandle {
   virtual ~PartitionHandle() = default;
 };
 
+using PartitionHandlePtr = std::shared_ptr<const PartitionHandle>;
+
 /// Enumerates splits. The table and partitions to cover are given to
 /// ConnectorSplitManager.
 class SplitSource {
@@ -430,7 +432,7 @@ class ConnectorSplitManager {
 
   /// Returns the list of all partitions that match the filters in
   /// 'tableHandle'. A non-partitioned table returns one partition.
-  virtual std::vector<std::shared_ptr<const PartitionHandle>> listPartitions(
+  virtual std::vector<PartitionHandlePtr> listPartitions(
       const ConnectorTableHandlePtr& tableHandle) = 0;
 
   /// Returns a SplitSource that covers the contents of 'partitions'. The set of
@@ -439,7 +441,7 @@ class ConnectorSplitManager {
   /// cluster.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorTableHandlePtr& tableHandle,
-      std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+      std::vector<PartitionHandlePtr> partitions,
       SplitOptions = {}) = 0;
 };
 

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -26,8 +26,7 @@
 
 namespace facebook::velox::connector::hive {
 
-std::vector<std::shared_ptr<const PartitionHandle>>
-LocalHiveSplitManager::listPartitions(
+std::vector<PartitionHandlePtr> LocalHiveSplitManager::listPartitions(
     const ConnectorTableHandlePtr& tableHandle) {
   // All tables are unpartitioned.
   std::unordered_map<std::string, std::optional<std::string>> empty;
@@ -36,7 +35,7 @@ LocalHiveSplitManager::listPartitions(
 
 std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const ConnectorTableHandlePtr& tableHandle,
-    std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+    std::vector<PartitionHandlePtr> /*partitions*/,
     SplitOptions options) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -56,12 +56,12 @@ class LocalHiveConnectorMetadata;
 class LocalHiveSplitManager : public ConnectorSplitManager {
  public:
   LocalHiveSplitManager(LocalHiveConnectorMetadata* /* metadata */) {}
-  std::vector<std::shared_ptr<const PartitionHandle>> listPartitions(
+  std::vector<PartitionHandlePtr> listPartitions(
       const ConnectorTableHandlePtr& tableHandle) override;
 
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorTableHandlePtr& tableHandle,
-      std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+      std::vector<PartitionHandlePtr> partitions,
       SplitOptions options = {}) override;
 };
 

--- a/axiom/optimizer/connectors/tests/CMakeLists.txt
+++ b/axiom/optimizer/connectors/tests/CMakeLists.txt
@@ -16,3 +16,22 @@ velox_add_library(velox_test_connector TestConnector.cpp)
 
 velox_link_libraries(velox_test_connector velox_connector_metadata
                      velox_common_base velox_memory velox_connector)
+
+add_executable(
+  velox_test_connector_test
+  TestConnectorTest.cpp)
+
+add_test(
+    velox_test_connector_test
+    velox_test_connector_test)
+
+target_link_libraries(
+  velox_test_connector_test
+  velox_test_connector
+  velox_common_base
+  velox_memory
+  velox_connector
+  velox_exec
+  velox_vector_test_lib
+  gtest
+  gtest_main)

--- a/axiom/optimizer/connectors/tests/TestConnector.cpp
+++ b/axiom/optimizer/connectors/tests/TestConnector.cpp
@@ -10,24 +10,234 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * See the License for the specific language governing
+ * permissions and limitations under the License.
  */
-
 #include "axiom/optimizer/connectors/tests/TestConnector.h"
 
 namespace facebook::velox::connector {
 
+TestTable::TestTable(
+    const std::string& name,
+    const RowTypePtr& schema,
+    TestConnector* connector)
+    : Table(name), connector_(connector) {
+  Table::type_ = schema;
+  std::vector<const Column*> columnVector;
+
+  exportedColumns_.reserve(schema->size());
+  columnVector.reserve(schema->size());
+  for (auto i = 0; i < schema->size(); ++i) {
+    const auto& columnName = schema->nameOf(i);
+    const auto& columnType = schema->childAt(i);
+    VELOX_CHECK(
+        !columnName.empty(), "column {} in table {} has empty name", i, name);
+    exportedColumns_.emplace_back(
+        std::make_unique<Column>(columnName, columnType));
+    columnVector.emplace_back(exportedColumns_.back().get());
+    auto [_, ok] = columns_.emplace(columnName, exportedColumns_.back().get());
+    VELOX_CHECK(ok, "duplicate column name '{}' in table {}", columnName, name);
+  }
+
+  auto layout =
+      std::make_unique<TestTableLayout>(name_, this, connector_, columnVector);
+  layouts_.push_back(layout.get());
+  exportedLayouts_.push_back(std::move(layout));
+  pool_ = memory::memoryManager()->addLeafPool(name + "_table");
+}
+
+std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {
+  std::vector<SplitAndGroup> result;
+  if (currentPartition_ >= partitions_.size()) {
+    result.push_back({nullptr, kUngroupedGroupId});
+  } else {
+    result.push_back(
+        {std::make_shared<ConnectorSplit>(connectorId_), kUngroupedGroupId});
+  }
+  currentPartition_++;
+  return result;
+}
+
+std::vector<PartitionHandlePtr> TestSplitManager::listPartitions(
+    const ConnectorTableHandlePtr&) {
+  return {std::make_shared<PartitionHandle>()};
+}
+
+std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
+    const ConnectorTableHandlePtr& tableHandle,
+    std::vector<PartitionHandlePtr> partitions,
+    SplitOptions) {
+  return std::make_shared<TestSplitSource>(
+      tableHandle->connectorId(), std::move(partitions));
+}
+
+Table* FOLLY_NULLABLE
+TestConnectorMetadata::findTableInternal(const std::string& name) {
+  auto it = tables_.find(name);
+  return it != tables_.end() ? it->second.get() : nullptr;
+}
+
+const Table* FOLLY_NULLABLE
+TestConnectorMetadata::findTable(const std::string& name) {
+  return findTableInternal(name);
+}
+
+ColumnHandlePtr TestConnectorMetadata::createColumnHandle(
+    const TableLayout& layout,
+    const std::string& columnName,
+    std::vector<common::Subfield>,
+    std::optional<TypePtr> castToType,
+    SubfieldMapping) {
+  auto column = layout.findColumn(columnName);
+  VELOX_CHECK_NOT_NULL(
+      column, "Column {} not found in table {}", columnName, layout.name());
+  return std::make_shared<TestColumnHandle>(
+      columnName, castToType.value_or(column->type()));
+}
+
 ConnectorTableHandlePtr TestConnectorMetadata::createTableHandle(
-    const TableLayout& /* layout */,
-    std::vector<ColumnHandlePtr> /* columnHandles */,
+    const TableLayout& layout,
+    std::vector<ColumnHandlePtr> columnHandles,
     core::ExpressionEvaluator& /* evaluator */,
     std::vector<core::TypedExprPtr> filters,
     std::vector<core::TypedExprPtr>& rejectedFilters,
     RowTypePtr /* dataColumns */,
     std::optional<LookupKeys>) {
   rejectedFilters = std::move(filters);
-  return std::make_shared<TestTableHandle>(connector_->connectorId());
+  return std::make_shared<TestTableHandle>(layout, std::move(columnHandles));
+}
+
+TestTable* TestConnectorMetadata::createTable(
+    const std::string& name,
+    const RowTypePtr& schema) {
+  auto table = std::make_unique<TestTable>(name, schema, connector_);
+  auto [it, ok] = tables_.emplace(name, std::move(table));
+  VELOX_CHECK(ok, "table {} already exists", name);
+  return it->second.get();
+}
+
+void TestConnectorMetadata::appendData(
+    const std::string& name,
+    const RowVectorPtr& data) {
+  auto it = tables_.find(name);
+  VELOX_CHECK(it != tables_.end(), "no table {} exists", name);
+  it->second->addData(data);
+}
+
+TestDataSource::TestDataSource(
+    const RowTypePtr& outputType,
+    const ColumnHandleMap& handles,
+    const Table* table,
+    memory::MemoryPool* pool)
+    : outputType_(outputType), pool_(pool) {
+  auto maybeTable = dynamic_cast<const TestTable*>(table);
+  VELOX_CHECK(maybeTable, "table {} not a TestTable", table->name());
+  data_ = maybeTable->data();
+
+  auto tableType = table->rowType();
+  outputMappings_.reserve(outputType_->size());
+  for (const auto& name : outputType->names()) {
+    VELOX_CHECK(
+        handles.contains(name),
+        "no handle for output column {} for table {}",
+        name,
+        table->name());
+    auto handle = handles.find(name)->second;
+
+    const auto idx = tableType->getChildIdxIfExists(handle->name());
+    VELOX_CHECK(
+        idx.has_value(),
+        "column '{}' not found in table '{}'.",
+        handle->name(),
+        table->name());
+    outputMappings_.emplace_back(idx.value());
+  }
+}
+
+void TestDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  split_ = std::move(split);
+}
+
+std::optional<RowVectorPtr> TestDataSource::next(
+    uint64_t,
+    velox::ContinueFuture&) {
+  VELOX_CHECK(split_, "no split added to DataSource");
+  if (data_.size() <= idx_) {
+    return nullptr;
+  }
+  auto vector = data_[idx_++];
+
+  completedRows_ += vector->size();
+  completedBytes_ += vector->retainedSize();
+
+  std::vector<VectorPtr> children;
+  children.reserve(outputMappings_.size());
+  for (const auto idx : outputMappings_) {
+    children.emplace_back(vector->childAt(idx));
+  }
+
+  return std::make_shared<RowVector>(
+      pool_, outputType_, BufferPtr(), vector->size(), std::move(children));
+}
+
+void TestDataSource::addDynamicFilter(
+    column_index_t,
+    const std::shared_ptr<common::Filter>&) {
+  VELOX_NYI("TestDataSource does not support dynamic filters");
+}
+
+std::unique_ptr<DataSource> TestConnector::createDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& columnHandles,
+    ConnectorQueryCtx* connectorQueryCtx) {
+  auto table = metadata_->findTable(tableHandle->name());
+  VELOX_CHECK(
+      table,
+      "cannot create data source for nonexistent table {}",
+      tableHandle->name());
+  return std::make_unique<TestDataSource>(
+      outputType, columnHandles, table, connectorQueryCtx->memoryPool());
+}
+
+std::unique_ptr<DataSink> TestConnector::createDataSink(
+    RowTypePtr,
+    ConnectorInsertTableHandlePtr tableHandle,
+    ConnectorQueryCtx*,
+    CommitStrategy) {
+  VELOX_CHECK(tableHandle, "table handle must be non-null");
+  auto table = metadata_->findTableInternal(tableHandle->toString());
+  VELOX_CHECK(
+      table,
+      "cannot create data sink for nonexistent table {}",
+      tableHandle->toString());
+  return std::make_unique<TestDataSink>(table);
+}
+
+TestTable* TestConnector::createTable(
+    const std::string& name,
+    const RowTypePtr& schema) {
+  return metadata_->createTable(name, schema);
+}
+
+void TestConnector::appendData(
+    const std::string& name,
+    const RowVectorPtr& data) {
+  metadata_->appendData(name, data);
+}
+
+std::shared_ptr<Connector> TestConnectorFactory::newConnector(
+    const std::string& id,
+    std::shared_ptr<const config::ConfigBase>,
+    folly::Executor*,
+    folly::Executor*) {
+  return std::make_shared<TestConnector>(id);
+}
+
+void TestDataSink::appendData(RowVectorPtr vector) {
+  if (vector) {
+    table_->addData(vector);
+  }
 }
 
 } // namespace facebook::velox::connector

--- a/axiom/optimizer/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/optimizer/connectors/tests/TestConnectorTest.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/connectors/tests/TestConnector.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/expression/Expr.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::connector {
+namespace {
+
+class TestConnectorTest : public ::testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    connector_ = std::make_shared<TestConnector>(connectorId_);
+  }
+
+  std::shared_ptr<TestConnector> connector_;
+  std::string connectorId_{"test"};
+};
+
+TEST_F(TestConnectorTest, connectorRegister) {
+  VELOX_ASSERT_THROW(
+      getConnector(connectorId_), "Connector with ID 'test' not registered");
+  registerConnector(connector_);
+
+  auto connector = getConnector(connectorId_);
+  EXPECT_EQ(connector_.get(), connector.get());
+  EXPECT_EQ(connector->connectorId(), connectorId_);
+  EXPECT_NE(connector->metadata(), nullptr);
+
+  unregisterConnector(connectorId_);
+  VELOX_ASSERT_THROW(
+      getConnector(connectorId_), "Connector with ID 'test' not registered");
+}
+
+TEST_F(TestConnectorTest, table) {
+  auto metadata = connector_->metadata();
+
+  auto schema = ROW({{"a", INTEGER()}, {"b", VARCHAR()}});
+  connector_->createTable("table", schema);
+  auto table = metadata->findTable("table");
+  EXPECT_NE(table, nullptr);
+  EXPECT_EQ(table->name(), "table");
+  EXPECT_EQ(table->numRows(), 0);
+  EXPECT_EQ(table->columnMap().size(), 2);
+  EXPECT_TRUE(table->columnMap().contains("a"));
+  EXPECT_TRUE(table->columnMap().contains("b"));
+
+  auto vector = makeRowVector(
+      {makeFlatVector<int>({0, 1, 2}),
+       makeFlatVector<StringView>({"a", "b", "c"})});
+  connector_->appendData("table", vector);
+  EXPECT_EQ(table->numRows(), 3);
+
+  vector = makeRowVector({makeFlatVector<int>({0, 1, 2})});
+  VELOX_ASSERT_THROW(
+      connector_->appendData("table", vector),
+      "appended data type ROW<c0:INTEGER> must match table type ROW<a:INTEGER,b:VARCHAR>");
+
+  connector_->createTable("noschema");
+  table = metadata->findTable("noschema");
+  EXPECT_NE(table, nullptr);
+  EXPECT_EQ(table->numRows(), 0);
+  EXPECT_EQ(table->columnMap().size(), 0);
+
+  table = metadata->findTable("notable");
+  EXPECT_EQ(table, nullptr);
+}
+
+TEST_F(TestConnectorTest, columnHandle) {
+  auto schema = ROW({{"a", INTEGER()}, {"b", VARCHAR()}});
+  connector_->createTable("table", schema);
+
+  auto metadata = connector_->metadata();
+  auto table = metadata->findTable("table");
+  auto& layout = *table->layouts()[0];
+
+  auto columnHandle = metadata->createColumnHandle(layout, "a");
+  EXPECT_NE(columnHandle, nullptr);
+
+  auto testColumnHandle =
+      std::dynamic_pointer_cast<const TestColumnHandle>(columnHandle);
+  EXPECT_NE(testColumnHandle, nullptr);
+  EXPECT_EQ(testColumnHandle->name(), "a");
+  EXPECT_EQ(testColumnHandle->type()->kind(), TypeKind::INTEGER);
+}
+
+TEST_F(TestConnectorTest, splitManager) {
+  auto schema = ROW({"a"}, {INTEGER()});
+  connector_->createTable("test_table", schema);
+
+  auto metadata = connector_->metadata();
+  auto splitManager = metadata->splitManager();
+  EXPECT_NE(splitManager, nullptr);
+}
+
+TEST_F(TestConnectorTest, splits) {
+  auto split = std::make_shared<ConnectorSplit>(connectorId_);
+  EXPECT_EQ(split->connectorId, connectorId_);
+}
+
+TEST_F(TestConnectorTest, dataSink) {
+  auto schema = ROW({"a"}, {INTEGER()});
+  auto handle = std::make_shared<TestInsertTableHandle>("table");
+  auto table = connector_->createTable("table", schema);
+  EXPECT_EQ(table->numRows(), 0);
+
+  auto dataSink = connector_->createDataSink(
+      schema, handle, nullptr, CommitStrategy::kNoCommit);
+  EXPECT_NE(dataSink, nullptr);
+
+  auto vector = makeRowVector({makeFlatVector<int>({0, 1, 2})});
+  dataSink->appendData(vector);
+  EXPECT_EQ(table->numRows(), 3);
+
+  vector = makeRowVector({makeFlatVector<int>({3, 4})});
+  dataSink->appendData(vector);
+  EXPECT_EQ(table->numRows(), 5);
+
+  dataSink->appendData(nullptr);
+  EXPECT_EQ(table->numRows(), 5);
+
+  EXPECT_TRUE(dataSink->finish());
+  EXPECT_TRUE(dataSink->close().empty());
+}
+
+TEST_F(TestConnectorTest, dataSource) {
+  auto schema = ROW({"a", "b"}, {INTEGER(), VARCHAR()});
+  auto table = connector_->createTable("table", schema);
+  auto& layout = *table->layouts()[0];
+  auto metadata = connector_->metadata();
+
+  std::vector<ColumnHandlePtr> columns;
+  columns.push_back(metadata->createColumnHandle(layout, "a"));
+  columns.push_back(metadata->createColumnHandle(layout, "b"));
+
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  std::vector<core::TypedExprPtr> empty;
+  auto tableHandle = metadata->createTableHandle(
+      layout, std::move(columns), *evaluator, empty, empty);
+
+  auto vector1 = makeRowVector(
+      {makeFlatVector<int>({0, 1}), makeFlatVector<StringView>({"a", "b"})});
+  connector_->appendData("table", vector1);
+  auto vector2 = makeRowVector(
+      {makeFlatVector<int>({3, 4}), makeFlatVector<StringView>({"d", "e"})});
+  connector_->appendData("table", vector2);
+
+  ColumnHandleMap handleMap;
+  handleMap.emplace("a", metadata->createColumnHandle(layout, "a"));
+  handleMap.emplace("b", metadata->createColumnHandle(layout, "b"));
+  auto dataSource = std::make_shared<TestDataSource>(
+      schema, std::move(handleMap), table, pool());
+  EXPECT_EQ(dataSource->getCompletedRows(), 0);
+
+  auto split = std::make_shared<ConnectorSplit>(connectorId_);
+  dataSource->addSplit(split);
+
+  velox::ContinueFuture future;
+  auto result = dataSource->next(0, future);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value()->size(), 2);
+  EXPECT_EQ(dataSource->getCompletedRows(), 2);
+  test::assertEqualVectors(vector1, result.value());
+
+  result = dataSource->next(0, future);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value()->size(), 2);
+  EXPECT_EQ(dataSource->getCompletedRows(), 4);
+  test::assertEqualVectors(vector2, result.value());
+
+  result = dataSource->next(0, future);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), nullptr);
+}
+
+TEST_F(TestConnectorTest, testColumnHandleCreation) {
+  auto columnHandle = std::make_shared<TestColumnHandle>("col", INTEGER());
+  EXPECT_EQ(columnHandle->name(), "col");
+  EXPECT_EQ(columnHandle->type()->kind(), TypeKind::INTEGER);
+}
+
+TEST_F(TestConnectorTest, tableLayout) {
+  auto schema = ROW({"a", "b"}, {INTEGER(), VARCHAR()});
+  auto table = connector_->createTable("table", schema);
+
+  auto& layout = *table->layouts()[0];
+  EXPECT_EQ(layout.name(), "table");
+
+  const auto& columnMap = table->columnMap();
+  EXPECT_NE(columnMap.find("a"), columnMap.end());
+  EXPECT_NE(columnMap.find("b"), columnMap.end());
+
+  auto col1 = layout.findColumn("a");
+  EXPECT_NE(col1, nullptr);
+  EXPECT_EQ(col1->name(), "a");
+  EXPECT_EQ(col1->type()->kind(), TypeKind::INTEGER);
+
+  auto col2 = layout.findColumn("b");
+  EXPECT_NE(col2, nullptr);
+  EXPECT_EQ(col2->name(), "b");
+  EXPECT_EQ(col2->type()->kind(), TypeKind::VARCHAR);
+
+  auto nonExistent = layout.findColumn("nonexistent");
+  EXPECT_EQ(nonExistent, nullptr);
+}
+
+} // namespace
+} // namespace facebook::velox::connector
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
@@ -28,14 +28,14 @@ FOLLY_ALWAYS_INLINE constexpr std::string_view defaultTpchNamespace() {
   return "tiny";
 }
 
-std::vector<std::shared_ptr<const PartitionHandle>>
-TpchSplitManager::listPartitions(const ConnectorTableHandlePtr& tableHandle) {
+std::vector<PartitionHandlePtr> TpchSplitManager::listPartitions(
+    const ConnectorTableHandlePtr& /*tableHandle*/) {
   return {std::make_shared<connector::PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const ConnectorTableHandlePtr& tableHandle,
-    std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+    std::vector<PartitionHandlePtr> /*partitions*/,
     SplitOptions options) {
   auto* tpchTableHandle =
       dynamic_cast<const TpchTableHandle*>(tableHandle.get());

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
@@ -56,12 +56,12 @@ class TpchSplitManager : public ConnectorSplitManager {
  public:
   TpchSplitManager(TpchConnectorMetadata* /* metadata */) {}
 
-  std::vector<std::shared_ptr<const PartitionHandle>> listPartitions(
+  std::vector<PartitionHandlePtr> listPartitions(
       const ConnectorTableHandlePtr& tableHandle) override;
 
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorTableHandlePtr& tableHandle,
-      std::vector<std::shared_ptr<const PartitionHandle>> partitions,
+      std::vector<PartitionHandlePtr> partitions,
       SplitOptions options = {}) override;
 };
 

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -176,7 +176,7 @@ TEST_F(PlanTest, queryGraph) {
 }
 
 TEST_F(PlanTest, agg) {
-  testConnector_->addTable(
+  testConnector_->createTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
 
   auto logicalPlan = lp::PlanBuilder()
@@ -200,7 +200,7 @@ TEST_F(PlanTest, agg) {
 // Verify that optimizer can handle connectors that do not support filter
 // pushdown.
 TEST_F(PlanTest, rejectedFilters) {
-  testConnector_->addTable(
+  testConnector_->createTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
 
   auto logicalPlan = lp::PlanBuilder()
@@ -218,7 +218,7 @@ TEST_F(PlanTest, rejectedFilters) {
 }
 
 TEST_F(PlanTest, inList) {
-  testConnector_->addTable(
+  testConnector_->createTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
 
   {

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -65,7 +65,7 @@ void QueryTestBase::SetUp() {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
 
-  schema_ = std::make_shared<velox::optimizer::SchemaResolver>(connector_, "");
+  schema_ = std::make_shared<velox::optimizer::SchemaResolver>();
   if (suiteHistory_) {
     history_ = std::move(suiteHistory_);
   } else {

--- a/axiom/optimizer/tests/SchemaResolverTest.cpp
+++ b/axiom/optimizer/tests/SchemaResolverTest.cpp
@@ -28,6 +28,7 @@ namespace {
 class SchemaResolverTest : public ::testing::Test {
  public:
   void SetUp() override {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     baseCatalog_ = generateCatalog("base", "baseschema");
     otherCatalog_ = generateCatalog("other", "otherschema");
     resolver_ = std::make_shared<SchemaResolver>(
@@ -65,7 +66,7 @@ class SchemaResolverTest : public ::testing::Test {
 TEST_F(SchemaResolverTest, bareTable) {
   auto lookup = "table";
   auto expect = "baseschema.table";
-  baseCatalog_.connector->addTable(expect);
+  baseCatalog_.connector->createTable(expect);
   auto table = resolver_->findTable(lookup);
   ASSERT_NE(table, nullptr);
   ASSERT_EQ(table->name(), expect);
@@ -90,7 +91,7 @@ TEST_F(SchemaResolverTest, invalidName) {
 
 TEST_F(SchemaResolverTest, tablePlusSchema) {
   auto lookup = "newschema.table";
-  baseCatalog_.connector->addTable(lookup);
+  baseCatalog_.connector->createTable(lookup);
   auto table = resolver_->findTable(lookup);
   ASSERT_NE(table, nullptr);
   ASSERT_EQ(table->name(), lookup);
@@ -99,14 +100,14 @@ TEST_F(SchemaResolverTest, tablePlusSchema) {
 TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
   auto lookup = "other.otherschema.table";
   auto expect = "otherschema.table";
-  otherCatalog_.connector->addTable(expect);
+  otherCatalog_.connector->createTable(expect);
   auto table = resolver_->findTable(lookup);
   ASSERT_NE(table, nullptr);
   ASSERT_EQ(table->name(), expect);
 
   lookup = "base.baseschema.table";
   expect = "baseschema.table";
-  baseCatalog_.connector->addTable(expect);
+  baseCatalog_.connector->createTable(expect);
   table = resolver_->findTable(lookup);
   ASSERT_NE(table, nullptr);
   ASSERT_EQ(table->name(), expect);

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -44,8 +44,6 @@ class TestConnectorQueryTest : public QueryTestBase {
     QueryTestBase::SetUp();
     connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
     connector::registerConnector(connector_);
-    schema_ =
-        std::make_shared<velox::optimizer::SchemaResolver>(connector_, "");
     options_.numWorkers = 1;
     options_.numDrivers = 16;
   }

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/exec/TableWriter.h"
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace facebook::velox::optimizer::test {
+namespace {
+
+class TestConnectorQueryTest : public QueryTestBase {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  static void SetUpTestCase() {
+    LocalRunnerTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    LocalRunnerTestBase::TearDownTestCase();
+  }
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
+    connector::registerConnector(connector_);
+    schema_ =
+        std::make_shared<velox::optimizer::SchemaResolver>(connector_, "");
+    options_.numWorkers = 1;
+    options_.numDrivers = 16;
+  }
+
+  void TearDown() override {
+    connector::unregisterConnector(kTestConnectorId);
+    connector_.reset();
+    QueryTestBase::TearDown();
+  }
+
+  runner::MultiFragmentPlanPtr appendTableWrite(
+      const runner::MultiFragmentPlanPtr& plan,
+      const RowTypePtr& schema,
+      const std::string& tableName) {
+    EXPECT_EQ(plan->fragments().size(), 1);
+    auto executableFragment = plan->fragments().back();
+    auto fragment = executableFragment.fragment;
+
+    auto source = fragment.planNode;
+    auto handle = std::make_shared<core::InsertTableHandle>(
+        kTestConnectorId,
+        std::make_shared<connector::TestInsertTableHandle>(tableName));
+    auto write = std::make_shared<core::TableWriteNode>(
+        "writenodeid",
+        source->outputType(),
+        schema->names(),
+        /*aggregationNode=*/nullptr,
+        std::move(handle),
+        /*hasPartitioningScheme=*/false,
+        exec::TableWriteTraits::outputType(nullptr),
+        connector::CommitStrategy::kTaskCommit,
+        source);
+
+    runner::ExecutableFragment writeFragment(executableFragment);
+    writeFragment.fragment = core::PlanFragment(
+        write,
+        fragment.executionStrategy,
+        fragment.numSplitGroups,
+        fragment.groupedExecutionLeafNodeIds);
+    std::vector<runner::ExecutableFragment> fragments = {writeFragment};
+
+    return std::make_shared<runner::MultiFragmentPlan>(fragments, options_);
+  }
+
+  void executePlanChecked(
+      const lp::LogicalPlanNodePtr& logicalPlan,
+      const RowVectorPtr& expected) {
+    auto results = runVelox(logicalPlan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
+
+  std::shared_ptr<connector::TestConnector> connector_;
+  runner::MultiFragmentPlan::Options options_;
+};
+
+TEST_F(TestConnectorQueryTest, selectFiltered) {
+  auto vector = makeRowVector({"a"}, {makeFlatVector<int64_t>({0, 1, 2})});
+  auto schema = vector->rowType();
+
+  connector_->createTable("t", schema);
+  connector_->appendData("t", vector);
+
+  lp::PlanBuilder::Context context(kTestConnectorId);
+  auto plan = lp::PlanBuilder(context).tableScan("t").filter("a > 0").build();
+  auto expected = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  executePlanChecked(plan, expected);
+}
+
+TEST_F(TestConnectorQueryTest, writeFiltered) {
+  auto vector = makeRowVector(
+      {"b", "c"},
+      {makeFlatVector<int64_t>({0, 1, 2}),
+       makeFlatVector<StringView>({"str", "ing", "val"})});
+  auto schema = vector->rowType();
+
+  auto table = connector_->createTable("u", schema);
+  EXPECT_NE(table, nullptr);
+
+  lp::PlanBuilder::Context context;
+  auto plan = lp::PlanBuilder(context).values({vector}).filter("b < 2").build();
+  auto expected = makeRowVector(
+      {makeFlatVector<int64_t>({0, 1}),
+       makeFlatVector<StringView>({"str", "ing"})});
+
+  auto fragmentedPlan = planVelox(plan, options_);
+  fragmentedPlan.plan = appendTableWrite(fragmentedPlan.plan, schema, "u");
+  runFragmentedPlan(fragmentedPlan);
+
+  EXPECT_EQ(table->data().size(), 1);
+  auto actual = table->data().front();
+  velox::test::assertEqualVectors(actual, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::optimizer::test

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -54,20 +54,10 @@ class TpchPlanTest : public virtual test::QueryTestBase {
 
   void SetUp() override {
     QueryTestBase::SetUp();
-    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
-    context_ = std::make_unique<QueryGraphContext>(*allocator_);
-    queryCtx() = context_.get();
 
     referenceBuilder_ = std::make_unique<exec::test::TpchQueryBuilder>(
         dwio::common::FileFormat::PARQUET);
     referenceBuilder_->initialize(FLAGS_data_path);
-  }
-
-  void TearDown() override {
-    context_.reset();
-    queryCtx() = nullptr;
-    allocator_.reset();
-    QueryTestBase::TearDown();
   }
 
   void checkTpch(int32_t query, const lp::LogicalPlanNodePtr& logicalPlan) {
@@ -148,8 +138,6 @@ class TpchPlanTest : public virtual test::QueryTestBase {
     auto referenceResult = assertSame(referencePlan, fragmentedPlan);
   }
 
-  std::unique_ptr<HashStringAllocator> allocator_;
-  std::unique_ptr<QueryGraphContext> context_;
   std::unique_ptr<exec::test::TpchQueryBuilder> referenceBuilder_;
 };
 

--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -186,7 +186,7 @@ class VeloxRunner : public QueryBenchmarkBase {
 
     registerHiveConnector();
 
-    schema_ = std::make_shared<optimizer::SchemaResolver>(connector_, "");
+    schema_ = std::make_shared<optimizer::SchemaResolver>();
 
     parser_ = setupQueryParser();
 


### PR DESCRIPTION
Summary:
For queries which reference tables residing on multiple connectors, we need a way to specify to the optimizer which connector to query for table metadata

Previously, with the physical input interfaces, we passed a fully-qualified table name (`[catalog].[schema].[query]`). Now there is a dedicated field in logical scan nodes for the connector ID

Modifying the schema lookup in Verax to respect this separately specified catalog by passing it explicitly. If the plan creator created the scan with a fully-qualified table name as before, the catalog specified there is compared against the separate connector ID parameter

Differential Revision: D79820585


