### PR TITLE
feat: Add support for localtime and localtimestamp functions

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -732,9 +732,9 @@ lp::ExprApi ExpressionPlanner::toExpr(
         case CurrentTime::Function::kTimestamp:
           return lp::Call("current_timestamp");
         case CurrentTime::Function::kLocaltime:
-          VELOX_NYI("LOCALTIME is not supported yet.");
+          return lp::Call("localtime");
         case CurrentTime::Function::kLocaltimestamp:
-          VELOX_NYI("LOCALTIMESTAMP is not supported yet.");
+          return lp::Call("localtimestamp");
       }
       VELOX_UNREACHABLE();
     }

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -371,17 +371,14 @@ TEST_F(ExpressionParserTest, extract) {
   test("SECOND", "second");
 }
 
-TEST_F(ExpressionParserTest, currentDateTime) {
-  // CURRENT_DATE and CURRENT_TIMESTAMP translate to zero-argument function
-  // calls.
+TEST_F(ExpressionParserTest, specialDateTimeFunctions) {
+  // Special date/time keywords translate to zero-argument function calls.
   EXPECT_EQ("current_date()", parseExpr("CURRENT_DATE")->toString());
   EXPECT_EQ("current_date()", parseExpr("current_date")->toString());
+  EXPECT_EQ("current_time()", parseExpr("CURRENT_TIME")->toString());
   EXPECT_EQ("current_timestamp()", parseExpr("CURRENT_TIMESTAMP")->toString());
-
-  // LOCALTIME and LOCALTIMESTAMP are not yet implemented.
-  VELOX_ASSERT_THROW(parseExpr("LOCALTIME"), "LOCALTIME is not supported yet");
-  VELOX_ASSERT_THROW(
-      parseExpr("LOCALTIMESTAMP"), "LOCALTIMESTAMP is not supported yet");
+  EXPECT_EQ("localtime()", parseExpr("LOCALTIME")->toString());
+  EXPECT_EQ("localtimestamp()", parseExpr("LOCALTIMESTAMP")->toString());
 
   // Precision is not supported.
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
This change implements parsing of SQL special date/time functions `localtime` and `localtimestamp`. 

Also has test coverage for `current_time`.

E.g 
```sql
SELECT * FROM t WHERE time_col > localtime
```

Differential Revision: D92071638


