### PR TITLE
refactor: Use TableLayout to create ColumnHandle and TableHandle

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -214,6 +214,69 @@ class PartitionType {
   }
 };
 
+// TODO Move to velox/type/Subfield.h
+using SubfieldPtr = std::shared_ptr<const velox::common::Subfield>;
+
+struct SubfieldPtrHasher {
+  size_t operator()(const SubfieldPtr& subfield) const {
+    return subfield->hash();
+  }
+};
+
+struct SubfieldPtrComparer {
+  bool operator()(const SubfieldPtr& lhs, const SubfieldPtr& rhs) const {
+    return *lhs == *rhs;
+  }
+};
+
+/// Subfield and default value for use in pushing down a complex type cast into
+/// a ColumnHandle.
+struct TargetSubfield {
+  SubfieldPtr target;
+  velox::Variant defaultValue;
+};
+
+using SubfieldMapping = folly::F14FastMap<
+    SubfieldPtr,
+    TargetSubfield,
+    SubfieldPtrHasher,
+    SubfieldPtrComparer>;
+
+/// A set of lookup keys. Lookup keys can be specified for supporting
+/// connector types when creating a ConnectorTableHandle. The corresponding
+/// DataSource will then be used with a lookup API. The keys should match a
+/// prefix of lookupKeys() of the TableLayout when making a
+/// ConnectorTableHandle. The leading keys are compared with equality. A
+/// trailing key part may be compared with range constraints. The flags have the
+/// same meaning as in common::BigintRange and related.
+struct LookupKeys {
+  /// Columns with equality constraints. Must be a prefix of the lookupKeys() in
+  /// TableLayout.
+  std::vector<std::string> equalityColumns;
+
+  /// Column on which a range condition is applied in lookup. Must be the
+  /// immediately following key in lookupKeys() order after the last column in
+  /// 'equalities'. If 'equalities' is empty, 'rangeColumn' must be the first in
+  /// lookupKeys() order.
+  std::optional<std::string> rangeColumn;
+
+  // True if the lookup has no lower bound for 'rangeColumn'.
+  bool lowerUnbounded{true};
+
+  /// true if the lookup specifies no upper bound for 'rangeColumn'.
+  bool upperUnbounded{true};
+
+  /// True if rangeColumn > range lookup lower bound.
+  bool lowerExclusive{false};
+
+  /// True if rangeColum < upper range lookup value.
+  bool upperExclusive{false};
+
+  /// True if matches for a range lookup should be returned in ascending order
+  /// of the range column. Some lookup sources may support descending order.
+  bool isAscending{true};
+};
+
 /// Represents a physical manifestation of a table. There is at least
 /// one layout but for tables that have multiple sort orders, partitionings,
 /// indices, column groups, etc. there is a separate layout for each. The layout
@@ -330,6 +393,43 @@ class TableLayout {
   /// Return a column with the matching name. Returns nullptr if not found.
   const Column* findColumn(std::string_view name) const;
 
+  /// Creates a ColumnHandle for 'columnName'. If the type is a complex type,
+  /// 'subfields' specifies which subfields need to be retrievd. Empty
+  /// 'subfields' means all are returned. If 'castToType' is present, this can
+  /// be a type that the column can be cast to. The set of supported casts
+  /// depends on the connector. In specific, a map may be cast to a struct. For
+  /// casts between complex types, 'subfieldMapping' maps from the subfield in
+  /// the data to the subfield in 'castToType'. The defaultValue is produced if
+  /// the key Subfield does not occur in the data. Subfields of 'castToType'
+  /// that are not covered by 'subfieldMapping' are set to null if 'castToType'
+  /// is a struct and are absent if 'castToType' is a map. See implementing
+  /// Connector for exact set of cast and subfield semantics.
+  virtual velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields = {},
+      std::optional<velox::TypePtr> castToType = std::nullopt,
+      SubfieldMapping subfieldMapping = {}) const = 0;
+
+  /// Returns a ConnectorTableHandle for use in createDataSource. 'filters' are
+  /// pushed down into the DataSource. 'filters' are expressions involving
+  /// literals and columns of 'layout'. The filters not supported by the target
+  /// system are returned in 'rejectedFilters'. 'rejectedFilters' will
+  /// have to be applied to the data returned by the DataSource.
+  /// 'rejectedFilters' may or may not be a subset of 'filters' or
+  /// subexpressions thereof. If 'lookupKeys' is present, these must match the
+  /// lookupKeys() in 'layout'. If 'dataColumns' is given, it must have all the
+  /// existing columns and may additionally specify casting from maps to structs
+  /// by giving a struct in the place of a map.
+  virtual velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns = nullptr,
+      std::optional<LookupKeys> lookupKeys = std::nullopt) const = 0;
+
  private:
   const std::string name_;
   const Table* table_;
