### PR TITLE
fix: Fix bug that prevents us from explore plan space

### DIFF
--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -491,9 +491,9 @@ bool NextJoin::isWorse(const NextJoin& other) const {
   float shuffle =
       plan->distribution().isSamePartition(other.plan->distribution())
       ? 0
-      : plan->cost().fanout * shuffleCost(plan->columns());
-  return cost.unitCost + cost.setupCost + shuffle >
-      other.cost.unitCost + other.cost.setupCost;
+      : other.cost.fanout * shuffleCost(other.plan->columns());
+  return cost.unitCost + cost.setupCost >
+      other.cost.unitCost + other.cost.setupCost + shuffle;
 }
 
 size_t MemoKey::hash() const {


### PR DESCRIPTION
Same issue reproduced when isWorse always returns false.


`isWorse` used for following logic if `plan` worse than `other.plan` then we need to remove plan.

If they have same partition it makes sense that we compare just their cost.

But if they're not same we should compare plan.cost against other.plan.cost + shuffle. Because we want to know that even after reshuffle other.plan will be cheaper than plan

Is everything else ok? No all code is full of such bugs...
(for an example here we're also should multiply unitCost by inputCardinality)

Unfortunately when I fix this, I found that in tpch q9 we starts to explore more plans, and some of this plans generated invalid. I don't understand what code is responsible for generating such invalid plans, and how we can prevent this from happens.

ERROR:
```
E20251019 21:22:50.839110 3090096 Exceptions.h:53] Line: /home/mironov/projects/serenedb/axiom/velox/velox/core/PlanNode.cpp:1502, Function:validate, Expression: leftType->containsChild(key->name()) Left side join key not found in left side output: s_suppkey, Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Left side join key not found in left side output: s_suppkey
Retriable: False
Expression: leftType->containsChild(key->name())
```

What is inside leftType, rigthType and outputType of this join
```
Left output column: p_partkey, ps_partkey, ps_suppkey, ps_supplycost
Right output column: l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount
Join output column: p_partkey, l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, ps_partkey, ps_suppkey, ps_supplycost,
```
