### PR TITLE
feat: Add support for subscript operator to PrestoParser

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -265,6 +265,11 @@ class ExprAnalyzer : public AstVisitor {
     }
   }
 
+  void visitSubscriptExpression(SubscriptExpression* node) override {
+    node->base()->accept(this);
+    node->index()->accept(this);
+  }
+
   void visitIdentifier(Identifier* node) override {
     // No function calls.
   }
@@ -594,6 +599,12 @@ class RelationPlanner : public AstVisitor {
         }
 
         return lp::Lambda(names, toExpr(lambda->body()));
+      }
+
+      case NodeType::kSubscriptExpression: {
+        auto* subscript = node->as<SubscriptExpression>();
+        return lp::Call(
+            "subscript", toExpr(subscript->base()), toExpr(subscript->index()));
       }
 
       default:

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1550,7 +1550,11 @@ std::any AstBuilder::visitRowConstructor(
 
 std::any AstBuilder::visitSubscript(PrestoSqlParser::SubscriptContext* ctx) {
   trace("visitSubscript");
-  return visitChildren(ctx);
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<SubscriptExpression>(
+          getLocation(ctx),
+          visitTyped<Expression>(ctx->primaryExpression()),
+          visitTyped<Expression>(ctx->valueExpression())));
 }
 
 std::any AstBuilder::visitSubqueryExpression(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -355,6 +355,11 @@ TEST_F(PrestoParserTest, concat) {
   testSql("SELECT n_name || n_comment FROM nation", matcher);
 }
 
+TEST_F(PrestoParserTest, subscript) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSql("SELECT array[1, 2, 3][1] FROM nation", matcher);
+}
+
 TEST_F(PrestoParserTest, selectStar) {
   auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan();
   testSql("SELECT * FROM nation", matcher);


### PR DESCRIPTION
Summary:
Enable queries like

> SELECT a[1] FROM t

Differential Revision: D86863356


