### PR TITLE
build(CI): Make format check to be compatible with Velox

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Currently this config mostly mirrors the default
+format:
+  line_width: 80
+  tab_size: 2
+  use_tabchars: false
+  max_pargs_hwrap: 4
+  max_subgroups_hwrap: 2
+  min_prefix_chars: 4
+  max_prefix_chars: 6
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  dangle_parens: false
+  command_case: canonical
+  keyword_case: unchanged
+  always_wrap:
+    - set_target_properties
+    - target_sources
+    - target_link_libraries
+parse:
+  # No custom functions defined - verax uses standard CMake functions
+  additional_commands: {}
+markup:
+  first_comment_is_literal: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,37 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 name: Linux Build
-
 on:
   push:
     branches:
       - main
     paths:
       - axiom/**
-      - velox/**
-      - '!velox/docs/**'
       - CMakeLists.txt
       - .github/workflows/build_and_test.yml
       - Makefile
-
   pull_request:
     paths:
       - axiom/**
-      - velox/**
-      - '!velox/docs/**'
       - CMakeLists.txt
       - .github/workflows/build_and_test.yml
       - Makefile
-
 permissions:
   contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
-
 jobs:
   build-verax:
     name: Build Verax
@@ -57,30 +47,25 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p "$CCACHE_DIR"
-
       # Get ccache from stash
       - name: Get Ccache Stash
         uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-ubuntu-debug-default-gcc
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           persist-credentials: false
-
       # Configure Git to trust the repository directory
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory "/__w/verax/verax"
           git config --global --add safe.directory "*"
-
       - name: Clear CCache Statistics
         run: |
           ccache -sz
-
       # Build Verax
       - name: Build Verax Debug
         id: build-verax
@@ -90,21 +75,18 @@ jobs:
         run: |
           # Build with reduced parallelism
           make debug
-
       # Display ccache statistics after build
       - name: CCache Statistics After Build
-        if: always()  # Run even if build failed
+        if: always() # Run even if build failed
         run: |
           echo "CCache statistics after build:"
           ccache -vs
-
       # Save ccache for future runs
       - name: Save ccache
         uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-ubuntu-debug-default-gcc
-
       # Run Verax tests (excluding velox tests)
       - name: Run Debug Tests
         working-directory: _build/debug

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 name: Preliminary Checks
-
 on:
   pull_request:
     types:
@@ -26,79 +24,56 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  group: >-
+    ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  preliminary-checks:
-    name: Preliminary Checks
+  pre-commit:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/facebookincubator/velox-dev:centos9
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
           persist-credentials: false
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        # v4.2.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-
 
-      - name: Configure Git Safe Directory
+      - name: Run pre-commit
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config --global --add safe.directory "*"
+          files=$(git diff --name-only HEAD^1 HEAD)
+          echo "::group::Changed files"
+          echo $files | tr ' ' '\n'
+          echo "::endgroup::"
+          pre-commit run --show-diff-on-failure --color=always --files $files
 
-      - name: Install dependencies
-        run: |
-          pip3 install regex
-          dnf install -y clang-tools-extra
-
-      - name: Check PR Title Format
+  title-check:
+    name: PR Title Format
+    runs-on: ubuntu-latest
+    steps:
+      - shell: python
         env:
           title: '${{ github.event.pull_request.title }}'
         run: |
-          python3 -c "
           import re
           import os
-          import sys
-
-          title = os.environ['title']
-          print(f'Checking PR title: {title}')
-
-          # Conventional commit format: type(scope)?: description
-          title_re = r'^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?!?: ([A-Z].+)[^.]$'
+          title = os.environ["title"]
+          title_re = r"^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?!?: ([A-Z].+)[^.]$"
           match = re.search(title_re, title)
 
           if match is None:
-            print('::error::Please follow conventional commit guidelines in PR titles:')
-            print('::error::Format: type(scope)?: Description')
-            print('::error::Types: feat, fix, build, test, docs, refactor, misc')
-            print('::error::Example: feat(optimizer): Add new optimization rule')
-            print('::error::Example: fix: Fix memory leak in query execution')
-            sys.exit(1)
+            print("::error::Please follow conventional commit guidelines in "
+                  + "commit titles as described in CONTRIBUTING.md")
+            exit(1)
           else:
-            print('✓ PR title follows conventional commit format')
-          "
-
-      - name: Run Format Check
-        run: |
-          echo "::group::Format Check - Changed files"
-          files=$(git diff --name-only HEAD^1 HEAD)
-          echo $files | tr ' ' '\n'
-          echo "::endgroup::"
-          echo "Running format check..."
-          python3 scripts/format-check.py format commit
-
-      - name: Run License Header Check
-        run: |
-          echo "::group::License Check - Changed files"
-          files=$(git diff --name-only HEAD^1 HEAD)
-          echo $files | tr ' ' '\n'
-          echo "::endgroup::"
-          echo "Running license header check..."
-          python3 scripts/format-check.py header commit
-
-      - name: Summary
-        run: |
-          echo "✅ All preliminary checks completed successfully!"
-          echo "  ✓ PR title format check"
-          echo "  ✓ Code format check"
-          echo "  ✓ License header check"
+            exit(0)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# See https://pre-commit.com for more information
+# General excludes, files can also be excluded on a hook level
+exclude: ^velox/.*|^build/.*|^cmake-build-.*|^scripts/.*
+default_install_hook_types: [pre-commit, pre-push]
+repos:
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+  - repo: local
+    hooks:
+      - id: cmake-format
+        name: cmake-format
+        description: Format CMake files.
+        entry: cmake-format
+        language: python
+        files: (CMakeLists.*|.*\.cmake|.*\.cmake.in)$
+        args: [--in-place]
+        require_serial: false
+        additional_dependencies: [cmake-format==0.6.13, pyyaml]
+      - id: license-header
+        name: license-header
+        description: Add missing license headers.
+        entry: ./scripts/license-header.py
+        args: [-i]
+        language: python
+        additional_dependencies: [regex]
+        require_serial: true
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.3
+    hooks:
+      - id: clang-format
+        files: \.(cpp|cc|c|h|hpp|inc|cu|cuh|clcpp|mm|metal)$
+  # Python
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: [-x, --severity=warning]
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+        # w: write changes, s: simplify, i set indent to 2 spaces
+        args: [-w, -s, -i, '2']
+  # The following checks mostly target GitHub Actions workflows.
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.0
+    hooks:
+      - id: yamllint
+        args: [--format, parsable, --strict]
+        exclude: .*\.clang-(tidy|format)|\.github/workflows/.*|\..*-format\.yaml|\.pre-commit-config\.yaml
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.16.0
+    hooks:
+      - id: yamlfmt
+        exclude: .*\.clang-(tidy|format)|\.github/workflows/.*|\..*-format\.yaml|\.pre-commit-config\.yaml
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.7.0
+    hooks:
+      - id: zizmor
+  - repo: https://github.com/mpalmer/action-validator
+    rev: 2f8be1d2066eb3687496a156d00b4f1b3ea7b028
+    hooks:
+      - id: action-validator

--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_fe_logical_plan Expr.cpp ExprPrinter.cpp
-                  LogicalPlanNode.cpp PlanPrinter.cpp ExprApi.cpp)
+velox_add_library(
+  velox_fe_logical_plan
+  Expr.cpp
+  ExprPrinter.cpp
+  LogicalPlanNode.cpp
+  PlanPrinter.cpp
+  ExprApi.cpp)
 
 velox_link_libraries(velox_fe_logical_plan velox_type)
 

--- a/axiom/logical_plan/tests/CMakeLists.txt
+++ b/axiom/logical_plan/tests/CMakeLists.txt
@@ -17,10 +17,11 @@ add_executable(velox_fe_logical_plan_tests
 
 add_test(velox_fe_logical_plan_tests velox_fe_logical_plan_tests)
 
-target_link_libraries(velox_fe_logical_plan_tests
-                      velox_fe_logical_plan_builder
-                      velox_fe_logical_plan
-                      velox_test_connector
-                      GTest::gtest
-                      GTest::gtest_main
-                      GTest::gmock)
+target_link_libraries(
+  velox_fe_logical_plan_tests
+  velox_fe_logical_plan_builder
+  velox_fe_logical_plan
+  velox_test_connector
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -18,13 +18,13 @@ add_subdirectory(connectors)
 
 add_library(velox_md_model Model.cpp)
 
-target_link_libraries(velox_md_model velox_exception)
-
+target_link_libraries(
+  velox_md_model velox_exception)
 
 add_library(velox_schema_resolver SchemaResolver.cpp SchemaUtils.cpp)
 
-target_link_libraries(velox_schema_resolver velox_connector_metadata
-                      velox_exception velox_vector)
+target_link_libraries(
+  velox_schema_resolver velox_connector_metadata velox_exception velox_vector)
 
 add_library(
   velox_verax

--- a/axiom/optimizer/connectors/CMakeLists.txt
+++ b/axiom/optimizer/connectors/CMakeLists.txt
@@ -15,8 +15,12 @@
 velox_add_library(velox_connector_metadata ConnectorMetadata.cpp
                   StatisticsBuilder.cpp)
 
-velox_link_libraries(velox_connector_metadata velox_common_base velox_memory
-                     velox_connector velox_dwio_dwrf_writer)
+velox_link_libraries(
+  velox_connector_metadata
+  velox_common_base
+  velox_memory
+  velox_connector
+  velox_dwio_dwrf_writer)
 
 add_subdirectory(hive)
 

--- a/axiom/optimizer/connectors/tests/CMakeLists.txt
+++ b/axiom/optimizer/connectors/tests/CMakeLists.txt
@@ -14,16 +14,16 @@
 
 velox_add_library(velox_test_connector TestConnector.cpp)
 
-velox_link_libraries(velox_test_connector velox_connector_metadata
-                     velox_common_base velox_memory velox_connector)
+velox_link_libraries(
+  velox_test_connector
+  velox_connector_metadata
+  velox_common_base
+  velox_memory
+  velox_connector)
 
-add_executable(
-  velox_test_connector_test
-  TestConnectorTest.cpp)
+add_executable(velox_test_connector_test TestConnectorTest.cpp)
 
-add_test(
-    velox_test_connector_test
-    velox_test_connector_test)
+add_test(velox_test_connector_test velox_test_connector_test)
 
 target_link_libraries(
   velox_test_connector_test

--- a/axiom/optimizer/connectors/tests/TestConnector.cpp
+++ b/axiom/optimizer/connectors/tests/TestConnector.cpp
@@ -10,8 +10,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing
- * permissions and limitations under the License.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "axiom/optimizer/connectors/tests/TestConnector.h"
 

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
@@ -1,4 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h"
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -67,8 +67,10 @@ velox_add_library(velox_optimizer_tests_hive_queries_test_base
 
 velox_link_libraries(
   velox_optimizer_tests_hive_queries_test_base
-  velox_optimizer_tests_parquet_tpch velox_optimizer_tests_plan_matcher
-  velox_optimizer_tests_query_sql_parser velox_optimizer_tests_query_test_base
+  velox_optimizer_tests_parquet_tpch
+  velox_optimizer_tests_plan_matcher
+  velox_optimizer_tests_query_sql_parser
+  velox_optimizer_tests_query_test_base
   axiom_runner_multifragment_plan
   axiom_runner_tests_utils)
 
@@ -77,9 +79,12 @@ add_executable(velox_optimizer_tests_tpch_plan TpchPlanTest.cpp)
 add_test(velox_optimizer_tests_tpch_plan velox_optimizer_tests_tpch_plan)
 
 target_link_libraries(
-  velox_optimizer_tests_tpch_plan velox_dwio_common_test_utils
-  velox_optimizer_tests_parquet_tpch velox_optimizer_tests_query_sql_parser
-  velox_optimizer_tests_query_test_base axiom_runner_tests_utils)
+  velox_optimizer_tests_tpch_plan
+  velox_dwio_common_test_utils
+  velox_optimizer_tests_parquet_tpch
+  velox_optimizer_tests_query_sql_parser
+  velox_optimizer_tests_query_test_base
+  axiom_runner_tests_utils)
 
 add_executable(
   velox_plan_test

--- a/axiom/optimizer/tests/QuerySqlParser.cpp
+++ b/axiom/optimizer/tests/QuerySqlParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/optimizer/tests/QuerySqlParser.h
+++ b/axiom/optimizer/tests/QuerySqlParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"

--- a/axiom/optimizer/tests/SchemaUtilsTest.cpp
+++ b/axiom/optimizer/tests/SchemaUtilsTest.cpp
@@ -1,4 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <gtest/gtest.h>
 

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 add_subdirectory(tests)
 
 velox_add_library(axiom_runner_multifragment_plan MultiFragmentPlan.cpp)

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "axiom/runner/MultiFragmentPlan.h"

--- a/axiom/runner/MultiFragmentPlan.cpp
+++ b/axiom/runner/MultiFragmentPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/MultiFragmentPlan.h
+++ b/axiom/runner/MultiFragmentPlan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "velox/core/PlanFragment.h"

--- a/axiom/runner/Runner.cpp
+++ b/axiom/runner/Runner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "velox/connectors/Connector.h"

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +25,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_runner_tests_utils
-            DistributedPlanBuilder.cpp LocalRunnerTestBase.cpp)
+add_library(axiom_runner_tests_utils DistributedPlanBuilder.cpp
+                                     LocalRunnerTestBase.cpp)
 
 target_link_libraries(
   axiom_runner_tests_utils
@@ -37,13 +50,12 @@ target_link_libraries(
   velox_parse_expression
   GTest::gtest)
 
-add_library(axiom_runner_tests_presto_query_replay_runner PrestoQueryReplayRunner.cpp)
+add_library(axiom_runner_tests_presto_query_replay_runner
+            PrestoQueryReplayRunner.cpp)
 
 target_link_libraries(
-  axiom_runner_tests_presto_query_replay_runner
-  axiom_runner_local_runner
-  velox_hive_connector
-  velox_exec_test_lib)
+  axiom_runner_tests_presto_query_replay_runner axiom_runner_local_runner
+  velox_hive_connector velox_exec_test_lib)
 
 add_executable(axiom_runner_tests_presto_query_replay_runner_test
                PrestoQueryReplayRunnerTest.cpp Main.cpp)

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/DistributedPlanBuilder.h
+++ b/axiom/runner/tests/DistributedPlanBuilder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/LocalRunnerTestBase.h
+++ b/axiom/runner/tests/LocalRunnerTestBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/Main.cpp
+++ b/axiom/runner/tests/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/PrestoQueryReplayRunner.h
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/runner/tests/PrestoQueryReplayRunnerTest.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunnerTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 add_subdirectory(tests)
 
 find_package(antlr4-runtime REQUIRED)
 
 add_library(
-    velox_presto_grammar_lib
-    PrestoSqlBaseListener.cpp
-    PrestoSqlBaseVisitor.cpp
-    PrestoSqlLexer.cpp
-    PrestoSqlListener.cpp
-    PrestoSqlParser.cpp
-    PrestoSqlVisitor.cpp
-)
+  velox_presto_grammar_lib
+  PrestoSqlBaseListener.cpp
+  PrestoSqlBaseVisitor.cpp
+  PrestoSqlLexer.cpp
+  PrestoSqlListener.cpp
+  PrestoSqlParser.cpp
+  PrestoSqlVisitor.cpp)
 
-target_link_libraries(velox_presto_grammar_lib antlr4_shared)
+target_link_libraries(
+  velox_presto_grammar_lib antlr4_shared)

--- a/axiom/sql/presto/PrestoSqlBaseListener.cpp
+++ b/axiom/sql/presto/PrestoSqlBaseListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlBaseListener.h
+++ b/axiom/sql/presto/PrestoSqlBaseListener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlBaseVisitor.cpp
+++ b/axiom/sql/presto/PrestoSqlBaseVisitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlBaseVisitor.h
+++ b/axiom/sql/presto/PrestoSqlBaseVisitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlLexer.cpp
+++ b/axiom/sql/presto/PrestoSqlLexer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlLexer.h
+++ b/axiom/sql/presto/PrestoSqlLexer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlListener.cpp
+++ b/axiom/sql/presto/PrestoSqlListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlListener.h
+++ b/axiom/sql/presto/PrestoSqlListener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlParser.cpp
+++ b/axiom/sql/presto/PrestoSqlParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlParser.h
+++ b/axiom/sql/presto/PrestoSqlParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlVisitor.cpp
+++ b/axiom/sql/presto/PrestoSqlVisitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/PrestoSqlVisitor.h
+++ b/axiom/sql/presto/PrestoSqlVisitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -19,8 +19,8 @@ find_package(antlr4-runtime REQUIRED)
 add_test(velox_presto_parser_test velox_presto_parser_test)
 
 target_link_libraries(
-    velox_presto_parser_test
-    velox_presto_grammar_lib
-    GTest::gtest
-    GTest::gtest_main
-    antlr4_shared)
+  velox_presto_parser_test
+  velox_presto_grammar_lib
+  GTest::gtest
+  GTest::gtest_main
+  antlr4_shared)

--- a/axiom/sql/presto/tests/GrammarTest.cpp
+++ b/axiom/sql/presto/tests/GrammarTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/tests/ParserHelper.cpp
+++ b/axiom/sql/presto/tests/ParserHelper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/tests/ParserHelper.h
+++ b/axiom/sql/presto/tests/ParserHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axiom/sql/presto/tests/UpperCasedInput.h
+++ b/axiom/sql/presto/tests/UpperCasedInput.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Was using the old python script which was deprecated in velox, now moving to velox style check. Thanks Krishna @kgpai for pointing out the difference. 

Also run the check for all files, and fix them accordingly.
```
feilongliu@feilongliu-mbp verax % /Users/feilongliu/Library/Python/3.12/bin/pre-commit run --all-files
Check for useless excludes...............................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable..........................Passed
cmake-format.............................................................Passed
license-header...........................................................Passed
clang-format.............................................................Passed
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
yamllint.............................................(no files to check)Skipped
yamlfmt..............................................(no files to check)Skipped
zizmor...................................................................Passed
Validate GitHub Actions workflows........................................Passed

```