### PR TITLE
feat(runner): Add Runner::printPlanWithStats() API

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -17,6 +17,7 @@
 #include "axiom/runner/LocalRunner.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/PlanNodeStats.h"
 
 namespace facebook::axiom::runner {
 namespace {
@@ -334,6 +335,18 @@ std::vector<velox::exec::TaskStats> LocalRunner::stats() const {
     result.push_back(std::move(stats));
   }
   return result;
+}
+
+std::string LocalRunner::printPlanWithStats(bool includeCustomStats) const {
+  std::stringstream out;
+  auto statsResults = stats();
+  VELOX_CHECK_EQ(statsResults.size(), fragments_.size());
+  for (size_t i = 0; i < fragments_.size(); i++) {
+    out << std::endl << fmt::format("[Fragment{}]", i) << std::endl;
+    out << velox::exec::printPlanWithStats(
+        *fragments_[i].fragment.planNode, statsResults[i], includeCustomStats);
+  }
+  return out.str();
 }
 
 std::vector<SplitSource::SplitAndGroup> SimpleSplitSource::getSplits(

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -73,6 +73,8 @@ class LocalRunner : public Runner,
 
   std::vector<velox::exec::TaskStats> stats() const override;
 
+  std::string printPlanWithStats(bool includeCustomStats) const override;
+
   void abort() override;
 
   void waitForCompletion(int32_t maxWaitMicros) override;

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -78,9 +78,17 @@ class Runner {
   virtual velox::RowVectorPtr next() = 0;
 
   /// Returns Task stats for each fragment of the plan. The stats correspond 1:1
-  /// to the stages in the MultiFragmentPlan. This may be called at any time.
-  /// before waitForCompletion() or abort().
+  /// to the stages in the MultiFragmentPlan, though not necessarily in the same
+  /// order in which they were specified in the fragmented plan. This may be
+  /// called at any time before waitForCompletion() or abort().
   virtual std::vector<velox::exec::TaskStats> stats() const = 0;
+
+  /// Returns human-friendly representation of the plan augmented with runtime
+  /// statistics. The implementation invokes velox::exec::printPlanWithStats().
+  /// May be called any time prior to abort() or waitForCompletion().
+  ///
+  /// @param includeCustomStats: print custom-defined OperatorStats fields
+  virtual std::string printPlanWithStats(bool includeCustomStats) const = 0;
 
   /// Returns the state of execution.
   virtual State state() const = 0;
@@ -94,7 +102,6 @@ class Runner {
   /// Waits up to 'maxWaitMicros' for all activity of the execution to cease.
   /// This is used in tests to ensure that all pools are empty and unreferenced
   /// before teradown.
-
   virtual void waitForCompletion(int32_t maxWaitMicros) = 0;
 };
 


### PR DESCRIPTION
Summary: would like the ability to print verbose execution statistics from LocalRunner. Adding a similar API to Task::getPlanWithStats, where here each fragment of the executable MultiFragmentPlan and the corresponding stats are logged via velox::exec::printPlanWithStats

Also piping through the flag to control the printing of custom operator stats

e.g.:
```
[Fragment0]
-- PartitionedOutput[2][partitionFunction: <Verax partition function spec> with 2 partitions Presto] -> c_name:VARCHAR, count:BIGINT
   Output: 1500 rows (44.08KB, 2 batches), Cpu time: 9.07ms, Wall time: 9.77ms, Blocked wall time: 0ns, Peak memory: 121.38KB, Memory allocations: 28, Threads: 32, CPU breakdown: B/I/O/F (1.94ms/1.25ms/4.89ms/981.04us)
      queuedWallNanos              sum: 27.93ms, count: 32, min: 104.00us, max: 2.26ms, avg: 872.66us
      runningAddInputWallNanos     sum: 1.26ms, count: 32, min: 0ns, max: 1.26ms, avg: 39.22us
      runningFinishWallNanos       sum: 1.14ms, count: 32, min: 25.61us, max: 50.36us, avg: 35.70us
      runningGetOutputWallNanos    sum: 5.06ms, count: 32, min: 46.10us, max: 2.99ms, avg: 158.18us
      shuffleCompressionKind       sum: 0, count: 32, min: 0, max: 0, avg: 0
      shuffleSerdeKind             sum: 0, count: 32, min: 0, max: 0, avg: 0
  -- Aggregation[1][PARTIAL [c_name] count := count("c_custkey")] -> c_name:VARCHAR, count:BIGINT
     Output: 1500 rows (335.72KB, 1 batches), Cpu time: 72.68ms, Wall time: 199.74ms, Blocked wall time: 0ns, Peak memory: 520.00KB, Memory allocations: 72, Threads: 32, CPU breakdown: B/I/O/F (1.68ms/27.43ms/42.38ms/1.19ms)
        distinctKey0                 sum: 1501, count: 1, min: 1501, max: 1501, avg: 1501
        hashtable.capacity           sum: 1537, count: 1, min: 1537, max: 1537, avg: 1537
        hashtable.numDistinct        sum: 1500, count: 1, min: 1500, max: 1500, avg: 1500
        hashtable.numRehashes        sum: 1, count: 1, min: 1, max: 1, avg: 1
        hashtable.numTombstones      sum: 0, count: 1, min: 0, max: 0, avg: 0
        runningAddInputWallNanos     sum: 29.04ms, count: 32, min: 0ns, max: 29.04ms, avg: 907.59us
        runningFinishWallNanos       sum: 1.32ms, count: 32, min: 26.23us, max: 68.44us, avg: 41.13us
        runningGetOutputWallNanos    sum: 167.45ms, count: 32, min: 3.25ms, max: 8.38ms, avg: 5.23ms
    -- TableScan[0][table: customer, scale factor: 0.01] -> c_name:VARCHAR, c_custkey:BIGINT
       Input: 1500 rows (143.44KB, 2 batches), Output: 1500 rows (143.44KB, 2 batches), Cpu time: 12.87s, Wall time: 12.89s, Blocked wall time: 1.17s, Peak memory: 396.00KB, Memory allocations: 33, Threads: 32, Splits: 1, CPU breakdown: B/I/O/F (774.84us/0ns/12.87s/133.81us)
          blockedWaitForSplitTimes        sum: 32, count: 32, min: 1, max: 1, avg: 1
          blockedWaitForSplitWallNanos    sum: 1.17s, count: 32, min: 33.67ms, max: 39.23ms, avg: 36.58ms
          connectorSplitSize              sum: 0, count: 1, min: 0, max: 0, avg: 0
          dataSourceAddSplitWallNanos     sum: 20.00us, count: 1, min: 20.00us, max: 20.00us, avg: 20.00us
          dataSourceReadWallNanos         sum: 12.87s, count: 3, min: 286.00us, max: 12.86s, avg: 4.29s
          queuedWallNanos                 sum: 13.04ms, count: 32, min: 43.00us, max: 1.16ms, avg: 407.53us
          runningAddInputWallNanos        sum: 0ns, count: 32, min: 0ns, max: 0ns, avg: 0ns
          runningFinishWallNanos          sum: 167.71us, count: 32, min: 2.26us, max: 12.57us, avg: 5.24us
          runningGetOutputWallNanos       sum: 12.89s, count: 32, min: 95.42us, max: 12.87s, avg: 402.70ms

[Fragment1]
-- PartitionedOutput[7][SINGLE Presto] -> expr_0:BIGINT
   Output: 1500 rows (13.09KB, 32 batches), Cpu time: 41.21ms, Wall time: 50.60ms, Blocked wall time: 0ns, Peak memory: 16.88KB, Memory allocations: 203, Threads: 32, CPU breakdown: B/I/O/F (3.54ms/8.60ms/27.58ms/1.49ms)
      queuedWallNanos              sum: 15.65ms, count: 32, min: 145.00us, max: 909.00us, avg: 489.09us
      runningAddInputWallNanos     sum: 12.39ms, count: 32, min: 92.60us, max: 1.40ms, avg: 387.04us
      runningFinishWallNanos       sum: 1.76ms, count: 32, min: 37.20us, max: 83.82us, avg: 54.98us
      runningGetOutputWallNanos    sum: 32.39ms, count: 32, min: 661.99us, max: 4.44ms, avg: 1.01ms
      shuffleCompressionKind       sum: 0, count: 32, min: 0, max: 0, avg: 0
      shuffleSerdeKind             sum: 0, count: 32, min: 0, max: 0, avg: 0
  -- Project[6][expressions: (expr_0:BIGINT, "count")] -> expr_0:BIGINT
     Output: 1500 rows (3.00MB, 32 batches), Cpu time: 10.96ms, Wall time: 12.04ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 32, CPU breakdown: B/I/O/F (3.80ms/549.58us/5.30ms/1.31ms)
        runningAddInputWallNanos     sum: 585.40us, count: 32, min: 11.55us, max: 34.78us, avg: 18.29us
[SNIP]
```

Reviewed By: NikhilCollooru

Differential Revision: D80673414


