### PR TITLE
feat: Add support for non-equi correlated scalar subqueries

### DIFF
--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -73,6 +73,24 @@ bool FunctionRegistry::registerCardinality(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerArbitrary(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (arbitrary_.has_value() && arbitrary_.value() != name) {
+    return false;
+  }
+  arbitrary_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerCount(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (count_.has_value() && count_.value() != name) {
+    return false;
+  }
+  count_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerSpecialForm(
     lp::SpecialForm specialForm,
     std::string_view name) {
@@ -211,6 +229,8 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerElementAt(fullName("element_at"));
   registry->registerSubscript(fullName("subscript"));
   registry->registerCardinality(fullName("cardinality"));
+  registry->registerArbitrary(fullName("arbitrary"));
+  registry->registerCount(fullName("count"));
 
   registry->registerReversibleFunction(fullName("eq"));
   registry->registerReversibleFunction(fullName("lt"), fullName("gt"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -268,6 +268,28 @@ class FunctionRegistry {
   /// 'cardinality' function is already registered.
   bool registerCardinality(std::string_view name);
 
+  /// Registers function 'name' that has semantics of Presto's 'arbitrary'
+  /// aggregate function, i.e. returns an arbitrary value from the group.
+  /// @return true if successfully registered, false if a different
+  /// 'arbitrary' function is already registered.
+  bool registerArbitrary(std::string_view name);
+
+  /// Returns the name of the 'arbitrary' aggregate function.
+  const std::optional<std::string>& arbitrary() const {
+    return arbitrary_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'count'
+  /// aggregate function, i.e. counts the number of rows in a group.
+  /// @return true if successfully registered, false if a different
+  /// 'count' function is already registered.
+  bool registerCount(std::string_view name);
+
+  /// Returns the name of the 'count' aggregate function.
+  const std::optional<std::string>& count() const {
+    return count_;
+  }
+
   bool registerSpecialForm(
       logical_plan::SpecialForm specialForm,
       std::string_view name);
@@ -301,6 +323,8 @@ class FunctionRegistry {
   std::optional<std::string> elementAt_;
   std::optional<std::string> subscript_;
   std::optional<std::string> cardinality_;
+  std::optional<std::string> arbitrary_;
+  std::optional<std::string> count_;
   folly::F14FastMap<std::string, std::string> reversibleFunctions_;
   folly::F14FastMap<logical_plan::SpecialForm, std::string> specialForms_;
 };

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -344,6 +344,9 @@ std::string JoinEdge::toString() const {
   if (!filter_.empty()) {
     out << " filter " << conjunctsToString(filter_);
   }
+  if (rowNumberColumn_) {
+    out << " row# " << rowNumberColumn_->toString();
+  }
   out << ">";
   return out.str();
 }
@@ -384,7 +387,7 @@ bool Expr::sameOrEqual(const Expr& other) const {
         return false;
       }
       for (auto i = 0; i < numArgs; ++i) {
-        if (as<Call>()->argAt(i)->sameOrEqual(*other.as<Call>()->argAt(i))) {
+        if (!as<Call>()->argAt(i)->sameOrEqual(*other.as<Call>()->argAt(i))) {
           return false;
         }
       }

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -222,6 +222,11 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const AssignUniqueId& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -356,6 +361,11 @@ class OnelineVisitor : public RelationOpVisitor {
   }
 
   void visit(const EnforceSingleRow& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const AssignUniqueId& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
   }

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -70,6 +70,10 @@ class RelationOpVisitor {
   virtual void visit(
       const EnforceSingleRow& op,
       RelationOpVisitorContext& context) const = 0;
+
+  virtual void visit(
+      const AssignUniqueId& op,
+      RelationOpVisitorContext& context) const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -140,13 +140,15 @@ struct Distribution {
       ExprVector partitionKeys,
       ExprVector orderKeys = {},
       OrderTypeVector orderTypes = {},
-      int32_t numKeysUnique = 0)
+      int32_t numKeysUnique = 0,
+      ExprVector clusterKeys = {})
       : distributionType_{distributionType},
         partitionKeys_{std::move(partitionKeys)},
         orderKeys_{std::move(orderKeys)},
         orderTypes_{std::move(orderTypes)},
         numKeysUnique_{numKeysUnique},
-        isBroadcast_{false} {
+        isBroadcast_{false},
+        clusterKeys_{std::move(clusterKeys)} {
     VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
     if (isGather()) {
       VELOX_CHECK_EQ(partitionKeys_.size(), 0);
@@ -213,6 +215,10 @@ struct Distribution {
     return numKeysUnique_;
   }
 
+  const ExprVector& clusterKeys() const {
+    return clusterKeys_;
+  }
+
   Distribution rename(const ExprVector& exprs, const ColumnVector& names) const;
 
   std::string toString() const;
@@ -239,6 +245,11 @@ struct Distribution {
   int32_t numKeysUnique_;
 
   bool isBroadcast_;
+
+  /// Clustering columns. Rows with the same values in these columns are
+  /// contiguous but not necessarily ordered. Enables streaming group by
+  /// when clustering keys are a subset of grouping keys.
+  ExprVector clusterKeys_;
 };
 
 struct SchemaTable;

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -206,6 +206,11 @@ class ToVelox {
       runner::ExecutableFragment& fragment,
       std::vector<runner::ExecutableFragment>& stages);
 
+  velox::core::PlanNodePtr makeAssignUniqueId(
+      const AssignUniqueId& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -239,6 +239,18 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 
+  /// Matches any streaming Aggregation node (input is pre-grouped on all
+  /// grouping keys).
+  PlanMatcherBuilder& streamingAggregation();
+
+  /// Matches a streaming Aggregation node with the specified grouping keys and
+  /// aggregate expressions.
+  /// @param groupingKeys Columns to group by.
+  /// @param aggregates Aggregate expressions.
+  PlanMatcherBuilder& streamingAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates);
+
   /// Matches a HashJoin node with the specified right side matcher.
   /// @param rightMatcher Matcher for the right (build) side of the join.
   PlanMatcherBuilder& hashJoin(
@@ -341,6 +353,16 @@ class PlanMatcherBuilder {
   /// Matches an EnforceSingleRow node, which validates that its input
   /// produces exactly one row. Used for scalar subqueries.
   PlanMatcherBuilder& enforceSingleRow();
+
+  /// Matches an AssignUniqueId node, which assigns unique identifiers to
+  /// each input row. Used for decorrelating subqueries with non-equi
+  /// correlation conditions.
+  PlanMatcherBuilder& assignUniqueId();
+
+  /// Matches an AssignUniqueId node and captures the unique ID column name
+  /// as a symbol alias for use in parent matchers via symbol rewriting.
+  /// @param alias The alias to use for the unique ID column.
+  PlanMatcherBuilder& assignUniqueId(const std::string& alias);
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.


### PR DESCRIPTION
Summary:
Add support for decorrelating scalar subqueries with non-equi correlation conditions (e.g., `n_regionkey < r_regionkey`).

The decorrelation strategy for non-equi conditions uses:
1. **AssignUniqueId** - Assigns a unique identifier to each outer row
2. **LEFT JOIN** - Joins outer with inner using the non-equi predicate as a filter
3. **Streaming Aggregation** - Groups by the unique ID to compute the aggregate per outer row

Differential Revision: D92435311


