### PR TITLE
fix: Restore the text of TPC-H q12

### DIFF
--- a/axiom/optimizer/tests/tpch.queries/q12.sql
+++ b/axiom/optimizer/tests/tpch.queries/q12.sql
@@ -23,8 +23,8 @@ where
 	and l_shipmode in ('MAIL', 'SHIP')
 	and l_commitdate < l_receiptdate
 	and l_shipdate < l_commitdate
-	-- TODO Restore the original query after fixing https://github.com/facebookincubator/velox/issues/14978
-	and l_receiptdate between date '1994-01-01' and date '1994-01-01' + interval '1' year
+	and l_receiptdate >= date '1994-01-01'
+	and cast(l_receiptdate as date) < date '1994-01-01' + interval '1' year
 group by
 	l_shipmode
 order by


### PR DESCRIPTION
Summary:
Query text was tweaked in https://github.com/facebookexperimental/verax/pull/441 to workaround a bug in Hive Connector: https://github.com/facebookincubator/velox/issues/14978

The bug has been fix. Hence, restoring the original text.

Differential Revision: D85907389


