### PR TITLE
refactor: Remove redundant parameter from Optimization::toVeloxPlan

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -39,8 +39,8 @@ float shuffleCost(const ColumnVector& columns) {
   return byteSize(columns);
 }
 
-float shuffleCost(const ExprVector& columns) {
-  return byteSize(columns);
+float shuffleCost(const ExprVector& exprs) {
+  return byteSize(exprs);
 }
 
 float selfCost(ExprCP expr) {

--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -123,9 +123,13 @@ struct Costs {
   static constexpr float kMinimumFilterCost = 2;
 };
 
+/// Returns shuffle cost for a single row. Depends on the number of types of
+/// columns.
 float shuffleCost(const ColumnVector& columns);
 
-float shuffleCost(const ExprVector& columns);
+/// Returns shuffle cost for a single row produced by specified expressions.
+/// Depends on the number of result types of the expressions.
+float shuffleCost(const ExprVector& exprs);
 
 /// Returns cost of 'expr' for one row, excluding cost of subexpressions.
 float selfCost(ExprCP expr);

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -180,9 +180,7 @@ std::shared_ptr<axiom::runner::Runner> prepareSampleRunner(
       FunctionSet());
   RelationOpPtr filter = make<Filter>(proj, ExprVector{filterExpr});
 
-  axiom::runner::MultiFragmentPlan::Options& options =
-      queryCtx()->optimization()->options();
-  auto plan = queryCtx()->optimization()->toVeloxPlan(filter, options);
+  auto plan = queryCtx()->optimization()->toVeloxPlan(filter);
   return std::make_shared<axiom::runner::LocalRunner>(
       plan.plan,
       sampleQueryCtx(queryCtx()->optimization()->queryCtxShared()),

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -179,7 +179,7 @@ std::string ValuesTable::toString() const {
   return out.str();
 }
 
-const JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
+JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
   if ((side == rightTable_ && !other) || (side == leftTable_ && other)) {
     return {
         rightTable_,
@@ -192,6 +192,7 @@ const JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
         markColumn_,
         rightUnique_};
   }
+
   return {
       leftTable_,
       leftKeys_,

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -444,7 +444,7 @@ struct Equivalence {
 struct JoinSide {
   PlanObjectCP table;
   const ExprVector& keys;
-  float fanout;
+  const float fanout;
   const bool isOptional;
   const bool isNonOptionalOfOuter;
   const bool isExists;
@@ -563,13 +563,14 @@ class JoinEdge {
         !rightNotExists_;
   }
 
-  // True if all tables referenced from 'leftKeys' must be placed before placing
-  // this.
+  /// True if all tables referenced from 'leftKeys' must be placed before
+  /// placing this.
   bool isNonCommutative() const {
     // Inner and full outer joins are commutative.
     if (rightOptional_ && leftOptional_) {
       return false;
     }
+
     return !leftTable_ || rightOptional_ || leftOptional_ || rightExists_ ||
         rightNotExists_ || markColumn_ || directed_;
   }
@@ -580,9 +581,9 @@ class JoinEdge {
     return isNonCommutative() && !rightNotExists_;
   }
 
-  // Returns the join side info for 'table'. If 'other' is set, returns the
-  // other side.
-  const JoinSide sideOf(PlanObjectCP side, bool other = false) const;
+  /// Returns the join side info for 'table'. If 'other' is set, returns the
+  /// other side.
+  JoinSide sideOf(PlanObjectCP side, bool other = false) const;
 
   /// Returns the table on the other side of 'table' and the number of rows in
   /// the returned table for one row in 'table'. If the join is not inner
@@ -619,11 +620,11 @@ class JoinEdge {
 
   std::string toString() const;
 
-  //// Fills in 'lrFanout' and 'rlFanout', 'leftUnique', 'rightUnique'.
+  /// Fills in 'lrFanout' and 'rlFanout', 'leftUnique', 'rightUnique'.
   void guessFanout();
 
-  // True if a hash join build can be broadcasted. Used when building on the
-  // right. None of the right hash join variants is broadcastable.
+  /// True if a hash join build can be broadcasted. Used when building on the
+  /// right. None of the right hash join variants are broadcastable.
   bool isBroadcastableType() const;
 
   /// Returns a key string for recording a join cardinality sample. The string
@@ -657,12 +658,12 @@ class JoinEdge {
   // True if 'lrFanout_' and 'rlFanout_' are set by setFanouts.
   bool fanoutsFixed_{false};
 
-  // Join condition for any non-equality  conditions for non-inner joins.
+  // Join condition for any non-equality conditions for non-inner joins.
   const ExprVector filter_;
 
   // True if an unprobed right side row produces a result with right side
-  // columns set and left side columns as null. Possible only be hash or
-  // merge.
+  // columns set and left side columns as null (right outer join). Possible only
+  // for hash or merge.
   const bool leftOptional_;
 
   // True if a right side miss produces a row with left side columns
@@ -678,7 +679,7 @@ class JoinEdge {
   const bool rightNotExists_;
 
   // Flag to set if right side has a match.
-  const ColumnCP markColumn_;
+  ColumnCP const markColumn_;
 
   // If directed non-outer edge. For example unnest or inner dependent on
   // optional of outer.

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -39,7 +39,7 @@ XxxP
 : Raw pointer to Xxx: XxxP := Xxx*
 
 XxxCP
-: Raw pointer to constant Xxx: XxxCP := const Xxx*
+: Raw pointer to constant Xxx: XxxCP := const Xxx*. Remember to place 'const' *after* the type: XxxCP const variableName. (const XxxCP doesn't produce the derired effect.)
 
 XxxVector
 : Standard vector of raw pointers to Xxx allocated from the arena: XxxVector := `std::vector<XxxP, QGAllocator<XxxP>>`.

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -348,9 +348,10 @@ using JoinCP = const Join*;
 /// cardinality of this is counted as setup cost in the first
 /// referencing join and not counted in subsequent ones.
 struct HashBuild : public RelationOp {
-  HashBuild(RelationOpPtr input, int32_t id, ExprVector _keys, PlanPtr plan);
+  HashBuild(RelationOpPtr input, int32_t id, ExprVector keys, PlanPtr plan);
 
   int32_t buildId{0};
+
   ExprVector keys;
   // The plan producing the build data. Used for deduplicating joins.
   PlanPtr plan;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -202,7 +202,7 @@ class ToGraph {
   ExprCP
   deduppedCall(Name name, Value value, ExprVector args, FunctionSet flags);
 
-  core::ExpressionEvaluator* evaluator() {
+  core::ExpressionEvaluator* evaluator() const {
     return &evaluator_;
   }
 
@@ -218,6 +218,12 @@ class ToGraph {
   }
 
  private:
+  static bool isSpecialForm(
+      const logical_plan::Expr* expr,
+      logical_plan::SpecialForm form) {
+    return expr->isSpecialForm() &&
+        expr->asUnchecked<logical_plan::SpecialFormExpr>()->form() == form;
+  }
   // For comparisons, swaps the args to have a canonical form for
   // deduplication. E.g column op constant, and Smaller plan object id
   // to the left.

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -59,7 +59,7 @@ std::vector<common::Subfield> columnSubfields(BaseTableCP table, int32_t id) {
             break;
           }
           if (first &&
-              optimization->opts().isMapAsStruct(
+              optimization->options().isMapAsStruct(
                   table->schemaTable->name, columnName)) {
             elements.push_back(std::make_unique<common::Subfield::NestedField>(
                 step.field ? std::string(step.field)

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -34,8 +34,8 @@ void VeloxHistory::recordJoinSample(
     float rl) {}
 
 std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
-  auto optimization = queryCtx()->optimization();
-  if (!optimization->opts().sampleJoins) {
+  const auto& options = queryCtx()->optimization()->options();
+  if (!options.sampleJoins) {
     return {0, 0};
   }
 
@@ -54,8 +54,8 @@ std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
       return it->second;
     }
   }
-  bool trace =
-      (optimization->opts().traceFlags & OptimizerOptions::kSample) != 0;
+
+  const bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;
 
   std::pair<float, float> pair;
   uint64_t start = getCurrentTimeMicro();
@@ -112,7 +112,7 @@ bool VeloxHistory::setLeafSelectivity(BaseTable& table, RowTypePtr scanType) {
     return false;
   }
   bool trace =
-      (optimization->opts().traceFlags & OptimizerOptions::kSample) != 0;
+      (optimization->options().traceFlags & OptimizerOptions::kSample) != 0;
   uint64_t start = getCurrentTimeMicro();
   auto sample = runnerTable->layouts()[0]->sample(
       handlePair.first, 1, handlePair.second, scanType);

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -229,7 +229,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   if (planString) {
     *planString = best->op->toString(true, false);
   }
-  return opt.toVeloxPlan(best->op, options);
+  return opt.toVeloxPlan(best->op);
 }
 
 TestResult QueryTestBase::runVelox(

--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -493,7 +493,7 @@ class VeloxRunner : public QueryBenchmarkBase {
                 << best->toString(true) << std::endl;
     }
 
-    return optimization.toVeloxPlan(best->op, opts);
+    return optimization.toVeloxPlan(best->op);
   }
 
   /// Runs a query and returns the result as a single vector in *resultVector,


### PR DESCRIPTION
Summary: Runner options used to be specified twice: (1) in the ctor of Optimization; (2) in the call to toVeloxPlan.

Differential Revision: D80315354
