### PR TITLE
feat: Add support for EXPLAIN to PrestoParser

### DIFF
--- a/axiom/optimizer/tests/PrestoParser.h
+++ b/axiom/optimizer/tests/PrestoParser.h
@@ -31,9 +31,7 @@ class PrestoParser {
       bool enableTracing = false);
 
  private:
-  logical_plan::LogicalPlanNodePtr doParse(
-      const std::string& sql,
-      bool enableTracing);
+  SqlStatementPtr doParse(const std::string& sql, bool enableTracing);
 
   const std::string defaultConnectorId_;
 

--- a/axiom/optimizer/tests/PrestoParserTest.cpp
+++ b/axiom/optimizer/tests/PrestoParserTest.cpp
@@ -444,5 +444,21 @@ TEST_F(PrestoParserTest, everything) {
       matcher);
 }
 
+TEST_F(PrestoParserTest, explain) {
+  test::PrestoParser parser(kTpchConnectorId, pool());
+
+  auto statement = parser.parse("EXPLAIN SELECT * FROM nation");
+  ASSERT_TRUE(statement->isExplain());
+
+  auto selectStatement =
+      statement->asUnchecked<test::ExplainStatement>()->statement();
+  ASSERT_TRUE(selectStatement->isSelect());
+
+  auto matcher = lp::LogicalPlanMatcherBuilder().tableScan();
+
+  auto logicalPlan = selectStatement->asUnchecked<SelectStatement>()->plan();
+  ASSERT_TRUE(matcher.build()->match(logicalPlan));
+}
+
 } // namespace
 } // namespace facebook::velox::optimizer::test

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -466,7 +466,11 @@ std::any AstBuilder::visitShowGrants(PrestoSqlParser::ShowGrantsContext* ctx) {
 
 std::any AstBuilder::visitExplain(PrestoSqlParser::ExplainContext* ctx) {
   trace("visitExplain");
-  return visitChildren(ctx);
+
+  return std::static_pointer_cast<Statement>(std::make_shared<Explain>(
+      getLocation(ctx),
+      visitTyped<Statement>(ctx->statement()),
+      visitTyped<ExplainOption>(ctx->explainOption())));
 }
 
 std::any AstBuilder::visitShowCreateTable(


### PR DESCRIPTION
Summary:
> $ buck run axiom/optimizer/tests:velox_sql -- --data_path /tmp/tpch/

```
SQL> explain select count(*) from nation;
Fragment 0: stage1 numWorkers=4:
-- PartitionedOutput[2][SINGLE Presto] -> count:BIGINT
  -- Aggregation[1][PARTIAL count := count()] -> count:BIGINT
    -- TableScan[0][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] ->

Fragment 1:  numWorkers=1:
-- Aggregation[5][FINAL count := count("count")] -> count:BIGINT
  -- LocalPartition[4][GATHER] -> count:BIGINT
    -- Exchange[3][Presto] -> count:BIGINT

Inputs:  3 <- stage1
```

Differential Revision: D81060587


