### PR TITLE
fix(runner): Fix wiring of remote exchanges with multiple sources

### DIFF
--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -219,9 +219,7 @@ TEST_F(SetTest, unionJoin) {
           .singleAggregation({}, {"sum(1)"})
           .planNode();
 
-  // Skip distributed run. Problem with local exchange source with
-  // multiple inputs.
-  checkSame(logicalPlan, referencePlan, {.numWorkers = 1, .numDrivers = 4});
+  checkSame(logicalPlan, referencePlan);
 }
 
 // Checks

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -437,6 +437,11 @@ void LocalRunner::makeStages(
           for (const auto& remote : sourceSplits) {
             task->addSplit(input.consumerNodeId, velox::exec::Split(remote));
           }
+        }
+      }
+
+      for (const auto& input : fragment.inputStages) {
+        for (auto& task : stage) {
           task->noMoreSplits(input.consumerNodeId);
         }
       }


### PR DESCRIPTION
Summary:
Query plans for UNION ALL contain remote exchanges that read from multiple fragments (sources). In this case, a single Exchange node needs to process remote splits that refer to different fragments. LocalRunner used to call Task::noMoreSplits() prematurely after adding splits for the first fragment. This caused failures when adding splits for the second fragment.

Fixes https://github.com/facebookincubator/axiom/issues/596

Differential Revision: D89670842


