### PR TITLE
feat(refactor): Make functionset be filled up in the constructors

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -459,14 +459,10 @@ importExpr(ExprCP expr, const ColumnVector& outer, const ExprVector& inner) {
     case PlanType::kCallExpr: {
       auto children = expr->children();
       ExprVector newChildren(children.size());
-      FunctionSet functions;
       bool anyChange = false;
       for (auto i = 0; i < children.size(); ++i) {
         newChildren[i] = importExpr(children[i]->as<Expr>(), outer, inner);
         anyChange |= newChildren[i] != children[i];
-        if (newChildren[i]->isFunction()) {
-          functions = functions | newChildren[i]->as<Call>()->functions();
-        }
       }
 
       if (!anyChange) {
@@ -474,8 +470,7 @@ importExpr(ExprCP expr, const ColumnVector& outer, const ExprVector& inner) {
       }
 
       const auto* call = expr->as<Call>();
-      return make<Call>(
-          call->name(), call->value(), std::move(newChildren), functions);
+      return make<Call>(call->name(), call->value(), std::move(newChildren));
     }
     default:
       VELOX_UNREACHABLE("{}", expr->toString());

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -39,6 +39,11 @@ class FunctionSet {
     return 0 != (set_ & item);
   }
 
+  FunctionSet& operator|=(const FunctionSet& other) {
+    set_ |= other.set_;
+    return *this;
+  }
+
   /// Unions 'this' and 'other' and returns the result.
   FunctionSet operator|(const FunctionSet& other) const {
     return FunctionSet(set_ | other.set_);

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -68,10 +68,7 @@ template <typename... T>
 ExprCP
 makeCall(std::string_view name, const velox::TypePtr& type, T... inputs) {
   return make<Call>(
-      toName(name),
-      Value(toType(type), 1),
-      ExprVector{inputs...},
-      FunctionSet{});
+      toName(name), Value(toType(type), 1), ExprVector{inputs...});
 }
 
 Value bigintValue() {
@@ -144,8 +141,7 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
     hashes.emplace_back(makeCall(kHash, velox::BIGINT(), key));
   }
 
-  ExprCP hash =
-      make<Call>(toName(kHashMix), bigintValue(), hashes, FunctionSet{});
+  ExprCP hash = make<Call>(toName(kHashMix), bigintValue(), hashes);
 
   ColumnCP hashColumn = make<Column>(toName("hash"), nullptr, hash->value());
   RelationOpPtr project = make<Project>(

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -793,7 +793,6 @@ void Optimization::addAggregation(
         agg->name(),
         agg->value(),
         std::move(args),
-        agg->functions(),
         agg->isDistinct(),
         condition,
         agg->intermediateType(),
@@ -1857,10 +1856,7 @@ ExprCP Optimization::combineLeftDeep(Name func, const ExprVector& exprs) {
   ExprCP result = copy[0];
   for (auto i = 1; i < copy.size(); ++i) {
     result = toGraph_.deduppedCall(
-        func,
-        result->value(),
-        ExprVector{result, copy[i]},
-        result->functions() | copy[i]->functions());
+        func, result->value(), ExprVector{result, copy[i]});
   }
   return result;
 }

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -128,9 +128,9 @@ Call::Call(PlanType type, Name name, const Value& value, ExprVector args)
     columns_.unionSet(arg->columns());
     subexpressions_.unionSet(arg->subexpressions());
     subexpressions_.add(arg);
+    functions_ |= availableFunctions(arg);
   }
 
-  functions_ |= availableFunctions(args_);
 }
 
 std::string Call::toString() const {

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -130,7 +130,6 @@ Call::Call(PlanType type, Name name, const Value& value, ExprVector args)
     subexpressions_.add(arg);
     functions_ |= availableFunctions(arg);
   }
-
 }
 
 std::string Call::toString() const {

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -97,22 +97,14 @@ std::string Column::toString() const {
 
 namespace {
 
+// Helper to efficiently collect function sets from arguments.
+// Only calls the virtual functions() method for Call expressions.
 FunctionSet availableFunctions(const ExprCP& arg) {
   if (arg->is(PlanType::kCallExpr) || arg->is(PlanType::kAggregateExpr)) {
     return arg->as<Call>()->functions();
   }
 
   return FunctionSet(0);
-}
-
-// Helper to efficiently collect function sets from arguments.
-// Only calls the virtual functions() method for Call expressions.
-FunctionSet availableFunctions(const ExprVector& args) {
-  FunctionSet result;
-  for (auto arg : args) {
-    result |= availableFunctions(arg);
-  }
-  return result;
 }
 
 } // namespace

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -245,15 +245,10 @@ using FunctionMetadataCP = const FunctionMetadata*;
 /// subexpressions.
 class Call : public Expr {
  public:
-  Call(
-      PlanType type,
-      Name name,
-      const Value& value,
-      ExprVector args,
-      FunctionSet functions);
+  Call(PlanType type, Name name, const Value& value, ExprVector args);
 
-  Call(Name name, Value value, ExprVector args, FunctionSet functions)
-      : Call(PlanType::kCallExpr, name, value, std::move(args), functions) {}
+  Call(Name name, Value value, ExprVector args)
+      : Call(PlanType::kCallExpr, name, value, std::move(args)) {}
 
   Name name() const {
     return name_;
@@ -289,15 +284,16 @@ class Call : public Expr {
     return metadata_;
   }
 
+ protected:
+  // Set of functions used in 'this' and 'args'.
+  FunctionSet functions_;
+
  private:
   // name of function.
   Name const name_;
 
   // Arguments.
   const ExprVector args_;
-
-  // Set of functions used in 'this' and 'args'.
-  const FunctionSet functions_;
 
   FunctionMetadataCP metadata_;
 };
@@ -822,35 +818,11 @@ class Aggregate : public Call {
       Name name,
       const Value& value,
       ExprVector args,
-      FunctionSet functions,
       bool isDistinct,
       ExprCP condition,
       const velox::Type* intermediateType,
       ExprVector orderKeys,
-      OrderTypeVector orderTypes)
-      : Call(
-            PlanType::kAggregateExpr,
-            name,
-            value,
-            std::move(args),
-            functions | FunctionSet::kAggregate),
-        isDistinct_(isDistinct),
-        condition_(condition),
-        intermediateType_(intermediateType),
-        orderKeys_(std::move(orderKeys)),
-        orderTypes_(std::move(orderTypes)) {
-    VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
-
-    for (auto& arg : this->args()) {
-      rawInputType_.push_back(arg->value().type);
-    }
-    if (condition_) {
-      columns_.unionSet(condition_->columns());
-    }
-    for (auto& key : orderKeys_) {
-      columns_.unionSet(key->columns());
-    }
-  }
+      OrderTypeVector orderTypes);
 
   ExprCP condition() const {
     return condition_;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -164,8 +164,7 @@ class ToGraph {
 
   /// Creates or returns pre-existing function call with name+args. If
   /// deterministic, a new ExprCP is remembered for reuse.
-  ExprCP
-  deduppedCall(Name name, Value value, ExprVector args, FunctionSet flags);
+  ExprCP deduppedCall(Name name, Value value, ExprVector args);
 
   /// True if 'expr' is of the form a = b where a depends on one of 'tables' and
   /// b on the other. If true, returns the side depending on tables[0] in 'left'


### PR DESCRIPTION
make function set be evaluated in constructors. Before the PR it must be filled up and passed into. I think it better to make code more consistent and convenient to make it act like column union.
it's a convenient way to make them be filled up like columns 
added |= operator for FunctionSets