### PR TITLE
fix: WriteTest::createTableAsSelectSql

### DIFF
--- a/axiom/connectors/SchemaResolver.h
+++ b/axiom/connectors/SchemaResolver.h
@@ -30,19 +30,28 @@ class SchemaResolver {
 
   virtual ~SchemaResolver() = default;
 
-  // Converts a table name to a resolved Table, or nullptr if the table doesn't
-  // exist. If a connector for the specified catalog doesn't exist, an error
-  // will be returned. Input table name can be any of the following formats:
-  //   - "tablename"
-  //   - "schema.tablename"
-  //   - "catalog.schema.tablename"
-  // If schema is omitted, defaultSchema will be prepended prior to lookup.
-  // If the table name specifies a different catalog than the one specified
-  // as a parameter, an error will be thrown.
-  virtual TablePtr findTable(std::string_view catalog, std::string_view name);
+  /// Adds a table that hasn't been committed yet to the schema. Used to
+  /// register target table for CREATE TABLE AS SELECT queries. Can be called
+  /// only once.
+  void setTargetTable(std::string_view catalog, TablePtr table);
+
+  /// Converts a table name to a resolved Table, or nullptr if the table doesn't
+  /// exist. If a connector for the specified catalog doesn't exist, an error
+  /// will be returned. Input table name can be any of the following formats:
+  ///   - "tablename"
+  ///   - "schema.tablename"
+  ///   - "catalog.schema.tablename"
+  /// If schema is omitted, defaultSchema will be prepended prior to lookup.
+  /// If the table name specifies a different catalog than the one specified
+  /// as a parameter, an error will be thrown.
+  virtual TablePtr findTable(std::string_view catalog, std::string_view name)
+      const;
 
  private:
   const std::string defaultSchema_;
+
+  std::string targetCatalog_;
+  TablePtr targetTable_;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -104,7 +104,7 @@ ColumnCP SchemaTable::findColumn(std::string_view name) const {
 
 Schema::Schema(
     const char* name,
-    connector::SchemaResolver* source,
+    const connector::SchemaResolver* source,
     LocusCP locus)
     : name_{name}, source_{source}, defaultLocus_{locus} {}
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -375,7 +375,7 @@ struct SchemaTable {
 class Schema {
  public:
   /// Constructs a Schema for producing executable plans, backed by 'source'.
-  Schema(Name name, connector::SchemaResolver* source, LocusCP locus);
+  Schema(Name name, const connector::SchemaResolver* source, LocusCP locus);
 
   /// Returns the table with 'name' or nullptr if not found, using
   /// the connector specified by connectorId to perform table lookups.
@@ -398,7 +398,7 @@ class Schema {
   // In the tables map, the key is the full table name and the value is
   // schema table (optimizer object) and connector table (connector object).
   mutable NameMap<NameMap<Table>> connectorTables_;
-  connector::SchemaResolver* source_{nullptr};
+  const connector::SchemaResolver* source_;
   LocusCP defaultLocus_;
 };
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -130,6 +130,15 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const runner::MultiFragmentPlan::Options& options,
     std::string* planString) {
+  connector::SchemaResolver schemaResolver;
+  return planVelox(plan, schemaResolver, options, planString);
+}
+
+optimizer::PlanAndStats QueryTestBase::planVelox(
+    const logical_plan::LogicalPlanNodePtr& plan,
+    const connector::SchemaResolver& schemaResolver,
+    const runner::MultiFragmentPlan::Options& options,
+    std::string* planString) {
   auto& queryCtx = getQueryCtx();
 
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool_.get());
@@ -141,7 +150,6 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
-  connector::SchemaResolver schemaResolver;
   optimizer::Schema veraxSchema("test", &schemaResolver, /*locus=*/nullptr);
 
   auto session = std::make_shared<Session>(queryCtx->queryId());
@@ -165,7 +173,15 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
 TestResult QueryTestBase::runVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const runner::MultiFragmentPlan::Options& options) {
-  auto veloxPlan = planVelox(plan, options);
+  auto veloxPlan = planVelox(plan, options, nullptr);
+  return runFragmentedPlan(veloxPlan);
+}
+
+TestResult QueryTestBase::runVelox(
+    const logical_plan::LogicalPlanNodePtr& plan,
+    const connector::SchemaResolver& schemaResolver,
+    const runner::MultiFragmentPlan::Options& options) {
+  auto veloxPlan = planVelox(plan, schemaResolver, options, nullptr);
   return runFragmentedPlan(veloxPlan);
 }
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -18,6 +18,7 @@
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gflags/gflags.h>
+#include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/LocalRunner.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
@@ -54,8 +55,26 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
           },
       std::string* planString = nullptr);
 
+  optimizer::PlanAndStats planVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      const connector::SchemaResolver& schemaResolver,
+      const runner::MultiFragmentPlan::Options& options =
+          {
+              .numWorkers = 4,
+              .numDrivers = 4,
+          },
+      std::string* planString = nullptr);
+
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
+      const runner::MultiFragmentPlan::Options& options = {
+          .numWorkers = 4,
+          .numDrivers = 4,
+      });
+
+  TestResult runVelox(
+      const logical_plan::LogicalPlanNodePtr& plan,
+      const connector::SchemaResolver& schemaResolver,
       const runner::MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,


### PR DESCRIPTION
Summary:
The test used to mistakenly create and commit empty table before inserting. The test should create the table using ConnectorMetadata::createTable API, then write data, then commit.

Extended SchemaResolver to allow specifying not-yet committed table being written to by CREATE TABLE AS SELECT query. This allows the optimizer to resolve this table.

Differential Revision: D84700917


