### PR TITLE
fix: Fix SQL parsing of CROSS JOIN UNNEST

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -252,6 +252,19 @@ class PlanBuilder {
       const std::vector<ExprApi>& unnestExprs,
       bool withOrdinality = false);
 
+  /// An alternative way to specify aliases for unnested columns. A preferred
+  /// way is by using ExprApi::unnestAs.
+  ///
+  /// @param alias Optional alias for the relation produced by unnest.
+  /// @param columnAliases An optional list of aliases for columns produced by
+  /// unnest. The list can be empty or must have a non-empty alias for each
+  /// column.
+  PlanBuilder& unnest(
+      const std::vector<ExprApi>& unnestExprs,
+      bool withOrdinality,
+      const std::optional<std::string>& alias,
+      const std::vector<std::string>& columnAliases);
+
   PlanBuilder& join(
       const PlanBuilder& right,
       const std::string& condition,

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -154,7 +154,24 @@ class ToTextVisitor : public PlanNodeVisitor {
 
   void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const override {
-    appendNode("Unnest", node, context);
+    auto& myContext = static_cast<Context&>(context);
+
+    myContext.out << makeIndent(myContext.indent) << "- Unnest:";
+    appendOutputType(node, myContext);
+    myContext.out << std::endl;
+
+    const auto size = node.unnestExpressions().size();
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (auto i = 0; i < size; ++i) {
+      myContext.out << indent << "["
+                    << folly::join(", ", node.unnestedNames().at(i)) << "]"
+                    << " := "
+                    << ExprPrinter::toText(*node.unnestExpressions().at(i))
+                    << std::endl;
+    }
+
+    appendInputs(node, myContext);
   }
 
  private:

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -340,7 +340,9 @@ TEST_F(PlanPrinterTest, unnest) {
     EXPECT_THAT(
         lines,
         testing::ElementsAre(
-            testing::Eq("- Unnest: -> ROW<e:INTEGER>"), testing::Eq("")));
+            testing::Eq("- Unnest: -> ROW<e:INTEGER>"),
+            testing::Eq("    [e] := [1,2,3]"),
+            testing::Eq("")));
   }
 
   {
@@ -358,6 +360,7 @@ TEST_F(PlanPrinterTest, unnest) {
             testing::StartsWith("    x := x"),
             testing::StartsWith("    expr := plus(x, CAST(1 AS INTEGER))"),
             testing::Eq("  - Unnest: -> ROW<x:INTEGER>"),
+            testing::Eq("      [x] := [1,2,3]"),
             testing::Eq("")));
   }
 
@@ -372,6 +375,7 @@ TEST_F(PlanPrinterTest, unnest) {
         lines,
         testing::ElementsAre(
             testing::Eq("- Unnest: -> ROW<k:INTEGER,v:INTEGER>"),
+            testing::Eq("    [k, v] := map([1,2,3], [10,20,30])"),
             testing::Eq("")));
   }
 
@@ -390,6 +394,7 @@ TEST_F(PlanPrinterTest, unnest) {
             testing::StartsWith("- Project:"),
             testing::StartsWith("    expr := plus(x, y)"),
             testing::Eq("  - Unnest: -> ROW<x:INTEGER,y:INTEGER>"),
+            testing::Eq("      [x, y] := map([1,2,3], [10,20,30])"),
             testing::Eq("")));
   }
 
