### PR TITLE
fix(parser): Handle floating point values with scientific notation

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -2198,7 +2198,8 @@ std::any AstBuilder::visitDecimalLiteral(
 std::any AstBuilder::visitDoubleLiteral(
     PrestoSqlParser::DoubleLiteralContext* ctx) {
   trace("visitDoubleLiteral");
-  return visitChildren(ctx);
+  return std::static_pointer_cast<Expression>(std::make_shared<DoubleLiteral>(
+      getLocation(ctx), std::stod(ctx->getText())));
 }
 
 std::any AstBuilder::visitIntegerLiteral(


### PR DESCRIPTION
Summary:
While we handle DECIMAL_VALUE float constants correctly, we don't handle scientific notation DOUBLE_VALUE constants. The handling is actually identical, we can use the `std::stod` function in either case

In this change I am adding that handling

Differential Revision: D89737221


