### PR TITLE
refactor(connector): Define Axiom HiveMetadataConfig object

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include "axiom/cli/Console.h"
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
@@ -89,8 +90,8 @@ class Connectors {
       folly::IOThreadPoolExecutor* ioExecutor,
       optimizer::VeloxHistory& history) {
     std::unordered_map<std::string, std::string> connectorConfig = {
-        {velox::connector::hive::HiveConfig::kLocalDataPath, dataPath},
-        {velox::connector::hive::HiveConfig::kLocalFileFormat, dataFormat},
+        {connector::hive::HiveMetadataConfig::kLocalDataPath, dataPath},
+        {connector::hive::HiveMetadataConfig::kLocalFileFormat, dataFormat},
     };
 
     auto config =

--- a/axiom/connectors/hive/CMakeLists.txt
+++ b/axiom/connectors/hive/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(
   axiom_hive_connector_metadata
   HiveConnectorMetadata.cpp
+  HiveMetadataConfig.cpp
   LocalHiveConnectorMetadata.cpp
   StatisticsBuilder.cpp
 )

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -229,9 +229,6 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       velox::connector::hive::HiveConnector* hiveConnector,
       bool includeHiddenColumns = true)
       : hiveConnector_(hiveConnector),
-        hiveConfig_(
-            std::make_shared<velox::connector::hive::HiveConfig>(
-                hiveConnector->connectorConfig())),
         includeHiddenColumns_{includeHiddenColumns} {}
 
   ConnectorWriteHandlePtr beginWrite(
@@ -256,7 +253,6 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       std::string_view table) const = 0;
 
   velox::connector::hive::HiveConnector* const hiveConnector_;
-  const std::shared_ptr<velox::connector::hive::HiveConfig> hiveConfig_;
 
   bool includeHiddenColumns_{true};
 };

