### PR TITLE
fix: EXPLAIN DROP TABLE

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1308,6 +1308,11 @@ SqlStatementPtr doPlan(
         *query->as<CreateTable>(), defaultConnectorId, defaultSchema);
   }
 
+  if (query->is(NodeType::kDropTable)) {
+    return parseDropTable(
+        *query->as<DropTable>(), defaultConnectorId, defaultSchema);
+  }
+
   if (query->is(NodeType::kShowCatalogs)) {
     return parseShowCatalogs(*query->as<ShowCatalogs>(), defaultConnectorId);
   }
@@ -1361,11 +1366,6 @@ SqlStatementPtr PrestoParser::doParse(
     auto sqlStatement = doPlan(
         explain->statement(), defaultConnectorId_, defaultSchema_, parseSql);
     return parseExplain(*explain, sqlStatement);
-  }
-
-  if (query->is(NodeType::kDropTable)) {
-    return parseDropTable(
-        *query->as<DropTable>(), defaultConnectorId_, defaultSchema_);
   }
 
   if (query->is(NodeType::kUse)) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -775,6 +775,24 @@ TEST_F(PrestoParserTest, explainInsert) {
   }
 }
 
+TEST_F(PrestoParserTest, explainCreateTable) {
+  testExplainDdl(
+      "EXPLAIN CREATE TABLE t (id INTEGER)", SqlStatementKind::kCreateTable);
+  testExplainDdl(
+      "EXPLAIN CREATE TABLE IF NOT EXISTS t (id INTEGER)",
+      SqlStatementKind::kCreateTable);
+  testExplainDdl(
+      "EXPLAIN CREATE TABLE t (id INTEGER, ds VARCHAR) "
+      "WITH (partitioned_by = ARRAY['ds'])",
+      SqlStatementKind::kCreateTable);
+}
+
+TEST_F(PrestoParserTest, explainDropTable) {
+  testExplainDdl("EXPLAIN DROP TABLE t", SqlStatementKind::kDropTable);
+  testExplainDdl(
+      "EXPLAIN DROP TABLE IF EXISTS u", SqlStatementKind::kDropTable);
+}
+
 TEST_F(PrestoParserTest, showCatalogs) {
   {
     auto matcher = matchValues();

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -87,6 +87,19 @@ void PrestoParserTestBase::testExplain(
   }
 }
 
+void PrestoParserTestBase::testExplainDdl(
+    std::string_view sql,
+    SqlStatementKind expectedKind) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isExplain());
+
+  auto* explainStatement = statement->as<ExplainStatement>();
+  ASSERT_EQ(explainStatement->statement()->kind(), expectedKind);
+}
+
 void PrestoParserTestBase::testSelect(
     std::string_view sql,
     lp::test::LogicalPlanMatcherBuilder& matcher,

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -48,6 +48,10 @@ class PrestoParserTestBase : public testing::Test {
       std::string_view sql,
       facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher);
 
+  /// Verifies that EXPLAIN can parse DDL statements (CREATE TABLE, DROP TABLE).
+  /// DDL statements do not have logical plans, so we only verify parsing.
+  void testExplainDdl(std::string_view sql, SqlStatementKind expectedKind);
+
   /// Parses a SELECT statement and verifies the logical plan matches.
   /// Optionally checks that the expected set of views were accessed.
   void testSelect(


### PR DESCRIPTION
Summary:

```
explain drop table some_table;
```
fails with 
`Unsupported statement type: DropTable - Native Coordinator Query Failed
`

This is because it hit the explain branch before it reached the kDropTable branch in doParse, and doPlan does not handle kDropTable.

fix: move the handling of kDropTable from doParse -> doPlan

Differential Revision: D92474492


