### PR TITLE
fix(parser): Global aggregation with HAVING clause

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1216,7 +1216,9 @@ class RelationPlanner : public AstVisitor {
     return toExpr(expr);
   }
 
-  bool tryAddGlobalAgg(const std::vector<SelectItemPtr>& selectItems) {
+  bool tryAddGlobalAgg(
+      const std::vector<SelectItemPtr>& selectItems,
+      const ExpressionPtr& having) {
     for (const auto& item : selectItems) {
       if (item->is(NodeType::kAllColumns)) {
         return false;
@@ -1241,7 +1243,7 @@ class RelationPlanner : public AstVisitor {
       return false;
     }
 
-    addGroupBy(selectItems, {}, /*having=*/nullptr, /*orderBy=*/nullptr);
+    addGroupBy(selectItems, {}, having, /*orderBy=*/nullptr);
     return true;
   }
 
@@ -1552,7 +1554,7 @@ class RelationPlanner : public AstVisitor {
         builder_->distinct();
       }
     } else {
-      if (tryAddGlobalAgg(selectItems)) {
+      if (tryAddGlobalAgg(selectItems, node->having())) {
         // Nothing else to do.
       } else {
         // SELECT a, b -> builder.project({a, b})

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -926,13 +926,23 @@ TEST_F(PrestoParserTest, with) {
 }
 
 TEST_F(PrestoParserTest, countStar) {
-  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate();
+  {
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate();
 
-  testSql("SELECT count(*) FROM nation", matcher);
-  testSql("SELECT count(1) FROM nation", matcher);
+    testSql("SELECT count(*) FROM nation", matcher);
+    testSql("SELECT count(1) FROM nation", matcher);
 
-  testSql("SELECT count(1) \"count\" FROM nation", matcher);
-  testSql("SELECT count(1) AS \"count\" FROM nation", matcher);
+    testSql("SELECT count(1) \"count\" FROM nation", matcher);
+    testSql("SELECT count(1) AS \"count\" FROM nation", matcher);
+  }
+
+  {
+    // Global aggregation with HAVING clause.
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().tableScan().aggregate().filter();
+    testSql("SELECT count(*) FROM nation HAVING count(*) > 100", matcher);
+  }
 }
 
 TEST_F(PrestoParserTest, aggregateCoercions) {


### PR DESCRIPTION
Summary:
Fix SQL parser bug where HAVING clause was lost for global aggregations
(queries with aggregates but no GROUP BY clause).

The tryAddGlobalAgg function was passing nullptr for the having parameter
to addGroupBy, causing queries like:

  SELECT count(*) c FROM nation HAVING count(*) > 100

to be parsed without the HAVING filter.

Differential Revision: D91944945


