### PR TITLE
feat: Enable EXISTS subqueries that reference multiple outer tables

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -155,21 +155,28 @@ void reducingJoinsRecursive(
     }
 
     JoinSide other = join->sideOf(candidate, true);
-    VELOX_DCHECK_NOT_NULL(other.table);
+    if (other.table == nullptr) {
+      continue;
+    }
+
     if (!state.dt->hasTable(other.table) || !state.dt->hasJoin(join)) {
       continue;
     }
+
     if (other.table->isNot(PlanType::kTableNode) &&
         other.table->isNot(PlanType::kValuesTableNode) &&
         other.table->isNot(PlanType::kUnnestTableNode)) {
       continue;
     }
+
     if (visited.contains(other.table)) {
       continue;
     }
+
     if (other.fanout > maxFanout) {
       continue;
     }
+
     visited.add(other.table);
     auto fanout = fanoutFromRoot * other.fanout;
     if (fanout < 0.9) {
@@ -179,6 +186,7 @@ void reducingJoinsRecursive(
         maxFanout = 1;
       }
     }
+
     path.push_back(other.table);
     isLeaf = false;
     reducingJoinsRecursive(

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -62,7 +62,12 @@ std::string PlanObjectSet::toString(bool names) const {
   forEach([&](auto object) {
     out << object->id();
     if (names) {
-      out << ": " << object->toString() << " ";
+      if (object->isTable()) {
+        out << ": " << cname(object);
+      } else {
+        out << ": " << object->toString() << " ";
+      }
+
     } else {
       out << " ";
     }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1135,4 +1135,7 @@ class WritePlan : public PlanObject {
 
 using WritePlanCP = const WritePlan*;
 
+/// @return cname if 'relation' is a table, otherwise throw.
+Name cname(PlanObjectCP relation);
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -29,7 +29,7 @@ namespace facebook::axiom::optimizer {
 
 void PlanCost::add(RelationOp& op) {
   cost += op.cost().totalCost();
-  cardinality = op.cost().resultCardinality();
+  cardinality = op.resultCardinality();
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Enable queries like

> with t as (select n_nationkey as nkey, r_regionkey as rkey from nation, region where n_regionkey = r_regionkey)
select * from t where exists (SELECT * FROM nation WHERE n_nationkey = nkey and n_regionkey = rkey)

Differential Revision: D91275580


