### PR TITLE
refactor: Introduce ConnectorMetadata registry

### DIFF
--- a/axiom/optimizer/connectors/ConnectorMetadata.h
+++ b/axiom/optimizer/connectors/ConnectorMetadata.h
@@ -531,6 +531,10 @@ class ConnectorMetadata {
   /// Velox.
   static ConnectorMetadata* metadata(std::string_view connectorId);
   static ConnectorMetadata* metadata(Connector* connector);
+  static void registerMetadata(
+      std::string_view connectorId,
+      std::shared_ptr<ConnectorMetadata> metadata);
+  static void unregisterMetadata(std::string_view connectorId);
 
   virtual ~ConnectorMetadata() = default;
 

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -916,22 +916,4 @@ void LocalHiveConnectorMetadata::finishWrite(
   loadTable(layout.table().name(), localHandle->locationHandle()->targetPath());
 }
 
-namespace {
-class LocalHiveConnectorMetadataFactory : public HiveConnectorMetadataFactory {
- public:
-  std::shared_ptr<ConnectorMetadata> create(HiveConnector* connector) override {
-    auto hiveConfig =
-        std::make_shared<HiveConfig>(connector->connectorConfig());
-    auto path = hiveConfig->hiveLocalDataPath();
-    if (path.empty()) {
-      return nullptr;
-    }
-    return std::make_shared<LocalHiveConnectorMetadata>(connector);
-  }
-};
-
-bool dummy = registerHiveConnectorMetadataFactory(
-    std::make_unique<LocalHiveConnectorMetadataFactory>());
-} // namespace
-
 } // namespace facebook::velox::connector::hive

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(axiom_runner_tests_utils DistributedPlanBuilder.cpp
 target_link_libraries(
   axiom_runner_tests_utils
   axiom_runner_local_runner
+  velox_hive_connector_metadata
   velox_temp_path
   velox_exec_test_lib
   velox_exec

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -26,7 +27,20 @@ void LocalRunnerTestBase::SetUp() {
   velox::exec::ExchangeSource::factories().clear();
   velox::exec::ExchangeSource::registerFactory(
       velox::exec::test::createLocalExchangeSource);
-  ensureTestData();
+
+  if (!files_) {
+    makeTables(testTables_, files_);
+  }
+  // Destroy and rebuild the testing connector. The connector will
+  // show the metadata if the connector is wired for metadata.
+  setupConnector();
+}
+
+void LocalRunnerTestBase::TearDown() {
+  velox::connector::ConnectorMetadata::unregisterMetadata(
+      velox::exec::test::kHiveConnectorId);
+  velox::connector::unregisterConnector(velox::exec::test::kHiveConnectorId);
+  HiveConnectorTestBase::TearDown();
 }
 
 std::shared_ptr<velox::core::QueryCtx> LocalRunnerTestBase::makeQueryCtx(
@@ -49,15 +63,6 @@ std::shared_ptr<velox::core::QueryCtx> LocalRunnerTestBase::makeQueryCtx(
       queryId);
 }
 
-void LocalRunnerTestBase::ensureTestData() {
-  if (!files_) {
-    makeTables(testTables_, files_);
-  }
-  // Destroy and rebuild the testing connector. The connector will
-  // show the metadata if the connector is wired for metadata.
-  setupConnector();
-}
-
 void LocalRunnerTestBase::setupConnector() {
   velox::connector::unregisterConnector(velox::exec::test::kHiveConnectorId);
 
@@ -72,6 +77,12 @@ void LocalRunnerTestBase::setupConnector() {
       std::make_shared<velox::config::ConfigBase>(std::move(configs)),
       ioExecutor_.get());
   velox::connector::registerConnector(hiveConnector);
+
+  velox::connector::ConnectorMetadata::registerMetadata(
+      velox::exec::test::kHiveConnectorId,
+      std::make_shared<velox::connector::hive::LocalHiveConnectorMetadata>(
+          dynamic_cast<velox::connector::hive::HiveConnector*>(
+              hiveConnector.get())));
 }
 
 void LocalRunnerTestBase::makeTables(

--- a/axiom/runner/tests/LocalRunnerTestBase.h
+++ b/axiom/runner/tests/LocalRunnerTestBase.h
@@ -54,7 +54,7 @@ class LocalRunnerTestBase : public velox::exec::test::HiveConnectorTestBase {
 
   void SetUp() override;
 
-  void ensureTestData();
+  void TearDown() override;
 
   /// Re-creates the connector with kHiveConnectorId with a config
   /// that points to the temp directory created by 'this'. If the


### PR DESCRIPTION
Summary:
Another step towards removing velox::connector::Connector::metadata() API.

Remove calls to velox::connector::hive::registerHiveConnectorMetadataFactory.

Differential Revision: D82051221


