### PR TITLE
fix: Make sameOrEqual work properly

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -373,7 +373,7 @@ bool Expr::sameOrEqual(const Expr& other) const {
         return false;
       }
       for (auto i = 0; i < numArgs; ++i) {
-        if (as<Call>()->argAt(i)->sameOrEqual(*other.as<Call>()->argAt(i))) {
+        if (!as<Call>()->argAt(i)->sameOrEqual(*other.as<Call>()->argAt(i))) {
           return false;
         }
       }


### PR DESCRIPTION
This pull request fixes a logical error in the `Expr::sameOrEqual` method in `QueryGraph.cpp`. The change corrects the condition for comparing arguments in function call expressions.

* Fixed the argument comparison logic in `Expr::sameOrEqual` so that it returns `false` if any argument is not the same or equal, rather than if any argument is the same or equal.