### PR TITLE
feat: Add parsing for TPC-H q2,17

### DIFF
--- a/axiom/optimizer/tests/PrestoParser.cpp
+++ b/axiom/optimizer/tests/PrestoParser.cpp
@@ -454,7 +454,10 @@ class RelationPlanner : public sql::AstVisitor {
         if (query->is(sql::NodeType::kQuery)) {
           auto builder = std::move(builder_);
 
-          builder_ = newBuilder();
+          lp::PlanBuilder::Scope scope;
+          builder->captureScope(scope);
+
+          builder_ = newBuilder(scope);
           processQuery(query->as<sql::Query>());
           auto subqueryBuider = builder_;
 

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -88,8 +88,22 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
     return sql;
   }
 
+  std::string readTpchSql(int32_t query) {
+    return readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+  }
+
+  void parseTpchSql(int32_t query) {
+    auto sql = readTpchSql(query);
+
+    auto statement = prestoParser_->parse(sql);
+
+    ASSERT_TRUE(statement->isSelect());
+    ASSERT_TRUE(
+        statement->asUnchecked<test::SelectStatement>()->plan() != nullptr);
+  }
+
   void checkTpchSql(int32_t query) {
-    auto sql = readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+    auto sql = readTpchSql(query);
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
     checkResults(sql, referencePlan);
   }
@@ -122,8 +136,9 @@ TEST_F(TpchPlanTest, q01) {
   checkTpchSql(1);
 }
 
-TEST_F(TpchPlanTest, DISABLED_q02) {
-  // TODO Implement. Requires subqueries support.
+TEST_F(TpchPlanTest, q02) {
+  // TODO Add support for subqueries.
+  parseTpchSql(2);
 }
 
 TEST_F(TpchPlanTest, q03) {
@@ -483,8 +498,9 @@ TEST_F(TpchPlanTest, DISABLED_q16) {
   // TODO Implement.
 }
 
-TEST_F(TpchPlanTest, DISABLED_q17) {
+TEST_F(TpchPlanTest, q17) {
   // TODO Implement.
+  parseTpchSql(17);
 }
 
 TEST_F(TpchPlanTest, DISABLED_q18) {

--- a/axiom/optimizer/tests/tpch.queries/q17.sql
+++ b/axiom/optimizer/tests/tpch.queries/q17.sql
@@ -1,0 +1,20 @@
+-- TPC-H/TPC-R Small-Quantity-Order Revenue Query (Q17)
+-- Functional Query Definition
+-- Approved February 1998
+select
+	sum(l.l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem as l,
+	part as p
+where
+	p.p_partkey = l.l_partkey
+	and p.p_brand = 'Brand#23'
+	and p.p_container = 'MED BOX'
+	and l.l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p.p_partkey
+	);

--- a/axiom/optimizer/tests/tpch.queries/q2.sql
+++ b/axiom/optimizer/tests/tpch.queries/q2.sql
@@ -1,0 +1,47 @@
+-- TPC-H/TPC-R Minimum Cost Supplier Query (Q2)
+-- Functional Query Definition
+-- Approved February 1998
+select
+	s.s_acctbal,
+	s.s_name,
+	n.n_name,
+	p.p_partkey,
+	p.p_mfgr,
+	s.s_address,
+	s.s_phone,
+	s.s_comment
+from
+	part as p,
+	supplier as s,
+	partsupp as ps,
+	nation as n,
+	region as r
+where
+	p.p_partkey = ps.ps_partkey
+	and s.s_suppkey = ps.ps_suppkey
+	and p.p_size = 15
+	and p.p_type like '%BRASS'
+	and s.s_nationkey = n.n_nationkey
+	and n.n_regionkey = r.r_regionkey
+	and r.r_name = 'EUROPE'
+	and ps.ps_supplycost = (
+		select
+			min(ps.ps_supplycost)
+		from
+			partsupp as ps,
+			supplier as s,
+			nation as n,
+			region as r
+		where
+			p.p_partkey = ps.ps_partkey
+			and s.s_suppkey = ps.ps_suppkey
+			and s.s_nationkey = n.n_nationkey
+			and n.n_regionkey = r.r_regionkey
+			and r.r_name = 'EUROPE'
+	)
+order by
+	s.s_acctbal desc,
+	n.n_name,
+	s.s_name,
+	p.p_partkey
+limit 100;


### PR DESCRIPTION
Summary: These queries require subquery support in the optimizer. At this point we can parse, but not optimize them.

Differential Revision: D81176406