@@ -409,69 +509,6 @@ class Table : public std::enable_shared_from_this<Table> {
 };
 
 using TablePtr = std::shared_ptr<const Table>;
-
-// TODO Move to velox/type/Subfield.h
-using SubfieldPtr = std::shared_ptr<const velox::common::Subfield>;
-
-struct SubfieldPtrHasher {
-  size_t operator()(const SubfieldPtr& subfield) const {
-    return subfield->hash();
-  }
-};
-
-struct SubfieldPtrComparer {
-  bool operator()(const SubfieldPtr& lhs, const SubfieldPtr& rhs) const {
-    return *lhs == *rhs;
-  }
-};
-
-/// Subfield and default value for use in pushing down a complex type cast into
-/// a ColumnHandle.
-struct TargetSubfield {
-  SubfieldPtr target;
-  velox::Variant defaultValue;
-};
-
-using SubfieldMapping = folly::F14FastMap<
-    SubfieldPtr,
-    TargetSubfield,
-    SubfieldPtrHasher,
-    SubfieldPtrComparer>;
-
-/// A set of lookup keys. Lookup keys can be specified for supporting
-/// connector types when creating a ConnectorTableHandle. The corresponding
-/// DataSource will then be used with a lookup API. The keys should match a
-/// prefix of lookupKeys() of the TableLayout when making a
-/// ConnectorTableHandle. The leading keys are compared with equality. A
-/// trailing key part may be compared with range constraints. The flags have the
-/// same meaning as in common::BigintRange and related.
-struct LookupKeys {
-  /// Columns with equality constraints. Must be a prefix of the lookupKeys() in
-  /// TableLayout.
-  std::vector<std::string> equalityColumns;
-
-  /// Column on which a range condition is applied in lookup. Must be the
-  /// immediately following key in lookupKeys() order after the last column in
-  /// 'equalities'. If 'equalities' is empty, 'rangeColumn' must be the first in
-  /// lookupKeys() order.
-  std::optional<std::string> rangeColumn;
-
-  // True if the lookup has no lower bound for 'rangeColumn'.
-  bool lowerUnbounded{true};
-
-  /// true if the lookup specifies no upper bound for 'rangeColumn'.
-  bool upperUnbounded{true};
-
-  /// True if rangeColumn > range lookup lower bound.
-  bool lowerExclusive{false};
-
-  /// True if rangeColum < upper range lookup value.
-  bool upperExclusive{false};
-
-  /// True if matches for a range lookup should be returned in ascending order
-  /// of the range column. Some lookup sources may support descending order.
-  bool isAscending{true};
-};
 
 /// Contains the information for an in-progress write operation. This may
 /// include insert, update, or delete of an existing table, or insertion into a
