### PR TITLE
docs: Add tpchgen CLI and debugging tips

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -48,4 +48,8 @@ add_executable(axiom_graphviz QueryGraphviz.cpp)
 
 target_link_libraries(axiom_graphviz axiom_cli)
 
+add_executable(axiom_tpchgen GenerateTpchData.cpp)
+
+target_link_libraries(axiom_tpchgen axiom_cli velox_exec_test_lib)
+
 add_subdirectory(tests)

--- a/axiom/cli/tests/TpchgenTest.md
+++ b/axiom/cli/tests/TpchgenTest.md
@@ -1,0 +1,153 @@
+# Smoke tests for tpchgen
+
+## Missing --data_path shows error
+
+```scrut
+$ $TPCHGEN 2>&1
+Error: --data_path must be specified.
+[1]
+```
+
+## Invalid --sf shows error
+
+```scrut
+$ $TPCHGEN --data_path "$TMPDIR/tpch" --sf 0 2>&1
+Error: --sf must be positive.
+[1]
+```
+
+## Invalid --data_format shows error
+
+```scrut
+$ $TPCHGEN --data_path "$TMPDIR/tpch" --data_format csv 2>&1
+Error: Unsupported data format: 'csv'. Use 'parquet' or 'dwrf'.
+[1]
+```
+
+## Unwritable --data_path shows error
+
+```scrut
+$ $TPCHGEN --data_path /dev/null/invalid 2>&1
+Error: Cannot create directory '/dev/null/invalid': * (glob)
+[1]
+```
+
+## Generate parquet data at sf=0.01
+
+```scrut
+$ $TPCHGEN --data_path "$TMPDIR/tpch-parquet" --sf 0.01 2>&1
+Generating TPC-H data (sf=0.01, format=parquet, compression=none) in * (glob)
+Generating part * (glob)
+Generated part: 2000 rows in * seconds. (glob)
+Generating supplier * (glob)
+Generated supplier: 100 rows in * seconds. (glob)
+Generating partsupp * (glob)
+Generated partsupp: 8000 rows in * seconds. (glob)
+Generating customer * (glob)
+Generated customer: 1500 rows in * seconds. (glob)
+Generating orders * (glob)
+Generated orders: 15000 rows in * seconds. (glob)
+Generating lineitem * (glob)
+Generated lineitem: 60175 rows in * seconds. (glob)
+Generating nation * (glob)
+Generated nation: 25 rows in * seconds. (glob)
+Generating region * (glob)
+Generated region: 5 rows in * seconds. (glob)
+```
+
+## Verify parquet files exist
+
+```scrut
+$ ls "$TMPDIR/tpch-parquet" | sort
+customer
+lineitem
+nation
+orders
+part
+partsupp
+region
+supplier
+```
+
+## Define count query
+
+```scrut
+$ QUERY="SELECT 'customer' AS tbl, count(*) AS cnt FROM customer UNION ALL SELECT 'lineitem', count(*) FROM lineitem UNION ALL SELECT 'nation', count(*) FROM nation UNION ALL SELECT 'orders', count(*) FROM orders UNION ALL SELECT 'part', count(*) FROM part UNION ALL SELECT 'partsupp', count(*) FROM partsupp UNION ALL SELECT 'region', count(*) FROM region UNION ALL SELECT 'supplier', count(*) FROM supplier ORDER BY 1"
+```
+
+## Verify parquet row counts using CLI
+
+```scrut
+$ $CLI --data_path "$TMPDIR/tpch-parquet" --query "$QUERY" 2>/dev/null
+ROW<tbl:VARCHAR,cnt:BIGINT>
+---------+------
+tbl      |   cnt
+---------+------
+customer |  1500
+lineitem | 60175
+nation   |    25
+orders   | 15000
+part     |  2000
+partsupp |  8000
+region   |     5
+supplier |   100
+(8 rows in 1 batches)
+
+```
+
+## Generate dwrf
+
+```scrut
+$ $TPCHGEN --data_path "$TMPDIR/tpch-dwrf" --sf 0.01 --data_format dwrf --compression zstd 2>&1 | grep -v '^I[0-9]'
+Generating TPC-H data (sf=0.01, format=dwrf, compression=zstd) in * (glob)
+Generating part * (glob)
+Generated part: 2000 rows in * seconds. (glob)
+Generating supplier * (glob)
+Generated supplier: 100 rows in * seconds. (glob)
+Generating partsupp * (glob)
+Generated partsupp: 8000 rows in * seconds. (glob)
+Generating customer * (glob)
+Generated customer: 1500 rows in * seconds. (glob)
+Generating orders * (glob)
+Generated orders: 15000 rows in * seconds. (glob)
+Generating lineitem * (glob)
+Generated lineitem: 60175 rows in * seconds. (glob)
+Generating nation * (glob)
+Generated nation: 25 rows in * seconds. (glob)
+Generating region * (glob)
+Generated region: 5 rows in * seconds. (glob)
+```
+
+## Verify dwrf files exist
+
+```scrut
+$ ls "$TMPDIR/tpch-dwrf" | sort
+customer
+lineitem
+nation
+orders
+part
+partsupp
+region
+supplier
+```
+
+## Verify dwrf row counts using CLI
+
+```scrut
+$ $CLI --data_path "$TMPDIR/tpch-dwrf" --data_format dwrf --query "$QUERY" 2>/dev/null
+ROW<tbl:VARCHAR,cnt:BIGINT>
+---------+------
+tbl      |   cnt
+---------+------
+customer |  1500
+lineitem | 60175
+nation   |    25
+orders   | 15000
+part     |  2000
+partsupp |  8000
+region   |     5
+supplier |   100
+(8 rows in 1 batches)
+
+```

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -5,6 +5,7 @@ See also:
 - [Join Planning](docs/JoinPlanning.md) - Control flow and state management in join order enumeration
 - [Filter Selectivity](docs/FilterSelectivity.md) - How filter selectivity is estimated for cost-based optimization
 - [Cardinality Estimation](docs/CardinalityEstimation.md) - How output cardinality is estimated for each operator
