### PR TITLE
refactor: Rename History::setLeafSelectivity to estimateLeafSelectivity

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -35,6 +35,27 @@ void History::updateFromFile(const std::string& path) {
   }
 }
 
+void History::recordSampledLeafSelectivity(
+    std::string_view handle,
+    float selectivity,
+    bool overwrite) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!overwrite && sampledLeafSelectivities_.contains(handle)) {
+    return;
+  }
+  sampledLeafSelectivities_[handle] = selectivity;
+}
+
+std::optional<float> History::findSampledLeafSelectivity(
+    std::string_view handle) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto it = sampledLeafSelectivities_.find(handle);
+  if (it != sampledLeafSelectivities_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
 float shuffleCost(const ColumnVector& columns) {
   return byteSize(columns) * Costs::kByteShuffleCost;
 }

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -83,12 +83,13 @@ class Optimization {
         baseTable, leafColumns, topColumns, typeMap);
   }
 
-  /// Sets 'filterSelectivity' of 'baseTable' from history. Returns true if set.
-  /// 'scanType' is the set of sampled columns with possible map to struct cast.
-  bool setLeafSelectivity(
+  /// Estimates 'filterSelectivity' of 'baseTable' from history. Returns true if
+  /// set. 'scanType' is the set of sampled columns with possible map to struct
+  /// cast.
+  bool estimateLeafSelectivity(
       BaseTable& baseTable,
       const velox::RowTypePtr& scanType) {
-    return history_.setLeafSelectivity(baseTable, scanType);
+    return history_.estimateLeafSelectivity(baseTable, scanType);
   }
 
   void filterUpdated(BaseTableCP baseTable, bool updateSelectivity = true) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1914,7 +1914,7 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
   auto scanType = optimization->subfieldPushdownScanType(
       baseTable, baseTable->columns, top, map);
 
-  optimization->setLeafSelectivity(*baseTable, scanType);
+  optimization->estimateLeafSelectivity(*baseTable, scanType);
   currentDt_->addTable(baseTable);
 }
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -192,7 +192,8 @@ void ToVelox::filterUpdated(BaseTableCP table, bool updateSelectivity) {
 
   setLeafHandle(table->id(), std::move(handle), std::move(rejectedFilters));
   if (updateSelectivity) {
-    optimization->setLeafSelectivity(*const_cast<BaseTable*>(table), scanType);
+    optimization->estimateLeafSelectivity(
+        *const_cast<BaseTable*>(table), scanType);
   }
 }
 

--- a/axiom/optimizer/VeloxHistory.h
+++ b/axiom/optimizer/VeloxHistory.h
@@ -36,10 +36,15 @@ class VeloxHistory : public History {
 
   void recordCost(const RelationOp& op, Cost cost) override {}
 
-  /// Sets the filter selectivity of a table scan. Returns true if there is data
-  /// to back the estimate and false if this is a pure guess.
-  bool setLeafSelectivity(BaseTable& table, const velox::RowTypePtr& scanType)
-      override;
+  /// Estimates filter selectivity for a table scan and updates column value
+  /// constraints (cardinality, min, max, trueFraction, nullFraction, nullable)
+  /// based on the table's filters. If sampling is enabled and a physical table
+  /// is available, samples the table to refine the selectivity estimate.
+  /// Returns true if the estimate is backed by sampling, false if it relies
+  /// solely on statistics-based estimation.
+  bool estimateLeafSelectivity(
+      BaseTable& table,
+      const velox::RowTypePtr& scanType) override;
 
   /// Stores observed costs and cardinalities from a query execution. If 'op' is
   /// non-null, non-leaf costs from non-leaf levels are recorded. Otherwise only


### PR DESCRIPTION
Summary:
Rename setLeafSelectivity to estimateLeafSelectivity to better reflect the method's actual purpose: it estimates filter selectivity based on sampling or statistics, rather than simply setting a value.

Also clean up the History API:
- Remove the public recordLeafSelectivity method from the base class
- Replace with protected recordSampledLeafSelectivity and findSampledLeafSelectivity methods
- Rename leafSelectivities_ to sampledLeafSelectivities_ to clarify this cache is only populated when sampling is enabled

Differential Revision: D92851591


