### PR TITLE
fix: Column pruning for Values node

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -94,19 +94,20 @@ add_executable(
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp
   JoinTest.cpp
+  ParquetTpchTest.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp
   RelationOpPrinterTest.cpp
   SetTest.cpp
-  SubqueryTest.cpp
-  UnnestTest.cpp
-  ParquetTpchTest.cpp
-  SyntacticJoinOrderTest.cpp
   SubfieldTest.cpp
+  SubqueryTest.cpp
+  SyntacticJoinOrderTest.cpp
   FeatureGen.cpp
   Genies.cpp
   TestConnectorQueryTest.cpp
   TpchConnectorQueryTest.cpp
+  UnnestTest.cpp
+  ValuesTest.cpp
   WriteTest.cpp
 )
 

--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -19,13 +19,13 @@
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
-namespace facebook::axiom::optimizer::test {
+namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class FilterPushdownTest : public HiveQueriesTestBase {};
+class FilterPushdownTest : public test::HiveQueriesTestBase {};
 
 TEST_F(FilterPushdownTest, throughAggregation) {
   auto logicalPlan = lp::PlanBuilder()
@@ -37,7 +37,7 @@ TEST_F(FilterPushdownTest, throughAggregation) {
   {
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan("orders", lt("o_custkey", 100L))
+                       .hiveScan("orders", test::lt("o_custkey", 100L))
                        .singleAggregation()
                        .filter("a0 > 200.0")
                        .build();
@@ -63,7 +63,7 @@ TEST_F(FilterPushdownTest, redundantCast) {
 
   auto plan = toSingleNodePlan(logicalPlan);
   auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("nation", lt("n_nationkey", 10L))
+                     .hiveScan("nation", test::lt("n_nationkey", 10L))
                      .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -116,7 +116,7 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto matcher =
         core::PlanMatcherBuilder()
-            .hiveScan("nation", lt("n_nationkey", 10L))
+            .hiveScan("nation", test::lt("n_nationkey", 10L))
             .hashJoin(
                 startMatcher("region").build(), velox::core::JoinType::kInner)
             .aggregation()
@@ -139,7 +139,7 @@ TEST_F(FilterPushdownTest, throughJoin) {
     auto matcher = startMatcher("nation")
                        .hashJoin(
                            core::PlanMatcherBuilder()
-                               .hiveScan("region", lt("r_regionkey", 10L))
+                               .hiveScan("region", test::lt("r_regionkey", 10L))
                                .build(),
                            velox::core::JoinType::kInner)
                        .aggregation()
@@ -150,4 +150,4 @@ TEST_F(FilterPushdownTest, throughJoin) {
 }
 
 } // namespace
-} // namespace facebook::axiom::optimizer::test
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -19,18 +19,18 @@
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 
-namespace facebook::axiom::optimizer::test {
+namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class JoinTest : public QueryTestBase {
+class JoinTest : public test::QueryTestBase {
  protected:
   static constexpr auto kTestConnectorId = "test";
 
   void SetUp() override {
-    QueryTestBase::SetUp();
+    test::QueryTestBase::SetUp();
 
     testConnector_ =
         std::make_shared<connector::TestConnector>(kTestConnectorId);
@@ -40,7 +40,7 @@ class JoinTest : public QueryTestBase {
   void TearDown() override {
     velox::connector::unregisterConnector(kTestConnectorId);
 
-    QueryTestBase::TearDown();
+    test::QueryTestBase::TearDown();
   }
 
   std::shared_ptr<connector::TestConnector> testConnector_;
@@ -259,4 +259,4 @@ TEST_F(JoinTest, outerJoinWithInnerJoin) {
 }
 
 } // namespace
-} // namespace facebook::axiom::optimizer::test
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -664,33 +664,6 @@ TEST_F(PlanTest, filterBreakup) {
   checkSame(logicalPlan, referencePlan);
 }
 
-// Tests that value nodes can have complex literal types.
-TEST_F(PlanTest, valuesComplex) {
-  auto rowVector = makeRowVector({
-      makeArrayVector<StringView>({{"nation1.0", "nation1.1"}, {"nation2"}}),
-      makeMapVectorFromJson<int32_t, int64_t>({"{1: 10, 2: 20}", "{3: 30}"}),
-      makeRowVector({
-          makeFlatVector<int64_t>({1, 2}),
-          makeFlatVector<StringView>({"n1", "n2"}),
-      }),
-  });
-
-  const auto connectorId = exec::test::kHiveConnectorId;
-
-  lp::PlanBuilder::Context ctx{connectorId};
-  auto logicalPlan = lp::PlanBuilder(ctx).values({rowVector}).build();
-  auto plan = toSingleNodePlan(logicalPlan);
-
-  auto expectedType = ROW({
-      ARRAY(VARCHAR()),
-      MAP(INTEGER(), BIGINT()),
-      ROW({BIGINT(), VARCHAR()}),
-  });
-
-  auto matcher = core::PlanMatcherBuilder().values(expectedType).build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
-}
-
 TEST_F(PlanTest, values) {
   auto nationType =
       ROW({"n_nationkey", "n_regionkey", "n_name", "n_comment"},

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -18,13 +18,13 @@
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 
-namespace facebook::axiom::optimizer::test {
+namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class SubqueryTest : public HiveQueriesTestBase {};
+class SubqueryTest : public test::HiveQueriesTestBase {};
 
 TEST_F(SubqueryTest, scalar) {
   // = <subquery>
@@ -59,7 +59,7 @@ TEST_F(SubqueryTest, scalar) {
                        .tableScan("nation")
                        .hashJoin(
                            core::PlanMatcherBuilder()
-                               .hiveScan("region", gt("r_name", "ASIA"))
+                               .hiveScan("region", test::gt("r_name", "ASIA"))
                                .build(),
                            velox::core::JoinType::kLeftSemiFilter)
                        .build();
@@ -79,7 +79,7 @@ TEST_F(SubqueryTest, scalar) {
                        .tableScan("nation")
                        .hashJoin(
                            core::PlanMatcherBuilder()
-                               .hiveScan("region", gt("r_name", "ASIA"))
+                               .hiveScan("region", test::gt("r_name", "ASIA"))
                                .build(),
                            velox::core::JoinType::kAnti)
                        .build();
@@ -89,4 +89,4 @@ TEST_F(SubqueryTest, scalar) {
 }
 
 } // namespace
-} // namespace facebook::axiom::optimizer::test
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/ValuesTest.cpp
+++ b/axiom/optimizer/tests/ValuesTest.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class ValuesTest : public test::QueryTestBase {};
+
+TEST_F(ValuesTest, columnPruning) {
+  auto rowVector = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int32_t>({1, 10}),
+          makeFlatVector<int32_t>({2, 20}),
+          makeFlatVector<int32_t>({3, 30}),
+      });
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .values(ROW({"a", "c"}, INTEGER()))
+                     .project()
+                     .build();
+
+  {
+    auto logicalPlan =
+        lp::PlanBuilder()
+            .values(rowVector->rowType(), {rowVector->variantAt(0)})
+            .map({"a + c as x", "a - c as y"})
+            .build();
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  {
+    auto logicalPlan = lp::PlanBuilder()
+                           .values({rowVector})
+                           .map({"a + c as x", "a - c as y"})
+                           .build();
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Tests that value nodes can have complex literal types.
+TEST_F(ValuesTest, complexTypes) {
+  auto rowVector = makeRowVector({
+      makeArrayVector<std::string>({{"nation1.0", "nation1.1"}, {"nation2"}}),
+      makeMapVectorFromJson<int32_t, int64_t>({"{1: 10, 2: 20}", "{3: 30}"}),
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2}),
+          makeFlatVector({"n1", "n2"}),
+      }),
+  });
+
+  auto logicalPlan = lp::PlanBuilder().values({rowVector}).build();
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto expectedType = ROW({
+      ARRAY(VARCHAR()),
+      MAP(INTEGER(), BIGINT()),
+      ROW({BIGINT(), VARCHAR()}),
+  });
+
+  auto matcher = core::PlanMatcherBuilder().values(expectedType).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary: ToVelox::makeValues didn't handle column pruning for Values nodes defined using Variants.

Differential Revision: D88147617


