### PR TITLE
feat: Add table write logical plan node and partition type

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -24,6 +24,7 @@ const auto& nodeKindNames() {
   static const folly::F14FastMap<NodeKind, std::string_view> kNames = {
       {NodeKind::kValues, "VALUES"},
       {NodeKind::kTableScan, "TABLE_SCAN"},
+      {NodeKind::kTableWrite, "TABLE_WRITE"},
       {NodeKind::kFilter, "FILTER"},
       {NodeKind::kProject, "PROJECT"},
       {NodeKind::kAggregate, "AGGREGATE"},
@@ -360,5 +361,26 @@ void UnnestNode::accept(
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
 }
+
+void TableWriteNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+namespace {
+folly::F14FastMap<WriteKind, std::string> writeKindNames() {
+  static const folly::F14FastMap<WriteKind, std::string> kNames = {
+      {WriteKind::kInsert, "kInsert"},
+      {WriteKind::kUpdate, "kUpdate"},
+      {WriteKind::kDelete, "kDelete"},
+  };
+
+  return kNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
 
 } // namespace facebook::velox::logical_plan

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -33,6 +33,7 @@ enum class NodeKind {
   kLimit = 7,
   kSet = 8,
   kUnnest = 9,
+  kTableWrite = 10,
 };
 
 VELOX_DECLARE_ENUM_NAME(NodeKind)
@@ -684,4 +685,112 @@ class UnnestNode : public LogicalPlanNode {
 
 using UnnestNodePtr = std::shared_ptr<const UnnestNode>;
 
+/// Corresponds to connector::WriteKind.
+enum class WriteKind {
+  // Rows are added . All columns are written and either have a value in from an
+  // expression in the table writer or get a default from the schema. This
+  // covers insert, create table and replacing a Hive partition and any other
+  // use that adds whole rows.
+  kInsert,
+
+  // Individual rows are deleted. Only row ids as per
+  // ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
+  kDelete,
+
+  // Column values in individual rows are changed. The TableWriter
+  // gets first the row ids as per ConnectorMetadata::rowIdHandles()
+  // and then new values for the columns being changed. The new values
+  // may overlap with row ids if the row id is a set of primary key
+  // columns.
+  kUpdate
+};
+
+VELOX_DECLARE_ENUM_NAME(WriteKind);
+
+/// Implements insert/delete/update as per 'kind'.
+class TableWriteNode : public LogicalPlanNode {
+ public:
+  /// @param id Unique ID of the plan node.
+  /// @param connectorId ID of the connector to use to access the table.
+  /// @param tableName Table name.
+  /// @param kind - Indicates the type of write (insert/delete/update)
+  /// @param values - Expressions producing the values to write.. Correspond 1:1
+  /// to 'columnNames'.
+  /// @param columnNames A List of columns in the table being written. 1:1 to
+  /// 'inputNames'. 'columnNames' must refer to columns in the table but their
+  /// number or order does not have to correspond to the table. Missing columns
+  /// in insert get their default from the table.
+  /// @param outputType - Connector dependent output.
+  /// @param options - Writer dependent options. Mayy specify compression or
+  /// encoding options. The table always specifies partitioning. 'options' are
+  /// only for advanced/testing features.
+  TableWriteNode(
+      const std::string& id,
+      const LogicalPlanNodePtr& input,
+      const std::string& connectorId,
+      const std::string& tableName,
+      WriteKind kind,
+      const std::vector<ExprPtr>& values,
+      const std::vector<std::string>& columnNames,
+      const RowTypePtr& outputType,
+      const std::unordered_map<std::string, std::string>& options = {})
+      : LogicalPlanNode(NodeKind::kTableWrite, id, {input}, outputType),
+        connectorId_(connectorId),
+        tableName_(tableName),
+        writeKind_(kind),
+        values_(values),
+        columnNames_(columnNames),
+        options_(options) {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const std::string& tableName() const {
+    return tableName_;
+  }
+
+  WriteKind writeKind() const {
+    return writeKind_;
+  }
+
+  const std::vector<ExprPtr>& values() const {
+    return values_;
+  }
+
+  const std::vector<std::string>& columnNames() const {
+    return columnNames_;
+  }
+
+  const std::unordered_map<std::string, std::string>& options() const {
+    return options_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static RowTypePtr makeWriteType();
+
+  const std::string connectorId_;
+  const std::string tableName_;
+  const WriteKind writeKind_;
+  const std::vector<ExprPtr> values_;
+  const std::vector<std::string> columnNames_;
+  const std::unordered_map<std::string, std::string> options_;
+};
+
+using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
+
 } // namespace facebook::velox::logical_plan
+
+template <>
+struct fmt::formatter<facebook::velox::logical_plan::WriteKind>
+    : fmt::formatter<string_view> {
+  template <typename FormatContext>
+  auto format(facebook::velox::logical_plan::WriteKind k, FormatContext& ctx)
+      const {
+    return formatter<string_view>::format(
+        facebook::velox::logical_plan::WriteKindName::toName(k), ctx);
+  }
+};

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1219,6 +1219,40 @@ PlanBuilder& PlanBuilder::offset(int64_t offset) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& connectorId,
+    const std::string& tableName,
+    WriteKind kind,
+    const std::vector<ExprApi>& values,
+    const std::vector<std::string>& columnNames,
+    const std::unordered_map<std::string, std::string> options) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Table write node cannot be a leaf node");
+
+  auto connector = connector::getConnector(connectorId);
+  VELOX_CHECK_NOT_NULL(connector);
+  VELOX_CHECK_EQ(kind, WriteKind::kInsert);
+  auto metadata = connector->metadata();
+  VELOX_CHECK_NOT_NULL(metadata);
+  std::vector<ExprPtr> exprs;
+  for (const auto& expr : values) {
+    exprs.push_back(resolveScalarTypes(expr.expr()));
+  }
+
+  node_ = std::make_shared<TableWriteNode>(
+      nextId(),
+      node_,
+      connectorId,
+      tableName,
+      kind,
+      std::move(exprs),
+      columnNames,
+      metadata->tableWriteOutputType(
+          node_->outputType(), connector::WriteKind::kInsert),
+      options);
+
+  return *this;
+}
+
 ExprPtr PlanBuilder::resolveInputName(
     const std::optional<std::string>& alias,
     const std::string& name) const {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -306,6 +306,14 @@ class PlanBuilder {
 
   PlanBuilder& offset(int64_t offset);
 
+  PlanBuilder& tableWrite(
+      const std::string& connectorId,
+      const std::string& tableName,
+      WriteKind kind,
+      const std::vector<ExprApi>& values,
+      const std::vector<std::string>& columnNames,
+      const std::unordered_map<std::string, std::string> options = {});
+
   PlanBuilder& as(const std::string& alias);
 
   PlanBuilder& captureScope(Scope& scope) {

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -58,6 +58,10 @@ class PlanNodeVisitor {
   virtual void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const = 0;
 
+  virtual void visit(
+      const TableWriteNode& node,
+      PlanNodeVisitorContext& context) const = 0;
+
  protected:
   void visitInputs(const LogicalPlanNode& node, PlanNodeVisitorContext& ctx)
       const {

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -174,6 +174,27 @@ class ToTextVisitor : public PlanNodeVisitor {
     appendInputs(node, myContext);
   }
 
+  void visit(const TableWriteNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- TableWrite:";
+
+    appendOutputType(node, myContext);
+
+    myContext.out << std::endl;
+
+    const auto size = node.columnNames().size();
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (auto i = 0; i < size; ++i) {
+      myContext.out << indent << node.columnNames().at(i)
+                    << " := " << ExprPrinter::toText(*node.values().at(i))
+                    << std::endl;
+    }
+
+    appendInputs(node, myContext);
+  }
+
  private:
   static std::string makeIndent(int32_t size) {
     return std::string(size * 2, ' ');
@@ -341,6 +362,13 @@ class CollectExprStatsPlanNodeVisitor : public PlanNodeVisitor {
       const override {
     auto& stats = static_cast<Context&>(context).stats;
     collectExprStats(node.unnestExpressions(), stats);
+    visitInputs(node, context);
+  }
+
+  void visit(const TableWriteNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& stats = static_cast<Context&>(context).stats;
+    collectExprStats(node.values(), stats);
     visitInputs(node, context);
   }
 
@@ -606,6 +634,25 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
   void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const override {
     appendNode(node, context);
+  }
+
+  void visit(const TableWriteNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    appendHeader(node, myContext);
+
+    if (!myContext.skeletonOnly) {
+      const auto indent = makeIndent(myContext.indent + 3);
+      myContext.out << indent << "table: " << node.tableName() << std::endl;
+      myContext.out << indent << "connector: " << node.connectorId()
+                    << std::endl;
+      myContext.out << indent << "columns: " << node.columnNames().size()
+                    << std::endl;
+
+      appendExpressions(node.values(), myContext);
+    }
+
+    appendInputs(node, myContext);
   }
 
  private:

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -1101,5 +1101,54 @@ TEST_F(PlanPrinterTest, coercions) {
           testing::Eq("")));
 }
 
+TEST_F(PlanPrinterTest, tableWrite) {
+  auto plan = PlanBuilder()
+                  .tableScan(kTestConnectorId, "test", {"a", "b"})
+                  .tableWrite(
+                      kTestConnectorId,
+                      "output_table",
+                      WriteKind::kInsert,
+                      {Sql("a"), Sql("cast(b as varchar)")},
+                      {"col_a", "col_b"})
+                  .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- TableWrite"),
+          testing::StartsWith("    col_a := a"),
+          testing::StartsWith("    col_b := CAST(b AS VARCHAR)"),
+          testing::StartsWith("  - TableScan"),
+          testing::Eq("")));
+
+  lines = toSummaryLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::Eq("- TABLE_WRITE [1]: 0 fields"),
+          testing::Eq("      table: output_table"),
+          testing::Eq("      connector: test"),
+          testing::Eq("      columns: 2"),
+          testing::Eq("      expressions: CAST: 1, field: 2"),
+          testing::Eq("  - TABLE_SCAN [0]: 2 fields: a BIGINT, b DOUBLE"),
+          testing::Eq("        table: test"),
+          testing::Eq("        connector: test"),
+          testing::Eq("")));
+
+  lines = toSkeletonLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::Eq("- TABLE_WRITE [1]: 0 fields"),
+          testing::Eq("  - TABLE_SCAN [0]: 2 fields"),
+          testing::Eq("        table: test"),
+          testing::Eq("        connector: test"),
+          testing::Eq("")));
+}
+
 } // namespace
 } // namespace facebook::velox::logical_plan

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -33,6 +33,9 @@ using AggregationPlanCP = const AggregationPlan*;
 enum class OrderType;
 using OrderTypeVector = std::vector<OrderType, QGAllocator<OrderType>>;
 
