### PR TITLE
feat: Add support for non-correlated subqueries used in filters

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -404,7 +404,9 @@ class PlanBuilder {
   /// anonymous, assigns unique name before returning.
   std::string findOrAssignOutputNameAt(size_t index) const;
 
-  LogicalPlanNodePtr build();
+  /// @param useIds Boolean indicating whether to use user-specified names or
+  /// use auto-generated IDs for the output column names.
+  LogicalPlanNodePtr build(bool useIds = false);
 
  private:
   std::string nextId() {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -569,11 +569,11 @@ class JoinEdge {
   /// True if inner join.
   bool isInner() const {
     return !leftOptional_ && !rightOptional_ && !rightExists_ &&
-        !rightNotExists_;
+        !rightNotExists_ && !markColumn_;
   }
 
   bool isSemi() const {
-    return rightExists_;
+    return rightExists_ || (markColumn_ != nullptr);
   }
 
   bool isAnti() const {

--- a/axiom/optimizer/Subfields.cpp
+++ b/axiom/optimizer/Subfields.cpp
@@ -445,6 +445,12 @@ void ToGraph::markSubfields(
     return;
   }
 
+  if (expr->isSubquery()) {
+    // TODO We may not necessarily need all outputs of the subquery.
+    markAllSubfields(*expr->as<lp::SubqueryExpr>()->subquery());
+    return;
+  }
+
   VELOX_UNREACHABLE("Unhandled expr: {}", lp::ExprPrinter::toText(*expr));
 }
 

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -521,13 +521,11 @@ TEST_F(TpchPlanTest, q14) {
 }
 
 TEST_F(TpchPlanTest, q15) {
-  // TODO Add support for subqueries.
-  parseTpchSql(15);
+  checkTpchSql(15);
 }
 
 TEST_F(TpchPlanTest, q16) {
-  // TODO Implement.
-  parseTpchSql(16);
+  checkTpchSql(16);
 }
 
 TEST_F(TpchPlanTest, q17) {
@@ -536,8 +534,7 @@ TEST_F(TpchPlanTest, q17) {
 }
 
 TEST_F(TpchPlanTest, q18) {
-  // TODO Add support for subqueries.
-  parseTpchSql(18);
+  checkTpchSql(18);
 }
 
 TEST_F(TpchPlanTest, q19) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -308,7 +308,7 @@ class RelationPlanner : public AstVisitor {
           auto subqueryBuider = builder_;
 
           builder_ = std::move(builder);
-          return lp::Subquery(subqueryBuider->build());
+          return lp::Subquery(subqueryBuider->build(/*useIds=*/true));
         }
 
         VELOX_NYI(


### PR DESCRIPTION
Summary: Add minimal support for non-correlated subqueries used in a filter. Enables TPC-H q15, 16 and 18.

Add logic to process non-correlated subqueries found in a filter.

IN <subquery> expression is handled by creating a new DT for the subquery and adding a semi-join edge to the current DT. The IN predicate is then replaced with a 'mark' column produced by the join.

Other <subquery> expressions are handled by creating a new DT for the subquery and replacing the expression with the only column produced by the DT.

Differential Revision: D85625835


