### PR TITLE
refactor: Make joins more clear

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -216,19 +216,17 @@ void DerivedTable::linkTablesToJoins() {
   // from all the tables it depends on.
   for (auto join : joins) {
     PlanObjectSet tables;
-    if (join->isInner() && join->directed()) {
+    if (join->leftTable()) {
       tables.add(join->leftTable());
     } else {
       for (auto key : join->leftKeys()) {
-        tables.unionSet(key->allTables());
-      }
-      for (auto key : join->rightKeys()) {
         tables.unionSet(key->allTables());
       }
       for (auto conjunct : join->filter()) {
         tables.unionSet(conjunct->allTables());
       }
     }
+    tables.add(join->rightTable());
     tables.forEachMutable([&](PlanObjectP table) {
       if (table->is(PlanType::kTableNode)) {
         table->as<BaseTable>()->addJoinedBy(join);
@@ -496,11 +494,11 @@ bool DerivedTable::isWrapOnly() const {
       exprs.empty();
 }
 
-ExprCP DerivedTable::exportExpr(ExprCP expr) {
+ExprCP DerivedTable::exportExpr(ExprCP expr) const {
   return replaceInputs(expr, exprs, columns);
 }
 
-ExprCP DerivedTable::importExpr(ExprCP expr) {
+ExprCP DerivedTable::importExpr(ExprCP expr) const {
   return replaceInputs(expr, columns, exprs);
 }
 
@@ -528,7 +526,7 @@ void DerivedTable::importJoinsIntoFirstDt(const DerivedTable* firstDt) {
   newFirst->cname = firstDt->as<DerivedTable>()->cname;
   newFirst->conjuncts = firstDt->conjuncts;
 
-  const int32_t previousNumJoins = newFirst->joins.size();
+  const size_t previousNumJoins = newFirst->joins.size();
   for (auto& join : joins) {
     auto other = join->otherSide(firstDt);
     if (!other) {
@@ -839,12 +837,12 @@ ExprVector extractCommon(ExprVector& disjuncts, ExprCP* replacement) {
 // conjuncts from outer DTs.
 void expandConjuncts(ExprVector& conjuncts) {
   bool any = false;
-  auto firstUnprocessed = 0;
+  size_t firstUnprocessed = 0;
   do {
     any = false;
 
     const auto end = conjuncts.size();
-    for (auto i = firstUnprocessed; i < end; ++i) {
+    for (size_t i = firstUnprocessed; i < end; ++i) {
       const auto& conjunct = conjuncts[i];
       if (isCallExpr(conjunct, SpecialFormCallNames::kOr) &&
           !conjunct->containsNonDeterministic()) {
@@ -937,11 +935,15 @@ void DerivedTable::distributeConjuncts() {
       }
 
       if (tables[0]->is(PlanType::kValuesTableNode)) {
-        continue; // ValuesTable does not have filter push-down.
+        continue; // ValuesTable does not have filter pushdown.
       }
 
       if (tables[0]->is(PlanType::kUnnestTableNode)) {
-        continue; // UnnestTable does not have filter push-down.
+        // UnnestTable does not implement filter pushdown yet.
+        // TODO: We can push down predicate to left side of unnest if
+        // 1. it only depends on the replicated columns
+        // 2. we can make subfield access for unnested columns
+        continue;
       }
 
       if (tables[0]->is(PlanType::kDerivedTableNode)) {

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -169,13 +169,13 @@ struct DerivedTable : public PlanObject {
 
   /// Return a copy of 'expr', replacing references to this DT's 'columns' with
   /// corresponding 'exprs'.
-  ExprCP importExpr(ExprCP expr);
+  ExprCP importExpr(ExprCP expr) const;
 
   /// Return a copy of 'expr', replacing references to this DT's 'exprs' with
   /// corresponding 'columns'.
   /// TODO Handle cases when 'expr' contains columns that are not exported by
   /// the DT.
-  ExprCP exportExpr(ExprCP expr);
+  ExprCP exportExpr(ExprCP expr) const;
 
   bool isTable() const override {
     return true;

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -102,13 +102,13 @@ std::string visitJoinEdge(const JoinEdge& edge) {
     out << " SEMI ";
   } else if (edge.isAnti()) {
     out << " ANTI ";
-  } else if (edge.leftOptional() && edge.rightOptional()) {
+  } else if (edge.isFullOuter()) {
     out << " FULL OUTER ";
-  } else if (edge.leftOptional()) {
+  } else if (edge.isRightOuter()) {
     out << " RIGHT ";
-  } else if (edge.rightOptional()) {
+  } else if (edge.isLeftOuter()) {
     out << " LEFT ";
-  } else if (edge.directed()) {
+  } else if (edge.isUnnest()) {
     out << " UNNEST ";
   } else {
     out << " INNER ";

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -35,7 +35,7 @@ class FunctionSet {
   explicit FunctionSet(uint64_t set) : set_(set) {}
 
   /// True if 'item' is in 'this'.
-  bool contains(int64_t item) const {
+  bool contains(uint64_t item) const {
     return 0 != (set_ & item);
   }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -220,7 +220,7 @@ class Optimization {
   // side is made, we further check if reducing joins applying to the probe can
   // be used to further reduce the build. These last joins are added as
   // 'existences' in the candidate.
-  std::vector<JoinCandidate> nextJoins(PlanState& state);
+  std::vector<JoinCandidate> nextJoins(PlanState& state) const;
 
   // Adds group by, order by, top k, limit to 'plan'. Updates 'plan' if
   // relation ops added. Sets cost in 'state'.
@@ -242,10 +242,7 @@ class Optimization {
   // placed, adds them to 'state.placed' and calls makeJoins()
   // recursively to make the rest of the plan. Returns false if no
   // unplaced conjuncts were found and plan construction should proceed.
-  bool placeConjuncts(
-      RelationOpPtr plan,
-      PlanState& state,
-      bool allowNondeterministic);
+  bool placeConjuncts(RelationOpPtr plan, PlanState& state, bool joinsPlaced);
 
   // Helper function that calls makeJoins recursively for each of
   // 'nextJoins'. The point of making 'nextJoins' first and only then

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -145,18 +145,21 @@ class PlanObjectSet : public BitSet {
  public:
   /// True if id of 'object' is in 'this'.
   bool contains(PlanObjectCP object) const {
+    VELOX_DCHECK_NOT_NULL(object);
     return object->id() < bits_.size() * 64 &&
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
   /// Inserts id of 'object'.
   void add(PlanObjectCP object) {
+    VELOX_DCHECK_NOT_NULL(object);
     auto id = object->id();
     BitSet::add(id);
   }
 
   /// Erases id of 'object'.
   void erase(PlanObjectCP object) {
+    VELOX_DCHECK_NOT_NULL(object);
     BitSet::erase(object->id());
   }
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -229,10 +229,10 @@ JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
         rightTable_,
         rightKeys_,
         lrFanout_,
-        rightOptional_,
-        leftOptional_,
-        rightExists_,
-        rightNotExists_,
+        rightOptional(),
+        leftOptional(),
+        isSemi(),
+        isAnti(),
         markColumn_,
         rightUnique_};
   }
@@ -241,16 +241,12 @@ JoinSide JoinEdge::sideOf(PlanObjectCP side, bool other) const {
       leftTable_,
       leftKeys_,
       rlFanout_,
-      leftOptional_,
-      rightOptional_,
+      leftOptional(),
+      rightOptional(),
       false,
       false,
-      markColumn_,
+      nullptr,
       leftUnique_};
-}
-
-bool JoinEdge::isBroadcastableType() const {
-  return !leftOptional_;
 }
 
 void JoinEdge::addEquality(ExprCP left, ExprCP right, bool update) {
@@ -300,19 +296,20 @@ std::string JoinEdge::toString() const {
   std::stringstream out;
   out << "<join "
       << (leftTable_ ? leftTable_->toString() : " multiple tables ");
-  if (leftOptional_ && rightOptional_) {
-    out << " full outr ";
-  } else if (markColumn_) {
-    out << " exists project ";
-  } else if (rightOptional_) {
+  if (isFullOuter()) {
+    out << " full outer ";
+  } else if (isLeftOuter()) {
     out << " left ";
-  } else if (rightExists_) {
+  } else if (isSemi()) {
     out << " exists ";
-  } else if (rightNotExists_) {
+    if (markColumn_) {
+      out << "project ";
+    }
+  } else if (isAnti()) {
     out << " not exists ";
-  } else if (leftOptional_) {
+  } else if (isRightOuter()) {
     out << " right ";
-  } else if (directed_) {
+  } else if (isUnnest()) {
     out << " unnest ";
   } else {
     out << " inner ";
@@ -469,11 +466,11 @@ PlanObjectSet JoinEdge::allTables() const {
 }
 
 namespace {
-template <typename U>
+
 inline CPSpan<Column> toRangeCast(const ExprVector& exprs) {
-  return CPSpan<Column>(
-      reinterpret_cast<const Column* const*>(exprs.data()), exprs.size());
+  return {reinterpret_cast<const Column* const*>(exprs.data()), exprs.size()};
 }
+
 } // namespace
 
 void JoinEdge::guessFanout() {
@@ -481,6 +478,7 @@ void JoinEdge::guessFanout() {
     return;
   }
 
+  // TODO: Why fanouts are set to 1.1 and 1 when left table is null?
   if (leftTable_ == nullptr) {
     lrFanout_ = 1.1;
     rlFanout_ = 1;
@@ -489,8 +487,8 @@ void JoinEdge::guessFanout() {
 
   auto* opt = queryCtx()->optimization();
   auto samplePair = opt->history().sampleJoin(this);
-  auto left = joinCardinality(leftTable_, toRangeCast<Column>(leftKeys_));
-  auto right = joinCardinality(rightTable_, toRangeCast<Column>(rightKeys_));
+  auto left = joinCardinality(leftTable_, toRangeCast(leftKeys_));
+  auto right = joinCardinality(rightTable_, toRangeCast(rightKeys_));
   leftUnique_ = left.unique;
   rightUnique_ = right.unique;
   if (samplePair.first == 0 && samplePair.second == 0) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -491,27 +491,25 @@ struct JoinSide {
 /// decomposable and reorderable conjuncts.
 class JoinEdge {
  public:
-  /// Default is INNER JOIN.
+  enum class JoinType : uint8_t {
+    kInner,
+    kLeft,
+    kRight,
+    kFull,
+    kSemi,
+    kAnti,
+    kUnnest,
+  };
+
   struct Spec {
     /// Filter conjuncts to be applied after the join. Only for non-inner joins.
     ExprVector filter;
 
-    /// True for RIGHT and FULL OUTER JOIN. The output may have no match on the
-    /// left side.
-    bool leftOptional{false};
+    /// Join type.
+    JoinType joinType{JoinType::kInner};
 
-    /// True for LEFT and FULL OUTER JOIN. The output may have no match on the
-    /// right side.
-    bool rightOptional{false};
-
-    /// True for EXISTS subquery. Mutually exclusive with 'rightNotExists'.
-    bool rightExists{false};
-
-    /// True for NOT EXISTS subquery. Mutually exclusive with 'rightExists'.
-    bool rightNotExists{false};
-
-    /// Marker column produced by 'exists' or 'not exists' join. If set, the
-    /// 'rightExists' must be true.
+    /// Marker column produced by 'exists' or 'not exists' join.
+    ///  If set, the 'joinType' must be kSemi.
     ColumnCP markColumn{nullptr};
 
     /// Columns produced by the 'left' side of a RIGHT or FULL OUTER join.
@@ -527,8 +525,6 @@ class JoinEdge {
 
     /// Input expressions corresponding 1:1 to 'rightColumns'.
     ExprVector rightExprs;
-
-    bool directed{false};
   };
 
   /// @param leftTable The left table of the join. May be nullptr if 'leftKeys'
@@ -539,38 +535,28 @@ class JoinEdge {
       : leftTable_(leftTable),
         rightTable_(rightTable),
         filter_(std::move(spec.filter)),
-        leftOptional_(spec.leftOptional),
-        rightOptional_(spec.rightOptional),
-        rightExists_(spec.rightExists),
-        rightNotExists_(spec.rightNotExists),
-        directed_(spec.directed),
+        joinType_(spec.joinType),
         markColumn_(spec.markColumn),
         leftColumns_{spec.leftColumns},
         leftExprs_{spec.leftExprs},
         rightColumns_{spec.rightColumns},
         rightExprs_{spec.rightExprs} {
-    VELOX_CHECK_NOT_NULL(rightTable);
-
-    if (isInner()) {
-      VELOX_CHECK_NOT_NULL(
-          leftTable, "Hyper edge is not supported for an inner join");
-      VELOX_CHECK(filter_.empty(), "Filter is not allowed for an inner join");
-    }
-
-    VELOX_CHECK(!rightExists_ || !rightNotExists_);
-
-    if (markColumn_) {
-      VELOX_CHECK(rightExists_);
-    }
+    // Only left join can have null left table.
+    VELOX_DCHECK(leftTable_ || isLeftOuter());
+    VELOX_DCHECK_NOT_NULL(rightTable_);
+    // filter_ is only for non-inner joins.
+    VELOX_DCHECK(filter_.empty() || !isInner());
+    // Mark column only for semi joins.
+    VELOX_DCHECK(!markColumn_ || isSemi());
 
     if (!leftColumns_.empty()) {
-      VELOX_CHECK(leftOptional_);
-      VELOX_CHECK_EQ(leftColumns_.size(), leftExprs_.size());
+      VELOX_DCHECK(leftOptional());
+      VELOX_DCHECK_EQ(leftColumns_.size(), leftExprs_.size());
     }
 
     if (!rightColumns_.empty()) {
-      VELOX_CHECK(rightOptional_);
-      VELOX_CHECK_EQ(rightColumns_.size(), rightExprs_.size());
+      VELOX_DCHECK(rightOptional());
+      VELOX_DCHECK_EQ(rightColumns_.size(), rightExprs_.size());
     }
   }
 
@@ -588,7 +574,7 @@ class JoinEdge {
         rightTable,
         Spec{
             .filter = std::move(filter),
-            .rightExists = true,
+            .joinType = JoinType::kSemi,
             .markColumn = markColumn,
         });
   }
@@ -596,19 +582,20 @@ class JoinEdge {
   static JoinEdge* makeNotExists(
       PlanObjectCP leftTable,
       PlanObjectCP rightTable) {
-    return make<JoinEdge>(leftTable, rightTable, Spec{.rightNotExists = true});
+    return make<JoinEdge>(
+        leftTable, rightTable, Spec{.joinType = JoinType::kAnti});
   }
 
   static JoinEdge* makeUnnest(
       PlanObjectCP leftTable,
       PlanObjectCP rightTable,
       ExprVector unnestExprs) {
-    VELOX_DCHECK_NOT_NULL(leftTable);
-    auto* edge = make<JoinEdge>(leftTable, rightTable, Spec{.directed = true});
+    auto* edge = make<JoinEdge>(
+        leftTable, rightTable, Spec{.joinType = JoinType::kUnnest});
     edge->leftKeys_ = std::move(unnestExprs);
     // TODO Not sure to what values fanout need to be set,
     // (1, 1) looks ok, but tests don't produce expected plans.
-    edge->setFanouts(2, 2);
+    edge->setFanouts(2, 1);
     return edge;
   }
 
@@ -644,11 +631,11 @@ class JoinEdge {
   }
 
   bool leftOptional() const {
-    return leftOptional_;
+    return isRightOuter() || isFullOuter();
   }
 
   bool rightOptional() const {
-    return rightOptional_;
+    return isLeftOuter() || isFullOuter();
   }
 
   ColumnCP markColumn() const {
@@ -671,49 +658,54 @@ class JoinEdge {
     return rightExprs_;
   }
 
-  bool directed() const {
-    return directed_;
-  }
-
   void addEquality(ExprCP left, ExprCP right, bool update = false);
 
   /// True if inner join.
   bool isInner() const {
-    return !leftOptional_ && !rightOptional_ && !rightExists_ &&
-        !rightNotExists_;
+    return joinType_ == JoinType::kInner;
   }
 
   /// True if this is an EXISTS join.
   bool isSemi() const {
-    return rightExists_;
+    return joinType_ == JoinType::kSemi;
   }
 
   /// True if this is a NOT EXISTS join.
   bool isAnti() const {
-    return rightNotExists_;
+    return joinType_ == JoinType::kAnti;
   }
 
   /// True if this is a LEFT join.
   bool isLeftOuter() const {
-    return rightOptional_ && !leftOptional_ && !isSemi() && !isAnti();
+    return joinType_ == JoinType::kLeft;
+  }
+
+  /// True if this is a RIGHT join.
+  bool isRightOuter() const {
+    return joinType_ == JoinType::kRight;
+  }
+
+  /// True if this is a FULL OUTER join.
+  bool isFullOuter() const {
+    return joinType_ == JoinType::kFull;
+  }
+
+  /// True if this is an UNNEST join.
+  bool isUnnest() const {
+    return joinType_ == JoinType::kUnnest;
   }
 
   /// True if all tables referenced from 'leftKeys' must be placed before
   /// placing this.
   bool isNonCommutative() const {
     // Inner and full outer joins are commutative.
-    if (rightOptional_ && leftOptional_) {
-      return false;
-    }
-
-    return !leftTable_ || rightOptional_ || leftOptional_ || rightExists_ ||
-        rightNotExists_ || directed_;
+    return !isInner() && !isFullOuter();
   }
 
   /// True if has a hash based variant that builds on the left and probes on the
   /// right.
   bool hasRightHashVariant() const {
-    return isNonCommutative() && !rightNotExists_;
+    return isNonCommutative() && !isAnti() && !isUnnest();
   }
 
   /// Returns the join side info for 'table'. If 'other' is set, returns the
@@ -761,7 +753,9 @@ class JoinEdge {
 
   /// True if a hash join build can be broadcasted. Used when building on the
   /// right. None of the right hash join variants are broadcastable.
-  bool isBroadcastableType() const;
+  bool isBroadcastableType() const {
+    return !leftOptional();
+  }
 
   /// Returns a key string for recording a join cardinality sample. The string
   /// is empty if not applicable. The bool is true if the key has right table
@@ -797,26 +791,8 @@ class JoinEdge {
   // 'leftKeys' select max 1 'rightTable' row.
   bool rightUnique_{false};
 
-  // True if an unprobed right side row produces a result with right side
-  // columns set and left side columns as null (right outer join). Possible only
-  // for hash or merge.
-  const bool leftOptional_;
-
-  // True if a right side miss produces a row with left side columns
-  // and a null for right side columns (left outer join). A full outer
-  // join has both left and right optional.
-  const bool rightOptional_;
-
-  // True if the right side is only checked for existence of a match. If
-  // rightOptional is set, this can project out a null for misses.
-  const bool rightExists_;
-
-  // True if produces a result for left if no match on the right.
-  const bool rightNotExists_;
-
-  // If directed non-outer edge. For example unnest or inner dependent on
-  // optional of outer.
-  const bool directed_;
+  // Join type.
+  const JoinType joinType_;
 
   // Flag to set if right side has a match.
   ColumnCP const markColumn_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1232,34 +1232,51 @@ void extractNonInnerJoinEqualities(
     ExprVector& leftKeys,
     ExprVector& rightKeys,
     PlanObjectSet& allLeft) {
-  for (auto i = 0; i < conjuncts.size(); ++i) {
-    const auto* conjunct = conjuncts[i];
-    if (isCallExpr(conjunct, eq)) {
-      const auto* eq = conjunct->as<Call>();
-      const auto leftTables = eq->argAt(0)->allTables();
-      const auto rightTables = eq->argAt(1)->allTables();
+  VELOX_DCHECK_NOT_NULL(right);
 
-      if (leftTables.empty() || rightTables.empty()) {
-        continue;
-      }
-
-      if (rightTables.size() == 1 && rightTables.contains(right) &&
-          !leftTables.contains(right)) {
-        allLeft.unionSet(leftTables);
-        leftKeys.push_back(eq->argAt(0));
-        rightKeys.push_back(eq->argAt(1));
-        conjuncts.erase(conjuncts.begin() + i);
-        --i;
-      } else if (
-          leftTables.size() == 1 && leftTables.contains(right) &&
-          !rightTables.contains(right)) {
-        allLeft.unionSet(rightTables);
-        leftKeys.push_back(eq->argAt(1));
-        rightKeys.push_back(eq->argAt(0));
-        conjuncts.erase(conjuncts.begin() + i);
-        --i;
-      }
+  std::erase_if(conjuncts, [&](ExprCP conjunct) {
+    if (!isCallExpr(conjunct, eq)) {
+      return false;
     }
+    const auto* eq = conjunct->as<Call>();
+    const auto* leftArg = eq->argAt(0);
+    const auto* rightArg = eq->argAt(1);
+    const auto leftTables = leftArg->allTables();
+    const auto rightTables = rightArg->allTables();
+
+    if (leftTables.empty() || rightTables.empty()) {
+      return false;
+    }
+    if (rightTables.size() == 1 && rightTables.contains(right) &&
+        !leftTables.contains(right)) {
+      allLeft.unionSet(leftTables);
+      leftKeys.push_back(leftArg);
+      rightKeys.push_back(rightArg);
+      return true;
+    }
+    if (leftTables.size() == 1 && leftTables.contains(right) &&
+        !rightTables.contains(right)) {
+      allLeft.unionSet(rightTables);
+      leftKeys.push_back(rightArg);
+      rightKeys.push_back(leftArg);
+      return true;
+    }
+    return false;
+  });
+}
+
+JoinEdge::JoinType toJoinType(lp::JoinType joinType) {
+  switch (joinType) {
+    case lp::JoinType::kInner:
+      return JoinEdge::JoinType::kInner;
+    case lp::JoinType::kLeft:
+      return JoinEdge::JoinType::kLeft;
+    case lp::JoinType::kRight:
+      return JoinEdge::JoinType::kRight;
+    case lp::JoinType::kFull:
+      return JoinEdge::JoinType::kFull;
+    default:
+      VELOX_UNREACHABLE();
   }
 }
 
@@ -1297,44 +1314,44 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
   if (isInner) {
     currentDt_->conjuncts.insert(
         currentDt_->conjuncts.end(), conjuncts.begin(), conjuncts.end());
-  } else {
-    const bool leftOptional =
-        joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
-    const bool rightOptional =
-        joinType == lp::JoinType::kLeft || joinType == lp::JoinType::kFull;
+    return;
+  }
+  const bool leftOptional =
+      joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
+  const bool rightOptional =
+      joinType == lp::JoinType::kLeft || joinType == lp::JoinType::kFull;
 
-    // If non-inner, and many tables on the right they are one dt. If a single
-    // table then this too is the last in 'tables'.
-    auto rightTable = currentDt_->tables.back();
+  // If non-inner, and many tables on the right they are one dt. If a single
+  // table then this too is the last in 'tables'.
+  auto rightTable = currentDt_->tables.back();
 
-    ExprVector leftKeys;
-    ExprVector rightKeys;
-    PlanObjectSet leftTables;
-    extractNonInnerJoinEqualities(
-        equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
+  ExprVector leftKeys;
+  ExprVector rightKeys;
+  PlanObjectSet leftTables;
+  extractNonInnerJoinEqualities(
+      equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    JoinEdge::Spec joinSpec{
-        .filter = std::move(conjuncts),
-        .leftOptional = leftOptional,
-        .rightOptional = rightOptional,
-    };
+  VELOX_DCHECK_EQ(leftKeys.size(), rightKeys.size());
+  JoinEdge::Spec joinSpec{
+      .filter = std::move(conjuncts),
+      .joinType = toJoinType(joinType),
+  };
 
-    if (leftOptional) {
-      addJoinColumns(*join.left(), joinSpec.leftColumns, joinSpec.leftExprs);
-    }
+  if (leftOptional) {
+    addJoinColumns(*join.left(), joinSpec.leftColumns, joinSpec.leftExprs);
+  }
 
-    if (rightOptional) {
-      addJoinColumns(*join.right(), joinSpec.rightColumns, joinSpec.rightExprs);
-    }
+  if (rightOptional) {
+    addJoinColumns(*join.right(), joinSpec.rightColumns, joinSpec.rightExprs);
+  }
 
-    auto* edge = make<JoinEdge>(
-        leftTables.size() == 1 ? leftTables.onlyObject() : nullptr,
-        rightTable,
-        std::move(joinSpec));
-    currentDt_->joins.push_back(edge);
-    for (auto i = 0; i < leftKeys.size(); ++i) {
-      edge->addEquality(leftKeys[i], rightKeys[i]);
-    }
+  auto* edge = make<JoinEdge>(
+      leftTables.size() == 1 ? leftTables.onlyObject() : nullptr,
+      rightTable,
+      std::move(joinSpec));
+  currentDt_->joins.push_back(edge);
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    edge->addEquality(leftKeys[i], rightKeys[i]);
   }
 }
 
@@ -1677,7 +1694,9 @@ void ToGraph::processSubqueries(const logical_plan::FilterNode& filter) {
       correlatedConjuncts_.clear();
 
       auto* join = make<JoinEdge>(
-          leftTable, subqueryDt, JoinEdge::Spec{.rightOptional = true});
+          leftTable,
+          subqueryDt,
+          JoinEdge::Spec{.joinType = JoinEdge::JoinType::kLeft});
       for (auto i = 0; i < leftKeys.size(); ++i) {
         join->addEquality(leftKeys[i], rightKeys[i]);
       }

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -364,7 +364,7 @@ class ToGraph {
   folly::F14FastMap<std::string, ExprCP> renames_;
 
   // Symbols from the 'outer' query. Used when processing correlated subqueries.
-  const folly::F14FastMap<std::string, ExprCP>* correlations_;
+  const folly::F14FastMap<std::string, ExprCP>* correlations_{nullptr};
 
   // True if expression is allowed to reference symbols from the 'outer' query.
   bool allowCorrelations_{false};


### PR DESCRIPTION

This PR refactors the join representation in the query optimizer by replacing boolean flags (leftOptional, rightOptional, rightExists, rightNotExists, directed) with an explicit JoinType enum. This makes the join semantics clearer and more maintainable.

Key changes:
- Introduces a JoinType enum (kInner, kLeft, kRight, kFull, kSemi, kAnti, kUnnest) to replace multiple boolean flags
- Refactors JoinEdge constructor and methods to use the new enum
- Updates join creation sites throughout the codebase to use the new JoinType API
