### PR TITLE
feat(parse): Make specific PrestoParseError for parsing errors

### DIFF
--- a/axiom/sql/presto/PrestoParseError.h
+++ b/axiom/sql/presto/PrestoParseError.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace axiom::sql::presto {
+
+/// Exception thrown when parsing a Presto SQL query fails.
+/// The message contains the detailed error message from the parser.
+class PrestoParseError : public std::exception {
+ public:
+  /* implicit */ PrestoParseError(std::string_view message)
+      : message_(message) {}
+
+  std::string_view message() const noexcept {
+    return message_;
+  }
+
+  const char* what() const noexcept override {
+    return message_.data();
+  }
+
+ private:
+  std::string message_;
+};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/PrestoParseError.h"
 #include "axiom/sql/presto/ast/AstBuilder.h"
 #include "axiom/sql/presto/ast/AstPrinter.h"
 #include "axiom/sql/presto/ast/UpperCaseInputStream.h"
@@ -75,7 +76,7 @@ class ParserHelper {
     auto ctx = parser_->singleStatement();
 
     if (parser_->getNumberOfSyntaxErrors() > 0) {
-      throw std::runtime_error(errorListener_.firstError);
+      throw PrestoParseError(errorListener_.firstError);
     }
 
     return ctx->statement();

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -21,6 +21,7 @@
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "axiom/logical_plan/ExprPrinter.h"
 #include "axiom/logical_plan/PlanPrinter.h"
+#include "axiom/sql/presto/PrestoParseError.h"
 #include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/tpch/TpchConnector.h"
@@ -406,7 +407,7 @@ TEST_F(PrestoParserTest, syntaxErrors) {
   auto parser = makeParser();
   EXPECT_THAT(
       [&]() { parser.parse("SELECT * FROM"); },
-      ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
           "Syntax error at 1:13: mismatched input '<EOF>'")));
 
   EXPECT_THAT(
@@ -415,12 +416,12 @@ TEST_F(PrestoParserTest, syntaxErrors) {
             "SELECT * FROM nation\n"
             "WHERE");
       },
-      ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
           "Syntax error at 2:5: mismatched input '<EOF>'")));
 
   EXPECT_THAT(
       [&]() { parser.parse("SELECT * FROM (VALUES 1, 2, 3)) blah..."); },
-      ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
           "Syntax error at 1:30: mismatched input ')' expecting <EOF>")));
 }
 


### PR DESCRIPTION
Summary:
Currently a parse error is thrown as std::runtime_error. This is
not very specific, making identification and reporting to users difficult
if it is deep in the stack.

This makes a specific PrestoParseError that's raised by the parser. It
wraps the same message as in the std::runtime_error. Future changes could
make it more structured if that's useful.

Two altenratives/extensions:
1. Should it be named PrestoSqlError?
2. Should there be an axiom::sql::ParseError that either is a superclass of
axiom::sql::presto::PrestoParseError or used instead of PrestoParseError?
Perhaps with an errorKind or other distinguisher?

Differential Revision: D91421653


