### PR TITLE
fix: Filter pushdown through the outer join

### DIFF
--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -236,6 +236,11 @@ const PlanObjectSet& PlanState::downstreamColumns() const {
     if (addFilter && !join->filter().empty()) {
       addExprs(join->filter());
     }
+
+    if (addFilter) {
+      addExprs(join->leftExprs());
+      addExprs(join->rightExprs());
+    }
   }
 
   // Filters.

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -162,6 +162,10 @@ class Path {
     return id_;
   }
 
+  bool empty() const {
+    return steps_.empty();
+  }
+
   void setId(int32_t id) const {
     VELOX_CHECK(mutable_);
     id_ = id;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -340,6 +340,11 @@ class ToGraph {
 
   ColumnCP addMarkColumn();
 
+  void addJoinColumns(
+      const logical_plan::LogicalPlanNode& joinSide,
+      ColumnVector& columns,
+      ExprVector& exprs);
+
   // Cache of resolved table schemas.
   Schema schema_;
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ add_executable(
   HiveAggregationQueriesTest.cpp
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp
+  JoinTest.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp
   RelationOpPrinterTest.cpp

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -174,7 +174,7 @@ TEST_F(DerivedTablePrinterTest, basic) {
             testing::Eq("  joins:"),
             testing::Eq("    t2 LEFT t3 ON t2.a = t3.x"),
             testing::Eq("  syntactic join order: 3, 8"),
-            testing::Eq("  aggregates: sum(multiply(t2.b, t3.y)) AS sum"),
+            testing::Eq("  aggregates: sum(multiply(t2.b, dt1.y)) AS sum"),
             testing::Eq("  grouping keys: t2.a"),
             testing::Eq(""),
             testing::Eq("t2: a, b"),


### PR DESCRIPTION
Summary:
ToGraph converts logical plan tree into a Query Graph. The conversion involves creating graph objects such as tables, columns, expressions. New columns are created from nodes such as Values, TableScan, Project, Aggregate. Filter, Sort, Limit do not make new columns. Available columns are stored in renames_ map keyed on the symbol name found in the logical plan.

Each column indicates where it is coming from: a BaseTable, a ValuesTable or a DerivedTable. Columns produced by TableScan nodes are associated with the corresponding BaseTable. Columns produced by the Aggregation are associated with the containing DerivedTable. A filter expression that depends solely on columns from a single BaseTable can be pushed down into that table.

Before this change, the Join node didn’t make new columns. This is fine for INNER join, but is incorrect for outer joins (left, right and full). Outer joins need to make new columns for the ‘optional’ side of the join. LEFT join makes new columns for the right side. RIGHT join makes new columns for the left side. FULL join makes new columns for both sides.

When a join doesn’t make a new column, the filter on top of that join may get incorrectly pushed down below the join. Consider an example,

```
SELECT * FROM (
  SELECT * FROM t LEFT JOIN u ON t.id = u.id
) 
WHERE u.data is null
```

This query has a join followed by a filter that depends only on columns from the right side of the join. However, this filter cannot be pushed down under the join because the join changes the column, by adding NULL rows.

This change fixes plans for queries with filters over outer joins.

This issue was uncovered by changes in #599.

Fixes https://github.com/facebookincubator/axiom/issues/606

Co-authored-by: MBkkt

Differential Revision: D86776319


