### PR TITLE
fix: Preserve catalog and schema parts of the table name when parsing SQL

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(
   FeatureGen.cpp
   Genies.cpp
   TestConnectorQueryTest.cpp
+  TpchConnectorQueryTest.cpp
   WriteTest.cpp
 )
 

--- a/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/tests/ParquetTpchTest.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "axiom/sql/presto/PrestoParser.h"
+
+namespace facebook::axiom::optimizer::test {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class TpchConnectorQueryTest : public QueryTestBase {
+ protected:
+  static constexpr auto kTpchConnectorId = "tpch";
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    ParquetTpchTest::registerTpchConnector(kTpchConnectorId);
+  }
+
+  void TearDown() override {
+    ParquetTpchTest::unregisterTpchConnector(kTpchConnectorId);
+    QueryTestBase::TearDown();
+  }
+
+  lp::LogicalPlanNodePtr parseSql(std::string_view sql) {
+    ::axiom::sql::presto::PrestoParser parser(kTpchConnectorId, pool());
+    auto statement = parser.parse(sql);
+
+    VELOX_CHECK(statement->isSelect());
+    return statement->as<::axiom::sql::presto::SelectStatement>()->plan();
+  }
+
+  // Run "SELECT count(*) FROM <table>" query and return the result.
+  int64_t runCountStar(std::string_view tableName) {
+    const auto query = fmt::format("SELECT count(*) FROM {}", tableName);
+
+    auto logicalPlan = parseSql(query);
+    auto result = runVelox(logicalPlan);
+    VELOX_CHECK_EQ(result.results.size(), 1);
+
+    auto rowVector = result.results.at(0);
+    VELOX_CHECK_EQ(rowVector->size(), 1);
+
+    const auto value = rowVector->childAt(0)->variantAt(0);
+    VELOX_CHECK(!value.isNull());
+
+    return value.value<int64_t>();
+  }
+};
+
+TEST_F(TpchConnectorQueryTest, scaleFactors) {
+  ASSERT_EQ(15'000, runCountStar("orders"));
+  ASSERT_EQ(15'000, runCountStar("tiny.orders"));
+  ASSERT_EQ(15'000, runCountStar("tpch.tiny.orders"));
+
+  ASSERT_EQ(1'500'000, runCountStar("sf1.orders"));
+  ASSERT_EQ(1'500'000, runCountStar("tpch.sf1.orders"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::test

--- a/axiom/sql/presto/ast/AstExpressions.h
+++ b/axiom/sql/presto/ast/AstExpressions.h
@@ -62,6 +62,10 @@ class QualifiedName : public Expression {
     return parts_;
   }
 
+  std::string fullyQualifiedName() const {
+    return folly::join(".", parts_);
+  }
+
   std::string suffix() const {
     return parts_.empty() ? "" : parts_.back();
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -692,7 +692,7 @@ TEST_F(PrestoParserTest, insertIntoTable) {
 
     VELOX_ASSERT_THROW(
         parser.parse("INSERT INTO nation SELECT 100, 'n-100', 2, 3"),
-        "Wrong column type: BIGINT vs. VARCHAR, column n_comment in table nation");
+        "Wrong column type: BIGINT vs. VARCHAR, column n_comment in table tiny.nation");
   }
 }
 


### PR DESCRIPTION
Summary:
```
$  buck run mode/opt axiom/optimizer/tests:velox_sql

SQL> select count(*) from orders;
ROW<count:BIGINT>
-----
count
-----
15000
(1 rows in 1 batches)

SQL> select count(*) from sf1.orders;
ROW<count:BIGINT>
-------
  count
-------
1500000
(1 rows in 1 batches)
```

Differential Revision: D86311744


