### PR TITLE
refactor: Delete ExecutableFragment.scans variable

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1172,10 +1172,10 @@ velox::core::PlanNodePtr ToVelox::makeScan(
         *scan.index->layout, column->name(), std::move(subfields));
   }
 
-  auto scanNode = std::make_shared<velox::core::TableScanNode>(
-      nextId(), outputType, tableHandle, assignments);
+  velox::core::PlanNodePtr result =
+      std::make_shared<velox::core::TableScanNode>(
+          nextId(), outputType, tableHandle, assignments);
 
-  velox::core::PlanNodePtr result = scanNode;
   if (filter != nullptr) {
     result =
         std::make_shared<velox::core::FilterNode>(nextId(), filter, result);
@@ -1186,8 +1186,6 @@ velox::core::PlanNodePtr ToVelox::makeScan(
   }
 
   makePredictionAndHistory(result->id(), &scan);
-
-  fragment.scans.push_back(scanNode);
 
   columnAlteredTypes_.clear();
   return result;

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -85,9 +85,6 @@ TEST_F(HiveLimitQueriesTest, limit) {
     const auto& fragments = distributedPlan.plan->fragments();
     ASSERT_EQ(2, fragments.size());
 
-    EXPECT_EQ(fragments.at(0).scans.size(), 1);
-    EXPECT_EQ(fragments.at(1).scans.size(), 0);
-
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
                        .partialLimit(0, 10)
@@ -154,9 +151,6 @@ TEST_F(HiveLimitQueriesTest, offset) {
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
     const auto& fragments = distributedPlan.plan->fragments();
     ASSERT_EQ(2, fragments.size());
-
-    EXPECT_EQ(fragments.at(0).scans.size(), 1);
-    EXPECT_EQ(fragments.at(1).scans.size(), 0);
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
@@ -266,9 +260,6 @@ TEST_F(HiveLimitQueriesTest, orderByLimit) {
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
     const auto& fragments = distributedPlan.plan->fragments();
     ASSERT_EQ(2, fragments.size());
-
-    EXPECT_EQ(fragments.at(0).scans.size(), 1);
-    EXPECT_EQ(fragments.at(1).scans.size(), 0);
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()

--- a/axiom/runner/MultiFragmentPlan.h
+++ b/axiom/runner/MultiFragmentPlan.h
@@ -52,9 +52,6 @@ struct ExecutableFragment {
   /// Source fragments and Exchange node ids for remote shuffles producing input
   /// for 'this'.
   std::vector<InputStage> inputStages;
-
-  /// Table scan nodes in 'this'.
-  std::vector<std::shared_ptr<const velox::core::TableScanNode>> scans;
 };
 
 /// Describes a distributed plan handed to a Runner for parallel/distributed

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -50,24 +50,8 @@ runner::MultiFragmentPlanPtr DistributedPlanBuilder::build() {
   return std::make_shared<runner::MultiFragmentPlan>(fragments(), options_);
 }
 
-namespace {
-void gatherScans(
-    const velox::core::PlanNodePtr& plan,
-    std::vector<velox::core::TableScanNodePtr>& scans) {
-  if (auto scan =
-          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
-    scans.push_back(scan);
-    return;
-  }
-  for (auto& source : plan->sources()) {
-    gatherScans(source, scans);
-  }
-}
-} // namespace
-
 void DistributedPlanBuilder::newFragment(int32_t width) {
   if (current_) {
-    gatherScans(planNode_, current_->scans);
     current_->fragment = velox::core::PlanFragment(std::move(planNode_));
     fragments_.push_back(std::move(*current_));
   }

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -92,27 +92,6 @@ std::vector<std::string> getStringListFromJson(const folly::dynamic& json) {
   return result;
 }
 
-void getScanNodesImpl(
-    const velox::core::PlanNodePtr& plan,
-    std::vector<velox::core::TableScanNodePtr>& result) {
-  if (auto tableScan =
-          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
-    result.push_back(tableScan);
-    return;
-  }
-  for (const auto& child : plan->sources()) {
-    getScanNodesImpl(child, result);
-  }
-}
-
-// Return all table scan nodes in 'plan'.
-std::vector<velox::core::TableScanNodePtr> getScanNodes(
-    const velox::core::PlanNodePtr& plan) {
-  std::vector<velox::core::TableScanNodePtr> result;
-  getScanNodesImpl(plan, result);
-  return result;
-}
-
 // Return true if 'node' is a gathering PartitionedOutput node.
 bool isGatheringPartition(const velox::core::PlanNodePtr& node) {
   if (auto partitionedOutput =
@@ -177,7 +156,6 @@ struct PlanFragmentInfo {
   velox::core::PlanNodePtr plan;
   folly::F14FastMap<std::string, folly::F14FastSet<std::string>>
       remoteTaskIdMap;
-  std::vector<velox::core::TableScanNodePtr> scans;
   int32_t numWorkers{0};
 };
 
@@ -190,8 +168,6 @@ std::vector<ExecutableFragment> createExecutableFragments(
         (planFragmentInfo.numWorkers > 0) ? planFragmentInfo.numWorkers : 1;
     executableFragment.fragment =
         velox::core::PlanFragment{planFragmentInfo.plan};
-
-    executableFragment.scans = planFragmentInfo.scans;
 
     std::vector<InputStage> inputStages;
     const auto& remoteTaskIdMap = planFragmentInfo.remoteTaskIdMap;
@@ -285,7 +261,7 @@ MultiFragmentPlanPtr PrestoQueryReplayRunner::deserializeSupportedPlan(
     if (!isSupported(jsonRecords[i], plan)) {
       return nullptr;
     }
-    planFragments[taskPrefix].scans = getScanNodes(plan);
+
     planFragments[taskPrefix].plan = plan;
   }
 


### PR DESCRIPTION
Summary: 'scans' variable stores redundant information that can be extracted from 'fragment.planNode'. This redundancy is error prone as there is no validation that 'scans' value matches 'fragment.planNode'.

Differential Revision: D83235139


