### PR TITLE
Do not pushdown filter below limit

### DIFF
--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -127,6 +127,22 @@ TEST_F(HiveQueriesTest, orderOfOperations) {
           .filter("length(n_name) < cnt"),
       scanMatcher().partialAggregation().finalAggregation().filter(
           "\"dt1.cnt\" > 10 and \"dt1.cnt\" > length(\"t2.n_name\")"));
+
+  // Multiple filters are allowed before a limit.
+  test(
+      scan("nation")
+          .filter("n_nationkey > 2")
+          .limit(10)
+          .filter("n_nationkey < 100")
+          .filter("n_regionkey > 10")
+          .limit(5)
+          .filter("n_nationkey > 70")
+          .filter("n_regionkey < 7"),
+      scanMatcher()
+          .finalLimit(0, 10)
+          .filter("\"dt1.n_nationkey\" < 100 AND \"dt1.n_regionkey\" > 10")
+          .finalLimit(0, 5)
+          .filter("\"dt3.n_nationkey\" > 70 AND \"dt3.n_regionkey\" < 7"));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
It is incorrect to reorder filter and limit.

```
select n_name, n_nationkey from (
    select * from tpch.tiny.nation limit 5 
)
where n_nationkey % 2 = 1

  n_name   | n_nationkey
-----------+-------------
 PERU      |          17
 INDONESIA |           9
 ARGENTINA |           1
(3 rows)

```

vs.

```
select n_name, n_nationkey 
from tpch.tiny.nation 
where n_nationkey % 2 = 1 
limit 5 

  n_name   | n_nationkey
-----------+-------------
 PERU      |          17
 ARGENTINA |           1
 INDONESIA |           9
 ROMANIA   |          19
 CANADA    |           3
(5 rows)
```

Differential Revision: D80196630


