### PR TITLE
refactor: Add ConnectorSession parameter to ConnectorMetadata and ConnectorSplitManager APIs

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/common/Enums.h"
+#include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/Connector.h"
@@ -452,39 +453,28 @@ class ConnectorWriteHandle {
 
 using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 
-/// Represents session status for update operations. May for example
-/// encapsulate a transaction state. The minimal implementation does nothing,
-/// which amounts to all write operations being non-isolated and autocommitting.
-/// Connector specific implementations have their specific transaction
-/// functions.
-class ConnectorSession {
- public:
-  virtual ~ConnectorSession() = default;
-};
-
-using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;
-
 /// Specifies what type of write is intended when initiating or concluding a
 /// write operation.
 enum class WriteKind {
-  // A write operation to a new table which does not yet exist in the connector.
-  // Covers both creation of an empty table and create as select operations.
+  /// A write operation to a new table which does not yet exist in the
+  /// connector. Covers both creation of an empty table and create as select
+  /// operations.
   kCreate = 1,
 
-  // Rows are added and all columns must be specified for the TableWriter.
-  // Covers insert, Hive partition replacement or any other operation which adds
-  // whole rows.
+  /// Rows are added and all columns must be specified for the TableWriter.
+  /// Covers insert, Hive partition replacement or any other operation which
+  /// adds whole rows.
   kInsert = 2,
 
-  // Individual rows are deleted. Only row ids as per
-  // ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
+  /// Individual rows are deleted. Only row ids as per
+  /// ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
   kDelete = 3,
 
-  // Column values in individual rows are changed. The TableWriter
-  // gets first the row ids as per ConnectorMetadata::rowIdHandles()
-  // and then new values for the columns being changed. The new values
-  // may overlap with row ids if the row id is a set of primary key
-  // columns.
+  /// Column values in individual rows are changed. The TableWriter
+  /// gets first the row ids as per ConnectorMetadata::rowIdHandles()
+  /// and then new values for the columns being changed. The new values
+  /// may overlap with row ids if the row id is a set of primary key
+  /// columns.
   kUpdate = 4,
 };
 
@@ -521,6 +511,7 @@ class ConnectorMetadata {
   /// is a struct and are absent if 'castToType' is a map. See implementing
   /// Connector for exact set of cast and subfield semantics.
   virtual velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layoutData,
       const std::string& columnName,
       std::vector<velox::common::Subfield> subfields = {},
@@ -538,6 +529,7 @@ class ConnectorMetadata {
   /// existing columns and may additionally specify casting from maps to structs
   /// by giving a struct in the place of a map.
   virtual velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,
       velox::core::ExpressionEvaluator& evaluator,
@@ -577,10 +569,10 @@ class ConnectorMetadata {
   /// table is not available via the findTable interface until after finishWrite
   /// completes.
   virtual TablePtr createTable(
+      const ConnectorSessionPtr& session,
       const std::string& tableName,
       const velox::RowTypePtr& rowType,
-      const folly::F14FastMap<std::string, std::string>& options,
-      const ConnectorSessionPtr& session) {
+      const folly::F14FastMap<std::string, std::string>& options) {
     VELOX_UNSUPPORTED();
   }
 
@@ -593,9 +585,9 @@ class ConnectorMetadata {
   /// connector-dependent, and ConnectorSession may be null for connectors which
   /// do not require it.
   virtual ConnectorWriteHandlePtr beginWrite(
+      const ConnectorSessionPtr& session,
       const TablePtr& table,
-      WriteKind kind,
-      const ConnectorSessionPtr& session) {
+      WriteKind kind) {
     VELOX_UNSUPPORTED();
   }
 
@@ -609,9 +601,9 @@ class ConnectorMetadata {
   /// return an already-fulfilled future to the caller. ConnectorSession may be
   /// null for connectors which do not require it.
   virtual velox::ContinueFuture finishWrite(
+      const ConnectorSessionPtr& session,
       const ConnectorWriteHandlePtr& handle,
-      const std::vector<velox::RowVectorPtr>& writerResult,
-      const ConnectorSessionPtr& session) {
+      const std::vector<velox::RowVectorPtr>& writerResult) {
     VELOX_UNSUPPORTED();
   }
 
@@ -623,8 +615,8 @@ class ConnectorMetadata {
   /// synchronous operation, the connector should perform the abort and return
   /// an already-fulfilled future.
   virtual velox::ContinueFuture abortWrite(
-      const ConnectorWriteHandlePtr& handle,
-      const ConnectorSessionPtr& session) {
+      const ConnectorSessionPtr& session,
+      const ConnectorWriteHandlePtr& handle) {
     return velox::ContinueFuture();
   }
 

--- a/axiom/connectors/ConnectorSession.h
+++ b/axiom/connectors/ConnectorSession.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+
+namespace facebook::axiom::connector {
+
+/// Read-only query-specific information.
+class ConnectorSession final {
+ public:
+  ConnectorSession(std::string queryId) : queryId_{queryId} {}
+
+  const std::string& queryId() const {
+    return queryId_;
+  }
+
+ private:
+  const std::string queryId_;
+};
+
+using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <velox/connectors/Connector.h>
+#include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
 
@@ -69,6 +70,7 @@ class ConnectorSplitManager {
   /// Returns a list of all partitions that match the filters in
   /// 'tableHandle'. A non-partitioned table returns one partition.
   virtual std::vector<PartitionHandlePtr> listPartitions(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) = 0;
 
   /// Returns a SplitSource that covers the contents of 'partitions'. The set of
@@ -76,6 +78,7 @@ class ConnectorSplitManager {
   /// partitions in a specific order or distribute them to specific nodes in a
   /// cluster.
   virtual std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       SplitOptions = {}) = 0;

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -39,6 +39,7 @@ velox::connector::hive::HiveColumnHandle::ColumnType columnType(
 } // namespace
 
 velox::connector::ColumnHandlePtr HiveConnectorMetadata::createColumnHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layout,
     const std::string& columnName,
     std::vector<velox::common::Subfield> subfields,
@@ -58,6 +59,7 @@ velox::connector::ColumnHandlePtr HiveConnectorMetadata::createColumnHandle(
 
 velox::connector::ConnectorTableHandlePtr
 HiveConnectorMetadata::createTableHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layout,
     std::vector<velox::connector::ColumnHandlePtr> columnHandles,
     velox::core::ExpressionEvaluator& evaluator,
@@ -121,9 +123,9 @@ std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(
 } // namespace
 
 ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
+    const ConnectorSessionPtr& session,
     const TablePtr& table,
-    WriteKind kind,
-    const ConnectorSessionPtr& session) {
+    WriteKind kind) {
   ensureInitialized();
   VELOX_CHECK(
       kind == WriteKind::kCreate || kind == WriteKind::kInsert,
@@ -151,7 +153,7 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
   for (const auto& name : hiveLayout->rowType()->names()) {
     inputColumns.push_back(std::static_pointer_cast<
                            const velox::connector::hive::HiveColumnHandle>(
-        createColumnHandle(*hiveLayout, name)));
+        createColumnHandle(session, *hiveLayout, name)));
   }
 
   std::shared_ptr<const velox::connector::hive::HiveBucketProperty>

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -40,11 +40,6 @@ struct HivePartitionHandle : public PartitionHandle {
   const std::optional<int32_t> tableBucketNumber;
 };
 
-class HiveConnectorSession : public ConnectorSession {
- public:
-  ~HiveConnectorSession() override = default;
-};
-
 /// Describes a Hive table layout. Adds a file format and a list of
 /// Hive partitioning columns and an optional bucket count to the base
 /// TableLayout. The partitioning in TableLayout referes to bucketing.
@@ -164,6 +159,7 @@ class HiveConnectorMetadata : public ConnectorMetadata {
             hiveConnector->connectorConfig())) {}
 
   velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       const std::string& columnName,
       std::vector<velox::common::Subfield> subfields = {},
@@ -171,6 +167,7 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       SubfieldMapping subfieldMapping = {}) override;
 
   velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,
       velox::core::ExpressionEvaluator& evaluator,
@@ -180,9 +177,9 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       std::optional<LookupKeys> lookupKeys) override;
 
   ConnectorWriteHandlePtr beginWrite(
+      const ConnectorSessionPtr& session,
       const TablePtr& table,
-      WriteKind kind,
-      const ConnectorSessionPtr& session) override;
+      WriteKind kind) override;
 
  protected:
   virtual void ensureInitialized() const {}

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -63,10 +63,13 @@ class LocalHiveConnectorMetadata;
 class LocalHiveSplitManager : public ConnectorSplitManager {
  public:
   LocalHiveSplitManager(LocalHiveConnectorMetadata* /* metadata */) {}
+
   std::vector<PartitionHandlePtr> listPartitions(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 
   std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       SplitOptions options = {}) override;
@@ -235,19 +238,19 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const std::string& queryId);
 
   TablePtr createTable(
+      const ConnectorSessionPtr& session,
       const std::string& tableName,
       const velox::RowTypePtr& rowType,
-      const folly::F14FastMap<std::string, std::string>& options,
-      const ConnectorSessionPtr& session) override;
+      const folly::F14FastMap<std::string, std::string>& options) override;
 
   velox::ContinueFuture finishWrite(
+      const ConnectorSessionPtr& session,
       const ConnectorWriteHandlePtr& handle,
-      const std::vector<velox::RowVectorPtr>& /*writerResult*/,
-      const ConnectorSessionPtr& /*session*/) override;
+      const std::vector<velox::RowVectorPtr>& writerResult) override;
 
   velox::ContinueFuture abortWrite(
-      const ConnectorWriteHandlePtr& handle,
-      const ConnectorSessionPtr& session) override;
+      const ConnectorSessionPtr& session,
+      const ConnectorWriteHandlePtr& handle) override;
 
   std::string tablePath(std::string_view table) const override {
     return fmt::format("{}/{}", hiveConfig_->hiveLocalDataPath(), table);

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -62,11 +62,13 @@ std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {
 }
 
 std::vector<PartitionHandlePtr> TestSplitManager::listPartitions(
+    const ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr&) {
   return {std::make_shared<PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
+    const ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& partitions,
     SplitOptions) {
@@ -85,6 +87,7 @@ TablePtr TestConnectorMetadata::findTable(std::string_view name) {
 }
 
 velox::connector::ColumnHandlePtr TestConnectorMetadata::createColumnHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layout,
     const std::string& columnName,
     std::vector<velox::common::Subfield>,
@@ -99,6 +102,7 @@ velox::connector::ColumnHandlePtr TestConnectorMetadata::createColumnHandle(
 
 velox::connector::ConnectorTableHandlePtr
 TestConnectorMetadata::createTableHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layout,
     std::vector<velox::connector::ColumnHandlePtr> columnHandles,
     velox::core::ExpressionEvaluator& /* evaluator */,

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -146,9 +146,11 @@ class TestSplitSource : public SplitSource {
 class TestSplitManager : public ConnectorSplitManager {
  public:
   std::vector<PartitionHandlePtr> listPartitions(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 
   std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       SplitOptions options = {}) override;
@@ -252,6 +254,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   }
 
   velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       const std::string& columnName,
       std::vector<velox::common::Subfield> subfields = {},
@@ -259,6 +262,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
       SubfieldMapping subfieldMapping = {}) override;
 
   velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,
       velox::core::ExpressionEvaluator& evaluator,

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -108,7 +108,8 @@ TEST_F(TestConnectorTest, columnHandle) {
   auto table = metadata_->findTable("table");
   auto& layout = *table->layouts()[0];
 
-  auto columnHandle = metadata_->createColumnHandle(layout, "a");
+  auto columnHandle =
+      metadata_->createColumnHandle(/*session=*/nullptr, layout, "a");
   EXPECT_NE(columnHandle, nullptr);
 
   auto testColumnHandle =
@@ -163,14 +164,21 @@ TEST_F(TestConnectorTest, dataSource) {
   auto& layout = *table->layouts()[0];
 
   std::vector<velox::connector::ColumnHandlePtr> columns;
-  columns.push_back(metadata_->createColumnHandle(layout, "a"));
-  columns.push_back(metadata_->createColumnHandle(layout, "b"));
+  columns.push_back(
+      metadata_->createColumnHandle(/*session=*/nullptr, layout, "a"));
+  columns.push_back(
+      metadata_->createColumnHandle(/*session=*/nullptr, layout, "b"));
 
   auto evaluator =
       std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
   std::vector<core::TypedExprPtr> empty;
   auto tableHandle = metadata_->createTableHandle(
-      layout, std::move(columns), *evaluator, empty, empty);
+      /*session=*/nullptr,
+      layout,
+      std::move(columns),
+      *evaluator,
+      empty,
+      empty);
 
   auto vector1 = makeRowVector(
       {makeFlatVector<int>({0, 1}), makeFlatVector<StringView>({"a", "b"})});
@@ -180,8 +188,10 @@ TEST_F(TestConnectorTest, dataSource) {
   connector_->appendData("table", vector2);
 
   velox::connector::ColumnHandleMap handleMap;
-  handleMap.emplace("a", metadata_->createColumnHandle(layout, "a"));
-  handleMap.emplace("b", metadata_->createColumnHandle(layout, "b"));
+  handleMap.emplace(
+      "a", metadata_->createColumnHandle(/*session=*/nullptr, layout, "a"));
+  handleMap.emplace(
+      "b", metadata_->createColumnHandle(/*session=*/nullptr, layout, "b"));
   auto dataSource = std::make_shared<TestDataSource>(
       schema, std::move(handleMap), table, pool());
   EXPECT_EQ(dataSource->getCompletedRows(), 0);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -69,11 +69,13 @@ double getScaleFactor(const std::string& schema) {
 } // namespace
 
 std::vector<PartitionHandlePtr> TpchSplitManager::listPartitions(
+    const connector::ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
   return {std::make_shared<connector::PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
+    const connector::ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     SplitOptions options) {
@@ -146,6 +148,7 @@ TpchConnectorMetadata::TpchConnectorMetadata(
 }
 
 velox::connector::ColumnHandlePtr TpchConnectorMetadata::createColumnHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layoutData,
     const std::string& columnName,
     std::vector<velox::common::Subfield> subfields,
@@ -156,6 +159,7 @@ velox::connector::ColumnHandlePtr TpchConnectorMetadata::createColumnHandle(
 
 velox::connector::ConnectorTableHandlePtr
 TpchConnectorMetadata::createTableHandle(
+    const ConnectorSessionPtr& session,
     const TableLayout& layout,
     std::vector<velox::connector::ColumnHandlePtr> /*columnHandles*/,
     velox::core::ExpressionEvaluator& /*evaluator*/,

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -19,7 +19,6 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/tpch/TpchConnector.h"
-#include "velox/core/QueryCtx.h"
 #include "velox/tpch/gen/TpchGen.h"
 
 namespace facebook::axiom::connector::tpch {
@@ -57,9 +56,11 @@ class TpchSplitManager : public ConnectorSplitManager {
   TpchSplitManager(TpchConnectorMetadata* /* metadata */) {}
 
   std::vector<PartitionHandlePtr> listPartitions(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 
   std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       SplitOptions options = {}) override;
@@ -184,6 +185,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   }
 
   velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layoutData,
       const std::string& columnName,
       std::vector<velox::common::Subfield> subfields = {},
@@ -191,6 +193,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
       SubfieldMapping subfieldMapping = {}) override;
 
   velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
       const TableLayout& layout,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,
       velox::core::ExpressionEvaluator& evaluator,

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -118,7 +118,8 @@ TEST_F(TpchConnectorMetadataTest, createColumnHandle) {
   const auto& layouts = table->layouts();
   ASSERT_FALSE(layouts.empty());
 
-  auto columnHandle = metadata_->createColumnHandle(*layouts[0], "orderkey");
+  auto columnHandle = metadata_->createColumnHandle(
+      /*session=*/nullptr, *layouts[0], "orderkey");
   ASSERT_NE(columnHandle, nullptr);
 
   auto* tpchColumnHandle =
@@ -142,7 +143,12 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
   auto evaluator = std::make_unique<velox::exec::SimpleExpressionEvaluator>(
       nullptr, nullptr);
   auto tableHandle = metadata_->createTableHandle(
-      *layouts[0], columnHandles, *evaluator, empty, empty);
+      /*session=*/nullptr,
+      *layouts[0],
+      columnHandles,
+      *evaluator,
+      empty,
+      empty);
   ASSERT_NE(tableHandle, nullptr);
 
   auto* tpchTableHandle =
@@ -170,13 +176,20 @@ TEST_F(TpchConnectorMetadataTest, splitGeneration) {
   auto evaluator = std::make_unique<velox::exec::SimpleExpressionEvaluator>(
       nullptr, nullptr);
   auto tableHandle = metadata_->createTableHandle(
-      *layouts[0], columnHandles, *evaluator, empty, empty);
+      /*session=*/nullptr,
+      *layouts[0],
+      columnHandles,
+      *evaluator,
+      empty,
+      empty);
   ASSERT_NE(tableHandle, nullptr);
 
-  auto partitions = splitManager->listPartitions(tableHandle);
+  auto partitions =
+      splitManager->listPartitions(/*session=*/nullptr, tableHandle);
   ASSERT_EQ(partitions.size(), 1);
 
-  auto splitSource = splitManager->getSplitSource(tableHandle, partitions);
+  auto splitSource = splitManager->getSplitSource(
+      /*session=*/nullptr, tableHandle, partitions);
   ASSERT_NE(splitSource, nullptr);
   auto splits = splitSource->getSplits(1024 * 1024); // 1MB target
   ASSERT_FALSE(splits.empty());

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -15,10 +15,9 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <algorithm>
 #include <cstdint>
-#include <string>
-#include <vector>
 
 namespace facebook::axiom::optimizer {
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -195,7 +195,10 @@ void ToVelox::filterUpdated(BaseTableCP table, bool updateSelectivity) {
     auto subfields = columnSubfields(table, id.value());
 
     columns.push_back(metadata->createColumnHandle(
-        *layout, dataColumns->nameOf(i), std::move(subfields)));
+        /*session=*/nullptr,
+        *layout,
+        dataColumns->nameOf(i),
+        std::move(subfields)));
   }
   auto allFilters = std::move(pushdownConjuncts);
   if (remainingFilter) {
@@ -203,7 +206,12 @@ void ToVelox::filterUpdated(BaseTableCP table, bool updateSelectivity) {
   }
   std::vector<velox::core::TypedExprPtr> rejectedFilters;
   auto handle = metadata->createTableHandle(
-      *layout, columns, *evaluator, std::move(allFilters), rejectedFilters);
+      /*session=*/nullptr,
+      *layout,
+      columns,
+      *evaluator,
+      std::move(allFilters),
+      rejectedFilters);
 
   setLeafHandle(table->id(), handle, std::move(rejectedFilters));
   if (updateSelectivity) {
@@ -1059,7 +1067,10 @@ velox::core::PlanNodePtr ToVelox::makeScan(
     auto scanColumnName =
         isSubfieldPushdown ? column->name() : column->outputName();
     assignments[scanColumnName] = connectorMetadata->createColumnHandle(
-        *scan.index->layout, column->name(), std::move(subfields));
+        /*session=*/nullptr,
+        *scan.index->layout,
+        column->name(),
+        std::move(subfields));
   }
 
   velox::core::PlanNodePtr result =

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -34,6 +34,7 @@ class SplitSourceFactory {
   /// the fragment. The source will be invoked to produce splits for
   /// each individual worker running the scan.
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) = 0;
 };
 
@@ -47,6 +48,7 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
       : nodeSplitMap_(std::move(nodeSplitMap)) {}
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) override;
 
  private:
@@ -63,6 +65,7 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
       : options_(std::move(options)) {}
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) override;
 
  protected:
@@ -135,6 +138,7 @@ class LocalRunner : public Runner,
   void makeStages(const std::shared_ptr<velox::exec::Task>& lastStageTask);
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan);
 
   // Serializes 'cursor_' and 'error_'.


### PR DESCRIPTION
Summary:
Repurpose unused ConnectorSession to store read-only query-specific information. Start by storing query ID. Add session argument to connector APIs. Pass nullptr from the callers.

A follow-up will 
- introduce a Session class with a toConnector(connectorId) method for creating ConnectorSession views;
- update Optimizer API to take Session;
- update implementation to create ConnectorSessions and pass these to connector APIs.

Reviewed By: hdikeman

Differential Revision: D84167014


