### PR TITLE
feat: Add address, undefined, thread sanitizers in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,20 +36,23 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-axiom:
-    name: Build Axiom
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [none, address, undefined, thread]
+    name: Build Axiom with ${{ matrix.sanitizer }} sanitizer
     runs-on: 16-core-ubuntu
     container:
       image: ghcr.io/facebookincubator/velox-dev:centos9
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
-      VELOX_DEPENDENCY_SOURCE: SYSTEM
-      ICU_SOURCE: SYSTEM
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           persist-credentials: false
+
       # Configure Git to trust the repository directory
       - name: Configure Git Safe Directory
         run: |
@@ -85,14 +88,26 @@ jobs:
         run: |
           ccache -sz
 
-      # Build Axiom
+      # Build Axiom Debug
       - name: Build Axiom Debug
-        id: build-axiom
+        if: ${{ matrix.sanitizer == 'none' }}
         env:
           MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
           CPU_TARGET: "avx"
+          VELOX_DEPENDENCY_SOURCE: SYSTEM
+          ICU_SOURCE: SYSTEM
         run: |
           make debug
+
+      - name: Build Axiom Debug with ${{ matrix.sanitizer }} sanitizer
+        if: ${{ matrix.sanitizer != 'none' }}
+        env:
+          MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
+          CPU_TARGET: "avx"
+          VELOX_DEPENDENCY_SOURCE: BUNDLED
+          ICU_SOURCE: BUNDLED
+        run: |
+          make debug-${{ matrix.sanitizer }}
 
       # Display ccache statistics after build
       - name: CCache Statistics After Build

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,19 @@ debug:            #: Build with debugging symbols
 	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug
 	$(MAKE) build BUILD_DIR=debug -j ${NUM_THREADS}
 
+debug-sanitizer:  #: Build with debugging symbols and some sanitizer
+	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug EXTRA_CMAKE_FLAGS="-DVELOX_DEPENDENCY_SOURCE=BUNDLED -DCMAKE_CXX_FLAGS='-fsanitize=$(SANITIZER)' -DCMAKE_SHARED_LINKER_FLAGS='-fsanitize=$(SANITIZER)' -DCMAKE_SHARED_LINKER_FLAGS='-fsanitize=$(SANITIZER)' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=$(SANITIZER)' $(EXTRA_CMAKE_FLAGS)"
+	$(MAKE) build BUILD_DIR=debug -j ${NUM_THREADS}
+
+debug-address:    #: Build with debugging symbols and address sanitizer
+	$(MAKE) debug-sanitizer SANITIZER=address
+
+debug-undefined:  #: Build with debugging symbols and undefined sanitizer
+	$(MAKE) debug-sanitizer SANITIZER=undefined
+
+debug-thread:     #: Build with debugging symbols and thread sanitizer
+	$(MAKE) debug-sanitizer SANITIZER=thread
+
 release:          #: Build the release version
 	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=Release && \
 	$(MAKE) build BUILD_DIR=release


### PR DESCRIPTION
It's poor man solution but it's better than nothing.

Ideally we need to use latest stable clang, lld, compiler-rt and llvm libc++ (from source)

And check all combinations of release, debug, arm, x86


UPDATE:
It doesn't work because Axiom CI relies on a lot of gcc/centos specific stuff.
We need to somehow break this and compiles with clang, compiler-rt, lld at least.