### PR TITLE
feat: Add TempProjections that replace input columns

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -520,18 +520,23 @@ namespace {
 // related functions.
 class TempProjections {
  public:
-  TempProjections(ToVelox& tv, const RelationOp& input)
-      : toVelox_(tv), input_(input) {
+  TempProjections(
+      ToVelox& tv,
+      const RelationOp& input,
+      bool useAllColumns = true)
+      : toVelox_{tv}, input_{input} {
     exprChannel_.reserve(input_.columns().size());
     names_.reserve(input_.columns().size());
     exprs_.reserve(input_.columns().size());
     fieldRefs_.reserve(input_.columns().size());
     for (const auto& column : input_.columns()) {
-      auto [it, emplaced] = exprChannel_.emplace(column, nextChannel_);
+      auto [it, emplaced] =
+          exprChannel_.emplace(column, Channel{nextChannel_, useAllColumns});
       if (!emplaced) {
         continue;
       }
       ++nextChannel_;
+      usedChannel_ += useAllColumns ? 1 : 0;
       names_.push_back(ToVelox::outputName(column));
       auto fieldRef = std::make_shared<velox::core::FieldAccessTypedExpr>(
           toTypePtr(column->value().type), names_.back());
@@ -542,11 +547,14 @@ class TempProjections {
 
   velox::core::FieldAccessTypedExprPtr toFieldRef(
       ExprCP expr,
-      const std::string* optName = nullptr) {
-    auto [it, emplaced] = exprChannel_.emplace(expr, nextChannel_);
+      const std::string* optName = nullptr,
+      bool forceNewName = true) {
+    auto [it, emplaced] =
+        exprChannel_.emplace(expr, Channel{nextChannel_, true});
     if (emplaced) {
       VELOX_CHECK(expr->isNot(PlanType::kColumnExpr));
       ++nextChannel_;
+      ++usedChannel_;
       exprs_.push_back(queryCtx()->optimization()->toTypedExpr(expr));
       names_.push_back(
           optName ? *optName : fmt::format("__r{}", nextChannel_ - 1));
@@ -554,14 +562,17 @@ class TempProjections {
           toTypePtr(expr->value().type), names_.back()));
       return fieldRefs_.back();
     }
-    auto fieldRef = fieldRefs_[it->second];
-    if (optName && *optName != fieldRef->name()) {
+    usedChannel_ += it->second.used ? 0 : 1;
+    it->second.used = true;
+    auto fieldRef = fieldRefs_[it->second.idx];
+    if (forceNewName && optName && *optName != fieldRef->name()) {
       auto aliasFieldRef = std::make_shared<velox::core::FieldAccessTypedExpr>(
           toTypePtr(expr->value().type), *optName);
       names_.push_back(*optName);
       exprs_.push_back(fieldRef);
       fieldRefs_.push_back(aliasFieldRef);
-      exprChannel_[expr] = nextChannel_++;
+      exprChannel_[expr] = {nextChannel_++, true};
+      ++usedChannel_;
       return aliasFieldRef;
     }
     return fieldRef;
@@ -570,34 +581,65 @@ class TempProjections {
   template <typename Result = velox::core::FieldAccessTypedExprPtr>
   std::vector<Result> toFieldRefs(
       const ExprVector& exprs,
-      const std::vector<std::string>* optNames = nullptr) {
+      const std::vector<std::string>* optNames = nullptr,
+      bool forceNewNames = true) {
     std::vector<Result> result;
     result.reserve(exprs.size());
     for (auto i = 0; i < exprs.size(); ++i) {
-      result.push_back(
-          toFieldRef(exprs[i], optNames ? &(*optNames)[i] : nullptr));
+      result.push_back(toFieldRef(
+          exprs[i], optNames ? &(*optNames)[i] : nullptr, forceNewNames));
     }
     return result;
   }
 
   velox::core::PlanNodePtr maybeProject(velox::core::PlanNodePtr inputNode) && {
+    VELOX_DCHECK_LE(usedChannel_, nextChannel_);
     if (nextChannel_ == input_.columns().size()) {
+      // TODO: Maybe for some plans we want to reduce projections
+      // if usedChannel_ < nextChannel_.
       return inputNode;
     }
 
+    const auto notNeededChannels = nextChannel_ - usedChannel_;
+    if (notNeededChannels != 0) {
+      folly::F14FastSet<uint32_t> unusedChannels;
+      unusedChannels.reserve(notNeededChannels);
+      for (const auto& expr : exprChannel_) {
+        if (!expr.second.used) {
+          unusedChannels.emplace(expr.second.idx);
+        }
+      }
+      VELOX_DCHECK_EQ(notNeededChannels, unusedChannels.size());
+      std::erase_if(names_, [&, i = uint32_t{0}](const auto&) mutable {
+        return unusedChannels.contains(i++);
+      });
+      std::erase_if(exprs_, [&, i = uint32_t{0}](const auto&) mutable {
+        return unusedChannels.contains(i++);
+      });
+    }
+
     return std::make_shared<velox::core::ProjectNode>(
-        toVelox_.nextId(), std::move(names_), std::move(exprs_), inputNode);
+        toVelox_.nextId(),
+        std::move(names_),
+        std::move(exprs_),
+        std::move(inputNode));
   }
 
  private:
   ToVelox& toVelox_;
   const RelationOp& input_;
+  uint32_t usedChannel_{0};
   uint32_t nextChannel_{0};
   std::vector<velox::core::FieldAccessTypedExprPtr> fieldRefs_;
   std::vector<std::string> names_;
   std::vector<velox::core::TypedExprPtr> exprs_;
-  folly::F14FastMap<ExprCP, uint32_t> exprChannel_;
+  struct Channel {
+    uint32_t idx = 0;
+    bool used = false;
+  };
+  folly::F14FastMap<ExprCP, Channel> exprChannel_;
 };
+
 } // namespace
 
 runner::ExecutableFragment ToVelox::newFragment() {
@@ -1214,8 +1256,6 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
     const Join& join,
     runner::ExecutableFragment& fragment,
     std::vector<runner::ExecutableFragment>& stages) {
-  TempProjections leftProjections(*this, *join.input());
-  TempProjections rightProjections(*this, *join.right);
   auto left = makeFragment(join.input(), fragment, stages);
   auto right = makeFragment(join.right, fragment, stages);
   if (join.method == JoinMethod::kCross) {
@@ -1223,8 +1263,8 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
         nextId(),
         join.joinType,
         nullptr,
-        std::move(leftProjections).maybeProject(left),
-        std::move(rightProjections).maybeProject(right),
+        std::move(left),
+        std::move(right),
         makeOutputType(join.columns()));
     if (join.filter.empty()) {
       makePredictionAndHistory(joinNode->id(), &join);
@@ -1233,6 +1273,10 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
     return std::make_shared<velox::core::FilterNode>(
         nextId(), toAnd(join.filter), joinNode);
   }
+  // TODO: We can avoid to project extra columns here if join.columns() isn't
+  // all left and right columns concatenated.
+  TempProjections leftProjections{*this, *join.input()};
+  TempProjections rightProjections{*this, *join.right};
 
   auto leftKeys = leftProjections.toFieldRefs(join.leftKeys);
   auto rightKeys = rightProjections.toFieldRefs(join.rightKeys);
@@ -1262,7 +1306,7 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       op.step == velox::core::AggregationNode::Step::kSingle;
   const auto numKeys = op.groupingKeys.size();
 
-  TempProjections projections(*this, *op.input());
+  TempProjections projections{*this, *op.input(), false};
   std::vector<std::string> aggregateNames;
   std::vector<velox::core::AggregationNode::Aggregate> aggregates;
   for (size_t i = 0; i < op.aggregates.size(); ++i) {

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -216,7 +216,6 @@ TEST_F(PlanTest, agg) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    std::cerr << plan->toString(true, true) << std::endl;
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -207,18 +207,22 @@ TEST_F(PlanTest, queryGraph) {
 
 TEST_F(PlanTest, agg) {
   testConnector_->createTable(
-      "numbers", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}));
+      "numbers", ROW({"a", "b", "c"}, {DOUBLE(), DOUBLE(), VARCHAR()}));
 
   auto logicalPlan = lp::PlanBuilder()
                          .tableScan(kTestConnectorId, "numbers", {"a", "b"})
-                         .aggregate({"a"}, {"sum(b)"})
+                         .aggregate({"a"}, {"sum(a + b)"})
                          .build();
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
+    std::cerr << plan->toString(true, true) << std::endl;
 
-    auto matcher =
-        core::PlanMatcherBuilder().tableScan().singleAggregation().build();
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .project({"a", "a + b"})
+                       .singleAggregation()
+                       .build();
 
     ASSERT_TRUE(matcher->match(plan));
   }
@@ -227,6 +231,7 @@ TEST_F(PlanTest, agg) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
+                       .project({"a", "a + b"})
                        .partialAggregation()
                        .localPartition()
                        .finalAggregation()


### PR DESCRIPTION
Such suboptimal (b is unnecessary) plan produced for my test without my patch

```cpp
-- Aggregation[2][SINGLE [a] sum := sum("__r2")] -> a:DOUBLE, sum:DOUBLE
  -- Project[1][expressions: (a:DOUBLE, "a"), (b:DOUBLE, "b"), (__r2:DOUBLE, plus("a","b"))] -> a:DOUBLE, b:DOUBLE, __r2:DOUBLE
    -- TableScan[0][numbers] -> a:DOUBLE, b:DOUBLE
```

This also required for Unnest and TableWrite