### PR TITLE
feat: Add basic text table support to HiveConnector

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -25,6 +25,8 @@
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/dwio/text/RegisterTextReader.h"
+#include "velox/dwio/text/RegisterTextWriter.h"
 
 namespace facebook::axiom {
 namespace {
@@ -40,6 +42,8 @@ class Connectors {
     velox::parquet::registerParquetWriterFactory();
     velox::dwrf::registerDwrfReaderFactory();
     velox::dwrf::registerDwrfWriterFactory();
+    velox::text::registerTextReaderFactory();
+    velox::text::registerTextWriterFactory();
 
     std::shared_ptr<velox::connector::Connector> connector;
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -211,7 +211,7 @@ velox::connector::ConnectorTableHandlePtr HiveTableLayout::createTableHandle(
       std::move(subfieldFilters),
       remainingFilter,
       dataColumns ? dataColumns : rowType(),
-      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      serdeParameters(),
       filterColumnHandles,
       sampleRate);
 }
@@ -241,7 +241,8 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
   VELOX_CHECK_NOT_NULL(hiveLayout);
   auto storageFormat = hiveLayout->fileFormat();
 
-  std::unordered_map<std::string, std::string> serdeParameters;
+  const auto& serdeParameters = hiveLayout->serdeParameters();
+
   const std::shared_ptr<velox::dwio::common::WriterOptions> writerOptions;
 
   velox::common::CompressionKind compressionKind;
@@ -320,6 +321,8 @@ void HiveConnectorMetadata::validateOptions(
       HiveWriteOptions::kSortedBy,
       HiveWriteOptions::kFileFormat,
       HiveWriteOptions::kCompressionKind,
+      HiveWriteOptions::kFieldDelim,
+      HiveWriteOptions::kSerializationNullFormat,
   };
 
   for (auto& pair : options) {

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -111,6 +111,14 @@ class HiveTableLayout : public TableLayout {
     return partitionType_.has_value() ? &partitionType_.value() : nullptr;
   }
 
+  /// Returns SerDe parameters for this layout. Default implementation returns
+  /// empty map. Derived classes can override to provide actual parameters.
+  virtual const std::unordered_map<std::string, std::string>& serdeParameters()
+      const {
+    static const std::unordered_map<std::string, std::string> kEmpty;
+    return kEmpty;
+  }
+
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,
       const std::string& columnName,
@@ -189,6 +197,12 @@ class HiveWriteOptions {
   /// The table compression kind. See velox::common::CompressionKind.
   /// The default is ZSTD compression.
   static constexpr auto kCompressionKind = "compression_kind";
+
+  /// Field delimiter for TEXT format files.
+  static constexpr auto kFieldDelim = "field.delim";
+
+  /// Null string format for TEXT format files.
+  static constexpr auto kSerializationNullFormat = "serialization.null.format";
 };
 
 class HiveConnectorMetadata : public ConnectorMetadata {

--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/dwio/text/RegisterTextReader.h"
+#include "velox/dwio/text/RegisterTextWriter.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class CsvReadWriteTest : public test::HiveQueriesTestBase {
+ protected:
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+    velox::text::registerTextReaderFactory();
+    velox::text::registerTextWriterFactory();
+  }
+
+  void TearDown() override {
+    velox::text::unregisterTextReaderFactory();
+    velox::text::unregisterTextWriterFactory();
+    HiveQueriesTestBase::TearDown();
+  }
+};
+
+TEST_F(CsvReadWriteTest, validateSchemaFileProperties) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("custom_delimiter_test");
+  };
+
+  auto tableType = ROW({
+      {"id", INTEGER()},
+      {"count", BIGINT()},
+      {"price", DOUBLE()},
+      {"name", VARCHAR()},
+      {"active", BOOLEAN()},
+  });
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {"file_format", "text"},
+      {"field.delim", "|"},
+      {"serialization.null.format", ""},
+  };
+
+  std::string csvFilePath = getTestDataPath("custom_delim/data.csv");
+  createTableFromFiles(
+      "custom_delimiter_test", tableType, {csvFilePath}, options);
+
+  hiveMetadata().reloadTableFromPath("custom_delimiter_test");
+
+  auto table = hiveMetadata().findTable("custom_delimiter_test");
+  ASSERT_NE(table, nullptr);
+
+  const auto& tableOptions = table->options();
+
+  ASSERT_TRUE(tableOptions.count("file_format"));
+  EXPECT_EQ(tableOptions.at("file_format").value<std::string>(), "text");
+
+  ASSERT_TRUE(tableOptions.count("field.delim"));
+  EXPECT_EQ(tableOptions.at("field.delim").value<std::string>(), "|");
+
+  ASSERT_TRUE(tableOptions.count("serialization.null.format"));
+  EXPECT_EQ(
+      tableOptions.at("serialization.null.format").value<std::string>(), "");
+}
+
+// Test reading CSV with custom delimiter and representative data types.
+TEST_F(CsvReadWriteTest, readCustomDelimiterWithVariousTypes) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("custom_delimiter_test");
+  };
+
+  auto tableType = ROW({
+      {"id", INTEGER()},
+      {"count", BIGINT()},
+      {"price", DOUBLE()},
+      {"name", VARCHAR()},
+      {"active", BOOLEAN()},
+  });
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {"file_format", "text"},
+      {"field.delim", "|"},
+      {"serialization.null.format", ""},
+  };
+
+  std::string csvFilePath = getTestDataPath("custom_delim/data.csv");
+  createTableFromFiles(
+      "custom_delimiter_test", tableType, {csvFilePath}, options);
+
+  auto expectedData = makeRowVector(
+      {"id", "count", "price", "name", "active"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4}),
+          makeFlatVector<int64_t>({100, 200, 300, 400}),
+          makeNullableFlatVector<double>({99.5, 149.99, std::nullopt, 29.99}),
+          makeNullableFlatVector<std::string>(
+              {"Product A", std::nullopt, "Product C", "Product D"}),
+          makeFlatVector<bool>({true, false, true, false}),
+      });
+
+  checkTableData("custom_delimiter_test", {expectedData});
+}
+
+// Test writing CSV using INSERT statement with various data types.
+TEST_F(CsvReadWriteTest, writeWithInsertStatement) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("csv_write_test");
+  };
+
+  auto tableType = ROW({
+      {"id", BIGINT()},
+      {"description", VARCHAR()},
+      {"amount", DOUBLE()},
+      {"is_active", BOOLEAN()},
+  });
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {"file_format", "text"},
+      {"field.delim", "\1"},
+      {"serialization.null.format", "\\N"},
+  };
+
+  createEmptyTable("csv_write_test", tableType, options);
+
+  auto expectedData = makeRowVector(
+      {"id", "description", "amount", "is_active"},
+      {
+          makeNullableFlatVector<int64_t>({10, std::nullopt, 30, 40}),
+          makeNullableFlatVector<std::string>(
+              {"First item", std::nullopt, "Third item", "Fourth item"}),
+          makeNullableFlatVector<double>({100.5, 200.0, std::nullopt, 400.25}),
+          makeNullableFlatVector<bool>({true, false, std::nullopt, true}),
+      });
+
+  auto logicalPlan = parseInsert(
+      "INSERT INTO csv_write_test "
+      "SELECT * FROM (VALUES "
+      "  (10, 'First item', 100.5, true), "
+      "  (NULL, NULL, 200.0, false), "
+      "  (30, 'Third item', NULL, NULL), "
+      "  (40, 'Fourth item', 400.25, true)"
+      ")");
+
+  runVelox(logicalPlan);
+
+  checkTableData("csv_write_test", {expectedData});
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -39,6 +39,8 @@ class HiveQueriesTestBase : public QueryTestBase {
 
   logical_plan::LogicalPlanNodePtr parseSelect(std::string_view sql);
 
+  logical_plan::LogicalPlanNodePtr parseInsert(std::string_view sql);
+
   using QueryTestBase::toSingleNodePlan;
 
   velox::core::PlanNodePtr toSingleNodePlan(
@@ -67,13 +69,33 @@ class HiveQueriesTestBase : public QueryTestBase {
     return *metadata_;
   }
 
+  /// Creates an empty table with the given schema and options.
+  /// If a table with the same name already exists, it is dropped first.
+  void createEmptyTable(
+      const std::string& name,
+      const velox::RowTypePtr& tableType,
+      const folly::F14FastMap<std::string, velox::Variant>& options = {});
+
+  /// Checks that the data in the specified table matches the expected data.
+  void checkTableData(
+      const std::string& tableName,
+      const std::vector<velox::RowVectorPtr>& expectedData);
+
+  /// Creates a table from external files by copying them into the table
+  /// directory.
+  void createTableFromFiles(
+      const std::string& tableName,
+      const velox::RowTypePtr& tableType,
+      const std::vector<std::string>& filePaths,
+      const folly::F14FastMap<std::string, velox::Variant>& options = {});
+
  private:
   inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
       gTempDirectory;
 
   std::unique_ptr<::axiom::sql::presto::PrestoParser> prestoParser_;
   std::shared_ptr<velox::connector::Connector> connector_;
-  connector::hive::LocalHiveConnectorMetadata* metadata_;
+  connector::hive::LocalHiveConnectorMetadata* metadata_{};
 };
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
 
@@ -278,6 +279,11 @@ velox::core::PlanNodePtr QueryTestBase::toSingleNodePlan(
 
   EXPECT_EQ(1, plan->fragments().size());
   return plan->fragments().at(0).fragment.planNode;
+}
+
+std::string QueryTestBase::getTestDataPath(const std::string& filename) {
+  return velox::test::getDataFilePath(
+      "axiom/optimizer/tests", fmt::format("test_data/{}", filename));
 }
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -152,6 +152,9 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
     return *gSuiteHistory;
   }
 
