### PR TITLE
feat: Do not create projections for constant args to aggregates

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -886,8 +886,9 @@ class AggregationPlan : public PlanObject {
         aggregates_(std::move(aggregates)),
         columns_(std::move(columns)),
         intermediateColumns_(std::move(intermediateColumns)) {
-    VELOX_CHECK_EQ(groupingKeys.size() + aggregates.size(), columns.size());
-    VELOX_CHECK_EQ(aggregates.size(), intermediateColumns.size());
+    VELOX_CHECK(!groupingKeys_.empty() || !aggregates_.empty());
+    VELOX_CHECK_EQ(groupingKeys_.size() + aggregates_.size(), columns_.size());
+    VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
   }
 
   const ExprVector& groupingKeys() const {

--- a/axiom/optimizer/tests/AggregationPlanTest.cpp
+++ b/axiom/optimizer/tests/AggregationPlanTest.cpp
@@ -77,10 +77,8 @@ TEST_F(AggregationPlanTest, dedupGroupingKeysAndAggregates) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       // TODO Fix the optiimizer to not create projections for
-                       // constant inputs to aggregate functions.
-                       .project({"1", "a + b"})
-                       .singleAggregation({"x"}, {"count(__r2)"})
+                       .project({"a + b"})
+                       .singleAggregation({"x"}, {"count(1)"})
                        .project({"x", "x", "count", "count"})
                        .build();
 

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -132,32 +132,21 @@ TEST_F(HiveQueriesTest, orderOfOperations) {
   test(
       scan("nation")
           .orderBy({"n_nationkey"})
-
           .aggregate({"n_name"}, {"count(1)"})
           .orderBy({"n_name desc"}),
       // Fix this plan. There should be no partial agg.
-      scanMatcher()
-          // TODO Fix this plan. There should be no project for literal '1'
-          // that's the input to count.
-          .project()
-          .singleAggregation()
-          .orderBy({"n_name desc"}));
+      scanMatcher().singleAggregation().orderBy({"n_name desc"}));
 
   // Multiple filters after groupBy. Filters that depend solely on grouping
   // keys are pushed down below the groupBy.
   test(
       scan("nation")
-
           .aggregate({"n_name"}, {"count(1) as cnt"})
           .filter("n_name > 'a'")
           .filter("cnt > 10")
           .filter("length(n_name) < cnt"),
-      scanMatcher()
-          // TODO Fix this plan. There should be no project for literal '1'
-          // that's the input to count.
-          .project()
-          .singleAggregation()
-          .filter("cnt > 10 and cnt > length(n_name)"));
+      scanMatcher().singleAggregation().filter(
+          "cnt > 10 and cnt > length(n_name)"));
 
   // Multiple filters are allowed before a limit.
   test(

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -809,8 +809,7 @@ TEST_F(PlanTest, unionJoin) {
                             .build())
                     .build(),
                 core::JoinType::kInner)
-            .project()
-            .singleAggregation()
+            .singleAggregation({}, {"sum(1)"})
             .build();
 
     ASSERT_TRUE(matcher->match(plan));


### PR DESCRIPTION
Summary:
Before: 

> SELECT k, count(1) FROM t GROUP BY 1

was planned as Scan -> Project(__r2: 1) -> Agg(k, count(__r2))

After:

There is no Project: Scan -> Agg(k, count(1)).

Differential Revision: D83271286


