### PR TITLE
fix: Deadlock and timeout handling in LocalRunner::waitForCompletion

### DIFF
--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -125,7 +125,8 @@ class LocalRunner : public Runner,
   void abort() override;
 
   /// @pre state() != State::kInitialized
-  void waitForCompletion(int32_t maxWaitMicros) override;
+  /// @return true if all tasks completed within the timeout, false otherwise.
+  bool waitForCompletion(int32_t maxWaitMicros) override;
 
   State state() const override {
     return state_;

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -58,8 +58,9 @@ class Runner {
 
   /// Waits up to 'maxWaitMicros' for all activity of the execution to cease.
   /// This is used in tests to ensure that all pools are empty and unreferenced
-  /// before teardown.
-  virtual void waitForCompletion(int32_t maxWaitMicros) = 0;
+  /// before teardown. Returns true if all activity ceased within the timeout,
+  /// false otherwise.
+  virtual bool waitForCompletion(int32_t maxWaitMicros) = 0;
 };
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -148,14 +148,17 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     auto scan = makeScanPlan(numWorkers);
     auto localRunner = makeRunner(scan);
 
-    auto results = readCursor(localRunner);
+    {
+      auto results = readCursor(localRunner);
 
-    int32_t count = 0;
-    for (auto& rows : results) {
-      count += rows->size();
+      int32_t count = 0;
+      for (auto& rows : results) {
+        count += rows->size();
+      }
+      EXPECT_EQ(250'000, count);
     }
-    localRunner->waitForCompletion(kWaitTimeoutUs);
-    EXPECT_EQ(250'000, count);
+
+    ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
   }
 
   std::shared_ptr<LocalRunner> makeRunner(MultiFragmentPlanPtr plan) {


### PR DESCRIPTION
Summary:
Fix two bugs in LocalRunner::waitForCompletion:

1. **Inconsistent timeout behavior**: The previous loop-based implementation had a bug where timeout was only detected on the *next* iteration of the loop. For single-task queries (like `SELECT 1`), there was no next iteration, so timeouts were silently ignored. With 2+ tasks, the timeout would be detected and cause a crash.

2. **Deadlock waiting for cursor's task**: The code was waiting for all tasks to be deleted via `taskDeletionFuture()`, but `cursor_` still held a reference to the last stage's task, preventing it from being destroyed. This caused a deadlock on simple queries.

Changes:
- Use `folly::collectAll` to wait on all futures with a single timeout instead of looping
- Reset `cursor_` before waiting to allow the task to be destroyed
- Change the API to return `bool` indicating success (true) or timeout (false) instead of crashing

Fixes https://github.com/facebookincubator/axiom/issues/729

Differential Revision: D92000156


