### PR TITLE
fix: Remove  Locus

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -76,7 +76,7 @@ PlanAndStats Optimization::toVeloxPlan(
 
   VeloxHistory history;
 
-  Schema schema("default", schemaResolver.get(), /* locus */ nullptr);
+  Schema schema("default", schemaResolver.get());
 
   auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 
@@ -479,9 +479,7 @@ bool isIndexColocated(
     const ExprVector& lookupValues,
     const RelationOpPtr& input) {
   const auto& distribution = info.index->distribution;
-  if (distribution.isBroadcast &&
-      input->distribution().distributionType.locus ==
-          distribution.distributionType.locus) {
+  if (distribution.isBroadcast) {
     return true;
   }
 
@@ -1550,7 +1548,6 @@ Distribution somePartition(const RelationOpPtrVector& inputs) {
   DistributionType distributionType;
   distributionType.numPartitions =
       queryCtx()->optimization()->runnerOptions().numWorkers;
-  distributionType.locus = firstInput->distribution().distributionType.locus;
 
   return {distributionType, std::move(columns)};
 }

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -102,11 +102,8 @@ ColumnCP SchemaTable::findColumn(std::string_view name) const {
   return it->second;
 }
 
-Schema::Schema(
-    const char* name,
-    connector::SchemaResolver* source,
-    LocusCP locus)
-    : name_{name}, source_{source}, defaultLocus_{locus} {}
+Schema::Schema(Name name, connector::SchemaResolver* source)
+    : name_{name}, source_{source} {}
 
 SchemaTableCP Schema::findTable(
     std::string_view connectorId,
@@ -140,7 +137,6 @@ SchemaTableCP Schema::findTable(
     columns.push_back(column);
   }
   DistributionType defaultDistributionType;
-  defaultDistributionType.locus = defaultLocus_;
   schemaTable->addIndex(
       toName("pk"),
       0,

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -79,45 +79,6 @@ AXIOM_DECLARE_ENUM_NAME(OrderType);
 
 using OrderTypeVector = QGVector<OrderType>;
 
-/// Represents a system that contains or produces data. For cases of federation
-/// where data is only accessible via a specific instance of a specific type of
-/// system, the locus represents the instance and the subclass of Locus
-/// represents the type of system for a schema object. For a RelationOp, the
-/// locus of its distribution means that the op is performed by the
-/// corresponding system. Distributions can be copartitioned only if their locus
-/// is equal (==) to the other locus. A Locus is referenced by raw pointer and
-/// may be allocated from outside the optimization arena. It is immutable and
-/// lives past the optimizer arena.
-class Locus {
- public:
-  explicit Locus(Name name, velox::connector::Connector* connector)
-      : name_(name), connector_(connector) {}
-
-  virtual ~Locus() = default;
-
-  Name name() const {
-    // Make sure the name is in the current optimization
-    // arena. 'this' may live across several arenas.
-    return toName(name_);
-  }
-
-  const velox::connector::Connector* connector() const {
-    // // 'connector_' can be nullptr if no executable plans are made.
-    VELOX_CHECK_NOT_NULL(connector_);
-    return connector_;
-  }
-
-  std::string toString() const {
-    return name_;
-  }
-
- private:
-  const Name name_;
-  const velox::connector::Connector* connector_;
-};
-
-using LocusCP = const Locus*;
-
 /// Method for determining a partition given an ordered list of partitioning
 /// keys. Hive hash is an example, range partitioning is another. Add values
 /// here for more types.
@@ -132,7 +93,6 @@ enum class ShuffleMode : uint8_t {
 struct DistributionType {
   bool operator==(const DistributionType& other) const = default;
 
-  LocusCP locus{nullptr};
   int32_t numPartitions{1};
   bool isGather{false};
   ShuffleMode mode{ShuffleMode::kNone};
@@ -371,11 +331,11 @@ struct SchemaTable {
 /// optimization arena.  Objects of different catalogs/schemas get
 /// added to 'this' on first use. The Schema feeds from a
 /// SchemaResolver which interfaces to a local/remote metadata
-/// repository. The objects have a default Locus for convenience.
+/// repository.
 class Schema {
  public:
   /// Constructs a Schema for producing executable plans, backed by 'source'.
-  Schema(Name name, connector::SchemaResolver* source, LocusCP locus);
+  Schema(Name name, connector::SchemaResolver* source);
 
   /// Returns the table with 'name' or nullptr if not found, using
   /// the connector specified by connectorId to perform table lookups.
@@ -399,7 +359,6 @@ class Schema {
   // schema table (optimizer object) and connector table (connector object).
   mutable NameMap<NameMap<Table>> connectorTables_;
   connector::SchemaResolver* source_{nullptr};
-  LocusCP defaultLocus_;
 };
 
 using SchemaP = Schema*;

--- a/axiom/optimizer/tests/AxiomSql.cpp
+++ b/axiom/optimizer/tests/AxiomSql.cpp
@@ -497,10 +497,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
       optimizer::queryCtx() = nullptr;
     };
 
-    // The default Locus for planning is the system and data of
-    // 'connector_'.
-    optimizer::Locus locus(connector_->connectorId().c_str(), connector_.get());
-    optimizer::Schema veraxSchema("test", schema_.get(), &locus);
+    optimizer::Schema veraxSchema("test", schema_.get());
     exec::SimpleExpressionEvaluator evaluator(
         queryCtx.get(), optimizerPool_.get());
 

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -81,7 +81,7 @@ class DerivedTablePrinterTest : public ::testing::Test {
     VeloxHistory history;
 
     auto schemaResolver = std::make_shared<connector::SchemaResolver>();
-    Schema schema("default", schemaResolver.get(), /* locus */ nullptr);
+    Schema schema("default", schemaResolver.get());
 
     auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -62,7 +62,7 @@ class PrecomputeProjectionTest : public ::testing::Test {
     VeloxHistory history;
 
     auto schemaResolver = std::make_shared<connector::SchemaResolver>();
-    Schema schema("default", schemaResolver.get(), /* locus */ nullptr);
+    Schema schema("default", schemaResolver.get());
 
     auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -142,7 +142,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
       queryCtx.get(), optimizerPool_.get());
 
   connector::SchemaResolver schemaResolver;
-  optimizer::Schema veraxSchema("test", &schemaResolver, /*locus=*/nullptr);
+  optimizer::Schema veraxSchema("test", &schemaResolver);
 
   auto session = std::make_shared<Session>(queryCtx->queryId());
 


### PR DESCRIPTION
Locus was introduced to represent different storage systems being accessed in a single query. We believe we do not need a separate abstraction and can use Connector instead.