### PR TITLE
fix: Add runtime validation for scalar subqueries (EnforceSingleRow)

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -72,6 +72,11 @@ struct DerivedTable : public PlanObject {
   /// operation (setOp is set).
   ExprVector exprs;
 
+  /// True if this DT is expected to produce exactly 1 row and must be validated
+  /// at runtime. Set for scalar subqueries that don't naturally guarantee
+  /// single-row output (no global aggregation).
+  bool enforceSingleRow{false};
+
   /// References all joins where 'this' is an end point.
   JoinEdgeVector joinedBy;
 
@@ -219,6 +224,12 @@ struct DerivedTable : public PlanObject {
       return table->is(PlanType::kUnnestTableNode);
     });
   }
+
+  /// Sets enforceSingleRow flag if this DT doesn't naturally guarantee
+  /// single-row output. A global aggregation (no grouping keys) without
+  /// HAVING clause guarantees exactly one row; otherwise, runtime validation
+  /// is needed for scalar subqueries.
+  void ensureSingleRow();
 
   /// True if contains one derived table in 'tables' and adds no change to its
   /// result set.

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -140,6 +140,10 @@ std::string visitDerivedTable(const DerivedTable& dt) {
     }
   }
 
+  if (dt.enforceSingleRow) {
+    out << "  enforce single row" << std::endl;
+  }
+
   if (!dt.tables.empty()) {
     out << "  tables: ";
     int32_t i = 0;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -908,6 +908,12 @@ void Optimization::addPostprocess(
     state.addCost(*limit);
     plan = limit;
   }
+
+  if (dt->enforceSingleRow) {
+    auto enforceSingleRow = make<EnforceSingleRow>(plan);
+    state.addCost(*enforceSingleRow);
+    plan = enforceSingleRow;
+  }
 }
 
 namespace {

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -119,6 +119,7 @@ enum class RelType {
   kValues,
   kUnnest,
   kTableWrite,
+  kEnforceSingleRow,
 };
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
@@ -665,5 +666,19 @@ struct TableWrite : public RelationOp {
 };
 
 using TableWriteCP = const TableWrite*;
+
+/// Validates that input produces exactly one row. Used for scalar subqueries.
+/// Fails at runtime if input produces zero or more than one row.
+struct EnforceSingleRow : public RelationOp {
+  explicit EnforceSingleRow(RelationOpPtr input);
+
+  std::string toString(bool recursive, bool detail) const override;
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+};
+
+using EnforceSingleRowCP = const EnforceSingleRow*;
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -217,6 +217,11 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const EnforceSingleRow& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -346,6 +351,11 @@ class OnelineVisitor : public RelationOpVisitor {
   }
 
   void visit(const TableWrite& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const EnforceSingleRow& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
   }

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -66,6 +66,10 @@ class RelationOpVisitor {
 
   virtual void visit(const TableWrite& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(
+      const EnforceSingleRow& op,
+      RelationOpVisitorContext& context) const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2137,12 +2137,9 @@ void ToGraph::processSubqueries(
           currentDt_->removeLastTable(subqueryDt);
           continue;
         }
-
-        // TODO Handle the case when subquery returns no rows. Fail if subquery
-        // is used in a comparison (x = <subquery>), constant fold if used as an
-        // IN LIST (x IN <subquery>).
       }
 
+      subqueryDt->ensureSingleRow();
       subqueries_.emplace(subquery, subqueryDt->columns.front());
     } else {
       VELOX_CHECK_EQ(

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -201,6 +201,11 @@ class ToVelox {
       runner::ExecutableFragment& fragment,
       std::vector<runner::ExecutableFragment>& stages);
 
+  velox::core::PlanNodePtr makeEnforceSingleRow(
+      const EnforceSingleRow& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -300,6 +300,14 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffleMerge();
 
+  /// Matches a broadcast shuffle boundary in a distributed plan.
+  /// Verifies that PartitionedOutputNode::isBroadcast() is true.
+  PlanMatcherBuilder& broadcast();
+
+  /// Matches a gather shuffle boundary in a distributed plan.
+  /// Verifies that PartitionedOutputNode::numPartitions() == 1.
+  PlanMatcherBuilder& gather();
+
   /// Matches any Limit node regardless of offset, count, or partial/final step.
   PlanMatcherBuilder& limit();
 
@@ -329,6 +337,10 @@ class PlanMatcherBuilder {
 
   /// Matches any TableWrite node.
   PlanMatcherBuilder& tableWrite();
+
+  /// Matches an EnforceSingleRow node, which validates that its input
+  /// produces exactly one row. Used for scalar subqueries.
+  PlanMatcherBuilder& enforceSingleRow();
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.


### PR DESCRIPTION
Summary:
Scalar subqueries must return exactly one row. Previously, subqueries that returned zero or multiple rows would silently produce incorrect results. Now, they fail at runtime with a clear error message.

**EnforceSingleRow implementation**:

- Add enforceSingleRow flag to DerivedTable, set via ensureSingleRow() method.
- Skip validation when single-row output is guaranteed: global aggregation without HAVING, or single-row VALUES.
- Add EnforceSingleRow RelationOp that wraps the subquery plan
Convert to Velox's EnforceSingleRowNode which throws "Expected single row of input" at runtime.

Differential Revision: D92314028


