### PR TITLE
fix: Relax check for fanout in Aggregation ctor

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -765,7 +765,7 @@ Aggregation::Aggregation(
     cost_.fanout = 1.0f / std::max<float>(1, cost_.inputCardinality);
   }
 
-  VELOX_CHECK_LE(cost_.fanout, 1.0f);
+  VELOX_CHECK_LE(cost_.fanout, 1.0001f);
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Aggregation fanout should never exceed 1. Hence, we have a check in Aggregation's ctor:

```
VELOX_CHECK_LE(cost_.fanout, 1.0f);
```

This check fails sometimes:

```
Reason: (1.0000001 vs. 1)
Retriable: False
Expression: cost_.fanout <= 1.0f
Function: Aggregation
File: fbcode/axiom/optimizer/RelationOp.cpp
Line: 768
```

Relax the check to unblock.

Differential Revision: D88221033


