### PR TITLE
feat: Handle LIMIT 0 in ToGraph (#16146)

### DIFF
--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -317,6 +317,15 @@ class ToGraph {
 
   void makeValuesTable(const logical_plan::ValuesNode& values);
 
+  // Creates a ValuesTable with the output schema of 'node' using 'data'.
+  // The 'node' does not need to be a ValuesNode - used when replacing a
+  // subtree with a ValuesTable, e.g. for empty result optimizations.
+  ValuesTable* makeValuesTable(
+      const logical_plan::LogicalPlanNode& node,
+      ValuesTable::Data data);
+
+  void makeEmptyValuesTable(const logical_plan::LogicalPlanNode& node);
+
   // Adds 'node' and descendants to query graph wrapped inside a
   // DerivedTable. Done for joins to the right of non-inner joins,
   // group bys as non-top operators, whenever descendents of 'node'

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1390,6 +1390,13 @@ velox::core::PlanNodePtr ToVelox::makeValues(
     }
   }
 
+  if (newValues.empty()) {
+    auto* pool = queryCtx()->optimization()->evaluator()->pool();
+    newValues.emplace_back(
+        std::dynamic_pointer_cast<velox::RowVector>(
+            velox::BaseVector::create(newType, 0, pool)));
+  }
+
   auto valuesNode =
       std::make_shared<velox::core::ValuesNode>(nextId(), std::move(newValues));
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -247,5 +247,9 @@ inline auto gt(const std::string& name, const std::string& value) {
 
 } // namespace facebook::axiom::optimizer::test
 
-#define AXIOM_ASSERT_PLAN(plan, matcher) \
-  ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+#define AXIOM_ASSERT_PLAN(plan, matcher)        \
+  {                                             \
+    auto _axiom_plan_ = (plan);                 \
+    ASSERT_TRUE((matcher)->match(_axiom_plan_)) \
+        << _axiom_plan_->toString(true, true);  \
+  }


### PR DESCRIPTION
Summary: 
This change handles LIMIT 0 by skipping the input subtree and replacing it with an empty `ValuesTable`. This optimization avoids building unnecessary plan nodes when the result is known to be zero rows.

Changes:
- Early LIMIT 0 detection in ToGraph: When LimitNode::count() == 0, we skip building the input subtree entirely and create an empty ValuesTable with the proper output schema.

- Schema preservation in `ToVelox`: When converting an empty `ValuesTable` to Velox, we create a RowVector with 0 rows but proper type schema. This ensures column names and types are preserved (matching SQL behavior where SELECT * FROM t LIMIT 0 returns column metadata with 0 rows).

- Also added an update to AXIOM_ASSERT_PLAN to fix issue of double evaluation.

Differential Revision: D91646381


