### PR TITLE
fix(parser): Use milliseconds when creating literals of type INTERVAL_DAY_TIME

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -579,7 +579,7 @@ class RelationPlanner : public AstVisitor {
         } else {
           const auto seconds = parseDayTimeInterval(
               interval->value(), interval->startField(), interval->endField());
-          return lp::Lit(multiplier * seconds, INTERVAL_DAY_TIME());
+          return lp::Lit(multiplier * seconds * 1'000, INTERVAL_DAY_TIME());
         }
       }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -508,7 +508,7 @@ TEST_F(PrestoParserTest, types) {
 TEST_F(PrestoParserTest, intervalDayTime) {
   auto parser = makeParser();
 
-  auto test = [&](std::string_view sql, int64_t expected) {
+  auto test = [&](std::string_view sql, int64_t expectedSeconds) {
     SCOPED_TRACE(sql);
     auto expr = parser.parseExpression(sql);
 
@@ -517,7 +517,7 @@ TEST_F(PrestoParserTest, intervalDayTime) {
 
     auto value = expr->as<lp::ConstantExpr>()->value();
     ASSERT_FALSE(value->isNull());
-    ASSERT_EQ(value->value<int64_t>(), expected);
+    ASSERT_EQ(value->value<int64_t>(), expectedSeconds * 1'000);
   };
 
   test("INTERVAL '2' DAY", 2 * 24 * 60 * 60);


### PR DESCRIPTION
Summary
INTERVAL '1' DAY was incorrectly parsed as the integer 86400. Since INTERVAL_DAY_TIME values are stored in milliseconds, the correct value is 86,400,000.
Fixes queries such as:

> VALUES sequence(from_iso8601_date('2020-01-01'), date('2024-09-30'), INTERVAL '1' DAY)

Differential Revision: D92179225


