### PR TITLE
refactor(parser): Prevent accidental usage of DuckDB SQL Parser

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -126,7 +126,7 @@ core::ExprPtr replaceInputs(
 // Walks the expression tree looking for aggregate function calls and appending
 // these to 'aggregates'.
 void findAggregates(
-    const core::ExprPtr expr,
+    const core::ExprPtr& expr,
     std::vector<lp::ExprApi>& aggregates,
     ExprSet& aggregateSet) {
   switch (expr->kind()) {
@@ -373,12 +373,13 @@ std::pair<std::string, std::string> toConnectorTable(
 
 class RelationPlanner : public AstVisitor {
  public:
-  explicit RelationPlanner(
+  RelationPlanner(
       const std::string& defaultConnectorId,
       const std::optional<std::string>& defaultSchema,
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql)
-      : context_{defaultConnectorId},
+      : context_{defaultConnectorId, /*queryCtxPtr=*/nullptr,
+        /*hook=*/nullptr, std::make_shared<lp::ThrowingSqlExpressionsParser>()},
         defaultSchema_{defaultSchema},
         parseSql_{parseSql},
         builder_(newBuilder()) {}


### PR DESCRIPTION
Summary:
PrestoParser relies on logical_plan::PlanBuilder for type resolution. By default, PlanBuilder offers APIs that accept SQL strings and utilize the DuckDB Parser for parsing. However, in PrestoParser, we aim to avoid these DuckDB-based APIs and transition other usages of PlanBuilder to leverage PrestoParser instead.

Migration Plan:

1. Enable SQL Parser Specification: Update the construction of PlanBuilder to allow specifying which SQL parser to use.
2. PrestoParser Integration: Implement an always-throwing parser and use it to construct PlanBuilder in PrestoParser to ensure DuckDB parsing is not inadvertently used.
3. Migrate other usages of PlanBuilder to adopt PrestoSQL Parser, removing dependency on DuckDB SQL.

This diff implements steps 1 and 2. A follow-up is needed to implement step 3.

Differential Revision: D90560345


