### PR TITLE
Remove unused exception parameter from avatar/platform/service/ServiceWarmupManager.cpp

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -132,7 +132,7 @@ void filterUpdated(BaseTableCP table, bool updateSelectivity) {
         continue;
       }
       pushdownConjuncts.push_back(typedExpr);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       remainingConjuncts.push_back(std::move(typedExpr));
     }
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968918


