### PR TITLE
feat(parser): Add GROUPING SETS, ROLLUP, and CUBE support

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -15,6 +15,7 @@
  */
 #include "axiom/logical_plan/PlanBuilder.h"
 #include <velox/common/base/Exceptions.h>
+#include <numeric>
 #include <vector>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/logical_plan/NameMappings.h"
@@ -487,10 +488,10 @@ PlanBuilder& PlanBuilder::with(const std::vector<ExprApi>& projections) {
   return *this;
 }
 
-PlanBuilder& PlanBuilder::aggregate(
-    const std::vector<std::string>& groupingKeys,
+namespace {
+std::vector<PlanBuilder::AggregateOptions> parseAggregateOptions(
     const std::vector<std::string>& aggregates) {
-  std::vector<AggregateOptions> options;
+  std::vector<PlanBuilder::AggregateOptions> options;
   options.reserve(aggregates.size());
   for (const auto& sql : aggregates) {
     auto aggregateExpr = velox::duckdb::parseAggregateExpr(sql, {});
@@ -508,8 +509,17 @@ PlanBuilder& PlanBuilder::aggregate(
         std::move(sortingKeys),
         aggregateExpr.distinct);
   }
+  return options;
+}
+} // namespace
 
-  return aggregate(parse(groupingKeys), parse(aggregates), options);
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates) {
+  return aggregate(
+      parse(groupingKeys),
+      parse(aggregates),
+      parseAggregateOptions(aggregates));
 }
 
 PlanBuilder& PlanBuilder::aggregate(
@@ -531,38 +541,7 @@ PlanBuilder& PlanBuilder::aggregate(
   std::vector<AggregateExprPtr> exprs;
   exprs.reserve(aggregates.size());
 
-  VELOX_USER_CHECK(options.size() == aggregates.size());
-  for (size_t i = 0; i < aggregates.size(); ++i) {
-    const auto& aggregate = aggregates[i];
-
-    ExprPtr filter;
-    if (options[i].filter != nullptr) {
-      filter = resolveScalarTypes(options[i].filter);
-    }
-
-    std::vector<SortingField> sortingFields;
-    sortingFields.reserve(options[i].orderBy.size());
-    for (const auto& key : options[i].orderBy) {
-      auto expr = resolveScalarTypes(key.expr.expr());
-
-      sortingFields.push_back(
-          SortingField{expr, SortOrder(key.ascending, key.nullsFirst)});
-    }
-
-    AggregateExprPtr expr;
-    expr = resolveAggregateTypes(
-        aggregate.expr(), filter, sortingFields, options[i].distinct);
-
-    if (aggregate.name().has_value()) {
-      const auto& alias = aggregate.name().value();
-      outputNames.push_back(newName(alias));
-      newOutputMapping->add(alias, outputNames.back());
-    } else {
-      outputNames.push_back(newName(expr->name()));
-    }
-
-    exprs.emplace_back(std::move(expr));
-  }
+  resolveAggregates(aggregates, options, outputNames, exprs, *newOutputMapping);
 
   node_ = std::make_shared<AggregateNode>(
       nextId(),
@@ -576,6 +555,239 @@ PlanBuilder& PlanBuilder::aggregate(
   outputMapping_ = std::move(newOutputMapping);
 
   return *this;
+}
+
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<std::vector<ExprApi>>& groupingSets,
+    const std::vector<ExprApi>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    const std::string& groupingSetIndexName) {
+  // Extract unique grouping keys from all sets and build index mapping.
+  std::vector<ExprApi> groupingKeys;
+  velox::core::ExprMap<int32_t> exprToIndex;
+
+  auto getOrAddKey = [&](const ExprApi& expr) -> int32_t {
+    int32_t idx = static_cast<int32_t>(groupingKeys.size());
+    auto [it, inserted] = exprToIndex.try_emplace(expr.expr(), idx);
+    if (inserted) {
+      groupingKeys.push_back(expr);
+    }
+    return it->second;
+  };
+
+  // Build index-based grouping sets.
+  std::vector<std::vector<int32_t>> groupingSetsIndices;
+  groupingSetsIndices.reserve(groupingSets.size());
+  for (const auto& groupingSet : groupingSets) {
+    std::vector<int32_t> indices;
+    indices.reserve(groupingSet.size());
+    for (const auto& expr : groupingSet) {
+      indices.push_back(getOrAddKey(expr));
+    }
+    groupingSetsIndices.push_back(std::move(indices));
+  }
+
+  return aggregate(
+      groupingKeys,
+      groupingSetsIndices,
+      aggregates,
+      options,
+      groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregates,
+    const std::string& groupingSetIndexName) {
+  std::vector<std::vector<ExprApi>> exprGroupingSets;
+  exprGroupingSets.reserve(groupingSets.size());
+  for (const auto& groupingSet : groupingSets) {
+    exprGroupingSets.push_back(parse(groupingSet));
+  }
+  return aggregate(
+      exprGroupingSets,
+      parse(aggregates),
+      parseAggregateOptions(aggregates),
+      groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::vector<int32_t>>& groupingSets,
+    const std::vector<std::string>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    const std::string& groupingSetIndexName) {
+  return aggregate(
+      parse(groupingKeys),
+      groupingSets,
+      parse(aggregates),
+      options,
+      groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::aggregate(
+    const std::vector<ExprApi>& groupingKeys,
+    const std::vector<std::vector<int32_t>>& groupingSets,
+    const std::vector<ExprApi>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    const std::string& groupingSetIndexName) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Aggregate node cannot be a leaf node");
+
+  const auto numKeys = static_cast<int32_t>(groupingKeys.size());
+  for (const auto& groupingSet : groupingSets) {
+    for (const auto index : groupingSet) {
+      VELOX_USER_CHECK_LT(
+          index, numKeys, "Grouping set index {} is out of bounds", index);
+    }
+  }
+
+  velox::core::ExprMap<bool> seen;
+  for (const auto& key : groupingKeys) {
+    VELOX_USER_CHECK(
+        seen.try_emplace(key.expr(), true).second, "Duplicate grouping key");
+  }
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(groupingKeys.size() + aggregates.size() + 1);
+
+  std::vector<ExprPtr> keyExprs;
+  keyExprs.reserve(groupingKeys.size());
+
+  auto newOutputMapping = std::make_shared<NameMappings>();
+
+  resolveProjections(groupingKeys, outputNames, keyExprs, *newOutputMapping);
+
+  std::vector<AggregateExprPtr> exprs;
+  exprs.reserve(aggregates.size());
+
+  resolveAggregates(aggregates, options, outputNames, exprs, *newOutputMapping);
+
+  outputNames.push_back(newName(groupingSetIndexName));
+  newOutputMapping->add(groupingSetIndexName, outputNames.back());
+
+  node_ = std::make_shared<AggregateNode>(
+      nextId(),
+      std::move(node_),
+      std::move(keyExprs),
+      groupingSets,
+      std::move(exprs),
+      std::move(outputNames));
+
+  newOutputMapping->enableUnqualifiedAccess();
+  outputMapping_ = std::move(newOutputMapping);
+
+  return *this;
+}
+
+void PlanBuilder::resolveAggregates(
+    const std::vector<ExprApi>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    std::vector<std::string>& outputNames,
+    std::vector<AggregateExprPtr>& exprs,
+    NameMappings& mappings) {
+  if (!options.empty()) {
+    VELOX_USER_CHECK_EQ(options.size(), aggregates.size());
+  }
+
+  for (size_t i = 0; i < aggregates.size(); ++i) {
+    const auto& aggregate = aggregates[i];
+
+    ExprPtr filter;
+    std::vector<SortingField> sortingFields;
+    bool distinct = false;
+
+    if (!options.empty()) {
+      if (options[i].filter != nullptr) {
+        filter = resolveScalarTypes(options[i].filter);
+      }
+
+      sortingFields.reserve(options[i].orderBy.size());
+      for (const auto& key : options[i].orderBy) {
+        auto expr = resolveScalarTypes(key.expr.expr());
+
+        sortingFields.push_back(
+            SortingField{expr, SortOrder(key.ascending, key.nullsFirst)});
+      }
+
+      distinct = options[i].distinct;
+    }
+
+    AggregateExprPtr expr;
+    expr = resolveAggregateTypes(
+        aggregate.expr(), filter, sortingFields, distinct);
+
+    if (aggregate.name().has_value()) {
+      const auto& alias = aggregate.name().value();
+      outputNames.push_back(newName(alias));
+      mappings.add(alias, outputNames.back());
+    } else {
+      outputNames.push_back(newName(expr->name()));
+    }
+
+    exprs.emplace_back(std::move(expr));
+  }
+}
+
+PlanBuilder& PlanBuilder::rollup(
+    const std::vector<ExprApi>& groupingKeys,
+    const std::vector<ExprApi>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    const std::string& groupingSetIndexName) {
+  // ROLLUP(a, b, c) -> [[0,1,2], [0,1], [0], []]
+  std::vector<std::vector<int32_t>> groupingSets;
+  groupingSets.reserve(groupingKeys.size() + 1);
+
+  for (size_t i = groupingKeys.size(); i > 0; --i) {
+    std::vector<int32_t> indices(i);
+    std::iota(indices.begin(), indices.end(), 0);
+    groupingSets.push_back(std::move(indices));
+  }
+  groupingSets.emplace_back();
+
+  return aggregate(
+      groupingKeys, groupingSets, aggregates, options, groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::rollup(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::string& groupingSetIndexName) {
+  return rollup(
+      parse(groupingKeys), parse(aggregates), {}, groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::cube(
+    const std::vector<ExprApi>& groupingKeys,
+    const std::vector<ExprApi>& aggregates,
+    const std::vector<AggregateOptions>& options,
+    const std::string& groupingSetIndexName) {
+  // CUBE(a, b) -> [[0,1], [0], [1], []]
+  const size_t n = groupingKeys.size();
+
+  const size_t numSets = 1ULL << n;
+  std::vector<std::vector<int32_t>> groupingSets;
+  groupingSets.reserve(numSets);
+
+  for (size_t mask = numSets; mask > 0; --mask) {
+    size_t bits = mask - 1;
+    std::vector<int32_t> indices;
+    for (size_t i = 0; i < n; ++i) {
+      if (bits & (1ULL << (n - 1 - i))) {
+        indices.push_back(static_cast<int32_t>(i));
+      }
+    }
+    groupingSets.push_back(std::move(indices));
+  }
+
+  return aggregate(
+      groupingKeys, groupingSets, aggregates, options, groupingSetIndexName);
+}
+
+PlanBuilder& PlanBuilder::cube(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::string& groupingSetIndexName) {
+  return cube(parse(groupingKeys), parse(aggregates), {}, groupingSetIndexName);
 }
 
 PlanBuilder& PlanBuilder::distinct() {

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -89,6 +89,27 @@ class ToTextVisitor : public PlanNodeVisitor {
 
     myContext.out << ")";
 
+    // Print grouping sets if present
+    if (!node.groupingSets().empty()) {
+      myContext.out << " GROUPING SETS [";
+      for (size_t i = 0; i < node.groupingSets().size(); ++i) {
+        if (i > 0) {
+          myContext.out << ", ";
+        }
+        myContext.out << "(";
+        const auto& groupingSet = node.groupingSets()[i];
+        for (size_t j = 0; j < groupingSet.size(); ++j) {
+          if (j > 0) {
+            myContext.out << ", ";
+          }
+          myContext.out << ExprPrinter::toText(
+              *node.groupingKeys().at(groupingSet[j]));
+        }
+        myContext.out << ")";
+      }
+      myContext.out << "]";
+    }
+
     appendOutputType(node, myContext);
 
     myContext.out << std::endl;

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -481,6 +481,149 @@ TEST_F(PlanPrinterTest, distinctSortedMaskedAgg) {
           testing::Eq("")));
 }
 
+TEST_F(PlanPrinterTest, aggregateGroupingSets) {
+  auto rowType = ROW({"a", "b", "c"}, INTEGER());
+  std::vector<Variant> data{
+      Variant::row({1, 10, 100}),
+      Variant::row({2, 20, 200}),
+  };
+
+  auto plan =
+      PlanBuilder()
+          .values(rowType, data)
+          .aggregate(
+              {{"a", "b"}, {"a"}, {}}, {"sum(c) as total"}, "$grouping_set_id")
+          .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith(
+              "- Aggregate(a, b) GROUPING SETS [(a, b), (a), ()]"),
+          testing::StartsWith("    total := sum(c)"),
+          testing::StartsWith("  - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, groupingSetsDistinctAgg) {
+  auto rowType = ROW({"a", "b", "c"}, INTEGER());
+  std::vector<Variant> data{
+      Variant::row({1, 10, 100}),
+      Variant::row({1, 10, 100}),
+      Variant::row({2, 20, 200}),
+  };
+
+  auto plan = PlanBuilder()
+                  .values(rowType, data)
+                  .aggregate(
+                      {{"a", "b"}, {"a"}, {}},
+                      {"sum(distinct c) as distinct_sum"},
+                      "$grouping_set_id")
+                  .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith(
+              "- Aggregate(a, b) GROUPING SETS [(a, b), (a), ()]"),
+          testing::StartsWith("    distinct_sum := sum(DISTINCT c)"),
+          testing::StartsWith("  - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, groupingSetsSortedAgg) {
+  auto rowType = ROW({"a", "b", "c"}, INTEGER());
+  std::vector<Variant> data{
+      Variant::row({1, 10, 100}),
+      Variant::row({1, 20, 200}),
+      Variant::row({2, 30, 300}),
+  };
+
+  auto plan = PlanBuilder()
+                  .values(rowType, data)
+                  .aggregate(
+                      {{"a"}, {}},
+                      {"array_agg(b order by c desc) as ordered_array"},
+                      "$grouping_set_id")
+                  .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("- Aggregate(a) GROUPING SETS [(a), ()]"),
+          testing::StartsWith(
+              "    ordered_array := array_agg(b ORDER BY c DESC"),
+          testing::StartsWith("  - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, groupingSetsMaskedAgg) {
+  auto rowType =
+      ROW({"a", "b", "c", "d"}, {INTEGER(), INTEGER(), INTEGER(), BOOLEAN()});
+  std::vector<Variant> data{
+      Variant::row({1, 10, 100, true}),
+      Variant::row({1, 20, 200, false}),
+      Variant::row({2, 30, 300, true}),
+  };
+
+  auto plan = PlanBuilder()
+                  .values(rowType, data)
+                  .aggregate(
+                      {{"a", "b"}, {"a"}, {}},
+                      {"sum(c) filter (where d) as filtered_sum"},
+                      "$grouping_set_id")
+                  .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith(
+              "- Aggregate(a, b) GROUPING SETS [(a, b), (a), ()]"),
+          testing::StartsWith("    filtered_sum := sum(c) FILTER (WHERE d)"),
+          testing::StartsWith("  - Values"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, groupingSetsDistinctSortedMaskedAgg) {
+  auto rowType =
+      ROW({"a", "b", "c", "d"}, {INTEGER(), INTEGER(), INTEGER(), BOOLEAN()});
+  std::vector<Variant> data{
+      Variant::row({1, 10, 100, true}),
+      Variant::row({1, 10, 200, true}),
+      Variant::row({1, 20, 300, false}),
+      Variant::row({2, 30, 400, true}),
+  };
+
+  auto plan =
+      PlanBuilder()
+          .values(rowType, data)
+          .aggregate(
+              {{"a", "b"}, {"a"}, {}},
+              {"array_agg(distinct b order by c desc) filter (where d) as complex_agg"},
+              "$grouping_set_id")
+          .build();
+
+  auto lines = toLines(plan);
+
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith(
+              "- Aggregate(a, b) GROUPING SETS [(a, b), (a), ()]"),
+          testing::StartsWith(
+              "    complex_agg := array_agg(DISTINCT b ORDER BY c DESC NULLS LAST) FILTER (WHERE d)"),
+          testing::StartsWith("  - Values"),
+          testing::Eq("")));
+}
+
 TEST_F(PlanPrinterTest, unnest) {
   {
     auto plan = PlanBuilder().unnest({"array[1, 2, 3]"}).build();

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1093,24 +1093,38 @@ std::any AstBuilder::visitSingleGroupingSet(
 
 std::any AstBuilder::visitRollup(PrestoSqlParser::RollupContext* ctx) {
   trace("visitRollup");
-  return visitChildren("visitRollup", ctx);
+
+  auto expressions = visitTyped<Expression>(ctx->expression());
+  return std::static_pointer_cast<GroupingElement>(
+      std::make_shared<Rollup>(getLocation(ctx), expressions));
 }
 
 std::any AstBuilder::visitCube(PrestoSqlParser::CubeContext* ctx) {
   trace("visitCube");
-  return visitChildren("visitCube", ctx);
+
+  auto expressions = visitTyped<Expression>(ctx->expression());
+  return std::static_pointer_cast<GroupingElement>(
+      std::make_shared<Cube>(getLocation(ctx), expressions));
 }
 
 std::any AstBuilder::visitMultipleGroupingSets(
     PrestoSqlParser::MultipleGroupingSetsContext* ctx) {
   trace("visitMultipleGroupingSets");
-  return visitChildren("visitMultipleGroupingSets", ctx);
+
+  std::vector<std::vector<ExpressionPtr>> sets;
+  sets.reserve(ctx->groupingSet().size());
+  for (auto* groupingSetCtx : ctx->groupingSet()) {
+    sets.emplace_back(visitTyped<Expression>(groupingSetCtx->expression()));
+  }
+  return std::static_pointer_cast<GroupingElement>(
+      std::make_shared<GroupingSets>(getLocation(ctx), sets));
 }
 
 std::any AstBuilder::visitGroupingSet(
     PrestoSqlParser::GroupingSetContext* ctx) {
   trace("visitGroupingSet");
-  return visitChildren("visitGroupingSet", ctx);
+
+  VELOX_UNREACHABLE("visitGroupingSet should not be called directly");
 }
 
 std::any AstBuilder::visitNamedQuery(PrestoSqlParser::NamedQueryContext* ctx) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -979,6 +979,213 @@ TEST_F(PrestoParserTest, simpleGroupBy) {
   }
 }
 
+TEST_F(PrestoParserTest, groupingSets) {
+  lp::AggregateNodePtr agg;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate(
+      [&](const auto& node) {
+        agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+      });
+
+  testSql(
+      "SELECT n_regionkey, count(1) FROM nation "
+      "GROUP BY GROUPING SETS (n_regionkey, ())",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(0),
+          testing::IsEmpty()));
+
+  // Test ordinals in GROUPING SETS: GROUPING SETS ((1, 2), (1))
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((1, 2), (1))",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1), testing::ElementsAre(0)));
+}
+
+TEST_F(PrestoParserTest, rollup) {
+  lp::AggregateNodePtr agg;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate(
+      [&](const auto& node) {
+        agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+      });
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY ROLLUP(n_regionkey, n_name)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(0),
+          testing::IsEmpty()));
+
+  testSql(
+      "SELECT n_regionkey, count(1) FROM nation "
+      "GROUP BY ROLLUP(n_regionkey)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
+}
+
+TEST_F(PrestoParserTest, cube) {
+  lp::AggregateNodePtr agg;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate(
+      [&](const auto& node) {
+        agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+      });
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY CUBE(n_regionkey, n_name)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(0),
+          testing::ElementsAre(1),
+          testing::IsEmpty()));
+
+  testSql(
+      "SELECT n_regionkey, count(1) FROM nation "
+      "GROUP BY CUBE(n_regionkey)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
+}
+
+TEST_F(PrestoParserTest, mixedGroupByWithRollup) {
+  lp::AggregateNodePtr agg;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate(
+      [&](const auto& node) {
+        agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+      });
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY n_regionkey, ROLLUP(n_name)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1), testing::ElementsAre(0)));
+}
+
+TEST_F(PrestoParserTest, groupingSetsOrdinalCaching) {
+  lp::AggregateNodePtr agg;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate(
+      [&](const auto& node) {
+        agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+      });
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((1), (1, 2), (2))",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0),
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(1)));
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY ROLLUP(1, 2)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(0),
+          testing::IsEmpty()));
+
+  testSql(
+      "SELECT n_regionkey, n_name, count(1) FROM nation "
+      "GROUP BY CUBE(1, 2)",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0, 1),
+          testing::ElementsAre(0),
+          testing::ElementsAre(1),
+          testing::IsEmpty()));
+}
+
+TEST_F(PrestoParserTest, groupingSetsSubqueryOrdinal) {
+  lp::AggregateNodePtr agg;
+  auto matcher =
+      lp::test::LogicalPlanMatcherBuilder()
+          .tableScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .project();
+
+  testSql(
+      "SELECT (SELECT 1), n_name, count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((1), (1, 2))",
+      matcher);
+  ASSERT_TRUE(agg != nullptr);
+  EXPECT_THAT(
+      agg->groupingSets(),
+      testing::ElementsAre(
+          testing::ElementsAre(0), testing::ElementsAre(0, 1)));
+}
+
+TEST_F(PrestoParserTest, cubeColumnLimit) {
+  // CUBE is limited to 30 columns (2^30 grouping sets).
+  // Generate a query with 31 columns to verify the limit is enforced.
+  std::string columns;
+  for (int i = 1; i <= 31; ++i) {
+    if (i > 1) {
+      columns += ", ";
+    }
+    columns += fmt::format("c{}", i);
+  }
+
+  std::string sql = fmt::format(
+      "SELECT {}, count(1) FROM (SELECT 1 as c1, 2 as c2, 3 as c3, 4 as c4, "
+      "5 as c5, 6 as c6, 7 as c7, 8 as c8, 9 as c9, 10 as c10, "
+      "11 as c11, 12 as c12, 13 as c13, 14 as c14, 15 as c15, 16 as c16, "
+      "17 as c17, 18 as c18, 19 as c19, 20 as c20, 21 as c21, 22 as c22, "
+      "23 as c23, 24 as c24, 25 as c25, 26 as c26, 27 as c27, 28 as c28, "
+      "29 as c29, 30 as c30, 31 as c31) GROUP BY CUBE({})",
+      columns,
+      columns);
+
+  VELOX_ASSERT_THROW(parseSql(sql), "CUBE supports at most 30 columns");
+}
+
 TEST_F(PrestoParserTest, distinct) {
   {
     auto matcher =


### PR DESCRIPTION
Summary: Adds support for GROUPING SETS, ROLLUP, and CUBE.

**Design:**
- Unified code path for GROUP BY and GROUPING SETS via expandGroupingSets()
- Two caching mechanisms: AST pointer cache (exprCache) for subquery ordinal deduplication. And Expression cache (exprToIndex) for grouping key deduplication
- PlanBuilder: string, expression, and index-based grouping sets APIs with rollup()/cube() convenience methods
- CUBE limited to 30 columns similar to [Presto](https://github.com/prestodb/presto/blob/master/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java#L3920)


**Cache Detail:**
Two caches used during grouping set expansion:

1. exprCache (AST pointer → ExprApi)

Caches resolved expressions during expandGroupingSets(). For ordinals like GROUP BY 1, the cache key is the SELECT item's AST pointer. 

This ensures the same ordinal always returns the same ExprApi instance - necessary for subqueries where ExprMap (IExpr* based) cannot deduplicate different instances of the same subquery.

2. exprToIndex (IExpr → int32_t)

Builds unique grouping keys when converting to index-based representation. For GROUPING SETS ((a, b), (a, c)), this produces groupingKeys = [a, b, c] and indices = [[0, 1], [0, 2]].

Differential Revision: D91610080


