### PR TITLE
Remove unused exception parameter from axiom/runner/LocalRunner.cpp

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -441,7 +441,7 @@ void LocalRunner::makeStages(
         }
       }
     }
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     onError(std::current_exception());
   }
 }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D88448342


