### PR TITLE
feat: Support rewrite of complex type functions when they are accesse…

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(
   PlanObject.cpp
   Schema.cpp
   QueryGraph.cpp
+  "Names.cpp"
   QueryGraphContext.cpp
   Filters.cpp
   Cost.cpp

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -25,7 +25,8 @@ namespace facebook::velox::optimizer {
 struct FunctionMetadata {
   bool processSubfields() const {
     return subfieldArg.has_value() || !fieldIndexForArg.empty() ||
-        isArrayConstructor || isMapConstructor || valuePathToArgPath;
+        isArrayConstructor || isMapConstructor || valuePathToArgPath ||
+        explode || expandFunction || !lambdas.empty();
   }
 
   const LambdaInfo* lambdaInfo(int32_t index) const {
@@ -89,6 +90,16 @@ struct FunctionMetadata {
       const logical_plan::CallExpr* call,
       std::vector<PathCP>& paths)>
       explode;
+
+  /// Hook for rewriting a call to a function. In the case of a
+  /// complex type function with subfield related metadata,
+  /// 'logicalExplode' is used if there are only getters over the
+  /// function. For functions with subfield related metadata options,
+  /// 'expandFunction is used only if the function is accessed as a
+  /// whole. If returns non-nullptr, the returned expression is used
+  /// in the place of the function.
+  std::function<logical_plan::ExprPtr(const logical_plan::CallExpr*)>
+      expandFunction;
 };
 
 using FunctionMetadataCP = const FunctionMetadata*;

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -36,12 +36,12 @@ Value intValue() {
 
 ExprCP bigintLit(int64_t n) {
   return make<Literal>(
-      bigintValue(), queryCtx()->registerVariant(std::make_unique<variant>(n)));
+      bigintValue(), queryCtx()->registerVariant(std::make_shared<variant>(n)));
 }
 
 ExprCP intLit(int32_t n) {
   return make<Literal>(
-      intValue(), queryCtx()->registerVariant(std::make_unique<variant>(n)));
+      intValue(), queryCtx()->registerVariant(std::make_shared<variant>(n)));
 }
 
 // Returns an int64 hash with low 28 bits set.

--- a/axiom/optimizer/Names.cpp
+++ b/axiom/optimizer/Names.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/Names.h"
+
+namespace facebook::velox::optimizer {
+
+// The names of known functions and special forms are declared
+// statically in one translation unit to ensure that all references
+// end up pointing to the same string. In this way the constants like kEq
+// et al can be compared by pointer to toName("eq") etc., as long as
+// the set of interned names in QueryGraphContext is initialized
+// with this set.
+
+const char* Names::kEq = "eq";
+const char* Names::kLt = "lt";
+const char* Names::kLte = "lte";
+const char* Names::kGt = "gt";
+const char* Names::kGte = "gte";
+const char* Names::kPlus = "plus";
+const char* Names::kMultiply = "multiply";
+const char* Names::kAnd = "and";
+const char* Names::kOr = "or";
+const char* Names::kCast = "cast";
+const char* Names::kTryCast = "trycast";
+const char* Names::kTry = "try";
+const char* Names::kCoalesce = "coalesce";
+const char* Names::kIf = "if";
+const char* Names::kSwitch = "switch";
+const char* Names::kIn = "in";
+const char* Names::kSubscript = "subscript";
+
+std::unordered_set<std::string_view> Names::builtinNames() {
+  static std::unordered_set<std::string_view> names = {
+      Names::kEq,
+      Names::kLt,
+      Names::kLte,
+      Names::kGt,
+      Names::kGte,
+      Names::kPlus,
+      Names::kMultiply,
+      Names::kAnd,
+      Names::kOr,
+      Names::kCast,
+      Names::kTryCast,
+      Names::kTry,
+      Names::kCoalesce,
+      Names::kIf,
+      Names::kSwitch,
+      Names::kIn,
+      Names::kSubscript,
+  };
+
+  return names;
+}
+
+bool Names::isCanonicalizable(const char* name) {
+  return name == kEq || name == kLt || name == kLte || name == kGt ||
+      name == kGte || name == kPlus || name == kMultiply || name == kAnd ||
+      name == kOr;
+}
+
+const char* Names::reverse(const char* name) {
+  if (name == kLt) {
+    return kGt;
+  }
+  if (name == kLte) {
+    return kGte;
+  }
+  if (name == kGt) {
+    return kLt;
+  }
+  if (name == kGte) {
+    return kLte;
+  }
+  return name;
+}
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Names.h
+++ b/axiom/optimizer/Names.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+#include <unordered_set>
+
+namespace facebook::velox::optimizer {
+
+struct Names {
+  static const char* kEq;
+  static const char* kLt;
+  static const char* kLte;
+  static const char* kGt;
+  static const char* kGte;
+  static const char* kPlus;
+  static const char* kMultiply;
+  static const char* kAnd;
+  static const char* kOr;
+  static const char* kCast;
+  static const char* kTryCast;
+  static const char* kTry;
+  static const char* kCoalesce;
+  static const char* kIf;
+  static const char* kSwitch;
+  static const char* kIn;
+  static const char* kSubscript;
+
+  static std::unordered_set<std::string_view> builtinNames();
+
+  static bool isCanonicalizable(const char* name);
+  static const char* reverse(const char* name);
+};
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -146,11 +146,6 @@ class Optimization {
   bool cnamesInExpr() const {
     return cnamesInExpr_;
   }
-
-  BuiltinNames& builtinNames() {
-    return toGraph_.builtinNames();
-  }
-
   /// Returns a dedupped left deep reduction with 'func' for the
   /// elements in set1 and set2. The elements are sorted on plan object
   /// id and then combined into a left deep reduction on 'func'.
@@ -159,6 +154,10 @@ class Optimization {
 
   /// Produces trace output if event matches 'traceFlags_'.
   void trace(int32_t event, int32_t id, const Cost& cost, RelationOp& plan);
+
+  bool isMapAsStruct(ColumnCP column) const {
+    return toVelox_.isMapAsStruct(column);
+  }
 
  private:
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -48,9 +48,6 @@ void PlanObjectSet::unionColumns(ExprCP expr) {
     case PlanType::kColumnExpr:
       add(expr);
       return;
-    case PlanType::kFieldExpr:
-      unionColumns(expr->as<Field>()->base());
-      return;
     case PlanType::kAggregateExpr: {
       auto condition = expr->as<Aggregate>()->condition();
       if (condition) {

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -29,7 +29,6 @@ enum class PlanType {
   kLiteralExpr,
   kCallExpr,
   kAggregateExpr,
-  kFieldExpr,
   kLambdaExpr,
   // Plan nodes.
   kTableNode,

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -109,17 +109,6 @@ std::string Call::toString() const {
   return out.str();
 }
 
-std::string Field::toString() const {
-  std::stringstream out;
-  out << base_->toString() << ".";
-  if (field_) {
-    out << field_;
-  } else {
-    out << fmt::format("{}", index_);
-  }
-  return out.str();
-}
-
 std::optional<BitSet> SubfieldSet::findSubfields(int32_t id) const {
   for (auto i = 0; i < ids.size(); ++i) {
     if (ids[i] == id) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/Names.h"
 #include "axiom/optimizer/Schema.h"
 #include "velox/core/PlanNode.h"
 
@@ -229,42 +230,6 @@ inline folly::Range<T*> toRange(const std::vector<T, QGAllocator<T>>& v) {
   return folly::Range<T const*>(v.data(), v.size());
 }
 
-class Field : public Expr {
- public:
-  Field(const Type* type, ExprCP base, Name field)
-      : Expr(PlanType::kFieldExpr, Value(type, 1)), field_(field), base_(base) {
-    columns_ = base->columns();
-    subexpressions_ = base->subexpressions();
-  }
-
-  Field(const Type* type, ExprCP base, int32_t index)
-      : Expr(PlanType::kFieldExpr, Value(type, 1)),
-        field_(nullptr),
-        index_(index),
-        base_(base) {
-    columns_ = base->columns();
-    subexpressions_ = base->subexpressions();
-  }
-
-  Name field() const {
-    return field_;
-  }
-
-  int32_t index() const {
-    return index_;
-  }
-
-  std::string toString() const override;
-
-  ExprCP base() const {
-    return base_;
-  }
-
- private:
-  Name field_;
-  int32_t index_;
-  ExprCP base_;
-};
 
 struct SubfieldSet {
   /// Id of an accessed column of complex type.

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -292,4 +292,12 @@ PathCP toPath(std::span<const Step> steps, bool reverse) {
   return queryCtx()->toPath(path);
 }
 
+const Variant* QueryGraphContext::registerVariant(
+    std::shared_ptr<const Variant> value) {
+  auto pair = variants_.insert(value);
+  auto* rawPtr = pair.first->get();
+  reverseConstantDedup_[rawPtr] = value;
+  return rawPtr;
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -340,7 +340,16 @@ void ToGraph::markSubfields(
     // If the function is some kind of constructor, like
     // make_row_from_map or make_named_row, then a path over it
     // selects one argument. If there is no path, all arguments are
-    // implicitly accessed.
+    // implicitly accessed. If the whole value of make_row_from_map is accessed,
+    // this does not yet access the whole map but just the keys listed in
+    // make_row_from_map.
+    if (metadata->expandFunction && steps.empty()) {
+      auto newExpr = metadata->expandFunction(call);
+      if (newExpr) {
+        markSubfields(newExpr, steps, isControl, context);
+        return;
+      }
+    }
     if (metadata->valuePathToArgPath && !steps.empty()) {
       auto pair = metadata->valuePathToArgPath(steps, *call);
       markSubfields(expr->inputAt(pair.second), pair.first, isControl, context);

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -88,18 +88,23 @@ class ToVelox {
     return column->alias() ? column->alias() : column->toString();
   }
 
+  /// True if a scan should expose 'column' of 'table' as a struct only
+  /// containing the accessed keys. 'column' must be a top level map column.
+  bool isMapAsStruct(ColumnCP column) const {
+    VELOX_CHECK_NOT_NULL(column->schemaColumn());
+    if (column->value().type->kind() != TypeKind::MAP) {
+      return false;
+    }
+    return optimizerOptions_.isMapAsStruct(
+        column->relation()->as<BaseTable>()->schemaTable->name, column->name());
+  }
+
  private:
   void setLeafHandle(
       int32_t id,
       const connector::ConnectorTableHandlePtr& handle,
       const std::vector<core::TypedExprPtr>& extraFilters) {
     leafHandles_[id] = std::make_pair(handle, extraFilters);
-  }
-
-  /// True if a scan should expose 'column' of 'table' as a struct only
-  /// containing the accessed keys. 'column' must be a top level map column.
-  bool isMapAsStruct(Name table, Name column) {
-    return optimizerOptions_.isMapAsStruct(table, column);
   }
 
   // Makes an output type for use in PlanNode et al. If 'columnType' is set,

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -46,6 +46,7 @@ class SubfieldTest : public QueryTestBase,
     LocalRunnerTestBase::localFileFormat_ = "dwrf";
     LocalRunnerTestBase::SetUpTestCase();
     registerDfFunctions();
+    registerGenieUdfs();
   }
 
   static void TearDownTestCase() {
@@ -63,6 +64,7 @@ class SubfieldTest : public QueryTestBase,
         break;
       case 3:
         optimizerOptions_ = OptimizerOptions{.pushdownSubfields = true};
+        optimizerOptions_.allMapsAsStruct = true;
         optimizerOptions_.mapAsStruct["features"] = {
             "float_features", "id_list_features", "id_score_list_features"};
         break;
@@ -597,7 +599,8 @@ TEST_P(SubfieldTest, blackbox) {
 
   lp::PlanBuilder::Context ctx(kHiveConnectorId);
   ctx.hook = [](const auto& name, const auto& args) -> lp::ExprPtr {
-    if (name == "map_row_from_map") {
+    if (name == "map_row_from_map" || name == "make_row_from_map" ||
+        name == "padded_make_row_from_map") {
       VELOX_CHECK(args.at(2)->isConstant());
       auto names = args.at(2)
                        ->template asUnchecked<lp::ConstantExpr>()
@@ -634,6 +637,82 @@ TEST_P(SubfieldTest, blackbox) {
           .build();
 
   ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
+
+  logicalPlan =
+      lp::PlanBuilder(ctx)
+          .tableScan("t")
+          .project(
+              {"make_row_from_map(m, array[1, 2, 3], array['f1', 'f2', 'f3']) as m"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  verifyRequiredSubfields(
+      plan, {{"m", {subfield("1"), subfield("2"), subfield("3")}}});
+
+  if (GetParam() == 1) {
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .project(
+                {"row_constructor(subscript(m_4,1),subscript(m_4,2),subscript(m_4,3))"})
+            .build();
+
+    ASSERT_TRUE(matcher->match(plan));
+  } else {
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().project().project().build();
+
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  logicalPlan =
+      lp::PlanBuilder(ctx, true)
+          .tableScan("t")
+          .project(
+              {"identity(make_row_from_map(m, array[1, 2, 3], array['f1', 'f2', 'f3'])) as m"})
+          .project(
+              {"if (m.f1 < 0, ceil(m.f1), floor(m.f1)) as f1b",
+               "if (m.f2 < 0, 1 + floor(m.f2), ceil(m.f2) + 1) as f2b"})
+          .project({"f1b + 1 as f1b1", "f1b * 2 as f1b2b", "f2b * 3 as f2b3"})
+          .build();
+
+  // Enable parallel project for the remainder of this test. This is reset in
+  // SetUp().
+  optimizerOptions_.parallelProjectWidth = 2;
+  plan = toSingleNodePlan(logicalPlan);
+
+  verifyRequiredSubfields(
+      plan, {{"m", {subfield("1"), subfield("2"), subfield("3")}}});
+
+  if (GetParam() == 1) {
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .parallelProject()
+            .parallelProject(
+                {"identity(row_constructor(subscript(m_7,1),subscript(m_7,2),subscript(m_7,3)))"})
+            .parallelProject()
+            .parallelProject()
+            .project()
+            .build();
+
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  logicalPlan =
+      lp::PlanBuilder(ctx, true)
+          .tableScan("t")
+          .project(
+              {"make_row_from_map(m, array[1, 2, 3], array['f1', 'f2', 'f3']) as m"})
+          .project(
+              {"if (coalesce(m.f1, 1::REAL) < 0, ceil(coalesce(m.f1, 1::REAL)), floor(coalesce(m.f1, 1::REAL))) as f1b",
+               "if (coalesce(m.f2, 1::REAL) < 0, 1 + floor(coalesce(m.f2, 2::real)), ceil(coalesce(m.f2, 3::REAL)) + 1) as f2b"})
+          .project({"f1b + 1 as f1b1", "f1b * 2 as f1b2b", "f2b * 3 as f2b3"})
+          .build();
+
+  plan = toSingleNodePlan(logicalPlan);
+  std::cout << plan->toString(true, true);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/axiom/optimizer/tests/utils/DfFunctions.cpp
+++ b/axiom/optimizer/tests/utils/DfFunctions.cpp
@@ -69,6 +69,33 @@ std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
   return std::make_pair(newFields, 0);
 }
 
+lp::ExprPtr addPaddingCoalesce(const lp::ExprPtr& expr) {
+  const auto& type = expr->type();
+  lp::ConstantExprPtr deflt;
+  switch (type->kind()) {
+    case TypeKind::REAL:
+      deflt = std::make_shared<lp::ConstantExpr>(
+          REAL(), std::make_shared<Variant>(Variant(static_cast<float>(0))));
+      break;
+    case TypeKind::ARRAY: {
+      auto emptyArray = Variant::array({});
+      deflt = std::make_shared<lp::ConstantExpr>(
+          type, std::make_shared<Variant>(Variant(emptyArray)));
+      break;
+    }
+    case TypeKind::MAP: {
+      auto emptyMap = Variant::map({});
+      deflt = std::make_shared<lp::ConstantExpr>(
+          type, std::make_shared<Variant>(Variant(emptyMap)));
+      break;
+    }
+    default:
+      VELOX_NYI("padded_make_row_from_map type {}", type->toString());
+  }
+  return std::make_shared<lp::SpecialFormExpr>(
+      type, lp::SpecialForm::kCoalesce, std::vector<lp::ExprPtr>{expr, deflt});
+}
+
 std::unordered_map<PathCP, lp::ExprPtr> makeRowFromMapExplodeGeneric(
     const lp::CallExpr* call,
     std::vector<PathCP>& paths,
@@ -101,32 +128,7 @@ std::unordered_map<PathCP, lp::ExprPtr> makeRowFromMapExplodeGeneric(
             std::make_shared<lp::ConstantExpr>(
                 subscriptType, std::make_shared<Variant>(keys[nth]))});
     if (addCoalesce) {
-      lp::ConstantExprPtr deflt;
-      switch (type->kind()) {
-        case TypeKind::REAL:
-          deflt = std::make_shared<lp::ConstantExpr>(
-              REAL(),
-              std::make_shared<Variant>(Variant(static_cast<float>(0))));
-          break;
-        case TypeKind::ARRAY: {
-          auto emptyArray = Variant::array({});
-          deflt = std::make_shared<lp::ConstantExpr>(
-              type, std::make_shared<Variant>(Variant(emptyArray)));
-          break;
-        }
-        case TypeKind::MAP: {
-          auto emptyMap = Variant::map({});
-          deflt = std::make_shared<lp::ConstantExpr>(
-              type, std::make_shared<Variant>(Variant(emptyMap)));
-          break;
-        }
-        default:
-          VELOX_NYI("padded_make_row_from_map type {}", type->toString());
-      }
-      getter = std::make_shared<lp::SpecialFormExpr>(
-          type,
-          lp::SpecialForm::kCoalesce,
-          std::vector<lp::ExprPtr>{getter, deflt});
+      getter = addPaddingCoalesce(getter);
     }
     it->second = getter;
   }
@@ -143,6 +145,33 @@ std::unordered_map<PathCP, lp::ExprPtr> paddedMakeRowFromMapExplode(
     const lp::CallExpr* call,
     std::vector<PathCP>& paths) {
   return makeRowFromMapExplodeGeneric(call, paths, true);
+}
+
+lp::ExprPtr makeRowFromMapToConstructor(
+    const lp::CallExpr* call,
+    bool isPadded) {
+  std::vector<lp::ExprPtr> inputs;
+  auto keys = call->inputAt(1);
+  VELOX_CHECK(keys->isConstant());
+  std::vector<Variant> keyIds =
+      keys->asUnchecked<lp::ConstantExpr>()->value()->value<TypeKind::ARRAY>();
+  for (auto& id : keyIds) {
+    inputs.push_back(
+        std::make_shared<lp::CallExpr>(
+            call->type()->childAt(0),
+            "subscript",
+            std::vector<lp::ExprPtr>{
+                call->inputAt(0),
+                std::make_shared<lp::ConstantExpr>(
+                    keys->type()->childAt(0), std::make_shared<Variant>(id))}));
+  }
+  if (isPadded) {
+    for (auto& input : inputs) {
+      input = addPaddingCoalesce(input);
+    }
+  }
+  return std::make_shared<lp::CallExpr>(
+      call->type(), "row_constructor", std::move(inputs));
 }
 
 lp::ExprPtr makeRowFromMapHook(
@@ -229,6 +258,10 @@ void registerDfFunctions() {
 
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->explode = makeRowFromMapExplode;
+    metadata->expandFunction = [](const lp::CallExpr* call) {
+      return makeRowFromMapToConstructor(call, false);
+    };
+
     metadata->valuePathToArgPath = makeRowFromMapSubfield;
     registry->registerFunction(kMakeRowFromMap, std::move(metadata));
   }
@@ -239,6 +272,9 @@ void registerDfFunctions() {
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->explode = paddedMakeRowFromMapExplode;
     metadata->valuePathToArgPath = makeRowFromMapSubfield;
+    metadata->expandFunction = [](const lp::CallExpr* call) {
+      return makeRowFromMapToConstructor(call, true);
+    };
     registry->registerFunction(kPaddedMakeRowFromMap, std::move(metadata));
   }
 


### PR DESCRIPTION
…d as a whole

We have a case of f(make_row_from_map(c, ids, names)). f is unknown. When accessing the map as a row and projecting the columns of the row as top level columns, we expect make_row_from_map to become a row constructor.

This is different from the case of getters or oyther known functions over make_row_from_map, where the getter is replaced by the top level column and there is no make_row_from_map.

We add a hook to FunctionMetadata for this.