### PR TITLE
fix(parser): Force parsing all of SQL text

### DIFF
--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <boost/algorithm/string.hpp>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -83,8 +84,15 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
     return sql;
   }
 
-  std::string readTpchSql(int32_t query) {
-    return readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+  static std::string readTpchSql(int32_t query) {
+    auto sql = readSqlFromFile(fmt::format("tpch.queries/q{}.sql", query));
+
+    // Drop trailing semicolon.
+    boost::trim_right(sql);
+    if (!sql.empty() && sql.back() == ';') {
+      sql.pop_back();
+    }
+    return sql;
   }
 
   lp::LogicalPlanNodePtr parseTpchSql(int32_t query) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -72,13 +72,13 @@ class ParserHelper {
   }
 
   PrestoSqlParser::StatementContext* parse() const {
-    auto ctx = parser_->statement();
+    auto ctx = parser_->singleStatement();
 
     if (parser_->getNumberOfSyntaxErrors() > 0) {
       throw std::runtime_error(errorListener_.firstError);
     }
 
-    return ctx;
+    return ctx->statement();
   }
 
  private:

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -398,6 +398,11 @@ TEST_F(PrestoParserTest, syntaxErrors) {
       },
       ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
           "Syntax error at 2:5: mismatched input '<EOF>'")));
+
+  EXPECT_THAT(
+      [&]() { parser.parse("SELECT * FROM (VALUES 1, 2, 3)) blah..."); },
+      ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+          "Syntax error at 1:30: mismatched input ')' expecting <EOF>")));
 }
 
 TEST_F(PrestoParserTest, types) {


### PR DESCRIPTION
Summary:
Before the fix, a query that has a valid prefix might succeed.

```
$ buck run axiom/cli:cli -- --query "SELECT * FROM (VALUES 1, 2, 3)) blah..."

ROW<c0:INTEGER>
--
c0
--
 1
 2
 3
(3 rows in 3 batches)
```

After the fix, the query fails.

```
Parse failed: Syntax error at 1:30: mismatched input ')' expecting <EOF>
```

Differential Revision: D91201780


