### PR TITLE
feat: Optimize outer join to less restrictive joins

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -307,6 +307,11 @@ struct DerivedTable : public PlanObject {
   // - LEFT join + filter on right columns → INNER join
   // - FULL join + filter on right columns → RIGHT join
   // - FULL join + filter on left columns → LEFT join
+  // - FULL join + filter on both left and right columns → INNER join
+  //
+  // The filter can reference columns from multiple tables; as long as it
+  // references at least one column from the optional side, it will reject
+  // NULLs on that side.
   //
   // @param allowNondeterministic If true, non-deterministic conjuncts are
   // considered for join conversion.


### PR DESCRIPTION
Summary:
The optimization is a follow up from https://github.com/facebookincubator/axiom/pull/854. It relaxes the single table constraint so that it can optimize the outer join when columns of multiple tables are in the predicate.

An example query is:
"select * from nation left join region on n_regionkey = r_regionkey where n_name > r_name". The query can be optimized to an inner join because the predicate is NULL rejecting, effectively eliminating NULL rows.

It performs the following optimizations for multiple table columns:
- LEFT join + filter on right columns → INNER join
- FULL join + filter on both columns → INNER join

By changing from isSubset() to hasIntersection() when checking conjuncts, it consider all the conjunct columns (n_name, r_name) to enable this optimization. For FULL join, If both sides have intersections, it can be optimized directly to an INNER join.

Fixes https://github.com/facebookincubator/axiom/issues/872

Differential Revision: D92931721


