### PR TITLE
fix: Allow unqualified names after join (#699)

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -104,6 +104,27 @@ void NameMappings::merge(const NameMappings& other) {
   }
 }
 
+void NameMappings::enableUnqualifiedAccess() {
+  folly::F14FastMap<std::string, size_t> counts;
+  for (const auto& [name, id] : mappings_) {
+    counts[name.name]++;
+  }
+
+  std::vector<std::pair<std::string, std::string>> toAdd;
+
+  for (auto& [name, id] : mappings_) {
+    if (counts.at(name.name) == 1) {
+      if (name.alias.has_value()) {
+        toAdd.emplace_back(name.name, id);
+      }
+    }
+  }
+
+  for (const auto& [name, id] : toAdd) {
+    add(name, id);
+  }
+}
+
 folly::F14FastMap<std::string, std::string> NameMappings::uniqueNames() const {
   folly::F14FastMap<std::string, std::string> names;
   for (const auto& [name, id] : mappings_) {

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -45,7 +45,7 @@ class NameMappings {
   /// Returns ID for the specified 'name' if exists.
   std::optional<std::string> lookup(const std::string& name) const;
 
-  /// Returns ID for the specified 'name' if exists.
+  /// Returns ID for the specified 'alias.name' if exists.
   std::optional<std::string> lookup(
       const std::string& alias,
       const std::string& name) const;
@@ -68,6 +68,9 @@ class NameMappings {
   ///
   /// Used in PlanBuilder::join() API.
   void merge(const NameMappings& other);
+
+  /// Enables unqualified access to unique names.
+  void enableUnqualifiedAccess();
 
   /// Returns a mapping from IDs to unaliased names for a subset of columns with
   /// unique names.

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -385,6 +385,7 @@ PlanBuilder& PlanBuilder::project(const std::vector<ExprApi>& projections) {
   node_ = std::make_shared<ProjectNode>(
       nextId(), std::move(node_), std::move(outputNames), std::move(exprs));
 
+  newOutputMapping->enableUnqualifiedAccess();
   outputMapping_ = std::move(newOutputMapping);
 
   return *this;
@@ -424,6 +425,7 @@ PlanBuilder& PlanBuilder::with(const std::vector<ExprApi>& projections) {
   node_ = std::make_shared<ProjectNode>(
       nextId(), std::move(node_), std::move(outputNames), std::move(exprs));
 
+  newOutputMapping->enableUnqualifiedAccess();
   outputMapping_ = std::move(newOutputMapping);
 
   return *this;
@@ -514,6 +516,7 @@ PlanBuilder& PlanBuilder::aggregate(
       std::move(exprs),
       std::move(outputNames));
 
+  newOutputMapping->enableUnqualifiedAccess();
   outputMapping_ = std::move(newOutputMapping);
 
   return *this;

--- a/axiom/logical_plan/tests/NameMappingsTest.cpp
+++ b/axiom/logical_plan/tests/NameMappingsTest.cpp
@@ -150,4 +150,23 @@ TEST(NameMappingsTest, basic) {
   }
 }
 
+TEST(NameMappingsTest, enableUnqualifiedAccess) {
+  NameMappings mappings;
+  mappings.add(
+      NameMappings::QualifiedName{.alias = "n1", .name = "n_nationkey"},
+      "nationkey1");
+  mappings.add(
+      NameMappings::QualifiedName{.alias = "n1", .name = "n_name"}, "name1");
+
+  ASSERT_FALSE(mappings.lookup("n_nationkey").has_value());
+  ASSERT_FALSE(mappings.lookup("n_name").has_value());
+
+  mappings.enableUnqualifiedAccess();
+  ASSERT_TRUE(mappings.lookup("n_name").has_value());
+  ASSERT_EQ("name1", mappings.lookup("n_name").value());
+
+  ASSERT_TRUE(mappings.lookup("n_nationkey").has_value());
+  ASSERT_EQ("nationkey1", mappings.lookup("n_nationkey").value());
+}
+
 } // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1038,5 +1038,18 @@ TEST_F(PrestoParserTest, view) {
       {"tiny.view"});
 }
 
+TEST_F(PrestoParserTest, unqualifiedAccessAfterJoin) {
+  auto sql =
+      "SELECT n_name FROM (SELECT n1.n_name as n_name FROM nation n1, nation n2)";
+
+  auto matcher =
+      lp::test::LogicalPlanMatcherBuilder()
+          .tableScan()
+          .join(lp::test::LogicalPlanMatcherBuilder().tableScan().build())
+          .project()
+          .project();
+  testSql(sql, matcher);
+}
+
 } // namespace
 } // namespace axiom::sql::presto


### PR DESCRIPTION
Summary:

Enable queries like

> SELECT n_name FROM (SELECT n1.n_name as n_name FROM nation n1, nation n2)

Reviewed By: amitkdutta

Differential Revision: D88641787


