### PR TITLE
feat: Add support for constant folding metadata-only subqueries

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -188,6 +188,19 @@ struct DerivedTable : public PlanObject {
     joinOrder.push_back(table->id());
   }
 
+  void removeLastTable(PlanObjectCP table) {
+    VELOX_CHECK(!tables.empty());
+    VELOX_CHECK(tables.back() == table);
+
+    tables.pop_back();
+
+    if (std::ranges::find(tables, table) == tables.end()) {
+      tableSet.erase(table);
+    }
+
+    joinOrder.pop_back();
+  }
+
   /// True if 'table' is of 'this'.
   bool hasTable(PlanObjectCP table) const {
     return tableSet.contains(table);

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -30,6 +30,13 @@ class FunctionSet {
   /// Indicates a non-determinstic function in the set.
   static constexpr uint64_t kNonDeterministic = 1UL << 1;
 
+  /// Indicates an aggregate function that is sensitive to the order of inputs.
+  /// Same inputs provided in a different order may produce different results.
+  static constexpr uint64_t kOrderSensitiveAggregate = 1UL << 2;
+
+  /// Indicates an aggregate function that ignores duplicate inputs.
+  static constexpr uint64_t kIgnoreDuplicatesAggregate = 1UL << 3;
+
   FunctionSet() : set_(0) {}
 
   explicit FunctionSet(uint64_t set) : set_(set) {}

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -117,6 +117,12 @@ class Optimization {
 
   void makeJoins(PlanState& state);
 
+  /// Adds single aggregation on top of 'input'.
+  /// @param dt Derived table with an aggregation.
+  static RelationOpPtr planSingleAggregation(
+      DerivedTableCP dt,
+      RelationOpPtr& input);
+
   const std::shared_ptr<velox::core::QueryCtx>& veloxQueryCtx() const {
     return veloxQueryCtx_;
   }

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1086,6 +1086,30 @@ void Project::accept(
   visitor.visit(*this, context);
 }
 
+// static
+bool Project::isRedundant(
+    const RelationOpPtr& input,
+    const ExprVector& exprs,
+    const ColumnVector& columns) {
+  const auto& inputColumns = input->columns();
+
+  if (inputColumns.size() != exprs.size()) {
+    return false;
+  }
+
+  for (auto i = 0; i < inputColumns.size(); ++i) {
+    if (inputColumns[i] != exprs[i]) {
+      return false;
+    }
+
+    if (inputColumns[i]->outputName() != columns[i]->outputName()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 OrderBy::OrderBy(
     RelationOpPtr input,
     ExprVector orderKeys,

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -459,6 +459,14 @@ class Project : public RelationOp {
       const RelationOpVisitor& visitor,
       RelationOpVisitorContext& context) const override;
 
+  /// Returns true if input's columns match 'exprs' and 'columns' exactly.
+  /// Specifically, for each input column, input->columns[i] == exprs[i] and
+  /// input->columns[i]->outputName() == columns[i]->outputName().
+  static bool isRedundant(
+      const RelationOpPtr& input,
+      const ExprVector& exprs,
+      const ColumnVector& columns);
+
  private:
   const ExprVector exprs_;
   const bool redundant_;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -373,9 +373,9 @@ class ToGraph {
   // 'outer' query.
   ExprVector correlatedConjuncts_;
 
-  // Maps an expression that contains a subquery to a column that should be used
-  // instead. Populated in 'processSubqueries()'.
-  folly::F14FastMap<logical_plan::ExprPtr, ColumnCP> subqueries_;
+  // Maps an expression that contains a subquery to a column or constant that
+  // should be used instead. Populated in 'processSubqueries()'.
+  folly::F14FastMap<logical_plan::ExprPtr, ExprCP> subqueries_;
 
   folly::
       F14FastMap<TypedVariant, ExprCP, TypedVariantHasher, TypedVariantComparer>

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -103,13 +103,6 @@ void HiveQueriesTestBase::checkSingleNodePlan(
   ASSERT_TRUE(matcher->match(fragments.at(0).fragment.planNode));
 }
 
-lp::LogicalPlanNodePtr HiveQueriesTestBase::parseSelect(std::string_view sql) {
-  auto statement = prestoParser_->parse(sql);
-
-  VELOX_CHECK(statement->isSelect());
-  return statement->as<::axiom::sql::presto::SelectStatement>()->plan();
-}
-
 lp::LogicalPlanNodePtr HiveQueriesTestBase::parseInsert(std::string_view sql) {
   auto statement = prestoParser_->parse(sql);
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -37,7 +37,11 @@ class HiveQueriesTestBase : public QueryTestBase {
   /// Returns a schema of a TPC-H table.
   velox::RowTypePtr getSchema(std::string_view tableName);
 
-  logical_plan::LogicalPlanNodePtr parseSelect(std::string_view sql);
+  using QueryTestBase::parseSelect;
+
+  logical_plan::LogicalPlanNodePtr parseSelect(std::string_view sql) {
+    return QueryTestBase::parseSelect(sql, velox::exec::test::kHiveConnectorId);
+  }
 
   logical_plan::LogicalPlanNodePtr parseInsert(std::string_view sql);
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "axiom/sql/presto/PrestoParser.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
@@ -63,6 +64,18 @@ void QueryTestBase::TearDown() {
   queryCtx_.reset();
   optimizerPool_.reset();
   LocalRunnerTestBase::TearDown();
+}
+
+logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
+    std::string_view sql,
+    const std::string& defaultConnectorId) {
+  ::axiom::sql::presto::PrestoParser parser(
+      defaultConnectorId, std::nullopt, pool());
+
+  auto statement = parser.parse(sql);
+
+  VELOX_CHECK(statement->isSelect());
+  return statement->as<::axiom::sql::presto::SelectStatement>()->plan();
 }
 
 namespace {

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -48,6 +48,10 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   void TearDown() override;
 
+  logical_plan::LogicalPlanNodePtr parseSelect(
+      std::string_view sql,
+      const std::string& defaultConnectorId);
+
   /// @param planFilePathPrefix If specified, writes the query graph, optimized
   /// and executable plans to files with specified path prefix.
   optimizer::PlanAndStats planVelox(


### PR DESCRIPTION
Summary:
Constant fold scalar non-correlated subqueries that can be computed using metadata alone.

For example, Hive connector can compute subqueries that use only partition keys:

```
SELECT ... WHERE ds = (SELECT max(ds) from t)
```

Extend ConnectorMetadata to add APIs to return a set of columns that have discrete values that can be listed from metadata alone. Extend subquery handling in ToGraph to constant fold scalar non-correlated subquery that represents a global aggregation over base table, uses only discrete-value columns and uses aggregation that either ignores duplicates or runs over distinct values.

Differential Revision: D87949063


