### PR TITLE
feat: Add support for EXPLAIN ANALYZE

### DIFF
--- a/axiom/optimizer/tests/PrestoParser.cpp
+++ b/axiom/optimizer/tests/PrestoParser.cpp
@@ -1171,9 +1171,11 @@ SqlStatementPtr PrestoParser::doParse(
 
   RelationPlanner planner(defaultConnectorId_);
   if (query->is(sql::NodeType::kExplain)) {
-    query->as<sql::Explain>()->statement()->accept(&planner);
+    auto* explain = query->as<sql::Explain>();
+    explain->statement()->accept(&planner);
     return std::make_shared<ExplainStatement>(
-        std::make_shared<SelectStatement>(planner.getPlan()));
+        std::make_shared<SelectStatement>(planner.getPlan()),
+        explain->isAnalyze());
   }
 
   if (query->is(sql::NodeType::kShowColumns)) {

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -263,14 +263,8 @@ std::string QueryTestBase::veloxString(
     auto it = scans.find(planNodeId);
     if (it != scans.end()) {
       const auto* scan = it->second;
-      for (auto& pair : scan->assignments()) {
-        // TODO Add toString() API to ColumnHandle.
-        if (auto* hiveColumn =
-                dynamic_cast<const connector::hive::HiveColumnHandle*>(
-                    pair.second.get())) {
-          stream << indentation << pair.first << " = " << hiveColumn->name()
-                 << std::endl;
-        }
+      for (const auto& [name, handle] : scan->assignments()) {
+        stream << indentation << name << " = " << handle->name() << std::endl;
       }
     }
   };

--- a/axiom/optimizer/tests/SqlStatement.h
+++ b/axiom/optimizer/tests/SqlStatement.h
@@ -59,7 +59,7 @@ class SelectStatement : public SqlStatement {
   explicit SelectStatement(logical_plan::LogicalPlanNodePtr plan)
       : SqlStatement(SqlStatementKind::kSelect), plan_{std::move(plan)} {}
 
-  logical_plan::LogicalPlanNodePtr plan() const {
+  const logical_plan::LogicalPlanNodePtr& plan() const {
     return plan_;
   }
 
@@ -69,16 +69,22 @@ class SelectStatement : public SqlStatement {
 
 class ExplainStatement : public SqlStatement {
  public:
-  explicit ExplainStatement(SqlStatementPtr statement)
+  explicit ExplainStatement(SqlStatementPtr statement, bool analyze = false)
       : SqlStatement(SqlStatementKind::kExplain),
-        statement_{std::move(statement)} {}
+        statement_{std::move(statement)},
+        analyze_{analyze} {}
 
-  SqlStatementPtr statement() const {
+  const SqlStatementPtr& statement() const {
     return statement_;
+  }
+
+  bool isAnalyze() const {
+    return analyze_;
   }
 
  private:
   const SqlStatementPtr statement_;
+  const bool analyze_;
 };
 
 } // namespace facebook::velox::optimizer::test

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -470,6 +470,8 @@ std::any AstBuilder::visitExplain(PrestoSqlParser::ExplainContext* ctx) {
   return std::static_pointer_cast<Statement>(std::make_shared<Explain>(
       getLocation(ctx),
       visitTyped<Statement>(ctx->statement()),
+      ctx->ANALYZE() != nullptr,
+      ctx->VERBOSE() != nullptr,
       visitTyped<ExplainOption>(ctx->explainOption())));
 }
 

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -997,7 +997,15 @@ void AstPrinter::visitDelete(Delete* node) {
 
 // Utility Statements
 void AstPrinter::visitExplain(Explain* node) {
-  printHeader("Explain", node);
+  printHeader("Explain", node, [&](std::ostream& out) {
+    if (node->isAnalyze()) {
+      out << "analyze ";
+    }
+
+    if (node->isVerbose()) {
+      out << "verbose";
+    }
+  });
 
   indent_++;
   printChild("Statement", node->statement());

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -599,13 +599,25 @@ class Explain : public Statement {
   Explain(
       NodeLocation location,
       const StatementPtr& statement,
+      bool analyze,
+      bool verbose,
       const std::vector<std::shared_ptr<ExplainOption>>& options)
       : Statement(NodeType::kExplain, location),
         statement_(statement),
+        analyze_(analyze),
+        verbose_(verbose),
         options_(options) {}
 
   const StatementPtr& statement() const {
     return statement_;
+  }
+
+  bool isAnalyze() const {
+    return analyze_;
+  }
+
+  bool isVerbose() const {
+    return verbose_;
   }
 
   const std::vector<std::shared_ptr<ExplainOption>>& options() const {
@@ -615,8 +627,10 @@ class Explain : public Statement {
   void accept(AstVisitor* visitor) override;
 
  private:
-  StatementPtr statement_;
-  std::vector<std::shared_ptr<ExplainOption>> options_;
+  const StatementPtr statement_;
+  const bool analyze_;
+  const bool verbose_;
+  const std::vector<std::shared_ptr<ExplainOption>> options_;
 };
 
 class Analyze : public Statement {


### PR DESCRIPTION
Summary:
```
SQL> explain select * from region where r_name like 'A%';
Fragment 0: stage1 numWorkers=4:
-- PartitionedOutput[1][SINGLE Presto] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
  -- TableScan[0][table: region, remaining filter: (like("r_name",A%)), data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
     Estimate: 3 rows, 0B peak memory

Fragment 1:  numWorkers=1:
-- Exchange[2][Presto] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
   Input Fragment 0

SQL> explain analyze select * from region where r_name like 'A%';
Fragment 0: stage1 numWorkers=4:
-- PartitionedOutput[1][SINGLE Presto] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
   Output: 3 rows (340B, 1 batches), Cpu time: 2.47ms, Wall time: 2.62ms, Blocked wall time: 0ns, Peak memory: 17.12KB, Memory allocations: 5, Threads: 16, CPU breakdown: B/I/O/F (457.69us/439.63us/1.32ms/247.99us)
  -- TableScan[0][table: region, remaining filter: (like("r_name",A%)), data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
     Estimate: 3 rows, 0B peak memory
     Input: 3 rows (787B, 1 batches), Raw Input: 5 rows (2.30KB), Output: 3 rows (787B, 1 batches), Cpu time: 8.23ms, Wall time: 10.24ms, Blocked wall time: 92.60ms, Peak memory: 4.19KB, Memory allocations: 39, Threads: 16, Splits: 1, CPU breakdown: B/I/O/F (263.67us/0ns/7.92ms/50.59us)

Fragment 1:  numWorkers=1:
-- Exchange[2][Presto] -> r_regionkey:BIGINT, r_name:VARCHAR, r_comment:VARCHAR
   Input: 3 rows (544B, 2 batches), Output: 3 rows (544B, 2 batches), Cpu time: 5.97ms, Wall time: 8.55ms, Blocked wall time: 8.72ms, Peak memory: 1.00KB, Memory allocations: 10, Threads: 4, Splits: 4, CPU breakdown: B/I/O/F (5.44ms/0ns/509.58us/21.16us)
   Input Fragment 0

(3 rows in 1 batches)
```

Differential Revision: D81567216
