### PR TITLE
refactor: Move TempProjections to Optimization (from ToVelox)

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
   ToGraph.cpp
   Subfields.cpp
   Optimization.cpp
+  PrecomputeProjection.cpp
   Plan.cpp
   BitSet.cpp
   ParallelExpr.cpp

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -40,7 +40,7 @@ class Optimization {
       OptimizerOptions options = {},
       runner::MultiFragmentPlan::Options runnerOptions = {});
 
-  // Simplified API for usage in testing and tooling.
+  /// Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
       const logical_plan::LogicalPlanNode& logicalPlan,
       velox::memory::MemoryPool& pool,

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -18,6 +18,32 @@
 
 namespace facebook::axiom::optimizer {
 
+namespace {
+const auto& planTypeNames() {
+  static const folly::F14FastMap<PlanType, std::string_view> kNames = {
+      {PlanType::kColumnExpr, "ColumnExpr"},
+      {PlanType::kLiteralExpr, "LiteralExpr"},
+      {PlanType::kCallExpr, "CallExpr"},
+      {PlanType::kAggregateExpr, "AggregateExpr"},
+      {PlanType::kFieldExpr, "FieldExpr"},
+      {PlanType::kLambdaExpr, "LambdaExpr"},
+      {PlanType::kTableNode, "TableNode"},
+      {PlanType::kValuesTableNode, "ValuesTableNode"},
+      {PlanType::kUnnestTableNode, "UnnestTableNode"},
+      {PlanType::kDerivedTableNode, "DerivedTableNode"},
+      {PlanType::kAggregationNode, "AggregationNode"},
+      {PlanType::kProjectNode, "ProjectNode"},
+      {PlanType::kFilterNode, "FilterNode"},
+      {PlanType::kJoinNode, "JoinNode"},
+      {PlanType::kOrderByNode, "OrderByNode"},
+      {PlanType::kLimitNode, "LimitNode"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(PlanType, planTypeNames);
+
 size_t PlanObject::hash() const {
   auto h = static_cast<size_t>(id_);
   for (auto& child : children()) {

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/common/Enums.h"
 #include "axiom/optimizer/BitSet.h"
 
 namespace facebook::axiom::optimizer {
@@ -43,6 +44,8 @@ enum class PlanType : uint32_t {
   kOrderByNode,
   kLimitNode,
 };
+
+AXIOM_DECLARE_ENUM_NAME(PlanType);
 
 /// True if 'type' is an expression with a value.
 inline bool isExprType(PlanType type) {

--- a/axiom/optimizer/PrecomputeProjection.cpp
+++ b/axiom/optimizer/PrecomputeProjection.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/PrecomputeProjection.h"
+
+namespace facebook::axiom::optimizer {
+
+PrecomputeProjection::PrecomputeProjection(
+    const RelationOpPtr& input,
+    DerivedTableCP dt,
+    bool projectAllInputs)
+    : input_{input}, dt_{dt} {
+  if (projectAllInputs) {
+    projectColumns_.reserve(input->columns().size());
+    projectExprs_.reserve(input->columns().size());
+    for (const auto* column : input->columns()) {
+      addToProject(column, column);
+    }
+  }
+}
+
+ExprCP PrecomputeProjection::toColumn(
+    ExprCP expr,
+    ColumnCP alias,
+    bool preserveLiterals) {
+  if (preserveLiterals && expr->is(PlanType::kLiteralExpr)) {
+    return expr;
+  }
+
+  auto it = projections_.find(expr);
+  if (it != projections_.end()) {
+    return it->second;
+  }
+
+  if (expr->is(PlanType::kColumnExpr) && (alias == nullptr || alias == expr)) {
+    addToProject(expr, expr->as<Column>());
+    return expr;
+  }
+
+  auto* column = make<Column>(
+      toName(fmt::format("__p{}", expr->id())),
+      dt_,
+      expr->value(),
+      alias != nullptr ? alias->name() : nullptr);
+
+  addToProject(expr, column);
+  needsProject_ = true;
+  return column;
+}
+
+ExprVector PrecomputeProjection::toColumns(
+    const ExprVector& exprs,
+    const ColumnVector* aliases,
+    bool preserveLiterals) {
+  ExprVector columns;
+  columns.reserve(exprs.size());
+
+  for (auto i = 0; i < exprs.size(); ++i) {
+    columns.emplace_back(toColumn(
+        exprs[i],
+        aliases != nullptr ? (*aliases)[i] : nullptr,
+        preserveLiterals));
+  }
+
+  return columns;
+}
+
+void PrecomputeProjection::addToProject(ExprCP expr, ColumnCP column) {
+  projectExprs_.emplace_back(expr);
+  projectColumns_.emplace_back(column);
+  projections_.emplace(expr, column);
+}
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/PrecomputeProjection.h
+++ b/axiom/optimizer/PrecomputeProjection.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/DerivedTable.h"
+#include "axiom/optimizer/RelationOp.h"
+
+namespace facebook::axiom::optimizer {
+
+/// Builder-style class to generate an optional ProjectOp node that computes
+/// expressions needed by nodes that cannot evaluate expressions directly.
+///
+/// The only Velox plan nodes that can evaluate expressions directly are Filter
+/// and Project. Other nodes require expressions precomputed. Some nodes allow
+/// constant expressions.
+///
+/// Aggregation node requires grouping keys, aggregate masks and inputs to
+/// aggregates precomputed. It allows constant expressions for inputs to
+/// aggregates, but not for grouping keys or masks.
+///
+/// OrderBy node requires sorting keys precomputed.
+///
+/// HashJoin node requires join keys precomputed. It allows arbitrary
+/// expressions for the extra filter.
+///
+/// Unnest node requires replicated and unnest columns precomputed.
+///
+/// In addition, Aggregation allows to specify output name for the aggregate
+/// columns, but not for grouping keys. It projects grouping keys as is. Hence,
+/// it may be necessary to add Project node before Aggregation to rename
+/// grouping keys. For example, this would be the case for "SELECT k as key,
+/// count(1) FROM t GROUP BY 1" query.
+///
+/// The basic usage of this class is the following:
+///   - Create an instance by providing an input RelationOp and a DerivedTable
+///   it comes from.
+///   - Call toColumn(expr) or toColumns(exprs) for all expressions used in the
+///   relation.
+///   - Call maybeProject() to retrieve the new input RelationOp (either
+///   original one or the one with ProjectOp on top).
+///   - Re-write the relation to replace expressions with columns from the new
+///   input.
+///
+/// By default, all input columns are projected out alongside new expressions.
+/// To project only necessary columns, set 'projectAllInputs' to false in the
+/// ctor. (Used for Unnest and Aggregation.)
+///
+/// By default, all non-column expressions are replaced with projections. To
+/// preserve both column and literal expressions, set 'preserveLiterals' to true
+/// when calling toColumn(s). (Used for Aggregation.)
+///
+/// toColumn(s) methods take an optional 'alias(es)' parameter to specify that
+/// the expression must be accessible with a particular name. This is needed to
+/// ensure that grouping keys projected out of an Aggregation have specific
+/// names. (TODO: Extend AggregationNode in Velox to allow specifying output
+/// names for grouping keys.)
+class PrecomputeProjection {
+ public:
+  /// @param input Input relation.
+  /// @param dt DerivedTable the relations belong to. Used to specify DT for
+  /// newly-created columns.
+  /// TODO Do not require a DerivedTable here. Allow for creating ephemeral
+  /// columns that are not associated with a BaseTable or a DerivedTable.
+  PrecomputeProjection(
+      const RelationOpPtr& input,
+      DerivedTableCP dt,
+      bool projectAllInputs = true);
+
+  /// @param alias Optional column that specifies the required alias for the
+  /// expression.
+  ExprCP toColumn(
+      ExprCP expr,
+      ColumnCP alias = nullptr,
+      bool preserveLiterals = false);
+
+  /// @param aliases Optional list of columns that specify the required aliases
+  /// for the expression. If specified, must correspond 1:1 to 'exprs'. May have
+  /// more entries than 'exprs'.
+  ExprVector toColumns(
+      const ExprVector& exprs,
+      const ColumnVector* aliases = nullptr,
+      bool preserveLiterals = false);
+
+  /// @returns the original 'input' with an optional ProjectOp on top.
+  RelationOpPtr maybeProject() && {
+    if (needsProject_) {
+      return make<Project>(input_, projectExprs_, projectColumns_);
+    }
+
+    return input_;
+  }
+
+ private:
+  void addToProject(ExprCP expr, ColumnCP column);
+
+  const RelationOpPtr& input_;
+  DerivedTableCP const dt_;
+
+  // A list of expressions to project. Populated with input columns in the ctor
+  // (if projectAllInputs is true). Apppended to by 'toColumn(s)' methods.
+  ExprVector projectExprs_;
+
+  // A list of columns to project. 1:1 with 'projectExprs_'.
+  ColumnVector projectColumns_;
+
+  // A mapping of expressions already present in 'projectExprs_'. The key is an
+  // expression from 'projectExprs_'. The value is the corresponding column from
+  // 'projectColumns_'.
+  folly::F14FastMap<ExprCP, ColumnCP> projections_;
+
+  // True if there is a non-trivial expression over inputs or an input column
+  // needs to be projected with a different name.
+  bool needsProject_{false};
+};
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -482,10 +482,12 @@ std::string Repartition::toString(bool recursive, bool detail) const {
 }
 
 namespace {
-ColumnVector concatColumns(const ColumnVector& lhs, const ColumnVector& rhs) {
+ColumnVector concatColumns(const ExprVector& lhs, const ColumnVector& rhs) {
   ColumnVector result;
   result.reserve(lhs.size() + rhs.size());
-  result.insert(result.end(), lhs.begin(), lhs.end());
+  for (const auto& expr : lhs) {
+    result.push_back(expr->as<Column>());
+  }
   result.insert(result.end(), rhs.begin(), rhs.end());
   return result;
 }
@@ -493,7 +495,7 @@ ColumnVector concatColumns(const ColumnVector& lhs, const ColumnVector& rhs) {
 
 Unnest::Unnest(
     RelationOpPtr input,
-    ColumnVector replicateColumns,
+    ExprVector replicateColumns,
     ExprVector unnestExprs,
     ColumnVector unnestedColumns)
     : RelationOp{RelType::kUnnest, input, input->distribution(), concatColumns(replicateColumns, unnestedColumns)},

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -431,12 +431,13 @@ using HashBuildCP = const HashBuild*;
 struct Unnest : public RelationOp {
   Unnest(
       RelationOpPtr input,
-      ColumnVector replicateColumns,
+      ExprVector replicateColumns,
       ExprVector unnestExprs,
       ColumnVector unnestedColumns);
 
-  ColumnVector replicateColumns;
+  ExprVector replicateColumns;
   ExprVector unnestExprs;
+
   // Columns correspond to expressions but not 1:1,
   // it can be 2:1 (for MAP) and 1:1 (for ARRAY).
   ColumnVector unnestedColumns;

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -89,6 +89,13 @@ class ToVelox {
   }
 
  private:
+  velox::core::FieldAccessTypedExprPtr toFieldRef(ExprCP expr);
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> toFieldRefs(
+      const ExprVector& exprs);
+
+  std::vector<velox::core::TypedExprPtr> toTypedExprs(const ExprVector& exprs);
+
   void setLeafHandle(
       int32_t id,
       velox::connector::ConnectorTableHandlePtr handle,

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -1386,8 +1386,8 @@ TEST_F(PlanTest, orderByDuplicateKeys) {
   auto matcher = core::PlanMatcherBuilder()
                      .tableScan("t")
                      .project({"a", "multiply(a, 2)"})
-                     .orderBy({"__r1 DESC"})
-                     .project()
+                     .orderBy({"\"dt1.__p5\" DESC"})
+                     .project({"a * 2", "a * 2"})
                      .build();
 
   ASSERT_TRUE(matcher->match(plan));

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -189,9 +189,9 @@ TEST_F(UnnestTest, unnest) {
         core::PlanMatcherBuilder()
             .values()
             .project({"x", "array_distinct(a_a_y)", "array_distinct(a_a_z)"})
-            .unnest({"x"}, {"__r3", "__r4"})
+            .unnest({"x"}, {"\"dt1.__p5\"", "\"dt1.__p6\""})
             .project({"x", "array_distinct(a_y)", "array_distinct(a_z)"})
-            .unnest({"x"}, {"__r3", "__r4"})
+            .unnest({"x"}, {"\"dt1.__p10\"", "\"dt1.__p11\""})
             .project(expectedNames)
             .build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);


### PR DESCRIPTION
Summary:
First step to address https://github.com/facebookexperimental/verax/issues/374

We'd like to keep ToVelox a thin translation layer between physical plan (RelationOp tree) and Velox plan (velox::core::PlanNode tree). The Optimizer core is responsible for adding all necessary projections and making sure there are no unnecessary duplication or redundancy.

The new class, PrecomputeProjection, is similar to TempProjections but operates on physical plan.

Follow-ups:
- Add unit tests for PrecomputeProjection.
- Add tests for masked aggregations.
- Add tests for extra filter in joins.
- Add tests for expressions in shuffle.
- Extend PlanMatcher to not require hardcoding optimizer generated names.
- Optimize away constant grouping keys in aggregations.

Differential Revision: D83320042


