### PR TITLE
fix(parser): Handle ParenthesizedRelation

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1040,7 +1040,7 @@ std::any AstBuilder::visitLateral(PrestoSqlParser::LateralContext* ctx) {
 std::any AstBuilder::visitParenthesizedRelation(
     PrestoSqlParser::ParenthesizedRelationContext* ctx) {
   trace("visitParenthesizedRelation");
-  return visitChildren(ctx);
+  return visitTyped<Relation>(ctx->relation());
 }
 
 std::any AstBuilder::visitExpression(PrestoSqlParser::ExpressionContext* ctx) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -210,6 +210,14 @@ TEST_F(PrestoParserTest, unnest) {
         "WITH a AS (SELECT array[1,2,3] as x) SELECT t.x + 1 FROM a, unnest(A.x) as T(X)",
         matcher);
   }
+
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().unnest();
+
+    testSql(
+        "SELECT * FROM (nation cross join unnest(array[1,2,3]) as t(x))",
+        matcher);
+  }
 }
 
 TEST_F(PrestoParserTest, syntaxErrors) {


### PR DESCRIPTION
Summary:
Enable queries like

> select * from (nation cross join unnest(array[1,2,3]) as t(x));

Differential Revision: D88560382


