### PR TITLE
fix: Aggregations with expressions shared between grouping keys and aggregates

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1215,6 +1215,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       op.step == velox::core::AggregationNode::Step::kSingle;
   const auto numKeys = op.groupingKeys.size();
 
+  auto keys = toFieldRefs(op.groupingKeys);
+
   std::vector<std::string> aggregateNames;
   std::vector<velox::core::AggregationNode::Aggregate> aggregates;
   for (size_t i = 0; i < op.aggregates.size(); ++i) {
@@ -1249,8 +1251,6 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       aggregates.push_back({.call = call, .rawInputTypes = rawInputTypes});
     }
   }
-
-  auto keys = toFieldRefs(op.groupingKeys);
 
   if (options_.numDrivers > 1 &&
       (op.step == velox::core::AggregationNode::Step::kFinal ||


### PR DESCRIPTION
Fix optimization for aggregations that share expressions between grouping keys and aggregates. For example,

> SELECT a + b, count(a + b) FROM t GROUP BY 1

The error was due to adding shared expressions to `renames_`  before translating all expressions for the aggregation node.

This fix is to record renames in a separate map while processing aggregation node, then move it to `renames_`.