### PR TITLE
refactor: Remove redundant code from DerivedTable::importJoinsIntoFirstDt

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -525,8 +525,6 @@ void DerivedTable::importJoinsIntoFirstDt(const DerivedTable* firstDt) {
   }
 
   auto* newFirst = make<DerivedTable>(*firstDt->as<DerivedTable>());
-  newFirst->cname = firstDt->as<DerivedTable>()->cname;
-  newFirst->conjuncts = firstDt->conjuncts;
 
   const int32_t previousNumJoins = newFirst->joins.size();
   for (auto& join : joins) {

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -211,7 +211,7 @@ PlanObjectSet PlanState::computeDownstreamColumns(bool includeFilters) const {
 
   auto addExpr = [&](ExprCP expr) { result.unionColumns(translateExpr(expr)); };
 
-  auto addExprs = [&](ExprVector exprs) {
+  auto addExprs = [&](const ExprVector& exprs) {
     for (auto expr : exprs) {
       addExpr(expr);
     }


### PR DESCRIPTION
Differential Revision: D88068189


