### PR TITLE
feat: Add core::IExpr::replaceInputs API

### DIFF
--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -45,7 +45,7 @@ class SubqueryExpr : public core::IExpr {
  public:
   // @param subquery A plan tree that produces a single column.
   explicit SubqueryExpr(logical_plan::LogicalPlanNodePtr subquery)
-      : IExpr({}), subquery_(std::move(subquery)) {}
+      : IExpr(IExpr::Kind::kSubquery, {}), subquery_(std::move(subquery)) {}
 
   const logical_plan::LogicalPlanNodePtr& subquery() const {
     return subquery_;
@@ -53,6 +53,11 @@ class SubqueryExpr : public core::IExpr {
 
   std::string toString() const override {
     return "<subquery>";
+  }
+
+  ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override {
+    VELOX_CHECK_EQ(newInputs.size(), 0);
+    return std::make_shared<SubqueryExpr>(subquery_);
   }
 
  private:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14543

This API is helpful for re-writing expression trees in https://github.com/facebookexperimental/verax/pull/217

Specifically, it is used to split a SELECT with a mix of aggregations and scalar expressions into Agg followed by Project.

For example, SELECT sum(a) / count(1) FROM t is rewritten as

```
- Project: s / c
   - Agg: s := sum(a), c := count(1)
```

Reviewed By: xiaoxmeng

Differential Revision: D80670441


