### PR TITLE
refactor: Introduce PlanObjectSet::toObjects()

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -290,7 +290,7 @@ void DerivedTable::import(
     const std::vector<PlanObjectSet>& existences,
     float existsFanout) {
   tableSet = _tables;
-  _tables.forEach([&](auto table) { tables.push_back(table); });
+  tables = _tables.toObjects();
   for (auto join : super.joins) {
     if (_tables.contains(join->rightTable()) && join->leftTable() &&
         _tables.contains(join->leftTable())) {
@@ -305,8 +305,7 @@ void DerivedTable::import(
     // of these tables goes into its own derived table which is joined
     // with exists to the main table(s) in the 'this'.
     importedExistences.unionSet(exists);
-    PlanObjectVector existsTables;
-    exists.forEach([&](auto object) { existsTables.push_back(object); });
+    auto existsTables = exists.toObjects();
     auto existsJoin = makeExists(firstTable, exists);
     if (existsTables.size() > 1) {
       // There is a join on the right of exists. Needs its own dt.

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -1666,8 +1666,7 @@ float startingScore(PlanObjectCP table) {
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   auto& dt = state.dt;
   if (!plan) {
-    std::vector<PlanObjectCP> firstTables;
-    dt->startTables.forEach([&](auto table) { firstTables.push_back(table); });
+    auto firstTables = dt->startTables.toObjects();
     std::vector<float> scores(firstTables.size());
     for (auto i = 0; i < firstTables.size(); ++i) {
       auto table = firstTables[i];

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -166,6 +166,17 @@ class PlanObjectSet : public BitSet {
     }
   }
 
+  /// Returns the objects corresponding to ids in 'this' as a vector of const
+  /// T*.
+  template <typename T = PlanObject>
+  std::vector<const T*, QGAllocator<const T*>> toObjects() const {
+    std::vector<const T*, QGAllocator<const T*>> objects;
+    objects.reserve(size());
+    forEach(
+        [&](auto object) { objects.emplace_back(object->template as<T>()); });
+    return objects;
+  }
+
   /// Applies 'func' to each object in 'this'.
   template <typename Func>
   void forEach(Func func) const {
@@ -181,15 +192,6 @@ class PlanObjectSet : public BitSet {
     velox::bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, [&](auto i) {
       func(ctx->mutableObjectAt(i));
     });
-  }
-
-  /// Returns the objects corresponding to ids in 'this' as a vector of T.
-  template <typename T = PlanObjectP>
-  std::vector<T> objects() const {
-    std::vector<T> result;
-    forEach(
-        [&](auto object) { result.push_back(reinterpret_cast<T>(object)); });
-    return result;
   }
 
   /// Prnts the contents with ids and the string representation of the objects

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1023,10 +1023,7 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
     extractNonInnerJoinEqualities(
         conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    std::vector<PlanObjectCP> leftTableVector;
-    leftTableVector.reserve(leftTables.size());
-    leftTables.forEach(
-        [&](PlanObjectCP table) { leftTableVector.push_back(table); });
+    auto leftTableVector = leftTables.toObjects();
 
     auto* edge = make<JoinEdge>(
         leftTableVector.size() == 1 ? leftTableVector[0] : nullptr,


### PR DESCRIPTION
Summary: To allow easily convert a set of plan object IDs to a std::vector of PlanObjectCPs.

Differential Revision: D80936887


