### PR TITLE
feat: Extend RelationOpPrinter to optionally print cardinality and cost for each node

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -211,7 +211,8 @@ std::string SqlQueryRunner::runExplain(
           options,
           nullptr,
           [&](const auto& plan) {
-            text = optimizer::RelationOpPrinter::toText(plan);
+            text = optimizer::RelationOpPrinter::toText(
+                plan, {.includeCost = true});
             return false; // Stop optimization.
           });
       return text;

--- a/axiom/optimizer/RelationOpPrinter.h
+++ b/axiom/optimizer/RelationOpPrinter.h
@@ -19,10 +19,17 @@
 
 namespace facebook::axiom::optimizer {
 
+struct RelationOpToTextOptions {
+  /// Include the estimate of the cardinality and cost of each plan node.
+  bool includeCost{false};
+};
+
 class RelationOpPrinter {
  public:
   /// Returns a multi-line text representatino of the plan tree.
-  static std::string toText(const RelationOp& root);
+  static std::string toText(
+      const RelationOp& root,
+      const RelationOpToTextOptions& options = {});
 
   /// Returns a one-line summary of the plan. Includes tables and joins. Useful
   /// for debugging join order.


### PR DESCRIPTION
Summary:
```
SQL> explain (type optimized) select count(*) from nation;
Project (redundant) -> dt1.count
  Estimates: cardinality = 1, cost = 0.00
    dt1.count := dt1.count
  Aggregation -> dt1.count
    Estimates: cardinality = 1, cost = 0.00
      dt1.count := count()
    Repartition -> dt1.count
      Estimates: cardinality = 1, cost = 8.00
      Aggregation -> dt1.count
        Estimates: cardinality = 1, cost = 0.00
          dt1.count := count()
        TableScan ->
          Estimates: cardinality = 25, cost = 0.00
          table: nation
```

Differential Revision: D87329413


