### PR TITLE
feat(connectors): Switch dataPath -> tablePath API

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -179,9 +179,7 @@ HiveConnectorMetadata::createInsertTableHandle(
   }
   return std::make_shared<velox::connector::hive::HiveInsertTableHandle>(
       inputColumns,
-      makeLocationHandle(
-          fmt::format("{}/{}", dataPath(), layout.table().name()),
-          std::nullopt),
+      makeLocationHandle(tablePath(layout.table().name()), std::nullopt),
       storageFormat,
       bucketProperty,
       compressionKind,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -174,10 +174,8 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       velox::connector::hive::LocationHandle::TableType tableType =
           velox::connector::hive::LocationHandle::TableType::kNew) = 0;
 
-  /// Returns the path to the filesystem root for the data managed by
-  /// 'this'. Directories inside this correspond to schemas and
-  /// tables.
-  virtual std::string dataPath() const = 0;
+  /// Return the filesystem path for the storage of the specified table.
+  virtual std::string tablePath(std::string_view table) const = 0;
 
   velox::connector::hive::HiveConnector* const hiveConnector_;
   const std::shared_ptr<velox::connector::hive::HiveConfig> hiveConfig_;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -816,7 +816,7 @@ void LocalHiveConnectorMetadata::createTable(
   VELOX_CHECK_EQ(kind, TableKind::kTable);
   validateOptions(options);
   ensureInitialized();
-  auto path = fmt::format("{}/{}", dataPath(), tableName);
+  auto path = tablePath(tableName);
   if (dirExists(path)) {
     if (errorIfExists) {
       VELOX_USER_FAIL("Table {} already exists", tableName);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -250,8 +250,8 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const ConnectorSessionPtr& /*session*/) override;
 
  protected:
-  std::string dataPath() const override {
-    return hiveConfig_->hiveLocalDataPath();
+  std::string tablePath(std::string_view table) const override {
+    return fmt::format("{}/{}", hiveConfig_->hiveLocalDataPath(), table);
   }
 
   std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(


### PR DESCRIPTION
Summary:
The actual construction of the table path should be implementation-specific. e.g., it should be possible for a variety of Hive datastore to switch the storage path depending on the table. For example, if a Hive implementation would like to obfuscate the table path during write

Since all current callers of this API only use the path to construct a table directory, it's easy to pull this logic into the API itself

Differential Revision: D83078815


