### PR TITLE
feat: Add support for AT TIME ZONE expression

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -345,6 +345,11 @@ class ExprAnalyzer : public AstVisitor {
     }
   }
 
+  void visitAtTimeZone(AtTimeZone* node) override {
+    node->value()->accept(this);
+    node->timeZone()->accept(this);
+  }
+
   size_t numAggregates_{0};
   std::optional<std::string> aggregateName_;
 };
@@ -556,6 +561,14 @@ class RelationPlanner : public AstVisitor {
         } else {
           return lp::Cast(type, toExpr(cast->expression(), aggregateOptions));
         }
+      }
+
+      case NodeType::kAtTimeZone: {
+        auto* atTimeZone = node->as<AtTimeZone>();
+        return lp::Call(
+            "at_timezone",
+            toExpr(atTimeZone->value(), aggregateOptions),
+            toExpr(atTimeZone->timeZone(), aggregateOptions));
       }
 
       case NodeType::kSimpleCaseExpression: {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1343,7 +1343,12 @@ std::any AstBuilder::visitArithmeticUnary(
 
 std::any AstBuilder::visitAtTimeZone(PrestoSqlParser::AtTimeZoneContext* ctx) {
   trace("visitAtTimeZone");
-  return visitChildren("visitAtTimeZone", ctx);
+
+  auto value = visitExpression(ctx->valueExpression());
+  auto timeZone = visitExpression(ctx->timeZoneSpecifier());
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<AtTimeZone>(getLocation(ctx), value, timeZone));
 }
 
 std::any AstBuilder::visitDereference(
@@ -1856,7 +1861,7 @@ std::any AstBuilder::visitTimeZoneInterval(
 std::any AstBuilder::visitTimeZoneString(
     PrestoSqlParser::TimeZoneStringContext* ctx) {
   trace("visitTimeZoneString");
-  return visitChildren("visitTimeZoneString", ctx);
+  return visitExpression(ctx->string());
 }
 
 std::any AstBuilder::visitComparisonOperator(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -596,6 +596,16 @@ TEST_F(PrestoParserTest, timestampLiteral) {
       "Not a valid timestamp literal");
 }
 
+TEST_F(PrestoParserTest, atTimeZone) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+  testSql(
+      "SELECT from_unixtime(1700000000, 'UTC') AT TIME ZONE 'America/New_York'",
+      matcher);
+  testSql(
+      "SELECT date_format(date_trunc('hour', from_unixtime(1700000000, 'UTC') AT TIME ZONE 'GMT'), '%Y-%m-%d+%H:00')",
+      matcher);
+}
+
 TEST_F(PrestoParserTest, null) {
   auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
   testSql("SELECT 1 is null", matcher);


### PR DESCRIPTION
Summary:

Enable queries like
```sql
SELECT from_unixtime(ts, 'UTC') AT TIME ZONE 'America/New_York' 
```

Differential Revision: D91243949


