### PR TITLE
Remove unused exception parameter from axiom/optimizer/tests/VeloxSql.cpp

### DIFF
--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -343,7 +343,7 @@ class VeloxRunner : public QueryBenchmarkBase {
           for (auto& dim : parameters_) {
             modifiedFlags_.insert(dim.flag);
           }
-        } catch (const std::exception& e) {
+        } catch (const std::exception&) {
         }
         hasReferenceResult_ = false;
         referenceResult_.clear();


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968939


