### PR TITLE
fix(parser): Represent ColumnDefinition types as TypeSignature

### DIFF
--- a/axiom/sql/presto/ast/AstSupport.h
+++ b/axiom/sql/presto/ast/AstSupport.h
@@ -481,13 +481,13 @@ class ColumnDefinition : public TableElement {
   ColumnDefinition(
       NodeLocation location,
       const std::shared_ptr<Identifier>& name,
-      const std::string& columnType,
+      TypeSignaturePtr columnType,
       bool nullable,
       const std::vector<std::shared_ptr<Property>>& properties,
       std::optional<std::string> comment = std::nullopt)
       : TableElement(NodeType::kColumnDefinition, location),
         name_(name),
-        columnType_(columnType),
+        columnType_(std::move(columnType)),
         nullable_(nullable),
         properties_(properties),
         comment_(std::move(comment)) {}
@@ -496,7 +496,7 @@ class ColumnDefinition : public TableElement {
     return name_;
   }
 
-  const std::string& columnType() const {
+  const TypeSignaturePtr& columnType() const {
     return columnType_;
   }
 
@@ -516,7 +516,7 @@ class ColumnDefinition : public TableElement {
 
  private:
   std::shared_ptr<Identifier> name_;
-  std::string columnType_;
+  TypeSignaturePtr columnType_;
   bool nullable_;
   std::vector<std::shared_ptr<Property>> properties_;
   std::optional<std::string> comment_;


### PR DESCRIPTION
Summary:
In a previous change, to enable CREATE TABLE, I converted column types as strings and used some Velox Presto SQL type utilities to later parse those strings into Velox types

At the time I did not validate parsing of complex Presto typestrings, such as `MAP<VARCHAR, ARRAY<INTEGER>>` or other compound types, but there are some issues with representing these types as a pure string in ColumnDefinition. For example, the `getText()` representation of `ROW(a INTEGER, b VARCHAR)` is `ROW(aINTEGER, bVARCHAR)`, so typestrings must be carefully constructed. Also, Velox and Presto do not agree on <> or () for separators, meaning some custom logic must be baked in for character transforms

After investigating, I realized we already have a built-in method for representing a TypeSignature (the TypeSignature class) so we should move ColumnDefinition to that

By doing so, we can reuse the (PrestoSqlParser::TypeContext -> TypeSignature) logic AND the (TypeSignature -> velox::TypePtr) logic, and avoid introducing an separate type parsing path to PrestoParser

Differential Revision: D92100074


