### PR TITLE
feat: Make getSplits call async

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ if(COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
   string(APPEND CMAKE_CXX_FLAGS " -Wno-nullability-completeness")
 endif()
 
+check_cxx_compiler_flag("-fcoroutines" COMPILER_HAS_F_COROUTINES)
+if(COMPILER_HAS_F_COROUTINES)
+  string(APPEND CMAKE_CXX_FLAGS " -fcoroutines")
+endif()
+
 # Axiom, Velox and folly need to be compiled with the same compiler flags.
 execute_process(
   COMMAND

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -26,4 +26,4 @@ endif()
 
 add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp SchemaUtils.cpp)
 
-target_link_libraries(axiom_connectors velox_common_base velox_memory velox_connector)
+target_link_libraries(axiom_connectors velox_common_base velox_memory velox_connector Folly::folly)

--- a/axiom/connectors/hive/CMakeLists.txt
+++ b/axiom/connectors/hive/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   velox_hdfs
   velox_gcs
   velox_abfs
+  Folly::folly
 )
 
 if(AXIOM_BUILD_TESTING)

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -119,69 +119,45 @@ T ceil2(T x, T y) {
 }
 } // namespace
 
-std::vector<SplitSource::SplitAndGroup> LocalHiveSplitSource::getSplits(
-    uint64_t targetBytes) {
-  std::vector<SplitAndGroup> result;
-  uint64_t bytes = 0;
-  for (;;) {
-    if (currentFile_ >= static_cast<int32_t>(files_.size())) {
-      result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-      return result;
-    }
-
-    if (currentSplit_ >= fileSplits_.size()) {
-      fileSplits_.clear();
-      ++currentFile_;
-      if (currentFile_ >= files_.size()) {
-        result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-        return result;
-      }
-
-      currentSplit_ = 0;
-      const auto& filePath = files_[currentFile_]->path;
-      const auto fileSize = fs::file_size(filePath);
-      int64_t splitsPerFile =
-          ceil2<uint64_t>(fileSize, options_.fileBytesPerSplit);
-      if (options_.targetSplitCount) {
-        auto numFiles = files_.size();
-        if (splitsPerFile * numFiles < options_.targetSplitCount) {
-          // Divide the file into more splits but still not smaller than 64MB.
-          auto perFile = ceil2<uint64_t>(options_.targetSplitCount, numFiles);
-          int64_t bytesInSplit = ceil2<uint64_t>(fileSize, perFile);
-          splitsPerFile = ceil2<uint64_t>(
-              fileSize, std::max<uint64_t>(bytesInSplit, 32 << 20));
-        }
-      }
-      // Take the upper bound.
-      const int64_t splitSize = ceil2<uint64_t>(fileSize, splitsPerFile);
-      for (int i = 0; i < splitsPerFile; ++i) {
-        auto builder =
-            velox::connector::hive::HiveConnectorSplitBuilder(filePath)
-                .connectorId(connectorId_)
-                .fileFormat(format_)
-                .start(i * splitSize)
-                .length(splitSize);
-
-        auto* info = files_[currentFile_];
-        if (info->bucketNumber.has_value()) {
-          builder.tableBucketNumber(info->bucketNumber.value());
-        }
-        for (auto& pair : info->partitionKeys) {
-          builder.partitionKey(pair.first, pair.second);
-        }
-        if (!serdeParameters_.empty()) {
-          builder.serdeParameters(serdeParameters_);
-        }
-        fileSplits_.push_back(builder.build());
+folly::coro::AsyncGenerator<SplitSource::SplitAndGroup>
+LocalHiveSplitSource::getSplitGenerator() {
+  auto self = shared_from_this();
+  for (int32_t fileIdx = 0; fileIdx < files_.size(); ++fileIdx) {
+    const auto& filePath = files_[fileIdx]->path;
+    const auto fileSize = fs::file_size(filePath);
+    int64_t splitsPerFile =
+        ceil2<uint64_t>(fileSize, options_.fileBytesPerSplit);
+    if (options_.targetSplitCount) {
+      auto numFiles = files_.size();
+      if (splitsPerFile * numFiles < options_.targetSplitCount) {
+        // Divide the file into more splits but still not smaller than 64MB.
+        auto perFile = ceil2<uint64_t>(options_.targetSplitCount, numFiles);
+        int64_t bytesInSplit = ceil2<uint64_t>(fileSize, perFile);
+        splitsPerFile = ceil2<uint64_t>(
+            fileSize, std::max<uint64_t>(bytesInSplit, 32 << 20));
       }
     }
-    result.push_back(SplitAndGroup{std::move(fileSplits_[currentSplit_++]), 0});
-    bytes +=
-        reinterpret_cast<const velox::connector::hive::HiveConnectorSplit*>(
-            result.back().split.get())
-            ->length;
-    if (bytes > targetBytes) {
-      return result;
+    // Take the upper bound.
+    const int64_t splitSize = ceil2<uint64_t>(fileSize, splitsPerFile);
+    for (int i = 0; i < splitsPerFile; ++i) {
+      auto builder = velox::connector::hive::HiveConnectorSplitBuilder(filePath)
+                         .connectorId(connectorId_)
+                         .fileFormat(format_)
+                         .start(i * splitSize)
+                         .length(splitSize);
+
+      auto* info = files_[fileIdx];
+      if (info->bucketNumber.has_value()) {
+        builder.tableBucketNumber(info->bucketNumber.value());
+      }
+      for (auto& pair : info->partitionKeys) {
+        builder.partitionKey(pair.first, pair.second);
+      }
+      if (!serdeParameters_.empty()) {
+        builder.serdeParameters(serdeParameters_);
+      }
+      auto split = builder.build();
+      co_yield SplitAndGroup{std::move(split), 0};
     }
   }
 }

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -50,8 +50,7 @@ class LocalHiveSplitSource : public SplitSource {
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const SplitOptions options_;
@@ -59,9 +58,6 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> fileSplits_;
-  int32_t currentFile_{-1};
-  int32_t currentSplit_{0};
 };
 
 class LocalHiveConnectorMetadata;

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   velox_common_base
   velox_memory
   velox_connector
+  Folly::folly
 )
 
 add_executable(axiom_test_connector_test TestConnectorTest.cpp)
@@ -34,6 +35,7 @@ target_link_libraries(
   velox_connector
   velox_exec
   velox_vector_test_lib
+  Folly::folly
   gtest
   gtest_main
 )

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -149,12 +149,11 @@ class TestSplitSource : public SplitSource {
   TestSplitSource(const std::string& connectorId, size_t splitCount)
       : connectorId_(connectorId), splitCount_(splitCount) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const std::string connectorId_;
   const size_t splitCount_;
-  bool done_{false};
 };
 
 /// SplitManager embedded in the TestConnector. Returns one

--- a/axiom/connectors/tpch/CMakeLists.txt
+++ b/axiom/connectors/tpch/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   axiom_connectors
   velox_tpch_connector
   velox_tpch_gen
+  Folly::folly
 )
 
 if(AXIOM_BUILD_TESTING)

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -92,53 +92,27 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
       options);
 }
 
-std::vector<SplitSource::SplitAndGroup> TpchSplitSource::getSplits(
-    uint64_t targetBytes) {
-  std::vector<SplitAndGroup> result;
-
-  if (splits_.empty()) {
-    // Generate splits if not already done
-    auto rowType = velox::tpch::getTableSchema(table_);
-    size_t rowSize = 0;
-    for (size_t i = 0; i < rowType->children().size(); i++) {
-      // TODO: use actual size
-      rowSize += 10;
-    }
-    const auto totalRows = velox::tpch::getRowCount(table_, scaleFactor_);
-    const auto rowsPerSplit = options_.fileBytesPerSplit / rowSize;
-    const auto numSplits = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
-
-    // TODO: adjust numSplits based on options_.targetSplitCount
-    for (int64_t i = 0; i < numSplits; ++i) {
-      splits_.push_back(
-          std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
-              connectorId_, numSplits, i));
-    }
+folly::coro::AsyncGenerator<SplitSource::SplitAndGroup>
+TpchSplitSource::getSplitGenerator() {
+  auto self = shared_from_this();
+  // Generate splits on-the-fly
+  auto rowType = velox::tpch::getTableSchema(table_);
+  size_t rowSize = 0;
+  for (size_t i = 0; i < rowType->children().size(); i++) {
+    // TODO: use actual size
+    rowSize += 10;
   }
+  const auto totalRows = velox::tpch::getRowCount(table_, scaleFactor_);
+  const auto rowsPerSplit = options_.fileBytesPerSplit / rowSize;
+  const auto numSplits = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
 
-  if (currentSplit_ >= splits_.size()) {
-    result.push_back(kNoMoreSplits);
-    return result;
+  // TODO: adjust numSplits based on options_.targetSplitCount
+  for (int64_t i = 0; i < numSplits; ++i) {
+    co_yield SplitAndGroup{
+        std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
+            connectorId_, numSplits, i),
+        0};
   }
-
-  uint64_t bytes = 0;
-  while (currentSplit_ < splits_.size()) {
-    auto split = splits_[currentSplit_++];
-    result.emplace_back(SplitAndGroup{split, 0});
-
-    // TODO: use a more accurate size for the split
-    bytes += options_.fileBytesPerSplit;
-
-    if (bytes > targetBytes) {
-      break;
-    }
-  }
-
-  if (result.empty()) {
-    result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-  }
-
-  return result;
 }
 
 TpchConnectorMetadata::TpchConnectorMetadata(

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/experimental/coro/AsyncGenerator.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/tpch/TpchConnector.h"
@@ -39,8 +40,7 @@ class TpchSplitSource : public SplitSource {
         scaleFactor_(scaleFactor),
         connectorId_(connectorId) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const SplitOptions options_;

--- a/axiom/connectors/tpch/tests/CMakeLists.txt
+++ b/axiom/connectors/tpch/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib
+  Folly::folly
   GTest::gtest
   GTest::gtest_main
 )

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(
   velox_dwio_dwrf_writer
   velox_exec
   velox_cursor
+  Folly::folly
 )

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/coro/AsyncScope.h>
+
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/runner/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
@@ -85,6 +87,11 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr);
+
+  ~LocalRunner() override;
+
+  LocalRunner(LocalRunner&&) = delete;
+  LocalRunner& operator=(LocalRunner&&) = delete;
 
   /// First call starts execution.
   velox::RowVectorPtr next() override;
@@ -168,6 +175,8 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
+  bool splitScopeJoined_{false};
 };
 
 } // namespace facebook::axiom::runner


### PR DESCRIPTION
Summary: Make the getSplits call async via coroutines so that the thread is not blocked while splits are being created/generated.

Differential Revision: D91800596


