### PR TITLE
fix: Fix derived table breaks on with joins

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -36,11 +36,11 @@ void History::updateFromFile(const std::string& path) {
 }
 
 float shuffleCost(const ColumnVector& columns) {
-  return byteSize(columns);
+  return byteSize(columns) * Costs::kByteShuffleCost;
 }
 
 float shuffleCost(const ExprVector& exprs) {
-  return byteSize(exprs);
+  return byteSize(exprs) * Costs::kByteShuffleCost;
 }
 
 float selfCost(ExprCP expr) {
@@ -84,6 +84,64 @@ float costWithChildren(ExprCP expr, const PlanObjectSet& notCounting) {
     default:
       return 0;
   }
+}
+
+float Costs::cacheMissClocks(float workingSet, float accessBytes) {
+  // x86 cache architecture constants
+  const float kCacheLineSize = 64.0f; // Cache line size in bytes
+  const float kL1Size = 32.0f * 1024.0f; // L1 cache: 32 KB
+  const float kL2Size = 256.0f * 1024.0f; // L2 cache: 256 KB
+  const float kL3Size = 8.0f * 1024.0f *
+      1024.0f; // L3 cache: 8 MB per query, total cache is larger.
+
+  // Cache latencies in CPU cycles
+  const float kL1Latency = 2.0f; // L1 hit: 2 cycles
+  const float kL2Latency = 6.0f; // L2 hit: 6 cycles
+  const float kL3Latency =
+      22.0f; // L3 hit: 22 cycles
+             // Memory miss: 60 cycles. The real latency is higher but for hash
+             // tables where many concurrent misses pending at the same time, 65
+             // agrees somewhat with observations.
+  const float kMemoryLatency = 60.0f;
+
+  // Compute number of cache lines accessed.
+  // For each byte beyond the first cache line, we count 1/64 of the miss cost,
+  // which effectively means accessBytes / kCacheLineSize cache lines.
+  float numCacheLines =
+      1 + (accessBytes > 1 ? accessBytes / kCacheLineSize : 0);
+
+  // Compute expected latency per cache line access based on working set size.
+  // For random access patterns, the probability of finding data in a cache
+  // level is proportional to the ratio of cache size to working set size.
+  // When the working set exceeds a cache level, we blend between that level
+  // and the next level based on the cache occupancy fraction.
+  float expectedLatency;
+
+  if (workingSet <= kL1Size) {
+    // Working set fits entirely in L1 cache
+    expectedLatency = kL1Latency;
+  } else if (workingSet <= kL2Size) {
+    // Working set exceeds L1 but fits in L2
+    // Blend between L1 and L2 latencies proportional to L1 occupancy
+    float l1Fraction = kL1Size / workingSet;
+    expectedLatency =
+        l1Fraction * kL1Latency + (1.0f - l1Fraction) * kL2Latency;
+  } else if (workingSet <= kL3Size) {
+    // Working set exceeds L2 but fits in L3
+    // Blend between L2 and L3 latencies proportional to L2 occupancy
+    float l2Fraction = kL2Size / workingSet;
+    expectedLatency =
+        l2Fraction * kL2Latency + (1.0f - l2Fraction) * kL3Latency;
+  } else {
+    // Working set exceeds L3, spills to main memory
+    // Blend between L3 and memory latencies proportional to L3 occupancy
+    float l3Fraction = kL3Size / workingSet;
+    expectedLatency =
+        l3Fraction * kL3Latency + (1.0f - l3Fraction) * kMemoryLatency;
+  }
+
+  // Total cost is the number of cache lines accessed times the expected latency
+  return numCacheLines * expectedLatency;
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -165,7 +165,9 @@ struct DerivedTable : public PlanObject {
       PlanObjectCP firstTable,
       const PlanObjectSet& superTables,
       const std::vector<PlanObjectSet>& existences,
-      float existsFanout = 1);
+      float existsFanout = 1,
+      PlanObjectSet extraConjuncts = PlanObjectSet(),
+      PlanObjectSet columns = PlanObjectSet());
 
   /// Return a copy of 'expr', replacing references to this DT's 'columns' with
   /// corresponding 'exprs'.
