### PR TITLE
refactor: Remove connector::TableKind

### DIFF
--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -17,15 +17,7 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 
 namespace facebook::axiom::connector {
-
 namespace {
-const auto& tableKindNames() {
-  static const folly::F14FastMap<TableKind, std::string_view> kNames = {
-      {TableKind::kTable, "TABLE"},
-      {TableKind::kTempTable, "TEMP_TABLE"},
-  };
-  return kNames;
-}
 
 const auto& writeKindNames() {
   static const folly::F14FastMap<WriteKind, std::string_view> kNames = {
@@ -38,8 +30,6 @@ const auto& writeKindNames() {
 }
 
 } // namespace
-
-AXIOM_DEFINE_ENUM_NAME(TableKind, tableKindNames);
 
 AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -171,11 +171,6 @@ class Column {
   std::mutex mutex_;
 };
 
-/// Describes the kind of table, e.g. durable vs. temporary.
-enum class TableKind { kTable, kTempTable };
-
-AXIOM_DECLARE_ENUM_NAME(TableKind);
-
 class Table;
 
 /// Represents sorting order. Duplicate of core::SortOrder.
@@ -359,11 +354,9 @@ class Table : public std::enable_shared_from_this<Table> {
   Table(
       std::string name,
       velox::RowTypePtr type,
-      TableKind kind = TableKind::kTable,
       folly::F14FastMap<std::string, velox::Variant> options = {})
       : name_(std::move(name)),
         type_(std::move(type)),
-        kind_(kind),
         options_(std::move(options)) {
     VELOX_CHECK(!name_.empty());
     VELOX_CHECK_NOT_NULL(type_);
@@ -376,10 +369,6 @@ class Table : public std::enable_shared_from_this<Table> {
   /// Returns all columns as RowType.
   const velox::RowTypePtr& type() const {
     return type_;
-  }
-
-  TableKind kind() const {
-    return kind_;
   }
 
   /// Returns the mapping of columns keyed on column names as abstract,
@@ -416,7 +405,6 @@ class Table : public std::enable_shared_from_this<Table> {
   // Discovered from data. In the event of different types, we take the
   // latest (i.e. widest) table type.
   const velox::RowTypePtr type_;
-  const TableKind kind_;
   const folly::F14FastMap<std::string, velox::Variant> options_;
 };
 
@@ -721,7 +709,5 @@ class ConnectorMetadata {
 };
 
 } // namespace facebook::axiom::connector
-
-AXIOM_ENUM_FORMATTER(facebook::axiom::connector::TableKind);
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::connector::WriteKind);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -141,11 +141,7 @@ class LocalTable : public Table {
       std::string name,
       velox::RowTypePtr type,
       folly::F14FastMap<std::string, velox::Variant> options = {})
-      : Table(
-            std::move(name),
-            std::move(type),
-            TableKind::kTable,
-            std::move(options)) {
+      : Table(std::move(name), std::move(type), std::move(options)) {
     for (auto i = 0; i < Table::type()->size(); ++i) {
       const auto& name = Table::type()->nameOf(i);
       auto column = std::make_unique<Column>(name, Table::type()->childAt(i));


### PR DESCRIPTION
This type varies across connectors and is not used by core components like LogicalPlan, Optimizer, or Runner. Since it's an unnecessary abstraction with a flawed design, we should remove it now before it becomes more entrenched.

For an example in SereneDB we have 
- Temporary tables
- RocksDB tables and indexes
- Search Indexes
- System catalog tables (pg_type, pg_class, etc)

They're all have different `axiom::connector::Table` implementation, because `numRows` required to be implemented in a different way