### PR TITLE
Bug fix for complex types in ValuesNode

### DIFF
--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -48,6 +48,7 @@ Name toName(std::string_view string) {
 const Type* QueryGraphContext::toType(const TypePtr& type) {
   return dedupType(type).get();
 }
+
 TypePtr QueryGraphContext::dedupType(const TypePtr& type) {
   auto it = deduppedTypes_.find(type);
   if (it != deduppedTypes_.end()) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -220,7 +220,7 @@ void ToGraph::getExprForField(
       auto it = renames_.find(name);
       VELOX_CHECK(it != renames_.end());
       auto maybeColumn = it->second;
-      VELOX_CHECK(maybeColumn->type() == PlanType::kColumnExpr);
+      VELOX_CHECK_EQ(maybeColumn->type(), PlanType::kColumnExpr);
       resultColumn = maybeColumn->as<Column>();
       resultExpr = nullptr;
       context = nullptr;
@@ -1171,7 +1171,7 @@ PlanObjectP ToGraph::makeValuesTable(const lp::ValuesNode& values) {
     VELOX_DCHECK_LT(i, type->size());
 
     const auto& name = names[i];
-    Value value{type->childAt(i).get(), cardinality};
+    Value value{toType(type->childAt(i)), cardinality};
     auto* column = make<Column>(toName(name), valuesTable, value);
     valuesTable->columns.push_back(column);
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -39,6 +39,10 @@ class PlanMatcherBuilder {
       common::SubfieldFilters subfieldFilters,
       const std::string& remainingFilter = "");
 
+  PlanMatcherBuilder& values();
+
+  PlanMatcherBuilder& values(const TypePtr& type);
+
   PlanMatcherBuilder& filter();
 
   PlanMatcherBuilder& filter(const std::string& predicate);
@@ -86,6 +90,7 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
 
   std::shared_ptr<PlanMatcher> build() {
+    VELOX_USER_CHECK_NOT_NULL(matcher_, "Cannot build an empty PlanMatcher.");
     return matcher_;
   }
 


### PR DESCRIPTION
Summary:
Complex types in value nodes were failing because the type pointer was
not being acquired in QueryGraphContext.

Differential Revision: D80222042
