### PR TITLE
feat(cli): Create SqlQueryRunner helpers on the fly

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
 
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;
-  runner.initialize([&](auto& /* history */) {
+  runner.initialize([&]() {
     auto defaultConnector = connectors.registerTpchConnector();
     if (!FLAGS_data_path.empty()) {
       defaultConnector = connectors.registerLocalHiveConnector(

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -209,16 +209,6 @@ void Console::readCommands(const std::string& prompt) {
       continue;
     }
 
-    if (command.starts_with("savehistory")) {
-      runner_.saveHistory(FLAGS_data_path + "/.history");
-      continue;
-    }
-
-    if (command.starts_with("clearhistory")) {
-      runner_.clearHistory();
-      continue;
-    }
-
     runNoThrow(command);
   }
 }

--- a/axiom/cli/QueryGraphviz.cpp
+++ b/axiom/cli/QueryGraphviz.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
 
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;
-  runner.initialize([&](auto& /*history*/) {
+  runner.initialize([&]() {
     auto defaultConnector = connectors.registerTpchConnector();
     if (!FLAGS_data_path.empty()) {
       defaultConnector = connectors.registerLocalHiveConnector(

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -40,7 +40,7 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   std::unique_ptr<SqlQueryRunner> makeRunner() {
     auto runner = std::make_unique<SqlQueryRunner>();
 
-    runner->initialize([&](auto&) {
+    runner->initialize([&]() {
       static int32_t kCounter = 0;
 
       auto testConnector =

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -124,6 +124,9 @@ class LocalRunner : public Runner,
   /// Best-effort attempt to cancel the execution.
   void abort() override;
 
+  /// Waits for `maxWaitMicros` microseconds for all tasks to complete.
+  /// If `maxWaitMicros <= 0` this will check if the tasks are completed and
+  /// return false immediately if not.
   /// @pre state() != State::kInitialized
   /// @return true if all tasks completed within the timeout, false otherwise.
   bool waitForCompletion(int32_t maxWaitMicros) override;


### PR DESCRIPTION
Summary:
Remove PrestoParser, SchemaResolver, and VeloxHistory as instance variables and
instead create as needed. This allows us to have each query have its own
default schema (and even connector). Also allow caller to specify query maxWait
in RunOptions

Also change some VELOX_CHECKs to VELOX_USER_CHECKs when the issue is in
user-supplied SQL statements.

Differential Revision: D91166982


