### PR TITLE
fix(parser): Struct fields with quoted names

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -924,7 +924,18 @@ class RelationPlanner : public AstVisitor {
         parameters.emplace_back(parseType(type->parameters().at(1)));
       } else if (baseName == "ROW") {
         for (const auto& param : type->parameters()) {
-          parameters.emplace_back(parseType(param), param->rowFieldName());
+          auto fieldName = param->rowFieldName();
+
+          // TODO Extend Velox's RowType to support quoted / delimited field
+          // names.
+          if (fieldName.has_value()) {
+            if (fieldName->starts_with('\"') && fieldName->ends_with('\"') &&
+                fieldName->size() >= 2) {
+              fieldName = fieldName->substr(1, fieldName->size() - 2);
+            }
+          }
+
+          parameters.emplace_back(parseType(param), fieldName);
         }
       } else if (baseName == "DECIMAL") {
         VELOX_USER_CHECK_EQ(2, numParams);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -257,6 +257,10 @@ TEST_F(PrestoParserTest, types) {
   test(
       "cast(null as row(a int, b double))",
       ROW({"a", "b"}, {INTEGER(), DOUBLE()}));
+
+  test(
+      R"(cast(json_parse('{"foo": 1, "bar": 2}') as row(foo bigint, "BAR" int)).BAR)",
+      INTEGER());
 }
 
 TEST_F(PrestoParserTest, intervalDayTime) {


### PR DESCRIPTION
Summary:
Fixes queries like

> SELECT cast(... as row(a "Abc"),...).Abc

Differential Revision: D88177915


