### PR TITLE
feat: Add support for INSERT INTO SQL

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1021,8 +1021,14 @@ velox::ContinueFuture LocalHiveConnectorMetadata::abortWrite(
 }
 
 std::optional<std::string> LocalHiveConnectorMetadata::makeStagingDirectory(
-    std::string_view table) const {
-  return createTemporaryDirectory(hiveConfig_->hiveLocalDataPath(), table);
+    std::string_view tableName) const {
+  return createTemporaryDirectory(hiveConfig_->hiveLocalDataPath(), tableName);
+}
+
+bool LocalHiveConnectorMetadata::dropTableIfExists(std::string_view tableName) {
+  std::lock_guard<std::mutex> l(mutex_);
+  deleteDirectoryRecursive(tablePath(tableName));
+  return tables_.erase(tableName) == 1;
 }
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -252,12 +252,14 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const ConnectorSessionPtr& session,
       const ConnectorWriteHandlePtr& handle) noexcept override;
 
-  std::string tablePath(std::string_view table) const override {
-    return fmt::format("{}/{}", hiveConfig_->hiveLocalDataPath(), table);
+  std::string tablePath(std::string_view tableName) const override {
+    return fmt::format("{}/{}", hiveConfig_->hiveLocalDataPath(), tableName);
   }
 
   std::optional<std::string> makeStagingDirectory(
-      std::string_view table) const override;
+      std::string_view tableName) const override;
+
+  bool dropTableIfExists(std::string_view tableName);
 
  private:
   void ensureInitialized() const override;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -123,6 +123,10 @@ std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
   return it->second;
 }
 
