### PR TITLE
fix(parser): Parse small integer literals as INTEGER

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -140,6 +140,7 @@ class PlanBuilder {
         nameAllocator_{context.nameAllocator},
         outerScope_{std::move(outerScope)},
         parseOptions_{.parseInListAsArray = false},
+        enableCoersions_{enableCoersions},
         resolver_{
             context.queryCtx,
             enableCoersions,
@@ -472,6 +473,7 @@ class PlanBuilder {
   const std::shared_ptr<NameAllocator> nameAllocator_;
   const Scope outerScope_;
   const velox::parse::ParseOptions parseOptions_;
+  const bool enableCoersions_;
 
   LogicalPlanNodePtr node_;
 

--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -125,7 +125,7 @@ TEST_F(CsvReadWriteTest, writeWithInsertStatement) {
   };
 
   auto tableType = ROW({
-      {"id", BIGINT()},
+      {"id", INTEGER()},
       {"description", VARCHAR()},
       {"amount", DOUBLE()},
       {"is_active", BOOLEAN()},
@@ -142,7 +142,7 @@ TEST_F(CsvReadWriteTest, writeWithInsertStatement) {
   auto expectedData = makeRowVector(
       {"id", "description", "amount", "is_active"},
       {
-          makeNullableFlatVector<int64_t>({10, std::nullopt, 30, 40}),
+          makeNullableFlatVector<int32_t>({10, std::nullopt, 30, 40}),
           makeNullableFlatVector<std::string>(
               {"First item", std::nullopt, "Third item", "Fourth item"}),
           makeNullableFlatVector<double>({100.5, 200.0, std::nullopt, 400.25}),

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -271,7 +271,7 @@ TEST_F(WriteTest, insertSql) {
   };
 
   createTable(
-      "test", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}), {});
+      "test", ROW({"a", "b", "c"}, {INTEGER(), DOUBLE(), VARCHAR()}), {});
 
   auto parseSql = [&](std::string_view sql) {
     ::axiom::sql::presto::PrestoParser parser(
@@ -304,7 +304,7 @@ TEST_F(WriteTest, insertSql) {
   checkTableData(
       "test",
       makeRowVector({
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
           makeFlatVector<double>({0.123, 1.23, 0.3, 0.4, 0.5}),
           makeNullableFlatVector<std::string>(
               {"foo", "bar", std::nullopt, std::nullopt, std::nullopt}),
@@ -323,7 +323,7 @@ TEST_F(WriteTest, createTableAsSelectSql) {
     checkTableData(
         "test",
         makeRowVector({
-            makeFlatVector<int64_t>({1}),
+            makeFlatVector<int32_t>({1}),
             makeFlatVector<double>({0.123}),
             makeFlatVector<std::string>({"foo"}),
         }));
@@ -343,7 +343,7 @@ TEST_F(WriteTest, createTableAsSelectSql) {
     checkTableData(
         "test",
         makeRowVector({
-            makeFlatVector<int64_t>({1, 2, 3}),
+            makeFlatVector<int32_t>({1, 2, 3}),
             makeFlatVector<double>({0.1, 0.2, 0.3}),
         }));
   }

--- a/axiom/optimizer/tests/tpch.queries/q16.sql
+++ b/axiom/optimizer/tests/tpch.queries/q16.sql
@@ -15,7 +15,7 @@ where
 	p.p_partkey = ps.ps_partkey
 	and p.p_brand <> 'Brand#45'
 	and p.p_type not like 'MEDIUM POLISHED%'
-	and cast(p.p_size as bigint) in (49, 14, 23, 45, 19, 3, 36, 9)
+	and p.p_size in (49, 14, 23, 45, 19, 3, 36, 9)
 	and ps.ps_suppkey not in (
 		select
 			s_suppkey

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -595,8 +595,15 @@ class RelationPlanner : public AstVisitor {
       case NodeType::kBooleanLiteral:
         return lp::Lit(node->as<BooleanLiteral>()->value());
 
-      case NodeType::kLongLiteral:
-        return lp::Lit(node->as<LongLiteral>()->value());
+      case NodeType::kLongLiteral: {
+        const auto value = node->as<LongLiteral>()->value();
+        if (value >= std::numeric_limits<int32_t>::min() &&
+            value <= std::numeric_limits<int32_t>::max()) {
+          return lp::Lit(static_cast<int32_t>(value));
+        } else {
+          return lp::Lit(value);
+        }
+      }
 
       case NodeType::kDoubleLiteral:
         return lp::Lit(node->as<DoubleLiteral>()->value());


### PR DESCRIPTION
Summary:
Before this change, all integer literals were parsed as BIGINT. Now, integers that fit into 32-bit range are parsed as INTEGER.

```
presto> select typeof(1), typeof(3000000000);
  _col0  | _col1
---------+--------
 integer | bigint
(1 row)
```

Also,
- Add coercion support to PlanBuilder::write.
- Fix TPC-H q16 text to remove cast-to-bigint. This cast is not present in the standard.

Differential Revision: D88254430


