### PR TITLE
feat(optimizer): Add support for queries using UNNEST WITH ORDINALITY clause

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "axiom/logical_plan/PlanBuilder.h"
 #include <velox/common/base/Exceptions.h>
 #include <vector>
@@ -681,7 +680,7 @@ PlanBuilder& PlanBuilder::unnest(
 
   std::optional<std::string> ordinalityName;
   if (withOrdinality) {
-    ordinalityName = newName("orginality");
+    ordinalityName = newName("ordinality");
   }
 
   bool flattenArrayOfRows = false;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -963,6 +963,9 @@ struct UnnestTable : public PlanObject {
   // All joins where 'this' is an end point.
   JoinEdgeVector joinedBy;
 
+  // Ordinality column if ordinality clause is present.
+  ColumnCP ordinalityColumn{nullptr};
+
   float cardinality() const {
     // TODO Should be changed later to actual cardinality.
     return 1;

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -537,7 +537,8 @@ struct Unnest : public RelationOp {
       RelationOpPtr input,
       ExprVector replicateColumns,
       ExprVector unnestExprs,
-      ColumnVector unnestedColumns);
+      ColumnVector unnestedColumns,
+      ColumnCP ordinalityColumn);
 
   const ExprVector replicateColumns;
   const ExprVector unnestExprs;
@@ -545,6 +546,7 @@ struct Unnest : public RelationOp {
   // Columns correspond to expressions but not 1:1,
   // it can be 2:1 (for MAP) and 1:1 (for ARRAY).
   const ColumnVector unnestedColumns;
+  const ColumnCP ordinalityColumn;
 
   std::string toString(bool recursive, bool detail) const override;
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
@@ -1144,7 +1143,9 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
       toFieldRefs(op.replicateColumns),
       toFieldRefs(op.unnestExprs),
       std::move(unnestNames),
-      std::nullopt,
+      op.ordinalityColumn
+          ? std::optional<std::string>(op.ordinalityColumn->outputName())
+          : std::nullopt,
       std::nullopt,
       std::move(input));
 }

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -90,7 +90,8 @@ class PlanMatcherBuilder {
 
   PlanMatcherBuilder& unnest(
       const std::vector<std::string>& replicateExprs,
-      const std::vector<std::string>& unnestExprs);
+      const std::vector<std::string>& unnestExprs,
+      const std::optional<std::string>& ordinalityName = std::nullopt);
 
   PlanMatcherBuilder& aggregation();
 


### PR DESCRIPTION
Summary:
 
Add support for queries using UNNEST WITH ORDINALITY clause.
* Propagates the ordinality column from the logical plan to the Velox physical plan.
* Prune the ordinality column if not used

Fixes https://github.com/facebookincubator/axiom/issues/246

Pull Request resolved: https://github.com/facebookincubator/axiom/pull/757
GitHub Author: Suryadev Sahadevan Rajesh <suryadev@meta.com>

Differential Revision: D90652011

Added Unit Tests 

We test the following cases for ordinality:

 "Value and Order Correctness":
1. Existing Velox/Backend Unit Tests

 "Schema Correctness":
   2. Ordinality column Present
   3. Ordinality column not Present
   4. Correct position (project reordering) and Aliasing
   5. Ordinality column pruned
   6. For unnest with ordinality other clauses and operators - existing unit tests for unnest  operators.



Axiom CLI (E2E)
```
buck run axiom/cli:cli
```

```
SQL> SELECT * FROM unnest(array[1, 2, 3], array[4, 5]) with ordinality;
ROW<e:INTEGER,e_0:INTEGER,ordinality:BIGINT>
--+------+-----------
e |  e_0 | ordinality
--+------+-----------
1 |    4 |          1
2 |    5 |          2
3 | null |          3
(3 rows in 1 batches)

509.51ms / 6.45ms user / 4.57ms system (2%)
```
with aliases

```
SQL> SELECT * FROM unnest(array[1, 2, 3], array[4, 5]) with ordinality as t(a, b, c);
ROW<a:INTEGER,b:INTEGER,c:BIGINT>
--+------+--
a |    b | c
--+------+--
1 |    4 | 1
2 |    5 | 2
3 | null | 3
(3 rows in 1 batches)

509.96ms / 7.33ms user / 4.10ms system (2%)
```

Ordinality column computation pruning 

```
buck run axiom/cli:cli
```


Logical Plan Inspection

```
SQL> EXPLAIN SELECT a, b FROM unnest(array[1, 2, 3], array[4, 5]) with ordinality as t(a, b, c);
Fragment 0:  numWorkers=1:
-- Project[3][expressions: (a:INTEGER, "e"), (b:INTEGER, "e_0")] -> a:INTEGER, b:INTEGER
  -- Unnest[2][dt3.__p6, dt3.__p10] -> e:INTEGER, e_0:INTEGER
    -- Project[1][expressions: (dt3.__p6:ARRAY<INTEGER>, {1, 2, 3}), (dt3.__p10:ARRAY<INTEGER>, {4, 5})] -> "dt3.__p6":ARRAY<INTEGER>, "dt3.__p10":ARRAY<INTEGER>
      -- Values[0][1 rows in 1 vectors] ->
         Estimate: 1 rows, 0B peak memory


3.56ms / 3.52ms user / 0ns system (98%)
```

Correctness Test
```
SQL> SELECT a, b FROM unnest(array[1, 2, 3], array[4, 5]) with ordinality as t(a, b, c);
ROW<a:INTEGER,b:INTEGER>
--+-----
a |    b
--+-----
1 |    4
2 |    5
3 | null
(3 rows in 1 batches)

509.92ms / 8.53ms user / 3.18ms system (2%)
```