### PR TITLE
feat: Add option to use syntactic join order

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -126,6 +126,11 @@ struct DerivedTable : public PlanObject {
   /// not try to further restrict this with probe side.
   bool noImportOfExists{false};
 
+  /// A list of PlanObject IDs for 'tables' in the order of appearance in the
+  /// query. Used to produce syntactic join order if requested. Table with id
+  /// joinOrder[i] can only be placed after tables before it are placed.
+  std::vector<int32_t, QGAllocator<int32_t>> joinOrder;
+
   /// Postprocessing clauses: group by, having, order by, limit, offset.
 
   AggregationPlanCP aggregation{nullptr};
@@ -172,6 +177,13 @@ struct DerivedTable : public PlanObject {
 
   bool isTable() const override {
     return true;
+  }
+
+  void addTable(PlanObjectCP table) {
+    tables.push_back(table);
+    tableSet.add(table);
+
+    joinOrder.push_back(table->id());
   }
 
   /// True if 'table' is of 'this'.

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -173,6 +173,9 @@ std::string visitDerivedTable(const DerivedTable& dt) {
     for (const auto& joinEdge : dt.joins) {
       out << "    " << visitJoinEdge(*joinEdge) << std::endl;
     }
+
+    out << "  syntactic join order: " << folly::join(", ", dt.joinOrder)
+        << std::endl;
   }
 
   if (dt.hasAggregation()) {

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <iostream>
 #include <utility>
+#include "axiom/optimizer/DerivedTablePrinter.h"
+#include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PrecomputeProjection.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "velox/expression/Expr.h"
@@ -40,6 +42,7 @@ Optimization::Optimization(
       logicalPlan_(&logicalPlan),
       history_(history),
       veloxQueryCtx_(std::move(veloxQueryCtx)),
+      topState_{*this, nullptr},
       toGraph_{schema, evaluator, options_},
       toVelox_{session_, runnerOptions_, options_} {
   queryCtx()->optimization() = this;
@@ -299,12 +302,12 @@ void forJoinedTables(const PlanState& state, Func func) {
             break;
           }
         }
-        if (usable) {
+        if (usable && state.mayConsiderNext(join->rightTable())) {
           func(join, join->rightTable(), join->lrFanout());
         }
       } else {
         auto [table, fanout] = join->otherTable(placedTable);
-        if (!state.dt->hasTable(table)) {
+        if (!state.dt->hasTable(table) || !state.mayConsiderNext(table)) {
           continue;
         }
         func(join, table, fanout);
@@ -346,7 +349,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
           candidates.emplace_back(join, joined, fanout);
           if (join->isInner()) {
             if (!addExtraEdges(state, candidates.back())) {
-              // Drop the candidate if the edge was a subsumed in some other
+              // Drop the candidate if the edge was subsumed in some other
               // edge.
               candidates.pop_back();
             }
@@ -354,16 +357,18 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
         }
       });
 
-  // Take the  first hand joined tables and bundle them with reducing joins that
+  // Take the first hand joined tables and bundle them with reducing joins that
   // can go on the build side.
   std::vector<JoinCandidate> bushes;
-  for (auto& candidate : candidates) {
-    if (auto bush = reducingJoins(state, candidate)) {
-      bushes.push_back(std::move(bush.value()));
+  if (!options_.syntacticJoinOrder) {
+    for (auto& candidate : candidates) {
+      if (auto bush = reducingJoins(state, candidate)) {
+        bushes.push_back(std::move(bush.value()));
+      }
     }
+    candidates.insert(candidates.begin(), bushes.begin(), bushes.end());
   }
 
-  candidates.insert(candidates.begin(), bushes.begin(), bushes.end());
   std::ranges::sort(
       candidates, [](const JoinCandidate& left, const JoinCandidate& right) {
         return left.fanout < right.fanout;
@@ -371,7 +376,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   if (candidates.empty()) {
     // There are no join edges. There could still be cross joins.
     state.dt->startTables.forEach([&](PlanObjectCP object) {
-      if (!state.placed.contains(object)) {
+      if (!state.placed.contains(object) && state.mayConsiderNext(object)) {
         candidates.emplace_back(nullptr, object, tableCardinality(object));
       }
     });
@@ -674,6 +679,28 @@ bool isRedundantProject(
   return true;
 }
 
+// Check if 'plan' is an identity projection. If so, return its input.
+// Otherwise, return 'plan'.
+const RelationOpPtr& maybeDropProject(const RelationOpPtr& plan) {
+  if (plan->is(RelType::kProject)) {
+    bool redundant = true;
+
+    const auto* project = plan->as<Project>();
+    for (auto i = 0; i < project->columns().size(); ++i) {
+      if (project->columns()[i] != project->exprs()[i]) {
+        redundant = false;
+        break;
+      }
+    }
+
+    if (redundant) {
+      return plan->input();
+    }
+  }
+
+  return plan;
+}
+
 } // namespace
 
 void Optimization::addPostprocess(
@@ -702,9 +729,21 @@ void Optimization::addPostprocess(
   }
 
   if (!dt->columns.empty()) {
-    ExprVector exprs = state.exprsToColumns(dt->exprs);
+    ColumnVector usedColumns;
+    ExprVector usedExprs;
+    for (auto i = 0; i < dt->exprs.size(); ++i) {
+      const auto* expr = dt->exprs[i];
+      if (state.targetExprs.contains(expr)) {
+        usedColumns.emplace_back(dt->columns[i]);
+        usedExprs.emplace_back(state.toColumn(expr));
+      }
+    }
+
     plan = make<Project>(
-        plan, exprs, dt->columns, isRedundantProject(plan, exprs, dt->columns));
+        maybeDropProject(plan),
+        usedExprs,
+        usedColumns,
+        isRedundantProject(plan, usedExprs, usedColumns));
   }
 
   if (!dt->hasOrderBy() && dt->limit > kMaxLimitBeforeProject) {
@@ -1249,12 +1288,13 @@ void Optimization::addJoin(
   }
 
   std::vector<NextJoin> toTry;
-
   joinByIndex(plan, candidate, state, toTry);
 
   const auto sizeAfterIndex = toTry.size();
   joinByHash(plan, candidate, state, toTry);
-  if (toTry.size() > sizeAfterIndex && candidate.join->isNonCommutative() &&
+
+  if (!options_.syntacticJoinOrder && toTry.size() > sizeAfterIndex &&
+      candidate.join->isNonCommutative() &&
       candidate.join->hasRightHashVariant()) {
     // There is a hash based candidate with a non-commutative join. Try a right
     // join variant.
@@ -1561,13 +1601,22 @@ std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
 } // namespace
 
 void Optimization::makeJoins(PlanState& state) {
-  auto firstTables = state.dt->startTables.toObjects();
+  PlanObjectVector firstTables;
+
+  if (options_.syntacticJoinOrder) {
+    const auto firstTableId = state.dt->joinOrder[0];
+    VELOX_CHECK(state.dt->startTables.BitSet::contains(firstTableId));
+
+    firstTables.push_back(queryCtx()->objectAt(firstTableId));
+  } else {
+    firstTables = state.dt->startTables.toObjects();
 
 #ifndef NDEBUG
-  for (auto table : firstTables) {
-    state.debugSetFirstTable(table->id());
-  }
+    for (auto table : firstTables) {
+      state.debugSetFirstTable(table->id());
+    }
 #endif
+  }
 
   auto sortedIndices = sortByStartingScore(firstTables);
 
@@ -1658,6 +1707,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   for (auto& candidate : candidates) {
     addJoin(candidate, plan, state, nextJoins);
   }
+
   tryNextJoins(state, nextJoins);
 }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -335,7 +335,7 @@ class Optimization {
 
   // The top level PlanState. Contains the set of top level interesting plans.
   // Must stay alive as long as the Plans and RelationOps are reeferenced.
-  PlanState topState_{*this, nullptr};
+  PlanState topState_;
 
   // Controls tracing.
   int32_t traceFlags_{0};

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -58,6 +58,11 @@ struct OptimizerOptions {
   /// Produce trace of plan candidates.
   uint32_t traceFlags{0};
 
+  /// Disable cost-based join order selection. Perform the joins in the exact
+  /// sequence specified in the query.
+  /// TODO Make this work for non-inner joins.
+  bool syntacticJoinOrder = false;
+
   bool isMapAsStruct(const char* table, const char* column) const {
     if (allMapsAsStruct) {
       return true;

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -67,7 +67,7 @@ std::string PlanObjectSet::toString(bool names) const {
   forEach([&](auto object) {
     out << object->id();
     if (names) {
-      out << ": " << object->toString() << std::endl;
+      out << ": " << object->toString() << " ";
     } else {
       out << " ";
     }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -865,8 +865,12 @@ velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
   std::vector<velox::column_index_t> keyIndices;
   keyIndices.reserve(keys.size());
   for (const auto& key : keys) {
+    VELOX_CHECK(
+        key->isFieldAccessKind(),
+        "Expected field reference, but got: {}",
+        key->toString());
     keyIndices.push_back(inputType->getChildIdx(
-        dynamic_cast<const velox::core::FieldAccessTypedExpr*>(key.get())
+        key->template asUnchecked<velox::core::FieldAccessTypedExpr>()
             ->name()));
   }
   return std::make_shared<HashPartitionFunctionSpec>(

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ add_executable(
   PlanTest.cpp
   UnnestTest.cpp
   ParquetTpchTest.cpp
+  SyntacticJoinOrderTest.cpp
   SubfieldTest.cpp
   FeatureGen.cpp
   Genies.cpp

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -168,6 +168,7 @@ TEST_F(DerivedTablePrinterTest, basic) {
             testing::Eq("  tables: t2, t3"),
             testing::Eq("  joins:"),
             testing::Eq("    t2 LEFT t3 ON t2.a = t3.x"),
+            testing::Eq("  syntactic join order: 3, 8"),
             testing::Eq("  aggregates: sum(multiply(t2.b, t3.y)) AS sum"),
             testing::Eq("  grouping keys: t2.a"),
             testing::Eq(""),

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -383,7 +383,7 @@ TEST_F(PlanTest, specialFormConstantFold) {
     ASSERT_TRUE(matcher->match(plan));
   }
 
-  std::vector<TestCase> prjectTestCases = {
+  std::vector<TestCase> projectTestCases = {
       {"if(2 > 1, 1, 0)", "1"},
       {"if(2 < 1, 1, 0)", "0"},
       {"cast(1 as BOOLEAN)", "true"},
@@ -408,7 +408,7 @@ TEST_F(PlanTest, specialFormConstantFold) {
       {"coalesce(cast(null as bigint), 5 * 2)", "10"},
   };
 
-  for (const auto& testCase : prjectTestCases) {
+  for (const auto& testCase : projectTestCases) {
     SCOPED_TRACE("Expression: " + testCase.expression);
     auto logicalPlan = lp::PlanBuilder()
                            .tableScan(kTestConnectorId, "numbers")
@@ -576,7 +576,6 @@ TEST_F(PlanTest, filterImport) {
   auto ordersType = ROW({"o_custkey", "o_totalprice"}, {BIGINT(), DOUBLE()});
 
   const auto connectorId = exec::test::kHiveConnectorId;
-  const auto connector = velox::connector::getConnector(connectorId);
 
   auto logicalPlan = lp::PlanBuilder()
                          .tableScan(connectorId, "orders", ordersType->names())

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -91,6 +91,14 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
           .numDrivers = 4,
       });
 
+  void checkSame(
+      const logical_plan::LogicalPlanNodePtr& planNode,
+      const std::vector<velox::RowVectorPtr>& referenceResult,
+      const axiom::runner::MultiFragmentPlan::Options& options = {
+          .numWorkers = 4,
+          .numDrivers = 4,
+      });
+
   velox::core::PlanNodePtr toSingleNodePlan(
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       int32_t numDrivers = 1);
@@ -101,6 +109,10 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
       int32_t numDrivers = 1) {
     checkSame(
         planNode, referencePlan, {.numWorkers = 1, .numDrivers = numDrivers});
+  }
+
+  velox::memory::MemoryPool& optimizerPool() const {
+    return *optimizerPool_;
   }
 
   std::shared_ptr<velox::core::QueryCtx>& getQueryCtx();

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/ParquetTpchTest.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/PrestoParser.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+#define AXIOM_ASSERT_PLAN(plan, matcher) \
+  ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+
+class SyntacticJoinOrderTest : public test::QueryTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::QueryTestBase::SetUpTestCase();
+
+    gTempDirectory = velox::exec::test::TempDirectoryPath::create();
+
+    auto path = gTempDirectory->getPath();
+    test::ParquetTpchTest::createTables(path);
+
+    LocalRunnerTestBase::localDataPath_ = path;
+    LocalRunnerTestBase::localFileFormat_ =
+        velox::dwio::common::FileFormat::PARQUET;
+  }
+
+  static void TearDownTestCase() {
+    gTempDirectory.reset();
+    test::QueryTestBase::TearDownTestCase();
+  }
+
+  lp::LogicalPlanNodePtr parseSql(const std::string& sql) const {
+    test::PrestoParser parser{exec::test::kHiveConnectorId, &optimizerPool()};
+    auto statement = parser.parse(sql);
+    VELOX_CHECK(statement->isSelect());
+
+    return statement->asUnchecked<test::SelectStatement>()->plan();
+  }
+
+  inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
+      gTempDirectory;
+};
+
+TEST_F(SyntacticJoinOrderTest, innerJoins) {
+  lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
+
+  optimizerOptions_.sampleJoins = false;
+
+  auto startMatcher = [](const auto& tableName) {
+    return core::PlanMatcherBuilder().tableScan(tableName);
+  };
+
+  // Optimized join order: lineitem x (customer x orders).
+  auto optimizedMatcher =
+      startMatcher("lineitem")
+          .hashJoin(startMatcher("customer")
+                        .hashJoin(startMatcher("orders").build())
+                        .build())
+          .aggregation()
+          .build();
+
+  // Reference Velox plan.
+  auto* metadata =
+      connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto startReferencePlan = [&](const auto& tableName) {
+    return exec::test::PlanBuilder(planNodeIdGenerator)
+        .tableScan(tableName, metadata->findTable(tableName)->type());
+  };
+
+  auto referencePlan =
+      startReferencePlan("lineitem")
+          .filter("l_shipdate > date '1995-03-15'")
+          .hashJoin(
+              {"l_orderkey"},
+              {"o_orderkey"},
+              startReferencePlan("customer")
+                  .filter("c_mktsegment = 'BUILDING'")
+                  .hashJoin(
+                      {"c_custkey"},
+                      {"o_custkey"},
+                      startReferencePlan("orders")
+                          .filter("o_orderdate < date '1995-03-15'")
+                          .planNode(),
+                      /*filter=*/"",
+                      {"o_orderkey"})
+                  .planNode(),
+              /*filter=*/"",
+              {})
+          .singleAggregation({}, {"count(1)"})
+          .planNode();
+
+  auto reference = runVelox(referencePlan);
+  auto referenceResults = reference.results;
+
+  // Syntactic join order: (a x b) x c.
+  {
+    // Test all possible join orders that do not involve cross joins (i.e. do
+    // not start with lineitem x customer).
+    std::vector<std::vector<std::string>> testOrders = {
+        {"customer", "orders", "lineitem"},
+        // {"customer", "lineitem", "orders"},
+        {"orders", "customer", "lineitem"},
+        {"orders", "lineitem", "customer"},
+        // {"lineitem", "customer", "orders"},
+        {"lineitem", "orders", "customer"},
+    };
+
+    for (const auto& order : testOrders) {
+      SCOPED_TRACE(folly::join(", ", order));
+
+      auto logicalPlan =
+          lp::PlanBuilder(context)
+              .tableScan(order[0])
+              .crossJoin(lp::PlanBuilder(context).tableScan(order[1]))
+              .crossJoin(lp::PlanBuilder(context).tableScan(order[2]))
+              .filter("c_mktsegment = 'BUILDING'")
+              .filter("c_custkey = o_custkey")
+              .filter("l_orderkey = o_orderkey")
+              .filter("o_orderdate < date '1995-03-15'")
+              .filter("l_shipdate > date '1995-03-15'")
+              .aggregate({}, {"count(1)"})
+              .build();
+
+      {
+        optimizerOptions_.syntacticJoinOrder = false;
+        auto plan = toSingleNodePlan(logicalPlan);
+        AXIOM_ASSERT_PLAN(plan, optimizedMatcher);
+      }
+
+      {
+        optimizerOptions_.syntacticJoinOrder = true;
+        auto plan = toSingleNodePlan(logicalPlan);
+
+        auto matcher = startMatcher(order[0])
+                           .hashJoin(startMatcher(order[1]).build())
+                           .hashJoin(startMatcher(order[2]).build())
+                           .aggregation()
+                           .build();
+        AXIOM_ASSERT_PLAN(plan, matcher);
+
+        checkSame(logicalPlan, referenceResults);
+      }
+    }
+  }
+
+  // Syntactic join order: a x (b x c).
+  {
+    // Until we add support for x-joins, we need to make sure that intital DTs
+    // do not contain x-joins. Hence, we provide a filter to join b x c in the
+    // test orders below.
+
+    // Test all possible join orders that do not involve
+    // cross joins (i.e. do not join lineitem x customer).
+    std::vector<std::pair<std::vector<std::string>, std::string>> testOrders = {
+        {{"customer", "orders", "lineitem"}, "l_orderkey = o_orderkey"},
+        {{"customer", "lineitem", "orders"}, "l_orderkey = o_orderkey"},
+        // {"orders", "customer", "lineitem"},
+        // {"orders", "lineitem", "customer"},
+        {{"lineitem", "customer", "orders"}, "c_custkey = o_custkey"},
+        {{"lineitem", "orders", "customer"}, "c_custkey = o_custkey"},
+    };
+
+    for (const auto& [order, filter] : testOrders) {
+      SCOPED_TRACE(folly::join(", ", order));
+
+      auto logicalPlan =
+          lp::PlanBuilder(context)
+              .tableScan(order[0])
+              .crossJoin(lp::PlanBuilder(context).tableScan(order[1]).join(
+                  lp::PlanBuilder(context).tableScan(order[2]),
+                  filter,
+                  lp::JoinType::kInner))
+              .filter("c_mktsegment = 'BUILDING'")
+              .filter("c_custkey = o_custkey")
+              .filter("l_orderkey = o_orderkey")
+              .filter("o_orderdate < date '1995-03-15'")
+              .filter("l_shipdate > date '1995-03-15'")
+              .aggregate({}, {"count(1)"})
+              .build();
+
+      {
+        optimizerOptions_.syntacticJoinOrder = false;
+        auto plan = toSingleNodePlan(logicalPlan);
+        AXIOM_ASSERT_PLAN(plan, optimizedMatcher);
+      }
+
+      {
+        optimizerOptions_.syntacticJoinOrder = true;
+        auto plan = toSingleNodePlan(logicalPlan);
+
+        auto matcher =
+            startMatcher(order[0])
+                .hashJoin(startMatcher(order[1])
+                              .hashJoin(startMatcher(order[2]).build())
+                              .build())
+                .aggregation()
+                .build();
+        AXIOM_ASSERT_PLAN(plan, matcher);
+
+        checkSame(logicalPlan, referenceResults);
+      }
+    }
+  }
+}
+
+TEST_F(SyntacticJoinOrderTest, outerJoins) {
+  optimizerOptions_.sampleJoins = false;
+
+  auto startMatcher = [](const auto& tableName) {
+    return core::PlanMatcherBuilder().tableScan(tableName);
+  };
+
+  // Optimized join order: lineitem x orders.
+  auto optimizedMatcher =
+      startMatcher("lineitem")
+          .hashJoin(startMatcher("orders").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  // Reference Velox plan.
+  auto* metadata =
+      connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto startReferencePlan = [&](const auto& tableName) {
+    return exec::test::PlanBuilder(planNodeIdGenerator)
+        .tableScan(tableName, metadata->findTable(tableName)->type());
+  };
+
+  auto referencePlan = startReferencePlan("lineitem")
+                           .hashJoin(
+                               {"l_orderkey"},
+                               {"o_orderkey"},
+                               startReferencePlan("orders").planNode(),
+                               /*filter=*/"l_returnflag = 'R'",
+                               {},
+                               core::JoinType::kLeft)
+                           .singleAggregation({}, {"count(1)"})
+                           .planNode();
+
+  auto reference = runVelox(referencePlan);
+  auto referenceResults = reference.results;
+
+  // Syntactic join order: a LEFT JOIN b.
+  {
+    auto logicalPlan = parseSql(
+        "SELECT count(*) FROM lineitem LEFT JOIN orders ON "
+        "l_orderkey = o_orderkey and l_returnflag = 'R'");
+
+    {
+      optimizerOptions_.syntacticJoinOrder = false;
+      auto plan = toSingleNodePlan(logicalPlan);
+      AXIOM_ASSERT_PLAN(plan, optimizedMatcher);
+
+      checkSame(logicalPlan, referenceResults);
+    }
+
+    {
+      optimizerOptions_.syntacticJoinOrder = true;
+      auto plan = toSingleNodePlan(logicalPlan);
+      AXIOM_ASSERT_PLAN(plan, optimizedMatcher);
+
+      checkSame(logicalPlan, referenceResults);
+    }
+  }
+
+  // Syntactic join order: b RIGHT JOIN a.
+  {
+    auto logicalPlan = parseSql(
+        "SELECT count(*) FROM orders RIGHT JOIN lineitem ON "
+        "l_orderkey = o_orderkey and l_returnflag = 'R'");
+
+    {
+      optimizerOptions_.syntacticJoinOrder = false;
+      auto plan = toSingleNodePlan(logicalPlan);
+      AXIOM_ASSERT_PLAN(plan, optimizedMatcher);
+
+      checkSame(logicalPlan, referenceResults);
+    }
+
+    {
+      optimizerOptions_.syntacticJoinOrder = true;
+      auto plan = toSingleNodePlan(logicalPlan);
+
+      auto matcher =
+          startMatcher("orders")
+              .hashJoin(
+                  startMatcher("lineitem").build(), core::JoinType::kRight)
+              .aggregation()
+              .build();
+      AXIOM_ASSERT_PLAN(plan, matcher);
+
+      checkSame(logicalPlan, referenceResults);
+    }
+  }
+}
+
+#undef AXIOM_ASSERT_PLAN
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary: Add OptimizerOptions::syntacticJoinOrder flag to disable cost-base join order selection and produce the joins sequence as specified in the query.

Differential Revision: D84203333


