### PR TITLE
feat: Implement Output Format CLI Option

### DIFF
--- a/axiom/cli/AlignedTablePrinter.cpp
+++ b/axiom/cli/AlignedTablePrinter.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/AlignedTablePrinter.h"
+#include <iomanip>
+#include <iostream>
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+
+namespace {
+
+constexpr const char* kColumnSeparator = " | ";
+constexpr const char* kSeparatorJunction = "-+-";
+
+int64_t countResults(const std::vector<RowVectorPtr>& results) {
+  int64_t numRows = 0;
+  for (const auto& result : results) {
+    numRows += result->size();
+  }
+  return numRows;
+}
+
+} // namespace
+
+int32_t AlignedTablePrinter::printResults(
+    const std::vector<RowVectorPtr>& results,
+    int32_t maxRows) {
+  const auto numRows = countResults(results);
+
+  auto printFooter = [numRows, numBatches = results.size()]() {
+    std::cout << "(" << numRows << " rows in " << numBatches << " batches)"
+              << std::endl
+              << std::endl;
+  };
+
+  if (numRows == 0) {
+    printFooter();
+    return 0;
+  }
+
+  const auto type = results.front()->rowType();
+  std::cout << type->toString() << std::endl;
+
+  const auto numColumns = type->size();
+
+  std::vector<std::vector<std::string>> data;
+  std::vector<int> widths(numColumns, 0);
+  std::vector<bool> alignLeft(numColumns);
+
+  for (auto i = 0; i < numColumns; ++i) {
+    widths[i] = static_cast<int>(type->nameOf(i).size());
+    alignLeft[i] = type->childAt(i)->isVarchar();
+  }
+
+  auto printTableSeparator = [&widths, numColumns]() {
+    std::cout << std::setfill('-');
+    for (auto i = 0; i < numColumns; ++i) {
+      if (i > 0) {
+        std::cout << kSeparatorJunction;
+      }
+      std::cout << std::setw(widths[i]) << "";
+    }
+    std::cout << std::endl << std::setfill(' ');
+  };
+
+  auto printTableRow =
+      [&widths, &alignLeft, numColumns](const std::vector<std::string>& row) {
+        for (auto i = 0; i < numColumns; ++i) {
+          if (i > 0) {
+            std::cout << kColumnSeparator;
+          }
+          std::cout << std::setw(widths[i]);
+          std::cout << (alignLeft[i] ? std::left : std::right);
+          std::cout << row[i];
+        }
+        std::cout << std::endl;
+      };
+
+  int32_t numPrinted = 0;
+
+  auto printCompleteTable = [&]() {
+    printTableSeparator();
+    printTableRow(type->names());
+    printTableSeparator();
+
+    for (const auto& row : data) {
+      printTableRow(row);
+    }
+
+    if (numPrinted < numRows) {
+      std::cout << std::endl
+                << "..." << (numRows - numPrinted) << " more rows."
+                << std::endl;
+    }
+
+    printFooter();
+  };
+
+  // Iterate through result batches and accumulate data rows.
+  for (const auto& result : results) {
+    for (auto row = 0; row < result->size(); ++row) {
+      data.emplace_back();
+
+      auto& rowData = data.back();
+      rowData.resize(numColumns);
+
+      // Convert each column value to string and track maximum width.
+      for (auto column = 0; column < numColumns; ++column) {
+        rowData[column] = result->childAt(column)->toString(row);
+        widths[column] =
+            std::max(widths[column], static_cast<int>(rowData[column].size()));
+      }
+
+      ++numPrinted;
+      if (numPrinted >= maxRows) {
+        printCompleteTable();
+        return static_cast<int32_t>(numRows);
+      }
+    }
+  }
+
+  printCompleteTable();
+
+  return static_cast<int32_t>(numRows);
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/AlignedTablePrinter.h
+++ b/axiom/cli/AlignedTablePrinter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/cli/OutputPrinter.h"
+
+namespace axiom::sql {
+
+/// Prints query results as aligned tables.
+class AlignedTablePrinter : public OutputPrinter {
+ public:
+  AlignedTablePrinter() = default;
+
+  int32_t printResults(
+      const std::vector<facebook::velox::RowVectorPtr>& results,
+      int32_t maxRows) override;
+};
+
+} // namespace axiom::sql

--- a/axiom/cli/JsonPrinter.cpp
+++ b/axiom/cli/JsonPrinter.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/JsonPrinter.h"
+#include <folly/json.h>
+#include <iostream>
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+
+namespace {
+
+// Converts a Variant to a folly::dynamic for JSON serialization.
+//
+// We use a hybrid approach instead of directly using Variant::toJson() because
+// Variant serializes ROW types as arrays (e.g., ["value1", "value2"]), but we
+// want a standard JSON format (e.g., {"field1": "value1", "field2":
+// "value2"}) for better usability and compatibility with downstream tools.
+//
+// The hybrid approach leverages variantAt() for efficient value extraction
+// but has more complex logic for complex types
+folly::dynamic variantToDynamic(const Variant& variant, const TypePtr& type) {
+  if (variant.isNull()) {
+    return nullptr;
+  }
+
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      // ROW types must be serialized as objects with named fields, not arrays.
+      // This preserves field names in the JSON output for self-documentation.
+      folly::dynamic obj = folly::dynamic::object;
+      const auto& rowType = type->asRow();
+      const auto& names = rowType.names();
+      const auto& rowValue = variant.row();
+      for (auto i = 0; i < names.size(); ++i) {
+        obj[names[i]] = variantToDynamic(rowValue[i], rowType.childAt(i));
+      }
+      return obj;
+    }
+    case TypeKind::ARRAY: {
+      folly::dynamic arr = folly::dynamic::array;
+      const auto& arrayValue = variant.array();
+      const auto& elementType = type->asArray().elementType();
+      for (const auto& element : arrayValue) {
+        arr.push_back(variantToDynamic(element, elementType));
+      }
+      return arr;
+    }
+    case TypeKind::MAP: {
+      folly::dynamic obj = folly::dynamic::object;
+      const auto& mapValue = variant.map();
+      for (const auto& [key, value] : mapValue) {
+        // Convert key to string for JSON object key.
+        // JSON objects require string keys, so we convert non-string types.
+        std::string keyStr;
+        if (key.kind() == TypeKind::VARCHAR ||
+            key.kind() == TypeKind::VARBINARY) {
+          keyStr = key.value<std::string>();
+        } else {
+          // For non-string keys (e.g., integers), serialize to JSON string.
+          keyStr = key.toJson(type->asMap().keyType());
+        }
+        obj[keyStr] = variantToDynamic(value, type->asMap().valueType());
+      }
+      return obj;
+    }
+    default:
+      // For scalar types, Variant::toJson() produces the correct format.
+      return folly::parseJson(variant.toJson(type));
+  }
+}
+
+} // namespace
+
+int32_t JsonPrinter::printResults(
+    const std::vector<RowVectorPtr>& results,
+    int32_t maxRows) {
+  int32_t numPrinted = 0;
+  int32_t totalRows = 0;
+
+  for (const auto& result : results) {
+    totalRows += result->size();
+
+    if (result->size() == 0) {
+      continue;
+    }
+
+    const auto& rowType = result->rowType();
+    const auto& columnNames = rowType->names();
+    const auto numColumns = columnNames.size();
+
+    for (vector_size_t row = 0; row < result->size(); ++row) {
+      if (numPrinted >= maxRows) {
+        return totalRows;
+      }
+
+      folly::dynamic jsonObj = folly::dynamic::object;
+
+      for (auto col = 0; col < numColumns; ++col) {
+        const auto& columnName = columnNames[col];
+        const auto& columnVector = result->childAt(col);
+        const auto& columnType = rowType->childAt(col);
+
+        auto variant = columnVector->variantAt(row);
+        jsonObj[columnName] = variantToDynamic(variant, columnType);
+      }
+
+      std::cout << folly::toJson(jsonObj) << std::endl;
+      ++numPrinted;
+    }
+  }
+
+  return totalRows;
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/JsonPrinter.h
+++ b/axiom/cli/JsonPrinter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/cli/OutputPrinter.h"
+
+namespace axiom::sql {
+
+/// Prints query results as JSON Lines (one JSON object per row).
+class JsonPrinter : public OutputPrinter {
+ public:
+  JsonPrinter() = default;
+
+  int32_t printResults(
+      const std::vector<facebook::velox::RowVectorPtr>& results,
+      int32_t maxRows) override;
+};
+
+} // namespace axiom::sql

--- a/axiom/cli/OutputFormat.cpp
+++ b/axiom/cli/OutputFormat.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/OutputFormat.h"
+
+namespace axiom::sql {
+
+namespace {
+const auto& outputFormatNames() {
+  static const folly::F14FastMap<OutputFormat, std::string_view> kNames = {
+      {OutputFormat::kAligned, "ALIGNED"},
+      {OutputFormat::kJson, "JSON"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(OutputFormat, outputFormatNames);
+
+} // namespace axiom::sql

--- a/axiom/cli/OutputFormat.h
+++ b/axiom/cli/OutputFormat.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/common/Enums.h"
+
+namespace axiom::sql {
+
+/// Output format for query results.
+///
+/// Supported formats:
+/// - kAligned: Table format with column alignment (human-readable)
+/// - kJson: JSON Lines format with one JSON object per row (machine-readable)
+enum class OutputFormat {
+  kAligned,
+  kJson,
+};
+
+AXIOM_DECLARE_ENUM_NAME(OutputFormat);
+
+} // namespace axiom::sql

--- a/axiom/cli/OutputPrinter.h
+++ b/axiom/cli/OutputPrinter.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace axiom::sql {
+
+/// Timing statistics for query execution.
+///
+/// Captures wall clock time, user CPU time, and system CPU time for a query.
+/// Used to provide performance metrics to users.
+struct Timing {
+  /// Wall clock time elapsed in microseconds.
+  uint64_t micros{0};
+
+  /// User CPU time in nanoseconds.
+  /// Time spent executing user-mode code (application logic).
+  uint64_t userNanos{0};
+
+  /// System CPU time in nanoseconds.
+  /// Time spent in kernel mode (system calls, I/O).
+  uint64_t systemNanos{0};
+
+  /// Formats timing information as a human-readable string.
+  ///
+  /// Example output: "1.5s / 800ms user / 150ms system (63%)"
+  /// The percentage indicates CPU utilization relative to wall clock time.
+  std::string toString() const {
+    double pct = 0;
+    if (micros > 0) {
+      pct = 100.0 * (userNanos + systemNanos) / (micros * 1000);
+    }
+
+    std::stringstream out;
+    out << facebook::velox::succinctNanos(micros * 1000) << " / "
+        << facebook::velox::succinctNanos(userNanos) << " user / "
+        << facebook::velox::succinctNanos(systemNanos) << " system (" << pct
+        << "%)";
+    return out.str();
+  }
+};
+
+/// Abstract interface for formatting and printing query results.
+///
+/// This interface allows the CLI to support multiple output formats (aligned
+/// tables, JSON, CSV, etc.) without coupling the query execution logic to the
+/// presentation layer. Implementations handle both result formatting and
+/// optional timing information display.
+///
+/// Implementations must be thread-safe for the printResults() call, as they
+/// may be invoked from multiple contexts.
+class OutputPrinter {
+ public:
+  virtual ~OutputPrinter() = default;
+
+  /// Prints query results to stdout.
+  ///
+  /// Formats and outputs the query results according to the specific
+  /// implementation (e.g., as aligned tables or JSON). Results are provided
+  /// as batches of row vectors, which the printer iterates through.
+  ///
+  /// @param results Vector of RowVectorPtr batches containing the query output.
+  ///                Each batch may contain multiple rows. The printer should
+  ///                handle batching transparently to the user.
+  /// @param maxRows Maximum number of rows to print. If the total row count
+  ///                exceeds this limit, implementations should truncate output
+  ///                and optionally indicate that rows were omitted.
+  /// @return The total number of rows across all batches (not just printed).
+  ///         This allows callers to report statistics even when output is
+  ///         truncated.
+  virtual int32_t printResults(
+      const std::vector<facebook::velox::RowVectorPtr>& results,
+      int32_t maxRows) = 0;
+};
+
+} // namespace axiom::sql

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -13,33 +13,20 @@
 # limitations under the License.
 
 add_executable(
-  axiom_sql
-  AxiomSql.cpp
-  Console.cpp
-  SqlQueryRunner.cpp
-  AlignedTablePrinter.cpp
-  JsonPrinter.cpp
-  OutputFormat.cpp
-  linenoise/linenoise.c
+  axiom_cli_output_printer_test
+  OutputPrinterTest.cpp
+  ../AlignedTablePrinter.cpp
+  ../JsonPrinter.cpp
+  ../OutputFormat.cpp
 )
+
+add_test(axiom_cli_output_printer_test axiom_cli_output_printer_test)
 
 target_link_libraries(
-  axiom_sql
-  axiom_runner_local_runner
-  axiom_runner_multifragment_plan
-  axiom_optimizer
-  axiom_hive_connector_metadata
-  axiom_tpch_connector_metadata
-  axiom_sql_presto_parser
-  velox_exec_test_lib
-  velox_dwio_common
-  velox_dwio_parquet_reader
-  velox_dwio_native_parquet_reader
-  velox_parse_parser
-  velox_parse_expression
-  velox_parse_utils
+  axiom_cli_output_printer_test
+  velox_vector
+  velox_vector_test_lib
+  folly
+  GTest::gtest
+  GTest::gtest_main
 )
-
-if(AXIOM_BUILD_TESTING)
-  add_subdirectory(tests)
-endif()

--- a/axiom/cli/tests/OutputPrinterTest.cpp
+++ b/axiom/cli/tests/OutputPrinterTest.cpp
@@ -1,0 +1,652 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+#include <sstream>
+#include "axiom/cli/AlignedTablePrinter.h"
+#include "axiom/cli/JsonPrinter.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace axiom::sql {
+namespace {
+
+using namespace facebook::velox;
+
+class OutputPrinterTest : public ::testing::Test,
+                          public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::string captureOutput(const std::function<void()>& func) {
+    std::stringstream buffer;
+    std::streambuf* oldCout = std::cout.rdbuf(buffer.rdbuf());
+    func();
+    std::cout.rdbuf(oldCout);
+    return buffer.str();
+  }
+  RowVectorPtr createTestData() {
+    return makeRowVector(
+        {"id", "name", "age", "score"},
+        {
+            makeFlatVector<int32_t>({1, 2, 3}),
+            makeFlatVector<std::string>({"Alice", "Bob", "Charlie"}),
+            makeFlatVector<int64_t>({30, 25, 35}),
+            makeFlatVector<double>({95.5, 87.3, 92.1}),
+        });
+  }
+
+  RowVectorPtr createTestDataWithNulls() {
+    return makeRowVector(
+        {"id", "name", "value"},
+        {
+            makeNullableFlatVector<int32_t>({1, std::nullopt, 3}),
+            makeNullableFlatVector<std::string>(
+                {"Alice", std::nullopt, "Charlie"}),
+            makeNullableFlatVector<double>({10.5, 20.0, std::nullopt}),
+        });
+  }
+};
+
+TEST_F(OutputPrinterTest, JsonPrinterBasic) {
+  auto data = createTestData();
+  JsonPrinter printer;
+
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 3);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_EQ(json1["name"].asString(), "Alice");
+  EXPECT_EQ(json1["age"].asInt(), 30);
+  EXPECT_DOUBLE_EQ(json1["score"].asDouble(), 95.5);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_EQ(json2["name"].asString(), "Bob");
+  EXPECT_EQ(json2["age"].asInt(), 25);
+  EXPECT_DOUBLE_EQ(json2["score"].asDouble(), 87.3);
+
+  auto json3 = folly::parseJson(lines[2]);
+  EXPECT_EQ(json3["id"].asInt(), 3);
+  EXPECT_EQ(json3["name"].asString(), "Charlie");
+  EXPECT_EQ(json3["age"].asInt(), 35);
+  EXPECT_DOUBLE_EQ(json3["score"].asDouble(), 92.1);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterWithNulls) {
+  auto data = createTestDataWithNulls();
+  JsonPrinter printer;
+
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 3);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_EQ(json1["name"].asString(), "Alice");
+  EXPECT_DOUBLE_EQ(json1["value"].asDouble(), 10.5);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_TRUE(json2["id"].isNull());
+  EXPECT_TRUE(json2["name"].isNull());
+  EXPECT_DOUBLE_EQ(json2["value"].asDouble(), 20.0);
+
+  auto json3 = folly::parseJson(lines[2]);
+  EXPECT_EQ(json3["id"].asInt(), 3);
+  EXPECT_EQ(json3["name"].asString(), "Charlie");
+  EXPECT_TRUE(json3["value"].isNull());
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterMaxRows) {
+  auto data = createTestData();
+  JsonPrinter printer;
+
+  auto output = captureOutput([&]() {
+    auto rowsPrinted = printer.printResults({data}, 2);
+    EXPECT_EQ(rowsPrinted, 3);
+  });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterEmptyResults) {
+  JsonPrinter printer;
+
+  auto output = captureOutput([&]() {
+    std::vector<RowVectorPtr> emptyResults;
+    auto rowsPrinted = printer.printResults(emptyResults, 100);
+    EXPECT_EQ(rowsPrinted, 0);
+  });
+
+  EXPECT_TRUE(output.empty());
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterMultipleBatches) {
+  auto data1 = makeRowVector(
+      {"id", "name"},
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<std::string>({"Alice", "Bob"}),
+      });
+
+  auto data2 = makeRowVector(
+      {"id", "name"},
+      {
+          makeFlatVector<int32_t>({3, 4}),
+          makeFlatVector<std::string>({"Charlie", "Diana"}),
+      });
+
+  JsonPrinter printer;
+
+  auto output =
+      captureOutput([&]() { printer.printResults({data1, data2}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 4);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_EQ(json1["name"].asString(), "Alice");
+
+  auto json4 = folly::parseJson(lines[3]);
+  EXPECT_EQ(json4["id"].asInt(), 4);
+  EXPECT_EQ(json4["name"].asString(), "Diana");
+}
+
+TEST_F(OutputPrinterTest, AlignedTablePrinterBasic) {
+  auto data = createTestData();
+  AlignedTablePrinter printer;
+
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  EXPECT_TRUE(output.find("id") != std::string::npos);
+  EXPECT_TRUE(output.find("name") != std::string::npos);
+  EXPECT_TRUE(output.find("age") != std::string::npos);
+  EXPECT_TRUE(output.find("score") != std::string::npos);
+  EXPECT_TRUE(output.find("Alice") != std::string::npos);
+  EXPECT_TRUE(output.find("Bob") != std::string::npos);
+  EXPECT_TRUE(output.find("Charlie") != std::string::npos);
+  EXPECT_TRUE(output.find("(3 rows in 1 batches)") != std::string::npos);
+  EXPECT_TRUE(output.find("-+-") != std::string::npos);
+  EXPECT_TRUE(output.find(" | ") != std::string::npos);
+}
+
+TEST_F(OutputPrinterTest, AlignedTablePrinterMaxRows) {
+  auto data = createTestData();
+  AlignedTablePrinter printer;
+
+  auto output = captureOutput([&]() {
+    auto rowsPrinted = printer.printResults({data}, 2);
+    EXPECT_EQ(rowsPrinted, 3);
+  });
+
+  EXPECT_TRUE(output.find("...1 more rows.") != std::string::npos);
+  EXPECT_TRUE(output.find("Alice") != std::string::npos);
+  EXPECT_TRUE(output.find("Bob") != std::string::npos);
+  EXPECT_TRUE(output.find("Charlie") == std::string::npos);
+}
+
+TEST_F(OutputPrinterTest, AlignedTablePrinterEmptyResults) {
+  AlignedTablePrinter printer;
+
+  auto output = captureOutput([&]() {
+    std::vector<RowVectorPtr> emptyResults;
+    auto rowsPrinted = printer.printResults(emptyResults, 100);
+    EXPECT_EQ(rowsPrinted, 0);
+  });
+
+  EXPECT_TRUE(output.find("(0 rows in 0 batches)") != std::string::npos);
+}
+
+TEST_F(OutputPrinterTest, TimingToString) {
+  Timing timing;
+  timing.micros = 1000000;
+  timing.userNanos = 800000000;
+  timing.systemNanos = 150000000;
+
+  auto str = timing.toString();
+
+  EXPECT_TRUE(str.find("user") != std::string::npos);
+  EXPECT_TRUE(str.find("system") != std::string::npos);
+  EXPECT_TRUE(str.find('%') != std::string::npos);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterBooleanTypes) {
+  auto data = makeRowVector(
+      {"id", "active"},
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<bool>({true, false}),
+      });
+
+  JsonPrinter printer;
+
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_TRUE(json1["active"].asBool());
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_FALSE(json2["active"].asBool());
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterArrayType) {
+  auto data = makeRowVector(
+      {
+          "id",
+          "tags",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeArrayVector<int32_t>({
+              {1, 2, 3},
+              {4, 5},
+          }),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_TRUE(json1["tags"].isArray());
+  EXPECT_EQ(json1["tags"].size(), 3);
+  EXPECT_EQ(json1["tags"][0].asInt(), 1);
+  EXPECT_EQ(json1["tags"][1].asInt(), 2);
+  EXPECT_EQ(json1["tags"][2].asInt(), 3);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_TRUE(json2["tags"].isArray());
+  EXPECT_EQ(json2["tags"].size(), 2);
+  EXPECT_EQ(json2["tags"][0].asInt(), 4);
+  EXPECT_EQ(json2["tags"][1].asInt(), 5);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterArrayWithNulls) {
+  auto elements =
+      makeNullableFlatVector<int32_t>({1, std::nullopt, 3, 4, std::nullopt});
+  auto data = makeRowVector(
+      {
+          "id",
+          "values",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeArrayVector({0, 3}, elements),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["values"].size(), 3);
+  EXPECT_EQ(json1["values"][0].asInt(), 1);
+  EXPECT_TRUE(json1["values"][1].isNull());
+  EXPECT_EQ(json1["values"][2].asInt(), 3);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["values"].size(), 2);
+  EXPECT_EQ(json2["values"][0].asInt(), 4);
+  EXPECT_TRUE(json2["values"][1].isNull());
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterMapType) {
+  auto data = makeRowVector(
+      {
+          "id",
+          "attributes",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeMapVector<int32_t, std::string>({
+              {{1, "one"}, {2, "two"}},
+              {{3, "three"}},
+          }),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_TRUE(json1["attributes"].isObject());
+  EXPECT_EQ(json1["attributes"]["1"].asString(), "one");
+  EXPECT_EQ(json1["attributes"]["2"].asString(), "two");
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_TRUE(json2["attributes"].isObject());
+  EXPECT_EQ(json2["attributes"]["3"].asString(), "three");
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterNestedStructType) {
+  auto innerData = makeRowVector(
+      {
+          "street",
+          "zip",
+      },
+      {
+          makeFlatVector<std::string>({"123 Main St", "456 Oak Ave"}),
+          makeFlatVector<int32_t>({12345, 67890}),
+      });
+
+  auto data = makeRowVector(
+      {
+          "id",
+          "name",
+          "address",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<std::string>({"Alice", "Bob"}),
+          innerData,
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_EQ(json1["name"].asString(), "Alice");
+  EXPECT_TRUE(json1["address"].isObject());
+  EXPECT_EQ(json1["address"]["street"].asString(), "123 Main St");
+  EXPECT_EQ(json1["address"]["zip"].asInt(), 12345);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_EQ(json2["name"].asString(), "Bob");
+  EXPECT_TRUE(json2["address"].isObject());
+  EXPECT_EQ(json2["address"]["street"].asString(), "456 Oak Ave");
+  EXPECT_EQ(json2["address"]["zip"].asInt(), 67890);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterComplexNestedTypes) {
+  auto arrayElements = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6},
+  });
+
+  auto innerStruct = makeRowVector(
+      {
+          "count",
+          "items",
+      },
+      {
+          makeFlatVector<int32_t>({10, 20, 30}),
+          arrayElements,
+      });
+
+  auto data = makeRowVector(
+      {
+          "id",
+          "data",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          innerStruct,
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 3);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_TRUE(json1["data"].isObject());
+  EXPECT_EQ(json1["data"]["count"].asInt(), 10);
+  EXPECT_TRUE(json1["data"]["items"].isArray());
+  EXPECT_EQ(json1["data"]["items"].size(), 3);
+  EXPECT_EQ(json1["data"]["items"][0].asInt(), 1);
+  EXPECT_EQ(json1["data"]["items"][1].asInt(), 2);
+  EXPECT_EQ(json1["data"]["items"][2].asInt(), 3);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_EQ(json2["data"]["count"].asInt(), 20);
+  EXPECT_EQ(json2["data"]["items"].size(), 2);
+  EXPECT_EQ(json2["data"]["items"][0].asInt(), 4);
+  EXPECT_EQ(json2["data"]["items"][1].asInt(), 5);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterAllNumericTypes) {
+  auto data = makeRowVector(
+      {
+          "tiny",
+          "small",
+          "normal",
+          "big",
+          "real_val",
+          "double_val",
+      },
+      {
+          makeFlatVector<int8_t>({1, -2}),
+          makeFlatVector<int16_t>({100, -200}),
+          makeFlatVector<int32_t>({10000, -20000}),
+          makeFlatVector<int64_t>({1000000L, -2000000L}),
+          makeFlatVector<float>({1.5f, -2.5f}),
+          makeFlatVector<double>({99.99, -88.88}),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["tiny"].asInt(), 1);
+  EXPECT_EQ(json1["small"].asInt(), 100);
+  EXPECT_EQ(json1["normal"].asInt(), 10000);
+  EXPECT_EQ(json1["big"].asInt(), 1000000);
+  EXPECT_FLOAT_EQ(json1["real_val"].asDouble(), 1.5f);
+  EXPECT_DOUBLE_EQ(json1["double_val"].asDouble(), 99.99);
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["tiny"].asInt(), -2);
+  EXPECT_EQ(json2["small"].asInt(), -200);
+  EXPECT_EQ(json2["normal"].asInt(), -20000);
+  EXPECT_EQ(json2["big"].asInt(), -2000000);
+  EXPECT_FLOAT_EQ(json2["real_val"].asDouble(), -2.5f);
+  EXPECT_DOUBLE_EQ(json2["double_val"].asDouble(), -88.88);
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterDateType) {
+  auto data = makeRowVector(
+      {
+          "id",
+          "birth_date",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<int32_t>({19054, 19419}, DATE()),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_TRUE(json1["birth_date"].isString());
+  EXPECT_EQ(json1["birth_date"].asString(), "2022-03-03");
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_TRUE(json2["birth_date"].isString());
+  EXPECT_EQ(json2["birth_date"].asString(), "2023-03-03");
+}
+
+TEST_F(OutputPrinterTest, JsonPrinterTimestampType) {
+  auto data = makeRowVector(
+      {
+          "id",
+          "created_at",
+      },
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<Timestamp>(
+              {Timestamp(1672531200, 0), Timestamp(1704067200, 0)}),
+      });
+
+  JsonPrinter printer;
+  auto output = captureOutput([&]() { printer.printResults({data}, 100); });
+
+  std::istringstream stream(output);
+  std::string line;
+  std::vector<std::string> lines;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+
+  EXPECT_EQ(lines.size(), 2);
+
+  auto json1 = folly::parseJson(lines[0]);
+  EXPECT_EQ(json1["id"].asInt(), 1);
+  EXPECT_TRUE(json1["created_at"].isString());
+
+  auto json2 = folly::parseJson(lines[1]);
+  EXPECT_EQ(json2["id"].asInt(), 2);
+  EXPECT_TRUE(json2["created_at"].isString());
+}
+
+} // namespace
+} // namespace axiom::sql


### PR DESCRIPTION
Summary:
Add --output_format CLI flag to axiom-sql CLI to support multiple output formats for query results. This enables machine-readable output for scripting and automation use cases (amongst other cases, but the JSON design is specifically intended to be compatible).

Implemented formats:
ALIGNED: Table format with column alignment (default, refactored from 
existing implementation)
JSON: JSON Lines format with one JSON object per row
Changes:
- Introduce OutputPrinter interface to abstract result formatting
- Implement AlignedTablePrinter for existing table-based output
- Implement JsonPrinter for JSON Lines output format
- Refactor Console to use OutputPrinter
- Add tests for both output formats

Followups will add additional formats (CSV, TSV, etc.) following the 
same general approach.

```bash
buck2 run fbcode//axiom/cli:cli --   --output_format=JSON   --query="SELECT 
    1 as id,
    'Alice' as name,
    true as active,
    ARRAY[1, 2, 3] as scores,
    MAP(ARRAY['a', 'b'], ARRAY[1, 2]) as data"
```

Output: ```{"active":true,"scores":[1,2,3],"data":{"b":2,"a":1},"name":"Alice","id":1}```

Differential Revision: D88109475


