### PR TITLE
feat(parser): Add support for aggegate expressionsons in ORDER BY

### DIFF
--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -341,9 +341,9 @@ struct SortKey {
   SortKey(ExprApi input, bool ascending, bool nullsFirst)
       : expr{std::move(input)}, ascending{ascending}, nullsFirst(nullsFirst) {}
 
-  const ExprApi expr;
-  const bool ascending;
-  const bool nullsFirst;
+  ExprApi expr;
+  bool ascending;
+  bool nullsFirst;
 };
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -844,6 +844,64 @@ TEST_F(PrestoParserTest, aggregateOptions) {
   ASSERT_EQ(1, agg->aggregateAt(0)->ordering().size());
 }
 
+TEST_F(PrestoParserTest, orderBy) {
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                       .tableScan()
+                       .aggregate()
+                       .sort()
+                       .project();
+
+    testSql(
+        "select n_regionkey from nation group by 1 order by count(1)", matcher);
+  }
+
+  {
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate().sort();
+
+    testSql(
+        "select n_regionkey, count(1) from nation group by 1 order by count(1)",
+        matcher);
+
+    testSql(
+        "select n_regionkey, count(1) from nation group by 1 order by 2",
+        matcher);
+
+    testSql(
+        "select n_regionkey, count(1) as c from nation group by 1 order by c",
+        matcher);
+  }
+
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                       .tableScan()
+                       .aggregate()
+                       .project()
+                       .sort();
+
+    testSql(
+        "select n_regionkey, count(1) * 2 from nation group by 1 order by 2",
+        matcher);
+
+    testSql(
+        "select n_regionkey, count(1) * 2 from nation group by 1 order by count(1) * 2",
+        matcher);
+  }
+
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                       .tableScan()
+                       .aggregate()
+                       .project()
+                       .sort()
+                       .project();
+    testSql(
+        "select n_regionkey, count(1) * 2 from nation group by 1 order by count(1) * 3",
+        matcher);
+  }
+}
+
 TEST_F(PrestoParserTest, join) {
   {
     auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().join(


### PR DESCRIPTION
Summary:
Enable queries like

> SELECT key FROM t GROUP BY key ORDER BY count(1)

Sorting keys in ORDER by clause may have a number of forms:

- An ordinal identifying an output column in SELECT: ORDER BY 1, 2, 3
- An expression over output columns: ORDER BY f(key)
- An expression that uses aggregate functions: ORDER BY f(count(1))

These forms can be mixed: ORDER BY 1, f(key), count(1).

Hence, ORDER BY may contribute aggregations, may reference grouping keys and aggregations that are not used in SELECT clause, and may apply scalar expression over the values produced by SELECT clause.

Differential Revision: D90336938


