### PR TITLE
WIP: Sometimes we can avoid join by expression and replace it with join by columns 

### DIFF
--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -427,12 +427,8 @@ std::pair<JoinSide, JoinSide> JoinCandidate::joinSides() const {
 
 namespace {
 bool hasEqual(ExprCP key, const ExprVector& keys) {
-  if (key->isNot(PlanType::kColumnExpr) || !key->as<Column>()->equivalence()) {
-    return false;
-  }
-
   return std::ranges::any_of(
-      keys, [&](ExprCP e) { return key->sameOrEqual(*e); });
+      keys, [&](ExprCP e) { return sameOrEqual(key, e); });
 }
 } // namespace
 

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -844,26 +844,17 @@ class Aggregate : public Call {
       const velox::Type* intermediateType,
       ExprVector orderKeys,
       OrderTypeVector orderTypes)
-      : Call(
-            PlanType::kAggregateExpr,
-            name,
-            value,
-            std::move(args),
-            functions | FunctionSet::kAggregate),
-        isDistinct_(isDistinct),
-        condition_(condition),
-        intermediateType_(intermediateType),
-        orderKeys_(std::move(orderKeys)),
-        orderTypes_(std::move(orderTypes)) {
+      : Call{PlanType::kAggregateExpr, name, value, std::move(args), functions | FunctionSet::kAggregate},
+        isDistinct_{isDistinct},
+        condition_{condition},
+        intermediateType_{intermediateType},
+        orderKeys_{std::move(orderKeys)},
+        orderTypes_{std::move(orderTypes)} {
     VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
-
-    for (auto& arg : this->args()) {
-      rawInputType_.push_back(arg->value().type);
-    }
     if (condition_) {
       columns_.unionSet(condition_->columns());
     }
-    for (auto& key : orderKeys_) {
+    for (const auto* key : orderKeys_) {
       columns_.unionSet(key->columns());
     }
   }
@@ -880,10 +871,6 @@ class Aggregate : public Call {
     return intermediateType_;
   }
 
-  const TypeVector& rawInputType() const {
-    return rawInputType_;
-  }
-
   const ExprVector& orderKeys() const {
     return orderKeys_;
   }
@@ -895,12 +882,11 @@ class Aggregate : public Call {
   std::string toString() const override;
 
  private:
-  bool isDistinct_;
-  ExprCP condition_;
-  const velox::Type* intermediateType_;
-  TypeVector rawInputType_;
-  ExprVector orderKeys_;
-  OrderTypeVector orderTypes_;
+  const bool isDistinct_;
+  const ExprCP condition_;
+  const velox::Type* const intermediateType_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
 };
 
 using AggregateCP = const Aggregate*;

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -485,12 +485,7 @@ using JoinCP = const Join*;
 /// cardinality of this is counted as setup cost in the first
 /// referencing join and not counted in subsequent ones.
 struct HashBuild : public RelationOp {
-  HashBuild(RelationOpPtr input, ExprVector keys, PlanP plan);
-
-  const ExprVector keys;
-
-  // The plan producing the build data. Used for deduplicating joins.
-  PlanP plan;
+  HashBuild(RelationOpPtr input, size_t numKeys);
 
   std::string toString(bool recursive, bool detail) const override;
 

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -359,7 +359,7 @@ bool Distribution::isSamePartition(const Distribution& other) const {
     return false;
   }
   for (auto i = 0; i < partition.size(); ++i) {
-    if (!partition[i]->sameOrEqual(*other.partition[i])) {
+    if (!sameOrEqual(partition[i], other.partition[i])) {
       return false;
     }
   }
@@ -371,7 +371,7 @@ bool Distribution::isSameOrder(const Distribution& other) const {
     return false;
   }
   for (size_t i = 0; i < orderKeys.size(); ++i) {
-    if (!orderKeys[i]->sameOrEqual(*other.orderKeys[i]) ||
+    if (!sameOrEqual(orderKeys[i], other.orderKeys[i]) ||
         orderTypes[i] != other.orderTypes[i]) {
       return false;
     }

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ add_executable(
   Genies.cpp
   TestConnectorQueryTest.cpp
   WriteTest.cpp
+  #QueryGraphTest.cpp
 )
 
 add_test(axiom_optimizer_tests axiom_optimizer_tests)

--- a/axiom/optimizer/tests/QueryGraphTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphTest.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/VeloxHistory.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+namespace facebook::axiom::optimizer {
+namespace {
+
+class QueryGraphTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+  }
+
+  void SetUp() override {
+    rootPool_ = memory::memoryManager()->addRootPool("root");
+    optimizerPool_ = rootPool_->addLeafChild("optimizer");
+    allocator_ =
+        std::make_unique<velox::HashStringAllocator>(optimizerPool_.get());
+    context_ = std::make_unique<QueryGraphContext>(*allocator_);
+    queryCtx() = context_.get();
+  }
+
+  void TearDown() override {
+    queryCtx() = nullptr;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> optimizerPool_;
+  std::unique_ptr<velox::HashStringAllocator> allocator_;
+  std::unique_ptr<QueryGraphContext> context_;
+};
+
+TEST_F(QueryGraphTest, sameOrEqual) {
+  Variant variant1 = 1;
+  Variant variant2 = 2;
+  auto* literal1 = make<Literal>(Value{toType(velox::INTEGER()), 1}, &variant1);
+  auto* literal2 = make<Literal>(Value{toType(velox::INTEGER()), 1}, &variant1);
+  auto* literal3 = make<Literal>(Value{toType(velox::INTEGER()), 1}, &variant2);
+
+  {
+    SCOPED_TRACE("Literals");
+
+    EXPECT_TRUE(literal1->sameOrEqual(*literal1));
+    EXPECT_TRUE(literal2->sameOrEqual(*literal2));
+    EXPECT_TRUE(literal3->sameOrEqual(*literal3));
+
+    EXPECT_TRUE(literal1->sameOrEqual(*literal2));
+    EXPECT_TRUE(literal2->sameOrEqual(*literal1));
+
+    EXPECT_FALSE(literal1->sameOrEqual(*literal3));
+    EXPECT_FALSE(literal3->sameOrEqual(*literal1));
+  }
+  {
+    SCOPED_TRACE("Calls(name different)");
+
+    auto* call1 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal2},
+        FunctionSet{});
+    auto* call2 = make<Call>(
+        "greatest",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal2},
+        FunctionSet{});
+
+    EXPECT_TRUE(call1->sameOrEqual(*call1));
+    EXPECT_TRUE(call2->sameOrEqual(*call2));
+
+    EXPECT_FALSE(call1->sameOrEqual(*call2));
+    EXPECT_FALSE(call2->sameOrEqual(*call1));
+  }
+  {
+    SCOPED_TRACE("Calls(args count different)");
+
+    auto* call1 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal1},
+        FunctionSet{});
+    auto* call2 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal1, literal1},
+        FunctionSet{});
+
+    EXPECT_TRUE(call1->sameOrEqual(*call1));
+    EXPECT_TRUE(call2->sameOrEqual(*call2));
+
+    EXPECT_FALSE(call1->sameOrEqual(*call2));
+    EXPECT_FALSE(call2->sameOrEqual(*call1));
+  }
+  {
+    SCOPED_TRACE("Calls(args different)");
+
+    auto* call1 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal2},
+        FunctionSet{});
+    auto* call2 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal2},
+        FunctionSet{});
+    auto* call3 = make<Call>(
+        "least",
+        Value{toType(velox::INTEGER()), 1},
+        ExprVector{literal1, literal3},
+        FunctionSet{});
+
+    EXPECT_TRUE(call1->sameOrEqual(*call1));
+    EXPECT_TRUE(call2->sameOrEqual(*call2));
+    EXPECT_TRUE(call3->sameOrEqual(*call3));
+
+    EXPECT_TRUE(call1->sameOrEqual(*call2));
+    EXPECT_TRUE(call2->sameOrEqual(*call1));
+
+    EXPECT_FALSE(call1->sameOrEqual(*call3));
+    EXPECT_FALSE(call3->sameOrEqual(*call1));
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
This can be also implemented for Unnest and Aggregate.

So something like `unnest(a) join unnest(b)` can be translated to `a join b => unnest(a) => unnest(b)`