+  /// Returns the full path to a test data file.
+  static std::string getTestDataPath(const std::string& filename);
+
   OptimizerOptions optimizerOptions_;
 
  private:

--- a/axiom/optimizer/tests/test_data/custom_delim/.schema
+++ b/axiom/optimizer/tests/test_data/custom_delim/.schema
@@ -1,0 +1,30 @@
+{
+  "fileFormat": "text",
+  "dataColumns": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "count",
+      "type": "bigint"
+    },
+    {
+      "name": "price",
+      "type": "double"
+    },
+    {
+      "name": "name",
+      "type": "string"
+    },
+    {
+      "name": "active",
+      "type": "boolean"
+    }
+  ],
+  "partitionColumns": [],
+  "serdeOptions": {
+    "fieldDelim": "|",
+    "nullString": ""
+  }
+}

--- a/axiom/optimizer/tests/test_data/custom_delim/data.csv
+++ b/axiom/optimizer/tests/test_data/custom_delim/data.csv
@@ -1,0 +1,4 @@
+1|100|99.5|Product A|true
+2|200|149.99||false
+3|300||Product C|true
+4|400|29.99|Product D|false


### PR DESCRIPTION
Summary:
Goal is to be able to read/write to local csv (or other text) files. We plan to use those for basic test fixture support as they're easy for humans to review relative to other formats in a CI/unit test format.
  --data_path /tmp/axiom_csv_test \
  --data_format text \
  --query "SELECT * FROM employees;"

Differential Revision: D87649578


