### PR TITLE
feat(connectors): Allow TPCH ConnectorMetadata to resolve any scale factor

### DIFF
--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -175,17 +175,13 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   explicit TpchConnectorMetadata(
       velox::connector::tpch::TpchConnector* tpchConnector);
 
-  void initialize() override;
+  void initialize() override {}
 
   TablePtr findTable(const std::string& name) override;
 
   ConnectorSplitManager* splitManager() override {
-    ensureInitialized();
     return &splitManager_;
   }
-
-  std::shared_ptr<velox::core::QueryCtx> makeQueryCtx(
-      const std::string& queryId);
 
   velox::connector::ColumnHandlePtr createColumnHandle(
       const TableLayout& layoutData,
@@ -246,28 +242,14 @@ class TpchConnectorMetadata : public ConnectorMetadata {
     return tpchConnector_;
   }
 
-  const folly::F14FastMap<std::string, std::shared_ptr<TpchTable>>& tables()
-      const {
-    ensureInitialized();
-    return tables_;
-  }
-
  private:
-  void ensureInitialized() const;
-  void makeQueryCtx();
-  void initializeTables();
-  void loadTable(
-      velox::tpch::Table tpchTable,
-      const std::string& ns,
-      double scaleFactor);
+  TablePtr loadTable(
+      const std::optional<std::string>& ns,
+      const std::string& name);
 
-  mutable std::mutex mutex_;
-  mutable bool initialized_{false};
   velox::connector::tpch::TpchConnector* tpchConnector_;
   std::shared_ptr<velox::memory::MemoryPool> rootPool_{
       velox::memory::memoryManager()->addRootPool()};
-  std::shared_ptr<velox::core::QueryCtx> queryCtx_;
-  folly::F14FastMap<std::string, std::shared_ptr<TpchTable>> tables_;
   TpchSplitManager splitManager_;
 };
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -59,7 +59,7 @@ TEST_F(TpchConnectorMetadataTest, findAllTables) {
 
 TEST_F(TpchConnectorMetadataTest, findAllScaleFactors) {
   std::vector<int> scaleFactors = {
-      1, 100, 1000, 10000, 100000, 300, 3000, 30000};
+      1, 10, 100, 1000, 10000, 100000, 30, 300, 3000, 30000};
   auto tableName = "customer";
   for (const auto& scaleFactor : scaleFactors) {
     auto qualifiedName = fmt::format("sf{}.{}", scaleFactor, tableName);
@@ -76,6 +76,10 @@ TEST_F(TpchConnectorMetadataTest, invalidLookups) {
   auto table = metadata_->findTable("invalidtable");
   EXPECT_EQ(table, nullptr);
   table = metadata_->findTable("invalidschema.lineitem");
+  EXPECT_EQ(table, nullptr);
+  table = metadata_->findTable("sflarge.customer");
+  EXPECT_EQ(table, nullptr);
+  table = metadata_->findTable("sf000.supplier");
   EXPECT_EQ(table, nullptr);
 }
 


### PR DESCRIPTION
Summary:
Previously, since ConnectorMetadata returned a naked pointer to callers of findTable, we had to create TPCH tables up front and keep the references in a table array

Now that we return a shared pointer from findTable, we can create TPCH tables on demand so long as the scale factor requested is a valid one

The motivation is two-fold: (1) this brings us into spec with the Presto frontend, which permits any integer-valued scale factor, and (2) we would like to benchmark scale factors in the intermediate range (10, 25, 30). sf1 is too small and sf100 is too large for local benchmarking

Differential Revision: D82475141


