### PR TITLE
feat(parser): Add support for SHOW FUNCTIONS command

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -590,7 +590,18 @@ std::any AstBuilder::visitShowRoleGrants(
 std::any AstBuilder::visitShowFunctions(
     PrestoSqlParser::ShowFunctionsContext* ctx) {
   trace("visitShowFunctions");
-  return visitChildren(ctx);
+
+  std::optional<std::string> likePattern;
+  std::optional<std::string> escape;
+  if (ctx->LIKE() != nullptr) {
+    likePattern = visitExpression(ctx->pattern)->as<StringLiteral>()->value();
+  }
+
+  if (ctx->ESCAPE() != nullptr) {
+    escape = visitExpression(ctx->escape)->as<StringLiteral>()->value();
+  }
+  return std::static_pointer_cast<Statement>((std::make_shared<ShowFunctions>(
+      getLocation(ctx), std::move(likePattern), std::move(escape))));
 }
 
 std::any AstBuilder::visitShowSession(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -762,4 +762,8 @@ void ShowColumns::accept(AstVisitor* visitor) {
   visitor->visitShowColumns(this);
 }
 
+void ShowFunctions::accept(AstVisitor* visitor) {
+  visitor->visitShowFunctions(this);
+}
+
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -1179,4 +1179,8 @@ void AstPrinter::visitShowColumns(ShowColumns* node) {
   printHeader("ShowColumns", node);
 }
 
+void AstPrinter::visitShowFunctions(ShowFunctions* node) {
+  printHeader("ShowFunctions", node);
+}
+
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstPrinter.h
+++ b/axiom/sql/presto/ast/AstPrinter.h
@@ -294,6 +294,8 @@ class AstPrinter : public AstVisitor {
 
   void visitShowColumns(ShowColumns* node) override;
 
+  void visitShowFunctions(ShowFunctions* node) override;
+
  private:
   void defaultVisit(Node* node) override {
     printIndent();

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -742,4 +742,29 @@ class ShowColumns : public Statement {
   std::shared_ptr<QualifiedName> table_;
 };
 
+class ShowFunctions : public Statement {
+ public:
+  ShowFunctions(
+      NodeLocation location,
+      std::optional<std::string> likePattern,
+      std::optional<std::string> escape)
+      : Statement(NodeType::kShowFunctions, location),
+        likePattern_(std::move(likePattern)),
+        escape_(std::move(escape)) {}
+
+  const std::optional<std::string>& getLikePattern() const {
+    return likePattern_;
+  }
+
+  const std::optional<std::string>& getEscape() const {
+    return escape_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::optional<std::string> likePattern_;
+  std::optional<std::string> escape_;
+};
+
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -555,6 +555,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowFunctions(ShowFunctions* node) {
+    defaultVisit(node);
+  }
+
   // Generic visit method
   virtual void visit(Node* node) {
     defaultVisit(node);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -872,6 +872,11 @@ TEST_F(PrestoParserTest, describe) {
   testSql("SHOW COLUMNS FROM lineitem", matcher);
 }
 
+TEST_F(PrestoParserTest, showFunctions) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values();
+  testSql("SHOW FUNCTIONS", matcher);
+}
+
 TEST_F(PrestoParserTest, insertIntoTable) {
   {
     auto matcher =


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebookincubator/axiom/pull/695

Add support for SHOW FUNCTIONS command.

- Include all scalar, aggregate and window functions.
- Each row of output represents a single function signature. A given function may appear multiple times if it has multiple signatures.


A follow-up with add support for LIKE predicate as well as function metadata.


```
SQL> SHOW FUNCTIONS;
ROW<Function:VARCHAR,"Function Type":VARCHAR,Signature:VARCHAR>
----------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------
Function                                      | Function Type | Signature                                                                                                             
----------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------
corr_extract_double                           | scalar        | (row(double,bigint,double,double,double,double)) -> double                                                            
contains                                      | scalar        | (array(T),T) -> boolean                                                                                               
$internal$json_string_to_row_cast             | scalar        | (varchar) -> row(unknown)                                                                                             
covar_pop_extract_double                      | scalar        | (row(double,bigint,double,double)) -> double                                                                          
none_match                                    | scalar        | (array(T),function(T,boolean)) -> boolean                                                                             
checksum_extract                              | scalar        | (bigint) -> varbinary                                                                                                 
bitwise_or_agg_extract                        | scalar        | (tinyint) -> tinyint                                                                                                  
bitwise_or_agg_extract                        | scalar        | (smallint) -> smallint                                                                                                
bitwise_or_agg_extract                        | scalar        | (integer) -> integer                                                                                                  
bitwise_or_agg_extract                        | scalar        | (bigint) -> bigint                                                                                                    
regexp_like                                   | scalar        | (varchar,varchar) -> boolean                                                                                          
regexp_like                                   | scalar        | (varchar,unknown) -> boolean                                                                                          
regexp_like                                   | scalar        | (unknown,varchar) -> boolean                                                                                          
regexp_like                                   | scalar        | (unknown,unknown) -> boolean                                                                                          
max_extract                                   | scalar        | (T) -> T                                                                                                              
max_extract                                   | scalar        | (row(bigint,array(tinyint))) -> array(tinyint)                                                                        
max_extract                                   | scalar        | (row(bigint,array(integer))) -> array(integer)                                                                        
max_extract                                   | scalar        | (row(bigint,array(smallint))) -> array(smallint)                                                                      
max_extract                                   | scalar        | (row(bigint,array(bigint))) -> array(bigint)                                                                          
max_extract                                   | scalar        | (row(bigint,array(real))) -> array(real)                                                                              
max_extract                                   | scalar        | (row(bigint,array(double))) -> array(double)                                                                          
max_extract                                   | scalar        | (row(bigint,array(varchar))) -> array(varchar)                                                                        
max_extract                                   | scalar        | (row(bigint,array(DECIMAL(a_precision,a_scale)))) -> array(DECIMAL(a_precision,a_scale))                              
avg_extract_double                            | scalar        | (row(double,bigint)) -> double                                                                                        
array_duplicates                              | scalar        | (array(bigint)) -> array(bigint)                                                                                      
array_duplicates                              | scalar        | (array(varchar)) -> array(varchar)                                                                                    
arbitrary_extract                             | scalar        | (T) -> T  

...2733 more rows.
(2833 rows in 2833 batches)

553.87ms / 41.85ms user / 21.25ms system (11%)

```