### PR TITLE
refactor(Cursor): Preserve vector encoded copy

### DIFF
--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<KeyFreq> runJoinSample(
   int32_t rowCount = 0;
   while (auto rows = runner.next()) {
     rowCount += rows->size();
-    auto hashes = rows->childAt(0)->as<velox::FlatVector<int64_t>>();
+    auto hashes = rows->childAt(0)->as<velox::SimpleVector<int64_t>>();
     for (auto i = 0; i < hashes->size(); ++i) {
       if (!hashes->isNullAt(i)) {
         ++(*result)[static_cast<uint32_t>(hashes->valueAt(i))];


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16086

Updates vector copy step to use EncodedVectorCopy as a means to preserve flat map encoding. This will prevent errors like we see in https://github.com/facebookincubator/velox/issues/15485 where copies fail due to mismatched vector encodings.

Differential Revision: D91169890