@@ -560,45 +597,6 @@ class ConnectorMetadata {
   /// the ConnectorMetadata to the connector so that Connector methods
   /// that refer to metadata are available.
   virtual void initialize() = 0;
-
-  /// Creates a ColumnHandle for 'columnName'. If the type is a complex type,
-  /// 'subfields' specifies which subfields need to be retrievd. Empty
-  /// 'subfields' means all are returned. If 'castToType' is present, this can
-  /// be a type that the column can be cast to. The set of supported casts
-  /// depends on the connector. In specific, a map may be cast to a struct. For
-  /// casts between complex types, 'subfieldMapping' maps from the subfield in
-  /// the data to the subfield in 'castToType'. The defaultValue is produced if
-  /// the key Subfield does not occur in the data. Subfields of 'castToType'
-  /// that are not covered by 'subfieldMapping' are set to null if 'castToType'
-  /// is a struct and are absent if 'castToType' is a map. See implementing
-  /// Connector for exact set of cast and subfield semantics.
-  virtual velox::connector::ColumnHandlePtr createColumnHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layoutData,
-      const std::string& columnName,
-      std::vector<velox::common::Subfield> subfields = {},
-      std::optional<velox::TypePtr> castToType = std::nullopt,
-      SubfieldMapping subfieldMapping = {}) = 0;
-
-  /// Returns a ConnectorTableHandle for use in createDataSource. 'filters' are
-  /// pushed down into the DataSource. 'filters' are expressions involving
-  /// literals and columns of 'layout'. The filters not supported by the target
-  /// system are returned in 'rejectedFilters'. 'rejectedFilters' will
-  /// have to be applied to the data returned by the DataSource.
-  /// 'rejectedFilters' may or may not be a subset of 'filters' or
-  /// subexpressions thereof. If 'lookupKeys' is present, these must match the
-  /// lookupKeys() in 'layout'. If 'dataColumns' is given, it must have all the
-  /// existing columns and may additionally specify casting from maps to structs
-  /// by giving a struct in the place of a map.
-  virtual velox::connector::ConnectorTableHandlePtr createTableHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      velox::core::ExpressionEvaluator& evaluator,
-      std::vector<velox::core::TypedExprPtr> filters,
-      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
-      velox::RowTypePtr dataColumns = nullptr,
-      std::optional<LookupKeys> = std::nullopt) = 0;
 
   /// Return a ConnectorTablePtr given the table name. Table name is provided
   /// without the connector ID prefix for the connector. The returned Table

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -111,6 +111,22 @@ class HiveTableLayout : public TableLayout {
     return partitionType_.has_value() ? &partitionType_.value() : nullptr;
   }
 
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields = {},
+      std::optional<velox::TypePtr> castToType = std::nullopt,
+      SubfieldMapping subfieldMapping = {}) const override;
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
+
  protected:
   const velox::dwio::common::FileFormat fileFormat_;
   const std::vector<const Column*> hivePartitionColumns_;
