### PR TITLE
misc: Respect Linux cgroups restrictions when sizing thread pools

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "axiom/logical_plan/PlanPrinter.h"
 #include "axiom/optimizer/ConstantExprEvaluator.h"
 #include "axiom/optimizer/DerivedTablePrinter.h"
@@ -176,7 +177,7 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   ++queryCounter_;
 
   executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(std::max<int32_t>(
-      std::thread::hardware_concurrency() * 2,
+      folly::hardware_concurrency() * 2,
       options.numWorkers * options.numDrivers * 2 + 2));
 
   return velox::core::QueryCtx::create(

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/init/Init.h>
+#include <folly/system/HardwareConcurrency.h>
 #include <gflags/gflags.h>
 #include <sys/resource.h>
 #include <sys/time.h>
@@ -188,7 +189,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     executor_ =
         std::make_shared<folly::CPUThreadPoolExecutor>(std::max<int32_t>(
-            std::thread::hardware_concurrency() * 2,
+            folly::hardware_concurrency() * 2,
             FLAGS_num_workers * FLAGS_num_drivers * 2 + 2));
     spillExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(4);
   }

--- a/axiom/optimizer/tests/ParquetTpchTest.cpp
+++ b/axiom/optimizer/tests/ParquetTpchTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/ParquetTpchTest.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -72,12 +73,12 @@ void doCreateTables(std::string_view path) {
     }
 
     const int32_t numDrivers =
-        std::min<int32_t>(numSplits, std::thread::hardware_concurrency());
+        std::min<int32_t>(numSplits, folly::hardware_concurrency());
 
     LOG(INFO) << "Creating TPC-H table " << tableName
               << " scaleFactor=" << FLAGS_tpch_scale
               << " numSplits=" << numSplits << " numDrivers=" << numDrivers
-              << " hw concurrency=" << std::thread::hardware_concurrency();
+              << " hw concurrency=" << folly::hardware_concurrency();
     auto rows = AssertQueryBuilder(plan)
                     .splits(std::move(splits))
                     .maxDrivers(numDrivers)


### PR DESCRIPTION
Summary:
This change replaces uses of std::thread::hardware_concurrency with
folly::hardware_concurrency the latter of which always respects
container restrictions while the former does not.  This ensures that
when running inside of a Linux container with restrictions on the
available processors, thread pools and other data structures will not
be over-provisioned.

Differential Revision: D87913058


