### PR TITLE
refactor: Remove unused members and remove logical prefix from members

### DIFF
--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -50,7 +50,7 @@ FunctionMetadataCP functionMetadata(const std::string& name) {
 namespace {
 std::pair<std::vector<Step>, int32_t> rowConstructorSubfield(
     const std::vector<Step>& steps,
-    const logical_plan::CallExpr& call) {
+    const lp::CallExpr& call) {
   VELOX_CHECK(steps.back().kind == StepKind::kField);
   auto field = steps.back().field;
   auto idx = call.type()->as<TypeKind::ROW>().getChildIdx(field);
@@ -59,10 +59,10 @@ std::pair<std::vector<Step>, int32_t> rowConstructorSubfield(
   return std::make_pair(newFields, idx);
 }
 
-std::unordered_map<PathCP, logical_plan::ExprPtr> rowConstructorExplode(
-    const logical_plan::CallExpr* call,
+std::unordered_map<PathCP, lp::ExprPtr> rowConstructorExplode(
+    const lp::CallExpr* call,
     std::vector<PathCP>& paths) {
-  std::unordered_map<PathCP, logical_plan::ExprPtr> result;
+  std::unordered_map<PathCP, lp::ExprPtr> result;
   for (auto& path : paths) {
     const auto& steps = path->steps();
     if (steps.empty()) {
@@ -121,7 +121,7 @@ bool declareBuiltIn() {
   {
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->valuePathToArgPath = rowConstructorSubfield;
-    metadata->logicalExplode = rowConstructorExplode;
+    metadata->explode = rowConstructorExplode;
     FunctionRegistry::instance()->registerFunction(
         "row_constructor", std::move(metadata));
   }

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -85,15 +85,10 @@ struct FunctionMetadata {
   /// the function applies array sort to all arrays in a map. suppose it is used
   /// in [k1][0] and [k2][1]. This could return [k1] = array_sort(arg[k1]) and
   /// k2 = array_sort(arg[k2]. 'arg'  comes from 'call'.
-  std::function<std::unordered_map<PathCP, core::TypedExprPtr>(
-      const core::CallTypedExpr* call,
-      std::vector<PathCP>& paths)>
-      explode;
-
   std::function<std::unordered_map<PathCP, logical_plan::ExprPtr>(
       const logical_plan::CallExpr* call,
       std::vector<PathCP>& paths)>
-      logicalExplode;
+      explode;
 };
 
 using FunctionMetadataCP = const FunctionMetadata*;

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -31,7 +31,7 @@ namespace facebook::velox::optimizer {
 class Optimization {
  public:
   Optimization(
-      const logical_plan::LogicalPlanNode& plan,
+      const logical_plan::LogicalPlanNode& logicalPlan,
       const Schema& schema,
       History& history,
       std::shared_ptr<core::QueryCtx> veloxQueryCtx,
@@ -41,7 +41,7 @@ class Optimization {
 
   // Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
-      const logical_plan::LogicalPlanNode& plan,
+      const logical_plan::LogicalPlanNode& logicalPlan,
       velox::memory::MemoryPool& pool,
       OptimizerOptions options = {},
       axiom::runner::MultiFragmentPlan::Options runnerOptions = {});
@@ -290,7 +290,7 @@ class Optimization {
   const bool isSingleWorker_;
 
   // Top level plan to optimize.
-  const logical_plan::LogicalPlanNode* const plan_;
+  const logical_plan::LogicalPlanNode* const logicalPlan_;
 
   // Source of historical cost/cardinality information.
   History& history_;

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -41,7 +41,7 @@ class Optimization {
 
   // Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
-      const logical_plan::LogicalPlanNode& logicalPlan,
+      const logical_plan::LogicalPlanNode& plan,
       velox::memory::MemoryPool& pool,
       OptimizerOptions options = {},
       axiom::runner::MultiFragmentPlan::Options runnerOptions = {});
@@ -290,7 +290,7 @@ class Optimization {
   const bool isSingleWorker_;
 
   // Top level plan to optimize.
-  const logical_plan::LogicalPlanNode* const logicalPlan_;
+  const logical_plan::LogicalPlanNode* const plan_;
 
   // Source of historical cost/cardinality information.
   History& history_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -62,10 +62,8 @@ ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   return e;
 }
 
-void ToGraph::setDtOutput(
-    DerivedTableP dt,
-    const lp::LogicalPlanNode& logicalPlan) {
-  const auto& outputType = logicalPlan.outputType();
+void ToGraph::setDtOutput(DerivedTableP dt, const lp::LogicalPlanNode& plan) {
+  const auto& outputType = plan.outputType();
   for (auto i = 0; i < outputType->size(); ++i) {
     const auto& type = outputType->childAt(i);
     const auto& name = outputType->nameOf(i);
@@ -804,8 +802,8 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
   auto* name = toName(exec::sanitizeName(call->name()));
   funcs = funcs | functionBits(name);
 
-  if (metadata->logicalExplode) {
-    auto map = metadata->logicalExplode(call, paths);
+  if (metadata->explode) {
+    auto map = metadata->explode(call, paths);
     std::unordered_map<PathCP, ExprCP> translated;
     for (const auto& [path, expr] : map) {
       translated[path] = translateExpr(expr);
@@ -848,20 +846,19 @@ ExprVector ToGraph::translateColumns(const std::vector<lp::ExprPtr>& source) {
   return result;
 }
 
-AggregationPlanCP ToGraph::translateAggregation(
-    const lp::AggregateNode& logicalAgg) {
-  ExprVector groupingKeys = translateColumns(logicalAgg.groupingKeys());
+AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
+  ExprVector groupingKeys = translateColumns(agg.groupingKeys());
   AggregateVector aggregates;
   ColumnVector columns;
 
-  for (auto i = 0; i < logicalAgg.groupingKeys().size(); ++i) {
-    auto name = toName(logicalAgg.outputType()->nameOf(i));
+  for (auto i = 0; i < agg.groupingKeys().size(); ++i) {
+    auto name = toName(agg.outputType()->nameOf(i));
     auto* key = groupingKeys[i];
 
     if (key->is(PlanType::kColumnExpr)) {
       columns.push_back(key->as<Column>());
     } else {
-      toType(logicalAgg.outputType()->childAt(i));
+      toType(agg.outputType()->childAt(i));
 
       auto* column = make<Column>(name, currentDt_, key->value(), name);
       columns.push_back(column);
@@ -872,13 +869,13 @@ AggregationPlanCP ToGraph::translateAggregation(
 
   // The keys for intermediate are the same as for final.
   ColumnVector intermediateColumns = columns;
-  for (auto channel : usedChannels(logicalAgg)) {
-    if (channel < logicalAgg.groupingKeys().size()) {
+  for (auto channel : usedChannels(agg)) {
+    if (channel < agg.groupingKeys().size()) {
       continue;
     }
 
-    const auto i = channel - logicalAgg.groupingKeys().size();
-    const auto& aggregate = logicalAgg.aggregates()[i];
+    const auto i = channel - agg.groupingKeys().size();
+    const auto& aggregate = agg.aggregates()[i];
     ExprVector args = translateColumns(aggregate->inputs());
 
     FunctionSet funcs;
@@ -897,7 +894,7 @@ AggregationPlanCP ToGraph::translateAggregation(
     auto accumulatorType = toType(
         exec::resolveAggregateFunction(aggregate->name(), argTypes).second);
     Value finalValue = Value(toType(aggregate->type()), 1);
-    auto* agg = make<Aggregate>(
+    auto* aggregateExpr = make<Aggregate>(
         aggName,
         finalValue,
         args,
@@ -906,16 +903,16 @@ AggregationPlanCP ToGraph::translateAggregation(
         condition,
         false,
         accumulatorType);
-    auto name = toName(logicalAgg.outputNames()[channel]);
-    auto* column = make<Column>(name, currentDt_, agg->value(), name);
+    auto name = toName(agg.outputNames()[channel]);
+    auto* column = make<Column>(name, currentDt_, aggregateExpr->value(), name);
     columns.push_back(column);
 
-    auto intermediateValue = agg->value();
+    auto intermediateValue = aggregateExpr->value();
     intermediateValue.type = accumulatorType;
     auto* intermediateColumn =
         make<Column>(name, currentDt_, intermediateValue, name);
     intermediateColumns.push_back(intermediateColumn);
-    auto dedupped = queryCtx()->dedup(agg);
+    auto dedupped = queryCtx()->dedup(aggregateExpr);
     aggregates.push_back(dedupped->as<Aggregate>());
 
     renames_[name] = columns.back();
@@ -1500,11 +1497,11 @@ DerivedTableP ToGraph::translateUnion(
   return setDt;
 }
 
-DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
-  markAllSubfields(logicalPlan);
+DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& plan) {
+  markAllSubfields(plan);
 
   currentDt_ = newDt();
-  makeQueryGraph(logicalPlan, kAllAllowedInDt);
+  makeQueryGraph(plan, kAllAllowedInDt);
   return currentDt_;
 }
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -62,8 +62,10 @@ ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   return e;
 }
 
-void ToGraph::setDtOutput(DerivedTableP dt, const lp::LogicalPlanNode& plan) {
-  const auto& outputType = plan.outputType();
+void ToGraph::setDtOutput(
+    DerivedTableP dt,
+    const lp::LogicalPlanNode& logicalPlan) {
+  const auto& outputType = logicalPlan.outputType();
   for (auto i = 0; i < outputType->size(); ++i) {
     const auto& type = outputType->childAt(i);
     const auto& name = outputType->nameOf(i);
@@ -1497,11 +1499,11 @@ DerivedTableP ToGraph::translateUnion(
   return setDt;
 }
 
-DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& plan) {
-  markAllSubfields(plan);
+DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
+  markAllSubfields(logicalPlan);
 
   currentDt_ = newDt();
-  makeQueryGraph(plan, kAllAllowedInDt);
+  makeQueryGraph(logicalPlan, kAllAllowedInDt);
   return currentDt_;
 }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -194,14 +194,11 @@ class ToGraph {
 
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
   /// DerivedTable.
-  DerivedTableP makeQueryGraph(
-      const logical_plan::LogicalPlanNode& logicalPlan);
+  DerivedTableP makeQueryGraph(const logical_plan::LogicalPlanNode& plan);
 
   // Sets the columns to project out from the root DerivedTable based on
   // 'logicalPlan'.
-  void setDtOutput(
-      DerivedTableP dt,
-      const logical_plan::LogicalPlanNode& logicalPlan);
+  void setDtOutput(DerivedTableP dt, const logical_plan::LogicalPlanNode& plan);
 
   Name newCName(const std::string& prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -194,11 +194,14 @@ class ToGraph {
 
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
   /// DerivedTable.
-  DerivedTableP makeQueryGraph(const logical_plan::LogicalPlanNode& plan);
+  DerivedTableP makeQueryGraph(
+      const logical_plan::LogicalPlanNode& logicalPlan);
 
   // Sets the columns to project out from the root DerivedTable based on
   // 'logicalPlan'.
-  void setDtOutput(DerivedTableP dt, const logical_plan::LogicalPlanNode& plan);
+  void setDtOutput(
+      DerivedTableP dt,
+      const logical_plan::LogicalPlanNode& logicalPlan);
 
   Name newCName(const std::string& prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -89,11 +89,11 @@ class SubfieldTest : public QueryTestBase,
         "genie", std::make_unique<FunctionMetadata>(*metadata));
 
     auto explodingMetadata = std::make_unique<FunctionMetadata>(*metadata);
-    explodingMetadata->logicalExplode = logicalExplodeGenie;
+    explodingMetadata->explode = explodeGenie;
     registry->registerFunction("exploding_genie", std::move(explodingMetadata));
   }
 
-  static std::unordered_map<PathCP, lp::ExprPtr> logicalExplodeGenie(
+  static std::unordered_map<PathCP, lp::ExprPtr> explodeGenie(
       const lp::CallExpr* call,
       std::vector<PathCP>& paths) {
     // This function understands paths like [1][cc], [2][cc],

--- a/axiom/optimizer/tests/utils/DfFunctions.cpp
+++ b/axiom/optimizer/tests/utils/DfFunctions.cpp
@@ -228,7 +228,7 @@ void registerDfFunctions() {
     registerFeatureFuncHook(kMakeRowFromMap, makeRowFromMapHook);
 
     auto metadata = std::make_unique<FunctionMetadata>();
-    metadata->logicalExplode = makeRowFromMapExplode;
+    metadata->explode = makeRowFromMapExplode;
     metadata->valuePathToArgPath = makeRowFromMapSubfield;
     registry->registerFunction(kMakeRowFromMap, std::move(metadata));
   }
@@ -237,7 +237,7 @@ void registerDfFunctions() {
     registerFeatureFuncHook(kPaddedMakeRowFromMap, makeRowFromMapHook);
 
     auto metadata = std::make_unique<FunctionMetadata>();
-    metadata->logicalExplode = paddedMakeRowFromMapExplode;
+    metadata->explode = paddedMakeRowFromMapExplode;
     metadata->valuePathToArgPath = makeRowFromMapSubfield;
     registry->registerFunction(kPaddedMakeRowFromMap, std::move(metadata));
   }
@@ -247,7 +247,7 @@ void registerDfFunctions() {
 
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->valuePathToArgPath = makeNamedRowSubfield;
-    metadata->logicalExplode = makeNamedRowExplode;
+    metadata->explode = makeNamedRowExplode;
     registry->registerFunction(kMakeNamedRow, std::move(metadata));
   }
 }


### PR DESCRIPTION
This was unused

```cpp
  std::function<std::unordered_map<PathCP, core::TypedExprPtr>(
      const core::CallTypedExpr* call,
      std::vector<PathCP>& paths)>
      explode;
```