### PR TITLE
fix: Allow duplicate aliases in Presto SQL projections

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -101,10 +101,11 @@ void NameMappings::setAlias(const std::string& alias) {
   }
 }
 
-void NameMappings::merge(const NameMappings& other) {
+void NameMappings::merge(const NameMappings& other, bool allowDuplicates) {
   for (const auto& [name, id] : other.mappings_) {
     if (mappings_.contains(name)) {
       VELOX_CHECK(!name.alias.has_value());
+      VELOX_USER_CHECK(allowDuplicates, "Duplicate name: {}", name.toString());
       mappings_.erase(name);
     } else {
       mappings_.emplace(name, id);

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -70,13 +70,14 @@ class NameMappings {
   void setAlias(const std::string& alias);
 
   /// Merges mappings from 'other' into this. Removes unqualified access to
-  /// non-unique names.
+  /// non-unique names. If 'allowDuplicates' is false, throws on duplicate
+  /// unqualified names instead of removing access.
   ///
   /// @pre IDs are unique across 'this' and 'other'. This expectation is not
   /// verified explicitly. Violations would lead to undefined behavior.
   ///
-  /// Used in PlanBuilder::join() API.
-  void merge(const NameMappings& other);
+  /// Used in PlanBuilder::join() and PlanBuilder::unnest() APIs.
+  void merge(const NameMappings& other, bool allowDuplicates = true);
 
   /// Enables unqualified access to unique names.
   void enableUnqualifiedAccess();

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -898,7 +898,9 @@ TEST_F(UnnestTest, limit) {
 
 TEST_F(UnnestTest, join) {
   auto startLogicalPlan = [&](lp::PlanBuilder::Context& ctx) {
-    return lp::PlanBuilder{ctx}.values({rowVector_});
+    return lp::PlanBuilder{
+        ctx, /*enableCoercions=*/false, /*allowDuplicateAliases=*/true}
+        .values({rowVector_});
   };
 
   auto startReferencePlan = [&](auto& planNodeIdGenerator) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1928,7 +1928,10 @@ class RelationPlanner : public AstVisitor {
   std::shared_ptr<lp::PlanBuilder> newBuilder(
       const lp::PlanBuilder::Scope& outerScope = nullptr) {
     return std::make_shared<lp::PlanBuilder>(
-        context_, /* enableCoersions */ true, outerScope);
+        context_,
+        /*enableCoercions=*/true,
+        /*allowDuplicateAliases=*/true,
+        outerScope);
   }
 
   lp::PlanBuilder::Context context_;


### PR DESCRIPTION
Summary:
Fix "Duplicate name" errors when Presto SQL projections produce columns with the same alias (e.g., SELECT a as x, b as x).

Behavior:
SELECT a as x, b as x FROM t → succeeds, outputs both columns
SELECT a as x, u.x FROM ... UNNEST(b) AS u(x)) ->  succeeds, outputs both columns
SELECT x FROM (SELECT a as x, b as x ...) → fails with "Column 'x' is ambiguous"

Changes:
Added allowDuplicateAliases flag to PlanBuilder (true for Presto SQL, default false for DataFrame API)
Added tryAdd() to NameMappings to silently skip duplicate mappings

Known limitations:
Display shows x | x_0 not x | x : Presto Java solves this with separate columnNames list in OutputNode for display names. Fixing in Axiom requires display name tracking through result serialization. This is out of scope for this PR.

Differential Revision: D92626236


