### PR TITLE
fix: Change flattenDt to account DerivedTable properties

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -594,32 +594,76 @@ void DerivedTable::importJoinsIntoFirstDt(const DerivedTable* firstDt) {
 }
 
 void DerivedTable::flattenDt(const DerivedTable* dt) {
-  // TODO: std::move(...)?
   VELOX_DCHECK_NOT_NULL(dt);
   VELOX_DCHECK_EQ(tables.size(), 1);
   VELOX_DCHECK(tables[0] == dt);
-  VELOX_DCHECK_EQ(cardinality, dt->cardinality);
+  VELOX_DCHECK_NULL(dt->write);
+  if (hasAggregation() && dt->hasAggregation()) {
+    // Can't have two aggregations in single dt.
+    return;
+  }
+  if (hasLimit() || dt->hasLimit()) {
+    // TODO: Can we combine limits?
+    // But we need to account cardinality, aggregation, order in such case.
+    return;
+  }
+  if (write) {
+    // We shouldn't flatten into a dt that writes.
+    // TODO: We can avoid this with putting write in the end of addPostprocess.
+    return;
+  }
+  // TODO: Use std::move(...)?
+
+  cardinality = dt->cardinality;
   cname = dt->cname;
   columns = dt->columns;
   exprs = dt->exprs;
-  VELOX_DCHECK(joinedBy == dt->joinedBy);
+  joinedBy = dt->joinedBy;
   tables = dt->tables;
   tableSet = dt->tableSet;
+
+  // TODO: Is setop possible here at all?
   VELOX_DCHECK(setOp == dt->setOp);
   VELOX_DCHECK(children == dt->children);
+
+  // TODO: Is it true?
   VELOX_DCHECK(singleRowDts == dt->singleRowDts);
-  VELOX_DCHECK(startTables == dt->startTables);
+
+  startTables = dt->startTables;
   joins = dt->joins;
+
+  // TODO: Is it true?
   VELOX_DCHECK(conjuncts == dt->conjuncts);
+
   // TODO: Why unionSet here?
   importedExistences.unionSet(dt->importedExistences);
+
   fullyImported = dt->fullyImported;
-  VELOX_DCHECK_EQ(noImportOfExists, dt->noImportOfExists);
+
+  // TODO: Is this correct?
+  // I made it like this for consistency with unionSet above.
+  noImportOfExists = noImportOfExists && dt->noImportOfExists;
+
   joinOrder = dt->joinOrder;
-  aggregation = dt->aggregation;
-  having = dt->having;
-  VELOX_DCHECK(orderKeys == dt->orderKeys);
-  VELOX_DCHECK(orderTypes == dt->orderTypes);
+
+  if (!aggregation) {
+    aggregation = dt->aggregation;
+    VELOX_DCHECK(having.empty());
+    having = dt->having;
+  } else {
+    VELOX_DCHECK_NULL(dt->aggregation);
+    VELOX_DCHECK(dt->having.empty());
+  }
+
+  if (orderKeys.empty()) {
+    orderKeys = dt->orderKeys;
+    VELOX_DCHECK(orderTypes.empty());
+    orderTypes = dt->orderTypes;
+  } else {
+    VELOX_DCHECK(dt->orderKeys.empty());
+    VELOX_DCHECK(dt->orderTypes.empty());
+  }
+
   VELOX_DCHECK(limit == dt->limit);
   VELOX_DCHECK(offset == dt->offset);
   VELOX_DCHECK(write == dt->write);

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -594,17 +594,35 @@ void DerivedTable::importJoinsIntoFirstDt(const DerivedTable* firstDt) {
 }
 
 void DerivedTable::flattenDt(const DerivedTable* dt) {
-  tables = dt->tables;
+  // TODO: std::move(...)?
+  VELOX_DCHECK_NOT_NULL(dt);
+  VELOX_DCHECK_EQ(tables.size(), 1);
+  VELOX_DCHECK(tables[0] == dt);
+  VELOX_DCHECK_EQ(cardinality, dt->cardinality);
   cname = dt->cname;
-  tableSet = dt->tableSet;
-  joins = dt->joins;
-  joinOrder = dt->joinOrder;
   columns = dt->columns;
   exprs = dt->exprs;
-  fullyImported = dt->fullyImported;
+  VELOX_DCHECK(joinedBy == dt->joinedBy);
+  tables = dt->tables;
+  tableSet = dt->tableSet;
+  VELOX_DCHECK(setOp == dt->setOp);
+  VELOX_DCHECK(children == dt->children);
+  VELOX_DCHECK(singleRowDts == dt->singleRowDts);
+  VELOX_DCHECK(startTables == dt->startTables);
+  joins = dt->joins;
+  VELOX_DCHECK(conjuncts == dt->conjuncts);
+  // TODO: Why unionSet here?
   importedExistences.unionSet(dt->importedExistences);
+  fullyImported = dt->fullyImported;
+  VELOX_DCHECK_EQ(noImportOfExists, dt->noImportOfExists);
+  joinOrder = dt->joinOrder;
   aggregation = dt->aggregation;
   having = dt->having;
+  VELOX_DCHECK(orderKeys == dt->orderKeys);
+  VELOX_DCHECK(orderTypes == dt->orderTypes);
+  VELOX_DCHECK(limit == dt->limit);
+  VELOX_DCHECK(offset == dt->offset);
+  VELOX_DCHECK(write == dt->write);
 }
 
 void DerivedTable::makeProjection(const ExprVector& exprs) {


### PR DESCRIPTION
I don't know how to test this, but I saw similar changes in Orri commit and thinks there's more issues.

Also cardinality and some other fields (joinedBy/startTables) didn't assign now