### PR TITLE
fix: Save and restore exprToColumn in PlanStateSaver

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1068,7 +1068,7 @@ void Optimization::addOrderBy(
   auto orderKeys = precompute.toColumns(dt->orderKeys);
 
   for (auto i = 0; i < orderKeys.size(); ++i) {
-    state.exprToColumn[dt->orderKeys[i]] = orderKeys[i];
+    state.addExprToColumn(dt->orderKeys[i], orderKeys[i]);
   }
 
   state.place(dt->orderKeys);


### PR DESCRIPTION
Summary:
PlanStateSaver was not saving and restoring `exprToColumn`, causing state to leak between planning branches. When the optimizer explored one join order and processed ORDER BY (which populates `exprToColumn` with precomputed column mappings), then backtracked to try a different join order, the stale mappings would affect downstream column computation for the build side of joins.

This manifested as "Field not found" errors when planning queries with cross joins and ORDER BY on computed expressions.

Fixes https://github.com/facebookincubator/axiom/issues/728

Differential Revision: D91970714


