### PR TITLE
feat: Extend QueryTestBase::planVelox to allow saving query plans

### DIFF
--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -51,8 +51,7 @@ class ToTextVisitor : public RelationOpVisitor {
     if (!table.filter.empty()) {
       appendLine(
           fmt::format(
-              "multi-column filters: {}",
-              conjunctsToString(table.columnFilters)));
+              "multi-column filters: {}", conjunctsToString(table.filter)));
     }
   }
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -46,6 +46,8 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   void TearDown() override;
 
+  /// @param planFilePathPrefix If specified, writes the query graph, optimized
+  /// and executable plans to files with specified path prefix.
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
       const runner::MultiFragmentPlan::Options& options =
@@ -53,7 +55,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
               .numWorkers = 4,
               .numDrivers = 4,
           },
-      std::string* planString = nullptr);
+      const std::optional<std::string>& planFilePathPrefix = std::nullopt);
 
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
@@ -63,7 +65,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
               .numWorkers = 4,
               .numDrivers = 4,
           },
-      std::string* planString = nullptr);
+      const std::optional<std::string>& planFilePathPrefix = std::nullopt);
 
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -565,6 +565,29 @@ TEST_F(TpchPlanTest, q22) {
   checkTpchSql(22);
 }
 
+// Use to re-generate the plans stored in tpch.plans directory.
+TEST_F(TpchPlanTest, DISABLED_makePlans) {
+  const auto path =
+      velox::test::getDataFilePath("axiom/optimizer/tests", "tpch.plans");
+
+  const runner::MultiFragmentPlan::Options options{
+      .numWorkers = 1, .numDrivers = 1};
+
+  for (auto q = 1; q <= 22; ++q) {
+    LOG(ERROR) << "q" << q;
+    const bool originalEnableReducingExistences =
+        optimizerOptions_.enableReducingExistences;
+    optimizerOptions_.enableReducingExistences = (q != 20);
+    SCOPE_EXIT {
+      optimizerOptions_.enableReducingExistences =
+          originalEnableReducingExistences;
+    };
+
+    auto logicalPlan = parseTpchSql(q);
+    planVelox(logicalPlan, options, fmt::format("{}/q{}", path, q));
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer
 

--- a/axiom/optimizer/tests/tpch.plans/q1.plans
+++ b/axiom/optimizer/tests/tpch.plans/q1.plans
@@ -1,0 +1,76 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order
+  output:
+    l_returnflag := t2.l_returnflag
+    l_linestatus := t2.l_linestatus
+    sum_qty := dt1.sum_qty
+    sum_base_price := dt1.sum_base_price
+    sum_disc_price := dt1.sum_disc_price
+    sum_charge := dt1.sum_charge
+    avg_qty := dt1.avg_qty
+    avg_price := dt1.avg_price
+    avg_disc := dt1.avg_disc
+    count_order := dt1.count_order
+  tables: t2
+  aggregates: sum(t2.l_quantity) AS sum_qty, sum(t2.l_extendedprice) AS sum_base_price, sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS sum_disc_price, sum(multiply(multiply(t2.l_extendedprice, minus(1, t2.l_discount)), plus(t2.l_tax, 1))) AS sum_charge, avg(t2.l_quantity) AS avg_qty, avg(t2.l_extendedprice) AS avg_price, avg(t2.l_discount) AS avg_disc, count() AS count_order
+  grouping keys: t2.l_returnflag, t2.l_linestatus
+  orderBy: t2.l_returnflag ASC NULLS LAST, t2.l_linestatus ASC NULLS LAST
+
+t2: l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate
+  table: lineitem
+  single-column filters: lt(t2.l_shipdate, "1998-09-03")
+
+
+Optimized plan (oneline):
+
+lineitem
+
+Optimized plan:
+
+Project (redundant) -> dt1.l_returnflag, dt1.l_linestatus, dt1.sum_qty, dt1.sum_base_price, dt1.sum_disc_price, dt1.sum_charge, dt1.avg_qty, dt1.avg_price, dt1.avg_disc, dt1.count_order
+    dt1.l_returnflag := t2.l_returnflag
+    dt1.l_linestatus := t2.l_linestatus
+    dt1.sum_qty := dt1.sum_qty
+    dt1.sum_base_price := dt1.sum_base_price
+    dt1.sum_disc_price := dt1.sum_disc_price
+    dt1.sum_charge := dt1.sum_charge
+    dt1.avg_qty := dt1.avg_qty
+    dt1.avg_price := dt1.avg_price
+    dt1.avg_disc := dt1.avg_disc
+    dt1.count_order := dt1.count_order
+  OrderBy -> t2.l_returnflag, t2.l_linestatus, dt1.sum_qty, dt1.sum_base_price, dt1.sum_disc_price, dt1.sum_charge, dt1.avg_qty, dt1.avg_price, dt1.avg_disc, dt1.count_order
+    Aggregation (t2.l_returnflag, t2.l_linestatus) -> t2.l_returnflag, t2.l_linestatus, dt1.sum_qty, dt1.sum_base_price, dt1.sum_disc_price, dt1.sum_charge, dt1.avg_qty, dt1.avg_price, dt1.avg_disc, dt1.count_order
+        dt1.sum_qty := sum(t2.l_quantity)
+        dt1.sum_base_price := sum(t2.l_extendedprice)
+        dt1.sum_disc_price := sum(dt1.__p39)
+        dt1.sum_charge := sum(dt1.__p46)
+        dt1.avg_qty := avg(t2.l_quantity)
+        dt1.avg_price := avg(t2.l_extendedprice)
+        dt1.avg_disc := avg(t2.l_discount)
+        dt1.count_order := count()
+      Project -> t2.l_returnflag, t2.l_linestatus, t2.l_quantity, t2.l_extendedprice, dt1.__p39, dt1.__p46, t2.l_discount
+          t2.l_returnflag := t2.l_returnflag
+          t2.l_linestatus := t2.l_linestatus
+          t2.l_quantity := t2.l_quantity
+          t2.l_extendedprice := t2.l_extendedprice
+          dt1.__p39 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+          dt1.__p46 := multiply(multiply(t2.l_extendedprice, minus(1, t2.l_discount)), plus(t2.l_tax, 1))
+          t2.l_discount := t2.l_discount
+        TableScan -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t2.l_tax, t2.l_returnflag, t2.l_linestatus
+          table: lineitem
+          single-column filters: lt(t2.l_shipdate, "1998-09-03")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[3][l_returnflag ASC NULLS LAST, l_linestatus ASC NULLS LAST] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+  -- Aggregation[2][SINGLE [l_returnflag, l_linestatus] sum_qty := sum("l_quantity"), sum_base_price := sum("l_extendedprice"), sum_disc_price := sum("dt1.__p39"), sum_charge := sum("dt1.__p46"), avg_qty := avg("l_quantity"), avg_price := avg("l_extendedprice"), avg_disc := avg("l_discount"), count_order := count()] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+    -- Project[1][expressions: (l_returnflag:VARCHAR, "l_returnflag"), (l_linestatus:VARCHAR, "l_linestatus"), (l_quantity:DOUBLE, "l_quantity"), (l_extendedprice:DOUBLE, "l_extendedprice"), (dt1.__p39:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount"))), (dt1.__p46:DOUBLE, multiply(multiply("l_extendedprice",minus(1,"l_discount")),plus("l_tax",1))), (l_discount:DOUBLE, "l_discount")] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, l_quantity:DOUBLE, l_extendedprice:DOUBLE, "dt1.__p39":DOUBLE, "dt1.__p46":DOUBLE, l_discount:DOUBLE
+      -- TableScan[0][table: lineitem, range filters: [(l_shipdate, BigintRange: [-9223372036854775808, 10471] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_tax:DOUBLE, l_returnflag:VARCHAR, l_linestatus:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q10.plans
+++ b/axiom/optimizer/tests/tpch.plans/q10.plans
@@ -1,0 +1,105 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment
+  output:
+    c_custkey := t2.c_custkey
+    c_name := t2.c_name
+    revenue := dt1.revenue
+    c_acctbal := t2.c_acctbal
+    n_name := t5.n_name
+    c_address := t2.c_address
+    c_phone := t2.c_phone
+    c_comment := t2.c_comment
+  tables: t2, t3, t4, t5
+  joins:
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey
+    t2 INNER t5 ON t2.c_nationkey = t5.n_nationkey
+  syntactic join order: 9, 26, 46, 55
+  aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
+  grouping keys: t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment
+  orderBy: dt1.revenue DESC NULLS LAST
+  limit: 20
+
+t2: c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment
+  table: customer
+
+t3: o_orderkey, o_custkey, o_orderdate
+  table: orders
+  single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(__cast(t3.o_orderdate), "1994-01-01")
+
+t4: l_orderkey, l_extendedprice, l_discount, l_returnflag
+  table: lineitem
+  single-column filters: eq(t4.l_returnflag, "R")
+
+t5: n_nationkey, n_name
+  table: nation
+
+
+Optimized plan (oneline):
+
+(lineitem INNER ((customer INNER orders) INNER nation))
+
+Optimized plan:
+
+Project -> dt1.c_custkey, dt1.c_name, dt1.revenue, dt1.c_acctbal, dt1.n_name, dt1.c_address, dt1.c_phone, dt1.c_comment
+    dt1.c_custkey := t2.c_custkey
+    dt1.c_name := t2.c_name
+    dt1.revenue := dt1.revenue
+    dt1.c_acctbal := t2.c_acctbal
+    dt1.n_name := t5.n_name
+    dt1.c_address := t2.c_address
+    dt1.c_phone := t2.c_phone
+    dt1.c_comment := t2.c_comment
+  OrderBy -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.revenue
+    Aggregation (t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment) -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.revenue
+        dt1.revenue := sum(dt1.__p77)
+      Project -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.__p77
+          t2.c_custkey := t2.c_custkey
+          t2.c_name := t2.c_name
+          t2.c_acctbal := t2.c_acctbal
+          t2.c_phone := t2.c_phone
+          t5.n_name := t5.n_name
+          t2.c_address := t2.c_address
+          t2.c_comment := t2.c_comment
+          dt1.__p77 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t4.l_extendedprice, t4.l_discount, t5.n_name
+            t4.l_orderkey = t3.o_orderkey
+          TableScan -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+            table: lineitem
+            single-column filters: eq(t4.l_returnflag, "R")
+          HashBuild -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t3.o_custkey, t5.n_nationkey, t5.n_name
+            Join INNER Hash -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t3.o_custkey, t5.n_nationkey, t5.n_name
+                t2.c_nationkey = t5.n_nationkey
+              Join INNER Hash -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t3.o_custkey
+                  t2.c_custkey = t3.o_custkey
+                TableScan -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment
+                  table: customer
+                HashBuild -> t3.o_orderkey, t3.o_custkey
+                  TableScan -> t3.o_orderkey, t3.o_custkey
+                    table: orders
+                    single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(__cast(t3.o_orderdate), "1994-01-01")
+              HashBuild -> t5.n_nationkey, t5.n_name
+                TableScan -> t5.n_nationkey, t5.n_name
+                  table: nation
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[10][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (revenue:DOUBLE, "revenue"), (c_acctbal:DOUBLE, "c_acctbal"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_phone:VARCHAR, "c_phone"), (c_comment:VARCHAR, "c_comment")] -> c_custkey:BIGINT, c_name:VARCHAR, revenue:DOUBLE, c_acctbal:DOUBLE, n_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_comment:VARCHAR
+  -- TopN[9][20 revenue DESC NULLS LAST] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+    -- Aggregation[8][SINGLE [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] revenue := sum("dt1.__p77")] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+      -- Project[7][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (c_acctbal:DOUBLE, "c_acctbal"), (c_phone:VARCHAR, "c_phone"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_comment:VARCHAR, "c_comment"), (dt1.__p77:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, "dt1.__p77":DOUBLE
+        -- HashJoin[6][INNER l_orderkey=o_orderkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+          -- TableScan[0][table: lineitem, range filters: [(l_returnflag, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- HashJoin[5][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, o_orderkey:BIGINT, o_custkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+            -- HashJoin[3][INNER c_custkey=o_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, o_orderkey:BIGINT, o_custkey:BIGINT
+              -- TableScan[1][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR
+              -- TableScan[2][table: orders, range filters: [(o_orderdate, BigintRange: [8674, 9223372036854775807] no nulls)], remaining filter: (lt(cast("o_orderdate" as DATE),1994-01-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT
+            -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q11.plans
+++ b/axiom/optimizer/tests/tpch.plans/q11.plans
@@ -1,0 +1,135 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt5: ps_partkey, value
+  output:
+    ps_partkey := dt1.ps_partkey
+    value := dt1.value
+  tables: dt1, dt13
+  filter: gt(dt1.value, dt13.expr)
+  orderBy: dt1.value DESC NULLS LAST
+
+dt1: ps_partkey, value
+  output:
+    ps_partkey := t2.ps_partkey
+    value := dt1.value
+  tables: t2, t3, t4
+  joins:
+    t2 INNER t3 ON t2.ps_suppkey = t3.s_suppkey
+    t3 INNER t4 ON t3.s_nationkey = t4.n_nationkey
+  syntactic join order: 6, 18, 25
+  aggregates: sum(multiply(t2.ps_supplycost, __cast(t2.ps_availqty))) AS value
+  grouping keys: t2.ps_partkey
+
+t2: ps_partkey, ps_suppkey, ps_availqty, ps_supplycost
+  table: partsupp
+
+t3: s_suppkey, s_nationkey
+  table: supplier
+
+t4: n_nationkey, n_name
+  table: nation
+  single-column filters: eq(t4.n_name, "GERMANY")
+
+dt13: expr
+  output:
+    expr := multiply(dt13.sum, 0.0001)
+  tables: t14, t15, t16
+  joins:
+    t14 INNER t15 ON t14.ps_suppkey = t15.s_suppkey
+    t15 INNER t16 ON t15.s_nationkey = t16.n_nationkey
+  syntactic join order: 51, 55, 58
+  aggregates: sum(multiply(t14.ps_supplycost, __cast(t14.ps_availqty))) AS sum
+
+t14: ps_suppkey, ps_availqty, ps_supplycost
+  table: partsupp
+
+t15: s_suppkey, s_nationkey
+  table: supplier
+
+t16: n_nationkey, n_name
+  table: nation
+  single-column filters: eq(t16.n_name, "GERMANY")
+
+
+Optimized plan (oneline):
+
+((partsupp INNER (supplier INNER nation)) INNER (partsupp INNER (supplier INNER nation)))
+
+Optimized plan:
+
+Project -> dt5.ps_partkey, dt5.value
+    dt5.ps_partkey := dt1.ps_partkey
+    dt5.value := dt1.value
+  OrderBy -> dt1.ps_partkey, dt1.value, dt13.expr
+    Filter -> dt1.ps_partkey, dt1.value, dt13.expr
+        gt(dt1.value, dt13.expr)
+      Join INNER Cross -> dt1.ps_partkey, dt1.value, dt13.expr
+        Project (redundant) -> dt1.ps_partkey, dt1.value
+            dt1.ps_partkey := t2.ps_partkey
+            dt1.value := dt1.value
+          Aggregation (t2.ps_partkey) -> t2.ps_partkey, dt1.value
+              dt1.value := sum(dt1.__p33)
+            Project -> t2.ps_partkey, dt1.__p33
+                t2.ps_partkey := t2.ps_partkey
+                dt1.__p33 := multiply(t2.ps_supplycost, __cast(t2.ps_availqty))
+              Join INNER Hash -> t2.ps_partkey, t2.ps_availqty, t2.ps_supplycost
+                  t2.ps_suppkey = t3.s_suppkey
+                TableScan -> t2.ps_partkey, t2.ps_suppkey, t2.ps_availqty, t2.ps_supplycost
+                  table: partsupp
+                HashBuild -> t3.s_suppkey, t3.s_nationkey, t4.n_nationkey
+                  Join INNER Hash -> t3.s_suppkey, t3.s_nationkey, t4.n_nationkey
+                      t3.s_nationkey = t4.n_nationkey
+                    TableScan -> t3.s_suppkey, t3.s_nationkey
+                      table: supplier
+                    HashBuild -> t4.n_nationkey
+                      TableScan -> t4.n_nationkey
+                        table: nation
+                        single-column filters: eq(t4.n_name, "GERMANY")
+        Project -> dt13.expr
+            dt13.expr := multiply(dt13.sum, 0.0001)
+          Aggregation -> dt13.sum
+              dt13.sum := sum(dt13.__p65)
+            Project -> dt13.__p65
+                dt13.__p65 := multiply(t14.ps_supplycost, __cast(t14.ps_availqty))
+              Join INNER Hash -> t14.ps_availqty, t14.ps_supplycost
+                  t14.ps_suppkey = t15.s_suppkey
+                TableScan -> t14.ps_suppkey, t14.ps_availqty, t14.ps_supplycost
+                  table: partsupp
+                HashBuild -> t15.s_suppkey, t15.s_nationkey, t16.n_nationkey
+                  Join INNER Hash -> t15.s_suppkey, t15.s_nationkey, t16.n_nationkey
+                      t15.s_nationkey = t16.n_nationkey
+                    TableScan -> t15.s_suppkey, t15.s_nationkey
+                      table: supplier
+                    HashBuild -> t16.n_nationkey
+                      TableScan -> t16.n_nationkey
+                        table: nation
+                        single-column filters: eq(t16.n_name, "GERMANY")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[18][expressions: (ps_partkey:BIGINT, "ps_partkey"), (value:DOUBLE, "value")] -> ps_partkey:BIGINT, value:DOUBLE
+  -- OrderBy[17][value DESC NULLS LAST] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+    -- Filter[0][expression: gt("value","expr")] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+      -- NestedLoopJoin[16][INNER] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+        -- Aggregation[7][SINGLE [ps_partkey] value := sum("dt1.__p33")] -> ps_partkey:BIGINT, value:DOUBLE
+          -- Project[6][expressions: (ps_partkey:BIGINT, "ps_partkey"), (dt1.__p33:DOUBLE, multiply("ps_supplycost",cast("ps_availqty" as DOUBLE)))] -> ps_partkey:BIGINT, "dt1.__p33":DOUBLE
+            -- HashJoin[5][INNER ps_suppkey=s_suppkey] -> ps_partkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+              -- TableScan[1][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+              -- HashJoin[4][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_nationkey:BIGINT, n_nationkey:BIGINT
+                -- TableScan[2][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                -- TableScan[3][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT
+        -- Project[15][expressions: (expr:DOUBLE, multiply("sum",0.0001))] -> expr:DOUBLE
+          -- Aggregation[14][SINGLE sum := sum("dt13.__p65")] -> sum:DOUBLE
+            -- Project[13][expressions: (dt13.__p65:DOUBLE, multiply("ps_supplycost_3",cast("ps_availqty_2" as DOUBLE)))] -> "dt13.__p65":DOUBLE
+              -- HashJoin[12][INNER ps_suppkey_1=s_suppkey_5] -> ps_availqty_2:INTEGER, ps_supplycost_3:DOUBLE
+                -- TableScan[8][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_suppkey_1:BIGINT, ps_availqty_2:INTEGER, ps_supplycost_3:DOUBLE
+                -- HashJoin[11][INNER s_nationkey_8=n_nationkey_12] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT, n_nationkey_12:BIGINT
+                  -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT
+                  -- TableScan[10][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_12:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q12.plans
+++ b/axiom/optimizer/tests/tpch.plans/q12.plans
@@ -1,0 +1,67 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: l_shipmode, high_line_count, low_line_count
+  output:
+    l_shipmode := t3.l_shipmode
+    high_line_count := dt1.high_line_count
+    low_line_count := dt1.low_line_count
+  tables: t2, t3
+  joins:
+    t2 INNER t3 ON t2.o_orderkey = t3.l_orderkey
+  syntactic join order: 10, 29
+  aggregates: sum(__switch(__or(eq(t2.o_orderpriority, "1-URGENT"), eq(t2.o_orderpriority, "2-HIGH")), 1, 0)) AS high_line_count, sum(__switch(__and(neq(t2.o_orderpriority, "1-URGENT"), neq(t2.o_orderpriority, "2-HIGH")), 1, 0)) AS low_line_count
+  grouping keys: t3.l_shipmode
+  orderBy: t3.l_shipmode ASC NULLS LAST
+
+t2: o_orderkey, o_orderpriority
+  table: orders
+
+t3: l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode
+  table: lineitem
+  single-column filters: __in(t3.l_shipmode, "MAIL", "SHIP") and gte(t3.l_receiptdate, "1994-01-01") and lt(__cast(t3.l_receiptdate), "1995-01-01")
+  multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate) and lt(t3.l_shipdate, t3.l_commitdate)
+
+
+Optimized plan (oneline):
+
+(orders INNER lineitem)
+
+Optimized plan:
+
+Project (redundant) -> dt1.l_shipmode, dt1.high_line_count, dt1.low_line_count
+    dt1.l_shipmode := t3.l_shipmode
+    dt1.high_line_count := dt1.high_line_count
+    dt1.low_line_count := dt1.low_line_count
+  OrderBy -> t3.l_shipmode, dt1.high_line_count, dt1.low_line_count
+    Aggregation (t3.l_shipmode) -> t3.l_shipmode, dt1.high_line_count, dt1.low_line_count
+        dt1.high_line_count := sum(dt1.__p58)
+        dt1.low_line_count := sum(dt1.__p65)
+      Project -> t3.l_shipmode, dt1.__p58, dt1.__p65
+          t3.l_shipmode := t3.l_shipmode
+          dt1.__p58 := __switch(__or(eq(t2.o_orderpriority, "1-URGENT"), eq(t2.o_orderpriority, "2-HIGH")), 1, 0)
+          dt1.__p65 := __switch(__and(neq(t2.o_orderpriority, "1-URGENT"), neq(t2.o_orderpriority, "2-HIGH")), 1, 0)
+        Join INNER Hash -> t2.o_orderpriority, t3.l_shipmode
+            t2.o_orderkey = t3.l_orderkey
+          TableScan -> t2.o_orderkey, t2.o_orderpriority
+            table: orders
+          HashBuild -> t3.l_orderkey, t3.l_shipmode
+            TableScan -> t3.l_orderkey, t3.l_shipmode
+              table: lineitem
+              single-column filters: __in(t3.l_shipmode, "MAIL", "SHIP") and gte(t3.l_receiptdate, "1994-01-01") and lt(__cast(t3.l_receiptdate), "1995-01-01")
+              multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate) and lt(t3.l_shipdate, t3.l_commitdate)
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[5][l_shipmode ASC NULLS LAST] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+  -- Aggregation[4][SINGLE [l_shipmode] high_line_count := sum("dt1.__p58"), low_line_count := sum("dt1.__p65")] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+    -- Project[3][expressions: (l_shipmode:VARCHAR, "l_shipmode"), (dt1.__p58:BIGINT, switch(or(eq("o_orderpriority",1-URGENT),eq("o_orderpriority",2-HIGH)),1,0)), (dt1.__p65:BIGINT, switch(and(neq("o_orderpriority",1-URGENT),neq("o_orderpriority",2-HIGH)),1,0))] -> l_shipmode:VARCHAR, "dt1.__p58":BIGINT, "dt1.__p65":BIGINT
+      -- HashJoin[2][INNER o_orderkey=l_orderkey] -> o_orderpriority:VARCHAR, l_shipmode:VARCHAR
+        -- TableScan[0][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR
+        -- TableScan[1][table: lineitem, range filters: [(l_receiptdate, BigintRange: [8766, 9223372036854775807] no nulls), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (and(lt(cast("l_receiptdate" as DATE),1995-01-01),lt("l_commitdate","l_receiptdate"),lt("l_shipdate","l_commitdate"))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_shipmode:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q13.plans
+++ b/axiom/optimizer/tests/tpch.plans/q13.plans
@@ -1,0 +1,69 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt4: c_count, custdist
+  output:
+    c_count := dt1.c_count
+    custdist := dt4.custdist
+  tables: dt1
+  aggregates: count() AS custdist
+  grouping keys: dt1.c_count
+  orderBy: dt4.custdist DESC NULLS LAST, dt1.c_count DESC NULLS LAST
+
+dt1: c_count
+  output:
+    c_count := dt1.count
+  tables: t2, t3
+  joins:
+    t2 LEFT t3 ON t2.c_custkey = t3.o_custkey FILTER not(like(t3.o_comment, "%special%requests%"))
+  syntactic join order: 9, 20
+  aggregates: count(t3.o_orderkey) AS count
+  grouping keys: t2.c_custkey
+
+t2: c_custkey
+  table: customer
+
+t3: o_orderkey, o_custkey, o_comment
+  table: orders
+
+
+Optimized plan (oneline):
+
+(customer LEFT orders)
+
+Optimized plan:
+
+Project (redundant) -> dt4.c_count, dt4.custdist
+    dt4.c_count := dt1.c_count
+    dt4.custdist := dt4.custdist
+  OrderBy -> dt1.c_count, dt4.custdist
+    Aggregation (dt1.c_count) -> dt1.c_count, dt4.custdist
+        dt4.custdist := count()
+      Project -> dt1.c_count
+          dt1.c_count := dt1.count
+        Aggregation (t2.c_custkey) -> t2.c_custkey, dt1.count
+            dt1.count := count(t3.o_orderkey)
+          Join LEFT Hash -> t2.c_custkey, t3.o_orderkey
+              t2.c_custkey = t3.o_custkey
+              not(like(t3.o_comment, "%special%requests%"))
+            TableScan -> t2.c_custkey
+              table: customer
+            HashBuild -> t3.o_orderkey, t3.o_custkey, t3.o_comment
+              TableScan -> t3.o_orderkey, t3.o_custkey, t3.o_comment
+                table: orders
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[6][custdist DESC NULLS LAST, c_count DESC NULLS LAST] -> c_count:BIGINT, custdist:BIGINT
+  -- Aggregation[5][SINGLE [c_count] custdist := count()] -> c_count:BIGINT, custdist:BIGINT
+    -- Project[4][expressions: (c_count:BIGINT, "count")] -> c_count:BIGINT
+      -- Aggregation[3][SINGLE [c_custkey] count := count("o_orderkey")] -> c_custkey:BIGINT, count:BIGINT
+        -- HashJoin[2][LEFT c_custkey=o_custkey, filter: not(like("o_comment",%special%requests%))] -> c_custkey:BIGINT, o_orderkey:BIGINT
+          -- TableScan[0][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT
+          -- TableScan[1][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_comment:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q14.plans
+++ b/axiom/optimizer/tests/tpch.plans/q14.plans
@@ -1,0 +1,57 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: promo_revenue
+  output:
+    promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_0)
+  tables: t2, t3
+  joins:
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey
+  syntactic join order: 17, 31
+  aggregates: sum(__switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)) AS sum, sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS sum_0
+
+t2: l_partkey, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: gte(t2.l_shipdate, "1995-09-01") and lt(__cast(t2.l_shipdate), "1995-10-01")
+
+t3: p_partkey, p_type
+  table: part
+
+
+Optimized plan (oneline):
+
+(part INNER lineitem)
+
+Optimized plan:
+
+Project -> dt1.promo_revenue
+    dt1.promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_0)
+  Aggregation -> dt1.sum, dt1.sum_0
+      dt1.sum := sum(dt1.__p53)
+      dt1.sum_0 := sum(dt1.__p51)
+    Project -> dt1.__p53, dt1.__p51
+        dt1.__p53 := __switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)
+        dt1.__p51 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+      Join INNER Hash -> t2.l_extendedprice, t2.l_discount, t3.p_type
+          t3.p_partkey = t2.l_partkey
+        TableScan -> t3.p_partkey, t3.p_type
+          table: part
+        HashBuild -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
+          TableScan -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
+            table: lineitem
+            single-column filters: gte(t2.l_shipdate, "1995-09-01") and lt(__cast(t2.l_shipdate), "1995-10-01")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[5][expressions: (promo_revenue:DOUBLE, divide(multiply("sum",100),"sum_0"))] -> promo_revenue:DOUBLE
+  -- Aggregation[4][SINGLE sum := sum("dt1.__p53"), sum_0 := sum("dt1.__p51")] -> sum:DOUBLE, sum_0:DOUBLE
+    -- Project[3][expressions: (dt1.__p53:DOUBLE, switch(like("p_type",PROMO%),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p51:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p53":DOUBLE, "dt1.__p51":DOUBLE
+      -- HashJoin[2][INNER p_partkey=l_partkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, p_type:VARCHAR
+        -- TableScan[0][table: part, data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_type:VARCHAR
+        -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9374, 9223372036854775807] no nulls)], remaining filter: (lt(cast("l_shipdate" as DATE),1995-10-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q15.plans
+++ b/axiom/optimizer/tests/tpch.plans/q15.plans
@@ -1,0 +1,117 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: s_suppkey, s_name, s_address, s_phone, total_revenue
+  output:
+    s_suppkey := t2.s_suppkey
+    s_name := t2.s_name
+    s_address := t2.s_address
+    s_phone := t2.s_phone
+    total_revenue := dt3.total_revenue
+  tables: t2, dt3, dt7
+  joins:
+    t2 INNER dt3 ON t2.s_suppkey = dt3.l_suppkey
+    dt3 INNER dt7 ON dt3.total_revenue = dt7.max
+  syntactic join order: 8, 13, 77
+  orderBy: t2.s_suppkey ASC NULLS LAST
+
+t2: s_suppkey, s_name, s_address, s_phone
+  table: supplier
+
+dt3: l_suppkey, total_revenue
+  output:
+    l_suppkey := t4.l_suppkey
+    total_revenue := dt3.total_revenue
+  tables: t4
+  aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS total_revenue
+  grouping keys: t4.l_suppkey
+
+t4: l_suppkey, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: gte(t4.l_shipdate, "1996-01-01") and lt(__cast(t4.l_shipdate), "1996-04-01")
+
+dt7: max
+  output:
+    max := dt7.max
+  tables: dt5
+  aggregates: max(dt5.total_revenue_19) AS max
+
+dt5: total_revenue_19
+  output:
+    total_revenue_19 := dt5.total_revenue_17
+  tables: t6
+  aggregates: sum(multiply(t6.l_extendedprice, minus(1, t6.l_discount))) AS total_revenue_17
+  grouping keys: t6.l_suppkey
+
+t6: l_suppkey, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: gte(t6.l_shipdate, "1996-01-01") and lt(__cast(t6.l_shipdate), "1996-04-01")
+
+
+Optimized plan (oneline):
+
+((lineitem INNER lineitem) INNER supplier)
+
+Optimized plan:
+
+Project (redundant) -> dt1.s_suppkey, dt1.s_name, dt1.s_address, dt1.s_phone, dt1.total_revenue
+    dt1.s_suppkey := t2.s_suppkey
+    dt1.s_name := t2.s_name
+    dt1.s_address := t2.s_address
+    dt1.s_phone := t2.s_phone
+    dt1.total_revenue := dt3.total_revenue
+  OrderBy -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
+    Join INNER Hash -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
+        dt3.l_suppkey = t2.s_suppkey
+      Join INNER Hash -> dt3.total_revenue, dt3.l_suppkey
+          dt3.total_revenue = dt7.max
+        Project (redundant) -> dt3.l_suppkey, dt3.total_revenue
+            dt3.l_suppkey := t4.l_suppkey
+            dt3.total_revenue := dt3.total_revenue
+          Aggregation (t4.l_suppkey) -> t4.l_suppkey, dt3.total_revenue
+              dt3.total_revenue := sum(dt3.__p49)
+            Project -> t4.l_suppkey, dt3.__p49
+                t4.l_suppkey := t4.l_suppkey
+                dt3.__p49 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+              TableScan -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                table: lineitem
+                single-column filters: gte(t4.l_shipdate, "1996-01-01") and lt(__cast(t4.l_shipdate), "1996-04-01")
+        HashBuild -> dt7.max
+          Project (redundant) -> dt7.max
+              dt7.max := dt7.max
+            Aggregation -> dt7.max
+                dt7.max := max(dt5.total_revenue_19)
+              Project -> dt5.total_revenue_19
+                  dt5.total_revenue_19 := dt5.total_revenue_17
+                Aggregation (t6.l_suppkey) -> t6.l_suppkey, dt5.total_revenue_17
+                    dt5.total_revenue_17 := sum(dt5.__p71)
+                  Project -> t6.l_suppkey, dt5.__p71
+                      t6.l_suppkey := t6.l_suppkey
+                      dt5.__p71 := multiply(t6.l_extendedprice, minus(1, t6.l_discount))
+                    TableScan -> t6.l_suppkey, t6.l_extendedprice, t6.l_discount
+                      table: lineitem
+                      single-column filters: gte(t6.l_shipdate, "1996-01-01") and lt(__cast(t6.l_shipdate), "1996-04-01")
+      HashBuild -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone
+        TableScan -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone
+          table: supplier
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[11][s_suppkey ASC NULLS LAST] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+  -- HashJoin[10][INNER l_suppkey=s_suppkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+    -- HashJoin[8][INNER total_revenue=max] -> total_revenue:DOUBLE, l_suppkey:BIGINT
+      -- Aggregation[2][SINGLE [l_suppkey] total_revenue := sum("dt3.__p49")] -> l_suppkey:BIGINT, total_revenue:DOUBLE
+        -- Project[1][expressions: (l_suppkey:BIGINT, "l_suppkey"), (dt3.__p49:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_suppkey:BIGINT, "dt3.__p49":DOUBLE
+          -- TableScan[0][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9223372036854775807] no nulls)], remaining filter: (lt(cast("l_shipdate" as DATE),1996-04-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+      -- Aggregation[7][SINGLE max := max("total_revenue_19")] -> max:DOUBLE
+        -- Project[6][expressions: (total_revenue_19:DOUBLE, "total_revenue_17")] -> total_revenue_19:DOUBLE
+          -- Aggregation[5][SINGLE [l_suppkey_2] total_revenue_17 := sum("dt5.__p71")] -> l_suppkey_2:BIGINT, total_revenue_17:DOUBLE
+            -- Project[4][expressions: (l_suppkey_2:BIGINT, "l_suppkey_2"), (dt5.__p71:DOUBLE, multiply("l_extendedprice_5",minus(1,"l_discount_6")))] -> l_suppkey_2:BIGINT, "dt5.__p71":DOUBLE
+              -- TableScan[3][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9223372036854775807] no nulls)], remaining filter: (lt(cast("l_shipdate" as DATE),1996-04-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_suppkey_2:BIGINT, l_extendedprice_5:DOUBLE, l_discount_6:DOUBLE
+    -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q16.plans
+++ b/axiom/optimizer/tests/tpch.plans/q16.plans
@@ -1,0 +1,85 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: p_brand, p_type, p_size, supplier_cnt
+  output:
+    p_brand := t3.p_brand
+    p_type := t3.p_type
+    p_size := t3.p_size
+    supplier_cnt := dt1.supplier_cnt
+  tables: t2, t3, dt4
+  joins:
+    t2 SEMI dt4 ON t2.ps_suppkey = dt4.s_suppkey
+    t2 INNER t3 ON t2.ps_partkey = t3.p_partkey
+  syntactic join order: 6, 18, 23
+  aggregates: count(t2.ps_suppkey) AS supplier_cnt
+  grouping keys: t3.p_brand, t3.p_type, t3.p_size
+  filter: not(dt1.__mark0)
+  orderBy: dt1.supplier_cnt DESC NULLS LAST, t3.p_brand ASC NULLS LAST, t3.p_type ASC NULLS LAST, t3.p_size ASC NULLS LAST
+
+t2: ps_partkey, ps_suppkey
+  table: partsupp
+
+t3: p_partkey, p_brand, p_type, p_size
+  table: part
+  single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(__cast(t3.p_size), 49, 14, 23, 45, 19, 3, 36, 9)
+
+dt4: s_suppkey
+  output:
+    s_suppkey := t5.s_suppkey
+  tables: t5
+
+t5: s_suppkey, s_comment
+  table: supplier
+  single-column filters: like(t5.s_comment, "%Customer%Complaints%")
+
+
+Optimized plan (oneline):
+
+((partsupp INNER part) LEFT SEMI (PROJECT) supplier)
+
+Optimized plan:
+
+Project (redundant) -> dt1.p_brand, dt1.p_type, dt1.p_size, dt1.supplier_cnt
+    dt1.p_brand := t3.p_brand
+    dt1.p_type := t3.p_type
+    dt1.p_size := t3.p_size
+    dt1.supplier_cnt := dt1.supplier_cnt
+  OrderBy -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
+    Aggregation (t3.p_brand, t3.p_type, t3.p_size) -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
+        dt1.supplier_cnt := count(t2.ps_suppkey)
+      Filter -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size, dt1.__mark0
+          not(dt1.__mark0)
+        Join LEFT SEMI (PROJECT) Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size, dt1.__mark0
+            t2.ps_suppkey = dt4.s_suppkey
+          Join INNER Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
+              t2.ps_partkey = t3.p_partkey
+            TableScan -> t2.ps_partkey, t2.ps_suppkey
+              table: partsupp
+            HashBuild -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+              TableScan -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+                table: part
+                single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(__cast(t3.p_size), 49, 14, 23, 45, 19, 3, 36, 9)
+          HashBuild -> dt4.s_suppkey
+            Project (redundant) -> dt4.s_suppkey
+                dt4.s_suppkey := t5.s_suppkey
+              TableScan -> t5.s_suppkey
+                table: supplier
+                single-column filters: like(t5.s_comment, "%Customer%Complaints%")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[7][supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+  -- Aggregation[6][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+    -- Filter[0][expression: not("dt1.__mark0")] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, "dt1.__mark0":BOOLEAN
+      -- HashJoin[5][LEFT SEMI (PROJECT) ps_suppkey=s_suppkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, "dt1.__mark0":BOOLEAN
+        -- HashJoin[3][INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+          -- TableScan[1][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
+          -- TableScan[2][table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, null not allowed))], remaining filter: (and(not(like("p_type",MEDIUM POLISHED%)),in(cast("p_size" as BIGINT),{49, 14, 23, 45, 19, ...3 more}))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+        -- TableScan[4][table: supplier, remaining filter: (like("s_comment",%Customer%Complaints%)), data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q17.plans
+++ b/axiom/optimizer/tests/tpch.plans/q17.plans
@@ -1,0 +1,82 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: avg_yearly
+  output:
+    avg_yearly := divide(dt1.sum, 7)
+  tables: t2, t3, dt4
+  joins:
+    t3 LEFT dt4 ON t3.p_partkey = dt4.__gk6
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey
+  syntactic join order: 17, 30, 34
+  aggregates: sum(t2.l_extendedprice) AS sum
+  filter: lt(t2.l_quantity, dt4.expr)
+
+t2: l_partkey, l_quantity, l_extendedprice
+  table: lineitem
+
+t3: p_partkey, p_brand, p_container
+  table: part
+  single-column filters: eq(t3.p_brand, "Brand#23") and eq(t3.p_container, "MED BOX")
+
+dt4: __gk6, expr
+  output:
+    __gk6 := t5.l_partkey
+    expr := multiply(dt4.avg, 0.2)
+  tables: t5
+  aggregates: avg(t5.l_quantity) AS avg
+  grouping keys: t5.l_partkey
+
+t5: l_partkey, l_quantity
+  table: lineitem
+
+
+Optimized plan (oneline):
+
+(lineitem RIGHT (lineitem INNER part))
+
+Optimized plan:
+
+Project -> dt1.avg_yearly
+    dt1.avg_yearly := divide(dt1.sum, 7)
+  Aggregation -> dt1.sum
+      dt1.sum := sum(t2.l_extendedprice)
+    Filter -> t2.l_quantity, t2.l_extendedprice, dt4.expr
+        lt(t2.l_quantity, dt4.expr)
+      Join RIGHT Hash -> t2.l_quantity, t2.l_extendedprice, dt4.expr
+          dt4.__gk6 = t3.p_partkey
+        Project -> dt4.__gk6, dt4.expr
+            dt4.__gk6 := t5.l_partkey
+            dt4.expr := multiply(dt4.avg, 0.2)
+          Aggregation (t5.l_partkey) -> t5.l_partkey, dt4.avg
+              dt4.avg := avg(t5.l_quantity)
+            TableScan -> t5.l_partkey, t5.l_quantity
+              table: lineitem
+        HashBuild -> t2.l_quantity, t2.l_extendedprice, t3.p_partkey
+          Join INNER Hash -> t2.l_quantity, t2.l_extendedprice, t3.p_partkey
+              t2.l_partkey = t3.p_partkey
+            TableScan -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice
+              table: lineitem
+            HashBuild -> t3.p_partkey
+              TableScan -> t3.p_partkey
+                table: part
+                single-column filters: eq(t3.p_brand, "Brand#23") and eq(t3.p_container, "MED BOX")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[9][expressions: (avg_yearly:DOUBLE, divide("sum",7))] -> avg_yearly:DOUBLE
+  -- Aggregation[8][SINGLE sum := sum("l_extendedprice")] -> sum:DOUBLE
+    -- Filter[0][expression: lt("l_quantity","expr")] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+      -- HashJoin[7][RIGHT dt4.__gk6=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+        -- Project[3][expressions: (dt4.__gk6:BIGINT, "l_partkey_1"), (expr:DOUBLE, multiply("avg",0.2))] -> "dt4.__gk6":BIGINT, expr:DOUBLE
+          -- Aggregation[2][SINGLE [l_partkey_1] avg := avg("l_quantity_4")] -> l_partkey_1:BIGINT, avg:DOUBLE
+            -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey_1:BIGINT, l_quantity_4:DOUBLE
+        -- HashJoin[6][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, p_partkey:BIGINT
+          -- TableScan[4][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE
+          -- TableScan[5][table: part, range filters: [(p_brand, Filter(BytesValues, deterministic, null not allowed)), (p_container, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q18.plans
+++ b/axiom/optimizer/tests/tpch.plans/q18.plans
@@ -1,0 +1,107 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum_18
+  output:
+    c_name := t2.c_name
+    c_custkey := t2.c_custkey
+    o_orderkey := t3.o_orderkey
+    o_orderdate := t3.o_orderdate
+    o_totalprice := t3.o_totalprice
+    sum_18 := dt1.sum_18
+  tables: t2, t3, t4, dt5
+  joins:
+    t3 SEMI dt5 ON t3.o_orderkey = dt5.l_orderkey_17
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey
+  syntactic join order: 9, 21, 42, 45
+  aggregates: sum(t4.l_quantity) AS sum_18
+  grouping keys: t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice
+  filter: dt1.__mark0
+  orderBy: t3.o_totalprice DESC NULLS LAST, t3.o_orderdate ASC NULLS LAST
+  limit: 100
+
+t2: c_custkey, c_name
+  table: customer
+
+t3: o_orderkey, o_custkey, o_totalprice, o_orderdate
+  table: orders
+
+t4: l_orderkey, l_quantity
+  table: lineitem
+
+dt5: l_orderkey_17
+  output:
+    l_orderkey_17 := t6.l_orderkey
+  tables: t6
+  aggregates: sum(t6.l_quantity) AS sum
+  grouping keys: t6.l_orderkey
+  having: gt(dt5.sum, 300)
+
+t6: l_orderkey, l_quantity
+  table: lineitem
+
+
+Optimized plan (oneline):
+
+((lineitem INNER (orders INNER customer)) LEFT SEMI (PROJECT) lineitem)
+
+Optimized plan:
+
+Project (redundant) -> dt1.c_name, dt1.c_custkey, dt1.o_orderkey, dt1.o_orderdate, dt1.o_totalprice, dt1.sum_18
+    dt1.c_name := t2.c_name
+    dt1.c_custkey := t2.c_custkey
+    dt1.o_orderkey := t3.o_orderkey
+    dt1.o_orderdate := t3.o_orderdate
+    dt1.o_totalprice := t3.o_totalprice
+    dt1.sum_18 := dt1.sum_18
+  OrderBy -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_18
+    Aggregation (t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice) -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_18
+        dt1.sum_18 := sum(t4.l_quantity)
+      Filter -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity, dt1.__mark0
+          dt1.__mark0
+        Join LEFT SEMI (PROJECT) Hash -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity, dt1.__mark0
+            t3.o_orderkey = dt5.l_orderkey_17
+          Join INNER Hash -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity
+              t4.l_orderkey = t3.o_orderkey
+            TableScan -> t4.l_orderkey, t4.l_quantity
+              table: lineitem
+            HashBuild -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
+              Join INNER Hash -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
+                  t3.o_custkey = t2.c_custkey
+                TableScan -> t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
+                  table: orders
+                HashBuild -> t2.c_custkey, t2.c_name
+                  TableScan -> t2.c_custkey, t2.c_name
+                    table: customer
+          HashBuild -> dt5.l_orderkey_17
+            Project -> dt5.l_orderkey_17
+                dt5.l_orderkey_17 := t6.l_orderkey
+              Filter -> t6.l_orderkey, dt5.sum
+                  gt(dt5.sum, 300)
+                Aggregation (t6.l_orderkey) -> t6.l_orderkey, dt5.sum
+                    dt5.sum := sum(t6.l_quantity)
+                  TableScan -> t6.l_orderkey, t6.l_quantity
+                    table: lineitem
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- TopN[12][100 o_totalprice DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_18:DOUBLE
+  -- Aggregation[11][SINGLE [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] sum_18 := sum("l_quantity")] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_18:DOUBLE
+    -- Filter[0][expression: "dt1.__mark0"] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE, "dt1.__mark0":BOOLEAN
+      -- HashJoin[10][LEFT SEMI (PROJECT) o_orderkey=l_orderkey_17] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE, "dt1.__mark0":BOOLEAN
+        -- HashJoin[5][INNER l_orderkey=o_orderkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
+          -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_quantity:DOUBLE
+          -- HashJoin[4][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE
+            -- TableScan[2][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE
+            -- TableScan[3][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR
+        -- Project[9][expressions: (l_orderkey_17:BIGINT, "l_orderkey_0")] -> l_orderkey_17:BIGINT
+          -- Filter[6][expression: gt("sum",300)] -> l_orderkey_0:BIGINT, sum:DOUBLE
+            -- Aggregation[8][SINGLE [l_orderkey_0] sum := sum("l_quantity_4")] -> l_orderkey_0:BIGINT, sum:DOUBLE
+              -- TableScan[7][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_0:BIGINT, l_quantity_4:DOUBLE
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q19.plans
+++ b/axiom/optimizer/tests/tpch.plans/q19.plans
@@ -1,0 +1,60 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: revenue
+  output:
+    revenue := dt1.revenue
+  tables: t2, t3
+  joins:
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey
+  syntactic join order: 17, 33
+  aggregates: sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS revenue
+  filter: __or(__and(between(__cast(t3.p_size), 1, 15), __and(lte(t2.l_quantity, 30), __and(gte(t2.l_quantity, 20), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))))), __or(__and(between(__cast(t3.p_size), 1, 5), __and(lte(t2.l_quantity, 11), __and(gte(t2.l_quantity, 1), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))))), __and(between(__cast(t3.p_size), 1, 10), __and(lte(t2.l_quantity, 20), __and(gte(t2.l_quantity, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))))
+
+t2: l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode
+  table: lineitem
+  single-column filters: __in(t2.l_shipmode, "AIR", "AIR REG") and eq(t2.l_shipinstruct, "DELIVER IN PERSON") and __or(__and(gte(t2.l_quantity, 20), lte(t2.l_quantity, 30)), __or(__and(gte(t2.l_quantity, 1), lte(t2.l_quantity, 11)), __and(gte(t2.l_quantity, 10), lte(t2.l_quantity, 20))))
+
+t3: p_partkey, p_brand, p_size, p_container
+  table: part
+  multi-column filters: __or(__and(between(__cast(t3.p_size), 1, 15), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))), __or(__and(between(__cast(t3.p_size), 1, 5), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))), __and(between(__cast(t3.p_size), 1, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))
+
+
+Optimized plan (oneline):
+
+(lineitem INNER part)
+
+Optimized plan:
+
+Project (redundant) -> dt1.revenue
+    dt1.revenue := dt1.revenue
+  Aggregation -> dt1.revenue
+      dt1.revenue := sum(dt1.__p121)
+    Project -> dt1.__p121
+        dt1.__p121 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+      Filter -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
+          __or(__and(between(__cast(t3.p_size), 1, 15), __and(lte(t2.l_quantity, 30), __and(gte(t2.l_quantity, 20), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))))), __or(__and(between(__cast(t3.p_size), 1, 5), __and(lte(t2.l_quantity, 11), __and(gte(t2.l_quantity, 1), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))))), __and(between(__cast(t3.p_size), 1, 10), __and(lte(t2.l_quantity, 20), __and(gte(t2.l_quantity, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))))
+        Join INNER Hash -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
+            t2.l_partkey = t3.p_partkey
+          TableScan -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice, t2.l_discount
+            table: lineitem
+            single-column filters: __in(t2.l_shipmode, "AIR", "AIR REG") and eq(t2.l_shipinstruct, "DELIVER IN PERSON") and __or(__and(gte(t2.l_quantity, 20), lte(t2.l_quantity, 30)), __or(__and(gte(t2.l_quantity, 1), lte(t2.l_quantity, 11)), __and(gte(t2.l_quantity, 10), lte(t2.l_quantity, 20))))
+          HashBuild -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
+            TableScan -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
+              table: part
+              multi-column filters: __or(__and(between(__cast(t3.p_size), 1, 15), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))), __or(__and(between(__cast(t3.p_size), 1, 5), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))), __and(between(__cast(t3.p_size), 1, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Aggregation[5][SINGLE revenue := sum("dt1.__p121")] -> revenue:DOUBLE
+  -- Project[4][expressions: (dt1.__p121:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p121":DOUBLE
+    -- Filter[0][expression: or(and(between(cast("p_size" as BIGINT),1,15),and(lte("l_quantity",30),and(gte("l_quantity",20),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))))),or(and(between(cast("p_size" as BIGINT),1,5),and(lte("l_quantity",11),and(gte("l_quantity",1),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))))),and(between(cast("p_size" as BIGINT),1,10),and(lte("l_quantity",20),and(gte("l_quantity",10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))))] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+      -- HashJoin[3][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+        -- TableScan[1][table: lineitem, range filters: [(l_shipinstruct, Filter(BytesValues, deterministic, null not allowed)), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (or(and(gte("l_quantity",20),lte("l_quantity",30)),or(and(gte("l_quantity",1),lte("l_quantity",11)),and(gte("l_quantity",10),lte("l_quantity",20))))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+        -- TableScan[2][table: part, remaining filter: (or(and(between(cast("p_size" as BIGINT),1,15),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between(cast("p_size" as BIGINT),1,5),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between(cast("p_size" as BIGINT),1,10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q2.plans
+++ b/axiom/optimizer/tests/tpch.plans/q2.plans
@@ -1,0 +1,164 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
+  output:
+    s_acctbal := t3.s_acctbal
+    s_name := t3.s_name
+    n_name := t5.n_name
+    p_partkey := t2.p_partkey
+    p_mfgr := t2.p_mfgr
+    s_address := t3.s_address
+    s_phone := t3.s_phone
+    s_comment := t3.s_comment
+  tables: t2, t3, t4, t5, t6, dt7
+  joins:
+    t2 LEFT dt7 ON t2.p_partkey = dt7.__gk12
+    t2 INNER t4 ON t2.p_partkey = t4.ps_partkey
+    t3 INNER t4 ON t3.s_suppkey = t4.ps_suppkey
+    t3 INNER t5 ON t3.s_nationkey = t5.n_nationkey
+    t5 INNER t6 ON t5.n_regionkey = t6.r_regionkey
+    t4 INNER dt7 ON t4.ps_supplycost = dt7.min
+  syntactic join order: 10, 22, 35, 43, 50, 53
+  orderBy: t3.s_acctbal DESC NULLS LAST, t5.n_name ASC NULLS LAST, t3.s_name ASC NULLS LAST, t2.p_partkey ASC NULLS LAST
+  limit: 100
+
+t2: p_partkey, p_mfgr, p_type, p_size
+  table: part
+  single-column filters: eq(__cast(t2.p_size), 15) and like(t2.p_type, "%BRASS")
+
+t3: s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment
+  table: supplier
+
+t4: ps_partkey, ps_suppkey, ps_supplycost
+  table: partsupp
+
+t5: n_nationkey, n_name, n_regionkey
+  table: nation
+
+t6: r_regionkey, r_name
+  table: region
+  single-column filters: eq(t6.r_name, "EUROPE")
+
+dt7: __gk12, min
+  output:
+    __gk12 := t8.ps_partkey
+    min := dt7.min
+  tables: t8, t9, t10, t11
+  joins:
+    t8 INNER t9 ON t8.ps_suppkey = t9.s_suppkey
+    t9 INNER t10 ON t9.s_nationkey = t10.n_nationkey
+    t10 INNER t11 ON t10.n_regionkey = t11.r_regionkey
+  syntactic join order: 54, 58, 61, 64
+  aggregates: min(t8.ps_supplycost) AS min
+  grouping keys: t8.ps_partkey
+
+t8: ps_partkey, ps_suppkey, ps_supplycost
+  table: partsupp
+
+t9: s_suppkey, s_nationkey
+  table: supplier
+
+t10: n_nationkey, n_regionkey
+  table: nation
+
+t11: r_regionkey, r_name
+  table: region
+  single-column filters: eq(t11.r_name, "EUROPE")
+
+
+Optimized plan (oneline):
+
+((partsupp INNER (supplier INNER (nation INNER region))) RIGHT ((partsupp INNER part) INNER (supplier INNER (nation INNER region))))
+
+Optimized plan:
+
+Project -> dt1.s_acctbal, dt1.s_name, dt1.n_name, dt1.p_partkey, dt1.p_mfgr, dt1.s_address, dt1.s_phone, dt1.s_comment
+    dt1.s_acctbal := t3.s_acctbal
+    dt1.s_name := t3.s_name
+    dt1.n_name := t5.n_name
+    dt1.p_partkey := t2.p_partkey
+    dt1.p_mfgr := t2.p_mfgr
+    dt1.s_address := t3.s_address
+    dt1.s_phone := t3.s_phone
+    dt1.s_comment := t3.s_comment
+  OrderBy -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+    Join RIGHT Hash -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+        dt7.__gk12 = t2.p_partkey
+      Project -> dt7.__gk12
+          dt7.__gk12 := t8.ps_partkey
+        Aggregation (t8.ps_partkey) -> t8.ps_partkey, dt7.min
+            dt7.min := min(t8.ps_supplycost)
+          Join INNER Hash -> t8.ps_partkey, t8.ps_supplycost
+              t8.ps_suppkey = t9.s_suppkey
+            TableScan -> t8.ps_partkey, t8.ps_suppkey, t8.ps_supplycost
+              table: partsupp
+            HashBuild -> t9.s_suppkey, t9.s_nationkey, t10.n_nationkey, t10.n_regionkey, t11.r_regionkey
+              Join INNER Hash -> t9.s_suppkey, t9.s_nationkey, t10.n_nationkey, t10.n_regionkey, t11.r_regionkey
+                  t9.s_nationkey = t10.n_nationkey
+                TableScan -> t9.s_suppkey, t9.s_nationkey
+                  table: supplier
+                HashBuild -> t10.n_nationkey, t10.n_regionkey, t11.r_regionkey
+                  Join INNER Hash -> t10.n_nationkey, t10.n_regionkey, t11.r_regionkey
+                      t10.n_regionkey = t11.r_regionkey
+                    TableScan -> t10.n_nationkey, t10.n_regionkey
+                      table: nation
+                    HashBuild -> t11.r_regionkey
+                      TableScan -> t11.r_regionkey
+                        table: region
+                        single-column filters: eq(t11.r_name, "EUROPE")
+      HashBuild -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t4.ps_supplycost, t5.n_name
+        Join INNER Hash -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t4.ps_supplycost, t5.n_name
+            t4.ps_suppkey = t3.s_suppkey
+          Join INNER Hash -> t2.p_partkey, t2.p_mfgr, t4.ps_suppkey, t4.ps_supplycost
+              t4.ps_partkey = t2.p_partkey
+            TableScan -> t4.ps_partkey, t4.ps_suppkey, t4.ps_supplycost
+              table: partsupp
+            HashBuild -> t2.p_partkey, t2.p_mfgr
+              TableScan -> t2.p_partkey, t2.p_mfgr
+                table: part
+                single-column filters: eq(__cast(t2.p_size), 15) and like(t2.p_type, "%BRASS")
+          HashBuild -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_nationkey, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_nationkey, t5.n_name, t5.n_regionkey, t6.r_regionkey
+            Join INNER Hash -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_nationkey, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_nationkey, t5.n_name, t5.n_regionkey, t6.r_regionkey
+                t3.s_nationkey = t5.n_nationkey
+              TableScan -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_nationkey, t3.s_phone, t3.s_acctbal, t3.s_comment
+                table: supplier
+              HashBuild -> t5.n_nationkey, t5.n_name, t5.n_regionkey, t6.r_regionkey
+                Join INNER Hash -> t5.n_nationkey, t5.n_name, t5.n_regionkey, t6.r_regionkey
+                    t5.n_regionkey = t6.r_regionkey
+                  TableScan -> t5.n_nationkey, t5.n_name, t5.n_regionkey
+                    table: nation
+                  HashBuild -> t6.r_regionkey
+                    TableScan -> t6.r_regionkey
+                      table: region
+                      single-column filters: eq(t6.r_name, "EUROPE")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[38][expressions: (s_acctbal:DOUBLE, "s_acctbal"), (s_name:VARCHAR, "s_name"), (n_name:VARCHAR, "n_name"), (p_partkey:BIGINT, "p_partkey"), (p_mfgr:VARCHAR, "p_mfgr"), (s_address:VARCHAR, "s_address"), (s_phone:VARCHAR, "s_phone"), (s_comment:VARCHAR, "s_comment")] -> s_acctbal:DOUBLE, s_name:VARCHAR, n_name:VARCHAR, p_partkey:BIGINT, p_mfgr:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_comment:VARCHAR
+  -- TopN[37][100 s_acctbal DESC NULLS LAST, n_name ASC NULLS LAST, s_name ASC NULLS LAST, p_partkey ASC NULLS LAST] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+    -- HashJoin[36][RIGHT dt7.__gk12=p_partkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+      -- Project[26][expressions: (dt7.__gk12:BIGINT, "ps_partkey_0")] -> "dt7.__gk12":BIGINT
+        -- Aggregation[25][SINGLE [ps_partkey_0] min := min("ps_supplycost_3")] -> ps_partkey_0:BIGINT, min:DOUBLE
+          -- HashJoin[24][INNER ps_suppkey_1=s_suppkey_5] -> ps_partkey_0:BIGINT, ps_supplycost_3:DOUBLE
+            -- TableScan[18][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey_0:BIGINT, ps_suppkey_1:BIGINT, ps_supplycost_3:DOUBLE
+            -- HashJoin[23][INNER s_nationkey_8=n_nationkey_12] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT, n_nationkey_12:BIGINT, n_regionkey_14:BIGINT, r_regionkey_16:BIGINT
+              -- TableScan[19][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT
+              -- HashJoin[22][INNER n_regionkey_14=r_regionkey_16] -> n_nationkey_12:BIGINT, n_regionkey_14:BIGINT, r_regionkey_16:BIGINT
+                -- TableScan[20][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_12:BIGINT, n_regionkey_14:BIGINT
+                -- TableScan[21][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey_16:BIGINT
+      -- HashJoin[35][INNER ps_suppkey=s_suppkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, ps_supplycost:DOUBLE, n_name:VARCHAR
+        -- HashJoin[29][INNER ps_partkey=p_partkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+          -- TableScan[27][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+          -- TableScan[28][table: part, remaining filter: (and(eq(cast("p_size" as BIGINT),15),like("p_type",%BRASS))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_mfgr:VARCHAR
+        -- HashJoin[34][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+          -- TableScan[30][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR
+          -- HashJoin[33][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+            -- TableScan[31][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+            -- TableScan[32][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q20.plans
+++ b/axiom/optimizer/tests/tpch.plans/q20.plans
@@ -1,0 +1,136 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: s_name, s_address
+  output:
+    s_name := t2.s_name
+    s_address := t2.s_address
+  tables: t2, t3, dt4
+  joins:
+    t2 SEMI dt4 ON t2.s_suppkey = dt4.ps_suppkey
+    t2 INNER t3 ON t2.s_nationkey = t3.n_nationkey
+  syntactic join order: 8, 17, 20
+  filter: dt1.__mark1
+  orderBy: t2.s_name ASC NULLS LAST
+
+t2: s_suppkey, s_name, s_address, s_nationkey
+  table: supplier
+
+t3: n_nationkey, n_name
+  table: nation
+  single-column filters: eq(t3.n_name, "CANADA")
+
+dt4: ps_suppkey
+  output:
+    ps_suppkey := t5.ps_suppkey
+  tables: t5, dt6, dt10
+  joins:
+    t5 LEFT dt6 ON t5.ps_partkey = dt6.__gk8 AND t5.ps_suppkey = dt6.__gk9
+    t5 SEMI dt10 ON t5.ps_partkey = dt10.p_partkey
+  syntactic join order: 26, 30, 77
+  filter: dt4.__mark0 and lt(dt6.expr, __cast(t5.ps_availqty))
+
+t5: ps_partkey, ps_suppkey, ps_availqty
+  table: partsupp
+
+dt6: __gk8, __gk9, expr
+  output:
+    __gk8 := t7.l_partkey
+    __gk9 := t7.l_suppkey
+    expr := multiply(dt6.sum, 0.5)
+  tables: t7
+  aggregates: sum(t7.l_quantity) AS sum
+  grouping keys: t7.l_partkey, t7.l_suppkey
+
+t7: l_partkey, l_suppkey, l_quantity, l_shipdate
+  table: lineitem
+  single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(__cast(t7.l_shipdate), "1995-01-01")
+
+dt10: p_partkey
+  output:
+    p_partkey := t11.p_partkey
+  tables: t11
+
+t11: p_partkey, p_name
+  table: part
+  single-column filters: like(t11.p_name, "forest%")
+
+
+Optimized plan (oneline):
+
+(((partsupp LEFT SEMI (PROJECT) part) LEFT lineitem) RIGHT SEMI (PROJECT) (supplier INNER nation))
+
+Optimized plan:
+
+Project -> dt1.s_name, dt1.s_address
+    dt1.s_name := t2.s_name
+    dt1.s_address := t2.s_address
+  OrderBy -> t2.s_name, t2.s_address, dt1.__mark1
+    Filter -> t2.s_name, t2.s_address, dt1.__mark1
+        dt1.__mark1
+      Join RIGHT SEMI (PROJECT) Hash -> t2.s_name, t2.s_address, dt1.__mark1
+          dt4.ps_suppkey = t2.s_suppkey
+        Project -> dt4.ps_suppkey
+            dt4.ps_suppkey := t5.ps_suppkey
+          Filter -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
+              lt(dt6.expr, __cast(t5.ps_availqty))
+            Join LEFT Hash -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
+                t5.ps_partkey = dt6.__gk8
+                t5.ps_suppkey = dt6.__gk9
+              Filter -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty, dt4.__mark0
+                  dt4.__mark0
+                Join LEFT SEMI (PROJECT) Hash -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty, dt4.__mark0
+                    t5.ps_partkey = dt10.p_partkey
+                  TableScan -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                    table: partsupp
+                  HashBuild -> dt10.p_partkey
+                    Project (redundant) -> dt10.p_partkey
+                        dt10.p_partkey := t11.p_partkey
+                      TableScan -> t11.p_partkey
+                        table: part
+                        single-column filters: like(t11.p_name, "forest%")
+              HashBuild -> dt6.__gk8, dt6.__gk9, dt6.expr
+                Project -> dt6.__gk8, dt6.__gk9, dt6.expr
+                    dt6.__gk8 := t7.l_partkey
+                    dt6.__gk9 := t7.l_suppkey
+                    dt6.expr := multiply(dt6.sum, 0.5)
+                  Aggregation (t7.l_partkey, t7.l_suppkey) -> t7.l_partkey, t7.l_suppkey, dt6.sum
+                      dt6.sum := sum(t7.l_quantity)
+                    TableScan -> t7.l_partkey, t7.l_suppkey, t7.l_quantity
+                      table: lineitem
+                      single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(__cast(t7.l_shipdate), "1995-01-01")
+        HashBuild -> t2.s_suppkey, t2.s_name, t2.s_address
+          Join INNER Hash -> t2.s_suppkey, t2.s_name, t2.s_address
+              t2.s_nationkey = t3.n_nationkey
+            TableScan -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_nationkey
+              table: supplier
+            HashBuild -> t3.n_nationkey
+              TableScan -> t3.n_nationkey
+                table: nation
+                single-column filters: eq(t3.n_name, "CANADA")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[16][expressions: (s_name:VARCHAR, "s_name"), (s_address:VARCHAR, "s_address")] -> s_name:VARCHAR, s_address:VARCHAR
+  -- OrderBy[15][s_name ASC NULLS LAST] -> s_name:VARCHAR, s_address:VARCHAR, "dt1.__mark1":BOOLEAN
+    -- Filter[0][expression: "dt1.__mark1"] -> s_name:VARCHAR, s_address:VARCHAR, "dt1.__mark1":BOOLEAN
+      -- HashJoin[14][RIGHT SEMI (PROJECT) ps_suppkey=s_suppkey] -> s_name:VARCHAR, s_address:VARCHAR, "dt1.__mark1":BOOLEAN
+        -- Project[10][expressions: (ps_suppkey:BIGINT, "ps_suppkey")] -> ps_suppkey:BIGINT
+          -- Filter[1][expression: lt("expr",cast("ps_availqty" as DOUBLE))] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+            -- HashJoin[9][LEFT ps_partkey=dt6.__gk8 AND ps_suppkey=dt6.__gk9] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+              -- Filter[2][expression: "dt4.__mark0"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER, "dt4.__mark0":BOOLEAN
+                -- HashJoin[5][LEFT SEMI (PROJECT) ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER, "dt4.__mark0":BOOLEAN
+                  -- TableScan[3][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+                  -- TableScan[4][table: part, remaining filter: (like("p_name",forest%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT
+              -- Project[8][expressions: (dt6.__gk8:BIGINT, "l_partkey"), (dt6.__gk9:BIGINT, "l_suppkey"), (expr:DOUBLE, multiply("sum",0.5))] -> "dt6.__gk8":BIGINT, "dt6.__gk9":BIGINT, expr:DOUBLE
+                -- Aggregation[7][SINGLE [l_partkey, l_suppkey] sum := sum("l_quantity")] -> l_partkey:BIGINT, l_suppkey:BIGINT, sum:DOUBLE
+                  -- TableScan[6][table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast("l_shipdate" as DATE),1995-01-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE
+        -- HashJoin[13][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR
+          -- TableScan[11][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT
+          -- TableScan[12][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q21.plans
+++ b/axiom/optimizer/tests/tpch.plans/q21.plans
@@ -1,0 +1,163 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: s_name, numwait
+  output:
+    s_name := t2.s_name
+    numwait := dt1.numwait
+  tables: t2, t3, t4, t5, dt6, dt8
+  joins:
+    t3 SEMI dt6 ON t3.l_orderkey = dt6.l_orderkey_0 FILTER neq(dt6.l_suppkey_2, t3.l_suppkey)
+    t3 SEMI dt8 ON t3.l_orderkey = dt8.l_orderkey_16 FILTER neq(dt8.l_suppkey_18, t3.l_suppkey)
+    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey
+    t3 INNER t4 ON t3.l_orderkey = t4.o_orderkey
+    t2 INNER t5 ON t2.s_nationkey = t5.n_nationkey
+  syntactic join order: 8, 28, 42, 49, 52, 91
+  aggregates: count() AS numwait
+  grouping keys: t2.s_name
+  filter: dt1.__mark0 and not(dt1.__mark1)
+  orderBy: dt1.numwait DESC NULLS LAST, t2.s_name ASC NULLS LAST
+  limit: 100
+
+t2: s_suppkey, s_name, s_nationkey
+  table: supplier
+
+t3: l_orderkey, l_suppkey, l_commitdate, l_receiptdate
+  table: lineitem
+  multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate)
+
+t4: o_orderkey, o_orderstatus
+  table: orders
+  single-column filters: eq(t4.o_orderstatus, "F")
+
+t5: n_nationkey, n_name
+  table: nation
+  single-column filters: eq(t5.n_name, "SAUDI ARABIA")
+
+dt6: l_orderkey_0, l_partkey_1, l_suppkey_2, l_linenumber_3, l_quantity_4, l_extendedprice_5, l_discount_6, l_tax_7, l_returnflag_8, l_linestatus_9, l_shipdate_10, l_commitdate_11, l_receiptdate_12, l_shipinstruct_13, l_shipmode_14, l_comment_15
+  output:
+    l_orderkey_0 := t7.l_orderkey
+    l_partkey_1 := t7.l_partkey
+    l_suppkey_2 := t7.l_suppkey
+    l_linenumber_3 := t7.l_linenumber
+    l_quantity_4 := t7.l_quantity
+    l_extendedprice_5 := t7.l_extendedprice
+    l_discount_6 := t7.l_discount
+    l_tax_7 := t7.l_tax
+    l_returnflag_8 := t7.l_returnflag
+    l_linestatus_9 := t7.l_linestatus
+    l_shipdate_10 := t7.l_shipdate
+    l_commitdate_11 := t7.l_commitdate
+    l_receiptdate_12 := t7.l_receiptdate
+    l_shipinstruct_13 := t7.l_shipinstruct
+    l_shipmode_14 := t7.l_shipmode
+    l_comment_15 := t7.l_comment
+  tables: t7
+
+t7: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  table: lineitem
+
+dt8: l_orderkey_16, l_partkey_17, l_suppkey_18, l_linenumber_19, l_quantity_20, l_extendedprice_21, l_discount_22, l_tax_23, l_returnflag_24, l_linestatus_25, l_shipdate_26, l_commitdate_27, l_receiptdate_28, l_shipinstruct_29, l_shipmode_30, l_comment_31
+  output:
+    l_orderkey_16 := t9.l_orderkey
+    l_partkey_17 := t9.l_partkey
+    l_suppkey_18 := t9.l_suppkey
+    l_linenumber_19 := t9.l_linenumber
+    l_quantity_20 := t9.l_quantity
+    l_extendedprice_21 := t9.l_extendedprice
+    l_discount_22 := t9.l_discount
+    l_tax_23 := t9.l_tax
+    l_returnflag_24 := t9.l_returnflag
+    l_linestatus_25 := t9.l_linestatus
+    l_shipdate_26 := t9.l_shipdate
+    l_commitdate_27 := t9.l_commitdate
+    l_receiptdate_28 := t9.l_receiptdate
+    l_shipinstruct_29 := t9.l_shipinstruct
+    l_shipmode_30 := t9.l_shipmode
+    l_comment_31 := t9.l_comment
+  tables: t9
+
+t9: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  table: lineitem
+  multi-column filters: lt(t9.l_commitdate, t9.l_receiptdate)
+
+
+Optimized plan (oneline):
+
+(lineitem RIGHT SEMI (PROJECT) (((lineitem INNER (supplier INNER nation)) INNER orders) LEFT SEMI (PROJECT) lineitem))
+
+Optimized plan:
+
+Project (redundant) -> dt1.s_name, dt1.numwait
+    dt1.s_name := t2.s_name
+    dt1.numwait := dt1.numwait
+  OrderBy -> t2.s_name, dt1.numwait
+    Aggregation (t2.s_name) -> t2.s_name, dt1.numwait
+        dt1.numwait := count()
+      Filter -> t2.s_name, dt1.__mark0
+          dt1.__mark0
+        Join RIGHT SEMI (PROJECT) Hash -> t2.s_name, dt1.__mark0
+            dt6.l_orderkey_0 = t3.l_orderkey
+            neq(dt6.l_suppkey_2, t3.l_suppkey)
+          Project (redundant) -> dt6.l_orderkey_0, dt6.l_suppkey_2
+              dt6.l_orderkey_0 := t7.l_orderkey
+              dt6.l_suppkey_2 := t7.l_suppkey
+            TableScan -> t7.l_orderkey, t7.l_suppkey
+              table: lineitem
+          HashBuild -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark1
+            Filter -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark1
+                not(dt1.__mark1)
+              Join LEFT SEMI (PROJECT) Hash -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark1
+                  t3.l_orderkey = dt8.l_orderkey_16
+                  neq(dt8.l_suppkey_18, t3.l_suppkey)
+                Join INNER Hash -> t2.s_name, t3.l_orderkey, t3.l_suppkey
+                    t3.l_orderkey = t4.o_orderkey
+                  Join INNER Hash -> t2.s_name, t3.l_orderkey, t3.l_suppkey
+                      t3.l_suppkey = t2.s_suppkey
+                    TableScan -> t3.l_orderkey, t3.l_suppkey
+                      table: lineitem
+                      multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate)
+                    HashBuild -> t2.s_suppkey, t2.s_name, t2.s_nationkey, t5.n_nationkey
+                      Join INNER Hash -> t2.s_suppkey, t2.s_name, t2.s_nationkey, t5.n_nationkey
+                          t2.s_nationkey = t5.n_nationkey
+                        TableScan -> t2.s_suppkey, t2.s_name, t2.s_nationkey
+                          table: supplier
+                        HashBuild -> t5.n_nationkey
+                          TableScan -> t5.n_nationkey
+                            table: nation
+                            single-column filters: eq(t5.n_name, "SAUDI ARABIA")
+                  HashBuild -> t4.o_orderkey
+                    TableScan -> t4.o_orderkey
+                      table: orders
+                      single-column filters: eq(t4.o_orderstatus, "F")
+                HashBuild -> dt8.l_orderkey_16, dt8.l_suppkey_18
+                  Project (redundant) -> dt8.l_orderkey_16, dt8.l_suppkey_18
+                      dt8.l_orderkey_16 := t9.l_orderkey
+                      dt8.l_suppkey_18 := t9.l_suppkey
+                    TableScan -> t9.l_orderkey, t9.l_suppkey
+                      table: lineitem
+                      multi-column filters: lt(t9.l_commitdate, t9.l_receiptdate)
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- TopN[14][100 numwait DESC NULLS LAST, s_name ASC NULLS LAST] -> s_name:VARCHAR, numwait:BIGINT
+  -- Aggregation[13][SINGLE [s_name] numwait := count()] -> s_name:VARCHAR, numwait:BIGINT
+    -- Filter[0][expression: "dt1.__mark0"] -> s_name:VARCHAR, "dt1.__mark0":BOOLEAN
+      -- HashJoin[12][RIGHT SEMI (PROJECT) l_orderkey_0=l_orderkey, filter: neq("l_suppkey_2","l_suppkey")] -> s_name:VARCHAR, "dt1.__mark0":BOOLEAN
+        -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_0:BIGINT, l_suppkey_2:BIGINT
+        -- Filter[2][expression: not("dt1.__mark1")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark1":BOOLEAN
+          -- HashJoin[11][LEFT SEMI (PROJECT) l_orderkey=l_orderkey_16, filter: neq("l_suppkey_18","l_suppkey")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark1":BOOLEAN
+            -- HashJoin[9][INNER l_orderkey=o_orderkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+              -- HashJoin[7][INNER l_suppkey=s_suppkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+                -- TableScan[3][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_suppkey:BIGINT
+                -- HashJoin[6][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_nationkey:BIGINT, n_nationkey:BIGINT
+                  -- TableScan[4][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_nationkey:BIGINT
+                  -- TableScan[5][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT
+              -- TableScan[8][table: orders, range filters: [(o_orderstatus, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT
+            -- TableScan[10][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_16:BIGINT, l_suppkey_18:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q22.plans
+++ b/axiom/optimizer/tests/tpch.plans/q22.plans
@@ -1,0 +1,107 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: cntrycode, numcust, totacctbal
+  output:
+    cntrycode := dt1.cntrycode
+    numcust := dt1.numcust
+    totacctbal := dt1.totacctbal
+  tables: t2, dt3, dt5
+  joins:
+    t2 SEMI dt5 ON t2.c_custkey = dt5.o_custkey
+  syntactic join order: 9, 13, 35
+  aggregates: count() AS numcust, sum(t2.c_acctbal) AS totacctbal
+  grouping keys: substr(t2.c_phone, 1, 2)
+  filter: gt(t2.c_acctbal, dt3.avg) and not(dt1.__mark0)
+  orderBy: dt1.cntrycode ASC NULLS LAST
+
+t2: c_custkey, c_phone, c_acctbal
+  table: customer
+  single-column filters: __in(substr(t2.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
+
+dt3: avg
+  output:
+    avg := dt3.avg
+  tables: t4
+  aggregates: avg(t4.c_acctbal) AS avg
+
+t4: c_phone, c_acctbal
+  table: customer
+  single-column filters: gt(t4.c_acctbal, 0) and __in(substr(t4.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
+
+dt5: o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
+  output:
+    o_orderkey := t6.o_orderkey
+    o_custkey := t6.o_custkey
+    o_orderstatus := t6.o_orderstatus
+    o_totalprice := t6.o_totalprice
+    o_orderdate := t6.o_orderdate
+    o_orderpriority := t6.o_orderpriority
+    o_clerk := t6.o_clerk
+    o_shippriority := t6.o_shippriority
+    o_comment := t6.o_comment
+  tables: t6
+
+t6: o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
+  table: orders
+
+
+Optimized plan (oneline):
+
+((customer INNER customer) LEFT SEMI (PROJECT) orders)
+
+Optimized plan:
+
+Project (redundant) -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
+    dt1.cntrycode := dt1.cntrycode
+    dt1.numcust := dt1.numcust
+    dt1.totacctbal := dt1.totacctbal
+  OrderBy -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
+    Aggregation (dt1.__p67) -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
+        dt1.numcust := count()
+        dt1.totacctbal := sum(t2.c_acctbal)
+      Project -> dt1.__p67, t2.c_acctbal
+          dt1.__p67 := substr(t2.c_phone, 1, 2)
+          t2.c_acctbal := t2.c_acctbal
+        Filter -> t2.c_phone, t2.c_acctbal, dt1.__mark0
+            not(dt1.__mark0)
+          Join LEFT SEMI (PROJECT) Hash -> t2.c_phone, t2.c_acctbal, dt1.__mark0
+              t2.c_custkey = dt5.o_custkey
+            Filter -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
+                gt(t2.c_acctbal, dt3.avg)
+              Join INNER Cross -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
+                TableScan -> t2.c_custkey, t2.c_phone, t2.c_acctbal
+                  table: customer
+                  single-column filters: __in(substr(t2.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
+                Project (redundant) -> dt3.avg
+                    dt3.avg := dt3.avg
+                  Aggregation -> dt3.avg
+                      dt3.avg := avg(t4.c_acctbal)
+                    TableScan -> t4.c_acctbal
+                      table: customer
+                      single-column filters: gt(t4.c_acctbal, 0) and __in(substr(t4.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
+            HashBuild -> dt5.o_custkey
+              Project (redundant) -> dt5.o_custkey
+                  dt5.o_custkey := t6.o_custkey
+                TableScan -> t6.o_custkey
+                  table: orders
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[10][cntrycode ASC NULLS LAST] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+  -- Aggregation[9][SINGLE [cntrycode] numcust := count(), totacctbal := sum("c_acctbal")] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+    -- Project[8][expressions: (cntrycode:VARCHAR, substr("c_phone",1,2)), (c_acctbal:DOUBLE, "c_acctbal")] -> cntrycode:VARCHAR, c_acctbal:DOUBLE
+      -- Filter[0][expression: not("dt1.__mark0")] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark0":BOOLEAN
+        -- HashJoin[7][LEFT SEMI (PROJECT) c_custkey=o_custkey] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark0":BOOLEAN
+          -- Filter[1][expression: gt("c_acctbal","avg")] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+            -- NestedLoopJoin[5][INNER] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+              -- TableScan[2][table: customer, remaining filter: (in(substr("c_phone",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE
+              -- Aggregation[4][SINGLE avg := avg("c_acctbal_5")] -> avg:DOUBLE
+                -- TableScan[3][table: customer, range filters: [(c_acctbal, DoubleRange: (0.000000, nan] no nulls)], remaining filter: (in(substr("c_phone",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_acctbal_5:DOUBLE
+          -- TableScan[6][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_custkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q3.plans
+++ b/axiom/optimizer/tests/tpch.plans/q3.plans
@@ -1,0 +1,84 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: l_orderkey, revenue, o_orderdate, o_shippriority
+  output:
+    l_orderkey := t4.l_orderkey
+    revenue := dt1.revenue
+    o_orderdate := t3.o_orderdate
+    o_shippriority := t3.o_shippriority
+  tables: t2, t3, t4
+  joins:
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey
+  syntactic join order: 9, 21, 42
+  aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
+  grouping keys: t4.l_orderkey, t3.o_orderdate, t3.o_shippriority
+  orderBy: dt1.revenue DESC NULLS LAST, t3.o_orderdate ASC NULLS LAST
+  limit: 10
+
+t2: c_custkey, c_mktsegment
+  table: customer
+  single-column filters: eq(t2.c_mktsegment, "BUILDING")
+
+t3: o_orderkey, o_custkey, o_orderdate, o_shippriority
+  table: orders
+  single-column filters: lt(t3.o_orderdate, "1995-03-15")
+
+t4: l_orderkey, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: gt(t4.l_shipdate, "1995-03-15")
+
+
+Optimized plan (oneline):
+
+(lineitem INNER (orders INNER customer))
+
+Optimized plan:
+
+Project -> dt1.l_orderkey, dt1.revenue, dt1.o_orderdate, dt1.o_shippriority
+    dt1.l_orderkey := t4.l_orderkey
+    dt1.revenue := dt1.revenue
+    dt1.o_orderdate := t3.o_orderdate
+    dt1.o_shippriority := t3.o_shippriority
+  OrderBy -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.revenue
+    Aggregation (t4.l_orderkey, t3.o_orderdate, t3.o_shippriority) -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.revenue
+        dt1.revenue := sum(dt1.__p61)
+      Project -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.__p61
+          t4.l_orderkey := t4.l_orderkey
+          t3.o_orderdate := t3.o_orderdate
+          t3.o_shippriority := t3.o_shippriority
+          dt1.__p61 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash -> t3.o_orderdate, t3.o_shippriority, t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+            t4.l_orderkey = t3.o_orderkey
+          TableScan -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+            table: lineitem
+            single-column filters: gt(t4.l_shipdate, "1995-03-15")
+          HashBuild -> t2.c_custkey, t3.o_orderkey, t3.o_custkey, t3.o_orderdate, t3.o_shippriority
+            Join INNER Hash -> t2.c_custkey, t3.o_orderkey, t3.o_custkey, t3.o_orderdate, t3.o_shippriority
+                t3.o_custkey = t2.c_custkey
+              TableScan -> t3.o_orderkey, t3.o_custkey, t3.o_orderdate, t3.o_shippriority
+                table: orders
+                single-column filters: lt(t3.o_orderdate, "1995-03-15")
+              HashBuild -> t2.c_custkey
+                TableScan -> t2.c_custkey
+                  table: customer
+                  single-column filters: eq(t2.c_mktsegment, "BUILDING")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[20][expressions: (l_orderkey:BIGINT, "l_orderkey"), (revenue:DOUBLE, "revenue"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority")] -> l_orderkey:BIGINT, revenue:DOUBLE, o_orderdate:DATE, o_shippriority:INTEGER
+  -- TopN[19][10 revenue DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+    -- Aggregation[18][SINGLE [l_orderkey, o_orderdate, o_shippriority] revenue := sum("dt1.__p61")] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+      -- Project[17][expressions: (l_orderkey:BIGINT, "l_orderkey"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority"), (dt1.__p61:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, "dt1.__p61":DOUBLE
+        -- HashJoin[16][INNER l_orderkey=o_orderkey] -> o_orderdate:DATE, o_shippriority:INTEGER, l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- TableScan[12][table: lineitem, range filters: [(l_shipdate, BigintRange: [9205, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- HashJoin[15][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+            -- TableScan[13][table: orders, range filters: [(o_orderdate, BigintRange: [-9223372036854775808, 9203] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+            -- TableScan[14][table: customer, range filters: [(c_mktsegment, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q4.plans
+++ b/axiom/optimizer/tests/tpch.plans/q4.plans
@@ -1,0 +1,85 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: o_orderpriority, order_count
+  output:
+    o_orderpriority := t2.o_orderpriority
+    order_count := dt1.order_count
+  tables: t2, dt3
+  joins:
+    t2 SEMI dt3 ON t2.o_orderkey = dt3.l_orderkey
+  syntactic join order: 10, 14
+  aggregates: count() AS order_count
+  grouping keys: t2.o_orderpriority
+  filter: dt1.__mark0
+  orderBy: t2.o_orderpriority ASC NULLS LAST
+
+t2: o_orderkey, o_orderdate, o_orderpriority
+  table: orders
+  single-column filters: gte(t2.o_orderdate, "1993-07-01") and lt(__cast(t2.o_orderdate), "1993-10-01")
+
+dt3: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  output:
+    l_orderkey := t4.l_orderkey
+    l_partkey := t4.l_partkey
+    l_suppkey := t4.l_suppkey
+    l_linenumber := t4.l_linenumber
+    l_quantity := t4.l_quantity
+    l_extendedprice := t4.l_extendedprice
+    l_discount := t4.l_discount
+    l_tax := t4.l_tax
+    l_returnflag := t4.l_returnflag
+    l_linestatus := t4.l_linestatus
+    l_shipdate := t4.l_shipdate
+    l_commitdate := t4.l_commitdate
+    l_receiptdate := t4.l_receiptdate
+    l_shipinstruct := t4.l_shipinstruct
+    l_shipmode := t4.l_shipmode
+    l_comment := t4.l_comment
+  tables: t4
+
+t4: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  table: lineitem
+  multi-column filters: lt(t4.l_commitdate, t4.l_receiptdate)
+
+
+Optimized plan (oneline):
+
+(lineitem RIGHT SEMI (PROJECT) orders)
+
+Optimized plan:
+
+Project (redundant) -> dt1.o_orderpriority, dt1.order_count
+    dt1.o_orderpriority := t2.o_orderpriority
+    dt1.order_count := dt1.order_count
+  OrderBy -> t2.o_orderpriority, dt1.order_count
+    Aggregation (t2.o_orderpriority) -> t2.o_orderpriority, dt1.order_count
+        dt1.order_count := count()
+      Filter -> t2.o_orderpriority, dt1.__mark0
+          dt1.__mark0
+        Join RIGHT SEMI (PROJECT) Hash -> t2.o_orderpriority, dt1.__mark0
+            dt3.l_orderkey = t2.o_orderkey
+          Project (redundant) -> dt3.l_orderkey
+              dt3.l_orderkey := t4.l_orderkey
+            TableScan -> t4.l_orderkey
+              table: lineitem
+              multi-column filters: lt(t4.l_commitdate, t4.l_receiptdate)
+          HashBuild -> t2.o_orderkey, t2.o_orderpriority
+            TableScan -> t2.o_orderkey, t2.o_orderpriority
+              table: orders
+              single-column filters: gte(t2.o_orderdate, "1993-07-01") and lt(__cast(t2.o_orderdate), "1993-10-01")
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[5][o_orderpriority ASC NULLS LAST] -> o_orderpriority:VARCHAR, order_count:BIGINT
+  -- Aggregation[4][SINGLE [o_orderpriority] order_count := count()] -> o_orderpriority:VARCHAR, order_count:BIGINT
+    -- Filter[0][expression: "dt1.__mark0"] -> o_orderpriority:VARCHAR, "dt1.__mark0":BOOLEAN
+      -- HashJoin[3][RIGHT SEMI (PROJECT) l_orderkey=o_orderkey] -> o_orderpriority:VARCHAR, "dt1.__mark0":BOOLEAN
+        -- TableScan[1][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT
+        -- TableScan[2][table: orders, range filters: [(o_orderdate, BigintRange: [8582, 9223372036854775807] no nulls)], remaining filter: (lt(cast("o_orderdate" as DATE),1993-10-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q5.plans
+++ b/axiom/optimizer/tests/tpch.plans/q5.plans
@@ -1,0 +1,110 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: n_name, revenue
+  output:
+    n_name := t6.n_name
+    revenue := dt1.revenue
+  tables: t2, t3, t4, t5, t6, t7
+  joins:
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey
+    t4 INNER t5 ON t4.l_suppkey = t5.s_suppkey
+    t2 INNER t5 ON t2.c_nationkey = t5.s_nationkey
+    t5 INNER t6 ON t5.s_nationkey = t6.n_nationkey
+    t6 INNER t7 ON t6.n_regionkey = t7.r_regionkey
+    t2 INNER t6 ON t2.c_nationkey = t6.n_nationkey
+  syntactic join order: 9, 21, 41, 53, 60, 67
+  aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
+  grouping keys: t6.n_name
+  orderBy: dt1.revenue DESC NULLS LAST
+
+t2: c_custkey, c_nationkey
+  table: customer
+
+t3: o_orderkey, o_custkey, o_orderdate
+  table: orders
+  single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(__cast(t3.o_orderdate), "1995-01-01")
+
+t4: l_orderkey, l_suppkey, l_extendedprice, l_discount
+  table: lineitem
+
+t5: s_suppkey, s_nationkey
+  table: supplier
+
+t6: n_nationkey, n_name, n_regionkey
+  table: nation
+
+t7: r_regionkey, r_name
+  table: region
+  single-column filters: eq(t7.r_name, "ASIA")
+
+
+Optimized plan (oneline):
+
+((lineitem INNER ((customer INNER (nation INNER region)) INNER orders)) INNER supplier)
+
+Optimized plan:
+
+Project (redundant) -> dt1.n_name, dt1.revenue
+    dt1.n_name := t6.n_name
+    dt1.revenue := dt1.revenue
+  OrderBy -> t6.n_name, dt1.revenue
+    Aggregation (t6.n_name) -> t6.n_name, dt1.revenue
+        dt1.revenue := sum(dt1.__p92)
+      Project -> t6.n_name, dt1.__p92
+          t6.n_name := t6.n_name
+          dt1.__p92 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash -> t4.l_extendedprice, t4.l_discount, t6.n_name
+            t6.n_nationkey = t5.s_nationkey
+            t4.l_suppkey = t5.s_suppkey
+          Join INNER Hash -> t2.c_nationkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t6.n_nationkey, t6.n_name
+              t4.l_orderkey = t3.o_orderkey
+            TableScan -> t4.l_orderkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+              table: lineitem
+            HashBuild -> t2.c_custkey, t2.c_nationkey, t3.o_orderkey, t3.o_custkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+              Join INNER Hash -> t2.c_custkey, t2.c_nationkey, t3.o_orderkey, t3.o_custkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                  t2.c_custkey = t3.o_custkey
+                Join INNER Hash -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                    t2.c_nationkey = t6.n_nationkey
+                  TableScan -> t2.c_custkey, t2.c_nationkey
+                    table: customer
+                  HashBuild -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                    Join INNER Hash -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                        t6.n_regionkey = t7.r_regionkey
+                      TableScan -> t6.n_nationkey, t6.n_name, t6.n_regionkey
+                        table: nation
+                      HashBuild -> t7.r_regionkey
+                        TableScan -> t7.r_regionkey
+                          table: region
+                          single-column filters: eq(t7.r_name, "ASIA")
+                HashBuild -> t3.o_orderkey, t3.o_custkey
+                  TableScan -> t3.o_orderkey, t3.o_custkey
+                    table: orders
+                    single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(__cast(t3.o_orderdate), "1995-01-01")
+          HashBuild -> t5.s_suppkey, t5.s_nationkey
+            TableScan -> t5.s_suppkey, t5.s_nationkey
+              table: supplier
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- OrderBy[13][revenue DESC NULLS LAST] -> n_name:VARCHAR, revenue:DOUBLE
+  -- Aggregation[12][SINGLE [n_name] revenue := sum("dt1.__p92")] -> n_name:VARCHAR, revenue:DOUBLE
+    -- Project[11][expressions: (n_name:VARCHAR, "n_name"), (dt1.__p92:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, "dt1.__p92":DOUBLE
+      -- HashJoin[10][INNER n_nationkey=s_nationkey AND l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+        -- HashJoin[8][INNER l_orderkey=o_orderkey] -> c_nationkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_nationkey:BIGINT, n_name:VARCHAR
+          -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- HashJoin[7][INNER c_custkey=o_custkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, o_orderkey:BIGINT, o_custkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+            -- HashJoin[5][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+              -- TableScan[1][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+              -- HashJoin[4][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+                -- TableScan[2][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+                -- TableScan[3][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey:BIGINT
+            -- TableScan[6][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast("o_orderdate" as DATE),1995-01-01)), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT
+        -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q6.plans
+++ b/axiom/optimizer/tests/tpch.plans/q6.plans
@@ -1,0 +1,41 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: revenue
+  output:
+    revenue := dt1.revenue
+  tables: t2
+  aggregates: sum(multiply(t2.l_extendedprice, t2.l_discount)) AS revenue
+
+t2: l_quantity, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: gte(t2.l_shipdate, "1994-01-01") and lt(__cast(t2.l_shipdate), "1995-01-01") and between(t2.l_discount, 0.049999999999999996, 0.07) and lt(t2.l_quantity, 24)
+
+
+Optimized plan (oneline):
+
+lineitem
+
+Optimized plan:
+
+Project (redundant) -> dt1.revenue
+    dt1.revenue := dt1.revenue
+  Aggregation -> dt1.revenue
+      dt1.revenue := sum(dt1.__p48)
+    Project -> dt1.__p48
+        dt1.__p48 := multiply(t2.l_extendedprice, t2.l_discount)
+      TableScan -> t2.l_extendedprice, t2.l_discount
+        table: lineitem
+        single-column filters: gte(t2.l_shipdate, "1994-01-01") and lt(__cast(t2.l_shipdate), "1995-01-01") and between(t2.l_discount, 0.049999999999999996, 0.07) and lt(t2.l_quantity, 24)
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Aggregation[2][SINGLE revenue := sum("dt1.__p48")] -> revenue:DOUBLE
+  -- Project[1][expressions: (dt1.__p48:DOUBLE, multiply("l_extendedprice","l_discount"))] -> "dt1.__p48":DOUBLE
+    -- TableScan[0][table: lineitem, range filters: [(l_discount, DoubleRange: [0.050000, 0.070000] no nulls), (l_quantity, DoubleRange: (-inf, 24.000000) no nulls), (l_shipdate, BigintRange: [8766, 9223372036854775807] no nulls)], remaining filter: (lt(cast("l_shipdate" as DATE),1995-01-01)), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_extendedprice:DOUBLE, l_discount:DOUBLE
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q7.plans
+++ b/axiom/optimizer/tests/tpch.plans/q7.plans
@@ -1,0 +1,120 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: supp_nation, cust_nation, l_year, revenue
+  output:
+    supp_nation := t6.n_name
+    cust_nation := t7.n_name
+    l_year := dt1.l_year
+    revenue := dt1.revenue
+  tables: t2, t3, t4, t5, t6, t7
+  joins:
+    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey
+    t3 INNER t4 ON t3.l_orderkey = t4.o_orderkey
+    t4 INNER t5 ON t4.o_custkey = t5.c_custkey
+    t2 INNER t6 ON t2.s_nationkey = t6.n_nationkey
+    t5 INNER t7 ON t5.c_nationkey = t7.n_nationkey
+  syntactic join order: 8, 27, 42, 53, 60, 63
+  aggregates: sum(multiply(t3.l_extendedprice, minus(1, t3.l_discount))) AS revenue
+  grouping keys: t6.n_name, t7.n_name, year(t3.l_shipdate)
+  filter: __or(__and(eq(t6.n_name, "FRANCE"), eq(t7.n_name, "GERMANY")), __and(eq(t6.n_name, "GERMANY"), eq(t7.n_name, "FRANCE")))
+  orderBy: t6.n_name ASC NULLS LAST, t7.n_name ASC NULLS LAST, dt1.l_year ASC NULLS LAST
+
+t2: s_suppkey, s_nationkey
+  table: supplier
+
+t3: l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate
+  table: lineitem
+  single-column filters: between(t3.l_shipdate, "1995-01-01", "1996-12-31")
+
+t4: o_orderkey, o_custkey
+  table: orders
+
+t5: c_custkey, c_nationkey
+  table: customer
+
+t6: n_nationkey, n_name
+  table: nation
+  single-column filters: __or(eq(t6.n_name, "FRANCE"), eq(t6.n_name, "GERMANY"))
+
+t7: n_nationkey, n_name
+  table: nation
+  single-column filters: __or(eq(t7.n_name, "GERMANY"), eq(t7.n_name, "FRANCE"))
+
+
+Optimized plan (oneline):
+
+((lineitem INNER (orders INNER (customer INNER nation))) INNER (supplier INNER nation))
+
+Optimized plan:
+
+Project -> dt1.supp_nation, dt1.cust_nation, dt1.l_year, dt1.revenue
+    dt1.supp_nation := t6.n_name
+    dt1.cust_nation := t7.n_name
+    dt1.l_year := dt1.l_year
+    dt1.revenue := dt1.revenue
+  OrderBy -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
+    Aggregation (t6.n_name, t7.n_name, dt1.__p87) -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
+        dt1.revenue := sum(dt1.__p92)
+      Project -> t6.n_name, t7.n_name, dt1.__p87, dt1.__p92
+          t6.n_name := t6.n_name
+          t7.n_name := t7.n_name
+          dt1.__p87 := year(t3.l_shipdate)
+          dt1.__p92 := multiply(t3.l_extendedprice, minus(1, t3.l_discount))
+        Filter -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
+            __or(__and(eq(t6.n_name, "FRANCE"), eq(t7.n_name, "GERMANY")), __and(eq(t6.n_name, "GERMANY"), eq(t7.n_name, "FRANCE")))
+          Join INNER Hash -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
+              t3.l_suppkey = t2.s_suppkey
+            Join INNER Hash -> t3.l_suppkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t7.n_name
+                t3.l_orderkey = t4.o_orderkey
+              TableScan -> t3.l_orderkey, t3.l_suppkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate
+                table: lineitem
+                single-column filters: between(t3.l_shipdate, "1995-01-01", "1996-12-31")
+              HashBuild -> t4.o_orderkey, t4.o_custkey, t5.c_custkey, t5.c_nationkey, t7.n_nationkey, t7.n_name
+                Join INNER Hash -> t4.o_orderkey, t4.o_custkey, t5.c_custkey, t5.c_nationkey, t7.n_nationkey, t7.n_name
+                    t4.o_custkey = t5.c_custkey
+                  TableScan -> t4.o_orderkey, t4.o_custkey
+                    table: orders
+                  HashBuild -> t5.c_custkey, t5.c_nationkey, t7.n_nationkey, t7.n_name
+                    Join INNER Hash -> t5.c_custkey, t5.c_nationkey, t7.n_nationkey, t7.n_name
+                        t5.c_nationkey = t7.n_nationkey
+                      TableScan -> t5.c_custkey, t5.c_nationkey
+                        table: customer
+                      HashBuild -> t7.n_nationkey, t7.n_name
+                        TableScan -> t7.n_nationkey, t7.n_name
+                          table: nation
+                          single-column filters: __or(eq(t7.n_name, "GERMANY"), eq(t7.n_name, "FRANCE"))
+            HashBuild -> t2.s_suppkey, t2.s_nationkey, t6.n_nationkey, t6.n_name
+              Join INNER Hash -> t2.s_suppkey, t2.s_nationkey, t6.n_nationkey, t6.n_name
+                  t2.s_nationkey = t6.n_nationkey
+                TableScan -> t2.s_suppkey, t2.s_nationkey
+                  table: supplier
+                HashBuild -> t6.n_nationkey, t6.n_name
+                  TableScan -> t6.n_nationkey, t6.n_name
+                    table: nation
+                    single-column filters: __or(eq(t6.n_name, "FRANCE"), eq(t6.n_name, "GERMANY"))
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[15][expressions: (supp_nation:VARCHAR, "n_name"), (cust_nation:VARCHAR, "n_name_1"), (l_year:BIGINT, "l_year"), (revenue:DOUBLE, "revenue")] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+  -- OrderBy[14][n_name ASC NULLS LAST, n_name_1 ASC NULLS LAST, l_year ASC NULLS LAST] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+    -- Aggregation[13][SINGLE [n_name, n_name_1, l_year] revenue := sum("dt1.__p92")] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+      -- Project[12][expressions: (n_name:VARCHAR, "n_name"), (n_name_1:VARCHAR, "n_name_1"), (l_year:BIGINT, year("l_shipdate")), (dt1.__p92:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, "dt1.__p92":DOUBLE
+        -- Filter[0][expression: or(and(eq("n_name",FRANCE),eq("n_name_1",GERMANY)),and(eq("n_name",GERMANY),eq("n_name_1",FRANCE)))] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_1:VARCHAR
+          -- HashJoin[11][INNER l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_1:VARCHAR
+            -- HashJoin[7][INNER l_orderkey=o_orderkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name_1:VARCHAR
+              -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+              -- HashJoin[6][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey_0:BIGINT, n_name_1:VARCHAR
+                -- TableScan[2][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT
+                -- HashJoin[5][INNER c_nationkey=n_nationkey_0] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey_0:BIGINT, n_name_1:VARCHAR
+                  -- TableScan[3][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                  -- TableScan[4][table: nation, range filters: [(n_name, Filter(MultiRange, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+            -- HashJoin[10][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+              -- TableScan[8][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+              -- TableScan[9][table: nation, range filters: [(n_name, Filter(MultiRange, deterministic, null not allowed))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q8.plans
+++ b/axiom/optimizer/tests/tpch.plans/q8.plans
@@ -1,0 +1,134 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: o_year, mkt_share
+  output:
+    o_year := dt1.o_year
+    mkt_share := divide(dt1.sum, dt1.sum_4)
+  tables: t2, t3, t4, t5, t6, t7, t8, t9
+  joins:
+    t2 INNER t4 ON t2.p_partkey = t4.l_partkey
+    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey
+    t4 INNER t5 ON t4.l_orderkey = t5.o_orderkey
+    t5 INNER t6 ON t5.o_custkey = t6.c_custkey
+    t6 INNER t7 ON t6.c_nationkey = t7.n_nationkey
+    t7 INNER t9 ON t7.n_regionkey = t9.r_regionkey
+    t3 INNER t8 ON t3.s_nationkey = t8.n_nationkey
+  syntactic join order: 10, 20, 39, 54, 66, 73, 76, 82
+  aggregates: sum(__switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)) AS sum, sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS sum_4
+  grouping keys: year(t5.o_orderdate)
+  orderBy: dt1.o_year ASC NULLS LAST
+
+t2: p_partkey, p_type
+  table: part
+  single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
+
+t3: s_suppkey, s_nationkey
+  table: supplier
+
+t4: l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount
+  table: lineitem
+
+t5: o_orderkey, o_custkey, o_orderdate
+  table: orders
+  single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
+
+t6: c_custkey, c_nationkey
+  table: customer
+
+t7: n_nationkey, n_regionkey
+  table: nation
+
+t8: n_nationkey, n_name
+  table: nation
+
+t9: r_regionkey, r_name
+  table: region
+  single-column filters: eq(t9.r_name, "AMERICA")
+
+
+Optimized plan (oneline):
+
+((supplier INNER ((lineitem INNER part) INNER ((orders INNER customer) INNER (nation INNER region)))) INNER nation)
+
+Optimized plan:
+
+Project -> dt1.o_year, dt1.mkt_share
+    dt1.o_year := dt1.o_year
+    dt1.mkt_share := divide(dt1.sum, dt1.sum_4)
+  OrderBy -> dt1.o_year, dt1.sum, dt1.sum_4
+    Aggregation (dt1.__p103) -> dt1.o_year, dt1.sum, dt1.sum_4
+        dt1.sum := sum(dt1.__p113)
+        dt1.sum_4 := sum(dt1.__p108)
+      Project -> dt1.__p103, dt1.__p113, dt1.__p108
+          dt1.__p103 := year(t5.o_orderdate)
+          dt1.__p113 := __switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)
+          dt1.__p108 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash -> t4.l_extendedprice, t4.l_discount, t5.o_orderdate, t8.n_name
+            t3.s_nationkey = t8.n_nationkey
+          Join INNER Hash -> t3.s_nationkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
+              t3.s_suppkey = t4.l_suppkey
+            TableScan -> t3.s_suppkey, t3.s_nationkey
+              table: supplier
+            HashBuild -> t2.p_partkey, t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+              Join INNER Hash -> t2.p_partkey, t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                  t4.l_orderkey = t5.o_orderkey
+                Join INNER Hash -> t2.p_partkey, t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                    t4.l_partkey = t2.p_partkey
+                  TableScan -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                    table: lineitem
+                  HashBuild -> t2.p_partkey
+                    TableScan -> t2.p_partkey
+                      table: part
+                      single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
+                HashBuild -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                  Join INNER Hash -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                      t6.c_nationkey = t7.n_nationkey
+                    Join INNER Hash -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey
+                        t5.o_custkey = t6.c_custkey
+                      TableScan -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate
+                        table: orders
+                        single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
+                      HashBuild -> t6.c_custkey, t6.c_nationkey
+                        TableScan -> t6.c_custkey, t6.c_nationkey
+                          table: customer
+                    HashBuild -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                      Join INNER Hash -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                          t7.n_regionkey = t9.r_regionkey
+                        TableScan -> t7.n_nationkey, t7.n_regionkey
+                          table: nation
+                        HashBuild -> t9.r_regionkey
+                          TableScan -> t9.r_regionkey
+                            table: region
+                            single-column filters: eq(t9.r_name, "AMERICA")
+          HashBuild -> t8.n_nationkey, t8.n_name
+            TableScan -> t8.n_nationkey, t8.n_name
+              table: nation
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[24][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_4"))] -> o_year:BIGINT, mkt_share:DOUBLE
+  -- OrderBy[23][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+    -- Aggregation[22][SINGLE [o_year] sum := sum("dt1.__p113"), sum_4 := sum("dt1.__p108")] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+      -- Project[21][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p113:DOUBLE, switch(eq("n_name_1",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p108:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p113":DOUBLE, "dt1.__p108":DOUBLE
+        -- HashJoin[20][INNER s_nationkey=n_nationkey_0] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_1:VARCHAR
+          -- HashJoin[18][INNER s_suppkey=l_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+            -- TableScan[6][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+            -- HashJoin[17][INNER l_orderkey=o_orderkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+              -- HashJoin[9][INNER l_partkey=p_partkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- TableScan[7][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- TableScan[8][table: part, range filters: [(p_type, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT
+              -- HashJoin[16][INNER c_nationkey=n_nationkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+                -- HashJoin[12][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT
+                  -- TableScan[10][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                  -- TableScan[11][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                -- HashJoin[15][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+                  -- TableScan[13][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+                  -- TableScan[14][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>] -> r_regionkey:BIGINT
+          -- TableScan[19][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+
+___END___

--- a/axiom/optimizer/tests/tpch.plans/q9.plans
+++ b/axiom/optimizer/tests/tpch.plans/q9.plans
@@ -1,0 +1,112 @@
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: nation, o_year, sum_profit
+  output:
+    nation := t7.n_name
+    o_year := dt1.o_year
+    sum_profit := dt1.sum_profit
+  tables: t2, t3, t4, t5, t6, t7
+  joins:
+    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey
+    t4 INNER t5 ON t4.l_suppkey = t5.ps_suppkey AND t4.l_partkey = t5.ps_partkey
+    t2 INNER t4 ON t2.p_partkey = t4.l_partkey
+    t4 INNER t6 ON t4.l_orderkey = t6.o_orderkey
+    t3 INNER t7 ON t3.s_nationkey = t7.n_nationkey
+    t3 INNER t5 ON t3.s_suppkey = t5.ps_suppkey
+    t5 INNER t2 ON t5.ps_partkey = t2.p_partkey
+  syntactic join order: 10, 20, 39, 51, 64, 71
+  aggregates: sum(minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))) AS sum_profit
+  grouping keys: t7.n_name, year(t6.o_orderdate)
+  orderBy: t7.n_name ASC NULLS LAST, dt1.o_year DESC NULLS LAST
+
+t2: p_partkey, p_name
+  table: part
+  single-column filters: like(t2.p_name, "%green%")
+
+t3: s_suppkey, s_nationkey
+  table: supplier
+
+t4: l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount
+  table: lineitem
+
+t5: ps_partkey, ps_suppkey, ps_supplycost
+  table: partsupp
+
+t6: o_orderkey, o_orderdate
+  table: orders
+
+t7: n_nationkey, n_name
+  table: nation
+
+
+Optimized plan (oneline):
+
+(((orders INNER (lineitem INNER (partsupp INNER part))) INNER supplier) INNER nation)
+
+Optimized plan:
+
+Project -> dt1.nation, dt1.o_year, dt1.sum_profit
+    dt1.nation := t7.n_name
+    dt1.o_year := dt1.o_year
+    dt1.sum_profit := dt1.sum_profit
+  OrderBy -> t7.n_name, dt1.o_year, dt1.sum_profit
+    Aggregation (t7.n_name, dt1.__p82) -> t7.n_name, dt1.o_year, dt1.sum_profit
+        dt1.sum_profit := sum(dt1.__p89)
+      Project -> t7.n_name, dt1.__p82, dt1.__p89
+          t7.n_name := t7.n_name
+          dt1.__p82 := year(t6.o_orderdate)
+          dt1.__p89 := minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))
+        Join INNER Hash -> t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate, t7.n_name
+            t3.s_nationkey = t7.n_nationkey
+          Join INNER Hash -> t3.s_nationkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate
+              t4.l_suppkey = t3.s_suppkey
+            Join INNER Hash -> t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_suppkey, t5.ps_supplycost, t6.o_orderdate
+                t6.o_orderkey = t4.l_orderkey
+              TableScan -> t6.o_orderkey, t6.o_orderdate
+                table: orders
+              HashBuild -> t2.p_partkey, t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                Join INNER Hash -> t2.p_partkey, t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                    t4.l_suppkey = t5.ps_suppkey
+                    t4.l_partkey = t5.ps_partkey
+                  TableScan -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount
+                    table: lineitem
+                  HashBuild -> t2.p_partkey, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                    Join INNER Hash -> t2.p_partkey, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                        t5.ps_partkey = t2.p_partkey
+                      TableScan -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                        table: partsupp
+                      HashBuild -> t2.p_partkey
+                        TableScan -> t2.p_partkey
+                          table: part
+                          single-column filters: like(t2.p_name, "%green%")
+            HashBuild -> t3.s_suppkey, t3.s_nationkey
+              TableScan -> t3.s_suppkey, t3.s_nationkey
+                table: supplier
+          HashBuild -> t7.n_nationkey, t7.n_name
+            TableScan -> t7.n_nationkey, t7.n_name
+              table: nation
+
+
+Executable Velox plan:
+
+Fragment 0:  numWorkers=0:
+-- Project[26][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+  -- OrderBy[25][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+    -- Aggregation[24][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p89")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+      -- Project[23][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p89:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p89":DOUBLE
+        -- HashJoin[22][INNER s_nationkey=n_nationkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
+          -- HashJoin[20][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE
+            -- HashJoin[18][INNER o_orderkey=l_orderkey] -> l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE, o_orderdate:DATE
+              -- TableScan[12][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderdate:DATE
+              -- HashJoin[17][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                -- TableScan[13][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- HashJoin[16][INNER ps_partkey=p_partkey] -> p_partkey:BIGINT, ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- TableScan[14][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- TableScan[15][table: part, remaining filter: (like("p_name",%green%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT
+            -- TableScan[19][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+          -- TableScan[21][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+
+___END___


### PR DESCRIPTION
Summary: Use the new functionality to generate plans for TPC-H queries with numWorkers = 1 and numDrivers = 1. Add these plans to the repo to allow for easier inspection.

Differential Revision: D85948009


