### PR TITLE
fix(optimizer): Fix index-based subfield access

### DIFF
--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -232,14 +232,17 @@ const std::string& specialForm(lp::SpecialForm specialForm) {
 
 namespace {
 std::pair<std::vector<Step>, int32_t> rowConstructorSubfield(
-    const std::vector<Step>& steps,
+    std::span<const Step> steps,
     const lp::CallExpr& call) {
   VELOX_CHECK(steps.back().kind == StepKind::kField);
-  auto field = steps.back().field;
-  auto idx = call.type()->as<velox::TypeKind::ROW>().getChildIdx(field);
-  auto newFields = steps;
+  auto& step = steps.back();
+  auto idx = step.id;
+  if (step.field) {
+    idx = call.type()->asRow().getChildIdx(step.field);
+  }
+  std::vector<Step> newFields(steps.begin(), steps.end());
   newFields.pop_back();
-  return std::make_pair(newFields, idx);
+  return std::make_pair(std::move(newFields), idx);
 }
 
 folly::F14FastMap<PathCP, lp::ExprPtr> rowConstructorExplode(

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -165,7 +165,7 @@ struct FunctionMetadata {
 
   using ValuePathToArgPath =
       std::function<std::pair<std::vector<Step>, int32_t>(
-          const std::vector<Step>&,
+          std::span<const Step>,
           const logical_plan::CallExpr& call)>;
 
   /// Translates a path over the function result to a path over an argument.

--- a/axiom/optimizer/PlanUtils.cpp
+++ b/axiom/optimizer/PlanUtils.cpp
@@ -112,13 +112,22 @@ Step extractDereferenceStep(const logical_plan::ExprPtr& expr) {
 
   auto index = maybeIntegerLiteral(field);
   Name name = nullptr;
-  if (!index.has_value()) {
+
+  if (index.has_value()) {
+    VELOX_CHECK(
+        *index >= 0 && *index <= std::numeric_limits<uint32_t>::max(),
+        "Dereference index out of range.");
+    auto fieldName = rowType.nameOf(static_cast<uint32_t>(*index));
+    if (!fieldName.empty()) {
+      name = toName(fieldName);
+    }
+  } else {
     const auto& fieldName = field->value()->value<velox::TypeKind::VARCHAR>();
     name = toName(fieldName);
     index = rowType.getChildIdx(name);
   }
 
-  return Step{.kind = StepKind::kField, .field = name, .id = index.value()};
+  return Step{.kind = StepKind::kField, .field = name, .id = *index};
 }
 
 std::string conjunctsToString(const ExprVector& conjuncts) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1233,9 +1233,7 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
   bool allUsed = false;
 
   const auto& argOrginal = metadata->argOrdinal;
-  if (argOrginal.empty()) {
-    allUsed = true;
-  } else {
+  if (!argOrginal.empty()) {
     for (auto i = 0; i < paths.size(); ++i) {
       if (std::find(argOrginal.begin(), argOrginal.end(), i) ==
           argOrginal.end()) {
@@ -1250,6 +1248,23 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
         usedArgs.add(maybeArg.value());
       }
     }
+  } else if (metadata->valuePathToArgPath) {
+    // For functions like row_constructor that use valuePathToArgPath instead
+    // of a static argOrdinal mapping, derive usedArgs from each tracked
+    // subfield path.
+    for (const auto& path : paths) {
+      const auto& steps = path->steps();
+      if (steps.empty()) {
+        continue;
+      }
+      // Reverse steps to leaf-to-root order for valuePathToArgPath.
+      Path reversed{steps, std::true_type{}};
+      auto [remainingSteps, argIdx] =
+          metadata->valuePathToArgPath(reversed.steps(), *call);
+      usedArgs.add(argIdx);
+    }
+  } else {
+    allUsed = true;
   }
 
   const auto& inputs = call->inputs();

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -407,26 +407,123 @@ TEST_P(SubfieldTest, structs) {
       ROW({"s1", "s2", "s3"},
           {BIGINT(), ROW({"s2s1"}, {BIGINT()}), ARRAY(BIGINT())});
   auto rowType = ROW({"s", "i"}, {structType, BIGINT()});
-  auto vectors = makeVectors(rowType, 10, 10);
+  auto vectors = makeVectors(rowType, 1, 1);
   createTable("structs", vectors);
 
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("structs", rowType->names())
-                         .project({"s.s1", "s.s3[1]"})
-                         .build();
+  {
+    // Dereference struct fields by name.
+    auto logicalPlan = lp::PlanBuilder(makeContext(), /*enableCoercions=*/true)
+                           .tableScan("structs", rowType->names())
+                           .project({"s.s1 as s1", "s.s3[1]"})
+                           .filter("s1 < 10")
+                           .build();
+    auto fragmentedPlan = planVelox(logicalPlan);
 
-  auto fragmentedPlan = planVelox(logicalPlan);
+    // t2.s = HiveColumnHandle [... requiredSubfields: [ s.s1 s.s3[1] ]]
+    verifyRequiredSubfields(
+        extractPlanNode(fragmentedPlan), {{"s", {".s1", ".s3[1]"}}});
 
-  // t2.s = HiveColumnHandle [... requiredSubfields: [ s.s1 s.s3[0] ]]
-  verifyRequiredSubfields(
-      extractPlanNode(fragmentedPlan), {{"s", {".s1", ".s3[1]"}}});
+    auto referencePlan = PlanBuilder()
+                             .tableScan("structs", rowType)
+                             .filter("s.s1 < 10")
+                             .project({"s.s1", "s.s3[1]"})
+                             .planNode();
+    checkSame(fragmentedPlan, referencePlan);
+  }
 
-  auto referencePlan = PlanBuilder()
-                           .tableScan("structs", rowType)
-                           .project({"s.s1", "s.s3[1]"})
-                           .planNode();
+  {
+    // Dereference struct fields by indices.
+    auto logicalPlan = lp::PlanBuilder(makeContext(), /*enableCoercions=*/true)
+                           .tableScan("structs", rowType->names())
+                           .project({"s[1] as s1", "s[2].s2s1", "s[3][1]"})
+                           .filter("s1 < 10")
+                           .build();
+    auto fragmentedPlan = planVelox(logicalPlan);
 
-  checkSame(fragmentedPlan, referencePlan);
+    verifyRequiredSubfields(
+        extractPlanNode(fragmentedPlan),
+        {{"s", {".s1", ".s2.s2s1", ".s3[1]"}}});
+
+    auto referencePlan = PlanBuilder()
+                             .tableScan("structs", rowType)
+                             .filter("s.s1 < 10")
+                             .project({"s.s1", "(s.s2).s2s1", "s.s3[1]"})
+                             .planNode();
+    checkSame(fragmentedPlan, referencePlan);
+  }
+}
+
+TEST_P(SubfieldTest, anonymousStructs) {
+  auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), ARRAY(BIGINT())});
+  auto vectors = makeVectors(rowType, 1, 1);
+  createTable("anon_structs", vectors);
+
+  {
+    // Dereference anonymous struct field in projection.
+    auto logicalPlan = parseSelect(
+        "SELECT row(a, b, c).field0, row(a, b, c)[3][1] FROM anon_structs",
+        kHiveConnectorId);
+    auto fragmentedPlan = planVelox(logicalPlan);
+
+    verifyRequiredSubfields(
+        extractPlanNode(fragmentedPlan), {{"a", {}}, {"c", {"[1]"}}});
+
+    auto referencePlan = PlanBuilder()
+                             .tableScan("anon_structs", rowType)
+                             .project({"a", "c[1]"})
+                             .planNode();
+    checkSame(fragmentedPlan, referencePlan);
+  }
+
+  {
+    // Dereference anonymous struct field in filter.
+    auto logicalPlan = parseSelect(
+        "SELECT row(a, b, c).field2[1] FROM anon_structs WHERE row(a, b, c).field0 > 0 ",
+        kHiveConnectorId);
+    auto fragmentedPlan = planVelox(logicalPlan);
+
+    verifyRequiredSubfields(extractPlanNode(fragmentedPlan), {{"c", {"[1]"}}});
+
+    auto referencePlan = PlanBuilder()
+                             .tableScan("anon_structs", rowType)
+                             .filter("a > 0")
+                             .project({"c[1]"})
+                             .planNode();
+    checkSame(fragmentedPlan, referencePlan);
+  }
+}
+
+TEST_P(SubfieldTest, anonymousStructTableScan) {
+  // Simulate filtering or projection on a table scan column with unnamed struct
+  // fields and verify that Axiom throws the "Index subfield not suitable for
+  // pruning" error as expected.
+  auto innerType = ROW({"s1", "", ""}, {BIGINT(), BIGINT(), ARRAY(BIGINT())});
+  auto rowType = ROW({"s"}, {innerType});
+  auto vectors = makeVectors(rowType, 1, 1);
+  createTable("anon_scan", vectors);
+
+  {
+    // Anonymous struct access in project.
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("anon_scan", rowType->names())
+                           .project({"s[1] as s1", "s[3][1]"})
+                           .build();
+
+    VELOX_ASSERT_THROW(
+        planVelox(logicalPlan), "Index subfield not suitable for pruning");
+  }
+
+  {
+    // Anonymous struct access in filter.
+    auto logicalPlan = lp::PlanBuilder(makeContext(), /*enableCoercions=*/true)
+                           .tableScan("anon_scan", rowType->names())
+                           .project({"s[3][1] as arr_elem"})
+                           .filter("arr_elem > 0")
+                           .build();
+
+    VELOX_ASSERT_THROW(
+        planVelox(logicalPlan), "Index subfield not suitable for pruning");
+  }
 }
 
 TEST_P(SubfieldTest, genie) {

--- a/axiom/optimizer/tests/utils/DfFunctions.cpp
+++ b/axiom/optimizer/tests/utils/DfFunctions.cpp
@@ -35,7 +35,7 @@ void registerFeatureFuncHook(
 }
 
 std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
-    const std::vector<Step>& steps,
+    std::span<const Step> steps,
     const lp::CallExpr& call) {
   VELOX_CHECK(steps.back().kind == StepKind::kField);
   auto& list = call.inputAt(2)
@@ -58,7 +58,7 @@ std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
   VELOX_CHECK(
       found != -1, "Subfield not found in make_row_from_map: {}", field);
 
-  auto newFields = steps;
+  std::vector<Step> newFields(steps.begin(), steps.end());
   newFields.pop_back();
   newFields.push_back(
       optimizer::Step{
@@ -68,7 +68,7 @@ std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
                     ->value()
                     ->value<TypeKind::ARRAY>()[found]
                     .value<int32_t>()});
-  return std::make_pair(newFields, 0);
+  return std::make_pair(std::move(newFields), 0);
 }
 
 folly::F14FastMap<PathCP, lp::ExprPtr> makeRowFromMapExplodeGeneric(
@@ -184,14 +184,14 @@ lp::ExprPtr makeNamedRowHook(
 }
 
 std::pair<std::vector<Step>, int32_t> makeNamedRowSubfield(
-    const std::vector<Step>& steps,
+    std::span<const Step> steps,
     const lp::CallExpr& call) {
   VELOX_CHECK(steps.back().kind == StepKind::kField);
   auto field = steps.back().field;
   auto idx = call.type()->as<TypeKind::ROW>().getChildIdx(field);
-  auto newFields = steps;
+  std::vector<Step> newFields(steps.begin(), steps.end());
   newFields.pop_back();
-  return std::make_pair(newFields, 2 * idx + 1);
+  return std::make_pair(std::move(newFields), 2 * idx + 1);
 }
 
 folly::F14FastMap<PathCP, lp::ExprPtr> makeNamedRowExplode(


### PR DESCRIPTION
Summary:
Currently, when SubfieldTracker makes a subfield access and when ToGraph 
translate a logical subfield access to Expr, if the subfield is accessed through 
index, Axiom creates a Step with the field name being a nullptr. This was initially 
done to support subfield access in anonymous structs where there is no field 
name. However, this causes problems because there are some places in Axiom 
that reject a Step with no field name and some places that dereference the field 
name directly without checking for nullptr. 

E.g., given a table with a struct column `t(s1 BIGINT, s2 REAL)`, accessing 
subfields by index like:

  SELECT s[1] as s1 FROM t where s1 > 10;

would fail because the index-based access `s[1]` produced a Step with a nullptr
field name, which downstream code in columnSubfields() in ToVelox
does not handle.

Similarly, accessing fields of anonymous structs built via row_constructor like:

  SELECT row(s1, s2).field0, row(s1, s2)[1] FROM t

triggered a bug in rowConstructorSubfield that dereferences step.field that is 
a nullptr.

This PR fixes these issues by popuplating the `field` name when creating a Step 
when the field name is non-empty (i.e., access to named structs). This 
PR also makes rowConstructorSubfield only dereference the `field` when it's 
not nullptr. Additionally, the unit tests added in this PR reveals another bug in 
ToGraph::translateSubfieldFunction that it assumes an expression accesses all 
fields if the function's metadata has empty argOrdinal. This doesn't work for 
row_constructor because it has no static argOrdinal but uses 
valuePathToArgPath.So this PR makes ToGraph::translateSubfieldFunction to 
use valuePathToArgPath when argOrdinal is empty, to match 
SubfieldTracker::markSubfields.

Differential Revision: D93285784


