### PR TITLE
feat: Add suport for parsing of POSITION

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1873,7 +1873,15 @@ std::any AstBuilder::visitExists(PrestoSqlParser::ExistsContext* ctx) {
 
 std::any AstBuilder::visitPosition(PrestoSqlParser::PositionContext* ctx) {
   trace("visitPosition");
-  return visitChildren("visitPosition", ctx);
+
+  // POSITION(x IN y) is equivalent to strpos(y, x)
+  return std::static_pointer_cast<Expression>(std::make_shared<FunctionCall>(
+      getLocation(ctx),
+      std::make_shared<QualifiedName>(
+          getLocation(ctx), std::vector<std::string>{"strpos"}),
+      std::vector<std::shared_ptr<Expression>>{
+          visitTyped<Expression>(ctx->valueExpression(1)),
+          visitTyped<Expression>(ctx->valueExpression(0))}));
 }
 
 std::any AstBuilder::visitSearchedCase(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -805,6 +805,12 @@ TEST_F(PrestoParserTest, concat) {
   testSql("SELECT n_name || n_comment FROM nation", matcher);
 }
 
+TEST_F(PrestoParserTest, position) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSql("SELECT POSITION('A' IN n_name) FROM nation", matcher);
+  testSql("SELECT POSITION(n_comment IN n_name) FROM nation", matcher);
+}
+
 TEST_F(PrestoParserTest, subscript) {
   auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
   testSql("SELECT array[1, 2, 3][1] FROM nation", matcher);


### PR DESCRIPTION
Summary:
Add support for parsing on position

POSITION(x IN Y) ->  strpos(Y, X)

Reference: https://prestodb.io/docs/current/functions/string.html#strpos-string-substring-instance-bigint

Differential Revision: D92632138


