### PR TITLE
fix(parser): Parse IS DISTINCT FROM clause

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -769,7 +769,7 @@ class RelationPlanner : public AstVisitor {
       case ComparisonExpression::Operator::kGreaterThanOrEqual:
         return "gte";
       case ComparisonExpression::Operator::kIsDistinctFrom:
-        VELOX_NYI("Not yet supported comparison operator: is_distinct_from");
+        return "distinct_from";
     }
 
     folly::assume_unreachable();

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1215,7 +1215,18 @@ std::any AstBuilder::visitNullPredicate(
 std::any AstBuilder::visitDistinctFrom(
     PrestoSqlParser::DistinctFromContext* ctx) {
   trace("visitDistinctFrom");
-  return visitChildren(ctx);
+
+  auto leftExpr = visitExpression(ctx->value);
+  auto rightExpr = visitExpression(ctx->right);
+
+  auto distinctFrom = std::static_pointer_cast<Expression>(
+      std::make_shared<ComparisonExpression>(
+          getLocation(ctx),
+          ComparisonExpression::Operator::kIsDistinctFrom,
+          leftExpr,
+          rightExpr));
+
+  return wrapInNot(distinctFrom, ctx->NOT());
 }
 
 std::any AstBuilder::visitValueExpressionDefault(

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -121,6 +121,8 @@ std::string toString(ComparisonExpression::Operator op) {
       return ">";
     case ComparisonExpression::Operator::kGreaterThanOrEqual:
       return ">=";
+    case ComparisonExpression::Operator::kIsDistinctFrom:
+      return "IS DISTINCT FROM";
     default:
       throw std::runtime_error("Unsupported comparison operator");
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -530,6 +530,22 @@ TEST_F(PrestoParserTest, unaryArithmetic) {
   ASSERT_EQ(project->expressionAt(0)->toString(), "1");
 }
 
+TEST_F(PrestoParserTest, distinctFrom) {
+  lp::ProjectNodePtr project;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project(
+      [&](const auto& node) {
+        project = std::dynamic_pointer_cast<const lp::ProjectNode>(node);
+      });
+
+  testSql("SELECT 1 is distinct from 2", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "distinct_from(1, 2)");
+
+  testSql("SELECT 1 is not distinct from 2", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "not(distinct_from(1, 2))");
+}
+
 TEST_F(PrestoParserTest, in) {
   {
     auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();


### PR DESCRIPTION
Summary:
Fixes queries like

> SELECT 1 is distinct from 2;

Differential Revision: D89642390


