### PR TITLE
Fix reducing existences

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1013,6 +1013,7 @@ void Optimization::joinByIndex(
   }
 }
 
+  
 void Optimization::joinByHash(
     const RelationOpPtr& plan,
     const JoinCandidate& candidate,
@@ -1164,7 +1165,6 @@ void Optimization::joinByHash(
       candidate.join->filter(),
       fanout,
       std::move(columns));
-
   state.addCost(*join);
   state.cost.setupCost += buildState.cost.unitCost + buildState.cost.setupCost;
   state.cost.totalBytes += buildState.cost.totalBytes;

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -360,6 +360,9 @@ namespace facebook::axiom::optimizer {
 
 const JoinEdgeVector& joinedBy(PlanObjectCP table);
 
+/// Returns the columns of a BaseTable, DerivedTable, or ValuesTable.
+const ColumnVector& tableColumns(PlanObjectCP table);
+
 /// Returns  the inverse join type, e.g. right outer from left outer.
 /// TODO Move this function to Velox.
 velox::core::JoinType reverseJoinType(velox::core::JoinType joinType);

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -552,6 +552,14 @@ class JoinEdge {
     return rightOptional_;
   }
 
+  bool rightExists() const {
+    return rightExists_;
+  }
+
+  bool rightNotExists() const {
+    return rightNotExists_;
+  }
+
   bool directed() const {
     return directed_;
   }
@@ -580,7 +588,7 @@ class JoinEdge {
       return false;
     }
 
-    return !leftTable_ || rightOptional_ || leftOptional_ || rightExists_ ||
+    return rightOptional_ || leftOptional_ || rightExists_ ||
         rightNotExists_ || markColumn_ || directed_;
   }
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -24,6 +24,7 @@
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/vector/VariantToVector.h"
+#include "axiom/optimizer/DerivedTablePrinter.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -1524,6 +1525,10 @@ extern std::string veloxToString(const velox::core::PlanNode* plan) {
 
 extern std::string planString(const runner::MultiFragmentPlan* plan) {
   return plan->toString(true);
+}
+
+extern std::string dtString(const DerivedTable* dt) {
+  return DerivedTablePrinter::toText(*dt);
 }
 
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
When we import an already placed table or tables into a build side for cardinality reduction as a semijoin:

- The colums on the right side of the semijoin must not be added to downstreamColumns. A semijoin (exists) or antijoin (not exists) does not produce columns, except maybe a mark. Also, if the join has filters, the columns in the filter that come from the right side are not downstream columns.

- When a semijoin right side is a join, that join may itself contain existences. The right sides of these existences are not suitable for joining to the table or dt being reduced, since a semijoin right side does not produce columns. So, do not consider these for joining the reducing existence to the thing being reduced.

Fixes https://github.com/facebookincubator/axiom/issues/530