### PR TITLE
feat: Add optimizer support for writing partitioned tables

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -349,13 +349,13 @@ void LocalTable::makeDefaultLayout(
       this,
       metadata.hiveConnector(),
       std::move(columns),
+      std::nullopt,
       empty,
       empty,
       std::vector<SortOrder>{},
       empty,
       empty,
-      metadata.fileFormat(),
-      std::nullopt);
+      metadata.fileFormat());
   layout->setFiles(std::move(files));
   exportedLayouts_.push_back(layout.get());
   layouts_.push_back(std::move(layout));
@@ -663,13 +663,13 @@ std::shared_ptr<LocalTable> createLocalTable(
       table.get(),
       connector,
       columns,
+      numBuckets,
       bucketedBy,
       sortedBy,
       sortOrders,
       /*lookupKeys=*/std::vector<const Column*>{},
       partitionedBy,
-      createTableOptions.fileFormat.value(),
-      numBuckets);
+      createTableOptions.fileFormat.value());
   table->addLayout(std::move(layout));
   return table;
 }

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -84,25 +84,25 @@ class LocalHiveTableLayout : public HiveTableLayout {
       const Table* table,
       velox::connector::Connector* connector,
       std::vector<const Column*> columns,
+      std::optional<int32_t> numBuckets,
       std::vector<const Column*> partitioning,
       std::vector<const Column*> orderColumns,
       std::vector<SortOrder> sortOrder,
       std::vector<const Column*> lookupKeys,
       std::vector<const Column*> hivePartitionColumns,
-      velox::dwio::common::FileFormat fileFormat,
-      std::optional<int32_t> numBuckets = std::nullopt)
+      velox::dwio::common::FileFormat fileFormat)
       : HiveTableLayout(
             name,
             table,
             connector,
             columns,
+            numBuckets,
             partitioning,
             orderColumns,
             sortOrder,
             lookupKeys,
             hivePartitionColumns,
-            fileFormat,
-            numBuckets) {}
+            fileFormat) {}
 
   std::pair<int64_t, int64_t> sample(
       const velox::connector::ConnectorTableHandlePtr& handle,

--- a/axiom/connectors/hive/StatisticsBuilder.cpp
+++ b/axiom/connectors/hive/StatisticsBuilder.cpp
@@ -101,6 +101,11 @@ template <typename Builder, typename T>
 void StatisticsBuilderImpl::addStats(
     velox::dwrf::StatisticsBuilder* builder,
     const velox::BaseVector& vector) {
+  VELOX_CHECK(
+      vector.type()->equivalent(*type_),
+      "Type mismatch: {} vs. {}",
+      vector.type()->toString(),
+      type_->toString());
   auto* typedVector = vector.asUnchecked<velox::SimpleVector<T>>();
   T previous{};
   bool hasPrevious = false;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -936,7 +936,8 @@ class WritePlan : public PlanObject {
  public:
   /// @param table The table to write to.
   /// @param kind Indicates the type of write (create/insert/delete/update)
-  /// @param columnExprs Expressions producing the values to write.
+  /// @param columnExprs Expressions producing the values to write. 1:1 with the
+  /// table schema.
   WritePlan(
       const connector::Table& table,
       connector::WriteKind kind,

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -471,13 +471,13 @@ std::string Repartition::toString(bool recursive, bool detail) const {
   if (recursive) {
     out << input()->toString(true, detail) << " ";
   }
-  const auto& distributionType = distribution().distributionType;
+
   if (distribution().isBroadcast) {
     out << "broadcast ";
-  } else if (distributionType.isGather) {
+  } else if (distribution().isGather()) {
     out << "gather ";
   } else {
-    out << "shuffle ";
+    out << "repartition ";
     if (detail) {
       out << distribution().toString() << " ";
     }
@@ -851,11 +851,12 @@ std::string UnionAll::toString(bool recursive, bool detail) const {
   return out.str();
 }
 
+// TODO Figure out a cleaner solution to setting 'distribution' and 'columns'.
 TableWrite::TableWrite(
     RelationOpPtr input,
     ExprVector inputColumns,
     const WritePlan* write)
-    : RelationOp{RelType::kTableWrite, std::move(input), Distribution::gather(), {}},
+    : RelationOp{RelType::kTableWrite, input, input->distribution().isGather() ? Distribution::gather() : Distribution(), {}},
       inputColumns{std::move(inputColumns)},
       write{write} {
   cost_.inputCardinality = inputCardinality();

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -111,6 +111,7 @@ SchemaTableCP Schema::findTable(
   for (const auto* layout : connectorTable->layouts()) {
     VELOX_CHECK_NOT_NULL(layout);
     Distribution distribution;
+    distribution.distributionType = DistributionType(layout->partitionType());
     appendColumns(layout->partitionColumns(), distribution.partition);
     appendColumns(layout->orderColumns(), distribution.orderKeys);
 
@@ -420,7 +421,7 @@ std::string Distribution::toString() const {
     return "broadcast";
   }
 
-  if (distributionType.isGather) {
+  if (distributionType.isGather()) {
     return "gather";
   }
 
@@ -428,7 +429,11 @@ std::string Distribution::toString() const {
   if (!partition.empty()) {
     out << "P ";
     exprsToString(partition, out);
-    out << " Velox hash";
+    if (distributionType.partitionType() != nullptr) {
+      out << " " << distributionType.partitionType()->toString();
+    } else {
+      out << " Velox hash";
+    }
   }
   if (!orderKeys.empty()) {
     out << " O ";

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -917,4 +917,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::orderBy(
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::tableWrite() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<PlanMatcherImpl<TableWriteNode>>(
+      std::vector<std::shared_ptr<PlanMatcher>>{matcher_});
+  return *this;
+}
+
 } // namespace facebook::velox::core

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -146,6 +146,8 @@ class PlanMatcherBuilder {
 
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
 
+  PlanMatcherBuilder& tableWrite();
+
   std::shared_ptr<PlanMatcher> build() {
     VELOX_USER_CHECK_NOT_NULL(matcher_, "Cannot build an empty PlanMatcher.");
     return matcher_;


### PR DESCRIPTION
Summary: In multi-node setup, when writing to partitioned table (bucketed Hive tables), check if input is already partitioned in a compatible way. If not, add a shuffle.

In single-node multi-threaded setup, add local exchange before partitioned write.

Check the table layout to determine whether write is partitioned or not. Tables with multiple layouts are not supported yet. To support these, we'll need to introduce layout-for-write or primary layout or similar.

Differential Revision: D84718419


