### PR TITLE
fix: Crash in extractCommon(): handle empty disjunct after extracting common conjuncts

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2746,6 +2746,7 @@ PlanP Optimization::makeDtPlan(
 }
 
 ExprCP Optimization::combineLeftDeep(Name func, const ExprVector& exprs) {
+  VELOX_CHECK(!exprs.empty());
   ExprVector copy = exprs;
   std::ranges::sort(copy, [&](ExprCP left, ExprCP right) {
     return left->id() < right->id();

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -211,6 +211,10 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 };
 
 /// Filters on BIGINT columns.
+inline auto eq(const std::string& name, int64_t n) {
+  return velox::common::test::singleSubfieldFilter(name, velox::exec::equal(n));
+}
+
 inline auto lt(const std::string& name, int64_t n) {
   return velox::common::test::singleSubfieldFilter(
       name, velox::exec::lessThan(n));


### PR DESCRIPTION
Summary:
In extractCommon() in DerivedTable.cpp, when processing an OR expression like (A OR (A AND B)):

- The function flattens each disjunct into its conjuncts: flat[0] = [A], flat[1] = [A, B]
- It finds A is common across all disjuncts, extracts it, and removes it from each flat list
- flat[0] becomes empty — that disjunct was entirely subsumed by the common factor
- The code then called combineLeftDeep(kAnd, flat[0]) which asserts !exprs.empty()f→ crash

Fix: Before calling combineLeftDeep on the flat lists, check if any disjunct's flat list is empty (meaning it was fully subsumed by the common conjuncts). If so, the entire OR is trivially true, so skip setting *replacement — the common factors are still returned and correctly appended by the caller in expandConjuncts.

Differential Revision: D93596620


