### PR TITLE
fix: Avoid crashing when planning LEFT CROSS JOIN

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -132,8 +132,6 @@ bool isSingleRowDt(PlanObjectCP object) {
 PlanObjectSet findSingleRowDts(
     const PlanObjectSet& tables,
     const JoinEdgeVector& joins) {
-  PlanObjectSet singleRowDts;
-
   // Remove tables that are joined to other tables.
   auto tablesCopy = tables;
   int32_t numSingle = 0;
@@ -147,6 +145,7 @@ PlanObjectSet findSingleRowDts(
     }
   }
 
+  PlanObjectSet singleRowDts;
   tablesCopy.forEach([&](PlanObjectCP object) {
     if (isSingleRowDt(object)) {
       ++numSingle;

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -387,6 +387,8 @@ PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
 }
 
 PlanP PlanSet::best(const Distribution& distribution, bool& needsShuffle) {
+  VELOX_CHECK_GT(plans.size(), 0, "No plans to pick best from");
+
   PlanP best = nullptr;
   PlanP match = nullptr;
   float bestCost = -1;

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -62,12 +62,8 @@ std::string PlanObjectSet::toString(bool names) const {
   forEach([&](auto object) {
     out << object->id();
     if (names) {
-      if (object->isTable()) {
-        out << ": " << cname(object);
-      } else {
-        out << ": " << object->toString() << " ";
-      }
-
+      out << ": " << (object->isTable() ? cname(object) : object->toString())
+          << " ";
     } else {
       out << " ";
     }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1597,6 +1597,8 @@ void ToGraph::translateJoin(const lp::JoinNode& join) {
     extractNonInnerJoinEqualities(
         equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
+    VELOX_CHECK(!leftTables.empty(), "Outer cross joins are not supported yet");
+
     JoinEdge::Spec joinSpec{
         .filter = std::move(conjuncts),
         .leftOptional = leftOptional,

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -18,6 +18,7 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -415,6 +416,30 @@ TEST_F(JoinTest, crossJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+TEST_F(JoinTest, leftCrossJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+
+  // TODO Make these queries work.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM t LEFT JOIN (SELECT count(*) FROM u) ON 1 = 1",
+        kTestConnectorId);
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan),
+        "Outer cross joins are not supported yet");
+  }
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM (SELECT count(*) FROM t) LEFT JOIN (SELECT count(*) FROM u) ON 1 = 1",
+        kTestConnectorId);
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan),
+        "Outer cross joins are not supported yet");
   }
 }
 


### PR DESCRIPTION
Summary:
Avoid crashing when optimizing queries with LEFT CROSS JOINS. The query would still fail, but not bring down the server. A proper fix will be need to be developed separately.

The following queries used to crash:

> select * from nation left join (SELECT count(*) from region) on 1 = 1

> select * from (SELECT count(*) from nation) left join (SELECT count(*) from region) on 1 = 1

Differential Revision: D91366436


