### PR TITLE
fix: Fix distribution and plan enumeration

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -478,33 +478,33 @@ bool isIndexColocated(
     const IndexInfo& info,
     const ExprVector& lookupValues,
     const RelationOpPtr& input) {
-  const auto& distribution = info.index->distribution;
-  if (distribution.isBroadcast) {
-    return true;
+  const auto& current = input->distribution();
+  const auto& desired = info.index->distribution;
+  if (const auto needsShuffle = current.maybeNeedsShuffle(desired)) {
+    return !*needsShuffle;
   }
 
+  // TODO: Code in this function actually doesn't feel right.
+
+  if (!hasCopartition(current.partitionType(), desired.partitionType())) {
+    return false;
+  }
+
+  if (current.partition.empty()) {
+    return false;
+  }
+
+  if (current.partition.size() != desired.partition.size()) {
+    return false;
+  }
+
+  // We should check it when we will add indexes.
   // True if 'input' is partitioned so that each partitioning key is joined to
   // the corresponding partition key in 'info'.
-  if (input->distribution().distributionType != distribution.distributionType) {
-    return false;
-  }
-
-  if (input->distribution().partition.empty()) {
-    return false;
-  }
-
-  if (input->distribution().partition.size() != distribution.partition.size()) {
-    return false;
-  }
-
-  for (auto i = 0; i < input->distribution().partition.size(); ++i) {
-    auto nthKey = position(lookupValues, *input->distribution().partition[i]);
-    if (nthKey != kNotFound) {
-      if (info.schemaColumn(info.lookupKeys.at(nthKey)) !=
-          distribution.partition.at(i)) {
-        return false;
-      }
-    } else {
+  for (size_t i = 0; i < current.partition.size(); ++i) {
+    auto nthKey = position(lookupValues, *current.partition[i]);
+    if (nthKey == kNotFound ||
+        info.schemaColumn(info.lookupKeys[nthKey]) != desired.partition[i]) {
       return false;
     }
   }
@@ -699,16 +699,6 @@ const RelationOpPtr& maybeDropProject(const RelationOpPtr& plan) {
   return plan;
 }
 
-const connector::PartitionType* copartitionType(
-    const connector::PartitionType* first,
-    const connector::PartitionType* second) {
-  if (first != nullptr && second != nullptr) {
-    return first->copartition(*second);
-  }
-
-  return nullptr;
-}
-
 RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
   if (isSingleWorker() || plan->distribution().isGather()) {
     return plan;
@@ -740,15 +730,11 @@ RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
     keyValues.emplace_back(write->columnExprs().at(index));
   }
 
-  const auto* planPartitionType =
-      plan->distribution().distributionType.partitionType();
-
-  auto copartition =
-      copartitionType(planPartitionType, layout->partitionType());
+  const auto* planPartitionType = plan->distribution().partitionType();
 
   // Copartitioning is possible if PartitionTypes are compatible and the table
   // has no fewer partitions than the plan.
-  bool shuffle = !copartition || copartition != planPartitionType;
+  bool shuffle = !hasCopartition(planPartitionType, layout->partitionType());
   if (!shuffle) {
     // Check that the partition keys of the plan are assigned pairwise to the
     // partition columns of the layout.
@@ -1474,10 +1460,12 @@ void Optimization::addJoin(
 
   // If one is much better do not try the other.
   if (toTry.size() == 2 && candidate.tables.size() == 1) {
+    VELOX_DCHECK(!options_.syntacticJoinOrder);
     if (toTry[0].isWorse(toTry[1])) {
-      toTry.erase(toTry.begin());
+      toTry[0] = std::move(toTry[1]);
+      toTry.pop_back();
     } else if (toTry[1].isWorse(toTry[0])) {
-      toTry.erase(toTry.begin() + 1);
+      toTry.pop_back();
     }
   }
   result.insert(result.end(), toTry.begin(), toTry.end());

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -103,10 +103,6 @@ Plan::Plan(RelationOpPtr op, const PlanState& state)
       columns(exprColumns(state.targetExprs)),
       fullyImported(state.dt->fullyImported) {}
 
-bool Plan::isStateBetter(const PlanState& state, float margin) const {
-  return cost.cost > state.cost.cost + margin;
-}
-
 std::string Plan::printCost() const {
   return cost.toString();
 }
@@ -304,70 +300,77 @@ std::string PlanState::printPlan(RelationOpPtr op, bool detail) const {
 }
 
 PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
-  int32_t replaceIndex = -1;
-  const float shuffle = shuffleCost(plan->columns()) * state.cost.cardinality;
+  const float shuffleCostPerRow = shuffleCost(plan->columns());
 
-  if (!plans.empty()) {
-    // Compare with existing. If there is one with same distribution and new is
-    // better, replace. If there is one with a different distribution and the
-    // new one can produce the same distribution by repartition, for cheaper,
-    // add the new one and delete the old one.
-    for (auto i = 0; i < plans.size(); ++i) {
-      auto old = plans[i].get();
-      if (state.input != old->input) {
-        continue;
-      }
-
-      const bool newIsBetter = old->isStateBetter(state);
-      const bool newIsBetterWithShuffle = old->isStateBetter(state, shuffle);
-      const bool sameDist =
-          old->op->distribution().isSamePartition(plan->distribution());
-      const bool sameOrder =
-          old->op->distribution().isSameOrder(plan->distribution());
-      if (sameDist && sameOrder) {
-        if (newIsBetter) {
-          replaceIndex = i;
-          continue;
-        }
-        // There's a better one with same dist and partition.
-        return nullptr;
-      }
-
-      if (newIsBetterWithShuffle && old->op->distribution().orderKeys.empty()) {
-        // Old plan has no order and is worse than new plus shuffle. Can't win.
-        // Erase.
-        queryCtx()->optimization()->trace(
-            OptimizerOptions::kExceededBest,
-            state.dt->id(),
-            old->cost,
-            *old->op);
-        plans.erase(plans.begin() + i);
-        --i;
-        continue;
-      }
-
-      if (plan->distribution().orderKeys.empty() &&
-          !old->isStateBetter(state, -shuffle)) {
-        // New has no order and old would beat it even after adding shuffle.
-        return nullptr;
-      }
+  // Determine is old plan worse the new one in all aspects.
+  auto isWorse = [&](const Plan& old) {
+    if (plan->distribution().needsSort(old.op->distribution())) {
+      // New plan needs a sort to match the old one, so cannot compare.
+      return false;
     }
+    const bool needsShuffle =
+        plan->distribution().needsShuffle(old.op->distribution());
+    return old.cost.cost >
+        state.cost.totalCost(needsShuffle ? shuffleCostPerRow : 0);
+  };
+
+  // Determine is old plan better than the new one in all aspects.
+  auto isBetter = [&](const Plan& old) {
+    if (old.op->distribution().needsSort(plan->distribution())) {
+      // Old plan needs a sort to match the new one, so cannot compare.
+      return false;
+    }
+    const bool needsShuffle =
+        old.op->distribution().needsShuffle(plan->distribution());
+    return state.cost.cost >
+        old.cost.totalCost(needsShuffle ? shuffleCost(old.op->columns()) : 0);
+  };
+
+  // Compare with existing plans.
+  const auto plansSize = plans.size();
+  enum {
+    kFoundWorse = -1,
+    kNone = 0,
+    kFoundBetter = 1,
+  };
+  auto found = kNone;
+  for (size_t i = 0; i < plans.size(); ++i) {
+    const auto& old = *plans[i];
+    if (old.input != state.input) {
+      // Different plans, cannot compare.
+      continue;
+    }
+    if (isWorse(old)) {
+      // Remove old plan, it is worse than the new one in all aspects.
+      queryCtx()->optimization()->trace(
+          OptimizerOptions::kExceededBest, state.dt->id(), old.cost, *old.op);
+      std::swap(plans[i], plans.back());
+      plans.pop_back();
+      --i;
+      found = kFoundWorse;
+    } else if (found == kNone && isBetter(old)) {
+      // Old plan is better than the new one in all aspects.
+      found = kFoundBetter;
+    }
+  }
+  if (found == kFoundBetter) {
+    // No existing plan was worse than the new one in all aspects,
+    // and at least one existing plan is better than the new one in all aspects.
+    // So don't add the new plan.
+    return nullptr;
   }
 
   auto newPlan = std::make_unique<Plan>(std::move(plan), state);
   auto* result = newPlan.get();
 
-  const auto newPlanCost = result->cost.cost + shuffle;
+  const auto newPlanCost = result->cost.totalCost(shuffleCostPerRow);
   bestCostWithShuffle = std::min(bestCostWithShuffle, newPlanCost);
-  if (replaceIndex >= 0) {
-    plans[replaceIndex] = std::move(newPlan);
-  } else {
-    plans.push_back(std::move(newPlan));
-  }
+  plans.push_back(std::move(newPlan));
   return result;
 }
 
-PlanP PlanSet::best(const Distribution& distribution, bool& needsShuffle) {
+PlanP PlanSet::best(const Distribution& desired, bool& needsShuffle) {
+  // TODO: Consider desired order here too.
   PlanP best = nullptr;
   PlanP match = nullptr;
   float bestCost = -1;
@@ -386,7 +389,7 @@ PlanP PlanSet::best(const Distribution& distribution, bool& needsShuffle) {
     };
 
     update(best, bestCost);
-    if (!single && plan->op->distribution().isSamePartition(distribution)) {
+    if (!single && !plan->op->distribution().needsShuffle(desired)) {
       update(match, matchCost);
     }
   }
@@ -398,9 +401,9 @@ PlanP PlanSet::best(const Distribution& distribution, bool& needsShuffle) {
   }
 
   if (match) {
-    const float shuffle =
-        shuffleCost(best->op->columns()) * best->cost.cardinality;
-    if (matchCost <= bestCost + shuffle) {
+    const float bestCostWithShuffle =
+        best->cost.totalCost(shuffleCost(best->op->columns()));
+    if (matchCost <= bestCostWithShuffle) {
       return match;
     }
   }
@@ -513,12 +516,14 @@ std::string JoinCandidate::toString() const {
 }
 
 bool NextJoin::isWorse(const NextJoin& other) const {
-  float shuffle = 0;
-  if (!plan->distribution().isSamePartition(other.plan->distribution())) {
-    shuffle = other.cost.cardinality * shuffleCost(other.plan->columns());
+  if (other.plan->distribution().needsSort(plan->distribution())) {
+    // 'other' needs a sort to match 'plan', so cannot compare.
+    return false;
   }
-
-  return cost.cost > other.cost.cost + shuffle;
+  const auto needsShuffle =
+      other.plan->distribution().needsShuffle(plan->distribution());
+  return cost.cost > other.cost.totalCost(
+                         needsShuffle ? shuffleCost(other.plan->columns()) : 0);
 }
 
 size_t MemoKey::hash() const {

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -35,6 +35,11 @@ struct PlanCost {
   /// Number of output rows.
   float cardinality{1};
 
+  /// Total cost of the plan with cost of reshuffling included.
+  float totalCost(float shuffleCostPerRow) const {
+    return cost + shuffleCostPerRow * cardinality;
+  }
+
   std::string toString() const {
     return fmt::format("cost: {}, cardinality: {}", cost, cardinality);
   }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -794,7 +794,7 @@ template <typename ExprType>
 velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
     const velox::RowTypePtr& inputType,
     const std::vector<ExprType>& keys,
-    const Distribution& distribution) {
+    const DistributionType& distribution) {
   if (distribution.isBroadcast || keys.empty()) {
     return std::make_shared<velox::core::GatherPartitionFunctionSpec>();
   }
@@ -811,8 +811,7 @@ velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
             ->name()));
   }
 
-  if (const auto* partitionType =
-          distribution.distributionType.partitionType()) {
+  if (const auto* partitionType = distribution.partitionType) {
     return partitionType->makeSpec(
         keyIndices, /*constants=*/{}, /*isLocal=*/false);
   }
@@ -1214,7 +1213,7 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       fragment.width = 1;
     } else {
       auto partition = createPartitionFunctionSpec(
-          input->outputType(), keys, Distribution{});
+          input->outputType(), keys, DistributionType{});
       input = std::make_shared<velox::core::LocalPartitionNode>(
           nextId(),
           velox::core::LocalPartitionNode::Type::kRepartition,
@@ -1251,7 +1250,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   const auto keys = toTypedExprs(repartition.distribution().partition);
 
   const auto& distribution = repartition.distribution();
-  if (distribution.isBroadcast) {
+  if (distribution.isBroadcast()) {
     VELOX_CHECK_EQ(0, keys.size());
     source.fragment.planNode = velox::core::PartitionedOutputNode::broadcast(
         nextId(), 1, outputType, exchangeSerdeKind_, sourcePlan);
@@ -1263,7 +1262,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   } else {
     VELOX_CHECK_NE(0, keys.size());
     auto partitionFunctionFactory = createPartitionFunctionSpec(
-        sourcePlan->outputType(), keys, distribution);
+        sourcePlan->outputType(), keys, distribution.distributionType);
 
     source.fragment.planNode =
         std::make_shared<velox::core::PartitionedOutputNode>(


### PR DESCRIPTION
If any questions "why", please ask, I spent some time in trying to understand what current code wants and what is actually written.

In short I did following:
- Remove `DistributionType::numPartitions`, because it was unused and confusing
- Remove `DistributionType::mode`, because it was unused and confusing
- Remove `isSamePartition` because it was incorrect for broadcast at least
- Add `needsShuffle` instead of `isSamePartition`, it will work correct for broadcast and will allow more cases
- Replace `isSameOrder` with `needsSort`, now if something has sort over "a, b" we don't need to resort for sort "a"
- Fix plan enumeration and shuffle costs they're both was incorrect

Some Notes:

All current tests are passed except few with incorrect join order expected in the tests, such tests adjusted

In most places Cost::cost used as plan cost, plan input cardinality is always 1, so we can omit inputCardinality from computation for them. But in such case function will became invalid for relation. If needed we can have two functions 

Currently input/result cardinality doesn't handle something like `select count(*) from (select 1 limit 0)` 
Because cardinality stored as fanout and multiply doesn't handle this case in a good way.
I have idea how to fix this, but it will be done in the next PR (because requires some refactoring in how we process cost)
```cpp
// select count(*) from (select 1 limit 0)
// i -- input cardinality
// f -- fanout
// r -- result cardinality (i * f) 
// value scan  i=1 f=1 r=1
// project     i=1 f=1 r=1
// limit       i=1 f=0 r=0
// aggregation i=0 f=? r=1 (now f will be NaN, because divide by zero)
```

### Follow ups:
1. Now shuffle cost for broadcast, gather and partition is same, I'm not sure it's right, especially for broadcast
   - As workaround we can multiply broadcast shuffle cost part by number of workers.
2. I'm not sure how velox works, do we keep order of rows after broadcast? If yes, we can keep everything in Distribution::broadcast and only replace DistributionType. It can allow us to enumerate some interesting plans in future, but I think it can be bad in terms of choice of best plan before we fix 1.