### PR TITLE
fix: Avoid WriteKind duplication between connector and logical plan

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_common Session.cpp)
+add_library(axiom_common Session.cpp WriteKind.cpp)
 
 target_link_libraries(axiom_common axiom_connectors)

--- a/axiom/common/WriteKind.cpp
+++ b/axiom/common/WriteKind.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/WriteKind.h"
+
+namespace facebook::axiom {
+namespace {
+
+const auto& writeKindNames() {
+  static const folly::F14FastMap<WriteKind, std::string_view> kNames = {
+      {WriteKind::kCreate, "CREATE"},
+      {WriteKind::kInsert, "INSERT"},
+      {WriteKind::kUpdate, "UPDATE"},
+      {WriteKind::kDelete, "DELETE"},
+  };
+  return kNames;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
+
+} // namespace facebook::axiom

--- a/axiom/common/WriteKind.h
+++ b/axiom/common/WriteKind.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/common/Enums.h"
+
+namespace facebook::axiom {
+
+/// Specifies what type of write is intended when initiating or concluding a
+/// write operation.
+enum class WriteKind {
+  /// A write operation to a new table which does not yet exist in the
+  /// connector. Covers both creation of an empty table and create as select
+  /// operations.
+  kCreate = 1,
+
+  /// Rows are added and all columns must be specified for the TableWriter.
+  /// Covers insert, Hive partition replacement or any other operation which
+  /// adds whole rows.
+  kInsert = 2,
+
+  /// Individual rows are deleted. Only row ids as per
+  /// ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
+  kDelete = 3,
+
+  /// Column values in individual rows are changed. The TableWriter
+  /// gets first the row ids as per ConnectorMetadata::rowIdHandles()
+  /// and then new values for the columns being changed. The new values
+  /// may overlap with row ids if the row id is a set of primary key
+  /// columns.
+  kUpdate = 4,
+};
+
+AXIOM_DECLARE_ENUM_NAME(WriteKind);
+
+} // namespace facebook::axiom
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::WriteKind);

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -26,4 +26,4 @@ endif()
 
 add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp SchemaUtils.cpp)
 
