### PR TITLE
feat: Add tableAliases and cteNames to SqlStatement

### DIFF
--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -17,6 +17,7 @@
 #include "axiom/sql/presto/SqlStatement.h"
 
 #include <folly/container/F14Map.h>
+#include <map>
 
 namespace axiom::sql::presto {
 
@@ -120,8 +121,14 @@ CreateTableAsSelectStatement::CreateTableAsSelectStatement(
     RowTypePtr tableSchema,
     std::unordered_map<std::string, lp::ExprPtr> properties,
     lp::LogicalPlanNodePtr plan,
-    std::unordered_map<std::pair<std::string, std::string>, std::string> views)
-    : SqlStatement(SqlStatementKind::kCreateTableAsSelect, std::move(views)),
+    std::unordered_map<std::pair<std::string, std::string>, std::string> views,
+    std::map<std::string, std::string> tableAliases,
+    std::vector<std::string> cteNames)
+    : SqlStatement(
+          SqlStatementKind::kCreateTableAsSelect,
+          std::move(views),
+          std::move(tableAliases),
+          std::move(cteNames)),
       connectorId_{std::move(connectorId)},
       tableName_{std::move(tableName)},
       tableSchema_{std::move(tableSchema)},


### PR DESCRIPTION
Summary:
## Context

We need information about the table aliases and CTE names in the backend, so this expose those to the logical plan. We propose to store these in `SqlStatement`.

## Summary

Grafts the tableAliases/cteNames tracking from D92553385 into SqlStatement, without the TableFunctionRelation grammar/AST changes.

- Added tableAliases() and cteNames() accessors to SqlStatement, returning table-to-alias mappings from FROM clauses and CTE names from WITH clauses respectively.
- Extended SelectStatement, InsertStatement, and CreateTableAsSelectStatement constructors to accept and forward these new parameters.
- Updated RelationPlanner to record table-to-alias mappings when processing aliased relations, and to extract CTE names from withQueries_.
- Removed the tableFunctionRelation test which requires grammar changes not included in this diff.
- Added tableAliases and cteNames tests to verify the new functionality.

Differential Revision: D93526068


