### PR TITLE
fix: Handle split generation errors in LocalRunner

### DIFF
--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -124,6 +124,7 @@ class LocalRunner : public Runner,
   /// Best-effort attempt to cancel the execution.
   void abort() override;
 
+  /// @pre state() != State::kInitialized
   void waitForCompletion(int32_t maxWaitMicros) override;
 
   State state() const override {


### PR DESCRIPTION
Summary: Make sure to close Velox Task gracefully when split generation triggers an error.

Differential Revision: D87861680


