### PR TITLE
feat: Pretty-print query results in the CLI

### DIFF
--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -696,31 +696,100 @@ class VeloxRunner : public QueryBenchmarkBase {
       numRows += result->size();
     }
 
-    std::cout << "Results: " << numRows << " rows in " << results.size()
-              << " batches" << std::endl;
+    auto printFooter = [&]() {
+      std::cout << "(" << numRows << " rows in " << results.size()
+                << " batches)" << std::endl
+                << std::endl;
+    };
 
-    if (numRows > 0) {
-      std::cout << results.front()->type()->toString() << std::endl;
+    if (numRows == 0) {
+      printFooter();
+      return 0;
     }
 
-    numRows = 0;
-    for (auto vectorIndex = 0; vectorIndex < results.size(); ++vectorIndex) {
-      const auto& vector = results[vectorIndex];
-      for (vector_size_t i = 0; i < vector->size(); ++i) {
-        std::cout << vector->deprecatedToString(i, 100) << std::endl;
-        if (++numRows >= FLAGS_max_rows) {
-          int32_t numLeft = (vector->size() - (i - 1));
-          ++vectorIndex;
-          for (; vectorIndex < results.size(); ++vectorIndex) {
-            numLeft += results[vectorIndex]->size();
-          }
-          if (numLeft) {
-            std::cout << fmt::format("{} more rows.", numLeft) << std::endl;
-          }
-          return numRows + numLeft;
+    const auto type = results.front()->rowType();
+    std::cout << type->toString() << std::endl;
+
+    const auto numColumns = type->size();
+
+    std::vector<std::vector<std::string>> data;
+    std::vector<size_t> widths(numColumns, 0);
+    std::vector<bool> alignLeft(numColumns);
+
+    for (auto i = 0; i < numColumns; ++i) {
+      widths[i] = type->nameOf(i).size();
+      alignLeft[i] = type->childAt(i)->isVarchar();
+    }
+
+    auto printSeparator = [&]() {
+      std::cout << std::setfill('-');
+      for (auto i = 0; i < numColumns; ++i) {
+        if (i > 0) {
+          std::cout << "-+-";
+        }
+        std::cout << std::setw(widths[i]) << "";
+      }
+      std::cout << std::endl;
+      std::cout << std::setfill(' ');
+    };
+
+    auto printRow = [&](const auto& row) {
+      for (auto i = 0; i < numColumns; ++i) {
+        if (i > 0) {
+          std::cout << " | ";
+        }
+        std::cout << std::setw(widths[i]);
+        if (alignLeft[i]) {
+          std::cout << std::left;
+        } else {
+          std::cout << std::right;
+        }
+        std::cout << row[i];
+      }
+      std::cout << std::endl;
+    };
+
+    int32_t numPrinted = 0;
+
+    auto doPrint = [&]() {
+      printSeparator();
+      printRow(type->names());
+      printSeparator();
+
+      for (auto row : data) {
+        printRow(row);
+      }
+
+      if (numPrinted < numRows) {
+        std::cout << std::endl;
+        std::cout << "..." << (numRows - numPrinted) << " more rows."
+                  << std::endl;
+      }
+
+      printFooter();
+    };
+
+    for (const auto& result : results) {
+      for (auto row = 0; row < result->size(); ++row) {
+        data.emplace_back();
+
+        auto& rowData = data.back();
+        rowData.resize(numColumns);
+        for (auto column = 0; column < numColumns; ++column) {
+          rowData[column] = result->childAt(column)->toString(row);
+          widths[column] = std::max(widths[column], rowData[column].size());
+        }
+
+        ++numPrinted;
+        if (numPrinted >= FLAGS_max_rows) {
+          doPrint();
+          return numRows;
         }
       }
     }
+
+    doPrint();
+
     return numRows;
   }
 


### PR DESCRIPTION
Summary:
> $ buck run axiom/optimizer/tests:velox_sql -- --data_path /tmp/tpch/ --query "SELECT * FROM nation LIMIT 7";

```
------------+-----------+-------------+------------------------------------------------------------------------------------------------------------
n_nationkey | n_name    | n_regionkey | n_comment
------------+-----------+-------------+------------------------------------------------------------------------------------------------------------
          0 | ALGERIA   |           0 |  haggle. carefully final deposits detect slyly agai
          1 | ARGENTINA |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
          2 | BRAZIL    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special
          3 | CANADA    |           1 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
          4 | EGYPT     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
          5 | ETHIOPIA  |           0 | ven packages wake quickly. regu
          6 | FRANCE    |           3 | refully final requests. regular, ironi
(7 rows in 1 batches)
```

Differential Revision: D80866795


