### PR TITLE
refactor: Don't throw unnecessary exception

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -179,7 +179,7 @@ ExprCP ToGraph::tryFoldConstant(
     auto typedExpr = queryCtx()->optimization()->toTypedExpr(call);
     auto exprSet = evaluator_.compile(typedExpr);
     const auto& first = *exprSet->exprs().front();
-    if (first.specialFormKind() != velox::exec::SpecialFormKind::kConstant) {
+    if (!first.isConstant()) {
       return nullptr;
     }
     const auto& constantExpr =


### PR DESCRIPTION
This will simplify debugging and can improve performance.

>     if (first.specialFormKind() != velox::exec::SpecialFormKind::kConstant) {

'first' is velox::exec::Expr. Expr::specialFormKind() API is defined as 

```
  SpecialFormKind specialFormKind() const {
    return specialFormKind_.value();
  }
```

This API throws if Expr is not a special form. To avoid unnecessary exception, we change the code to use Expr::isConstant() API:

```
  bool isConstant() const {
    return specialFormKind_ == SpecialFormKind::kConstant;
  }
```