### PR TITLE
refactor: Single source of truth for function names

### DIFF
--- a/axiom/optimizer/BuiltinNames.cpp
+++ b/axiom/optimizer/BuiltinNames.cpp
@@ -40,7 +40,7 @@ BuiltinNames::BuiltinNames()
       _if{toName(SpecialFormCallNames::kIf)},
       _switch{toName(SpecialFormCallNames::kSwitch)},
       _in{toName(SpecialFormCallNames::kIn)},
-      canonicalizable{
+      canonicalizable_{
           eq,
           neq,
           lt,

--- a/axiom/optimizer/BuiltinNames.cpp
+++ b/axiom/optimizer/BuiltinNames.cpp
@@ -1,0 +1,80 @@
+#include "axiom/optimizer/BuiltinNames.h"
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::velox::optimizer {
+
+BuiltinNames::BuiltinNames()
+    : eq{toName("eq")},
+      neq{toName("neq")},
+      lt{toName("lt")},
+      lte{toName("lte")},
+      gt{toName("gt")},
+      gte{toName("gte")},
+      plus{toName("plus")},
+      multiply{toName("multiply")},
+      cardinality{toName("cardinality")},
+      subscript{toName("subscript")},
+      elementAt{toName("element_at")},
+      _and{toName(SpecialFormCallNames::kAnd)},
+      _or{toName(SpecialFormCallNames::kOr)},
+      _cast{toName(SpecialFormCallNames::kCast)},
+      _tryCast{toName(SpecialFormCallNames::kTryCast)},
+      _try{toName(SpecialFormCallNames::kTry)},
+      _coalesce{toName(SpecialFormCallNames::kCoalesce)},
+      _if{toName(SpecialFormCallNames::kIf)},
+      _switch{toName(SpecialFormCallNames::kSwitch)},
+      _in{toName(SpecialFormCallNames::kIn)},
+      canonicalizable{
+          eq,
+          neq,
+          lt,
+          lte,
+          gt,
+          gte,
+          plus,
+          multiply,
+          _and,
+          _or,
+      } {}
+
+Name BuiltinNames::reverse(Name name) const {
+  if (name == lt) {
+    return gt;
+  }
+  if (name == lte) {
+    return gte;
+  }
+  if (name == gt) {
+    return lt;
+  }
+  if (name == gte) {
+    return lte;
+  }
+  return name;
+}
+
+Name BuiltinNames::crc32() const {
+  return toName("crc32");
+}
+
+Name BuiltinNames::bitwiseAnd() const {
+  return toName("bitwise_and");
+}
+
+Name BuiltinNames::bitwiseRightShift() const {
+  return toName("bitwise_right_shift");
+}
+
+Name BuiltinNames::bitwiseXor() const {
+  return toName("bitwise_xor");
+}
+
+Name BuiltinNames::hash() const {
+  return toName("hash");
+}
+
+Name BuiltinNames::mod() const {
+  return toName("mod");
+}
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/BuiltinNames.cpp
+++ b/axiom/optimizer/BuiltinNames.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "axiom/optimizer/BuiltinNames.h"
 #include "axiom/optimizer/QueryGraph.h"
 

--- a/axiom/optimizer/BuiltinNames.h
+++ b/axiom/optimizer/BuiltinNames.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Set.h>
+
+namespace facebook::velox::optimizer {
+
+/// Pointer to an arena allocated interned copy of a null terminated string.
+/// Used for identifiers. Allows comparing strings by comparing pointers.
+using Name = const char*;
+
+struct BuiltinNames {
+  BuiltinNames();
+
+  BuiltinNames(BuiltinNames&&) = delete;
+  BuiltinNames(const BuiltinNames&) = delete;
+  BuiltinNames& operator=(BuiltinNames&&) = delete;
+  BuiltinNames& operator=(const BuiltinNames&) = delete;
+
+  Name reverse(Name op) const;
+
+  bool isCanonicalizable(Name name) const {
+    return canonicalizable.contains(name);
+  }
+
+  // Used for function registry
+  static constexpr std::string_view kTransformValues = "transform_values";
+  static constexpr std::string_view kTransform = "transform";
+  static constexpr std::string_view kZip = "zip";
+  static constexpr std::string_view kRowConstructor = "row_constructor";
+
+  // Used for join sample
+  Name crc32() const;
+  Name bitwiseAnd() const;
+  Name bitwiseRightShift() const;
+  Name bitwiseXor() const;
+  Name hash() const;
+  Name mod() const;
+
+  // Used for subfields
+  Name cardinality;
+  Name subscript;
+  Name elementAt;
+
+  // Used for canonicalization
+  Name eq;
+  Name neq;
+  Name lt;
+  Name lte;
+  Name gt;
+  Name gte;
+  Name plus;
+  Name multiply;
+
+  Name _and;
+  Name _or;
+  Name _cast;
+  Name _tryCast;
+  Name _try;
+  Name _coalesce;
+  Name _if;
+  Name _switch;
+  Name _in;
+
+  folly::F14FastSet<Name> canonicalizable;
+};
+
+} // namespace facebook::velox::optimizer

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
 
 add_library(
   velox_verax
+  BuiltinNames.cpp
   DerivedTable.cpp
   DerivedTablePrinter.cpp
   ToGraph.cpp

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -631,7 +631,7 @@ bool isJoinEquality(
     ExprCP& right) {
   if (expr->is(PlanType::kCallExpr)) {
     auto call = expr->as<Call>();
-    if (call->name() == toName("eq")) {
+    if (call->name() == builtinNames().eq) {
       left = call->argAt(0);
       right = call->argAt(1);
       auto leftTable = singleTable(left);
@@ -850,7 +850,7 @@ ExprVector extractPerTable(
     std::vector<ExprVector>& orOfAnds) {
   PlanObjectSet tables;
   auto optimization = queryCtx()->optimization();
-  auto& names = optimization->builtinNames();
+  const auto& names = builtinNames();
   tables = disjuncts[0]->allTables();
   if (tables.size() <= 1) {
     // All must depend on the same set of more than 1 table.
@@ -900,7 +900,7 @@ ExprVector extractCommon(ExprVector& disjuncts, ExprCP* replacement) {
   std::unordered_set<ExprCP> distinct;
   PlanObjectSet tableSet;
   auto optimization = queryCtx()->optimization();
-  auto& names = optimization->builtinNames();
+  const auto& names = builtinNames();
   ExprVector result;
   // Remove duplicates.
   bool changeOriginal = false;
@@ -966,7 +966,7 @@ ExprVector extractCommon(ExprVector& disjuncts, ExprCP* replacement) {
 } // namespace
 
 void DerivedTable::expandConjuncts() {
-  const auto& names = queryCtx()->optimization()->builtinNames();
+  const auto& names = builtinNames();
   bool any;
   std::unordered_set<int32_t> processed;
   auto firstUnprocessed = numCanonicalConjuncts;

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -17,7 +17,6 @@
 #include "axiom/optimizer/FunctionRegistry.h"
 
 namespace facebook::velox::optimizer {
-namespace lp = facebook::velox::logical_plan;
 
 FunctionMetadataCP FunctionRegistry::metadata(std::string_view name) const {
   auto it = metadata_.find(name);
@@ -90,7 +89,7 @@ bool declareBuiltIn() {
     metadata->subfieldArg = 0;
     metadata->cost = 40;
     FunctionRegistry::instance()->registerFunction(
-        "transform_values", std::move(metadata));
+        BuiltinNames::kTransformValues, std::move(metadata));
   }
   {
     LambdaInfo info{
@@ -101,7 +100,7 @@ bool declareBuiltIn() {
     metadata->subfieldArg = 0;
     metadata->cost = 20;
     FunctionRegistry::instance()->registerFunction(
-        "transform", std::move(metadata));
+        BuiltinNames::kTransform, std::move(metadata));
   }
   {
     LambdaInfo info{
@@ -112,14 +111,15 @@ bool declareBuiltIn() {
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->lambdas.push_back(std::move(info));
     metadata->cost = 20;
-    FunctionRegistry::instance()->registerFunction("zip", std::move(metadata));
+    FunctionRegistry::instance()->registerFunction(
+        BuiltinNames::kZip, std::move(metadata));
   }
   {
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->valuePathToArgPath = rowConstructorSubfield;
     metadata->explode = rowConstructorExplode;
     FunctionRegistry::instance()->registerFunction(
-        "row_constructor", std::move(metadata));
+        BuiltinNames::kRowConstructor, std::move(metadata));
   }
   return true;
 }

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/FunctionRegistry.h"
 
 namespace facebook::velox::optimizer {
+namespace lp = facebook::velox::logical_plan;
 
 FunctionMetadataCP FunctionRegistry::metadata(std::string_view name) const {
   auto it = metadata_.find(name);

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -147,10 +147,6 @@ class Optimization {
     return cnamesInExpr_;
   }
 
-  BuiltinNames& builtinNames() {
-    return toGraph_.builtinNames();
-  }
-
   /// Returns a dedupped left deep reduction with 'func' for the
   /// elements in set1 and set2. The elements are sorted on plan object
   /// id and then combined into a left deep reduction on 'func'.

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -406,7 +406,7 @@ struct SpecialFormCallNames {
   static constexpr const char* kSwitch = "switch";
   static constexpr const char* kIn = "in";
 
-  static const char* toCallName(const logical_plan::SpecialForm& form) {
+  static const char* toCallName(logical_plan::SpecialForm form) {
     namespace lp = facebook::velox::logical_plan;
 
     switch (form) {

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -292,4 +292,15 @@ PathCP toPath(std::span<const Step> steps, bool reverse) {
   return queryCtx()->toPath(path);
 }
 
+const BuiltinNames& QueryGraphContext::builtinNames() {
+  if (!builtinNames_) {
+    builtinNames_ = std::make_unique<const BuiltinNames>();
+  }
+  return *builtinNames_;
+}
+
+const BuiltinNames& builtinNames() {
+  return queryCtx()->builtinNames();
+}
+
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "axiom/optimizer/ArenaCache.h"
+#include "axiom/optimizer/BuiltinNames.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/type/Variant.h"
 #include "velox/vector/BaseVector.h"
@@ -27,10 +28,6 @@
 /// Thread local context and utilities for query planning.
 
 namespace facebook::velox::optimizer {
-
-/// Pointer to an arena allocated interned copy of a null terminated string.
-/// Used for identifiers. Allows comparing strings by comparing pointers.
-using Name = const char*;
 
 /// Shorthand for a view on an array of T*
 template <typename T>
@@ -329,6 +326,8 @@ class QueryGraphContext {
 
   VectorPtr toVectorPtr(const BaseVector* vector);
 
+  const BuiltinNames& builtinNames();
+
  private:
   TypePtr dedupType(const TypePtr& type);
 
@@ -367,10 +366,14 @@ class QueryGraphContext {
   Optimization* optimization_{nullptr};
 
   std::vector<std::unique_ptr<Variant>> allVariants_;
+
+  std::unique_ptr<const BuiltinNames> builtinNames_;
 };
 
 /// Returns a mutable reference to the calling thread's QueryGraphContext.
 QueryGraphContext*& queryCtx();
+
+const BuiltinNames& builtinNames();
 
 template <class T>
 T* QGAllocator<T>::allocate(std::size_t n) {

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -283,14 +283,15 @@ void ToGraph::markSubfields(
 
   if (expr->isCall()) {
     const auto& name = expr->asUnchecked<lp::CallExpr>()->name();
-    if (name == "cardinality") {
+    const auto& names = builtinNames();
+    if (name == names.cardinality) {
       steps.push_back({.kind = StepKind::kCardinality});
       markSubfields(expr->inputAt(0), steps, isControl, context);
       steps.pop_back();
       return;
     }
 
-    if (name == "subscript" || name == "element_at") {
+    if (name == names.subscript || name == names.elementAt) {
       auto constant = tryFoldConstant(expr->inputAt(1));
       if (!constant) {
         std::vector<Step> subSteps;
@@ -541,7 +542,7 @@ lp::ExprPtr ToGraph::stepToLogicalPlanGetter(
       if (argType->kind() == TypeKind::ARRAY) {
         return std::make_shared<lp::CallExpr>(
             argType->childAt(0),
-            "subscript",
+            builtinNames().subscript,
             arg,
             makeKey<int32_t>(INTEGER(), step.id));
       }
@@ -568,7 +569,7 @@ lp::ExprPtr ToGraph::stepToLogicalPlanGetter(
       }
 
       return std::make_shared<lp::CallExpr>(
-          argType->childAt(1), "subscript", arg, key);
+          argType->childAt(1), builtinNames().subscript, arg, key);
     }
 
     default:

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -22,35 +22,6 @@
 
 namespace facebook::velox::optimizer {
 
-struct BuiltinNames {
-  BuiltinNames();
-
-  Name reverse(Name op) const;
-
-  bool isCanonicalizable(Name name) const {
-    return canonicalizable.find(name) != canonicalizable.end();
-  }
-
-  Name eq;
-  Name lt;
-  Name lte;
-  Name gt;
-  Name gte;
-  Name plus;
-  Name multiply;
-  Name _and;
-  Name _or;
-  Name cast;
-  Name tryCast;
-  Name _try;
-  Name coalesce;
-  Name _if;
-  Name _switch;
-  Name in;
-
-  folly::F14FastSet<Name> canonicalizable;
-};
-
 /// Struct for resolving which logical PlanNode or Lambda defines which
 /// field for column and subfield tracking.
 /// Only one of planNode or call + lambdaOrdinal is set.
@@ -206,8 +177,6 @@ class ToGraph {
   Name newCName(const std::string& prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));
   }
-
-  BuiltinNames& builtinNames();
 
   /// Creates or returns pre-existing function call with name+args. If
   /// deterministic, a new ExprCP is remembered for reuse.
@@ -522,8 +491,6 @@ class ToGraph {
   // Map from leaf PlanNode to corresponding PlanObject
   std::unordered_map<const logical_plan::LogicalPlanNode*, PlanObjectCP>
       planLeaves_;
-
-  std::unique_ptr<BuiltinNames> builtinNames_;
 };
 
 } // namespace facebook::velox::optimizer

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -343,13 +343,13 @@ core::TypedExprPtr stepToGetter(Step step, core::TypedExprPtr arg) {
         return std::make_shared<core::CallTypedExpr>(
             type->as<TypeKind::MAP>().childAt(1),
             std::vector<core::TypedExprPtr>{arg, key},
-            "subscript");
+            builtinNames().subscript);
       }
       return std::make_shared<core::CallTypedExpr>(
           type->childAt(0),
           std::vector<core::TypedExprPtr>{
               arg, makeKey<int32_t>(INTEGER(), step.id)},
-          "subscript");
+          builtinNames().subscript);
     }
 
     default:
@@ -418,9 +418,9 @@ core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
     case PlanType::kCallExpr: {
       std::vector<core::TypedExprPtr> inputs;
       auto call = expr->as<Call>();
-      const auto& builtinNames = queryCtx()->optimization()->builtinNames();
+      const auto& names = builtinNames();
 
-      if (call->name() == builtinNames.in) {
+      if (call->name() == names._in) {
         VELOX_USER_CHECK_GE(call->args().size(), 2);
         inputs.push_back(toTypedExpr(call->args().at(0)));
         inputs.push_back(createArrayForInList(*call, inputs.back()->type()));
@@ -430,12 +430,12 @@ core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
         }
       }
 
-      if (call->name() == builtinNames.cast) {
+      if (call->name() == names._cast) {
         return std::make_shared<core::CastTypedExpr>(
             toTypePtr(expr->value().type), std::move(inputs), false);
       }
 
-      if (call->name() == builtinNames.tryCast) {
+      if (call->name() == names._tryCast) {
         return std::make_shared<core::CastTypedExpr>(
             toTypePtr(expr->value().type), std::move(inputs), true);
       }


### PR DESCRIPTION
We're using presto functions with "presto_" suffix, so for us really important to have single place where all these functions defined.

Also I think it's important for future verax to be compatible with different velox functions.