### PR TITLE
fix: Fix qualified cross join handling in optimizer

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -141,6 +141,11 @@ PlanObjectSet findSingleRowDts(
     for (auto& key : join->leftKeys()) {
       tablesCopy.except(key->allTables());
     }
+    // An outer cross join can have a left table with no left keys and no
+    // filter.
+    if (join->leftTable()) {
+      tablesCopy.erase(join->leftTable());
+    }
     for (auto& filter : join->filter()) {
       tablesCopy.except(filter->allTables());
     }
@@ -227,6 +232,12 @@ void DerivedTable::linkTablesToJoins() {
       }
       for (auto conjunct : join->filter()) {
         tables.unionSet(conjunct->allTables());
+      }
+      // There can be an edge that has no columns for a qualified cross join.
+      // Add the end points unconditionally.
+      tables.add(join->rightTable());
+      if (join->leftTable()) {
+        tables.add(join->leftTable());
       }
     }
     tables.forEachMutable([&](PlanObjectP table) {

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -465,16 +465,18 @@ const QGString& Join::historyKey() const {
 Join* Join::makeCrossJoin(
     RelationOpPtr input,
     RelationOpPtr right,
+    velox::core::JoinType joinType,
+    ExprVector filter,
     ColumnVector columns) {
   float fanout = right->resultCardinality();
   return make<Join>(
       JoinMethod::kCross,
-      velox::core::JoinType::kInner,
+      joinType,
       std::move(input),
       std::move(right),
       ExprVector{},
       ExprVector{},
-      ExprVector{},
+      std::move(filter),
       fanout,
       std::move(columns));
 }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -489,8 +489,12 @@ struct Join : public RelationOp {
       float fanout,
       ColumnVector columns);
 
-  static Join*
-  makeCrossJoin(RelationOpPtr input, RelationOpPtr right, ColumnVector columns);
+  static Join* makeCrossJoin(
+      RelationOpPtr input,
+      RelationOpPtr right,
+      velox::core::JoinType joinType,
+      ExprVector filter,
+      ColumnVector columns);
 
   const JoinMethod method;
   const velox::core::JoinType joinType;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1630,8 +1630,6 @@ void ToGraph::translateJoin(
     extractNonInnerJoinEqualities(
         equality_, conjuncts, rightTable, leftKeys, rightKeys, leftTables);
 
-    VELOX_CHECK(!leftTables.empty(), "Outer cross joins are not supported yet");
-
     JoinEdge::Spec joinSpec{
         .filter = std::move(conjuncts),
         .leftOptional = leftOptional,
@@ -1644,6 +1642,14 @@ void ToGraph::translateJoin(
 
     if (rightOptional) {
       addJoinColumns(*right, joinSpec.rightColumns, joinSpec.rightExprs);
+    }
+
+    if (leftTables.empty()) {
+      VELOX_CHECK_EQ(
+          2,
+          currentDt_->tables.size(),
+          "The left of a non-inner join is expected to be one table");
+      leftTables.add(currentDt_->tables[0]);
     }
 
     auto* edge = make<JoinEdge>(

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -466,23 +466,42 @@ TEST_F(JoinTest, leftCrossJoin) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
 
-  // TODO Make these queries work.
   {
     auto logicalPlan = parseSelect(
         "SELECT * FROM t LEFT JOIN (SELECT count(*) FROM u) ON 1 = 1",
         kTestConnectorId);
-    VELOX_ASSERT_THROW(
-        toSingleNodePlan(logicalPlan),
-        "Outer cross joins are not supported yet");
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan("t")
+            .nestedLoopJoin(
+                core::PlanMatcherBuilder().tableScan("u").aggregation().build(),
+                core::JoinType::kLeft)
+            // TODO Remove redundant projection.
+            .project()
+            .build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   {
     auto logicalPlan = parseSelect(
         "SELECT * FROM (SELECT count(*) FROM t) LEFT JOIN (SELECT count(*) FROM u) ON 1 = 1",
         kTestConnectorId);
-    VELOX_ASSERT_THROW(
-        toSingleNodePlan(logicalPlan),
-        "Outer cross joins are not supported yet");
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan("t")
+            .aggregation()
+            .nestedLoopJoin(
+                core::PlanMatcherBuilder().tableScan("u").aggregation().build(),
+                core::JoinType::kLeft)
+            .project()
+            .build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -121,7 +121,8 @@ class PlanMatcherBuilder {
       JoinType joinType);
 
   PlanMatcherBuilder& nestedLoopJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher);
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      JoinType joinType = JoinType::kInner);
 
   PlanMatcherBuilder& localPartition();
 


### PR DESCRIPTION
Summary:
This diff fixes the handling of qualified cross joins in the
Axiom optimizer.  A qualified cross join is a cross join with a
condition that always evaluates to true (e.g., `1=1` or an expression
that effectively reduces to a tautology). Non-equality joins are
treated as cross joins until we add conectors that support index base
range lookup.

The key changes ensure that join edges properly track their endpoint
tables even when there are no column references in the join
condition. This enables queries with outer cross joins.

Note: Explicit right outer cross joins will be supported when normalizing right joins to left joins.

Differential Revision: D91637123