+class WritePlan;
+using WritePlanCP = const WritePlan*;
+
 /// Represents a derived table, i.e. a SELECT in a FROM clause. This is the
 /// basic unit of planning. Derived tables can be merged and split apart from
 /// other ones. Join types and orders are decided within each derived table. A
@@ -51,6 +54,7 @@ using OrderTypeVector = std::vector<OrderType, QGAllocator<OrderType>>;
 ///   5. SELECT (projections)
 ///   6. ORDER BY (sort)
 ///   7. OFFSET and LIMIT (limit)
+/// 8. TableWriter: (insert/delete/update)
 ///
 struct DerivedTable : public PlanObject {
   DerivedTable() : PlanObject(PlanType::kDerivedTableNode) {}
@@ -139,6 +143,9 @@ struct DerivedTable : public PlanObject {
   /// Limit and offset.
   int64_t limit{-1};
   int64_t offset{0};
+
+  // Table write
+  WritePlanCP write{nullptr};
 
   /// Adds an equijoin edge between 'left' and 'right'.
   void addJoinEquality(ExprCP left, ExprCP right);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -643,12 +643,75 @@ void alignJoinSides(
   otherInput = repartition;
 }
 
+RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
+  if (isSingleWorker() || plan->distribution().distributionType.isGather) {
+    return plan;
+  }
+
+  const auto* write = state.dt->write;
+  auto& partition = write->layout()->partitionColumns();
+  if (partition.empty()) {
+    // The write is not partitioned on columns of the layout. ToVelox will add
+    // no or an arbitrary repartition regardless of plan.
+    return plan;
+  }
+
+  ExprVector keyValues;
+  for (auto i = 0; i < partition.size(); ++i) {
+    // find the value for each partition column.
+    auto name = toName(partition[i]->name());
+    auto it = std::find(write->columns().begin(), write->columns().end(), name);
+    VELOX_CHECK(
+        it != write->columns().end(), "No value for partition column {}", name);
+    keyValues.push_back(write->values()[i]);
+  }
+
+  auto copartition = copartitionType(
+      plan->distribution().distributionType.partitionType,
+      write->layout()->partitionType());
+  // Copartitioning is possible if PartitionTypes are compatible and the table
+  // has no fewer partitions than the plan.
+  bool shuffle =
+      !copartition || copartition == write->layout()->partitionType();
+  if (!shuffle) {
+    // Check that the partition keys of the plan are assigned pairwise to the
+    // partition columns of the layout.
+    for (auto i = 0; i < keyValues.size(); ++i) {
+      auto key = keyValues[i];
+      auto nthKey = position(plan->distribution().partition, *key);
+      if (nthKey != i) {
+        shuffle = true;
+        break;
+      }
+    }
+  }
+  if (!shuffle) {
+    return plan;
+  }
+
+  Distribution distribution(
+      plan->distribution().distributionType, std::move(keyValues));
+  auto* repartition =
+      make<Repartition>(plan, std::move(distribution), plan->columns());
+  state.addCost(*repartition);
+  return repartition;
+}
 } // namespace
 
 void Optimization::addPostprocess(
     DerivedTableCP dt,
     RelationOpPtr& plan,
     PlanState& state) {
+  if (dt->write) {
+    VELOX_CHECK(
+        dt->aggregation == nullptr && dt->orderKeys.empty() &&
+            dt->limit == -1 && dt->offset == 0,
+        "A write does not mix with other postprocess");
+    plan = repartitionForWrite(plan, state);
+    plan = make<TableWrite>(plan, dt->write);
+    return;
+  }
+
   if (dt->aggregation) {
     const auto& aggPlan = dt->aggregation;
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -160,6 +160,14 @@ class Optimization {
   /// Produces trace output if event matches 'traceFlags_'.
   void trace(int32_t event, int32_t id, const Cost& cost, RelationOp& plan);
 
+  connector::ConnectorInsertTableHandlePtr writeHandle(int32_t id) {
+    return toGraph_.writeHandles().at(id);
+  }
+
+  const std::unordered_set<connector::TablePtr> retainedTables() const {
+    return retainedTables_;
+  }
+
  private:
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -19,6 +19,10 @@
 #include <unordered_map>
 #include <vector>
 
+namespace facebook::velox::connector {
+class ConnectorSession;
+}
+
 namespace facebook::velox::optimizer {
 
 struct OptimizerOptions {
@@ -57,6 +61,9 @@ struct OptimizerOptions {
 
   /// Produce trace of plan candidates.
   int32_t traceFlags{0};
+
+  /// ConnectorSession, needed for write operations.
+  std::shared_ptr<connector::ConnectorSession> session{nullptr};
 
   bool isMapAsStruct(const char* table, const char* column) const {
     if (allMapsAsStruct) {

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -45,6 +45,15 @@ void planBreakpoint() {
   LOG(INFO) << "Join order breakpoint";
 }
 
+const connector::PartitionType* copartitionType(
+    const connector::PartitionType* first,
+    const connector::PartitionType* second) {
+  if (!first || !second) {
+    return nullptr;
+  }
+  return first->copartition(*second);
+}
+
 void PlanState::debugSetFirstTable(int32_t id) {
   if (dt->id() == debugDt) {
     debugPlacedTables.resize(1);
@@ -173,6 +182,11 @@ const PlanObjectSet& PlanState::downstreamColumns() const {
       } else if (targetColumns.contains(aggToPlace->columns()[i])) {
         result.unionColumns(aggToPlace->aggregates()[i - numGroupingKeys]);
       }
+    }
+  }
+  if (dt->write && !placed.contains(dt->write)) {
+    for (auto i = 0; i < dt->write->columns().size(); ++i) {
+      result.unionColumns(dt->write->values()[i]);
     }
   }
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -345,6 +345,14 @@ namespace facebook::velox::optimizer {
 
 const JoinEdgeVector& joinedBy(PlanObjectCP table);
 
+/// Compares 'first' and 'second' and returns the one that should be
+/// the repartition partitioning to do copartition with the two. If
+/// there is no copartition possibility or if either or both are
+/// nullptr, returns nullptr.
+const connector::PartitionType* copartitionType(
+    const connector::PartitionType* first,
+    const connector::PartitionType* second);
+
 /// Returns  the inverse join type, e.g. right outer from left outer.
 /// TODO Move this function to Velox.
 core::JoinType reverseJoinType(core::JoinType joinType);

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -40,6 +40,7 @@ enum class PlanType {
   kFilterNode,
   kJoinNode,
   kOrderByNode,
+  kWriteNode,
   kLimitNode,
 };
 

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -926,4 +926,56 @@ class AggregationPlan : public PlanObject {
 
 using AggregationPlanCP = const AggregationPlan*;
 
+using NameVector = std::vector<Name, QGAllocator<Name>>;
+
+class WritePlan : public PlanObject {
+ public:
+  WritePlan(
+      Name table,
+      const connector::TableLayout* layout,
+      logical_plan::WriteKind kind,
+      ExprVector values,
+      NameVector columns,
+      ColumnVector output)
+      : PlanObject(PlanType::kWriteNode),
+        table_(table),
+        layout_(layout),
+        kind_(kind),
+        values_(values),
+        columns_(columns),
+        output_(output) {}
+
+  Name table() const {
+    return table_;
+  }
+
+  const connector::TableLayout* layout() const {
+    return layout_;
+  }
+
+  logical_plan::WriteKind kind() const {
+    return kind_;
+  }
+
+  const ExprVector values() const {
+    return values_;
+  }
+
+  const NameVector& columns() const {
+    return columns_;
+  }
+
+  const ColumnVector& output() const {
+    return output_;
+  }
+
+ private:
+  Name table_;
+  const connector::TableLayout* layout_;
+  logical_plan::WriteKind kind_;
+  ExprVector values_;
+  NameVector columns_;
+  ColumnVector output_;
+};
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -827,4 +827,45 @@ std::string UnionAll::toString(bool recursive, bool detail) const {
   return out.str();
 }
 
+TableWrite::TableWrite(RelationOpPtr input, const WritePlan* write)
+    : RelationOp(RelType::kTableWrite, input, Distribution(), write->output()),
+      write(write) {
+  cost_.inputCardinality = inputCardinality();
+  cost_.unitCost = 0.01;
+}
+
+std::string TableWrite::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  if (recursive) {
+    out << input()->toString(true, detail) << " ";
+  }
+
+  if (detail) {
+    out << fmt::format(
+        "TableWrite to {} ({} columns)",
+        write->table(),
+        write->columns().size());
+
+    const auto& values = write->values();
+    const auto& columnNames = write->columns();
+
+    if (!values.empty()) {
+      out << " expressions:";
+      for (size_t i = 0; i < values.size() && i < columnNames.size(); ++i) {
+        out << " " << columnNames[i] << "=" << values[i]->toString();
+        if (i < values.size() - 1) {
+          out << ",";
+        }
+      }
+    }
+
+    printCost(detail, out);
+  } else {
+    out << fmt::format(
+        "TableWrite {} columns to {}", write->columns().size(), write->table());
+  }
+
+  return out.str();
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -92,6 +92,7 @@ enum class RelType {
   kUnionAll,
   kLimit,
   kValues,
+  kTableWrite,
 };
 
 VELOX_DECLARE_ENUM_NAME(RelType)
@@ -464,5 +465,15 @@ struct Limit : public RelationOp {
 };
 
 using LimitCP = const Limit*;
+
+struct TableWrite : public RelationOp {
+  TableWrite(RelationOpPtr input, const WritePlan* write);
+
+  const WritePlan* write;
+
+  std::string toString(bool recursive, bool detail) const override;
+};
+
+using TableWriteCP = const TableWrite*;
 
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -129,18 +129,43 @@ SchemaTableCP Schema::findTable(
     schemaTable->columns[column->name()] = column;
     columns.push_back(column);
   }
-  DistributionType defaultDistributionType;
-  defaultDistributionType.locus = defaultLocus_;
+  auto findColumn = [&](const std::string& name) -> ColumnCP {
+    auto interned = toName(name);
+    for (auto* column : columns) {
+      if (column->name() == interned) {
+        return column;
+      }
+    }
+    VELOX_FAIL("Partition or order column not in layout columns");
+  };
+
+  auto layout = connectorTable->layouts()[0];
+  DistributionType distribution;
+  distribution.partitionType = layout->partitionType();
+  if (distribution.partitionType &&
+      distribution.partitionType->numPartitions().has_value()) {
+    distribution.numPartitions =
+        distribution.partitionType->numPartitions().value();
+  }
+  distribution.locus = defaultLocus_;
+  ColumnVector partition;
+  for (auto& part : layout->partitionColumns()) {
+    partition.push_back(findColumn(part->name()));
+  }
+  ColumnVector order;
+  for (auto* column : layout->orderColumns()) {
+    order.push_back(findColumn(column->name()));
+  }
+
   schemaTable->addIndex(
       toName("pk"),
-      0,
-      0,
-      {},
-      defaultDistributionType,
-      {},
-      std::move(columns),
-      connectorTable->layouts()[0]);
-  addTable(schemaTable);
+      layout->uniquePrifixColumns(),
+      order.size(),
+      order,
+      distribution,
+      partition,
+      columns,
+      layout);
   queryCtx()->optimization()->retainConnectorTable(std::move(connectorTable));
   return schemaTable;
 }
@@ -433,6 +458,9 @@ std::string Distribution::toString() const {
   std::stringstream out;
   if (!partition.empty()) {
     out << "P ";
+    if (distributionType.partitionType) {
+      out << " " << distributionType.partitionType->toString() << " ";
+    }
     exprsToString(partition, out);
     out << " " << distributionType.numPartitions << " ways";
   }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -35,6 +35,8 @@ using NameMap = std::unordered_map<
     std::equal_to<Name>,
     QGAllocator<std::pair<const Name, T>>>;
 
+using TypeCP = const Type*;
+
 /// Represents constraints on a column value or intermediate result.
 struct Value {
   Value(const velox::Type* _type, float _cardinality)
@@ -114,35 +116,49 @@ class Locus {
 
 using LocusCP = const Locus*;
 
-/// Method for determining a partition given an ordered list of partitioning
-/// keys. Hive hash is an example, range partitioning is another. Add values
-/// here for more types.
-enum class ShuffleMode : uint8_t {
-  kNone,
-  kHive,
-};
-
-/// Distribution of data. 'numPartitions' is 1 if the data is not partitioned.
-/// There is copartitioning if the DistributionType is the same on both sides
-/// and both sides have an equal number of 1:1 type matched partitioning keys.
+/// Distribution of data. This describes a possible partition function
+/// that assigns a row of data to a partition based on some
+/// combination of partition keys. For a join to be copartitioned,
+/// both sides must have compatible partition functions and the join
+/// keys must include the partition keys.  'numPartitions' is 1 if the
+/// data is not partitioned.
 struct DistributionType {
-  bool operator==(const DistributionType& other) const = default;
+  bool operator==(const DistributionType& other) const {
+    return typesCompatible(partitionType, other.partitionType) &&
+        locus == other.locus && isGather == other.isGather;
+  }
 
-  LocusCP locus{nullptr};
+  static bool typesCompatible(
+      const connector::PartitionType* left,
+      const connector::PartitionType* right) {
+    if (left != nullptr && right != nullptr &&
+        left->copartition(*right) != nullptr) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Partition function. nullptr means Velox default, copartitioned only with
+  /// itself.
+  const connector::PartitionType* partitionType{nullptr};
   int32_t numPartitions{1};
+  LocusCP locus{nullptr};
   bool isGather{false};
-  ShuffleMode mode{ShuffleMode::kNone};
 
   static DistributionType gather() {
-    static constexpr DistributionType kGather = {
-        .isGather = true,
-    };
+    static const DistributionType kGather = {
+        .partitionType = nullptr,
+        .numPartitions = 1,
+        .locus = nullptr,
+        .isGather = true};
+
     return kGather;
   }
 };
 
-// Describes output of relational operator. If base table, cardinality is
-// after filtering.
+// Describes output of relational operator. If this is partitioned on
+// some keys, distributionType gives the partition function and
+// 'partition' gives the input of the partition function.
 struct Distribution {
   explicit Distribution() = default;
   Distribution(

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -124,6 +124,20 @@ void ToGraph::markFieldAccessed(
 }
 
 void ToGraph::markFieldAccessed(
+    const lp::TableWriteNode& write,
+    int32_t ordinal,
+    std::vector<Step>& steps,
+    bool isControl) {
+  std::vector<Step> empty;
+  const auto ctx = fromNode(write.onlyInput());
+  for (auto& expr : write.values()) {
+    std::vector<Step> empty;
+    markSubfields(expr, empty, isControl, ctx.toCtx());
+  }
+  return;
+}
+
+void ToGraph::markFieldAccessed(
     const LogicalContextSource& source,
     int32_t ordinal,
     std::vector<Step>& steps,
@@ -170,6 +184,12 @@ void ToGraph::markFieldAccessed(
   if (kind == lp::NodeKind::kSet) {
     const auto* set = source.planNode->asUnchecked<lp::SetNode>();
     markFieldAccessed(*set, ordinal, steps, isControl);
+    return;
+  }
+
+  if (kind == lp::NodeKind::kTableWrite) {
+    const auto* write = source.planNode->asUnchecked<lp::TableWriteNode>();
+    markFieldAccessed(*write, ordinal, steps, isControl);
     return;
   }
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1310,6 +1310,84 @@ PlanObjectP ToGraph::addLimit(const lp::LimitNode& limitNode) {
   return currentDt_;
 }
 
+PlanObjectP ToGraph::addWrite(const lp::TableWriteNode& tableWrite) {
+  VELOX_CHECK_NULL(currentDt_->write, "Only one TableWrite allowed");
+  auto connector = connector::getConnector(tableWrite.connectorId());
+  VELOX_CHECK_NOT_NULL(connector);
+  auto* metadata = connector->metadata();
+  VELOX_CHECK_NOT_NULL(metadata);
+
+  const auto* schemaTable =
+      schema_.findTable(tableWrite.connectorId(), tableWrite.tableName());
+  VELOX_CHECK_NOT_NULL(
+      schemaTable,
+      "Table not found: {} via connector {}",
+      tableWrite.tableName(),
+      tableWrite.connectorId());
+
+  VELOX_CHECK_EQ(
+      schemaTable->columnGroups.size(),
+      1,
+      "Only one materialization supported for table write");
+
+  auto* layout = schemaTable->columnGroups[0]->layout;
+  auto rowType = layout->rowType();
+
+  NameVector columns;
+  ExprVector values;
+  for (auto i = 0; i < rowType->size(); ++i) {
+    auto name = rowType->nameOf(i);
+    auto it = std::find(
+        tableWrite.columnNames().begin(), tableWrite.columnNames().end(), name);
+    if (it == tableWrite.columnNames().end()) {
+      columns.push_back(toName(name));
+      auto connectorColumn = layout->table().findColumn(name);
+      values.push_back(make<Literal>(
+          Value(toType(rowType->childAt(i)), 1),
+          queryCtx()->registerVariant(
+              std::make_unique<Variant>(connectorColumn->defaultValue()))));
+    } else {
+      auto nth = it - tableWrite.columnNames().begin();
+      columns.push_back(toName(name));
+      values.push_back(translateExpr(tableWrite.values()[nth]));
+    }
+  }
+  ColumnVector outputColumns;
+  for (auto i = 0; i < tableWrite.outputType()->size(); ++i) {
+    auto name = toName(tableWrite.outputType()->nameOf(i));
+    outputColumns.push_back(make<Column>(
+        name,
+        currentDt_,
+        Value(toType(tableWrite.outputType()->childAt(i)), 1),
+        name));
+    renames_[tableWrite.outputType()->nameOf(i)] = outputColumns.back();
+  }
+  currentDt_->write = make<WritePlan>(
+      toName(tableWrite.tableName()),
+      layout,
+      tableWrite.writeKind(),
+      std::move(values),
+      std::move(columns),
+      outputColumns);
+  // currentDt_->columns = outputColumns;
+
+  auto& options = queryCtx()->optimization()->options();
+  VELOX_CHECK_NOT_NULL(
+      options.session, "Must have a ConnectorSession for write operations");
+
+  VELOX_CHECK_EQ(tableWrite.writeKind(), lp::WriteKind::kInsert);
+
+  auto handle = metadata->createInsertTableHandle(
+      *layout,
+      layout->rowType(),
+      tableWrite.options(),
+      connector::WriteKind::kInsert,
+      options.session);
+  writeHandles_[currentDt_->write->id()] = handle;
+
+  return currentDt_;
+}
+
 namespace {
 bool hasNondeterministic(const lp::ExprPtr& expr) {
   if (const auto* call = expr->asUnchecked<lp::CallExpr>()) {
@@ -1628,6 +1706,10 @@ PlanObjectP ToGraph::makeQueryGraph(
       currentDt_->tableSet.add(setDt);
       return currentDt_;
     }
+    case lp::NodeKind::kTableWrite: {
+      wrapInDt(*node.onlyInput());
+      return addWrite(*node.asUnchecked<lp::TableWriteNode>());
+    }
     case lp::NodeKind::kUnnest:
     default:
       VELOX_NYI(
@@ -1640,7 +1722,7 @@ std::string leString(const lp::Expr* e) {
   return lp::ExprPrinter::toText(*e);
 }
 
-std::string pString(const lp::LogicalPlanNode* p) {
+std::string lpString(const lp::LogicalPlanNode* p) {
   return lp::PlanPrinter::toText(*p);
 }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -229,6 +229,11 @@ class ToGraph {
     }
   }
 
+  std::unordered_map<int32_t, connector::ConnectorInsertTableHandlePtr>&
+  writeHandles() {
+    return writeHandles_;
+  }
+
  private:
   static bool isSpecialForm(
       const logical_plan::ExprPtr& expr,
@@ -353,6 +358,8 @@ class ToGraph {
 
   PlanObjectP addOrderBy(const logical_plan::SortNode& order);
 
+  PlanObjectP addWrite(const logical_plan::TableWriteNode& TableWriteNode);
+
   bool isSubfield(
       const logical_plan::ExprPtr& expr,
       Step& step,
@@ -395,6 +402,12 @@ class ToGraph {
 
   void markFieldAccessed(
       const logical_plan::SetNode& set,
+      int32_t ordinal,
+      std::vector<Step>& steps,
+      bool isControl);
+
+  void markFieldAccessed(
+      const logical_plan::TableWriteNode& write,
       int32_t ordinal,
       std::vector<Step>& steps,
       bool isControl);
@@ -524,6 +537,8 @@ class ToGraph {
       planLeaves_;
 
   std::unique_ptr<BuiltinNames> builtinNames_;
+  std::unordered_map<int32_t, connector::ConnectorInsertTableHandlePtr>
+      writeHandles_;
 };
 
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -199,13 +199,23 @@ PlanAndStats ToVelox::toVeloxPlan(
   top.fragment.planNode = makeFragment(std::move(plan), top, stages);
   stages.push_back(std::move(top));
 
+  axiom::runner::FinishWrite finishWrites = nullptr;
+  if (!finishWrites_.empty()) {
+    finishWrites = [finishes = std::move(finishWrites_)](
+                       bool success, const std::vector<RowVectorPtr>& results) {
+      for (auto& finish : finishes) {
+        finish(success, results);
+      }
+    };
+  }
+
   for (const auto& stage : stages) {
     velox::core::PlanConsistencyChecker::check(stage.fragment.planNode);
   }
 
   return PlanAndStats{
       std::make_shared<axiom::runner::MultiFragmentPlan>(
-          std::move(stages), options),
+          std::move(stages), options, finishWrites),
       std::move(nodeHistory_),
       std::move(prediction_)};
 }
@@ -551,6 +561,20 @@ class TempProjections {
         toVelox_.nextId(), std::move(names_), std::move(exprs_), inputNode);
   }
 
+  /// Returns a projection that has exactly the fields in 'names'.
+  core::PlanNodePtr projectNamed(
+      core::PlanNodePtr inputNode,
+      const std::vector<std::string>& names) {
+    std::vector<core::TypedExprPtr> exprs;
+    for (auto& name : names) {
+      auto it = std::find(names_.begin(), names_.end(), name);
+      VELOX_CHECK(it != names_.end());
+      exprs.push_back(exprs_[it - names_.begin()]);
+    }
+    return std::make_shared<core::ProjectNode>(
+        toVelox_.nextId(), std::move(names), std::move(exprs), inputNode);
+  }
+
  private:
   ToVelox& toVelox_;
   const RelationOp& input_;
@@ -866,8 +890,8 @@ template <typename ExprType>
 core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
     const RowTypePtr& inputType,
     const std::vector<ExprType>& keys,
-    bool isBroadcast) {
-  if (isBroadcast) {
+    const Distribution& distribution) {
+  if (distribution.isBroadcast) {
     return std::make_shared<BroadcastPartitionFunctionSpec>();
   }
 
@@ -881,8 +905,12 @@ core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
     keyIndices.push_back(inputType->getChildIdx(
         dynamic_cast<const core::FieldAccessTypedExpr*>(key.get())->name()));
   }
-  return std::make_shared<HashPartitionFunctionSpec>(
-      inputType, std::move(keyIndices));
+  if (!distribution.distributionType.partitionType) {
+    return std::make_shared<HashPartitionFunctionSpec>(
+        inputType, std::move(keyIndices));
+  }
+  return distribution.distributionType.partitionType->makeSpec(
+      keyIndices, {}, false);
 }
 
 bool hasSubfieldPushdown(const TableScan& scan) {
@@ -1276,8 +1304,8 @@ core::PlanNodePtr ToVelox::makeAggregation(
       project = core::LocalPartitionNode::gather(nextId(), std::move(inputs));
       fragment.width = 1;
     } else {
-      auto partition =
-          createPartitionFunctionSpec(project->outputType(), keys, false);
+      auto partition = createPartitionFunctionSpec(
+          project->outputType(), keys, Distribution());
       project = std::make_shared<core::LocalPartitionNode>(
           nextId(),
           core::LocalPartitionNode::Type::kRepartition,
@@ -1317,8 +1345,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   auto partitioningInput = std::move(project).maybeProject(sourcePlan);
 
   auto partitionFunctionFactory = createPartitionFunctionSpec(
-      partitioningInput->outputType(), keys, distribution.isBroadcast);
-
+      partitioningInput->outputType(), keys, distribution);
   source.fragment.planNode = std::make_shared<core::PartitionedOutputNode>(
       nextId(),
       distribution.isBroadcast
@@ -1436,6 +1463,81 @@ core::PlanNodePtr ToVelox::makeValues(
   return valuesNode;
 }
 
+core::PlanNodePtr ToVelox::makeWrite(
+    const TableWrite& op,
+    ExecutableFragment& fragment,
+    std::vector<axiom::runner::ExecutableFragment>& stages) {
+  core::PlanNodePtr input = makeFragment(op.input(), fragment, stages);
+  TempProjections projections(*this, *op.input());
+  auto* write = op.write;
+  auto* layout = write->layout();
+  auto handle = queryCtx()->optimization()->writeHandle(write->id());
+  std::vector<std::string> names;
+  std::vector<core::FieldAccessTypedExprPtr> fields;
+  for (auto i = 0; i < write->values().size(); ++i) {
+    std::string name = write->columns()[i];
+    names.push_back(name);
+    fields.push_back(projections.toFieldRef(write->values()[i], &name));
+  }
+  input = projections.projectNamed(input, names);
+
+  auto& partitionColumns = layout->partitionColumns();
+  if (!partitionColumns.empty()) {
+    std::vector<column_index_t> channels;
+    std::vector<VectorPtr> constants;
+    for (auto i = 0; i < partitionColumns.size(); ++i) {
+      channels.push_back(
+          input->outputType()->getChildIdx(partitionColumns[i]->name()));
+      constants.push_back(nullptr);
+    }
+
+    auto spec =
+        write->layout()->partitionType()->makeSpec(channels, constants, true);
+    auto inputs = std::vector<core::PlanNodePtr>{input};
+    input = std::make_shared<core::LocalPartitionNode>(
+        nextId(),
+        core::LocalPartitionNode::Type::kRepartition,
+        false,
+        spec,
+        inputs);
+  }
+  std::vector<std::string> columnNames;
+  for (auto* name : write->columns()) {
+    columnNames.push_back(name);
+  }
+  auto* metadata = write->layout()->connector()->metadata();
+  auto session = queryCtx()->optimization()->options().session;
+  std::unordered_set<connector::TablePtr> retainedTables =
+      queryCtx()->optimization()->retainedTables();
+  // The finish function needs to capture the retained tables, which also keeps
+  // layout live past the Optimization.
+  finishWrites_.push_back(
+      [handle, metadata, layout, session, retainedTables](
+          bool success, const std::vector<RowVectorPtr>& results) {
+        metadata->finishWrite(
+            *layout,
+            handle,
+            success,
+            results,
+            connector::WriteKind::kInsert,
+            session);
+      });
+
+  auto outputType = metadata->tableWriteOutputType(
+      layout->rowType(), connector::WriteKind::kInsert);
+  return std::make_shared<core::TableWriteNode>(
+      nextId(),
+      input->outputType(),
+      columnNames,
+      std::nullopt,
+      std::make_shared<const core::InsertTableHandle>(
+          write->layout()->connector()->connectorId(), handle),
+      false,
+      outputType,
+      connector::CommitStrategy::kNoCommit,
+      input);
+}
+
 void ToVelox::makePredictionAndHistory(
     const core::PlanNodeId& id,
     const RelationOp* op) {
@@ -1473,6 +1575,8 @@ core::PlanNodePtr ToVelox::makeFragment(
       return makeUnionAll(*op->as<UnionAll>(), fragment, stages);
     case RelType::kValues:
       return makeValues(*op->as<Values>(), fragment);
+    case RelType::kTableWrite:
+      return makeWrite(*op->as<TableWrite>(), fragment, stages);
     default:
       VELOX_FAIL(
           "Unsupported RelationOp {}", static_cast<int32_t>(op->relType()));

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -181,6 +181,11 @@ class ToVelox {
       const Values& values,
       axiom::runner::ExecutableFragment& fragment);
 
+  core::PlanNodePtr makeWrite(
+      const TableWrite& values,
+      axiom::runner::ExecutableFragment& fragment,
+      std::vector<axiom::runner::ExecutableFragment>& stages);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the
@@ -265,6 +270,7 @@ class ToVelox {
 
   // Serial number for stages in executable plan.
   int32_t stageCounter_{0};
+  std::vector<axiom::runner::FinishWrite> finishWrites_;
 };
 
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/connectors/ConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/ConnectorMetadata.cpp
@@ -18,6 +18,15 @@
 
 namespace facebook::velox::connector {
 
+Variant Column::makeDefaultValue(
+    const TypePtr& type,
+    std::optional<Variant>& value) {
+  if (value.has_value()) {
+    return value.value();
+  }
+  return Variant::null(type->kind());
+}
+
 namespace {
 const auto& tableKindNames() {
   static const folly::F14FastMap<TableKind, std::string_view> kNames = {

--- a/axiom/optimizer/connectors/ConnectorMetadata.h
+++ b/axiom/optimizer/connectors/ConnectorMetadata.h
@@ -30,6 +30,8 @@ class ITypedExpr;
 using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
 
 class PartitionFunctionSpec;
+using PartitionFunctionSpecPtr =
+    std::shared_ptr<const core::PartitionFunctionSpec>;
 } // namespace facebook::velox::core
 
 /// Base classes for schema elements used in execution. A ConnectorMetadata
@@ -135,8 +137,13 @@ class Column {
  public:
   virtual ~Column() = default;
 
-  Column(std::string name, TypePtr type)
-      : name_(std::move(name)), type_(std::move(type)) {}
+  Column(
+      const std::string& name,
+      TypePtr type,
+      std::optional<Variant> defaultValue = std::nullopt)
+      : name_(name),
+        type_(std::move(type)),
+        defaultValue_(makeDefaultValue(type_, defaultValue)) {}
 
   const ColumnStatistics* stats() const {
     return latestStats_;
@@ -166,20 +173,23 @@ class Column {
     return type_;
   }
 
+  const Variant& defaultValue() const {
+    return defaultValue_;
+  }
+
   /// Returns approximate number of distinct values. Returns 'defaultValue' if
   /// no information.
   int64_t approxNumDistinct(int64_t defaultValue = 1000) const {
     if (auto* s = stats()) {
       return s->numDistinct.value_or(defaultValue);
     }
-
     return defaultValue;
   }
 
  protected:
   const std::string name_;
   const TypePtr type_;
-
+  const Variant defaultValue_;
   // The latest element added to 'allStats_'.
   tsan_atomic<ColumnStatistics*> latestStats_{nullptr};
 
@@ -188,6 +198,10 @@ class Column {
   std::vector<std::unique_ptr<ColumnStatistics>> allStats_;
 
  private:
+  static Variant makeDefaultValue(
+      const TypePtr& type,
+      std::optional<Variant>& value);
+
   // Serializes changes to statistics.
   std::mutex mutex_;
 };
@@ -203,6 +217,46 @@ class Table;
 struct SortOrder {
   bool isAscending{true};
   bool isNullsFirst{false};
+};
+
+/// Represents a partitioning function. Partitions can be copartitioned if the
+/// types are compatible.
+class PartitionType {
+ public:
+
+  virtual ~PartitionType() = default;
+  virtual std::optional<int32_t> numPartitions() const {
+    return std::nullopt;
+  }
+
+  /// Returns 'this' or '&other' if the partitions are
+  /// compatible. Partitions are compatible if data in one partitioned
+  /// dataset can only match data in the same partition of another
+  /// dataset if joined on equality of partition keys. Compatibility
+  /// is not strict equality in the case of e.g. Hive where a dataset
+  /// partitioned 8 ways is compatible with one partitioned 16 ways if
+  /// the function is the same. In such a case the partition to use is
+  /// the 8 way one. On the 16 side data from partitions 0 and 1 match
+  /// 0 on the 8 side and 2, 3 match 1 and so on.
+  virtual const PartitionType* copartition(const PartitionType& other) const {
+    return nullptr;
+  }
+
+  /// Returns the types of the partitioning keys. Empty if no partitioning.
+  virtual const std::vector<TypePtr>& partitionKeyTypes() const = 0;
+
+  /// Returns a factory that makes partition functions. The function
+  /// gets a RowVector and calculates a partition number from the
+  /// columns identified by 'channels'. If channels[i] ==
+  /// kConstantChannel then the corresponding element of 'constants'
+  /// is used. 'isLocal' differentiates between remote and ocal
+  /// exchange.
+  virtual core::PartitionFunctionSpecPtr makeSpec(
+      const std::vector<column_index_t>& channels,
+      const std::vector<VectorPtr>& constants,
+      bool isLocal) const = 0;
+
+  virtual std::string toString() const = 0;
 };
 
 /// Represents a physical manifestation of a table. There is at least
@@ -254,6 +308,13 @@ class TableLayout {
     return partitionColumns_;
   }
 
+  ///  Returns a partitionType. Describes how the value in partitionColumns()
+  ///  determines a partition. The returned value is owned by 'this'. nullptr if
+  ///  'partitionColumns_' is empty.
+  virtual const PartitionType* partitionType() const {
+    return nullptr;
+  }
+
   /// Columns on which content is ordered within the range of rows covered by a
   /// Split.
   const std::vector<const Column*>& orderColumns() const {
@@ -272,6 +333,12 @@ class TableLayout {
   /// the range must be on the next. This coresponds to a multipart key.
   const std::vector<const Column*>& lookupKeys() const {
     return lookupKeys_;
+  }
+
+  ///  Numb er of leading equalities  on orderColumns or lookupKeys needed to
+  ///  get exactly one or zero matches.
+  virtual int32_t uniquePrifixColumns() const {
+    return 0;
   }
 
   /// True if a full table scan is supported. Some lookup sources prohibit this.
@@ -518,20 +585,6 @@ struct LookupKeys {
   bool isAscending{true};
 };
 
-/// Describes how to repartition data before a TableWriter.
-struct WritePartitionInfo {
-  /// Columns for partitioning. Names refer to the column names in the insert
-  /// table handle. Empty if any worker can write any row.
-  const std::vector<std::string> columns;
-
-  /// Specifies the partition function. nullptr if 'columns' is empty.
-  const std::shared_ptr<const core::PartitionFunctionSpec> partitionSpec;
-
-  /// Maximum number of workers. For example, having more workers than there are
-  /// partitions makes no sense.
-  const int32_t maxWorkers;
-};
-
 /// Representts session status for update operations. May for example
 /// encapsulate a transaction state. The minimal implementation does nothing,
 /// which amounts to all write operations being non-isolated and autocommitting.
@@ -677,21 +730,27 @@ class ConnectorMetadata {
       WriteKind kind,
       const ConnectorSessionPtr& session) = 0;
 
-  /// Returns specification for repartitioning data before the table writer
-  /// stage.
-  virtual WritePartitionInfo writePartitionInfo(
-      const ConnectorInsertTableHandlePtr& handle) = 0;
-
   /// Finalizes a table write. This runs once after all the table writers have
   /// finished. The result sets from the table writer fragments are passed as
   /// 'writerResults'. Their format and meaning is connector specific. the
-  /// RowType is given by the outputType() of the TableWriter.
+  /// RowType is given by the outputType() of the TableWriter. If 'success' is
+  /// false, the write should be cancelled and possible partial results deleted.
+  /// In this case 'writerResult' may be empty.
   virtual void finishWrite(
       const TableLayout& layout,
       const ConnectorInsertTableHandlePtr& handle,
+      bool success,
       const std::vector<RowVectorPtr>& writerResult,
       WriteKind kind,
       const ConnectorSessionPtr& session) = 0;
+
+  /// Returns the output type of TableWrite operator for a row with columns as
+  /// in 'rowType'.
+  virtual RowTypePtr tableWriteOutputType(
+      const RowTypePtr& rowType,
+      WriteKind kind) const {
+    VELOX_UNSUPPORTED();
+  }
 
   /// Returns column handles whose value uniquely identifies a row for creating
   /// an update or delete record. These may be for example some connector

--- a/axiom/optimizer/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/hive/HiveConnectorMetadata.cpp
@@ -22,6 +22,55 @@
 
 namespace facebook::velox::connector::hive {
 
+const PartitionType* HivePartitionType::copartition(
+    const PartitionType& any) const {
+  if (const auto* hivePartitionType =
+          dynamic_cast<const HivePartitionType*>(&any)) {
+    const auto& myTypes = partitionKeyTypes();
+    const auto& otherTypes = hivePartitionType->partitionKeyTypes();
+
+    if (myTypes.size() == otherTypes.size()) {
+      bool typesCompatible = true;
+      for (size_t i = 0; i < myTypes.size(); ++i) {
+        if (!myTypes[i]->equivalent(*otherTypes[i])) {
+          typesCompatible = false;
+          break;
+        }
+      }
+
+      if (typesCompatible) {
+        if (numBuckets_ % hivePartitionType->numBuckets_ == 0) {
+          return hivePartitionType;
+        } else if (hivePartitionType->numBuckets_ % numBuckets_ == 0) {
+          return this;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+core::PartitionFunctionSpecPtr HivePartitionType::makeSpec(
+    const std::vector<column_index_t>& channels,
+    const std::vector<VectorPtr>& constants,
+    bool isLocal) const {
+  return std::make_shared<HivePartitionFunctionSpec>(
+      numBuckets_, channels, constants);
+}
+
+std::string HivePartitionType::toString() const {
+  std::string typeNames;
+  if (!partitionKeyTypes_.empty()) {
+    std::vector<std::string> typeStrs;
+    typeStrs.reserve(partitionKeyTypes_.size());
+    for (const auto& type : partitionKeyTypes_) {
+      typeStrs.push_back(type->toString());
+    }
+    typeNames = " [" + folly::join(", ", typeStrs) + "]";
+  }
+  return fmt::format("Hive {} buckets{}", numBuckets_, typeNames);
+}
+
 namespace {
 HiveColumnHandle::ColumnType columnType(
     const HiveTableLayout& layout,
@@ -174,7 +223,7 @@ ConnectorInsertTableHandlePtr HiveConnectorMetadata::createInsertTableHandle(
       inputColumns,
       makeLocationHandle(
           fmt::format("{}/{}", dataPath(), layout.table().name()),
-          std::nullopt),
+          makeStagingDirectory()),
       storageFormat,
       bucketProperty,
       compressionKind,
@@ -197,6 +246,15 @@ void HiveConnectorMetadata::validateOptions(
       VELOX_USER_FAIL("Option {} is not supported", pair.first);
     }
   }
+}
+
+RowTypePtr HiveConnectorMetadata::tableWriteOutputType(
+    const RowTypePtr& /*rowType*/,
+    WriteKind kind) const {
+  VELOX_CHECK_EQ(kind, WriteKind::kInsert);
+  return ROW(
+      {"numWrittenRows", "fragment", "tableCommitContext"},
+      {BIGINT(), VARBINARY(), VARBINARY()});
 }
 
 } // namespace facebook::velox::connector::hive

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -35,6 +35,7 @@
 
 namespace facebook::velox::connector::hive {
 
+namespace fs = std::filesystem;
 std::vector<PartitionHandlePtr> LocalHiveSplitManager::listPartitions(
     const ConnectorTableHandlePtr& tableHandle) {
   // All tables are unpartitioned.
@@ -775,6 +776,59 @@ void deleteDirectoryContents(const std::string& path) {
   closedir(dir);
 }
 
+fs::path createTemporaryDirectory(const fs::path& parentDir) {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<uint32_t> dis(1, 1000000);
+  static std::mutex mutex;
+  fs::path tempDirPath;
+  std::lock_guard<std::mutex> l(mutex);
+  for (;;) {
+    do {
+      uint32_t randomNumber = dis(gen);
+      tempDirPath = parentDir / ("temp_" + std::to_string(randomNumber));
+    } while (fs::exists(tempDirPath));
+    if (common::generateFileDirectory(tempDirPath.c_str())) {
+      return tempDirPath;
+    }
+  }
+}
+
+std::string LocalHiveConnectorMetadata::makeStagingDirectory() {
+  return createTemporaryDirectory(fmt::format("{}/.staging", dataPath()));
+}
+
+void moveFilesRecursively(
+    const fs::path& sourceDir,
+    const fs::path& targetDir) {
+  if (!fs::exists(sourceDir) || !fs::is_directory(sourceDir)) {
+    throw std::runtime_error(
+        "Source directory does not exist or is not a directory: " +
+        sourceDir.string());
+  }
+  // Create the target directory if it doesn't exist
+  if (!fs::exists(targetDir)) {
+    fs::create_directories(targetDir);
+  }
+  // Recursively iterate through the source directory
+  for (const auto& entry : fs::recursive_directory_iterator(sourceDir)) {
+    if (entry.is_regular_file()) {
+      // Compute the relative path from the source directory
+      fs::path relPath = fs::relative(entry.path(), sourceDir);
+      fs::path destPath = targetDir / relPath;
+      // Create enclosing directories in the target if they don't exist
+      fs::create_directories(destPath.parent_path());
+      // Move the file
+      fs::rename(entry.path(), destPath);
+    }
+  }
+  // Optionally, remove empty directories in the source
+  deleteDirectoryContents(sourceDir);
+  if (fs::is_empty(sourceDir)) {
+    fs::remove(sourceDir);
+  }
+}
+
 // Helper: Check if directory exists
 bool dirExists(const std::string& path) {
   struct stat info;
@@ -894,7 +948,7 @@ void LocalHiveConnectorMetadata::createTable(
   std::string filePath = path + "/.schema";
 
   std::lock_guard<std::mutex> l(mutex_);
-  folly::writeFileAtomic(filePath, jsonStr.data(), jsonStr.size());
+  folly::writeFileAtomic(filePath, jsonStr);
   tables_.erase(tableName);
   loadTable(tableName, path);
 }
@@ -902,11 +956,19 @@ void LocalHiveConnectorMetadata::createTable(
 void LocalHiveConnectorMetadata::finishWrite(
     const TableLayout& layout,
     const ConnectorInsertTableHandlePtr& handle,
+    bool success,
     const std::vector<RowVectorPtr>& /*writerResult*/,
     WriteKind /*kind*/,
     const ConnectorSessionPtr& /*session*/) {
   std::lock_guard<std::mutex> l(mutex_);
   auto localHandle = dynamic_cast<const HiveInsertTableHandle*>(handle.get());
+  if (!success) {
+    deleteDirectoryContents(localHandle->locationHandle()->writePath());
+    return;
+  }
+  moveFilesRecursively(
+      localHandle->locationHandle()->writePath(),
+      localHandle->locationHandle()->targetPath());
   loadTable(layout.table().name(), localHandle->locationHandle()->targetPath());
 }
 

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h
@@ -242,6 +242,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   void finishWrite(
       const TableLayout& layout,
       const ConnectorInsertTableHandlePtr& /*handle*/,
+      bool success,
       const std::vector<RowVectorPtr>& /*writerResult*/,
       WriteKind /*kind*/,
       const ConnectorSessionPtr& /*session*/) override;
@@ -250,6 +251,8 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   std::string dataPath() const override {
     return hiveConfig_->hiveLocalDataPath();
   }
+
+  std::string makeStagingDirectory() override;
 
   std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
       std::string targetDirectory,

--- a/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -198,7 +198,7 @@ TEST_F(HiveConnectorMetadataTest, createTable) {
       builder.planNode());
   auto result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
   metadata->finishWrite(
-      *layout, connectorHandle, {result}, WriteKind::kInsert, session);
+			*layout, connectorHandle, true, {result}, WriteKind::kInsert, session);
 
   std::string id = "readQ";
   axiom::runner::MultiFragmentPlan::Options runnerOptions = {

--- a/axiom/optimizer/connectors/tests/TestConnector.h
+++ b/axiom/optimizer/connectors/tests/TestConnector.h
@@ -284,18 +284,20 @@ class TestConnectorMetadata : public ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
-  WritePartitionInfo writePartitionInfo(
-      const ConnectorInsertTableHandlePtr& handle) override {
-    VELOX_UNSUPPORTED();
-  }
-
   void finishWrite(
       const TableLayout& layout,
       const ConnectorInsertTableHandlePtr& handle,
+      bool success,
       const std::vector<RowVectorPtr>& writerResult,
       WriteKind kind,
       const ConnectorSessionPtr& session) override {
     VELOX_UNSUPPORTED();
+  }
+
+  RowTypePtr tableWriteOutputType(
+      const RowTypePtr& /*rowType*/,
+      WriteKind /*kind*/) const override {
+    return ROW({}, {});
   }
 
   std::vector<ColumnHandlePtr> rowIdHandles(

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
@@ -220,14 +220,10 @@ class TpchConnectorMetadata : public ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
-  WritePartitionInfo writePartitionInfo(
-      const ConnectorInsertTableHandlePtr& handle) override {
-    VELOX_UNSUPPORTED();
-  }
-
   void finishWrite(
       const TableLayout& layout,
       const ConnectorInsertTableHandlePtr& handle,
+      bool success,
       const std::vector<RowVectorPtr>& writerResult,
       WriteKind kind,
       const ConnectorSessionPtr& session) override {

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -107,7 +107,8 @@ add_executable(
   SubfieldTest.cpp
   FeatureGen.cpp
   Genies.cpp
-  SchemaResolverTest.cpp)
+  SchemaResolverTest.cpp
+  WritePartitionTest.cpp)
 
 add_test(velox_plan_test velox_plan_test)
 

--- a/axiom/optimizer/tests/WritePartitionTest.cpp
+++ b/axiom/optimizer/tests/WritePartitionTest.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/connectors/hive/HiveConnectorMetadata.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace facebook::velox::optimizer {
+namespace {
+
+class WritePartitionTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    test::HiveQueriesTestBase::TearDownTestCase();
+  }
+
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+    connector_ = connector::getConnector(velox::exec::test::kHiveConnectorId);
+    metadata_ = dynamic_cast<connector::hive::HiveConnectorMetadata*>(
+        connector_->metadata());
+    optimizerOptions_.session =
+        std::make_shared<connector::hive::HiveConnectorSession>();
+    parquet::registerParquetReaderFactory();
+    parquet::registerParquetWriterFactory();
+  }
+
+  void TearDown() override {
+    connector_.reset();
+    HiveQueriesTestBase::TearDown();
+    parquet::unregisterParquetReaderFactory();
+    parquet::unregisterParquetWriterFactory();
+  }
+
+  std::vector<RowVectorPtr>
+  makeTestData(int32_t numBatches, int32_t batchSize, int32_t dayOffset = 0) {
+    std::vector<RowVectorPtr> data;
+    for (auto i = 0; i < numBatches; ++i) {
+      auto start = i * batchSize;
+      std::string str;
+      data.push_back(makeRowVector(
+          {"key1", "key2", "data", "ds"},
+          {makeFlatVector<int64_t>(
+               batchSize, [&](auto row) { return row + start; }),
+           makeFlatVector<int32_t>(
+               batchSize, [&](auto row) { return (row + start) % 19; }),
+           makeFlatVector<int64_t>(
+               batchSize, [&](auto row) { return row + start + 2; }),
+           makeFlatVector<StringView>(batchSize, [&](auto row) {
+             str = fmt::format("2025-09-{}", dayOffset + ((row + start) % 2));
+             return StringView(str);
+           })}));
+    }
+    return data;
+  }
+
+  std::vector<lp::ExprApi> exprs(std::vector<std::string> strings) {
+    std::vector<lp::ExprApi> exprs;
+    for (auto& string : strings) {
+      exprs.push_back(lp::Sql(string));
+    }
+    return exprs;
+  }
+
+  std::shared_ptr<connector::Connector> connector_;
+  connector::ConnectorMetadata* metadata_;
+  connector::ConnectorSessionPtr session{
+      std::make_shared<connector::hive::HiveConnectorSession>()};
+};
+
+TEST_F(WritePartitionTest, write) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+
+  constexpr int32_t kTestBatchSize = 2048;
+
+  auto tableType = ROW(
+      {{"key1", BIGINT()},
+       {"key2", INTEGER()},
+       {"data", BIGINT()},
+       {"data2", VARCHAR()},
+       {"ds", VARCHAR()}});
+
+  std::unordered_map<std::string, std::string> options = {
+      {"bucketed_by", "key1,key2"},
+      {"bucket_count", "16"},
+      {"partitioned_by", "ds"},
+      {"file_format", "parquet"},
+      {"compression_kind", "snappy"}};
+
+  metadata_->createTable("test", tableType, options, session, false);
+
+  auto data = makeTestData(10, kTestBatchSize);
+
+  auto write1 = lp::PlanBuilder(context)
+                    .values({data})
+                    .tableWrite(
+                        exec::test::kHiveConnectorId,
+                        "test",
+                        lp::WriteKind::kInsert,
+                        exprs({"key1", "key2", "data", "ds"}),
+                        {"key1", "key2", "data", "ds"})
+                    .build();
+  runVelox(write1);
+
+  auto countPlan =
+      lp::PlanBuilder(context)
+          .tableScan(exec::test::kHiveConnectorId, "test", {"key1"})
+          .aggregate({}, {"count(1)"})
+          .build();
+
+  {
+    auto result = runVelox(countPlan);
+    EXPECT_EQ(
+        kTestBatchSize * 10,
+        result.results[0]->childAt(0)->as<FlatVector<int64_t>>()->valueAt(0));
+  }
+  auto errorData = makeTestData(100, kTestBatchSize, 3);
+  auto errorPlan =
+      lp::PlanBuilder(context)
+          .values(errorData)
+          .tableWrite(
+              exec::test::kHiveConnectorId,
+              "test",
+              lp::WriteKind::kInsert,
+              exprs({"key1", "key2", "key1 % (key1 - 200000)", "ds"}),
+              {"key1", "key2", "data", "ds"})
+          .build();
+  VELOX_ASSERT_THROW(runVelox(errorPlan), "ivide by");
+
+  {
+    auto result = runVelox(countPlan);
+    EXPECT_EQ(
+        kTestBatchSize * 10,
+        result.results[0]->childAt(0)->as<FlatVector<int64_t>>()->valueAt(0));
+  }
+
+  auto readPlan = lp::PlanBuilder(context)
+                      .tableScan(
+                          exec::test::kHiveConnectorId,
+                          "test",
+                          {"key1", "key2", "data", "data2", "ds"})
+                      .filter("data2 is null")
+                      .project({"key1", "key2", "data", "ds"})
+                      .build();
+
+  {
+    auto result = runVelox(readPlan);
+    exec::test::assertEqualResults(data, result.results);
+  }
+
+  // Create a second table to copy the first one into. Values runs single node,
+  // the copy runs distributed.
+  std::unordered_map<std::string, std::string> options2 = {
+      {"bucketed_by", "key1"},
+      {"bucket_count", "16"},
+      {"partitioned_by", "ds"},
+      {"file_format", "parquet"},
+      {"compression_kind", "snappy"}};
+  metadata_->createTable("test2", tableType, options2, session, false);
+
+  auto copyPlan = lp::PlanBuilder(context)
+                      .tableScan(
+                          exec::test::kHiveConnectorId,
+                          "test",
+                          {"key1", "key2", "data", "data2", "ds"})
+                      .tableWrite(
+                          exec::test::kHiveConnectorId,
+                          "test2",
+                          lp::WriteKind::kInsert,
+                          exprs({"key1", "key2", "data", "data2", "ds"}),
+                          {"key1", "key2", "data", "data2", "ds"})
+                      .build();
+  runVelox(copyPlan);
+
+  readPlan = lp::PlanBuilder(context)
+                 .tableScan(
+                     exec::test::kHiveConnectorId,
+                     "test2",
+                     {"key1", "key2", "data", "data2", "ds"})
+                 .filter("data2 is null")
+                 .project({"key1", "key2", "data", "ds"})
+                 .build();
+
+  {
+    auto result = runVelox(readPlan);
+    exec::test::assertEqualResults(data, result.results);
+  }
+}
+} // namespace
+} // namespace facebook::velox::optimizer

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -82,6 +82,10 @@ class LocalRunner : public Runner,
   }
 
  private:
+  // Reads all results and calls 'finishWrite_'  on the results. Calls
+  // 'finishWrite_' with false and rethrows if exception.
+  void runWrite();
+
   void start();
 
   void makeStages(const std::shared_ptr<velox::exec::Task>& lastStageTask);
@@ -94,7 +98,7 @@ class LocalRunner : public Runner,
 
   const std::vector<ExecutableFragment> fragments_;
   const MultiFragmentPlan::Options options_;
-
+  const FinishWrite finishWrite_;
   velox::exec::CursorParameters params_;
 
   velox::tsan_atomic<State> state_{State::kInitialized};

--- a/axiom/runner/MultiFragmentPlan.h
+++ b/axiom/runner/MultiFragmentPlan.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanFragment.h"
+#include "velox/vector/ComplexVector.h"
 
 namespace facebook::axiom::runner {
 
@@ -28,6 +29,14 @@ struct InputStage {
   /// Task prefix of producer stage.
   std::string producerTaskPrefix;
 };
+
+/// Connector-supplied function for indicating completion of a write query.
+/// 'success' is true if the results should be persisted. If success' is true,
+/// 'results' must be the concatenation of the results from tableWrite
+/// operators. if 'success' is false, the write should not be persisted and
+/// 'results' can be empty. Possible ACID properties depend on the connector.
+using FinishWrite = std::function<
+    void(bool success, const std::vector<velox::RowVectorPtr>& result)>;
 
 /// Describes a fragment of a distributed plan. This allows a run
 /// time to distribute fragments across workers and to set up
@@ -78,8 +87,13 @@ class MultiFragmentPlan {
     int32_t numDrivers{4};
   };
 
-  MultiFragmentPlan(std::vector<ExecutableFragment> fragments, Options options)
-      : fragments_(std::move(fragments)), options_(std::move(options)) {}
+  MultiFragmentPlan(
+      std::vector<ExecutableFragment> fragments,
+      Options options,
+      FinishWrite finishWrite = nullptr)
+      : fragments_(std::move(fragments)),
+        options_(std::move(options)),
+        finishWrite_(finishWrite) {}
 
   const std::vector<ExecutableFragment>& fragments() const {
     return fragments_;
@@ -87,6 +101,10 @@ class MultiFragmentPlan {
 
   const Options& options() const {
     return options_;
+  }
+
+  FinishWrite finishWrite() const {
+    return finishWrite_;
   }
 
   /// @param detailed If true, includes details of each plan node. Otherwise,
@@ -100,6 +118,7 @@ class MultiFragmentPlan {
  private:
   const std::vector<ExecutableFragment> fragments_;
   const Options options_;
+  FinishWrite finishWrite_;
 };
 
 using MultiFragmentPlanPtr = std::shared_ptr<const MultiFragmentPlan>;


### PR DESCRIPTION
Adds a logical plan node for table write and generate write plans and produce a write finishing function.

Adds a PartitionType to ConnectorMetadata. This supports flexible determiniation of possible copartitioning.

- Uses  connector::PartitionType to describe a partition function.

- Adds a ConnectorMetadata method for getting the result type of a table write.

- Adds failure recovery to LocalHiveConnectorMetadata. Files are first staged in a temp directory and moved to the destination only at in the success case of the write finishing function.

- Adds a separate write execution path to LocalRunner. This silenntly gathers results from the write query and passes these to the write finishing function. Calls the write finishing function with success or with failure if the query has an error.