### PR TITLE
refactor: Centralize DerivedTable initialization in initializePlans

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -50,12 +50,7 @@ Optimization::Optimization(
       toVelox_{session_, runnerOptions_, options_} {
   queryCtx()->optimization() = this;
   root_ = toGraph_.makeQueryGraph(*logicalPlan_);
-  root_->distributeConjuncts();
-  root_->addImpliedJoins();
-  root_->linkTablesToJoins();
-  for (auto* join : root_->joins) {
-    join->guessFanout();
-  }
+  root_->initializePlans();
 }
 
 // static


### PR DESCRIPTION
Summary:
Introduce a new `initializePlans()` method that handles all DerivedTable initialization in a single traversal. Previously, initialization was scattered across `Optimization` constructor and `ToGraph` methods, with `makeInitialPlan()` called separately for each DerivedTable as it was created.

The new approach:
- Performs top-down `distributeConjuncts()` to push filters down the tree
- Performs bottom-up `finalizeJoins()` (which combines addImpliedJoins, linkTablesToJoins, setStartTables, and guessFanout) and memoization
- Handles UNION/UNION ALL branches by aggregating cardinality and column statistics from children

This centralizes the initialization logic, making it easier to reason about the order of operations and ensuring all DerivedTables are properly initialized before optimization begins.

Differential Revision: D92290059