+- [Debugging Tips](docs/DebuggingTips.md) - Using the CLI, generating TPC-H data, speeding up test runs, adding debug logging
 
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.
 

--- a/axiom/optimizer/docs/DebuggingTips.md
+++ b/axiom/optimizer/docs/DebuggingTips.md
@@ -1,0 +1,189 @@
+# Debugging Tips
+
+Tips for debugging the Axiom optimizer.
+
+## 1. Using the CLI to Get a Query Plan
+
+Use the `axiom/cli:cli` target to run queries against TPC-H data and view their plans:
+
+```bash
+buck run axiom/cli:cli -- \
+  --data_path /home/$USER/tpch/sf0.1/ \
+  --num-workers 1 \
+  --num-drivers 1 \
+  --debug \
+  --query "EXPLAIN SELECT * FROM lineitem LIMIT 10"
+```
+
+### Key flags
+
+| Flag | Description |
+|------|-------------|
+| `--data_path` | Path to TPC-H data directory |
+| `--data_format` | Data format: `parquet` or `dwrf` (default: `parquet`) |
+| `--num-workers` | Number of workers (use 1 for single-node plans) |
+| `--num-drivers` | Number of drivers per worker (use 1 for single-threaded plans) |
+| `--debug` | Enable glog output to stderr (disabled by default) |
+| `--query` | SQL query to execute (use `EXPLAIN` prefix to see the plan). Multiple queries can be separated by `;` |
+
+### TPC-H Data Directories
+
+Two pre-generated TPC-H datasets are available:
+
+| Path | Scale Factor | Size | Use Case |
+|------|--------------|------|----------|
+| `/home/$USER/tpch/sf0.1/` | 0.1 | ~60K lineitem rows | Fast iteration, debugging |
+| `/home/$USER/tpch/sf1/` | 1.0 | ~6M lineitem rows | Larger-scale testing |
+
+Tests use `sf0.1` because they regenerate data on the fly and cannot
+afford larger scales.  Note that query plans may differ across scale
+factors because the optimizer uses data statistics (row counts,
+cardinalities) that change with scale.
+
+### Generating TPC-H Data
+
+If you don't have TPC-H data, generate it using the `axiom/cli:tpchgen` CLI:
+
+```bash
+buck run axiom/cli:tpchgen -- \
+  --data_path /home/$USER/tpch/sf0.1 --sf 0.1
+```
+
+To generate data in DWRF format:
+
+```bash
+buck run axiom/cli:tpchgen -- \
+  --data_path /home/$USER/tpch/sf0.1-dwrf --sf 0.1 \
+  --data_format dwrf --compression zstd
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--data_path` | (required) | Output directory for TPC-H data |
+| `--sf` | `0.1` | TPC-H scale factor (e.g., 0.1, 1, 10) |
+| `--data_format` | `parquet` | Data format: `parquet` or `dwrf` |
+| `--compression` | `none` | Compression: `none`, `snappy`, `zlib`, `zstd`, `lz4`, `gzip`. Not all options work with all formats, e.g. DWRF doesn't support `snappy`. |
+
+**Note:** When querying data generated with a non-default `--data_format`,
+specify the same format in the query CLI. For example, to query DWRF data:
+
+```bash
+buck run axiom/cli:cli -- \
+  --data_path /home/$USER/tpch/sf0.1-dwrf \
+  --data_format dwrf \
+  --query "SELECT count(*) FROM lineitem"
+```
+
+### Example: View TPC-H q5 plan
+
+```bash
+buck run axiom/cli:cli -- \
+  --data_path /home/$USER/tpch/sf0.1/ \
+  --num-workers 1 \
+  --num-drivers 1 \
+  --query "EXPLAIN $(cat axiom/optimizer/tests/tpch/queries/q5.sql)"
+```
+
+## 2. Speeding Up Test Runs with Pre-generated Data
+
+By default, `HiveQueriesTestBase::SetUpTestCase()` generates TPC-H
+Parquet data in a temporary directory on every test run.  This takes
+~10-20 seconds and is wasteful when iterating on optimizer changes.
+
+### The slow path (default)
+
+```cpp
+// static
+void HiveQueriesTestBase::SetUpTestCase() {
+  test::QueryTestBase::SetUpTestCase();
+
+  gTempDirectory = exec::test::TempDirectoryPath::create();
+  test::ParquetTpchTest::createTables(gTempDirectory->getPath());
+
+  LocalRunnerTestBase::localDataPath_ = gTempDirectory->getPath();
+  LocalRunnerTestBase::localFileFormat_ =
+      velox::dwio::common::FileFormat::PARQUET;
+}
+```
+
+### The fast path (for local development)
+
+Comment out the data generation and point to a pre-existing directory:
+
+```cpp
+// static
+void HiveQueriesTestBase::SetUpTestCase() {
+  test::QueryTestBase::SetUpTestCase();
+
+  // gTempDirectory = exec::test::TempDirectoryPath::create();
+  // test::ParquetTpchTest::createTables(gTempDirectory->getPath());
+
+  LocalRunnerTestBase::localDataPath_ = "/home/mbasmanova/tpch/sf0.1";
+  LocalRunnerTestBase::localFileFormat_ =
+      velox::dwio::common::FileFormat::PARQUET;
+}
+```
+
+**Warning:** Remember to revert this change before committing!
+The CI needs the dynamic data generation.
+
+## 3. Adding Debug Logging
+
+For temporary debugging, use `LOG(ERROR)` to print diagnostic
+information:
+
+```cpp
+LOG(ERROR) << "reducingJoins: fanout=" << fanout
+           << " existences.size()=" << existences.size();
+```
+
+`LOG(ERROR)` is used instead of `LOG(INFO)` because error-level logs
+are always visible regardless of logging configuration.
+
+**Note:** By default, `buck test` only shows logs for failing tests.
+To see logs for passing tests, use `--print-passing-details`:
+
+```bash
+buck test axiom/optimizer/tests:tpch_plan -- q5 --print-passing-details
+```
+
+**Warning:** Remove all debug logging before committing!
+
+## 4. TPC-H Query Tests
+
+`TpchPlanTest` tests all 22 TPC-H queries. For each query, the test verifies:
+
+1. **Query results** — `checkTpchSql(n)` executes the query and compares results against a reference Velox plan
+2. **Single-node plan shape** — `AXIOM_ASSERT_PLAN(plan, matcher)` validates the optimized plan structure matches expected patterns
+3. **Multi-node plan generation** — `ASSERT_NO_THROW(planVelox(parseTpchSql(n)))` confirms the optimizer can successfully generate a distributed plan
+
+### Running TPC-H tests
+
+```bash
+# Run all 22 TPC-H query tests
+buck test axiom/optimizer/tests:tpch_plan
+
+# Run a specific query test
+buck test axiom/optimizer/tests:tpch_plan -- q5
+```
+
+### Regenerating plan files
+
+The `tpch/plans` directory is checked into the repo and contains a snapshot of the TPC-H single-node plans. These files are useful for reviewing expected plan shapes, but they are not used directly by the tests.
+
+`DISABLED_makePlans` generates files in the `tpch/plans` directory.
+Each `.plans` file contains:
+
+- **Query graph** — `DerivedTable::toString()` output showing the parsed query structure with tables, joins, filters, and aggregations
+- **Optimized plan (oneline)** — `RelationOp::toOneline()` output, a compact one-liner showing the join tree structure
+- **Optimized plan** — `RelationOp::toString()` output, the full optimized logical plan with all operators
+- **Executable Velox plan** — `MultiFragmentPlan::toString()` output, the distributed execution plan with Velox operators
+
+To regenerate all plan files after changing the optimizer, run from the `fbcode` directory:
+
+```bash
+cd fbcode
+buck run axiom/optimizer/tests:tpch_plan -- \
+  --gtest_filter="TpchPlanTest.DISABLED_makePlans" \
+  --gtest_also_run_disabled_tests
+```


### PR DESCRIPTION
Summary:
Add a tpchgen CLI tool for generating TPC-H data in Parquet or DWRF formats with configurable scale factor and compression.

Add DebuggingTips.md with practical guidance on using the CLI to inspect query plans, speeding up test runs with pre-generated data, and running TPC-H query tests.

Add scrut tests for tpchgen covering error handling, data generation in both formats, and end-to-end row count verification via the query CLI.

Differential Revision: D93402353