@@ -183,24 +199,6 @@ class HiveConnectorMetadata : public ConnectorMetadata {
         hiveConfig_(
             std::make_shared<velox::connector::hive::HiveConfig>(
                 hiveConnector->connectorConfig())) {}
-
-  velox::connector::ColumnHandlePtr createColumnHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      const std::string& columnName,
-      std::vector<velox::common::Subfield> subfields = {},
-      std::optional<velox::TypePtr> castToType = std::nullopt,
-      SubfieldMapping subfieldMapping = {}) override;
-
-  velox::connector::ConnectorTableHandlePtr createTableHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      velox::core::ExpressionEvaluator& evaluator,
-      std::vector<velox::core::TypedExprPtr> filters,
-      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
-      velox::RowTypePtr dataColumns,
-      std::optional<LookupKeys> lookupKeys) override;
 
   ConnectorWriteHandlePtr beginWrite(
       const ConnectorSessionPtr& session,

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -853,8 +853,8 @@ void LocalTable::sampleNumDistincts(
   std::vector<velox::connector::ColumnHandlePtr> columns;
   columns.reserve(type_->size());
   for (auto i = 0; i < type_->size(); ++i) {
-    columns.push_back(metadata->createColumnHandle(
-        /*session=*/nullptr, *layout, type_->nameOf(i)));
+    columns.push_back(layout->createColumnHandle(
+        /*session=*/nullptr, type_->nameOf(i)));
   }
 
   auto* localHiveMetadata =
@@ -863,8 +863,8 @@ void LocalTable::sampleNumDistincts(
       *localHiveMetadata->connectorQueryCtx()->expressionEvaluator();
 
   std::vector<velox::core::TypedExprPtr> ignore;
-  auto handle = metadata->createTableHandle(
-      /*session=*/nullptr, *layout, columns, evaluator, {}, ignore);
+  auto handle = layout->createTableHandle(
+      /*session=*/nullptr, columns, evaluator, {}, ignore);
 
   auto* localLayout = dynamic_cast<LocalHiveTableLayout*>(layout);
   VELOX_CHECK_NOT_NULL(localLayout, "Expecting a local hive layout");

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -165,8 +165,8 @@ class LocalHiveConnectorMetadataTest
     velox::connector::ColumnHandleMap assignments;
     const auto* layout = getLayout(table);
     for (auto i = 0; i < tableType->size(); ++i) {
-      assignments[tableType->nameOf(i)] = metadata_->createColumnHandle(
-          /*session=*/nullptr, *layout, tableType->nameOf(i));
+      assignments[tableType->nameOf(i)] = layout->createColumnHandle(
+          /*session=*/nullptr, tableType->nameOf(i));
     }
     auto plan = exec::test::PlanBuilder()
                     .tableScan(
@@ -231,16 +231,14 @@ TEST_F(LocalHiveConnectorMetadataTest, basic) {
   ASSERT_TRUE(column != nullptr);
   EXPECT_EQ(250'000, table->numRows());
   auto* layout = table->layouts()[0];
-  auto columnHandle =
-      metadata_->createColumnHandle(/*session=*/nullptr, *layout, "c0");
+  auto columnHandle = layout->createColumnHandle(/*session=*/nullptr, "c0");
   std::vector<velox::connector::ColumnHandlePtr> columns = {columnHandle};
   std::vector<core::TypedExprPtr> filters;
   std::vector<core::TypedExprPtr> rejectedFilters;
   auto ctx = metadata_->connectorQueryCtx();
 
-  auto tableHandle = metadata_->createTableHandle(
+  auto tableHandle = layout->createTableHandle(
       /*session=*/nullptr,
-      *layout,
       columns,
       *ctx->expressionEvaluator(),
       filters,

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -86,32 +86,29 @@ TablePtr TestConnectorMetadata::findTable(std::string_view name) {
   return findTableInternal(name);
 }
 
-velox::connector::ColumnHandlePtr TestConnectorMetadata::createColumnHandle(
+velox::connector::ColumnHandlePtr TestTableLayout::createColumnHandle(
     const ConnectorSessionPtr& session,
-    const TableLayout& layout,
     const std::string& columnName,
-    std::vector<velox::common::Subfield>,
+    std::vector<velox::common::Subfield> subfields,
     std::optional<velox::TypePtr> castToType,
-    SubfieldMapping) {
-  auto column = layout.findColumn(columnName);
+    SubfieldMapping subfieldMapping) const {
+  auto column = findColumn(columnName);
   VELOX_CHECK_NOT_NULL(
-      column, "Column {} not found in table {}", columnName, layout.name());
+      column, "Column {} not found in table {}", columnName, name());
   return std::make_shared<TestColumnHandle>(
       columnName, castToType.value_or(column->type()));
 }
 
-velox::connector::ConnectorTableHandlePtr
-TestConnectorMetadata::createTableHandle(
+velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
     const ConnectorSessionPtr& session,
-    const TableLayout& layout,
     std::vector<velox::connector::ColumnHandlePtr> columnHandles,
     velox::core::ExpressionEvaluator& /* evaluator */,
     std::vector<velox::core::TypedExprPtr> filters,
     std::vector<velox::core::TypedExprPtr>& rejectedFilters,
     velox::RowTypePtr /* dataColumns */,
-    std::optional<LookupKeys>) {
+    std::optional<LookupKeys> lookupKeys) const {
   rejectedFilters = std::move(filters);
-  return std::make_shared<TestTableHandle>(layout, std::move(columnHandles));
+  return std::make_shared<TestTableHandle>(*this, std::move(columnHandles));
 }
 
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -54,6 +54,22 @@ class TestTableLayout : public TableLayout {
       std::vector<ColumnStatistics>*) const override {
     return std::make_pair(1'000, 1'000);
   }
+
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields,
+      std::optional<velox::TypePtr> castToType,
+      SubfieldMapping subfieldMapping) const override;
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -252,24 +268,6 @@ class TestConnectorMetadata : public ConnectorMetadata {
   ConnectorSplitManager* splitManager() override {
     return splitManager_.get();
   }
-
-  velox::connector::ColumnHandlePtr createColumnHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      const std::string& columnName,
-      std::vector<velox::common::Subfield> subfields = {},
-      std::optional<velox::TypePtr> castToType = std::nullopt,
-      SubfieldMapping subfieldMapping = {}) override;
-
-  velox::connector::ConnectorTableHandlePtr createTableHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      velox::core::ExpressionEvaluator& evaluator,
-      std::vector<velox::core::TypedExprPtr> filters,
-      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
-      velox::RowTypePtr dataColumns,
-      std::optional<LookupKeys>) override;
 
   /// Create and return a TestTable with the specified name and schema in the
   /// in-memory map maintained in the connector metadata. If the table already

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -108,8 +108,7 @@ TEST_F(TestConnectorTest, columnHandle) {
   auto table = metadata_->findTable("table");
   auto& layout = *table->layouts()[0];
 
-  auto columnHandle =
-      metadata_->createColumnHandle(/*session=*/nullptr, layout, "a");
+  auto columnHandle = layout.createColumnHandle(/*session=*/nullptr, "a");
   EXPECT_NE(columnHandle, nullptr);
 
   auto testColumnHandle =
@@ -164,17 +163,15 @@ TEST_F(TestConnectorTest, dataSource) {
   auto& layout = *table->layouts()[0];
 
   std::vector<velox::connector::ColumnHandlePtr> columns;
-  columns.push_back(
-      metadata_->createColumnHandle(/*session=*/nullptr, layout, "a"));
-  columns.push_back(
-      metadata_->createColumnHandle(/*session=*/nullptr, layout, "b"));
+  columns.push_back(layout.createColumnHandle(/*session=*/nullptr, "a"));
+  columns.push_back(layout.createColumnHandle(/*session=*/nullptr, "b"));
 
   auto evaluator =
       std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
   std::vector<core::TypedExprPtr> empty;
-  auto tableHandle = metadata_->createTableHandle(
+  auto tableHandle = layout.createTableHandle(
       /*session=*/nullptr,
-      layout,
+
       std::move(columns),
       *evaluator,
       empty,
@@ -188,10 +185,8 @@ TEST_F(TestConnectorTest, dataSource) {
   connector_->appendData("table", vector2);
 
   velox::connector::ColumnHandleMap handleMap;
-  handleMap.emplace(
-      "a", metadata_->createColumnHandle(/*session=*/nullptr, layout, "a"));
-  handleMap.emplace(
-      "b", metadata_->createColumnHandle(/*session=*/nullptr, layout, "b"));
+  handleMap.emplace("a", layout.createColumnHandle(/*session=*/nullptr, "a"));
+  handleMap.emplace("b", layout.createColumnHandle(/*session=*/nullptr, "b"));
   auto dataSource = std::make_shared<TestDataSource>(
       schema, std::move(handleMap), table, pool());
   EXPECT_EQ(dataSource->getCompletedRows(), 0);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -147,27 +147,23 @@ TpchConnectorMetadata::TpchConnectorMetadata(
   VELOX_CHECK_NOT_NULL(tpchConnector);
 }
 
-velox::connector::ColumnHandlePtr TpchConnectorMetadata::createColumnHandle(
+velox::connector::ColumnHandlePtr TpchTableLayout::createColumnHandle(
     const ConnectorSessionPtr& session,
-    const TableLayout& layoutData,
     const std::string& columnName,
     std::vector<velox::common::Subfield> subfields,
     std::optional<velox::TypePtr> castToType,
-    SubfieldMapping subfieldMapping) {
+    SubfieldMapping subfieldMapping) const {
   return std::make_shared<velox::connector::tpch::TpchColumnHandle>(columnName);
 }
 
-velox::connector::ConnectorTableHandlePtr
-TpchConnectorMetadata::createTableHandle(
+velox::connector::ConnectorTableHandlePtr TpchTableLayout::createTableHandle(
     const ConnectorSessionPtr& session,
-    const TableLayout& layout,
     std::vector<velox::connector::ColumnHandlePtr> /*columnHandles*/,
     velox::core::ExpressionEvaluator& /*evaluator*/,
     std::vector<velox::core::TypedExprPtr> filters,
     std::vector<velox::core::TypedExprPtr>& /*rejectedFilters*/,
     velox::RowTypePtr /*dataColumns*/,
-    std::optional<LookupKeys> /*lookupKeys*/) {
-  auto* tpchLayout = dynamic_cast<const TpchTableLayout*>(&layout);
+    std::optional<LookupKeys> /*lookupKeys*/) const {
   velox::core::TypedExprPtr filterExpression;
   for (auto& filter : filters) {
     if (!filterExpression) {
@@ -182,9 +178,9 @@ TpchConnectorMetadata::createTableHandle(
   }
 
   return std::make_shared<velox::connector::tpch::TpchTableHandle>(
-      tpchConnector_->connectorId(),
-      tpchLayout->getTpchTable(),
-      tpchLayout->getScaleFactor(),
+      connector()->connectorId(),
+      getTpchTable(),
+      getScaleFactor(),
       std::move(filterExpression));
 }
 

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -110,6 +110,22 @@ class TpchTableLayout : public TableLayout {
       velox::HashStringAllocator* allocator = nullptr,
       std::vector<ColumnStatistics>* statistics = nullptr) const override;
 
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields,
+      std::optional<velox::TypePtr> castToType,
+      SubfieldMapping subfieldMapping) const override;
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
+
  private:
   const velox::tpch::Table tpchTable_;
   const double scaleFactor_;
@@ -183,24 +199,6 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   ConnectorSplitManager* splitManager() override {
     return &splitManager_;
   }
-
-  velox::connector::ColumnHandlePtr createColumnHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layoutData,
-      const std::string& columnName,
-      std::vector<velox::common::Subfield> subfields = {},
-      std::optional<velox::TypePtr> castToType = std::nullopt,
-      SubfieldMapping subfieldMapping = {}) override;
-
-  velox::connector::ConnectorTableHandlePtr createTableHandle(
-      const ConnectorSessionPtr& session,
-      const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      velox::core::ExpressionEvaluator& evaluator,
-      std::vector<velox::core::TypedExprPtr> filters,
-      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
-      velox::RowTypePtr dataColumns = nullptr,
-      std::optional<LookupKeys> = std::nullopt) override;
 
   velox::connector::tpch::TpchConnector* tpchConnector() const {
     return tpchConnector_;

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -118,8 +118,8 @@ TEST_F(TpchConnectorMetadataTest, createColumnHandle) {
   const auto& layouts = table->layouts();
   ASSERT_FALSE(layouts.empty());
 
-  auto columnHandle = metadata_->createColumnHandle(
-      /*session=*/nullptr, *layouts[0], "orderkey");
+  auto columnHandle = layouts[0]->createColumnHandle(
+      /*session=*/nullptr, "orderkey");
   ASSERT_NE(columnHandle, nullptr);
 
   auto* tpchColumnHandle =
@@ -142,13 +142,8 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
   std::vector<velox::core::TypedExprPtr> empty;
   auto evaluator = std::make_unique<velox::exec::SimpleExpressionEvaluator>(
       nullptr, nullptr);
-  auto tableHandle = metadata_->createTableHandle(
-      /*session=*/nullptr,
-      *layouts[0],
-      columnHandles,
-      *evaluator,
-      empty,
-      empty);
+  auto tableHandle = layouts[0]->createTableHandle(
+      /*session=*/nullptr, columnHandles, *evaluator, empty, empty);
   ASSERT_NE(tableHandle, nullptr);
 
   auto* tpchTableHandle =
@@ -175,13 +170,8 @@ TEST_F(TpchConnectorMetadataTest, splitGeneration) {
   std::vector<velox::core::TypedExprPtr> empty;
   auto evaluator = std::make_unique<velox::exec::SimpleExpressionEvaluator>(
       nullptr, nullptr);
-  auto tableHandle = metadata_->createTableHandle(
-      /*session=*/nullptr,
-      *layouts[0],
-      columnHandles,
-      *evaluator,
-      empty,
-      empty);
+  auto tableHandle = layouts[0]->createTableHandle(
+      /*session=*/nullptr, columnHandles, *evaluator, empty, empty);
   ASSERT_NE(tableHandle, nullptr);
 
   auto partitions =


### PR DESCRIPTION
Refactors the API for creating column and table handles by moving createColumnHandle and createTableHandle methods from ConnectorMetadata to TableLayout. This change allows these methods to be called directly on layout objects, simplifying the API by removing the redundant layout parameter.
* Moved createColumnHandle and createTableHandle from ConnectorMetadata base class to TableLayout base class
* Updated all connector implementations (Tpch, Hive, Test) to implement these methods in their respective TableLayout subclasses
* Updated all call sites throughout the codebase to call these methods on layout objects instead of metadata objects



This not only simplify code for reader and writers (devs who wants to create their own connector), but it also allows us to avoid dynamic_cast