### PR TITLE
Fold RelationOp::setCost into ctor

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -17,44 +17,9 @@
 #include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/JsonUtil.h"
-#include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
 
 namespace facebook::velox::optimizer {
-
-// Collection of per operation costs for a target system.  The base
-// unit is the time to memcpy a cache line in a large memcpy on one
-// core. This is ~6GB/s, so ~10ns. Other times are expressed as
-// multiples of that.
-struct Costs {
-  static float byteShuffleCost() {
-    return 12; // ~500MB/s
-  }
-
-  static float hashProbeCost(float cardinality) {
-    return cardinality < 10000 ? kArrayProbeCost
-        : cardinality < 500000 ? kSmallHashCost
-                               : kLargeHashCost;
-  }
-
-  static constexpr float kKeyCompareCost =
-      6; // ~30 instructions to find, decode and an compare
-  static constexpr float kArrayProbeCost = 2; // ~10 instructions.
-  static constexpr float kSmallHashCost = 10; // 50 instructions
-  static constexpr float kLargeHashCost = 40; // 2 LLC misses
-  static constexpr float kColumnRowCost = 5;
-  static constexpr float kColumnByteCost = 0.1;
-
-  // Cost of hash function on one column.
-  static constexpr float kHashColumnCost = 0.5;
-
-  // Cost of getting a column from a hash table
-  static constexpr float kHashExtractColumnCost = 0.5;
-
-  // Minimal cost of calling a filter function, e.g. comparing two numeric
-  // exprss.
-  static constexpr float kMinimumFilterCost = 2;
-};
 
 void History::saveToFile(const std::string& path) {
   auto json = serialize();
@@ -70,167 +35,12 @@ void History::updateFromFile(const std::string& path) {
   }
 }
 
-void RelationOp::setCost(const PlanState& state) {
-  cost_.inputCardinality = state.cost.fanout;
-}
-
-float ColumnGroup::lookupCost(float range) const {
-  // Add 2 because it takes a compare and access also if hitting the
-  // same row. log(1) == 0, so this would other wise be zero cost.
-  return Costs::kKeyCompareCost * log(range + 2) / log(2);
-}
-
-float orderPrefixDistance(
-    RelationOpPtr input,
-    ColumnGroupP index,
-    const ExprVector& keys) {
-  int32_t i = 0;
-  float selection = 1;
-  for (; i < input->distribution().order.size() &&
-       i < index->distribution().order.size() && i < keys.size();
-       ++i) {
-    if (input->distribution().order[i]->sameOrEqual(*keys[i])) {
-      selection *= index->distribution().order[i]->value().cardinality;
-    }
-  }
-  return selection;
-}
-
-namespace {
-
-// For leaf nodes, the fanout represents the cardinality, and the unitCost is
-// the total cost.
-// For non-leaf nodes, the fanout represents the change in cardinality (output
-// cardinality / input cardinality), and the unitCost is the per-row cost.
-void updateLeafCost(
-    float cardinality,
-    const ColumnVector& columns,
-    Cost& cost) {
-  cost.fanout = cardinality;
-  const auto size = byteSize(columns);
-  const auto numColumns = columns.size();
-  const auto rowCost = numColumns * Costs::kColumnRowCost +
-      std::max<float>(0, size - 8 * numColumns) * Costs::kColumnByteCost;
-  cost.unitCost += cost.fanout * rowCost;
-}
-
-} // namespace
-
-void TableScan::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  if (!keys.empty()) {
-    float lookupRange(index->distribution().cardinality);
-    float orderSelectivity = orderPrefixDistance(this->input(), index, keys);
-    auto distance = lookupRange / std::max<float>(1, orderSelectivity);
-    float batchSize = std::min<float>(cost_.inputCardinality, 10000);
-    if (orderSelectivity == 1) {
-      // The data does not come in key order.
-      float batchCost = index->lookupCost(lookupRange) +
-          index->lookupCost(lookupRange / batchSize) *
-              std::max<float>(1, batchSize);
-      cost_.unitCost = batchCost / batchSize;
-    } else {
-      float batchCost = index->lookupCost(lookupRange) +
-          index->lookupCost(distance) * std::max<float>(1, batchSize);
-      cost_.unitCost = batchCost / batchSize;
-    }
-    return;
-  }
-  const auto cardinality =
-      index->distribution().cardinality * baseTable->filterSelectivity;
-  updateLeafCost(cardinality, columns_, cost_);
-}
-
-void Values::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  const auto cardinality = valuesTable.cardinality();
-  updateLeafCost(cardinality, columns_, cost_);
-}
-
-void Aggregation::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  float cardinality = 1;
-  for (auto key : groupingKeys) {
-    cardinality *= key->value().cardinality;
-  }
-  // The estimated output is input minus the times an input is a
-  // duplicate of a key already in the input. The cardinality of the
-  // result is (d - d * 1 - (1 / d))^n. where d is the number of
-  // potentially distinct keys and n is the number of elements in the
-  // input. This approaches d as n goes to infinity. The chance of one in d
-  // being unique after n values is 1 - (1/d)^n.
-  auto nOut = cardinality -
-      cardinality * pow(1.0 - (1.0 / cardinality), cost_.inputCardinality);
-  cost_.fanout = nOut / cost_.inputCardinality;
-  cost_.unitCost = groupingKeys.size() * Costs::hashProbeCost(nOut);
-  float rowBytes = byteSize(groupingKeys) + byteSize(aggregates);
-  cost_.totalBytes = nOut * rowBytes;
-}
-
-template <typename V>
-std::pair<float, float> shuffleCostV(const V& columns) {
-  float size = byteSize(columns);
-  return {size * Costs::byteShuffleCost(), size};
-}
-
 float shuffleCost(const ColumnVector& columns) {
-  return shuffleCostV(columns).second;
+  return byteSize(columns);
 }
 
 float shuffleCost(const ExprVector& columns) {
-  return shuffleCostV(columns).second;
-}
-
-void Repartition::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  auto pair = shuffleCostV(columns_);
-  cost_.unitCost = pair.second;
-  cost_.transferBytes = cost_.inputCardinality * pair.first;
-}
-
-void HashBuild::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  cost_.unitCost = keys.size() * Costs::kHashColumnCost +
-      Costs::hashProbeCost(cost_.inputCardinality) +
-      this->input()->columns().size() * Costs::kHashExtractColumnCost * 2;
-  cost_.totalBytes =
-      cost_.inputCardinality * byteSize(this->input()->columns());
-}
-
-void Join::setCost(const PlanState& input) {
-  RelationOp::setCost(input);
-  float buildSize = right->cost().inputCardinality;
-  auto rowCost =
-      right->input()->columns().size() * Costs::kHashExtractColumnCost;
-  cost_.unitCost = Costs::hashProbeCost(buildSize) + cost_.fanout * rowCost +
-      leftKeys.size() * Costs::kHashColumnCost;
-}
-
-void Filter::setCost(const PlanState& /*input*/) {
-  cost_.unitCost = Costs::kMinimumFilterCost * exprs_.size();
-  // We assume each filter selects 4/5. Small effect makes it so
-  // join and scan selectivities that are better known have more
-  // influence on plan cardinality. To be filled in from history.
-  cost_.fanout = pow(0.8, exprs_.size());
-}
-
-void UnionAll::setCost(const PlanState& input) {
-  for (auto& in : inputs) {
-    cost_.inputCardinality += in->cost().inputCardinality * in->cost().fanout;
-  }
-}
-
-void Limit::setCost(const PlanState& input) {
-  cost_.unitCost = 0.01;
-  if (input.cost.inputCardinality <= limit) {
-    // Input cardinality does not exceed the limit. The limit is no-op. Doesn't
-    // change cardinality.
-    cost_.fanout = 1;
-  } else {
-    // Input cardinality exceeds the limit. Calculate fanout to ensure that
-    // fanout * limit = input-cardinality.
-    cost_.fanout = limit / input.cost.inputCardinality;
-  }
+  return byteSize(columns);
 }
 
 float selfCost(ExprCP expr) {

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -146,9 +146,6 @@ std::string Plan::toString(bool detail) const {
 }
 
 void PlanState::addCost(RelationOp& op) {
-  if (!static_cast<bool>(op.cost().unitCost)) {
-    op.setCost(*this);
-  }
   cost.unitCost += cost.inputCardinality * cost.fanout * op.cost().unitCost;
   cost.setupCost += op.cost().setupCost;
   cost.fanout *= op.cost().fanout;

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/RelationOp.h"
@@ -428,6 +429,12 @@ std::string Distribution::toString() const {
     out << " first " << numKeysUnique << " unique";
   }
   return out.str();
+}
+
+float ColumnGroup::lookupCost(float range) const {
+  // Add 2 because it takes a compare and access also if hitting the
+  // same row. log(1) == 0, so this would other wise be zero cost.
+  return Costs::kKeyCompareCost * log(range + 2) / log(2);
 }
 
 } // namespace facebook::velox::optimizer


### PR DESCRIPTION
Summary:
RelationOp stores the estimate for output cardinality in 2 places:
- distribution().cardinality
- cost_.inputCardinality * cost_.fanout

distribution().cardinality is set in ctor, while cost_ is set in a separate setCost() method called externally.

This leads to discrepancies and makes these values unreliable.

This change removes RelationOp::setCost() method and folds its logic into ctor. This way both distribution and cost are filled at the same time.

These values are still not quite right. A follow-up is needed to fix them up. We also need to figure out how to write tests to ensure these values are right.

Differential Revision: D80092069


