### PR TITLE
feat: Remove workaround to optimize TPC-H q20

### DIFF
--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -630,14 +630,6 @@ TEST_F(TpchPlanTest, q19) {
 }
 
 TEST_F(TpchPlanTest, q20) {
-  // TODO Fix the plan when 'enableReducingExistences' is true.
-  const bool originalEnableReducingExistences =
-      optimizerOptions_.enableReducingExistences;
-  optimizerOptions_.enableReducingExistences = false;
-  SCOPE_EXIT {
-    optimizerOptions_.enableReducingExistences =
-        originalEnableReducingExistences;
-  };
   checkTpchSql(20);
 
   // TODO Verify the plan.


### PR DESCRIPTION
Summary: There was a bug that prevented q20 to work with default setting of enableReducingExistences = true. It appears that the issue has been addressed. Remove the workaround.

Differential Revision: D92868028


