### PR TITLE
fix: ExceptionContextSetter was used in a wrong way

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1504,7 +1504,7 @@ PlanObjectP ToGraph::makeQueryGraph(
     const lp::LogicalPlanNode& node,
     uint64_t allowedInDt) {
   ToGraphContext ctx(&node);
-  ExceptionContextSetter(makeExceptionContext(&ctx));
+  ExceptionContextSetter exceptionContext{makeExceptionContext(&ctx)};
   switch (node.kind()) {
     case lp::NodeKind::kValues:
       return makeValuesTable(*node.asUnchecked<lp::ValuesNode>());


### PR DESCRIPTION
Right now in the code created new context, set it and immediately set previous context back and destroy new context.

Improvement in velox (to avoid such errors in more cases)
https://github.com/facebookincubator/velox/pull/14578