### PR TITLE
fix: Fix typo in VeloxHistory

### DIFF
--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -233,7 +233,7 @@ void VeloxHistory::recordVeloxExecution(
           planHistory_[keyIt->second] =
               NodePrediction{.cardinality = static_cast<float>(actualRows)};
         }
-        if (op.operatorType == "TableScanOperator") {
+        if (op.operatorType == "TableScan") {
           if (const auto* scan = findScan(op.planNodeId, plan.plan)) {
             std::string handle = scan->tableHandle()->toString();
             recordLeafSelectivity(


### PR DESCRIPTION
We need to check TableScan instead of TableScanOperator, because there's no TableScanOperator

But tests are failed, looks like this bug hides other bugs

@mbasmanova 

Maybe as temporary solution we should disable VeloxHistory?