@@ -211,6 +213,10 @@ struct DerivedTable : public PlanObject {
   bool hasLimit() const {
     return limit >= 0;
   }
+
+  // True if contains one derived table in 'tables'  and adds no change to its
+  // result set.
+  bool isWrapOnly() const;
 
   void addJoinedBy(JoinEdgeP join);
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -56,7 +56,6 @@ Optimization::Optimization(
   toGraph_.setDtOutput(root_, *logicalPlan_);
 }
 
-// static
 PlanAndStats Optimization::toVeloxPlan(
     const logical_plan::LogicalPlanNode& logicalPlan,
     velox::memory::MemoryPool& pool,
@@ -89,7 +88,19 @@ PlanAndStats Optimization::toVeloxPlan(
       std::move(runnerOptions)};
 
   auto best = opt.bestPlan();
+  opt.trace(OptimizerOptions::kRetained, 0, best->cost, *best->op);
   return opt.toVeloxPlan(best->op);
+}
+
+std::string Optimization::memoString() const {
+  std::stringstream out;
+  for (auto& [key, planSet] : memo_) {
+    out << key.toString() << " plans= " << std::endl;
+    for (auto& plan : planSet.plans) {
+      out << plan->toString(true) << std::endl;
+    }
+  }
+  return out.str();
 }
 
 void Optimization::trace(
@@ -140,7 +151,15 @@ void reducingJoinsRecursive(
         resultFunc = {}) {
   bool isLeaf = true;
   for (auto join : joinedBy(candidate)) {
-    if (join->leftOptional() || join->rightOptional()) {
+    if (join->isLeftOuter() && candidate == join->rightTable() &&
+        candidate->is(PlanType::kDerivedTableNode)) {
+      // One can restrict the build of the optional side by a
+      // restriction on the probe. This happens specially when value
+      // subqueries are represented as optional sides of left
+      // oj. These are often aggregations and htere is no point
+      // creating values for groups that can't be probed.
+      ;
+    } else if (join->leftOptional() || join->rightOptional()) {
       continue;
     }
     JoinSide other = join->sideOf(candidate, true);
@@ -192,6 +211,16 @@ void reducingJoinsRecursive(
   }
 }
 
+bool allowReducingInnerJoins(const JoinCandidate& candidate) {
+  if (!candidate.join->isInner()) {
+    return false;
+  }
+  if (candidate.tables[0]->is(PlanType::kDerivedTableNode)) {
+    return false;
+  }
+  return true;
+}
+
 // For an inner join, see if can bundle reducing joins on the build.
 std::optional<JoinCandidate> reducingJoins(
     const PlanState& state,
@@ -202,7 +231,7 @@ std::optional<JoinCandidate> reducingJoins(
   float fanout = candidate.fanout;
 
   PlanObjectSet reducingSet;
-  if (candidate.join->isInner()) {
+  if (allowReducingInnerJoins(candidate)) {
     PlanObjectSet visited = state.placed;
     VELOX_DCHECK(!candidate.tables.empty());
     visited.add(candidate.tables[0]);
@@ -317,23 +346,24 @@ void forJoinedTables(const PlanState& state, Func func) {
 }
 
 bool addExtraEdges(PlanState& state, JoinCandidate& candidate) {
-  // See if there are more join edges from the first of 'candidate' to already
-  // placed tables. Fill in the non-redundant equalities into the join edge.
-  // Make a new edge if the edge would be altered.
+  // See if there are more join edges from any of 'candidate' inner joined
+  // tables to already placed tables. Fill in the non-redundant equalities into
+  // the join edge. Make a new edge if the edge would be altered.
   auto* originalJoin = candidate.join;
-  auto* table = candidate.tables[0];
-  for (auto* otherJoin : joinedBy(table)) {
-    if (otherJoin == originalJoin || !otherJoin->isInner()) {
-      continue;
+  for (auto* table : candidate.tables) {
+    for (auto* otherJoin : joinedBy(table)) {
+      if (otherJoin == originalJoin || !otherJoin->isInner()) {
+        continue;
+      }
+      auto [otherTable, fanout] = otherJoin->otherTable(table);
+      if (!state.dt->hasTable(otherTable)) {
+        continue;
+      }
+      if (candidate.isDominantEdge(state, otherJoin)) {
+        break;
+      }
+      candidate.addEdge(state, otherJoin, table);
     }
-    auto [otherTable, fanout] = otherJoin->otherTable(table);
-    if (!state.dt->hasTable(otherTable)) {
-      continue;
-    }
-    if (candidate.isDominantEdge(state, otherJoin)) {
-      return false;
-    }
-    candidate.addEdge(state, otherJoin);
   }
   return true;
 }
@@ -913,7 +943,8 @@ void Optimization::addAggregation(
         std::move(finalGroupingKeys),
         std::move(aggregates),
         velox::core::AggregationNode::Step::kFinal,
-        aggPlan->columns());
+        aggPlan->columns(),
+        partialAgg);
 
     state.addCost(*finalAgg);
     plan = finalAgg;
@@ -1017,6 +1048,21 @@ void Optimization::joinByIndex(
   }
 }
 
+namespace {
+// Given a MemoKey for a build side, picks the deterministic conjuncts from
+// 'state.dt' that are fully defined in terms of 'key.tables'.
+void gatherConjunctsForKey(PlanState& state, MemoKey& key) {
+  for (auto& conjunct : state.dt->conjuncts) {
+    if (conjunct->containsFunction(FunctionSet::kNonDeterministic)) {
+      continue;
+    }
+    if (conjunct->allTables().isSubset(key.tables)) {
+      key.extraConjuncts.add(conjunct);
+    }
+  }
+}
+} // namespace
+
 void Optimization::joinByHash(
     const RelationOpPtr& plan,
     const JoinCandidate& candidate,
@@ -1046,7 +1092,13 @@ void Optimization::joinByHash(
     buildTables.add(buildTable);
   }
 
+  // The build side dt does not need to produce columns that it uses
+  // internally, only the columns that are downstream if we consider
+  // the build to be placed. So, provisionally mark build side tables
+  // as placed for the downstreamColumns().
+  state.placed.unionSet(buildTables);
   buildColumns.intersect(state.downstreamColumns());
+  state.placed.except(buildTables);
   buildColumns.unionColumns(build.keys);
   buildColumns.unionSet(buildFilterColumns);
   state.columns.unionSet(buildColumns);
@@ -1054,6 +1106,9 @@ void Optimization::joinByHash(
   MemoKey memoKey{
       candidate.tables[0], buildColumns, buildTables, candidate.existences};
 
+  if (candidate.join->isInner()) {
+    gatherConjunctsForKey(state, memoKey);
+  }
   Distribution forBuild;
   if (plan->distribution().isGather()) {
     forBuild = Distribution::gather();
@@ -1075,7 +1130,7 @@ void Optimization::joinByHash(
   } else {
     state.placed.unionSet(buildTables);
   }
-
+  state.placed.unionSet(memoKey.extraConjuncts);
   PlanState buildState(state.optimization, state.dt, buildPlan);
   RelationOpPtr buildInput = buildPlan->op;
   RelationOpPtr probeInput = plan;
@@ -1238,7 +1293,6 @@ void Optimization::joinByHashRight(
   buildColumns.unionObjects(buildInput->columns());
 
   const auto leftJoinType = probe.leftJoinType();
-  const auto fanout = fanoutJoinTypeLimit(leftJoinType, candidate.fanout);
 
   // Change the join type to the right join variant.
   const auto rightJoinType = reverseJoinType(leftJoinType);
@@ -1246,9 +1300,38 @@ void Optimization::joinByHashRight(
       leftJoinType != rightJoinType,
       "Join type does not have right hash join variant");
 
+  float markTrueFraction = Value::kUnknown;
   const bool buildOnly =
       rightJoinType == velox::core::JoinType::kRightSemiFilter ||
       rightJoinType == velox::core::JoinType::kRightSemiProject;
+
+  // Initialize fanout to invalid value, check that it is assigned after the
+  // below switch.
+  float fanout = -1;
+  switch (rightJoinType) {
+    case velox::core::JoinType::kRightSemiFilter:
+      fanout = 1.0 / candidate.fanout;
+      break;
+    case velox::core::JoinType::kRightSemiProject:
+      markTrueFraction = 1 / fanout;
+      fanout = state.cost.cardinality < 1
+          ? 1
+          : state.cost.cardinality / probePlan->cost.cardinality;
+      break;
+    case velox::core::JoinType::kRight:
+      // A right oj produces every probe side row plus unhit build side rows.
+      // rlFanout is the approximation but never < 1.
+      fanout = std::max<float>(candidate.join->rlFanout(), 1);
+      break;
+    case velox::core::JoinType::kLeft:
+      // A right oj reversed produces every right side row and never limits the
+      // lrFanout.
+      fanout = std::max<float>(candidate.join->lrFanout(), 1);
+      break;
+    default:
+      VELOX_UNREACHABLE("Bad right join type {}", rightJoinType);
+  }
+  VELOX_CHECK_GE(fanout, 0);
 
   ColumnVector columns;
   PlanObjectSet columnSet;
@@ -1272,7 +1355,7 @@ void Optimization::joinByHashRight(
 
   if (mark) {
     const_cast<Value*>(&mark->value())->trueFraction =
-        std::min<float>(1, candidate.fanout);
+        std::min<float>(1, markTrueFraction);
     columns.push_back(mark);
   }
 
@@ -1451,7 +1534,7 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
   state.columns.unionSet(dtColumns);
 
   MemoKey key;
-  key.columns = std::move(dtColumns);
+  key.columns = dtColumns;
   key.firstTable = from;
   key.tables.add(from);
 
@@ -1479,7 +1562,7 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
 
   if (reduction < 0.9) {
     key.tables = reducingSet;
-    key.columns = state.downstreamColumns();
+    key.columns = dtColumns;
     plan = makePlan(key, Distribution{}, PlanObjectSet{}, 1, state, ignore);
     // Not all reducing joins are necessarily retained in the plan. Only mark
     // the ones fully imported as placed.
@@ -1768,7 +1851,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
     }
 
     addPostprocess(dt, plan, state);
-    auto kept = state.plans.addPlan(plan, state);
+    auto kept = state.plans.addPlan(plan, state, isSingleWorker_);
     trace(
         kept ? OptimizerOptions::kRetained : OptimizerOptions::kExceededBest,
         dt->id(),
@@ -1780,6 +1863,13 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   std::vector<NextJoin> nextJoins;
   nextJoins.reserve(candidates.size());
   for (auto& candidate : candidates) {
+    if (candidate.tables.size() > 1) {
+      // When there are multiple tables on the build side, we need to consider
+      // all edges that go from already placed tables to the bushy build side.
+      // So far, we have only filled in the edges for the first in
+      // 'candidate.tables'.
+      addExtraEdges(state, candidate);
+    }
     addJoin(candidate, plan, state, nextJoins);
   }
 
@@ -1894,7 +1984,13 @@ PlanP Optimization::makeDtPlan(
     auto dt = make<DerivedTable>();
     dt->cname = newCName("tmp_dt");
     dt->import(
-        *state.dt, key.firstTable, key.tables, key.existences, existsFanout);
+        *state.dt,
+        key.firstTable,
+        key.tables,
+        key.existences,
+        existsFanout,
+        key.extraConjuncts,
+        key.columns);
 
     PlanState inner(*this, dt);
     if (key.firstTable->is(PlanType::kDerivedTableNode)) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -173,6 +173,8 @@ class Optimization {
   void trace(uint32_t event, int32_t id, const PlanCost& cost, RelationOp& plan)
       const;
 
+  std::string memoString() const;
+
  private:
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.

--- a/axiom/optimizer/ParallelExpr.cpp
+++ b/axiom/optimizer/ParallelExpr.cpp
@@ -172,13 +172,13 @@ velox::core::PlanNodePtr ToVelox::makeParallelProject(
     group->emplace_back(toTypedExpr(expr));
 
     if (expr->is(PlanType::kColumnExpr)) {
-      names.push_back(expr->as<Column>()->outputName());
+      names.push_back(sanitizeFieldName(expr->as<Column>()->outputName()));
     } else {
       names.push_back(fmt::format("__temp{}", expr->id()));
     }
 
     auto fieldAccess = std::make_shared<velox::core::FieldAccessTypedExpr>(
-        group->back()->type(), names.back());
+        group->back()->type(), sanitizeFieldName(names.back()));
     projectedExprs_[expr] = fieldAccess;
   }
 
@@ -365,7 +365,7 @@ velox::core::PlanNodePtr ToVelox::maybeParallelProject(
   finalExprs.reserve(exprs.size());
 
   for (auto i = 0; i < exprs.size(); ++i) {
-    names.emplace_back(columns[i]->outputName());
+    names.emplace_back(sanitizeFieldName(columns[i]->outputName()));
     finalExprs.emplace_back(toTypedExpr(exprs[i]));
   }
 

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -27,8 +27,21 @@ namespace {
 bool isSingleWorker() {
   return queryCtx()->optimization()->runnerOptions().numWorkers == 1;
 }
-
 } // namespace
+
+std::string MemoKey::toString() const {
+  std::stringstream out;
+  out << "{MemoKey Columns: ";
+  out << columns.toString(1) << " Tables " << tables.toString(1)
+      << " extraConjuncts=" << extraConjuncts.toString(1) << " ";
+  if (!existences.empty()) {
+    out << std::endl << " existences=";
+    for (auto& existence : existences) {
+      out << " exists= " << existence.toString(1) << std::endl;
+    }
+  }
+  return out.str();
+}
 
 PlanState::PlanState(Optimization& optimization, DerivedTableCP dt)
     : optimization(optimization),
@@ -121,6 +134,9 @@ std::string Plan::toString(bool detail) const {
 void PlanState::addCost(RelationOp& op) {
   cost.cost += op.cost().totalCost();
   cost.cardinality = op.cost().resultCardinality();
+  if (std::isnan(cost.cost) || std::isnan(cost.cardinality)) {
+    printf("bing\n");
+  }
 }
 
 bool PlanState::mayConsiderNext(PlanObjectCP table) const {
@@ -298,9 +314,15 @@ std::string PlanState::printPlan(RelationOpPtr op, bool detail) const {
   return plan->toString(detail);
 }
 
-PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
+PlanP PlanSet::addPlan(
+    RelationOpPtr plan,
+    PlanState& state,
+    bool isSingleWorker) {
   int32_t replaceIndex = -1;
-  const float shuffle = shuffleCost(plan->columns()) * state.cost.cardinality;
+  bool isRoot = state.dt->id() == 0;
+  const float shuffle = isSingleWorker
+      ? 0
+      : shuffleCost(plan->columns()) * state.cost.cardinality;
 
   if (!plans.empty()) {
     // Compare with existing. If there is one with same distribution and new is
@@ -315,7 +337,9 @@ PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
 
       const bool newIsBetter = old->isStateBetter(state);
       const bool newIsBetterWithShuffle = old->isStateBetter(state, shuffle);
-      const bool sameDist =
+      // We do not differentiate plans by their result distribution for root
+      // plans or single worker plans.
+      const bool sameDist = isRoot || isSingleWorker ||
           old->op->distribution().isSamePartition(plan->distribution());
       const bool sameOrder =
           old->op->distribution().isSameOrder(plan->distribution());
@@ -436,8 +460,10 @@ bool hasEqual(ExprCP key, const ExprVector& keys) {
 }
 } // namespace
 
-void JoinCandidate::addEdge(PlanState& state, JoinEdgeP edge) {
-  auto* joined = tables[0];
+void JoinCandidate::addEdge(
+    PlanState& state,
+    JoinEdgeP edge,
+    PlanObjectCP joined) {
   auto newTableSide = edge->sideOf(joined);
   auto newPlacedSide = edge->sideOf(joined, true);
   VELOX_CHECK_NOT_NULL(newPlacedSide.table);
@@ -518,6 +544,9 @@ bool NextJoin::isWorse(const NextJoin& other) const {
 
 size_t MemoKey::hash() const {
   size_t hash = tables.hash();
+  if (!extraConjuncts.empty()) {
+    hash = velox::bits::commutativeHashMix(hash, extraConjuncts.hash());
+  }
   for (auto& exists : existences) {
     hash = velox::bits::commutativeHashMix(hash, exists.hash());
   }
@@ -526,7 +555,7 @@ size_t MemoKey::hash() const {
 
 bool MemoKey::operator==(const MemoKey& other) const {
   if (firstTable == other.firstTable && columns == other.columns &&
-      tables == other.tables) {
+      tables == other.tables && extraConjuncts == other.extraConjuncts) {
     if (existences.size() != other.existences.size()) {
       return false;
     }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -584,6 +584,10 @@ class JoinEdge {
     return rightExists_ || (markColumn_ != nullptr);
   }
 
+  bool isLeftOuter() const {
+    return rightOptional_ && !leftOptional_ && !isSemi() && !isAnti();
+  }
+
   bool isAnti() const {
     return rightNotExists_;
   }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -529,7 +529,8 @@ struct Aggregation : public RelationOp {
       ExprVector groupingKeys,
       AggregateVector aggregates,
       velox::core::AggregationNode::Step step,
-      ColumnVector columns);
+      ColumnVector columns,
+      const Aggregation* partial = nullptr);
 
   const ExprVector groupingKeys;
   const AggregateVector aggregates;
@@ -542,6 +543,14 @@ struct Aggregation : public RelationOp {
   void accept(
       const RelationOpVisitor& visitor,
       RelationOpVisitorContext& context) const override;
+
+ private:
+  void setCostWithGroups(
+      int64_t inputBeforePartial,
+      int32_t width,
+      float maxPartialAggregationMemory,
+      float abandonPartialAggregationMinRows,
+      float abandonPartialAggregationMinPct);
 };
 
 /// Represents an order by. The order is given by the distribution.

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -84,8 +84,10 @@ SchemaTableCP Schema::findTable(
   auto& tableColumns = connectorTable->columnMap();
   schemaColumns.reserve(tableColumns.size());
   for (const auto& [columnName, tableColumn] : tableColumns) {
-    const auto cardinality = static_cast<float>(tableColumn->approxNumDistinct(
-        static_cast<int64_t>(connectorTable->numRows())));
+    const auto cardinality = std::max<float>(
+        tableColumn->approxNumDistinct(
+            static_cast<int64_t>(connectorTable->numRows())),
+        1.0f);
     Value value(toType(tableColumn->type()), cardinality);
     auto* column = make<Column>(toName(columnName), nullptr, value);
     schemaColumns[column->name()] = column;

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -39,6 +39,8 @@ using NameMap = std::unordered_map<
 
 /// Represents constraints on a column value or intermediate result.
 struct Value {
+  static constexpr float kUnknown = -1;
+
   Value(const velox::Type* type, float cardinality)
       : type{type}, cardinality{cardinality} {}
 
@@ -56,8 +58,8 @@ struct Value {
 
   // Estimate of true fraction for booleans. 0 means always
   // false. This is an estimate and 1 or 0 do not allow pruning
-  // dependent code paths.
-  float trueFraction{1};
+  // dependent code paths. kUnknown
+  float trueFraction{kUnknown};
 
   // 0 means no nulls, 0.5 means half are null.
   float nullFraction{0};
@@ -285,7 +287,7 @@ float baseSelectivity(PlanObjectCP object);
 struct SchemaTable {
   explicit SchemaTable(const connector::Table& connectorTable)
       : connectorTable{&connectorTable},
-        cardinality{static_cast<float>(connectorTable.numRows())} {}
+        cardinality{std::max<float>(connectorTable.numRows(), 1.0f)} {}
 
   ColumnGroupCP addIndex(
       const connector::TableLayout& layout,

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "axiom/optimizer/ToVelox.h"
+#include <algorithm>
+#include <iostream>
+#include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "velox/core/PlanConsistencyChecker.h"
@@ -52,6 +55,12 @@ ToVelox::ToVelox(
       optimizerOptions_{optimizerOptions},
       isSingle_{options.numWorkers == 1},
       subscript_{FunctionRegistry::instance()->subscript()} {}
+
+std::string sanitizeFieldName(std::string_view name) {
+  std::string result(name);
+  std::replace(result.begin(), result.end(), '.', '_');
+  return result;
+}
 
 namespace {
 
@@ -204,6 +213,11 @@ PlanAndStats ToVelox::toVeloxPlan(
     const runner::MultiFragmentPlan::Options& options) {
   options_ = options;
 
+  auto* opt = queryCtx()->optimization();
+  if ((opt->options().traceFlags & OptimizerOptions::kRetained) != 0) {
+    std::cout << "Velox Plan: " << plan->toString(true, false) << std::endl;
+  }
+
   prediction_.clear();
   nodeHistory_.clear();
 
@@ -253,7 +267,7 @@ velox::RowTypePtr ToVelox::makeOutputType(const ColumnVector& columns) const {
     }
     auto name = makeVeloxExprWithNoAlias_ ? std::string(column->name())
                                           : column->outputName();
-    names.push_back(name);
+    names.push_back(sanitizeFieldName(name));
     types.push_back(toTypePtr(columns[i]->value().type));
   }
   return ROW(std::move(names), std::move(types));
@@ -313,7 +327,7 @@ velox::core::TypedExprPtr stepToGetter(
         auto& type = arg->type()->childAt(
             arg->type()->as<velox::TypeKind::ROW>().getChildIdx(step.field));
         return std::make_shared<velox::core::FieldAccessTypedExpr>(
-            type, arg, step.field);
+            type, arg, sanitizeFieldName(step.field));
       }
       auto& type = arg->type()->childAt(step.id);
       return std::make_shared<velox::core::DereferenceTypedExpr>(
@@ -426,10 +440,10 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
       auto it = columnAlteredTypes_.find(column);
       if (it != columnAlteredTypes_.end()) {
         return std::make_shared<velox::core::FieldAccessTypedExpr>(
-            it->second, name);
+            it->second, sanitizeFieldName(name));
       }
       return std::make_shared<velox::core::FieldAccessTypedExpr>(
-          toTypePtr(expr->value().type), name);
+          toTypePtr(expr->value().type), sanitizeFieldName(name));
     }
     case PlanType::kCallExpr: {
       std::vector<velox::core::TypedExprPtr> inputs;
@@ -471,7 +485,7 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
         return std::make_shared<velox::core::FieldAccessTypedExpr>(
             toTypePtr(expr->value().type),
             toTypedExpr(expr->as<Field>()->base()),
-            field);
+            sanitizeFieldName(field));
       }
       return std::make_shared<velox::core::DereferenceTypedExpr>(
           toTypePtr(expr->value().type),
@@ -496,7 +510,7 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
       std::vector<std::string> names;
       std::vector<velox::TypePtr> types;
       for (auto& c : lambda->args()) {
-        names.push_back(c->toString());
+        names.push_back(sanitizeFieldName(c->toString()));
         types.push_back(toTypePtr(c->value().type));
       }
       return std::make_shared<velox::core::LambdaTypedExpr>(
@@ -615,7 +629,7 @@ velox::core::FieldAccessTypedExprPtr ToVelox::toFieldRef(ExprCP expr) {
 
   auto column = expr->as<Column>();
   return std::make_shared<velox::core::FieldAccessTypedExpr>(
-      toTypePtr(column->value().type), column->outputName());
+      toTypePtr(column->value().type), sanitizeFieldName(column->outputName()));
 }
 
 std::vector<velox::core::FieldAccessTypedExprPtr> ToVelox::toFieldRefs(
@@ -839,7 +853,7 @@ velox::RowTypePtr skylineStruct(BaseTableCP baseTable, ColumnCP column) {
     const auto& first = path->steps()[0];
     auto name =
         first.field ? std::string{first.field} : fmt::format("{}", first.id);
-    names.push_back(name);
+    names.push_back(sanitizeFieldName(name));
     types.push_back(valueType);
   });
 
@@ -862,7 +876,7 @@ velox::RowTypePtr ToVelox::subfieldPushdownScanType(
       }
       top.add(topColumn);
       topColumns.push_back(topColumn);
-      names.push_back(topColumn->name());
+      names.push_back(sanitizeFieldName(topColumn->name()));
       if (isMapAsStruct(baseTable->schemaTable->name(), topColumn->name())) {
         types.push_back(skylineStruct(baseTable, topColumn));
         typeMap[topColumn] = types.back();
@@ -874,7 +888,7 @@ velox::RowTypePtr ToVelox::subfieldPushdownScanType(
         continue;
       }
       topColumns.push_back(column);
-      names.push_back(column->name());
+      names.push_back(sanitizeFieldName(column->name()));
       types.push_back(toTypePtr(column->value().type));
     }
   }
@@ -890,7 +904,7 @@ velox::core::PlanNodePtr ToVelox::makeSubfieldProjections(
   std::vector<std::string> names;
   std::vector<velox::core::TypedExprPtr> exprs;
   for (auto* column : scan.columns()) {
-    names.push_back(column->outputName());
+    names.push_back(sanitizeFieldName(column->outputName()));
     exprs.push_back(toTypedExpr(column));
   }
   return std::make_shared<velox::core::ProjectNode>(
@@ -943,7 +957,8 @@ velox::core::TypedExprPtr toAndWithAliases(
   for (const auto& column : baseTable->columns) {
     auto name = column->name();
     mapping[name] = std::make_shared<velox::core::FieldAccessTypedExpr>(
-        toTypePtr(column->value().type), column->outputName());
+        toTypePtr(column->value().type),
+        sanitizeFieldName(column->outputName()));
 
     if (usedFieldNames.contains(name)) {
       if (!columnSet.contains(column)) {
@@ -1070,7 +1085,7 @@ velox::core::PlanNodePtr ToVelox::makeProject(
   names.reserve(numOutputs);
   exprs.reserve(numOutputs);
   for (auto i = 0; i < numOutputs; ++i) {
-    names.push_back(project.columns()[i]->outputName());
+    names.push_back(sanitizeFieldName(project.columns()[i]->outputName()));
     exprs.push_back(toTypedExpr(project.exprs()[i]));
   }
 
@@ -1114,7 +1129,10 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
       right,
       makeOutputType(join.columns()));
 
-  makePredictionAndHistory(joinNode->id(), &join);
+  auto* buildOp = join.right->as<HashBuild>();
+  float buildCost = buildOp->cost().unitCost * buildOp->cost().inputCardinality;
+  makePredictionAndHistory(
+      joinNode->id(), &join, buildCost, buildOp->cost().totalBytes);
   return joinNode;
 }
 
@@ -1190,7 +1208,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
           type,
           aggregate->name(),
           std::make_shared<velox::core::FieldAccessTypedExpr>(
-              toTypePtr(aggregate->intermediateType()), aggregateNames.back()));
+              toTypePtr(aggregate->intermediateType()),
+              sanitizeFieldName(aggregateNames.back())));
       aggregates.push_back({.call = call, .rawInputTypes = rawInputTypes});
     }
   }
@@ -1217,7 +1236,7 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
     }
   }
 
-  return std::make_shared<velox::core::AggregationNode>(
+  auto result = std::make_shared<velox::core::AggregationNode>(
       nextId(),
       op.step,
       keys,
@@ -1226,6 +1245,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       aggregates,
       false,
       input);
+  makePredictionAndHistory(result->id(), &op);
+  return result;
 }
 
 velox::core::PlanNodePtr ToVelox::makeRepartition(
@@ -1270,6 +1291,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
             exchangeSerdeKind_,
             sourcePlan);
   }
+  makePredictionAndHistory(source.fragment.planNode->id(), &repartition);
 
   if (exchange == nullptr) {
     exchange = std::make_shared<velox::core::ExchangeNode>(
@@ -1390,7 +1412,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   inputNames.reserve(tableWrite.inputColumns.size());
   inputTypes.reserve(tableWrite.inputColumns.size());
   for (const auto* column : tableWrite.inputColumns) {
-    inputNames.push_back(column->as<Column>()->outputName());
+    inputNames.push_back(sanitizeFieldName(column->as<Column>()->outputName()));
     inputTypes.push_back(toTypePtr(column->value().type));
   }
 
@@ -1449,9 +1471,14 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
 
 void ToVelox::makePredictionAndHistory(
     const velox::core::PlanNodeId& id,
-    const RelationOp* op) {
+    const RelationOp* op,
+    float extraCost,
+    float extraBytes) {
   nodeHistory_[id] = op->historyKey();
-  prediction_[id] = NodePrediction{.cardinality = op->resultCardinality()};
+  prediction_[id] = NodePrediction{
+      .cardinality = op->resultCardinality(),
+      .peakMemory = op->cost().totalBytes + extraBytes,
+      .cpu = op->cost().totalCost() + extraCost};
 }
 
 velox::core::PlanNodePtr ToVelox::makeFragment(
@@ -1502,6 +1529,10 @@ extern std::string veloxToString(const velox::core::PlanNode* plan) {
 
 extern std::string planString(const runner::MultiFragmentPlan* plan) {
   return plan->toString(true);
+}
+
+extern std::string dtString(const DerivedTable* dt) {
+  return DerivedTablePrinter::toText(*dt);
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -216,7 +216,9 @@ class ToVelox {
   // after the plan is executed.
   void makePredictionAndHistory(
       const velox::core::PlanNodeId& id,
-      const RelationOp* op);
+      const RelationOp* op,
+      float extraCost = 0,
+      float extraMemory = 0);
 
   // Returns a stack of parallel project nodes if parallelization makes sense.
   // nullptr means use regular ProjectNode in output.
@@ -292,5 +294,9 @@ class ToVelox {
 
   runner::FinishWrite finishWrite_;
 };
+
+/// Replaces dots with underscores so that field names can be read back as names
+/// and not as getters.
+std::string sanitizeFieldName(std::string_view name);
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -127,8 +127,11 @@ bool VeloxHistory::setLeafSelectivity(
     return true;
   }
 
+  // When finding no hits, do not make a selectivity of 0 because this makes /0
+  // or *0 and *0 is 0, which makes any subsequent operations 0 regardless of
+  // cost. So as not to underflow, count non-existent as 09 rows.
   table.filterSelectivity =
-      static_cast<float>(sample.second) / static_cast<float>(sample.first);
+      std::max<float>(0.9f, sample.second) / static_cast<float>(sample.first);
   recordLeafSelectivity(string, table.filterSelectivity, false);
 
   bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(
   gtest_main
 )
 
-add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp)
+add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp PlanMatcherGenerator.cpp)
 
 target_link_libraries(
   axiom_optimizer_tests_plan_matcher
@@ -68,7 +68,7 @@ target_link_libraries(
   axiom_runner_tests_utils
 )
 
-add_executable(axiom_optimizer_tpch_plan_test TpchPlanTest.cpp)
+add_executable(axiom_optimizer_tpch_plan_test TpchPlanTest.cpp TpchPlanStability.cpp)
 
 add_test(
   NAME axiom_optimizer_tpch_plan_test
@@ -94,6 +94,7 @@ add_executable(
   HiveQueriesTest.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp
+  PlanMatcherGeneratorTest.cpp
   RelationOpPrinterTest.cpp
   SetTest.cpp
   UnnestTest.cpp
@@ -136,6 +137,43 @@ target_link_libraries(
   axiom_hive_connector_metadata
   axiom_tpch_connector_metadata
   axiom_sql_presto_parser
+  velox_exec_test_lib
+  velox_dwio_common
+  velox_dwio_parquet_reader
+  velox_dwio_native_parquet_reader
+  velox_parse_parser
+  velox_parse_expression
+  velox_parse_utils
+)
+
+target_link_libraries(
+  axiom_sql
+  axiom_runner_local_runner
+  axiom_runner_multifragment_plan
+  axiom_optimizer
+  axiom_hive_connector_metadata
+  axiom_tpch_connector_metadata
+  axiom_sql_presto_parser
+  velox_exec_test_lib
+  velox_dwio_common
+  velox_dwio_parquet_reader
+  velox_dwio_native_parquet_reader
+  velox_parse_parser
+  velox_parse_expression
+  velox_parse_utils
+)
+
+add_executable(axiom_sql_benchmark AxiomSqlBenchmark.cpp linenoise/linenoise.c)
+
+target_link_libraries(
+  axiom_sql_benchmark
+  axiom_runner_local_runner
+  axiom_runner_multifragment_plan
+  axiom_optimizer
+  axiom_hive_connector_metadata
+  axiom_tpch_connector_metadata
+  axiom_sql_presto_parser
+  velox_query_benchmark
   velox_exec_test_lib
   velox_dwio_common
   velox_dwio_parquet_reader

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -658,6 +658,39 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
   const std::optional<JoinType> joinType_;
 };
 
+class NestedLoopJoinMatcher : public PlanMatcherImpl<NestedLoopJoinNode> {
+ public:
+  explicit NestedLoopJoinMatcher(
+      const std::shared_ptr<PlanMatcher>& left,
+      const std::shared_ptr<PlanMatcher>& right)
+      : PlanMatcherImpl<NestedLoopJoinNode>({left, right}) {}
+
+  NestedLoopJoinMatcher(
+      const std::shared_ptr<PlanMatcher>& left,
+      const std::shared_ptr<PlanMatcher>& right,
+      JoinType joinType)
+      : PlanMatcherImpl<NestedLoopJoinNode>({left, right}),
+        joinType_{joinType} {}
+
+  MatchResult matchDetails(
+      const NestedLoopJoinNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+
+    if (joinType_.has_value()) {
+      EXPECT_EQ(
+          JoinTypeName::toName(plan.joinType()),
+          JoinTypeName::toName(joinType_.value()));
+    }
+
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  const std::optional<JoinType> joinType_;
+};
+
 #undef AXIOM_TEST_RETURN
 #undef AXIOM_TEST_RETURN_IF_FAILURE
 
@@ -826,6 +859,22 @@ PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ =
       std::make_shared<HashJoinMatcher>(matcher_, rightMatcher, joinType);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(
+    const std::shared_ptr<PlanMatcher>& rightMatcher) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<NestedLoopJoinMatcher>(matcher_, rightMatcher);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(
+    const std::shared_ptr<PlanMatcher>& rightMatcher,
+    JoinType joinType) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ =
+      std::make_shared<NestedLoopJoinMatcher>(matcher_, rightMatcher, joinType);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -119,6 +119,13 @@ class PlanMatcherBuilder {
       const std::shared_ptr<PlanMatcher>& rightMatcher,
       JoinType joinType);
 
+  PlanMatcherBuilder& nestedLoopJoin(
+      const std::shared_ptr<PlanMatcher>& rightMatcher);
+
+  PlanMatcherBuilder& nestedLoopJoin(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      JoinType joinType);
+
   PlanMatcherBuilder& localPartition();
 
   PlanMatcherBuilder& localPartition(

--- a/axiom/optimizer/tests/PlanMatcherGenerator.cpp
+++ b/axiom/optimizer/tests/PlanMatcherGenerator.cpp
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::core {
+
+namespace {
+
+/// Escapes a string for use in C++ string literals.
+std::string escapeString(const std::string& str) {
+  std::ostringstream oss;
+  for (char c : str) {
+    switch (c) {
+      case '"':
+        oss << "\\\"";
+        break;
+      case '\\':
+        oss << "\\\\";
+        break;
+      case '\n':
+        oss << "\\n";
+        break;
+      case '\t':
+        oss << "\\t";
+        break;
+      default:
+        oss << c;
+    }
+  }
+  return oss.str();
+}
+
+/// Generates a vector literal from a vector of strings.
+std::string generateVectorLiteral(const std::vector<std::string>& items) {
+  if (items.empty()) {
+    return "{}";
+  }
+
+  std::ostringstream oss;
+  oss << "{";
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << "\"" << escapeString(items[i]) << "\"";
+  }
+  oss << "}";
+  return oss.str();
+}
+
+/// Generates code for a TableScanNode.
+std::string generateTableScanCode(const TableScanNode& node) {
+  const auto& tableName = node.tableHandle()->name();
+
+  // Get the column names and types
+
+  std::ostringstream oss;
+  oss << ".tableScan(\"" << escapeString(tableName) << "\")";
+
+  return oss.str();
+}
+
+/// Generates code for a ValuesNode.
+std::string generateValuesCode(const ValuesNode& node) {
+  return ".values()";
+}
+
+/// Generates code for a FilterNode.
+std::string generateFilterCode(const FilterNode& node) {
+  const auto& predicate = node.filter();
+  std::ostringstream oss;
+  oss << ".filter(\"" << escapeString(predicate->toString()) << "\")";
+  return oss.str();
+}
+
+/// Generates code for a ProjectNode.
+std::string generateProjectCode(const ProjectNode& node) {
+  const auto& projections = node.projections();
+  const auto& names = node.names();
+
+  std::vector<std::string> expressions;
+  for (size_t i = 0; i < projections.size(); ++i) {
+    std::string exprStr = projections[i]->toString();
+    // Add alias if the name differs from the expression
+    if (names[i] != exprStr) {
+      exprStr += " AS " + names[i];
+    }
+    expressions.push_back(exprStr);
+  }
+
+  std::ostringstream oss;
+  oss << ".project(" << generateVectorLiteral(expressions) << ")";
+  return oss.str();
+}
+
+/// Generates code for a ParallelProjectNode.
+std::string generateParallelProjectCode(const ParallelProjectNode& node) {
+  const auto& projections = node.projections();
+  const auto& names = node.names();
+
+  std::vector<std::string> expressions;
+  for (size_t i = 0; i < projections.size(); ++i) {
+    std::string exprStr = projections[i]->toString();
+    if (names[i] != exprStr) {
+      exprStr += " AS " + names[i];
+    }
+    expressions.push_back(exprStr);
+  }
+
+  std::ostringstream oss;
+  oss << ".parallelProject(" << generateVectorLiteral(expressions) << ")";
+  return oss.str();
+}
+
+/// Generates code for an AggregationNode.
+std::string generateAggregationCode(const AggregationNode& node) {
+  const auto& groupingKeys = node.groupingKeys();
+  const auto& aggregates = node.aggregates();
+  const auto& aggregateNames = node.aggregateNames();
+  const auto step = node.step();
+
+  std::vector<std::string> groupingKeyStrs;
+  for (const auto& key : groupingKeys) {
+    groupingKeyStrs.push_back(key->toString());
+  }
+
+  std::vector<std::string> aggregateStrs;
+  for (size_t i = 0; i < aggregates.size(); ++i) {
+    std::string aggStr = aggregates[i].call->toString();
+    if (aggregateNames[i] != aggStr) {
+      aggStr += " AS " + aggregateNames[i];
+    }
+    aggregateStrs.push_back(aggStr);
+  }
+
+  std::ostringstream oss;
+
+  // Determine the aggregation type
+  std::string stepMethod;
+  switch (step) {
+    case AggregationNode::Step::kSingle:
+      stepMethod = "singleAggregation";
+      break;
+    case AggregationNode::Step::kPartial:
+      stepMethod = "partialAggregation";
+      break;
+    case AggregationNode::Step::kFinal:
+      stepMethod = "finalAggregation";
+      break;
+    case AggregationNode::Step::kIntermediate:
+      stepMethod = "aggregation"; // Use generic for intermediate
+      break;
+  }
+
+  oss << "." << stepMethod << "(";
+  oss << generateVectorLiteral(groupingKeyStrs);
+  oss << ", ";
+  oss << generateVectorLiteral(aggregateStrs);
+  oss << ")";
+
+  return oss.str();
+}
+
+/// Generates code for an UnnestNode.
+std::string generateUnnestCode(const UnnestNode& node) {
+  const auto& replicateVars = node.replicateVariables();
+  const auto& unnestVars = node.unnestVariables();
+
+  std::vector<std::string> replicateStrs;
+  for (const auto& var : replicateVars) {
+    replicateStrs.push_back(var->toString());
+  }
+
+  std::vector<std::string> unnestStrs;
+  for (const auto& var : unnestVars) {
+    unnestStrs.push_back(var->toString());
+  }
+
+  std::ostringstream oss;
+  oss << ".unnest(";
+  oss << generateVectorLiteral(replicateStrs);
+  oss << ", ";
+  oss << generateVectorLiteral(unnestStrs);
+  oss << ")";
+
+  return oss.str();
+}
+
+/// Generates code for a LimitNode.
+std::string generateLimitCode(const LimitNode& node) {
+  const auto offset = node.offset();
+  const auto count = node.count();
+  const auto isPartial = node.isPartial();
+
+  std::ostringstream oss;
+  if (isPartial) {
+    oss << ".partialLimit(" << offset << ", " << count << ")";
+  } else {
+    oss << ".finalLimit(" << offset << ", " << count << ")";
+  }
+
+  return oss.str();
+}
+
+/// Generates code for a TopNNode.
+std::string generateTopNCode(const TopNNode& node) {
+  const auto count = node.count();
+
+  std::ostringstream oss;
+  oss << ".topN(" << count << ")";
+
+  return oss.str();
+}
+
+/// Generates code for an OrderByNode.
+std::string generateOrderByCode(const OrderByNode& node) {
+  const auto& sortingKeys = node.sortingKeys();
+  const auto& sortingOrders = node.sortingOrders();
+
+  std::vector<std::string> orderingStrs;
+  for (size_t i = 0; i < sortingKeys.size(); ++i) {
+    std::ostringstream oss;
+    oss << sortingKeys[i]->toString();
+    oss << " " << (sortingOrders[i].isAscending() ? "ASC" : "DESC");
+    oss << " NULLS " << (sortingOrders[i].isNullsFirst() ? "FIRST" : "LAST");
+    orderingStrs.push_back(oss.str());
+  }
+
+  std::ostringstream oss;
+  oss << ".orderBy(" << generateVectorLiteral(orderingStrs) << ")";
+
+  return oss.str();
+}
+
+/// Generates code for a LocalPartitionNode.
+std::string generateLocalPartitionCode(const LocalPartitionNode& node) {
+  return ".localPartition()";
+}
+
+/// Generates code for a LocalMergeNode.
+std::string generateLocalMergeCode(const LocalMergeNode& node) {
+  return ".localMerge()";
+}
+
+/// Generates code for a PartitionedOutputNode.
+std::string generatePartitionedOutputCode(const PartitionedOutputNode& node) {
+  return ".partitionedOutput()";
+}
+
+/// Generates code for an ExchangeNode.
+std::string generateExchangeCode(const ExchangeNode& node) {
+  return ".exchange()";
+}
+
+/// Generates code for a MergeExchangeNode.
+std::string generateMergeExchangeCode(const MergeExchangeNode& node) {
+  return ".mergeExchange()";
+}
+
+/// Generates code for a TableWriteNode.
+std::string generateTableWriteCode(const TableWriteNode& node) {
+  return ".tableWrite()";
+}
+
+/// Forward declarations
+std::string generatePlanMatcherCodeImpl(
+    const PlanNodePtr& planNode,
+    std::unordered_map<const PlanNode*, std::string>& rightMatchers);
+void generateJoinMatchers(
+    const PlanNodePtr& planNode,
+    std::vector<std::string>& matchers,
+    int& matcherCounter,
+    std::unordered_map<const PlanNode*, std::string>& rightMatchers);
+
+/// Generates the matcher variable name for a join side.
+std::string getJoinMatcherVarName(int counter) {
+  if (counter == 0) {
+    return "rightMatcher";
+  }
+  return "rightMatcher" + std::to_string(counter);
+}
+
+/// Collects all join right-side matchers in the tree.
+void generateJoinMatchers(
+    const PlanNodePtr& planNode,
+    std::vector<std::string>& matchers,
+    int& matcherCounter,
+    std::unordered_map<const PlanNode*, std::string>& rightMatchers) {
+  if (auto* joinNode = dynamic_cast<const HashJoinNode*>(planNode.get())) {
+    VELOX_CHECK_EQ(
+        joinNode->sources().size(), 2, "HashJoinNode must have 2 sources");
+
+    // Recursively process left side for nested joins
+    generateJoinMatchers(
+        joinNode->sources()[0], matchers, matcherCounter, rightMatchers);
+
+    // Generate matcher for the right side
+    const auto& rightSource = joinNode->sources()[1];
+
+    // First, collect any nested joins on the right side
+    generateJoinMatchers(rightSource, matchers, matcherCounter, rightMatchers);
+
+    // Then generate the matcher for this right side
+    std::string rightMatcherCode =
+        generatePlanMatcherCodeImpl(rightSource, rightMatchers);
+    std::string matcherVar = getJoinMatcherVarName(matcherCounter++);
+
+    // Record the mapping from right child PlanNode to matcher variable name
+    rightMatchers[rightSource.get()] = matcherVar;
+
+    std::ostringstream oss;
+    oss << "auto " << matcherVar << " = core::PlanMatcherBuilder()";
+    oss << rightMatcherCode;
+    oss << ".build();";
+
+    matchers.push_back(oss.str());
+  } else if (
+      auto* joinNode =
+          dynamic_cast<const NestedLoopJoinNode*>(planNode.get())) {
+    VELOX_CHECK_EQ(
+        joinNode->sources().size(),
+        2,
+        "NestedLoopJoinNode must have 2 sources");
+
+    // Recursively process left side for nested joins
+    generateJoinMatchers(
+        joinNode->sources()[0], matchers, matcherCounter, rightMatchers);
+
+    // Generate matcher for the right side
+    const auto& rightSource = joinNode->sources()[1];
+
+    // First, collect any nested joins on the right side
+    generateJoinMatchers(rightSource, matchers, matcherCounter, rightMatchers);
+
+    // Then generate the matcher for this right side
+    std::string rightMatcherCode =
+        generatePlanMatcherCodeImpl(rightSource, rightMatchers);
+    std::string matcherVar = getJoinMatcherVarName(matcherCounter++);
+
+    // Record the mapping from right child PlanNode to matcher variable name
+    rightMatchers[rightSource.get()] = matcherVar;
+
+    std::ostringstream oss;
+    oss << "auto " << matcherVar << " = core::PlanMatcherBuilder()";
+    oss << rightMatcherCode;
+    oss << ".build();";
+
+    matchers.push_back(oss.str());
+  } else {
+    // Recursively process sources
+    for (const auto& source : planNode->sources()) {
+      generateJoinMatchers(source, matchers, matcherCounter, rightMatchers);
+    }
+  }
+}
+
+/// Generates code for a HashJoinNode (inline call only, not the right matcher).
+std::string generateHashJoinCode(
+    const HashJoinNode& node,
+    const std::unordered_map<const PlanNode*, std::string>& rightMatchers) {
+  // Look up the matcher variable name for this join's right child
+  const auto& rightSource = node.sources()[1];
+  auto it = rightMatchers.find(rightSource.get());
+  VELOX_CHECK(it != rightMatchers.end(), "Right matcher not found for join");
+  std::string matcherVar = it->second;
+
+  const auto joinType = node.joinType();
+  std::ostringstream oss;
+  oss << ".hashJoin(" << matcherVar << ", velox::core::JoinType::";
+
+  // Map JoinType to its enum name
+  switch (joinType) {
+    case JoinType::kInner:
+      oss << "kInner";
+      break;
+    case JoinType::kLeft:
+      oss << "kLeft";
+      break;
+    case JoinType::kRight:
+      oss << "kRight";
+      break;
+    case JoinType::kFull:
+      oss << "kFull";
+      break;
+    case JoinType::kLeftSemiProject:
+      oss << "kLeftSemiProject";
+      break;
+    case JoinType::kRightSemiProject:
+      oss << "kRightSemiProject";
+      break;
+    case JoinType::kLeftSemiFilter:
+      oss << "kLeftSemiFilter";
+      break;
+    case JoinType::kRightSemiFilter:
+      oss << "kRightSemiFilter";
+      break;
+    case JoinType::kAnti:
+      oss << "kAnti";
+      break;
+    default:
+      oss << "kInner"; // Default fallback
+  }
+
+  oss << ")";
+
+  return oss.str();
+}
+
+/// Generates code for a NestedLoopJoinNode (inline call only, not the right
+/// matcher).
+std::string generateNestedLoopJoinCode(
+    const NestedLoopJoinNode& node,
+    const std::unordered_map<const PlanNode*, std::string>& rightMatchers) {
+  // Look up the matcher variable name for this join's right child
+  const auto& rightSource = node.sources()[1];
+  auto it = rightMatchers.find(rightSource.get());
+  VELOX_CHECK(it != rightMatchers.end(), "Right matcher not found for join");
+  std::string matcherVar = it->second;
+
+  const auto joinType = node.joinType();
+  std::ostringstream oss;
+  oss << ".nestedLoopJoin(" << matcherVar << ", velox::core::JoinType::";
+
+  // Map JoinType to its enum name
+  switch (joinType) {
+    case JoinType::kInner:
+      oss << "kInner";
+      break;
+    case JoinType::kLeft:
+      oss << "kLeft";
+      break;
+    case JoinType::kRight:
+      oss << "kRight";
+      break;
+    case JoinType::kFull:
+      oss << "kFull";
+      break;
+    case JoinType::kLeftSemiProject:
+      oss << "kLeftSemiProject";
+      break;
+    case JoinType::kRightSemiProject:
+      oss << "kRightSemiProject";
+      break;
+    case JoinType::kLeftSemiFilter:
+      oss << "kLeftSemiFilter";
+      break;
+    case JoinType::kRightSemiFilter:
+      oss << "kRightSemiFilter";
+      break;
+    case JoinType::kAnti:
+      oss << "kAnti";
+      break;
+    default:
+      oss << "kInner"; // Default fallback
+  }
+
+  oss << ")";
+
+  return oss.str();
+}
+
+/// Recursive implementation of generatePlanMatcherCode
+std::string generatePlanMatcherCodeImpl(
+    const PlanNodePtr& planNode,
+    std::unordered_map<const PlanNode*, std::string>& rightMatchers) {
+  std::ostringstream result;
+
+  // Process sources first (post-order traversal for non-join nodes)
+  const auto& sources = planNode->sources();
+
+  // Special handling for joins which have two sources
+  if (auto* joinNode = dynamic_cast<const HashJoinNode*>(planNode.get())) {
+    // For joins, we generate the left source inline
+    // The right source matcher is generated separately
+    if (!sources.empty()) {
+      result << generatePlanMatcherCodeImpl(sources[0], rightMatchers);
+    }
+    result << generateHashJoinCode(*joinNode, rightMatchers);
+  } else if (
+      auto* joinNode =
+          dynamic_cast<const NestedLoopJoinNode*>(planNode.get())) {
+    // For joins, we generate the left source inline
+    // The right source matcher is generated separately
+    if (!sources.empty()) {
+      result << generatePlanMatcherCodeImpl(sources[0], rightMatchers);
+    }
+    result << generateNestedLoopJoinCode(*joinNode, rightMatchers);
+  } else {
+    // For non-join nodes, process the first source recursively
+    if (!sources.empty()) {
+      result << generatePlanMatcherCodeImpl(sources[0], rightMatchers);
+    }
+
+    // Generate code for the current node
+    if (auto* tableScan = dynamic_cast<const TableScanNode*>(planNode.get())) {
+      result << generateTableScanCode(*tableScan);
+    } else if (auto* values = dynamic_cast<const ValuesNode*>(planNode.get())) {
+      result << generateValuesCode(*values);
+    } else if (auto* filter = dynamic_cast<const FilterNode*>(planNode.get())) {
+      result << generateFilterCode(*filter);
+    } else if (
+        auto* parallelProject =
+            dynamic_cast<const ParallelProjectNode*>(planNode.get())) {
+      result << generateParallelProjectCode(*parallelProject);
+    } else if (
+        auto* project = dynamic_cast<const ProjectNode*>(planNode.get())) {
+      result << generateProjectCode(*project);
+    } else if (
+        auto* agg = dynamic_cast<const AggregationNode*>(planNode.get())) {
+      result << generateAggregationCode(*agg);
+    } else if (auto* unnest = dynamic_cast<const UnnestNode*>(planNode.get())) {
+      result << generateUnnestCode(*unnest);
+    } else if (auto* limit = dynamic_cast<const LimitNode*>(planNode.get())) {
+      result << generateLimitCode(*limit);
+    } else if (auto* topN = dynamic_cast<const TopNNode*>(planNode.get())) {
+      result << generateTopNCode(*topN);
+    } else if (
+        auto* orderBy = dynamic_cast<const OrderByNode*>(planNode.get())) {
+      result << generateOrderByCode(*orderBy);
+    } else if (
+        auto* localPartition =
+            dynamic_cast<const LocalPartitionNode*>(planNode.get())) {
+      result << generateLocalPartitionCode(*localPartition);
+    } else if (
+        auto* localMerge =
+            dynamic_cast<const LocalMergeNode*>(planNode.get())) {
+      result << generateLocalMergeCode(*localMerge);
+    } else if (
+        auto* partitionedOutput =
+            dynamic_cast<const PartitionedOutputNode*>(planNode.get())) {
+      result << generatePartitionedOutputCode(*partitionedOutput);
+    } else if (
+        auto* mergeExchange =
+            dynamic_cast<const MergeExchangeNode*>(planNode.get())) {
+      result << generateMergeExchangeCode(*mergeExchange);
+    } else if (
+        auto* exchange = dynamic_cast<const ExchangeNode*>(planNode.get())) {
+      result << generateExchangeCode(*exchange);
+    } else if (
+        auto* tableWrite =
+            dynamic_cast<const TableWriteNode*>(planNode.get())) {
+      result << generateTableWriteCode(*tableWrite);
+    } else {
+      // For unknown node types, add a comment
+      result << "  // Unknown node type: "
+             << folly::demangle(typeid(*planNode).name());
+    }
+  }
+
+  return result.str();
+}
+
+} // namespace
+
+std::string generatePlanMatcherCode(
+    const PlanNodePtr& planNode,
+    const std::string& builderVarName) {
+  std::ostringstream oss;
+
+  // Create the map to track right child PlanNode -> matcher variable name
+  std::unordered_map<const PlanNode*, std::string> rightMatchers;
+
+  // First, collect all join right-side matchers
+  std::vector<std::string> joinMatchers;
+  int matcherCounter = 0;
+  generateJoinMatchers(planNode, joinMatchers, matcherCounter, rightMatchers);
+
+  // Generate the join matchers first
+  for (const auto& matcher : joinMatchers) {
+    oss << matcher << "\n\n";
+  }
+
+  // Then generate the main matcher
+  oss << "auto " << builderVarName << " = core::PlanMatcherBuilder()";
+  oss << generatePlanMatcherCodeImpl(planNode, rightMatchers);
+  oss << ".build();\n";
+
+  return oss.str();
+}
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/PlanMatcherGenerator.h
+++ b/axiom/optimizer/tests/PlanMatcherGenerator.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::core {
+
+/// Generates C++ code that constructs a PlanMatcher tree matching the given
+/// PlanNode tree.
+///
+/// @param planNode The PlanNode tree to generate matcher code for.
+/// @param builderVarName The name of the PlanMatcherBuilder variable to use
+///                       in the generated code (default: "builder").
+/// @return A string containing C++ code that uses PlanMatcherBuilder to
+///         construct a matcher tree.
+///
+/// Example:
+///   auto plan = ...; // some PlanNode tree
+///   std::string code = generatePlanMatcherCode(plan);
+///   // code will contain something like:
+///   // core::PlanMatcherBuilder()
+///   //   .tableScan("t")
+///   //   .filter("a > 10")
+///   //   .project({"a", "b"})
+///   //   .build();
+std::string generatePlanMatcherCode(
+    const PlanNodePtr& planNode,
+    const std::string& builderVarName = "builder");
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/PlanMatcherGenerator.md
+++ b/axiom/optimizer/tests/PlanMatcherGenerator.md
@@ -1,0 +1,195 @@
+# PlanMatcherGenerator
+
+A utility to generate C++ code for constructing `PlanMatcher` trees from `PlanNode` trees.
+
+## Overview
+
+The `PlanMatcherGenerator` takes a `velox::core::PlanNode` tree and generates C++ code that uses `PlanMatcherBuilder` to construct an equivalent `PlanMatcher` tree. This is useful for:
+
+- Creating test assertions from actual query plans
+- Documenting expected plan structures
+- Quickly generating matcher code instead of writing it manually
+
+## API
+
+### Main Function
+
+```cpp
+std::string generatePlanMatcherCode(
+    const PlanNodePtr& planNode,
+    const std::string& builderVarName = "builder");
+```
+
+**Parameters:**
+- `planNode`: The root of the PlanNode tree to convert
+- `builderVarName`: Optional name for the builder variable (default: "builder")
+
+**Returns:** A string containing C++ code that constructs a PlanMatcher tree
+
+## Usage Example
+
+```cpp
+#include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+
+// Create or obtain a PlanNode tree
+auto logicalPlan = toLogicalPlan("SELECT name, age * 2 FROM users WHERE age > 18");
+auto plan = toSingleNodePlan(logicalPlan);
+
+// Generate the matcher code
+std::string matcherCode = facebook::velox::core::generatePlanMatcherCode(plan);
+
+// Print the generated code
+std::cout << matcherCode << std::endl;
+```
+
+**Output:**
+```cpp
+auto builder = core::PlanMatcherBuilder()
+  .tableScan("users")
+  .filter("age > 18")
+  .project({"name", "age * 2 AS c1"})
+  .build();
+```
+
+## Supported Node Types
+
+The generator supports the following PlanNode types:
+
+### Leaf Nodes
+- **TableScanNode**: Generates `.tableScan("table_name")`
+- **ValuesNode**: Generates `.values()`
+- **ExchangeNode**: Generates `.exchange()`
+- **MergeExchangeNode**: Generates `.mergeExchange()`
+
+### Unary Operators (Single Input)
+- **FilterNode**: Generates `.filter("predicate")`
+- **ProjectNode**: Generates `.project({"expr1", "expr2 AS alias"})`
+- **ParallelProjectNode**: Generates `.parallelProject({"expr1", "expr2"})`
+- **AggregationNode**: Generates aggregation calls based on step:
+  - `.singleAggregation({"key1", "key2"}, {"agg1", "agg2"})`
+  - `.partialAggregation({"key1"}, {"count(*) AS cnt"})`
+  - `.finalAggregation({"key1"}, {"count(a0) AS cnt"})`
+- **UnnestNode**: Generates `.unnest({"replicate_cols"}, {"unnest_cols"})`
+- **LimitNode**: Generates `.partialLimit(offset, count)` or `.finalLimit(offset, count)`
+- **TopNNode**: Generates `.topN(count)`
+- **OrderByNode**: Generates `.orderBy({"col1 ASC NULLS FIRST", "col2 DESC"})`
+- **LocalPartitionNode**: Generates `.localPartition()`
+- **LocalMergeNode**: Generates `.localMerge()`
+- **PartitionedOutputNode**: Generates `.partitionedOutput()`
+- **TableWriteNode**: Generates `.tableWrite()`
+
+### Binary Operators (Two Inputs)
+- **HashJoinNode**: Generates code with a separate matcher for the right side:
+  ```cpp
+  auto rightMatcher = core::PlanMatcherBuilder()
+    .tableScan("right_table")
+    .build();
+
+  auto builder = core::PlanMatcherBuilder()
+    .tableScan("left_table")
+    .hashJoin(rightMatcher, JoinType::kInner)
+    .build();
+  ```
+
+## Integration
+
+### Adding to Your Test File
+
+1. Include the header:
+   ```cpp
+   #include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+   ```
+
+2. Generate matcher code for your plan:
+   ```cpp
+   auto plan = ...; // your PlanNode
+   auto code = facebook::velox::core::generatePlanMatcherCode(plan);
+   std::cout << code << std::endl;
+   ```
+
+3. Copy the generated code into your test:
+   ```cpp
+   TEST_F(MyTest, testQuery) {
+     auto plan = toSingleNodePlan(toLogicalPlan("SELECT ..."));
+
+     // Generated code goes here:
+     auto matcher = core::PlanMatcherBuilder()
+       .tableScan("my_table")
+       .filter("condition")
+       .build();
+
+     AXIOM_ASSERT_PLAN(plan, matcher);
+   }
+   ```
+
+## Advanced Usage
+
+### Customizing the Builder Variable Name
+
+```cpp
+std::string code = generatePlanMatcherCode(plan, "myMatcher");
+// Generates: auto myMatcher = core::PlanMatcherBuilder()...
+```
+
+### Handling Complex Joins
+
+For join nodes, the generator creates a separate matcher for the right side:
+
+```cpp
+// Input: A join between two table scans
+auto plan = ...; // SELECT * FROM a JOIN b ON a.id = b.id
+
+// Generated output:
+auto rightMatcher = core::PlanMatcherBuilder()
+  .tableScan("b")
+  .build();
+
+auto builder = core::PlanMatcherBuilder()
+  .tableScan("a")
+  .hashJoin(rightMatcher, JoinType::kInner)
+  .build();
+```
+
+## Implementation Details
+
+The generator uses the following approach:
+
+1. **Post-order Traversal**: Processes the PlanNode tree from leaves to root
+2. **Dynamic Type Detection**: Uses `dynamic_cast` to identify node types
+3. **Expression Conversion**: Converts `TypedExpr` objects to string representations
+4. **Code Generation**: Builds up the PlanMatcherBuilder chain
+
+### Node Type Handling
+
+For each node type, the generator:
+- Extracts relevant properties (predicates, expressions, keys, etc.)
+- Formats them as C++ string literals or vectors
+- Generates the appropriate PlanMatcherBuilder method call
+
+## Limitations
+
+1. **Expression Fidelity**: The generator uses `toString()` on expressions, which may not exactly match the original SQL syntax
+2. **Type Information**: Currently doesn't generate detailed type information for table scans
+3. **Complex Filters**: Subfield filters in HiveScan nodes are not yet supported
+4. **Unknown Node Types**: Generates a comment for unsupported node types
+
+## Future Enhancements
+
+Potential improvements:
+- Add support for more specialized matchers (e.g., `hiveScan` with filters)
+- Include output type information where relevant
+- Better formatting for complex expressions
+- Support for window functions and other advanced features
+
+## Files
+
+- `PlanMatcherGenerator.h`: Header file with function declaration
+- `PlanMatcherGenerator.cpp`: Implementation
+- `PlanMatcherGeneratorTest.cpp`: Unit tests
+- `PlanMatcherGeneratorExample.cpp`: Usage examples
+
+## See Also
+
+- `PlanMatcher.h`: PlanMatcher interface and PlanMatcherBuilder
+- `PlanMatcher.cpp`: PlanMatcher implementations
+- `velox/core/PlanNode.h`: PlanNode definitions

--- a/axiom/optimizer/tests/PlanMatcherGeneratorExample.cpp
+++ b/axiom/optimizer/tests/PlanMatcherGeneratorExample.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+
+/// Example usage of generatePlanMatcherCode
+///
+/// This example shows how to use the PlanMatcherGenerator to convert a
+/// PlanNode tree into C++ code that constructs an equivalent PlanMatcher.
+///
+/// Usage:
+///   // Given a PlanNode tree:
+///   auto plan = ...; // your PlanNode tree
+///
+///   // Generate the matcher code:
+///   std::string matcherCode =
+///   facebook::velox::core::generatePlanMatcherCode(plan);
+///
+///   // Print or save the generated code:
+///   std::cout << matcherCode << std::endl;
+///
+/// The generated code will look something like:
+///
+///   auto builder = core::PlanMatcherBuilder()
+///     .tableScan("my_table")
+///     .filter("age > 18")
+///     .project({"name", "age * 2 AS double_age"})
+///     .singleAggregation({"name"}, {"count(*) AS cnt"})
+///     .build();
+///
+/// You can then copy this code into your test file and use it to match plans.
+
+int main() {
+  std::cout << "PlanMatcherGenerator - Example Usage" << std::endl;
+  std::cout << "=====================================" << std::endl;
+  std::cout << std::endl;
+  std::cout << "To use the PlanMatcherGenerator:" << std::endl;
+  std::cout << std::endl;
+  std::cout << "1. Include the header:" << std::endl;
+  std::cout << "   #include \"axiom/optimizer/tests/PlanMatcherGenerator.h\""
+            << std::endl;
+  std::cout << std::endl;
+  std::cout << "2. Call the function with your PlanNode:" << std::endl;
+  std::cout << "   auto plan = ...; // your PlanNode tree" << std::endl;
+  std::cout
+      << "   std::string code = facebook::velox::core::generatePlanMatcherCode(plan);"
+      << std::endl;
+  std::cout << std::endl;
+  std::cout << "3. Use the generated code in your tests:" << std::endl;
+  std::cout << "   std::cout << code << std::endl;" << std::endl;
+  std::cout << std::endl;
+  std::cout << "Example output:" << std::endl;
+  std::cout << "  auto matcher = core::PlanMatcherBuilder()" << std::endl;
+  std::cout << "    .tableScan(\"employees\")" << std::endl;
+  std::cout << "    .filter(\"salary > 50000\")" << std::endl;
+  std::cout << "    .project({\"name\", \"salary\"})" << std::endl;
+  std::cout << "    .build();" << std::endl;
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/axiom/optimizer/tests/PlanMatcherGeneratorTest.cpp
+++ b/axiom/optimizer/tests/PlanMatcherGeneratorTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+#include <gtest/gtest.h>
+#include <iostream>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class PlanMatcherGeneratorTest : public test::HiveQueriesTestBase {};
+
+TEST_F(PlanMatcherGeneratorTest, filterProject) {
+  // Test with an actual SQL query - parse and get logical plan
+  auto statement =
+      prestoParser().parse("SELECT n_name FROM nation WHERE n_regionkey > 2");
+  ASSERT_TRUE(statement->isSelect());
+  auto logicalPlan =
+      statement->as<::axiom::sql::presto::SelectStatement>()->plan();
+
+  // Convert to single node plan
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // Generate the matcher code
+  auto code = core::generatePlanMatcherCode(plan);
+
+  std::cout
+      << "Generated code for 'SELECT n_name FROM nation WHERE n_regionkey > 2':\n"
+      << code << std::endl;
+
+  EXPECT_FALSE(code.empty());
+}
+
+TEST_F(PlanMatcherGeneratorTest, aggregation) {
+  // Test with an aggregation query
+  auto statement = prestoParser().parse(
+      "SELECT n_regionkey, count(*) FROM nation GROUP BY n_regionkey");
+  ASSERT_TRUE(statement->isSelect());
+  auto logicalPlan =
+      statement->as<::axiom::sql::presto::SelectStatement>()->plan();
+
+  // Convert to single node plan
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // Generate the matcher code
+  auto code = core::generatePlanMatcherCode(plan);
+
+  std::cout
+      << "Generated code for 'SELECT n_regionkey, count(*) FROM nation GROUP BY n_regionkey':\n"
+      << code << std::endl;
+
+  EXPECT_FALSE(code.empty());
+  EXPECT_TRUE(code.find("Aggregation") != std::string::npos);
+}
+
+TEST_F(PlanMatcherGeneratorTest, join) {
+  // Test with a join query
+  auto statement = prestoParser().parse(
+      "SELECT n_name, r_name FROM nation, region WHERE n_regionkey = r_regionkey");
+  ASSERT_TRUE(statement->isSelect());
+  auto logicalPlan =
+      statement->as<::axiom::sql::presto::SelectStatement>()->plan();
+
+  // Convert to single node plan
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // Generate the matcher code
+  auto code = core::generatePlanMatcherCode(plan);
+
+  std::cout << "Generated code for join query:\n" << code << std::endl;
+
+  EXPECT_FALSE(code.empty());
+  EXPECT_TRUE(code.find("hashJoin") != std::string::npos);
+  EXPECT_TRUE(code.find("rightMatcher") != std::string::npos);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -126,6 +126,25 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       int32_t numDrivers = 1);
 
+  /// Checks that a plan contains (or doesn't contain) expected patterns.
+  /// @param plan The plan node to check.
+  /// @param expected Vector of regex patterns (RE2) to search for.
+  /// @param negative If false (default), expects all patterns to be found in
+  /// order. If true, expects that NOT all patterns are found in order (i.e.,
+  /// at least one pattern is missing or out of order).
+  void checkPlanText(
+      const velox::core::PlanNodePtr& plan,
+      const std::vector<std::string>& expected,
+      bool negative = false);
+
+  void explain(
+      const logical_plan::LogicalPlanNodePtr& query,
+      std::string* shortRel,
+      std::string* longRel,
+      std::string* graph,
+      const runner::MultiFragmentPlan::Options& runnerOptions = {},
+      const OptimizerOptions& optimizerOptions = {});
+
   void checkSameSingleNode(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const velox::core::PlanNodePtr& referencePlan,
@@ -154,6 +173,11 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   OptimizerOptions optimizerOptions_;
 
+  /// History shared between tests in a test suite. This is kept between tests
+  /// if going to save the history at the end or if 'keepHistoryBetweenTests_'
+  inline static std::unique_ptr<VeloxHistory> gSuiteHistory;
+  inline static bool keepHistoryBetweenTests_{false};
+
  private:
   std::shared_ptr<velox::memory::MemoryPool> optimizerPool_;
 
@@ -162,7 +186,6 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   std::unique_ptr<optimizer::VeloxHistory> history_;
 
   inline static int32_t gQueryCounter{0};
-  inline static std::unique_ptr<VeloxHistory> gSuiteHistory;
 };
 
 inline auto gte(const std::string& name, int64_t n) {

--- a/axiom/optimizer/tests/SqlQueryRunner.h
+++ b/axiom/optimizer/tests/SqlQueryRunner.h
@@ -47,6 +47,9 @@ class SqlQueryRunner {
     int32_t numDrivers{4};
     uint64_t splitTargetBytes{16 << 20};
     uint32_t optimizerTraceFlags{0};
+    bool enableReducingExistences{true};
+    bool includeRuntimeStats{false};
+    bool syntacticJoinOrder{false};
   };
 
   SqlResult run(std::string_view sql, const RunOptions& options);
@@ -62,6 +65,10 @@ class SqlQueryRunner {
   void clearHistory() {
     history_ = std::make_unique<facebook::axiom::optimizer::VeloxHistory>();
   }
+
+  void saveColumnStats(const std::string& path);
+
+  void loadColumnStats(const std::string& path);
 
  private:
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(

--- a/axiom/optimizer/tests/TpchPlanStability.cpp
+++ b/axiom/optimizer/tests/TpchPlanStability.cpp
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <fstream>
+#include <functional>
+#include <sstream>
+#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/tests/PlanMatcherGenerator.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+
+DECLARE_string(record_plans);
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class TpchPlanStability : public virtual test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    gSuiteHistory = std::make_unique<optimizer::VeloxHistory>();
+    keepHistoryBetweenTests_ = true;
+    // Initialize VeloxHistory from tpch30samples.json
+    suiteHistory().updateFromFile("tpch30samples.json");
+  }
+
+  static void TearDownTestCase() {
+    test::HiveQueriesTestBase::TearDownTestCase();
+  }
+
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+
+    // Load column stats from tpch30stats.json
+    auto* connectorMetadata =
+        connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId);
+    auto* hiveMetadata =
+        dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(
+            connectorMetadata);
+    VELOX_CHECK_NOT_NULL(hiveMetadata);
+    hiveMetadata->loadColumnStats("tpch30stats.json");
+  }
+
+  void TearDown() override {
+    HiveQueriesTestBase::TearDown();
+  }
+
+  void recordPlanCheckerStart(int32_t queryNo) {
+    if (FLAGS_record_plans.empty()) {
+      return;
+    }
+
+    auto filename = fmt::format("{}_check_{}.inc", FLAGS_record_plans, queryNo);
+    std::ofstream file(filename);
+
+    if (!file.is_open()) {
+      LOG(ERROR) << "Failed to open file: " << filename;
+      return;
+    }
+
+    file << "void " << FLAGS_record_plans << "DefineCheckers" << queryNo
+         << "() {\n";
+    file.close();
+  }
+
+  void recordPlanCheckerEnd(int32_t queryNo) {
+    if (FLAGS_record_plans.empty()) {
+      return;
+    }
+
+    auto filename = fmt::format("{}_check_{}.inc", FLAGS_record_plans, queryNo);
+    std::ofstream file(filename, std::ios::app);
+
+    if (!file.is_open()) {
+      LOG(ERROR) << "Failed to open file: " << filename;
+      return;
+    }
+
+    file << "}\n";
+    file.close();
+  }
+
+  void recordPlanChecker(
+      int32_t queryNo,
+      const lp::LogicalPlanNodePtr& logicalPlan,
+      const PlanAndStats& planAndStats,
+      int32_t numWorkers,
+      int32_t numDrivers) {
+    if (FLAGS_record_plans.empty()) {
+      return;
+    }
+
+    auto filename = fmt::format("{}_check_{}.inc", FLAGS_record_plans, queryNo);
+    std::ofstream file(filename, std::ios::app);
+
+    if (!file.is_open()) {
+      LOG(ERROR) << "Failed to open file: " << filename;
+      return;
+    }
+
+    // Get the short RelationOp representation
+    std::string shortRel;
+    QueryTestBase::explain(
+        logicalPlan,
+        &shortRel,
+        nullptr,
+        nullptr,
+        runner::MultiFragmentPlan::Options{
+            .numWorkers = numWorkers, .numDrivers = numDrivers});
+
+    file << "// Configuration: numWorkers=" << numWorkers
+         << ", numDrivers=" << numDrivers << "\n";
+    file << "setChecker(" << queryNo << ", " << numWorkers << ", " << numDrivers
+         << ", [](const PlanAndStats& planAndStats) {\n";
+
+    // Add the plan as a comment for readability
+    file << "  // Plan:\n";
+    std::istringstream planStream(shortRel);
+    std::string line;
+    while (std::getline(planStream, line)) {
+      file << "  // " << line << "\n";
+    }
+    file << "\n";
+
+    const auto& fragments = planAndStats.plan->fragments();
+    for (size_t i = 0; i < fragments.size(); ++i) {
+      const auto& fragment = fragments[i];
+      const auto& topNode = fragment.fragment.planNode;
+
+      file << "  // Fragment " << i << "\n";
+      file << "  {\n";
+      file << "    " << velox::core::generatePlanMatcherCode(topNode, "matcher")
+           << ";\n";
+      file << "    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()["
+           << i << "].fragment.planNode));\n";
+      file << "  }\n";
+    }
+
+    file << "});\n\n";
+    file.close();
+  }
+
+  static std::string readSqlFromFile(const std::string& filePath) {
+    auto path = velox::test::getDataFilePath("axiom/optimizer/tests", filePath);
+    std::ifstream inputFile(path, std::ifstream::binary);
+
+    VELOX_CHECK(inputFile, "Failed to open SQL file: {}", path);
+
+    // Find out file size.
+    auto begin = inputFile.tellg();
+    inputFile.seekg(0, std::ios::end);
+    auto end = inputFile.tellg();
+
+    const auto fileSize = end - begin;
+    VELOX_CHECK_GT(fileSize, 0, "SQL file is empty: {}", path);
+
+    // Read the file.
+    std::string sql;
+    sql.resize(fileSize);
+
+    inputFile.seekg(begin);
+    inputFile.read(sql.data(), fileSize);
+    inputFile.close();
+
+    return sql;
+  }
+
+  std::string readTpchSql(int32_t query) {
+    return readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+  }
+
+  lp::LogicalPlanNodePtr parseTpchSql(int32_t query) {
+    auto sql = readTpchSql(query);
+
+    ::axiom::sql::presto::PrestoParser prestoParser(
+        exec::test::kHiveConnectorId, pool());
+    auto statement = prestoParser.parse(sql);
+
+    VELOX_CHECK(statement->isSelect());
+
+    auto logicalPlan =
+        statement->as<::axiom::sql::presto::SelectStatement>()->plan();
+    VELOX_CHECK_NOT_NULL(logicalPlan);
+
+    return logicalPlan;
+  }
+
+  void checkPlan(int32_t query) {
+    // Configuration: 1 worker, 4 drivers
+    const int32_t numWorkers = 1;
+    const int32_t numDrivers = 4;
+
+    // Parse the SQL query
+    auto logicalPlan = parseTpchSql(query);
+
+    // Generate the plan
+    auto planAndStats = planVelox(
+        logicalPlan,
+        runner::MultiFragmentPlan::Options{
+            .numWorkers = numWorkers, .numDrivers = numDrivers});
+
+    // If FLAGS_record_plans is set, record the plan
+    if (!FLAGS_record_plans.empty()) {
+      recordPlanCheckerStart(query);
+      recordPlanChecker(
+          query, logicalPlan, planAndStats, numWorkers, numDrivers);
+      recordPlanCheckerEnd(query);
+    } else {
+      // If not recording, check the plan if a checker exists
+      auto* checker = getChecker(query, numWorkers, numDrivers);
+      if (checker) {
+        (*checker)(planAndStats);
+      }
+    }
+
+    // Plans are not run
+  }
+
+#include "h30_check_1.inc"
+#include "h30_check_10.inc"
+#include "h30_check_11.inc"
+#include "h30_check_12.inc"
+#include "h30_check_13.inc"
+#include "h30_check_14.inc"
+#include "h30_check_15.inc"
+#include "h30_check_16.inc"
+#include "h30_check_17.inc"
+#include "h30_check_18.inc"
+#include "h30_check_19.inc"
+#include "h30_check_2.inc"
+#include "h30_check_20.inc"
+#include "h30_check_21.inc"
+#include "h30_check_22.inc"
+#include "h30_check_3.inc"
+#include "h30_check_4.inc"
+#include "h30_check_5.inc"
+#include "h30_check_6.inc"
+#include "h30_check_7.inc"
+#include "h30_check_8.inc"
+#include "h30_check_9.inc"
+};
+
+TEST_F(TpchPlanStability, q01) {
+  h30DefineCheckers1();
+  checkPlan(1);
+}
+
+TEST_F(TpchPlanStability, q02) {
+  h30DefineCheckers2();
+  checkPlan(2);
+}
+
+TEST_F(TpchPlanStability, q03) {
+  h30DefineCheckers3();
+  checkPlan(3);
+}
+
+TEST_F(TpchPlanStability, q04) {
+  h30DefineCheckers4();
+  checkPlan(4);
+}
+
+TEST_F(TpchPlanStability, q05) {
+  h30DefineCheckers5();
+  checkPlan(5);
+}
+
+TEST_F(TpchPlanStability, q06) {
+  h30DefineCheckers6();
+  checkPlan(6);
+}
+
+TEST_F(TpchPlanStability, q07) {
+  h30DefineCheckers7();
+  checkPlan(7);
+}
+
+TEST_F(TpchPlanStability, q08) {
+  h30DefineCheckers8();
+  checkPlan(8);
+}
+
+TEST_F(TpchPlanStability, q09) {
+  h30DefineCheckers9();
+  checkPlan(9);
+}
+
+TEST_F(TpchPlanStability, q10) {
+  h30DefineCheckers10();
+  checkPlan(10);
+}
+
+TEST_F(TpchPlanStability, q11) {
+  h30DefineCheckers11();
+  checkPlan(11);
+}
+
+TEST_F(TpchPlanStability, q12) {
+  h30DefineCheckers12();
+  checkPlan(12);
+}
+
+TEST_F(TpchPlanStability, q13) {
+  h30DefineCheckers13();
+  checkPlan(13);
+}
+
+TEST_F(TpchPlanStability, q14) {
+  h30DefineCheckers14();
+  checkPlan(14);
+}
+
+TEST_F(TpchPlanStability, q15) {
+  h30DefineCheckers15();
+  checkPlan(15);
+}
+
+TEST_F(TpchPlanStability, q16) {
+  h30DefineCheckers16();
+  checkPlan(16);
+}
+
+TEST_F(TpchPlanStability, q17) {
+  h30DefineCheckers17();
+  checkPlan(17);
+}
+
+TEST_F(TpchPlanStability, q18) {
+  h30DefineCheckers18();
+  checkPlan(18);
+}
+
+TEST_F(TpchPlanStability, q19) {
+  h30DefineCheckers19();
+  checkPlan(19);
+}
+
+TEST_F(TpchPlanStability, q20) {
+  h30DefineCheckers20();
+  checkPlan(20);
+}
+
+TEST_F(TpchPlanStability, q21) {
+  h30DefineCheckers21();
+  checkPlan(21);
+}
+
+TEST_F(TpchPlanStability, q22) {
+  h30DefineCheckers22();
+  checkPlan(22);
+}
+
+} // namespace
+
+std::string tryParse(char* text) {
+  std::string str = text;
+  try {
+    auto expr = parse::parseExpr(str, {});
+    return expr->toString();
+  } catch (const std::exception& e) {
+    printf("Error %s\n", e.what());
+    return "ERROR";
+  }
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/h01_check_1.inc
+++ b/axiom/optimizer/tests/h01_check_1.inc
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers1() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(1, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 7 columns  SINGLE agg order by 2 columns  project 10
+    // columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_returnflag\" AS l_returnflag",
+                   "\"l_linestatus\" AS l_linestatus",
+                   "\"l_quantity\" AS l_quantity",
+                   "\"l_extendedprice\" AS l_extendedprice",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p39",
+                   "multiply(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),plus(\"l_tax\",1)) AS dt1___p46",
+                   "\"l_discount\" AS l_discount"})
+              .singleAggregation(
+                  {"\"l_returnflag\"", "\"l_linestatus\""},
+                  {"sum(\"l_quantity\") AS sum_qty",
+                   "sum(\"l_extendedprice\") AS sum_base_price",
+                   "sum(\"dt1___p39\") AS sum_disc_price",
+                   "sum(\"dt1___p46\") AS sum_charge",
+                   "avg(\"l_quantity\") AS avg_qty",
+                   "avg(\"l_extendedprice\") AS avg_price",
+                   "avg(\"l_discount\") AS avg_disc",
+                   "count() AS count_order"})
+              .orderBy(
+                  {"\"l_returnflag\" ASC NULLS LAST",
+                   "\"l_linestatus\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(1, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 7 columns  PARTIAL agg FINAL agg order by 2 columns
+    // project 10 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_returnflag\" AS l_returnflag",
+                   "\"l_linestatus\" AS l_linestatus",
+                   "\"l_quantity\" AS l_quantity",
+                   "\"l_extendedprice\" AS l_extendedprice",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p39",
+                   "multiply(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),plus(\"l_tax\",1)) AS dt1___p46",
+                   "\"l_discount\" AS l_discount"})
+              .partialAggregation(
+                  {"\"l_returnflag\"", "\"l_linestatus\""},
+                  {"sum(\"l_quantity\") AS sum_qty",
+                   "sum(\"l_extendedprice\") AS sum_base_price",
+                   "sum(\"dt1___p39\") AS sum_disc_price",
+                   "sum(\"dt1___p46\") AS sum_charge",
+                   "avg(\"l_quantity\") AS avg_qty",
+                   "avg(\"l_extendedprice\") AS avg_price",
+                   "avg(\"l_discount\") AS avg_disc",
+                   "count() AS count_order"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_returnflag\"", "\"l_linestatus\""},
+                  {"sum(\"sum_qty\") AS sum_qty",
+                   "sum(\"sum_base_price\") AS sum_base_price",
+                   "sum(\"sum_disc_price\") AS sum_disc_price",
+                   "sum(\"sum_charge\") AS sum_charge",
+                   "avg(\"avg_qty\") AS avg_qty",
+                   "avg(\"avg_price\") AS avg_price",
+                   "avg(\"avg_disc\") AS avg_disc",
+                   "count(\"count_order\") AS count_order"})
+              .orderBy(
+                  {"\"l_returnflag\" ASC NULLS LAST",
+                   "\"l_linestatus\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(1, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 7 columns  PARTIAL agg repartition  FINAL agg order
+    // by 2 columns  project 10 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_returnflag\" AS l_returnflag",
+                   "\"l_linestatus\" AS l_linestatus",
+                   "\"l_quantity\" AS l_quantity",
+                   "\"l_extendedprice\" AS l_extendedprice",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p39",
+                   "multiply(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),plus(\"l_tax\",1)) AS dt1___p46",
+                   "\"l_discount\" AS l_discount"})
+              .partialAggregation(
+                  {"\"l_returnflag\"", "\"l_linestatus\""},
+                  {"sum(\"l_quantity\") AS sum_qty",
+                   "sum(\"l_extendedprice\") AS sum_base_price",
+                   "sum(\"dt1___p39\") AS sum_disc_price",
+                   "sum(\"dt1___p46\") AS sum_charge",
+                   "avg(\"l_quantity\") AS avg_qty",
+                   "avg(\"l_extendedprice\") AS avg_price",
+                   "avg(\"l_discount\") AS avg_disc",
+                   "count() AS count_order"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"l_returnflag\"", "\"l_linestatus\""},
+                             {"sum(\"sum_qty\") AS sum_qty",
+                              "sum(\"sum_base_price\") AS sum_base_price",
+                              "sum(\"sum_disc_price\") AS sum_disc_price",
+                              "sum(\"sum_charge\") AS sum_charge",
+                              "avg(\"avg_qty\") AS avg_qty",
+                              "avg(\"avg_price\") AS avg_price",
+                              "avg(\"avg_disc\") AS avg_disc",
+                              "count(\"count_order\") AS count_order"})
+                         .orderBy(
+                             {"\"l_returnflag\" ASC NULLS LAST",
+                              "\"l_linestatus\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(1, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 7 columns  PARTIAL agg repartition  FINAL agg order
+    // by 2 columns  project 10 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_returnflag\" AS l_returnflag",
+                   "\"l_linestatus\" AS l_linestatus",
+                   "\"l_quantity\" AS l_quantity",
+                   "\"l_extendedprice\" AS l_extendedprice",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p39",
+                   "multiply(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),plus(\"l_tax\",1)) AS dt1___p46",
+                   "\"l_discount\" AS l_discount"})
+              .partialAggregation(
+                  {"\"l_returnflag\"", "\"l_linestatus\""},
+                  {"sum(\"l_quantity\") AS sum_qty",
+                   "sum(\"l_extendedprice\") AS sum_base_price",
+                   "sum(\"dt1___p39\") AS sum_disc_price",
+                   "sum(\"dt1___p46\") AS sum_charge",
+                   "avg(\"l_quantity\") AS avg_qty",
+                   "avg(\"l_extendedprice\") AS avg_price",
+                   "avg(\"l_discount\") AS avg_disc",
+                   "count() AS count_order"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"l_returnflag\"", "\"l_linestatus\""},
+                             {"sum(\"sum_qty\") AS sum_qty",
+                              "sum(\"sum_base_price\") AS sum_base_price",
+                              "sum(\"sum_disc_price\") AS sum_disc_price",
+                              "sum(\"sum_charge\") AS sum_charge",
+                              "avg(\"avg_qty\") AS avg_qty",
+                              "avg(\"avg_price\") AS avg_price",
+                              "avg(\"avg_disc\") AS avg_disc",
+                              "count(\"count_order\") AS count_order"})
+                         .orderBy(
+                             {"\"l_returnflag\" ASC NULLS LAST",
+                              "\"l_linestatus\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_10.inc
+++ b/axiom/optimizer/tests/h01_check_10.inc
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers10() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(10, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (customer t2*H  (orders t3  Build )*H  (nation t5  Build )
+    // project 8 columns   Build ) project 8 columns  SINGLE agg order by 1
+    // columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"c_phone\" AS c_phone",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_comment\" AS c_comment",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p77"})
+              .singleAggregation(
+                  {"\"c_custkey\"",
+                   "\"c_name\"",
+                   "\"c_acctbal\"",
+                   "\"c_phone\"",
+                   "\"n_name\"",
+                   "\"c_address\"",
+                   "\"c_comment\""},
+                  {"sum(\"dt1___p77\") AS revenue"})
+              .topN(20)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"revenue\" AS revenue",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_phone\" AS c_phone",
+                   "\"c_comment\" AS c_comment"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(10, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (customer t2*H  (orders t3  Build )*H  (nation t5  Build )
+    // project 8 columns   Build ) project 8 columns  PARTIAL agg FINAL agg
+    // order by 1 columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"c_phone\" AS c_phone",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_comment\" AS c_comment",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p77"})
+              .partialAggregation(
+                  {"\"c_custkey\"",
+                   "\"c_name\"",
+                   "\"c_acctbal\"",
+                   "\"c_phone\"",
+                   "\"n_name\"",
+                   "\"c_address\"",
+                   "\"c_comment\""},
+                  {"sum(\"dt1___p77\") AS revenue"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_custkey\"",
+                   "\"c_name\"",
+                   "\"c_acctbal\"",
+                   "\"c_phone\"",
+                   "\"n_name\"",
+                   "\"c_address\"",
+                   "\"c_comment\""},
+                  {"sum(\"revenue\") AS revenue"})
+              .topN(20)
+              .localMerge()
+              .finalLimit(0, 20)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"revenue\" AS revenue",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_phone\" AS c_phone",
+                   "\"c_comment\" AS c_comment"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(10, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (customer t2*H  (orders t3 broadcast   Build )*H  (nation
+    // t5 broadcast   Build ) project 8 columns  broadcast   Build ) project 8
+    // columns  PARTIAL agg repartition  FINAL agg order by 1 columns  project 8
+    // columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"c_phone\" AS c_phone",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_comment\" AS c_comment",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p77"})
+              .partialAggregation(
+                  {"\"c_custkey\"",
+                   "\"c_name\"",
+                   "\"c_acctbal\"",
+                   "\"c_phone\"",
+                   "\"n_name\"",
+                   "\"c_address\"",
+                   "\"c_comment\""},
+                  {"sum(\"dt1___p77\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"c_custkey\"",
+                              "\"c_name\"",
+                              "\"c_acctbal\"",
+                              "\"c_phone\"",
+                              "\"n_name\"",
+                              "\"c_address\"",
+                              "\"c_comment\""},
+                             {"sum(\"revenue\") AS revenue"})
+                         .topN(20)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 20)
+                         .project(
+                             {"\"c_custkey\" AS c_custkey",
+                              "\"c_name\" AS c_name",
+                              "\"revenue\" AS revenue",
+                              "\"c_acctbal\" AS c_acctbal",
+                              "\"n_name\" AS n_name",
+                              "\"c_address\" AS c_address",
+                              "\"c_phone\" AS c_phone",
+                              "\"c_comment\" AS c_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(10, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (customer t2*H  (orders t3 broadcast   Build )*H  (nation
+    // t5 broadcast   Build ) project 8 columns  broadcast   Build ) project 8
+    // columns  PARTIAL agg repartition  FINAL agg order by 1 columns  project 8
+    // columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"c_custkey\" AS c_custkey",
+                   "\"c_name\" AS c_name",
+                   "\"c_acctbal\" AS c_acctbal",
+                   "\"c_phone\" AS c_phone",
+                   "\"n_name\" AS n_name",
+                   "\"c_address\" AS c_address",
+                   "\"c_comment\" AS c_comment",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p77"})
+              .partialAggregation(
+                  {"\"c_custkey\"",
+                   "\"c_name\"",
+                   "\"c_acctbal\"",
+                   "\"c_phone\"",
+                   "\"n_name\"",
+                   "\"c_address\"",
+                   "\"c_comment\""},
+                  {"sum(\"dt1___p77\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"c_custkey\"",
+                              "\"c_name\"",
+                              "\"c_acctbal\"",
+                              "\"c_phone\"",
+                              "\"n_name\"",
+                              "\"c_address\"",
+                              "\"c_comment\""},
+                             {"sum(\"revenue\") AS revenue"})
+                         .topN(20)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 20)
+                         .project(
+                             {"\"c_custkey\" AS c_custkey",
+                              "\"c_name\" AS c_name",
+                              "\"revenue\" AS revenue",
+                              "\"c_acctbal\" AS c_acctbal",
+                              "\"n_name\" AS n_name",
+                              "\"c_address\" AS c_address",
+                              "\"c_phone\" AS c_phone",
+                              "\"c_comment\" AS c_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_11.inc
+++ b/axiom/optimizer/tests/h01_check_11.inc
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers11() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(11, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (supplier t3*H  (nation t4  Build ) project 1 columns
+    // Build ) project 2 columns  SINGLE agg project 2 columns *M  (partsupp
+    // t14*H  (supplier t15*H  (nation t16  Build ) project 1 columns   Build )
+    // project 1 columns  SINGLE agg project 1 columns ) filter 1 exprs  order
+    // by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .project(
+                  {"multiply(\"ps_supplycost_3\",cast(\"ps_availqty_2\" as DOUBLE)) AS dt13___p65"})
+              .singleAggregation({}, {"sum(\"dt13___p65\") AS sum"})
+              .project({"multiply(\"sum\",0.0001) AS expr"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"ps_partkey\" AS ps_partkey",
+                   "multiply(\"ps_supplycost\",cast(\"ps_availqty\" as DOUBLE)) AS dt1___p33"})
+              .singleAggregation(
+                  {"\"ps_partkey\""}, {"sum(\"dt1___p33\") AS value"})
+              .nestedLoopJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .filter("gt(\"value\",\"expr\")")
+              .orderBy({"\"value\" DESC NULLS LAST"})
+              .project({"\"ps_partkey\" AS ps_partkey", "\"value\" AS value"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(11, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (supplier t3*H  (nation t4  Build ) project 1 columns
+    // Build ) project 2 columns  PARTIAL agg FINAL agg project 2 columns *M
+    // (partsupp t14*H  (supplier t15*H  (nation t16  Build ) project 1 columns
+    // Build ) project 1 columns  PARTIAL agg FINAL agg project 1 columns )
+    // filter 1 exprs  order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .project(
+                  {"multiply(\"ps_supplycost_3\",cast(\"ps_availqty_2\" as DOUBLE)) AS dt13___p65"})
+              .partialAggregation({}, {"sum(\"dt13___p65\") AS sum"})
+              .localPartition()
+              .finalAggregation({}, {"sum(\"sum\") AS sum"})
+              .project({"multiply(\"sum\",0.0001) AS expr"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"ps_partkey\" AS ps_partkey",
+                   "multiply(\"ps_supplycost\",cast(\"ps_availqty\" as DOUBLE)) AS dt1___p33"})
+              .partialAggregation(
+                  {"\"ps_partkey\""}, {"sum(\"dt1___p33\") AS value"})
+              .localPartition()
+              .finalAggregation({"\"ps_partkey\""}, {"sum(\"value\") AS value"})
+              .nestedLoopJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .filter("gt(\"value\",\"expr\")")
+              .orderBy({"\"value\" DESC NULLS LAST"})
+              .localMerge()
+              .project({"\"ps_partkey\" AS ps_partkey", "\"value\" AS value"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(11, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (supplier t3*H  (nation t4 broadcast   Build ) project 1
+    // columns  broadcast   Build ) project 2 columns  PARTIAL agg repartition
+    // FINAL agg project 2 columns *M  (partsupp t14*H  (supplier t15*H  (nation
+    // t16 broadcast   Build ) project 1 columns  broadcast   Build ) project 1
+    // columns  PARTIAL agg gather  FINAL agg project 1 columns  broadcast )
+    // filter 1 exprs  order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"ps_partkey\" AS ps_partkey",
+                   "multiply(\"ps_supplycost\",cast(\"ps_availqty\" as DOUBLE)) AS dt1___p33"})
+              .partialAggregation(
+                  {"\"ps_partkey\""}, {"sum(\"dt1___p33\") AS value"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"multiply(\"ps_supplycost_3\",cast(\"ps_availqty_2\" as DOUBLE)) AS dt13___p65"})
+              .partialAggregation({}, {"sum(\"dt13___p65\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"sum(\"sum\") AS sum"})
+                         .project({"multiply(\"sum\",0.0001) AS expr"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation({"\"ps_partkey\""}, {"sum(\"value\") AS value"})
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"value\",\"expr\")")
+              .orderBy({"\"value\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .mergeExchange()
+              .project({"\"ps_partkey\" AS ps_partkey", "\"value\" AS value"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(11, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (supplier t3*H  (nation t4 broadcast   Build ) project 1
+    // columns  broadcast   Build ) project 2 columns  PARTIAL agg repartition
+    // FINAL agg project 2 columns *M  (partsupp t14*H  (supplier t15*H  (nation
+    // t16 broadcast   Build ) project 1 columns  broadcast   Build ) project 1
+    // columns  PARTIAL agg gather  FINAL agg project 1 columns  broadcast )
+    // filter 1 exprs  order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"ps_partkey\" AS ps_partkey",
+                   "multiply(\"ps_supplycost\",cast(\"ps_availqty\" as DOUBLE)) AS dt1___p33"})
+              .partialAggregation(
+                  {"\"ps_partkey\""}, {"sum(\"dt1___p33\") AS value"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"multiply(\"ps_supplycost_3\",cast(\"ps_availqty_2\" as DOUBLE)) AS dt13___p65"})
+              .partialAggregation({}, {"sum(\"dt13___p65\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"sum(\"sum\") AS sum"})
+                         .project({"multiply(\"sum\",0.0001) AS expr"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation({"\"ps_partkey\""}, {"sum(\"value\") AS value"})
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"value\",\"expr\")")
+              .orderBy({"\"value\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .mergeExchange()
+              .project({"\"ps_partkey\" AS ps_partkey", "\"value\" AS value"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_12.inc
+++ b/axiom/optimizer/tests/h01_check_12.inc
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers12() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(12, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H  (lineitem t3  Build ) project 3 columns  SINGLE agg order by
+    // 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_shipmode\" AS l_shipmode",
+                   "switch(\"or\"(eq(\"o_orderpriority\",'1-URGENT'),eq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p58",
+                   "switch(\"and\"(neq(\"o_orderpriority\",'1-URGENT'),neq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p65"})
+              .singleAggregation(
+                  {"\"l_shipmode\""},
+                  {"sum(\"dt1___p58\") AS high_line_count",
+                   "sum(\"dt1___p65\") AS low_line_count"})
+              .orderBy({"\"l_shipmode\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(12, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H  (lineitem t3  Build ) project 3 columns  PARTIAL agg FINAL
+    // agg order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_shipmode\" AS l_shipmode",
+                   "switch(\"or\"(eq(\"o_orderpriority\",'1-URGENT'),eq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p58",
+                   "switch(\"and\"(neq(\"o_orderpriority\",'1-URGENT'),neq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p65"})
+              .partialAggregation(
+                  {"\"l_shipmode\""},
+                  {"sum(\"dt1___p58\") AS high_line_count",
+                   "sum(\"dt1___p65\") AS low_line_count"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_shipmode\""},
+                  {"sum(\"high_line_count\") AS high_line_count",
+                   "sum(\"low_line_count\") AS low_line_count"})
+              .orderBy({"\"l_shipmode\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(12, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H  (lineitem t3 broadcast   Build ) project 3 columns  PARTIAL
+    // agg repartition  FINAL agg order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_shipmode\" AS l_shipmode",
+                   "switch(\"or\"(eq(\"o_orderpriority\",'1-URGENT'),eq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p58",
+                   "switch(\"and\"(neq(\"o_orderpriority\",'1-URGENT'),neq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p65"})
+              .partialAggregation(
+                  {"\"l_shipmode\""},
+                  {"sum(\"dt1___p58\") AS high_line_count",
+                   "sum(\"dt1___p65\") AS low_line_count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"l_shipmode\""},
+                             {"sum(\"high_line_count\") AS high_line_count",
+                              "sum(\"low_line_count\") AS low_line_count"})
+                         .orderBy({"\"l_shipmode\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(12, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H  (lineitem t3 broadcast   Build ) project 3 columns  PARTIAL
+    // agg repartition  FINAL agg order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_shipmode\" AS l_shipmode",
+                   "switch(\"or\"(eq(\"o_orderpriority\",'1-URGENT'),eq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p58",
+                   "switch(\"and\"(neq(\"o_orderpriority\",'1-URGENT'),neq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p65"})
+              .partialAggregation(
+                  {"\"l_shipmode\""},
+                  {"sum(\"dt1___p58\") AS high_line_count",
+                   "sum(\"dt1___p65\") AS low_line_count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"l_shipmode\""},
+                             {"sum(\"high_line_count\") AS high_line_count",
+                              "sum(\"low_line_count\") AS low_line_count"})
+                         .orderBy({"\"l_shipmode\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_13.inc
+++ b/axiom/optimizer/tests/h01_check_13.inc
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers13() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(13, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t3*H right (customer t2  Build ) SINGLE agg project 1 columns
+    // SINGLE agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .singleAggregation(
+                  {"\"c_custkey\""}, {"count(\"o_orderkey\") AS count"})
+              .project({"\"count\" AS c_count"})
+              .singleAggregation({"\"c_count\""}, {"count() AS custdist"})
+              .orderBy(
+                  {"\"custdist\" DESC NULLS LAST",
+                   "\"c_count\" DESC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(13, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t3*H right (customer t2  Build ) PARTIAL agg FINAL agg project 1
+    // columns  PARTIAL agg FINAL agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .partialAggregation(
+                  {"\"c_custkey\""}, {"count(\"o_orderkey\") AS count"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_custkey\""}, {"count(\"count\") AS count"})
+              .project({"\"count\" AS c_count"})
+              .partialAggregation({"\"c_count\""}, {"count() AS custdist"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_count\""}, {"count(\"custdist\") AS custdist"})
+              .orderBy(
+                  {"\"custdist\" DESC NULLS LAST",
+                   "\"c_count\" DESC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(13, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t3 repartition *H right (customer t2 repartition   Build ) PARTIAL
+    // agg repartition  FINAL agg project 1 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .partialAggregation(
+                  {"\"c_custkey\""}, {"count(\"o_orderkey\") AS count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"c_custkey\""}, {"count(\"count\") AS count"})
+              .project({"\"count\" AS c_count"})
+              .partialAggregation({"\"c_count\""}, {"count() AS custdist"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"c_count\""}, {"count(\"custdist\") AS custdist"})
+              .orderBy(
+                  {"\"custdist\" DESC NULLS LAST",
+                   "\"c_count\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(13, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t3 repartition *H right (customer t2 repartition   Build ) PARTIAL
+    // agg repartition  FINAL agg project 1 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .partialAggregation(
+                  {"\"c_custkey\""}, {"count(\"o_orderkey\") AS count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_custkey\""}, {"count(\"count\") AS count"})
+              .project({"\"count\" AS c_count"})
+              .partialAggregation({"\"c_count\""}, {"count() AS custdist"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_count\""}, {"count(\"custdist\") AS custdist"})
+              .orderBy(
+                  {"\"custdist\" DESC NULLS LAST",
+                   "\"c_count\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_14.inc
+++ b/axiom/optimizer/tests/h01_check_14.inc
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers14() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(14, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // part t3*H  (lineitem t2  Build ) project 2 columns  SINGLE agg project 1
+    // columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("part")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"switch(\"like\"(\"p_type\",'PROMO%'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p53",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p51"})
+              .singleAggregation(
+                  {},
+                  {"sum(\"dt1___p53\") AS sum", "sum(\"dt1___p51\") AS sum_0"})
+              .project(
+                  {"divide(multiply(\"sum\",100),\"sum_0\") AS promo_revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(14, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // part t3*H  (lineitem t2  Build ) project 2 columns  PARTIAL agg FINAL agg
+    // project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("part")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"switch(\"like\"(\"p_type\",'PROMO%'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p53",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p51"})
+              .partialAggregation(
+                  {},
+                  {"sum(\"dt1___p53\") AS sum", "sum(\"dt1___p51\") AS sum_0"})
+              .localPartition()
+              .finalAggregation(
+                  {}, {"sum(\"sum\") AS sum", "sum(\"sum_0\") AS sum_0"})
+              .project(
+                  {"divide(multiply(\"sum\",100),\"sum_0\") AS promo_revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(14, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // part t3*H  (lineitem t2 broadcast   Build ) project 2 columns  PARTIAL
+    // agg gather  FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("part")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"switch(\"like\"(\"p_type\",'PROMO%'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p53",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p51"})
+              .partialAggregation(
+                  {},
+                  {"sum(\"dt1___p53\") AS sum", "sum(\"dt1___p51\") AS sum_0"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {}, {"sum(\"sum\") AS sum", "sum(\"sum_0\") AS sum_0"})
+              .project(
+                  {"divide(multiply(\"sum\",100),\"sum_0\") AS promo_revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(14, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // part t3*H  (lineitem t2 broadcast   Build ) project 2 columns  PARTIAL
+    // agg gather  FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("part")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"switch(\"like\"(\"p_type\",'PROMO%'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p53",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p51"})
+              .partialAggregation(
+                  {},
+                  {"sum(\"dt1___p53\") AS sum", "sum(\"dt1___p51\") AS sum_0"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {}, {"sum(\"sum\") AS sum", "sum(\"sum_0\") AS sum_0"})
+              .project(
+                  {"divide(multiply(\"sum\",100),\"sum_0\") AS promo_revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_15.inc
+++ b/axiom/optimizer/tests/h01_check_15.inc
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers15() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(15, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 2 columns  SINGLE agg project 2 columns *H  (lineitem
+    // t6 project 2 columns  SINGLE agg project 1 columns  SINGLE agg project 1
+    // columns   Build )*H  (supplier t2  Build ) order by 1 columns  project 5
+    // columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey_2\" AS l_suppkey_2",
+                   "multiply(\"l_extendedprice_5\",minus(1,\"l_discount_6\")) AS dt5___p71"})
+              .singleAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"dt5___p71\") AS total_revenue_17"})
+              .project({"\"total_revenue_17\" AS total_revenue_19"})
+              .singleAggregation({}, {"max(\"total_revenue_19\") AS max"})
+              .build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey\" AS l_suppkey",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt3___p49"})
+              .singleAggregation(
+                  {"\"l_suppkey\""}, {"sum(\"dt3___p49\") AS total_revenue"})
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .orderBy({"\"s_suppkey\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(15, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 2 columns  PARTIAL agg FINAL agg project 2 columns *H
+    // (lineitem t6 project 2 columns  PARTIAL agg FINAL agg project 1 columns
+    // PARTIAL agg FINAL agg project 1 columns   Build )*H  (supplier t2  Build
+    // ) order by 1 columns  project 5 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey_2\" AS l_suppkey_2",
+                   "multiply(\"l_extendedprice_5\",minus(1,\"l_discount_6\")) AS dt5___p71"})
+              .partialAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"dt5___p71\") AS total_revenue_17"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"total_revenue_17\") AS total_revenue_17"})
+              .project({"\"total_revenue_17\" AS total_revenue_19"})
+              .partialAggregation({}, {"max(\"total_revenue_19\") AS max"})
+              .localPartition()
+              .finalAggregation({}, {"max(\"max\") AS max"})
+              .build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey\" AS l_suppkey",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt3___p49"})
+              .partialAggregation(
+                  {"\"l_suppkey\""}, {"sum(\"dt3___p49\") AS total_revenue"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_suppkey\""},
+                  {"sum(\"total_revenue\") AS total_revenue"})
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .orderBy({"\"s_suppkey\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(15, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 2 columns  PARTIAL agg repartition  FINAL agg project
+    // 2 columns *H  (lineitem t6 project 2 columns  PARTIAL agg repartition
+    // FINAL agg project 1 columns  PARTIAL agg gather  FINAL agg project 1
+    // columns  broadcast   Build )*H  (supplier t2 repartition   Build ) order
+    // by 1 columns  project 5 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey\" AS l_suppkey",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt3___p49"})
+              .partialAggregation(
+                  {"\"l_suppkey\""}, {"sum(\"dt3___p49\") AS total_revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey_2\" AS l_suppkey_2",
+                   "multiply(\"l_extendedprice_5\",minus(1,\"l_discount_6\")) AS dt5___p71"})
+              .partialAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"dt5___p71\") AS total_revenue_17"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"total_revenue_17\") AS total_revenue_17"})
+              .project({"\"total_revenue_17\" AS total_revenue_19"})
+              .partialAggregation({}, {"max(\"total_revenue_19\") AS max"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"max(\"max\") AS max"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"l_suppkey\""},
+                             {"sum(\"total_revenue\") AS total_revenue"})
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .orderBy({"\"s_suppkey\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(15, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 2 columns  PARTIAL agg repartition  FINAL agg project
+    // 2 columns *H  (lineitem t6 project 2 columns  PARTIAL agg repartition
+    // FINAL agg project 1 columns  PARTIAL agg gather  FINAL agg project 1
+    // columns  broadcast   Build )*H  (supplier t2 repartition   Build ) order
+    // by 1 columns  project 5 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey\" AS l_suppkey",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt3___p49"})
+              .partialAggregation(
+                  {"\"l_suppkey\""}, {"sum(\"dt3___p49\") AS total_revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"\"l_suppkey_2\" AS l_suppkey_2",
+                   "multiply(\"l_extendedprice_5\",minus(1,\"l_discount_6\")) AS dt5___p71"})
+              .partialAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"dt5___p71\") AS total_revenue_17"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_suppkey_2\""},
+                  {"sum(\"total_revenue_17\") AS total_revenue_17"})
+              .project({"\"total_revenue_17\" AS total_revenue_19"})
+              .partialAggregation({}, {"max(\"total_revenue_19\") AS max"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"max(\"max\") AS max"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"l_suppkey\""},
+                             {"sum(\"total_revenue\") AS total_revenue"})
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .orderBy({"\"s_suppkey\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_16.inc
+++ b/axiom/optimizer/tests/h01_check_16.inc
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers16() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(16, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (part t3  Build )*H exists-flag (supplier t5 project 1
+    // columns   Build ) filter 1 exprs  SINGLE agg order by 4 columns  project
+    // 4 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .singleAggregation(
+                  {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                  {"count(\"ps_suppkey\") AS supplier_cnt"})
+              .orderBy(
+                  {"\"supplier_cnt\" DESC NULLS LAST",
+                   "\"p_brand\" ASC NULLS LAST",
+                   "\"p_type\" ASC NULLS LAST",
+                   "\"p_size\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(16, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (part t3  Build )*H exists-flag (supplier t5 project 1
+    // columns   Build ) filter 1 exprs  PARTIAL agg FINAL agg order by 4
+    // columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .partialAggregation(
+                  {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                  {"count(\"ps_suppkey\") AS supplier_cnt"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                  {"count(\"supplier_cnt\") AS supplier_cnt"})
+              .orderBy(
+                  {"\"supplier_cnt\" DESC NULLS LAST",
+                   "\"p_brand\" ASC NULLS LAST",
+                   "\"p_type\" ASC NULLS LAST",
+                   "\"p_size\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(16, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (part t3 broadcast   Build )*H exists-flag (supplier t5
+    // project 1 columns  broadcast   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 4 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .partialAggregation(
+                  {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                  {"count(\"ps_suppkey\") AS supplier_cnt"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                             {"count(\"supplier_cnt\") AS supplier_cnt"})
+                         .orderBy(
+                             {"\"supplier_cnt\" DESC NULLS LAST",
+                              "\"p_brand\" ASC NULLS LAST",
+                              "\"p_type\" ASC NULLS LAST",
+                              "\"p_size\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(16, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t2*H  (part t3 broadcast   Build )*H exists-flag (supplier t5
+    // project 1 columns  broadcast   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 4 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .partialAggregation(
+                  {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                  {"count(\"ps_suppkey\") AS supplier_cnt"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"p_brand\"", "\"p_type\"", "\"p_size\""},
+                             {"count(\"supplier_cnt\") AS supplier_cnt"})
+                         .orderBy(
+                             {"\"supplier_cnt\" DESC NULLS LAST",
+                              "\"p_brand\" ASC NULLS LAST",
+                              "\"p_type\" ASC NULLS LAST",
+                              "\"p_size\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_17.inc
+++ b/axiom/optimizer/tests/h01_check_17.inc
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers17() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(17, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3  Build )*H left (lineitem t5*H exists (part t3
+    // Build ) SINGLE agg project 2 columns   Build ) filter 1 exprs  SINGLE agg
+    // project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiFilter)
+              .singleAggregation(
+                  {"\"l_partkey_1\""}, {"avg(\"l_quantity_4\") AS avg"})
+              .project(
+                  {"\"l_partkey_1\" AS dt4___gk6",
+                   "multiply(\"avg\",0.2) AS expr"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kLeft)
+              .filter("lt(\"l_quantity\",\"expr\")")
+              .singleAggregation({}, {"sum(\"l_extendedprice\") AS sum"})
+              .project({"divide(\"sum\",7) AS avg_yearly"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(17, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3  Build )*H left (lineitem t5*H exists (part t3
+    // Build ) PARTIAL agg FINAL agg project 2 columns   Build ) filter 1 exprs
+    // PARTIAL agg FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiFilter)
+              .partialAggregation(
+                  {"\"l_partkey_1\""}, {"avg(\"l_quantity_4\") AS avg"})
+              .localPartition()
+              .finalAggregation({"\"l_partkey_1\""}, {"avg(\"avg\") AS avg"})
+              .project(
+                  {"\"l_partkey_1\" AS dt4___gk6",
+                   "multiply(\"avg\",0.2) AS expr"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kLeft)
+              .filter("lt(\"l_quantity\",\"expr\")")
+              .partialAggregation({}, {"sum(\"l_extendedprice\") AS sum"})
+              .localPartition()
+              .finalAggregation({}, {"sum(\"sum\") AS sum"})
+              .project({"divide(\"sum\",7) AS avg_yearly"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(17, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3 broadcast   Build )*H left (lineitem t5*H exists
+    // (part t3 broadcast   Build ) PARTIAL agg repartition  FINAL agg project 2
+    // columns  broadcast   Build ) filter 1 exprs  PARTIAL agg gather  FINAL
+    // agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partialAggregation(
+                  {"\"l_partkey_1\""}, {"avg(\"l_quantity_4\") AS avg"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation({"\"l_partkey_1\""}, {"avg(\"avg\") AS avg"})
+              .project(
+                  {"\"l_partkey_1\" AS dt4___gk6",
+                   "multiply(\"avg\",0.2) AS expr"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeft)
+              .filter("lt(\"l_quantity\",\"expr\")")
+              .partialAggregation({}, {"sum(\"l_extendedprice\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"sum(\"sum\") AS sum"})
+                         .project({"divide(\"sum\",7) AS avg_yearly"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(17, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3 broadcast   Build )*H left (lineitem t5*H exists
+    // (part t3 broadcast   Build ) PARTIAL agg repartition  FINAL agg project 2
+    // columns  broadcast   Build ) filter 1 exprs  PARTIAL agg gather  FINAL
+    // agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partialAggregation(
+                  {"\"l_partkey_1\""}, {"avg(\"l_quantity_4\") AS avg"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation({"\"l_partkey_1\""}, {"avg(\"avg\") AS avg"})
+              .project(
+                  {"\"l_partkey_1\" AS dt4___gk6",
+                   "multiply(\"avg\",0.2) AS expr"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeft)
+              .filter("lt(\"l_quantity\",\"expr\")")
+              .partialAggregation({}, {"sum(\"l_extendedprice\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"sum(\"sum\") AS sum"})
+                         .project({"divide(\"sum\",7) AS avg_yearly"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_18.inc
+++ b/axiom/optimizer/tests/h01_check_18.inc
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers18() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(18, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build ) project 5 columns
+    // Build )*H exists-flag (lineitem t6*H exists (orders t3*H  (customer t2
+    // Build ) project 1 columns   Build ) SINGLE agg filter 1 exprs  project 1
+    // columns   Build ) filter 1 exprs  SINGLE agg order by 2 columns  project
+    // 6 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .project({"\"o_orderkey\" AS edt13_edt13_t3_o_orderkey"})
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kLeftSemiFilter)
+              .singleAggregation(
+                  {"\"l_orderkey_0\""}, {"sum(\"l_quantity_4\") AS sum"})
+              .filter("gt(\"sum\",300)")
+              .project({"\"l_orderkey_0\" AS l_orderkey_17"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .singleAggregation(
+                  {"\"c_name\"",
+                   "\"c_custkey\"",
+                   "\"o_orderkey\"",
+                   "\"o_orderdate\"",
+                   "\"o_totalprice\""},
+                  {"sum(\"l_quantity\") AS sum_18"})
+              .topN(100)
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(18, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build ) project 5 columns
+    // Build )*H exists-flag (lineitem t6 PARTIAL agg FINAL agg filter 1 exprs
+    // project 1 columns   Build ) filter 1 exprs  PARTIAL agg FINAL agg order
+    // by 2 columns  project 6 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .partialAggregation(
+                  {"\"l_orderkey_0\""}, {"sum(\"l_quantity_4\") AS sum"})
+              .localPartition()
+              .finalAggregation({"\"l_orderkey_0\""}, {"sum(\"sum\") AS sum"})
+              .filter("gt(\"sum\",300)")
+              .project({"\"l_orderkey_0\" AS l_orderkey_17"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"c_name\"",
+                   "\"c_custkey\"",
+                   "\"o_orderkey\"",
+                   "\"o_orderdate\"",
+                   "\"o_totalprice\""},
+                  {"sum(\"l_quantity\") AS sum_18"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"c_name\"",
+                   "\"c_custkey\"",
+                   "\"o_orderkey\"",
+                   "\"o_orderdate\"",
+                   "\"o_totalprice\""},
+                  {"sum(\"sum_18\") AS sum_18"})
+              .topN(100)
+              .localMerge()
+              .finalLimit(0, 100)
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(18, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build ) project 5
+    // columns  broadcast   Build ) repartition *H exists-flag (lineitem t6
+    // PARTIAL agg repartition  FINAL agg filter 1 exprs  project 1 columns
+    // Build ) filter 1 exprs  PARTIAL agg repartition  FINAL agg order by 2
+    // columns  project 6 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .partialAggregation(
+                  {"\"l_orderkey_0\""}, {"sum(\"l_quantity_4\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation({"\"l_orderkey_0\""}, {"sum(\"sum\") AS sum"})
+              .filter("gt(\"sum\",300)")
+              .project({"\"l_orderkey_0\" AS l_orderkey_17"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"c_name\"",
+                   "\"c_custkey\"",
+                   "\"o_orderkey\"",
+                   "\"o_orderdate\"",
+                   "\"o_totalprice\""},
+                  {"sum(\"l_quantity\") AS sum_18"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"c_name\"",
+                              "\"c_custkey\"",
+                              "\"o_orderkey\"",
+                              "\"o_orderdate\"",
+                              "\"o_totalprice\""},
+                             {"sum(\"sum_18\") AS sum_18"})
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder().mergeExchange().finalLimit(0, 100).build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(18, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build ) project 5
+    // columns  broadcast   Build ) repartition *H exists-flag (lineitem t6
+    // PARTIAL agg repartition  FINAL agg filter 1 exprs  project 1 columns
+    // Build ) filter 1 exprs  PARTIAL agg repartition  FINAL agg order by 2
+    // columns  project 6 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .partialAggregation(
+                  {"\"l_orderkey_0\""}, {"sum(\"l_quantity_4\") AS sum"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation({"\"l_orderkey_0\""}, {"sum(\"sum\") AS sum"})
+              .filter("gt(\"sum\",300)")
+              .project({"\"l_orderkey_0\" AS l_orderkey_17"})
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"c_name\"",
+                   "\"c_custkey\"",
+                   "\"o_orderkey\"",
+                   "\"o_orderdate\"",
+                   "\"o_totalprice\""},
+                  {"sum(\"l_quantity\") AS sum_18"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"c_name\"",
+                              "\"c_custkey\"",
+                              "\"o_orderkey\"",
+                              "\"o_orderdate\"",
+                              "\"o_totalprice\""},
+                             {"sum(\"sum_18\") AS sum_18"})
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder().mergeExchange().finalLimit(0, 100).build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_19.inc
+++ b/axiom/optimizer/tests/h01_check_19.inc
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers19() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(19, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3  Build ) filter 1 exprs  project 1 columns SINGLE
+    // agg project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,15),\"and\"(lte(\"l_quantity\",30),\"and\"(gte(\"l_quantity\",20),\"and\"(eq(\"p_brand\",'Brand#34'),\"in\"(\"p_container\",array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))))),\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,5),\"and\"(lte(\"l_quantity\",11),\"and\"(gte(\"l_quantity\",1),\"and\"(eq(\"p_brand\",'Brand#12'),\"in\"(\"p_container\",array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))))),\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,10),\"and\"(lte(\"l_quantity\",20),\"and\"(gte(\"l_quantity\",10),\"and\"(eq(\"p_brand\",'Brand#23'),\"in\"(\"p_container\",array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))))")
+              .project(
+                  {"multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p121"})
+              .singleAggregation({}, {"sum(\"dt1___p121\") AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(19, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3  Build ) filter 1 exprs  project 1 columns
+    // PARTIAL agg FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,15),\"and\"(lte(\"l_quantity\",30),\"and\"(gte(\"l_quantity\",20),\"and\"(eq(\"p_brand\",'Brand#34'),\"in\"(\"p_container\",array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))))),\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,5),\"and\"(lte(\"l_quantity\",11),\"and\"(gte(\"l_quantity\",1),\"and\"(eq(\"p_brand\",'Brand#12'),\"in\"(\"p_container\",array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))))),\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,10),\"and\"(lte(\"l_quantity\",20),\"and\"(gte(\"l_quantity\",10),\"and\"(eq(\"p_brand\",'Brand#23'),\"in\"(\"p_container\",array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))))")
+              .project(
+                  {"multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p121"})
+              .partialAggregation({}, {"sum(\"dt1___p121\") AS revenue"})
+              .localPartition()
+              .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(19, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3 broadcast   Build ) filter 1 exprs  project 1
+    // columns  PARTIAL agg gather  FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,15),\"and\"(lte(\"l_quantity\",30),\"and\"(gte(\"l_quantity\",20),\"and\"(eq(\"p_brand\",'Brand#34'),\"in\"(\"p_container\",array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))))),\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,5),\"and\"(lte(\"l_quantity\",11),\"and\"(gte(\"l_quantity\",1),\"and\"(eq(\"p_brand\",'Brand#12'),\"in\"(\"p_container\",array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))))),\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,10),\"and\"(lte(\"l_quantity\",20),\"and\"(gte(\"l_quantity\",10),\"and\"(eq(\"p_brand\",'Brand#23'),\"in\"(\"p_container\",array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))))")
+              .project(
+                  {"multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p121"})
+              .partialAggregation({}, {"sum(\"dt1___p121\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(19, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3 broadcast   Build ) filter 1 exprs  project 1
+    // columns  PARTIAL agg gather  FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,15),\"and\"(lte(\"l_quantity\",30),\"and\"(gte(\"l_quantity\",20),\"and\"(eq(\"p_brand\",'Brand#34'),\"in\"(\"p_container\",array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))))),\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,5),\"and\"(lte(\"l_quantity\",11),\"and\"(gte(\"l_quantity\",1),\"and\"(eq(\"p_brand\",'Brand#12'),\"in\"(\"p_container\",array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))))),\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,10),\"and\"(lte(\"l_quantity\",20),\"and\"(gte(\"l_quantity\",10),\"and\"(eq(\"p_brand\",'Brand#23'),\"in\"(\"p_container\",array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))))")
+              .project(
+                  {"multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p121"})
+              .partialAggregation({}, {"sum(\"dt1___p121\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_2.inc
+++ b/axiom/optimizer/tests/h01_check_2.inc
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers2() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(2, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t4*H  (part t2  Build )*H  (supplier t3*H  (nation t5*H  (region
+    // t6  Build ) project 2 columns   Build ) project 7 columns   Build )*H
+    // left (supplier t9*H  (partsupp t8*H exists (part t2  Build ) project 3
+    // columns   Build )*H  (nation t10*H  (region t11  Build ) project 1
+    // columns   Build ) SINGLE agg project 1 columns   Build ) order by 4
+    // columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kLeftSemiFilter)
+              .build();
+
+      auto rightMatcher6 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher7 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher6, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher8 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher5, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher7, velox::core::JoinType::kInner)
+              .singleAggregation(
+                  {"\"ps_partkey_0\""}, {"min(\"ps_supplycost_3\") AS min"})
+              .project({"\"ps_partkey_0\" AS dt7___gk12"})
+              .build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher8, velox::core::JoinType::kLeft)
+                         .topN(100)
+                         .project(
+                             {"\"s_acctbal\" AS s_acctbal",
+                              "\"s_name\" AS s_name",
+                              "\"n_name\" AS n_name",
+                              "\"p_partkey\" AS p_partkey",
+                              "\"p_mfgr\" AS p_mfgr",
+                              "\"s_address\" AS s_address",
+                              "\"s_phone\" AS s_phone",
+                              "\"s_comment\" AS s_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(2, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t4*H  (part t2  Build )*H  (supplier t3*H  (nation t5*H  (region
+    // t6  Build ) project 2 columns   Build ) project 7 columns   Build )*H
+    // left (supplier t9*H  (partsupp t8*H exists (part t2  Build ) project 3
+    // columns   Build )*H  (nation t10*H  (region t11  Build ) project 1
+    // columns   Build ) PARTIAL agg FINAL agg project 1 columns   Build ) order
+    // by 4 columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kLeftSemiFilter)
+              .build();
+
+      auto rightMatcher6 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher7 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher6, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher8 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher5, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher7, velox::core::JoinType::kInner)
+              .partialAggregation(
+                  {"\"ps_partkey_0\""}, {"min(\"ps_supplycost_3\") AS min"})
+              .localPartition()
+              .finalAggregation({"\"ps_partkey_0\""}, {"min(\"min\") AS min"})
+              .project({"\"ps_partkey_0\" AS dt7___gk12"})
+              .build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher8, velox::core::JoinType::kLeft)
+                         .topN(100)
+                         .localMerge()
+                         .finalLimit(0, 100)
+                         .project(
+                             {"\"s_acctbal\" AS s_acctbal",
+                              "\"s_name\" AS s_name",
+                              "\"n_name\" AS n_name",
+                              "\"p_partkey\" AS p_partkey",
+                              "\"p_mfgr\" AS p_mfgr",
+                              "\"s_address\" AS s_address",
+                              "\"s_phone\" AS s_phone",
+                              "\"s_comment\" AS s_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(2, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t4*H  (part t2 broadcast   Build )*H  (supplier t3*H  (nation
+    // t5*H  (region t6 broadcast   Build ) project 2 columns  broadcast   Build
+    // ) project 7 columns  broadcast   Build )*H left (partsupp t8*H exists
+    // (part t2 broadcast   Build )*H  (supplier t9*H  (nation t10*H  (region
+    // t11 broadcast   Build ) project 1 columns  broadcast   Build ) project 1
+    // columns  broadcast   Build ) PARTIAL agg repartition  FINAL agg project 1
+    // columns  broadcast   Build ) order by 4 columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .partialAggregation(
+                  {"\"ps_partkey_0\""}, {"min(\"ps_supplycost_3\") AS min"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation({"\"ps_partkey_0\""}, {"min(\"min\") AS min"})
+              .project({"\"ps_partkey_0\" AS dt7___gk12"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+    // Fragment 10
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher2 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher2, velox::core::JoinType::kLeft)
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[10].fragment.planNode));
+    }
+    // Fragment 11
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 100)
+                         .project(
+                             {"\"s_acctbal\" AS s_acctbal",
+                              "\"s_name\" AS s_name",
+                              "\"n_name\" AS n_name",
+                              "\"p_partkey\" AS p_partkey",
+                              "\"p_mfgr\" AS p_mfgr",
+                              "\"s_address\" AS s_address",
+                              "\"s_phone\" AS s_phone",
+                              "\"s_comment\" AS s_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[11].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(2, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // partsupp t4*H  (part t2 broadcast   Build )*H  (supplier t3*H  (nation
+    // t5*H  (region t6 broadcast   Build ) project 2 columns  broadcast   Build
+    // ) project 7 columns  broadcast   Build )*H left (partsupp t8*H exists
+    // (part t2 broadcast   Build )*H  (supplier t9*H  (nation t10*H  (region
+    // t11 broadcast   Build ) project 1 columns  broadcast   Build ) project 1
+    // columns  broadcast   Build ) PARTIAL agg repartition  FINAL agg project 1
+    // columns  broadcast   Build ) order by 4 columns  project 8 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .partialAggregation(
+                  {"\"ps_partkey_0\""}, {"min(\"ps_supplycost_3\") AS min"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation({"\"ps_partkey_0\""}, {"min(\"min\") AS min"})
+              .project({"\"ps_partkey_0\" AS dt7___gk12"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+    // Fragment 10
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher2 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher2, velox::core::JoinType::kLeft)
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[10].fragment.planNode));
+    }
+    // Fragment 11
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 100)
+                         .project(
+                             {"\"s_acctbal\" AS s_acctbal",
+                              "\"s_name\" AS s_name",
+                              "\"n_name\" AS n_name",
+                              "\"p_partkey\" AS p_partkey",
+                              "\"p_mfgr\" AS p_mfgr",
+                              "\"s_address\" AS s_address",
+                              "\"s_phone\" AS s_phone",
+                              "\"s_comment\" AS s_comment"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[11].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_20.inc
+++ b/axiom/optimizer/tests/h01_check_20.inc
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers20() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(20, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 SINGLE agg project 3 columns *H right (partsupp t5*H
+    // exists-flag (part t11 project 1 columns   Build ) filter 1 exprs *H
+    // exists (supplier t2*H  (nation t3  Build ) project 1 columns   Build )
+    // Build ) filter 1 exprs  project 1 columns *H right exists-flag (supplier
+    // t2*H  (nation t3  Build )  Build ) filter 1 exprs  order by 1 columns
+    // project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project({"\"s_suppkey\" AS edt14_edt14_t2_s_suppkey"})
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt4___mark0\"")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kLeftSemiFilter)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .singleAggregation(
+                  {"\"l_partkey\"", "\"l_suppkey\""},
+                  {"sum(\"l_quantity\") AS sum"})
+              .project(
+                  {"\"l_partkey\" AS dt6___gk8",
+                   "\"l_suppkey\" AS dt6___gk9",
+                   "multiply(\"sum\",0.5) AS expr"})
+              .hashJoin(rightMatcher3, velox::core::JoinType::kRight)
+              .filter("lt(\"expr\",cast(\"ps_availqty\" as DOUBLE))")
+              .project({"\"ps_suppkey\" AS ps_suppkey"})
+              .hashJoin(rightMatcher5, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark1\"")
+              .orderBy({"\"s_name\" ASC NULLS LAST"})
+              .project({"\"s_name\" AS s_name", "\"s_address\" AS s_address"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(20, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 PARTIAL agg FINAL agg project 3 columns *H right (partsupp
+    // t5*H exists-flag (part t11 project 1 columns   Build ) filter 1 exprs *H
+    // exists (supplier t2*H  (nation t3  Build ) project 1 columns   Build )
+    // Build ) filter 1 exprs  project 1 columns *H right exists-flag (supplier
+    // t2*H  (nation t3  Build )  Build ) filter 1 exprs  order by 1 columns
+    // project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project({"\"s_suppkey\" AS edt14_edt14_t2_s_suppkey"})
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt4___mark0\"")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kLeftSemiFilter)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .partialAggregation(
+                  {"\"l_partkey\"", "\"l_suppkey\""},
+                  {"sum(\"l_quantity\") AS sum"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_partkey\"", "\"l_suppkey\""}, {"sum(\"sum\") AS sum"})
+              .project(
+                  {"\"l_partkey\" AS dt6___gk8",
+                   "\"l_suppkey\" AS dt6___gk9",
+                   "multiply(\"sum\",0.5) AS expr"})
+              .hashJoin(rightMatcher3, velox::core::JoinType::kRight)
+              .filter("lt(\"expr\",cast(\"ps_availqty\" as DOUBLE))")
+              .project({"\"ps_suppkey\" AS ps_suppkey"})
+              .hashJoin(rightMatcher5, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark1\"")
+              .orderBy({"\"s_name\" ASC NULLS LAST"})
+              .localMerge()
+              .project({"\"s_name\" AS s_name", "\"s_address\" AS s_address"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(20, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 PARTIAL agg repartition  FINAL agg project 3 columns *H right
+    // (partsupp t5*H exists-flag (part t11 project 1 columns  broadcast   Build
+    // ) filter 1 exprs *H exists (supplier t2*H  (nation t3 broadcast   Build )
+    // project 1 columns  broadcast   Build ) repartition   Build ) filter 1
+    // exprs  project 1 columns  repartition *H right exists-flag (supplier t2*H
+    // (nation t3 broadcast   Build ) repartition   Build ) filter 1 exprs order
+    // by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partialAggregation(
+                             {"\"l_partkey\"", "\"l_suppkey\""},
+                             {"sum(\"l_quantity\") AS sum"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .project({"\"s_suppkey\" AS edt14_edt14_t2_s_suppkey"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt4___mark0\"")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"l_partkey\"", "\"l_suppkey\""}, {"sum(\"sum\") AS sum"})
+              .project(
+                  {"\"l_partkey\" AS dt6___gk8",
+                   "\"l_suppkey\" AS dt6___gk9",
+                   "multiply(\"sum\",0.5) AS expr"})
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .filter("lt(\"expr\",cast(\"ps_availqty\" as DOUBLE))")
+              .project({"\"ps_suppkey\" AS ps_suppkey"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark1\"")
+              .orderBy({"\"s_name\" ASC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .mergeExchange()
+              .project({"\"s_name\" AS s_name", "\"s_address\" AS s_address"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(20, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 PARTIAL agg repartition  FINAL agg project 3 columns *H right
+    // (partsupp t5*H exists-flag (part t11 project 1 columns  broadcast   Build
+    // ) filter 1 exprs *H exists (supplier t2*H  (nation t3 broadcast   Build )
+    // project 1 columns  broadcast   Build ) repartition   Build ) filter 1
+    // exprs  project 1 columns  repartition *H right exists-flag (supplier t2*H
+    // (nation t3 broadcast   Build ) repartition   Build ) filter 1 exprs order
+    // by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partialAggregation(
+                             {"\"l_partkey\"", "\"l_suppkey\""},
+                             {"sum(\"l_quantity\") AS sum"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .project({"\"s_suppkey\" AS edt14_edt14_t2_s_suppkey"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt4___mark0\"")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_partkey\"", "\"l_suppkey\""}, {"sum(\"sum\") AS sum"})
+              .project(
+                  {"\"l_partkey\" AS dt6___gk8",
+                   "\"l_suppkey\" AS dt6___gk9",
+                   "multiply(\"sum\",0.5) AS expr"})
+              .hashJoin(rightMatcher, velox::core::JoinType::kRight)
+              .filter("lt(\"expr\",cast(\"ps_availqty\" as DOUBLE))")
+              .project({"\"ps_suppkey\" AS ps_suppkey"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark1\"")
+              .orderBy({"\"s_name\" ASC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .mergeExchange()
+              .project({"\"s_name\" AS s_name", "\"s_address\" AS s_address"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_21.inc
+++ b/axiom/optimizer/tests/h01_check_21.inc
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers21() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(21, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 project 2 columns *H right exists-flag (lineitem t9 project 2
+    // columns *H right exists-flag (lineitem t3*H  (supplier t2*H  (nation t5
+    // Build ) project 2 columns   Build )*H  (orders t4  Build )  Build )
+    // filter 1 exprs   Build ) filter 1 exprs  SINGLE agg order by 2 columns
+    // project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark1\")")
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .singleAggregation({"\"s_name\""}, {"count() AS numwait"})
+              .topN(100)
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(21, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 project 2 columns *H right exists-flag (lineitem t9 project 2
+    // columns *H right exists-flag (lineitem t3*H  (supplier t2*H  (nation t5
+    // Build ) project 2 columns   Build )*H  (orders t4  Build )  Build )
+    // filter 1 exprs   Build ) filter 1 exprs  PARTIAL agg FINAL agg order by 2
+    // columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark1\")")
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher4, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation({"\"s_name\""}, {"count() AS numwait"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"s_name\""}, {"count(\"numwait\") AS numwait"})
+              .topN(100)
+              .localMerge()
+              .finalLimit(0, 100)
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(21, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 project 2 columns  repartition *H right exists-flag (lineitem
+    // t9 project 2 columns  repartition *H right exists-flag (lineitem t3*H
+    // (supplier t2*H  (nation t5 broadcast   Build ) project 2 columns
+    // broadcast   Build )*H  (orders t4 broadcast   Build ) repartition   Build
+    // ) filter 1 exprs  repartition   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark1\")")
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation({"\"s_name\""}, {"count() AS numwait"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"s_name\""}, {"count(\"numwait\") AS numwait"})
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder().mergeExchange().finalLimit(0, 100).build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(21, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t7 project 2 columns  repartition *H right exists-flag (lineitem
+    // t9 project 2 columns  repartition *H right exists-flag (lineitem t3*H
+    // (supplier t2*H  (nation t5 broadcast   Build ) project 2 columns
+    // broadcast   Build )*H  (orders t4 broadcast   Build ) repartition   Build
+    // ) filter 1 exprs  repartition   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 2 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark1\")")
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation({"\"s_name\""}, {"count() AS numwait"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"s_name\""}, {"count(\"numwait\") AS numwait"})
+                         .topN(100)
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher =
+          core::PlanMatcherBuilder().mergeExchange().finalLimit(0, 100).build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_22.inc
+++ b/axiom/optimizer/tests/h01_check_22.inc
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers22() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(22, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t6 project 1 columns *H right exists-flag (customer t2*M (customer
+    // t4 SINGLE agg project 1 columns ) filter 1 exprs   Build ) filter 1 exprs
+    // project 2 columns  SINGLE agg order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .singleAggregation({}, {"avg(\"c_acctbal_5\") AS avg"})
+              .build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"c_acctbal\",\"avg\")")
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .project(
+                  {"substr(\"c_phone\",1,2) AS cntrycode",
+                   "\"c_acctbal\" AS c_acctbal"})
+              .singleAggregation(
+                  {"\"cntrycode\""},
+                  {"count() AS numcust", "sum(\"c_acctbal\") AS totacctbal"})
+              .orderBy({"\"cntrycode\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(22, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t6 project 1 columns *H right exists-flag (customer t2*M (customer
+    // t4 PARTIAL agg FINAL agg project 1 columns ) filter 1 exprs   Build )
+    // filter 1 exprs  project 2 columns  PARTIAL agg FINAL agg order by 1
+    // columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .partialAggregation({}, {"avg(\"c_acctbal_5\") AS avg"})
+              .localPartition()
+              .finalAggregation({}, {"avg(\"avg\") AS avg"})
+              .build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"c_acctbal\",\"avg\")")
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kRightSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .project(
+                  {"substr(\"c_phone\",1,2) AS cntrycode",
+                   "\"c_acctbal\" AS c_acctbal"})
+              .partialAggregation(
+                  {"\"cntrycode\""},
+                  {"count() AS numcust", "sum(\"c_acctbal\") AS totacctbal"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"cntrycode\""},
+                  {"count(\"numcust\") AS numcust",
+                   "sum(\"totacctbal\") AS totacctbal"})
+              .orderBy({"\"cntrycode\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(22, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // customer t2*M  (customer t4 PARTIAL agg gather  FINAL agg project 1
+    // columns  broadcast ) filter 1 exprs *H exists-flag (orders t6*H exists
+    // (customer t2 broadcast   Build ) project 1 columns  broadcast   Build )
+    // filter 1 exprs  project 2 columns  PARTIAL agg repartition  FINAL agg
+    // order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .partialAggregation({}, {"avg(\"c_acctbal_5\") AS avg"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"avg(\"avg\") AS avg"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"c_acctbal\",\"avg\")")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .project(
+                  {"substr(\"c_phone\",1,2) AS cntrycode",
+                   "\"c_acctbal\" AS c_acctbal"})
+              .partialAggregation(
+                  {"\"cntrycode\""},
+                  {"count() AS numcust", "sum(\"c_acctbal\") AS totacctbal"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"cntrycode\""},
+                             {"count(\"numcust\") AS numcust",
+                              "sum(\"totacctbal\") AS totacctbal"})
+                         .orderBy({"\"cntrycode\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(22, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // customer t2*M  (customer t4 PARTIAL agg gather  FINAL agg project 1
+    // columns  broadcast ) filter 1 exprs *H exists-flag (orders t6*H exists
+    // (customer t2 broadcast   Build ) project 1 columns  broadcast   Build )
+    // filter 1 exprs  project 2 columns  PARTIAL agg repartition  FINAL agg
+    // order by 1 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .partialAggregation({}, {"avg(\"c_acctbal_5\") AS avg"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"avg(\"avg\") AS avg"})
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter("gt(\"c_acctbal\",\"avg\")")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"not\"(\"dt1___mark0\")")
+              .project(
+                  {"substr(\"c_phone\",1,2) AS cntrycode",
+                   "\"c_acctbal\" AS c_acctbal"})
+              .partialAggregation(
+                  {"\"cntrycode\""},
+                  {"count() AS numcust", "sum(\"c_acctbal\") AS totacctbal"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"cntrycode\""},
+                             {"count(\"numcust\") AS numcust",
+                              "sum(\"totacctbal\") AS totacctbal"})
+                         .orderBy({"\"cntrycode\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_3.inc
+++ b/axiom/optimizer/tests/h01_check_3.inc
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers3() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(3, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build ) project 3 columns
+    // Build ) project 4 columns  SINGLE agg order by 2 columns  project 4
+    // columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p61"})
+              .singleAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"dt1___p61\") AS revenue"})
+              .topN(10)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"revenue\" AS revenue",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(3, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build ) project 3 columns
+    // Build ) project 4 columns  PARTIAL agg FINAL agg order by 2 columns
+    // project 4 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p61"})
+              .partialAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"dt1___p61\") AS revenue"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"revenue\") AS revenue"})
+              .topN(10)
+              .localMerge()
+              .finalLimit(0, 10)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"revenue\" AS revenue",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(3, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build ) project 3
+    // columns  broadcast   Build ) project 4 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p61"})
+              .partialAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"dt1___p61\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"revenue\") AS revenue"})
+              .topN(10)
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 10)
+                         .project(
+                             {"\"l_orderkey\" AS l_orderkey",
+                              "\"revenue\" AS revenue",
+                              "\"o_orderdate\" AS o_orderdate",
+                              "\"o_shippriority\" AS o_shippriority"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(3, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build ) project 3
+    // columns  broadcast   Build ) project 4 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .project(
+                  {"\"l_orderkey\" AS l_orderkey",
+                   "\"o_orderdate\" AS o_orderdate",
+                   "\"o_shippriority\" AS o_shippriority",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p61"})
+              .partialAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"dt1___p61\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""},
+                  {"sum(\"revenue\") AS revenue"})
+              .topN(10)
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .finalLimit(0, 10)
+                         .project(
+                             {"\"l_orderkey\" AS l_orderkey",
+                              "\"revenue\" AS revenue",
+                              "\"o_orderdate\" AS o_orderdate",
+                              "\"o_shippriority\" AS o_shippriority"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_4.inc
+++ b/axiom/optimizer/tests/h01_check_4.inc
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers4() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(4, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 1 columns *H right exists-flag (orders t2  Build )
+    // filter 1 exprs  SINGLE agg order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .singleAggregation(
+                  {"\"o_orderpriority\""}, {"count() AS order_count"})
+              .orderBy({"\"o_orderpriority\" ASC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(4, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4 project 1 columns *H right exists-flag (orders t2  Build )
+    // filter 1 exprs  PARTIAL agg FINAL agg order by 1 columns  project 2
+    // columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("orders").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"o_orderpriority\""}, {"count() AS order_count"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"o_orderpriority\""},
+                  {"count(\"order_count\") AS order_count"})
+              .orderBy({"\"o_orderpriority\" ASC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(4, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H exists-flag (lineitem t4*H exists (orders t2 broadcast Build
+    // ) project 1 columns  broadcast   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"o_orderpriority\""}, {"count() AS order_count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"o_orderpriority\""},
+                             {"count(\"order_count\") AS order_count"})
+                         .orderBy({"\"o_orderpriority\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(4, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t2*H exists-flag (lineitem t4*H exists (orders t2 broadcast Build
+    // ) project 1 columns  broadcast   Build ) filter 1 exprs  PARTIAL agg
+    // repartition  FINAL agg order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiFilter)
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject)
+              .filter("\"dt1___mark0\"")
+              .partialAggregation(
+                  {"\"o_orderpriority\""}, {"count() AS order_count"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"o_orderpriority\""},
+                             {"count(\"order_count\") AS order_count"})
+                         .orderBy({"\"o_orderpriority\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_5.inc
+++ b/axiom/optimizer/tests/h01_check_5.inc
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers5() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(5, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build )*H  (nation t6*H
+    // (region t7  Build ) project 2 columns   Build ) project 4 columns   Build
+    // )*H  (supplier t5  Build ) project 2 columns  SINGLE agg order by 1
+    // columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .singleAggregation(
+                  {"\"n_name\""}, {"sum(\"dt1___p92\") AS revenue"})
+              .orderBy({"\"revenue\" DESC NULLS LAST"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(5, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2  Build )*H  (nation t6*H
+    // (region t7  Build ) project 2 columns   Build ) project 4 columns   Build
+    // )*H  (supplier t5  Build ) project 2 columns  PARTIAL agg FINAL agg order
+    // by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\""}, {"sum(\"dt1___p92\") AS revenue"})
+              .localPartition()
+              .finalAggregation({"\"n_name\""}, {"sum(\"revenue\") AS revenue"})
+              .orderBy({"\"revenue\" DESC NULLS LAST"})
+              .localMerge()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(5, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build )*H  (nation
+    // t6*H  (region t7 broadcast   Build ) project 2 columns  broadcast   Build
+    // ) project 4 columns  broadcast   Build )*H  (supplier t5 broadcast Build
+    // ) project 2 columns  PARTIAL agg repartition  FINAL agg order by 1
+    // columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\""}, {"sum(\"dt1___p92\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation({"\"n_name\""}, {"sum(\"revenue\") AS revenue"})
+              .orderBy({"\"revenue\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(5, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t4*H  (orders t3*H  (customer t2 broadcast   Build )*H  (nation
+    // t6*H  (region t7 broadcast   Build ) project 2 columns  broadcast   Build
+    // ) project 4 columns  broadcast   Build )*H  (supplier t5 broadcast Build
+    // ) project 2 columns  PARTIAL agg repartition  FINAL agg order by 1
+    // columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\""}, {"sum(\"dt1___p92\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation({"\"n_name\""}, {"sum(\"revenue\") AS revenue"})
+              .orderBy({"\"revenue\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder().mergeExchange().build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_6.inc
+++ b/axiom/optimizer/tests/h01_check_6.inc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers6() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(6, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 1 columns  SINGLE agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"multiply(\"l_extendedprice\",\"l_discount\") AS dt1___p48"})
+              .singleAggregation({}, {"sum(\"dt1___p48\") AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(6, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 1 columns  PARTIAL agg FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"multiply(\"l_extendedprice\",\"l_discount\") AS dt1___p48"})
+              .partialAggregation({}, {"sum(\"dt1___p48\") AS revenue"})
+              .localPartition()
+              .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(6, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 1 columns  PARTIAL agg gather  FINAL agg project 1
+    // columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"multiply(\"l_extendedprice\",\"l_discount\") AS dt1___p48"})
+              .partialAggregation({}, {"sum(\"dt1___p48\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(6, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2 project 1 columns  PARTIAL agg gather  FINAL agg project 1
+    // columns
+
+    // Fragment 0
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .project(
+                  {"multiply(\"l_extendedprice\",\"l_discount\") AS dt1___p48"})
+              .partialAggregation({}, {"sum(\"dt1___p48\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_7.inc
+++ b/axiom/optimizer/tests/h01_check_7.inc
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers7() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(7, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t3*H  (orders t4*H  (customer t5*H  (nation t7  Build ) project
+    // 2 columns   Build ) project 2 columns   Build )*H  (supplier t2*H (nation
+    // t6  Build ) project 2 columns   Build ) filter 1 exprs  project 4 columns
+    // SINGLE agg order by 3 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(eq(\"n_name\",'FRANCE'),eq(\"n_name_1\",'GERMANY')),\"and\"(eq(\"n_name\",'GERMANY'),eq(\"n_name_1\",'FRANCE')))")
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "\"n_name_1\" AS n_name_1",
+                   "year(\"l_shipdate\") AS l_year",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .singleAggregation(
+                  {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                  {"sum(\"dt1___p92\") AS revenue"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST",
+                   "\"n_name_1\" ASC NULLS LAST",
+                   "\"l_year\" ASC NULLS LAST"})
+              .project(
+                  {"\"n_name\" AS supp_nation",
+                   "\"n_name_1\" AS cust_nation",
+                   "\"l_year\" AS l_year",
+                   "\"revenue\" AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(7, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t3*H  (orders t4*H  (customer t5*H  (nation t7  Build ) project
+    // 2 columns   Build ) project 2 columns   Build )*H  (supplier t2*H (nation
+    // t6  Build ) project 2 columns   Build ) filter 1 exprs  project 4 columns
+    // PARTIAL agg FINAL agg order by 3 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("customer")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(eq(\"n_name\",'FRANCE'),eq(\"n_name_1\",'GERMANY')),\"and\"(eq(\"n_name\",'GERMANY'),eq(\"n_name_1\",'FRANCE')))")
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "\"n_name_1\" AS n_name_1",
+                   "year(\"l_shipdate\") AS l_year",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                  {"sum(\"dt1___p92\") AS revenue"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                  {"sum(\"revenue\") AS revenue"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST",
+                   "\"n_name_1\" ASC NULLS LAST",
+                   "\"l_year\" ASC NULLS LAST"})
+              .localMerge()
+              .project(
+                  {"\"n_name\" AS supp_nation",
+                   "\"n_name_1\" AS cust_nation",
+                   "\"l_year\" AS l_year",
+                   "\"revenue\" AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(7, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t3*H  (orders t4*H  (customer t5*H  (nation t7 broadcast   Build
+    // ) project 2 columns  broadcast   Build ) project 2 columns  broadcast
+    // Build )*H  (supplier t2*H  (nation t6 broadcast   Build ) project 2
+    // columns  broadcast   Build ) filter 1 exprs  project 4 columns  PARTIAL
+    // agg repartition  FINAL agg order by 3 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(eq(\"n_name\",'FRANCE'),eq(\"n_name_1\",'GERMANY')),\"and\"(eq(\"n_name\",'GERMANY'),eq(\"n_name_1\",'FRANCE')))")
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "\"n_name_1\" AS n_name_1",
+                   "year(\"l_shipdate\") AS l_year",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                  {"sum(\"dt1___p92\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                             {"sum(\"revenue\") AS revenue"})
+                         .orderBy(
+                             {"\"n_name\" ASC NULLS LAST",
+                              "\"n_name_1\" ASC NULLS LAST",
+                              "\"l_year\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"n_name\" AS supp_nation",
+                              "\"n_name_1\" AS cust_nation",
+                              "\"l_year\" AS l_year",
+                              "\"revenue\" AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(7, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t3*H  (orders t4*H  (customer t5*H  (nation t7 broadcast   Build
+    // ) project 2 columns  broadcast   Build ) project 2 columns  broadcast
+    // Build )*H  (supplier t2*H  (nation t6 broadcast   Build ) project 2
+    // columns  broadcast   Build ) filter 1 exprs  project 4 columns  PARTIAL
+    // agg repartition  FINAL agg order by 3 columns  project 4 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("supplier")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(eq(\"n_name\",'FRANCE'),eq(\"n_name_1\",'GERMANY')),\"and\"(eq(\"n_name\",'GERMANY'),eq(\"n_name_1\",'FRANCE')))")
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "\"n_name_1\" AS n_name_1",
+                   "year(\"l_shipdate\") AS l_year",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                  {"sum(\"dt1___p92\") AS revenue"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"n_name\"", "\"n_name_1\"", "\"l_year\""},
+                             {"sum(\"revenue\") AS revenue"})
+                         .orderBy(
+                             {"\"n_name\" ASC NULLS LAST",
+                              "\"n_name_1\" ASC NULLS LAST",
+                              "\"l_year\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"n_name\" AS supp_nation",
+                              "\"n_name_1\" AS cust_nation",
+                              "\"l_year\" AS l_year",
+                              "\"revenue\" AS revenue"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_8.inc
+++ b/axiom/optimizer/tests/h01_check_8.inc
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers8() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(8, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (lineitem t4*H  (part t2  Build )*H  (orders t5*H
+    // (customer t6  Build )*H  (nation t7*H  (region t9  Build ) project 1
+    // columns   Build ) project 2 columns   Build ) project 4 columns   Build
+    // )*H  (nation t8  Build ) project 3 columns  SINGLE agg order by 1 columns
+    // project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher6 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher5, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher6, velox::core::JoinType::kInner)
+              .project(
+                  {"year(\"o_orderdate\") AS o_year",
+                   "switch(eq(\"n_name_1\",'BRAZIL'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p113",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p108"})
+              .singleAggregation(
+                  {"\"o_year\""},
+                  {"sum(\"dt1___p113\") AS sum",
+                   "sum(\"dt1___p108\") AS sum_4"})
+              .orderBy({"\"o_year\" ASC NULLS LAST"})
+              .project(
+                  {"\"o_year\" AS o_year",
+                   "divide(\"sum\",\"sum_4\") AS mkt_share"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(8, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (lineitem t4*H  (part t2  Build )*H  (orders t5*H
+    // (customer t6  Build )*H  (nation t7*H  (region t9  Build ) project 1
+    // columns   Build ) project 2 columns   Build ) project 4 columns   Build
+    // )*H  (nation t8  Build ) project 3 columns  PARTIAL agg FINAL agg order
+    // by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder().tableScan("customer").build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder().tableScan("region").build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("nation")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher5 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher6 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher5, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher6, velox::core::JoinType::kInner)
+              .project(
+                  {"year(\"o_orderdate\") AS o_year",
+                   "switch(eq(\"n_name_1\",'BRAZIL'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p113",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p108"})
+              .partialAggregation(
+                  {"\"o_year\""},
+                  {"sum(\"dt1___p113\") AS sum",
+                   "sum(\"dt1___p108\") AS sum_4"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"o_year\""},
+                  {"sum(\"sum\") AS sum", "sum(\"sum_4\") AS sum_4"})
+              .orderBy({"\"o_year\" ASC NULLS LAST"})
+              .localMerge()
+              .project(
+                  {"\"o_year\" AS o_year",
+                   "divide(\"sum\",\"sum_4\") AS mkt_share"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(8, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (lineitem t4*H  (part t2 broadcast   Build )*H  (orders
+    // t5*H  (customer t6 broadcast   Build )*H  (nation t7*H  (region t9
+    // broadcast   Build ) project 1 columns  broadcast   Build ) project 2
+    // columns  broadcast   Build ) project 4 columns  broadcast   Build )*H
+    // (nation t8 broadcast   Build ) project 3 columns  PARTIAL agg repartition
+    // FINAL agg order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"year(\"o_orderdate\") AS o_year",
+                   "switch(eq(\"n_name_1\",'BRAZIL'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p113",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p108"})
+              .partialAggregation(
+                  {"\"o_year\""},
+                  {"sum(\"dt1___p113\") AS sum",
+                   "sum(\"dt1___p108\") AS sum_4"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .finalAggregation(
+                             {"\"o_year\""},
+                             {"sum(\"sum\") AS sum", "sum(\"sum_4\") AS sum_4"})
+                         .orderBy({"\"o_year\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"o_year\" AS o_year",
+                              "divide(\"sum\",\"sum_4\") AS mkt_share"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(8, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (lineitem t4*H  (part t2 broadcast   Build )*H  (orders
+    // t5*H  (customer t6 broadcast   Build )*H  (nation t7*H  (region t9
+    // broadcast   Build ) project 1 columns  broadcast   Build ) project 2
+    // columns  broadcast   Build ) project 4 columns  broadcast   Build )*H
+    // (nation t8 broadcast   Build ) project 3 columns  PARTIAL agg repartition
+    // FINAL agg order by 1 columns  project 2 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("customer")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("region")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"year(\"o_orderdate\") AS o_year",
+                   "switch(eq(\"n_name_1\",'BRAZIL'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p113",
+                   "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p108"})
+              .partialAggregation(
+                  {"\"o_year\""},
+                  {"sum(\"dt1___p113\") AS sum",
+                   "sum(\"dt1___p108\") AS sum_4"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+    // Fragment 8
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .exchange()
+                         .localPartition()
+                         .finalAggregation(
+                             {"\"o_year\""},
+                             {"sum(\"sum\") AS sum", "sum(\"sum_4\") AS sum_4"})
+                         .orderBy({"\"o_year\" ASC NULLS LAST"})
+                         .localMerge()
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[8].fragment.planNode));
+    }
+    // Fragment 9
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"o_year\" AS o_year",
+                              "divide(\"sum\",\"sum_4\") AS mkt_share"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[9].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h01_check_9.inc
+++ b/axiom/optimizer/tests/h01_check_9.inc
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h01DefineCheckers9() {
+  // Configuration: numWorkers=1, numDrivers=1
+  setChecker(9, 1, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // orders t6*H  (lineitem t4*H  (partsupp t5*H  (part t2  Build ) project 3
+    // columns   Build ) project 7 columns   Build )*H  (supplier t3  Build )*H
+    // (nation t7  Build ) project 3 columns  SINGLE agg order by 2 columns
+    // project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder().tableScan("supplier").build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "year(\"o_orderdate\") AS o_year",
+                   "minus(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),multiply(\"l_quantity\",\"ps_supplycost\")) AS dt1___p89"})
+              .singleAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"dt1___p89\") AS sum_profit"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST", "\"o_year\" DESC NULLS LAST"})
+              .project(
+                  {"\"n_name\" AS nation",
+                   "\"o_year\" AS o_year",
+                   "\"sum_profit\" AS sum_profit"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(9, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (orders t6*H  (lineitem t4*H  (partsupp t5*H  (part t2
+    // Build ) project 3 columns   Build ) project 6 columns   Build ) project 6
+    // columns   Build )*H  (nation t7  Build ) project 3 columns  PARTIAL agg
+    // FINAL agg order by 2 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto rightMatcher1 =
+          core::PlanMatcherBuilder()
+              .tableScan("partsupp")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher2 =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher3 =
+          core::PlanMatcherBuilder()
+              .tableScan("orders")
+              .hashJoin(rightMatcher2, velox::core::JoinType::kInner)
+              .build();
+
+      auto rightMatcher4 =
+          core::PlanMatcherBuilder().tableScan("nation").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher3, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher4, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "year(\"o_orderdate\") AS o_year",
+                   "minus(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),multiply(\"l_quantity\",\"ps_supplycost\")) AS dt1___p89"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"dt1___p89\") AS sum_profit"})
+              .localPartition()
+              .finalAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"sum_profit\") AS sum_profit"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST", "\"o_year\" DESC NULLS LAST"})
+              .localMerge()
+              .project(
+                  {"\"n_name\" AS nation",
+                   "\"o_year\" AS o_year",
+                   "\"sum_profit\" AS sum_profit"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=1
+  setChecker(9, 4, 1, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (orders t6*H  (lineitem t4*H  (partsupp t5*H  (part t2
+    // broadcast   Build ) project 3 columns  broadcast   Build ) project 6
+    // columns  broadcast   Build ) project 6 columns  broadcast   Build )*H
+    // (nation t7 broadcast   Build ) project 3 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "year(\"o_orderdate\") AS o_year",
+                   "minus(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),multiply(\"l_quantity\",\"ps_supplycost\")) AS dt1___p89"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"dt1___p89\") AS sum_profit"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .finalAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"sum_profit\") AS sum_profit"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST", "\"o_year\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"n_name\" AS nation",
+                              "\"o_year\" AS o_year",
+                              "\"sum_profit\" AS sum_profit"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+
+  // Configuration: numWorkers=4, numDrivers=4
+  setChecker(9, 4, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // supplier t3*H  (orders t6*H  (lineitem t4*H  (partsupp t5*H  (part t2
+    // broadcast   Build ) project 3 columns  broadcast   Build ) project 6
+    // columns  broadcast   Build ) project 6 columns  broadcast   Build )*H
+    // (nation t7 broadcast   Build ) project 3 columns  PARTIAL agg repartition
+    // FINAL agg order by 2 columns  project 3 columns
+
+    // Fragment 0
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("part")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+    // Fragment 1
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("partsupp")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[1].fragment.planNode));
+    }
+    // Fragment 2
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("lineitem")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[2].fragment.planNode));
+    }
+    // Fragment 3
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("orders")
+                         .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[3].fragment.planNode));
+    }
+    // Fragment 4
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .tableScan("nation")
+                         .partitionedOutput()
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[4].fragment.planNode));
+    }
+    // Fragment 5
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().exchange().build();
+
+      auto rightMatcher1 = core::PlanMatcherBuilder().exchange().build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("supplier")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .hashJoin(rightMatcher1, velox::core::JoinType::kInner)
+              .project(
+                  {"\"n_name\" AS n_name",
+                   "year(\"o_orderdate\") AS o_year",
+                   "minus(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),multiply(\"l_quantity\",\"ps_supplycost\")) AS dt1___p89"})
+              .partialAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"dt1___p89\") AS sum_profit"})
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[5].fragment.planNode));
+    }
+    // Fragment 6
+    {
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .exchange()
+              .localPartition()
+              .finalAggregation(
+                  {"\"n_name\"", "\"o_year\""},
+                  {"sum(\"sum_profit\") AS sum_profit"})
+              .orderBy(
+                  {"\"n_name\" ASC NULLS LAST", "\"o_year\" DESC NULLS LAST"})
+              .localMerge()
+              .partitionedOutput()
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[6].fragment.planNode));
+    }
+    // Fragment 7
+    {
+      auto matcher = core::PlanMatcherBuilder()
+                         .mergeExchange()
+                         .project(
+                             {"\"n_name\" AS nation",
+                              "\"o_year\" AS o_year",
+                              "\"sum_profit\" AS sum_profit"})
+                         .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[7].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h30_check_1.inc
+++ b/axiom/optimizer/tests/h30_check_1.inc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers1() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(1, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t2 project 7 columns  PARTIAL agg FINAL agg order by 2 columns  project 10 columns
+
+  // Fragment 0
+  {
+    auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").project({"\"l_returnflag\" AS l_returnflag", "\"l_linestatus\" AS l_linestatus", "\"l_quantity\" AS l_quantity", "\"l_extendedprice\" AS l_extendedprice", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p39", "multiply(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),plus(\"l_tax\",1)) AS dt1___p46", "\"l_discount\" AS l_discount"}).partialAggregation({"\"l_returnflag\"", "\"l_linestatus\""}, {"sum(\"l_quantity\") AS sum_qty", "sum(\"l_extendedprice\") AS sum_base_price", "sum(\"dt1___p39\") AS sum_disc_price", "sum(\"dt1___p46\") AS sum_charge", "avg(\"l_quantity\") AS avg_qty", "avg(\"l_extendedprice\") AS avg_price", "avg(\"l_discount\") AS avg_disc", "count() AS count_order"}).localPartition().finalAggregation({"\"l_returnflag\"", "\"l_linestatus\""}, {"sum(\"sum_qty\") AS sum_qty", "sum(\"sum_base_price\") AS sum_base_price", "sum(\"sum_disc_price\") AS sum_disc_price", "sum(\"sum_charge\") AS sum_charge", "avg(\"avg_qty\") AS avg_qty", "avg(\"avg_price\") AS avg_price", "avg(\"avg_disc\") AS avg_disc", "count(\"count_order\") AS count_order"}).orderBy({"\"l_returnflag\" ASC NULLS LAST", "\"l_linestatus\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_10.inc
+++ b/axiom/optimizer/tests/h30_check_10.inc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers10() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(10, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4*H  (orders t3  Build )*H  (customer t2  Build )*H  (nation t5  Build ) project 8 columns  PARTIAL agg FINAL agg order by 1 columns  project 8 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("orders").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("customer").build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher1, velox::core::JoinType::kInner).hashJoin(rightMatcher2, velox::core::JoinType::kInner).project({"\"c_custkey\" AS c_custkey", "\"c_name\" AS c_name", "\"c_acctbal\" AS c_acctbal", "\"c_phone\" AS c_phone", "\"n_name\" AS n_name", "\"c_address\" AS c_address", "\"c_comment\" AS c_comment", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p77"}).partialAggregation({"\"c_custkey\"", "\"c_name\"", "\"c_acctbal\"", "\"c_phone\"", "\"n_name\"", "\"c_address\"", "\"c_comment\""}, {"sum(\"dt1___p77\") AS revenue"}).localPartition().finalAggregation({"\"c_custkey\"", "\"c_name\"", "\"c_acctbal\"", "\"c_phone\"", "\"n_name\"", "\"c_address\"", "\"c_comment\""}, {"sum(\"revenue\") AS revenue"}).topN(20).localMerge().finalLimit(0, 20).project({"\"c_custkey\" AS c_custkey", "\"c_name\" AS c_name", "\"revenue\" AS revenue", "\"c_acctbal\" AS c_acctbal", "\"n_name\" AS n_name", "\"c_address\" AS c_address", "\"c_phone\" AS c_phone", "\"c_comment\" AS c_comment"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_11.inc
+++ b/axiom/optimizer/tests/h30_check_11.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers11() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(11, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // partsupp t2*H  (supplier t3*H  (nation t4  Build ) project 1 columns   Build ) project 2 columns  PARTIAL agg FINAL agg project 2 columns *M  (partsupp t14*H  (supplier t15*H  (nation t16  Build ) project 1 columns   Build ) project 1 columns  PARTIAL agg FINAL agg project 1 columns ) filter 1 exprs  order by 1 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher3, velox::core::JoinType::kInner).project({"multiply(\"ps_supplycost_3\",cast(\"ps_availqty_2\" as DOUBLE)) AS dt13___p65"}).partialAggregation({}, {"sum(\"dt13___p65\") AS sum"}).localPartition().finalAggregation({}, {"sum(\"sum\") AS sum"}).project({"multiply(\"sum\",0.0001) AS expr"}).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher1, velox::core::JoinType::kInner).project({"\"ps_partkey\" AS ps_partkey", "multiply(\"ps_supplycost\",cast(\"ps_availqty\" as DOUBLE)) AS dt1___p33"}).partialAggregation({"\"ps_partkey\""}, {"sum(\"dt1___p33\") AS value"}).localPartition().finalAggregation({"\"ps_partkey\""}, {"sum(\"value\") AS value"}).nestedLoopJoin(rightMatcher4, velox::core::JoinType::kInner).filter("gt(\"value\",\"expr\")").orderBy({"\"value\" DESC NULLS LAST"}).localMerge().project({"\"ps_partkey\" AS ps_partkey", "\"value\" AS value"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_12.inc
+++ b/axiom/optimizer/tests/h30_check_12.inc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers12() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(12, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // orders t2*H  (lineitem t3  Build ) project 3 columns  PARTIAL agg FINAL agg order by 1 columns  project 3 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher, velox::core::JoinType::kInner).project({"\"l_shipmode\" AS l_shipmode", "switch(\"or\"(eq(\"o_orderpriority\",'1-URGENT'),eq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p58", "switch(\"and\"(neq(\"o_orderpriority\",'1-URGENT'),neq(\"o_orderpriority\",'2-HIGH')),1,0) AS dt1___p65"}).partialAggregation({"\"l_shipmode\""}, {"sum(\"dt1___p58\") AS high_line_count", "sum(\"dt1___p65\") AS low_line_count"}).localPartition().finalAggregation({"\"l_shipmode\""}, {"sum(\"high_line_count\") AS high_line_count", "sum(\"low_line_count\") AS low_line_count"}).orderBy({"\"l_shipmode\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_13.inc
+++ b/axiom/optimizer/tests/h30_check_13.inc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers13() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(13, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // orders t3*H right (customer t2  Build ) PARTIAL agg FINAL agg project 1 columns  PARTIAL agg FINAL agg order by 2 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("customer").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher, velox::core::JoinType::kRight).partialAggregation({"\"c_custkey\""}, {"count(\"o_orderkey\") AS count"}).localPartition().finalAggregation({"\"c_custkey\""}, {"count(\"count\") AS count"}).project({"\"count\" AS c_count"}).partialAggregation({"\"c_count\""}, {"count() AS custdist"}).localPartition().finalAggregation({"\"c_count\""}, {"count(\"custdist\") AS custdist"}).orderBy({"\"custdist\" DESC NULLS LAST", "\"c_count\" DESC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_14.inc
+++ b/axiom/optimizer/tests/h30_check_14.inc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers14() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(14, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // part t3*H  (lineitem t2  Build ) project 2 columns  PARTIAL agg FINAL agg project 1 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("lineitem").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("part").hashJoin(rightMatcher, velox::core::JoinType::kInner).project({"switch(\"like\"(\"p_type\",'PROMO%'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p53", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p51"}).partialAggregation({}, {"sum(\"dt1___p53\") AS sum", "sum(\"dt1___p51\") AS sum_0"}).localPartition().finalAggregation({}, {"sum(\"sum\") AS sum", "sum(\"sum_0\") AS sum_0"}).project({"divide(multiply(\"sum\",100),\"sum_0\") AS promo_revenue"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_15.inc
+++ b/axiom/optimizer/tests/h30_check_15.inc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers15() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(15, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // supplier t2*H  (lineitem t4 project 2 columns  PARTIAL agg FINAL agg project 2 columns   Build )*H  (lineitem t6 project 2 columns  PARTIAL agg FINAL agg project 1 columns  PARTIAL agg FINAL agg project 1 columns   Build ) order by 1 columns  project 5 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("lineitem").project({"\"l_suppkey\" AS l_suppkey", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt3___p49"}).partialAggregation({"\"l_suppkey\""}, {"sum(\"dt3___p49\") AS total_revenue"}).localPartition().finalAggregation({"\"l_suppkey\""}, {"sum(\"total_revenue\") AS total_revenue"}).build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("lineitem").project({"\"l_suppkey_2\" AS l_suppkey_2", "multiply(\"l_extendedprice_5\",minus(1,\"l_discount_6\")) AS dt5___p71"}).partialAggregation({"\"l_suppkey_2\""}, {"sum(\"dt5___p71\") AS total_revenue_17"}).localPartition().finalAggregation({"\"l_suppkey_2\""}, {"sum(\"total_revenue_17\") AS total_revenue_17"}).project({"\"total_revenue_17\" AS total_revenue_19"}).partialAggregation({}, {"max(\"total_revenue_19\") AS max"}).localPartition().finalAggregation({}, {"max(\"max\") AS max"}).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher1, velox::core::JoinType::kInner).orderBy({"\"s_suppkey\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_16.inc
+++ b/axiom/optimizer/tests/h30_check_16.inc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers16() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(16, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // partsupp t2*H  (part t3  Build )*H exists-flag (supplier t5 project 1 columns   Build ) filter 1 exprs  PARTIAL agg FINAL agg order by 4 columns  project 4 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("supplier").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject).filter("\"not\"(\"dt1___mark0\")").partialAggregation({"\"p_brand\"", "\"p_type\"", "\"p_size\""}, {"count(\"ps_suppkey\") AS supplier_cnt"}).localPartition().finalAggregation({"\"p_brand\"", "\"p_type\"", "\"p_size\""}, {"count(\"supplier_cnt\") AS supplier_cnt"}).orderBy({"\"supplier_cnt\" DESC NULLS LAST", "\"p_brand\" ASC NULLS LAST", "\"p_type\" ASC NULLS LAST", "\"p_size\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_17.inc
+++ b/axiom/optimizer/tests/h30_check_17.inc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers17() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(17, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t2*H  (part t3  Build )*H left (lineitem t5*H exists (part t3  Build ) PARTIAL agg FINAL agg project 2 columns   Build ) filter 1 exprs  PARTIAL agg FINAL agg project 1 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiFilter).partialAggregation({"\"l_partkey_1\""}, {"avg(\"l_quantity_4\") AS avg"}).localPartition().finalAggregation({"\"l_partkey_1\""}, {"avg(\"avg\") AS avg"}).project({"\"l_partkey_1\" AS dt4___gk6", "multiply(\"avg\",0.2) AS expr"}).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher2, velox::core::JoinType::kLeft).filter("lt(\"l_quantity\",\"expr\")").partialAggregation({}, {"sum(\"l_extendedprice\") AS sum"}).localPartition().finalAggregation({}, {"sum(\"sum\") AS sum"}).project({"divide(\"sum\",7) AS avg_yearly"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_18.inc
+++ b/axiom/optimizer/tests/h30_check_18.inc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers18() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(18, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4*H  (orders t3  Build )*H exists-flag (lineitem t6 PARTIAL agg FINAL agg filter 1 exprs  project 1 columns   Build ) filter 1 exprs *H  (customer t2  Build ) PARTIAL agg FINAL agg order by 2 columns  project 6 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("orders").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("lineitem").partialAggregation({"\"l_orderkey_0\""}, {"sum(\"l_quantity_4\") AS sum"}).localPartition().finalAggregation({"\"l_orderkey_0\""}, {"sum(\"sum\") AS sum"}).filter("gt(\"sum\",300)").project({"\"l_orderkey_0\" AS l_orderkey_17"}).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("customer").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher1, velox::core::JoinType::kLeftSemiProject).filter("\"dt1___mark0\"").hashJoin(rightMatcher2, velox::core::JoinType::kInner).partialAggregation({"\"c_name\"", "\"c_custkey\"", "\"o_orderkey\"", "\"o_orderdate\"", "\"o_totalprice\""}, {"sum(\"l_quantity\") AS sum_18"}).localPartition().finalAggregation({"\"c_name\"", "\"c_custkey\"", "\"o_orderkey\"", "\"o_orderdate\"", "\"o_totalprice\""}, {"sum(\"sum_18\") AS sum_18"}).topN(100).localMerge().finalLimit(0, 100).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_19.inc
+++ b/axiom/optimizer/tests/h30_check_19.inc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers19() {
+  // Configuration: numWorkers=1, numDrivers=4
+  setChecker(19, 1, 4, [](const PlanAndStats& planAndStats) {
+    // Plan:
+    // lineitem t2*H  (part t3  Build ) filter 1 exprs  project 1 columns
+    // PARTIAL agg FINAL agg project 1 columns
+
+    // Fragment 0
+    {
+      auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+      auto matcher =
+          core::PlanMatcherBuilder()
+              .tableScan("lineitem")
+              .hashJoin(rightMatcher, velox::core::JoinType::kInner)
+              .filter(
+                  "\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,15),\"and\"(lte(\"l_quantity\",30),\"and\"(gte(\"l_quantity\",20),\"and\"(eq(\"p_brand\",'Brand#34'),\"in\"(\"p_container\",array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))))),\"or\"(\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,5),\"and\"(lte(\"l_quantity\",11),\"and\"(gte(\"l_quantity\",1),\"and\"(eq(\"p_brand\",'Brand#12'),\"in\"(\"p_container\",array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))))),\"and\"(\"between\"(cast(\"p_size\" as BIGINT),1,10),\"and\"(lte(\"l_quantity\",20),\"and\"(gte(\"l_quantity\",10),\"and\"(eq(\"p_brand\",'Brand#23'),\"in\"(\"p_container\",array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))))")
+              .project(
+                  {"multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p121"})
+              .partialAggregation({}, {"sum(\"dt1___p121\") AS revenue"})
+              .localPartition()
+              .finalAggregation({}, {"sum(\"revenue\") AS revenue"})
+              .build();
+      ;
+      EXPECT_TRUE(
+          matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+    }
+  });
+}

--- a/axiom/optimizer/tests/h30_check_2.inc
+++ b/axiom/optimizer/tests/h30_check_2.inc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers2() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(2, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // partsupp t4*H  (part t2  Build )*H  (supplier t3*H  (nation t5*H  (region t6  Build ) project 2 columns   Build ) project 7 columns   Build )*H left (partsupp t8*H exists (part t2  Build )*H  (supplier t9*H  (nation t10*H  (region t11  Build ) project 1 columns   Build ) project 1 columns   Build ) PARTIAL agg FINAL agg project 1 columns   Build ) order by 4 columns  project 8 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("region").build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("nation").hashJoin(rightMatcher1, velox::core::JoinType::kInner).build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher5 = core::PlanMatcherBuilder().tableScan("region").build();
+
+auto rightMatcher6 = core::PlanMatcherBuilder().tableScan("nation").hashJoin(rightMatcher5, velox::core::JoinType::kInner).build();
+
+auto rightMatcher7 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher6, velox::core::JoinType::kInner).build();
+
+auto rightMatcher8 = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher4, velox::core::JoinType::kLeftSemiFilter).hashJoin(rightMatcher7, velox::core::JoinType::kInner).partialAggregation({"\"ps_partkey_0\""}, {"min(\"ps_supplycost_3\") AS min"}).localPartition().finalAggregation({"\"ps_partkey_0\""}, {"min(\"min\") AS min"}).project({"\"ps_partkey_0\" AS dt7___gk12"}).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher3, velox::core::JoinType::kInner).hashJoin(rightMatcher8, velox::core::JoinType::kLeft).topN(100).localMerge().finalLimit(0, 100).project({"\"s_acctbal\" AS s_acctbal", "\"s_name\" AS s_name", "\"n_name\" AS n_name", "\"p_partkey\" AS p_partkey", "\"p_mfgr\" AS p_mfgr", "\"s_address\" AS s_address", "\"s_phone\" AS s_phone", "\"s_comment\" AS s_comment"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_20.inc
+++ b/axiom/optimizer/tests/h30_check_20.inc
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers20() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(20, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t7 PARTIAL agg FINAL agg project 3 columns *H right (partsupp t5*H exists-flag (part t11 project 1 columns   Build ) filter 1 exprs *H exists (supplier t2*H  (nation t3  Build ) project 1 columns   Build )  Build ) filter 1 exprs  project 1 columns *H right exists-flag (supplier t2*H  (nation t3  Build )  Build ) filter 1 exprs  order by 1 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher1, velox::core::JoinType::kInner).project({"\"s_suppkey\" AS edt14_edt14_t2_s_suppkey"}).build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher, velox::core::JoinType::kLeftSemiProject).filter("\"dt4___mark0\"").hashJoin(rightMatcher2, velox::core::JoinType::kLeftSemiFilter).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher5 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher4, velox::core::JoinType::kInner).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").partialAggregation({"\"l_partkey\"", "\"l_suppkey\""}, {"sum(\"l_quantity\") AS sum"}).localPartition().finalAggregation({"\"l_partkey\"", "\"l_suppkey\""}, {"sum(\"sum\") AS sum"}).project({"\"l_partkey\" AS dt6___gk8", "\"l_suppkey\" AS dt6___gk9", "multiply(\"sum\",0.5) AS expr"}).hashJoin(rightMatcher3, velox::core::JoinType::kRight).filter("lt(\"expr\",cast(\"ps_availqty\" as DOUBLE))").project({"\"ps_suppkey\" AS ps_suppkey"}).hashJoin(rightMatcher5, velox::core::JoinType::kRightSemiProject).filter("\"dt1___mark1\"").orderBy({"\"s_name\" ASC NULLS LAST"}).localMerge().project({"\"s_name\" AS s_name", "\"s_address\" AS s_address"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_21.inc
+++ b/axiom/optimizer/tests/h30_check_21.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers21() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(21, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t7 project 2 columns *H right exists-flag (lineitem t9 project 2 columns *H right exists-flag (lineitem t3*H  (supplier t2*H  (nation t5  Build ) project 2 columns   Build )*H  (orders t4  Build )  Build ) filter 1 exprs   Build ) filter 1 exprs  PARTIAL agg FINAL agg order by 2 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("orders").build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher1, velox::core::JoinType::kInner).hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher3, velox::core::JoinType::kRightSemiProject).filter("\"not\"(\"dt1___mark1\")").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher4, velox::core::JoinType::kRightSemiProject).filter("\"dt1___mark0\"").partialAggregation({"\"s_name\""}, {"count() AS numwait"}).localPartition().finalAggregation({"\"s_name\""}, {"count(\"numwait\") AS numwait"}).topN(100).localMerge().finalLimit(0, 100).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_22.inc
+++ b/axiom/optimizer/tests/h30_check_22.inc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers22() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(22, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // orders t6 project 1 columns *H right exists-flag (customer t2*M  (customer t4 PARTIAL agg FINAL agg project 1 columns ) filter 1 exprs   Build ) filter 1 exprs  project 2 columns  PARTIAL agg FINAL agg order by 1 columns  project 3 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("customer").partialAggregation({}, {"avg(\"c_acctbal_5\") AS avg"}).localPartition().finalAggregation({}, {"avg(\"avg\") AS avg"}).build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("customer").nestedLoopJoin(rightMatcher, velox::core::JoinType::kInner).filter("gt(\"c_acctbal\",\"avg\")").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher1, velox::core::JoinType::kRightSemiProject).filter("\"not\"(\"dt1___mark0\")").project({"substr(\"c_phone\",1,2) AS cntrycode", "\"c_acctbal\" AS c_acctbal"}).partialAggregation({"\"cntrycode\""}, {"count() AS numcust", "sum(\"c_acctbal\") AS totacctbal"}).localPartition().finalAggregation({"\"cntrycode\""}, {"count(\"numcust\") AS numcust", "sum(\"totacctbal\") AS totacctbal"}).orderBy({"\"cntrycode\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_3.inc
+++ b/axiom/optimizer/tests/h30_check_3.inc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers3() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(3, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4*H  (orders t3*H  (customer t2  Build ) project 3 columns   Build ) project 4 columns  PARTIAL agg FINAL agg order by 2 columns  project 4 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("customer").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher1, velox::core::JoinType::kInner).project({"\"l_orderkey\" AS l_orderkey", "\"o_orderdate\" AS o_orderdate", "\"o_shippriority\" AS o_shippriority", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p61"}).partialAggregation({"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""}, {"sum(\"dt1___p61\") AS revenue"}).localPartition().finalAggregation({"\"l_orderkey\"", "\"o_orderdate\"", "\"o_shippriority\""}, {"sum(\"revenue\") AS revenue"}).topN(10).localMerge().finalLimit(0, 10).project({"\"l_orderkey\" AS l_orderkey", "\"revenue\" AS revenue", "\"o_orderdate\" AS o_orderdate", "\"o_shippriority\" AS o_shippriority"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_4.inc
+++ b/axiom/optimizer/tests/h30_check_4.inc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers4() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(4, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4 project 1 columns *H right exists-flag (orders t2  Build ) filter 1 exprs  PARTIAL agg FINAL agg order by 1 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("orders").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher, velox::core::JoinType::kRightSemiProject).filter("\"dt1___mark0\"").partialAggregation({"\"o_orderpriority\""}, {"count() AS order_count"}).localPartition().finalAggregation({"\"o_orderpriority\""}, {"count(\"order_count\") AS order_count"}).orderBy({"\"o_orderpriority\" ASC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_5.inc
+++ b/axiom/optimizer/tests/h30_check_5.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers5() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(5, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4*H  (orders t3*H  (customer t2*H  (nation t6*H  (region t7  Build ) project 2 columns   Build ) project 4 columns   Build ) project 4 columns   Build )*H  (supplier t5  Build ) project 2 columns  PARTIAL agg FINAL agg order by 1 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("region").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("nation").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("customer").hashJoin(rightMatcher1, velox::core::JoinType::kInner).build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("supplier").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher3, velox::core::JoinType::kInner).hashJoin(rightMatcher4, velox::core::JoinType::kInner).project({"\"n_name\" AS n_name", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"}).partialAggregation({"\"n_name\""}, {"sum(\"dt1___p92\") AS revenue"}).localPartition().finalAggregation({"\"n_name\""}, {"sum(\"revenue\") AS revenue"}).orderBy({"\"revenue\" DESC NULLS LAST"}).localMerge().build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_6.inc
+++ b/axiom/optimizer/tests/h30_check_6.inc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers6() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(6, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t2 project 1 columns  PARTIAL agg FINAL agg project 1 columns
+
+  // Fragment 0
+  {
+    auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").project({"multiply(\"l_extendedprice\",\"l_discount\") AS dt1___p48"}).partialAggregation({}, {"sum(\"dt1___p48\") AS revenue"}).localPartition().finalAggregation({}, {"sum(\"revenue\") AS revenue"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_7.inc
+++ b/axiom/optimizer/tests/h30_check_7.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers7() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(7, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t3*H  (supplier t2*H  (nation t6  Build ) project 2 columns   Build )*H  (orders t4*H  (customer t5*H  (nation t7  Build ) project 2 columns   Build ) project 2 columns   Build ) filter 1 exprs  project 4 columns  PARTIAL agg FINAL agg order by 3 columns  project 4 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("supplier").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("customer").hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher3, velox::core::JoinType::kInner).build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher1, velox::core::JoinType::kInner).hashJoin(rightMatcher4, velox::core::JoinType::kInner).filter("\"or\"(\"and\"(eq(\"n_name\",'FRANCE'),eq(\"n_name_1\",'GERMANY')),\"and\"(eq(\"n_name\",'GERMANY'),eq(\"n_name_1\",'FRANCE')))").project({"\"n_name\" AS n_name", "\"n_name_1\" AS n_name_1", "year(\"l_shipdate\") AS l_year", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p92"}).partialAggregation({"\"n_name\"", "\"n_name_1\"", "\"l_year\""}, {"sum(\"dt1___p92\") AS revenue"}).localPartition().finalAggregation({"\"n_name\"", "\"n_name_1\"", "\"l_year\""}, {"sum(\"revenue\") AS revenue"}).orderBy({"\"n_name\" ASC NULLS LAST", "\"n_name_1\" ASC NULLS LAST", "\"l_year\" ASC NULLS LAST"}).localMerge().project({"\"n_name\" AS supp_nation", "\"n_name_1\" AS cust_nation", "\"l_year\" AS l_year", "\"revenue\" AS revenue"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_8.inc
+++ b/axiom/optimizer/tests/h30_check_8.inc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers8() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(8, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // lineitem t4*H  (part t2  Build )*H  (orders t5*H  (customer t6*H  (nation t7*H  (region t9  Build ) project 1 columns   Build ) project 1 columns   Build ) project 2 columns   Build )*H  (supplier t3  Build )*H  (nation t8  Build ) project 3 columns  PARTIAL agg FINAL agg order by 1 columns  project 2 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("region").build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("nation").hashJoin(rightMatcher1, velox::core::JoinType::kInner).build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("customer").hashJoin(rightMatcher2, velox::core::JoinType::kInner).build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher3, velox::core::JoinType::kInner).build();
+
+auto rightMatcher5 = core::PlanMatcherBuilder().tableScan("supplier").build();
+
+auto rightMatcher6 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher, velox::core::JoinType::kInner).hashJoin(rightMatcher4, velox::core::JoinType::kInner).hashJoin(rightMatcher5, velox::core::JoinType::kInner).hashJoin(rightMatcher6, velox::core::JoinType::kInner).project({"year(\"o_orderdate\") AS o_year", "switch(eq(\"n_name_1\",'BRAZIL'),multiply(\"l_extendedprice\",minus(1,\"l_discount\")),0) AS dt1___p113", "multiply(\"l_extendedprice\",minus(1,\"l_discount\")) AS dt1___p108"}).partialAggregation({"\"o_year\""}, {"sum(\"dt1___p113\") AS sum", "sum(\"dt1___p108\") AS sum_4"}).localPartition().finalAggregation({"\"o_year\""}, {"sum(\"sum\") AS sum", "sum(\"sum_4\") AS sum_4"}).orderBy({"\"o_year\" ASC NULLS LAST"}).localMerge().project({"\"o_year\" AS o_year", "divide(\"sum\",\"sum_4\") AS mkt_share"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/h30_check_9.inc
+++ b/axiom/optimizer/tests/h30_check_9.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+void h30DefineCheckers9() {
+// Configuration: numWorkers=1, numDrivers=4
+setChecker(9, 1, 4, [](const PlanAndStats& planAndStats) {
+  // Plan:
+  // orders t6*H  (lineitem t4*H  (partsupp t5*H  (part t2  Build ) project 3 columns   Build ) project 7 columns   Build )*H  (supplier t3  Build )*H  (nation t7  Build ) project 3 columns  PARTIAL agg FINAL agg order by 2 columns  project 3 columns
+
+  // Fragment 0
+  {
+    auto rightMatcher = core::PlanMatcherBuilder().tableScan("part").build();
+
+auto rightMatcher1 = core::PlanMatcherBuilder().tableScan("partsupp").hashJoin(rightMatcher, velox::core::JoinType::kInner).build();
+
+auto rightMatcher2 = core::PlanMatcherBuilder().tableScan("lineitem").hashJoin(rightMatcher1, velox::core::JoinType::kInner).build();
+
+auto rightMatcher3 = core::PlanMatcherBuilder().tableScan("supplier").build();
+
+auto rightMatcher4 = core::PlanMatcherBuilder().tableScan("nation").build();
+
+auto matcher = core::PlanMatcherBuilder().tableScan("orders").hashJoin(rightMatcher2, velox::core::JoinType::kInner).hashJoin(rightMatcher3, velox::core::JoinType::kInner).hashJoin(rightMatcher4, velox::core::JoinType::kInner).project({"\"n_name\" AS n_name", "year(\"o_orderdate\") AS o_year", "minus(multiply(\"l_extendedprice\",minus(1,\"l_discount\")),multiply(\"l_quantity\",\"ps_supplycost\")) AS dt1___p89"}).partialAggregation({"\"n_name\"", "\"o_year\""}, {"sum(\"dt1___p89\") AS sum_profit"}).localPartition().finalAggregation({"\"n_name\"", "\"o_year\""}, {"sum(\"sum_profit\") AS sum_profit"}).orderBy({"\"n_name\" ASC NULLS LAST", "\"o_year\" DESC NULLS LAST"}).localMerge().project({"\"n_name\" AS nation", "\"o_year\" AS o_year", "\"sum_profit\" AS sum_profit"}).build();
+;
+    EXPECT_TRUE(matcher->match(planAndStats.plan->fragments()[0].fragment.planNode));
+  }
+});
+
+}

--- a/axiom/optimizer/tests/tpch.md
+++ b/axiom/optimizer/tests/tpch.md
@@ -1,0 +1,543 @@
+# TPC-H Plans
+
+This document covers TPC-H with Verax under different configurations of execution (single node and scale-out) and different data layouts, as in bucketed with optional sorting on keys.
+
+We wil extend this as support is added to the different data layouts and access methods. We begin with analyzing multithreaded single node execution. Subsequent sections will cover differences brought by distributed execution or different data layouts.
+
+## Environment
+
+We run the single node experiments using axiom_sql on a laptop against a 30G dataset with Parquet and snappy.  To repeat the below runs, use the query formulations in tpch.queries. To see plans and stats, use
+
+SQL> flag optimizer_trace = 15;
+SQL> flag include_runtime_stats = true;
+SQL flag num_workers = 1;
+SQL> flag num_drivers = <number of core threads>;
+
+We set num_workers = 1 to force single node plans. These run faster on a single system and are easier to read when we do not have exchanges between stages.
+
+## Single Node Multithreaded Execution
+
+###Q1
+
+The query is a simple scan of lineitem with a very low cardinality
+group by. All the work is in the table scan (65%( and partial
+aggregation (30%).
+
+
+
+
+###Q2
+
+The query takes partsupp info for a set of parts and a set of
+suppliers limited by geography. the selection on supplier is 1/5 and
+the selection on part is 1/300. So we first join partsupp with part
+and then with supplier. Then we get to the correlated subquery. This
+is flattened into a left join against a group by on the correlation
+keys which are p.p_partkey and s.s_suppkey. The aggregate is the min
+of cost. When building the group by, we add a semijoin with part that
+comes from the probe side so that we do not calculate the min cost for
+parts that will in any case not be probed.
+
+The one-line plan is:
+
+```
+partsupp t4*H
+  (part t2
+    Build
+  )*H
+  (supplier t3*H
+    (nation t5*H
+      (region t6
+        Build
+      )
+      project 2 columns
+      Build
+    )
+    project 7 columns
+    Build
+  )*H left
+  (partsupp t8*H exists
+    (part t2
+      Build
+    )*H
+    (supplier t9*H
+      (nation t10*H
+        (region t11
+          Build
+        )
+        project 1 columns
+        Build
+      )
+      project 1 columns
+      Build
+    )
+    PARTIAL agg
+    FINAL agg
+    project 1 columns
+    Build
+  )
+  order by 4 columns
+  project 8 columns
+```
+
+
+
+Note the exists with part in the subquery right of the left outer
+join. The existence being more selective than the supplier join, we do
+the existence first. This lan is likely the best or very close. The
+group by from hte subquery is smaller than partsupp, so doing this as
+a left outer join instead of right hand is better.
+
+
+
+###Q3
+
+The query is straightforward to do by hash. We select 1/5 of customer
+and 1/2 of orders. We first join orders x customer, build on that and
+then probe on lineitem. There is nticorrelation between the date
+filters on lineitem and orders but that does not affect the best plan
+choice.
+
+###Q4
+
+The trick in q4 is using a right hand semijoin to do the exists. If we
+probed with orders and built on lineitem, we would get a much larger
+build side. But using the right had semijoin, we get to build on the
+smaller side.  If we had shared key order between lineitem and orders
+we could look at other plans but in the hash based plan space we have
+the best outcome.
+
+Q5
+
+The filters are on region and order date. There is also a diamond between supplier and customer, this being that they have the same nation.
+We get the plan:
+
+```
+lineitem t4*H
+  (supplier t5*H
+    (nation t6*H
+      (region t7
+        Build
+      )
+      project 2 columns
+      Build
+    )
+    project 4 columns
+    Build
+  )*H
+  (orders t3
+    Build
+  )*H
+  (customer t2
+    Build
+  )
+  project 2 columns
+  PARTIAL agg
+  FINAL agg
+  order by 1 columns
+  project 2 columns
+```
+
+
+
+Lineitem is the driving table that is joined to 1/5 of supplier and
+then 1/7 of orders. Finally we join with customer on c_custkey and
+c_nationkey. The build of customer could have been restricted on
+c_nationkey being in the range of s_nationkey but we did not pick this
+restriction because this would have gone through a single equality in
+a join edge of two equalities. The plan is otherwise good and the
+extra reduction on customer ends up not being very important. This is
+a possible enhancement for completeness.
+
+###Q6
+
+We have a single scan, so there are no query optimization choices here.
+
+###Q7
+
+The query has filters on lineitem ship date and on customer and
+supplier nation. The trick is to understand the customer from france
+and supplier from Germany or customer from Germany and supplier from
+France construct. Customers not from France or Germany and suppliers
+not from France or Germany cannot be part of the result. The condition
+is broken up and pushed down into the scans of nation that are a
+reducing join against both customer and supplier.  The plan that we
+get:
+
+```
+lineitem t3*H
+  (supplier t2*H
+    (nation t6
+      Build
+    )
+    project 2 columns
+    Build
+  )*H
+  (orders t4*H
+    (customer t5*H
+      (nation t7
+        Build
+      )
+      project 2 columns
+      Build
+    )
+    project 2 columns
+    Build
+  )
+  filter 1 exprs
+  project 4 columns
+  PARTIAL agg
+  FINAL agg
+  order by 3 columns
+  project 4 columns
+```
+
+
+
+first joins with supplier because this is the smaller table and the reduction is the same as the one with orders, i.e. 2/25 in both cases. The biger table is slower to probe so we reduce with the smaller one first.
+
+###Q8
+
+The query has filters on region, selecting 1/5 of supplier or customer
+and the most selective filter on part, plus 2/7 selection on orders.
+
+The join order of first joining with part and then orders joined with customer makes sense, doing the more reducing join first. At the tail we have supplier and the supplier's nation.
+
+```
+lineitem t4*H
+  (part t2
+    Build
+  )*H
+  (orders t5*H
+    (customer t6*H
+      (nation t7*H
+        (region t9
+          Build
+        )
+        project 1 columns
+        Build
+      )
+      project 1 columns
+      Build
+    )
+    project 2 columns
+    Build
+  )*H
+  (supplier t3
+    Build
+  )*H
+  (nation t8
+    Build
+  )
+  project 3 columns
+  PARTIAL agg
+  FINAL agg
+  order by 1 columns
+  project 2 columns
+```
+
+
+###Q9
+
+The plan is a natural join of lineitem, orders, part, partsupp, supplier and nation. The only selection is 1/17 of part.
+
+The outcome is actually quite ingenious. One would think we should begin with lineitem x part. Instead we get:
+
+```
+orders t6*H
+  (partsupp t5*H
+    (lineitem t4*H
+      (part t2
+        Build
+      )
+      project 6 columns
+      Build
+    )
+    project 7 columns
+    Build
+  )*H
+  (supplier t3
+    Build
+  )*H
+  (nation t7
+    Build
+  )
+  project 3 columns
+  PARTIAL agg
+  FINAL agg
+  order by 2 columns
+  project 3 columns
+```
+
+
+
+We get a complicated build side that has 1/17 of lineitem as a build
+and partsupp as a probe. Since partsupp is 1/8 of lineitem, building
+on the join of lineitem and part builds on the smaller, as one
+should. Then we probe this with orders, which is 1/4th of lineitem,
+thus the biggest table. The rest is just 1:1 joins to supplier and
+nation.
+
+
+###Q10
+
+The join order is as expected, from largest to smallest. The trick
+question here is that the grouping keys are functionally dependent on
+c_custkey, so do not need to figure in hte group by at all. This
+information is not known because the schema does not have primary key
+information, so we cannot take advantage of this.
+
+```
+lineitem t4*H
+  (orders t3
+    Build
+  )*H
+  (customer t2
+    Build
+  )*H
+  (nation t5
+    Build
+  )
+  project 8 columns
+  PARTIAL agg
+  FINAL agg
+  order by 1 columns
+  project 8 columns
+```
+
+
+
+
+###Q11
+
+The join order is the usual, from large to small. The only particularity is the non-correlated subquery that repeats the same join steps. An optimization opportunity could be to reuse build sides but this is not something that Velox plans support at this time. Also, Practical need for this is not very high.
+
+###Q12
+
+
+In this query, we end up building on lineitem since the filters on it
+make it the smaller of the two tables. Everything else is
+unsurprising.
+
+###Q13
+
+This query has only two possible plans, left and right hand outer
+join. We correctly produce the right outer join, building on the left,
+i.e. customer, as it is much smaller than orders.
+
+
+###Q14
+
+The only noteworthy aspect is that we build on lineitem since its
+filters (1 month out of 7 years) make it smaller than part.
+
+###Q15
+
+The plan
+
+```
+lineitem t4
+  project 2 columns
+  PARTIAL agg
+  FINAL agg
+  project 2 columns
+*H
+  (lineitem t6
+    project 2 columns
+    PARTIAL agg
+    FINAL agg
+    project 1 columns
+    PARTIAL agg
+    FINAL agg
+    project 1 columns
+    Build
+  )*H
+  (supplier t2
+    Build
+  )
+  order by 1 columns
+  project 5 columns
+```
+
+
+We join with the aggregation on lineitem, which is the most selective join available for the first lineitem, , then we join with supplier.
+
+###Q16
+
+The join is biggest table first, with  part joined first because it is quite selective, more so than the exists with supplier.
+
+Q17
+
+The trick here is that we have a correlated subquery that flattens
+into a group by that aggregates over all of lineitem. We correctly
+observe that only lineitems with a very specific part will occur on
+the probe side, so we copy the restriction inside the group by as a
+semijoin (exists).
+
+```
+lineitem t2*H
+  (part t3
+    Build
+  )*H left
+  (lineitem t5*H exists
+    (part t3
+      Build
+    )
+    PARTIAL agg
+    FINAL agg
+    project 2 columns
+    Build
+  )
+  filter 1 exprs
+  PARTIAL agg
+  FINAL agg
+  project 1 columns
+```
+
+
+###Q18
+
+
+This query has exotic optimization possibilities that have to do with pushing down the top k through order by. Velox does not have execution support for this though.
+
+The standard full scan + hash join model of executing will as usual
+probe with the larger tables, producing the order lineitem, orders,
+customer. There is the subquery with lineitem with an actually very
+selective having.  The best join order would be lineitem x subquery x
+orders x customer. We get
+
+```
+lineitem t4*H
+  (orders t3
+    Build
+  )*H exists-flag
+  (lineitem t6
+    PARTIAL agg
+    FINAL agg
+    filter 1 exprs
+    project 1 columns
+    Build
+  )
+  filter 1 exprs
+*H
+  (customer t2
+    Build
+  )
+  PARTIAL agg
+  FINAL agg
+  order by 2 columns
+  project 6 columns
+```
+
+
+instead because the semijoin edge to the subquery is not translated
+via the equivalence class of l_orderkey, o_orderkey. If this were an
+inner edge it would be. So, expanding implied edges outside of just
+inner join edges would improve the plan by a little.
+
+##$#Q19
+
+The trick is to extract common pieces to push down into the scan of
+lineitem and part from the or of three ands in the single where clause.
+We extract the join condition that is present in all three disjuncts
+of the or. Then we extract an or to push dowbn into the scan of part
+and lineitem.  We build on part, as it is the smaller table.
+
+###Q20
+
+This is one of the harder queries. The main filters are 1/25 of
+supplier nations, 1/7 years of lineitem and ~1/20 of part.  The larger
+compute is the subquery with lineitem that adds up the volume for part
+and supplier combinations.
+
+The subquery flattens into a left oj with a group by derived table on the right.
+
+```
+lineitem t7
+  PARTIAL agg
+  FINAL agg
+  project 3 columns
+*H right
+  (partsupp t5*H exists-flag
+    (part t11
+      project 1 columns
+      Build
+    )
+    filter 1 exprs
+  *H exists
+    (supplier t2*H
+      (nation t3
+        Build
+      )
+      project 1 columns
+      Build
+    )
+    Build
+  )
+  filter 1 exprs
+  project 1 columns
+*H right exists-flag
+  (supplier t2*H
+    (nation t3
+      Build
+    )
+    Build
+  )
+  filter 1 exprs
+  order by 1 columns
+  project 2 columns
+```
+
+
+
+We should have the exists with part inside the aggregation on
+lineitem. To do this we need to consider existences as well as inner
+joins for when gathering reducing joins.
+
+###Q21
+
+The key insight is that the exists and not exists will apply to only
+1/50 or so of lineitem. The worst plan would be to build hash tables
+on the contents of the subqueries.
+
+The plan we get builds on lineitem l1 joined to supplier joined to nation joined to orders. This is probed in a right hand semijoin by the scan of lineite l2 and this is built and then probed by lineitem l3 in a right semijoin. The rigright semijoin flags marks the build side rows that get probed by the semijoined side and once the probe is complete, flags are produced for al build side rows to indicate if they were hit.
+
+The plan is  as expected.
+
+```
+lineitem t7
+  project 2 columns
+*H right exists-flag
+  (lineitem t9
+    project 2 columns
+  *H right exists-flag
+    (lineitem t3*H
+      (supplier t2*H
+        (nation t5
+          Build
+        )
+        project 2 columns
+        Build
+      )*H
+      (orders t4
+        Build
+      )
+      Build
+    )
+    filter 1 exprs
+    Build
+  )
+  filter 1 exprs
+  PARTIAL agg
+  FINAL agg
+  order by 2 columns
+  project 2 columns
+```
+
+
+###Q22
+
+
+The query is straightforward, with the not exists resolved with a
+right semijoin and the non-correlated subquery becoming a cross join
+to the one row result set of the non-grouped aggregation.

--- a/axiom/optimizer/tests/tpch30samples.json
+++ b/axiom/optimizer/tests/tpch30samples.json
@@ -1,0 +1,932 @@
+{
+  "joins": [
+    {
+      "key": "lineitem l_partkey  partsupp ps_partkey ",
+      "lr": 30.013731002807617,
+      "rl": 4.006462097167969
+    },
+    {
+      "key": "lineitem l_partkey l_suppkey  partsupp ps_partkey ps_suppkey ",
+      "lr": 7.5776543617248535,
+      "rl": 1.0013846158981323
+    },
+    {
+      "key": "customer c_nationkey  supplier s_nationkey ",
+      "lr": 0,
+      "rl": 0
+    },
+    {
+      "key": "nation n_regionkey  region r_regionkey ",
+      "lr": 5,
+      "rl": 1
+    },
+    {
+      "key": "lineitem l_suppkey  supplier s_suppkey ",
+      "lr": 599.5775146484375,
+      "rl": 1
+    },
+    {
+      "key": "part p_partkey  partsupp ps_partkey ",
+      "lr": 1.0014495849609375,
+      "rl": 4.00579833984375
+    },
+    {
+      "key": "lineitem l_partkey  part p_partkey ",
+      "lr": 30.05912208557129,
+      "rl": 1.0014495849609375
+    },
+    {
+      "key": "nation n_nationkey  supplier s_nationkey ",
+      "lr": 0,
+      "rl": 0
+    },
+    {
+      "key": "partsupp ps_suppkey  supplier s_suppkey ",
+      "lr": 80,
+      "rl": 1
+    },
+    {
+      "key": "customer c_nationkey  nation n_nationkey ",
+      "lr": 0,
+      "rl": 0
+    },
+    {
+      "key": "lineitem l_orderkey  orders o_orderkey ",
+      "lr": 4.0969648361206055,
+      "rl": 1.0112698078155518
+    },
+    {
+      "key": "customer c_custkey  orders o_custkey ",
+      "lr": 1.002375602722168,
+      "rl": 10.112638473510742
+    }
+  ],
+  "leaves": [
+    {
+      "key": "table: part, remaining filter: (like(\"p_name\",%green%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.054499998688697815
+    },
+    {
+      "key": "table: part, range filters: [(p_type, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.007000000216066837
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.3051535487174988
+    },
+    {
+      "key": "table: nation, remaining filter: (or(eq(\"n_name\",GERMANY),eq(\"n_name\",FRANCE))), data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.07999999821186066
+    },
+    {
+      "key": "table: nation, remaining filter: (or(eq(\"n_name\",FRANCE),eq(\"n_name\",GERMANY))), data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.07999999821186066
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.3028944432735443
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_discount, DoubleRange: [0.050000, 0.070000] no nulls), (l_quantity, DoubleRange: (-inf, 24.000000) no nulls), (l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"l_shipdate\" as DATE),1995-01-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_quantity, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_discount, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.01900603622198105
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_discount, DoubleRange: [0.050000, 0.070000] no nulls), (l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"l_shipdate\" as DATE),1995-01-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_discount, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.041726112365722656
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"o_orderdate\" as DATE),1995-01-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.1521788090467453
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9223372036854775807] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.6980015635490417
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8582, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"o_orderdate\" as DATE),1993-10-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.037673741579055786
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8582, 9223372036854775807] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.7737547159194946
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9205, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.5377705693244934
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [-9223372036854775808, 9203] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.48468753695487976
+    },
+    {
+      "key": "table: customer, range filters: [(c_mktsegment, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_mktsegment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.2022244930267334
+    },
+    {
+      "key": "table: part, remaining filter: (and(eq(cast(\"p_size\" as BIGINT),15),like(\"p_type\",%BRASS))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]",
+      "value": 0.004093749914318323
+    },
+    {
+      "key": "table: part, remaining filter: (eq(cast(\"p_size\" as BIGINT),15)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]",
+      "value": 0.020625000819563866
+    },
+    {
+      "key": "table: region, range filters: [(r_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.20000000298023224
+    },
+    {
+      "key": "table: region, data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: customer, remaining filter: (in(substr(\"c_phone\",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_phone, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.27628570795059204
+    },
+    {
+      "key": "table: customer, range filters: [(c_acctbal, DoubleRange: (0.000000, nan] no nulls)], remaining filter: (in(substr(\"c_phone\",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_phone, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: c_acctbal, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]]]",
+      "value": 0.2511836588382721
+    },
+    {
+      "key": "table: customer, range filters: [(c_acctbal, DoubleRange: (0.000000, nan] no nulls)], data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_acctbal, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]]]",
+      "value": 0.9097346663475037
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderstatus, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderstatus, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.486129492521286
+    },
+    {
+      "key": "table: lineitem, remaining filter: (lt(\"l_commitdate\",\"l_receiptdate\")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.6319712400436401
+    },
+    {
+      "key": "table: part, remaining filter: (like(\"p_name\",forest%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.01040625013411045
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"l_shipdate\" as DATE),1995-01-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.1532454639673233
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.7217952013015747
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [-9223372036854775808, 10471] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.9858746528625488
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipinstruct, Filter(BytesValues, deterministic, null not allowed)), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (or(and(gte(\"l_quantity\",20),lte(\"l_quantity\",30)),or(and(gte(\"l_quantity\",1),lte(\"l_quantity\",11)),and(gte(\"l_quantity\",10),lte(\"l_quantity\",20))))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_quantity, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipinstruct, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.021642129868268967
+    },
+    {
+      "key": "table: part, remaining filter: (or(and(between(cast(\"p_size\" as BIGINT),1,15),and(eq(\"p_brand\",Brand#34),in(\"p_container\",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between(cast(\"p_size\" as BIGINT),1,5),and(eq(\"p_brand\",Brand#12),in(\"p_container\",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between(cast(\"p_size\" as BIGINT),1,10),and(eq(\"p_brand\",Brand#23),in(\"p_container\",{MED BAG, MED BOX, MED PKG, MED PACK})))))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_container, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]",
+      "value": 0.002218750072643161
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipinstruct, Filter(BytesValues, deterministic, null not allowed)), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipinstruct, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.03596208617091179
+    },
+    {
+      "key": "table: part, range filters: [(p_brand, Filter(BytesValues, deterministic, null not allowed)), (p_container, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_container, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.0009218750055879354
+    },
+    {
+      "key": "table: part, range filters: [(p_brand, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.03946875035762787
+    },
+    {
+      "key": "table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, null not allowed))], remaining filter: (and(not(like(\"p_type\",MEDIUM POLISHED%)),in(cast(\"p_size\" as BIGINT),{49, 14, 23, 45, 19, ...3 more}))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]], HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.14926563203334808
+    },
+    {
+      "key": "table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, null not allowed))], remaining filter: (not(like(\"p_type\",MEDIUM POLISHED%))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.9288125038146973
+    },
+    {
+      "key": "table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.9606719017028809
+    },
+    {
+      "key": "table: supplier, remaining filter: (like(\"s_comment\",%Customer%Complaints%)), data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: s_comment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.00042857142398133874
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"l_shipdate\" as DATE),1996-04-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.03756958246231079
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.4170476496219635
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9374, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"l_shipdate\" as DATE),1995-10-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.012524488382041454
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipdate, BigintRange: [9374, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.4676174819469452
+    },
+    {
+      "key": "table: part, data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_receiptdate, BigintRange: [8766, 9223372036854775807] no nulls), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (and(lt(cast(\"l_receiptdate\" as DATE),1995-01-01),lt(\"l_commitdate\",\"l_receiptdate\"),lt(\"l_shipdate\",\"l_commitdate\"))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.0052649760618805885
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_receiptdate, BigintRange: [8766, 9223372036854775807] no nulls), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (and(lt(\"l_commitdate\",\"l_receiptdate\"),lt(\"l_shipdate\",\"l_commitdate\"))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.024771172553300858
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (and(lt(\"l_commitdate\",\"l_receiptdate\"),lt(\"l_shipdate\",\"l_commitdate\"))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.034308016300201416
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (lt(\"l_commitdate\",\"l_receiptdate\")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.18021632730960846
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_shipmode, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.2851082980632782
+    },
+    {
+      "key": "table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.03999999910593033
+    },
+    {
+      "key": "table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: lineitem, range filters: [(l_returnflag, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_returnflag, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]",
+      "value": 0.24816307425498962
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8674, 9223372036854775807] no nulls)], remaining filter: (lt(cast(\"o_orderdate\" as DATE),1994-01-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.03807942569255829
+    },
+    {
+      "key": "table: orders, range filters: [(o_orderdate, BigintRange: [8674, 9223372036854775807] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]",
+      "value": 0.7360810041427612
+    },
+    {
+      "key": "table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>",
+      "value": 1
+    },
+    {
+      "key": "table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>",
+      "value": 1
+    }
+  ],
+  "plans": [
+    {
+      "card": 175,
+      "key": "join (join (join (join (join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_partkey, ps_suppkey,  = l_partkey, l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders()) keys l_suppkey,  = s_suppkey, scan supplier()) keys s_nationkey,  = n_nationkey, scan nation()) group by n_name, o_year, "
+    },
+    {
+      "card": 2450,
+      "key": "join (join (join (join (join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_partkey, ps_suppkey,  = l_partkey, l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders()) keys l_suppkey,  = s_suppkey, scan supplier()) keys s_nationkey,  = n_nationkey, scan nation())"
+    },
+    {
+      "card": 9788571,
+      "key": "join (join (join (join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_partkey, ps_suppkey,  = l_partkey, l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders()) keys l_suppkey,  = s_suppkey, scan supplier())"
+    },
+    {
+      "card": 9788571,
+      "key": "join (join (join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_partkey, ps_suppkey,  = l_partkey, l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders())"
+    },
+    {
+      "card": 1305248,
+      "key": "join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp())"
+    },
+    {
+      "card": 9788571,
+      "key": "join (join (scan part(f: like(p_name, ?%green%?), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_partkey, ps_suppkey,  = l_partkey, l_suppkey, scan lineitem())"
+    },
+    {
+      "card": 326312,
+      "key": "scan part(f: like(p_name, ?%green%?), )"
+    },
+    {
+      "card": 2,
+      "key": "join (join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), )) keys o_orderkey,  = l_orderkey, join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), ))) keys l_suppkey,  = s_suppkey, scan supplier()) keys s_nationkey,  = n_nationkey, scan nation()) group by o_year, "
+    },
+    {
+      "card": 28,
+      "key": "join (join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), )) keys o_orderkey,  = l_orderkey, join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), ))) keys l_suppkey,  = s_suppkey, scan supplier()) keys s_nationkey,  = n_nationkey, scan nation())"
+    },
+    {
+      "card": 73741,
+      "key": "join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), )) keys o_orderkey,  = l_orderkey, join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), ))) keys l_suppkey,  = s_suppkey, scan supplier())"
+    },
+    {
+      "card": 73741,
+      "key": "join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), )) keys o_orderkey,  = l_orderkey, join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), )))"
+    },
+    {
+      "card": 2733152,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), ))"
+    },
+    {
+      "card": 899950,
+      "key": "join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), )) keys n_nationkey,  = c_nationkey, scan customer())"
+    },
+    {
+      "card": 5,
+      "key": "join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?AMERICA?), ))"
+    },
+    {
+      "card": 1,
+      "key": "scan region(f: eq(r_name, ?AMERICA?), )"
+    },
+    {
+      "card": 13674777,
+      "key": "scan orders(f: between(o_orderdate, ?1995-01-01?, ?1996-12-31?), )"
+    },
+    {
+      "card": 1212306,
+      "key": "join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), ))"
+    },
+    {
+      "card": 40345,
+      "key": "scan part(f: eq(p_type, ?ECONOMY ANODIZED STEEL?), )"
+    },
+    {
+      "card": 4,
+      "key": "join (join (join (scan customer() keys c_nationkey,  = n_nationkey, scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), )) keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey, join (join (scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: between(l_shipdate, ?1995-01-01?, ?1996-12-31?), ))) filter (__or(__and(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), __and(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?))), ) group by l_year, n_name, n_name, "
+    },
+    {
+      "card": 56,
+      "key": "join (join (join (scan customer() keys c_nationkey,  = n_nationkey, scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), )) keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey, join (join (scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: between(l_shipdate, ?1995-01-01?, ?1996-12-31?), ))) filter (__or(__and(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), __and(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?))), )"
+    },
+    {
+      "card": 350846,
+      "key": "join (join (join (scan customer() keys c_nationkey,  = n_nationkey, scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), )) keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey, join (join (scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: between(l_shipdate, ?1995-01-01?, ?1996-12-31?), )))"
+    },
+    {
+      "card": 3611797,
+      "key": "join (join (scan customer() keys c_nationkey,  = n_nationkey, scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), )) keys c_custkey,  = o_custkey, scan orders())"
+    },
+    {
+      "card": 360480,
+      "key": "join (scan customer() keys c_nationkey,  = n_nationkey, scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), ))"
+    },
+    {
+      "card": 2,
+      "key": "scan nation(f: __or(eq(n_name, ?GERMANY?), eq(n_name, ?FRANCE?)), )"
+    },
+    {
+      "card": 4385512,
+      "key": "join (join (scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: between(l_shipdate, ?1995-01-01?, ?1996-12-31?), ))"
+    },
+    {
+      "card": 4385512,
+      "key": "scan lineitem(f: between(l_shipdate, ?1995-01-01?, ?1996-12-31?), )"
+    },
+    {
+      "card": 24059,
+      "key": "join (scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), ) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 2,
+      "key": "scan nation(f: __or(eq(n_name, ?FRANCE?), eq(n_name, ?GERMANY?)), )"
+    },
+    {
+      "card": 1,
+      "key": "scan lineitem(f: between(l_discount, 0.049999999999999996, 0.07), f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), f: lt(l_quantity, 24), ) group by "
+    },
+    {
+      "card": 14,
+      "key": "scan lineitem(f: between(l_discount, 0.049999999999999996, 0.07), f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), f: lt(l_quantity, 24), )"
+    },
+    {
+      "card": 5,
+      "key": "join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )) keys n_nationkey, o_custkey,  = c_nationkey, c_custkey, scan customer()) group by n_name, "
+    },
+    {
+      "card": 175,
+      "key": "join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )) keys n_nationkey, o_custkey,  = c_nationkey, c_custkey, scan customer())"
+    },
+    {
+      "card": 5476462,
+      "key": "join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem()) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), ))"
+    },
+    {
+      "card": 6825548,
+      "key": "scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )"
+    },
+    {
+      "card": 36106880,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem())"
+    },
+    {
+      "card": 60186,
+      "key": "join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 5,
+      "key": "join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), ))"
+    },
+    {
+      "card": 1,
+      "key": "scan region(f: eq(r_name, ?ASIA?), )"
+    },
+    {
+      "card": 5,
+      "key": "join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-07-01?), f: lt(__cast(o_orderdate), ?1993-10-01?), )) filter (__mark0, ) group by o_orderpriority, "
+    },
+    {
+      "card": 5,
+      "key": "join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-07-01?), f: lt(__cast(o_orderdate), ?1993-10-01?), )) filter (__mark0, )"
+    },
+    {
+      "card": 1720611,
+      "key": "join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-07-01?), f: lt(__cast(o_orderdate), ?1993-10-01?), ))"
+    },
+    {
+      "card": 1720611,
+      "key": "scan orders(f: gte(o_orderdate, ?1993-07-01?), f: lt(__cast(o_orderdate), ?1993-10-01?), )"
+    },
+    {
+      "card": 339695,
+      "key": "join (join (scan customer(f: eq(c_mktsegment, ?BUILDING?), ) keys c_custkey,  = o_custkey, scan orders(f: lt(o_orderdate, ?1995-03-15?), )) keys o_orderkey,  = l_orderkey, scan lineitem(f: gt(l_shipdate, ?1995-03-15?), )) group by l_orderkey, o_orderdate, o_shippriority, "
+    },
+    {
+      "card": 339695,
+      "key": "join (join (scan customer(f: eq(c_mktsegment, ?BUILDING?), ) keys c_custkey,  = o_custkey, scan orders(f: lt(o_orderdate, ?1995-03-15?), )) keys o_orderkey,  = l_orderkey, scan lineitem(f: gt(l_shipdate, ?1995-03-15?), ))"
+    },
+    {
+      "card": 4379440,
+      "key": "join (scan customer(f: eq(c_mktsegment, ?BUILDING?), ) keys c_custkey,  = o_custkey, scan orders(f: lt(o_orderdate, ?1995-03-15?), ))"
+    },
+    {
+      "card": 900509,
+      "key": "scan customer(f: eq(c_mktsegment, ?BUILDING?), )"
+    },
+    {
+      "card": 21863668,
+      "key": "scan orders(f: lt(o_orderdate, ?1995-03-15?), )"
+    },
+    {
+      "card": 97039648,
+      "key": "scan lineitem(f: gt(l_shipdate, ?1995-03-15?), )"
+    },
+    {
+      "card": 19076,
+      "key": "join left(join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, join (scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ) keys p_partkey,  = ps_partkey, scan partsupp())) keys p_partkey,  = __gk12, join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, join exists(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ))) group by ps_partkey, )"
+    },
+    {
+      "card": 19076,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, join (scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ) keys p_partkey,  = ps_partkey, scan partsupp()))"
+    },
+    {
+      "card": 19076,
+      "key": "join (scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ) keys p_partkey,  = ps_partkey, scan partsupp())"
+    },
+    {
+      "card": 14155,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, join exists(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ))) group by ps_partkey, "
+    },
+    {
+      "card": 14155,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, join exists(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), )))"
+    },
+    {
+      "card": 19076,
+      "key": "join exists(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), ))"
+    },
+    {
+      "card": 60128,
+      "key": "join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), )) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 5,
+      "key": "join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?EUROPE?), ))"
+    },
+    {
+      "card": 1,
+      "key": "scan region(f: eq(r_name, ?EUROPE?), )"
+    },
+    {
+      "card": 23840,
+      "key": "scan part(f: eq(__cast(p_size), 15), f: like(p_type, ?%BRASS?), )"
+    },
+    {
+      "card": 7,
+      "key": "join right exists-flag(scan orders() keys o_custkey,  = c_custkey, join (scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), ) keys  = scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by ) filter (gt(c_acctbal, avg), )) filter (not(__mark0), ) group by cntrycode, "
+    },
+    {
+      "card": 7,
+      "key": "join right exists-flag(scan orders() keys o_custkey,  = c_custkey, join (scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), ) keys  = scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by ) filter (gt(c_acctbal, avg), )) filter (not(__mark0), )"
+    },
+    {
+      "card": 573038,
+      "key": "join right exists-flag(scan orders() keys o_custkey,  = c_custkey, join (scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), ) keys  = scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by ) filter (gt(c_acctbal, avg), ))"
+    },
+    {
+      "card": 573038,
+      "key": "join (scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), ) keys  = scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by ) filter (gt(c_acctbal, avg), )"
+    },
+    {
+      "card": 0,
+      "key": "join (scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), ) keys  = scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by )"
+    },
+    {
+      "card": 1259808,
+      "key": "scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), )"
+    },
+    {
+      "card": 1,
+      "key": "scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), ) group by "
+    },
+    {
+      "card": 14,
+      "key": "scan customer(f: __in(substr(c_phone, 1, 2), ?13?, ?31?, ?23?, ?29?, ?30?, ?18?, ?17?), f: gt(c_acctbal, 0), )"
+    },
+    {
+      "card": 11957,
+      "key": "join right exists-flag(scan lineitem() keys l_orderkey_0,  = l_orderkey, join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey_16,  = l_orderkey, join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), ))) filter (not(__mark1), )) filter (__mark0, ) group by s_name, "
+    },
+    {
+      "card": 11957,
+      "key": "join right exists-flag(scan lineitem() keys l_orderkey_0,  = l_orderkey, join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey_16,  = l_orderkey, join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), ))) filter (not(__mark1), )) filter (__mark0, )"
+    },
+    {
+      "card": 198791,
+      "key": "join right exists-flag(scan lineitem() keys l_orderkey_0,  = l_orderkey, join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey_16,  = l_orderkey, join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), ))) filter (not(__mark1), ))"
+    },
+    {
+      "card": 198791,
+      "key": "join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey_16,  = l_orderkey, join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), ))) filter (not(__mark1), )"
+    },
+    {
+      "card": 2192508,
+      "key": "join right exists-flag(scan lineitem(f: lt(l_commitdate, l_receiptdate), ) keys l_orderkey_16,  = l_orderkey, join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), )))"
+    },
+    {
+      "card": 2192508,
+      "key": "join (join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), )) keys l_orderkey,  = o_orderkey, scan orders(f: eq(o_orderstatus, ?F?), ))"
+    },
+    {
+      "card": 21923040,
+      "key": "scan orders(f: eq(o_orderstatus, ?F?), )"
+    },
+    {
+      "card": 4538215,
+      "key": "join (join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = l_suppkey, scan lineitem(f: lt(l_commitdate, l_receiptdate), ))"
+    },
+    {
+      "card": 11957,
+      "key": "join (scan nation(f: eq(n_name, ?SAUDI ARABIA?), ) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 1,
+      "key": "scan nation(f: eq(n_name, ?SAUDI ARABIA?), )"
+    },
+    {
+      "card": 113797648,
+      "key": "scan lineitem(f: lt(l_commitdate, l_receiptdate), )"
+    },
+    {
+      "card": 5404,
+      "key": "join right exists-flag(join right(scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), ) group by l_partkey, l_suppkey,  keys __gk8, __gk9,  = ps_partkey, ps_suppkey, join exists(join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, ) keys ps_suppkey,  = edt14.t2.s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier()))) filter (lt(expr, __cast(ps_availqty)), ) keys ps_suppkey,  = s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier())) filter (__mark1, )"
+    },
+    {
+      "card": 12012,
+      "key": "join right exists-flag(join right(scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), ) group by l_partkey, l_suppkey,  keys __gk8, __gk9,  = ps_partkey, ps_suppkey, join exists(join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, ) keys ps_suppkey,  = edt14.t2.s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier()))) filter (lt(expr, __cast(ps_availqty)), ) keys ps_suppkey,  = s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier()))"
+    },
+    {
+      "card": 7080,
+      "key": "join right(scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), ) group by l_partkey, l_suppkey,  keys __gk8, __gk9,  = ps_partkey, ps_suppkey, join exists(join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, ) keys ps_suppkey,  = edt14.t2.s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier()))) filter (lt(expr, __cast(ps_availqty)), )"
+    },
+    {
+      "card": 10416,
+      "key": "join right(scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), ) group by l_partkey, l_suppkey,  keys __gk8, __gk9,  = ps_partkey, ps_suppkey, join exists(join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, ) keys ps_suppkey,  = edt14.t2.s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier())))"
+    },
+    {
+      "card": 16355889,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), ) group by l_partkey, l_suppkey, "
+    },
+    {
+      "card": 10416,
+      "key": "join exists(join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, ) keys ps_suppkey,  = edt14.t2.s_suppkey, join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier()))"
+    },
+    {
+      "card": 10416,
+      "key": "join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), )) filter (__mark0, )"
+    },
+    {
+      "card": 960960,
+      "key": "join exists-flag(scan partsupp() keys ps_partkey,  = p_partkey, scan part(f: like(p_name, ?forest%?), ))"
+    },
+    {
+      "card": 12012,
+      "key": "join (scan nation(f: eq(n_name, ?CANADA?), ) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 1,
+      "key": "scan nation(f: eq(n_name, ?CANADA?), )"
+    },
+    {
+      "card": 65430,
+      "key": "scan part(f: like(p_name, ?forest%?), )"
+    },
+    {
+      "card": 27299146,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1994-01-01?), f: lt(__cast(l_shipdate), ?1995-01-01?), )"
+    },
+    {
+      "card": 4,
+      "key": "scan lineitem(f: lt(l_shipdate, ?1998-09-03?), ) group by l_linestatus, l_returnflag, "
+    },
+    {
+      "card": 56,
+      "key": "scan lineitem(f: lt(l_shipdate, ?1998-09-03?), )"
+    },
+    {
+      "card": 1,
+      "key": "join (scan lineitem(f: __in(l_shipmode, ?AIR?, ?AIR REG?), f: __or(__and(gte(l_quantity, 20), lte(l_quantity, 30)), __or(__and(gte(l_quantity, 1), lte(l_quantity, 11)), __and(gte(l_quantity, 10), lte(l_quantity, 20)))), f: eq(l_shipinstruct, ?DELIVER IN PERSON?), ) keys l_partkey,  = p_partkey, scan part(f: __or(__and(between(__cast(p_size), 1, 15), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))), __or(__and(between(__cast(p_size), 1, 5), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))), __and(between(__cast(p_size), 1, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))), )) filter (__or(__and(between(__cast(p_size), 1, 15), __and(lte(l_quantity, 30), __and(gte(l_quantity, 20), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))))), __or(__and(between(__cast(p_size), 1, 5), __and(lte(l_quantity, 11), __and(gte(l_quantity, 1), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))))), __and(between(__cast(p_size), 1, 10), __and(lte(l_quantity, 20), __and(gte(l_quantity, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))))), ) group by "
+    },
+    {
+      "card": 14,
+      "key": "join (scan lineitem(f: __in(l_shipmode, ?AIR?, ?AIR REG?), f: __or(__and(gte(l_quantity, 20), lte(l_quantity, 30)), __or(__and(gte(l_quantity, 1), lte(l_quantity, 11)), __and(gte(l_quantity, 10), lte(l_quantity, 20)))), f: eq(l_shipinstruct, ?DELIVER IN PERSON?), ) keys l_partkey,  = p_partkey, scan part(f: __or(__and(between(__cast(p_size), 1, 15), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))), __or(__and(between(__cast(p_size), 1, 5), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))), __and(between(__cast(p_size), 1, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))), )) filter (__or(__and(between(__cast(p_size), 1, 15), __and(lte(l_quantity, 30), __and(gte(l_quantity, 20), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))))), __or(__and(between(__cast(p_size), 1, 5), __and(lte(l_quantity, 11), __and(gte(l_quantity, 1), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))))), __and(between(__cast(p_size), 1, 10), __and(lte(l_quantity, 20), __and(gte(l_quantity, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))))), )"
+    },
+    {
+      "card": 9470,
+      "key": "join (scan lineitem(f: __in(l_shipmode, ?AIR?, ?AIR REG?), f: __or(__and(gte(l_quantity, 20), lte(l_quantity, 30)), __or(__and(gte(l_quantity, 1), lte(l_quantity, 11)), __and(gte(l_quantity, 10), lte(l_quantity, 20)))), f: eq(l_shipinstruct, ?DELIVER IN PERSON?), ) keys l_partkey,  = p_partkey, scan part(f: __or(__and(between(__cast(p_size), 1, 15), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))), __or(__and(between(__cast(p_size), 1, 5), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))), __and(between(__cast(p_size), 1, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))), ))"
+    },
+    {
+      "card": 9470,
+      "key": "scan lineitem(f: __in(l_shipmode, ?AIR?, ?AIR REG?), f: __or(__and(gte(l_quantity, 20), lte(l_quantity, 30)), __or(__and(gte(l_quantity, 1), lte(l_quantity, 11)), __and(gte(l_quantity, 10), lte(l_quantity, 20)))), f: eq(l_shipinstruct, ?DELIVER IN PERSON?), )"
+    },
+    {
+      "card": 14558,
+      "key": "scan part(f: __or(__and(between(__cast(p_size), 1, 15), __and(eq(p_brand, ?Brand#34?), __in(p_container, ?LG CASE?, ?LG BOX?, ?LG PACK?, ?LG PKG?))), __or(__and(between(__cast(p_size), 1, 5), __and(eq(p_brand, ?Brand#12?), __in(p_container, ?SM CASE?, ?SM BOX?, ?SM PACK?, ?SM PKG?))), __and(between(__cast(p_size), 1, 10), __and(eq(p_brand, ?Brand#23?), __in(p_container, ?MED BAG?, ?MED BOX?, ?MED PKG?, ?MED PACK?))))), )"
+    },
+    {
+      "card": 1917,
+      "key": "join (join exists-flag(join (scan customer() keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, ) keys o_orderkey,  = l_orderkey, scan lineitem()) group by c_custkey, c_name, o_orderdate, o_orderkey, o_totalprice, "
+    },
+    {
+      "card": 45000000,
+      "key": "scan lineitem() group by l_orderkey, "
+    },
+    {
+      "card": 1917,
+      "key": "join (join exists-flag(join (scan customer() keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, ) keys o_orderkey,  = l_orderkey, scan lineitem())"
+    },
+    {
+      "card": 1917,
+      "key": "join exists-flag(join (scan customer() keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, )"
+    },
+    {
+      "card": 45000000,
+      "key": "join exists-flag(join (scan customer() keys c_custkey,  = o_custkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), ))"
+    },
+    {
+      "card": 45000000,
+      "key": "join (scan customer() keys c_custkey,  = o_custkey, scan orders())"
+    },
+    {
+      "card": 1,
+      "key": "join left(join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) keys p_partkey,  = __gk6, join exists(scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) group by l_partkey, ) filter (lt(l_quantity, expr), ) group by "
+    },
+    {
+      "card": 6095,
+      "key": "join exists(scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) group by l_partkey, "
+    },
+    {
+      "card": 14,
+      "key": "join left(join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) keys p_partkey,  = __gk6, join exists(scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) group by l_partkey, ) filter (lt(l_quantity, expr), )"
+    },
+    {
+      "card": 182694,
+      "key": "join left(join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) keys p_partkey,  = __gk6, join exists(scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )) group by l_partkey, )"
+    },
+    {
+      "card": 74728,
+      "key": "join exists(scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), ))"
+    },
+    {
+      "card": 182694,
+      "key": "join (scan lineitem() keys l_partkey,  = p_partkey, scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), ))"
+    },
+    {
+      "card": 9788571,
+      "key": "scan lineitem()"
+    },
+    {
+      "card": 6095,
+      "key": "scan part(f: eq(p_brand, ?Brand#23?), f: eq(p_container, ?MED BOX?), )"
+    },
+    {
+      "card": 27840,
+      "key": "join exists-flag(join (scan part(f: __in(__cast(p_size), 49, 14, 23, 45, 19, 3, 36, 9), f: neq(p_brand, ?Brand#45?), f: not(like(p_type, ?MEDIUM POLISHED%?)), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_suppkey,  = s_suppkey, scan supplier(f: like(s_comment, ?%Customer%Complaints%?), )) filter (not(__mark0), ) group by p_brand, p_size, p_type, "
+    },
+    {
+      "card": 345798,
+      "key": "join exists-flag(join (scan part(f: __in(__cast(p_size), 49, 14, 23, 45, 19, 3, 36, 9), f: neq(p_brand, ?Brand#45?), f: not(like(p_type, ?MEDIUM POLISHED%?)), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_suppkey,  = s_suppkey, scan supplier(f: like(s_comment, ?%Customer%Complaints%?), )) filter (not(__mark0), )"
+    },
+    {
+      "card": 3562228,
+      "key": "join exists-flag(join (scan part(f: __in(__cast(p_size), 49, 14, 23, 45, 19, 3, 36, 9), f: neq(p_brand, ?Brand#45?), f: not(like(p_type, ?MEDIUM POLISHED%?)), ) keys p_partkey,  = ps_partkey, scan partsupp()) keys ps_suppkey,  = s_suppkey, scan supplier(f: like(s_comment, ?%Customer%Complaints%?), ))"
+    },
+    {
+      "card": 3562228,
+      "key": "join (scan part(f: __in(__cast(p_size), 49, 14, 23, 45, 19, 3, 36, 9), f: neq(p_brand, ?Brand#45?), f: not(like(p_type, ?MEDIUM POLISHED%?)), ) keys p_partkey,  = ps_partkey, scan partsupp())"
+    },
+    {
+      "card": 155,
+      "key": "scan supplier(f: like(s_comment, ?%Customer%Complaints%?), )"
+    },
+    {
+      "card": 890557,
+      "key": "scan part(f: __in(__cast(p_size), 49, 14, 23, 45, 19, 3, 36, 9), f: neq(p_brand, ?Brand#45?), f: not(like(p_type, ?MEDIUM POLISHED%?)), )"
+    },
+    {
+      "card": 0,
+      "key": "join (join (scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), ) group by l_suppkey,  keys l_suppkey,  = s_suppkey, scan supplier()) keys total_revenue,  = max, scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), ) group by l_suppkey,  group by )"
+    },
+    {
+      "card": 300000,
+      "key": "join (scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), ) group by l_suppkey,  keys l_suppkey,  = s_suppkey, scan supplier())"
+    },
+    {
+      "card": 1,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), ) group by l_suppkey,  group by "
+    },
+    {
+      "card": 14,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), ) group by l_suppkey, "
+    },
+    {
+      "card": 6589514,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1996-01-01?), f: lt(__cast(l_shipdate), ?1996-04-01?), )"
+    },
+    {
+      "card": 1,
+      "key": "join (scan lineitem(f: gte(l_shipdate, ?1995-09-01?), f: lt(__cast(l_shipdate), ?1995-10-01?), ) keys l_partkey,  = p_partkey, scan part()) group by "
+    },
+    {
+      "card": 14,
+      "key": "join (scan lineitem(f: gte(l_shipdate, ?1995-09-01?), f: lt(__cast(l_shipdate), ?1995-10-01?), ) keys l_partkey,  = p_partkey, scan part())"
+    },
+    {
+      "card": 2245483,
+      "key": "scan lineitem(f: gte(l_shipdate, ?1995-09-01?), f: lt(__cast(l_shipdate), ?1995-10-01?), )"
+    },
+    {
+      "card": 6000000,
+      "key": "scan part()"
+    },
+    {
+      "card": 45,
+      "key": "join right(scan orders() keys o_custkey,  = c_custkey, scan customer()) group by c_custkey,  group by c_count, "
+    },
+    {
+      "card": 588,
+      "key": "join right(scan orders() keys o_custkey,  = c_custkey, scan customer()) group by c_custkey, "
+    },
+    {
+      "card": 45988204,
+      "key": "join right(scan orders() keys o_custkey,  = c_custkey, scan customer())"
+    },
+    {
+      "card": 2,
+      "key": "join (scan lineitem(f: __in(l_shipmode, ?MAIL?, ?SHIP?), f: gte(l_receiptdate, ?1994-01-01?), f: lt(__cast(l_receiptdate), ?1995-01-01?), f: lt(l_commitdate, l_receiptdate), f: lt(l_shipdate, l_commitdate), ) keys l_orderkey,  = o_orderkey, scan orders()) group by l_shipmode, "
+    },
+    {
+      "card": 28,
+      "key": "join (scan lineitem(f: __in(l_shipmode, ?MAIL?, ?SHIP?), f: gte(l_receiptdate, ?1994-01-01?), f: lt(__cast(l_receiptdate), ?1995-01-01?), f: lt(l_commitdate, l_receiptdate), f: lt(l_shipdate, l_commitdate), ) keys l_orderkey,  = o_orderkey, scan orders())"
+    },
+    {
+      "card": 933168,
+      "key": "scan lineitem(f: __in(l_shipmode, ?MAIL?, ?SHIP?), f: gte(l_receiptdate, ?1994-01-01?), f: lt(__cast(l_receiptdate), ?1995-01-01?), f: lt(l_commitdate, l_receiptdate), f: lt(l_shipdate, l_commitdate), )"
+    },
+    {
+      "card": 45000000,
+      "key": "scan orders()"
+    },
+    {
+      "card": 0,
+      "key": "join (join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by  keys  = join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by ps_partkey, ) filter (gt(value, expr), )"
+    },
+    {
+      "card": 0,
+      "key": "join (join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by  keys  = join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by ps_partkey, )"
+    },
+    {
+      "card": 910366,
+      "key": "join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by ps_partkey, "
+    },
+    {
+      "card": 1,
+      "key": "join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp()) group by "
+    },
+    {
+      "card": 14,
+      "key": "join (join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier()) keys s_suppkey,  = ps_suppkey, scan partsupp())"
+    },
+    {
+      "card": 1305248,
+      "key": "scan partsupp()"
+    },
+    {
+      "card": 12090,
+      "key": "join (scan nation(f: eq(n_name, ?GERMANY?), ) keys n_nationkey,  = s_nationkey, scan supplier())"
+    },
+    {
+      "card": 300000,
+      "key": "scan supplier()"
+    },
+    {
+      "card": 1,
+      "key": "scan nation(f: eq(n_name, ?GERMANY?), )"
+    },
+    {
+      "card": 1148325,
+      "key": "join (join (join (scan lineitem(f: eq(l_returnflag, ?R?), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-10-01?), f: lt(__cast(o_orderdate), ?1994-01-01?), )) keys o_custkey,  = c_custkey, scan customer()) keys c_nationkey,  = n_nationkey, scan nation()) group by c_acctbal, c_address, c_comment, c_custkey, c_name, c_phone, n_name, "
+    },
+    {
+      "card": 1460264,
+      "key": "join (join (join (scan lineitem(f: eq(l_returnflag, ?R?), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-10-01?), f: lt(__cast(o_orderdate), ?1994-01-01?), )) keys o_custkey,  = c_custkey, scan customer()) keys c_nationkey,  = n_nationkey, scan nation())"
+    },
+    {
+      "card": 3434459,
+      "key": "join (join (scan lineitem(f: eq(l_returnflag, ?R?), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-10-01?), f: lt(__cast(o_orderdate), ?1994-01-01?), )) keys o_custkey,  = c_custkey, scan customer())"
+    },
+    {
+      "card": 25,
+      "key": "scan nation()"
+    },
+    {
+      "card": 899950,
+      "key": "scan customer()"
+    },
+    {
+      "card": 3434459,
+      "key": "join (scan lineitem(f: eq(l_returnflag, ?R?), ) keys l_orderkey,  = o_orderkey, scan orders(f: gte(o_orderdate, ?1993-10-01?), f: lt(__cast(o_orderdate), ?1994-01-01?), ))"
+    },
+    {
+      "card": 1718066,
+      "key": "scan orders(f: gte(o_orderdate, ?1993-10-01?), f: lt(__cast(o_orderdate), ?1994-01-01?), )"
+    },
+    {
+      "card": 44418612,
+      "key": "scan lineitem(f: eq(l_returnflag, ?R?), )"
+    },
+    {
+      "card": 1917,
+      "key": "join (join exists-flag(join (scan lineitem() keys l_orderkey,  = o_orderkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, ) keys o_custkey,  = c_custkey, scan customer()) group by c_custkey, c_name, o_orderdate, o_orderkey, o_totalprice, "
+    },
+    {
+      "card": 179998368,
+      "key": "join (scan lineitem() keys l_orderkey,  = o_orderkey, scan orders())"
+    },
+    {
+      "card": 179998368,
+      "key": "join exists-flag(join (scan lineitem() keys l_orderkey,  = o_orderkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), ))"
+    },
+    {
+      "card": 13419,
+      "key": "join exists-flag(join (scan lineitem() keys l_orderkey,  = o_orderkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, )"
+    },
+    {
+      "card": 1917,
+      "key": "join (join exists-flag(join (scan lineitem() keys l_orderkey,  = o_orderkey, scan orders()) keys o_orderkey,  = l_orderkey_17, scan lineitem() group by l_orderkey,  filter (gt(sum, 300), )) filter (__mark0, ) keys o_custkey,  = c_custkey, scan customer())"
+    },
+    {
+      "card": 5,
+      "key": "join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )) keys o_orderkey,  = l_orderkey, scan lineitem()) keys l_suppkey, n_nationkey,  = s_suppkey, s_nationkey, scan supplier()) group by n_name, "
+    },
+    {
+      "card": 5450573,
+      "key": "join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )) keys o_orderkey,  = l_orderkey, scan lineitem())"
+    },
+    {
+      "card": 70,
+      "key": "join (join (join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), )) keys o_orderkey,  = l_orderkey, scan lineitem()) keys l_suppkey, n_nationkey,  = s_suppkey, s_nationkey, scan supplier())"
+    },
+    {
+      "card": 1362236,
+      "key": "join (join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = c_nationkey, scan customer()) keys c_custkey,  = o_custkey, scan orders(f: gte(o_orderdate, ?1994-01-01?), f: lt(__cast(o_orderdate), ?1995-01-01?), ))"
+    },
+    {
+      "card": 899362,
+      "key": "join (join (scan nation() keys n_regionkey,  = r_regionkey, scan region(f: eq(r_name, ?ASIA?), )) keys n_nationkey,  = c_nationkey, scan customer())"
+    }
+  ]
+}

--- a/axiom/optimizer/tests/tpch30stats.json
+++ b/axiom/optimizer/tests/tpch30stats.json
@@ -1,0 +1,705 @@
+{
+  "customer": {
+    "columns": {
+      "c_acctbal": {
+        "max": "9999.960000000001",
+        "maxType": "DOUBLE",
+        "min": "-999.94",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4314159,
+        "numValues": 0
+      },
+      "c_address": {
+        "avgLength": 24,
+        "max": "\"zzwG011pNxeRs7TYcBDH36n8poMQDy,vX0jI3Rf\"",
+        "maxType": "VARCHAR",
+        "min": "\"  2C6OVhkRxmEI7W3o6 k8Mo6Bc0eiyPG\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4499952,
+        "numValues": 0
+      },
+      "c_comment": {
+        "avgLength": 72,
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4499617,
+        "numValues": 0
+      },
+      "c_custkey": {
+        "max": "451000",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4500000,
+        "numValues": 0
+      },
+      "c_mktsegment": {
+        "avgLength": 8,
+        "max": "\"MACHINERY\"",
+        "maxType": "VARCHAR",
+        "min": "\"AUTOMOBILE\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      },
+      "c_name": {
+        "avgLength": 18,
+        "max": "\"Customer#000451000\"",
+        "maxType": "VARCHAR",
+        "min": "\"Customer#000000001\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4500000,
+        "numValues": 0
+      },
+      "c_nationkey": {
+        "max": "24",
+        "maxType": "BIGINT",
+        "min": "0",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "c_phone": {
+        "avgLength": 15,
+        "max": "\"34-999-756-5736\"",
+        "maxType": "VARCHAR",
+        "min": "\"10-100-135-8525\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4499761,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "customer"
+      }
+    ],
+    "numRows": 4500000
+  },
+  "lineitem": {
+    "columns": {
+      "l_comment": {
+        "avgLength": 26,
+        "max": "\"ys special deposits nag about \"",
+        "maxType": "VARCHAR",
+        "min": "\" about the \"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 179728368,
+        "numValues": 0
+      },
+      "l_commitdate": {
+        "max": "\"1998-10-30\"",
+        "maxType": "INTEGER",
+        "min": "\"1992-02-07\"",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 2457,
+        "numValues": 0
+      },
+      "l_discount": {
+        "max": "0.1",
+        "maxType": "DOUBLE",
+        "min": "0",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 11,
+        "numValues": 0
+      },
+      "l_extendedprice": {
+        "max": "101248.5",
+        "maxType": "DOUBLE",
+        "min": "944.9200000000001",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 179728368,
+        "numValues": 0
+      },
+      "l_linenumber": {
+        "max": "7",
+        "maxType": "INTEGER",
+        "min": "1",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 7,
+        "numValues": 0
+      },
+      "l_linestatus": {
+        "avgLength": 1,
+        "max": "\"O\"",
+        "maxType": "VARCHAR",
+        "min": "\"F\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 2,
+        "numValues": 0
+      },
+      "l_orderkey": {
+        "max": "18000962",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 45359592,
+        "numValues": 0
+      },
+      "l_partkey": {
+        "max": "5998715",
+        "maxType": "BIGINT",
+        "min": "53",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5998662,
+        "numValues": 0
+      },
+      "l_quantity": {
+        "max": "50",
+        "maxType": "DOUBLE",
+        "min": "1",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 50,
+        "numValues": 0
+      },
+      "l_receiptdate": {
+        "max": "\"1998-12-16\"",
+        "maxType": "INTEGER",
+        "min": "\"1992-01-24\"",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 2518,
+        "numValues": 0
+      },
+      "l_returnflag": {
+        "avgLength": 1,
+        "max": "\"R\"",
+        "maxType": "VARCHAR",
+        "min": "\"A\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 3,
+        "numValues": 0
+      },
+      "l_shipdate": {
+        "max": "\"1998-12-01\"",
+        "maxType": "INTEGER",
+        "min": "\"1992-01-07\"",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 2520,
+        "numValues": 0
+      },
+      "l_shipinstruct": {
+        "avgLength": 11,
+        "max": "\"TAKE BACK RETURN\"",
+        "maxType": "VARCHAR",
+        "min": "\"COLLECT COD\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4,
+        "numValues": 0
+      },
+      "l_shipmode": {
+        "avgLength": 4,
+        "max": "\"TRUCK\"",
+        "maxType": "VARCHAR",
+        "min": "\"AIR\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 7,
+        "numValues": 0
+      },
+      "l_suppkey": {
+        "max": "300000",
+        "maxType": "BIGINT",
+        "min": "54",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 299946,
+        "numValues": 0
+      },
+      "l_tax": {
+        "max": "0.08",
+        "maxType": "DOUBLE",
+        "min": "0",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 9,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "lineitem"
+      }
+    ],
+    "numRows": 179998372
+  },
+  "nation": {
+    "columns": {
+      "n_comment": {
+        "avgLength": 74,
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "n_name": {
+        "avgLength": 7,
+        "max": "\"VIETNAM\"",
+        "maxType": "VARCHAR",
+        "min": "\"ALGERIA\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "n_nationkey": {
+        "max": "24",
+        "maxType": "BIGINT",
+        "min": "0",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "n_regionkey": {
+        "max": "4",
+        "maxType": "BIGINT",
+        "min": "0",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "nation"
+      }
+    ],
+    "numRows": 25
+  },
+  "orders": {
+    "columns": {
+      "o_clerk": {
+        "avgLength": 15,
+        "max": "\"Clerk#000030000\"",
+        "maxType": "VARCHAR",
+        "min": "\"Clerk#000000013\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 42311252,
+        "numValues": 0
+      },
+      "o_comment": {
+        "avgLength": 48,
+        "max": "\"zzle. carefully enticing deposits nag furio\"",
+        "maxType": "VARCHAR",
+        "min": "\" about the final platelets. dependen\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 44988748,
+        "numValues": 0
+      },
+      "o_custkey": {
+        "max": "4498843",
+        "maxType": "BIGINT",
+        "min": "712",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4498131,
+        "numValues": 0
+      },
+      "o_orderdate": {
+        "max": "\"1998-08-02\"",
+        "maxType": "INTEGER",
+        "min": "\"1992-01-01\"",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 2405,
+        "numValues": 0
+      },
+      "o_orderkey": {
+        "max": "18004000",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 45000000,
+        "numValues": 0
+      },
+      "o_orderpriority": {
+        "avgLength": 8,
+        "max": "\"5-LOW\"",
+        "maxType": "VARCHAR",
+        "min": "\"1-URGENT\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      },
+      "o_orderstatus": {
+        "avgLength": 1,
+        "max": "\"P\"",
+        "maxType": "VARCHAR",
+        "min": "\"F\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 3,
+        "numValues": 0
+      },
+      "o_shippriority": {
+        "max": "0",
+        "maxType": "INTEGER",
+        "min": "0",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 1,
+        "numValues": 0
+      },
+      "o_totalprice": {
+        "max": "468697.03",
+        "maxType": "DOUBLE",
+        "min": "1179.92",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 45000000,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "orders"
+      }
+    ],
+    "numRows": 45000000
+  },
+  "part": {
+    "columns": {
+      "p_brand": {
+        "avgLength": 8,
+        "max": "\"Brand#55\"",
+        "maxType": "VARCHAR",
+        "min": "\"Brand#11\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "p_comment": {
+        "avgLength": 13,
+        "max": "\"zzle. final, final\"",
+        "maxType": "VARCHAR",
+        "min": "\" Tires\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 4675031,
+        "numValues": 0
+      },
+      "p_container": {
+        "avgLength": 7,
+        "max": "\"WRAP PKG\"",
+        "maxType": "VARCHAR",
+        "min": "\"JUMBO BAG\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 40,
+        "numValues": 0
+      },
+      "p_mfgr": {
+        "avgLength": 14,
+        "max": "\"Manufacturer#5\"",
+        "maxType": "VARCHAR",
+        "min": "\"Manufacturer#1\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      },
+      "p_name": {
+        "avgLength": 32,
+        "max": "\"yellow white slate turquoise brown\"",
+        "maxType": "VARCHAR",
+        "min": "\"almond antique cyan blue pale\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5999719,
+        "numValues": 0
+      },
+      "p_partkey": {
+        "max": "661000",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5999625,
+        "numValues": 0
+      },
+      "p_retailprice": {
+        "max": "1959.96",
+        "maxType": "DOUBLE",
+        "min": "900.97",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 939937,
+        "numValues": 0
+      },
+      "p_size": {
+        "max": "50",
+        "maxType": "INTEGER",
+        "min": "1",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 50,
+        "numValues": 0
+      },
+      "p_type": {
+        "avgLength": 20,
+        "max": "\"STANDARD POLISHED TIN\"",
+        "maxType": "VARCHAR",
+        "min": "\"ECONOMY ANODIZED BRASS\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 150,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "part"
+      }
+    ],
+    "numRows": 6000000
+  },
+  "partsupp": {
+    "columns": {
+      "ps_availqty": {
+        "max": "9998",
+        "maxType": "INTEGER",
+        "min": "2",
+        "minType": "INTEGER",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 9996,
+        "numValues": 0
+      },
+      "ps_comment": {
+        "avgLength": 123,
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 24000000,
+        "numValues": 0
+      },
+      "ps_partkey": {
+        "max": "600250",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 6000000,
+        "numValues": 0
+      },
+      "ps_suppkey": {
+        "max": "275251",
+        "maxType": "BIGINT",
+        "min": "2",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 275249,
+        "numValues": 0
+      },
+      "ps_supplycost": {
+        "max": "999.94",
+        "maxType": "DOUBLE",
+        "min": "1.43",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 23580002,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "partsupp"
+      }
+    ],
+    "numRows": 24000000
+  },
+  "region": {
+    "columns": {
+      "r_comment": {
+        "avgLength": 66,
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      },
+      "r_name": {
+        "avgLength": 6,
+        "max": "\"MIDDLE EAST\"",
+        "maxType": "VARCHAR",
+        "min": "\"AFRICA\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      },
+      "r_regionkey": {
+        "max": "4",
+        "maxType": "BIGINT",
+        "min": "0",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 5,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "region"
+      }
+    ],
+    "numRows": 5
+  },
+  "supplier": {
+    "columns": {
+      "s_acctbal": {
+        "max": "9999.66",
+        "maxType": "DOUBLE",
+        "min": "-999.9200000000001",
+        "minType": "DOUBLE",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 295376,
+        "numValues": 0
+      },
+      "s_address": {
+        "avgLength": 25,
+        "max": "\"zztK9Cj VeF8skRl0EDMWOoDC \"",
+        "maxType": "VARCHAR",
+        "min": "\"  3baOZRmtC2D0uld6jRcQn3hB8jC\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 300000,
+        "numValues": 0
+      },
+      "s_comment": {
+        "avgLength": 62,
+        "max": "\"zzle furiously accounts. slyly silent dependencies are express \"",
+        "maxType": "VARCHAR",
+        "min": "\" Customer  blithely regular pinto beans. slyly express ideas uRecommendsy\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 299991,
+        "numValues": 0
+      },
+      "s_name": {
+        "avgLength": 18,
+        "max": "\"Supplier#000121000\"",
+        "maxType": "VARCHAR",
+        "min": "\"Supplier#000000001\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 300000,
+        "numValues": 0
+      },
+      "s_nationkey": {
+        "max": "24",
+        "maxType": "BIGINT",
+        "min": "0",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 25,
+        "numValues": 0
+      },
+      "s_phone": {
+        "avgLength": 15,
+        "max": "\"34-998-900-4911\"",
+        "maxType": "VARCHAR",
+        "min": "\"10-100-211-9178\"",
+        "minType": "VARCHAR",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 300000,
+        "numValues": 0
+      },
+      "s_suppkey": {
+        "max": "121000",
+        "maxType": "BIGINT",
+        "min": "1",
+        "minType": "BIGINT",
+        "nonNull": false,
+        "nullPct": 0,
+        "numDistinct": 300000,
+        "numValues": 0
+      }
+    },
+    "layouts": [
+      {
+        "name": "supplier"
+      }
+    ],
+    "numRows": 300000
+  }
+}


### PR DESCRIPTION
ToGraph builds derived tables bottom up. On the returning edge of recursion we add joins or dt postprocessing steps like group by or limit. When there are things that do not fit the implied processing order of a dt, i.e. joins, group by, having, orderby, limit/ofset, we wrap the plan so far in another dt. For example,

scan, limit, filter, limit

would have (scan, limit) in a dt and the filter and second limit in a dt containing the first one. Now, when a dt as above is to the right of a join, we must start the dt to the right from scratch, meaning that the tables in the dt must be empty and not contain tables from the left side. On the other hand, for a right side that does not  introduce a dt break, we must add the tables on the right to the dt where the left side was added.

To this effect we set and check allowedInDt correctly also for filters.