### PR TITLE
fix: Correlated EXISTS subqueries that do not project columns used in correlated conjuncts

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -477,6 +477,17 @@ bool DerivedTable::isWrapOnly() const {
 }
 
 ExprCP DerivedTable::exportExpr(ExprCP expr) {
+  expr->columns().forEach<Column>([&](auto* column) {
+    if (tableSet.contains(column->relation())) {
+      if (pushBackUnique(exprs, column)) {
+        const auto* columnName = toName(column->name());
+        auto outer =
+            make<Column>(columnName, this, column->value(), columnName);
+        columns.push_back(outer);
+      }
+    }
+  });
+
   return replaceInputs(expr, exprs, columns);
 }
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -163,10 +163,9 @@ struct DerivedTable : public PlanObject {
   /// corresponding 'exprs'.
   ExprCP importExpr(ExprCP expr);
 
-  /// Return a copy of 'expr', replacing references to this DT's 'exprs' with
-  /// corresponding 'columns'.
-  /// TODO Handle cases when 'expr' contains columns that are not exported by
-  /// the DT.
+  /// Returns a copy of 'expr', replacing references to this DT's 'exprs' with
+  /// the corresponding 'columns'. If 'expr' references columns not present in
+  /// DT's output, those columns are added.
   ExprCP exportExpr(ExprCP expr);
 
   bool isTable() const override {

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -90,12 +90,16 @@ Target transform(const V& set, Func func) {
   return result;
 }
 
-/// Adds 'element' to 'vector' if it is not in it.
+/// Adds 'element' to 'vector' if it is not in it. Return 'true' if element was
+/// appended, 'false' if it already existed.
 template <typename V, typename E>
-inline void pushBackUnique(V& vector, E& element) {
-  if (std::find(vector.begin(), vector.end(), element) == vector.end()) {
-    vector.push_back(element);
+inline bool pushBackUnique(V& vector, E& element) {
+  if (std::find(vector.begin(), vector.end(), element) != vector.end()) {
+    return false;
   }
+
+  vector.push_back(element);
+  return true;
 }
 
 /// Returns the integer value of 'variant'. Throws if this is not an integer.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2032,7 +2032,11 @@ void ToGraph::processSubqueries(
       auto tables = conjunct->allTables();
       tables.erase(subqueryDt);
 
-      VELOX_CHECK_EQ(1, tables.size());
+      VELOX_CHECK_EQ(
+          1,
+          tables.size(),
+          "Correlated conjuncts referencing multiple outer tables are not supported: {}",
+          conjunct->toString());
       if (leftTable == nullptr) {
         leftTable = tables.onlyObject();
       } else {


### PR DESCRIPTION
Summary:
Fixes queries like

> SELECT * FROM region WHERE EXISTS (SELECT 1 FROM nation WHERE r_regionkey = n_regionkey)

These queries used to fail with 

```
Reason: (1 vs. 2) Correlated conjuncts referencing multiple outer tables are not supported: eq(t2.r_regionkey, t4.n_regionkey)
Retriable: False
Expression: 1 == tables.size()
Function: processSubqueries
File: fbcode/axiom/optimizer/ToGraph.cpp
Line: 2044
```

Differential Revision: D90724079


