### PR TITLE
feat(optimizer): Support DISTINCT aggregation with single set of distinct arguments

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -558,8 +558,9 @@ bool isSingleWorker() {
 }
 
 RelationOpPtr repartitionForAgg(
-    AggregationPlanCP const agg,
     const RelationOpPtr& plan,
+    const ExprVector& groupingKeys,
+    const ColumnVector& intermediateColumns,
     PlanCost& cost) {
   if (isSingleWorker() || plan->distribution().isGather()) {
     return plan;
@@ -567,7 +568,7 @@ RelationOpPtr repartitionForAgg(
 
   // If no grouping and not yet gathered on a single node,
   // add a gather before final agg.
-  if (agg->groupingKeys().empty()) {
+  if (groupingKeys.empty()) {
     auto* gather =
         make<Repartition>(plan, Distribution::gather(), plan->columns());
     cost.add(*gather);
@@ -577,8 +578,9 @@ RelationOpPtr repartitionForAgg(
   // 'intermediateColumns' contains grouping keys followed by partial agg
   // results.
   ExprVector keyValues;
-  for (auto i = 0; i < agg->groupingKeys().size(); ++i) {
-    keyValues.push_back(agg->intermediateColumns()[i]);
+  keyValues.reserve(groupingKeys.size());
+  for (auto i = 0; i < groupingKeys.size(); ++i) {
+    keyValues.push_back(intermediateColumns[i]);
   }
 
   // Check if grouping keys is a superset of all partition keys. If partition
@@ -1067,10 +1069,11 @@ ExprVector computePreGroupedKeys(
 // repartitions by grouping keys and performs the final aggregation. Returns a
 // pair of the root to the aggregation plan and cost of this aggregation.
 std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
-    const AggregationPlan* aggPlan,
     RelationOpPtr plan,
     const ExprVector& groupingKeys,
-    const AggregateVector& aggregates) {
+    const AggregateVector& aggregates,
+    const ColumnVector& intermediateColumns,
+    const ColumnVector& outputColumns) {
   PlanCost splitAggCost;
   Aggregation* splitAggPlan;
 
@@ -1080,17 +1083,18 @@ std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kPartial,
-      aggPlan->intermediateColumns());
+      intermediateColumns);
 
   splitAggCost.add(*partialAgg);
-  plan = repartitionForAgg(aggPlan, partialAgg, splitAggCost);
+  plan = repartitionForAgg(
+      partialAgg, groupingKeys, intermediateColumns, splitAggCost);
 
-  const auto numKeys = aggPlan->groupingKeys().size();
+  const auto numKeys = groupingKeys.size();
 
   ExprVector finalGroupingKeys;
   finalGroupingKeys.reserve(numKeys);
   for (auto i = 0; i < numKeys; ++i) {
-    finalGroupingKeys.push_back(aggPlan->intermediateColumns()[i]);
+    finalGroupingKeys.push_back(intermediateColumns[i]);
   }
 
   splitAggPlan = make<Aggregation>(
@@ -1099,7 +1103,7 @@ std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kFinal,
-      aggPlan->columns());
+      outputColumns);
   splitAggCost.add(*splitAggPlan);
 
   return {splitAggPlan, splitAggCost};
@@ -1109,22 +1113,52 @@ std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
 // grouping keys and then aggregated in one step. Returns a pair of the root to
 // the aggregation plan and the cost of this aggregation.
 std::pair<Aggregation*, PlanCost> makeSingleAggregationPlan(
-    const AggregationPlan* aggPlan,
     RelationOpPtr plan,
     const ExprVector& groupingKeys,
-    const AggregateVector& aggregates) {
+    const AggregateVector& aggregates,
+    const ColumnVector& intermediateColumns,
+    const ColumnVector& outputColumns) {
   PlanCost singleAggCost;
-  plan = repartitionForAgg(aggPlan, plan, singleAggCost);
+  plan =
+      repartitionForAgg(plan, groupingKeys, intermediateColumns, singleAggCost);
   auto* singleAgg = make<Aggregation>(
       plan,
       groupingKeys,
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kSingle,
-      aggPlan->columns());
+      outputColumns);
   singleAggCost.add(*singleAgg);
 
   return {singleAgg, singleAggCost};
+}
+
+// Makes a split (two-phase) or single (one-phase) aggregation plan.
+// If groupingKeys is empty or alwaysPlanPartialAggregation is true, always
+// uses split aggregation. Otherwise, compares both plans and returns the one
+// with lower cost. Returns a pair of the root to the aggregation plan and its
+// cost.
+std::pair<Aggregation*, PlanCost> makeSplitOrSingleAggregationPlan(
+    const RelationOpPtr& plan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    const ColumnVector& intermediateColumns,
+    const ColumnVector& outputColumns,
+    bool alwaysPlanPartialAggregation) {
+  const auto& [splitAggPlan, splitAggCost] = makeSplitAggregationPlan(
+      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+
+  if (groupingKeys.empty() || alwaysPlanPartialAggregation) {
+    return {splitAggPlan, splitAggCost};
+  }
+
+  const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
+      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+
+  if (singleAggCost.cost < splitAggCost.cost) {
+    return {singleAgg, singleAggCost};
+  }
+  return {splitAggPlan, splitAggCost};
 }
 
 } // namespace
@@ -1148,6 +1182,60 @@ RelationOpPtr Optimization::planSingleAggregation(
       velox::core::AggregationNode::Step::kSingle,
       aggPlan->columns());
 }
+
+namespace {
+
+// Returns the common distinct arguments if all aggregates are DISTINCT with
+// the same set of arguments, no filters, and no order-by. Throws if any of
+// these conditions is not met.
+ExprVector getSingleDistinctArgs(const AggregateVector& aggregates) {
+  VELOX_CHECK(!aggregates.empty());
+
+  ExprVector commonArgs;
+  PlanObjectSet commonArgSet;
+  PlanObjectSet currentArgSet;
+  for (const auto* agg : aggregates) {
+    // Must be DISTINCT
+    if (!agg->isDistinct()) {
+      VELOX_UNSUPPORTED("Mix of DISTINCT and non-DISTINCT aggregates");
+    }
+    // No filter
+    if (agg->condition() != nullptr) {
+      VELOX_UNSUPPORTED("DISTINCT aggregates have filters");
+    }
+    // No order-by
+    if (!agg->orderKeys().empty()) {
+      VELOX_UNSUPPORTED("DISTINCT aggregates have ORDER BY");
+    }
+    // Check same args (as a set, using pointer equality since exprs are
+    // deduplicated)
+    if (commonArgs.empty()) {
+      commonArgs = agg->args();
+      commonArgSet = PlanObjectSet::fromObjects(commonArgs);
+    } else {
+      currentArgSet.clear();
+      currentArgSet.unionObjects(agg->args());
+      if (currentArgSet != commonArgSet) {
+        VELOX_UNSUPPORTED(
+            "DISTINCT aggregates have multiple sets of arguments");
+      }
+    }
+  }
+
+  return commonArgs;
+}
+
+// Returns a copy of aggregates with isDistinct set to false.
+AggregateVector dropDistinctFromAggregates(const AggregateVector& aggregates) {
+  AggregateVector result;
+  result.reserve(aggregates.size());
+  for (const auto* aggregate : aggregates) {
+    result.push_back(aggregate->dropDistinct());
+  }
+  return result;
+}
+
+} // namespace
 
 void Optimization::addAggregation(
     DerivedTableCP dt,
@@ -1178,6 +1266,17 @@ void Optimization::addAggregation(
     return;
   }
 
+  const auto hasDistinct = std::any_of(
+      aggregates.begin(), aggregates.end(), [](const auto& aggregate) {
+        return aggregate->isDistinct();
+      });
+  if (hasDistinct) {
+    auto distinctArgs = getSingleDistinctArgs(aggregates);
+    transformDistinctToGroupBy(
+        plan, state.cost, groupingKeys, distinctArgs, aggregates, aggPlan);
+    return;
+  }
+
   // Check if any aggregate has ORDER BY keys. If so, we must use single-step
   // aggregation because partial aggregation cannot preserve global ordering.
   const auto hasOrderBy =
@@ -1185,19 +1284,14 @@ void Optimization::addAggregation(
         return !agg->orderKeys().empty();
       });
   if (hasOrderBy) {
-    const auto& [singleAgg, singleAggCost] =
-        makeSingleAggregationPlan(aggPlan, plan, groupingKeys, aggregates);
+    const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
+        plan,
+        groupingKeys,
+        aggregates,
+        aggPlan->intermediateColumns(),
+        aggPlan->columns());
     plan = singleAgg;
     state.cost.add(singleAggCost);
-    return;
-  }
-
-  if (aggPlan->groupingKeys().empty() ||
-      options_.alwaysPlanPartialAggregation) {
-    const auto& [splitAggPlan, splitAggCost] =
-        makeSplitAggregationPlan(aggPlan, plan, groupingKeys, aggregates);
-    plan = splitAggPlan;
-    state.cost.add(splitAggCost);
     return;
   }
 
@@ -1209,21 +1303,66 @@ void Optimization::addAggregation(
   // partial agg also depends on the width of the data and configs so instead of
   // unbundling the cost functions we make different kinds of plans and use the
   // plan's functions.
-  // auto planBeforeAgg = plan;
-  const auto& [splitAggPlan, splitAggCost] =
-      makeSplitAggregationPlan(aggPlan, plan, groupingKeys, aggregates);
+  const auto& [selectedPlan, selectedCost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      groupingKeys,
+      aggregates,
+      aggPlan->intermediateColumns(),
+      aggPlan->columns(),
+      options_.alwaysPlanPartialAggregation);
+  plan = selectedPlan;
+  state.cost.add(selectedCost);
+}
 
-  // Now we make a plan without partial aggregation.
-  const auto& [singleAgg, singleAggCost] =
-      makeSingleAggregationPlan(aggPlan, plan, groupingKeys, aggregates);
-
-  if (singleAggCost.cost < splitAggCost.cost) {
-    plan = singleAgg;
-    state.cost.add(singleAggCost);
-    return;
+void Optimization::transformDistinctToGroupBy(
+    RelationOpPtr& plan,
+    PlanCost& cost,
+    const ExprVector& groupingKeys,
+    const ExprVector& distinctArgs,
+    const AggregateVector& aggregates,
+    AggregationPlanCP aggPlan) const {
+  // Build inner GROUP BY keys: groupingKeys union distinctArgs. We put
+  // groupingKeys at the beginning, followed by distinctArgs not appear in
+  // groupingKeys.
+  ExprVector innerKeys = groupingKeys;
+  PlanObjectSet innerKeySet = PlanObjectSet::fromObjects(groupingKeys);
+  for (const auto* arg : distinctArgs) {
+    if (!innerKeySet.contains(arg)) {
+      innerKeySet.add(arg);
+      innerKeys.push_back(arg);
+    }
   }
-  state.cost.add(splitAggCost);
-  plan = splitAggPlan;
+
+  // Make output columns of inner aggregation.
+  ColumnVector innerColumns;
+  innerColumns.reserve(innerKeys.size());
+  for (const auto* key : innerKeys) {
+    const auto* keyColumn = key->as<Column>();
+    VELOX_CHECK_NOT_NULL(keyColumn);
+    innerColumns.push_back(keyColumn);
+  }
+
+  const auto& [innerAgg, innerAggCost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      innerKeys,
+      AggregateVector{},
+      innerColumns,
+      innerColumns,
+      options_.alwaysPlanPartialAggregation);
+  cost.add(innerAggCost);
+  plan = innerAgg;
+
+  // Make non-distinct aggregation calls for the outer level.
+  auto nonDistinctAggregates = dropDistinctFromAggregates(aggregates);
+  const auto& [outerPlan, outerCost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      groupingKeys,
+      nonDistinctAggregates,
+      aggPlan->intermediateColumns(),
+      aggPlan->columns(),
+      options_.alwaysPlanPartialAggregation);
+  plan = outerPlan;
+  cost.add(outerCost);
 }
 
 void Optimization::addOrderBy(

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -240,6 +240,17 @@ class Optimization {
   void addAggregation(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
       const;
 
+  // Transforms aggregations where all aggregates are DISTINCT with the same
+  // args into a two-level aggregation: inner level GROUP BY (keys +
+  // distinct_args) -> outer level AGG without DISTINCT.
+  void transformDistinctToGroupBy(
+      RelationOpPtr& plan,
+      PlanCost& cost,
+      const ExprVector& groupingKeys,
+      const ExprVector& distinctArgs,
+      const AggregateVector& aggregates,
+      AggregationPlanCP aggPlan) const;
+
   void addOrderBy(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
       const;
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -160,6 +160,22 @@ std::string Aggregate::toString() const {
   return out.str();
 }
 
+const Aggregate* Aggregate::dropDistinct() const {
+  if (!isDistinct_) {
+    return this;
+  }
+  return make<Aggregate>(
+      name(),
+      value_,
+      args(),
+      functions(),
+      /*isDistinct=*/false,
+      condition_,
+      intermediateType_,
+      orderKeys_,
+      orderTypes_);
+}
+
 std::string Field::toString() const {
   std::stringstream out;
   out << base_->toString() << ".";

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1161,6 +1161,10 @@ class Aggregate : public Call {
     return orderTypes_;
   }
 
+  /// Returns a copy of 'this' with 'isDistinct' set to false. If 'isDistinct'
+  /// of this instance is already false, return 'this' directly.
+  const Aggregate* dropDistinct() const;
+
   std::string toString() const override;
 
  private:

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1494,13 +1494,6 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
           "DISTINCT with ORDER BY in same aggregation expression isn't supported yet");
     }
 
-    if (isDistinct) {
-      const auto& options = queryCtx()->optimization()->runnerOptions();
-      VELOX_CHECK(
-          options.numWorkers == 1 && options.numDrivers == 1,
-          "DISTINCT option for aggregation is supported only in single worker, single thread mode");
-    }
-
     auto name = toName(agg.outputNames()[channel]);
 
     AggregateDedupKey key{

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -103,8 +103,8 @@ class PlanMatcherImpl : public PlanMatcher {
  protected:
   virtual MatchResult matchDetails(
       const T& plan,
-      const std::unordered_map<std::string, std::string>& /* symbols */) const {
-    return MatchResult::success();
+      const std::unordered_map<std::string, std::string>& symbols) const {
+    return MatchResult::success(symbols);
   }
 
   const std::vector<std::shared_ptr<PlanMatcher>> sourceMatchers_;


### PR DESCRIPTION
Summary:
Previously, DISTINCT aggregation (e.g., count(DISTINCT b)) was only supported in single worker, single thread mode and no ORDER BY in the same expression.

This diff adds support for DISTINCT aggregation in distributed mode by transforming it into a two-level aggregation: the inner level performs GROUP BY (grouping_keys + distinct_args) to deduplicate rows, and the outer level applies the aggregation functions without the DISTINCT flag. For example, `SELECT a, count(DISTINCT b), sum(DISTINCT b) FROM t GROUP BY a` becomes an inner `GROUP BY (a, b)` followed by an outer `SELECT a, count(b), sum(b) GROUP BY a`. In this diff, ORDER BY remains disallowed with DISTINCT. A follow-up diff will add support for it.

The transformation is not supported if there exists
1. any aggregate is non-DISTINCT,
2. any aggregate has a filter condition,
3. aggregates have different sets of distinct arguments, e.g., `agg(a, b), agg(b, a, b)` is allowed, but `agg(a, b), agg(a, a)` and `agg(a, b), agg(c, d)` are not allowed.
4. any aggregate has ORDER BY.

Differential Revision: D92920128


