### PR TITLE
feat: Add TestConnector to CLI

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   axiom_optimizer
   axiom_hive_connector_metadata
   axiom_tpch_connector_metadata
+  axiom_test_connector
   axiom_sql_presto_parser
   velox_exec_test_lib
   velox_dwio_common

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -20,6 +20,7 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -115,6 +116,15 @@ Connectors::registerLocalHiveConnector(
       std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
           hiveConnector));
 
+  return connector;
+}
+
+std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(
+    const std::string& connectorId) {
+  connector::TestConnectorFactory factory(connectorId.c_str());
+  auto connector = factory.newConnector(connectorId);
+  connectorIds_.push_back(connector->connectorId());
+  velox::connector::registerConnector(connector);
   return connector;
 }
 

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -36,6 +36,7 @@ class Connectors {
  public:
   static constexpr const char* kTpchConnectorId = "tpch";
   static constexpr const char* kLocalHiveConnectorId = "hive";
+  static constexpr const char* kTestConnectorId = "test";
 
   Connectors();
 
@@ -65,6 +66,10 @@ class Connectors {
       const std::string& dataPath,
       const std::string& dataFormat,
       const std::string& connectorId = kLocalHiveConnectorId);
+
+  /// Registers an in-memory test connector under `connectorId`.
+  std::shared_ptr<velox::connector::Connector> registerTestConnector(
+      const std::string& connectorId = kTestConnectorId);
 
  protected:
   /// Initialize file formats and ioExecutor. Must be called before

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -72,6 +72,11 @@ class SqlQueryRunner {
       const presto::SqlStatement& statement,
       const RunOptions& options);
 
+  /// Splits SQL text into individual statements separated by semicolons.
+  /// @param sql SQL text containing one or more statements.
+  /// @return Vector of individual SQL statements.
+  std::vector<std::string_view> splitStatements(std::string_view sql);
+
   /// Parses SQL text containing one or more semicolon-separated statements.
   /// @param sql SQL text to parse.
   /// @return Vector of parsed statements.
@@ -102,14 +107,17 @@ class SqlQueryRunner {
     return config_;
   }
 
- private:
-  std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
-      const RunOptions& options);
+  facebook::axiom::connector::TablePtr createTable(
+      const presto::CreateTableStatement& statement);
 
   facebook::axiom::connector::TablePtr createTable(
       const presto::CreateTableAsSelectStatement& statement);
 
   std::string dropTable(const presto::DropTableStatement& statement);
