### PR TITLE
refactor: Remove redundant JoinEdge::rightExists and rightNotExists methods

### DIFF
--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -199,7 +199,7 @@ const PlanObjectSet& PlanState::downstreamColumns() const {
 
   // Joins.
   for (auto join : dt->joins) {
-    if (join->rightExists() || join->rightNotExists()) {
+    if (join->isSemi() || join->isAnti()) {
       if (placed.contains(join->rightTable())) {
         continue;
       }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -643,14 +643,6 @@ class JoinEdge {
     return rightOptional_;
   }
 
-  bool rightExists() const {
-    return rightExists_;
-  }
-
-  bool rightNotExists() const {
-    return rightNotExists_;
-  }
-
   ColumnCP markColumn() const {
     return markColumn_;
   }


### PR DESCRIPTION
Summary: These are duplicates of isSemi and isAnti.

Differential Revision: D87052090


