### PR TITLE
refactor: Reduce DerivedTable's API surface

### DIFF
--- a/axiom/optimizer/BitSet.h
+++ b/axiom/optimizer/BitSet.h
@@ -66,6 +66,7 @@ class BitSet {
           }
         });
   }
+
   size_t size() const {
     return velox::bits::countBits(
         bits_.data(), 0, static_cast<int32_t>(bits_.size() * 64));

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1638,9 +1638,6 @@ DerivedTableP ToGraph::translateSetJoin(
 void ToGraph::makeUnionDistributionAndStats(
     DerivedTableP setDt,
     DerivedTableP innerDt) {
-  if (setDt->distribution == nullptr) {
-    setDt->distribution = make<Distribution>();
-  }
   if (innerDt == nullptr) {
     innerDt = setDt;
   }
@@ -1651,8 +1648,8 @@ void ToGraph::makeUnionDistributionAndStats(
         "Union inputs must have same arity also after pruning");
 
     auto plan = innerDt->bestInitialPlan()->op;
-
     setDt->cardinality += plan->resultCardinality();
+
     for (auto i = 0; i < setDt->columns.size(); ++i) {
       // The Column is created in setDt before all branches are planned so the
       // value is mutated here.


### PR DESCRIPTION
Differential Revision: D85305923

- Move expandConjuncts and findSingleRowDts to .cpp.
- Make setStartTables and numCanonicalConjuncts private.
- Remove distribution.
- Fill in cardinality.