+
+ private:
+  std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
+      const RunOptions& options);
 
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -1,0 +1,102 @@
+# Smoke tests for CLI
+
+## TPC-H is the default catalog
+
+```scrut
+$ $CLI --query "SELECT count(*) as cnt FROM nation" 2>/dev/null
+ROW<cnt:BIGINT>
+---
+cnt
+---
+ 25
+(1 rows in 1 batches)
+
+```
+
+## Create and query table using test connector
+
+```scrut
+$ $CLI --query "CREATE TABLE test.default.t(a int, b int, c int); SELECT * FROM test.default.t" 2>/dev/null
+Created table: default.t
+(0 rows in 0 batches)
+
+```
+
+## Insert and select using test connector
+
+```scrut
+$ $CLI --query "CREATE TABLE test.default.t(a int, b int); INSERT INTO test.default.t VALUES (1, 2); SELECT * FROM test.default.t" 2>/dev/null
+Created table: default.t
+ROW<rows:BIGINT>
+----
+rows
+----
+   1
+(1 rows in 1 batches)
+
+ROW<a:INTEGER,b:INTEGER>
+--+--
+a | b
+--+--
+1 | 2
+(1 rows in 1 batches)
+
+```
+
+## Use --catalog and --schema flags
+
+```scrut
+$ $CLI --catalog test --schema default --query "CREATE TABLE t(x bigint, y bigint); INSERT INTO t VALUES (10, 20); INSERT INTO t VALUES (30, 40); SELECT * FROM t ORDER BY x" 2>/dev/null
+Created table: default.t
+ROW<rows:BIGINT>
+----
+rows
+----
+   1
+(1 rows in 1 batches)
+
+ROW<rows:BIGINT>
+----
+rows
+----
+   1
+(1 rows in 1 batches)
+
+ROW<x:BIGINT,y:BIGINT>
+---+---
+ x |  y
+---+---
+10 | 20
+30 | 40
+(2 rows in 1 batches)
+
+```
+
+## Drop table
+
+```scrut
+$ $CLI --catalog test --schema default --query "CREATE TABLE t(a int); DROP TABLE t; SELECT 1 as ok" 2>/dev/null
+Created table: default.t
+Dropped table: default.t
+ROW<ok:INTEGER>
+--
+ok
+--
+ 1
+(1 rows in 1 batches)
+
+```
+
+## Drop non-existent table with IF EXISTS
+
+```scrut
+$ $CLI --catalog test --schema default --query "DROP TABLE IF EXISTS t; SELECT 1 as ok" 2>/dev/null
+Table doesn't exist: default.t
+ROW<ok:INTEGER>
+--
+ok
+--
+ 1
+(1 rows in 1 batches)
+
+```

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -307,6 +307,22 @@ class TestConnectorMetadata : public ConnectorMetadata {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
 
+  TablePtr createTable(
+      const ConnectorSessionPtr& session,
+      const std::string& tableName,
+      const velox::RowTypePtr& rowType,
+      const folly::F14FastMap<std::string, velox::Variant>& options) override;
+
+  ConnectorWriteHandlePtr beginWrite(
+      const ConnectorSessionPtr& session,
+      const TablePtr& table,
+      WriteKind kind) override;
+
+  RowsFuture finishWrite(
+      const ConnectorSessionPtr& session,
+      const ConnectorWriteHandlePtr& handle,
+      const std::vector<velox::RowVectorPtr>& writeResults) override;
+
   bool dropTable(
       const ConnectorSessionPtr& session,
       std::string_view tableName,

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -66,13 +66,13 @@ class PrestoParser {
   /// @return input and output tables which the query references.
   ReferencedTables getReferencedTables(std::string_view sql);
 
- private:
-  SqlStatementPtr doParse(std::string_view sql, bool enableTracing);
-
   /// Splits SQL text into individual statements by semicolon delimiters.
   /// @param sql SQL text containing one or more statements.
-  /// @return Vector of individual SQL statements with semicolons removed.
-  static std::vector<std::string> splitStatements(std::string_view sql);
+  /// @return Vector of string_views into 'sql' for individual SQL statements.
+  static std::vector<std::string_view> splitStatements(std::string_view sql);
+
+ private:
+  SqlStatementPtr doParse(std::string_view sql, bool enableTracing);
 
   const std::string defaultConnectorId_;
   const std::optional<std::string> defaultSchema_;


### PR DESCRIPTION
Summary:
Register the TestConnector in the CLI so users can dynamically create in-memory tables and populate them with data. This enables workflows like:

```
$ buck run axiom/cli:cli -- --catalog test --schema default
> CREATE TABLE t(a int, b int);
> INSERT INTO t VALUES (1, 2);
> SELECT * FROM t
```

Key changes:

- Register TestConnector in CLI under connector ID \"test\".
- Add `--catalog` and `--schema` CLI flags to set default catalog and schema, allowing short table names.
- Implement `createTable`, `beginWrite`, and `finishWrite` in `TestConnectorMetadata` to support DDL and DML.
- Fix `parseInsert` to resolve connector ID via `toConnectorTable` instead of always using `defaultConnectorId`.
- Change `Console::runNoThrow` to parse and execute statements one at a time (instead of parsing all upfront), so that DDL takes effect before subsequent DML is parsed.

Differential Revision: D93610589


