### PR TITLE
refactor: Fold ToGraph::setDtOutput into makeQueryGraph

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -56,7 +56,6 @@ Optimization::Optimization(
   for (auto* join : root_->joins) {
     join->guessFanout();
   }
-  toGraph_.setDtOutput(root_, *logicalPlan_);
 }
 
 // static

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -333,15 +333,6 @@ lp::ValuesNodePtr tryFoldConstantDt(
 
 } // namespace
 
-void ToGraph::setDtOutput(DerivedTableP dt, const lp::LogicalPlanNode& node) {
-  const auto& type = *node.outputType();
-  for (const auto& name : type.names()) {
-    addDtColumn(dt, name);
-  }
-
-  // TODO Try constant fold the dt.
-}
-
 void ToGraph::setDtUsedOutput(
     DerivedTableP dt,
     const lp::LogicalPlanNode& node) {
@@ -2666,6 +2657,10 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
       }).markAll(logicalPlan);
   currentDt_ = newDt();
   makeQueryGraph(logicalPlan, kAllAllowedInDt);
+  setDtUsedOutput(currentDt_, logicalPlan);
+
+  // TODO Try constant fold the dt.
+
   return currentDt_;
 }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -108,10 +108,6 @@ class ToGraph {
   DerivedTableP makeQueryGraph(
       const logical_plan::LogicalPlanNode& logicalPlan);
 
-  // Sets the columns to project out from the root DerivedTable based on
-  // 'logicalPlan'.
-  void setDtOutput(DerivedTableP dt, const logical_plan::LogicalPlanNode& node);
-
   Name newCName(std::string_view prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));
   }


### PR DESCRIPTION
Summary:
Eliminate the separate `setDtOutput` call by moving its logic into `makeQueryGraph`.

The `setDtOutput` method was only called once, immediately after `makeQueryGraph`, with the same `logicalPlan` argument. By folding this logic into `makeQueryGraph`, we simplify the API and reduce the chance of forgetting to call `setDtOutput` after creating a query graph.

Differential Revision: D92258687


