### PR TITLE
fix: Field not found error in ToGraph::getExprForField

### DIFF
--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -587,6 +587,58 @@ TEST_P(SubfieldTest, maps) {
   testParallelExpr(opts, rowType);
 }
 
+TEST_P(SubfieldTest, blackbox) {
+  auto data = makeRowVector(
+      {"id", "m"},
+      {
+          makeFlatVector<int64_t>({1, 2}),
+          makeMapVectorFromJson<int32_t, float>(
+              {"{1: 0.1, 2: 0.2}", "{3: 0.3, 4: 0.4}"}),
+      });
+
+  createTable("t", {data});
+
+  lp::PlanBuilder::Context ctx(kHiveConnectorId);
+  ctx.hook = [](const auto& name, const auto& args) -> lp::ExprPtr {
+    if (name == "map_row_from_map") {
+      VELOX_CHECK(args.at(2)->isConstant());
+      auto names = args.at(2)
+                       ->template asUnchecked<lp::ConstantExpr>()
+                       ->value()
+                       ->template array<std::string>();
+
+      return std::make_shared<lp::CallExpr>(
+          ROW(names, std::vector<TypePtr>(names.size(), REAL())), name, args);
+    }
+
+    if (name == "make_named_row") {
+      std::vector<std::string> names;
+      for (auto i = 0; i < args.size(); i += 2) {
+        VELOX_CHECK(args.at(i)->isConstant());
+        names.push_back(args.at(i)
+                            ->template asUnchecked<lp::ConstantExpr>()
+                            ->value()
+                            ->template value<std::string>());
+      }
+      return std::make_shared<lp::CallExpr>(
+          ROW(names, std::vector<TypePtr>(names.size(), REAL())), name, args);
+    }
+
+    return nullptr;
+  };
+
+  auto logicalPlan =
+      lp::PlanBuilder(ctx)
+          .tableScan("t")
+          .project(
+              {"map_row_from_map(m, array[1, 2, 3], array['f1', 'f2', 'f3']) as m"})
+          .project({"make_named_row('x', m.f1, 'y', m.f2) as m"})
+          .project({"m.x", "m.y"})
+          .build();
+
+  ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SubfieldTests,
     SubfieldTest,


### PR DESCRIPTION
Summary:
Newly-added test used to fail when converting the following logical plan to query graph.

```
] - Project: -> ROW<expr:REAL>
    expr := DEREFERENCE(m_1, x)
  - Project: -> ROW<m_1:ROW<x:REAL,y:REAL>>
      m_1 := make_named_row(x, DEREFERENCE(m_0, f1), y, DEREFERENCE(m_0, f2))
    - Project: -> ROW<m_0:ROW<f1:REAL,f2:REAL,f3:REAL>>
        m_0 := map_row_from_map(m, [1,2,3], ["f1","f2","f3"])
      - TableScan: test.t -> ROW<a:BIGINT,m:MAP<BIGINT,REAL>>

terminate called after throwing an instance of 'facebook::velox::VeloxUserError'
  what():  Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Field not found: m_0. Available fields are: m_1.
Retriable: False
Context: Expr: make_named_row(x, DEREFERENCE(m_0, f1), y, DEREFERENCE(m_0, f2))
Function: getChildIdx
File: fbcode/velox/type/Type.cpp
Line: 440
```

Differential Revision: D81101533


