### PR TITLE
fix: Use qualified references when expanding SELECT alias.* after JOINs

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1364,6 +1364,11 @@ PlanBuilder& PlanBuilder::as(const std::string& alias) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::enableUnqualifiedAccess() {
+  outputMapping_->enableUnqualifiedAccess();
+  return *this;
+}
+
 std::string PlanBuilder::newName(const std::string& hint) {
   return nameAllocator_->newName(hint);
 }

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -506,6 +506,9 @@ class PlanBuilder {
 
   PlanBuilder& as(const std::string& alias);
 
+  /// Adds unqualified access for columns with unique names in the output.
+  PlanBuilder& enableUnqualifiedAccess();
+
   PlanBuilder& captureScope(Scope& scope) {
     scope = [this](const auto& alias, const auto& name) {
       return resolveInputName(alias, name);


### PR DESCRIPTION
Summary: Solves `cannot resolve column` error on joins by creating qualified column references using `lp::Sql(fmt::format("{}.{}", prefix.value(), name))` instead of unqualified `lp::Col(name)`. This ensures column resolution works correctly after JOINs where unqualified access may have been removed by `NameMappings::merge()`.

Differential Revision: D93277981


