### PR TITLE
refactor: Remove usage of folly::StringPiece in dwio

### DIFF
--- a/axiom/connectors/hive/StatisticsBuilder.cpp
+++ b/axiom/connectors/hive/StatisticsBuilder.cpp
@@ -124,7 +124,12 @@ void StatisticsBuilderImpl::addStats(
         previous = value;
       }
 
-      reinterpret_cast<Builder*>(builder)->addValues(value);
+      // TODO: Remove explicit std::string_view cast.
+      if constexpr (std::is_same_v<T, velox::StringView>) {
+        reinterpret_cast<Builder*>(builder)->addValues(std::string_view(value));
+      } else {
+        reinterpret_cast<Builder*>(builder)->addValues(value);
+      }
       previous = value;
       hasPrevious = true;
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/15225

X-link: https://github.com/facebookincubator/nimble/pull/287

Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Reviewed By: xiaoxmeng, Yuhta

Differential Revision: D85061784


