### PR TITLE
fix: Allow empty name mappings in qualified star projections

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -402,8 +402,6 @@ void PlanBuilder::resolveProjections(
           outputNames.push_back(id);
 
           const auto names = outputMapping_->reverseLookup(id);
-          VELOX_USER_CHECK(!names.empty());
-
           for (const auto& name : names) {
             mappings.add(name, id);
           }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1845,6 +1845,13 @@ TEST_F(PrestoParserTest, unqualifiedAccessAfterJoin) {
   testSql(sql, matcher);
 }
 
+TEST_F(PrestoParserTest, qualifiedStarInUnionAfterJoin) {
+  parseSql(
+      "SELECT * FROM (VALUES (1)) t(id) "
+      "UNION ALL "
+      "SELECT a.* FROM (VALUES (1)) a(id) JOIN (VALUES (2)) b(id) ON a.id = b.id");
+}
+
 TEST_F(PrestoParserTest, createTableAndInsert) {
   auto parser = makeParser();
 


### PR DESCRIPTION
Summary: reverseLookup can return empty for generated column names and shouldn't throw an error. 
Differential Revision: D92614072


