### PR TITLE
fix: Push-down limit physical node

### DIFF
--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -832,15 +832,14 @@ void Optimization::addPostprocess(
         dt->orderBy->distribution().orderType);
     state.addCost(*orderBy);
     plan = orderBy;
+  } else if (dt->limit >= 0) {
+    auto limit = make<Limit>(plan, dt->limit, dt->offset);
+    state.addCost(*limit);
+    plan = limit;
   }
   if (!dt->columns.empty()) {
     auto* project = make<Project>(plan, dt->exprs, dt->columns);
     plan = project;
-  }
-  if (dt->orderBy == nullptr && dt->limit >= 0) {
-    auto limit = make<Limit>(plan, dt->limit, dt->offset);
-    state.addCost(*limit);
-    plan = limit;
   }
 }
 


### PR DESCRIPTION
If I understand right PR approach is better for common case (reasonable and small limit value) and it can be worse for some edge cases.
So can we merge it this way?
And create issue about we need some cost based choice about push down projection/ limit.

Also this PR makes behavior of `limit` more similar to `order by + limit`