### PR TITLE
feat: Handle uncorrelated EXISTS subqueries

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -230,6 +230,10 @@ struct DerivedTable : public PlanObject {
   /// 'this' as a join side because join sides must have a cardinality guess.
   void makeInitialPlan();
 
+  /// Erases the existing Memo entry and re-runs makeInitialPlan. Use this after
+  /// modifying properties of an already-memoized DerivedTable.
+  void remakeInitialPlan();
+
   PlanP bestInitialPlan() const;
 
   std::string toString() const override;

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -1,5 +1,9 @@
 # Overall Flow
 
+See also:
+- [Subqueries](docs/Subqueries.md) - How subqueries are implemented in the optimizer
+- [Join Planning](docs/JoinPlanning.md) - Control flow and state management in join order enumeration
+
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.
 
 To produce an executable plan, the Optimizer converts Logical Plan to a Query Graph, runs cost-based plan enumeration algorithm to produce optimal physical plan, then converts physical plan to a multi-fragment Velox executable plan.

--- a/axiom/optimizer/docs/JoinPlanning.md
+++ b/axiom/optimizer/docs/JoinPlanning.md
@@ -1,0 +1,151 @@
+# Join Planning: Control Flow and State Management
+
+This document describes the control flow and state management in
+`Optimization::makeJoins`, the core algorithm for join order enumeration.
+
+## Overview
+
+There are **two overloads** of `makeJoins`:
+
+1. **`makeJoins(PlanState& state)`** - Entry point that initiates planning from
+   starting tables
+2. **`makeJoins(RelationOpPtr plan, PlanState& state)`** - Recursive function
+   that builds the plan incrementally
+
+## State Management via `PlanStateSaver`
+
+The key to understanding state management is the **`PlanStateSaver`** class
+(RAII guard):
+
+```cpp
+struct PlanStateSaver {
+  explicit PlanStateSaver(PlanState& state)
+      : state_(state),
+        placed_(state.placed),      // Copies current placed set
+        columns_(state.columns),    // Copies current columns set
+        cost_(state.cost),          // Copies current cost
+        numPlaced_(...) {}
+
+  ~PlanStateSaver() {
+    state_.placed = std::move(placed_);   // Restores on destruction
+    state_.columns = std::move(columns_);
+    state_.cost = cost_;
+    ...
+  }
+};
+```
+
+This enables **backtracking**: the optimizer can try different plans, modify
+state, and automatically restore it when the scope exits.
+
+## Control Flow Diagram
+
+```
+makeJoins(state)                         [Entry Point]
+    │
+    ├─► Determine starting tables (syntactic order or all start tables)
+    │
+    └─► For each starting table:
+            │
+            ├─► PlanStateSaver save(state)    ◄── Save state
+            ├─► state.placed.add(table)
+            ├─► state.columns.unionObjects(columns)
+            ├─► Create scan operation
+            ├─► state.addCost(*scan)
+            └─► makeJoins(scan, state)        ◄── Recurse
+                    │                              (state restored on return)
+                    ▼
+        ┌─────────────────────────────────────────────────────┐
+        │  makeJoins(plan, state)              [Recursive]    │
+        │                                                     │
+        │  1. Check cutoff: if cost > best, return early      │
+        │                                                     │
+        │  2. Place conjuncts (filters) if possible           │
+        │     └─► If placed, return (recursion continues      │
+        │         inside placeConjuncts)                      │
+        │                                                     │
+        │  3. Get next join candidates                        │
+        │     └─► nextJoins(state) returns joinable tables    │
+        │                                                     │
+        │  4. If no candidates (all tables placed):           │
+        │     ├─► Place remaining conjuncts                   │
+        │     ├─► Place single-row derived tables             │
+        │     ├─► Add postprocessing (GROUP BY, ORDER BY...)  │
+        │     ├─► state.plans.addPlan(plan, state)  ◄── SAVE  │
+        │     └─► return                                      │
+        │                                                     │
+        │  5. For each candidate, generate NextJoin options:  │
+        │     └─► addJoin(candidate, plan, state, nextJoins)  │
+        │         ├─► Try index join                          │
+        │         ├─► Try hash join                           │
+        │         └─► Each creates NextJoin with snapshot of: │
+        │             - placed, columns, cost, plan           │
+        │                                                     │
+        │  6. tryNextJoins(state, nextJoins):                 │
+        │     └─► For each NextJoin:                          │
+        │         ├─► PlanStateSaver save(state)              │
+        │         ├─► state.placed = next.placed              │
+        │         ├─► state.columns = next.columns            │
+        │         ├─► state.cost = next.cost                  │
+        │         └─► makeJoins(next.plan, state) ◄── RECURSE │
+        └─────────────────────────────────────────────────────┘
+```
+
+## Key State Fields in `PlanState`
+
+| Field | Purpose |
+|-------|---------|
+| `placed` | Set of objects (tables, conjuncts, etc.) already in the plan |
+| `columns` | Set of columns available from placed tables |
+| `cost` | Accumulated cost of the partial plan |
+| `plans` | Collection of completed plans (output) |
+| `dt` | The derived table being planned |
+| `targetExprs` | Expressions needed in final output |
+
+## State Transitions
+
+### Placing a table scan
+
+```cpp
+state.placed.add(table);
+state.columns.unionObjects(columns);
+state.addCost(*scan);
+```
+
+### Placing a join (via `NextJoin`)
+
+`NextJoin` captures a **snapshot** of `placed`, `columns`, `cost` after the
+join. `tryNextJoins` restores state from the snapshot before recursing.
+
+### Placing a filter
+
+```cpp
+state.placed.add(filter);
+state.addCost(*filter);
+```
+
+## Backtracking Pattern
+
+The optimizer explores multiple paths (different join orders, methods) using
+this pattern:
+
+```cpp
+for (auto& next : nextJoins) {
+    PlanStateSaver save(state);      // Save current state
+    state.placed = next.placed;       // Apply this branch's state
+    state.columns = next.columns;
+    state.cost = next.cost;
+    makeJoins(next.plan, state);      // Explore this path
+}                                     // ~PlanStateSaver restores state
+```
+
+This allows the optimizer to try all combinations and keep the best plans in
+`state.plans`.
+
+## Summary
+
+- **`PlanStateSaver`** provides automatic state save/restore (RAII)
+- **`NextJoin`** captures state snapshots for deferred exploration
+- **Recursion** explores the search space depth-first
+- **Cutoff** (`state.isOverBest()`) prunes unpromising branches
+- **`state.plans`** accumulates interesting completed plans

--- a/axiom/optimizer/docs/Subqueries.md
+++ b/axiom/optimizer/docs/Subqueries.md
@@ -1,0 +1,397 @@
+# Subquery Implementation in Axiom Optimizer
+
+This document describes how subqueries are implemented in the Axiom optimizer,
+including the data structures, processing flow, optimization techniques, and
+current limitations.
+
+## Overview
+
+The Axiom optimizer converts logical plan subquery expressions into
+`DerivedTable` nodes connected via specialized `JoinEdge` objects. The
+processing happens during the query graph construction phase (`ToGraph`), with
+support for three main subquery types:
+
+- **Scalar subqueries**: `x = <subquery>`, `x < (SELECT ...)`, etc.
+- **IN subqueries**: `x IN <subquery>`, `x NOT IN <subquery>`
+- **EXISTS subqueries**: `EXISTS <subquery>`, `NOT EXISTS <subquery>`
+
+Each type supports both **correlated** and **uncorrelated** variants.
+
+> **Note:** Currently, subqueries are supported only in filter predicates (WHERE
+> clause). Subqueries in projections (SELECT list) are not supported yet.
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `ToGraph.cpp` | Core subquery processing (`processSubqueries`, `translateSubquery`) |
+| `ToGraph.h` | Interface definitions and correlation state fields |
+| `QueryGraph.h` | `JoinEdge` representation including `makeExists` factory |
+| `DerivedTable.h` | Query graph nodes, `singleRowDts` for non-correlated scalars |
+| `tests/SubqueryTest.cpp` | Test suite demonstrating expected behavior |
+
+## Data Structures
+
+### Subqueries Struct
+
+Subqueries found in a predicate are categorized during extraction:
+
+```cpp
+struct Subqueries {
+  std::vector<lp::SubqueryExprPtr> scalars;    // x = <subquery>
+  std::vector<lp::ExprPtr> inPredicates;       // x IN <subquery>
+  std::vector<lp::ExprPtr> exists;             // EXISTS <subquery>
+
+  bool empty() const {
+    return scalars.empty() && inPredicates.empty() && exists.empty();
+  }
+};
+```
+
+### Correlation State (ToGraph.h, lines 428-440)
+
+The `ToGraph` class maintains state for handling correlated subqueries:
+
+```cpp
+// Symbols from the 'outer' query. Used when processing correlated subqueries.
+const folly::F14FastMap<std::string, ExprCP>* correlations_;
+
+// True if expression is allowed to reference symbols from the 'outer' query.
+bool allowCorrelations_{false};
+
+// Filter conjuncts found in a subquery that reference symbols from the
+// 'outer' query.
+ExprVector correlatedConjuncts_;
+
+// Maps an expression that contains a subquery to a column or constant that
+// should be used instead. Populated in 'processSubqueries()'.
+folly::F14FastMap<logical_plan::ExprPtr, ExprCP> subqueries_;
+```
+
+### Mark Columns
+
+Semi-joins use boolean "mark" columns to track row membership:
+
+```cpp
+auto* mark = toName(fmt::format("__mark{}", markCounter_++));
+auto* markColumn = make<Column>(mark, currentDt_, Value{toType(velox::BOOLEAN()), 2});
+```
+
+## Processing Flow
+
+### Entry Point: `processSubqueries()`
+
+```
+Filter predicate received in addFilter()
+            │
+            ▼
+extractSubqueries(predicate, subqueries)
+    - Identifies scalar, IN, and EXISTS subqueries recursively
+            │
+            ▼
+For each subquery type:
+            │
+    ┌───────┴────────┬─────────────────┐
+    ▼                ▼                 ▼
+  Scalars           IN              EXISTS
+```
+
+### Subquery Translation
+
+`translateSubquery()` creates an isolated scope for the subquery:
+
+```cpp
+DerivedTableP ToGraph::translateSubquery(
+    const logical_plan::LogicalPlanNode& node,
+    bool finalize) {
+  // Save outer query symbol map.
+  auto originalRenames = std::move(renames_);
+  renames_.clear();
+
+  // Enable correlation - inner query can see outer symbols.
+  correlations_ = &originalRenames;
+  SCOPE_EXIT { correlations_ = nullptr; };
+
+  // Create new DerivedTable for subquery.
+  auto* outerDt = std::exchange(currentDt_, newDt());
+  makeQueryGraph(node, kAllAllowedInDt);  // Recursive query graph build
+  auto* subqueryDt = currentDt_;
+
+  // Restore outer context.
+  currentDt_ = outerDt;
+  // ...
+  return subqueryDt;
+}
+```
+
+## Subquery Type Details
+
+### Scalar Subqueries
+
+**Uncorrelated scalar subqueries** can be:
+1. **Constant folded** if the subquery is foldable (see Constant Folding below)
+2. Converted to a **cross-join** with the outer query
+
+**Correlated scalar subqueries** create a **LEFT join** with correlation
+equality conditions:
+
+```cpp
+// Add LEFT join.
+auto* join = make<JoinEdge>(
+    leftTable, subqueryDt, JoinEdge::Spec{.rightOptional = true});
+for (auto i = 0; i < leftKeys.size(); ++i) {
+  join->addEquality(leftKeys[i], rightKeys[i]);
+}
+currentDt_->joins.push_back(join);
+subqueries_.emplace(subquery, subqueryDt->columns.back());
+```
+
+### IN Subqueries
+
+IN subqueries create **semi-joins** with a mark column:
+
+```cpp
+// x IN <subquery>
+auto* edge = JoinEdge::makeExists(leftTable, subqueryDt, markColumn);
+currentDt_->joins.push_back(edge);
+edge->addEquality(leftKey, subqueryDt->columns.front());
+subqueries_.emplace(expr, markColumn);
+```
+
+The resulting join types are:
+- `kLeftSemiFilter` for `IN`
+- `kAnti` for `NOT IN`
+
+### EXISTS Subqueries
+
+**Uncorrelated EXISTS** is transformed to check if any rows exist:
+
+```sql
+-- Original:
+SELECT * FROM region WHERE EXISTS (SELECT 1 FROM nation)
+
+-- Transformed to:
+SELECT * FROM region
+CROSS JOIN (
+  SELECT NOT(count = 0) as exists_flag
+  FROM (SELECT 1 FROM nation LIMIT 1) AGGREGATE count(*)
+)
+WHERE exists_flag
+```
+
+**Correlated EXISTS** creates a semi-join with mark column:
+
+```cpp
+auto* existsEdge = JoinEdge::makeExists(
+    leftTable, subqueryDt, markColumn, std::move(filter));
+currentDt_->joins.push_back(existsEdge);
+
+for (auto i = 0; i < leftKeys.size(); ++i) {
+  existsEdge->addEquality(leftKeys[i], rightKeys[i]);
+}
+
+subqueries_.emplace(expr, markColumn);
+```
+
+## JoinEdge Representation
+
+`JoinEdge::makeExists` creates a specialized join edge:
+
+```cpp
+static JoinEdge* makeExists(
+    PlanObjectCP leftTable,
+    PlanObjectCP rightTable,
+    ColumnCP markColumn = nullptr,
+    ExprVector filter = {}) {
+  return make<JoinEdge>(
+      leftTable,
+      rightTable,
+      Spec{
+          .filter = std::move(filter),
+          .rightExists = true,
+          .markColumn = markColumn,
+      });
+}
+```
+
+Join types used for subqueries:
+- `kLeftSemiFilter` for EXISTS/IN (keeps matching rows)
+- `kAnti` for NOT EXISTS/NOT IN (filters out matching rows)
+- `kLeft` with `rightOptional = true` for correlated scalars
+
+## Constant Folding Optimization
+
+The optimizer can evaluate certain scalar subqueries at compile time using
+`tryFoldConstantDt()`. This optimization relies on **discrete values** provided
+by the connector to enumerate all possible values for certain columns.
+
+### Conditions for Constant Folding
+
+1. Single table with global aggregation (no GROUP BY)
+2. Aggregate functions ignore duplicates (e.g., `max`, `min`) or use `DISTINCT`
+3. Aggregation uses only columns with discrete predicates (the connector must
+   provide the complete set of possible values for these columns)
+
+### Example
+
+```sql
+-- Before:
+SELECT * FROM t WHERE ds = (SELECT max(ds) FROM t)
+
+-- After constant folding (if discrete values are known):
+SELECT * FROM t WHERE ds = '2025-11-03'
+```
+
+### Implementation
+
+```cpp
+lp::ValuesNodePtr tryFoldConstantDt(DerivedTableP dt, velox::memory::MemoryPool* pool) {
+  // Check preconditions...
+  if (!dt->hasAggregation() || !dt->aggregation->groupingKeys().empty()) {
+    return nullptr;
+  }
+
+  for (const auto* agg : aggPlan->aggregates()) {
+    if (!agg->functions().contains(FunctionSet::kIgnoreDuplicatesAggregate) &&
+        !agg->isDistinct()) {
+      return nullptr;
+    }
+  }
+
+  // Execute plan and return constant result.
+  auto veloxPlan = queryCtx()->optimization()->toVeloxPlan(plan);
+  auto results = runConstantPlan(veloxPlan, pool);
+  return std::make_shared<lp::ValuesNode>(dt->cname, std::move(results));
+}
+```
+
+## SQL Examples and Expected Plans
+
+### Scalar Subquery
+
+```sql
+SELECT * FROM nation
+WHERE n_regionkey = (SELECT r_regionkey FROM region WHERE r_name LIKE 'AF%')
+
+-- Plan: nation → HashJoin(kInner) → region
+```
+
+### IN Subquery
+
+```sql
+SELECT * FROM nation
+WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name > 'ASIA')
+
+-- Plan: nation → HashJoin(kLeftSemiFilter) → region
+```
+
+### NOT IN Subquery
+
+```sql
+SELECT * FROM nation
+WHERE n_regionkey NOT IN (SELECT r_regionkey FROM region WHERE r_name > 'ASIA')
+
+-- Plan: nation → HashJoin(kAnti) → region
+```
+
+### Correlated EXISTS
+
+```sql
+SELECT * FROM nation
+WHERE EXISTS (SELECT 1 FROM region WHERE r_regionkey = n_regionkey)
+
+-- Plan: nation → HashJoin(kLeftSemiFilter) → region
+```
+
+### Correlated EXISTS with Non-Equality
+
+```sql
+SELECT * FROM nation
+WHERE EXISTS (SELECT 1 FROM region WHERE r_regionkey > n_regionkey)
+
+-- Plan: nation → NestedLoopJoin(kLeftSemiProject) → region → Filter → Project
+```
+
+### Uncorrelated EXISTS
+
+```sql
+SELECT * FROM region WHERE EXISTS (SELECT 1 FROM nation)
+
+-- Plan:
+-- region → NestedLoopJoin(kInner) → (
+--   nation → Limit(1) → Aggregate(count(*)) → Filter(NOT(count == 0)) → Project
+-- )
+```
+
+## Limitations and TODOs
+
+### Current Limitations
+
+1. **Subqueries only supported in filters**
+   - Subqueries can only appear in WHERE clause predicates
+   - Subqueries in SELECT list (projections) are not supported yet
+
+2. **Multi-table IN expressions not supported**
+   ```sql
+   -- Not supported:
+   WHERE (a, b) IN (SELECT x, y FROM t)
+   ```
+
+3. **Correlated conjuncts referencing multiple outer tables**
+   ```sql
+   -- Not supported:
+   WHERE EXISTS (SELECT 1 FROM t WHERE t.a = outer1.x AND t.b = outer2.y)
+   ```
+   Note: This limitation applies only when outer1 and outer2 are different
+   base tables, not aliases of the same derived table.
+
+4. **Multi-table expression in IN predicate left-hand side**
+   ```cpp
+   VELOX_CHECK_NOT_NULL(
+       leftTable,
+       "<expr> IN <subquery> with multi-table <expr> is not supported yet");
+   ```
+
+### Known TODOs (from source code)
+
+1. Handle the case when scalar subquery returns no rows (line 2104):
+   - Should fail if used in comparison (`x = <subquery>`)
+   - Could constant fold if used in IN list
+
+2. Support `SELECT COUNT(1) FROM (SELECT DISTINCT x FROM t)` for constant
+   folding (line 274)
+
+3. Support ORDER BY and LIMIT in constant foldable subqueries (lines 278-283)
+
+## Test Coverage
+
+The `SubqueryTest.cpp` file provides comprehensive test coverage:
+
+| Test Case | Description |
+|-----------|-------------|
+| `scalar` | Uncorrelated `=`, `IN`, `NOT IN` with type coercion |
+| `foldable` | Constant folding of `max`/`min` aggregates |
+| `correlatedExists` | Equality conditions, non-equality conditions, multiple outer tables |
+| `uncorrelatedExists` | `COUNT(*)` wrapper, `NOT EXISTS` |
+
+## Architectural Notes
+
+1. **DerivedTable Container**: Each subquery gets its own isolated `DerivedTable`
+   node, enabling independent optimization.
+
+2. **Join Edge Reuse**: Subqueries leverage the existing join planning
+   infrastructure, enabling cost-based join ordering to consider subquery joins.
+
+3. **Symbol Map Correlation**: Supports arbitrary nested correlation depths
+   through the `correlations_` pointer chain.
+
+4. **Mark Columns**: Simplify semi-join implementation by producing boolean
+   results without materializing full subquery results.
+
+5. **Early Constant Folding**: Reduces plan complexity and improves cardinality
+   estimates by evaluating foldable subqueries at planning time.
+
+## Related Documentation
+
+- See [JoinPlanning.md](JoinPlanning.md) for details on how joins (including
+  subquery joins) are planned and optimized.

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -21,6 +21,33 @@
 
 namespace facebook::velox::core {
 
+/// PlanMatcher is used to verify the structure and content of a Velox plan.
+///
+/// Expression Syntax:
+/// ------------------
+/// String expressions (e.g., in filter(), project(), singleAggregation()) are
+/// parsed as DuckDB SQL. Use DuckDB-compatible syntax for expressions.
+/// See https://duckdb.org/docs/stable/sql/functions/overview for reference.
+///
+/// Symbol Rewriting:
+/// -----------------
+/// PlanMatcher supports symbol (alias) capture and rewriting to allow
+/// verification of expressions that reference columns from child nodes.
+///
+/// When a matcher specifies an expression with an alias (e.g., "count(*) as
+/// c"), the alias is captured and mapped to the actual column name in the plan.
+/// Subsequent matchers can then use the alias in their expressions, and it will
+/// be rewritten to the actual column name before comparison.
+///
+/// Example:
+///   .singleAggregation({}, {"count(*) as c"})  // Captures alias 'c'
+///   .filter("not(eq(c, 0))")                   // 'c' is rewritten to actual
+///                                              // column name (e.g.,
+///                                              // "__count6")
+///
+/// Symbol rewriting is supported by: ProjectMatcher, AggregationMatcher,
+/// FilterMatcher, JoinMatcher. The symbols are propagated from child matchers
+/// to parent matchers during plan matching.
 class PlanMatcher {
  public:
   virtual ~PlanMatcher() = default;
@@ -53,10 +80,14 @@ class PlanMatcher {
 
 class PlanMatcherBuilder {
  public:
+  /// Matches any TableScan node regardless of table name or output type.
   PlanMatcherBuilder& tableScan();
 
+  /// Matches a TableScan node with the specified table name.
+  /// @param tableName The expected table name.
   PlanMatcherBuilder& tableScan(const std::string& tableName);
 
+  /// Matches a TableScan node with the specified table name and output type.
   /// @param tableName The name of the table.
   /// @param outputType The list of schema names and types of columns in the
   /// output of the scan node.
@@ -64,100 +95,185 @@ class PlanMatcherBuilder {
       const std::string& tableName,
       const RowTypePtr& outputType);
 
+  /// Matches a Hive TableScan node with the specified table name, subfield
+  /// filters, and optional remaining filter.
+  /// @param tableName The name of the table.
+  /// @param subfieldFilters Filters pushed down into the scan as subfield
+  /// filters.
+  /// @param remainingFilter Optional filter expression that couldn't be pushed
+  /// down into the scan.
   PlanMatcherBuilder& hiveScan(
       const std::string& tableName,
       common::SubfieldFilters subfieldFilters,
       const std::string& remainingFilter = "");
 
+  /// Matches any Values node regardless of type.
   PlanMatcherBuilder& values();
 
-  PlanMatcherBuilder& values(const TypePtr& type);
+  /// Matches a Values node with the specified output type.
+  /// @param outputType The expected output type of the Values node.
+  PlanMatcherBuilder& values(const RowTypePtr& outputType);
 
+  /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();
 
+  /// Matches a Filter node with the specified predicate expression.
+  /// Supports symbol rewriting from child matchers.
+  /// @param predicate The expected filter predicate (DuckDB SQL syntax).
   PlanMatcherBuilder& filter(const std::string& predicate);
 
+  /// Matches any Project node regardless of expressions.
   PlanMatcherBuilder& project();
 
+  /// Matches a Project node with the specified projection expressions.
+  /// Expressions with aliases (e.g., "a + b as c") capture the alias for use
+  /// in parent matchers via symbol rewriting.
+  /// @param expressions The expected projection expressions (DuckDB SQL
+  /// syntax).
   PlanMatcherBuilder& project(const std::vector<std::string>& expressions);
 
+  /// Matches any ParallelProject node regardless of expressions.
   PlanMatcherBuilder& parallelProject();
 
+  /// Matches a ParallelProject node with the specified projection expressions.
+  /// @param expressions The expected projection expressions (DuckDB SQL
+  /// syntax).
   PlanMatcherBuilder& parallelProject(
       const std::vector<std::string>& expressions);
 
+  /// Matches any Unnest node regardless of expressions.
   PlanMatcherBuilder& unnest();
 
+  /// Matches an Unnest node with the specified replicate and unnest
+  /// expressions.
+  /// @param replicateExprs Expressions that are replicated for each unnested
+  /// row. Supports symbol rewriting from child matchers (see class
+  /// documentation).
+  /// @param unnestExprs Array/map expressions to unnest. Supports symbol
+  /// rewriting from child matchers (see class documentation).
+  /// @param ordinalityName Optional name for the ordinality column.
   PlanMatcherBuilder& unnest(
       const std::vector<std::string>& replicateExprs,
       const std::vector<std::string>& unnestExprs,
       const std::optional<std::string>& ordinalityName = std::nullopt);
 
+  /// Matches any Aggregation node regardless of step or expressions.
   PlanMatcherBuilder& aggregation();
 
+  /// Matches any single (non-distributed) Aggregation node.
   PlanMatcherBuilder& singleAggregation();
 
+  /// Matches a single (non-distributed) Aggregation node with the specified
+  /// grouping keys and aggregate expressions.
+  /// @param groupingKeys Columns to group by.
+  /// @param aggregates Aggregate expressions (e.g., "sum(x)", "count(*) as c").
+  /// Supports alias capture for symbol rewriting in parent matchers.
   PlanMatcherBuilder& singleAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 
+  /// Matches any partial Aggregation node.
   PlanMatcherBuilder& partialAggregation();
 
+  /// Matches a partial Aggregation node with the specified grouping keys and
+  /// aggregate expressions.
+  /// @param groupingKeys Columns to group by.
+  /// @param aggregates Aggregate expressions.
   PlanMatcherBuilder& partialAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 
+  /// Matches any final Aggregation node.
   PlanMatcherBuilder& finalAggregation();
 
+  /// Matches a final Aggregation node with the specified grouping keys and
+  /// aggregate expressions.
+  /// @param groupingKeys Columns to group by.
+  /// @param aggregates Aggregate expressions.
   PlanMatcherBuilder& finalAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 
+  /// Matches a HashJoin node with the specified right side matcher.
+  /// @param rightMatcher Matcher for the right (build) side of the join.
   PlanMatcherBuilder& hashJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher);
 
+  /// Matches a HashJoin node with the specified right side matcher and join
+  /// type.
+  /// @param rightMatcher Matcher for the right (build) side of the join.
+  /// @param joinType Type of join (e.g., kInner, kLeft, kRight).
   PlanMatcherBuilder& hashJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher,
       JoinType joinType);
 
+  /// Matches a NestedLoopJoin node with the specified right side matcher and
+  /// join type.
+  /// @param rightMatcher Matcher for the right side of the join.
+  /// @param joinType Type of join (defaults to kInner).
   PlanMatcherBuilder& nestedLoopJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher,
       JoinType joinType = JoinType::kInner);
 
+  /// Matches any LocalPartition node.
   PlanMatcherBuilder& localPartition();
 
+  /// Matches a LocalPartition node with the specified source matchers.
+  /// @param matcher Matchers for the partition sources.
   PlanMatcherBuilder& localPartition(
       std::initializer_list<std::shared_ptr<PlanMatcher>> matcher);
 
+  /// Matches a LocalPartition node with a single source matcher.
+  /// @param matcher Matcher for the partition source.
   PlanMatcherBuilder& localPartition(
       const std::shared_ptr<PlanMatcher>& matcher) {
     return localPartition({matcher});
   }
 
+  /// Matches any LocalMerge node.
   PlanMatcherBuilder& localMerge();
 
+  /// Matches any PartitionedOutput node.
   PlanMatcherBuilder& partitionedOutput();
 
+  /// Matches any Exchange node.
   PlanMatcherBuilder& exchange();
 
+  /// Matches any MergeExchange node.
   PlanMatcherBuilder& mergeExchange();
 
+  /// Matches any Limit node regardless of offset, count, or partial/final step.
   PlanMatcherBuilder& limit();
 
+  /// Matches a partial Limit node with the specified offset and count.
+  /// @param offset Number of rows to skip.
+  /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& partialLimit(int64_t offset, int64_t count);
 
+  /// Matches a final Limit node with the specified offset and count.
+  /// @param offset Number of rows to skip.
+  /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& finalLimit(int64_t offset, int64_t count);
 
+  /// Matches any TopN node.
   PlanMatcherBuilder& topN();
 
+  /// Matches a TopN node with the specified count.
+  /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& topN(int64_t count);
 
+  /// Matches any OrderBy node.
   PlanMatcherBuilder& orderBy();
 
+  /// Matches an OrderBy node with the specified ordering.
+  /// @param ordering List of sort keys (e.g., {"a ASC", "b DESC"}).
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
 
+  /// Matches any TableWrite node.
   PlanMatcherBuilder& tableWrite();
 
+  /// Builds and returns the constructed PlanMatcher.
+  /// @throws VeloxUserError if matcher is empty.
   std::shared_ptr<PlanMatcher> build() {
     VELOX_USER_CHECK_NOT_NULL(matcher_, "Cannot build an empty PlanMatcher.");
     return matcher_;

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1213,10 +1213,11 @@ TEST_F(UnnestTest, ordinality) {
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
+    // Two arrays are unnested with ordinality column.
     auto matcher = core::PlanMatcherBuilder()
                        .values()
-                       .project()
-                       .unnest({}, {}, "ordinality")
+                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
+                       .unnest({}, {"foo", "bar"}, "ordinality")
                        .project({"e", "e_0", "ordinality"})
                        .build();
 
@@ -1230,10 +1231,11 @@ TEST_F(UnnestTest, ordinality) {
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
+    // Ordinality column is pruned because it's not used.
     auto matcher = core::PlanMatcherBuilder()
                        .values()
-                       .project()
-                       .unnest({}, {}, std::nullopt)
+                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
+                       .unnest({}, {"foo", "bar"}, std::nullopt)
                        .project({"e", "e_0"})
                        .build();
 
@@ -1247,10 +1249,11 @@ TEST_F(UnnestTest, ordinality) {
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
+    // Ordinality column is pruned because it's not used.
     auto matcher = core::PlanMatcherBuilder()
                        .values()
-                       .project()
-                       .unnest({}, {}, std::nullopt)
+                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
+                       .unnest({}, {"foo", "bar"}, std::nullopt)
                        .project({"1"})
                        .build();
 


### PR DESCRIPTION
Summary:
Add support for uncorrelated EXISTS subqueries by transforming them to a cross
join with COUNT(*) > 0 over (subquery + LIMIT 1).

This implementation:
- Detects uncorrelated EXISTS (when correlatedConjuncts_ is empty)
- Applies LIMIT 1 to short-circuit the subquery scan
- Wraps subquery in a DerivedTable with COUNT(*) aggregation
- Cross joins the wrapper with the outer query
- Replaces EXISTS expression with count > 0

Also fixes isSingleRowDt() to check for empty HAVING clause. A global
aggregation (no grouping keys) only returns exactly one row if there is no
HAVING clause that could filter it out. Without this fix, the wrapper DT
was incorrectly treated as single-row and pruned by the optimizer when its
columns were only used in filter predicates.

Differential Revision: D91945587
