### PR TITLE
fix: Import of reducing semi joins in q9

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "axiom/optimizer/DerivedTable.h"
+#include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
@@ -1025,45 +1026,7 @@ PlanP DerivedTable::bestInitialPlan() const {
 }
 
 std::string DerivedTable::toString() const {
-  std::stringstream out;
-  out << "{dt " << cname << " from ";
-  for (auto& table : tables) {
-    out << table->toString() << " ";
-  }
-
-  if (!joins.empty()) {
-    out << " joins ";
-    for (auto& join : joins) {
-      out << join->toString();
-    }
-  }
-
-  if (!conjuncts.empty()) {
-    out << " where " << conjunctsToString(conjuncts);
-  }
-
-  if (hasAggregation()) {
-    out << " group by " << aggregation->groupingKeys().size() << " keys, "
-        << aggregation->aggregates().size() << " aggregates ";
-
-    if (!having.empty()) {
-      out << " having " << conjunctsToString(having);
-    }
-  }
-
-  if (hasOrderBy()) {
-    out << " order by ";
-  }
-
-  if (hasLimit()) {
-    if (offset > 0) {
-      out << " offset " << offset << " ";
-    }
-    out << " limit " << limit;
-  }
-
-  out << "}";
-  return out.str();
+  return DerivedTablePrinter::toText(*this);
 }
 
 void DerivedTable::addJoinedBy(JoinEdgeP join) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -552,6 +552,14 @@ class JoinEdge {
     return rightOptional_;
   }
 
+  bool rightExists() const {
+    return rightExists_;
+  }
+
+  bool rightNotExists() const {
+    return rightNotExists_;
+  }
+
   bool directed() const {
     return directed_;
   }

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -331,13 +331,6 @@ TEST_F(TpchPlanTest, q08) {
 }
 
 TEST_F(TpchPlanTest, q09) {
-  // TODO Remove this after fixing
-  // https://github.com/facebookincubator/axiom/issues/530
-  optimizerOptions_.enableReducingExistences = false;
-  SCOPE_EXIT {
-    optimizerOptions_.enableReducingExistences = true;
-  };
-
   lp::PlanBuilder::Context context{exec::test::kHiveConnectorId};
   auto logicalPlan =
       lp::PlanBuilder(context)


### PR DESCRIPTION
Summary:
Partial fix for https://github.com/facebookincubator/axiom/issues/530

Adapted from Orri's https://github.com/facebookincubator/axiom/pull/551

When we import an already placed table or tables into a build side for cardinality reduction as a semijoin:

The colums on the right side of the semijoin must not be added to downstreamColumns. A semijoin (exists) or antijoin (not exists) does not produce columns, except maybe a mark. Also, if the join has filters, the columns in the filter that come from the right side are not downstream columns.

Co-authored-by: oerling

Differential Revision: D85464350


