### PR TITLE
fix: Type coercion for lambda functions

### DIFF
--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -582,12 +582,18 @@ SpecialFormExpr::SpecialFormExpr(
       break;
     case SpecialForm::kCast:
     case SpecialForm::kTryCast:
-    case SpecialForm::kTry:
       VELOX_USER_CHECK_EQ(
           inputs_.size(),
           1,
           "{} must have exactly one input",
           SpecialFormName::toName(form));
+      VELOX_CHECK(
+          !type_->isFunction(),
+          "Cannot apply CAST to function type: {}",
+          inputs_[0]->type()->toString());
+      break;
+    case SpecialForm::kTry:
+      VELOX_USER_CHECK_EQ(inputs_.size(), 1, "TRY must have exactly one input");
       break;
     case SpecialForm::kDereference:
       validateDereferenceInputs(type_, inputs_);

--- a/axiom/logical_plan/ExprResolver.h
+++ b/axiom/logical_plan/ExprResolver.h
@@ -18,6 +18,7 @@
 #include "axiom/logical_plan/Expr.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 
@@ -63,12 +64,28 @@ class ExprResolver {
 
  private:
   ExprPtr resolveLambdaExpr(
-      const velox::core::LambdaExpr* lambdaExpr,
+      const velox::core::LambdaExpr& lambdaExpr,
       const std::vector<velox::TypePtr>& lambdaInputTypes,
       const InputNameResolver& inputNameResolver) const;
 
   ExprPtr tryResolveCallWithLambdas(
       const std::shared_ptr<const velox::core::CallExpr>& callExpr,
+      const InputNameResolver& inputNameResolver) const;
+
+  // Resolves lambda arguments using already resolved non-lambda arguments.
+  // Populates 'resolvedInputs' entries that correspond to lambda arguments.
+  //
+  // @param inputs Function arguments.
+  // @param signature Function signature.
+  // @param resolvedInputs Partially resolved function arguments. 1:1 with
+  // 'inputs'. Non-lambda arguments are resolved and therefore not null. Lambda
+  // arguments may be null.
+  // @return True if all arguments were resolved successfully and
+  // 'resolvedInputs' was updated. False otherwise.
+  bool resolveLambdaArguments(
+      const std::vector<velox::core::ExprPtr>& inputs,
+      const velox::exec::FunctionSignature& signature,
+      std::vector<ExprPtr>& resolvedInputs,
       const InputNameResolver& inputNameResolver) const;
 
   ExprPtr tryFoldCall(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -151,6 +151,13 @@ class PrestoParserTest : public testing::Test {
     return parser.parse(sql, true);
   }
 
+  void testSqlExpression(std::string_view sql) {
+    SCOPED_TRACE(sql);
+    auto parser = makeParser();
+
+    ASSERT_NO_THROW(parser.parseExpression(sql, true));
+  }
+
   void testInsertSql(
       std::string_view sql,
       lp::test::LogicalPlanMatcherBuilder& matcher) {
@@ -1232,10 +1239,15 @@ TEST_F(PrestoParserTest, exists) {
 }
 
 TEST_F(PrestoParserTest, lambda) {
-  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+  testSqlExpression("filter(array[1,2,3], x -> x > 1)");
+  testSqlExpression("FILTER(array[1,2,3], x -> x > 1)");
 
-  testSql("SELECT filter(array[1,2,3], x -> x > 1)", matcher);
-  testSql("SELECT FILTER(array[1,2,3], x -> x > 1)", matcher);
+  testSqlExpression("filter(array[], x -> true)");
+
+  testSqlExpression("reduce(array[], map(), (s, x) -> s, s -> 123)");
+
+  testSqlExpression(
+      "reduce(array[], map(), (s, x) -> map(array[1], array[2]), s -> 123)");
 }
 
 TEST_F(PrestoParserTest, values) {


### PR DESCRIPTION
Summary:
Avoid Casting Lambdas During Resolution

When resolving lambda functions with coercions, we can hit an error if we try to apply a `CAST` to a `FunctionType`. This change improves lambda resolution to **avoid casting lambdas directly**.

## Example: `reduce`

See the `reduce` lambda function:  
https://facebookincubator.github.io/velox/functions/presto/array.html#reduce

> `reduce(array(T), initialState S, inputFunction(S, T, S), outputFunction(S, R)) → R`

The signature of `reduce` has **three** type parameters: **T**, **S**, and **R**.

- **T** and **S** are determined by the first two **non-lambda** arguments.
- The types of the **lambda arguments** are derived from **T** and **S**.
- **R** is determined by the **second** lambda argument.

## Specific Invocation

> `reduce(array[], map(), (s, x) -> map(array[1], array[2]), s -> 123)`

The types of the first two non-lambda arguments are:

- `ARRAY(UNKNOWN)`
- `MAP(UNKNOWN, UNKNOWN)`

Therefore, we derive:

- `T := UNKNOWN`
- `S := MAP(UNKNOWN, UNKNOWN)`

and expect the lambda argument types to be:

- `FUNCTION(MAP(UNKNOWN, UNKNOWN), UNKNOWN, MAP(UNKNOWN, UNKNOWN))`
- `FUNCTION(MAP(UNKNOWN, UNKNOWN), R)`

### Resolving the First Lambda

The first lambda argument is:

> `(s, x) -> map(array[1], array[2])`

To infer its type, we substitute:

- `s` with `MAP(UNKNOWN, UNKNOWN)`
- `x` with `UNKNOWN`

Then we resolve the lambda body:

> `map(array[1], array[2])`

which resolves to:

- `MAP(INTEGER, INTEGER)`

So the inferred type of the first lambda becomes:

- `FUNCTION(MAP(UNKNOWN, UNKNOWN), UNKNOWN, MAP(INTEGER, INTEGER))`

This does **not** match the expected:

- `FUNCTION(MAP(UNKNOWN, UNKNOWN), UNKNOWN, MAP(UNKNOWN, UNKNOWN))`

## Coercion Decision (and the Pitfall)

To reconcile this mismatch, we decide to coerce **S** from `MAP(UNKNOWN, UNKNOWN)` to `MAP(INTEGER, INTEGER)`. With that coercion, the call aligns with the `reduce` signature.

Conceptually, we end up with:

- `T := UNKNOWN`
- `S := MAP(INTEGER, INTEGER)`

and the rewritten arguments would be:

- array[] -> unmodified
- map() -> cast(map() as map(integer, integer))
- (s, x) -> map(array[1], array[2]) -> function(map(integer, integer), unknown, map(integer, integer))

However, we must be careful **not to apply coercion to the lambda argument itself**: there is **no `CAST` for function types**.

## Correct Approach

Instead of casting a lambda, we should:

1. Apply coercions to **non-lambda** arguments (e.g., `map()`).
2. Then **re-resolve** the lambda arguments under the updated types.

Differential Revision: D91779574


