### PR TITLE
fix: Avoid a crash in JoinEdge::guessFanout() for hyper edge

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -415,6 +415,13 @@ void JoinEdge::guessFanout() {
   if (fanoutsFixed_) {
     return;
   }
+
+  if (leftTable_ == nullptr) {
+    lrFanout_ = 1.1;
+    rlFanout_ = 1;
+    return;
+  }
+
   auto* opt = queryCtx()->optimization();
   auto samplePair = opt->history().sampleJoin(this);
   auto left = joinCardinality(leftTable_, toRangeCast<Column>(leftKeys_));


### PR DESCRIPTION
Summary: JoinEdge::guessFanout() crashed for hyper edges where leftTable_ is null. "Fix" that by hard-coding fanouts.

Differential Revision: D80989892


