### PR TITLE
feat: Move findTable to smart pointer return type

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -118,7 +118,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   auto* metadata = connector::getConnector(connectorId)->metadata();
-  auto* table = metadata->findTable(tableName);
+  auto table = metadata->findTable(tableName);
   VELOX_USER_CHECK_NOT_NULL(table, "Table not found: {}", tableName);
   const auto& schema = table->rowType();
 
@@ -163,7 +163,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   auto* metadata = connector::getConnector(connectorId)->metadata();
-  auto* table = metadata->findTable(tableName);
+  auto table = metadata->findTable(tableName);
   VELOX_USER_CHECK_NOT_NULL(table, "Table not found: {}", tableName);
   const auto& schema = table->rowType();
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -446,6 +446,13 @@ class Optimization {
     return history_;
   }
 
+  /// Retain a reference to the provided ConnectorTablePtr to ensure
+  /// the Table is retained for the duration of Optimization, even if
+  /// dropped by the corresponding ConnectorMetadata.
+  void retainConnectorTable(connector::ConnectorTablePtr table) {
+    retainedTables_.insert(std::move(table));
+  }
+
   /// If false, correlation names are not included in Column::toString(). Used
   /// for canonicalizing join cache keys.
   bool& cnamesInExpr() {
@@ -605,6 +612,9 @@ class Optimization {
   History& history_;
 
   std::shared_ptr<core::QueryCtx> queryCtx_;
+
+  // Set of tables in use by the Optimizer.
+  std::unordered_set<connector::ConnectorTablePtr> retainedTables_;
 
   // Top DerivedTable when making a QueryGraph from PlanNode.
   DerivedTableP root_;

--- a/axiom/optimizer/SchemaResolver.cpp
+++ b/axiom/optimizer/SchemaResolver.cpp
@@ -20,7 +20,7 @@
 
 namespace facebook::velox::optimizer {
 
-const connector::Table* SchemaResolver::findTable(
+connector::ConnectorTablePtr SchemaResolver::findTable(
     const std::string& catalog,
     const std::string& name) {
   TableNameParser parser(name);

--- a/axiom/optimizer/SchemaResolver.h
+++ b/axiom/optimizer/SchemaResolver.h
@@ -38,7 +38,7 @@ class SchemaResolver {
   // If schema is omitted, defaultSchema will be prepended prior to lookup.
   // If the table name specifies a different catalog than the one specified
   // as a parameter, an error will be thrown.
-  virtual const connector::Table* findTable(
+  virtual connector::ConnectorTablePtr findTable(
       const std::string& catalog,
       const std::string& name);
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -220,7 +220,7 @@ RowTypePtr ToVelox::makeOutputType(const ColumnVector& columns) {
         continue;
       }
 
-      auto* runnerTable = schemaTable->connectorTable;
+      auto runnerTable = schemaTable->connectorTable;
       if (runnerTable) {
         auto* runnerColumn = runnerTable->findColumn(std::string(
             column->topColumn() ? column->topColumn()->name()

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -101,7 +101,7 @@ bool VeloxHistory::setLeafSelectivity(BaseTable& table, RowTypePtr scanType) {
       return true;
     }
   }
-  auto* runnerTable = table.schemaTable->connectorTable;
+  auto runnerTable = table.schemaTable->connectorTable;
   if (!runnerTable) {
     // If there is no physical table to go to: Assume 1/10 if any filters.
     if (table.columnFilters.empty() && table.filter.empty()) {

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -193,7 +193,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
 
   void initialize() override;
 
-  const Table* findTable(const std::string& name) override;
+  ConnectorTablePtr findTable(const std::string& name) override;
 
   ConnectorSplitManager* splitManager() override {
     ensureInitialized();
@@ -220,7 +220,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   /// ConnectorMetadata API. This This is only needed for running the
   /// DuckDB parser on testing queries since the latter needs a set of
   /// tables for name resolution.
-  const std::unordered_map<std::string, std::unique_ptr<LocalTable>>& tables()
+  const std::unordered_map<std::string, std::shared_ptr<LocalTable>>& tables()
       const {
     ensureInitialized();
     return tables_;
@@ -262,14 +262,14 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   void ensureInitialized() const override;
   void makeQueryCtx();
   void makeConnectorQueryCtx();
-  LocalTable* createTableFromSchema(
+  std::shared_ptr<LocalTable> createTableFromSchema(
       const std::string& name,
       const std::string& path);
   void readTables(const std::string& path);
 
   void loadTable(const std::string& tableName, const fs::path& tablePath);
 
-  LocalTable* findTableLocked(const std::string& name) const;
+  std::shared_ptr<LocalTable> findTableLocked(const std::string& name) const;
 
   mutable std::mutex mutex_;
   mutable bool initialized_{false};
@@ -280,11 +280,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   std::shared_ptr<core::QueryCtx> queryCtx_;
   std::shared_ptr<ConnectorQueryCtx> connectorQueryCtx_;
   dwio::common::FileFormat format_;
-  std::unordered_map<std::string, std::unique_ptr<LocalTable>> tables_;
-
-  // Superseded versions of tables. Need to stay live because pending
-  // optimization may reference a table that has been updated since.
-  std::vector<std::unique_ptr<LocalTable>> oldTables_;
+  std::unordered_map<std::string, std::shared_ptr<LocalTable>> tables_;
   LocalHiveSplitManager splitManager_;
 };
 

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
@@ -1,4 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h"
 
@@ -188,7 +202,7 @@ void TpchConnectorMetadata::loadTable(
   const auto tableType = velox::tpch::getTableSchema(tpchTable);
   const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor);
 
-  auto table = std::make_unique<TpchTable>(tableName, tpchTable, scaleFactor);
+  auto table = std::make_shared<TpchTable>(tableName, tpchTable, scaleFactor);
   table->numRows_ = numRows;
 
   for (auto i = 0; i < tableType->size(); ++i) {
@@ -267,14 +281,14 @@ std::string getQualifiedName(const std::string& name) {
   return qualifiedName;
 }
 
-const Table* TpchConnectorMetadata::findTable(const std::string& name) {
+ConnectorTablePtr TpchConnectorMetadata::findTable(const std::string& name) {
   ensureInitialized();
   const auto qualifiedName = getQualifiedName(name);
   auto it = tables_.find(qualifiedName);
   if (it == tables_.end()) {
     return nullptr;
   }
-  return it->second.get();
+  return it->second;
 }
 
 } // namespace facebook::velox::connector::tpch

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
@@ -177,7 +177,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
 
   void initialize() override;
 
-  const Table* findTable(const std::string& name) override;
+  ConnectorTablePtr findTable(const std::string& name) override;
 
   ConnectorSplitManager* splitManager() override {
     ensureInitialized();
@@ -207,7 +207,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
     return tpchConnector_;
   }
 
-  const std::unordered_map<std::string, std::unique_ptr<TpchTable>>& tables()
+  const std::unordered_map<std::string, std::shared_ptr<TpchTable>>& tables()
       const {
     ensureInitialized();
     return tables_;
@@ -228,7 +228,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   std::shared_ptr<memory::MemoryPool> rootPool_{
       memory::memoryManager()->addRootPool()};
   std::shared_ptr<core::QueryCtx> queryCtx_;
-  std::unordered_map<std::string, std::unique_ptr<TpchTable>> tables_;
+  std::unordered_map<std::string, std::shared_ptr<TpchTable>> tables_;
   TpchSplitManager splitManager_;
 };
 

--- a/axiom/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/optimizer/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -66,8 +66,7 @@ TEST_F(TpchConnectorMetadataTest, findAllScaleFactors) {
     auto table = metadata_->findTable(qualifiedName);
     ASSERT_NE(table, nullptr);
     EXPECT_EQ(table->name(), qualifiedName);
-    auto* tpchTable =
-        dynamic_cast<const facebook::velox::connector::tpch::TpchTable*>(table);
+    auto tpchTable = std::dynamic_pointer_cast<const TpchTable>(table);
     ASSERT_NE(tpchTable, nullptr);
     EXPECT_DOUBLE_EQ(tpchTable->getScaleFactor(), scaleFactor);
   }

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -111,9 +111,9 @@ std::unique_ptr<QuerySqlParser> HiveQueriesTestBase::makeQueryParser() {
       std::make_unique<QuerySqlParser>(exec::test::kHiveConnectorId, pool());
 
   auto registerTable = [&](const std::string& name) {
-    auto* table = connector::getConnector(exec::test::kHiveConnectorId)
-                      ->metadata()
-                      ->findTable(name);
+    auto table = connector::getConnector(exec::test::kHiveConnectorId)
+                     ->metadata()
+                     ->findTable(name);
     parser->registerTable(name, table->rowType());
   };
 

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -80,9 +80,9 @@ class TpchPlanTest : public virtual test::QueryTestBase {
         exec::test::kHiveConnectorId, pool());
 
     auto registerTable = [&](const std::string& name) {
-      auto* table = connector::getConnector(exec::test::kHiveConnectorId)
-                        ->metadata()
-                        ->findTable(name);
+      auto table = connector::getConnector(exec::test::kHiveConnectorId)
+                       ->metadata()
+                       ->findTable(name);
       parser.registerTable(name, table->rowType());
     };
 


### PR DESCRIPTION
Summary:
was hard to manage the lifecycle of tables when the Optimizer (or other findTable callers) could dereference the pointer at any time. e.g. if a second concurrent query determines the table information is stale, or planning is stuck and the table is pushed out of cache, the server can segfault

Changing the return type to shared_ptr<const Table> (ConnectorTablePtr) and updating all the callers

Also, adding a set in the Optimizer to capture a reference to all the Tables used in Optimization, to prevent reclaimation prior to Optimization completion

Differential Revision: D80525688


