### PR TITLE
feat: WIP Add support for Unnest

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -387,9 +387,21 @@ PlanBuilder& PlanBuilder::unnest(
 
 PlanBuilder& PlanBuilder::unnest(
     const std::vector<ExprApi>& unnestExprs,
-    bool withOrdinality) {
+    bool withOrdinality,
+    const std::optional<std::string>& alias,
+    const std::vector<std::string>& unnestAliases) {
   auto newOutputMapping =
       node_ != nullptr ? outputMapping_ : std::make_shared<NameMappings>();
+
+  size_t index = 0;
+
+  auto addOutputMapping = [&](const std::string& name, const std::string& id) {
+    if (!newOutputMapping->lookup(name)) {
+      newOutputMapping->add(name, id);
+    }
+    newOutputMapping->add({.alias = alias, .name = name}, id);
+    ++index;
+  };
 
   std::vector<ExprPtr> exprs;
   std::vector<std::vector<std::string>> outputNames;
@@ -406,12 +418,36 @@ PlanBuilder& PlanBuilder::unnest(
     } else {
       switch (expr->type()->kind()) {
         case TypeKind::ARRAY:
-          outputNames.emplace_back(std::vector<std::string>{newName("e_")});
+          if (!unnestAliases.empty()) {
+            VELOX_USER_CHECK_LT(index, unnestAliases.size());
+
+            const auto& outputName = unnestAliases.at(index);
+            outputNames.emplace_back(
+                std::vector<std::string>{newName(outputName)});
+
+            addOutputMapping(outputName, outputNames.back().back());
+          } else {
+            outputNames.emplace_back(std::vector<std::string>{newName("e_")});
+          }
           break;
+
         case TypeKind::MAP:
-          outputNames.emplace_back(
-              std::vector<std::string>{newName("k_"), newName("v_")});
+          if (!unnestAliases.empty()) {
+            VELOX_USER_CHECK_LT(index, unnestAliases.size());
+
+            const auto& keyName = unnestAliases.at(index);
+            const auto& valueName = unnestAliases.at(index + 1);
+            outputNames.emplace_back(
+                std::vector<std::string>{newName(keyName), newName(valueName)});
+
+            addOutputMapping(keyName, outputNames.back().at(0));
+            addOutputMapping(valueName, outputNames.back().at(1));
+          } else {
+            outputNames.emplace_back(
+                std::vector<std::string>{newName("k_"), newName("v_")});
+          }
           break;
+
         default:
           VELOX_USER_FAIL(
               "Unsupported type to unnest: {}", expr->type()->toString());

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -250,7 +250,9 @@ class PlanBuilder {
 
   PlanBuilder& unnest(
       const std::vector<ExprApi>& unnestExprs,
-      bool withOrdinality = false);
+      bool withOrdinality = false,
+      const std::optional<std::string>& alias = std::nullopt,
+      const std::vector<std::string>& unnestAliases = {});
 
   PlanBuilder& join(
       const PlanBuilder& right,

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -154,7 +154,24 @@ class ToTextVisitor : public PlanNodeVisitor {
 
   void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const override {
-    appendNode("Unnest", node, context);
+    auto& myContext = static_cast<Context&>(context);
+
+    myContext.out << makeIndent(myContext.indent) << "- Unnest";
+    appendOutputType(node, myContext);
+    myContext.out << std::endl;
+
+    const auto size = node.unnestExpressions().size();
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (auto i = 0; i < size; ++i) {
+      myContext.out << indent << "["
+                    << folly::join(", ", node.unnestedNames().at(i)) << "]"
+                    << " := "
+                    << ExprPrinter::toText(*node.unnestExpressions().at(i))
+                    << std::endl;
+    }
+
+    appendInputs(node, myContext);
   }
 
  private:

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -196,7 +196,7 @@ void DerivedTable::findSingleRowDts() {
       singleRowDts.add(object);
     }
   });
-  // if everything is a single row dt, then process tese as cross products and
+  // if everything is a single row dt, then process these as cross products and
   // not as placed with filters.
   if (numSingle == tables.size()) {
     singleRowDts = PlanObjectSet();
@@ -227,6 +227,8 @@ void DerivedTable::linkTablesToJoins() {
         table->as<BaseTable>()->addJoinedBy(join);
       } else if (table->is(PlanType::kValuesTableNode)) {
         table->as<ValuesTable>()->addJoinedBy(join);
+      } else if (table->is(PlanType::kUnnestTableNode)) {
+        table->as<UnnestTable>()->addJoinedBy(join);
       } else {
         VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
         table->as<DerivedTable>()->addJoinedBy(join);
@@ -290,7 +292,8 @@ void DerivedTable::import(
     const std::vector<PlanObjectSet>& existences,
     float existsFanout) {
   tableSet = _tables;
-  _tables.forEach([&](auto table) { tables.push_back(table); });
+  tables = _tables.toVector();
+
   for (auto join : super.joins) {
     if (_tables.contains(join->rightTable()) && join->leftTable() &&
         _tables.contains(join->leftTable())) {
@@ -305,8 +308,7 @@ void DerivedTable::import(
     // of these tables goes into its own derived table which is joined
     // with exists to the main table(s) in the 'this'.
     importedExistences.unionSet(exists);
-    PlanObjectVector existsTables;
-    exists.forEach([&](auto object) { existsTables.push_back(object); });
+    auto existsTables = exists.toVector();
     auto existsJoin = makeExists(firstTable, exists);
     if (existsTables.size() > 1) {
       // There is a join on the right of exists. Needs its own dt.

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/DerivedTablePrinter.h"
+#include <sstream>
+#include "axiom/optimizer/PlanUtils.h"
+
+namespace facebook::velox::optimizer {
+
+namespace {
+
+std::string columnNames(const ColumnVector& columns) {
+  std::stringstream out;
+  int32_t i = 0;
+  for (auto column : columns) {
+    if (i > 0) {
+      out << ", ";
+    }
+    i++;
+    out << column->name();
+  }
+  return out.str();
+}
+
+std::string exprsToString(const ExprVector& exprs) {
+  std::stringstream out;
+  int32_t i = 0;
+  for (auto expr : exprs) {
+    if (i > 0) {
+      out << ", ";
+    }
+    i++;
+    out << expr->toString();
+  }
+  return out.str();
+}
+
+std::string tableName(PlanObjectCP table) {
+  switch (table->type()) {
+    case PlanType::kTableNode:
+      return table->as<BaseTable>()->cname;
+    case PlanType::kValuesTableNode:
+      return table->as<ValuesTable>()->cname;
+    case PlanType::kUnnestTableNode:
+      return table->as<UnnestTable>()->cname;
+    case PlanType::kDerivedTableNode:
+      return table->as<DerivedTable>()->cname;
+    default:
+      VELOX_FAIL();
+  }
+}
+
+std::string visitBaseTable(const BaseTable& table) {
+  std::stringstream out;
+  out << table.cname << ": " << columnNames(table.columns) << std::endl;
+  out << "  table: " << table.schemaTable->name << std::endl;
+  if (!table.columnFilters.empty()) {
+    out << "  single-column filters: " << conjunctsToString(table.columnFilters)
+        << std::endl;
+  }
+  if (!table.filter.empty()) {
+    out << "  multi-column filters: " << conjunctsToString(table.filter)
+        << std::endl;
+  }
+  return out.str();
+}
+
+std::string visitValuesTable(const ValuesTable& values) {
+  std::stringstream out;
+  out << values.cname << ": " << columnNames(values.columns) << std::endl;
+  return out.str();
+}
+
+std::string visitUnnestTable(const UnnestTable& unnest) {
+  std::stringstream out;
+  out << unnest.cname << ": " << columnNames(unnest.columns) << std::endl;
+  return out.str();
+}
+
+std::string visitJoinEdge(const JoinEdge& edge) {
+  std::stringstream out;
+  if (edge.leftTable() != nullptr) {
+    out << tableName(edge.leftTable());
+  } else {
+    out << "<multiple tables>";
+  }
+
+  if (edge.isSemi()) {
+    out << " SEMI ";
+  } else if (edge.isAnti()) {
+    out << " ANTI ";
+  } else if (edge.leftOptional() && edge.rightOptional()) {
+    out << " FULL OUTER ";
+  } else if (edge.leftOptional()) {
+    out << " RIGHT ";
+  } else if (edge.rightOptional()) {
+    out << " LEFT ";
+  } else {
+    out << " INNER ";
+  }
+
+  out << tableName(edge.rightTable());
+
+  out << " ON ";
+  for (auto i = 0; i < edge.leftKeys().size(); ++i) {
+    if (i > 0) {
+      out << " AND ";
+    }
+    out << edge.leftKeys()[i]->toString() << " = "
+        << edge.rightKeys()[i]->toString();
+  }
+
+  if (!edge.filter().empty()) {
+    out << " FILTER " << conjunctsToString(edge.filter());
+  }
+
+  return out.str();
+}
+
+std::string visitDerivedTable(const DerivedTable& dt) {
+  std::stringstream out;
+  out << dt.cname << ": " << columnNames(dt.columns) << std::endl;
+
+  out << "  output: " << std::endl;
+  for (auto i = 0; i < dt.columns.size(); ++i) {
+    out << "    " << dt.columns.at(i)->name()
+        << " := " << dt.exprs.at(i)->toString() << std::endl;
+  }
+
+  if (!dt.tables.empty()) {
+    out << "  tables: ";
+    int32_t i = 0;
+    for (const auto& table : dt.tables) {
+      if (i > 0) {
+        out << ", ";
+      }
+      i++;
+      out << tableName(table);
+    }
+    out << std::endl;
+  }
+
+  if (!dt.joins.empty()) {
+    out << "  joins: " << std::endl;
+    for (const auto& joinEdge : dt.joins) {
+      out << "    " << visitJoinEdge(*joinEdge) << std::endl;
+    }
+  }
+
+  if (dt.hasAggregation()) {
+    if (!dt.aggregation->aggregates().empty()) {
+      const auto numGroupingKeys = dt.aggregation->groupingKeys().size();
+
+      out << "  aggregates: ";
+      int32_t i = 0;
+      for (auto agg : dt.aggregation->aggregates()) {
+        if (i > 0) {
+          out << ", ";
+        }
+
+        out << agg->toString() << " AS "
+            << dt.aggregation->columns().at(i + numGroupingKeys)->name();
+
+        i++;
+      }
+      out << std::endl;
+    }
+
+    if (!dt.aggregation->groupingKeys().empty()) {
+      out << "  grouping keys: "
+          << exprsToString(dt.aggregation->groupingKeys()) << std::endl;
+    }
+
+    if (!dt.having.empty()) {
+      out << "  having: " << conjunctsToString(dt.having);
+    }
+  }
+
+  if (!dt.conjuncts.empty()) {
+    out << "  filter: " << conjunctsToString(dt.conjuncts) << std::endl;
+  }
+
+  if (dt.hasOrderBy()) {
+    out << "  orderBy: " << exprsToString(dt.orderKeys) << std::endl;
+  }
+
+  if (dt.hasLimit()) {
+    if (dt.offset > 0) {
+      out << "  offset: " << dt.offset << std::endl;
+    }
+    out << "  limit: " << dt.limit << std::endl;
+  }
+
+  for (const auto& table : dt.tables) {
+    out << std::endl;
+    switch (table->type()) {
+      case PlanType::kTableNode:
+        out << visitBaseTable(*table->as<BaseTable>());
+        break;
+      case PlanType::kValuesTableNode:
+        out << visitValuesTable(*table->as<ValuesTable>());
+        break;
+      case PlanType::kUnnestTableNode:
+        out << visitUnnestTable(*table->as<UnnestTable>());
+        break;
+      case PlanType::kDerivedTableNode:
+        return visitDerivedTable(*table->as<DerivedTable>());
+        break;
+      default:
+        VELOX_FAIL();
+    }
+  }
+
+  return out.str();
+}
+} // namespace
+
+// static
+std::string DerivedTablePrinter::toText(const DerivedTable& root) {
+  return visitDerivedTable(root);
+}
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/DerivedTablePrinter.h
+++ b/axiom/optimizer/DerivedTablePrinter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/DerivedTable.h"
+
+namespace facebook::velox::optimizer {
+
+class DerivedTablePrinter {
+ public:
+  static std::string toText(const DerivedTable& root);
+};
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/Cost.h"
+#include "axiom/optimizer/DerivedTablePrinter.h"
 
 #include <iostream>
 
@@ -96,6 +97,8 @@ Optimization::Optimization(
     join->guessFanout();
   }
   toGraph_.setDtOutput(root_, *logicalPlan_);
+
+  LOG(ERROR) << std::endl << DerivedTablePrinter::toText(*root_);
 }
 
 void Optimization::trace(
@@ -359,6 +362,10 @@ const JoinEdgeVector& joinedBy(PlanObjectCP table) {
 
   if (table->is(PlanType::kValuesTableNode)) {
     return table->as<ValuesTable>()->joinedBy;
+  }
+
+  if (table->is(PlanType::kUnnestTableNode)) {
+    return table->as<UnnestTable>()->joinedBy;
   }
 
   VELOX_DCHECK(table->is(PlanType::kDerivedTableNode));
@@ -1026,8 +1033,7 @@ void Optimization::joinByIndex(
       c.unionSet(filter->columns());
     }
 
-    ColumnVector columns;
-    c.forEach([&](PlanObjectCP o) { columns.push_back(o->as<Column>()); });
+    auto columns = c.toVector<Column>();
 
     auto* scan = make<TableScan>(
         newPartition,
@@ -1071,6 +1077,10 @@ PlanObjectSet availableColumns(PlanObjectCP object) {
     }
   } else if (object->is(PlanType::kValuesTableNode)) {
     for (auto& c : object->as<ValuesTable>()->columns) {
+      set.add(c);
+    }
+  } else if (object->is(PlanType::kUnnestTableNode)) {
+    for (auto& c : object->as<UnnestTable>()->columns) {
       set.add(c);
     }
   } else if (object->is(PlanType::kDerivedTableNode)) {
@@ -1416,6 +1426,26 @@ void Optimization::joinByHashRight(
   state.addNextJoin(&candidate, join, {buildOp}, toTry);
 }
 
+void Optimization::crossJoinUnnest(
+    const RelationOpPtr& plan,
+    const JoinCandidate& candidate,
+    PlanState& state,
+    std::vector<NextJoin>& toTry) {
+  auto c = state.downstreamColumns();
+  c.intersect(state.columns);
+
+  auto unnestTable = candidate.tables.at(0)->as<UnnestTable>();
+  c.unionColumns(unnestTable->columns);
+
+  auto* unnest =
+      make<Unnest>(plan, candidate.join->filter(), c.toVector<Column>());
+
+  state.placed.add(candidate.tables.at(0));
+  state.columns.unionSet(c);
+  state.addCost(*unnest);
+  state.addNextJoin(&candidate, unnest, {}, toTry);
+}
+
 void Optimization::crossJoin(
     const RelationOpPtr& plan,
     const JoinCandidate& candidate,
@@ -1432,6 +1462,13 @@ void Optimization::addJoin(
   std::vector<NextJoin> toTry;
   if (!candidate.join) {
     crossJoin(plan, candidate, state, toTry);
+    return;
+  }
+
+  if (candidate.tables.size() == 1 &&
+      candidate.tables[0]->is(PlanType::kUnnestTableNode)) {
+    crossJoinUnnest(plan, candidate, state, toTry);
+    result.insert(result.end(), toTry.begin(), toTry.end());
     return;
   }
 
@@ -1666,9 +1703,9 @@ float startingScore(PlanObjectCP table) {
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   auto& dt = state.dt;
   if (!plan) {
-    std::vector<PlanObjectCP> firstTables;
-    dt->startTables.forEach([&](auto table) { firstTables.push_back(table); });
+    auto firstTables = dt->startTables.toVector();
     std::vector<float> scores(firstTables.size());
+
     for (auto i = 0; i < firstTables.size(); ++i) {
       auto table = firstTables[i];
       state.debugSetFirstTable(table->id());

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -382,6 +382,10 @@ class Optimization {
     return toVelox_.toVeloxPlan(std::move(plan), runnerOptions_);
   }
 
+  const DerivedTable& queryGraph() const {
+    return *root_;
+  }
+
   std::pair<connector::ConnectorTableHandlePtr, std::vector<core::TypedExprPtr>>
   leafHandle(int32_t id) {
     return toVelox_.leafHandle(id);
@@ -593,6 +597,12 @@ class Optimization {
 
   // Tries a right hash join variant of left outer or left semijoin.
   void joinByHashRight(
+      const RelationOpPtr& plan,
+      const JoinCandidate& candidate,
+      PlanState& state,
+      std::vector<NextJoin>& toTry);
+
+  void crossJoinUnnest(
       const RelationOpPtr& plan,
       const JoinCandidate& candidate,
       PlanState& state,

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -34,6 +34,7 @@ enum class PlanType {
   // Plan nodes.
   kTableNode,
   kValuesTableNode,
+  kUnnestTableNode,
   kDerivedTableNode,
   kAggregationNode,
   kProjectNode,
@@ -166,6 +167,17 @@ class PlanObjectSet : public BitSet {
     }
   }
 
+  /// Returns the objects corresponding to ids in 'this' as a vector of const
+  /// T*.
+  template <typename T = PlanObject>
+  std::vector<const T*, QGAllocator<const T*>> toVector() const {
+    std::vector<const T*, QGAllocator<const T*>> objects;
+    objects.reserve(size());
+    forEach(
+        [&](auto object) { objects.emplace_back(object->template as<T>()); });
+    return objects;
+  }
+
   /// Applies 'func' to each object in 'this'.
   template <typename Func>
   void forEach(Func func) const {
@@ -181,15 +193,6 @@ class PlanObjectSet : public BitSet {
     velox::bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, [&](auto i) {
       func(ctx->mutableObjectAt(i));
     });
-  }
-
-  /// Returns the objects corresponding to ids in 'this' as a vector of T.
-  template <typename T = PlanObjectP>
-  std::vector<T> objects() const {
-    std::vector<T> result;
-    forEach(
-        [&](auto object) { result.push_back(reinterpret_cast<T>(object)); });
-    return result;
   }
 
   /// Prnts the contents with ids and the string representation of the objects

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -61,6 +61,9 @@ std::string Column::toString() const {
       case PlanType::kValuesTableNode:
         cname = relation_->as<ValuesTable>()->cname;
         break;
+      case PlanType::kUnnestTableNode:
+        cname = relation_->as<UnnestTable>()->cname;
+        break;
       case PlanType::kDerivedTableNode:
         cname = relation_->as<DerivedTable>()->cname;
         break;
@@ -104,8 +107,12 @@ std::string Call::toString() const {
   std::stringstream out;
   out << name_ << "(";
   for (auto i = 0; i < args_.size(); ++i) {
-    out << args_[i]->toString() << (i == args_.size() - 1 ? ")" : ", ");
+    if (i > 0) {
+      out << ", ";
+    }
+    out << args_[i]->toString();
   }
+  out << ")";
   return out.str();
 }
 
@@ -177,6 +184,14 @@ std::string ValuesTable::toString() const {
   out << "{" << PlanObject::toString();
   out << values.id() << " " << cname << "}";
   return out.str();
+}
+
+void UnnestTable::addJoinedBy(JoinEdgeP join) {
+  pushBackUnique(joinedBy, join);
+}
+
+std::string UnnestTable::toString() const {
+  return "<unnest>";
 }
 
 JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -545,7 +545,8 @@ class JoinEdge {
         markColumn_(spec.markColumn),
         directed_(spec.directed) {
     VELOX_CHECK_NOT_NULL(rightTable);
-    if (isInner()) {
+    // inner + directed == unnest.
+    if (isInner() && !directed_) {
       VELOX_CHECK(filter_.empty());
     }
   }
@@ -597,6 +598,14 @@ class JoinEdge {
   }
 
   void addEquality(ExprCP left, ExprCP right, bool update = false);
+
+  bool isSemi() const {
+    return rightExists_;
+  }
+
+  bool isAnti() const {
+    return rightNotExists_;
+  }
 
   /// True if inner join.
   bool isInner() const {
@@ -805,6 +814,28 @@ struct ValuesTable : public PlanObject {
 
   float cardinality() const {
     return values.cardinality();
+  }
+
+  bool isTable() const override {
+    return true;
+  }
+
+  void addJoinedBy(JoinEdgeP join);
+
+  std::string toString() const override;
+};
+
+struct UnnestTable : public PlanObject {
+  explicit UnnestTable() : PlanObject{PlanType::kUnnestTableNode} {}
+
+  Name cname{nullptr};
+
+  ColumnVector columns;
+
+  JoinEdgeVector joinedBy;
+
+  float cardinality() const {
+    return 1;
   }
 
   bool isTable() const override {

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -815,4 +815,57 @@ std::string UnionAll::toString(bool recursive, bool detail) const {
   return out.str();
 }
 
+Unnest::Unnest(
+    RelationOpPtr input,
+    ExprVector unnestExprs,
+    ColumnVector columns)
+    : RelationOp(RelType::kUnnest, input, input->distribution(), columns),
+      unnestExprs_{std::move(unnestExprs)} {
+  cost_.inputCardinality = inputCardinality();
+  cost_.fanout = 1;
+
+  // TODO Fill in cost_.unitCost and others.
+}
+
+const QGstring& Unnest::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::stringstream out;
+  auto* opt = queryCtx()->optimization();
+  ScopedVarSetter cname(&opt->cnamesInExpr(), false);
+  out << input_->historyKey() << " unnest " << "(";
+  std::vector<std::string> strings;
+  for (auto& expr : unnestExprs_) {
+    strings.push_back(expr->toString());
+  }
+  std::sort(strings.begin(), strings.end());
+  for (auto& s : strings) {
+    out << s << ", ";
+  }
+  out << ")";
+  key_ = sanitizeHistoryKey(out.str());
+  return key_;
+}
+
+std::string Unnest::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  if (recursive) {
+    out << input()->toString(true, detail) << " ";
+  }
+  if (detail) {
+    out << "Unnest (";
+    for (auto i = 0; i < unnestExprs_.size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      out << unnestExprs_[i]->toString();
+    }
+    out << ")\n";
+  } else {
+    out << "unnest " << unnestExprs_.size() << " exprs ";
+  }
+  return out.str();
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -361,6 +361,27 @@ struct HashBuild : public RelationOp {
 
 using HashBuildCP = const HashBuild*;
 
+class Unnest : public RelationOp {
+ public:
+  Unnest(RelationOpPtr input, ExprVector unnestExprs, ColumnVector columns);
+
+  const ExprVector& replicateExprs() const {
+    return replicateExprs_;
+  }
+
+  const ExprVector& unnestExprs() const {
+    return unnestExprs_;
+  }
+
+  const QGstring& historyKey() const override;
+
+  std::string toString(bool recursive, bool detail) const override;
+
+ private:
+  const ExprVector replicateExprs_;
+  const ExprVector unnestExprs_;
+};
+
 /// Represents aggregation with or without grouping.
 struct Aggregation : public RelationOp {
   Aggregation(

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -331,6 +331,13 @@ IndexInfo joinCardinality(PlanObjectCP table, CPSpan<Column> keys) {
     computeCardinalities(valuesTable->cardinality());
     return result;
   }
+
+  if (table->is(PlanType::kUnnestTableNode)) {
+    const auto* unnestTable = table->as<UnnestTable>();
+    computeCardinalities(unnestTable->cardinality());
+    return result;
+  }
+
   VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
   const auto* dt = table->as<DerivedTable>();
   computeCardinalities(dt->cardinality);

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -244,6 +244,7 @@ enum class RelType {
   kUnionAll,
   kLimit,
   kValues,
+  kUnnest,
 };
 
 /// Represents a relation (table) that is either physically stored or is the

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -105,6 +105,35 @@ void ToGraph::markFieldAccessed(
       return;
     }
 
+    if (kind == lp::NodeKind::kUnnest) {
+      auto* unnest = source.planNode->asUnchecked<lp::UnnestNode>();
+      if (!unnest->inputs().empty()) {
+        const auto& input = unnest->onlyInput();
+
+        const std::vector<const RowType*> inputContext = {
+            input->outputType().get()};
+        const std::vector<LogicalContextSource> inputSources = {
+            {.planNode = input.get()}};
+        std::vector<Step> subSteps;
+        auto mark = [&](const lp::ExprPtr& expr) {
+          markSubfields(expr, subSteps, isControl, inputContext, inputSources);
+        };
+
+        const auto& inputType = input->outputType();
+        if (ordinal < inputType->size()) {
+          auto expr = std::make_shared<lp::InputReferenceExpr>(
+              inputType->childAt(ordinal), inputType->nameOf(ordinal));
+          mark(expr);
+
+        } else {
+          const auto& unnestExpr =
+              unnest->unnestExpressions().at(ordinal - inputType->size());
+          mark(unnestExpr);
+        }
+      }
+      return;
+    }
+
     if (kind == lp::NodeKind::kSet) {
       const auto* set = source.planNode->asUnchecked<lp::SetNode>();
       for (const auto& input : set->inputs()) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -931,6 +931,46 @@ PlanObjectP ToGraph::addOrderBy(const lp::SortNode& order) {
   return currentDt_;
 }
 
+void ToGraph::translateUnnest(const logical_plan::UnnestNode& unnest) {
+  VELOX_CHECK(!unnest.inputs().empty());
+
+  makeQueryGraph(*unnest.onlyInput(), allow(PlanType::kJoinNode));
+
+  auto* unnestTable = make<UnnestTable>();
+  unnestTable->cname = newCName("ut");
+  planLeaves_[&unnest] = unnestTable;
+
+  const auto numInputColumns = unnest.onlyInput()->outputType()->size();
+
+  const auto& type = unnest.outputType();
+
+  for (auto i = numInputColumns; i < type->size(); ++i) {
+    const auto& name = type->nameOf(i);
+    Value value{toType(type->childAt(i)), 1};
+    auto* column = make<Column>(toName(name), unnestTable, value, toName(name));
+
+    unnestTable->columns.push_back(column);
+    renames_[name] = column;
+  }
+
+  currentDt_->tables.push_back(unnestTable);
+  currentDt_->tableSet.add(unnestTable);
+
+  // Add join edges.
+  for (const auto& unnestExpr : unnest.unnestExpressions()) {
+    auto expr = translateExpr(unnestExpr);
+    auto leftTables = expr->allTables();
+
+    auto leftTableVector = leftTables.toVector();
+
+    auto* edge = make<JoinEdge>(
+        leftTableVector.size() == 1 ? leftTableVector[0] : nullptr,
+        unnestTable,
+        JoinEdge::Spec{.filter = {expr}, .directed = true});
+    currentDt_->joins.push_back(edge);
+  }
+}
+
 namespace {
 
 // Fills 'leftKeys' and 'rightKeys's from 'conjuncts' so that
@@ -1023,10 +1063,7 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
     extractNonInnerJoinEqualities(
         conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    std::vector<PlanObjectCP> leftTableVector;
-    leftTableVector.reserve(leftTables.size());
-    leftTables.forEach(
-        [&](PlanObjectCP table) { leftTableVector.push_back(table); });
+    auto leftTableVector = leftTables.toVector();
 
     auto* edge = make<JoinEdge>(
         leftTableVector.size() == 1 ? leftTableVector[0] : nullptr,
@@ -1612,6 +1649,8 @@ PlanObjectP ToGraph::makeQueryGraph(
       return currentDt_;
     }
     case lp::NodeKind::kUnnest:
+      translateUnnest(*node.asUnchecked<lp::UnnestNode>());
+      return currentDt_;
     default:
       VELOX_NYI(
           "Unsupported PlanNode {}", lp::NodeKindName::toName(node.kind()));

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -310,6 +310,8 @@ class ToGraph {
   // Adds a JoinEdge corresponding to 'join' to the enclosing DerivedTable.
   void translateJoin(const logical_plan::JoinNode& join);
 
+  void translateUnnest(const logical_plan::UnnestNode& unnest);
+
   DerivedTableP translateSetJoin(
       const logical_plan::SetNode& set,
       DerivedTableP setDt);

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -196,6 +196,8 @@ PlanAndStats ToVelox::toVeloxPlan(
     plan = addGather(plan);
   }
 
+  LOG(ERROR) << std::endl << plan->toString(true, true);
+
   ExecutableFragment top;
   std::vector<ExecutableFragment> stages;
   top.fragment.planNode = makeFragment(std::move(plan), top, stages);
@@ -1376,6 +1378,43 @@ core::PlanNodePtr ToVelox::makeValues(
   return valuesNode;
 }
 
+core::PlanNodePtr ToVelox::makeUnnest(
+    const Unnest& unnest,
+    axiom::runner::ExecutableFragment& fragment,
+    std::vector<axiom::runner::ExecutableFragment>& stages) {
+  auto input = makeFragment(unnest.input(), fragment, stages);
+
+  TempProjections project(*this, *unnest.input());
+  auto unnestExprs = project.toFieldRefs(unnest.unnestExprs());
+
+  std::vector<core::FieldAccessTypedExprPtr> replicatedColumns;
+  replicatedColumns.reserve(input->outputType()->size());
+  for (auto i = 0; i < input->outputType()->size(); ++i) {
+    replicatedColumns.emplace_back(project.toFieldRef(unnest.columns()[i]));
+  }
+
+  auto unnestInput = project.maybeProject(input);
+
+  std::vector<std::string> unnestNames;
+  for (auto i = input->outputType()->size(); i < unnest.columns().size(); ++i) {
+    auto column = unnest.columns()[i];
+    unnestNames.push_back(outputName(column));
+  }
+
+  auto unnestNode = std::make_shared<core::UnnestNode>(
+      nextId(),
+      replicatedColumns,
+      unnestExprs,
+      unnestNames,
+      /* ordinalityName */ std::nullopt,
+      /* emptyUnnestValueName */ std::nullopt,
+      unnestInput);
+
+  makePredictionAndHistory(unnestNode->id(), &unnest);
+
+  return unnestNode;
+}
+
 void ToVelox::makePredictionAndHistory(
     const core::PlanNodeId& id,
     const RelationOp* op) {
@@ -1413,6 +1452,8 @@ core::PlanNodePtr ToVelox::makeFragment(
       return makeUnionAll(*op->as<UnionAll>(), fragment, stages);
     case RelType::kValues:
       return makeValues(*op->as<Values>(), fragment);
+    case RelType::kUnnest:
+      return makeUnnest(*op->as<Unnest>(), fragment, stages);
     default:
       VELOX_FAIL(
           "Unsupported RelationOp {}", static_cast<int32_t>(op->relType()));

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -189,6 +189,11 @@ class ToVelox {
       const Values& values,
       axiom::runner::ExecutableFragment& fragment);
 
+  core::PlanNodePtr makeUnnest(
+      const Unnest& unnest,
+      axiom::runner::ExecutableFragment& fragment,
+      std::vector<axiom::runner::ExecutableFragment>& stages);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/DerivedTablePrinter.h"
+#include <gtest/gtest.h>
+#include "axiom/optimizer/Plan.h"
+#include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/tests/PrestoParser.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/tpch/gen/TpchGen.h"
+
+namespace lp = facebook::velox::logical_plan;
+
+namespace facebook::velox::optimizer {
+namespace {
+
+class DerivedTablePrinterTest : public testing::Test {
+ public:
+  static constexpr auto kTestConnectorId = "test";
+
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+  }
+
+  void SetUp() override {
+    rootPool_ = memory::memoryManager()->addRootPool("root");
+    pool_ = rootPool_->addLeafChild("optimizer");
+
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    connector::registerConnector(testConnector_);
+
+    for (const auto& table : tpch::tables) {
+      const auto tableName = tpch::toTableName(table);
+      const auto tableSchema = tpch::getTableSchema(table);
+
+      testConnector_->createTable(std::string(tableName), tableSchema);
+    }
+  }
+
+  void TearDown() override {
+    connector::unregisterConnector(kTestConnectorId);
+  }
+
+  std::string printQueryGraph(const std::string& sql) {
+    test::PrestoParser parser(kTestConnectorId, pool_.get());
+    auto statement = parser.parse(sql);
+
+    VELOX_CHECK(statement->isSelect());
+    auto logicalPlan = statement->asUnchecked<test::SelectStatement>()->plan();
+
+    auto allocator = std::make_unique<HashStringAllocator>(pool_.get());
+    auto context = std::make_unique<QueryGraphContext>(*allocator);
+    queryCtx() = context.get();
+    SCOPE_EXIT {
+      queryCtx() = nullptr;
+    };
+
+    auto veloxQueryCtx = core::QueryCtx::create();
+    exec::SimpleExpressionEvaluator evaluator(veloxQueryCtx.get(), pool_.get());
+
+    velox::optimizer::VeloxHistory history;
+    velox::optimizer::SchemaResolver schemaResolver;
+
+    Locus locus(kTestConnectorId, testConnector_.get());
+    Schema schema("test", &schemaResolver, &locus);
+    Optimization opt(
+        *logicalPlan,
+        schema,
+        history,
+        veloxQueryCtx,
+        evaluator,
+        {.sampleJoins = false});
+
+    const auto& root = opt.queryGraph();
+
+    return DerivedTablePrinter::toText(root);
+  }
+
+  void testPrinter(const std::string& sql) {
+    LOG(ERROR) << sql << std::endl;
+    LOG(ERROR) << std::endl << printQueryGraph(sql);
+  }
+
+  static std::string readSqlFromFile(const std::string& filePath) {
+    auto path = velox::test::getDataFilePath("axiom/optimizer/tests", filePath);
+    std::ifstream inputFile(path, std::ifstream::binary);
+
+    VELOX_CHECK(inputFile, "Failed to open SQL file: {}", path);
+
+    // Find out file size.
+    auto begin = inputFile.tellg();
+    inputFile.seekg(0, std::ios::end);
+    auto end = inputFile.tellg();
+
+    const auto fileSize = end - begin;
+    VELOX_CHECK_GT(fileSize, 0, "SQL file is empty: {}", path);
+
+    // Read the file.
+    std::string sql;
+    sql.resize(fileSize);
+
+    inputFile.seekg(begin);
+    inputFile.read(sql.data(), fileSize);
+    inputFile.close();
+
+    return sql;
+  }
+
+  void testTpch(int32_t query) {
+    auto sql = readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+    testPrinter(sql);
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+
+  std::shared_ptr<connector::TestConnector> testConnector_;
+};
+
+TEST_F(DerivedTablePrinterTest, basic) {
+  testPrinter("SELECT count(1) FROM nation");
+  testPrinter("SELECT * FROM nation WHERE n_name like 'A%' LIMIT 2");
+  testPrinter("SELECT count(1) FROM nation GROUP BY n_regionkey");
+  testPrinter(
+      "SELECT r_name, count(1) FROM nation, region "
+      "WHERE n_regionkey = r_regionkey "
+      "GROUP BY 1 "
+      "ORDER BY 2");
+}
+
+TEST_F(DerivedTablePrinterTest, unnest) {
+  testPrinter("SELECT * FROM nation, UNNEST(array[n_nationkey, n_regionkey])");
+}
+
+TEST_F(DerivedTablePrinterTest, tpch01) {
+  testTpch(1);
+}
+
+TEST_F(DerivedTablePrinterTest, tpch03) {
+  testTpch(3);
+}
+
+} // namespace
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -35,6 +35,25 @@ class HiveQueriesTest : public test::HiveQueriesTestBase {
   }
 };
 
+TEST_F(HiveQueriesTest, unnest) {
+  auto scan = [&](const std::string& tableName) {
+    return exec::test::PlanBuilder().tableScan(tableName, getSchema(tableName));
+  };
+
+  checkResults(
+      "SELECT length(n_name), x + n_nationkey "
+      "FROM nation, unnest(array[n_nationkey, n_regionkey]) as t(x)",
+      scan("nation")
+          .project(
+              {"n_name",
+               "n_nationkey",
+               "n_regionkey",
+               "array[n_nationkey, n_regionkey] as a"})
+          .unnest({"n_name", "n_nationkey"}, {"a"})
+          .project({"length(n_name)", "a_e + n_nationkey"})
+          .planNode());
+}
+
 TEST_F(HiveQueriesTest, basic) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto scan = [&](const std::string& tableName) {

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/logical_plan/PlanPrinter.h"
 #include "axiom/optimizer/tests/ParquetTpchTest.h"
 
 namespace lp = facebook::velox::logical_plan;
@@ -96,11 +97,14 @@ void HiveQueriesTestBase::checkResults(
   ASSERT_TRUE(statement->isSelect());
   auto logicalPlan = statement->asUnchecked<test::SelectStatement>()->plan();
 
+  LOG(ERROR) << lp::PlanPrinter::toText(*logicalPlan);
+
   auto referenceResults = runVelox(referencePlan);
 
   // Distributed.
   {
     auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    LOG(ERROR) << plan.plan->toString();
     checkResults(plan, referenceResults);
   }
 


### PR DESCRIPTION
Summary:
> SELECT length(n_name), x + n_region_key
> FROM nation, unnest(array[n_regionkey, n_nation_key]) as t(x)

LogicalPlan -> QueryGraph -> RelationOp -> PlanNode

---- LogicalPlan:
```
- Project: -> ROW<expr:BIGINT,expr_0:BIGINT>
    expr := length(n_name)
    expr_0 := plus(x, n_nationkey)
  - Unnest -> ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR,x:BIGINT>
      [x] := array_constructor(n_nationkey, n_regionkey)
    - TableScan: tpch.nation -> ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>
```

---- QueryGraph:
```
dt1: expr, expr_0
  output:
    expr := length(t2.n_name)
    expr_0 := plus(t2.n_nationkey, ut3.x)
  tables: t2, ut3
  joins:
    t2 INNER ut3 ON  FILTER array_constructor(t2.n_nationkey, t2.n_regionkey)

t2: n_nationkey, n_name, n_regionkey
  table: nation

ut3: x
```
---- RelationOp:
```
nation t2 0n rows 0nCU

 Unnest (array_constructor(t2.n_nationkey, t2.n_regionkey))
 Project (dt1.expr = length(t2.n_name), dt1.expr_0 = plus(t2.n_nationkey, ut3.x))
 shuffle gather 0n rows 0nCU
```
---- PlanNode
```
Fragment 0: stage1 numWorkers=4:
-- PartitionedOutput[4][SINGLE Presto] -> expr:BIGINT, expr_0:BIGINT
  -- Project[3][expressions: (expr:BIGINT, length("n_name")), (expr_0:BIGINT, plus("n_nationkey","x"))] -> expr:BIGINT, expr_0:BIGINT
    -- Unnest[2][__r3] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, x:BIGINT
      -- Project[1][expressions: (n_nationkey:BIGINT, "n_nationkey"), (n_name:VARCHAR, "n_name"), (n_regionkey:BIGINT, "n_regionkey"), (__r3:ARRAY<BIGINT>, array_constructor("n_nationkey","n_regionkey"))] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, __r3:ARRAY<BIGINT>
        -- TableScan[0][table: nation, scale factor: 0.01] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT

Fragment 1:  numWorkers=1:
-- Exchange[5][Presto] -> expr:BIGINT, expr_0:BIGINT

Inputs:  5 <- stage1
```

Differential Revision: D80917824


