### PR TITLE
refactor: Delete QueryGraphContext::dedup API

### DIFF
--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -18,21 +18,6 @@
 
 namespace facebook::axiom::optimizer {
 
-size_t PlanObjectPHasher::operator()(const PlanObjectCP& object) const {
-  return object->hash();
-}
-
-bool PlanObjectPComparer::operator()(
-    const PlanObjectCP& lhs,
-    const PlanObjectCP& rhs) const {
-  if (rhs == lhs) {
-    return true;
-  }
-  return rhs && lhs && lhs->isExpr() && rhs->isExpr() &&
-      reinterpret_cast<const Expr*>(lhs)->sameOrEqual(
-          *reinterpret_cast<const Expr*>(rhs));
-}
-
 size_t PlanObject::hash() const {
   auto h = static_cast<size_t>(id_);
   for (auto& child : children()) {

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -44,11 +44,6 @@ QueryGraphContext*& queryCtx() {
   return context;
 }
 
-PlanObjectP QueryGraphContext::dedup(PlanObjectP object) {
-  auto pair = deduppedObjects_.insert(object);
-  return *pair.first;
-}
-
 const char* QueryGraphContext::toName(std::string_view str) {
   auto it = names_.find(str);
   if (it != names_.end()) {

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -41,14 +41,6 @@ class PlanObject;
 using PlanObjectP = PlanObject*;
 using PlanObjectCP = const PlanObject*;
 
-struct PlanObjectPHasher {
-  size_t operator()(const PlanObjectCP& object) const;
-};
-
-struct PlanObjectPComparer {
-  bool operator()(const PlanObjectCP& lhs, const PlanObjectCP& rhs) const;
-};
-
 struct TypeHasher {
   size_t operator()(const velox::TypePtr& type) const {
     // hash on recursive TypeKind. Structs that differ in field names
@@ -270,11 +262,6 @@ class QueryGraphContext {
 #endif
   }
 
-  /// Returns a canonical instance for all logically equal values of 'object'.
-  /// Returns 'object' on first call with object, thereafter the same physical
-  /// object if the argument is equal.
-  PlanObjectP dedup(PlanObjectP object);
-
   /// Returns the object associated to 'id'. See newId()
   PlanObjectCP objectAt(int32_t id) {
     return objects_[id];
@@ -343,10 +330,6 @@ class QueryGraphContext {
   // Set of interned copies of identifiers. insert() into this returns the
   // canonical interned copy of any string. Lifetime is limited to 'allocator_'.
   folly::F14FastSet<std::string_view> names_;
-
-  // Set for deduplicating planObject trees.
-  folly::F14FastSet<PlanObjectP, PlanObjectPHasher, PlanObjectPComparer>
-      deduppedObjects_;
 
   folly::F14FastSet<velox::TypePtr, TypeHasher, TypeComparer> deduppedTypes_;
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1000,8 +1000,10 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     auto* intermediateColumn =
         make<Column>(name, currentDt_, intermediateValue, name);
     intermediateColumns.push_back(intermediateColumn);
-    auto dedupped = queryCtx()->dedup(aggregateExpr);
-    aggregates.push_back(dedupped->as<Aggregate>());
+
+    // TODO Dedup aggregate expression using something similar to
+    // deduppedCall.
+    aggregates.push_back(aggregateExpr);
 
     renames_[name] = columns.back();
   }

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -38,27 +38,6 @@ struct MarkFieldsAccessedContext {
   std::span<const LogicalContextSource> sources;
 };
 
-struct ITypedExprHasher {
-  size_t operator()(const velox::core::ITypedExpr* expr) const {
-    return expr->hash();
-  }
-};
-
-struct ITypedExprComparer {
-  bool operator()(
-      const velox::core::ITypedExpr* lhs,
-      const velox::core::ITypedExpr* rhs) const {
-    return *lhs == *rhs;
-  }
-};
-
-// Map for deduplicating ITypedExpr trees.
-using ExprDedupMap = folly::F14FastMap<
-    const velox::core::ITypedExpr*,
-    ExprCP,
-    ITypedExprHasher,
-    ITypedExprComparer>;
-
 struct ExprDedupKey {
   Name func;
   const ExprVector* args;


### PR DESCRIPTION
Summary:
This API doesn't work and cannot be fixed. The implementation relies on PlanObject::hash() which includes ID, which is unique. Hence, two logically equivalent, but not identical objects are (virtually) never considered the same.

This API was used only in one place to dedup aggregate expressions. It didn't work, hence, no harm in deleting it.

A follow-up needs to introduce logic similar to QueryGraph::deduppedCall to dedup aggregate expressions. This would allow to drop duplicate aggregate expressions. E.g.  optimize "SELECT k, agg(x), agg(x) FROM ..." to "SELECT k, agg(x) FROM ...".

Differential Revision: D83243715


