### PR TITLE
fix: Fix pushdown conjuncts instead of generating join columns

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -918,6 +918,19 @@ void DerivedTable::distributeConjuncts() {
         tables[0]->as<DerivedTable>()->setOp.value() ==
             logical_plan::SetOperation::kUnionAll));
 
+  PlanObjectSet noPushdownTables;
+  for (const auto* join : joins) {
+    if (join->leftOptional()) {
+      // No pushdown to the left side of a RIGHT or FULL join.
+      noPushdownTables.add(join->leftTable());
+    }
+    if (join->rightOptional()) {
+      // No pushdown to the right side of a LEFT or FULL join.
+      noPushdownTables.add(join->rightTable());
+    }
+  }
+  VELOX_DCHECK(tables.size() > 1 || noPushdownTables.empty());
+
   for (auto i = 0; i < conjuncts.size(); ++i) {
     // No pushdown of non-deterministic except if only pushdown target is a
     // union all.
@@ -936,6 +949,10 @@ void DerivedTable::distributeConjuncts() {
 
       if (tables[0]->is(PlanType::kValuesTableNode)) {
         continue; // ValuesTable does not have filter pushdown.
+      }
+
+      if (noPushdownTables.contains(tables[0])) {
+        continue; // No pushdown if depends on an optional side of a join.
       }
 
       if (tables[0]->is(PlanType::kUnnestTableNode)) {

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -102,13 +102,13 @@ std::string visitJoinEdge(const JoinEdge& edge) {
     out << " SEMI ";
   } else if (edge.isAnti()) {
     out << " ANTI ";
-  } else if (edge.leftOptional() && edge.rightOptional()) {
+  } else if (edge.isFullOuter()) {
     out << " FULL OUTER ";
-  } else if (edge.leftOptional()) {
+  } else if (edge.isRightOuter()) {
     out << " RIGHT ";
-  } else if (edge.rightOptional()) {
+  } else if (edge.isLeftOuter()) {
     out << " LEFT ";
-  } else if (edge.directed()) {
+  } else if (edge.isUnnest()) {
     out << " UNNEST ";
   } else {
     out << " INNER ";

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -148,7 +148,6 @@ void reducingJoinsRecursive(
       // probe. This happens specially when value subqueries are represented as
       // optional sides of left join. These are often aggregations and there is
       // no point creating values for groups that can't be probed.
-      ;
     } else if (join->leftOptional() || join->rightOptional()) {
       continue;
     }
@@ -357,12 +356,9 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
         if (!state.placed.contains(joined) && state.dt->hasJoin(join) &&
             state.dt->hasTable(joined)) {
           candidates.emplace_back(join, joined, fanout);
-          if (join->isInner()) {
-            if (!addExtraEdges(state, candidates.back())) {
-              // Drop the candidate if the edge was subsumed in some other
-              // edge.
-              candidates.pop_back();
-            }
+          if (join->isInner() && !addExtraEdges(state, candidates.back())) {
+            // Drop the candidate if the edge was subsumed in some other edge.
+            candidates.pop_back();
           }
         }
       });
@@ -1594,8 +1590,7 @@ void Optimization::addJoin(
   }
 
   // If this candidate has multiple Unnest they all will be handled at once.
-  if (candidate.tables.size() >= 1 &&
-      candidate.tables[0]->is(PlanType::kUnnestTableNode)) {
+  if (candidate.join->isUnnest()) {
     crossJoinUnnest(plan, candidate, state, result);
     return;
   }
@@ -1607,7 +1602,6 @@ void Optimization::addJoin(
   joinByHash(plan, candidate, state, toTry);
 
   if (!options_.syntacticJoinOrder && toTry.size() > sizeAfterIndex &&
-      candidate.join->isNonCommutative() &&
       candidate.join->hasRightHashVariant()) {
     // There is a hash based candidate with a non-commutative join. Try a right
     // join variant.
@@ -1720,7 +1714,7 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
 bool Optimization::placeConjuncts(
     RelationOpPtr plan,
     PlanState& state,
-    bool allowNondeterministic) {
+    bool joinsPlaced) {
   PlanStateSaver save(state);
 
   PlanObjectSet columnsAndSingles = state.columns;
@@ -1729,7 +1723,7 @@ bool Optimization::placeConjuncts(
 
   ExprVector filters;
   for (auto& conjunct : state.dt->conjuncts) {
-    if (!allowNondeterministic && conjunct->containsNonDeterministic()) {
+    if (!joinsPlaced && conjunct->containsNonDeterministic()) {
       continue;
     }
     if (state.placed.contains(conjunct)) {
@@ -1877,29 +1871,11 @@ PlanP unionPlan(
   return plan;
 }
 
-float startingScore(PlanObjectCP table) {
-  if (table->is(PlanType::kTableNode)) {
-    return table->as<BaseTable>()->schemaTable->cardinality;
-  }
-
-  if (table->is(PlanType::kValuesTableNode)) {
-    return table->as<ValuesTable>()->cardinality();
-  }
-
-  if (table->is(PlanType::kUnnestTableNode)) {
-    VELOX_FAIL("UnnestTable cannot be a starting table");
-    // Because it's rigth side of directed inner (cross) join edge.
-    // Directed edges are non-commutative, so right side cannot be starting.
-  }
-
-  return 10;
-}
-
 std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
   std::vector<float> scores;
   scores.reserve(tables.size());
   for (auto table : tables) {
-    scores.emplace_back(startingScore(table));
+    scores.emplace_back(tableCardinality(table));
   }
 
   std::vector<int32_t> indices(tables.size());
@@ -1967,8 +1943,8 @@ void Optimization::makeJoins(PlanState& state) {
       makeJoins(scan, state);
     } else if (from->is(PlanType::kUnnestTableNode)) {
       VELOX_FAIL("UnnestTable cannot be a starting table");
-      // Because it's rigth side of directed inner (cross) join edge.
-      // Directed edges are non-commutative, so right side cannot be starting.
+      // Because it's right side of unnest join edge
+      // and they are non-commutative.
     } else {
       // Start with a derived table.
       placeDerivedTable(from->as<const DerivedTable>(), state);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1098,53 +1098,6 @@ void Optimization::joinByIndex(
   }
 }
 
-struct ProjectionBuilder {
-  ColumnVector columns;
-  ExprVector exprs;
-
-  // Project 'expr' as 'column'.
-  void add(ColumnCP column, ExprCP expr) {
-    columns.emplace_back(column);
-    exprs.emplace_back(expr);
-  }
-
-  RelationOp* build(RelationOp* input) {
-    return make<Project>(
-        input, exprs, columns, isRedundantProject(input, exprs, columns));
-  }
-
-  ColumnVector inputColumns() const {
-    ColumnVector columns;
-    columns.reserve(exprs.size());
-    for (const auto* expr : exprs) {
-      VELOX_DCHECK(expr->isColumn());
-      columns.emplace_back(expr->as<Column>());
-    }
-
-    return columns;
-  }
-
-  PlanObjectSet outputColumns() const {
-    PlanObjectSet columnSet;
-    columnSet.unionObjects(columns);
-    return columnSet;
-  }
-};
-
-folly::F14FastMap<PlanObjectCP, ExprCP> makeJoinColumnMapping(
-    JoinEdgeP joinEdge) {
-  folly::F14FastMap<PlanObjectCP, ExprCP> mapping;
-  for (auto i = 0; i < joinEdge->leftColumns().size(); ++i) {
-    mapping.emplace(joinEdge->leftColumns()[i], joinEdge->leftExprs()[i]);
-  }
-
-  for (auto i = 0; i < joinEdge->rightColumns().size(); ++i) {
-    mapping.emplace(joinEdge->rightColumns()[i], joinEdge->rightExprs()[i]);
-  }
-
-  return mapping;
-}
-
 namespace {
 
 // Check if 'mark' column produced by a SemiProject join is used only to filter
@@ -1292,29 +1245,13 @@ void Optimization::joinByHash(
   PlanObjectSet probeColumns;
   probeColumns.unionObjects(plan->columns());
 
+  ColumnVector columns;
+  PlanObjectSet columnSet;
   ColumnCP mark = nullptr;
-
-  auto* joinEdge = candidate.join;
-
-  PlanObjectSet joinColumns;
-  joinColumns.unionObjects(joinEdge->leftColumns());
-  joinColumns.unionObjects(joinEdge->rightColumns());
-
-  // Mapping from join output column to probe or build side input.
-  auto joinColumnMapping = makeJoinColumnMapping(joinEdge);
-
-  ProjectionBuilder projectionBuilder;
-  bool needsProjection = false;
 
   state.downstreamColumns().forEach<Column>([&](auto column) {
     if (column == build.markColumn) {
       mark = column;
-      return;
-    }
-
-    if (joinColumns.contains(column)) {
-      projectionBuilder.add(column, joinColumnMapping.at(column));
-      needsProjection = true;
       return;
     }
 
@@ -1323,7 +1260,8 @@ void Optimization::joinByHash(
       return;
     }
 
-    projectionBuilder.add(column, column);
+    columnSet.add(column);
+    columns.push_back(column);
   });
 
   if (mark) {
@@ -1335,10 +1273,11 @@ void Optimization::joinByHash(
 
   // If there is an existence flag, it is the rightmost result column.
   if (mark) {
-    projectionBuilder.add(mark, mark);
+    columnSet.add(mark);
+    columns.push_back(mark);
   }
 
-  state.columns = projectionBuilder.outputColumns();
+  state.columns = columnSet;
 
   const auto fanout = fanoutJoinTypeLimit(
       joinType,
@@ -1359,14 +1298,10 @@ void Optimization::joinByHash(
       std::move(buildKeys),
       candidate.join->filter(),
       fanout,
-      projectionBuilder.inputColumns());
+      std::move(columns));
 
   state.addCost(*join);
   state.cost.cost += buildState.cost.cost;
-
-  if (needsProjection) {
-    join = projectionBuilder.build(join);
-  }
 
   state.addNextJoin(&candidate, join, toTry);
 }
@@ -1447,29 +1382,13 @@ void Optimization::joinByHashRight(
       rightJoinType == velox::core::JoinType::kRightSemiFilter ||
       rightJoinType == velox::core::JoinType::kRightSemiProject;
 
+  ColumnVector columns;
+  PlanObjectSet columnSet;
   ColumnCP mark = nullptr;
-
-  auto* joinEdge = candidate.join;
-
-  PlanObjectSet joinColumns;
-  joinColumns.unionObjects(joinEdge->leftColumns());
-  joinColumns.unionObjects(joinEdge->rightColumns());
-
-  // Mapping from join output column to probe or build side input.
-  auto joinColumnMapping = makeJoinColumnMapping(joinEdge);
-
-  ProjectionBuilder projectionBuilder;
-  bool needsProjection = false;
 
   state.downstreamColumns().forEach<Column>([&](auto column) {
     if (column == probe.markColumn) {
       mark = column;
-      return;
-    }
-
-    if (joinColumns.contains(column)) {
-      projectionBuilder.add(column, joinColumnMapping.at(column));
-      needsProjection = true;
       return;
     }
 
@@ -1478,7 +1397,8 @@ void Optimization::joinByHashRight(
       return;
     }
 
-    projectionBuilder.add(column, column);
+    columnSet.add(column);
+    columns.push_back(column);
   });
 
   if (mark) {
@@ -1489,7 +1409,8 @@ void Optimization::joinByHashRight(
   tryOptimizeSemiProject(rightJoinType, mark, state, negation_);
 
   if (mark) {
-    projectionBuilder.add(mark, mark);
+    columnSet.add(mark);
+    columns.push_back(mark);
   }
 
   const auto fanout = fanoutJoinTypeLimit(
@@ -1500,7 +1421,7 @@ void Optimization::joinByHashRight(
 
   const auto buildCost = state.cost;
 
-  state.columns = projectionBuilder.outputColumns();
+  state.columns = columnSet;
   state.cost = probeState.cost;
   state.cost.cost += buildCost.cost;
 
@@ -1517,12 +1438,8 @@ void Optimization::joinByHashRight(
       std::move(buildKeys),
       candidate.join->filter(),
       fanout,
-      projectionBuilder.inputColumns());
+      std::move(columns));
   state.addCost(*join);
-
-  if (needsProjection) {
-    join = projectionBuilder.build(join);
-  }
 
   state.addNextJoin(&candidate, join, toTry);
 }
@@ -1721,6 +1638,19 @@ bool Optimization::placeConjuncts(
   state.dt->singleRowDts.forEach<DerivedTable>(
       [&](auto dt) { columnsAndSingles.unionObjects(dt->columns); });
 
+  PlanObjectSet noPushdownTables;
+  if (!joinsPlaced) {
+    for (const auto* join : state.dt->joins) {
+      if (join->leftOptional()) {
+        // No pushdown to the left side of a RIGHT or FULL join.
+        noPushdownTables.add(join->leftTable());
+      }
+      if (join->rightOptional()) {
+        // No pushdown to the right side of a LEFT or FULL join.
+        noPushdownTables.add(join->rightTable());
+      }
+    }
+  }
   ExprVector filters;
   for (auto& conjunct : state.dt->conjuncts) {
     if (!joinsPlaced && conjunct->containsNonDeterministic()) {
@@ -1728,6 +1658,12 @@ bool Optimization::placeConjuncts(
     }
     if (state.placed.contains(conjunct)) {
       continue;
+    }
+    if (!joinsPlaced) {
+      const auto* singleTable = conjunct->singleTable();
+      if (singleTable && noPushdownTables.contains(singleTable)) {
+        continue;
+      }
     }
     if (conjunct->columns().isSubset(state.columns)) {
       state.columns.add(conjunct);

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -242,10 +242,7 @@ class Optimization {
   // placed, adds them to 'state.placed' and calls makeJoins()
   // recursively to make the rest of the plan. Returns false if no
   // unplaced conjuncts were found and plan construction should proceed.
-  bool placeConjuncts(
-      RelationOpPtr plan,
-      PlanState& state,
-      bool allowNondeterministic);
+  bool placeConjuncts(RelationOpPtr plan, PlanState& state, bool joinsPlaced);
 
   // Helper function that calls makeJoins recursively for each of
   // 'nextJoins'. The point of making 'nextJoins' first and only then

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -256,11 +256,6 @@ PlanObjectSet PlanState::computeDownstreamColumns(bool includeFilters) const {
     if (addFilter && !join->filter().empty()) {
       addExprs(join->filter());
     }
-
-    if (addFilter) {
-      addExprs(join->leftExprs());
-      addExprs(join->rightExprs());
-    }
   }
 
   // Filters.

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -145,18 +145,21 @@ class PlanObjectSet : public BitSet {
  public:
   /// True if id of 'object' is in 'this'.
   bool contains(PlanObjectCP object) const {
+    VELOX_DCHECK_NOT_NULL(object);
     return object->id() < bits_.size() * 64 &&
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
   /// Inserts id of 'object'.
   void add(PlanObjectCP object) {
+    VELOX_DCHECK_NOT_NULL(object);
     auto id = object->id();
     BitSet::add(id);
   }
 
   /// Erases id of 'object'.
   void erase(PlanObjectCP object) {
+    VELOX_DCHECK_NOT_NULL(object);
     BitSet::erase(object->id());
   }
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -229,10 +229,10 @@ JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
         rightTable_,
         rightKeys_,
         lrFanout_,
-        rightOptional_,
-        leftOptional_,
-        rightExists_,
-        rightNotExists_,
+        rightOptional(),
+        leftOptional(),
+        isSemi(),
+        isAnti(),
         markColumn_,
         rightUnique_};
   }
@@ -241,16 +241,12 @@ JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
       leftTable_,
       leftKeys_,
       rlFanout_,
-      leftOptional_,
-      rightOptional_,
+      leftOptional(),
+      rightOptional(),
       false,
       false,
-      markColumn_,
+      nullptr,
       leftUnique_};
-}
-
-bool JoinEdge::isBroadcastableType() const {
-  return !leftOptional_;
 }
 
 void JoinEdge::addEquality(ExprCP left, ExprCP right, bool update) {
@@ -300,19 +296,20 @@ std::string JoinEdge::toString() const {
   std::stringstream out;
   out << "<join "
       << (leftTable_ ? leftTable_->toString() : " multiple tables ");
-  if (leftOptional_ && rightOptional_) {
-    out << " full outr ";
-  } else if (markColumn_) {
-    out << " exists project ";
-  } else if (rightOptional_) {
+  if (isFullOuter()) {
+    out << " full outer ";
+  } else if (isLeftOuter()) {
     out << " left ";
-  } else if (rightExists_) {
+  } else if (isSemi()) {
     out << " exists ";
-  } else if (rightNotExists_) {
+    if (markColumn_) {
+      out << "project ";
+    }
+  } else if (isAnti()) {
     out << " not exists ";
-  } else if (leftOptional_) {
+  } else if (isRightOuter()) {
     out << " right ";
-  } else if (directed_) {
+  } else if (isUnnest()) {
     out << " unnest ";
   } else {
     out << " inner ";
@@ -469,11 +466,11 @@ PlanObjectSet JoinEdge::allTables() const {
 }
 
 namespace {
-template <typename U>
+
 inline CPSpan<Column> toRangeCast(const ExprVector& exprs) {
-  return CPSpan<Column>(
-      reinterpret_cast<const Column* const*>(exprs.data()), exprs.size());
+  return {reinterpret_cast<const Column* const*>(exprs.data()), exprs.size()};
 }
+
 } // namespace
 
 void JoinEdge::guessFanout() {
@@ -481,6 +478,7 @@ void JoinEdge::guessFanout() {
     return;
   }
 
+  // TODO: Why fanouts are set to 1.1 and 1 when left table is null?
   if (leftTable_ == nullptr) {
     lrFanout_ = 1.1;
     rlFanout_ = 1;
@@ -489,8 +487,8 @@ void JoinEdge::guessFanout() {
 
   auto* opt = queryCtx()->optimization();
   auto samplePair = opt->history().sampleJoin(this);
-  auto left = joinCardinality(leftTable_, toRangeCast<Column>(leftKeys_));
-  auto right = joinCardinality(rightTable_, toRangeCast<Column>(rightKeys_));
+  auto left = joinCardinality(leftTable_, toRangeCast(leftKeys_));
+  auto right = joinCardinality(rightTable_, toRangeCast(rightKeys_));
   leftUnique_ = left.unique;
   rightUnique_ = right.unique;
   if (samplePair.first == 0 && samplePair.second == 0) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -511,20 +511,6 @@ class JoinEdge {
     /// Marker column produced by 'exists' or 'not exists' join.
     ///  If set, the 'joinType' must be kSemi.
     ColumnCP markColumn{nullptr};
-
-    /// Columns produced by the 'left' side of a RIGHT or FULL OUTER join.
-    /// Requires 'leftOptional' to be true.
-    ColumnVector leftColumns;
-
-    /// Input expressions corresponding 1:1 to 'leftColumns'.
-    ExprVector leftExprs;
-
-    /// Columns produced by the 'right' side of a LEFT or FULL OUTER join.
-    /// Requires 'rightOptional' to be true.
-    ColumnVector rightColumns;
-
-    /// Input expressions corresponding 1:1 to 'rightColumns'.
-    ExprVector rightExprs;
   };
 
   /// @param leftTable The left table of the join. May be nullptr if 'leftKeys'
@@ -536,11 +522,7 @@ class JoinEdge {
         rightTable_(rightTable),
         filter_(std::move(spec.filter)),
         joinType_(spec.joinType),
-        markColumn_(spec.markColumn),
-        leftColumns_{spec.leftColumns},
-        leftExprs_{spec.leftExprs},
-        rightColumns_{spec.rightColumns},
-        rightExprs_{spec.rightExprs} {
+        markColumn_(spec.markColumn) {
     // Only left join can have null left table.
     VELOX_DCHECK(leftTable_ || isLeftOuter());
     VELOX_DCHECK_NOT_NULL(rightTable_);
@@ -548,16 +530,6 @@ class JoinEdge {
     VELOX_DCHECK(filter_.empty() || !isInner());
     // Mark column only for semi joins.
     VELOX_DCHECK(!markColumn_ || isSemi());
-
-    if (!leftColumns_.empty()) {
-      VELOX_DCHECK(leftOptional());
-      VELOX_DCHECK_EQ(leftColumns_.size(), leftExprs_.size());
-    }
-
-    if (!rightColumns_.empty()) {
-      VELOX_DCHECK(rightOptional());
-      VELOX_DCHECK_EQ(rightColumns_.size(), rightExprs_.size());
-    }
   }
 
   static JoinEdge* makeInner(PlanObjectCP leftTable, PlanObjectCP rightTable) {
@@ -640,22 +612,6 @@ class JoinEdge {
 
   ColumnCP markColumn() const {
     return markColumn_;
-  }
-
-  const ColumnVector& leftColumns() const {
-    return leftColumns_;
-  }
-
-  const ExprVector& leftExprs() const {
-    return leftExprs_;
-  }
-
-  const ColumnVector& rightColumns() const {
-    return rightColumns_;
-  }
-
-  const ExprVector& rightExprs() const {
-    return rightExprs_;
   }
 
   void addEquality(ExprCP left, ExprCP right, bool update = false);
@@ -796,11 +752,6 @@ class JoinEdge {
 
   // Flag to set if right side has a match.
   ColumnCP const markColumn_;
-
-  const ColumnVector leftColumns_;
-  const ExprVector leftExprs_;
-  const ColumnVector rightColumns_;
-  const ExprVector rightExprs_;
 };
 
 using JoinEdgeP = JoinEdge*;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -491,27 +491,25 @@ struct JoinSide {
 /// decomposable and reorderable conjuncts.
 class JoinEdge {
  public:
-  /// Default is INNER JOIN.
+  enum class JoinType : uint8_t {
+    kInner,
+    kLeft,
+    kRight,
+    kFull,
+    kSemi,
+    kAnti,
+    kUnnest,
+  };
+
   struct Spec {
     /// Filter conjuncts to be applied after the join. Only for non-inner joins.
     ExprVector filter;
 
-    /// True for RIGHT and FULL OUTER JOIN. The output may have no match on the
-    /// left side.
-    bool leftOptional{false};
+    /// Join type.
+    JoinType joinType{JoinType::kInner};
 
-    /// True for LEFT and FULL OUTER JOIN. The output may have no match on the
-    /// right side.
-    bool rightOptional{false};
-
-    /// True for EXISTS subquery. Mutually exclusive with 'rightNotExists'.
-    bool rightExists{false};
-
-    /// True for NOT EXISTS subquery. Mutually exclusive with 'rightExists'.
-    bool rightNotExists{false};
-
-    /// Marker column produced by 'exists' or 'not exists' join. If set, the
-    /// 'rightExists' must be true.
+    /// Marker column produced by 'exists' or 'not exists' join.
+    ///  If set, the 'joinType' must be kSemi.
     ColumnCP markColumn{nullptr};
 
     /// Columns produced by the 'left' side of a RIGHT or FULL OUTER join.
@@ -527,8 +525,6 @@ class JoinEdge {
 
     /// Input expressions corresponding 1:1 to 'rightColumns'.
     ExprVector rightExprs;
-
-    bool directed{false};
   };
 
   /// @param leftTable The left table of the join. May be nullptr if 'leftKeys'
@@ -539,38 +535,28 @@ class JoinEdge {
       : leftTable_(leftTable),
         rightTable_(rightTable),
         filter_(std::move(spec.filter)),
-        leftOptional_(spec.leftOptional),
-        rightOptional_(spec.rightOptional),
-        rightExists_(spec.rightExists),
-        rightNotExists_(spec.rightNotExists),
-        directed_(spec.directed),
+        joinType_(spec.joinType),
         markColumn_(spec.markColumn),
         leftColumns_{spec.leftColumns},
         leftExprs_{spec.leftExprs},
         rightColumns_{spec.rightColumns},
         rightExprs_{spec.rightExprs} {
-    VELOX_CHECK_NOT_NULL(rightTable);
-
-    if (isInner()) {
-      VELOX_CHECK_NOT_NULL(
-          leftTable, "Hyper edge is not supported for an inner join");
-      VELOX_CHECK(filter_.empty(), "Filter is not allowed for an inner join");
-    }
-
-    VELOX_CHECK(!rightExists_ || !rightNotExists_);
-
-    if (markColumn_) {
-      VELOX_CHECK(rightExists_);
-    }
+    // Only left join can have null left table.
+    VELOX_DCHECK(leftTable_ || isLeftOuter());
+    VELOX_DCHECK_NOT_NULL(rightTable_);
+    // filter_ is only for non-inner joins.
+    VELOX_DCHECK(filter_.empty() || !isInner());
+    // Mark column only for semi joins.
+    VELOX_DCHECK(!markColumn_ || isSemi());
 
     if (!leftColumns_.empty()) {
-      VELOX_CHECK(leftOptional_);
-      VELOX_CHECK_EQ(leftColumns_.size(), leftExprs_.size());
+      VELOX_DCHECK(leftOptional());
+      VELOX_DCHECK_EQ(leftColumns_.size(), leftExprs_.size());
     }
 
     if (!rightColumns_.empty()) {
-      VELOX_CHECK(rightOptional_);
-      VELOX_CHECK_EQ(rightColumns_.size(), rightExprs_.size());
+      VELOX_DCHECK(rightOptional());
+      VELOX_DCHECK_EQ(rightColumns_.size(), rightExprs_.size());
     }
   }
 
@@ -588,7 +574,7 @@ class JoinEdge {
         rightTable,
         Spec{
             .filter = std::move(filter),
-            .rightExists = true,
+            .joinType = JoinType::kSemi,
             .markColumn = markColumn,
         });
   }
@@ -596,19 +582,20 @@ class JoinEdge {
   static JoinEdge* makeNotExists(
       PlanObjectCP leftTable,
       PlanObjectCP rightTable) {
-    return make<JoinEdge>(leftTable, rightTable, Spec{.rightNotExists = true});
+    return make<JoinEdge>(
+        leftTable, rightTable, Spec{.joinType = JoinType::kAnti});
   }
 
   static JoinEdge* makeUnnest(
       PlanObjectCP leftTable,
       PlanObjectCP rightTable,
       ExprVector unnestExprs) {
-    VELOX_DCHECK_NOT_NULL(leftTable);
-    auto* edge = make<JoinEdge>(leftTable, rightTable, Spec{.directed = true});
+    auto* edge = make<JoinEdge>(
+        leftTable, rightTable, Spec{.joinType = JoinType::kUnnest});
     edge->leftKeys_ = std::move(unnestExprs);
     // TODO Not sure to what values fanout need to be set,
     // (1, 1) looks ok, but tests don't produce expected plans.
-    edge->setFanouts(2, 2);
+    edge->setFanouts(2, 1);
     return edge;
   }
 
@@ -644,11 +631,11 @@ class JoinEdge {
   }
 
   bool leftOptional() const {
-    return leftOptional_;
+    return isRightOuter() || isFullOuter();
   }
 
   bool rightOptional() const {
-    return rightOptional_;
+    return isLeftOuter() || isFullOuter();
   }
 
   ColumnCP markColumn() const {
@@ -671,49 +658,54 @@ class JoinEdge {
     return rightExprs_;
   }
 
-  bool directed() const {
-    return directed_;
-  }
-
   void addEquality(ExprCP left, ExprCP right, bool update = false);
 
   /// True if inner join.
   bool isInner() const {
-    return !leftOptional_ && !rightOptional_ && !rightExists_ &&
-        !rightNotExists_;
+    return joinType_ == JoinType::kInner;
   }
 
   /// True if this is an EXISTS join.
   bool isSemi() const {
-    return rightExists_;
+    return joinType_ == JoinType::kSemi;
   }
 
   /// True if this is a NOT EXISTS join.
   bool isAnti() const {
-    return rightNotExists_;
+    return joinType_ == JoinType::kAnti;
   }
 
   /// True if this is a LEFT join.
   bool isLeftOuter() const {
-    return rightOptional_ && !leftOptional_ && !isSemi() && !isAnti();
+    return joinType_ == JoinType::kLeft;
+  }
+
+  /// True if this is a RIGHT join.
+  bool isRightOuter() const {
+    return joinType_ == JoinType::kRight;
+  }
+
+  /// True if this is a FULL OUTER join.
+  bool isFullOuter() const {
+    return joinType_ == JoinType::kFull;
+  }
+
+  /// True if this is an UNNEST join.
+  bool isUnnest() const {
+    return joinType_ == JoinType::kUnnest;
   }
 
   /// True if all tables referenced from 'leftKeys' must be placed before
   /// placing this.
   bool isNonCommutative() const {
     // Inner and full outer joins are commutative.
-    if (rightOptional_ && leftOptional_) {
-      return false;
-    }
-
-    return !leftTable_ || rightOptional_ || leftOptional_ || rightExists_ ||
-        rightNotExists_ || directed_;
+    return !isInner() && !isFullOuter();
   }
 
   /// True if has a hash based variant that builds on the left and probes on the
   /// right.
   bool hasRightHashVariant() const {
-    return isNonCommutative() && !rightNotExists_;
+    return isNonCommutative() && !isAnti() && !isUnnest();
   }
 
   /// Returns the join side info for 'table'. If 'other' is set, returns the
@@ -761,7 +753,9 @@ class JoinEdge {
 
   /// True if a hash join build can be broadcasted. Used when building on the
   /// right. None of the right hash join variants are broadcastable.
-  bool isBroadcastableType() const;
+  bool isBroadcastableType() const {
+    return !leftOptional();
+  }
 
   /// Returns a key string for recording a join cardinality sample. The string
   /// is empty if not applicable. The bool is true if the key has right table
@@ -797,26 +791,8 @@ class JoinEdge {
   // 'leftKeys' select max 1 'rightTable' row.
   bool rightUnique_{false};
 
-  // True if an unprobed right side row produces a result with right side
-  // columns set and left side columns as null (right outer join). Possible only
-  // for hash or merge.
-  const bool leftOptional_;
-
-  // True if a right side miss produces a row with left side columns
-  // and a null for right side columns (left outer join). A full outer
-  // join has both left and right optional.
-  const bool rightOptional_;
-
-  // True if the right side is only checked for existence of a match. If
-  // rightOptional is set, this can project out a null for misses.
-  const bool rightExists_;
-
-  // True if produces a result for left if no match on the right.
-  const bool rightNotExists_;
-
-  // If directed non-outer edge. For example unnest or inner dependent on
-  // optional of outer.
-  const bool directed_;
+  // Join type.
+  const JoinType joinType_;
 
   // Flag to set if right side has a match.
   ColumnCP const markColumn_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1232,34 +1232,51 @@ void extractNonInnerJoinEqualities(
     ExprVector& leftKeys,
     ExprVector& rightKeys,
     PlanObjectSet& allLeft) {
-  for (auto i = 0; i < conjuncts.size(); ++i) {
-    const auto* conjunct = conjuncts[i];
-    if (isCallExpr(conjunct, eq)) {
-      const auto* eq = conjunct->as<Call>();
-      const auto leftTables = eq->argAt(0)->allTables();
-      const auto rightTables = eq->argAt(1)->allTables();
+  VELOX_DCHECK_NOT_NULL(right);
 
-      if (leftTables.empty() || rightTables.empty()) {
-        continue;
-      }
-
-      if (rightTables.size() == 1 && rightTables.contains(right) &&
-          !leftTables.contains(right)) {
-        allLeft.unionSet(leftTables);
-        leftKeys.push_back(eq->argAt(0));
-        rightKeys.push_back(eq->argAt(1));
-        conjuncts.erase(conjuncts.begin() + i);
-        --i;
-      } else if (
-          leftTables.size() == 1 && leftTables.contains(right) &&
-          !rightTables.contains(right)) {
-        allLeft.unionSet(rightTables);
-        leftKeys.push_back(eq->argAt(1));
-        rightKeys.push_back(eq->argAt(0));
-        conjuncts.erase(conjuncts.begin() + i);
-        --i;
-      }
+  std::erase_if(conjuncts, [&](ExprCP conjunct) {
+    if (!isCallExpr(conjunct, eq)) {
+      return false;
     }
+    const auto* eq = conjunct->as<Call>();
+    const auto* leftArg = eq->argAt(0);
+    const auto* rightArg = eq->argAt(1);
+    const auto leftTables = leftArg->allTables();
+    const auto rightTables = rightArg->allTables();
+
+    if (leftTables.empty() || rightTables.empty()) {
+      return false;
+    }
+    if (rightTables.size() == 1 && rightTables.contains(right) &&
+        !leftTables.contains(right)) {
+      allLeft.unionSet(leftTables);
+      leftKeys.push_back(leftArg);
+      rightKeys.push_back(rightArg);
+      return true;
+    }
+    if (leftTables.size() == 1 && leftTables.contains(right) &&
+        !rightTables.contains(right)) {
+      allLeft.unionSet(rightTables);
+      leftKeys.push_back(rightArg);
+      rightKeys.push_back(leftArg);
+      return true;
+    }
+    return false;
+  });
+}
+
+JoinEdge::JoinType toJoinType(lp::JoinType joinType) {
+  switch (joinType) {
+    case lp::JoinType::kInner:
+      return JoinEdge::JoinType::kInner;
+    case lp::JoinType::kLeft:
+      return JoinEdge::JoinType::kLeft;
+    case lp::JoinType::kRight:
+      return JoinEdge::JoinType::kRight;
+    case lp::JoinType::kFull:
+      return JoinEdge::JoinType::kFull;
+    default:
+      VELOX_UNREACHABLE();
   }
 }
 
@@ -1297,44 +1314,44 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
   if (isInner) {
     currentDt_->conjuncts.insert(
         currentDt_->conjuncts.end(), conjuncts.begin(), conjuncts.end());
-  } else {
-    const bool leftOptional =
-        joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
-    const bool rightOptional =
-        joinType == lp::JoinType::kLeft || joinType == lp::JoinType::kFull;
+    return;
+  }
+  const bool leftOptional =
+      joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
+  const bool rightOptional =
+      joinType == lp::JoinType::kLeft || joinType == lp::JoinType::kFull;
 
-    // If non-inner, and many tables on the right they are one dt. If a single
-    // table then this too is the last in 'tables'.
-    auto rightTable = currentDt_->tables.back();
+  // If non-inner, and many tables on the right they are one dt. If a single
+  // table then this too is the last in 'tables'.
+  auto rightTable = currentDt_->tables.back();
 
-    ExprVector leftKeys;
-    ExprVector rightKeys;
-    PlanObjectSet leftTables;
-    extractNonInnerJoinEqualities(
-        equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
+  ExprVector leftKeys;
+  ExprVector rightKeys;
+  PlanObjectSet leftTables;
+  extractNonInnerJoinEqualities(
+      equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    JoinEdge::Spec joinSpec{
-        .filter = std::move(conjuncts),
-        .leftOptional = leftOptional,
-        .rightOptional = rightOptional,
-    };
+  VELOX_DCHECK_EQ(leftKeys.size(), rightKeys.size());
+  JoinEdge::Spec joinSpec{
+      .filter = std::move(conjuncts),
+      .joinType = toJoinType(joinType),
+  };
 
-    if (leftOptional) {
-      addJoinColumns(*join.left(), joinSpec.leftColumns, joinSpec.leftExprs);
-    }
+  if (leftOptional) {
+    addJoinColumns(*join.left(), joinSpec.leftColumns, joinSpec.leftExprs);
+  }
 
-    if (rightOptional) {
-      addJoinColumns(*join.right(), joinSpec.rightColumns, joinSpec.rightExprs);
-    }
+  if (rightOptional) {
+    addJoinColumns(*join.right(), joinSpec.rightColumns, joinSpec.rightExprs);
+  }
 
-    auto* edge = make<JoinEdge>(
-        leftTables.size() == 1 ? leftTables.onlyObject() : nullptr,
-        rightTable,
-        std::move(joinSpec));
-    currentDt_->joins.push_back(edge);
-    for (auto i = 0; i < leftKeys.size(); ++i) {
-      edge->addEquality(leftKeys[i], rightKeys[i]);
-    }
+  auto* edge = make<JoinEdge>(
+      leftTables.size() == 1 ? leftTables.onlyObject() : nullptr,
+      rightTable,
+      std::move(joinSpec));
+  currentDt_->joins.push_back(edge);
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    edge->addEquality(leftKeys[i], rightKeys[i]);
   }
 }
 
@@ -1677,7 +1694,9 @@ void ToGraph::processSubqueries(const logical_plan::FilterNode& filter) {
       correlatedConjuncts_.clear();
 
       auto* join = make<JoinEdge>(
-          leftTable, subqueryDt, JoinEdge::Spec{.rightOptional = true});
+          leftTable,
+          subqueryDt,
+          JoinEdge::Spec{.joinType = JoinEdge::JoinType::kLeft});
       for (auto i = 0; i < leftKeys.size(); ++i) {
         join->addEquality(leftKeys[i], rightKeys[i]);
       }

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -229,7 +229,7 @@ class ToGraph {
   void translateConjuncts(const logical_plan::ExprPtr& input, ExprVector& flat);
 
   // Adds a JoinEdge corresponding to 'join' to the enclosing DerivedTable.
-  void translateJoin(const logical_plan::JoinNode& join);
+  void addJoin(const logical_plan::JoinNode& join, uint64_t allowedInDt);
 
   // Given an INTERSECT or an EXCEPT set operation, create derived tables for
   // inputs, add them to 'currentDt_' and connect them with join edges.
@@ -337,11 +337,6 @@ class ToGraph {
   DerivedTableP translateSubquery(const logical_plan::LogicalPlanNode& node);
 
   ColumnCP addMarkColumn();
-
-  void addJoinColumns(
-      const logical_plan::LogicalPlanNode& joinSide,
-      ColumnVector& columns,
-      ExprVector& exprs);
 
   // Cache of resolved table schemas.
   Schema schema_;

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -174,7 +174,7 @@ TEST_F(DerivedTablePrinterTest, basic) {
             testing::Eq("  joins:"),
             testing::Eq("    t2 LEFT t3 ON t2.a = t3.x"),
             testing::Eq("  syntactic join order: 3, 8"),
-            testing::Eq("  aggregates: sum(multiply(t2.b, dt1.y)) AS sum"),
+            testing::Eq("  aggregates: sum(multiply(t2.b, t3.y)) AS sum"),
             testing::Eq("  grouping keys: t2.a"),
             testing::Eq(""),
             testing::Eq("t2: a, b"),

--- a/axiom/optimizer/tests/tpch.plans/q13.plans
+++ b/axiom/optimizer/tests/tpch.plans/q13.plans
@@ -19,7 +19,7 @@ dt1: c_count
   joins:
     t2 LEFT t3 ON t2.c_custkey = t3.o_custkey FILTER not(like(t3.o_comment, "%special%requests%"))
   syntactic join order: 9, 20
-  aggregates: count(dt1.o_orderkey) AS count
+  aggregates: count(t3.o_orderkey) AS count
   grouping keys: t2.c_custkey
 
 t2: c_custkey
@@ -44,18 +44,15 @@ Project (redundant) -> dt4.c_count, dt4.custdist
       Project -> dt1.c_count
           dt1.c_count := dt1.count
         Aggregation (t2.c_custkey) -> t2.c_custkey, dt1.count
-            dt1.count := count(dt1.o_orderkey)
-          Project (redundant) -> t2.c_custkey, dt1.o_orderkey
-              t2.c_custkey := t2.c_custkey
-              dt1.o_orderkey := t3.o_orderkey
-            Join RIGHT Hash -> t2.c_custkey, t3.o_orderkey
-                t3.o_custkey = t2.c_custkey
-                not(like(t3.o_comment, "%special%requests%"))
-              TableScan -> t3.o_orderkey, t3.o_custkey, t3.o_comment
-                table: orders
-              HashBuild -> t2.c_custkey
-                TableScan -> t2.c_custkey
-                  table: customer
+            dt1.count := count(t3.o_orderkey)
+          Join RIGHT Hash -> t2.c_custkey, t3.o_orderkey
+              t3.o_custkey = t2.c_custkey
+              not(like(t3.o_comment, "%special%requests%"))
+            TableScan -> t3.o_orderkey, t3.o_custkey, t3.o_comment
+              table: orders
+            HashBuild -> t2.c_custkey
+              TableScan -> t2.c_custkey
+                table: customer
 
 
 Executable Velox plan:


### PR DESCRIPTION
Adjust how do we pushdown and place conjuncts (filter expressions/predicates) instead of generate join columns.
"join columns" is design decision with different flaws:
1. it forces projection to be created right after join (so it can be project earlier than needed)
2. join columns will be projected separately from expressions where they used (so it can be unnecessary columns and project operations)
3. it requires to write code in each join method
4. it's probably slower, because a lot of allocations in this algorithm (in query graph and plan enumeration)