### PR TITLE
feat: Add JOIN USING support

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -85,6 +85,8 @@ std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
 }
 
 void NameMappings::setAlias(const std::string& alias) {
+  alias_ = alias;
+
   std::vector<std::pair<std::string, std::string>> names;
   for (auto it = mappings_.begin(); it != mappings_.end();) {
     if (it->first.alias.has_value()) {

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -69,6 +69,11 @@ class NameMappings {
   /// Used in PlanBuilder::as() API.
   void setAlias(const std::string& alias);
 
+  /// Returns the current alias, if set via 'setAlias()'.
+  const std::optional<std::string>& alias() const {
+    return alias_;
+  }
+
   /// Merges mappings from 'other' into this. Removes unqualified access to
   /// non-unique names.
   ///
@@ -108,6 +113,9 @@ class NameMappings {
 
   // IDs of hidden columns.
   folly::F14FastSet<std::string> hiddenIds_;
+
+  // Current alias, set by setAlias().
+  std::optional<std::string> alias_;
 };
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_library(axiom_logical_plan_matcher LogicalPlanMatcher.cpp)
 
-target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest)
+target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gmock GTest::gtest)
 
 add_executable(axiom_sql_presto_test PrestoParserTest.cpp TableExtractorTest.cpp)
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -62,6 +62,8 @@ class LogicalPlanMatcherBuilder {
 
   LogicalPlanMatcherBuilder& sample(OnMatchCallback onMatch = nullptr);
 
+  LogicalPlanMatcherBuilder& outputColumns(std::vector<std::string> expected);
+
   std::shared_ptr<LogicalPlanMatcher> build() {
     VELOX_USER_CHECK_NOT_NULL(
         matcher_, "Cannot build an empty LogicalPlanMatcher.");


### PR DESCRIPTION
**Summary:**
Adds support for `JOIN ... USING (columns)` syntax in the Presto SQL parser and logical Plan Builder.

**Implementation:**
Convert USING (col) to t1.col = t2.col equality conditions.
e.g `FROM t1 JOIN t2 USING (id, key)` -> `t1.id = t2.id AND t1.key = t2.key`.
Output column handling per  SQL standard: https://prestodb.io/docs/current/sql/select.html

1. USING columns appear first (single occurence. For FULL JOIN, USING columns use `COALESCE(left.col, right.col)`)
2. Remaining left table columns
3. Remaining right table columns

**Other changes**
- Add NameMappings::alias() getter
- Add OutputColumnsMatcher to LogicalPlanMatcherBuilder for test assertions

**Note** 
For nested joins without explicit aliases (e.g., `(t JOIN u USING (id)) JOIN v`),
we generate a synthetic alias suffixed with 'join'.

Axiom currently uses name-based column resolution and requires aliases to build qualified references, unlike Presto Java which handles this by using scope-based field tracking.

Differential Revision: D91906864


