### PR TITLE
fix: TPC-H q10 with sf 0.1

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -261,6 +261,11 @@ bool JoinEdge::isBroadcastableType() const {
 }
 
 void JoinEdge::addEquality(ExprCP left, ExprCP right, bool update) {
+  for (auto i = 0; i < leftKeys_.size(); ++i) {
+    if (leftKeys_[i] == left && rightKeys_[i] == right) {
+      return;
+    }
+  }
   leftKeys_.push_back(left);
   rightKeys_.push_back(right);
   if (update) {

--- a/axiom/optimizer/tests/ParquetTpchTest.cpp
+++ b/axiom/optimizer/tests/ParquetTpchTest.cpp
@@ -28,7 +28,7 @@ DEFINE_string(
     "",
     "Path to TPC-H data directory. If empty, the test creates a temp directory and deletes it on exit");
 DEFINE_bool(create_dataset, true, "Creates the TPC-H tables");
-DEFINE_double(tpch_scale, 0.01, "Scale factor");
+DEFINE_double(tpch_scale, 0.1, "Scale factor");
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -135,8 +135,8 @@ TEST_F(TpchPlanTest, stats) {
 
   verifyStats("region", 5);
   verifyStats("nation", 25);
-  verifyStats("orders", 15'000);
-  verifyStats("lineitem", 60'175);
+  verifyStats("orders", 150'000);
+  verifyStats("lineitem", 600'572);
 }
 
 TEST_F(TpchPlanTest, q01) {
@@ -379,6 +379,7 @@ TEST_F(TpchPlanTest, q10) {
                "c_comment"},
               {"sum(l_extendedprice * (1.0 - l_discount)) as revenue"})
           .orderBy({"revenue desc"})
+          .limit(20)
           .project(
               {"c_custkey",
                "c_name",

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -501,7 +501,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test WITH (bucket_count = 8, bucketed_by = ARRAY['key']) AS "
         "SELECT rand() as key, l_orderkey, l_partkey, l_linenumber FROM lineitem",
-        60175,
+        600'572,
         verifyPartitionedWrite);
 
     verifyPartitionedLayout(getLayout("test"), "key", 8);
@@ -510,7 +510,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test3 WITH (bucket_count = 16, bucketed_by = ARRAY['key']) AS "
         "SELECT key, l_orderkey, l_linenumber + 1 as x FROM test",
-        60175,
+        600'572,
         verifyCollocatedWrite);
 
     verifyPartitionedLayout(getLayout("test3"), "key", 16);
@@ -519,7 +519,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test2 WITH (bucket_count = 8, bucketed_by = ARRAY['key']) AS "
         "SELECT key, l_orderkey, l_linenumber + 1 as x FROM test",
-        60175,
+        600'572,
         verifyCollocatedWrite);
 
     verifyPartitionedLayout(getLayout("test2"), "key", 8);
@@ -528,7 +528,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test3 WITH (bucket_count = 16, bucketed_by = ARRAY['key']) AS "
         "SELECT key, l_orderkey, l_linenumber + 1 as x FROM test",
-        60175,
+        600'572,
         verifyCollocatedWrite);
 
     verifyPartitionedLayout(getLayout("test3"), "key", 16);
@@ -537,7 +537,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test4 WITH (bucket_count = 2, bucketed_by = ARRAY['key']) AS "
         "SELECT key, l_orderkey, l_linenumber + 1 as x FROM test",
-        60175,
+        600'572,
         verifyPartitionedWrite);
 
     verifyPartitionedLayout(getLayout("test4"), "key", 2);
@@ -552,7 +552,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test WITH (bucket_count = 128, bucketed_by = ARRAY['key']) AS "
         "SELECT rand() as key, l_orderkey, l_partkey, l_linenumber FROM lineitem",
-        60175,
+        600'572,
         [](const auto& plan) {
           const auto& fragments = plan.fragments();
           ASSERT_EQ(1, fragments.size());
@@ -579,7 +579,7 @@ TEST_F(WriteTest, createTableAsSelectBucketedSql) {
     runCtas(
         "CREATE TABLE test WITH (bucket_count = 64, bucketed_by = ARRAY['key']) AS "
         "SELECT rand() as key, l_orderkey, l_partkey, l_linenumber FROM lineitem",
-        60175,
+        600'572,
         [](const auto& plan) {
           const auto& fragments = plan.fragments();
           ASSERT_EQ(1, fragments.size());


### PR DESCRIPTION
Summary:
Increase TPC-H scale factor to 0.1 (from 0.01). 150K orders.

Fix a bug in q10 test, which missed a limit node in the logical plan. This bug wasn't visible with 0.01 scale factor.

Extend JoinEdge::addEquality to ignore duplicate equalities. These may happen if, for example, the query had duplicate join conditions.

 > SELECT * FROM t, u WHERE t.id = u.id AND t.id = u.id

Differential Revision: D85910590


