### PR TITLE
feat: Avoid use embedded aggregation op to collect column stats in table writers

### DIFF
--- a/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/optimizer/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -190,7 +190,7 @@ TEST_F(HiveConnectorMetadataTest, createTable) {
       idGenerator->next(),
       builder.planNode()->outputType(),
       tableType->names(),
-      nullptr,
+      std::nullopt,
       handle,
       false,
       resultType,

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -68,10 +68,10 @@ class TestConnectorQueryTest : public QueryTestBase {
         "writenodeid",
         source->outputType(),
         schema->names(),
-        /*aggregationNode=*/nullptr,
+        /*columnStatsSpec=*/std::nullopt,
         std::move(handle),
         /*hasPartitioningScheme=*/false,
-        exec::TableWriteTraits::outputType(nullptr),
+        exec::TableWriteTraits::outputType(std::nullopt),
         connector::CommitStrategy::kTaskCommit,
         source);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14595

This diff refactors the column statistics collection mechanism in table writers to avoid using embedded aggregation operations. Instead of relying on embedded aggregation operators to collect column statistics during table writing, this change introduces a dedicated `ColumnStatsCollector` component that handles statistics collection more efficiently and  `ColumnStatsSpec` to specify the aggregates functions used for statistic collection in table write plan node.

Reviewed By: mbasmanova

Differential Revision: D80904627


