### PR TITLE
fix: Left cross join followed by a filter on right side columns

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -494,7 +494,7 @@ void JoinEdge::guessFanout() {
     return;
   }
 
-  if (leftTable_ == nullptr) {
+  if (leftTable_ == nullptr || leftKeys_.empty()) {
     lrFanout_ = 1.1;
     rlFanout_ = 1;
     return;

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -410,7 +410,9 @@ bool Distribution::isSameOrder(const Distribution& other) const {
 Distribution Distribution::rename(
     const ExprVector& exprs,
     const ColumnVector& names) const {
-  VELOX_CHECK(!isBroadcast());
+  if (isBroadcast()) {
+    return *this;
+  }
 
   // Partitioning survives projection if all partitioning columns are projected
   // out.

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -513,12 +513,12 @@ TEST_F(JoinTest, leftCrossJoin) {
             .nestedLoopJoin(
                 core::PlanMatcherBuilder().tableScan("u").aggregation().build(),
                 core::JoinType::kLeft)
-            // TODO Remove redundant projection.
-            .project()
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
+
+    ASSERT_NO_THROW(planVelox(logicalPlan));
   }
 
   {
@@ -533,11 +533,32 @@ TEST_F(JoinTest, leftCrossJoin) {
             .nestedLoopJoin(
                 core::PlanMatcherBuilder().tableScan("u").aggregation().build(),
                 core::JoinType::kLeft)
-            .project()
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
+
+    ASSERT_NO_THROW(planVelox(logicalPlan));
+  }
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT a FROM t LEFT JOIN u ON 1 = 1 WHERE coalesce(x, 1) > 0",
+        kTestConnectorId);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan("t")
+                       .nestedLoopJoin(
+                           core::PlanMatcherBuilder().tableScan("u").build(),
+                           core::JoinType::kLeft)
+                       .filter()
+                       .project()
+                       .build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+
+    ASSERT_NO_THROW(planVelox(logicalPlan));
   }
 }
 


### PR DESCRIPTION
Summary:
Fixed left cross join with a filter referencing columns from the right side.

Example failing query:

> SELECT n_name FROM nation LEFT JOIN (VALUES (1,2),(3,4)) AS t(x,y) ON TRUE WHERE y > 0

`crossJoin` was missing logic to handle join columns (`JoinEdge.{rightColumns,leftColumns}`). These columns define aliases for nullable output columns on the optional side of outer joins. Without this logic, the filter `y > 0` couldn't find column `y` in the NLJ output.

Added `precomputeJoinInputs` and `ProjectionBuilder` logic to `crossJoin`.

Also, extracted shared `PrecomputeProjection` logic into a `precomputeJoinInputs` helper function to reduce code duplication between `joinByHash`, `joinByHashRight`, and `crossJoin`.

Differential Revision: D92043033


