### PR TITLE
build(CI): Set ccache for CMAKE_C_COMPILER_LAUNCHER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 ifndef USE_CCACHE
 ifneq ($(shell which ccache), )
-USE_CCACHE=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+USE_CCACHE=-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 $(info ✓ ccache detected and enabled: USE_CCACHE=$(USE_CCACHE))
 endif
 endif


### PR DESCRIPTION
From a debug CI run with verbose information (https://github.com/facebookexperimental/verax/actions/runs/17309281862/job/49139843171), I noticed that gcc is not using ccache. Need to set ccache for C_COMPILER too.