### PR TITLE
Do not use OrderBy (RelationOp) in DerivedTable

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -524,7 +524,7 @@ void DerivedTable::importJoinsIntoFirstDt(const DerivedTable* firstDt) {
     return;
   }
   auto initialTables = tables;
-  if (firstDt->limit != -1 || firstDt->orderBy) {
+  if (firstDt->hasLimit() || firstDt->hasOrderBy()) {
     // tables can't be imported but are marked as used so not tried again.
     for (auto i = 1; i < tables.size(); ++i) {
       importedExistences.add(tables[i]);

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -30,8 +30,8 @@ using JoinEdgeVector = std::vector<JoinEdgeP, QGAllocator<JoinEdgeP>>;
 struct AggregationPlan;
 using AggregationPlanCP = const AggregationPlan*;
 
-struct OrderBy;
-using OrderByP = OrderBy*;
+enum class OrderType;
+using OrderTypeVector = std::vector<OrderType, QGAllocator<OrderType>>;
 
 /// Represents a derived table, i.e. a SELECT in a FROM clause. This is the
 /// basic unit of planning. Derived tables can be merged and split apart from
@@ -114,7 +114,12 @@ struct DerivedTable : public PlanObject {
   /// Postprocessing clauses, group by, having, order by, limit, offset.
   AggregationPlanCP aggregation{nullptr};
   ExprVector having;
-  OrderByP orderBy{nullptr};
+
+  /// Order by.
+  ExprVector orderByKeys;
+  OrderTypeVector orderByTypes;
+
+  /// Limit and offset.
   int64_t limit{-1};
   int64_t offset{0};
 
@@ -170,6 +175,14 @@ struct DerivedTable : public PlanObject {
   /// inside the current dt when planning.
   bool hasJoin(JoinEdgeP join) const {
     return std::find(joins.begin(), joins.end(), join) != joins.end();
+  }
+
+  bool hasOrderBy() const {
+    return !orderByKeys.empty();
+  }
+
+  bool hasLimit() const {
+    return limit >= 0;
   }
 
   /// Fills in 'startTables_' to 'tables_' that are not to the right of

--- a/axiom/optimizer/LogicalPlanToGraph.cpp
+++ b/axiom/optimizer/LogicalPlanToGraph.cpp
@@ -864,7 +864,9 @@ PlanObjectP Optimization::addOrderBy(const lp::SortNode& order) {
     keys.push_back(translateExpr(field.expression));
   }
 
-  currentSelect_->orderBy = make<OrderBy>(nullptr, keys, orderType);
+  currentSelect_->orderByKeys = keys;
+  currentSelect_->orderByTypes = orderType;
+
   return currentSelect_;
 }
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -177,7 +177,7 @@ using PlanPtr = Plan*;
 
 /// A set of build sides. a candidate plan tracks all builds so that they can be
 /// reused
-using BuildSet = std::vector<HashBuildPtr>;
+using HashBuildVector = std::vector<HashBuildCP>;
 
 /// Item produced by optimization and kept in memo. Corresponds to
 /// pre-costed physical plan with costs and data properties.
@@ -211,7 +211,7 @@ struct Plan {
   PlanObjectSet input;
 
   // hash join builds placed in the plan. Allows reusing a build.
-  BuildSet builds;
+  HashBuildVector builds;
 
   // the tables/derived tables that are contained in this plan and need not be
   // addressed by enclosing plans. This is all the tables in a build side join
@@ -306,7 +306,7 @@ struct NextJoin {
       const Cost& cost,
       const PlanObjectSet& placed,
       const PlanObjectSet& columns,
-      const BuildSet& builds)
+      const HashBuildVector& builds)
       : candidate(candidate),
         plan(plan),
         cost(cost),
@@ -319,7 +319,7 @@ struct NextJoin {
   Cost cost;
   PlanObjectSet placed;
   PlanObjectSet columns;
-  BuildSet newBuilds;
+  HashBuildVector newBuilds;
 
   /// If true, only 'other' should be tried. Use to compare equivalent joins
   /// with different join method or partitioning.
@@ -361,7 +361,7 @@ struct PlanState {
 
   // All the hash join builds in any branch of the partial plan constructed so
   // far.
-  BuildSet builds;
+  HashBuildVector builds;
 
   // True if we should backtrack when 'costs' exceeds the best cost with shuffle
   // from already generated plans.
@@ -384,7 +384,7 @@ struct PlanState {
   void addCost(RelationOp& op);
 
   /// Adds 'added' to all hash join builds.
-  void addBuilds(const BuildSet& added);
+  void addBuilds(const HashBuildVector& added);
 
   // Specifies that the plan to make only references 'target' columns and
   // whatever these depend on. These refer to 'columns' of 'dt'.
@@ -399,7 +399,7 @@ struct PlanState {
   void addNextJoin(
       const JoinCandidate* candidate,
       RelationOpPtr plan,
-      BuildSet builds,
+      HashBuildVector builds,
       std::vector<NextJoin>& toTry) const;
 
   std::string printCost() const;
@@ -1001,7 +1001,7 @@ class Optimization {
   void translateNonEqualityJoin(const velox::core::NestedLoopJoinNode& join);
 
   // Adds order by information to the enclosing DerivedTable.
-  OrderByP translateOrderBy(const velox::core::OrderByNode& order);
+  OrderByCP translateOrderBy(const velox::core::OrderByNode& order);
 
   // Adds aggregation information to the enclosing DerivedTable.
   AggregationP translateAggregation(

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -302,7 +302,7 @@ class Repartition : public RelationOp {
   std::string toString(bool recursive, bool detail) const override;
 };
 
-using RepartitionPtr = const Repartition*;
+using RepartitionCP = const Repartition*;
 
 /// Represents a usually multitable filter not associated with any non-inner
 /// join. Non-equality constraints over inner joins become Filters.
@@ -402,7 +402,7 @@ struct Join : public RelationOp {
   std::string toString(bool recursive, bool detail) const override;
 };
 
-using JoinPtr = Join*;
+using JoinCP = const Join*;
 
 /// Occurs as right input of JoinOp with type kHash. Contains the
 /// cost and memory specific to building the table. Can be
@@ -430,7 +430,7 @@ struct HashBuild : public RelationOp {
   std::string toString(bool recursive, bool detail) const override;
 };
 
-using HashBuildPtr = HashBuild*;
+using HashBuildCP = const HashBuild*;
 
 /// Represents aggregation with or without grouping.
 struct Aggregation : public RelationOp {
@@ -472,30 +472,16 @@ struct Aggregation : public RelationOp {
 
 /// Represents an order by. The order is given by the distribution.
 struct OrderBy : public RelationOp {
-  OrderBy(
-      RelationOpPtr input,
-      ExprVector keys,
-      OrderTypeVector orderType,
-      PlanObjectSet dependentKeys = {})
+  OrderBy(RelationOpPtr input, ExprVector keys, OrderTypeVector orderType)
       : RelationOp(
             RelType::kOrderBy,
             input,
-            input ? input->distribution().copyWithOrder(keys, orderType)
-                  : Distribution(
-                        DistributionType(),
-                        1,
-                        {},
-                        std::move(keys),
-                        std::move(orderType))),
-        dependentKeys(std::move(dependentKeys)) {}
-
-  // Keys where the key expression is functionally dependent on
-  // another key or keys. These can be late materialized or converted
-  // to payload.
-  PlanObjectSet dependentKeys;
+            input->distribution().copyWithOrder(keys, orderType)) {}
 
   std::string toString(bool recursive, bool detail) const override;
 };
+
+using OrderByCP = const OrderBy*;
 
 /// Represents a union all.
 struct UnionAll : public RelationOp {
@@ -515,6 +501,8 @@ struct UnionAll : public RelationOp {
 
   const RelationOpPtrVector inputs;
 };
+
+using UnionAllCP = const UnionAll*;
 
 struct Limit : public RelationOp {
   Limit(RelationOpPtr input, int64_t limit, int64_t offset)
@@ -538,5 +526,7 @@ struct Limit : public RelationOp {
 
   std::string toString(bool recursive, bool detail) const override;
 };
+
+using LimitCP = const Limit*;
 
 } // namespace facebook::velox::optimizer


### PR DESCRIPTION
Summary:
Do not mix physical and logical plan nodes.

Next step is to remove AggregationPlan from DerivedTable.

Differential Revision: D80043274


