### PR TITLE
fix: Use inner expression Value for DerivedTable columns

### DIFF
--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -95,12 +95,14 @@ class PlanObject {
 
   template <typename T>
   T* as() {
+    VELOX_DCHECK_NOT_NULL(dynamic_cast<T*>(this));
     return reinterpret_cast<T*>(this);
   }
 
   /// Returns 'this' as const T.
   template <typename T>
   const T* as() const {
+    VELOX_DCHECK_NOT_NULL(dynamic_cast<const T*>(this));
     return reinterpret_cast<const T*>(this);
   }
 

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -174,11 +174,13 @@ class RelationOp {
 
   template <typename T>
   const T* as() const {
+    VELOX_DCHECK_NOT_NULL(dynamic_cast<const T*>(this));
     return static_cast<const T*>(this);
   }
 
   template <typename T>
   T* as() {
+    VELOX_DCHECK_NOT_NULL(dynamic_cast<T*>(this));
     return static_cast<T*>(this);
   }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -156,9 +156,7 @@ class ToGraph {
 
   // Sets the columns to project out from the root DerivedTable based on
   // 'logicalPlan'.
-  void setDtOutput(
-      DerivedTableP dt,
-      const logical_plan::LogicalPlanNode& logicalPlan);
+  void setDtOutput(DerivedTableP dt, const logical_plan::LogicalPlanNode& node);
 
   Name newCName(std::string_view prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));
@@ -414,6 +412,9 @@ class ToGraph {
   void finalizeDt(
       const logical_plan::LogicalPlanNode& node,
       DerivedTableP outerDt = nullptr);
+
+  // Adds a column 'name' from current DerivedTable to the 'dt'.
+  void addDtColumn(DerivedTableP dt, std::string_view name);
 
   void setDtUsedOutput(
       DerivedTableP dt,


### PR DESCRIPTION
Also,
* Do not create extra Columns for identity projections.
* Rename `pString` to `lpString` to be consistent with `leString`, these functions are used only with the debugger.