--- a/axiom/connectors/hive/HiveMetadataConfig.cpp
+++ b/axiom/connectors/hive/HiveMetadataConfig.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "velox/common/config/Config.h"
+
+namespace facebook::axiom::connector::hive {
+
+std::string HiveMetadataConfig::localDataPath() const {
+  return config_->get<std::string>(kLocalDataPath, "");
+}
+
+std::string HiveMetadataConfig::localFileFormat() const {
+  return config_->get<std::string>(kLocalFileFormat, "");
+}
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/HiveMetadataConfig.h
+++ b/axiom/connectors/hive/HiveMetadataConfig.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::config {
+class ConfigBase;
+}
+
+namespace facebook::axiom::connector::hive {
+
+class HiveMetadataConfig {
+ public:
+  /// The file system path containing local data to be used for query
+  /// planning and execution by LocalHiveConnectorMetadata.
+  static constexpr const char* kLocalDataPath = "hive_local_data_path";
+
+  /// The name of the file format to use for processing data at kLocalDataPath.
+  static constexpr const char* kLocalFileFormat = "hive_local_file_format";
+
+  std::string localDataPath() const;
+
+  std::string localFileFormat() const;
+
+  /// HiveMetadataConfig may be initialized from a base config which also
+  /// contains execution config defined in velox/connectors/hive/HiveConfig.h,
+  /// so some additional properties may be present which are not defined here.
+  explicit HiveMetadataConfig(
+      std::shared_ptr<const velox::config::ConfigBase> config)
+      : config_{std::move(config)} {
+    VELOX_CHECK_NOT_NULL(
+        config_, "Config is null for HiveMetadataConfig initialization");
+  }
+
+ protected:
+  const std::shared_ptr<const velox::config::ConfigBase>& config() const {
+    return config_;
+  }
+
+ private:
+  std::shared_ptr<const velox::config::ConfigBase> config_;
+};
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/StatisticsBuilder.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/memory/HashStringAllocator.h"
@@ -252,7 +253,8 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const ConnectorWriteHandlePtr& handle) noexcept override;
 
   std::string tablePath(std::string_view tableName) const override {
-    return fmt::format("{}/{}", hiveConfig_->hiveLocalDataPath(), tableName);
+    return fmt::format(
+        "{}/{}", hiveMetadataConfig_->localDataPath(), tableName);
   }
 
   std::optional<std::string> makeStagingDirectory(
@@ -294,6 +296,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   velox::dwio::common::FileFormat format_;
   folly::F14FastMap<std::string, std::shared_ptr<LocalTable>> tables_;
   LocalHiveSplitManager splitManager_;
+  std::shared_ptr<HiveMetadataConfig> hiveMetadataConfig_;
 };
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/tests/CMakeLists.txt
+++ b/axiom/connectors/hive/tests/CMakeLists.txt
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(axiom_local_hive_connector_metadata_test LocalHiveConnectorMetadataTest.cpp)
+add_executable(
+  axiom_hive_connector_metadata_test
+  LocalHiveConnectorMetadataTest.cpp
+  HiveMetadataConfigTest.cpp
+)
 
-add_test(axiom_local_hive_connector_metadata_test axiom_local_hive_connector_metadata_test)
+add_test(axiom_hive_connector_metadata_test axiom_hive_connector_metadata_test)
 
 target_link_libraries(
-  axiom_local_hive_connector_metadata_test
+  axiom_hive_connector_metadata_test
   axiom_hive_connector_metadata
   velox_hive_connector
   axiom_runner_tests_utils

--- a/axiom/connectors/hive/tests/HiveMetadataConfigTest.cpp
+++ b/axiom/connectors/hive/tests/HiveMetadataConfigTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "gtest/gtest.h"
+#include "velox/common/config/Config.h"
+
+namespace facebook::axiom::connector::hive {
+namespace {
+
+TEST(HiveMetadataConfigTest, defaultConfig) {
+  HiveMetadataConfig config(
+      std::make_shared<velox::config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
+  ASSERT_EQ(config.localDataPath(), "");
+  ASSERT_EQ(config.localFileFormat(), "");
+}
+
+TEST(HiveMetadataConfigTest, overrideConfig) {
+  std::unordered_map<std::string, std::string> properties = {
+      {HiveMetadataConfig::kLocalDataPath, "/path/to/data"},
+      {HiveMetadataConfig::kLocalFileFormat, "parquet"}};
+  HiveMetadataConfig config(
+      std::make_shared<velox::config::ConfigBase>(std::move(properties)));
+  ASSERT_EQ(config.localDataPath(), "/path/to/data");
+  ASSERT_EQ(config.localFileFormat(), "parquet");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::hive

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -22,6 +22,7 @@
 #include <sys/time.h>
 #include <iostream>
 #include "axiom/connectors/SchemaResolver.h"
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "axiom/logical_plan/PlanPrinter.h"
@@ -252,8 +253,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(8);
 
     std::unordered_map<std::string, std::string> connectorConfig = {
-        {velox::connector::hive::HiveConfig::kLocalDataPath, dataPath},
-        {velox::connector::hive::HiveConfig::kLocalFileFormat,
+        {connector::hive::HiveMetadataConfig::kLocalDataPath, dataPath},
+        {connector::hive::HiveMetadataConfig::kLocalFileFormat,
          FLAGS_data_format},
     };
 

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
-#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -67,8 +67,8 @@ std::shared_ptr<velox::core::QueryCtx> LocalRunnerTestBase::makeQueryCtx(
 
 void LocalRunnerTestBase::setupConnector() {
   std::unordered_map<std::string, std::string> configs;
-  configs[velox::connector::hive::HiveConfig::kLocalDataPath] = localDataPath_;
-  configs[velox::connector::hive::HiveConfig::kLocalFileFormat] =
+  configs[connector::hive::HiveMetadataConfig::kLocalDataPath] = localDataPath_;
+  configs[connector::hive::HiveMetadataConfig::kLocalFileFormat] =
       velox::dwio::common::toString(localFileFormat_);
 
   resetHiveConnector(


### PR DESCRIPTION
Summary:
Some Axiom-specific configuration options were added to the Velox HiveConfig. In the interest of keeping Axiom and Velox configuration separate, I am defining a new Axiom-specific configuration structure. This structure will still be initialized from the base configuration object accessible from the `Connector::connectorConfig()` API, which holds combined metadata config (Axiom HiveMetadataConfig) and execution config (Velox HiveConfig).

Following this diff, I will remove the deprecated options from Velox.

Related issue: https://github.com/facebookincubator/axiom/issues/779

Differential Revision: D91282682


