### PR TITLE
feat(parser): Add support for CREATE TABLE

### DIFF
--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -114,6 +114,25 @@ class Expr : public velox::ISerializable {
     return kind_ == ExprKind::kSubquery;
   }
 
+  /// Returns true if the expression appears constant such that it can be
+  /// evaluated without any runtime dependencies. Literals and some calls
+  /// with constant inputs are constant foldable while input references,
+  /// subqueries, and window functions are not.
+  bool looksConstant() const {
+    if (isConstant()) {
+      return true;
+    }
+    if (isInputReference()) {
+      return false;
+    }
+    for (const auto& input : inputs_) {
+      if (!input->looksConstant()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// Caller must ensure this kind is correct.
   template <typename T>
   const T* as() const {

--- a/axiom/logical_plan/tests/CMakeLists.txt
+++ b/axiom/logical_plan/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_logical_plan_tests
   ExprSerdeTest.cpp
+  ExprTest.cpp
   NameAllocatorTest.cpp
   NameMappingsTest.cpp
   ExprApiTest.cpp

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/Expr.h"
+#include <gtest/gtest.h>
+#include "velox/type/Type.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::logical_plan {
+namespace {
+
+class ExprTest : public testing::Test {
+ protected:
+  static ExprPtr literal(int64_t val, TypePtr type = BIGINT()) {
+    return std::make_shared<ConstantExpr>(
+        std::move(type), std::make_shared<Variant>(Variant(val)));
+  }
+
+  static ExprPtr inputRef(std::string name, TypePtr type = BIGINT()) {
+    return std::make_shared<InputReferenceExpr>(
+        std::move(type), std::move(name));
+  }
+
+  static ExprPtr
+  call(std::string name, std::vector<ExprPtr> inputs, TypePtr type = BIGINT()) {
+    return std::make_shared<CallExpr>(
+        std::move(type), std::move(name), std::move(inputs));
+  }
+
+  static ExprPtr cast(TypePtr type, ExprPtr input) {
+    return std::make_shared<SpecialFormExpr>(
+        std::move(type), SpecialForm::kCast, std::vector<ExprPtr>{input});
+  }
+
+  static void testLooksConstant(const ExprPtr& expr, bool expected) {
+    EXPECT_EQ(expr->looksConstant(), expected);
+  }
+};
+
+TEST_F(ExprTest, looksConstant) {
+  testLooksConstant(literal(1), true);
+  testLooksConstant(inputRef("a"), false);
+
+  testLooksConstant(call("plus", {literal(1), literal(2)}), true);
+  testLooksConstant(call("plus", {inputRef("a"), literal(1)}), false);
+
+  testLooksConstant(cast(DOUBLE(), literal(1)), true);
+  testLooksConstant(cast(DOUBLE(), inputRef("a")), false);
+}
+
+} // namespace
+} // namespace facebook::axiom::logical_plan

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -389,26 +389,12 @@ void ToGraph::translateConjuncts(const lp::ExprPtr& input, ExprVector& flat) {
   }
 }
 
-namespace {
-
-bool looksConstant(const lp::ExprPtr& expr) {
-  if (expr->isConstant()) {
-    return true;
-  }
-  if (expr->isInputReference()) {
-    return false;
-  }
-  return std::ranges::all_of(expr->inputs(), looksConstant);
-}
-
-} // namespace
-
 lp::ConstantExprPtr ToGraph::tryFoldConstant(const lp::ExprPtr& expr) {
   if (expr->isConstant()) {
     return std::static_pointer_cast<const lp::ConstantExpr>(expr);
   }
 
-  if (looksConstant(expr)) {
+  if (expr->looksConstant()) {
     auto literal = translateExpr(expr);
     if (literal->is(PlanType::kLiteralExpr)) {
       return std::make_shared<lp::ConstantExpr>(

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
   axiom_logical_plan_builder
   axiom_sql_presto_ast
   antlr4_shared
+  velox_type_parser
 )
 
 add_subdirectory(tests)


### PR DESCRIPTION
Summary:
Adding support for pure CREATE TABLE statements

Originally I asserted that CREATE TABLE components are a superset of CTAS: this is not true, there are two pieces which are not present in CTAS:

1. `LIKE` clauses, which pull from an existing table schema to define a table schema
2. constraints, which place extra conditions or add characteristics to columns

A new type was defined for constraint, but the logic for `LIKE` table lookup is identical to a table scan, so an existing utility can be used.

Common functionality was factored out between CREATE TABLE and CTAS where appropriate, but besides that, the bulk of this change was handling LIKE and constraint clauses

Differential Revision: D91715648


