### PR TITLE
Fix bug in expression canonicalization

### DIFF
--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -480,13 +480,13 @@ TEST_F(PlanTest, unionAll) {
     auto matcher =
         core::PlanMatcherBuilder()
             .hiveScan(
-                "nation", lte("n_nationkey", 10), "1 = (n_regionkey + 1) % 3")
+                "nation", lte("n_nationkey", 10), "(n_regionkey + 1) % 3 = 1")
             .project()
             .localPartition(core::PlanMatcherBuilder()
                                 .hiveScan(
                                     "nation",
                                     gte("n_nationkey", 14),
-                                    "1 = (n_regionkey + 1) % 3")
+                                    "(n_regionkey + 1) % 3 = 1")
                                 .project()
                                 .build())
             .project()
@@ -660,7 +660,7 @@ TEST_F(PlanTest, intersect) {
                                        .hiveScan(
                                            "nation",
                                            lte("n_nationkey", 20),
-                                           "1 = (n_regionkey + 1) % 3")
+                                           "(n_regionkey + 1) % 3 = 1")
                                        .project()
                                        .build(),
                                    core::JoinType::kRightSemiFilter)
@@ -722,7 +722,7 @@ TEST_F(PlanTest, except) {
     auto matcher =
         core::PlanMatcherBuilder()
             .hiveScan(
-                "nation", lte("n_nationkey", 20), "1 = (n_regionkey + 1) % 3")
+                "nation", lte("n_nationkey", 20), "(n_regionkey + 1) % 3 = 1")
             .project()
             .hashJoin(
                 core::PlanMatcherBuilder()


### PR DESCRIPTION
Summary:
Fixing a canonicalization bug found when integrating to PySpark. The
wrong condition would invert expressions based on the node ids only, at times
leaving expressions in non-canonicalized order (literal to the left, column
reference to the right). The wrong order would prevent these filters to be
pushed down.

Differential Revision: D80025735


