### PR TITLE
refactor: Remove RelType::kBase

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -784,7 +784,7 @@ struct BaseTable : public PlanObject {
   BitSet columnSubfields(int32_t id, bool payloadOnly, bool controlOnly) const;
 
   /// Returns possible indices for driving table scan of 'table'.
-  std::vector<ColumnGroupP> chooseLeafIndex() const {
+  std::vector<ColumnGroupCP> chooseLeafIndex() const {
     VELOX_DCHECK(!schemaTable->columnGroups.empty());
     return {schemaTable->columnGroups[0]};
   }


### PR DESCRIPTION
Summary:
RelType confusingly mixed schema objects (ColumnGroup) with physical plan nodes.

Refactor ColumnGroup to not use Relation as a base class. Move RelType to RelationOp.h and fold Relation class into RelationOp.

Differential Revision: D81032863


