### PR TITLE
fix: Populate 'columns' for Lambda expression

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -403,7 +403,15 @@ class Lambda : public Expr {
   Lambda(ColumnVector args, const velox::Type* type, ExprCP body)
       : Expr(PlanType::kLambdaExpr, Value(type, 1)),
         args_(std::move(args)),
-        body_(body) {}
+        body_(body) {
+    auto columns = body_->columns();
+    for (auto arg : args_) {
+      columns.erase(arg);
+    }
+
+    columns_.unionSet(columns);
+  }
+
   const ColumnVector& args() const {
     return args_;
   }


### PR DESCRIPTION
Summary:
Lambda expression doesn't have inputs, but lamda's body may use columns other than lambda arguments (captures). Record these in Lambda::columns.

Fixes: https://github.com/facebookincubator/axiom/issues/654

Differential Revision: D87900986


