### PR TITLE
fix: Handling of join conditions that use subfields

### DIFF
--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -270,7 +270,7 @@ class ToGraph {
       logical_plan::ExprPtr& input);
 
   void getExprForField(
-      const logical_plan::Expr* field,
+      const logical_plan::InputReferenceExpr* field,
       logical_plan::ExprPtr& resultExpr,
       ColumnCP& resultColumn,
       const logical_plan::LogicalPlanNode*& context);
@@ -362,8 +362,11 @@ class ToGraph {
   // Innermost DerivedTable when making a QueryGraph from PlanNode.
   DerivedTableP currentDt_{nullptr};
 
-  // Source PlanNode when inside addProjection() or 'addFilter().
-  const logical_plan::LogicalPlanNode* exprSource_{nullptr};
+  // Source LogicalPlanNode's for the node currently being processed. Used to
+  // translate expressions that involve subfields. Contains just one node if
+  // current node if Project or Filter. Contains two nodes if current node is a
+  // Join.
+  std::vector<const logical_plan::LogicalPlanNode*> exprSources_;
 
   // Map from lambda argument names to their corresponding columns when
   // translating inside a lambda body.


### PR DESCRIPTION
Summary:
## Overview

In ToGraph, expressions involving struct, map, or array accesses (subfields) are processed through a specialized path: `ToGraph::translateSubfield` and `ToGraph::getExprForField`. This logic extracts the "base" (the complex type column or expression) and the "path" (a sequence of struct, map, and array accesses). The process involves traversing the logical plan to the node that produces the complex type, which could be a leaf node (such as scan, values, or unnest) or a project node that generates the value via a function call.

## Key Problems

**Broken Derived Table Invariant**
   - The traversal in `ToGraph::getExprForField` does not respect derived table boundaries. As a result, translated expressions may reference derived tables not directly linked to the currentDt_, violating the core invariant: all expressions in a derived table must reference relations from `DerivedTable::tables`.
   - This leads to downstream failures in processing.

**Incorrect setup of `exprSource_` in Join processing**
   - The special path relies on `ToGraph::exprSource_` being set to the logical plan node that is the immediate source of the current node.
   - While `exprSource_` is set for Project and Filter nodes, it is not set for Join nodes. This causes failures when processing join conditions involving subfields, either due to `exprSource_` being unset or containing stale values.

## Fixes

- For the first issue, a band-aid solution short-circuits the logic of walking down the logical plan. A comprehensive revision of this logic is needed in a follow up.
- For the second issue, update `exprSource_` to support multiple nodes (since Join has two sources) and revise Join processing logic to set it appropriately.

## Simple Repros

**Broken Invariant:**

```
select * from (VALUES row(row(1, 2))) as t(x), unnest(array[1,2,3]) where x.c1 > 1
```
Before the fix, the filter is lost, resulting in incorrect output. After the fix, the filter is applied correctly, and the result is empty as expected.

Before the fix:

plan:
```
Fragment 0:  numWorkers=1:
-- Unnest[3][dt3.__p9] -> x:ROW<c1:INTEGER,c2:INTEGER>, e:INTEGER
  -- Project[2][expressions: (x:ROW<c1:INTEGER,c2:INTEGER>, "x"), (dt3.__p9:ARRAY<INTEGER>, {1, 2, 3})] -> x:ROW<c1:INTEGER,c2:INTEGER>, "dt3.__p9":ARRAY<INTEGER>
    -- Project[1][expressions: (x:ROW<c1:INTEGER,c2:INTEGER>, "c0")] -> x:ROW<c1:INTEGER,c2:INTEGER>
      -- Values[0][1 rows in 1 vectors] -> c0:ROW<c1:INTEGER,c2:INTEGER>
         Estimate: 1 rows, 0B peak memory
```

result:
```
-------+--
     x | e
-------+--
{1, 2} | 1
{1, 2} | 2
{1, 2} | 3
(3 rows in 1 batches)
```

After the fix:

plan:
```
Fragment 0:  numWorkers=1:
-- Unnest[4][dt3.__p9] -> x:ROW<c1:INTEGER,c2:INTEGER>, e:INTEGER
  -- Project[3][expressions: (x:ROW<c1:INTEGER,c2:INTEGER>, "x"), (dt3.__p9:ARRAY<INTEGER>, {1, 2, 3})] -> x:ROW<c1:INTEGER,c2:INTEGER>, "dt3.__p9":ARRAY<INTEGER>
    -- Project[2][expressions: (x:ROW<c1:INTEGER,c2:INTEGER>, "c0")] -> x:ROW<c1:INTEGER,c2:INTEGER>
      -- Filter[0][expression: gt("c0"["c1"],1)] -> c0:ROW<c1:INTEGER,c2:INTEGER>
         Estimate: 1 rows, 0B peak memory
        -- Values[1][1 rows in 1 vectors] -> c0:ROW<c1:INTEGER,c2:INTEGER>
           Estimate: 1 rows, 0B peak memory
```

result:
```
(0 rows in 0 batches)
```

**Join Issue**
```sql
SQL> select * from (VALUES row(row(1, 2))) as t(x) JOIN (VALUES row(row(1, 2))) as u(y) ON x.c1 = y.c1;
Query failed: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Field not found: x. Available fields are: c0_0.
Retriable: False
Context: Expr: eq(DEREFERENCE(x, c1), DEREFERENCE(y, c1))
Function: getChildIdx
File: fbcode/velox/type/Type.cpp
Line: 517
```
This fails with a "Field not found" error because `exprSource_` is not set for the Join node.

Differential Revision: D90797260


