### PR TITLE
Add support for EXPLAIN command to CLI

### DIFF
--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -487,9 +487,6 @@ struct hash<::facebook::velox::optimizer::MemoKey> {
 namespace facebook::velox::optimizer {
 
 struct OptimizerOptions {
-  /// Do not make shuffles or final gather stage.
-  bool singleStage{false};
-
   /// Parallelizes independent projections over this many threads. 1 means no
   /// parallel projection.
   int32_t parallelProjectWidth = 1;

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -1379,7 +1379,12 @@ class Optimization {
   };
 
   velox::runner::MultiFragmentPlan::Options options_;
+
+  // TODO Move this into MultiFragmentPlan::Options.
+  const VectorSerde::Kind exchangeSerdeKind_{VectorSerde::Kind::kPresto};
+
   PlanNodeIdGenerator idGenerator_;
+
   // Limit for a possible limit/top k order by for while making a Velox plan. -1
   // means no limit.
   int32_t toVeloxLimit_{-1};

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -49,13 +49,6 @@ std::string itemsToString(const T* items, int32_t n) {
 }
 } // namespace
 
-std::string RelationOp::toString(bool recursive, bool detail) const {
-  if (input_ && recursive) {
-    return input_->toString(true, detail);
-  }
-  return "";
-}
-
 // static
 Distribution TableScan::outputDistribution(
     const BaseTable* baseTable,
@@ -425,6 +418,34 @@ std::string Project::toString(bool recursive, bool detail) const {
     out << ")\n";
   } else {
     out << "project " << exprs_.size() << " columns ";
+  }
+  return out.str();
+}
+
+std::string OrderBy::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  if (recursive) {
+    out << input()->toString(true, detail) << " ";
+  }
+
+  if (detail) {
+    out << "OrderBy (" << distribution_.toString() << ")\n";
+  } else {
+    out << "order by " << distribution_.order.size() << " columns ";
+  }
+  return out.str();
+}
+
+std::string Limit::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  if (recursive) {
+    out << input()->toString(true, detail) << " ";
+  }
+
+  if (detail) {
+    out << "Limit (" << offset << ", " << limit << ")\n";
+  } else {
+    out << "offset " << offset << " limit " << limit << " ";
   }
   return out.str();
 }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -153,7 +153,7 @@ class RelationOp : public Relation {
   ///     - HashJoin
   ///       - Scan(region as t3)
   ///       - Scan(nation as t2)
-  virtual std::string toString(bool recursive, bool detail) const;
+  virtual std::string toString(bool recursive, bool detail) const = 0;
 
  protected:
   // adds a line of cost information to 'out'
@@ -470,6 +470,8 @@ struct OrderBy : public RelationOp {
   // another key or keys. These can be late materialized or converted
   // to payload.
   PlanObjectSet dependentKeys;
+
+  std::string toString(bool recursive, bool detail) const override;
 };
 
 /// Represents a union all.
@@ -505,6 +507,8 @@ struct Limit : public RelationOp {
 
   const int64_t limit;
   const int64_t offset;
+
+  std::string toString(bool recursive, bool detail) const override;
 };
 
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -15,9 +15,7 @@
  */
 
 #include "axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h"
-#include "velox/exec/tests/utils/DistributedPlanBuilder.h"
 #include "velox/exec/tests/utils/LocalRunnerTestBase.h"
-#include "velox/exec/tests/utils/QueryAssertions.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(
 
 add_executable(
   velox_plan_test
+  HiveLimitQueriesTest.cpp
   PlanMatcher.cpp
   PlanTest.cpp
   Tpch.cpp

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/ParquetTpchTest.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace facebook::velox::optimizer {
+namespace {
+
+class HiveLimitQueriesTest : public test::QueryTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::ParquetTpchTest::createTables();
+
+    LocalRunnerTestBase::testDataPath_ = FLAGS_data_path;
+    LocalRunnerTestBase::localFileFormat_ = "parquet";
+    LocalRunnerTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    LocalRunnerTestBase::TearDownTestCase();
+  }
+
+  RowTypePtr getSchema(const std::string& tableName) {
+    return connector::getConnector(exec::test::kHiveConnectorId)
+        ->metadata()
+        ->findTable("nation")
+        ->rowType();
+  }
+
+  void checkResults(
+      const lp::LogicalPlanNodePtr& logicalPlan,
+      const core::PlanNodePtr& referencePlan) {
+    VELOX_CHECK_NOT_NULL(logicalPlan);
+    VELOX_CHECK_NOT_NULL(referencePlan);
+
+    auto referenceResults = runVelox(referencePlan);
+
+    // Distributed.
+    {
+      auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+      checkResults(plan, referenceResults);
+    }
+
+    // Single node.
+    for (auto numDrivers : {1, 4}) {
+      SCOPED_TRACE(fmt::format("numWorkers: 1, numDrivers: {}", numDrivers));
+      auto plan =
+          planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = numDrivers});
+      checkResults(plan, referenceResults);
+    }
+  }
+
+  void checkResults(
+      const PlanAndStats& plan,
+      const test::TestResult& expected) {
+    auto results = runFragmentedPlan(plan);
+    exec::test::assertEqualResults(expected.results, results.results);
+  }
+
+  void checkSingleNodePlan(
+      const PlanAndStats& plan,
+      const std::shared_ptr<core::PlanMatcher>& matcher) {
+    SCOPED_TRACE(plan.plan->toString());
+
+    const auto& fragments = plan.plan->fragments();
+    ASSERT_EQ(1, fragments.size());
+
+    ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
+  }
+};
+
+// LIMIT 10
+TEST_F(HiveLimitQueriesTest, limit) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+  const auto nationType = getSchema("nation");
+
+  auto logicalPlan =
+      lp::PlanBuilder(context).tableScan("nation").limit(10).build();
+
+  auto referencePlan = exec::test::PlanBuilder()
+                           .tableScan("nation", nationType)
+                           .limit(0, 10, false)
+                           .planNode();
+  auto referenceResults = runVelox(referencePlan);
+
+  // Single driver.
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .finalLimit(0, 10)
+                       .build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Single node.
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 4");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .partialLimit(0, 10)
+                       .localPartition()
+                       .finalLimit(0, 10)
+                       .build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Distributed.
+  {
+    SCOPED_TRACE("numWorkers: 4, numDrivers: 4");
+    auto distributedPlan =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    const auto& fragments = distributedPlan.plan->fragments();
+    ASSERT_EQ(3, fragments.size());
+
+    EXPECT_EQ(fragments.at(0).scans.size(), 1);
+    EXPECT_EQ(fragments.at(1).scans.size(), 0);
+    EXPECT_EQ(fragments.at(2).scans.size(), 0);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .partialLimit(0, 10)
+                       .localPartition()
+                       .finalLimit(0, 10)
+                       .partitionedOutput()
+                       .build();
+    ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
+
+    matcher = core::PlanMatcherBuilder()
+                  .exchange()
+                  .finalLimit(0, 10)
+                  .partitionedOutput()
+                  .build();
+    ASSERT_TRUE(matcher->match(fragments.at(1).fragment.planNode));
+
+    checkResults(distributedPlan, referenceResults);
+  }
+}
+
+// OFFSET 5
+// LIMIT 10
+TEST_F(HiveLimitQueriesTest, offset) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+  const auto nationType = getSchema("nation");
+
+  auto logicalPlan =
+      lp::PlanBuilder(context).tableScan("nation").limit(5, 10).build();
+
+  auto referencePlan = exec::test::PlanBuilder()
+                           .tableScan("nation", nationType)
+                           .limit(5, 10, false)
+                           .planNode();
+  auto referenceResults = runVelox(referencePlan);
+
+  // Single driver.
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .finalLimit(5, 10)
+                       .build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Single node.
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 4");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .partialLimit(0, 15)
+                       .localPartition()
+                       .finalLimit(5, 10)
+                       .build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Distributed.
+  {
+    SCOPED_TRACE("numWorkers: 4, numDrivers: 4");
+    auto distributedPlan =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    const auto& fragments = distributedPlan.plan->fragments();
+    ASSERT_EQ(3, fragments.size());
+
+    EXPECT_EQ(fragments.at(0).scans.size(), 1);
+    EXPECT_EQ(fragments.at(1).scans.size(), 0);
+    EXPECT_EQ(fragments.at(2).scans.size(), 0);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project()
+                       .partialLimit(0, 15)
+                       .localPartition()
+                       .finalLimit(0, 15)
+                       .partitionedOutput()
+                       .build();
+    ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
+
+    matcher = core::PlanMatcherBuilder()
+                  .exchange()
+                  .finalLimit(5, 10)
+                  .partitionedOutput()
+                  .build();
+    ASSERT_TRUE(matcher->match(fragments.at(1).fragment.planNode));
+
+    checkResults(distributedPlan, referenceResults);
+  }
+}
+
+// ORDER BY name DESC
+// LIMIT 10
+TEST_F(HiveLimitQueriesTest, orderByLimit) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+  const auto nationType = getSchema("nation");
+
+  auto logicalPlan = lp::PlanBuilder(context)
+                         .tableScan("nation")
+                         .orderBy({"n_name desc"})
+                         .limit(10)
+                         .build();
+
+  auto referencePlan = exec::test::PlanBuilder()
+                           .tableScan("nation", nationType)
+                           .orderBy({"n_name desc"}, false)
+                           .limit(0, 10, false)
+                           .planNode();
+  auto referenceResults = runVelox(referencePlan);
+
+  // Single driver
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
+
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().topN(10).project().build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Single node.
+  {
+    SCOPED_TRACE("numWorkers: 1, numDrivers: 4");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .topN(10)
+                       .localMerge()
+                       .finalLimit(0, 10)
+                       .project()
+                       .build();
+
+    checkSingleNodePlan(plan, matcher);
+    checkResults(plan, referenceResults);
+  }
+
+  // Distributed.
+  {
+    SCOPED_TRACE("numWorkers: 4, numDrivers: 4");
+    auto distributedPlan =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    const auto& fragments = distributedPlan.plan->fragments();
+    ASSERT_EQ(3, fragments.size());
+
+    EXPECT_EQ(fragments.at(0).scans.size(), 1);
+    EXPECT_EQ(fragments.at(1).scans.size(), 0);
+    EXPECT_EQ(fragments.at(2).scans.size(), 0);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .topN(10)
+                       .localMerge()
+                       .partitionedOutput()
+                       .build();
+    ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
+
+    matcher = core::PlanMatcherBuilder()
+                  .mergeExchange()
+                  .finalLimit(0, 10)
+                  .project()
+                  .partitionedOutput()
+                  .build();
+    ASSERT_TRUE(matcher->match(fragments.at(1).fragment.planNode));
+
+    checkResults(distributedPlan, referenceResults);
+  }
+}
+
+// ORDER BY name DESC
+// OFFSET 5
+// LIMIT 10
+TEST_F(HiveLimitQueriesTest, orderByOffsetLimit) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+  const auto nationType = getSchema("nation");
+
+  auto plan = lp::PlanBuilder(context)
+                  .tableScan("nation")
+                  .orderBy({"n_name desc"})
+                  .limit(5, 10)
+                  .build();
+
+  auto reference = exec::test::PlanBuilder()
+                       .tableScan("nation", nationType)
+                       .orderBy({"n_name desc"}, false)
+                       .limit(5, 10, false)
+                       .planNode();
+
+  checkResults(plan, reference);
+}
+
+} // namespace
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/tests/ParquetTpchTest.h
+++ b/axiom/optimizer/tests/ParquetTpchTest.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <gtest/gtest.h>
-
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 DECLARE_string(data_path);
@@ -25,17 +23,22 @@ DECLARE_bool(create_dataset);
 
 namespace facebook::velox::optimizer::test {
 
-class ParquetTpchTest : public virtual testing::Test {
- protected:
-  static void SetUpTestCase();
-
-  static void TearDownTestCase();
+class ParquetTpchTest {
+ public:
+  /// Writes TPC-H tables in Parquet format to a temp directory. Use --data_path
+  /// GFlag to specify an alternative directory. That directory must exist.
+  ///
+  /// No-op if --data_path is specified, but --create_dataset is false.
+  ///
+  /// To create tables,
+  ///   - registers Hive and TPC-H connectors,
+  ///   - for each table, creates and runs Velox plan to read from TPC-H
+  ///   connector and
+  ///       write to Hive connector.
+  /// Unregisters Hive and TPC-H connectors before returning.
+  static void createTables();
 
  private:
-  static void saveTpchTablesAsParquet();
-
-  static std::string createPath_;
-  static std::string path_;
   static std::shared_ptr<exec::test::TempDirectoryPath> tempDirectory_;
 };
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -63,13 +63,23 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& localPartition(
       const std::shared_ptr<PlanMatcher>& matcher);
 
+  PlanMatcherBuilder& localMerge();
+
   PlanMatcherBuilder& partitionedOutput();
 
   PlanMatcherBuilder& exchange();
 
+  PlanMatcherBuilder& mergeExchange();
+
   PlanMatcherBuilder& limit();
 
-  PlanMatcherBuilder& limit(int64_t offset, int64_t count);
+  PlanMatcherBuilder& partialLimit(int64_t offset, int64_t count);
+
+  PlanMatcherBuilder& finalLimit(int64_t offset, int64_t count);
+
+  PlanMatcherBuilder& topN();
+
+  PlanMatcherBuilder& topN(int64_t count);
 
   std::shared_ptr<PlanMatcher> build() {
     return matcher_;

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -90,8 +90,7 @@ class PlanTest : public virtual test::ParquetTpchTest,
     auto fragmentedPlan = planVelox(planNode);
     ASSERT_TRUE(fragmentedPlan.plan != nullptr);
 
-    optimizer::test::TestResult referenceResult;
-    assertSame(referencePlan, fragmentedPlan, &referenceResult);
+    auto referenceResult = assertSame(referencePlan, fragmentedPlan);
 
     auto numWorkers = FLAGS_num_workers;
     if (numWorkers != 1) {

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -175,51 +175,6 @@ TEST_F(PlanTest, queryGraph) {
   EXPECT_EQ(interned2, interned);
 }
 
-TEST_F(PlanTest, limit) {
-  testConnector_->addTable(
-      "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
-
-  auto logicalPlan = lp::PlanBuilder()
-                         .tableScan(kTestConnectorId, "numbers", {"a", "b"})
-                         .limit(5, 10)
-                         .build();
-
-  // Verify single-node plan.
-  {
-    auto plan = toSingleNodePlan(logicalPlan);
-
-    auto matcher =
-        core::PlanMatcherBuilder().tableScan().project().limit(5, 10).build();
-    ASSERT_TRUE(matcher->match(plan));
-  }
-
-  // Verify distributed plan.
-  {
-    const auto distributedPlan = planVelox(logicalPlan);
-    const auto& fragments = distributedPlan.plan->fragments();
-    ASSERT_EQ(3, fragments.size());
-
-    EXPECT_EQ(fragments.at(0).scans.size(), 1);
-    EXPECT_EQ(fragments.at(1).scans.size(), 0);
-    EXPECT_EQ(fragments.at(2).scans.size(), 0);
-
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
-                       .project()
-                       .limit(5, 10)
-                       .partitionedOutput()
-                       .build();
-    ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
-
-    matcher = core::PlanMatcherBuilder()
-                  .exchange()
-                  .limit(5, 10)
-                  .partitionedOutput()
-                  .build();
-    ASSERT_TRUE(matcher->match(fragments.at(1).fragment.planNode));
-  }
-}
-
 TEST_F(PlanTest, agg) {
   testConnector_->addTable(
       "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));

--- a/axiom/optimizer/tests/QuerySqlParser.cpp
+++ b/axiom/optimizer/tests/QuerySqlParser.cpp
@@ -719,7 +719,7 @@ void QuerySqlParser::registerAggregateFunction(
       customAggregateFinalize);
 }
 
-lp::LogicalPlanNodePtr QuerySqlParser::parse(const std::string& sql) {
+SqlStatementPtr QuerySqlParser::parse(const std::string& sql) {
   // Disable the optimizer. Otherwise, the filter over table scan gets pushdown
   // as a callback that is impossible to recover.
   conn_.Query("PRAGMA disable_optimizer");
@@ -727,7 +727,15 @@ lp::LogicalPlanNodePtr QuerySqlParser::parse(const std::string& sql) {
   auto plan = conn_.ExtractPlan(sql);
 
   QueryContext queryContext{connectorId_};
-  return toPlanNode(*plan, pool_, queryContext);
+
+  if (plan->type == ::duckdb::LogicalOperatorType::LOGICAL_EXPLAIN) {
+    auto select = std::make_shared<SelectStatement>(
+        toPlanNode(*plan->children[0], pool_, queryContext));
+    return std::make_shared<ExplainStatement>(select);
+  }
+
+  return std::make_shared<SelectStatement>(
+      toPlanNode(*plan, pool_, queryContext));
 }
 
 } // namespace facebook::velox::optimizer::test

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -38,7 +38,7 @@ struct TestResult {
   /// Human readable Velox plan.
   std::string veloxString;
 
-  /// Human readable Verax  output.
+  /// Human readable Verax output.
   std::string planString;
 
   std::vector<exec::TaskStats> stats;
@@ -55,13 +55,13 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   TestResult runVelox(const logical_plan::LogicalPlanNodePtr& plan);
 
-  TestResult runFragmentedPlan(optimizer::PlanAndStats& plan);
+  TestResult runFragmentedPlan(const optimizer::PlanAndStats& plan);
 
   /// Checks that 'reference' and 'experiment' produce the same result.
-  void assertSame(
+  /// @return 'reference' result.
+  TestResult assertSame(
       const core::PlanNodePtr& reference,
-      optimizer::PlanAndStats& experiment,
-      TestResult* referenceReturn = nullptr);
+      const optimizer::PlanAndStats& experiment);
 
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
@@ -79,21 +79,11 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
   std::shared_ptr<optimizer::SchemaResolver> schema_;
 
  private:
-  core::PlanNodePtr toTableScan(
-      const std::string& id,
-      const std::string& name,
-      const RowTypePtr& rowType,
-      const std::vector<std::string>& columnNames);
-
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> optimizerPool_;
-  std::shared_ptr<memory::MemoryPool> schemaPool_;
-  std::shared_ptr<memory::MemoryPool> schemaRootPool_;
-  std::shared_ptr<core::QueryCtx> schemaQueryCtx_;
 
   // A QueryCtx created for each compiled query.
   std::shared_ptr<core::QueryCtx> queryCtx_;
-  std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::shared_ptr<connector::Connector> connector_;
   std::unique_ptr<velox::optimizer::VeloxHistory> history_;
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -53,7 +53,20 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
   /// Reads the data directory and picks up new tables.
   void tablesCreated();
 
+  optimizer::PlanAndStats planVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      std::string* planString = nullptr);
+
+  optimizer::PlanAndStats planVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      const runner::MultiFragmentPlan::Options& options,
+      std::string* planString = nullptr);
+
   TestResult runVelox(const logical_plan::LogicalPlanNodePtr& plan);
+
+  TestResult runVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      const runner::MultiFragmentPlan::Options& options);
 
   TestResult runFragmentedPlan(const optimizer::PlanAndStats& plan);
 
@@ -62,10 +75,6 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
   TestResult assertSame(
       const core::PlanNodePtr& reference,
       const optimizer::PlanAndStats& experiment);
-
-  optimizer::PlanAndStats planVelox(
-      const logical_plan::LogicalPlanNodePtr& plan,
-      std::string* planString = nullptr);
 
   std::shared_ptr<core::QueryCtx> getQueryCtx();
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -70,6 +70,8 @@ class QueryTestBase : public exec::test::LocalRunnerTestBase {
 
   TestResult runFragmentedPlan(const optimizer::PlanAndStats& plan);
 
+  TestResult runVelox(const core::PlanNodePtr& plan);
+
   /// Checks that 'reference' and 'experiment' produce the same result.
   /// @return 'reference' result.
   TestResult assertSame(

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -136,7 +136,11 @@ class TpchPlanTest : public virtual test::QueryTestBase {
     auto parser = makeQueryParser();
 
     auto sql = readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
-    auto logicalPlan = parser.parse(sql);
+    auto statement = parser.parse(sql);
+
+    ASSERT_TRUE(statement->isSelect());
+
+    auto logicalPlan = statement->asUnchecked<test::SelectStatement>()->plan();
 
     auto fragmentedPlan = planVelox(logicalPlan);
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -79,8 +79,7 @@ class TpchPlanTest : public virtual test::ParquetTpchTest,
     auto fragmentedPlan = planVelox(logicalPlan);
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
 
-    test::TestResult referenceResult;
-    assertSame(referencePlan, fragmentedPlan, &referenceResult);
+    auto referenceResult = assertSame(referencePlan, fragmentedPlan);
 
     const auto numWorkers = FLAGS_num_workers;
     if (numWorkers != 1) {
@@ -151,8 +150,7 @@ class TpchPlanTest : public virtual test::ParquetTpchTest,
     auto fragmentedPlan = planVelox(logicalPlan);
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
 
-    test::TestResult referenceResult;
-    assertSame(referencePlan, fragmentedPlan, &referenceResult);
+    auto referenceResult = assertSame(referencePlan, fragmentedPlan);
   }
 
   std::unique_ptr<HashStringAllocator> allocator_;

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -76,13 +76,9 @@ class TpchPlanTest : public virtual test::QueryTestBase {
 
     auto referenceResult = assertSame(referencePlan, fragmentedPlan);
 
-    const auto numWorkers = FLAGS_num_workers;
-    if (numWorkers != 1) {
-      gflags::FlagSaver saver;
-      FLAGS_num_workers = 1;
-
-      auto singlePlan = planVelox(logicalPlan);
-      ASSERT_TRUE(singlePlan.plan != nullptr);
+    if (FLAGS_num_workers != 1) {
+      auto singlePlan =
+          planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
       auto singleResult = runFragmentedPlan(singlePlan);
       exec::test::assertEqualResults(
           referenceResult.results, singleResult.results);

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -35,15 +35,13 @@ namespace lp = facebook::velox::logical_plan;
 namespace facebook::velox::optimizer {
 namespace {
 
-class TpchPlanTest : public virtual test::ParquetTpchTest,
-                     public virtual test::QueryTestBase {
+class TpchPlanTest : public virtual test::QueryTestBase {
  protected:
   static void SetUpTestCase() {
-    ParquetTpchTest::SetUpTestCase();
+    test::ParquetTpchTest::createTables();
+
     LocalRunnerTestBase::testDataPath_ = FLAGS_data_path;
     LocalRunnerTestBase::localFileFormat_ = "parquet";
-    connector::unregisterConnector(exec::test::kHiveConnectorId);
-    connector::unregisterConnectorFactory("hive");
     LocalRunnerTestBase::SetUpTestCase();
   }
 
@@ -52,11 +50,9 @@ class TpchPlanTest : public virtual test::ParquetTpchTest,
       suiteHistory().saveToFile(FLAGS_history_save_path);
     }
     LocalRunnerTestBase::TearDownTestCase();
-    ParquetTpchTest::TearDownTestCase();
   }
 
   void SetUp() override {
-    ParquetTpchTest::SetUp();
     QueryTestBase::SetUp();
     allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
     context_ = std::make_unique<QueryGraphContext>(*allocator_);
@@ -71,7 +67,6 @@ class TpchPlanTest : public virtual test::ParquetTpchTest,
     context_.reset();
     queryCtx() = nullptr;
     allocator_.reset();
-    ParquetTpchTest::TearDown();
     QueryTestBase::TearDown();
   }
 

--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/parse/TypeResolver.h"
 
 #include "axiom/logical_plan/PlanPrinter.h"
 #include "axiom/optimizer/Plan.h"
@@ -54,9 +55,13 @@ DEFINE_string(
     "",
     "Root path of data. Data layout must follow Hive-style partitioning. ");
 
+// Defined in velox/benchmarks/QueryBenchmarkBase.cpp
 DECLARE_string(ssd_path);
 DECLARE_int32(ssd_cache_gb);
 DECLARE_int32(ssd_checkpoint_interval_gb);
+DECLARE_int32(cache_gb);
+
+DEFINE_bool(use_mmap, false, "Use mmap for buffers and cache");
 
 DEFINE_int32(optimizer_trace, 0, "Optimizer trace level");
 
@@ -68,19 +73,22 @@ DEFINE_bool(print_short_plan, false, "Print one line plan from optimizer.");
 
 DEFINE_bool(print_velox_plan, false, "Print executable Velox plan");
 
-DEFINE_bool(print_stats, false, "print statistics");
+DEFINE_bool(
+    print_stats,
+    false,
+    "Print executable Velox plan annotated with runtime statistics");
+
+// Defined in velox/benchmarks/QueryBenchmarkBase.cpp
 DECLARE_bool(include_custom_stats);
 
 DEFINE_int32(max_rows, 100, "Max number of printed result rows");
 
 DEFINE_int32(num_workers, 4, "Number of in-process workers");
 
+// Defined in velox/benchmarks/QueryBenchmarkBase.cpp
 DECLARE_int32(num_drivers);
+
 DEFINE_int64(split_target_bytes, 16 << 20, "Approx bytes covered by one split");
-
-DECLARE_int32(cache_gb);
-
-DEFINE_bool(use_mmap, false, "Use mmap for buffers and cache");
 
 DEFINE_string(
     query,
@@ -266,25 +274,45 @@ class VeloxRunner : public QueryBenchmarkBase {
     return results;
   }
 
-  /// stores results and plans to 'ref', to be used with --check.
+  // Stores results and plans to 'ref', to be used with --check.
   void setRecordStream(std::ofstream* ref) {
     record_ = ref;
   }
 
-  /// Compares results to data in 'ref'. 'ref' is produced with --record.
+  // Compares results to data in 'ref'. 'ref' is produced with --record.
   void setCheckStream(std::ifstream* ref) {
     check_ = ref;
   }
 
   void run(const std::string& sql) {
+    optimizer::test::SqlStatementPtr sqlStatement;
+    try {
+      sqlStatement = parser_->parse(sql);
+    } catch (std::exception& e) {
+      std::cerr << "Failed to parse SQL: " << e.what() << std::endl;
+      return;
+    }
+
+    if (sqlStatement->isExplain()) {
+      runExplain(
+          *sqlStatement->asUnchecked<optimizer::test::ExplainStatement>());
+      return;
+    }
+
+    CHECK(sqlStatement->isSelect());
+
+    const auto logicalPlan =
+        sqlStatement->asUnchecked<optimizer::test::SelectStatement>()->plan();
+
     if (record_ || check_) {
       std::string error;
       std::string plan;
       std::vector<RowVectorPtr> result;
-      runSql(sql, nullptr, nullptr, &error);
+      runSql(logicalPlan, nullptr, nullptr, &error);
       if (error.empty()) {
-        runSql(sql, &result, &plan, &error);
+        runSql(logicalPlan, &result, &plan, &error);
       }
+
       if (record_) {
         if (!error.empty()) {
           writeString(error, *record_);
@@ -334,7 +362,7 @@ class VeloxRunner : public QueryBenchmarkBase {
       }
     } else {
       if (!FLAGS_test_flags_file.empty()) {
-        sql_ = sql;
+        logicalPlan_ = logicalPlan;
         try {
           parameters_.clear();
           runStats_.clear();
@@ -349,7 +377,7 @@ class VeloxRunner : public QueryBenchmarkBase {
         referenceResult_.clear();
         referenceRunner_.reset();
       } else {
-        runSql(sql);
+        runSql(logicalPlan);
       }
     }
   }
@@ -384,19 +412,10 @@ class VeloxRunner : public QueryBenchmarkBase {
     return fmt::format("predicted={} actual={} ", predicted, actual);
   }
 
-  /// Runs a query and returns the result as a single vector in *resultVector,
-  /// the plan text in *planString and the error message in *errorString.
-  /// *errorString is not set if no error. Any of these may be nullptr.
-  std::shared_ptr<runner::LocalRunner> runSql(
-      const std::string& sql,
-      std::vector<RowVectorPtr>* resultVector = nullptr,
-      std::string* planString = nullptr,
-      std::string* errorString = nullptr,
-      std::vector<exec::TaskStats>* statsReturn = nullptr,
-      RunStats* runStatsReturn = nullptr) {
+  std::shared_ptr<core::QueryCtx> newQuery() {
     ++queryCounter_;
 
-    auto queryCtx = core::QueryCtx::create(
+    return core::QueryCtx::create(
         executor_.get(),
         core::QueryConfig(config_),
         {},
@@ -404,21 +423,28 @@ class VeloxRunner : public QueryBenchmarkBase {
         rootPool_->shared_from_this(),
         spillExecutor_.get(),
         fmt::format("query_{}", queryCounter_));
+  }
 
-    logical_plan::LogicalPlanNodePtr plan;
-    try {
-      plan = parser_->parse(sql);
-    } catch (std::exception& e) {
-      std::cerr << "parse error: " << e.what() << std::endl;
-      if (errorString) {
-        *errorString = fmt::format("Parse error: {}", e.what());
-      }
-      return nullptr;
-    }
+  void runExplain(const optimizer::test::ExplainStatement& statement) {
+    CHECK(statement.statement()->isSelect());
 
+    auto plan = optimize(
+        statement.statement()
+            ->asUnchecked<optimizer::test::SelectStatement>()
+            ->plan(),
+        newQuery());
+
+    std::cout << plan.plan->toString() << std::endl;
+  }
+
+  optimizer::PlanAndStats optimize(
+      const logical_plan::LogicalPlanNodePtr& logicalPlan,
+      const std::shared_ptr<core::QueryCtx>& queryCtx,
+      const std::function<void(const optimizer::Plan&)>& peakAtBestPlan =
+          nullptr) {
     if (FLAGS_print_logical_plan) {
       std::cout << "Logical plan: " << std::endl
-                << logical_plan::PlanPrinter::toText(*plan) << std::endl;
+                << logical_plan::PlanPrinter::toText(*logicalPlan) << std::endl;
     }
 
     runner::MultiFragmentPlan::Options opts;
@@ -433,47 +459,71 @@ class VeloxRunner : public QueryBenchmarkBase {
       optimizer::queryCtx() = nullptr;
     };
 
+    // The default Locus for planning is the system and data of
+    // 'connector_'.
+    optimizer::Locus locus(connector_->connectorId().c_str(), connector_.get());
+    optimizer::Schema veraxSchema("test", schema_.get(), &locus);
+    exec::SimpleExpressionEvaluator evaluator(
+        queryCtx.get(), optimizerPool_.get());
+
+    optimizer::Optimization optimization(
+        *logicalPlan,
+        veraxSchema,
+        *history_,
+        queryCtx,
+        evaluator,
+        {.traceFlags = FLAGS_optimizer_trace},
+        opts);
+
+    auto best = optimization.bestPlan();
+
+    if (peakAtBestPlan) {
+      peakAtBestPlan(*best);
+    }
+
+    if (FLAGS_print_short_plan) {
+      std::cout << "Physical plan (oneline): " << best->toString(false)
+                << std::endl;
+    }
+
+    if (FLAGS_print_plan) {
+      std::cout << "Physical plan: " << std::endl
+                << best->toString(true) << std::endl;
+    }
+
+    return optimization.toVeloxPlan(best->op, opts);
+  }
+
+  /// Runs a query and returns the result as a single vector in *resultVector,
+  /// the plan text in *planString and the error message in *errorString.
+  /// *errorString is not set if no error. Any of these may be nullptr.
+  std::shared_ptr<runner::LocalRunner> runSql(
+      const logical_plan::LogicalPlanNodePtr& logicalPlan,
+      std::vector<RowVectorPtr>* resultVector = nullptr,
+      std::string* planString = nullptr,
+      std::string* errorString = nullptr,
+      std::vector<exec::TaskStats>* statsReturn = nullptr,
+      RunStats* runStatsReturn = nullptr) {
+    auto queryCtx = newQuery();
+
     optimizer::PlanAndStats planAndStats;
     try {
-      // The default Locus for planning is the system and data of 'connector_'.
-      optimizer::Locus locus(
-          connector_->connectorId().c_str(), connector_.get());
-      optimizer::Schema veraxSchema("test", schema_.get(), &locus);
-      exec::SimpleExpressionEvaluator evaluator(
-          queryCtx.get(), optimizerPool_.get());
-      optimizer::OptimizerOptions optimizerOpts = {
-          .traceFlags = FLAGS_optimizer_trace};
-      optimizer::Optimization opt(
-          *plan,
-          veraxSchema,
-          *history_,
-          queryCtx,
-          evaluator,
-          optimizerOpts,
-          opts);
-      auto best = opt.bestPlan();
-      if (planString) {
-        *planString = best->op->toString(true, false);
-      }
-      if (FLAGS_print_short_plan) {
-        std::cout << "Plan: " << best->toString(false);
-      }
-      if (FLAGS_print_plan) {
-        std::cout << "Plan: " << best->toString(true);
-      }
-
-      planAndStats = opt.toVeloxPlan(best->op, opts);
-
-      if (FLAGS_print_velox_plan) {
-        std::cout << "Velox executable plan: " << std::endl
-                  << planAndStats.plan->toString() << std::endl;
-      }
+      planAndStats = optimize(logicalPlan, queryCtx, [&](const auto& best) {
+        if (planString) {
+          *planString = best.op->toString(true, false);
+        }
+      });
     } catch (const std::exception& e) {
-      std::cerr << "optimizer error: " << e.what() << std::endl;
+      std::cerr << "Failed to optimize: " << e.what() << std::endl;
       if (errorString) {
-        *errorString = fmt::format("optimizer error: {}", e.what());
+        *errorString = fmt::format("Failed to optimize: {}", e.what());
       }
       return nullptr;
+    }
+
+    if (FLAGS_print_velox_plan) {
+      std::cout << "Velox executable plan: " << std::endl
+                << planAndStats.plan->toString() << std::endl;
     }
 
     RunStats runStats;
@@ -540,7 +590,8 @@ class VeloxRunner : public QueryBenchmarkBase {
 
   void runMain(std::ostream& out, RunStats& runStats) override {
     std::vector<RowVectorPtr> result;
-    auto runner = runSql(sql_, &result, nullptr, nullptr, nullptr, &runStats);
+    auto runner =
+        runSql(logicalPlan_, &result, nullptr, nullptr, nullptr, &runStats);
     if (FLAGS_check_test_flag_combinations) {
       if (hasReferenceResult_) {
         exec::test::assertEqualResults(referenceResult_, result);
@@ -565,8 +616,8 @@ class VeloxRunner : public QueryBenchmarkBase {
     }
   }
 
-  /// Returns exit status for run. 0 is passed, 1 is plan differences only, 2 is
-  /// result differences.
+  /// Returns exit status for run. 0 is passed, 1 is plan differences only, 2
+  /// is result differences.
   int32_t checkStatus() {
     std::cerr << numPassed_ << " passed " << numFailed_ << " failed "
               << numPlanMismatch_ << " plan mismatch " << numResultMismatch_
@@ -689,7 +740,7 @@ class VeloxRunner : public QueryBenchmarkBase {
   int32_t numPlanMismatch_{0};
   int32_t numResultMismatch_{0};
   int32_t queryCounter_{0};
-  std::string sql_;
+  logical_plan::LogicalPlanNodePtr logicalPlan_;
   bool hasReferenceResult_{false};
   // Keeps live 'referenceResult_'.
   std::shared_ptr<runner::LocalRunner> referenceRunner_;
@@ -743,7 +794,7 @@ void readCommands(
         std::cout << message;
         runner.modifiedFlags().insert(std::string(flag));
       } else {
-        std::cout << "No flag " << flag;
+        std::cout << "No flag " << flag << std::endl;
       }
       free(flag);
       free(value);


### PR DESCRIPTION
Summary:
EXPLAIN <query> command prints executable (Velox) plan.

EXPLAIN command supports print-logical-plan, print-short-plan and print-plan flags to print additional plans.

```
$ buck run axiom/optimizer/tests:velox_sql -- --data_path /tmp/tpch

SQL> explain select * from nation offset 5 limit 3;
Fragment 0: stage2 numWorkers=4:
-- PartitionedOutput[5][SINGLE Presto] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
  -- Limit[4][8] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
    -- LocalPartition[3][GATHER] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
      -- Limit[2][PARTIAL 8] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
        -- Project[1][expressions: (dt1._p:BIGINT, "t2.n_nationkey"), (dt1._p0:VARCHAR, "t2.n_name"), (dt1._p1:BIGINT, "t2.n_regionkey"), (dt1._p2:VARCHAR, "t2.n_comment")] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
          -- TableScan[0][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> "t2.n_nationkey":BIGINT, "t2.n_name":VARCHAR, "t2.n_regionkey":BIGINT, "t2.n_comment":VARCHAR

Fragment 1: stage1 numWorkers=1:
-- PartitionedOutput[8][SINGLE Presto] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
  -- Limit[7][3 offset 5] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
    -- Exchange[6][Presto] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR

Inputs:  6 <- stage2
Fragment 2:  numWorkers=1:
-- Exchange[9][Presto] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR

Inputs:  9 <- stage1

SQL> flag num-workers = 1;
num_workers set to 1

SQL> explain select * from nation offset 5 limit 3;
Fragment 0:  numWorkers=0:
-- Limit[4][3 offset 5] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
  -- LocalPartition[3][GATHER] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
    -- Limit[2][PARTIAL 8] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
      -- Project[1][expressions: (dt1._p:BIGINT, "t2.n_nationkey"), (dt1._p0:VARCHAR, "t2.n_name"), (dt1._p1:BIGINT, "t2.n_regionkey"), (dt1._p2:VARCHAR, "t2.n_comment")] -> "dt1._p":BIGINT, "dt1._p0":VARCHAR, "dt1._p1":BIGINT, "dt1._p2":VARCHAR
        -- TableScan[0][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> "t2.n_nationkey":BIGINT, "t2.n_name":VARCHAR, "t2.n_regionkey":BIGINT, "t2.n_comment":VARCHAR
```

Also,
- Implement toString for OrderBy and Limit. Remove default implementation of toString from to avoid forgetting to implement toString when adding new relations.

Differential Revision: D79993143


