### PR TITLE
build(CI): Install clang in CI file

### DIFF
--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -30,8 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  format-check:
-    name: Format Check
+  preliminary-checks:
+    name: Preliminary Checks
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/facebookincubator/velox-dev:centos9
@@ -46,68 +46,59 @@ jobs:
         run: |
           git config --global --add safe.directory "*"
 
-      - name: Install Python dependencies
+      - name: Install dependencies
         run: |
           pip3 install regex
+          dnf install -y clang-tools-extra
 
-      - name: Run format check
-        run: |
-          echo "::group::Changed files"
-          files=$(git diff --name-only HEAD^1 HEAD)
-          echo $files | tr ' ' '\n'
-          echo "::endgroup::"
-          python3 scripts/format-check.py format commit
-
-  license-check:
-    name: License Header Check
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/facebookincubator/velox-dev:centos9
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-          persist-credentials: false
-
-      - name: Configure Git Safe Directory
-        run: |
-          git config --global --add safe.directory "*"
-
-      - name: Install Python dependencies
-        run: |
-          pip3 install regex
-
-      - name: Run license header check
-        run: |
-          echo "::group::Changed files"
-          files=$(git diff --name-only HEAD^1 HEAD)
-          echo $files | tr ' ' '\n'
-          echo "::endgroup::"
-          python3 scripts/format-check.py header commit
-
-  title-check:
-    name: PR Title Format
-    runs-on: ubuntu-latest
-    steps:
-      - shell: python
+      - name: Check PR Title Format
         env:
           title: '${{ github.event.pull_request.title }}'
         run: |
+          python3 -c "
           import re
           import os
-          title = os.environ["title"]
+          import sys
+
+          title = os.environ['title']
+          print(f'Checking PR title: {title}')
+
           # Conventional commit format: type(scope)?: description
-          title_re = r"^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?!?: ([A-Z].+)[^.]$"
+          title_re = r'^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?!?: ([A-Z].+)[^.]$'
           match = re.search(title_re, title)
 
           if match is None:
-            print("::error::Please follow conventional commit guidelines in PR titles:")
-            print("::error::Format: type(scope)?: Description")
-            print("::error::Types: feat, fix, build, test, docs, refactor, misc")
-            print("::error::Example: feat(optimizer): Add new optimization rule")
-            print("::error::Example: fix: Fix memory leak in query execution")
-            exit(1)
+            print('::error::Please follow conventional commit guidelines in PR titles:')
+            print('::error::Format: type(scope)?: Description')
+            print('::error::Types: feat, fix, build, test, docs, refactor, misc')
+            print('::error::Example: feat(optimizer): Add new optimization rule')
+            print('::error::Example: fix: Fix memory leak in query execution')
+            sys.exit(1)
           else:
-            print("✓ PR title follows conventional commit format")
-            exit(0)
+            print('✓ PR title follows conventional commit format')
+          "
+
+      - name: Run Format Check
+        run: |
+          echo "::group::Format Check - Changed files"
+          files=$(git diff --name-only HEAD^1 HEAD)
+          echo $files | tr ' ' '\n'
+          echo "::endgroup::"
+          echo "Running format check..."
+          python3 scripts/format-check.py format commit
+
+      - name: Run License Header Check
+        run: |
+          echo "::group::License Check - Changed files"
+          files=$(git diff --name-only HEAD^1 HEAD)
+          echo $files | tr ' ' '\n'
+          echo "::endgroup::"
+          echo "Running license header check..."
+          python3 scripts/format-check.py header commit
+
+      - name: Summary
+        run: |
+          echo "✅ All preliminary checks completed successfully!"
+          echo "  ✓ PR title format check"
+          echo "  ✓ Code format check"
+          echo "  ✓ License header check"


### PR DESCRIPTION
* Install clang dependency in CI job
* Run the format check, PR title check and license header check in one single container 
Sample run: https://github.com/facebookexperimental/verax/actions/runs/16994432290