### PR TITLE
feat(optimizer): Support ORDER BY in aggregates for distributed mode

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1491,13 +1491,6 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
           "DISTINCT option for aggregation is supported only in single worker, single thread mode");
     }
 
-    if (!orderKeys.empty()) {
-      const auto& options = queryCtx()->optimization()->runnerOptions();
-      VELOX_CHECK(
-          options.numWorkers == 1 && options.numDrivers == 1,
-          "ORDER BY option for aggregation is supported only in single worker, single thread mode");
-    }
-
     auto name = toName(agg.outputNames()[channel]);
 
     AggregateDedupKey key{

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -142,15 +142,18 @@ std::shared_ptr<core::QueryCtx>& QueryTestBase::getQueryCtx() {
 optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const runner::MultiFragmentPlan::Options& options,
+    const std::optional<OptimizerOptions>& optimizerOptions,
     const std::optional<std::string>& planFilePathPrefix) {
   connector::SchemaResolver schemaResolver;
-  return planVelox(plan, schemaResolver, options, planFilePathPrefix);
+  return planVelox(
+      plan, schemaResolver, options, optimizerOptions, planFilePathPrefix);
 }
 
 optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const connector::SchemaResolver& schemaResolver,
     const runner::MultiFragmentPlan::Options& options,
+    const std::optional<OptimizerOptions>& optimizerOptions,
     const std::optional<std::string>& planFilePathPrefix) {
   auto& queryCtx = getQueryCtx();
 
@@ -187,7 +190,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
       *history_,
       queryCtx,
       evaluator,
-      optimizerOptions_,
+      optimizerOptions.value_or(optimizerOptions_),
       options);
   if (planPath != nullptr) {
     *planPath << "Query Graph:\n\n" << opt.rootDt()->toString() << "\n\n";

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -81,6 +81,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
               .numWorkers = 4,
               .numDrivers = 4,
           },
+      const std::optional<OptimizerOptions>& optimizerOptions = std::nullopt,
       const std::optional<std::string>& planFilePathPrefix = std::nullopt);
 
   optimizer::PlanAndStats planVelox(
@@ -91,6 +92,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
               .numWorkers = 4,
               .numDrivers = 4,
           },
+      const std::optional<OptimizerOptions>& optimizerOptions = std::nullopt,
       const std::optional<std::string>& planFilePathPrefix = std::nullopt);
 
   TestResult runVelox(

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -705,7 +705,11 @@ TEST_F(TpchPlanTest, DISABLED_makePlans) {
     };
 
     auto logicalPlan = parseTpchSql(q);
-    planVelox(logicalPlan, options, fmt::format("{}/q{}", path, q));
+    planVelox(
+        logicalPlan,
+        options,
+        /*optimizerOptions=*/std::nullopt,
+        fmt::format("{}/q{}", path, q));
   }
 }
 


### PR DESCRIPTION
Summary:
Previously, aggregation functions with ORDER BY keys (e.g., `array_agg(x ORDER BY y)`) would throw an error 
when running in distributed mode (multiple workers or drivers).

This diff removes the hard check in `ToGraph::translateAggregation()` that blocked ORDER BY aggregates in 
distributed mode, and instead enforces single-step aggregation in `Optimization::addAggregation()` when any 
aggregate has ORDER BY keys. This follows the same strategy as Presto-Java: https://github.com/prestodb/presto/blob/c3b3eeb6260a44753dd917ec129ff52a248effe6/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java#L59

This diff also enforce the optimizer to generate single-step aggregation when it has ORDER BY, even when OptimizerOption::alwaysPlanPartialAggregation == true.

**Why take this approach?**
Below are what other engines do with aggregation over sorted input.
* Presto-Java: Disallow aggregation over sorted input to be decomposed into partial + final steps.
* Spark: Spark allows aggregation over sorted input to be decomposed into partial + final steps, at the price of 
having each individual aggregation functions handle the ordering of inputs themselves. [In Spark-4.1.0, only 5 aggregations allow sorted input](https://spark.apache.org/docs/latest/sql-ref-functions-builtin.html#aggregate-functions).  
These functions are aware of and handle aggregation over sorted input by keeping the order-by value in 
companion with input values in the accumulator of every group. Functions that support both sorted and unsorted 
inputs require different code paths for the two cases. In contrast, Velox supports aggregation over sorted input at 
operator level and doesn't require individual functions to handle the ordering of inputs specially. This setup 
consequently requires the aggregation over sorted input after inputs have been shuffled by the grouping keys.
* DuckDB-1.3.1: DuckDB is for single-node with shared-memory among threads. DuckDB allows aggregation over 
sorted input to be decomposed, but the approach is specific to DuckDB's implementation of aggregation: Each 
thread first keeps all its input rows in a buffer during the first stage. After that finishes, each thread accesses all 
buffered rows of one grouping key, sorting and aggregating them. This approach would be similar to the single-
step aggregation approach in distributed execution mode.

Differential Revision: D92352633


