### PR TITLE
refactor: Introduce QGVector and rename QGstring to QGString

### DIFF
--- a/axiom/optimizer/BitSet.h
+++ b/axiom/optimizer/BitSet.h
@@ -88,7 +88,7 @@ class BitSet {
   }
 
   // A one bit corresponds to the id of each member.
-  std::vector<uint64_t, QGAllocator<uint64_t>> bits_;
+  QGVector<uint64_t> bits_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -25,13 +25,13 @@ using DistributionP = Distribution*;
 
 class JoinEdge;
 using JoinEdgeP = JoinEdge*;
-using JoinEdgeVector = std::vector<JoinEdgeP, QGAllocator<JoinEdgeP>>;
+using JoinEdgeVector = QGVector<JoinEdgeP>;
 
 class AggregationPlan;
 using AggregationPlanCP = const AggregationPlan*;
 
 enum class OrderType;
-using OrderTypeVector = std::vector<OrderType, QGAllocator<OrderType>>;
+using OrderTypeVector = QGVector<OrderType>;
 
 /// Represents a derived table, i.e. a SELECT in a FROM clause. This is the
 /// basic unit of planning. Derived tables can be merged and split apart from
@@ -79,7 +79,7 @@ struct DerivedTable : public PlanObject {
   /// All tables in FROM, either Table or DerivedTable. If Table, all
   /// filters resolvable with the table alone are in single column filters or
   /// 'filter' of BaseTable.
-  std::vector<PlanObjectCP, QGAllocator<PlanObjectCP>> tables;
+  QGVector<PlanObjectCP> tables;
 
   /// Repeats the contents of 'tables'. Used for membership check. A
   /// DerivedTable can be a subset of another, for example when planning a join
@@ -91,7 +91,7 @@ struct DerivedTable : public PlanObject {
   std::optional<logical_plan::SetOperation> setOp;
 
   /// Operands if 'this' is a set operation, e.g. union.
-  std::vector<DerivedTable*, QGAllocator<DerivedTable*>> children;
+  QGVector<DerivedTable*> children;
 
   /// Single row tables from non-correlated scalar subqueries.
   PlanObjectSet singleRowDts;

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -102,7 +102,7 @@ class PlanObject {
 
   /// Returns a view on children, e.g. arguments of a function call.
   virtual CPSpan<PlanObject> children() const {
-    return CPSpan<PlanObject>(nullptr, nullptr);
+    return {};
   }
 
   /// Returns true if 'this' is an expression with a value.
@@ -133,7 +133,7 @@ class PlanObject {
 
 using PlanObjectP = PlanObject*;
 using PlanObjectCP = const PlanObject*;
-using PlanObjectVector = std::vector<PlanObjectCP, QGAllocator<PlanObjectCP>>;
+using PlanObjectVector = QGVector<PlanObjectCP>;
 
 /// Set of PlanObjects. Uses the objects id() as an index into a bitmap.
 class PlanObjectSet : public BitSet {
@@ -170,8 +170,8 @@ class PlanObjectSet : public BitSet {
   /// Returns the objects corresponding to ids in 'this' as a vector of const
   /// T*.
   template <typename T = PlanObject>
-  std::vector<const T*, QGAllocator<const T*>> toObjects() const {
-    std::vector<const T*, QGAllocator<const T*>> objects;
+  QGVector<const T*> toObjects() const {
+    QGVector<const T*> objects;
     objects.reserve(size());
     forEach(
         [&](auto object) { objects.emplace_back(object->template as<T>()); });

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -192,11 +192,6 @@ class Column : public Expr {
   PathCP path_;
 };
 
-template <typename T>
-inline folly::Range<T*> toRange(const std::vector<T, QGAllocator<T>>& v) {
-  return folly::Range<T const*>(v.data(), v.size());
-}
-
 class Field : public Expr {
  public:
   Field(const velox::Type* type, ExprCP base, Name field)
@@ -239,11 +234,11 @@ class Field : public Expr {
 
 struct SubfieldSet {
   /// Id of an accessed column of complex type.
-  std::vector<int32_t, QGAllocator<int32_t>> ids;
+  QGVector<int32_t> ids;
 
   /// Set of subfield paths that are accessed for the corresponding 'column'.
   /// empty means that all subfields are accessed.
-  std::vector<BitSet, QGAllocator<BitSet>> subfields;
+  QGVector<BitSet> subfields;
 
   std::optional<BitSet> findSubfields(int32_t id) const;
 };
@@ -290,8 +285,7 @@ class Call : public Expr {
   }
 
   CPSpan<PlanObject> children() const override {
-    return folly::Range<PlanObjectCP const*>(
-        reinterpret_cast<PlanObjectCP const*>(args_.data()), args_.size());
+    return {reinterpret_cast<PlanObjectCP const*>(args_.data()), args_.size()};
   }
 
   std::string toString() const override;
@@ -684,7 +678,7 @@ class JoinEdge {
 };
 
 using JoinEdgeP = JoinEdge*;
-using JoinEdgeVector = std::vector<JoinEdgeP, QGAllocator<JoinEdgeP>>;
+using JoinEdgeVector = QGVector<JoinEdgeP>;
 
 /// Represents a reference to a table from a query. There is one of these
 /// for each occurrence of the schema table. A TableScan references one
@@ -772,8 +766,7 @@ struct ValuesTable : public PlanObject {
   std::string toString() const override;
 };
 
-using TypeVector =
-    std::vector<const velox::Type*, QGAllocator<const velox::Type*>>;
+using TypeVector = QGVector<const velox::Type*>;
 
 // Aggregate function. The aggregation and arguments are in the
 // inherited Call. The Value pertains to the aggregation
@@ -836,7 +829,7 @@ class Aggregate : public Call {
 };
 
 using AggregateCP = const Aggregate*;
-using AggregateVector = std::vector<AggregateCP, QGAllocator<AggregateCP>>;
+using AggregateVector = QGVector<AggregateCP>;
 
 class AggregationPlan : public PlanObject {
  public:

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -34,7 +34,7 @@ using Name = const char*;
 
 /// Shorthand for a view on an array of T*
 template <typename T>
-using CPSpan = folly::Range<const T* const*>;
+using CPSpan = std::span<const T* const>;
 
 class PlanObject;
 
@@ -94,6 +94,9 @@ struct QGAllocator {
   }
 };
 
+template <typename T>
+using QGVector = std::vector<T, QGAllocator<T>>;
+
 /// Elements of subfield paths. The QueryGraphContext holds a dedupped
 /// collection of distinct paths.
 enum class StepKind : uint8_t { kField, kSubscript, kCardinality };
@@ -118,7 +121,7 @@ struct Step {
   size_t hash() const;
 };
 
-using StepVector = std::vector<Step, QGAllocator<Step>>;
+using StepVector = QGVector<Step>;
 
 class BitSet;
 
@@ -404,10 +407,10 @@ inline void Path::operator delete(void* ptr) {
 // Forward declarations of common types and collections.
 class Expr;
 using ExprCP = const Expr*;
-using ExprVector = std::vector<ExprCP, QGAllocator<ExprCP>>;
+using ExprVector = QGVector<ExprCP>;
 
 class Column;
 using ColumnCP = const Column*;
-using ColumnVector = std::vector<ColumnCP, QGAllocator<ColumnCP>>;
+using ColumnVector = QGVector<ColumnCP>;
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -42,10 +42,10 @@ XxxCP
 : Raw pointer to constant Xxx: XxxCP := const Xxx*. Remember to place 'const' *after* the type: XxxCP const variableName. (const XxxCP doesn't produce the derired effect.)
 
 XxxVector
-: Standard vector of raw pointers to Xxx allocated from the arena: XxxVector := `std::vector<XxxP, QGAllocator<XxxP>>`.
+: Standard vector of raw pointers to Xxx allocated from the arena: XxxVector := `QGVector<XxxP>`.
 
 CPSpan<T>
-: A view on an array of const raw pointers `CPSpan<T> := folly::Range<const T* const*>`;
+: A view on an array of const raw pointers `CPSpan<T> := std::span<const T* const>`;
 
 LRFanout
 : Left-to-Right Fanout. The average number of right side rows selected for one row on the left.

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -248,19 +248,19 @@ const char* joinTypeLabel(velox::core::JoinType type) {
   }
 }
 
-QGstring sanitizeHistoryKey(std::string in) {
+QGString sanitizeHistoryKey(std::string in) {
   for (auto i = 0; i < in.size(); ++i) {
     unsigned char c = in[i];
     if (c < 32 || c > 127 || c == '{' || c == '}' || c == '"') {
       in[i] = '?';
     }
   }
-  return QGstring(in);
+  return QGString(in);
 }
 
 } // namespace
 
-const QGstring& TableScan::historyKey() const {
+const QGString& TableScan::historyKey() const {
   if (!key_.empty()) {
     return key_;
   }
@@ -312,7 +312,7 @@ Values::Values(const ValuesTable& valuesTable, ColumnVector columns)
   updateLeafCost(cardinality, columns_, cost_);
 }
 
-const QGstring& Values::historyKey() const {
+const QGString& Values::historyKey() const {
   if (!key_.empty()) {
     return key_;
   }
@@ -386,7 +386,7 @@ std::pair<std::string, std::string> joinKeysString(
 }
 } // namespace
 
-const QGstring& Join::historyKey() const {
+const QGString& Join::historyKey() const {
   if (!key_.empty()) {
     return key_;
   }
@@ -516,7 +516,7 @@ Aggregation::Aggregation(
   cost_.totalBytes = nOut * rowBytes;
 }
 
-const QGstring& Aggregation::historyKey() const {
+const QGString& Aggregation::historyKey() const {
   using velox::core::AggregationNode;
   if (step == AggregationNode::Step::kPartial ||
       step == AggregationNode::Step::kIntermediate) {
@@ -602,7 +602,7 @@ Filter::Filter(RelationOpPtr input, ExprVector exprs)
   cost_.fanout = std::pow(0.8F, numExprs);
 }
 
-const QGstring& Filter::historyKey() const {
+const QGString& Filter::historyKey() const {
   if (!key_.empty()) {
     return key_;
   }
@@ -770,11 +770,11 @@ UnionAll::UnionAll(RelationOpPtrVector inputsVector)
   // TODO Fill in cost_.unitCost and others.
 }
 
-const QGstring& UnionAll::historyKey() const {
+const QGString& UnionAll::historyKey() const {
   if (!key_.empty()) {
     return key_;
   }
-  std::vector<QGstring> keys;
+  std::vector<QGString> keys;
   for (const auto& in : inputs) {
     keys.push_back(in->historyKey());
   }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -76,7 +76,7 @@ struct Cost {
 /// A std::string with lifetime of the optimization. These are
 /// freeable unlike Names but can be held in objects that are
 /// dropped without destruction with the optimization arena.
-using QGstring =
+using QGString =
     std::basic_string<char, std::char_traits<char>, QGAllocator<char>>;
 
 /// Identifies the operator type producing the relation.
@@ -202,7 +202,7 @@ class RelationOp {
 
   /// Returns a key for retrieving/storing a historical record of execution for
   /// future costing.
-  virtual const QGstring& historyKey() const {
+  virtual const QGString& historyKey() const {
     VELOX_CHECK_NOT_NULL(input_, "Leaf RelationOps must specify a history key");
     return input_->historyKey();
   }
@@ -237,7 +237,7 @@ class RelationOp {
   Cost cost_;
 
   // Cache of history lookup key.
-  mutable QGstring key_;
+  mutable QGString key_;
 
  private:
   // thread local reference count. PlanObjects are freed when the
@@ -261,8 +261,7 @@ inline void intrusive_ptr_release(RelationOp* op) {
   }
 }
 
-using RelationOpPtrVector =
-    std::vector<RelationOpPtr, QGAllocator<RelationOpPtr>>;
+using RelationOpPtrVector = QGVector<RelationOpPtr>;
 
 /// Represents a full table scan or an index lookup.
 struct TableScan : public RelationOp {
@@ -285,7 +284,7 @@ struct TableScan : public RelationOp {
       ColumnGroupCP index,
       const ColumnVector& columns);
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 
@@ -317,7 +316,7 @@ struct TableScan : public RelationOp {
 struct Values : RelationOp {
   Values(const ValuesTable& valuesTable, ColumnVector columns);
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 
@@ -348,7 +347,7 @@ class Filter : public RelationOp {
     return exprs_;
   }
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 
@@ -402,7 +401,7 @@ struct Join : public RelationOp {
   // Total cost of build side plan. For documentation.
   Cost buildCost;
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 };
@@ -441,7 +440,7 @@ struct Aggregation : public RelationOp {
   const AggregateVector aggregates;
   const velox::core::AggregationNode::Step step;
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 };
@@ -467,7 +466,7 @@ using OrderByCP = const OrderBy*;
 struct UnionAll : public RelationOp {
   explicit UnionAll(RelationOpPtrVector inputsVector);
 
-  const QGstring& historyKey() const override;
+  const QGString& historyKey() const override;
 
   std::string toString(bool recursive, bool detail) const override;
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -73,7 +73,7 @@ enum class OrderType {
   kDescNullsLast
 };
 
-using OrderTypeVector = std::vector<OrderType, QGAllocator<OrderType>>;
+using OrderTypeVector = QGVector<OrderType>;
 
 /// Represents a system that contains or produces data. For cases of federation
 /// where data is only accessible via a specific instance of a specific type of
@@ -353,7 +353,7 @@ struct SchemaTable {
   NameMap<ColumnCP> columns;
 
   // All indices. Must contain at least one.
-  std::vector<ColumnGroupCP, QGAllocator<ColumnGroupCP>> columnGroups;
+  QGVector<ColumnGroupCP> columnGroups;
 
   // Table description from external schema. This is the
   // source-dependent representation from which 'this' was created.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1431,7 +1431,7 @@ DerivedTableP ToGraph::translateUnion(
     bool isTopLevel,
     bool& isLeftLeaf) {
   auto initialRenames = renames_;
-  std::vector<DerivedTableP, QGAllocator<DerivedTable*>> children;
+  QGVector<DerivedTableP> children;
   bool isFirst = true;
   DerivedTableP previousDt = currentDt_;
   for (auto& input : set.inputs()) {


### PR DESCRIPTION
* `QGstring` to `QGString`, because `QGAllocator` and `QGVector` and just common sense about codestyle and naming
* `std::span` used instead of `folly::Range`
* removed unused and unnecessary method
* Introduce `QGVector` for simplicity

