### PR TITLE
refactor: Remove calls to velox::connector::hive::registerTpchConnectorMetadataFactory API

### DIFF
--- a/axiom/optimizer/connectors/ConnectorMetadata.h
+++ b/axiom/optimizer/connectors/ConnectorMetadata.h
@@ -531,6 +531,10 @@ class ConnectorMetadata {
   /// Velox.
   static ConnectorMetadata* metadata(std::string_view connectorId);
   static ConnectorMetadata* metadata(Connector* connector);
+  static void registerMetadata(
+      std::string_view connectorId,
+      std::shared_ptr<ConnectorMetadata> metadata);
+  static void unregisterMetadata(std::string_view connectorId);
 
   virtual ~ConnectorMetadata() = default;
 

--- a/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -916,22 +916,4 @@ void LocalHiveConnectorMetadata::finishWrite(
   loadTable(layout.table().name(), localHandle->locationHandle()->targetPath());
 }
 
-namespace {
-class LocalHiveConnectorMetadataFactory : public HiveConnectorMetadataFactory {
- public:
-  std::shared_ptr<ConnectorMetadata> create(HiveConnector* connector) override {
-    auto hiveConfig =
-        std::make_shared<HiveConfig>(connector->connectorConfig());
-    auto path = hiveConfig->hiveLocalDataPath();
-    if (path.empty()) {
-      return nullptr;
-    }
-    return std::make_shared<LocalHiveConnectorMetadata>(connector);
-  }
-};
-
-bool dummy = registerHiveConnectorMetadataFactory(
-    std::make_unique<LocalHiveConnectorMetadataFactory>());
-} // namespace
-
 } // namespace facebook::velox::connector::hive

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.cpp
@@ -112,7 +112,9 @@ std::vector<SplitSource::SplitAndGroup> TpchSplitSource::getSplits(
 }
 
 TpchConnectorMetadata::TpchConnectorMetadata(TpchConnector* tpchConnector)
-    : tpchConnector_(tpchConnector), splitManager_(this) {}
+    : tpchConnector_(tpchConnector), splitManager_(this) {
+  VELOX_CHECK_NOT_NULL(tpchConnector);
+}
 
 void TpchConnectorMetadata::initialize() {
   makeQueryCtx();

--- a/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/optimizer/connectors/tpch/TpchConnectorMetadata.h
@@ -269,11 +269,4 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   TpchSplitManager splitManager_;
 };
 
-class TpchConnectorMetadataFactoryImpl : public TpchConnectorMetadataFactory {
- public:
-  std::shared_ptr<ConnectorMetadata> create(TpchConnector* connector) override {
-    return std::make_shared<TpchConnectorMetadata>(connector);
-  }
-};
-
 } // namespace facebook::velox::connector::tpch

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -49,7 +49,7 @@ void HiveQueriesTestBase::SetUp() {
 }
 
 void HiveQueriesTestBase::TearDown() {
-  connector::unregisterConnector(kTpchConnectorId);
+  test::ParquetTpchTest::unregisterTpchConnector(kTpchConnectorId);
   test::QueryTestBase::TearDown();
 }
 

--- a/axiom/optimizer/tests/ParquetTpchTest.h
+++ b/axiom/optimizer/tests/ParquetTpchTest.h
@@ -41,6 +41,8 @@ class ParquetTpchTest {
   static void createTables(std::string_view path);
 
   static void registerTpchConnector(const std::string& id);
+
+  static void unregisterTpchConnector(const std::string& id);
 };
 
 } // namespace facebook::velox::optimizer::test

--- a/axiom/optimizer/tests/PrestoParserTest.cpp
+++ b/axiom/optimizer/tests/PrestoParserTest.cpp
@@ -40,20 +40,23 @@ class PrestoParserTest : public testing::Test {
     auto emptyConfig = std::make_shared<config::ConfigBase>(
         std::unordered_map<std::string, std::string>());
 
-    velox::connector::tpch::registerTpchConnectorMetadataFactory(
-        std::make_unique<
-            velox::connector::tpch::TpchConnectorMetadataFactoryImpl>());
-
     connector::tpch::TpchConnectorFactory tpchConnectorFactory;
     auto tpchConnector =
         tpchConnectorFactory.newConnector(kTpchConnectorId, emptyConfig);
-    connector::registerConnector(std::move(tpchConnector));
+    connector::registerConnector(tpchConnector);
+
+    connector::ConnectorMetadata::registerMetadata(
+        kTpchConnectorId,
+        std::make_shared<connector::tpch::TpchConnectorMetadata>(
+            dynamic_cast<connector::tpch::TpchConnector*>(
+                tpchConnector.get())));
 
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
   }
 
   static void TearDownTestCase() {
+    connector::ConnectorMetadata::unregisterMetadata(kTpchConnectorId);
     connector::unregisterConnector(kTpchConnectorId);
   }
 

