### PR TITLE
fix: Fix printPlanWithStats for local runner

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -409,7 +409,9 @@ std::string LocalRunner::printPlanWithStats(
 
   return plan_->toString(
       true, [&](const auto& planNodeId, const auto& indentation, auto& out) {
-        addContext(planNodeId, indentation, out);
+        if (addContext) {
+          addContext(planNodeId, indentation, out);
+        }
 
         auto statsIt = planNodeStats.find(planNodeId);
         if (statsIt != planNodeStats.end()) {


### PR DESCRIPTION
Summary: `addContext` can be nullptr, do not call it if it's nullptr.

Differential Revision: D82774156


