### PR TITLE
feat: Normalize BETWEEN to x >= a AND a <= b (#875)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -912,16 +912,6 @@ bool dtHasLimit(const DerivedTable& dt) {
   return dt.hasLimit();
 }
 
-void flattenAll(ExprCP expr, Name func, ExprVector& flat) {
-  if (expr->isNot(PlanType::kCallExpr) || expr->as<Call>()->name() != func) {
-    flat.push_back(expr);
-    return;
-  }
-  for (auto arg : expr->as<Call>()->args()) {
-    flattenAll(arg, func, flat);
-  }
-}
-
 // 'disjuncts' is an OR of ANDs. If each disjunct depends on the same tables
 // and if each conjunct inside the ANDs in the OR depends on a single table,
 // then return for each distinct table an OR of ANDs. The disjuncts are the

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -91,6 +91,51 @@ bool FunctionRegistry::registerCount(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerBetween(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (between_.has_value() && between_.value() != name) {
+    return false;
+  }
+  between_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerGreaterThanOrEqual(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (greaterThanOrEqual_.has_value() && greaterThanOrEqual_.value() != name) {
+    return false;
+  }
+  greaterThanOrEqual_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerLessThanOrEqual(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (lessThanOrEqual_.has_value() && lessThanOrEqual_.value() != name) {
+    return false;
+  }
+  lessThanOrEqual_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerLeast(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (least_.has_value() && least_.value() != name) {
+    return false;
+  }
+  least_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerGreatest(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (greatest_.has_value() && greatest_.value() != name) {
+    return false;
+  }
+  greatest_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerSpecialForm(
     lp::SpecialForm specialForm,
     std::string_view name) {
@@ -264,6 +309,11 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerCardinality(fullName("cardinality"));
   registry->registerArbitrary(fullName("arbitrary"));
   registry->registerCount(fullName("count"));
+  registry->registerBetween(fullName("between"));
+  registry->registerGreaterThanOrEqual(fullName("gte"));
+  registry->registerLessThanOrEqual(fullName("lte"));
+  registry->registerLeast(fullName("least"));
+  registry->registerGreatest(fullName("greatest"));
 
   registry->registerAggregateEmptyResultResolver(
       {fullName("count_if"), fullName("approx_distinct")},

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -302,6 +302,61 @@ class FunctionRegistry {
     return count_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'between',
+  /// i.e. returns true if value is within the specified range [low, high].
+  /// @return true if successfully registered, false if a different
+  /// 'between' function is already registered.
+  bool registerBetween(std::string_view name);
+
+  /// Returns the name of the 'between' function.
+  const std::optional<std::string>& between() const {
+    return between_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'gte',
+  /// i.e. returns true if left argument is greater than or equal to right.
+  /// @return true if successfully registered, false if a different
+  /// 'greaterThanOrEqual' function is already registered.
+  bool registerGreaterThanOrEqual(std::string_view name);
+
+  /// Returns the name of the 'greaterThanOrEqual' function.
+  const std::optional<std::string>& greaterThanOrEqual() const {
+    return greaterThanOrEqual_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'lte',
+  /// i.e. returns true if left argument is less than or equal to right.
+  /// @return true if successfully registered, false if a different
+  /// 'lessThanOrEqual' function is already registered.
+  bool registerLessThanOrEqual(std::string_view name);
+
+  /// Returns the name of the 'lessThanOrEqual' function.
+  const std::optional<std::string>& lessThanOrEqual() const {
+    return lessThanOrEqual_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'least',
+  /// i.e. returns the smallest of the given arguments.
+  /// @return true if successfully registered, false if a different
+  /// 'least' function is already registered.
+  bool registerLeast(std::string_view name);
+
+  /// Returns the name of the 'least' function.
+  const std::optional<std::string>& least() const {
+    return least_;
+  }
+
+  /// Registers function 'name' that has semantics of Presto's 'greatest',
+  /// i.e. returns the largest of the given arguments.
+  /// @return true if successfully registered, false if a different
+  /// 'greatest' function is already registered.
+  bool registerGreatest(std::string_view name);
+
+  /// Returns the name of the 'greatest' function.
+  const std::optional<std::string>& greatest() const {
+    return greatest_;
+  }
+
   bool registerSpecialForm(
       logical_plan::SpecialForm specialForm,
       std::string_view name);
@@ -377,6 +432,11 @@ class FunctionRegistry {
   std::optional<std::string> cardinality_;
   std::optional<std::string> arbitrary_;
   std::optional<std::string> count_;
+  std::optional<std::string> between_;
+  std::optional<std::string> greaterThanOrEqual_;
+  std::optional<std::string> lessThanOrEqual_;
+  std::optional<std::string> least_;
+  std::optional<std::string> greatest_;
   folly::F14FastMap<std::string, std::string> reversibleFunctions_;
   folly::F14FastMap<logical_plan::SpecialForm, std::string> specialForms_;
   folly::F14FastMap<std::string, AggregateEmptyResultResolver>

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -149,6 +149,18 @@ class Optimization {
     return session_;
   }
 
+  const FunctionNames& functionNames() const {
+    return toGraph_.functionNames();
+  }
+
+  ExprCP deduppedCall(
+      Name name,
+      Value value,
+      ExprVector args,
+      FunctionSet flags) {
+    return toGraph_.deduppedCall(name, std::move(value), std::move(args), flags);
+  }
+
   const OptimizerOptions& options() const {
     return options_;
   }

--- a/axiom/optimizer/PlanUtils.cpp
+++ b/axiom/optimizer/PlanUtils.cpp
@@ -142,4 +142,14 @@ std::string exprsToString(const ExprVector& exprs) {
   return out.str();
 }
 
+void flattenAll(ExprCP expr, Name func, ExprVector& flat) {
+  if (expr->isNot(PlanType::kCallExpr) || expr->as<Call>()->name() != func) {
+    flat.push_back(expr);
+    return;
+  }
+  for (auto arg : expr->as<Call>()->args()) {
+    flattenAll(arg, func, flat);
+  }
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -120,4 +120,8 @@ std::string columnsToString(const ColumnVector& columns);
 
 std::string exprsToString(const ExprVector& exprs);
 
+/// Recursively flattens nested calls to the given function.
+/// For example, flattenAll(and(and(a, b), c), "and", flat) produces [a, b, c].
+void flattenAll(ExprCP expr, Name func, ExprVector& flat);
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -612,10 +612,10 @@ TEST_F(TpchPlanTest, q19) {
               core::PlanMatcherBuilder()
                   .hiveScan(
                       "part",
-                      {},
-                      "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
-                      "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
-                      "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
+                      common::test::SubfieldFiltersBuilder()
+                          .add("p_size", exec::greaterThanOrEqual(1LL))
+                          .build(),
+                      "\"or\"(\"and\"(lte(p_size,15),\"and\"(eq(p_brand,'Brand#34'),\"in\"(p_container,array['LG CASE', 'LG BOX', 'LG PACK', 'LG PKG']))),\"or\"(\"and\"(lte(p_size,5),\"and\"(eq(p_brand,'Brand#12'),\"in\"(p_container,array['SM CASE', 'SM BOX', 'SM PACK', 'SM PKG']))),\"and\"(lte(p_size,10),\"and\"(eq(p_brand,'Brand#23'),\"in\"(p_container,array['MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'])))))")
                   .build(),
               core::JoinType::kInner)
           .filter()


### PR DESCRIPTION
Summary:

Rewrite `x BETWEEN a AND b` to `x >= a AND x <= b` during query graph construction. This normalization enables extracting shared conjuncts from disjuncts. For example:

> (a BETWEEN 0 AND 10 AND b = 1) OR (a BETWEEN 0 AND 20 AND b = 2)

can be rewritten to:

> a >= 0 AND ((a <= 10 AND b = 1) OR (a <= 20 AND b = 2))

Extracted from https://github.com/facebookincubator/axiom/pull/702

Co-authored-by: oerling

Differential Revision: D92685072


