### PR TITLE
refactor(parser): Remove unused memory pool parameter from PrestoParser

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -70,8 +70,8 @@ void SqlQueryRunner::initialize(
 
   schema_ = std::make_shared<connector::SchemaResolver>();
 
-  prestoParser_ = std::make_unique<presto::PrestoParser>(
-      defaultConnectorId, defaultSchema, optimizerPool_.get());
+  prestoParser_ =
+      std::make_unique<presto::PrestoParser>(defaultConnectorId, defaultSchema);
 
   spillExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(4);
 }

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -180,7 +180,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     schema_ = std::make_shared<connector::SchemaResolver>();
 
     prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
-        connector_->connectorId(), std::nullopt, optimizerPool_.get());
+        connector_->connectorId(), std::nullopt);
 
     history_ = std::make_unique<optimizer::VeloxHistory>();
 

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -57,8 +57,7 @@ class DerivedTablePrinterTest : public ::testing::Test {
   }
 
   std::vector<std::string> toLines(const std::string& sql) {
-    ::axiom::sql::presto::PrestoParser parser{
-        kTestConnectorId, std::nullopt, optimizerPool_.get()};
+    ::axiom::sql::presto::PrestoParser parser{kTestConnectorId, std::nullopt};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -45,7 +45,7 @@ void HiveQueriesTestBase::SetUp() {
   test::QueryTestBase::SetUp();
 
   prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
-      exec::test::kHiveConnectorId, std::nullopt, pool());
+      exec::test::kHiveConnectorId, std::nullopt);
 
   connector_ = velox::connector::getConnector(exec::test::kHiveConnectorId);
   metadata_ = dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -69,8 +69,7 @@ void QueryTestBase::TearDown() {
 logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
     std::string_view sql,
     const std::string& defaultConnectorId) {
-  ::axiom::sql::presto::PrestoParser parser(
-      defaultConnectorId, std::nullopt, pool());
+  ::axiom::sql::presto::PrestoParser parser(defaultConnectorId, std::nullopt);
 
   auto statement = parser.parse(sql);
 

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -87,8 +87,7 @@ class RelationOpPrinterTest : public ::testing::Test {
   }
 
   lp::LogicalPlanNodePtr parse(const std::string& sql) {
-    ::axiom::sql::presto::PrestoParser parser{
-        kTestConnectorId, std::nullopt, optimizerPool_.get()};
+    ::axiom::sql::presto::PrestoParser parser{kTestConnectorId, std::nullopt};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -52,7 +52,7 @@ class SyntacticJoinOrderTest : public test::QueryTestBase {
 
   lp::LogicalPlanNodePtr parseSql(const std::string& sql) const {
     ::axiom::sql::presto::PrestoParser parser{
-        exec::test::kHiveConnectorId, std::nullopt, &optimizerPool()};
+        exec::test::kHiveConnectorId, std::nullopt};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 

--- a/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
@@ -42,8 +42,7 @@ class TpchConnectorQueryTest : public QueryTestBase {
   }
 
   lp::LogicalPlanNodePtr parseSql(std::string_view sql) {
-    ::axiom::sql::presto::PrestoParser parser(
-        kTpchConnectorId, std::nullopt, pool());
+    ::axiom::sql::presto::PrestoParser parser(kTpchConnectorId, std::nullopt);
     auto statement = parser.parse(sql);
 
     VELOX_CHECK(statement->isSelect());

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -99,7 +99,7 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
     auto sql = readTpchSql(query);
 
     ::axiom::sql::presto::PrestoParser prestoParser(
-        exec::test::kHiveConnectorId, std::nullopt, pool());
+        exec::test::kHiveConnectorId, std::nullopt);
     auto statement = prestoParser.parse(sql);
 
     VELOX_CHECK(statement->isSelect());

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -80,7 +80,7 @@ class WriteTest : public test::HiveQueriesTestBase {
     SCOPED_TRACE(sql);
 
     ::axiom::sql::presto::PrestoParser parser(
-        exec::test::kHiveConnectorId, std::nullopt, pool());
+        exec::test::kHiveConnectorId, std::nullopt);
 
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isCreateTableAsSelect());
@@ -395,7 +395,7 @@ TEST_F(WriteTest, insertSql) {
 
   auto parseSql = [&](std::string_view sql) {
     ::axiom::sql::presto::PrestoParser parser(
-        exec::test::kHiveConnectorId, std::nullopt, pool());
+        exec::test::kHiveConnectorId, std::nullopt);
 
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isInsert());

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -28,11 +28,9 @@ class PrestoParser {
   /// specify schema, i.e. SELECT * FROM name.
   PrestoParser(
       const std::string& defaultConnectorId,
-      const std::optional<std::string>& defaultSchema,
-      facebook::velox::memory::MemoryPool* pool)
+      const std::optional<std::string>& defaultSchema)
       : defaultConnectorId_{defaultConnectorId},
-        defaultSchema_{defaultSchema},
-        pool_{pool} {}
+        defaultSchema_{defaultSchema} {}
 
   SqlStatementPtr parse(std::string_view sql, bool enableTracing = false);
 
@@ -59,7 +57,6 @@ class PrestoParser {
 
   const std::string defaultConnectorId_;
   const std::optional<std::string> defaultSchema_;
-  facebook::velox::memory::MemoryPool* pool_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -85,10 +85,6 @@ class PrestoParserTest : public testing::Test {
     testConnector_.reset();
   }
 
-  memory::MemoryPool* pool() {
-    return pool_.get();
-  }
-
   void testExplain(
       std::string_view sql,
       lp::test::LogicalPlanMatcherBuilder& matcher) {
@@ -216,18 +212,13 @@ class PrestoParserTest : public testing::Test {
   }
 
   PrestoParser makeParser() {
-    return PrestoParser(defaultConnectorId_, defaultSchema_, pool());
+    return PrestoParser(defaultConnectorId_, defaultSchema_);
   }
 
   std::string defaultConnectorId_ = kTpchConnectorId;
   std::optional<std::string> defaultSchema_ = kTinySchema;
 
   std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
-
- private:
-  std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::memoryManager()->addRootPool()};
-  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
 };
 
 TEST_F(PrestoParserTest, parseMultiple) {


### PR DESCRIPTION
Summary:
The PrestoParser takes a memory pool as a parameter, but this is unused. Unlike Velox executable plans, Axiom logical plans do not need to allocate from pools during construction.

So this parameter can be removed and the relevant callers updated.

Differential Revision: D91365269


