### PR TITLE
feat: Add bucketing and Hive partition support to local Hive metadata

### DIFF
--- a/axiom/optimizer/connectors/ConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/ConnectorMetadata.cpp
@@ -16,8 +16,32 @@
 
 #include "axiom/optimizer/connectors/ConnectorMetadata.h"
 
-namespace facebook::velox::connectors {
+namespace facebook::velox::connector {
 
-void dummy() {}
+namespace {
+folly::F14FastMap<TableKind, std::string> tableKindNames() {
+  static const folly::F14FastMap<TableKind, std::string> kNames = {
+      {TableKind::kTable, "kTable"},
+      {TableKind::kTempTable, "kTempTable"},
+  };
 
-} // namespace facebook::velox::connectors
+  return kNames;
+}
+
+folly::F14FastMap<WriteKind, std::string> writeKindNames() {
+  static const folly::F14FastMap<WriteKind, std::string> kNames = {
+      {WriteKind::kInsert, "kInsert"},
+      {WriteKind::kUpdate, "kUpdate"},
+      {WriteKind::kDelete, "kDelete"},
+  };
+
+  return kNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(TableKind, tableKindNames);
+
+VELOX_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
+
+} // namespace facebook::velox::connector

--- a/axiom/optimizer/connectors/hive/CMakeLists.txt
+++ b/axiom/optimizer/connectors/hive/CMakeLists.txt
@@ -19,6 +19,7 @@ velox_link_libraries(
   velox_hive_connector_metadata
   velox_connector_metadata
   velox_hive_connector
+  velox_type_fbhive
   velox_dwio_catalog_fbhive
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer

--- a/axiom/optimizer/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/optimizer/connectors/hive/HiveConnectorMetadata.h
@@ -19,6 +19,7 @@
 #include "axiom/optimizer/connectors/ConnectorMetadata.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
@@ -41,13 +42,18 @@ struct HivePartitionHandle : public PartitionHandle {
   const std::optional<int32_t> tableBucketNumber;
 };
 
+class HiveConnectorSession : public connector::ConnectorSession {
+ public:
+  ~HiveConnectorSession() override = default;
+};
+
 /// Describes a Hive table layout. Adds a file format and a list of
 /// Hive partitioning columns and an optional bucket count to the base
-/// TableLayout. The partitioning in TableLayout does not differentiate between
-/// bucketing and Hive partitioning columns. The bucketing columns
-/// are the 'partitioning' columns minus the
-/// 'hivePartitioningColumns'. 'numBuckets' is the number of Hive buckets if
-/// 'partitionColumns' differs from 'hivePartitionColumns'.
+/// TableLayout. The partitioning in TableLayout referes to bucketing.
+/// 'numBuckets' is the number of Hive buckets if
+/// 'partitionColumns' is not empty. 'hivePartitionColumns' refers to Hive
+/// partitioning, i.e. columns whose value gives a directory in the ile storage
+/// tree.
 class HiveTableLayout : public TableLayout {
  public:
   HiveTableLayout(
@@ -121,7 +127,38 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       RowTypePtr dataColumns = nullptr,
       std::optional<LookupKeys> lookupKeys = std::nullopt) override;
 
+  ConnectorInsertTableHandlePtr createInsertTableHandle(
+      const TableLayout& layout,
+      const RowTypePtr& rowType,
+      const std::unordered_map<std::string, std::string>& options,
+      WriteKind kind,
+      const ConnectorSessionPtr& session) override;
+
+  virtual dwio::common::FileFormat fileFormat() const {
+    VELOX_UNSUPPORTED();
+  }
+
  protected:
+  virtual void ensureInitialized() const {}
+
+  virtual void validateOptions(
+      const std::unordered_map<std::string, std::string>& options) const;
+
+  virtual std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
+      std::string targetDirectory,
+      std::optional<std::string> writeDirectory,
+      connector::hive::LocationHandle::TableType tableType =
+          connector::hive::LocationHandle::TableType::kNew) {
+    VELOX_UNSUPPORTED();
+  }
+
+  /// Returns the path to the filesystem root for the data managed by
+  /// 'this'. Directories inside this correspond to schemas and
+  /// tables.
+  virtual std::string dataPath() const {
+    VELOX_UNSUPPORTED();
+  }
+
   HiveConnector* const hiveConnector_;
 };
 

--- a/axiom/optimizer/connectors/hive/README.md
+++ b/axiom/optimizer/connectors/hive/README.md
@@ -1,0 +1,56 @@
+HiveConnectorMetadata
+
+We define HiveConnectorMetadata as a general purpose base class of all
+Hive connectors. LocalHiveConnectorMetadata is a testing-only
+implementation of the interface that stores files and schema
+information in the local file system.
+
+Production implementtations are expected to connectt to a metadata server and to support some level of transactions.
+
+We define HiveConnectorLayout which adds Hive specific properties to
+the generic TableLayout. A TableLayout corresponds to a
+materialization of the table. In Hive there is always one
+materialization that may be variously bucketed and/or partitioned. The
+getter partitionColumns() in the generic TableLayout refers to Hive
+bucketing columns. therefor we add hivePartitionColumns which are the
+Hive partition columns, i.e. columns whose value specifies a directory
+for the files with a particular value of the column.  We also add
+numBuckets for accessing the bucket count.
+
+There could in principle be differently sorted and partitioned layouts
+of a table, possibly containing different subsets of the columns. We
+do not see this usage in Hive though but it is allowed by the
+interface.
+
+Our scope is not limited to Hive. It is therefore crucial to have a
+differentiation between table and a particular materialization of it
+to to cover a range of physical execution models including indexed
+access paths.
+
+The local implementation is initialized to point to a directory. The
+HiveConnectorMetadata reads the contents of the directory and
+interprets each directory as a table. If the directory contains a
+.schema file, we read the partition and bucketing information from the
+file. Otherwise we assume no bucketing or Hive partitioning and
+interpret all the files as data files.
+
+
+We offer a sample implementation of a write interface. The writes go
+directly into the directory of the table and are not in any way
+transactional. This may be completed in the future.
+
+The local implementation samples the files at startup and after
+writing. It also offers a sampling interface that reads some
+percentage of rows and with a set of filters and produces selectivity
+information and optional column by column statistics after filtering.
+
+Implementations over disagg storage and metadata servers can sample
+the actual data or return some estimate based on statistics kept by
+the metadata server. Sampling is preferrable but at the discretion of
+the implementation. Verax caches information from sampling and does
+not run the same sample repeatedly.
+
+
+For now the local connector metadata should be seen as a test-only
+reference implementation. A more complete DDL support will be added in
+time.

--- a/axiom/optimizer/connectors/hive/tests/CMakeLists.txt
+++ b/axiom/optimizer/connectors/hive/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_test(velox_hive_connector_metadata_test velox_hive_connector_metadata_test)
 target_link_libraries(
   velox_hive_connector_metadata_test
   velox_hive_connector_metadata
+  velox_connector_split_source
   velox_hive_connector
   velox_exec_runner_test_util
   velox_hive_partition_function

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -48,10 +48,8 @@ velox_link_libraries(
 velox_add_library(velox_optimizer_tests_query_sql_parser QuerySqlParser.cpp)
 
 velox_link_libraries(
-  velox_optimizer_tests_query_sql_parser
-  velox_fe_logical_plan_builder
-  velox_parse_parser
-  velox_vector)
+  velox_optimizer_tests_query_sql_parser velox_fe_logical_plan_builder
+  velox_parse_parser velox_vector)
 
 velox_add_library(velox_optimizer_tests_plan_matcher PlanMatcher.cpp)
 
@@ -59,28 +57,26 @@ velox_link_libraries(
   velox_optimizer_tests_plan_matcher
   velox_hive_connector
   velox_parse_parser
-)
+  GTest::gmock
+  glog::glog
+  GTest::gtest
+  GTest::gtest_main)
 
-velox_add_library(
-  velox_optimizer_tests_hive_queries_test_base
-  HiveQueriesTestBase.cpp)
+velox_add_library(velox_optimizer_tests_hive_queries_test_base
+                  HiveQueriesTestBase.cpp)
 
 velox_link_libraries(
   velox_optimizer_tests_hive_queries_test_base
-  velox_optimizer_tests_parquet_tpch
-  velox_optimizer_tests_plan_matcher
-  velox_optimizer_tests_query_sql_parser
-  velox_optimizer_tests_query_test_base)
+  velox_optimizer_tests_parquet_tpch velox_optimizer_tests_plan_matcher
+  velox_optimizer_tests_query_sql_parser velox_optimizer_tests_query_test_base)
 
 add_executable(velox_optimizer_tests_tpch_plan TpchPlanTest.cpp)
 
 add_test(velox_optimizer_tests_tpch_plan velox_optimizer_tests_tpch_plan)
 
 target_link_libraries(
-  velox_optimizer_tests_tpch_plan
-  velox_dwio_common_test_utils
-  velox_optimizer_tests_parquet_tpch
-  velox_optimizer_tests_query_sql_parser
+  velox_optimizer_tests_tpch_plan velox_dwio_common_test_utils
+  velox_optimizer_tests_parquet_tpch velox_optimizer_tests_query_sql_parser
   velox_optimizer_tests_query_test_base)
 
 add_executable(


### PR DESCRIPTION
Adds table creation and insert to LocalHiveConnectorMetadata.

If a table directory has a .schema file, this file is read to initialize bucket properties and partitioning columns. All table directories are read recursively and a file list is gathered with file paths, values of partitioning columns extracted from the directory path and a bucket number parsed from the file name.

Directories with no .schema continue to work as before. The table layout is inferred from the files.

Adds implementation of ConnectorMetadata write functions for insertion. An insert table handle is created with the partition and bucketing information from the single layout of a Hive table.