### PR TITLE
refactor: Introduce PlanCost

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -204,9 +204,8 @@ struct DerivedTable : public PlanObject {
 
   void addJoinedBy(JoinEdgeP join);
 
-  /// Memoizes plans for 'this' and fills in 'distribution_'. Needed
-  /// before adding 'this' as a join side because join sides must have
-  /// a cardinality guess.
+  /// Memoizes plans for 'this' and fills in 'cardinality'. Needed before adding
+  /// 'this' as a join side because join sides must have a cardinality guess.
   void makeInitialPlan();
 
   PlanP bestInitialPlan() const;

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -169,7 +169,7 @@ class Optimization {
   ExprCP combineLeftDeep(Name func, const ExprVector& exprs);
 
   /// Produces trace output if event matches 'traceFlags_'.
-  void trace(uint32_t event, int32_t id, const Cost& cost, RelationOp& plan)
+  void trace(uint32_t event, int32_t id, const PlanCost& cost, RelationOp& plan)
       const;
 
  private:

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -55,6 +55,9 @@ struct OptimizerOptions {
   /// disabled, a default selectivity will be used.
   bool sampleFilters{true};
 
+  /// Enable reducing semi joins.
+  bool enableReducingExistences{true};
+
   /// Produce trace of plan candidates.
   uint32_t traceFlags{0};
 

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -75,11 +75,16 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
     return core::PlanMatcherBuilder().tableScan(tableName);
   };
 
-  // Optimized join order: lineitem x (customer x orders).
+  // Cardinalities after filters:
+  //  - lineitem - 32.3K
+  //  - orders - 7.2K
+  //  - customer - 337
+
+  // Optimized join order: lineitem x (orders x customer).
   auto optimizedMatcher =
       startMatcher("lineitem")
-          .hashJoin(startMatcher("customer")
-                        .hashJoin(startMatcher("orders").build())
+          .hashJoin(startMatcher("orders")
+                        .hashJoin(startMatcher("customer").build())
                         .build())
           .aggregation()
           .build();

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -331,6 +331,13 @@ TEST_F(TpchPlanTest, q08) {
 }
 
 TEST_F(TpchPlanTest, q09) {
+  // TODO Remove this after fixing
+  // https://github.com/facebookincubator/axiom/issues/530
+  optimizerOptions_.enableReducingExistences = false;
+  SCOPE_EXIT {
+    optimizerOptions_.enableReducingExistences = true;
+  };
+
   lp::PlanBuilder::Context context{exec::test::kHiveConnectorId};
   auto logicalPlan =
       lp::PlanBuilder(context)


### PR DESCRIPTION
Summary: Cost struct is used to represent a cost of a single RelationOp as well as a cost of a Plan (a tree of RelationOp). This is confusing. Introduce PlanCost to represent the cost of a Plan and limit usage of Cost to representing the cost of a RelationOp.

Differential Revision: D85342911


