### PR TITLE
fix(cli): Collapse newlines/whitespace before appending to history

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-  axiom_sql
-  AxiomSql.cpp
+add_library(
+  axiom_cli
   Connectors.cpp
   Console.cpp
   SqlQueryRunner.cpp
@@ -25,7 +24,7 @@ add_executable(
 )
 
 target_link_libraries(
-  axiom_sql
+  axiom_cli
   axiom_runner_local_runner
   axiom_runner_multifragment_plan
   axiom_optimizer
@@ -41,19 +40,12 @@ target_link_libraries(
   velox_parse_utils
 )
 
-add_executable(axiom_graphviz Connectors.cpp QueryGraphviz.cpp SqlQueryRunner.cpp)
+add_executable(axiom_sql AxiomSql.cpp)
 
-target_link_libraries(
-  axiom_graphviz
-  axiom_runner_local_runner
-  axiom_runner_multifragment_plan
-  axiom_optimizer
-  axiom_tpch_connector_metadata
-  axiom_hive_connector_metadata
-  axiom_sql_presto_parser
-  velox_exec_test_lib
-  velox_parse_parser
-  velox_parse_expression
-  velox_parse_utils
-  Folly::folly
-)
+target_link_libraries(axiom_sql axiom_cli)
+
+add_executable(axiom_graphviz QueryGraphviz.cpp)
+
+target_link_libraries(axiom_graphviz axiom_cli)
+
+add_subdirectory(tests)

--- a/axiom/cli/StdinReader.cpp
+++ b/axiom/cli/StdinReader.cpp
@@ -22,6 +22,19 @@
 
 namespace axiom::cli {
 
+namespace {
+std::string collapseWhitespace(std::string str) {
+  std::replace_if(str.begin(), str.end(), ::isspace, ' ');
+  str.erase(
+      std::unique(
+          str.begin(),
+          str.end(),
+          [](char a, char b) { return a == ' ' && b == ' '; }),
+      str.end());
+  return str;
+}
+} // namespace
+
 std::string readCommand(const std::string& prompt, bool& atEnd) {
   std::stringstream command;
   atEnd = false;
@@ -59,7 +72,8 @@ std::string readCommand(const std::string& prompt, bool& atEnd) {
 
       if (line[i] == ';') {
         command << line.substr(startPos, i - startPos);
-        linenoiseHistoryAdd(fmt::format("{};", command.str()).c_str());
+        auto history = collapseWhitespace(command.str());
+        linenoiseHistoryAdd(fmt::format("{};", history).c_str());
         return command.str();
       }
 

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(axiom_cli_test SqlQueryRunnerTest.cpp StdinReaderTest.cpp)
+
+add_test(NAME axiom_cli_test COMMAND axiom_cli_test)
+
+target_link_libraries(
+  axiom_cli_test
+  axiom_cli
+  axiom_test_connector
+  velox_exec_test_lib
+  velox_vector_test_lib
+  GTest::gtest
+)

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -144,3 +145,9 @@ TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
 
 } // namespace
 } // namespace axiom::sql
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/axiom/cli/tests/StdinReaderTest.cpp
+++ b/axiom/cli/tests/StdinReaderTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/StdinReader.h"
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <cstdio>
+#include <fstream>
+#include "axiom/cli/linenoise/linenoise.h"
+
+namespace axiom::cli {
+namespace {
+
+class StdinReaderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    savedStdin_ = dup(STDIN_FILENO);
+    ASSERT_NE(savedStdin_, -1);
+  }
+
+  void TearDown() override {
+    dup2(savedStdin_, STDIN_FILENO);
+    close(savedStdin_);
+  }
+
+  void setStdInput(const std::string& input) {
+    int pipefd[2];
+    ASSERT_EQ(pipe(pipefd), 0);
+
+    ssize_t written = write(pipefd[1], input.data(), input.size());
+    ASSERT_EQ(written, static_cast<ssize_t>(input.size()));
+    close(pipefd[1]);
+
+    dup2(pipefd[0], STDIN_FILENO);
+    close(pipefd[0]);
+  }
+
+  void testSingleCommand(
+      const std::string& input,
+      const std::string& expected) {
+    setStdInput(input);
+    bool atEnd = false;
+    EXPECT_EQ(readCommand("SQL> ", atEnd), expected);
+    EXPECT_FALSE(atEnd);
+  }
+
+  void testMultiCommand(
+      const std::string& input,
+      const std::vector<std::string>& expected) {
+    setStdInput(input);
+    bool atEnd = false;
+    for (const auto& cmd : expected) {
+      EXPECT_EQ(readCommand("SQL> ", atEnd), cmd);
+      EXPECT_FALSE(atEnd);
+    }
+  }
+
+  std::vector<std::string> getHistory() {
+    char tmpFile[] = "/tmp/linenoise_test_XXXXXX";
+    int fd = mkstemp(tmpFile);
+    EXPECT_NE(fd, -1);
+    close(fd);
+    linenoiseHistorySave(tmpFile);
+
+    std::vector<std::string> lines;
+    std::ifstream file(tmpFile);
+    std::string line;
+    while (std::getline(file, line)) {
+      lines.push_back(line);
+    }
+    return lines;
+  }
+
+ private:
+  int savedStdin_;
+};
+
+TEST_F(StdinReaderTest, singleCommand) {
+  testSingleCommand("SELECT 1;\n", "SELECT 1");
+  testSingleCommand("DROP TABLE bar;\n", "DROP TABLE bar");
+}
+
+TEST_F(StdinReaderTest, multiCommand) {
+  testMultiCommand(
+      "SELECT 1;\nSELECT 2;\nSELECT 3;\n",
+      {"SELECT 1", "SELECT 2", "SELECT 3"});
+}
+
+TEST_F(StdinReaderTest, whitespace) {
+  testSingleCommand("   SELECT 1;\n", "SELECT 1");
+  testSingleCommand("SELECT 2;   \n", "SELECT 2");
+  testSingleCommand("\t\tSELECT 3;\n", "SELECT 3");
+  testSingleCommand("SELECT 4;\t\t\n", "SELECT 4");
+  testSingleCommand("  \t  SELECT 5;  \t  \n", "SELECT 5");
+  testSingleCommand("\r\nSELECT 6;\r\n", "SELECT 6");
+}
+
+TEST_F(StdinReaderTest, history) {
+  auto initialSize = getHistory().size();
+  testMultiCommand("SELECT\n1;\nSELECT 2;\n", {"SELECT\n1", "SELECT 2"});
+
+  auto history = getHistory();
+  ASSERT_EQ(history.size(), initialSize + 2);
+  EXPECT_EQ(history[history.size() - 2], "SELECT 1;");
+  EXPECT_EQ(history[history.size() - 1], "SELECT 2;");
+}
+
+} // namespace
+} // namespace axiom::cli


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/axiom/issues/862 is the original issue

In this change, I am collapsing all adjoining whitespace, including newlnes, tabs, carriages returns etc.,  before appending to history

I am also adding a CMake file which I think may have been missing, SqlQueryRunnerTest did not have one present

Differential Revision: D92472849


