### PR TITLE
Remove Distribution.cardinality

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1021,22 +1021,20 @@ void DerivedTable::makeInitialPlan() {
   }
 
   optimization->makeJoins(nullptr, state);
+
   Distribution emptyDistribution;
   bool needsShuffle;
   auto plan = state.plans.best(emptyDistribution, needsShuffle)->op;
+
   auto& distribution = plan->distribution();
   ExprVector partition = distribution.partition;
   ExprVector order = distribution.order;
   auto orderType = distribution.orderType;
   replace(partition, exprs, columns.data());
   replace(order, exprs, columns.data());
-  auto* dtDist = make<Distribution>(
-      distribution.distributionType,
-      distribution.cardinality,
-      partition,
-      order,
-      orderType);
-  this->distribution = dtDist;
+
+  this->distribution = make<Distribution>(
+      distribution.distributionType, partition, order, orderType);
   optimization->memo()[key] = std::move(state.plans);
 }
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -62,6 +62,8 @@ struct DerivedTable : public PlanObject {
   /// from enclosing query. Set for a non-top level dt.
   DistributionP distribution{nullptr};
 
+  float cardinality{};
+
   /// Correlation name.
   Name cname{nullptr};
 

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -146,8 +146,9 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
       TableScan::outputDistribution(base, index, columns),
       base,
       index,
-      index->distribution().cardinality,
+      index->table->cardinality,
       columns);
+
   ExprCP hash = makeHash(keys[0]);
   if (keys.size() == 1) {
     hash = mul(hash, 1815531889);

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -126,7 +126,7 @@ class RelationOp : public Relation {
       return 1;
     }
 
-    return input()->distribution().cardinality;
+    return input()->resultCardinality();
   }
 
   /// Returns the value constraints of 'expr' at the output of

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1219,8 +1219,7 @@ void ToGraph::makeSubfieldColumns(
   SubfieldProjections projections;
   auto* ctx = queryCtx();
   float card =
-      baseTable->schemaTable->columnGroups[0]->distribution().cardinality *
-      baseTable->filterSelectivity;
+      baseTable->schemaTable->cardinality * baseTable->filterSelectivity;
   paths.forEach([&](auto id) {
     auto* path = ctx->pathById(id);
     auto type = pathType(column->value().type, path);
@@ -1379,8 +1378,7 @@ void ToGraph::makeUnionDistributionAndStats(
     DerivedTableP setDt,
     DerivedTableP innerDt) {
   if (setDt->distribution == nullptr) {
-    DistributionType empty;
-    setDt->distribution = make<Distribution>(empty, 0, ExprVector{});
+    setDt->distribution = make<Distribution>();
   }
   if (innerDt == nullptr) {
     innerDt = setDt;
@@ -1393,7 +1391,7 @@ void ToGraph::makeUnionDistributionAndStats(
 
     auto plan = innerDt->bestInitialPlan()->op;
 
-    setDt->distribution->cardinality += plan->distribution().cardinality;
+    setDt->cardinality += plan->resultCardinality();
     for (auto i = 0; i < setDt->columns.size(); ++i) {
       // The Column is created in setDt before all branches are planned so the
       // value is mutated here.


### PR DESCRIPTION
Summary:
Distribution is used for 2 purposes:
- describes distribution of a dataset stored on disk or in memory;
- describes desired distribution in makePlan

'cardinality' makes sense in the first case, but not the second. Hence, it is confusing to include 'cardinality in Distribution.

Differential Revision: D80268058


