### PR TITLE
feat(parser): Add support for parsing queries wrapped in parentheses

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -869,7 +869,11 @@ std::any AstBuilder::visitInlineTable(
 
 std::any AstBuilder::visitSubquery(PrestoSqlParser::SubqueryContext* ctx) {
   trace("visitSubquery");
-  return visitChildren(ctx);
+
+  auto queryNoWith = visitTyped<Query>(ctx->queryNoWith());
+
+  return std::static_pointer_cast<QueryBody>(
+      std::make_shared<TableSubquery>(getLocation(ctx), queryNoWith));
 }
 
 std::any AstBuilder::visitSortItem(PrestoSqlParser::SortItemContext* ctx) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -625,6 +625,7 @@ TEST_F(PrestoParserTest, row) {
 TEST_F(PrestoParserTest, selectStar) {
   auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan();
   testSql("SELECT * FROM nation", matcher);
+  testSql("(SELECT * FROM nation)", matcher);
 
   // TODO Add support for these query shapes.
   EXPECT_THROW(parseSql("SELECT *, * FROM nation"), VeloxRuntimeError);


### PR DESCRIPTION
Summary:
Enables parsing for queries like

> (SELECT 1)

Not "redundant" parentheses around the query.

Differential Revision: D90285316


