### PR TITLE
perf(optimizer): Avoid redundant project for the unnest

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -100,6 +100,11 @@ class LogicalPlanNode {
     return inputs_;
   }
 
+  // Returns true if this node has exactly one input; false otherwise.
+  bool hasOnlyInput() const {
+    return inputs_.size() == 1;
+  }
+
   /// Returns the only input. Throws if there are zero or more than one inputs.
   const LogicalPlanNodePtr& onlyInput() const {
     VELOX_USER_CHECK_EQ(1, inputs_.size());

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -151,6 +151,11 @@ class Column : public Expr {
     return alias_ != nullptr ? alias_ : toString();
   }
 
+  /// Sets an alias for this column. Pass nullptr to clear the alias.
+  void setAlias(Name alias) const {
+    alias_ = alias;
+  }
+
   /// Asserts that 'this' and 'other' are joined on equality. This has a
   /// transitive effect, so if a and b are previously asserted equal and c is
   /// asserted equal to b, a and c are also equal.
@@ -181,7 +186,7 @@ class Column : public Expr {
   PlanObjectCP relation_;
 
   // Optional alias copied from the the logical plan.
-  Name alias_;
+  mutable Name alias_;
 
   // Equivalence class. Lists all columns directly or indirectly asserted equal
   // to 'this'.

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -442,6 +442,12 @@ class ToGraph {
   // Column and subfield info for items that only affect column values.
   PlanSubfields payloadSubfields_;
 
+  /// Parent mappings while traversing the logical plan.
+  folly::F14FastMap<
+      const logical_plan::LogicalPlanNode*,
+      const logical_plan::LogicalPlanNode*>
+      parents_;
+
   /// Expressions corresponding to skyline paths over a subfield decomposable
   /// function.
   folly::F14FastMap<const logical_plan::CallExpr*, SubfieldProjections>

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -91,6 +91,7 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& unnest(
       const std::vector<std::string>& replicateExprs,
       const std::vector<std::string>& unnestExprs,
+      const std::vector<std::string>& aliases,
       const std::optional<std::string>& ordinalityName = std::nullopt);
 
   PlanMatcherBuilder& aggregation();

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -200,10 +200,10 @@ TEST_F(UnnestTest, unnest) {
                 {"x",
                  "array_distinct(a_a_y) as a_y",
                  "array_distinct(a_a_z) as a_z"})
-            .unnest({"x"}, {"a_y", "a_z"})
+            .unnest({"x"}, {"a_y", "a_z"}, {})
             .project(
                 {"x", "array_distinct(a_y) as y", "array_distinct(a_z) as z"})
-            .unnest({"x"}, {"y", "z"})
+            .unnest({"x"}, {"y", "z"}, {})
             .project(expectedNames)
             .build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
@@ -1216,8 +1216,7 @@ TEST_F(UnnestTest, ordinality) {
     auto matcher = core::PlanMatcherBuilder()
                        .values()
                        .project()
-                       .unnest({}, {}, "ordinality")
-                       .project({"e", "e_0", "ordinality"})
+                       .unnest({}, {}, {"a", "b"}, "c")
                        .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -1225,7 +1224,7 @@ TEST_F(UnnestTest, ordinality) {
   }
   {
     auto query =
-        "SELECT a, b FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c)";
+        "SELECT a, b FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c) ";
     SCOPED_TRACE(query);
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
@@ -1233,8 +1232,7 @@ TEST_F(UnnestTest, ordinality) {
     auto matcher = core::PlanMatcherBuilder()
                        .values()
                        .project()
-                       .unnest({}, {}, std::nullopt)
-                       .project({"e", "e_0"})
+                       .unnest({}, {}, {"a", "b"}, std::nullopt)
                        .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -1242,7 +1240,7 @@ TEST_F(UnnestTest, ordinality) {
   }
   {
     auto query =
-        "SELECT 1 FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c)";
+        "SELECT 1 FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c) ";
     SCOPED_TRACE(query);
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
@@ -1250,7 +1248,7 @@ TEST_F(UnnestTest, ordinality) {
     auto matcher = core::PlanMatcherBuilder()
                        .values()
                        .project()
-                       .unnest({}, {}, std::nullopt)
+                       .unnest({}, {}, {}, std::nullopt)
                        .project({"1"})
                        .build();
 


### PR DESCRIPTION
Summary:
Avoid unnecessary project for the unnest by pushing the aliasing to the output name of the unnest node.

For the issue: https://github.com/facebookincubator/axiom/issues/787

Differential Revision: D91549738

Unit Tests

E2E Tests

```
buck run axiom/cli:cli
```
```
QL> EXPlAIN SELECT a, b FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c);
Fragment 0:  numWorkers=1:
-- Unnest[2][dt3.__p6, dt3.__p10] -> a:INTEGER, b:INTEGER
  -- Project[1][expressions: (dt3.__p6:ARRAY<INTEGER>, {1, 2, 3}), (dt3.__p10:ARRAY<INTEGER>, {4, 5})] -> "dt3.__p6":ARRAY<INTEGER>, "dt3.__p10":ARRAY<INTEGER>
    -- Values[0][1 rows in 1 vectors] -> 
       Estimate: 1 rows, 0B peak memory


4.56ms / 4.09ms user / 0ns system (89%)
```