@@ -411,6 +416,8 @@ TEST_F(PlanPrinterTest, unnest) {
             testing::StartsWith("    expr_0 := plus(x, CAST(y AS BIGINT))"),
             testing::StartsWith("    z := z"),
             testing::StartsWith("  - Unnest:"),
+            testing::StartsWith("      [x] := d"),
+            testing::StartsWith("      [y, z] := e"),
             testing::StartsWith("    - TableScan: test.test"),
             testing::Eq("")));
   }

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -290,7 +290,7 @@ void DerivedTable::import(
     const std::vector<PlanObjectSet>& existences,
     float existsFanout) {
   tableSet = _tables;
-  _tables.forEach([&](auto table) { tables.push_back(table); });
+  tables = _tables.toObjects();
   for (auto join : super.joins) {
     if (_tables.contains(join->rightTable()) && join->leftTable() &&
         _tables.contains(join->leftTable())) {
@@ -305,8 +305,7 @@ void DerivedTable::import(
     // of these tables goes into its own derived table which is joined
     // with exists to the main table(s) in the 'this'.
     importedExistences.unionSet(exists);
-    PlanObjectVector existsTables;
-    exists.forEach([&](auto object) { existsTables.push_back(object); });
+    auto existsTables = exists.toObjects();
     auto existsJoin = makeExists(firstTable, exists);
     if (existsTables.size() > 1) {
       // There is a join on the right of exists. Needs its own dt.

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -1666,8 +1666,7 @@ float startingScore(PlanObjectCP table) {
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   auto& dt = state.dt;
   if (!plan) {
-    std::vector<PlanObjectCP> firstTables;
-    dt->startTables.forEach([&](auto table) { firstTables.push_back(table); });
+    auto firstTables = dt->startTables.toObjects();
     std::vector<float> scores(firstTables.size());
     for (auto i = 0; i < firstTables.size(); ++i) {
       auto table = firstTables[i];

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -166,6 +166,17 @@ class PlanObjectSet : public BitSet {
     }
   }
 
+  /// Returns the objects corresponding to ids in 'this' as a vector of const
+  /// T*.
+  template <typename T = PlanObject>
+  std::vector<const T*, QGAllocator<const T*>> toObjects() const {
+    std::vector<const T*, QGAllocator<const T*>> objects;
+    objects.reserve(size());
+    forEach(
+        [&](auto object) { objects.emplace_back(object->template as<T>()); });
+    return objects;
+  }
+
   /// Applies 'func' to each object in 'this'.
   template <typename Func>
   void forEach(Func func) const {
@@ -181,15 +192,6 @@ class PlanObjectSet : public BitSet {
     velox::bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, [&](auto i) {
       func(ctx->mutableObjectAt(i));
     });
-  }
-
-  /// Returns the objects corresponding to ids in 'this' as a vector of T.
-  template <typename T = PlanObjectP>
-  std::vector<T> objects() const {
-    std::vector<T> result;
-    forEach(
-        [&](auto object) { result.push_back(reinterpret_cast<T>(object)); });
-    return result;
   }
 
   /// Prnts the contents with ids and the string representation of the objects

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1023,10 +1023,7 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
     extractNonInnerJoinEqualities(
         conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    std::vector<PlanObjectCP> leftTableVector;
-    leftTableVector.reserve(leftTables.size());
-    leftTables.forEach(
-        [&](PlanObjectCP table) { leftTableVector.push_back(table); });
+    auto leftTableVector = leftTables.toObjects();
 
     auto* edge = make<JoinEdge>(
         leftTableVector.size() == 1 ? leftTableVector[0] : nullptr,

--- a/axiom/optimizer/tests/PrestoParserTest.cpp
+++ b/axiom/optimizer/tests/PrestoParserTest.cpp
@@ -117,15 +117,14 @@ TEST_F(PrestoParserTest, unnest) {
   }
 
   {
-    auto matcher = lp::LogicalPlanMatcherBuilder().tableScan().join(
-        lp::LogicalPlanMatcherBuilder().unnest().build());
+    auto matcher = lp::LogicalPlanMatcherBuilder().tableScan().unnest();
     testSql(
         "SELECT * FROM nation, unnest(array[n_nationkey, n_regionkey])",
         matcher);
   }
+
   {
-    auto matcher = lp::LogicalPlanMatcherBuilder().tableScan().join(
-        lp::LogicalPlanMatcherBuilder().unnest().project().build());
+    auto matcher = lp::LogicalPlanMatcherBuilder().tableScan().unnest();
 
     testSql(
         "SELECT * FROM nation, unnest(array[n_nationkey, n_regionkey]) as t(x)",


### PR DESCRIPTION
Summary: Fix SQL parsing of `SELECT * FROM t, unnest(a)` into Scan -> Unnest vs. Join(Scan, Unnest).

Differential Revision: D80940365


