### PR TITLE
fix: Don't produce unnessary projections

### DIFF
--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -164,7 +164,7 @@ struct PlanSubfields {
     if (it == nodeFields.end()) {
       return false;
     }
-    return it->second.resultPaths.count(ordinal) != 0;
+    return it->second.resultPaths.contains(ordinal);
   }
 
   std::string toString() const;

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -236,8 +236,7 @@ TEST_F(HiveLimitQueriesTest, orderByLimit) {
     SCOPED_TRACE("numWorkers: 1, numDrivers: 1");
     auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
 
-    auto matcher =
-        core::PlanMatcherBuilder().tableScan().topN(10).project().build();
+    auto matcher = core::PlanMatcherBuilder().tableScan().topN(10).build();
 
     checkSingleNodePlan(plan, matcher);
     checkResults(plan, referenceResults);
@@ -253,7 +252,6 @@ TEST_F(HiveLimitQueriesTest, orderByLimit) {
                        .topN(10)
                        .localMerge()
                        .finalLimit(0, 10)
-                       .project()
                        .build();
 
     checkSingleNodePlan(plan, matcher);
@@ -279,11 +277,8 @@ TEST_F(HiveLimitQueriesTest, orderByLimit) {
                        .build();
     ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
 
-    matcher = core::PlanMatcherBuilder()
-                  .mergeExchange()
-                  .finalLimit(0, 10)
-                  .project()
-                  .build();
+    matcher =
+        core::PlanMatcherBuilder().mergeExchange().finalLimit(0, 10).build();
     ASSERT_TRUE(matcher->match(fragments.at(1).fragment.planNode));
 
     checkResults(distributedPlan, referenceResults);

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -125,12 +125,7 @@ TEST_F(HiveQueriesTest, orderOfOperations) {
           .orderBy({"n_nationkey"})
           .limit(10)
           .orderBy({"n_name desc"}),
-      scanMatcher()
-          .limit()
-          .topN()
-          .project()
-          .orderBy({"n_name desc"})
-          .project());
+      scanMatcher().limit().topN().orderBy({"n_name desc"}));
 
   // GroupBy drops preceding orderBy.
   test(
@@ -179,8 +174,7 @@ TEST_F(HiveQueriesTest, orderOfOperations) {
           .finalLimit(0, 10)
           .filter("n_nationkey < 100 AND n_regionkey > 10")
           .finalLimit(0, 5)
-          .filter("n_nationkey > 70 AND n_regionkey < 7")
-          .project());
+          .filter("n_nationkey > 70 AND n_regionkey < 7"));
 }
 
 } // namespace


### PR DESCRIPTION
Eliminate unnecessary projections that restore the order of columns.

- usedChannels now return sorted list (It's the root of issue)
- skylineStruct have similar issue, it change order of columns compared to implementation where control and payload is single map. So I also refactored it (as a bonus it should works better because doesn't have unordered set of strings)

Fixes https://github.com/facebookexperimental/verax/issues/307