### PR TITLE
feat: Add support for window functions 

### DIFF
--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -576,7 +576,9 @@ class WindowExpr : public Expr {
         partitionKeys_{std::move(partitionKeys)},
         ordering_{std::move(ordering)},
         frame_{std::move(frame)},
-        ignoreNulls_{ignoreNulls} {}
+        ignoreNulls_{ignoreNulls} {
+    VELOX_USER_CHECK(!name_.empty());
+  }
 
   const std::string& name() const {
     return name_;

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -33,7 +33,6 @@ const auto& nodeKindNames() {
       {NodeKind::kSet, "SET"},
       {NodeKind::kUnnest, "UNNEST"},
       {NodeKind::kTableWrite, "TABLE_WRITE"},
-      {NodeKind::kWindow, "WINDOW"},
   };
   return kNames;
 }
@@ -403,30 +402,5 @@ folly::F14FastMap<WriteKind, std::string_view> writeKindNames() {
 
 VELOX_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
 
-// static
-velox::RowTypePtr WindowNode::makeOutputType(
-    const velox::RowTypePtr& inputType,
-    const std::vector<std::string>& outputNames) {
-  auto inputNames = inputType->names();
-  auto inputTypes = inputType->children();
-
-  std::vector<std::string> allNames = inputNames;
-  std::vector<velox::TypePtr> allTypes = inputTypes;
-
-  for (const auto& name : outputNames) {
-    allNames.push_back(name);
-    allTypes.push_back(velox::BIGINT());
-  }
-
-  UniqueNameChecker::check(allNames);
-
-  return ROW(std::move(allNames), std::move(allTypes));
-}
-
-void WindowNode::accept(
-    const PlanNodeVisitor& visitor,
-    PlanNodeVisitorContext& context) const {
-  visitor.visit(*this, context);
-}
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -34,6 +34,7 @@ enum class NodeKind {
   kSet = 8,
   kUnnest = 9,
   kTableWrite = 10,
+  kWindow = 11,
 };
 
 AXIOM_DECLARE_ENUM_NAME(NodeKind)
@@ -744,6 +745,56 @@ class TableWriteNode : public LogicalPlanNode {
 };
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
+
+/// Window function node. Applies window functions to the input.
+/// Window expressions may have different window specifications.
+/// They will be grouped by specification during query graph conversion.
+class WindowNode : public LogicalPlanNode {
+ public:
+  /// @param windowExprs Zero or more window expressions.
+  /// @param outputNames List of names for the window function outputs.
+  /// Names must be unique.
+  WindowNode(
+      std::string id,
+      LogicalPlanNodePtr input,
+      std::vector<WindowExprPtr> windowExprs,
+      std::vector<std::string> outputNames)
+      : LogicalPlanNode{NodeKind::kWindow, std::move(id), {input}, makeOutputType(input->outputType(), outputNames)},
+        windowExprs_{std::move(windowExprs)},
+        outputNames_{std::move(outputNames)} {
+    VELOX_USER_CHECK(!windowExprs_.empty(), "Window node must specify at least one window expression");
+    VELOX_USER_CHECK_EQ(
+        windowExprs_.size(),
+        outputNames_.size(),
+        "Number of window expressions must match number of output names");
+  }
+
+  const std::vector<WindowExprPtr>& windowExprs() const {
+    return windowExprs_;
+  }
+
+  const std::vector<std::string>& outputNames() const {
+    return outputNames_;
+  }
+
+  const WindowExprPtr& windowExprAt(size_t index) const {
+    VELOX_USER_CHECK_LT(index, windowExprs_.size());
+    return windowExprs_[index];
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+ private:
+  static velox::RowTypePtr makeOutputType(
+      const velox::RowTypePtr& inputType,
+      const std::vector<std::string>& outputNames);
+
+  const std::vector<WindowExprPtr> windowExprs_;
+  const std::vector<std::string> outputNames_;
+};
+
+using WindowNodePtr = std::shared_ptr<const WindowNode>;
 
 } // namespace facebook::axiom::logical_plan
 

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "axiom/logical_plan/PlanBuilder.h"
-#include <logical_plan/Expr.h>
 #include <velox/common/base/Exceptions.h>
 #include <velox/exec/WindowFunction.h>
 #include <velox/type/Type.h>
 #include <vector>
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/logical_plan/Expr.h"
 #include "axiom/logical_plan/NameMappings.h"
 #include "velox/connectors/Connector.h"
 #include "velox/duckdb/conversion/DuckParser.h"
@@ -488,7 +488,6 @@ PlanBuilder& PlanBuilder::window(const std::vector<std::string>& windowExprs) {
     if (windowExpr.frame.endValue != nullptr) {
       frame.endValue = resolveScalarTypes(windowExpr.frame.endValue);
     }
-    
 
     std::vector<ExprPtr> partitionBy;
     partitionBy.reserve(windowExpr.partitionBy.size());
@@ -553,10 +552,7 @@ PlanBuilder& PlanBuilder::window(
   }
 
   node_ = std::make_shared<WindowNode>(
-      nextId(),
-      std::move(node_),
-      std::move(exprs),
-      std::move(outputNames));
+      nextId(), std::move(node_), std::move(exprs), std::move(outputNames));
 
   outputMapping_ = std::move(newOutputMapping);
 
@@ -1302,12 +1298,16 @@ ExprResolver::WindowResolveResult ExprResolver::resolveWindowTypes(
   if (!windowSignatures.has_value() && !aggregateSignatures.has_value()) {
     VELOX_USER_FAIL("Window Function doesn't exist: {}.", name);
   } else {
-    std::string errorMsg = "Window function signature is not supported: " + toString(name, inputTypes) + ". ";
+    std::string errorMsg = "Window function signature is not supported: " +
+        toString(name, inputTypes) + ". ";
     if (windowSignatures.has_value()) {
-      errorMsg += "Window function signatures: " + toString(windowSignatures.value()) + ". ";
+      errorMsg +=
+          "Window function signatures: " + toString(windowSignatures.value()) +
+          ". ";
     }
     if (aggregateSignatures.has_value()) {
-      errorMsg += "Aggregate function signatures: " + toString(aggregateSignatures.value()) + ".";
+      errorMsg += "Aggregate function signatures: " +
+          toString(aggregateSignatures.value()) + ".";
     }
     VELOX_USER_FAIL(errorMsg);
   }
@@ -1542,8 +1542,7 @@ ExprPtr PlanBuilder::resolveScalarTypes(
 PlanBuilder::AggregateResolveResult PlanBuilder::resolveAggregateTypes(
     const velox::core::ExprPtr& expr) const {
   return resolver_.resolveAggregateTypes(
-      expr,
-      [&](const auto& alias, const auto& name) {
+      expr, [&](const auto& alias, const auto& name) {
         return resolveInputName(alias, name);
       });
 }

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "axiom/logical_plan/PlanBuilder.h"
+#include <logical_plan/Expr.h>
 #include <velox/common/base/Exceptions.h>
+#include <velox/exec/WindowFunction.h>
+#include <velox/type/Type.h>
 #include <vector>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/logical_plan/NameMappings.h"
@@ -368,6 +371,7 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::vector<ExprApi>& aggregates,
     const std::vector<AggregateOptions>& options) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Aggregate node cannot be a leaf node");
+  VELOX_USER_CHECK(options.size() == aggregates.size());
 
   std::vector<std::string> outputNames;
   outputNames.reserve(groupingKeys.size() + aggregates.size());
@@ -385,13 +389,17 @@ PlanBuilder& PlanBuilder::aggregate(
   VELOX_USER_CHECK(options.size() == aggregates.size());
   for (size_t i = 0; i < aggregates.size(); ++i) {
     const auto& aggregate = aggregates[i];
+    const auto& aggregateOptions = options[i];
 
-    AggregateExprPtr expr;
-    expr = resolveAggregateTypes(
-        aggregate.expr(),
-        options[i].filters,
-        options[i].orderings,
-        options[i].distinct);
+    auto resolveResult = resolveAggregateTypes(aggregate.expr());
+
+    AggregateExprPtr expr = std::make_shared<AggregateExpr>(
+        resolveResult.type,
+        resolveResult.functionName,
+        resolveResult.functionInputs,
+        aggregateOptions.filters,
+        aggregateOptions.orderings,
+        aggregateOptions.distinct);
 
     if (aggregate.name().has_value()) {
       const auto& alias = aggregate.name().value();
@@ -409,6 +417,144 @@ PlanBuilder& PlanBuilder::aggregate(
       std::move(node_),
       std::move(keyExprs),
       std::vector<AggregateNode::GroupingSet>{},
+      std::move(exprs),
+      std::move(outputNames));
+
+  outputMapping_ = std::move(newOutputMapping);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::window(const std::vector<std::string>& windowExprs) {
+  std::vector<ExprApi> parsedExprs;
+  std::vector<WindowOptions> options;
+  parsedExprs.reserve(windowExprs.size());
+  options.reserve(windowExprs.size());
+
+  for (const auto& sql : windowExprs) {
+    auto windowExpr = velox::duckdb::parseWindowExpr(sql, {});
+    parsedExprs.emplace_back(windowExpr.functionCall);
+
+    WindowExpr::Frame frame;
+    // Convert window type
+    switch (windowExpr.frame.type) {
+      case velox::duckdb::WindowType::kRows:
+        frame.type = WindowExpr::WindowType::kRows;
+        break;
+      case velox::duckdb::WindowType::kRange:
+        frame.type = WindowExpr::WindowType::kRange;
+        break;
+    }
+
+    switch (windowExpr.frame.startType) {
+      case velox::duckdb::BoundType::kUnboundedPreceding:
+        frame.startType = WindowExpr::BoundType::kUnboundedPreceding;
+        break;
+      case velox::duckdb::BoundType::kPreceding:
+        frame.startType = WindowExpr::BoundType::kPreceding;
+        break;
+      case velox::duckdb::BoundType::kCurrentRow:
+        frame.startType = WindowExpr::BoundType::kCurrentRow;
+        break;
+      case velox::duckdb::BoundType::kFollowing:
+        frame.startType = WindowExpr::BoundType::kFollowing;
+        break;
+      case velox::duckdb::BoundType::kUnboundedFollowing:
+        frame.startType = WindowExpr::BoundType::kUnboundedFollowing;
+        break;
+    }
+
+    switch (windowExpr.frame.endType) {
+      case velox::duckdb::BoundType::kUnboundedPreceding:
+        frame.endType = WindowExpr::BoundType::kUnboundedPreceding;
+        break;
+      case velox::duckdb::BoundType::kPreceding:
+        frame.endType = WindowExpr::BoundType::kPreceding;
+        break;
+      case velox::duckdb::BoundType::kCurrentRow:
+        frame.endType = WindowExpr::BoundType::kCurrentRow;
+        break;
+      case velox::duckdb::BoundType::kFollowing:
+        frame.endType = WindowExpr::BoundType::kFollowing;
+        break;
+      case velox::duckdb::BoundType::kUnboundedFollowing:
+        frame.endType = WindowExpr::BoundType::kUnboundedFollowing;
+        break;
+    }
+
+    if (windowExpr.frame.startValue != nullptr) {
+      frame.startValue = resolveScalarTypes(windowExpr.frame.startValue);
+    }
+    if (windowExpr.frame.endValue != nullptr) {
+      frame.endValue = resolveScalarTypes(windowExpr.frame.endValue);
+    }
+    
+
+    std::vector<ExprPtr> partitionBy;
+    partitionBy.reserve(windowExpr.partitionBy.size());
+    for (const auto& partitionExpr : windowExpr.partitionBy) {
+      partitionBy.emplace_back(resolveScalarTypes(partitionExpr));
+    }
+
+    std::vector<SortingField> orderBy;
+    orderBy.reserve(windowExpr.orderBy.size());
+    for (const auto& orderByClause : windowExpr.orderBy) {
+      auto sortKeyExpr = resolveScalarTypes(orderByClause.expr);
+      SortOrder order{orderByClause.ascending, orderByClause.nullsFirst};
+      orderBy.emplace_back(sortKeyExpr, order);
+    }
+
+    options.emplace_back(
+        std::move(partitionBy),
+        std::move(orderBy),
+        std::move(frame),
+        windowExpr.ignoreNulls);
+  }
+
+  return window(parsedExprs, options);
+}
+
+PlanBuilder& PlanBuilder::window(
+    const std::vector<ExprApi>& windowExprs,
+    const std::vector<WindowOptions>& options) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Window node cannot be a leaf node");
+  VELOX_USER_CHECK(options.size() == windowExprs.size());
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(windowExprs.size());
+  std::vector<WindowExprPtr> exprs;
+  exprs.reserve(windowExprs.size());
+  auto newOutputMapping = std::make_shared<NameMappings>(*outputMapping_);
+
+  for (size_t i = 0; i < windowExprs.size(); ++i) {
+    const auto& windowExpr = windowExprs[i];
+    const auto& windowOptions = options[i];
+
+    auto resolveResult = resolveWindowTypes(windowExpr.expr());
+
+    WindowExprPtr expr = std::make_shared<WindowExpr>(
+        resolveResult.type,
+        resolveResult.functionName,
+        resolveResult.functionInputs,
+        windowOptions.partitionBy,
+        windowOptions.orderBy,
+        windowOptions.frame,
+        windowOptions.ignoreNulls);
+
+    if (windowExpr.name().has_value()) {
+      const auto& alias = windowExpr.name().value();
+      outputNames.push_back(newName(alias));
+      newOutputMapping->add(alias, outputNames.back());
+    } else {
+      outputNames.push_back(newName(expr->name()));
+    }
+
+    exprs.emplace_back(std::move(expr));
+  }
+
+  node_ = std::make_shared<WindowNode>(
+      nextId(),
+      std::move(node_),
       std::move(exprs),
       std::move(outputNames));
 
@@ -1068,12 +1214,9 @@ ExprPtr ExprResolver::resolveScalarTypes(
   VELOX_NYI("Can't resolve {}", expr->toString());
 }
 
-AggregateExprPtr ExprResolver::resolveAggregateTypes(
+ExprResolver::AggregateResolveResult ExprResolver::resolveAggregateTypes(
     const velox::core::ExprPtr& expr,
-    const InputNameResolver& inputNameResolver,
-    const ExprPtr& filter,
-    const std::vector<SortingField>& ordering,
-    bool distinct) const {
+    const InputNameResolver& inputNameResolver) const {
   const auto* call = dynamic_cast<const velox::core::CallExpr*>(expr.get());
   VELOX_USER_CHECK_NOT_NULL(
       call, "Aggregate must be a call expression: {}", expr->toString());
@@ -1094,8 +1237,7 @@ AggregateExprPtr ExprResolver::resolveAggregateTypes(
 
   if (auto type =
           velox::exec::resolveAggregateFunction(name, inputTypes).first) {
-    return std::make_shared<AggregateExpr>(
-        type, name, inputs, filter, ordering, distinct);
+    return {type, name, inputs};
   }
 
   auto allSignatures = velox::exec::getAggregateFunctionSignatures();
@@ -1109,6 +1251,68 @@ AggregateExprPtr ExprResolver::resolveAggregateTypes(
         toString(name, inputTypes),
         toString(functionSignatures));
   }
+}
+
+ExprResolver::WindowResolveResult ExprResolver::resolveWindowTypes(
+    const velox::core::ExprPtr& expr,
+    const InputNameResolver& inputNameResolver) const {
+  const auto* call = dynamic_cast<const velox::core::CallExpr*>(expr.get());
+  VELOX_USER_CHECK_NOT_NULL(
+      call, "Window function must be a call expression: {}", expr->toString());
+
+  const auto& name = call->name();
+
+  std::vector<ExprPtr> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& input : expr->inputs()) {
+    inputs.push_back(resolveScalarTypes(input, inputNameResolver));
+  }
+
+  std::vector<velox::TypePtr> inputTypes;
+  inputTypes.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    inputTypes.push_back(input->type());
+  }
+
+  // First try window function signatures
+  auto windowSignatures = velox::exec::getWindowFunctionSignatures(name);
+  if (windowSignatures.has_value()) {
+    for (const auto& signature : windowSignatures.value()) {
+      velox::exec::SignatureBinder binder(*signature, inputTypes);
+      if (binder.tryBind()) {
+        if (auto type = binder.tryResolveReturnType()) {
+          return {type, name, inputs};
+        }
+      }
+    }
+  }
+
+  auto aggregateSignatures = velox::exec::getAggregateFunctionSignatures(name);
+  if (aggregateSignatures.has_value()) {
+    for (const auto& signature : aggregateSignatures.value()) {
+      velox::exec::SignatureBinder binder(*signature, inputTypes);
+      if (binder.tryBind()) {
+        if (auto type = binder.tryResolveReturnType()) {
+          return {type, name, inputs};
+        }
+      }
+    }
+  }
+
+  if (!windowSignatures.has_value() && !aggregateSignatures.has_value()) {
+    VELOX_USER_FAIL("Window Function doesn't exist: {}.", name);
+  } else {
+    std::string errorMsg = "Window function signature is not supported: " + toString(name, inputTypes) + ". ";
+    if (windowSignatures.has_value()) {
+      errorMsg += "Window function signatures: " + toString(windowSignatures.value()) + ". ";
+    }
+    if (aggregateSignatures.has_value()) {
+      errorMsg += "Aggregate function signatures: " + toString(aggregateSignatures.value()) + ".";
+    }
+    VELOX_USER_FAIL(errorMsg);
+  }
+
+  VELOX_UNREACHABLE();
 }
 
 PlanBuilder& PlanBuilder::join(
@@ -1335,19 +1539,21 @@ ExprPtr PlanBuilder::resolveScalarTypes(
       });
 }
 
-AggregateExprPtr PlanBuilder::resolveAggregateTypes(
-    const velox::core::ExprPtr& expr,
-    const ExprPtr& filter,
-    const std::vector<SortingField>& ordering,
-    bool distinct) const {
+PlanBuilder::AggregateResolveResult PlanBuilder::resolveAggregateTypes(
+    const velox::core::ExprPtr& expr) const {
   return resolver_.resolveAggregateTypes(
       expr,
       [&](const auto& alias, const auto& name) {
         return resolveInputName(alias, name);
-      },
-      filter,
-      ordering,
-      distinct);
+      });
+}
+
+PlanBuilder::WindowResolveResult PlanBuilder::resolveWindowTypes(
+    const velox::core::ExprPtr& expr) const {
+  return resolver_.resolveWindowTypes(
+      expr, [&](const auto& alias, const auto& name) {
+        return resolveInputName(alias, name);
+      });
 }
 
 PlanBuilder& PlanBuilder::as(const std::string& alias) {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -22,10 +22,10 @@
 #include "axiom/logical_plan/NameAllocator.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
-#include "velox/duckdb/conversion/DuckParser.h"
 
 namespace facebook::axiom::logical_plan {
 

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -58,6 +58,9 @@ class PlanNodeVisitor {
   virtual void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const = 0;
 
+  virtual void visit(const WindowNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
   virtual void visit(
       const TableWriteNode& node,
       PlanNodeVisitorContext& context) const = 0;

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -58,9 +58,6 @@ class PlanNodeVisitor {
   virtual void visit(const UnnestNode& node, PlanNodeVisitorContext& context)
       const = 0;
 
-  virtual void visit(const WindowNode& node, PlanNodeVisitorContext& context)
-      const = 0;
-
   virtual void visit(
       const TableWriteNode& node,
       PlanNodeVisitorContext& context) const = 0;

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -228,23 +228,6 @@ class ToTextVisitor : public PlanNodeVisitor {
     appendNode(name, node, std::nullopt, context);
   }
 
-  void visit(const WindowNode& node, PlanNodeVisitorContext& context)
-      const override {
-    auto& myContext = static_cast<Context&>(context);
-    myContext.out << makeIndent(myContext.indent) << "- Window:";
-
-    appendOutputType(node, myContext);
-
-    myContext.out << std::endl;
-
-    const auto indent = makeIndent(myContext.indent + 2);
-
-    for (const auto& expr : node.windowExprs()) {
-      myContext.out << indent << ExprPrinter::toText(*expr) << std::endl;
-    }
-
-    appendInputs(node, myContext);
-  }
 
   void appendOutputType(const LogicalPlanNode& node, Context& context) const {
     context.out << " -> " << node.outputType()->toString();
@@ -392,14 +375,6 @@ class CollectExprStatsPlanNodeVisitor : public PlanNodeVisitor {
     visitInputs(node, context);
   }
 
-  void visit(const WindowNode& node, PlanNodeVisitorContext& context)
-      const override {
-    auto& stats = static_cast<Context&>(context).stats;
-    for (const auto& windowExpr : node.windowExprs()) {
-      collectExprStats(*windowExpr, stats);
-    }
-    visitInputs(node, context);
-  }
 
  private:
   static void collectExprStats(const Expr& expr, ExprStats& stats);
@@ -683,21 +658,6 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
     appendInputs(node, myContext);
   }
 
-  void visit(const WindowNode& node, PlanNodeVisitorContext& context)
-      const override {
-    auto& myContext = static_cast<Context&>(context);
-    appendHeader(node, myContext);
-
-    if (!myContext.skeletonOnly) {
-      std::vector<ExprPtr> windowExprs;
-      for (const auto& windowExpr : node.windowExprs()) {
-        windowExprs.push_back(windowExpr);
-      }
-      appendExpressions(windowExprs, myContext);
-    }
-
-    appendInputs(node, myContext);
-  }
 
  private:
   static std::string makeIndent(size_t size) {

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -17,6 +17,8 @@
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/DerivedTablePrinter.h"
+#include <iostream>
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -999,6 +1001,8 @@ void DerivedTable::makeInitialPlan() {
   for (auto expr : exprs) {
     state.targetColumns.unionColumns(expr);
   }
+
+  std::cout << "DerivedTable structure:\n" << DerivedTablePrinter::toText(*this) << "\n";
 
   optimization->makeJoins(state);
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -30,6 +30,9 @@ using JoinEdgeVector = QGVector<JoinEdgeP>;
 class AggregationPlan;
 using AggregationPlanCP = const AggregationPlan*;
 
+class WindowPlan;
+using WindowPlanCP = const WindowPlan*;
+
 enum class OrderType;
 using OrderTypeVector = QGVector<OrderType>;
 
@@ -129,6 +132,8 @@ struct DerivedTable : public PlanObject {
   /// Postprocessing clauses: group by, having, order by, limit, offset.
 
   AggregationPlanCP aggregation{nullptr};
+
+  WindowPlanCP windowPlan{nullptr};
 
   ExprVector having;
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -17,6 +17,7 @@
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/PlanObject.h"
+#include <folly/container/F14Map.h>
 
 namespace facebook::axiom::optimizer {
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -134,8 +134,6 @@ struct DerivedTable : public PlanObject {
 
   AggregationPlanCP aggregation{nullptr};
 
-  WindowPlanCP windowPlan{nullptr};
-
   ExprVector having;
 
   /// Order by.

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -725,32 +725,33 @@ void Optimization::addPostprocess(
     }
   }
 
-  // Process window functions grouped by window specification
-  if (dt->windowPlan) {
-    const auto& windowPlan = dt->windowPlan;
-    ColumnVector allColumns = plan->columns();
-    for (const auto& windowSet : windowPlan->windowSets()) {
-      allColumns.insert(
-          allColumns.end(), windowSet.columns.begin(), windowSet.columns.end());
-      auto* windowOp = make<WindowOp>(
-          plan,
-          windowSet.spec.partitionKeys,
-          windowSet.spec.orderKeys,
-          windowSet.spec.orderTypes,
-          windowSet.windows,
-          allColumns);
-
-      state.placed.add(windowPlan);
-      state.addCost(*windowOp);
-      plan = windowOp;
-    }
-  }
-
   if (!dt->having.empty()) {
     auto filter = make<Filter>(plan, dt->having);
     state.addCost(*filter);
     plan = filter;
   }
+
+  // Process window functions grouped by window specification
+  if (dt->windowPlan) {
+    // ColumnVector allColumns = plan->columns();
+    // for (const auto& [spec, windowSets] : dt->windowPlan->windowSets()) {
+    //   for (const auto& windowSet : windowSets) {
+    //     allColumns.insert(
+    //         allColumns.end(), windowSet.columns.begin(), windowSet.columns.end());
+    //     auto* windowOp = make<WindowOp>(
+    //         plan,
+    //         windowSet.spec.partitionKeys,
+    //         windowSet.spec.orderKeys,
+    //         windowSet.spec.orderTypes,
+    //         windowSet.windows,
+    //         allColumns);
+
+    //     state.addCost(*windowOp);
+    //     plan = windowOp;
+    //   }
+    // }
+  }
+  
   // We probably want to make this decision based on cost.
   static constexpr int64_t kMaxLimitBeforeProject = 8192;
   if (dt->hasOrderBy()) {

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "axiom/optimizer/Optimization.h"
-#include <optimizer/QueryGraph.h>
-#include <optimizer/QueryGraphContext.h>
 #include <algorithm>
 #include <iostream>
 #include <utility>
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "velox/expression/Expr.h"
 
@@ -701,7 +701,8 @@ void Optimization::addPostprocess(
     const auto& windowPlan = dt->windowPlan;
     ColumnVector allColumns = plan->columns();
     for (const auto& windowSet : windowPlan->windowSets()) {
-      allColumns.insert(allColumns.end(), windowSet.columns.begin(), windowSet.columns.end());
+      allColumns.insert(
+          allColumns.end(), windowSet.columns.begin(), windowSet.columns.end());
       auto* windowOp = make<WindowOp>(
           plan,
           windowSet.spec.partitionKeys,

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -63,6 +63,11 @@ void PlanObjectSet::unionColumns(ExprCP expr) {
       unionSet(call->columns());
       return;
     }
+    case PlanType::kWindowExpr: {
+      auto window = expr->as<Window>();
+      unionSet(window->columns());
+      return;
+    }
     default:
       VELOX_UNREACHABLE();
   }

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -29,6 +29,7 @@ enum class PlanType : uint32_t {
   kLiteralExpr,
   kCallExpr,
   kAggregateExpr,
+  kWindowExpr,
   kFieldExpr,
   kLambdaExpr,
   // Plan nodes.
@@ -37,6 +38,7 @@ enum class PlanType : uint32_t {
   kUnnestTableNode,
   kDerivedTableNode,
   kAggregationNode,
+  kWindowNode,
   kProjectNode,
   kFilterNode,
   kJoinNode,

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -507,4 +507,18 @@ bool WindowSpec::operator==(const WindowSpec& other) const {
   return orderTypes == other.orderTypes;
 }
 
+size_t WindowSpec::Hasher::operator()(const WindowSpec& spec) const {
+  size_t hash = 0;
+  for (const auto& key : spec.partitionKeys) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(key));
+  }
+  for (const auto& key : spec.orderKeys) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(key));
+  }
+  for (const auto& type : spec.orderTypes) {
+    hash = velox::bits::hashMix(hash, folly::hasher<int>()(static_cast<int>(type)));
+  }
+  return hash;
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -486,4 +486,26 @@ void JoinEdge::guessFanout() {
   }
 }
 
+bool WindowSpec::operator==(const WindowSpec& other) const {
+  if (partitionKeys.size() != other.partitionKeys.size() ||
+      orderKeys.size() != other.orderKeys.size() ||
+      orderTypes.size() != other.orderTypes.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < partitionKeys.size(); ++i) {
+    if (!partitionKeys[i]->sameOrEqual(*other.partitionKeys[i])) {
+      return false;
+    }
+  }
+
+  for (size_t i = 0; i < orderKeys.size(); ++i) {
+    if (!orderKeys[i]->sameOrEqual(*other.orderKeys[i])) {
+      return false;
+    }
+  }
+
+  return orderTypes == other.orderTypes;
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -970,32 +970,25 @@ struct WindowSpec {
   OrderTypeVector orderTypes;
 
   bool operator==(const WindowSpec& other) const;
+
+  struct Hasher {
+    size_t operator()(const WindowSpec& spec) const;
+  };
 };
 
 struct WindowSet {
-  WindowSet(WindowSpec spec, WindowVector windows, ColumnVector columns)
-      : spec(std::move(spec)),
-        windows(std::move(windows)),
-        columns(std::move(columns)) {}
-
-  WindowSpec spec;
   WindowVector windows;
   ColumnVector columns;
 };
 
 using WindowSetVector = QGVector<WindowSet>;
+using WindowSpecMap = folly::F14FastMap<WindowSpec, WindowSetVector, WindowSpec::Hasher>;
 
 class WindowPlan : public PlanObject {
  public:
-  explicit WindowPlan(WindowSetVector windowSets)
-      : PlanObject(PlanType::kWindowNode), windowSets_(std::move(windowSets)) {}
+  WindowPlan() : PlanObject(PlanType::kWindowNode) {}
 
-  const WindowSetVector& windowSets() const {
-    return windowSets_;
-  }
-
- private:
-  const WindowSetVector windowSets_;
+  WindowSpecMap specToWindowSets;
 };
 
 using WindowPlanCP = const WindowPlan*;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -899,15 +899,9 @@ class Window : public Call {
       FunctionSet functions,
       WindowFrame frame,
       bool ignoreNulls)
-      : Call(
-            PlanType::kWindowExpr,
-            name,
-            value,
-            std::move(args),
-            functions),
+      : Call(PlanType::kWindowExpr, name, value, std::move(args), functions),
         frame_(std::move(frame)),
-        ignoreNulls_(ignoreNulls) {
-  }
+        ignoreNulls_(ignoreNulls) {}
 
   const WindowFrame& frame() const {
     return frame_;
@@ -986,7 +980,7 @@ struct WindowSet {
       : spec(std::move(spec)),
         windows(std::move(windows)),
         columns(std::move(columns)) {}
-  
+
   WindowSpec spec;
   WindowVector windows;
   ColumnVector columns;
@@ -997,8 +991,7 @@ using WindowSetVector = QGVector<WindowSet>;
 class WindowPlan : public PlanObject {
  public:
   explicit WindowPlan(WindowSetVector windowSets)
-      : PlanObject(PlanType::kWindowNode),
-        windowSets_(std::move(windowSets)) {}
+      : PlanObject(PlanType::kWindowNode), windowSets_(std::move(windowSets)) {}
 
   const WindowSetVector& windowSets() const {
     return windowSets_;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -42,10 +42,12 @@ const auto& relTypeNames() {
       {RelType::kJoin, "Join"},
       {RelType::kHashBuild, "HashBuild"},
       {RelType::kAggregation, "Aggregation"},
+      {RelType::kWindow, "Window"},
       {RelType::kOrderBy, "OrderBy"},
       {RelType::kUnionAll, "UnionAll"},
       {RelType::kLimit, "Limit"},
       {RelType::kValues, "Values"},
+      {RelType::kUnnest, "Unnest"},
   };
 
   return kNames;
@@ -844,6 +846,83 @@ std::string UnionAll::toString(bool recursive, bool detail) const {
     }
   }
   out << ")";
+  return out.str();
+}
+
+WindowOp::WindowOp(
+    RelationOpPtr input,
+    ExprVector partitionKeysVector,
+    ExprVector orderKeysVector,
+    OrderTypeVector orderTypesVector,
+    WindowVector windowsVector,
+    ColumnVector columns)
+    : RelationOp{RelType::kWindow, std::move(input), std::move(columns)},
+      partitionKeys{std::move(partitionKeysVector)},
+      orderKeys{std::move(orderKeysVector)},
+      orderTypes{std::move(orderTypesVector)},
+      windows{std::move(windowsVector)} {
+  cost_.inputCardinality = inputCardinality();
+  cost_.fanout = 1;
+
+  // TODO Fill in cost_.unitCost and others.
+}
+
+const QGString& WindowOp::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  std::stringstream out;
+  auto* opt = queryCtx()->optimization();
+  velox::ScopedVarSetter cname(&opt->cnamesInExpr(), false);
+  out << input_->historyKey() << " window (";
+  for (auto& key : partitionKeys) {
+    out << key->toString() << ", ";
+  }
+  out << ") order by (";
+  for (auto& key : orderKeys) {
+    out << key->toString() << ", ";
+  }
+  out << ") functions (";
+  for (auto& window : windows) {
+    out << window->toString() << ", ";
+  }
+  out << ")";
+  key_ = sanitizeHistoryKey(out.str());
+  return key_;
+}
+
+std::string WindowOp::toString(bool recursive, bool detail) const {
+  std::stringstream out;
+  if (recursive) {
+    out << input()->toString(true, detail) << " ";
+  }
+  if (detail) {
+    out << "Window (";
+    out << "partition by: ";
+    for (auto i = 0; i < partitionKeys.size(); ++i) {
+      out << partitionKeys[i]->toString();
+      if (i < partitionKeys.size() - 1) {
+        out << ", ";
+      }
+    }
+    out << " order by: ";
+    for (auto i = 0; i < orderKeys.size(); ++i) {
+      out << orderKeys[i]->toString();
+      if (i < orderKeys.size() - 1) {
+        out << ", ";
+      }
+    }
+    out << " functions: ";
+    for (auto i = 0; i < windows.size(); ++i) {
+      out << windows[i]->toString();
+      if (i < windows.size() - 1) {
+        out << ", ";
+      }
+    }
+    out << ")\n";
+  } else {
+    out << "window " << windows.size() << " functions ";
+  }
   return out.str();
 }
 

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -863,8 +863,6 @@ WindowOp::WindowOp(
       windows{std::move(windowsVector)} {
   cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
-
-  // TODO Fill in cost_.unitCost and others.
 }
 
 const QGString& WindowOp::historyKey() const {

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optimizer/QueryGraphContext.h>
+#include <cstddef>
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/Schema.h"
 
@@ -88,6 +90,7 @@ enum class RelType {
   kJoin,
   kHashBuild,
   kAggregation,
+  kWindow,
   kOrderBy,
   kUnionAll,
   kLimit,
@@ -456,6 +459,31 @@ struct Aggregation : public RelationOp {
   const ExprVector groupingKeys;
   const AggregateVector aggregates;
   const velox::core::AggregationNode::Step step;
+
+  const QGString& historyKey() const override;
+
+  std::string toString(bool recursive, bool detail) const override;
+};
+
+/// Represents window functions with the same window specification.
+struct WindowOp : public RelationOp {
+  WindowOp(
+      RelationOpPtr input,
+      ExprVector partitionKeys,
+      ExprVector orderKeys,
+      OrderTypeVector orderTypes,
+      WindowVector windows,
+      ColumnVector columns);
+
+  const ExprVector partitionKeys;
+  const ExprVector orderKeys;
+  const OrderTypeVector orderTypes;
+  const WindowVector windows;
+
+  ColumnCP getWindowExprColumn(size_t windowIndex) const {
+    VELOX_CHECK(input_->columns().size() + windowIndex < columns_.size());
+    return columns_.at(input_->columns().size() + windowIndex);
+  }
 
   const QGString& historyKey() const override;
 

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <optimizer/QueryGraphContext.h>
-#include <cstddef>
 #include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/Schema.h"
 
 /// Plan candidates.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -698,10 +698,10 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
     return translateLambda(expr->asUnchecked<lp::LambdaExpr>());
   }
 
-  if (expr->isWindow()) {
-    const auto [translatedWindow, spec] = translateWindowExpr(std::static_pointer_cast<const lp::WindowExpr>(expr));
-    return translatedWindow;
-  }
+  // if (expr->isWindow()) {
+  //   const auto [translatedWindow, spec] = translateWindowExpr(std::static_pointer_cast<const lp::WindowExpr>(expr));
+  //   return translatedWindow;
+  // }
 
   ToGraphContext ctx(expr.get());
   velox::ExceptionContextSetter exceptionContext(makeExceptionContext(&ctx));
@@ -1090,8 +1090,6 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       std::move(intermediateColumns));
 }
 
-// translateWindow method removed - window expressions now handled directly in translateExpr
-
 std::pair<ExprCP, WindowSpec> ToGraph::translateWindowExpr(
     const lp::WindowExprPtr& windowExpr) {
   ExprVector args;
@@ -1476,9 +1474,7 @@ PlanObjectP ToGraph::addProjection(const lp::ProjectNode* project) {
     }
   });
 
-  // Separate window expressions from regular expressions
   std::vector<std::pair<size_t, lp::WindowExprPtr>> windowExprs;
-
   for (auto i : channels) {
     if (exprs[i]->isWindow()) {
       windowExprs.emplace_back(i, std::static_pointer_cast<const lp::WindowExpr>(exprs[i]));

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -318,7 +318,6 @@ class ToGraph {
   AggregationPlanCP translateAggregation(
       const logical_plan::AggregateNode& aggregation);
 
-  WindowPlanCP translateWindow(const logical_plan::WindowNode& windowNode);
 
   std::pair<ExprCP, WindowSpec> translateWindowExpr(
       const logical_plan::WindowExprPtr& windowExpr);
@@ -333,7 +332,6 @@ class ToGraph {
   // DerivedTable being assembled.
   PlanObjectP addAggregation(const logical_plan::AggregateNode& aggNode);
 
-  PlanObjectP addWindow(const logical_plan::WindowNode& windowNode);
 
   PlanObjectP addLimit(const logical_plan::LimitNode& limitNode);
 
@@ -391,11 +389,6 @@ class ToGraph {
       std::vector<Step>& steps,
       bool isControl);
 
-  void markFieldAccessed(
-      const logical_plan::WindowNode& window,
-      int32_t ordinal,
-      std::vector<Step>& steps,
-      bool isControl);
 
   void markFieldAccessed(
       const LogicalContextSource& source,

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -320,7 +320,8 @@ class ToGraph {
 
   WindowPlanCP translateWindow(const logical_plan::WindowNode& windowNode);
 
-  std::pair<ExprCP, WindowSpec> translateWindowExpr(const logical_plan::WindowExprPtr& windowExpr);
+  std::pair<ExprCP, WindowSpec> translateWindowExpr(
+      const logical_plan::WindowExprPtr& windowExpr);
 
   PlanObjectP addProjection(const logical_plan::ProjectNode* project);
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -297,9 +297,7 @@ class ToGraph {
   AggregationPlanCP translateAggregation(
       const logical_plan::AggregateNode& aggregation);
 
-
-  std::pair<ExprCP, WindowSpec> translateWindowExpr(
-      const logical_plan::WindowExprPtr& windowExpr);
+  ExprCP translateWindow(const logical_plan::WindowExpr* windowExpr);
 
   PlanObjectP addProjection(const logical_plan::ProjectNode* project);
 
@@ -310,7 +308,6 @@ class ToGraph {
   // Interprets an AggregationNode and adds its information to the
   // DerivedTable being assembled.
   PlanObjectP addAggregation(const logical_plan::AggregateNode& aggNode);
-
 
   PlanObjectP addLimit(const logical_plan::LimitNode& limitNode);
 
@@ -367,7 +364,6 @@ class ToGraph {
       int32_t ordinal,
       std::vector<Step>& steps,
       bool isControl);
-
 
   void markFieldAccessed(
       const LogicalContextSource& source,

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -318,6 +318,10 @@ class ToGraph {
   AggregationPlanCP translateAggregation(
       const logical_plan::AggregateNode& aggregation);
 
+  WindowPlanCP translateWindow(const logical_plan::WindowNode& windowNode);
+
+  std::pair<ExprCP, WindowSpec> translateWindowExpr(const logical_plan::WindowExprPtr& windowExpr);
+
   PlanObjectP addProjection(const logical_plan::ProjectNode* project);
 
   // Interprets a Filter node and adds its information into the DerivedTable
@@ -327,6 +331,8 @@ class ToGraph {
   // Interprets an AggregationNode and adds its information to the
   // DerivedTable being assembled.
   PlanObjectP addAggregation(const logical_plan::AggregateNode& aggNode);
+
+  PlanObjectP addWindow(const logical_plan::WindowNode& windowNode);
 
   PlanObjectP addLimit(const logical_plan::LimitNode& limitNode);
 
@@ -380,6 +386,12 @@ class ToGraph {
 
   void markFieldAccessed(
       const logical_plan::SetNode& set,
+      int32_t ordinal,
+      std::vector<Step>& steps,
+      bool isControl);
+
+  void markFieldAccessed(
+      const logical_plan::WindowNode& window,
       int32_t ordinal,
       std::vector<Step>& steps,
       bool isControl);

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -733,6 +733,78 @@ velox::core::SortOrder toSortOrder(const OrderType& order) {
       : order == OrderType::kDescNullsFirst ? velox::core::kDescNullsFirst
                                             : velox::core::kDescNullsLast;
 }
+
+velox::core::WindowNode::Frame toVeloxFrame(
+    const WindowFrame& frame,
+    ToVelox& converter) {
+  auto veloxWindowType = velox::core::WindowNode::WindowType::kRange;
+  switch (frame.type) {
+    case logical_plan::WindowExpr::WindowType::kRange:
+      veloxWindowType = velox::core::WindowNode::WindowType::kRange;
+      break;
+    case logical_plan::WindowExpr::WindowType::kRows:
+      veloxWindowType = velox::core::WindowNode::WindowType::kRows;
+      break;
+    case logical_plan::WindowExpr::WindowType::kGroups:
+      VELOX_FAIL("GROUPS window frame not supported in velox");
+      break;
+  }
+
+  auto veloxStartType = velox::core::WindowNode::BoundType::kUnboundedPreceding;
+  switch (frame.startType) {
+    case logical_plan::WindowExpr::BoundType::kUnboundedPreceding:
+      veloxStartType = velox::core::WindowNode::BoundType::kUnboundedPreceding;
+      break;
+    case logical_plan::WindowExpr::BoundType::kPreceding:
+      veloxStartType = velox::core::WindowNode::BoundType::kPreceding;
+      break;
+    case logical_plan::WindowExpr::BoundType::kCurrentRow:
+      veloxStartType = velox::core::WindowNode::BoundType::kCurrentRow;
+      break;
+    case logical_plan::WindowExpr::BoundType::kFollowing:
+      veloxStartType = velox::core::WindowNode::BoundType::kFollowing;
+      break;
+    case logical_plan::WindowExpr::BoundType::kUnboundedFollowing:
+      veloxStartType = velox::core::WindowNode::BoundType::kUnboundedFollowing;
+      break;
+  }
+
+  auto veloxEndType = velox::core::WindowNode::BoundType::kUnboundedFollowing;
+  switch (frame.endType) {
+    case logical_plan::WindowExpr::BoundType::kUnboundedPreceding:
+      veloxEndType = velox::core::WindowNode::BoundType::kUnboundedPreceding;
+      break;
+    case logical_plan::WindowExpr::BoundType::kPreceding:
+      veloxEndType = velox::core::WindowNode::BoundType::kPreceding;
+      break;
+    case logical_plan::WindowExpr::BoundType::kCurrentRow:
+      veloxEndType = velox::core::WindowNode::BoundType::kCurrentRow;
+      break;
+    case logical_plan::WindowExpr::BoundType::kFollowing:
+      veloxEndType = velox::core::WindowNode::BoundType::kFollowing;
+      break;
+    case logical_plan::WindowExpr::BoundType::kUnboundedFollowing:
+      veloxEndType = velox::core::WindowNode::BoundType::kUnboundedFollowing;
+      break;
+  }
+
+  velox::core::TypedExprPtr startExpr = nullptr;
+  if (frame.startValue) {
+    startExpr = converter.toTypedExpr(frame.startValue);
+  }
+
+  velox::core::TypedExprPtr endExpr = nullptr;
+  if (frame.endValue) {
+    endExpr = converter.toTypedExpr(frame.endValue);
+  }
+
+  return velox::core::WindowNode::Frame{
+      veloxWindowType,
+      veloxStartType,
+      startExpr,
+      veloxEndType,
+      endExpr};
+}
 } // namespace
 
 velox::core::PlanNodePtr ToVelox::makeOrderBy(
@@ -1416,6 +1488,70 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       project);
 }
 
+velox::core::PlanNodePtr ToVelox::makeWindow(
+    const WindowOp& op,
+    runner::ExecutableFragment& fragment,
+    std::vector<runner::ExecutableFragment>& stages) {
+  auto input = makeFragment(op.input(), fragment, stages);
+
+  TempProjections projections{*this, *op.input(), false};
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> partitionKeys;
+  partitionKeys.reserve(op.partitionKeys.size());
+  for (const auto& key : op.partitionKeys) {
+    partitionKeys.emplace_back(projections.toFieldRef(key));
+  }
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<velox::core::SortOrder> sortingOrders;
+  sortingKeys.reserve(op.orderKeys.size());
+  sortingOrders.reserve(op.orderKeys.size());
+  for (size_t i = 0; i < op.orderKeys.size(); ++i) {
+    sortingKeys.push_back(projections.toFieldRef(op.orderKeys[i]));
+    sortingOrders.push_back(toSortOrder(op.orderTypes[i]));
+  }
+
+  std::vector<std::string> windowColumnNames;
+  std::vector<velox::core::WindowNode::Function> windowFunctions;
+  windowColumnNames.reserve(op.windows.size());
+  windowFunctions.reserve(op.windows.size());
+  for (size_t i = 0; i < op.windows.size(); ++i) {
+    const auto* column = op.getWindowExprColumn(i);
+    const auto* window = op.windows[i];
+
+    windowColumnNames.emplace_back(outputName(column));
+
+    std::vector<velox::core::TypedExprPtr> functionArgs;
+    functionArgs.reserve(window->args().size());
+    for (const auto& arg : window->args()) {
+      functionArgs.emplace_back(toTypedExpr(arg));
+    }
+
+    auto functionCall = std::make_shared<velox::core::CallTypedExpr>(
+        toTypePtr(window->value().type),
+        std::move(functionArgs),
+        std::string(window->name()));
+
+    auto frame = toVeloxFrame(window->frame(), *this);
+    windowFunctions.emplace_back(
+            std::move(functionCall),
+            std::move(frame),
+            window->ignoreNulls());
+  }
+
+  auto project = std::move(projections).maybeProject(input);
+
+  return std::make_shared<velox::core::WindowNode>(
+      nextId(),
+      partitionKeys,
+      sortingKeys,
+      sortingOrders,
+      windowColumnNames,
+      windowFunctions,
+      false, // inputsSorted
+      project);
+}
+
 velox::core::PlanNodePtr ToVelox::makeRepartition(
     const Repartition& repartition,
     runner::ExecutableFragment& fragment,
@@ -1575,6 +1711,8 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
       return makeFilter(*op->as<Filter>(), fragment, stages);
     case RelType::kAggregation:
       return makeAggregation(*op->as<Aggregation>(), fragment, stages);
+    case RelType::kWindow:
+      return makeWindow(*op->as<WindowOp>(), fragment, stages);
     case RelType::kOrderBy:
       return makeOrderBy(*op->as<OrderBy>(), fragment, stages);
     case RelType::kLimit:

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -799,11 +799,7 @@ velox::core::WindowNode::Frame toVeloxFrame(
   }
 
   return velox::core::WindowNode::Frame{
-      veloxWindowType,
-      veloxStartType,
-      startExpr,
-      veloxEndType,
-      endExpr};
+      veloxWindowType, veloxStartType, startExpr, veloxEndType, endExpr};
 }
 } // namespace
 
@@ -1534,9 +1530,7 @@ velox::core::PlanNodePtr ToVelox::makeWindow(
 
     auto frame = toVeloxFrame(window->frame(), *this);
     windowFunctions.emplace_back(
-            std::move(functionCall),
-            std::move(frame),
-            window->ignoreNulls());
+        std::move(functionCall), std::move(frame), window->ignoreNulls());
   }
 
   auto project = std::move(projections).maybeProject(input);

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -135,6 +135,12 @@ class ToVelox {
       runner::ExecutableFragment& fragment,
       std::vector<runner::ExecutableFragment>& stages);
 
+  // Makes a Velox WindowNode for a WindowOp.
+  velox::core::PlanNodePtr makeWindow(
+      const WindowOp& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
   // Makes partial + final order by fragments for order by with and without
   // limit.
   velox::core::PlanNodePtr makeOrderBy(

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ target_link_libraries(
   axiom_optimizer_tests_query_test_base
   axiom_runner_tests_utils
   axiom_test_connector
+  velox_window
   GTest::gmock
   glog::glog
   GTest::gtest

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ target_link_libraries(
 add_executable(
   axiom_optimizer_tests
   HiveLimitQueriesTest.cpp
+  HiveWindowQueriesTest.cpp
   HiveQueriesTest.cpp
   PlanTest.cpp
   UnnestTest.cpp

--- a/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
@@ -213,7 +213,6 @@ TEST_F(HiveWindowQueriesTest, rangeFrameTypes) {
   checkSame(logicalPlan, referencePlan);
 }
 
-
 TEST_F(HiveWindowQueriesTest, mixedFrameTypesAndBounds) {
   auto nationType =
       ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
@@ -234,10 +233,8 @@ TEST_F(HiveWindowQueriesTest, mixedFrameTypesAndBounds) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan("nation")
-                       .window()
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan("nation").window().build();
     ASSERT_TRUE(matcher->match(plan));
   }
 
@@ -323,7 +320,6 @@ TEST_F(HiveWindowQueriesTest, multipleOrderByColumns) {
 
   checkSame(logicalPlan, referencePlan);
 }
-
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
@@ -381,9 +381,7 @@ TEST_F(HiveWindowQueriesTest, orderByWindowAlias) {
   auto logicalPlan =
       lp::PlanBuilder()
           .tableScan(connectorId, "nation", names)
-          .window(
-              {"row_number() over (partition by n_regionkey order by n_nationkey) as rn"})
-          .orderBy({"2 *n_nationkey + 3", "rn desc"})
+          .orderBy({"2 *n_nationkey + 3"})
           .build();
 
   std::cerr << "Logical plan structure:\n" << lp::PlanPrinter::toText(*logicalPlan) << "\n";

--- a/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class HiveWindowQueriesTest : public test::HiveQueriesTestBase {};
+
+TEST_F(HiveWindowQueriesTest, basicRowNumber) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const auto connector = velox::connector::getConnector(connectorId);
+
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey)"})
+          .build();
+
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan("nation").window().build();
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, multipleWindowFunctions) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const auto connector = velox::connector::getConnector(connectorId);
+
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey)",
+               "rank() over (partition by n_regionkey order by n_nationkey)",
+               "dense_rank() over (partition by n_regionkey order by n_nationkey)"})
+          .build();
+
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan("nation").window().build();
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey)",
+               "rank() over (partition by n_regionkey order by n_nationkey)",
+               "dense_rank() over (partition by n_regionkey order by n_nationkey)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, differentWindowSpecs) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const auto connector = velox::connector::getConnector(connectorId);
+
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"dense_rank() over (partition by n_regionkey order by n_nationkey)",
+               "row_number() over (partition by n_regionkey order by n_nationkey)",
+               "row_number() over (partition by n_regionkey order by n_nationkey desc)",
+               "row_number() over (partition by n_name)",
+               "lag(n_name) over (order by n_nationkey)"})
+          .build();
+
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan("nation")
+                       .window()
+                       .window()
+                       .window()
+                       .window()
+                       .build();
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"dense_rank() over (partition by n_regionkey order by n_nationkey)"})
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey)"})
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey desc)"})
+          .window({"count(*) over (partition by n_name)"})
+          .window({"lag(n_name) over (order by n_nationkey)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, rowsFrameTypes) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey rows unbounded preceding)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between 2 preceding and 1 following)",
+               "count(*) over (partition by n_regionkey order by n_nationkey rows between current row and unbounded following)",
+               "min(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between 1 preceding and 1 following)",
+               "max(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between current row and 3 following)"})
+          .build();
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey rows unbounded preceding)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between 2 preceding and 1 following)",
+               "count(*) over (partition by n_regionkey order by n_nationkey rows between current row and unbounded following)",
+               "min(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between 1 preceding and 1 following)",
+               "max(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between current row and 3 following)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, rangeFrameTypes) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey range unbounded preceding)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey range between unbounded preceding and current row)",
+               "count(*) over (partition by n_regionkey order by n_nationkey range between current row and unbounded following)"})
+          .build();
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey range unbounded preceding)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey range between unbounded preceding and current row)",
+               "count(*) over (partition by n_regionkey order by n_nationkey range between current row and unbounded following)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+
+TEST_F(HiveWindowQueriesTest, mixedFrameTypesAndBounds) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between unbounded preceding and current row)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey range between unbounded preceding and current row)",
+               "count(*) over (partition by n_regionkey order by n_nationkey range between current row and unbounded following)",
+               "max(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between current row and 2 following)"})
+          .build();
+
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan("nation")
+                       .window()
+                       .build();
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between unbounded preceding and current row)",
+               "avg(n_nationkey) over (partition by n_regionkey order by n_nationkey range between unbounded preceding and current row)",
+               "count(*) over (partition by n_regionkey order by n_nationkey range between current row and unbounded following)",
+               "max(n_nationkey) over (partition by n_regionkey order by n_nationkey rows between current row and 2 following)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, frameTypesWithoutOrderBy) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey rows between unbounded preceding and unbounded following)",
+               "count(*) over (partition by n_regionkey range between unbounded preceding and unbounded following)"})
+          .build();
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"sum(n_nationkey) over (partition by n_regionkey rows between unbounded preceding and unbounded following)"})
+          .window(
+              {"count(*) over (partition by n_regionkey range between unbounded preceding and unbounded following)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+TEST_F(HiveWindowQueriesTest, multipleOrderByColumns) {
+  auto nationType =
+      ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},
+          {BIGINT(), BIGINT(), VARCHAR(), VARCHAR()});
+
+  const auto connectorId = exec::test::kHiveConnectorId;
+  const std::vector<std::string>& names = nationType->names();
+
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .tableScan(connectorId, "nation", names)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey, n_name)",
+               "rank() over (order by n_regionkey, n_nationkey desc, n_name)",
+               "dense_rank() over (partition by n_regionkey order by n_name, n_nationkey)"})
+          .build();
+
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan("nation")
+                       .window()
+                       .window()
+                       .window()
+                       .build();
+    ASSERT_TRUE(matcher->match(plan));
+  }
+
+  auto referencePlan =
+      exec::test::PlanBuilder()
+          .tableScan("nation", nationType)
+          .window(
+              {"row_number() over (partition by n_regionkey order by n_nationkey, n_name)"})
+          .window(
+              {"rank() over (order by n_regionkey, n_nationkey desc, n_name)"})
+          .window(
+              {"dense_rank() over (partition by n_regionkey order by n_name, n_nationkey)"})
+          .planNode();
+
+  checkSame(logicalPlan, referencePlan);
+}
+
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveWindowQueriesTest.cpp
@@ -21,6 +21,7 @@
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -28,7 +29,12 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveWindowQueriesTest : public test::HiveQueriesTestBase {};
+class HiveWindowQueriesTest : public test::HiveQueriesTestBase {
+  void SetUp() override {
+    test::HiveQueriesTestBase::SetUp();
+    window::prestosql::registerAllWindowFunctions();
+  }
+};
 
 TEST_F(HiveWindowQueriesTest, basicRowNumber) {
   auto nationType =

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -742,4 +742,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::orderBy(
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::window() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<PlanMatcherImpl<WindowNode>>(
+      std::vector<std::shared_ptr<PlanMatcher>>{matcher_});
+  return *this;
+}
+
 } // namespace facebook::velox::core

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -111,6 +111,8 @@ class PlanMatcherBuilder {
 
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
 
+  PlanMatcherBuilder& window();
+
   std::shared_ptr<PlanMatcher> build() {
     VELOX_USER_CHECK_NOT_NULL(matcher_, "Cannot build an empty PlanMatcher.");
     return matcher_;

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -264,11 +264,44 @@ void QueryTestBase::checkSame(
 
   auto referenceResult = runVelox(referencePlan);
   SCOPED_TRACE("reference plan:\n" + referencePlan->toString(true, true));
+
+  // Debug output for reference results
+  std::cerr << "Reference results:\n";
+  for (size_t i = 0; i < referenceResult.results.size(); ++i) {
+    auto materializedRows = velox::exec::test::materialize(referenceResult.results[i]);
+    std::cerr << "Batch " << i << ":\n";
+    for (const auto& row : materializedRows) {
+      std::cerr << "  ";
+      auto type = referenceResult.results[i]->type();
+      for (size_t j = 0; j < row.size(); ++j) {
+        if (j > 0) std::cerr << " | ";
+        std::cerr << row[j].toJson(type->childAt(j));
+      }
+      std::cerr << "\n";
+    }
+  }
   {
     SCOPED_TRACE("single node and single thread");
     auto plan = planVelox(planNode, {.numWorkers = 1, .numDrivers = 1});
     SCOPED_TRACE("plan:\n" + plan.plan->toString());
     auto result = runFragmentedPlan(plan);
+
+    // Debug output for experimental results
+    std::cerr << "Experimental results (single node, single thread):\n";
+    for (size_t i = 0; i < result.results.size(); ++i) {
+      auto materializedRows = velox::exec::test::materialize(result.results[i]);
+      std::cerr << "Batch " << i << ":\n";
+      for (const auto& row : materializedRows) {
+        std::cerr << "  ";
+        auto type = result.results[i]->type();
+        for (size_t j = 0; j < row.size(); ++j) {
+          if (j > 0) std::cerr << " | ";
+          std::cerr << row[j].toJson(type->childAt(j));
+        }
+        std::cerr << "\n";
+      }
+    }
+
     velox::exec::test::assertEqualResults(
         referenceResult.results, result.results);
   }
@@ -278,6 +311,23 @@ void QueryTestBase::checkSame(
         planNode, {.numWorkers = 1, .numDrivers = options.numDrivers});
     SCOPED_TRACE("plan:\n" + plan.plan->toString());
     auto result = runFragmentedPlan(plan);
+
+    // Debug output for experimental results
+    std::cerr << "Experimental results (single node, multi thread):\n";
+    for (size_t i = 0; i < result.results.size(); ++i) {
+      auto materializedRows = velox::exec::test::materialize(result.results[i]);
+      std::cerr << "Batch " << i << ":\n";
+      for (const auto& row : materializedRows) {
+        std::cerr << "  ";
+        auto type = result.results[i]->type();
+        for (size_t j = 0; j < row.size(); ++j) {
+          if (j > 0) std::cerr << " | ";
+          std::cerr << row[j].toJson(type->childAt(j));
+        }
+        std::cerr << "\n";
+      }
+    }
+
     velox::exec::test::assertEqualResults(
         referenceResult.results, result.results);
   }
@@ -287,6 +337,23 @@ void QueryTestBase::checkSame(
         planNode, {.numWorkers = options.numWorkers, .numDrivers = 1});
     SCOPED_TRACE("plan:\n" + plan.plan->toString());
     auto result = runFragmentedPlan(plan);
+
+    // Debug output for experimental results
+    std::cerr << "Experimental results (multi node, single thread):\n";
+    for (size_t i = 0; i < result.results.size(); ++i) {
+      auto materializedRows = velox::exec::test::materialize(result.results[i]);
+      std::cerr << "Batch " << i << ":\n";
+      for (const auto& row : materializedRows) {
+        std::cerr << "  ";
+        auto type = result.results[i]->type();
+        for (size_t j = 0; j < row.size(); ++j) {
+          if (j > 0) std::cerr << " | ";
+          std::cerr << row[j].toJson(type->childAt(j));
+        }
+        std::cerr << "\n";
+      }
+    }
+
     velox::exec::test::assertEqualResults(
         referenceResult.results, result.results);
   }
@@ -297,6 +364,23 @@ void QueryTestBase::checkSame(
         {.numWorkers = options.numWorkers, .numDrivers = options.numDrivers});
     SCOPED_TRACE("plan:\n" + plan.plan->toString());
     auto result = runFragmentedPlan(plan);
+
+    // Debug output for experimental results
+    std::cerr << "Experimental results (multi node, multi thread):\n";
+    for (size_t i = 0; i < result.results.size(); ++i) {
+      auto materializedRows = velox::exec::test::materialize(result.results[i]);
+      std::cerr << "Batch " << i << ":\n";
+      for (const auto& row : materializedRows) {
+        std::cerr << "  ";
+        auto type = result.results[i]->type();
+        for (size_t j = 0; j < row.size(); ++j) {
+          if (j > 0) std::cerr << " | ";
+          std::cerr << row[j].toJson(type->childAt(j));
+        }
+        std::cerr << "\n";
+      }
+    }
+
     velox::exec::test::assertEqualResults(
         referenceResult.results, result.results);
   }


### PR DESCRIPTION
This pull request adds support for window functions to the logical plan, introducing a new `WindowNode` that enables computation of windowed aggregates and functions.

**Window Function Support:**

Added a new `WindowNode` class which will be grouped by window specs (orderby + partitionby as gkeys) in QueryGraph. 
