### PR TITLE
refactor: Add Memo wrapper class for memoization cache

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2285,9 +2285,8 @@ PlanP Optimization::makeDtPlan(
     const Distribution& distribution,
     float existsFanout,
     bool& needsShuffle) {
-  auto it = memo_.find(key);
-  PlanSet* plans{};
-  if (it == memo_.end()) {
+  PlanSet* plans = memo_.find(key);
+  if (plans == nullptr) {
     // Allocate temp DT in the arena. The DT may get flattened and then
     // PrecomputeProjection may create columns that reference that DT. Hence,
     // the DT's lifetime must extend to the lifetime of the optimization.
@@ -2303,10 +2302,8 @@ PlanP Optimization::makeDtPlan(
     }
 
     makeJoins(inner);
-    memo_[key] = std::move(inner.plans);
-    plans = &memo_[key];
-  } else {
-    plans = &it->second;
+    memo_.insert(key, std::move(inner.plans));
+    plans = memo_.find(key);
   }
   return plans->best(distribution, needsShuffle);
 }

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -334,7 +334,7 @@ class Optimization {
   // Top DerivedTable when making a QueryGraph from PlanNode.
   DerivedTableP root_;
 
-  folly::F14FastMap<MemoKey, PlanSet> memo_;
+  Memo memo_;
 
   // Set of previously planned dts for importing probe side reducing joins to a
   // build side

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -577,6 +577,14 @@ bool MemoKey::operator==(const MemoKey& other) const {
   return false;
 }
 
+std::string MemoKey::toString() const {
+  return fmt::format(
+      "MemoKey({}, columns: {}, tables: {})",
+      cname(firstTable),
+      columns.toString(true),
+      tables.toString(true));
+}
+
 velox::core::JoinType reverseJoinType(velox::core::JoinType joinType) {
   switch (joinType) {
     case velox::core::JoinType::kLeft:


### PR DESCRIPTION
Summary:
Wrap the memo_ map in Optimization with a Memo class to provide controlled access for adding entries and looking them up.

Also add MemoKey::toString().

Differential Revision: D91389521