--- a/axiom/optimizer/tests/VeloxSql.cpp
+++ b/axiom/optimizer/tests/VeloxSql.cpp
@@ -220,15 +220,18 @@ class VeloxRunner : public QueryBenchmarkBase {
   }
 
   std::shared_ptr<connector::Connector> registerTpchConnector() {
-    connector::tpch::registerTpchConnectorMetadataFactory(
-        std::make_unique<connector::tpch::TpchConnectorMetadataFactoryImpl>());
-
     auto emptyConfig = std::make_shared<config::ConfigBase>(
         std::unordered_map<std::string, std::string>());
 
     connector::tpch::TpchConnectorFactory factory;
     auto connector = factory.newConnector("tpch", emptyConfig);
     connector::registerConnector(connector);
+
+    connector::ConnectorMetadata::registerMetadata(
+        connector->connectorId(),
+        std::make_shared<connector::tpch::TpchConnectorMetadata>(
+            dynamic_cast<connector::tpch::TpchConnector*>(connector.get())));
+
     return connector;
   }
 

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(axiom_runner_tests_utils DistributedPlanBuilder.cpp
 target_link_libraries(
   axiom_runner_tests_utils
   axiom_runner_local_runner
+  velox_hive_connector_metadata
   velox_temp_path
   velox_exec_test_lib
   velox_exec

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "axiom/optimizer/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -26,7 +27,20 @@ void LocalRunnerTestBase::SetUp() {
   velox::exec::ExchangeSource::factories().clear();
   velox::exec::ExchangeSource::registerFactory(
       velox::exec::test::createLocalExchangeSource);
-  ensureTestData();
+
+  if (!files_) {
+    makeTables(testTables_, files_);
+  }
+  // Destroy and rebuild the testing connector. The connector will
+  // show the metadata if the connector is wired for metadata.
+  setupConnector();
+}
+
+void LocalRunnerTestBase::TearDown() {
+  velox::connector::ConnectorMetadata::unregisterMetadata(
+      velox::exec::test::kHiveConnectorId);
+  velox::connector::unregisterConnector(velox::exec::test::kHiveConnectorId);
+  HiveConnectorTestBase::TearDown();
 }
 
 std::shared_ptr<velox::core::QueryCtx> LocalRunnerTestBase::makeQueryCtx(
@@ -49,15 +63,6 @@ std::shared_ptr<velox::core::QueryCtx> LocalRunnerTestBase::makeQueryCtx(
       queryId);
 }
 
-void LocalRunnerTestBase::ensureTestData() {
-  if (!files_) {
-    makeTables(testTables_, files_);
-  }
-  // Destroy and rebuild the testing connector. The connector will
-  // show the metadata if the connector is wired for metadata.
-  setupConnector();
-}
-
 void LocalRunnerTestBase::setupConnector() {
   velox::connector::unregisterConnector(velox::exec::test::kHiveConnectorId);
 
@@ -72,6 +77,12 @@ void LocalRunnerTestBase::setupConnector() {
       std::make_shared<velox::config::ConfigBase>(std::move(configs)),
       ioExecutor_.get());
   velox::connector::registerConnector(hiveConnector);
+
+  velox::connector::ConnectorMetadata::registerMetadata(
+      velox::exec::test::kHiveConnectorId,
+      std::make_shared<velox::connector::hive::LocalHiveConnectorMetadata>(
+          dynamic_cast<velox::connector::hive::HiveConnector*>(
+              hiveConnector.get())));
 }
 
 void LocalRunnerTestBase::makeTables(

--- a/axiom/runner/tests/LocalRunnerTestBase.h
+++ b/axiom/runner/tests/LocalRunnerTestBase.h
@@ -54,7 +54,7 @@ class LocalRunnerTestBase : public velox::exec::test::HiveConnectorTestBase {
 
   void SetUp() override;
 
-  void ensureTestData();
+  void TearDown() override;
 
   /// Re-creates the connector with kHiveConnectorId with a config
   /// that points to the temp directory created by 'this'. If the


### PR DESCRIPTION
Summary: Another step towards removing velox::connector::Connector::metadata() API.

Differential Revision: D82055486


