### PR TITLE
refactor: Make MemoKey immutable and add PlanObjectSet factory methods

### DIFF
--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -318,15 +318,43 @@ struct PlanStateSaver {
 /// unless it is known never to have duplicates, it must become a
 /// semijoin and the original join must still stay in place in case
 /// there were duplicates.
+///
+/// MemoKey is immutable after construction. Use the static create() method
+/// to construct instances.
 struct MemoKey {
+  static MemoKey create(
+      PlanObjectCP firstTable,
+      PlanObjectSet columns,
+      PlanObjectSet tables,
+      std::vector<PlanObjectSet> existences = {}) {
+    VELOX_CHECK_NOT_NULL(firstTable);
+    VELOX_CHECK(tables.contains(firstTable));
+    return MemoKey{
+        firstTable,
+        std::move(columns),
+        std::move(tables),
+        std::move(existences)};
+  }
+
   bool operator==(const MemoKey& other) const;
 
   size_t hash() const;
 
-  PlanObjectCP firstTable;
-  PlanObjectSet columns;
-  PlanObjectSet tables;
-  std::vector<PlanObjectSet> existences;
+  const PlanObjectCP firstTable;
+  const PlanObjectSet columns;
+  const PlanObjectSet tables;
+  const std::vector<PlanObjectSet> existences;
+
+ private:
+  MemoKey(
+      PlanObjectCP firstTable,
+      PlanObjectSet columns,
+      PlanObjectSet tables,
+      std::vector<PlanObjectSet> existences)
+      : firstTable(firstTable),
+        columns(std::move(columns)),
+        tables(std::move(tables)),
+        existences(std::move(existences)) {}
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -147,6 +147,21 @@ using PlanObjectVector = QGVector<PlanObjectCP>;
 /// Set of PlanObjects. Uses the objects id() as an index into a bitmap.
 class PlanObjectSet : public BitSet {
  public:
+  /// Creates a PlanObjectSet containing a single object.
+  static PlanObjectSet single(PlanObjectCP object) {
+    PlanObjectSet set;
+    set.add(object);
+    return set;
+  }
+
+  /// Creates a PlanObjectSet from a collection of objects.
+  template <typename V>
+  static PlanObjectSet fromObjects(const V& objects) {
+    PlanObjectSet set;
+    set.unionObjects(objects);
+    return set;
+  }
+
   /// True if id of 'object' is in 'this'.
   bool contains(PlanObjectCP object) const {
     return object->id() < bits_.size() * 64 &&


### PR DESCRIPTION
Summary:
Make MemoKey struct immutable to prevent accidental mutation after construction.

- Add private constructor and static MemoKey::create() factory method with sanity checks (firstTable not null, tables contains firstTable)
- Make all MemoKey members const
- Add PlanObjectSet::single() and PlanObjectSet::fromObjects() factory methods for cleaner set construction
- Update all MemoKey creation sites to use the new factory method

Differential Revision: D91388838