-target_link_libraries(axiom_connectors velox_common_base velox_memory velox_connector)
+target_link_libraries(axiom_connectors axiom_common velox_common_base velox_memory velox_connector)

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -17,8 +17,8 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 
 namespace facebook::axiom::connector {
-
 namespace {
+
 const auto& tableKindNames() {
   static const folly::F14FastMap<TableKind, std::string_view> kNames = {
       {TableKind::kTable, "TABLE"},
@@ -27,21 +27,9 @@ const auto& tableKindNames() {
   return kNames;
 }
 
-const auto& writeKindNames() {
-  static const folly::F14FastMap<WriteKind, std::string_view> kNames = {
-      {WriteKind::kCreate, "CREATE"},
-      {WriteKind::kInsert, "INSERT"},
-      {WriteKind::kUpdate, "UPDATE"},
-      {WriteKind::kDelete, "DELETE"},
-  };
-  return kNames;
-}
-
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(TableKind, tableKindNames);
-
-AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
 
 namespace {
 velox::RowTypePtr makeRowType(const std::vector<const Column*>& columns) {

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/common/Enums.h"
+#include "axiom/common/WriteKind.h"
 #include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "velox/common/memory/HashStringAllocator.h"
@@ -525,33 +526,6 @@ class ConnectorWriteHandle {
 
 using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 
-/// Specifies what type of write is intended when initiating or concluding a
-/// write operation.
-enum class WriteKind {
-  /// A write operation to a new table which does not yet exist in the
-  /// connector. Covers both creation of an empty table and create as select
-  /// operations.
-  kCreate = 1,
-
-  /// Rows are added and all columns must be specified for the TableWriter.
-  /// Covers insert, Hive partition replacement or any other operation which
-  /// adds whole rows.
-  kInsert = 2,
-
-  /// Individual rows are deleted. Only row ids as per
-  /// ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
-  kDelete = 3,
-
-  /// Column values in individual rows are changed. The TableWriter
-  /// gets first the row ids as per ConnectorMetadata::rowIdHandles()
-  /// and then new values for the columns being changed. The new values
-  /// may overlap with row ids if the row id is a set of primary key
-  /// columns.
-  kUpdate = 4,
-};
-
-AXIOM_DECLARE_ENUM_NAME(WriteKind);
-
 using RowsFuture = folly::SemiFuture<int64_t>;
 
 class ConnectorMetadata {
@@ -723,5 +697,3 @@ class ConnectorMetadata {
 } // namespace facebook::axiom::connector
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::connector::TableKind);
-
-AXIOM_ENUM_FORMATTER(facebook::axiom::connector::WriteKind);

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -395,21 +395,4 @@ void TableWriteNode::accept(
   visitor.visit(*this, context);
 }
 
-namespace {
-
-folly::F14FastMap<WriteKind, std::string_view> writeKindNames() {
-  static const folly::F14FastMap<WriteKind, std::string_view> kNames = {
-      {WriteKind::kCreate, "CREATE"},
-      {WriteKind::kInsert, "INSERT"},
-      {WriteKind::kUpdate, "UPDATE"},
-      {WriteKind::kDelete, "DELETE"},
-  };
-
-  return kNames;
-}
-
-} // namespace
-
-VELOX_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
-
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/common/Enums.h"
+#include "axiom/common/WriteKind.h"
 #include "axiom/logical_plan/Expr.h"
 #include "velox/type/Variant.h"
 #include "velox/vector/ComplexVector.h"
@@ -667,32 +668,6 @@ class UnnestNode : public LogicalPlanNode {
 
 using UnnestNodePtr = std::shared_ptr<const UnnestNode>;
 
-/// Specifies what type of write is intended when initiating or concluding a
-/// write operation.
-enum class WriteKind {
-  // A write operation to a new table which does not yet exist in the connector.
-  // Covers both creation of an empty table and create as select operations.
-  kCreate = 1,
-
-  // Rows are added and all columns must be specified for the TableWriter.
-  // Covers insert, Hive partition replacement or any other operation which adds
-  // whole rows.
-  kInsert = 2,
-
-  // Individual rows are deleted. Only row ids as per
-  // ConnectorMetadata::rowIdHandles() are passed to the TableWriter.
-  kDelete = 3,
-
-  // Column values in individual rows are changed. The TableWriter
-  // gets first the row ids as per ConnectorMetadata::rowIdHandles()
-  // and then new values for the columns being changed. The new values
-  // may overlap with row ids if the row id is a set of primary key
-  // columns.
-  kUpdate = 4,
-};
-
-AXIOM_DECLARE_ENUM_NAME(WriteKind);
-
 /// Implements create/insert/delete/update as per 'writeKind'.
 ///
 /// The output schema contains a single BIGINT column named 'rows'. The value of
@@ -764,5 +739,3 @@ class TableWriteNode : public LogicalPlanNode {
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
 
 } // namespace facebook::axiom::logical_plan
-
-AXIOM_ENUM_FORMATTER(facebook::axiom::logical_plan::WriteKind);

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -956,7 +956,7 @@ class WritePlan : public PlanObject {
   /// table schema.
   WritePlan(
       const connector::Table& table,
-      connector::WriteKind kind,
+      WriteKind kind,
       ExprVector columnExprs)
       : PlanObject{PlanType::kWriteNode},
         table_{table},
@@ -969,7 +969,7 @@ class WritePlan : public PlanObject {
     return table_;
   }
 
-  connector::WriteKind kind() const {
+  WriteKind kind() const {
     return kind_;
   }
 
@@ -979,7 +979,7 @@ class WritePlan : public PlanObject {
 
  private:
   const connector::Table& table_;
-  const connector::WriteKind kind_;
+  const WriteKind kind_;
   const ExprVector columnExprs_;
 };
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1758,10 +1758,8 @@ void ToGraph::addLimit(const lp::LimitNode& limit) {
 }
 
 void ToGraph::addWrite(const lp::TableWriteNode& tableWrite) {
-  const auto writeKind =
-      static_cast<connector::WriteKind>(tableWrite.writeKind());
-  if (writeKind != connector::WriteKind::kInsert &&
-      writeKind != connector::WriteKind::kCreate) {
+  const auto writeKind = tableWrite.writeKind();
+  if (writeKind != WriteKind::kInsert && writeKind != WriteKind::kCreate) {
     VELOX_NYI("Only INSERT supported for TableWrite");
   }
   VELOX_CHECK_NULL(

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -189,15 +189,12 @@ TEST_F(DerivedTablePrinterTest, write) {
   connector_->addTable("c", ROW({"a", "b"}, INTEGER()));
   connector_->addTable("z", ROW({"x", "y"}, INTEGER()));
 
-  auto plan = lp::PlanBuilder()
-                  .tableScan(kTestConnectorId, "c")
-                  .tableWrite(
-                      kTestConnectorId,
-                      "z",
-                      lp::WriteKind::kInsert,
-                      {"y", "x"},
-                      {"a", "b"})
-                  .build();
+  auto plan =
+      lp::PlanBuilder()
+          .tableScan(kTestConnectorId, "c")
+          .tableWrite(
+              kTestConnectorId, "z", WriteKind::kInsert, {"y", "x"}, {"a", "b"})
+          .build();
 
   auto lines = toLines(*plan);
 

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -56,8 +56,7 @@ class WriteTest : public test::HiveQueriesTestBase {
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
     auto table = metadata_->createTable(session, name, tableType, options);
-    auto handle =
-        metadata_->beginWrite(session, table, connector::WriteKind::kCreate);
+    auto handle = metadata_->beginWrite(session, table, WriteKind::kCreate);
     metadata_->finishWrite(session, handle, {}).get();
   }
 
@@ -213,7 +212,7 @@ TEST_F(WriteTest, basic) {
                        .tableWrite(
                            exec::test::kHiveConnectorId,
                            "test",
-                           lp::WriteKind::kInsert,
+                           WriteKind::kInsert,
                            {"key1", "key2", "data", "ds"},
                            {"key1", "key2", "data", "ds"})
                        .build();
@@ -236,7 +235,7 @@ TEST_F(WriteTest, basic) {
                        .tableWrite(
                            exec::test::kHiveConnectorId,
                            "test",
-                           lp::WriteKind::kInsert,
+                           WriteKind::kInsert,
                            {"key1", "key2", "data", "ds"},
                            {"key1", "key2", "key1 % (key1 - 200000)", "ds"})
                        .build();
@@ -269,7 +268,7 @@ TEST_F(WriteTest, basic) {
                       .tableWrite(
                           exec::test::kHiveConnectorId,
                           "test2",
-                          lp::WriteKind::kInsert,
+                          WriteKind::kInsert,
                           {"key1", "key2", "data", "data2", "ds"},
                           {"key1", "key2", "data", "data2", "ds"})
                       .build();

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1391,7 +1391,7 @@ SqlStatementPtr parseInsert(
   planner.builder().tableWrite(
       connectorId,
       tableName,
-      lp::WriteKind::kInsert,
+      facebook::axiom::WriteKind::kInsert,
       columnNames,
       inputColumns);
 
@@ -1433,7 +1433,7 @@ SqlStatementPtr parseCreateTableAsSelect(
     planBuilder.tableWrite(
         connectorId,
         tableName,
-        lp::WriteKind::kCreate,
+        facebook::axiom::WriteKind::kCreate,
         columnNames,
         columnNames);
   } else {
@@ -1447,7 +1447,7 @@ SqlStatementPtr parseCreateTableAsSelect(
     planBuilder.tableWrite(
         connectorId,
         tableName,
-        lp::WriteKind::kCreate,
+        facebook::axiom::WriteKind::kCreate,
         columnNames,
         planBuilder.findOrAssignOutputNames());
   }


### PR DESCRIPTION
Acutally I think it will be better to logical plan depends on connector, but it is as it is