### PR TITLE
Add support for LIMIT

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -199,6 +199,19 @@ void UnionAll::setCost(const PlanState& input) {
   }
 }
 
+void Limit::setCost(const PlanState& input) {
+  cost_.unitCost = 0.01;
+  if (input.cost.inputCardinality <= limit) {
+    // Input cardinality does not exceed the limit. The limit is no-op. Doesn't
+    // change cardinality.
+    cost_.fanout = 1;
+  } else {
+    // Input cardinality exceeds the limit. Calculate fanout to ensure that
+    // fanout * limit = input-cardinality.
+    cost_.fanout = limit / input.cost.inputCardinality;
+  }
+}
+
 float selfCost(ExprCP expr) {
   switch (expr->type()) {
     case PlanType::kColumn: {

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -115,8 +115,8 @@ struct DerivedTable : public PlanObject {
   AggregationPlanCP aggregation{nullptr};
   ExprVector having;
   OrderByP orderBy{nullptr};
-  int32_t limit{-1};
-  int32_t offset{0};
+  int64_t limit{-1};
+  int64_t offset{0};
 
   /// Adds an equijoin edge between 'left' and 'right'. The flags correspond to
   /// the like-named members in Join.

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "axiom/logical_plan/Expr.h"
 #include "axiom/optimizer/QueryGraph.h"
 
 namespace facebook::velox::optimizer {

--- a/axiom/optimizer/LogicalPlanToGraph.cpp
+++ b/axiom/optimizer/LogicalPlanToGraph.cpp
@@ -1403,6 +1403,11 @@ PlanObjectP Optimization::makeQueryGraph(
       return addOrderBy(*node.asUnchecked<lp::SortNode>());
 
     case lp::NodeKind::kLimit: {
+      // TODO Allow multiple limits.
+      //
+      // SELECT * FROM (SELECT * FROM t LIMIT 10 OFFSET 5) LIMIT 10 OFFSET 5
+      // is equivalent to
+      //    SELECT * FROM t LIMIT 5 OFFSET 10
       if (!contains(allowedInDt, PlanType::kLimit)) {
         return wrapInDt(node);
       }

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -827,6 +827,11 @@ void Optimization::addPostprocess(
     auto* project = make<Project>(plan, dt->exprs, dt->columns);
     plan = project;
   }
+  if (dt->orderBy == nullptr && dt->limit >= 0) {
+    auto limit = make<Limit>(plan, dt->limit, dt->offset);
+    state.addCost(*limit);
+    plan = limit;
+  }
 }
 
 namespace {

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -1161,6 +1161,12 @@ class Optimization {
       velox::runner::ExecutableFragment& fragment,
       std::vector<velox::runner::ExecutableFragment>& stages);
 
+  // Makes partial + final limit fragments.
+  velox::core::PlanNodePtr makeLimit(
+      const Limit& op,
+      velox::runner::ExecutableFragment& fragment,
+      std::vector<velox::runner::ExecutableFragment>& stages);
+
   velox::core::PlanNodePtr makeScan(
       const TableScan& scan,
       velox::runner::ExecutableFragment& fragment,
@@ -1222,6 +1228,8 @@ class Optimization {
       const PlanObjectSet& topExprs,
       const PlanObjectSet& placed,
       const PlanObjectSet& extraColumns);
+
+  runner::ExecutableFragment newFragment();
 
   PlanObjectCP findLeaf(const logical_plan::LogicalPlanNode* node) {
     auto* leaf = logicalPlanLeaves_[node];

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "axiom/logical_plan/Expr.h"
 #include "axiom/optimizer/Schema.h"
 #include "velox/core/PlanNode.h"
 

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -491,4 +491,20 @@ struct UnionAll : public RelationOp {
   const RelationOpPtrVector inputs;
 };
 
+struct Limit : public RelationOp {
+  Limit(RelationOpPtr input, int64_t limit, int64_t offset)
+      : RelationOp(
+            RelType::kLimit,
+            input,
+            input->distribution(),
+            input->columns()),
+        limit{limit},
+        offset{offset} {}
+
+  void setCost(const PlanState& input) override;
+
+  const int64_t limit;
+  const int64_t offset;
+};
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -259,7 +259,8 @@ enum class RelType {
   kHashBuild,
   kAggregation,
   kOrderBy,
-  kUnionAll
+  kUnionAll,
+  kLimit,
 };
 
 /// Represents a relation (table) that is either physically stored or is the

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -63,6 +63,14 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& localPartition(
       const std::shared_ptr<PlanMatcher>& matcher);
 
+  PlanMatcherBuilder& partitionedOutput();
+
+  PlanMatcherBuilder& exchange();
+
+  PlanMatcherBuilder& limit();
+
+  PlanMatcherBuilder& limit(int64_t offset, int64_t count);
+
   std::shared_ptr<PlanMatcher> build() {
     return matcher_;
   }

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -228,9 +228,8 @@ std::shared_ptr<core::QueryCtx> QueryTestBase::getQueryCtx() {
   return queryCtx_;
 }
 
-template <typename PlanPtr>
-optimizer::PlanAndStats QueryTestBase::planFromTree(
-    const PlanPtr& plan,
+optimizer::PlanAndStats QueryTestBase::planVelox(
+    const logical_plan::LogicalPlanNodePtr& plan,
     std::string* planString) {
   auto queryCtx = getQueryCtx();
 
@@ -263,12 +262,6 @@ optimizer::PlanAndStats QueryTestBase::planFromTree(
     *planString = best->op->toString(true, false);
   }
   return opt.toVeloxPlan(best->op, opts);
-}
-
-optimizer::PlanAndStats QueryTestBase::planVelox(
-    const logical_plan::LogicalPlanNodePtr& plan,
-    std::string* planString) {
-  return planFromTree(plan, planString);
 }
 
 TestResult QueryTestBase::runVelox(

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -79,11 +79,6 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
   std::shared_ptr<optimizer::SchemaResolver> schema_;
 
  private:
-  template <typename PlanPtr>
-  optimizer::PlanAndStats planFromTree(
-      const PlanPtr& plan,
-      std::string* planString);
-
   core::PlanNodePtr toTableScan(
       const std::string& id,
       const std::string& name,


### PR DESCRIPTION
Summary: Part of https://github.com/facebookexperimental/verax/issues/136

Remaining follow-ups:
- Handle consecutive limits with optional projects in between.
- Add local exchange when numDrivers > 1.
- Handle limit followed by order by. Currently it is planned as TopN, which is incorrect.

Differential Revision: D79911387


