### PR TITLE
fix: Aggregation cardinality estimate

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -36,11 +36,11 @@ void History::updateFromFile(const std::string& path) {
 }
 
 float shuffleCost(const ColumnVector& columns) {
-  return byteSize(columns);
+  return byteSize(columns) * Costs::kByteShuffleCost;
 }
 
 float shuffleCost(const ExprVector& exprs) {
-  return byteSize(exprs);
+  return byteSize(exprs) * Costs::kByteShuffleCost;
 }
 
 float selfCost(ExprCP expr) {
@@ -84,6 +84,72 @@ float costWithChildren(ExprCP expr, const PlanObjectSet& notCounting) {
     default:
       return 0;
   }
+}
+
+float Costs::cacheMissClocks(float workingSet, float accessBytes) {
+  // x86 cache architecture constants.
+
+  // Cache line size in bytes.
+  const float kCacheLineSize = 64.0f;
+  // L1 cache: 32 KB.
+  const float kL1Size = 32.0f * 1024.0f;
+  // L2 cache: 256 KB.
+  const float kL2Size = 256.0f * 1024.0f;
+  // L3 cache: 8 MB per query, total cache is larger.
+  const float kL3Size = 8.0f * 1024.0f * 1024.0f;
+
+  // Cache latencies in CPU cycles.
+  // L1 hit: 2 cycles.
+  const float kL1Latency = 2.0f;
+  // L2 hit: 6 cycles.
+  const float kL2Latency = 6.0f;
+  // L3 hit: 22 cycles
+  // Memory miss: 60 cycles. The real latency is higher but for hash
+  // tables where many concurrent misses pending at the same time, 65
+  // agrees somewhat with observations.
+  const float kL3Latency = 22.0f;
+
+  const float kMemoryLatency = 60.0f;
+
+  // Compute number of cache lines accessed.
+  // For each byte beyond the first cache line, we count 1/64 of the miss cost,
+  // which effectively means accessBytes / kCacheLineSize cache lines.
+  float numCacheLines =
+      1 + (accessBytes > 1 ? accessBytes / kCacheLineSize : 0);
+
+  // Compute expected latency per cache line access based on working set size.
+  // For random access patterns, the probability of finding data in a cache
+  // level is proportional to the ratio of cache size to working set size.
+  // When the working set exceeds a cache level, we blend between that level
+  // and the next level based on the cache occupancy fraction.
+  float expectedLatency;
+
+  if (workingSet <= kL1Size) {
+    // Working set fits entirely in L1 cache.
+    expectedLatency = kL1Latency;
+  } else if (workingSet <= kL2Size) {
+    // Working set exceeds L1 but fits in L2.
+    // Blend between L1 and L2 latencies proportional to L1 occupancy.
+    float l1Fraction = kL1Size / workingSet;
+    expectedLatency =
+        l1Fraction * kL1Latency + (1.0f - l1Fraction) * kL2Latency;
+  } else if (workingSet <= kL3Size) {
+    // Working set exceeds L2 but fits in L3.
+    // Blend between L2 and L3 latencies proportional to L2 occupancy.
+    float l2Fraction = kL2Size / workingSet;
+    expectedLatency =
+        l2Fraction * kL2Latency + (1.0f - l2Fraction) * kL3Latency;
+  } else {
+    // Working set exceeds L3, spills to main memory.
+    // Blend between L3 and memory latencies proportional to L3 occupancy.
+    float l3Fraction = kL3Size / workingSet;
+    expectedLatency =
+        l3Fraction * kL3Latency + (1.0f - l3Fraction) * kMemoryLatency;
+  }
+
+  // Total cost is the number of cache lines accessed times the expected
+  // latency.
+  return numCacheLines * expectedLatency;
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -66,6 +66,10 @@ struct OptimizerOptions {
   /// TODO Make this work for non-inner joins.
   bool syntacticJoinOrder = false;
 
+  /// Disable cost-based decision re: whether to split an aggregation into
+  /// partial + final or not.
+  bool alwaysPlanPartialAggregation = false;
+
   bool isMapAsStruct(std::string_view table, std::string_view column) const {
     if (allMapsAsStruct) {
       return true;

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -118,11 +118,6 @@ std::string Plan::toString(bool detail) const {
   return result;
 }
 
-void PlanState::addCost(RelationOp& op) {
-  cost.cost += op.cost().totalCost();
-  cost.cardinality = op.cost().resultCardinality();
-}
-
 bool PlanState::mayConsiderNext(PlanObjectCP table) const {
   if (!syntacticJoinOrder_) {
     return true;

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -221,7 +221,9 @@ struct PlanState {
   std::vector<int32_t> debugPlacedTables;
 
   /// Updates 'cost' to reflect 'op' being placed on top of the partial plan.
-  void addCost(RelationOp& op);
+  void addCost(RelationOp& op) {
+    cost.add(op);
+  }
 
   /// Specifies that the plan-to-make only produces 'target' expressions and.
   /// These refer to 'exprs' of 'dt'.

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -285,7 +285,7 @@ float baseSelectivity(PlanObjectCP object);
 struct SchemaTable {
   explicit SchemaTable(const connector::Table& connectorTable)
       : connectorTable{&connectorTable},
-        cardinality{static_cast<float>(connectorTable.numRows())} {}
+        cardinality{std::max<float>(1, connectorTable.numRows())} {}
 
   ColumnGroupCP addIndex(
       const connector::TableLayout& layout,

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -127,8 +127,11 @@ bool VeloxHistory::setLeafSelectivity(
     return true;
   }
 
+  // When finding no hits, do not make a selectivity of 0 because this makes /0
+  // or *0 and *0 is 0, which makes any subsequent operations 0 regardless of
+  // cost. So as not to underflow, count non-existent as 0.9 rows.
   table.filterSelectivity =
-      static_cast<float>(sample.second) / static_cast<float>(sample.first);
+      std::max<float>(0.9f, sample.second) / static_cast<float>(sample.first);
   recordLeafSelectivity(string, table.filterSelectivity, false);
 
   bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -167,6 +167,8 @@ TEST_F(PlanTest, agg) {
   testConnector_->addTable(
       "numbers", ROW({"a", "b", "c"}, {DOUBLE(), DOUBLE(), VARCHAR()}));
 
+  optimizerOptions_.alwaysPlanPartialAggregation = true;
+
   auto logicalPlan = lp::PlanBuilder()
                          .tableScan(kTestConnectorId, "numbers", {"a", "b"})
                          .aggregate({"a"}, {"sum(a + b)"})

--- a/axiom/optimizer/tests/tpch.plans/q16.plans
+++ b/axiom/optimizer/tests/tpch.plans/q16.plans
@@ -38,7 +38,7 @@ t5: s_suppkey, s_comment
 
 Optimized plan (oneline):
 
-(supplier RIGHT SEMI (PROJECT) (partsupp INNER part))
+((partsupp INNER part) ANTI supplier)
 
 Optimized plan:
 
@@ -50,36 +50,33 @@ Project (redundant) -> dt1.p_brand, dt1.p_type, dt1.p_size, dt1.supplier_cnt
   OrderBy -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
     Aggregation (t3.p_brand, t3.p_type, t3.p_size) -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
         dt1.supplier_cnt := count(t2.ps_suppkey)
-      Filter -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size, dt1.__mark0
-          not(dt1.__mark0)
-        Join RIGHT SEMI (PROJECT) Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size, dt1.__mark0
-            dt4.s_suppkey = t2.ps_suppkey
+      Join ANTI Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
+          t2.ps_suppkey = dt4.s_suppkey
+        Join INNER Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
+            t2.ps_partkey = t3.p_partkey
+          TableScan -> t2.ps_partkey, t2.ps_suppkey
+            table: partsupp
+          HashBuild -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+            TableScan -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+              table: part
+              single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(__cast(t3.p_size), 49, 14, 23, 45, 19, 3, 36, 9)
+        HashBuild -> dt4.s_suppkey
           Project (redundant) -> dt4.s_suppkey
               dt4.s_suppkey := t5.s_suppkey
             TableScan -> t5.s_suppkey
               table: supplier
               single-column filters: like(t5.s_comment, "%Customer%Complaints%")
-          HashBuild -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
-            Join INNER Hash -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
-                t2.ps_partkey = t3.p_partkey
-              TableScan -> t2.ps_partkey, t2.ps_suppkey
-                table: partsupp
-              HashBuild -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
-                TableScan -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
-                  table: part
-                  single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(__cast(t3.p_size), 49, 14, 23, 45, 19, 3, 36, 9)
 
 
 Executable Velox plan:
 
 Fragment 0:  numWorkers=0:
--- OrderBy[7][supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
-  -- Aggregation[6][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
-    -- Filter[0][expression: not("dt1.__mark0")] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, "dt1.__mark0":BOOLEAN
-      -- HashJoin[5][RIGHT SEMI (PROJECT) s_suppkey=ps_suppkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, "dt1.__mark0":BOOLEAN
-        -- TableScan[1][table: supplier, remaining filter: (like("s_comment",%Customer%Complaints%)), data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: s_comment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> s_suppkey:BIGINT
-        -- HashJoin[4][INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
-          -- TableScan[2][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
-          -- TableScan[3][table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, no nulls))], remaining filter: (and(not(like("p_type",MEDIUM POLISHED%)),in(cast("p_size" as BIGINT),{49, 14, 23, 45, 19, ...3 more}))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]], HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+-- OrderBy[6][supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+  -- Aggregation[5][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+    -- HashJoin[4][ANTI ps_suppkey=s_suppkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+      -- HashJoin[2][INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+        -- TableScan[0][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
+        -- TableScan[1][table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, no nulls))], remaining filter: (and(not(like("p_type",MEDIUM POLISHED%)),in(cast("p_size" as BIGINT),{49, 14, 23, 45, 19, ...3 more}))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]], HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+      -- TableScan[3][table: supplier, remaining filter: (like("s_comment",%Customer%Complaints%)), data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: s_comment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> s_suppkey:BIGINT
 
 ___END___

--- a/axiom/optimizer/tests/tpch.plans/q20.plans
+++ b/axiom/optimizer/tests/tpch.plans/q20.plans
@@ -60,7 +60,7 @@ t11: p_partkey, p_name
 
 Optimized plan (oneline):
 
-(((partsupp LEFT SEMI (FILTER) part) LEFT lineitem) RIGHT SEMI (FILTER) (supplier INNER nation))
+((lineitem RIGHT (partsupp LEFT SEMI (FILTER) part)) RIGHT SEMI (FILTER) (supplier INNER nation))
 
 Optimized plan:
 
@@ -74,29 +74,29 @@ Project (redundant) -> dt1.s_name, dt1.s_address
           dt4.ps_suppkey := t5.ps_suppkey
         Filter -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
             lt(dt6.expr, __cast(t5.ps_availqty))
-          Join LEFT Hash -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
-              t5.ps_partkey = dt6.__gk8
-              t5.ps_suppkey = dt6.__gk9
-            Join LEFT SEMI (FILTER) Hash -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
-                t5.ps_partkey = dt10.p_partkey
-              TableScan -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
-                table: partsupp
-              HashBuild -> dt10.p_partkey
-                Project (redundant) -> dt10.p_partkey
-                    dt10.p_partkey := t11.p_partkey
-                  TableScan -> t11.p_partkey
-                    table: part
-                    single-column filters: like(t11.p_name, "forest%")
-            HashBuild -> dt6.__gk8, dt6.__gk9, dt6.expr
-              Project -> dt6.__gk8, dt6.__gk9, dt6.expr
-                  dt6.__gk8 := t7.l_partkey
-                  dt6.__gk9 := t7.l_suppkey
-                  dt6.expr := multiply(dt6.sum, 0.5)
-                Aggregation (t7.l_partkey, t7.l_suppkey) -> t7.l_partkey, t7.l_suppkey, dt6.sum
-                    dt6.sum := sum(t7.l_quantity)
-                  TableScan -> t7.l_partkey, t7.l_suppkey, t7.l_quantity
-                    table: lineitem
-                    single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(t7.l_shipdate, "1995-01-01")
+          Join RIGHT Hash -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
+              dt6.__gk8 = t5.ps_partkey
+              dt6.__gk9 = t5.ps_suppkey
+            Project -> dt6.__gk8, dt6.__gk9, dt6.expr
+                dt6.__gk8 := t7.l_partkey
+                dt6.__gk9 := t7.l_suppkey
+                dt6.expr := multiply(dt6.sum, 0.5)
+              Aggregation (t7.l_partkey, t7.l_suppkey) -> t7.l_partkey, t7.l_suppkey, dt6.sum
+                  dt6.sum := sum(t7.l_quantity)
+                TableScan -> t7.l_partkey, t7.l_suppkey, t7.l_quantity
+                  table: lineitem
+                  single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(t7.l_shipdate, "1995-01-01")
+            HashBuild -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+              Join LEFT SEMI (FILTER) Hash -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                  t5.ps_partkey = dt10.p_partkey
+                TableScan -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                  table: partsupp
+                HashBuild -> dt10.p_partkey
+                  Project (redundant) -> dt10.p_partkey
+                      dt10.p_partkey := t11.p_partkey
+                    TableScan -> t11.p_partkey
+                      table: part
+                      single-column filters: like(t11.p_name, "forest%")
       HashBuild -> t2.s_suppkey, t2.s_name, t2.s_address
         Join INNER Hash -> t2.s_suppkey, t2.s_name, t2.s_address
             t2.s_nationkey = t3.n_nationkey
@@ -115,13 +115,13 @@ Fragment 0:  numWorkers=0:
   -- HashJoin[12][RIGHT SEMI (FILTER) ps_suppkey=s_suppkey] -> s_name:VARCHAR, s_address:VARCHAR
     -- Project[8][expressions: (ps_suppkey:BIGINT, "ps_suppkey")] -> ps_suppkey:BIGINT
       -- Filter[0][expression: lt("expr",cast("ps_availqty" as DOUBLE))] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
-        -- HashJoin[7][LEFT ps_partkey=dt6.__gk8 AND ps_suppkey=dt6.__gk9] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
-          -- HashJoin[3][LEFT SEMI (FILTER) ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
-            -- TableScan[1][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
-            -- TableScan[2][table: part, remaining filter: (like("p_name",forest%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
-          -- Project[6][expressions: (dt6.__gk8:BIGINT, "l_partkey"), (dt6.__gk9:BIGINT, "l_suppkey"), (expr:DOUBLE, multiply("sum",0.5))] -> "dt6.__gk8":BIGINT, "dt6.__gk9":BIGINT, expr:DOUBLE
-            -- Aggregation[5][SINGLE [l_partkey, l_suppkey] sum := sum("l_quantity")] -> l_partkey:BIGINT, l_suppkey:BIGINT, sum:DOUBLE
-              -- TableScan[4][table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE
+        -- HashJoin[7][RIGHT dt6.__gk8=ps_partkey AND dt6.__gk9=ps_suppkey] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+          -- Project[3][expressions: (dt6.__gk8:BIGINT, "l_partkey"), (dt6.__gk9:BIGINT, "l_suppkey"), (expr:DOUBLE, multiply("sum",0.5))] -> "dt6.__gk8":BIGINT, "dt6.__gk9":BIGINT, expr:DOUBLE
+            -- Aggregation[2][SINGLE [l_partkey, l_suppkey] sum := sum("l_quantity")] -> l_partkey:BIGINT, l_suppkey:BIGINT, sum:DOUBLE
+              -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE
+          -- HashJoin[6][LEFT SEMI (FILTER) ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+            -- TableScan[4][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+            -- TableScan[5][table: part, remaining filter: (like("p_name",forest%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
     -- HashJoin[11][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR
       -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT
       -- TableScan[10][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT

--- a/axiom/optimizer/tests/tpch.plans/q5.plans
+++ b/axiom/optimizer/tests/tpch.plans/q5.plans
@@ -44,7 +44,7 @@ t7: r_regionkey, r_name
 
 Optimized plan (oneline):
 
-((lineitem INNER (orders INNER (orders RIGHT SEMI (FILTER) (customer INNER (nation INNER region))))) INNER supplier)
+((lineitem INNER ((orders INNER customer) INNER (nation INNER region))) INNER supplier)
 
 Optimized plan:
 
@@ -66,30 +66,24 @@ Project (redundant) -> dt1.n_name, dt1.revenue
               table: lineitem
             HashBuild -> t2.c_custkey, t2.c_nationkey, t3.o_orderkey, t3.o_custkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
               Join INNER Hash -> t2.c_custkey, t2.c_nationkey, t3.o_orderkey, t3.o_custkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                  t3.o_custkey = t2.c_custkey
-                TableScan -> t3.o_orderkey, t3.o_custkey
-                  table: orders
-                  single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
-                HashBuild -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                  Join RIGHT SEMI (FILTER) Hash -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                      t3.o_custkey = t2.c_custkey
-                    TableScan -> t3.o_custkey
-                      table: orders
-                      single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
-                    HashBuild -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                      Join INNER Hash -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                          t2.c_nationkey = t6.n_nationkey
-                        TableScan -> t2.c_custkey, t2.c_nationkey
-                          table: customer
-                        HashBuild -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                          Join INNER Hash -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
-                              t6.n_regionkey = t7.r_regionkey
-                            TableScan -> t6.n_nationkey, t6.n_name, t6.n_regionkey
-                              table: nation
-                            HashBuild -> t7.r_regionkey
-                              TableScan -> t7.r_regionkey
-                                table: region
-                                single-column filters: eq(t7.r_name, "ASIA")
+                  t2.c_nationkey = t6.n_nationkey
+                Join INNER Hash -> t2.c_custkey, t2.c_nationkey, t3.o_orderkey, t3.o_custkey
+                    t3.o_custkey = t2.c_custkey
+                  TableScan -> t3.o_orderkey, t3.o_custkey
+                    table: orders
+                    single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
+                  HashBuild -> t2.c_custkey, t2.c_nationkey
+                    TableScan -> t2.c_custkey, t2.c_nationkey
+                      table: customer
+                HashBuild -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                  Join INNER Hash -> t6.n_nationkey, t6.n_name, t6.n_regionkey, t7.r_regionkey
+                      t6.n_regionkey = t7.r_regionkey
+                    TableScan -> t6.n_nationkey, t6.n_name, t6.n_regionkey
+                      table: nation
+                    HashBuild -> t7.r_regionkey
+                      TableScan -> t7.r_regionkey
+                        table: region
+                        single-column filters: eq(t7.r_name, "ASIA")
           HashBuild -> t5.s_suppkey, t5.s_nationkey
             TableScan -> t5.s_suppkey, t5.s_nationkey
               table: supplier
@@ -98,21 +92,19 @@ Project (redundant) -> dt1.n_name, dt1.revenue
 Executable Velox plan:
 
 Fragment 0:  numWorkers=0:
--- OrderBy[15][revenue DESC NULLS LAST] -> n_name:VARCHAR, revenue:DOUBLE
-  -- Aggregation[14][SINGLE [n_name] revenue := sum("dt1.__p91")] -> n_name:VARCHAR, revenue:DOUBLE
-    -- Project[13][expressions: (n_name:VARCHAR, "n_name"), (dt1.__p91:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, "dt1.__p91":DOUBLE
-      -- HashJoin[12][INNER n_nationkey=s_nationkey AND l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
-        -- HashJoin[10][INNER l_orderkey=o_orderkey] -> c_nationkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_nationkey:BIGINT, n_name:VARCHAR
+-- OrderBy[13][revenue DESC NULLS LAST] -> n_name:VARCHAR, revenue:DOUBLE
+  -- Aggregation[12][SINGLE [n_name] revenue := sum("dt1.__p91")] -> n_name:VARCHAR, revenue:DOUBLE
+    -- Project[11][expressions: (n_name:VARCHAR, "n_name"), (dt1.__p91:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, "dt1.__p91":DOUBLE
+      -- HashJoin[10][INNER n_nationkey=s_nationkey AND l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+        -- HashJoin[8][INNER l_orderkey=o_orderkey] -> c_nationkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_nationkey:BIGINT, n_name:VARCHAR
           -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-          -- HashJoin[9][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, o_orderkey:BIGINT, o_custkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
-            -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
-            -- HashJoin[8][RIGHT SEMI (FILTER) o_custkey=c_custkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
-              -- TableScan[2][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_custkey:BIGINT
-              -- HashJoin[7][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
-                -- TableScan[3][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
-                -- HashJoin[6][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
-                  -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
-                  -- TableScan[5][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
-        -- TableScan[11][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+          -- HashJoin[7][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, o_orderkey:BIGINT, o_custkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+            -- HashJoin[3][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, o_orderkey:BIGINT, o_custkey:BIGINT
+              -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
+              -- TableScan[2][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+            -- HashJoin[6][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT, r_regionkey:BIGINT
+              -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+              -- TableScan[5][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+        -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
 
 ___END___

--- a/axiom/optimizer/tests/tpch.plans/q8.plans
+++ b/axiom/optimizer/tests/tpch.plans/q8.plans
@@ -51,7 +51,7 @@ t9: r_regionkey, r_name
 
 Optimized plan (oneline):
 
-((supplier INNER ((lineitem INNER part) INNER (orders INNER (orders RIGHT SEMI (FILTER) (customer INNER (nation INNER region)))))) INNER nation)
+((supplier INNER ((lineitem INNER part) INNER ((orders INNER customer) INNER (nation INNER region)))) INNER nation)
 
 Optimized plan:
 
@@ -85,30 +85,24 @@ Project -> dt1.o_year, dt1.mkt_share
                       single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
                 HashBuild -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
                   Join INNER Hash -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                      t5.o_custkey = t6.c_custkey
-                    TableScan -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate
-                      table: orders
-                      single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
-                    HashBuild -> t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                      Join RIGHT SEMI (FILTER) Hash -> t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                          t5.o_custkey = t6.c_custkey
-                        TableScan -> t5.o_custkey
-                          table: orders
-                          single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
-                        HashBuild -> t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                          Join INNER Hash -> t6.c_custkey, t6.c_nationkey, t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                              t6.c_nationkey = t7.n_nationkey
-                            TableScan -> t6.c_custkey, t6.c_nationkey
-                              table: customer
-                            HashBuild -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                              Join INNER Hash -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
-                                  t7.n_regionkey = t9.r_regionkey
-                                TableScan -> t7.n_nationkey, t7.n_regionkey
-                                  table: nation
-                                HashBuild -> t9.r_regionkey
-                                  TableScan -> t9.r_regionkey
-                                    table: region
-                                    single-column filters: eq(t9.r_name, "AMERICA")
+                      t6.c_nationkey = t7.n_nationkey
+                    Join INNER Hash -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate, t6.c_custkey, t6.c_nationkey
+                        t5.o_custkey = t6.c_custkey
+                      TableScan -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate
+                        table: orders
+                        single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
+                      HashBuild -> t6.c_custkey, t6.c_nationkey
+                        TableScan -> t6.c_custkey, t6.c_nationkey
+                          table: customer
+                    HashBuild -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                      Join INNER Hash -> t7.n_nationkey, t7.n_regionkey, t9.r_regionkey
+                          t7.n_regionkey = t9.r_regionkey
+                        TableScan -> t7.n_nationkey, t7.n_regionkey
+                          table: nation
+                        HashBuild -> t9.r_regionkey
+                          TableScan -> t9.r_regionkey
+                            table: region
+                            single-column filters: eq(t9.r_name, "AMERICA")
           HashBuild -> t8.n_nationkey, t8.n_name
             TableScan -> t8.n_nationkey, t8.n_name
               table: nation
@@ -117,26 +111,24 @@ Project -> dt1.o_year, dt1.mkt_share
 Executable Velox plan:
 
 Fragment 0:  numWorkers=0:
--- Project[26][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_4"))] -> o_year:BIGINT, mkt_share:DOUBLE
-  -- OrderBy[25][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
-    -- Aggregation[24][SINGLE [o_year] sum := sum("dt1.__p113"), sum_4 := sum("dt1.__p108")] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
-      -- Project[23][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p113:DOUBLE, switch(eq("n_name_1",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p108:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p113":DOUBLE, "dt1.__p108":DOUBLE
-        -- HashJoin[22][INNER s_nationkey=n_nationkey_0] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_1:VARCHAR
-          -- HashJoin[20][INNER s_suppkey=l_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+-- Project[24][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_4"))] -> o_year:BIGINT, mkt_share:DOUBLE
+  -- OrderBy[23][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+    -- Aggregation[22][SINGLE [o_year] sum := sum("dt1.__p113"), sum_4 := sum("dt1.__p108")] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+      -- Project[21][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p113:DOUBLE, switch(eq("n_name_1",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p108:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p113":DOUBLE, "dt1.__p108":DOUBLE
+        -- HashJoin[20][INNER s_nationkey=n_nationkey_0] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_1:VARCHAR
+          -- HashJoin[18][INNER s_suppkey=l_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
             -- TableScan[6][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
-            -- HashJoin[19][INNER l_orderkey=o_orderkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+            -- HashJoin[17][INNER l_orderkey=o_orderkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
               -- HashJoin[9][INNER l_partkey=p_partkey] -> p_partkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
                 -- TableScan[7][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
                 -- TableScan[8][table: part, range filters: [(p_type, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
-              -- HashJoin[18][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
-                -- TableScan[10][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
-                -- HashJoin[17][RIGHT SEMI (FILTER) o_custkey=c_custkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
-                  -- TableScan[11][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_custkey:BIGINT
-                  -- HashJoin[16][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
-                    -- TableScan[12][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
-                    -- HashJoin[15][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
-                      -- TableScan[13][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
-                      -- TableScan[14][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
-          -- TableScan[21][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+              -- HashJoin[16][INNER c_nationkey=n_nationkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+                -- HashJoin[12][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, c_custkey:BIGINT, c_nationkey:BIGINT
+                  -- TableScan[10][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                  -- TableScan[11][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                -- HashJoin[15][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_regionkey:BIGINT, r_regionkey:BIGINT
+                  -- TableScan[13][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+                  -- TableScan[14][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+          -- TableScan[19][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
 
 ___END___


### PR DESCRIPTION
Fix cardinality estimate and planning logic for aggregations. This fixes the plan for TPC-H q16.

Aggregation is planned as follows:

If 1 worker and 1 thread: all aggregations are planned as single aggregations.

A global aggregation always has partial + final since combining values on a single thread is never better than combining these on multiple threads with guaranteed reduction to one row per thread. 

Otherwise we compare a plan with a partial aggregation to a plan with a single aggregation and pick the one with less cost. See Optimization::addAggregation().

For use cases where statistics are not available, we provide an option to disable cost-based decisions and always split aggregation into partial + final: alwaysPlanPartialAggregation.

The cost of group-by is in Aggregation::setCostWithGroups(). This has an auxiliary function maxGroups() which calculates the maximum number of possible combinations of grouping keys. 

We distinguish between the number of input rows and the number of distinct input rows the actual input is drawn from. 

We calculate the size of the input domain by grouping the keys by table. If a key depends on many tables, we assign the key to its largest table.  If there is a single key per table in the grouping keys, we use its cardinality. This is always <= the cardinality of the table. If there are many keys from the table, we use a saturating product function to multiply the key cardinalities with a maximum of table cardinality for the count of distinct combinations. If the product is far from the max, this behaves like a multiplication. If the product is close to max, the function approaches max when the product goes to infinity.  In this way, more keys produce more groups but will not overflow the table size.

If we have many tables, we combine the table per-table cardinalities with a saturating product. Here we use the greater of 3*largest table size and an arbitrary 1e10, which is a proxy for  a large group by (10 billion groups).

Having determined the size of the pool from which the input is drawn, we use the coupon collector formula to see what reduction we expect. The size of the group-by is  expectedNumDistincts(inputRowCount, maxGroups).

expectedNumDistincts. This uses the coupon collector formula to estimate how many distinct values will occur in n tuples of input if there are k possible distinct tuples in the input.

We apply this formula to get the total expected fanout: numDistinct / numInput. This is always <= 1.

## Cost of partial aggregation

The partial capacity is the number of rows at the predicted width that fit in the memory budget for partial aggregation.

We see how many rows of input it will take to get this many distinct groups in the input of partial aggregation. With few groups, this will be a large number and with every row being unique this will be the capacity of the partial aggregation. The partial capacity / number of inputs to hit capacity is the reduction from partial. This reduction can however not be greater (lesser fanout) than the total reduction.

Given the reduction and given the expected reduction in the first abandon partial min rows rows, we see if partial will be abandoned at run time.

We set the cost and cardinality accordingly. Abandoned partial has a fanout of 1 and a low cost per byte of input row.

## Cost of final / single aggregation

If we are planning a final aggregation, we scale the input by the reduction expected from partial. This reduces the number of rows that will be shuffled into the final aggregation but does not reduce the size of the hash table. The final table will in the end contain all distinct groups from the input.

We check if we have a local exchange. This is the case if we have more than one thread per worker.. If so, we add a fraction of the shuffle cost as the cost of local exchange.

The cost has unitCost (per row cost) and total memory and fanout. The unit cost formula is the same for partial, final and single aggregations. The cost includes:

- Compute the hash of the grouping keys := Costs::kHashColumnCost * numKeys
- Lookup the hash in the hash table := Costs::hashTableCost(nOut)
- Compare the keys := kKeyCompareCost * numKeys
- Access the row of the hash table (twice) := 2 * Costs::hashRowCost(nOut, rowBytes)
- Update accumulators := aggregates.size() * Costs::kSimpleAggregateCost

The memory estimate is the estimated row size plus a typical overhead of 12. The table size is the number of distinct values at 12 bytes per value. 

The formula represents the added memory cost for larger tables. A more precise formula can be learned from examples.

The intended function of these mechanisms is to decide between partial + final aggregation and a single level of aggregation. Additionally, the cost should be comparable to the costs predicted for other operations like joins and shuffles.

Extracted from https://github.com/facebookincubator/axiom/pull/573
Co-authored-by: oerling

Differential Revision: D87333918


