### PR TITLE
refactor: Move test::readCursor to LocalRunnerTest

### DIFF
--- a/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -214,11 +214,10 @@ TEST_F(HiveConnectorMetadataTest, createTable) {
   rootBuilder.tableScan("test", tableType, {}, {}, "", tableType, assignments);
   auto readPlan = std::make_shared<runner::MultiFragmentPlan>(
       rootBuilder.fragments(), std::move(runnerOptions));
-  auto rootPool = memory::memoryManager()->addRootPool("readQ");
 
   auto localRunner = std::make_shared<runner::LocalRunner>(
-      std::move(readPlan), makeQueryCtx(id, rootPool.get()));
-  auto results = runner::test::readCursor(localRunner);
+      std::move(readPlan), makeQueryCtx(id));
+  auto results = readCursor(localRunner);
   exec::test::assertEqualResults({data}, results);
 }
 

--- a/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/HiveConnectorMetadataTest.cpp
@@ -36,6 +36,10 @@ class HiveConnectorMetadataTest : public runner::test::LocalRunnerTestBase {
   static constexpr int32_t kRowsPerVector = 10000;
 
   static void SetUpTestCase() {
+    // Creates the data and schema from 'testTables_'. These are created on the
+    // first test fixture initialization.
+    LocalRunnerTestBase::SetUpTestCase();
+
     // The lambdas will be run after this scope returns, so make captures
     // static.
     static int32_t counter1;
@@ -56,17 +60,14 @@ class HiveConnectorMetadataTest : public runner::test::LocalRunnerTestBase {
             .customizeData = customize1},
     };
 
-    // Creates the data and schema from 'testTables_'. These are created on the
-    // first test fixture initialization.
-    LocalRunnerTestBase::SetUpTestCase();
     parquet::registerParquetReaderFactory();
     parquet::registerParquetWriterFactory();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
     parquet::unregisterParquetWriterFactory();
     parquet::unregisterParquetReaderFactory();
+    LocalRunnerTestBase::TearDownTestCase();
   }
 
   static void makeAscending(const RowVectorPtr& rows, int32_t& counter) {

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -24,16 +24,7 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveLimitQueriesTest : public test::HiveQueriesTestBase {
- public:
-  static void SetUpTestCase() {
-    test::HiveQueriesTestBase::SetUpTestCase();
-  }
-
-  static void TearDownTestCase() {
-    test::HiveQueriesTestBase::TearDownTestCase();
-  }
-};
+class HiveLimitQueriesTest : public test::HiveQueriesTestBase {};
 
 // LIMIT 10
 TEST_F(HiveLimitQueriesTest, limit) {

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -25,16 +25,7 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveQueriesTest : public test::HiveQueriesTestBase {
- public:
-  static void SetUpTestCase() {
-    test::HiveQueriesTestBase::SetUpTestCase();
-  }
-
-  static void TearDownTestCase() {
-    test::HiveQueriesTestBase::TearDownTestCase();
-  }
-};
+class HiveQueriesTest : public test::HiveQueriesTestBase {};
 
 TEST_F(HiveQueriesTest, basic) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -80,7 +80,7 @@ TEST_F(HiveQueriesTest, basic) {
 
 TEST_F(HiveQueriesTest, crossJoin) {
   auto statement =
-      prestoParser_->parse("SELECT * FROM nation JOIN region ON true");
+      prestoParser().parse("SELECT * FROM nation JOIN region ON true");
 
   ASSERT_TRUE(statement->isSelect());
   auto logicalPlan = statement->asUnchecked<test::SelectStatement>()->plan();

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -24,29 +24,29 @@ namespace lp = facebook::axiom::logical_plan;
 
 // static
 void HiveQueriesTestBase::SetUpTestCase() {
+  test::QueryTestBase::SetUpTestCase();
+
   gTempDirectory = exec::test::TempDirectoryPath::create();
   test::ParquetTpchTest::createTables(gTempDirectory->getPath());
 
   LocalRunnerTestBase::testDataPath_ = gTempDirectory->getPath();
   LocalRunnerTestBase::localFileFormat_ = "parquet";
-  LocalRunnerTestBase::SetUpTestCase();
 }
 
 // static
 void HiveQueriesTestBase::TearDownTestCase() {
-  LocalRunnerTestBase::TearDownTestCase();
   gTempDirectory.reset();
+  test::QueryTestBase::TearDownTestCase();
 }
 
 void HiveQueriesTestBase::SetUp() {
   test::QueryTestBase::SetUp();
-  test::ParquetTpchTest::registerTpchConnector(kTpchConnectorId);
 
-  prestoParser_ = std::make_unique<PrestoParser>(kTpchConnectorId, pool());
+  prestoParser_ =
+      std::make_unique<PrestoParser>(exec::test::kHiveConnectorId, pool());
 }
 
 void HiveQueriesTestBase::TearDown() {
-  test::ParquetTpchTest::unregisterTpchConnector(kTpchConnectorId);
   test::QueryTestBase::TearDown();
 }
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -29,8 +29,9 @@ void HiveQueriesTestBase::SetUpTestCase() {
   gTempDirectory = exec::test::TempDirectoryPath::create();
   test::ParquetTpchTest::createTables(gTempDirectory->getPath());
 
-  LocalRunnerTestBase::testDataPath_ = gTempDirectory->getPath();
-  LocalRunnerTestBase::localFileFormat_ = "parquet";
+  LocalRunnerTestBase::localDataPath_ = gTempDirectory->getPath();
+  LocalRunnerTestBase::localFileFormat_ =
+      velox::dwio::common::FileFormat::PARQUET;
 }
 
 // static

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -26,12 +26,14 @@ class HiveQueriesTestBase : public test::QueryTestBase {
  protected:
   static void SetUpTestCase();
 
+  /// Creates TPC-H tables in a temp directory using PARQUET file format.
   void SetUp() override;
 
   void TearDown() override;
 
   static void TearDownTestCase();
 
+  /// Returns a schema of a TPC-H table.
   velox::RowTypePtr getSchema(std::string_view tableName);
 
   void checkResults(

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -26,8 +26,6 @@ class HiveQueriesTestBase : public test::QueryTestBase {
  protected:
   static void SetUpTestCase();
 
-  static constexpr auto kTpchConnectorId = "tpch";
-
   void SetUp() override;
 
   void TearDown() override;
@@ -54,6 +52,7 @@ class HiveQueriesTestBase : public test::QueryTestBase {
     return *prestoParser_;
   }
 
+ private:
   inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
       gTempDirectory;
 

--- a/axiom/optimizer/tests/ParquetTpchTest.cpp
+++ b/axiom/optimizer/tests/ParquetTpchTest.cpp
@@ -97,8 +97,6 @@ void registerHiveConnector(const std::string& id) {
 
 //  static
 void ParquetTpchTest::createTables(std::string_view path) {
-  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
-
   SCOPE_EXIT {
     velox::connector::unregisterConnector(
         std::string(PlanBuilder::kHiveDefaultConnectorId));

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -38,6 +38,8 @@ class PlanTest : public test::QueryTestBase {
   static constexpr auto kTestConnectorId = "test";
 
   static void SetUpTestCase() {
+    test::QueryTestBase::SetUpTestCase();
+
     std::string path;
     if (FLAGS_data_path.empty()) {
       gTempDirectory = velox::exec::test::TempDirectoryPath::create();
@@ -52,14 +54,13 @@ class PlanTest : public test::QueryTestBase {
 
     LocalRunnerTestBase::testDataPath_ = path;
     LocalRunnerTestBase::localFileFormat_ = "parquet";
-    LocalRunnerTestBase::SetUpTestCase();
 
     test::registerDfFunctions();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
     gTempDirectory.reset();
+    test::QueryTestBase::TearDownTestCase();
   }
 
   void SetUp() override {

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -52,8 +52,9 @@ class PlanTest : public test::QueryTestBase {
       }
     }
 
-    LocalRunnerTestBase::testDataPath_ = path;
-    LocalRunnerTestBase::localFileFormat_ = "parquet";
+    LocalRunnerTestBase::localDataPath_ = path;
+    LocalRunnerTestBase::localFileFormat_ =
+        velox::dwio::common::FileFormat::PARQUET;
 
     test::registerDfFunctions();
   }
@@ -680,8 +681,8 @@ TEST_F(PlanTest, filterBreakup) {
   }
 
   auto referenceBuilder = std::make_unique<exec::test::TpchQueryBuilder>(
-      dwio::common::FileFormat::PARQUET);
-  referenceBuilder->initialize(LocalRunnerTestBase::testDataPath_);
+      LocalRunnerTestBase::localFileFormat_);
+  referenceBuilder->initialize(LocalRunnerTestBase::localDataPath_);
 
   auto referencePlan = referenceBuilder->getQueryPlan(19).plan;
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -15,29 +15,17 @@
  */
 
 #include "axiom/optimizer/tests/QueryTestBase.h"
-
-#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
-#include "velox/dwio/dwrf/RegisterDwrfReader.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/exec/tests/utils/QueryAssertions.h"
-
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/SchemaResolver.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
-#include "velox/serializers/PrestoSerializer.h"
 
 DECLARE_string(data_path);
 
 DEFINE_uint32(optimizer_trace, 0, "Optimizer trace level");
-
-DEFINE_bool(print_plan, false, "Print optimizer results");
-
-DEFINE_string(data_format, "parquet", "Data format");
 
 DEFINE_string(
     history_save_path,
@@ -47,29 +35,18 @@ DEFINE_string(
 using namespace facebook::velox;
 
 namespace facebook::axiom::optimizer::test {
-using namespace facebook::velox::exec;
 
 void QueryTestBase::SetUp() {
   runner::test::LocalRunnerTestBase::SetUp();
-  connector_ = velox::connector::getConnector(exec::test::kHiveConnectorId);
-  rootPool_ = memory::memoryManager()->addRootPool("axiom_sql");
-  optimizerPool_ = rootPool_->addLeafChild("optimizer");
 
-  parquet::registerParquetReaderFactory();
-  dwrf::registerDwrfReaderFactory();
-  exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);
-  if (!isRegisteredVectorSerde()) {
-    serializer::presto::PrestoVectorSerde::registerVectorSerde();
-  }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
-    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
-  }
+  optimizerPool_ = rootPool_->addLeafChild("optimizer");
 
   if (gSuiteHistory) {
     history_ = std::move(gSuiteHistory);
   } else {
     history_ = std::make_unique<optimizer::VeloxHistory>();
   }
+
   optimizerOptions_ = OptimizerOptions();
   optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
 
@@ -83,18 +60,8 @@ void QueryTestBase::TearDown() {
     gSuiteHistory = std::move(history_);
   }
   queryCtx_.reset();
-  velox::connector::unregisterConnector(exec::test::kHiveConnectorId);
-  connector_.reset();
   optimizerPool_.reset();
-  rootPool_.reset();
   LocalRunnerTestBase::TearDown();
-}
-
-void QueryTestBase::tablesCreated() {
-  auto metadata = dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(
-      connector::ConnectorMetadata::metadata(connector_.get()));
-  VELOX_CHECK_NOT_NULL(metadata);
-  metadata->reinitialize();
 }
 
 namespace {
@@ -136,10 +103,7 @@ TestResult QueryTestBase::runFragmentedPlan(
 
   result.runner =
       std::make_shared<runner::LocalRunner>(fragmentedPlan.plan, getQueryCtx());
-
-  while (auto rows = result.runner->next()) {
-    result.results.push_back(std::move(rows));
-  }
+  result.results = readCursor(result.runner);
   result.stats = result.runner->stats();
   history_->recordVeloxExecution(fragmentedPlan, result.stats);
 
@@ -151,21 +115,9 @@ std::shared_ptr<core::QueryCtx>& QueryTestBase::getQueryCtx() {
     return queryCtx_;
   }
 
-  ++gQueryCounter;
+  queryCtx_ = runner::test::LocalRunnerTestBase::makeQueryCtx(
+      fmt::format("q{}", ++gQueryCounter));
 
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-      connectorConfigs = {
-          {exec::test::kHiveConnectorId,
-           std::make_shared<config::ConfigBase>(folly::copy(hiveConfig_))}};
-
-  queryCtx_ = core::QueryCtx::create(
-      executor_.get(),
-      core::QueryConfig(config_),
-      std::move(connectorConfigs),
-      cache::AsyncDataCache::getInstance(),
-      rootPool_->shared_from_this(),
-      spillExecutor_.get(),
-      fmt::format("query_{}", gQueryCounter));
   return queryCtx_;
 }
 
@@ -175,8 +127,6 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
     std::string* planString) {
   auto& queryCtx = getQueryCtx();
 
-  // The default Locus for planning is the system and data of 'connector_'.
-  optimizer::Locus locus(connector_->connectorId().c_str(), connector_.get());
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool_.get());
   auto context = std::make_unique<optimizer::QueryGraphContext>(*allocator);
   optimizer::queryCtx() = context.get();
@@ -187,7 +137,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
       queryCtx.get(), optimizerPool_.get());
 
   optimizer::SchemaResolver schemaResolver;
-  optimizer::Schema veraxSchema("test", &schemaResolver, &locus);
+  optimizer::Schema veraxSchema("test", &schemaResolver, /*locus=*/nullptr);
 
   optimizer::Optimization opt(
       *plan,

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -35,12 +35,8 @@ struct TestResult {
   /// runner's cursor, so runner must destruct last.
   std::vector<velox::RowVectorPtr> results;
 
-  /// Human readable Velox plan.
-  std::string veloxString;
-
-  /// Human readable Verax output.
-  std::string planString;
-
+  /// Runtime stats retrieved from Velox tasks. One entry per fragment. See
+  /// LocalRunner::stats() for details.
   std::vector<velox::exec::TaskStats> stats;
 };
 
@@ -71,23 +67,26 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   TestResult runFragmentedPlan(const optimizer::PlanAndStats& plan);
 
-  TestResult runVelox(
-      const velox::core::PlanNodePtr& plan,
-      runner::MultiFragmentPlan::Options options = {
-          .numWorkers = 1,
-          .numDrivers = 4,
-      });
+  /// Runs the given single-stage Velox plan single-threaded.
+  TestResult runVelox(const velox::core::PlanNodePtr& plan);
 
   /// Checks that 'reference' and 'experiment' produce the same result.
+  /// Runs 'reference' plan single-threaded.
   /// @return 'reference' result.
-  TestResult assertSame(
-      const velox::core::PlanNodePtr& reference,
+  TestResult checkSame(
       const optimizer::PlanAndStats& experiment,
-      const runner::MultiFragmentPlan::Options& options = {
-          .numWorkers = 1,
-          .numDrivers = 4,
-      });
+      const velox::core::PlanNodePtr& reference);
 
+  /// Checks that 'reference' and 'velox' produce the same result.
+  /// Runs 'referencePlan' single-threaded. Runs 'planNode' multiple times using
+  /// different parallelism settings. Runs single-node-single-threaded,
+  /// single-node-multi-threaded, multi-node-single-threaded, and
+  /// multi-node-multi-threaded. Uses options.numWorkers for multi-node runs and
+  /// options.numDrivers for multi-threaded runs. Doesn't run with higher
+  /// parallelism than specified in 'options'. E.g. if options = {.numWorkers =
+  /// 1, .numDrivers = 1}, then runs only once (single-node-single-threaded).
+  /// All runs are expected to produce the same result that matches result of
+  /// 'referencePlan'.
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const velox::core::PlanNodePtr& referencePlan,
@@ -100,16 +99,13 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       int32_t numDrivers = 1);
 
-  std::shared_ptr<velox::core::QueryCtx> getQueryCtx();
-
-  std::string veloxString(const runner::MultiFragmentPlanPtr& plan);
+  std::shared_ptr<velox::core::QueryCtx>& getQueryCtx();
 
   static VeloxHistory& suiteHistory() {
     return *gSuiteHistory;
   }
 
   OptimizerOptions optimizerOptions_;
-  std::shared_ptr<optimizer::SchemaResolver> schema_;
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -18,7 +18,6 @@
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gflags/gflags.h>
-#include "axiom/optimizer/SchemaResolver.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/LocalRunner.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
@@ -45,9 +44,6 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   void SetUp() override;
 
   void TearDown() override;
-
-  /// Reads the data directory and picks up new tables.
-  void tablesCreated();
 
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
@@ -108,12 +104,10 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   OptimizerOptions optimizerOptions_;
 
  private:
-  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> optimizerPool_;
 
   // A QueryCtx created for each compiled query.
   std::shared_ptr<velox::core::QueryCtx> queryCtx_;
-  std::shared_ptr<velox::connector::Connector> connector_;
   std::unique_ptr<optimizer::VeloxHistory> history_;
 
   inline static int32_t gQueryCounter{0};

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -106,14 +106,14 @@ class SubfieldTest : public QueryTestBase,
                      public testing::WithParamInterface<int32_t> {
  protected:
   static void SetUpTestCase() {
+    QueryTestBase::SetUpTestCase();
     testDataPath_ = FLAGS_subfield_data_path;
     LocalRunnerTestBase::localFileFormat_ = "dwrf";
-    LocalRunnerTestBase::SetUpTestCase();
     registerDfFunctions();
   }
 
   static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
+    QueryTestBase::TearDownTestCase();
   }
 
   void SetUp() override {
@@ -263,7 +263,7 @@ class SubfieldTest : public QueryTestBase,
   }
 
   void testParallelExpr(FeatureOptions& opts, const RowTypePtr& rowType) {
-    core::PlanNodePtr veloxPlan;
+    core::PlanNodePtr referencePlan;
     // No randoms in test expr, different runs must come out the same.
     opts.randomPct = 0;
 
@@ -274,13 +274,13 @@ class SubfieldTest : public QueryTestBase,
       opts.rng.seed(1);
       makeExprs(opts, names, exprs);
 
-      auto builder = PlanBuilder()
-                         .tableScan("features", rowType)
-                         .addNode([&](std::string id, auto node) {
-                           return std::make_shared<core::ProjectNode>(
-                               id, std::move(names), std::move(exprs), node);
-                         });
-      veloxPlan = builder.planNode();
+      referencePlan = PlanBuilder()
+                          .tableScan("features", rowType)
+                          .addNode([&](std::string id, auto node) {
+                            return std::make_shared<core::ProjectNode>(
+                                id, std::move(names), std::move(exprs), node);
+                          })
+                          .planNode();
     }
 
     std::vector<std::string> names;
@@ -309,7 +309,7 @@ class SubfieldTest : public QueryTestBase,
 
     ASSERT_TRUE(parallelProject != nullptr);
 
-    assertSame(veloxPlan, fragmentedPlan);
+    checkSame(fragmentedPlan, referencePlan);
   }
 
   std::string subfield(std::string_view first, std::string_view rest = "")
@@ -417,8 +417,35 @@ class SubfieldTest : public QueryTestBase,
     }
   }
 
-  core::PlanNodePtr extractPlanNode(const PlanAndStats& plan) {
+  static core::PlanNodePtr extractPlanNode(const PlanAndStats& plan) {
     return plan.plan->fragments().at(0).fragment.planNode;
+  }
+
+  static std::string veloxString(const runner::MultiFragmentPlanPtr& plan) {
+    folly::F14FastMap<core::PlanNodeId, const core::TableScanNode*> scans;
+    for (const auto& fragment : plan->fragments()) {
+      velox::core::PlanNode::findFirstNode(
+          fragment.fragment.planNode.get(), [&](const auto* node) {
+            if (auto scan = dynamic_cast<const core::TableScanNode*>(node)) {
+              scans.emplace(scan->id(), scan);
+            }
+            return false;
+          });
+    }
+
+    auto planNodeDetails = [&](const core::PlanNodeId& planNodeId,
+                               std::string_view indentation,
+                               std::ostream& stream) {
+      auto it = scans.find(planNodeId);
+      if (it != scans.end()) {
+        const auto* scan = it->second;
+        for (const auto& [name, handle] : scan->assignments()) {
+          stream << indentation << name << " = " << handle->name() << std::endl;
+        }
+      }
+    };
+
+    return plan->toString(true, planNodeDetails);
   }
 };
 
@@ -447,7 +474,7 @@ TEST_P(SubfieldTest, structs) {
                            .project({"s.s1", "s.s3[1]"})
                            .planNode();
 
-  assertSame(referencePlan, fragmentedPlan);
+  checkSame(fragmentedPlan, referencePlan);
 }
 
 TEST_P(SubfieldTest, maps) {

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -107,8 +107,9 @@ class SubfieldTest : public QueryTestBase,
  protected:
   static void SetUpTestCase() {
     QueryTestBase::SetUpTestCase();
-    testDataPath_ = FLAGS_subfield_data_path;
-    LocalRunnerTestBase::localFileFormat_ = "dwrf";
+    LocalRunnerTestBase::localDataPath_ = FLAGS_subfield_data_path;
+    LocalRunnerTestBase::localFileFormat_ =
+        velox::dwio::common::FileFormat::DWRF;
     registerDfFunctions();
   }
 
@@ -366,11 +367,11 @@ class SubfieldTest : public QueryTestBase,
       const std ::vector<RowVectorPtr>& vectors,
       const std::shared_ptr<dwrf::Config>& config =
           std::make_shared<dwrf::Config>()) {
-    auto fs = filesystems::getFileSystem(testDataPath_, {});
-    fs->mkdir(fmt::format("{}/{}", testDataPath_, name));
+    auto fs = filesystems::getFileSystem(localDataPath_, {});
+    fs->mkdir(fmt::format("{}/{}", localDataPath_, name));
 
     const auto filePath =
-        fmt::format("{}/{}/{}.dwrf", testDataPath_, name, name);
+        fmt::format("{}/{}/{}.dwrf", localDataPath_, name, name);
     writeToFile(filePath, vectors, config);
     tablesCreated();
   }

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/tests/TestConnector.h"
-#include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/exec/TableWriter.h"
@@ -32,14 +31,6 @@ namespace lp = facebook::axiom::logical_plan;
 class TestConnectorQueryTest : public QueryTestBase {
  protected:
   static constexpr auto kTestConnectorId = "test";
-
-  static void SetUpTestCase() {
-    LocalRunnerTestBase::SetUpTestCase();
-  }
-
-  static void TearDownTestCase() {
-    LocalRunnerTestBase::TearDownTestCase();
-  }
 
   void SetUp() override {
     QueryTestBase::SetUp();

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -50,8 +50,8 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
     HiveQueriesTestBase::SetUp();
 
     referenceBuilder_ = std::make_unique<exec::test::TpchQueryBuilder>(
-        dwio::common::FileFormat::PARQUET);
-    referenceBuilder_->initialize(LocalRunnerTestBase::testDataPath_);
+        LocalRunnerTestBase::localFileFormat_);
+    referenceBuilder_->initialize(LocalRunnerTestBase::localDataPath_);
   }
 
   void TearDown() override {

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -33,6 +33,10 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   static constexpr int32_t kNumRows = kNumFiles * kNumVectors * kRowsPerVector;
 
   static void SetUpTestCase() {
+    // Creates the data and schema from 'testTables_'. These are created on the
+    // first test fixture initialization.
+    LocalRunnerTestBase::SetUpTestCase();
+
     // The lambdas will be run after this scope returns, so make captures
     // static.
     static int32_t counter1;
@@ -64,10 +68,6 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
             .numVectorsPerFile = kNumVectors,
             .numFiles = kNumFiles,
             .customizeData = customize2}};
-
-    // Creates the data and schema from 'testTables_'. These are created on the
-    // first test fixture initialization.
-    LocalRunnerTestBase::SetUpTestCase();
   }
 
   void TearDown() override {


### PR DESCRIPTION
Also,
- Rename LocalRunnerTestBase::testDataPath_ to localDataPath_ to match localFileFormat_.
- Change LocalRunnerTestBase::localFileFormat_'s type to velox::dwio::common::FileFormat.
- Make LocalRunnerTestBase::makeTables and setupConnector methods private.
- Remove LocalRunnerTestBase::makeSimpleSplitSourceFactory.
- Move QueryTestBase::tablesCreated to LocalRunnerTestBase.

At the moment, there are 3 base classes:
- class LocalRunnerTestBase : public velox::exec::test::HiveConnectorTestBase
- class QueryTestBase : public runner::test::LocalRunnerTestBase
- class HiveQueriesTestBase : public test::QueryTestBase

LocalRunnerTestBase is responsible for creating tables with random data and registering LocalHiveConnectorMetadata.

QueryTestBase provides helper methods for creating and running optimized plans. This class doesn't need to be tightly coupled with HiveConnector.

HiveQueriesTestBase is responsible for creating TPC-H tables.

Differential Revision: D83530959
