### PR TITLE
feat(cli): Extract Connectors class to be public interface

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -16,110 +16,8 @@
 
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
+#include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
-#include "axiom/connectors/hive/HiveMetadataConfig.h"
-#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
-#include "axiom/connectors/tpch/TpchConnectorMetadata.h"
-#include "velox/connectors/Connector.h"
-#include "velox/connectors/hive/HiveConnector.h"
-#include "velox/dwio/dwrf/RegisterDwrfReader.h"
-#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/dwio/parquet/RegisterParquetWriter.h"
-#include "velox/dwio/text/RegisterTextReader.h"
-#include "velox/dwio/text/RegisterTextWriter.h"
-
-namespace facebook::axiom {
-namespace {
-
-class Connectors {
- public:
-  Connectors(const std::string& dataPath, const std::string& dataFormat)
-      : dataPath_{dataPath}, dataFormat_{dataFormat} {}
-
-  std::string initialize(optimizer::VeloxHistory& history) {
-    velox::dwio::common::registerFileSinks();
-    velox::parquet::registerParquetReaderFactory();
-    velox::parquet::registerParquetWriterFactory();
-    velox::dwrf::registerDwrfReaderFactory();
-    velox::dwrf::registerDwrfWriterFactory();
-    velox::text::registerTextReaderFactory();
-    velox::text::registerTextWriterFactory();
-
-    std::shared_ptr<velox::connector::Connector> connector;
-
-    // Register the Hive connector.
-    if (!dataPath_.empty()) {
-      ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(8);
-      connector = registerHiveConnector(
-          dataPath_, dataFormat_, ioExecutor_.get(), history);
-    }
-
-    // Register the TPC-H connector.
-    {
-      auto tpchConnector = registerTpchConnector();
-      if (connector == nullptr) {
-        connector = tpchConnector;
-      }
-    }
-
-    return connector->connectorId();
-  }
-
- private:
-  std::shared_ptr<velox::connector::Connector> registerTpchConnector() {
-    auto emptyConfig = std::make_shared<velox::config::ConfigBase>(
-        std::unordered_map<std::string, std::string>{});
-
-    velox::connector::tpch::TpchConnectorFactory factory;
-    auto connector = factory.newConnector("tpch", emptyConfig);
-    velox::connector::registerConnector(connector);
-
-    connector::ConnectorMetadata::registerMetadata(
-        connector->connectorId(),
-        std::make_shared<connector::tpch::TpchConnectorMetadata>(
-            dynamic_cast<velox::connector::tpch::TpchConnector*>(
-                connector.get())));
-
-    return connector;
-  }
-
-  std::shared_ptr<velox::connector::Connector> registerHiveConnector(
-      const std::string& dataPath,
-      const std::string& dataFormat,
-      folly::IOThreadPoolExecutor* ioExecutor,
-      optimizer::VeloxHistory& history) {
-    std::unordered_map<std::string, std::string> connectorConfig = {
-        {connector::hive::HiveMetadataConfig::kLocalDataPath, dataPath},
-        {connector::hive::HiveMetadataConfig::kLocalFileFormat, dataFormat},
-    };
-
-    auto config =
-        std::make_shared<velox::config::ConfigBase>(std::move(connectorConfig));
-
-    velox::connector::hive::HiveConnectorFactory factory;
-    auto connector = factory.newConnector("hive", config, ioExecutor);
-    velox::connector::registerConnector(connector);
-
-    connector::ConnectorMetadata::registerMetadata(
-        connector->connectorId(),
-        std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
-            dynamic_cast<velox::connector::hive::HiveConnector*>(
-                connector.get())));
-
-    if (!dataPath.empty()) {
-      history.updateFromFile(dataPath + "/.history");
-    }
-
-    return connector;
-  }
-
-  const std::string dataPath_;
-  const std::string dataFormat_;
-  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
-};
-} // namespace
-} // namespace facebook::axiom
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv, false);
@@ -127,11 +25,15 @@ int main(int argc, char** argv) {
   facebook::velox::memory::MemoryManager::initialize(
       facebook::velox::memory::MemoryManager::Options{});
 
-  facebook::axiom::Connectors connectors{FLAGS_data_path, FLAGS_data_format};
-
+  facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;
-  runner.initialize([&](auto& history) {
-    return std::make_pair(connectors.initialize(history), std::nullopt);
+  runner.initialize([&](auto& /* history */) {
+    auto defaultConnector = connectors.registerTpchConnector();
+    if (!FLAGS_data_path.empty()) {
+      defaultConnector = connectors.registerLocalHiveConnector(
+          FLAGS_data_path, FLAGS_data_format);
+    }
+    return std::make_pair(defaultConnector->connectorId(), std::nullopt);
   });
 
   axiom::sql::Console console{runner};

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_sql
   AxiomSql.cpp
+  Connectors.cpp
   Console.cpp
   SqlQueryRunner.cpp
   ResultPrinter.cpp

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/Connectors.h"
+
+#include <folly/system/HardwareConcurrency.h>
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/tpch/TpchConnectorMetadata.h"
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/dwio/text/RegisterTextReader.h"
+#include "velox/dwio/text/RegisterTextWriter.h"
+
+namespace facebook::axiom {
+
+namespace {
+
+void initializeFileFormats() {
+  velox::dwio::common::registerFileSinks();
+  velox::parquet::registerParquetReaderFactory();
+  velox::parquet::registerParquetWriterFactory();
+  velox::dwrf::registerDwrfReaderFactory();
+  velox::dwrf::registerDwrfWriterFactory();
+  velox::text::registerTextReaderFactory();
+  velox::text::registerTextWriterFactory();
+}
+
+} // namespace
+
+Connectors::Connectors() {
+  initialize();
+}
+
+Connectors::~Connectors() {
+  for (const auto& connectorId : connectorIds_) {
+    velox::connector::unregisterConnector(connectorId);
+  }
+}
+
+void Connectors::initialize() {
+  static folly::once_flag kInitialized;
+  folly::call_once(kInitialized, [this]() {
+    initializeFileFormats();
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
+        std::thread::hardware_concurrency(),
+        std::make_shared<folly::NamedThreadFactory>("io"));
+  });
+}
+
+std::shared_ptr<velox::connector::Connector> Connectors::registerTpchConnector(
+    const std::string& connectorId) {
+  auto emptyConfig = std::make_shared<velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+
+  velox::connector::tpch::TpchConnectorFactory factory;
+  auto connector = factory.newConnector(connectorId, emptyConfig);
+  connectorIds_.push_back(connector->connectorId());
+  velox::connector::registerConnector(connector);
+
+  auto tpchConnector =
+      dynamic_cast<velox::connector::tpch::TpchConnector*>(connector.get());
+  VELOX_CHECK_NOT_NULL(tpchConnector);
+  connector::ConnectorMetadata::registerMetadata(
+      connector->connectorId(),
+      std::make_shared<connector::tpch::TpchConnectorMetadata>(tpchConnector));
+
+  return connector;
+}
+
+std::shared_ptr<velox::connector::Connector>
+Connectors::registerLocalHiveConnector(
+    const std::string& dataPath,
+    const std::string& dataFormat,
+    const std::string& connectorId) {
+  std::unordered_map<std::string, std::string> connectorConfig = {
+      {connector::hive::HiveMetadataConfig::kLocalDataPath, dataPath},
+      {connector::hive::HiveMetadataConfig::kLocalFileFormat, dataFormat},
+  };
+
+  auto config =
+      std::make_shared<velox::config::ConfigBase>(std::move(connectorConfig));
+
+  velox::connector::hive::HiveConnectorFactory factory;
+  auto connector = factory.newConnector(connectorId, config, ioExecutor());
+  connectorIds_.push_back(connector->connectorId());
+  velox::connector::registerConnector(connector);
+
+  auto hiveConnector =
+      dynamic_cast<velox::connector::hive::HiveConnector*>(connector.get());
+  VELOX_CHECK_NOT_NULL(hiveConnector);
+  connector::ConnectorMetadata::registerMetadata(
+      connector->connectorId(),
+      std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
+          hiveConnector));
+
+  return connector;
+}
+
+} // namespace facebook::axiom

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "folly/executors/IOThreadPoolExecutor.h"
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom {
+
+/**
+ * Helper class to register connectors for Axiom and Velox.
+ *
+ * This class handles the details of registering TPCH connectors
+ * and connectors for tables stored in the local filesystem in
+ * Parquet or ORC format.
+ */
+class Connectors {
+ public:
+  static constexpr const char* kTpchConnectorId = "tpch";
+  static constexpr const char* kLocalHiveConnectorId = "hive";
+
+  Connectors();
+
+  Connectors(const Connectors&) = delete;
+  Connectors& operator=(const Connectors&) = delete;
+  Connectors(Connectors&&) = default;
+  Connectors& operator=(Connectors&&) = default;
+
+  /// Unregister all connectors with ids in `connectorIds_`.
+  virtual ~Connectors();
+
+  /// Registers the TPCH connector under the connector ID "tpch".
+  /// This allows queries like "select * from tpch.sf1.lineitem".
+  std::shared_ptr<velox::connector::Connector> registerTpchConnector(
+      const std::string& connectorId = kTpchConnectorId);
+
+  /// Registers the connector for tables stored in the local filesystem under
+  /// `dataPath`. Table "foo" will be stored as files in format `dataFormat` in
+  /// the directory `${dataPath}/foo`. Allowed formats are "parquet", "dwrf",
+  /// and "text". "text" is a simple text format with one row per line, with
+  /// 0x01 as a column separator.
+  ///
+  /// The connector is registered under `connectorId`, so queries can access
+  /// local tables like "INSERT INTO ${connectorId}.write_table SELECT * FROM
+  /// ${connectorId}.read_table".
+  std::shared_ptr<velox::connector::Connector> registerLocalHiveConnector(
+      const std::string& dataPath,
+      const std::string& dataFormat,
+      const std::string& connectorId = kLocalHiveConnectorId);
+
+ protected:
+  /// Initialize file formats and ioExecutor. Must be called before
+  /// registering any connectors.
+  void initialize();
+
+  /// Returns ioExecutor_ if initialized, otherwise nullptr.
+  folly::Executor* ioExecutor() {
+    return ioExecutor_.get();
+  }
+
+  // Unregister these on destruction.
+  std::vector<std::string> connectorIds_{};
+
+ private:
+  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+};
+
+} // namespace facebook::axiom


### PR DESCRIPTION
Summary:
The Connectors classes have useful logic to initialize
connectors. To use SqlQueryRunner as a library, it will be helpful
for users to have this class to instantiate their own SqlQueryRunner.

The history code when registering a connector is not fully functional so we
remove it in this diff.

Differential Revision: D91146323


