### PR TITLE
test: Add distributed plan matching with shuffle boundaries

### DIFF
--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -253,3 +253,10 @@ inline auto gt(const std::string& name, const std::string& value) {
     ASSERT_TRUE((matcher)->match(_axiom_plan_)) \
         << _axiom_plan_->toString(true, true);  \
   }
+
+#define AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher) \
+  {                                                  \
+    auto _axiom_plan_ = (plan);                      \
+    ASSERT_TRUE((matcher)->match(*_axiom_plan_))     \
+        << _axiom_plan_->toString(true);             \
+  }


### PR DESCRIPTION
Summary:
Extend PlanMatcher to support matching distributed multi-fragment plans using a single matcher.

Previously, testing distributed plans required matching each fragment separately:

```
ASSERT_EQ(4, fragments.size());
AXIOM_ASSERT_PLAN(fragments[0].planNode, matcher0);
AXIOM_ASSERT_PLAN(fragments[1].planNode, matcher1);
...
```

Now, use shuffle() to mark fragment boundaries and AXIOM_ASSERT_DISTRIBUTED_PLAN to verify the entire distributed plan:

```
auto matcher = core::PlanMatcherBuilder()
    .tableScan("nation")
    .partialAggregation()
    .shuffle()  // marks exchange boundary
    .localPartition()
    .finalAggregation()
    .build();
AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
```

For joins, the right-side matcher can also contain shuffle() boundaries:

```
auto rightMatcher = core::PlanMatcherBuilder()
    .tableScan("region")
    .shuffle()
    .build();

auto matcher = core::PlanMatcherBuilder()
    .tableScan("nation")
    .shuffle()
    .hashJoin(rightMatcher, core::JoinType::kInner)
    .shuffle()
    .build();
AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
```

Use shuffleMerge() instead of shuffle() when the plan uses MergeExchange for ordered data.

Differential Revision: D91985216


