### PR TITLE
refactor: Add convenient PlanBuilder::tableWrite methods

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/logical_plan/NameMappings.h"
-#include "velox/connectors/Connector.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
@@ -1320,6 +1319,23 @@ PlanBuilder& PlanBuilder::tableWrite(
       std::move(options));
 
   return *this;
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    std::string tableName,
+    WriteKind kind,
+    std::vector<std::string> columnNames,
+    folly::F14FastMap<std::string, std::string> options) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Table write node cannot be a leaf node");
+  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+
+  return tableWrite(
+      defaultConnectorId_.value(),
+      std::move(tableName),
+      kind,
+      std::move(columnNames),
+      findOrAssignOutputNames(),
+      std::move(options));
 }
 
 ExprPtr PlanBuilder::resolveInputName(

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -45,16 +45,21 @@ void HiveQueriesTestBase::SetUp() {
 
   prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
       exec::test::kHiveConnectorId, std::nullopt, pool());
+
+  connector_ = velox::connector::getConnector(exec::test::kHiveConnectorId);
+  metadata_ = dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(
+      connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId));
 }
 
 void HiveQueriesTestBase::TearDown() {
+  metadata_ = nullptr;
+  connector_.reset();
+
   test::QueryTestBase::TearDown();
 }
 
 RowTypePtr HiveQueriesTestBase::getSchema(std::string_view tableName) {
-  return connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId)
-      ->findTable(tableName)
-      ->type();
+  return metadata_->findTable(tableName)->type();
 }
 
 void HiveQueriesTestBase::checkResults(

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "axiom/sql/presto/PrestoParser.h"
@@ -50,11 +51,21 @@ class HiveQueriesTestBase : public test::QueryTestBase {
     return *prestoParser_;
   }
 
+  velox::connector::Connector& hiveConnector() const {
+    return *connector_;
+  }
+
+  connector::hive::LocalHiveConnectorMetadata& hiveMetadata() const {
+    return *metadata_;
+  }
+
  private:
   inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
       gTempDirectory;
 
   std::unique_ptr<::axiom::sql::presto::PrestoParser> prestoParser_;
+  std::shared_ptr<velox::connector::Connector> connector_;
+  connector::hive::LocalHiveConnectorMetadata* metadata_;
 };
 
 } // namespace facebook::axiom::optimizer::test


### PR DESCRIPTION
Summary:
Add PlanBuilder::tableWrite(tableName, writeKind, columnNames) API that uses default connector ID from the context and writes input values as is.

Also, add hiveConnector() and hiveMetadata() getters to HiveQueriesTestBase.

Differential Revision: D87054938


