### PR TITLE
Fix unreachable-break issue in avatar/franz/common/RenderSpecUtils.cpp +5

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -491,7 +491,6 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
           toTypePtr(expr->value().type),
           toTypedExpr(expr->as<Field>()->base()),
           expr->as<Field>()->index());
-      break;
     }
     case PlanType::kLiteralExpr: {
       const auto* literal = expr->as<Literal>();


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D89225686


