### PR TITLE
fix: Pre-commit error on python14

### DIFF
--- a/scripts/license-header.py
+++ b/scripts/license-header.py
@@ -112,9 +112,13 @@ file_types = OrderedDict(
 )
 
 file_pattern = regex.compile(
-    "|".join(["^" + fnmatch.translate(type) + "$" for type in file_types.keys()])
+    "|".join(
+        [
+            "^" + fnmatch.translate(type).replace(r"\z", r"\Z") + "$"
+            for type in file_types.keys()
+        ]
+    )
 )
-
 
 def get_filename(filename):
     return os.path.basename(filename)


### PR DESCRIPTION
license-header...........................................................Failed
- hook id: license-header
- exit code: 1

Traceback (most recent call last):
  File "/axiom/./scripts/license-header.py", line 114, in <module>
    file_pattern = regex.compile(
        "|".join(["^" + fnmatch.translate(type) + "$" for type in file_types.keys()])
    )

Same fix with https://github.com/facebookincubator/velox/pull/15893