### PR TITLE
fix: Cross join with a single-row subquery

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -121,8 +121,9 @@ namespace {
 bool isSingleRowDt(PlanObjectCP object) {
   if (object->is(PlanType::kDerivedTableNode)) {
     auto dt = object->as<DerivedTable>();
-    return dt->limit == 1 ||
-        (dt->aggregation && dt->aggregation->groupingKeys().empty());
+    return (
+        dt->aggregation && dt->aggregation->groupingKeys().empty() &&
+        dt->limit != 0 && dt->offset == 0);
   }
   return false;
 }

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -168,6 +168,16 @@ class PlanObjectSet : public BitSet {
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
+  template <typename V>
+  bool containsAny(const V& objects) const {
+    for (const auto& object : objects) {
+      if (contains(object)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Inserts id of 'object'.
   void add(PlanObjectCP object) {
     auto id = object->id();

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1071,7 +1071,6 @@ class AggregationPlan : public PlanObject {
         aggregates_(std::move(aggregates)),
         columns_(std::move(columns)),
         intermediateColumns_(std::move(intermediateColumns)) {
-    VELOX_CHECK(!groupingKeys_.empty() || !aggregates_.empty());
     VELOX_CHECK_EQ(groupingKeys_.size() + aggregates_.size(), columns_.size());
     VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
   }


### PR DESCRIPTION
Summary:
Fix queries like

> SELECT n_name FROM nation, (SELECT count(*) FROM region)

which feature a cross join with a single-row subquery whose output columns are not used.

Differential Revision: D91594738


