### PR TITLE
feat: Add support for parsing lambda functions

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1469,7 +1469,19 @@ std::any AstBuilder::visitCast(PrestoSqlParser::CastContext* ctx) {
 
 std::any AstBuilder::visitLambda(PrestoSqlParser::LambdaContext* ctx) {
   trace("visitLambda");
-  return visitChildren(ctx);
+
+  std::vector<std::shared_ptr<LambdaArgumentDeclaration>> arguments;
+  arguments.reserve(ctx->identifier().size());
+  for (auto* identifierCtx : ctx->identifier()) {
+    arguments.emplace_back(
+        std::make_shared<LambdaArgumentDeclaration>(
+            getLocation(identifierCtx), visitIdentifier(identifierCtx)));
+  }
+
+  auto body = visitTyped<Expression>(ctx->expression());
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<LambdaExpression>(getLocation(ctx), arguments, body));
 }
 
 std::any AstBuilder::visitParenthesizedExpression(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -546,6 +546,12 @@ TEST_F(PrestoParserTest, exists) {
       matcher);
 }
 
+TEST_F(PrestoParserTest, lambda) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+
+  testSql("SELECT filter(array[1,2,3], x -> x > 1)", matcher);
+}
+
 TEST_F(PrestoParserTest, everything) {
   auto matcher =
       lp::test::LogicalPlanMatcherBuilder()


### PR DESCRIPTION
Summary:
Enables SQL parsing for queries that use lambda functions and array constructors:

> SELECT filter(array[1,2,3], x -> x > 1)

Differential Revision: D86517753


