### PR TITLE
fix: Check allowed-in-dt before adding orderBy or limit

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1827,6 +1827,11 @@ void ToGraph::makeQueryGraph(
       return;
     }
     case lp::NodeKind::kSort: {
+      if (!contains(allowedInDt, lp::NodeKind::kSort)) {
+        wrapInDt(node);
+        return;
+      }
+
       // Multiple orderBys are allowed before a limit. Last one wins. Previous
       // are dropped. If arrives after limit, then starts a new DT.
 
@@ -1840,6 +1845,11 @@ void ToGraph::makeQueryGraph(
       return;
     }
     case lp::NodeKind::kLimit: {
+      if (!contains(allowedInDt, lp::NodeKind::kLimit)) {
+        wrapInDt(node);
+        return;
+      }
+
       // Multiple limits are allowed. If already present, then it is combined
       // with the new limit.
       makeQueryGraph(*node.onlyInput(), allowedInDt);


### PR DESCRIPTION
Differential Revision: D85428042

When translating join's inputs with limit or order by, make sure to wrap these in their own DTs.

