### PR TITLE
refactor: Introduce DesiredDistribution

### DIFF
--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -196,7 +196,7 @@ class Optimization {
   PlanP makePlan(
       const DerivedTable& dt,
       const MemoKey& key,
-      const Distribution& distribution,
+      const std::optional<DesiredDistribution>& distribution,
       const PlanObjectSet& boundColumns,
       float existsFanout,
       bool& needsShuffle);
@@ -204,7 +204,7 @@ class Optimization {
   PlanP makeUnionPlan(
       const DerivedTable& dt,
       const MemoKey& key,
-      const Distribution& distribution,
+      const std::optional<DesiredDistribution>& distribution,
       const PlanObjectSet& boundColumns,
       float existsFanout,
       bool& needsShuffle);
@@ -212,7 +212,7 @@ class Optimization {
   PlanP makeDtPlan(
       const DerivedTable& dt,
       const MemoKey& key,
-      const Distribution& distribution,
+      const std::optional<DesiredDistribution>& distribution,
       float existsFanout,
       bool& needsShuffle);
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -81,12 +81,14 @@ struct PlanSet {
 
   /// Returns the best plan that produces 'distribution'. If the best plan has
   /// some other distribution, sets 'needsShuffle ' to true.
-  PlanP best(const Distribution& distribution, bool& needsShuffle);
+  PlanP best(
+      const std::optional<DesiredDistribution>& distribution,
+      bool& needsShuffle);
 
   /// Returns the best plan when we're ok with any distribution.
   PlanP best() {
     bool ignore = false;
-    return best(Distribution(/*broadcast=*/false), ignore);
+    return best(std::nullopt, ignore);
   }
 
   /// Compares 'plan' to already seen plans and retains it if it is

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -177,13 +177,13 @@ Distribution TableScan::outputDistribution(
 
   const auto& distribution = index->distribution;
 
-  ExprVector partition;
+  ExprVector partitionKeys;
   ExprVector orderKeys;
   OrderTypeVector orderTypes;
   // if all partitioning columns are projected, the output is partitioned.
-  if (isSubset(distribution.partition(), schemaColumns)) {
-    partition = distribution.partition();
-    replace(partition, schemaColumns, columns.data());
+  if (isSubset(distribution.partitionKeys(), schemaColumns)) {
+    partitionKeys = distribution.partitionKeys();
+    replace(partitionKeys, schemaColumns, columns.data());
   }
 
   auto numPrefix = prefixSize(distribution.orderKeys(), schemaColumns);
@@ -196,7 +196,7 @@ Distribution TableScan::outputDistribution(
   }
   return Distribution(
       distribution.distributionType(),
-      std::move(partition),
+      std::move(partitionKeys),
       std::move(orderKeys),
       std::move(orderTypes),
       distribution.numKeysUnique() <= numPrefix ? distribution.numKeysUnique()

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -70,7 +70,7 @@ class ToTextVisitor : public RelationOpVisitor {
             : op.distribution().isGather()
             ? "(gather)"
             : fmt::format(
-                  "({})", exprsToString(op.distribution().partition())));
+                  "({})", exprsToString(op.distribution().partitionKeys())));
 
     printInput(*op.input(), myCtx);
   }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1258,7 +1258,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
 
   const auto& distribution = repartition.distribution();
 
-  const auto keys = toTypedExprs(distribution.partition());
+  const auto keys = toTypedExprs(distribution.partitionKeys());
 
   if (distribution.isBroadcast()) {
     VELOX_CHECK_EQ(0, keys.size());


### PR DESCRIPTION
Summary:
De-flake Optimization::makePlan by introducing a dedicated struct to represent the desired distribution.

The DesiredDistribution struct specifies:
 - The desired partitioning keys
 - The partitioning function

DesiredDistribution does not support gather or broadcast distributions. If a broadcast distribution is required, it must be applied explicitly.

Differential Revision: D91708782


