### PR TITLE
feat: Support scalar subqueries in projections

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1464,6 +1464,7 @@ void Optimization::joinByHash(
   RelationOp* join = make<Join>(
       JoinMethod::kHash,
       joinType,
+      candidate.join->isNullAwareIn(),
       probeInput,
       buildOp,
       std::move(probeKeys),
@@ -1626,6 +1627,7 @@ void Optimization::joinByHashRight(
   RelationOp* join = make<Join>(
       JoinMethod::kHash,
       rightJoinType,
+      candidate.join->isNullAwareIn(),
       probeInput,
       buildOp,
       std::move(probeKeys),

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -387,6 +387,7 @@ AXIOM_DEFINE_ENUM_NAME(JoinMethod, joinMethodNames);
 Join::Join(
     JoinMethod method,
     velox::core::JoinType joinType,
+    bool nullAware,
     RelationOpPtr lhs,
     RelationOpPtr rhs,
     ExprVector lhsKeys,
@@ -397,6 +398,7 @@ Join::Join(
     : RelationOp{RelType::kJoin, std::move(lhs), std::move(columns)},
       method{method},
       joinType{joinType},
+      nullAware{nullAware},
       right{std::move(rhs)},
       leftKeys{std::move(lhsKeys)},
       rightKeys{std::move(rhsKeys)},
@@ -472,6 +474,7 @@ Join* Join::makeCrossJoin(
   return make<Join>(
       JoinMethod::kCross,
       joinType,
+      /*nullAware=*/false,
       std::move(input),
       std::move(right),
       ExprVector{},

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -481,6 +481,7 @@ struct Join : public RelationOp {
   Join(
       JoinMethod method,
       velox::core::JoinType joinType,
+      bool nullAware,
       RelationOpPtr lhs,
       RelationOpPtr rhs,
       ExprVector lhsKeys,
@@ -498,6 +499,9 @@ struct Join : public RelationOp {
 
   const JoinMethod method;
   const velox::core::JoinType joinType;
+  /// When true, the join semantic is IN / NOT IN. When false, the join semantic
+  /// is EXISTS / NOT EXISTS.
+  const bool nullAware;
   const RelationOpPtr right;
   const ExprVector leftKeys;
   const ExprVector rightKeys;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -371,15 +371,20 @@ class ToGraph {
   std::pair<ExprVector, OrderTypeVector> dedupOrdering(
       const std::vector<logical_plan::SortingField>& ordering);
 
-  // Process non-correlated subqueries used in filter's predicate and populate
-  // subqueries_ map. For each IN <subquery> expression, create a separate DT
-  // for the subquery and add a semi-join edge. Replace the whole IN predicate
-  // with a 'mark' column produced by the join. For other <subquery>
+  // Process subqueries used in filter's predicate or projection expressions
+  // and populate subqueries_ map. For each IN <subquery> expression, create a
+  // separate DT for the subquery and add a semi-join edge. Replace the whole IN
+  // predicate with a 'mark' column produced by the join. For other <subquery>
   // expressions, create a separate DT and replace the expression with the only
   // column produced by the DT.
+  //
+  // @param input The logical plan node to use when finalizing the DT.
+  // @param expr The expression to scan for subqueries.
+  // @param filter If true, indicates this is processing a filter predicate.
   void processSubqueries(
       const logical_plan::LogicalPlanNode& input,
-      const logical_plan::ExprPtr& predicate);
+      const logical_plan::ExprPtr& expr,
+      bool filter);
 
   // Translates a subquery into a DerivedTable. Sets up correlations_ to allow
   // the subquery to reference columns from the outer query. After translation,

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1115,10 +1115,14 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
   auto leftKeys = toFieldRefs(join.leftKeys);
   auto rightKeys = toFieldRefs(join.rightKeys);
 
+  // nullAware is only supported for semi project and anti joins.
+  const bool nullAware =
+      join.nullAware && velox::core::isNullAwareSupported(join.joinType);
+
   auto joinNode = std::make_shared<velox::core::HashJoinNode>(
       nextId(),
       join.joinType,
-      false,
+      nullAware,
       leftKeys,
       rightKeys,
       toAnd(join.filter),

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -199,13 +199,17 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& hashJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher);
 
-  /// Matches a HashJoin node with the specified right side matcher and join
-  /// type.
+  /// Matches a HashJoin node with the specified right side matcher, join type,
+  /// and nullAware flag.
   /// @param rightMatcher Matcher for the right (build) side of the join.
   /// @param joinType Type of join (e.g., kInner, kLeft, kRight).
+  /// @param nullAware When true, the join semantic is IN / NOT IN. When false,
+  /// the join semantic is EXISTS / NOT EXISTS. Applies only to semi project
+  /// and anti joins.
   PlanMatcherBuilder& hashJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher,
-      JoinType joinType);
+      JoinType joinType,
+      bool nullAware = false);
 
   /// Matches a NestedLoopJoin node with the specified right side matcher and
   /// join type.

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -529,7 +529,10 @@ TEST_F(TpchPlanTest, q16) {
   auto matcher =
       startMatcher("partsupp")
           .hashJoin(startMatcher("part").build(), core::JoinType::kInner)
-          .hashJoin(startMatcher("supplier").build(), core::JoinType::kAnti)
+          .hashJoin(
+              startMatcher("supplier").build(),
+              core::JoinType::kAnti,
+              /*nullAware=*/true)
           .aggregation()
           .orderBy()
           .build();


### PR DESCRIPTION
Summary:
Scalar subqueries in the SELECT clause were not being processed because `addProjection` didn't call `processSubqueries` like `addFilter` does. This caused queries like `SELECT r_name, (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) FROM region` to fail with NOT_IMPLEMENTED error.

The fix adds a call to `processSubqueries` for each projection expression, enabling correlated scalar subqueries to be decorrelated and transformed into LEFT JOINs.

Additionally, this change:
- Adds `nullAware` to `JoinEdge` and `Join` to distinguish **IN** vs **EXISTS** semantics
- Sets `nullAware=true` for **IN** subqueries (in both filters and projections)
- Plumbs `nullAware` to Velox `HashJoinNode` only for supported join types: `kAnti`, `kLeftSemiProject`, `kRightSemiProject`
- Extends PlanMatcher to assert `nullAware` in tests

The following query illustrates the semantic difference between IN and EXISTS:

```
SELECT DISTINCT
    n_regionkey,
    NULLIF(n_regionkey, 2) IN (
        SELECT
            r_regionkey
        FROM region
    ),
    EXISTS (
        SELECT
            *
        FROM tpch.tiny.region
        WHERE
            r_regionkey = NULLIF(n_regionkey, 2)
    )
FROM nation
WHERE
    n_regionkey IN (1, 2)

ROW<n_regionkey:BIGINT,expr:BOOLEAN,expr_3:BOOLEAN>
------------+------+-------
n_regionkey | expr | expr_3
------------+------+-------
          1 | true |   true
          2 | null |  false
(2 rows in 2 batches)
```

Differential Revision: D91956810
