### PR TITLE
refactor: Remove redundant HiveQueriesTestBase::checkResults method

### DIFF
--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -173,7 +173,7 @@ TEST_F(HiveLimitQueriesTest, offsetOnly) {
                        .limit(5, noLimit, false)
                        .planNode();
 
-  checkResults(plan, reference);
+  checkSame(plan, reference);
 }
 
 // OFFSET <very large>
@@ -195,7 +195,7 @@ TEST_F(HiveLimitQueriesTest, veryLargeOffset) {
                        .limit(noLimit - 5, 100, false)
                        .planNode();
 
-  checkResults(plan, reference);
+  checkSame(plan, reference);
 }
 
 // ORDER BY name DESC
@@ -287,7 +287,7 @@ TEST_F(HiveLimitQueriesTest, orderByOffsetLimit) {
                        .limit(5, 10, false)
                        .planNode();
 
-  checkResults(plan, reference);
+  checkSame(plan, reference);
 }
 
 } // namespace

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -69,41 +69,7 @@ void HiveQueriesTestBase::checkResults(
   auto logicalPlan =
       statement->as<::axiom::sql::presto::SelectStatement>()->plan();
 
-  checkResults(logicalPlan, referencePlan);
-}
-
-void HiveQueriesTestBase::checkResults(
-    const lp::LogicalPlanNodePtr& logicalPlan,
-    const core::PlanNodePtr& referencePlan) {
-  VELOX_CHECK_NOT_NULL(logicalPlan);
-  VELOX_CHECK_NOT_NULL(referencePlan);
-
-  auto referenceResult = runVelox(referencePlan);
-  SCOPED_TRACE("reference plan:\n" + referencePlan->toString(true, true));
-  {
-    SCOPED_TRACE("single node and single thread");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 1});
-    SCOPED_TRACE("plan:\n" + plan.plan->toString());
-    checkResults(plan, referenceResult);
-  }
-  {
-    SCOPED_TRACE("single node and multi thread");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
-    SCOPED_TRACE("plan:\n" + plan.plan->toString());
-    checkResults(plan, referenceResult);
-  }
-  {
-    SCOPED_TRACE("multi node and single thread");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1});
-    SCOPED_TRACE("plan:\n" + plan.plan->toString());
-    checkResults(plan, referenceResult);
-  }
-  {
-    SCOPED_TRACE("multi node and multi thread");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
-    SCOPED_TRACE("plan:\n" + plan.plan->toString());
-    checkResults(plan, referenceResult);
-  }
+  checkSame(logicalPlan, referencePlan);
 }
 
 void HiveQueriesTestBase::checkResults(

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -40,10 +40,6 @@ class HiveQueriesTestBase : public test::QueryTestBase {
       std::string_view sql,
       const velox::core::PlanNodePtr& referencePlan);
 
-  void checkResults(
-      const logical_plan::LogicalPlanNodePtr& logicalPlan,
-      const velox::core::PlanNodePtr& referencePlan);
-
   void checkResults(PlanAndStats& plan, const test::TestResult& expected);
 
   void checkSingleNodePlan(

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -60,7 +60,7 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
 
   void checkTpch(int32_t query, const lp::LogicalPlanNodePtr& logicalPlan) {
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
-    checkResults(logicalPlan, referencePlan);
+    checkSame(logicalPlan, referencePlan);
   }
 
   static std::string readSqlFromFile(const std::string& filePath) {
@@ -109,9 +109,9 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
   }
 
   void checkTpchSql(int32_t query) {
-    auto logicalPlan = parseTpchSql(query);
+    auto sql = readTpchSql(query);
     auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
-    checkResults(logicalPlan, referencePlan);
+    checkResults(sql, referencePlan);
   }
 
   std::unique_ptr<exec::test::TpchQueryBuilder> referenceBuilder_;


### PR DESCRIPTION
Summary: HiveQueriesTestBase::checkResults is the same as QueriesTestBase::checkSame.

Differential Revision: D85566738


