### PR TITLE
Enable filter length for plan summary printing

### DIFF
--- a/axiom/logical_plan/PlanPrinter.h
+++ b/axiom/logical_plan/PlanPrinter.h
@@ -61,6 +61,13 @@ struct PlanSummaryOptions {
   };
 
   AggregateOptions aggregate = {};
+
+  // Options that apply specifically to FILTER nodes.
+  struct FilterOptions {
+    size_t maxConditions = 50;
+  };
+
+  FilterOptions filter = {};
 };
 
 class PlanPrinter {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14710

Enable filter condition length setup from planSummary options. Allows printing longer filter node condition outputs without getting truncated.

Differential Revision: D81531071


