### PR TITLE
refactor: FileMetadata to support writing of ORC's proto for ORC writing preparation

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -26,6 +26,7 @@
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/dwrf/common/FileMetadata.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 #include "velox/type/fbhive/HiveTypeSerializer.h"


### PR DESCRIPTION
Summary:
As mentioned in this [comment](https://github.com/facebookincubator/velox/pull/12487#issuecomment-2715722942), PR [12487 ](https://github.com/facebookincubator/velox/pull/12487) modified too much code. To facilitate reading, the PR was split into multiple PRs. This is the first PR, which mainly introduces various wrappers, allowing us to write data in DWRF and ORC formats in the same code.

CC: Yuhta majetideepak

X-link: https://github.com/facebookincubator/velox/pull/12616

Reviewed By: Yuhta

Differential Revision: D71047997

Pulled By: HuamengJiang


