### PR TITLE
refactor: Cleanup test framework

### DIFF
--- a/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -36,6 +36,10 @@ class HiveConnectorMetadataTest : public runner::test::LocalRunnerTestBase {
   static constexpr int32_t kRowsPerVector = 10000;
 
   static void SetUpTestCase() {
+    // Creates the data and schema from 'testTables_'. These are created on the
+    // first test fixture initialization.
+    LocalRunnerTestBase::SetUpTestCase();
+
     // The lambdas will be run after this scope returns, so make captures
     // static.
     static int32_t counter1;
@@ -56,17 +60,14 @@ class HiveConnectorMetadataTest : public runner::test::LocalRunnerTestBase {
             .customizeData = customize1},
     };
 
-    // Creates the data and schema from 'testTables_'. These are created on the
-    // first test fixture initialization.
-    LocalRunnerTestBase::SetUpTestCase();
     parquet::registerParquetReaderFactory();
     parquet::registerParquetWriterFactory();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
     parquet::unregisterParquetWriterFactory();
     parquet::unregisterParquetReaderFactory();
+    LocalRunnerTestBase::TearDownTestCase();
   }
 
   static void makeAscending(const RowVectorPtr& rows, int32_t& counter) {

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -80,7 +80,7 @@ TEST_F(HiveQueriesTest, basic) {
 
 TEST_F(HiveQueriesTest, crossJoin) {
   auto statement =
-      prestoParser_->parse("SELECT * FROM nation JOIN region ON true");
+      prestoParser().parse("SELECT * FROM nation JOIN region ON true");
 
   ASSERT_TRUE(statement->isSelect());
   auto logicalPlan = statement->asUnchecked<test::SelectStatement>()->plan();

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -24,29 +24,29 @@ namespace lp = facebook::axiom::logical_plan;
 
 // static
 void HiveQueriesTestBase::SetUpTestCase() {
+  test::QueryTestBase::SetUpTestCase();
+
   gTempDirectory = exec::test::TempDirectoryPath::create();
   test::ParquetTpchTest::createTables(gTempDirectory->getPath());
 
   LocalRunnerTestBase::testDataPath_ = gTempDirectory->getPath();
   LocalRunnerTestBase::localFileFormat_ = "parquet";
-  LocalRunnerTestBase::SetUpTestCase();
 }
 
 // static
 void HiveQueriesTestBase::TearDownTestCase() {
-  LocalRunnerTestBase::TearDownTestCase();
   gTempDirectory.reset();
+  test::QueryTestBase::TearDownTestCase();
 }
 
 void HiveQueriesTestBase::SetUp() {
   test::QueryTestBase::SetUp();
-  test::ParquetTpchTest::registerTpchConnector(kTpchConnectorId);
 
-  prestoParser_ = std::make_unique<PrestoParser>(kTpchConnectorId, pool());
+  prestoParser_ =
+      std::make_unique<PrestoParser>(exec::test::kHiveConnectorId, pool());
 }
 
 void HiveQueriesTestBase::TearDown() {
-  test::ParquetTpchTest::unregisterTpchConnector(kTpchConnectorId);
   test::QueryTestBase::TearDown();
 }
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -26,8 +26,6 @@ class HiveQueriesTestBase : public test::QueryTestBase {
  protected:
   static void SetUpTestCase();
 
-  static constexpr auto kTpchConnectorId = "tpch";
-
   void SetUp() override;
 
   void TearDown() override;
@@ -54,6 +52,7 @@ class HiveQueriesTestBase : public test::QueryTestBase {
     return *prestoParser_;
   }
 
+ private:
   inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
       gTempDirectory;
 

--- a/axiom/optimizer/tests/ParquetTpchTest.cpp
+++ b/axiom/optimizer/tests/ParquetTpchTest.cpp
@@ -97,8 +97,6 @@ void registerHiveConnector(const std::string& id) {
 
 //  static
 void ParquetTpchTest::createTables(std::string_view path) {
-  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
-
   SCOPE_EXIT {
     velox::connector::unregisterConnector(
         std::string(PlanBuilder::kHiveDefaultConnectorId));

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -38,6 +38,8 @@ class PlanTest : public test::QueryTestBase {
   static constexpr auto kTestConnectorId = "test";
 
   static void SetUpTestCase() {
+    test::QueryTestBase::SetUpTestCase();
+
     std::string path;
     if (FLAGS_data_path.empty()) {
       gTempDirectory = velox::exec::test::TempDirectoryPath::create();
@@ -52,14 +54,13 @@ class PlanTest : public test::QueryTestBase {
 
     LocalRunnerTestBase::testDataPath_ = path;
     LocalRunnerTestBase::localFileFormat_ = "parquet";
-    LocalRunnerTestBase::SetUpTestCase();
 
     test::registerDfFunctions();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
     gTempDirectory.reset();
+    test::QueryTestBase::TearDownTestCase();
   }
 
   void SetUp() override {

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -35,12 +35,8 @@ struct TestResult {
   /// runner's cursor, so runner must destruct last.
   std::vector<velox::RowVectorPtr> results;
 
-  /// Human readable Velox plan.
-  std::string veloxString;
-
-  /// Human readable Verax output.
-  std::string planString;
-
+  /// Runtime stats retrieved from Velox tasks. One entry per fragment. See
+  /// LocalRunner::stats() for details.
   std::vector<velox::exec::TaskStats> stats;
 };
 
@@ -71,23 +67,26 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   TestResult runFragmentedPlan(const optimizer::PlanAndStats& plan);
 
-  TestResult runVelox(
-      const velox::core::PlanNodePtr& plan,
-      runner::MultiFragmentPlan::Options options = {
-          .numWorkers = 1,
-          .numDrivers = 4,
-      });
+  /// Runs the given single-stage Velox plan single-threaded.
+  TestResult runVelox(const velox::core::PlanNodePtr& plan);
 
   /// Checks that 'reference' and 'experiment' produce the same result.
+  /// Runs 'reference' plan single-threaded.
   /// @return 'reference' result.
-  TestResult assertSame(
-      const velox::core::PlanNodePtr& reference,
+  TestResult checkSame(
       const optimizer::PlanAndStats& experiment,
-      const runner::MultiFragmentPlan::Options& options = {
-          .numWorkers = 1,
-          .numDrivers = 4,
-      });
+      const velox::core::PlanNodePtr& reference);
 
+  /// Checks that 'reference' and 'velox' produce the same result.
+  /// Runs 'referencePlan' single-threaded. Runs 'planNode' multiple times using
+  /// different parallelism settings. Runs single-node-single-threaded,
+  /// single-node-multi-threaded, multi-node-single-threaded, and
+  /// multi-node-multi-threaded. Uses options.numWorkers for multi-node runs and
+  /// options.numDrivers for multi-threaded runs. Doesn't run with higher
+  /// parallelism than specified in 'options'. E.g. if options = {.numWorkers =
+  /// 1, .numDrivers = 1}, then runs only once (single-node-single-threaded).
+  /// All runs are expected to produce the same result that matches result of
+  /// 'referencePlan'.
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const velox::core::PlanNodePtr& referencePlan,
@@ -100,16 +99,13 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       int32_t numDrivers = 1);
 
-  std::shared_ptr<velox::core::QueryCtx> getQueryCtx();
-
-  std::string veloxString(const runner::MultiFragmentPlanPtr& plan);
+  std::shared_ptr<velox::core::QueryCtx>& getQueryCtx();
 
   static VeloxHistory& suiteHistory() {
     return *gSuiteHistory;
   }
 
   OptimizerOptions optimizerOptions_;
-  std::shared_ptr<optimizer::SchemaResolver> schema_;
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -106,14 +106,14 @@ class SubfieldTest : public QueryTestBase,
                      public testing::WithParamInterface<int32_t> {
  protected:
   static void SetUpTestCase() {
+    QueryTestBase::SetUpTestCase();
     testDataPath_ = FLAGS_subfield_data_path;
     LocalRunnerTestBase::localFileFormat_ = "dwrf";
-    LocalRunnerTestBase::SetUpTestCase();
     registerDfFunctions();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
+    QueryTestBase::TearDownTestCase();
   }
 
   void SetUp() override {
@@ -263,7 +263,7 @@ class SubfieldTest : public QueryTestBase,
   }
 
   void testParallelExpr(FeatureOptions& opts, const RowTypePtr& rowType) {
-    core::PlanNodePtr veloxPlan;
+    core::PlanNodePtr referencePlan;
     // No randoms in test expr, different runs must come out the same.
     opts.randomPct = 0;
 
@@ -274,13 +274,13 @@ class SubfieldTest : public QueryTestBase,
       opts.rng.seed(1);
       makeExprs(opts, names, exprs);
 
-      auto builder = PlanBuilder()
-                         .tableScan("features", rowType)
-                         .addNode([&](std::string id, auto node) {
-                           return std::make_shared<core::ProjectNode>(
-                               id, std::move(names), std::move(exprs), node);
-                         });
-      veloxPlan = builder.planNode();
+      referencePlan = PlanBuilder()
+                          .tableScan("features", rowType)
+                          .addNode([&](std::string id, auto node) {
+                            return std::make_shared<core::ProjectNode>(
+                                id, std::move(names), std::move(exprs), node);
+                          })
+                          .planNode();
     }
 
     std::vector<std::string> names;
@@ -309,7 +309,7 @@ class SubfieldTest : public QueryTestBase,
 
     ASSERT_TRUE(parallelProject != nullptr);
 
-    assertSame(veloxPlan, fragmentedPlan);
+    checkSame(fragmentedPlan, referencePlan);
   }
 
   std::string subfield(std::string_view first, std::string_view rest = "")
@@ -417,8 +417,35 @@ class SubfieldTest : public QueryTestBase,
     }
   }
 
-  core::PlanNodePtr extractPlanNode(const PlanAndStats& plan) {
+  static core::PlanNodePtr extractPlanNode(const PlanAndStats& plan) {
     return plan.plan->fragments().at(0).fragment.planNode;
+  }
+
+  static std::string veloxString(const runner::MultiFragmentPlanPtr& plan) {
+    folly::F14FastMap<core::PlanNodeId, const core::TableScanNode*> scans;
+    for (const auto& fragment : plan->fragments()) {
+      velox::core::PlanNode::findFirstNode(
+          fragment.fragment.planNode.get(), [&](const auto* node) {
+            if (auto scan = dynamic_cast<const core::TableScanNode*>(node)) {
+              scans.emplace(scan->id(), scan);
+            }
+            return false;
+          });
+    }
+
+    auto planNodeDetails = [&](const core::PlanNodeId& planNodeId,
+                               std::string_view indentation,
+                               std::ostream& stream) {
+      auto it = scans.find(planNodeId);
+      if (it != scans.end()) {
+        const auto* scan = it->second;
+        for (const auto& [name, handle] : scan->assignments()) {
+          stream << indentation << name << " = " << handle->name() << std::endl;
+        }
+      }
+    };
+
+    return plan->toString(true, planNodeDetails);
   }
 };
 
@@ -447,7 +474,7 @@ TEST_P(SubfieldTest, structs) {
                            .project({"s.s1", "s.s3[1]"})
                            .planNode();
 
-  assertSame(referencePlan, fragmentedPlan);
+  checkSame(fragmentedPlan, referencePlan);
 }
 
 TEST_P(SubfieldTest, maps) {

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/tests/TestConnector.h"
-#include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/exec/TableWriter.h"
@@ -32,14 +31,6 @@ namespace lp = facebook::axiom::logical_plan;
 class TestConnectorQueryTest : public QueryTestBase {
  protected:
   static constexpr auto kTestConnectorId = "test";
-
-  static void SetUpTestCase() {
-    LocalRunnerTestBase::SetUpTestCase();
-  }
-
-  static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
-  }
 
   void SetUp() override {
     QueryTestBase::SetUp();

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -33,6 +33,10 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   static constexpr int32_t kNumRows = kNumFiles * kNumVectors * kRowsPerVector;
 
   static void SetUpTestCase() {
+    // Creates the data and schema from 'testTables_'. These are created on the
+    // first test fixture initialization.
+    LocalRunnerTestBase::SetUpTestCase();
+
     // The lambdas will be run after this scope returns, so make captures
     // static.
     static int32_t counter1;
@@ -64,10 +68,6 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
             .numVectorsPerFile = kNumVectors,
             .numFiles = kNumFiles,
             .customizeData = customize2}};
-
-    // Creates the data and schema from 'testTables_'. These are created on the
-    // first test fixture initialization.
-    LocalRunnerTestBase::SetUpTestCase();
   }
 
   void TearDown() override {


### PR DESCRIPTION
Summary:
- Remove TPC-H Connector from HiveQueriesTestBase.
- Make gTempDirectory and prestoParser_ member variable private in HiveQueriesTestBase.
- Ensure proper chaining and order of SetUpTestCase calls. Derived class must calls its immediate base class.
- Remove memory::MemoryManager::testingSetInstance call from ParquetTpchTest::createTables
- Remove TestResult.veloxString and planString.
- Remove unused 'options' parameter from QueryTestBase::runVelox.
- Rename QueryTestBase::assertSame to checkSame and remove unused 'options' parameter.
- Document QueryTestBase::checkSame method.
- Remove unnecessary QueryTestBase::schema_ member variable.
- Move QueryTestBase::veloxString method to the only caller (SubfieldTest).

Differential Revision: D83528788


