### PR TITLE
feat: Add tracing for query graph composition, Optimize first DPP DF

### DIFF
--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -22,6 +22,12 @@
 namespace facebook::velox::optimizer {
 
 struct OptimizerOptions {
+  /// Bit masks for use in 'traceFlags'.
+  static constexpr int32_t kRetained = 1;
+  static constexpr int32_t kExceededBest = 2;
+  static constexpr int32_t kSample = 4;
+  static constexpr int32_t kPreprocess = 8;
+
   /// Parallelizes independent projections over this many threads. 1 means no
   /// parallel projection.
   int32_t parallelProjectWidth = 1;
@@ -29,6 +35,10 @@ struct OptimizerOptions {
   /// Produces skyline subfield sets of complex type columns as top level
   /// columns in table scan.
   bool pushdownSubfields{false};
+
+  /// Makes all maps for which a known subset of keys is accessed to
+  /// be projected out as structs.
+  bool allMapsAsStruct{false};
 
   /// Map from table name to  list of map columns to be read as structs unless
   /// the whole map is accessed as a map.
@@ -40,6 +50,9 @@ struct OptimizerOptions {
   int32_t traceFlags{0};
 
   bool isMapAsStruct(const char* table, const char* column) const {
+    if (allMapsAsStruct) {
+      return true;
+    }
     auto it = mapAsStruct.find(table);
     if (it == mapAsStruct.end()) {
       return false;

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -104,9 +104,10 @@ void Optimization::trace(
     const Cost& cost,
     RelationOp& plan) {
   if (event & opts_.traceFlags) {
-    std::cout << (event == kRetained ? "Retained: " : "Abandoned: ") << id
-              << ": " << cost.toString(true, true) << ": " << " "
-              << plan.toString(true, false) << std::endl;
+    std::cout << (event == OptimizerOptions::kRetained ? "Retained: "
+                                                       : "Abandoned: ")
+              << id << ": " << cost.toString(true, true) << ": "
+              << " " << plan.toString(true, false) << std::endl;
   }
 }
 
@@ -161,7 +162,7 @@ void PlanState::addNextJoin(
   if (!isOverBest()) {
     toTry.emplace_back(candidate, plan, cost, placed, columns, builds);
   } else {
-    optimization.trace(Optimization::kExceededBest, dt->id(), cost, *plan);
+    optimization.trace(OptimizerOptions::kExceededBest, dt->id(), cost, *plan);
   }
 }
 
@@ -273,7 +274,10 @@ PlanPtr PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
         // Old plan has no order and is worse than new plus shuffle. Can't win.
         // rase.
         queryCtx()->optimization()->trace(
-            Optimization::kExceededBest, state.dt->id(), old->cost, *old->op);
+            OptimizerOptions::kExceededBest,
+            state.dt->id(),
+            old->cost,
+            *old->op);
         plans.erase(plans.begin() + i);
         --i;
         continue;
@@ -1719,7 +1723,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
     }
   } else {
     if (state.isOverBest()) {
-      trace(kExceededBest, dt->id(), state.cost, *plan);
+      trace(OptimizerOptions::kExceededBest, dt->id(), state.cost, *plan);
       return;
     }
     // Add multitable filters not associated to a non-inner join.
@@ -1733,7 +1737,11 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
       }
       addPostprocess(dt, plan, state);
       auto kept = state.plans.addPlan(plan, state);
-      trace(kept ? kRetained : kExceededBest, dt->id(), state.cost, *plan);
+      trace(
+          kept ? OptimizerOptions::kRetained : OptimizerOptions::kExceededBest,
+          dt->id(),
+          state.cost,
+          *plan);
 
       return;
     }

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -360,10 +360,6 @@ namespace facebook::velox::optimizer {
 /// instance must stay live as long as a returned plan is live.
 class Optimization {
  public:
-  static constexpr int32_t kRetained = 1;
-  static constexpr int32_t kExceededBest = 2;
-  static constexpr int32_t kSample = 4;
-
   Optimization(
       const logical_plan::LogicalPlanNode& plan,
       const Schema& schema,

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -210,6 +210,13 @@ class ToGraph {
       Step,
       const logical_plan::ExprPtr& arg);
 
+  template <typename Func>
+  void trace(int32_t event, Func f) {
+    if ((options_.traceFlags & event) != 0) {
+      f();
+    }
+  }
+
  private:
   // For comparisons, swaps the args to have a canonical form for
   // deduplication. E.g column op constant, and Smaller plan object id

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -55,7 +55,8 @@ std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
       return it->second;
     }
   }
-  bool trace = (optimization->opts().traceFlags & Optimization::kSample) != 0;
+  bool trace =
+      (optimization->opts().traceFlags & OptimizerOptions::kSample) != 0;
 
   std::pair<float, float> pair;
   uint64_t start = getCurrentTimeMicro();
@@ -111,7 +112,8 @@ bool VeloxHistory::setLeafSelectivity(BaseTable& table, RowTypePtr scanType) {
     }
     return false;
   }
-  bool trace = (optimization->opts().traceFlags & Optimization::kSample) != 0;
+  bool trace =
+      (optimization->opts().traceFlags & OptimizerOptions::kSample) != 0;
   uint64_t start = getCurrentTimeMicro();
   auto sample = runnerTable->layouts()[0]->sample(
       handlePair.first, 1, handlePair.second, scanType);


### PR DESCRIPTION
Adds bit mask 8 to ttrace flags to enable preprocessor tracing.

Adds a scoped error message context to query graph construction.

- Adds output for cardinality() path.

- Allows pushdown of non-deterministic filters past cardinality neutral boundaries, like single table and single union all.

- Adds items to make_row_from_map test

- Adds processing of make_named_row without transformation to row_constructor.

- Makes first DPP dataframe pass through Verax without errors.