### PR TITLE
feat: Enable LocalRunner serialExecution to run single-threaded

### DIFF
--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -129,6 +129,10 @@ class LocalRunner : public Runner,
     return state_;
   }
 
+  void setSingleThreadedExecution() {
+    params_.serialExecution = true;
+  }
+
  private:
   void start();
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14390

Allows LocalRunner user to enable CursorParameter serialExecution in order to run cursor in single-threaded mode. This is important for LocalRunnerService to adjust multi-threading or single-threaded execution depending on its run.

Differential Revision: D79850066