### PR TITLE
feat: Extend connector::Table to support hidden columns

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -66,6 +66,15 @@ class HivePartitionType : public connector::PartitionType {
   const std::vector<velox::TypePtr> partitionKeyTypes_;
 };
 
+class HiveTable : public Table {
+ public:
+  HiveTable(
+      std::string name,
+      velox::RowTypePtr type,
+      bool bucketed,
+      folly::F14FastMap<std::string, velox::Variant> options);
+};
+
 /// Describes a Hive table layout. Adds a file format and a list of
 /// Hive partitioning columns and an optional bucket count to the base
 /// TableLayout. The partitioning in TableLayout referes to bucketing.

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -100,11 +100,6 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       TestConnector* connector);
 
-  const folly::F14FastMap<std::string, const Column*>& columnMap()
-      const override {
-    return columns_;
-  }
-
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
   }
@@ -145,8 +140,6 @@ class TestTable : public Table {
 
  private:
   velox::connector::Connector* connector_;
-  folly::F14FastMap<std::string, const Column*> columns_;
-  std::vector<std::unique_ptr<Column>> exportedColumns_;
   std::vector<const TableLayout*> layouts_;
   std::unique_ptr<TestTableLayout> exportedLayout_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -139,23 +139,16 @@ class TpchTable : public Table {
       velox::tpch::Table tpchTable,
       double scaleFactor,
       int64_t numRows)
-      : Table(std::move(name), std::move(type)),
+      : Table(std::move(name), makeColumns(type)),
         tpchTable_(tpchTable),
         scaleFactor_(scaleFactor),
         numRows_{numRows} {}
-
-  folly::F14FastMap<std::string, std::unique_ptr<Column>>& columns() {
-    return columns_;
-  }
 
   const std::vector<const TableLayout*>& layouts() const override {
     return exportedLayouts_;
   }
 
-  const folly::F14FastMap<std::string, const Column*>& columnMap()
-      const override;
-
-  void makeDefaultLayout(TpchConnectorMetadata& metadata, double scaleFactor);
+  void makeDefaultLayout(TpchConnectorMetadata& metadata);
 
   uint64_t numRows() const override {
     return numRows_;
@@ -171,10 +164,6 @@ class TpchTable : public Table {
 
  private:
   mutable std::mutex mutex_;
-
-  folly::F14FastMap<std::string, std::unique_ptr<Column>> columns_;
-
-  mutable folly::F14FastMap<std::string, const Column*> exportedColumns_;
 
   std::vector<std::unique_ptr<TableLayout>> layouts_;
 


### PR DESCRIPTION
Summary:
Table object used to have 2 APIs: type() and columnMap().

Table::type() API returned table schema, a list of visible column names and types, as a RowType.

Table::columnMap() API returned a map of 'Column' objects keyed by name.

There was no API that returned all columns, including hidden, in order. 

This diff adds Table::allColumns() API to return a list of 'Column' objects for all columns, including hidden. Also, the constructor of Table object is modified to take a list of unique_ptr<const Column> for all columns instead of RowType. This allows to move shared logic into Table object and simply implementation of derived classes.

Differential Revision: D90213809


