### PR TITLE
misc: Respect Linux cgroups restrictions when sizing thread pools

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -64,7 +64,7 @@ void Connectors::initialize() {
   folly::call_once(kInitialized, [this]() {
     initializeFileFormats();
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
-        std::thread::hardware_concurrency(),
+        folly::hardware_concurrency(),
         std::make_shared<folly::NamedThreadFactory>("io"));
   });
 }


### PR DESCRIPTION
Summary:
This change replaces uses of std::thread::hardware_concurrency with
folly::available_concurrency the latter of which always respects
container restrictions while the former does not.  This ensures that
when running inside of a Linux container with restrictions on the
available processors, thread pools and other data structures will not
be over-provisioned.

This change is a follow-up to my earlier change (D87913058) addressing
an additional case that may have been overlooked.

Differential Revision: D91283628


