### PR TITLE
build: Enable VELOX_MONO_LIBRARY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BUILD_BASE_DIR=_build
 BUILD_DIR=release
 BUILD_TYPE=Release
 
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DAXIOM_BUILD_TESTING=ON
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DAXIOM_BUILD_TESTING=ON -DVELOX_MONO_LIBRARY=ON
 
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -24,6 +24,6 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-velox_add_library(axiom_connector_metadata ConnectorMetadata.cpp)
+add_library(axiom_connector_metadata ConnectorMetadata.cpp)
 
-velox_link_libraries(axiom_connector_metadata velox_common_base velox_memory velox_connector)
+target_link_libraries(axiom_connector_metadata velox_common_base velox_memory velox_connector)

--- a/axiom/connectors/hive/CMakeLists.txt
+++ b/axiom/connectors/hive/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 add_library(
   axiom_hive_connector_metadata
-  OBJECT
   HiveConnectorMetadata.cpp
   LocalHiveConnectorMetadata.cpp
   StatisticsBuilder.cpp

--- a/axiom/connectors/tpch/CMakeLists.txt
+++ b/axiom/connectors/tpch/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_tpch_connector_metadata OBJECT TpchConnectorMetadata.cpp)
+add_library(axiom_tpch_connector_metadata TpchConnectorMetadata.cpp)
 
 target_link_libraries(
   axiom_tpch_connector_metadata

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -43,8 +43,6 @@ add_library(
   VeloxHistory.cpp
 )
 
-add_dependencies(axiom_optimizer velox_hive_connector)
-
 target_link_libraries(
   axiom_optimizer
   velox_core

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -103,7 +103,6 @@ add_executable(
   PlanTest.cpp
   UnnestTest.cpp
   ParquetTpchTest.cpp
-  QueryTestBase.cpp
   SubfieldTest.cpp
   FeatureGen.cpp
   Genies.cpp


### PR DESCRIPTION
* Don't use `OBJECT` unless required
* Don't use `velox_add_library` for targets that don't start with `velox_` prefix
* Remove unnecessary `add_dependencies`
* Remove `QueryTestBase.cpp` duplication (it's referenced in two libraries, and one library linked to another)
* Use `VELOX_MONO_LIBRARY` in Axiom CI to make build faster and ensure it works