### PR TITLE
feat(parser): Add support for simple CASE statement

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1605,7 +1605,13 @@ std::any AstBuilder::visitBooleanLiteral(
 
 std::any AstBuilder::visitSimpleCase(PrestoSqlParser::SimpleCaseContext* ctx) {
   trace("visitSimpleCase");
-  return visitChildren("visitSimpleCase", ctx);
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<SimpleCaseExpression>(
+          getLocation(ctx),
+          visitTyped<Expression>(ctx->valueExpression()),
+          visitTyped<WhenClause>(ctx->whenClause()),
+          visitTyped<Expression>(ctx->elseExpression)));
 }
 
 std::any AstBuilder::visitColumnReference(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -646,6 +646,25 @@ TEST_F(PrestoParserTest, ifClause) {
   }
 }
 
+TEST_F(PrestoParserTest, switch) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+
+  testSql(
+      "SELECT case when n_nationkey > 2 then 100 when n_name like 'A%' then 200 end FROM nation",
+      matcher);
+  testSql(
+      "SELECT case when n_nationkey > 2 then 100 when n_name like 'A%' then 200 else 300 end FROM nation",
+      matcher);
+
+  testSql(
+      "SELECT case n_nationkey when 1 then 100 when 2 then 200 end FROM nation",
+      matcher);
+
+  testSql(
+      "SELECT case n_nationkey when 1 then 100 when 2 then 200 else 300 end FROM nation",
+      matcher);
+}
+
 TEST_F(PrestoParserTest, in) {
   {
     auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();


### PR DESCRIPTION
Summary:
Enable queries like

> SELECT case x when 1 then 'a' when 2 then 'b' end FROM t

Differential Revision: D91130441


