### PR TITLE
feat: Multi Statement CLI Execution

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -58,7 +58,7 @@ void Console::initialize() {
 
 void Console::run() {
   if (!FLAGS_query.empty()) {
-    runNoThrow(FLAGS_query);
+    runNoThrow(FLAGS_query, false);
   } else {
     std::cout << "Axiom SQL. Type statement and end with ;.\n"
                  "flag name = value; sets a gflag.\n"
@@ -215,32 +215,46 @@ int32_t printResults(const std::vector<RowVectorPtr>& results) {
 }
 } // namespace
 
-void Console::runNoThrow(std::string_view sql) {
+void Console::runNoThrow(std::string_view sql, bool isInteractive) {
+  const SqlQueryRunner::RunOptions options{
+      .numWorkers = FLAGS_num_workers,
+      .numDrivers = FLAGS_num_drivers,
+      .splitTargetBytes = FLAGS_split_target_bytes,
+      .optimizerTraceFlags = FLAGS_optimizer_trace,
+      .debugMode = FLAGS_debug,
+  };
+
+  decltype(runner_.parseMultiple(sql)) statements;
   try {
-    Timing timing;
-    const auto result = time<SqlQueryRunner::SqlResult>(
-        [&]() {
-          return runner_.run(
-              sql,
-              {
-                  .numWorkers = FLAGS_num_workers,
-                  .numDrivers = FLAGS_num_drivers,
-                  .splitTargetBytes = FLAGS_split_target_bytes,
-                  .optimizerTraceFlags = FLAGS_optimizer_trace,
-                  .debugMode = FLAGS_debug,
-              });
-        },
-        timing);
-
-    if (result.message.has_value()) {
-      std::cout << result.message.value() << std::endl;
-    } else {
-      printResults(result.results);
-    }
-    std::cout << timing.toString() << std::endl;
-
+    // Parse all statements upfront.
+    statements = runner_.parseMultiple(sql);
   } catch (std::exception& e) {
-    std::cerr << "Query failed: " << e.what() << std::endl;
+    std::cerr << "Parse failed: " << e.what() << std::endl;
+    return;
+  }
+
+  // Execute each statement with timing.
+  for (const auto& statement : statements) {
+    try {
+      Timing statementTiming;
+      auto result = time<SqlQueryRunner::SqlResult>(
+          [&]() { return runner_.run(*statement, options); }, statementTiming);
+
+      if (result.message.has_value()) {
+        std::cout << result.message.value() << std::endl;
+      } else {
+        printResults(result.results);
+      }
+
+      if (isInteractive) {
+        // In interactive mode, show per-statement timing.
+        std::cout << statementTiming.toString() << std::endl;
+      }
+    } catch (std::exception& e) {
+      std::cerr << "Query failed: " << e.what() << std::endl;
+      // Stop executing remaining statements in this block.
+      return;
+    }
   }
 }
 

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -28,11 +28,19 @@ class Console {
 
   void initialize();
 
+  /// Runs the CLI, either executing a single query if passed in
+  /// or entering interactive mode to read commands from stdin.
   void run();
 
  private:
-  void runNoThrow(std::string_view sql);
+  // Executes SQL and prints results, catching any exceptions.
+  // @param sql The SQL text to execute, which may contain multiple
+  // semicolon-separated statements.
+  // @param isInteractive If true, shows timing after each statement for
+  // multi-statement queries.
+  void runNoThrow(std::string_view sql, bool isInteractive = true);
 
+  // Reads and executes commands from standard input in interactive mode.
   void readCommands(const std::string& prompt);
 
   SqlQueryRunner& runner_;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -52,7 +52,18 @@ class SqlQueryRunner {
     bool debugMode{false};
   };
 
+  /// Runs a single SQL statement and returns the result.
   SqlResult run(std::string_view sql, const RunOptions& options);
+
+  /// Runs a single parsed SQL statement and returns the result.
+  SqlResult run(
+      const presto::SqlStatement& statement,
+      const RunOptions& options);
+
+  /// Parses SQL text containing one or more semicolon-separated statements.
+  /// @param sql SQL text to parse.
+  /// @return Vector of parsed statements.
+  std::vector<presto::SqlStatementPtr> parseMultiple(std::string_view sql);
 
   std::unordered_map<std::string, std::string>& sessionConfig() {
     return config_;


### PR DESCRIPTION
Summary:
Leverage the new multi-statement parsing to execute multiple statements when a delimeted query is submitted.

Aligned with presto-cli in that:

Extra padding for results when run non-interactive is minimal. [We'll iterate on this in a followup; it's currently more verbose].

In interactive mode, clearly separate result sets.

Differential Revision: D89218112


