### PR TITLE
feat: Normalize BETWEEN to x >= a AND a <= b

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -912,16 +912,6 @@ bool dtHasLimit(const DerivedTable& dt) {
   return dt.hasLimit();
 }
 
-void flattenAll(ExprCP expr, Name func, ExprVector& flat) {
-  if (expr->isNot(PlanType::kCallExpr) || expr->as<Call>()->name() != func) {
-    flat.push_back(expr);
-    return;
-  }
-  for (auto arg : expr->as<Call>()->args()) {
-    flattenAll(arg, func, flat);
-  }
-}
-
 // 'disjuncts' is an OR of ANDs. If each disjunct depends on the same tables
 // and if each conjunct inside the ANDs in the OR depends on a single table,
 // then return for each distinct table an OR of ANDs. The disjuncts are the

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -91,6 +91,33 @@ bool FunctionRegistry::registerCount(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerBetween(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (between_.has_value() && between_.value() != name) {
+    return false;
+  }
+  between_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerGreaterThanOrEqual(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (greaterThanOrEqual_.has_value() && greaterThanOrEqual_.value() != name) {
+    return false;
+  }
+  greaterThanOrEqual_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerLessThanOrEqual(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (lessThanOrEqual_.has_value() && lessThanOrEqual_.value() != name) {
+    return false;
+  }
+  lessThanOrEqual_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerSpecialForm(
     lp::SpecialForm specialForm,
     std::string_view name) {
@@ -264,6 +291,9 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerCardinality(fullName("cardinality"));
   registry->registerArbitrary(fullName("arbitrary"));
   registry->registerCount(fullName("count"));
+  registry->registerBetween(fullName("between"));
+  registry->registerGreaterThanOrEqual(fullName("gte"));
+  registry->registerLessThanOrEqual(fullName("lte"));
 
   registry->registerAggregateEmptyResultResolver(
       {fullName("count_if"), fullName("approx_distinct")},

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -302,6 +302,39 @@ class FunctionRegistry {
     return count_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'between',
+  /// i.e. returns true if value is within the specified range [low, high].
+  /// @return true if successfully registered, false if a different
+  /// 'between' function is already registered.
+  bool registerBetween(std::string_view name);
+
+  /// Returns the name of the 'between' function.
+  const std::optional<std::string>& between() const {
+    return between_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'gte',
+  /// i.e. returns true if left argument is greater than or equal to right.
+  /// @return true if successfully registered, false if a different
+  /// 'greaterThanOrEqual' function is already registered.
+  bool registerGreaterThanOrEqual(std::string_view name);
+
+  /// Returns the name of the 'greaterThanOrEqual' function.
+  const std::optional<std::string>& greaterThanOrEqual() const {
+    return greaterThanOrEqual_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'lte',
+  /// i.e. returns true if left argument is less than or equal to right.
+  /// @return true if successfully registered, false if a different
+  /// 'lessThanOrEqual' function is already registered.
+  bool registerLessThanOrEqual(std::string_view name);
+
+  /// Returns the name of the 'lessThanOrEqual' function.
+  const std::optional<std::string>& lessThanOrEqual() const {
+    return lessThanOrEqual_;
+  }
+
   bool registerSpecialForm(
       logical_plan::SpecialForm specialForm,
       std::string_view name);
@@ -377,6 +410,9 @@ class FunctionRegistry {
   std::optional<std::string> cardinality_;
   std::optional<std::string> arbitrary_;
   std::optional<std::string> count_;
+  std::optional<std::string> between_;
+  std::optional<std::string> greaterThanOrEqual_;
+  std::optional<std::string> lessThanOrEqual_;
   folly::F14FastMap<std::string, std::string> reversibleFunctions_;
   folly::F14FastMap<logical_plan::SpecialForm, std::string> specialForms_;
   folly::F14FastMap<std::string, AggregateEmptyResultResolver>

--- a/axiom/optimizer/PlanUtils.cpp
+++ b/axiom/optimizer/PlanUtils.cpp
@@ -142,4 +142,14 @@ std::string exprsToString(const ExprVector& exprs) {
   return out.str();
 }
 
+void flattenAll(ExprCP expr, Name func, ExprVector& flat) {
+  if (expr->isNot(PlanType::kCallExpr) || expr->as<Call>()->name() != func) {
+    flat.push_back(expr);
+    return;
+  }
+  for (auto arg : expr->as<Call>()->args()) {
+    flattenAll(arg, func, flat);
+  }
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -120,4 +120,8 @@ std::string columnsToString(const ColumnVector& columns);
 
 std::string exprsToString(const ExprVector& exprs);
 
+/// Recursively flattens nested calls to the given function.
+/// For example, flattenAll(and(and(a, b), c), "and", flat) produces [a, b, c].
+void flattenAll(ExprCP expr, Name func, ExprVector& flat);
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -36,6 +36,11 @@ namespace lp = facebook::axiom::logical_plan;
 namespace facebook::axiom::optimizer {
 namespace {
 
+bool isSpecialForm(const lp::ExprPtr& expr, lp::SpecialForm form) {
+  return expr->isSpecialForm() &&
+      expr->as<lp::SpecialFormExpr>()->form() == form;
+}
+
 Value toValue(const velox::TypePtr& type, float cardinality) {
   return Value{toType(type), cardinality};
 }
@@ -124,6 +129,17 @@ ToGraph::ToGraph(
 
   if (auto count = registry->count()) {
     functionNames_.count = toName(count.value());
+  }
+
+  // Initialize between, gte, lte for rewriting between to and(gte, lte).
+  if (auto between = registry->between()) {
+    functionNames_.between = toName(between.value());
+  }
+  if (auto gte = registry->greaterThanOrEqual()) {
+    functionNames_.gte = toName(gte.value());
+  }
+  if (auto lte = registry->lessThanOrEqual()) {
+    functionNames_.lte = toName(lte.value());
   }
 }
 
@@ -392,7 +408,13 @@ void ToGraph::translateConjuncts(const lp::ExprPtr& input, ExprVector& flat) {
   } else {
     auto translatedExpr = translateExpr(input);
     if (!isConstantTrue(translatedExpr)) {
-      flat.push_back(translatedExpr);
+      // If the translated expression is an 'and' call, flatten it
+      if (translatedExpr->is(PlanType::kCallExpr) &&
+          translatedExpr->as<Call>()->name() == SpecialFormCallNames::kAnd) {
+        flattenAll(translatedExpr, SpecialFormCallNames::kAnd, flat);
+      } else {
+        flat.push_back(translatedExpr);
+      }
     }
   }
 }
@@ -875,6 +897,24 @@ bool shouldInvert(ExprCP left, ExprCP right) {
 
 } // namespace
 
+ExprCP ToGraph::rewriteCall(Name name, const ExprVector& args) {
+  // Rewrite between(x, a, b) to and(gte(x, a), lte(x, b)).
+  if (args.size() == 3 && functionNames_.between != nullptr &&
+      functionNames_.gte != nullptr && functionNames_.lte != nullptr &&
+      name == functionNames_.between) {
+    auto value = toValue(velox::BOOLEAN(), 2);
+
+    auto* gteExpr =
+        deduppedCall(functionNames_.gte, value, {args[0], args[1]}, {});
+    auto* lteExpr =
+        deduppedCall(functionNames_.lte, value, {args[0], args[2]}, {});
+    auto* andExpr =
+        deduppedCall(SpecialFormCallNames::kAnd, value, {gteExpr, lteExpr}, {});
+    return andExpr;
+  }
+  return nullptr;
+}
+
 void ToGraph::canonicalizeCall(Name& name, ExprVector& args) {
   if (args.size() != 2) {
     return;
@@ -896,7 +936,14 @@ ExprCP ToGraph::deduppedCall(
     Value value,
     ExprVector args,
     FunctionSet flags) {
+  // Check if the call should be rewritten to a different expression.
+  if (auto* rewritten = rewriteCall(name, args)) {
+    return rewritten;
+  }
+
+  // Canonicalize arguments (e.g., swap args for reversible functions).
   canonicalizeCall(name, args);
+
   ExprDedupKey key = {name, args};
 
   auto [it, emplaced] = functionDedup_.try_emplace(key);

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -57,6 +57,9 @@ struct FunctionNames {
   Name elementAt{nullptr};
   Name subscript{nullptr};
   Name cardinality{nullptr};
+  Name between{nullptr};
+  Name gte{nullptr};
+  Name lte{nullptr};
 
   /// Aggregate functions.
   Name arbitrary{nullptr};
@@ -159,17 +162,14 @@ class ToGraph {
     }
   }
 
- private:
-  static bool isSpecialForm(
-      const logical_plan::ExprPtr& expr,
-      logical_plan::SpecialForm form) {
-    return expr->isSpecialForm() &&
-        expr->as<logical_plan::SpecialFormExpr>()->form() == form;
-  }
+  // Rewrites a function call to a different expression if applicable.
+  // For example, rewrites between(x, a, b) to and(gte(x, a), lte(x, b)).
+  // Returns nullptr if no rewrite is needed.
+  ExprCP rewriteCall(Name name, const ExprVector& args);
 
-  // For comparisons, swaps the args to have a canonical form for
-  // deduplication. E.g column op constant, and smaller plan object id
-  // to the left.
+  // Canonicalizes function call by reordering arguments for reversible
+  // functions like gt/lt to ensure consistent argument order. Modifies
+  // 'name' and 'args' in place.
   void canonicalizeCall(Name& name, ExprVector& args);
 
   // Handles correlation processing for aggregations in correlated subqueries.

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -606,7 +606,6 @@ TEST_F(PlanTest, filterBreakup) {
             .add("l_quantity", exec::betweenDouble(1.0, 30.0))
             .build();
 
-    auto plan = toSingleNodePlan(logicalPlan);
     auto matcher =
         core::PlanMatcherBuilder()
             .hiveScan("lineitem", std::move(lineitemFilters))
@@ -614,16 +613,17 @@ TEST_F(PlanTest, filterBreakup) {
                 core::PlanMatcherBuilder()
                     .hiveScan(
                         "part",
-                        {},
-                        "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
-                        "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
-                        "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))")
+                        common::test::SubfieldFiltersBuilder()
+                            .add("p_size", exec::greaterThanOrEqual(1LL))
+                            .build(),
+                        "\"or\"(\"and\"(lte(p_size,15),\"and\"(eq(p_brand,'Brand#34'),\"like\"(p_container,'LG%'))),\"or\"(\"and\"(lte(p_size,5),\"and\"(eq(p_brand,'Brand#12'),\"like\"(p_container,'SM%'))),\"and\"(lte(p_size,10),\"and\"(eq(p_brand,'Brand#23'),\"like\"(p_container,'MED%')))))")
                     .build())
             .filter()
             .project()
             .singleAggregation()
             .build();
 
+    auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -612,10 +612,10 @@ TEST_F(TpchPlanTest, q19) {
               core::PlanMatcherBuilder()
                   .hiveScan(
                       "part",
-                      {},
-                      "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
-                      "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
-                      "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
+                      common::test::SubfieldFiltersBuilder()
+                          .add("p_size", exec::greaterThanOrEqual(1LL))
+                          .build(),
+                      "\"or\"(\"and\"(lte(p_size,15),\"and\"(eq(p_brand,'Brand#34'),\"in\"(p_container,array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))),\"or\"(\"and\"(lte(p_size,5),\"and\"(eq(p_brand,'Brand#12'),\"in\"(p_container,array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))),\"and\"(lte(p_size,10),\"and\"(eq(p_brand,'Brand#23'),\"in\"(p_container,array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))")
                   .build(),
               core::JoinType::kInner)
           .filter()


### PR DESCRIPTION
Summary:
Rewrite `x BETWEEN a AND b` to `x >= a AND x <= b` during query graph construction. This normalization enables extracting shared conjuncts from disjuncts. For example:

> (a BETWEEN 0 AND 10 AND b = 1) OR (a BETWEEN 0 AND 20 AND b = 2)

can be rewritten to:

> a >= 0 AND ((a <= 10 AND b = 1) OR (a <= 20 AND b = 2))

Extracted from https://github.com/facebookincubator/axiom/pull/702

Co-authored-by: oerling

Differential Revision: D92685072


