### PR TITLE
Fix output names and drop redundant projects

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -94,6 +94,7 @@ class ExprResolver {
   static inline int32_t literalsCounter_{0};
 };
 
+// Make sure to specify Context.queryCtx to enable constand folding.
 class PlanBuilder {
  public:
   struct Context {

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -451,15 +451,14 @@ class Optimization {
     return history_;
   }
 
-  /// If false, correlation names are not included in Column::toString(),. Used
+  /// If false, correlation names are not included in Column::toString(). Used
   /// for canonicalizing join cache keys.
   bool& cnamesInExpr() {
     return cnamesInExpr_;
   }
 
-  /// Map for canonicalizing correlation names when making history cache keys.
-  std::unordered_map<Name, Name>*& canonicalCnames() {
-    return canonicalCnames_;
+  bool cnamesInExpr() const {
+    return cnamesInExpr_;
   }
 
   BuiltinNames& builtinNames() {
@@ -631,8 +630,6 @@ class Optimization {
   const bool isSingle_;
 
   bool cnamesInExpr_{true};
-
-  std::unordered_map<Name, Name>* canonicalCnames_{nullptr};
 
   ToGraph toGraph_;
 

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -154,9 +154,10 @@ class Literal : public Expr {
 class Column : public Expr {
  public:
   Column(
-      Name _name,
-      PlanObjectP _relation,
+      Name name,
+      PlanObjectP relation,
       const Value& value,
+      Name alias = nullptr,
       Name nameInTable = nullptr,
       ColumnCP topColumn = nullptr,
       PathCP path = nullptr);
@@ -167,6 +168,10 @@ class Column : public Expr {
 
   PlanObjectCP relation() const {
     return relation_;
+  }
+
+  Name alias() const {
+    return alias_;
   }
 
   ColumnCP schemaColumn() const {
@@ -198,6 +203,9 @@ class Column : public Expr {
 
   // The defining BaseTable or DerivedTable.
   PlanObjectP relation_;
+
+  // Optional alias copied from the the logical plan.
+  Name alias_;
 
   // Equivalence class. Lists all columns directly or indirectly asserted equal
   // to 'this'.

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -79,6 +79,11 @@ class ToVelox {
 
   void filterUpdated(BaseTableCP baseTable, bool updateSelectivity = true);
 
+  // Returns column name to use in the Velox plan.
+  static std::string outputName(ColumnCP column) {
+    return column->alias() ? column->alias() : column->toString();
+  }
+
  private:
   void setLeafHandle(
       int32_t id,

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -151,10 +151,15 @@ void predictionWarnings(
     const PlanAndStats& plan,
     const core::PlanNodeId& id,
     int64_t actualRows,
-    int64_t predictedRows) {
+    float predictedRows) {
   if (actualRows == 0 && predictedRows == 0) {
     return;
   }
+
+  if (std::isnan(predictedRows)) {
+    return;
+  }
+
   std::string historyKey;
   auto it = plan.history.find(id);
   if (it != plan.history.end()) {

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -90,7 +90,7 @@ add_executable(
   PlanTest.cpp
   ParquetTpchTest.cpp
   QueryTestBase.cpp
-  LogicalSubfieldTest.cpp
+  SubfieldTest.cpp
   FeatureGen.cpp
   Genies.cpp
   SchemaResolverTest.cpp)

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -44,11 +44,8 @@ TEST_F(HiveLimitQueriesTest, limit) {
     SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
     auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
-                       .project()
-                       .finalLimit(0, 10)
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().finalLimit(0, 10).build();
 
     checkSingleNodePlan(plan, matcher);
     checkResults(plan, referenceResults);
@@ -61,7 +58,6 @@ TEST_F(HiveLimitQueriesTest, limit) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .project()
                        .partialLimit(0, 10)
                        .localPartition()
                        .finalLimit(0, 10)
@@ -84,7 +80,6 @@ TEST_F(HiveLimitQueriesTest, limit) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .project()
                        .partialLimit(0, 10)
                        .localPartition()
                        .finalLimit(0, 10)
@@ -119,11 +114,8 @@ TEST_F(HiveLimitQueriesTest, offset) {
     SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
     auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
-                       .project()
-                       .finalLimit(5, 10)
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().finalLimit(5, 10).build();
 
     checkSingleNodePlan(plan, matcher);
     checkResults(plan, referenceResults);
@@ -136,7 +128,6 @@ TEST_F(HiveLimitQueriesTest, offset) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .project()
                        .partialLimit(0, 15)
                        .localPartition()
                        .finalLimit(5, 10)
@@ -159,7 +150,6 @@ TEST_F(HiveLimitQueriesTest, offset) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .project()
                        .partialLimit(0, 15)
                        .localPartition()
                        .finalLimit(0, 15)

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -33,14 +33,6 @@ class PlanMatcherImpl : public PlanMatcher {
 
   bool match(const PlanNodePtr& plan) const override {
     const auto* specificNode = dynamic_cast<const T*>(plan.get());
-
-    // Ignore project nodes until optimizer is fixed to avoid adding redundant
-    // ones.
-    if (specificNode == nullptr &&
-        dynamic_cast<const ProjectNode*>(plan.get())) {
-      return match(plan->sources()[0]);
-    }
-
     EXPECT_TRUE(specificNode != nullptr)
         << "Expected " << folly::demangle(typeid(T).name()) << ", but got "
         << plan->toString(false, false);

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -38,8 +38,8 @@ namespace lp = facebook::velox::logical_plan;
 
 namespace facebook::velox::optimizer {
 
-class LogicalSubfieldTest : public QueryTestBase,
-                            public testing::WithParamInterface<int32_t> {
+class SubfieldTest : public QueryTestBase,
+                     public testing::WithParamInterface<int32_t> {
  protected:
   static void SetUpTestCase() {
     testDataPath_ = FLAGS_subfield_data_path;
@@ -266,7 +266,6 @@ class LogicalSubfieldTest : public QueryTestBase,
             .unionAll(lp::PlanBuilder(ctx).tableScan("features"))
             .project({"float_features as float_features_1"})
             .project({"float_features_1 as float_features_2"})
-
             .project(
                 {"make_row_from_map(float_features_2, array[10010, 10020, 10030], array['f1', 'f2', 'f3']) as r"})
             .project({"r as r1"})
@@ -289,7 +288,6 @@ class LogicalSubfieldTest : public QueryTestBase,
     auto matcher =
         core::PlanMatcherBuilder()
             .hiveScan("features", {}, "float_features[10010] + 1 < 10000")
-            .project()
             .localPartition(
                 core::PlanMatcherBuilder()
                     .hiveScan(
@@ -373,7 +371,7 @@ class LogicalSubfieldTest : public QueryTestBase,
   }
 };
 
-TEST_P(LogicalSubfieldTest, structs) {
+TEST_P(SubfieldTest, structs) {
   auto structType =
       ROW({"s1", "s2", "s3"},
           {BIGINT(), ROW({"s2s1"}, {BIGINT()}), ARRAY(BIGINT())});
@@ -401,7 +399,7 @@ TEST_P(LogicalSubfieldTest, structs) {
   assertSame(referencePlan, fragmentedPlan);
 }
 
-TEST_P(LogicalSubfieldTest, maps) {
+TEST_P(SubfieldTest, maps) {
   FeatureOptions opts;
   opts.rng.seed(1);
   auto vectors = makeFeatures(1, 100, opts, pool_.get());
@@ -590,8 +588,8 @@ TEST_P(LogicalSubfieldTest, maps) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    LogicalSubfieldTests,
-    LogicalSubfieldTest,
+    SubfieldTests,
+    SubfieldTest,
     testing::ValuesIn(std::vector<int32_t>{1, 2, 3}));
 
 } // namespace facebook::velox::optimizer


### PR DESCRIPTION
Summary:
Fix output names to match logical plan. Remove some redundant projects.

- In ToGraph, store names from logical plan in Column.alias.
- In ToVelox, use Column.alias for names in Velox plan.

Fixes https://github.com/facebookexperimental/verax/issues/195

Differential Revision: D80229006