+bool TestConnectorMetadata::dropTableIfExists(const std::string& name) {
+  return tables_.erase(name) == 1;
+}
+
 void TestConnectorMetadata::appendData(
     std::string_view name,
     const velox::RowVectorPtr& data) {
@@ -226,6 +230,10 @@ std::shared_ptr<TestTable> TestConnector::addTable(
     const std::string& name,
     const velox::RowTypePtr& schema) {
   return metadata_->addTable(name, schema);
+}
+
+bool TestConnector::dropTableIfExists(const std::string& name) {
+  return metadata_->dropTableIfExists(name);
 }
 
 void TestConnector::appendData(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -283,6 +283,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
   /// into the internal memory pool associated with the table.
   void appendData(std::string_view name, const velox::RowVectorPtr& data);
 
+  bool dropTableIfExists(const std::string& name);
+
  private:
   TestConnector* connector_;
   folly::F14FastMap<std::string, std::shared_ptr<TestTable>> tables_;
@@ -387,6 +389,8 @@ class TestConnector : public velox::connector::Connector {
   /// DataSource corresponding to this table. Appended data is copied
   /// to the internal memory pool of the associated table.
   void appendData(std::string_view name, const velox::RowVectorPtr& data);
+
+  bool dropTableIfExists(const std::string& name);
 
  private:
   const std::shared_ptr<TestConnectorMetadata> metadata_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1530,7 +1530,12 @@ PlanObjectP ToGraph::addWrite(const lp::TableWriteNode& tableWrite) {
       columnExprs.push_back(make<Literal>(
           Value{toType(tableColumn->type()), 1}, &tableColumn->defaultValue()));
     }
-    VELOX_DCHECK(*tableSchema.childAt(i) == *columnExprs.back()->value().type);
+    VELOX_DCHECK(
+        *tableSchema.childAt(i) == *columnExprs.back()->value().type,
+        "Wrong column type: {}, {} vs. {}",
+        columnName,
+        tableSchema.childAt(i)->toString(),
+        columnExprs.back()->value().type->toString());
   }
 
   renames_.clear();

--- a/axiom/optimizer/tests/LogicalPlanMatcher.cpp
+++ b/axiom/optimizer/tests/LogicalPlanMatcher.cpp
@@ -66,6 +66,12 @@ class LogicalPlanMatcherImpl : public LogicalPlanMatcher {
 };
 } // namespace
 
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::tableWrite() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<LogicalPlanMatcherImpl<TableWriteNode>>(matcher_);
+  return *this;
+}
+
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::tableScan() {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<LogicalPlanMatcherImpl<TableScanNode>>();

--- a/axiom/optimizer/tests/LogicalPlanMatcher.h
+++ b/axiom/optimizer/tests/LogicalPlanMatcher.h
@@ -29,6 +29,8 @@ class LogicalPlanMatcher {
 
 class LogicalPlanMatcherBuilder {
  public:
+  LogicalPlanMatcherBuilder& tableWrite();
+
   LogicalPlanMatcherBuilder& tableScan();
 
   LogicalPlanMatcherBuilder& values();

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -111,6 +111,14 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
         planNode, referencePlan, {.numWorkers = 1, .numDrivers = numDrivers});
   }
 
+  void checkSameSingleNode(
+      const logical_plan::LogicalPlanNodePtr& planNode,
+      const std::vector<velox::RowVectorPtr>& referenceResult,
+      int32_t numDrivers = 1) {
+    checkSame(
+        planNode, referenceResult, {.numWorkers = 1, .numDrivers = numDrivers});
+  }
+
   velox::memory::MemoryPool& optimizerPool() const {
     return *optimizerPool_;
   }

--- a/axiom/optimizer/tests/SqlStatement.h
+++ b/axiom/optimizer/tests/SqlStatement.h
@@ -22,6 +22,7 @@ namespace facebook::axiom::optimizer::test {
 
 enum class SqlStatementKind {
   kSelect,
+  kInsert,
   kExplain,
 };
 
@@ -37,6 +38,10 @@ class SqlStatement {
 
   bool isSelect() const {
     return kind_ == SqlStatementKind::kSelect;
+  }
+
+  bool isInsert() const {
+    return kind_ == SqlStatementKind::kInsert;
   }
 
   bool isExplain() const {
@@ -58,6 +63,19 @@ class SelectStatement : public SqlStatement {
  public:
   explicit SelectStatement(logical_plan::LogicalPlanNodePtr plan)
       : SqlStatement(SqlStatementKind::kSelect), plan_{std::move(plan)} {}
+
+  const logical_plan::LogicalPlanNodePtr& plan() const {
+    return plan_;
+  }
+
+ private:
+  const logical_plan::LogicalPlanNodePtr plan_;
+};
+
+class InsertStatement : public SqlStatement {
+ public:
+  explicit InsertStatement(logical_plan::LogicalPlanNodePtr plan)
+      : SqlStatement(SqlStatementKind::kInsert), plan_{std::move(plan)} {}
 
   const logical_plan::LogicalPlanNodePtr& plan() const {
     return plan_;

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -291,7 +291,17 @@ std::any AstBuilder::visitDropTable(PrestoSqlParser::DropTableContext* ctx) {
 
 std::any AstBuilder::visitInsertInto(PrestoSqlParser::InsertIntoContext* ctx) {
   trace("visitInsertInto");
-  return visitChildren(ctx);
+
+  std::vector<std::shared_ptr<Identifier>> columns;
+  if (ctx->columnAliases()) {
+    columns = visitTyped<Identifier>(ctx->columnAliases()->identifier());
+  };
+
+  return std::static_pointer_cast<Statement>(std::make_shared<Insert>(
+      getLocation(ctx),
+      getQualifiedName(ctx->qualifiedName()),
+      std::move(columns),
+      visitTyped<Statement>(ctx->query())));
 }
 
 std::any AstBuilder::visitDelete(PrestoSqlParser::DeleteContext* ctx) {


### PR DESCRIPTION
Summary: Add support for queries like INSERT INTO test SELECT ...

Earlier changes added support for INSERT INTO logical plans. This change adds missing pieces to support same queries expressed in SQL.

Differential Revision: D84600741


