### PR TITLE
feat(parser): Add support for USE command

### DIFF
--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -100,3 +100,32 @@ ok
 (1 rows in 1 batches)
 
 ```
+
+## USE catalog.schema
+
+```scrut
+$ $CLI --query "USE test.default; CREATE TABLE t(x int, y int); INSERT INTO t VALUES (1, 2); SELECT * FROM t" 2>/dev/null
+Using test.default
+Created table: default.t
+ROW<rows:BIGINT>
+----
+rows
+----
+   1
+(1 rows in 1 batches)
+
+ROW<x:INTEGER,y:INTEGER>
+--+--
+x | y
+--+--
+1 | 2
+(1 rows in 1 batches)
+
+```
+
+## USE with non-existent catalog
+
+```scrut
+$ $CLI --query "USE blah.default" 2>&1 | grep Reason
+Reason: Catalog does not exist: blah
+```

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2551,6 +2551,16 @@ SqlStatementPtr PrestoParser::doParse(
         *query->as<DropTable>(), defaultConnectorId_, defaultSchema_);
   }
 
+  if (query->is(NodeType::kUse)) {
+    auto* use = query->as<Use>();
+    std::optional<std::string> catalog;
+    if (use->catalog()) {
+      catalog = use->catalog()->value();
+    }
+    return std::make_shared<UseStatement>(
+        std::move(catalog), use->schema()->value());
+  }
+
   return doPlan(query, defaultConnectorId_, defaultSchema_, parseSql);
 }
 

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -33,6 +33,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kInsert, "INSERT"},
       {SqlStatementKind::kDropTable, "DROP TABLE"},
       {SqlStatementKind::kExplain, "EXPLAIN"},
+      {SqlStatementKind::kUse, "USE"},
   };
 
   return kNames;

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -30,6 +30,7 @@ enum class SqlStatementKind {
   kInsert,
   kDropTable,
   kExplain,
+  kUse,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SqlStatementKind);
@@ -72,6 +73,10 @@ class SqlStatement {
 
   bool isExplain() const {
     return kind_ == SqlStatementKind::kExplain;
+  }
+
+  bool isUse() const {
+    return kind_ == SqlStatementKind::kUse;
   }
 
   template <typename T>
@@ -320,6 +325,27 @@ class ExplainStatement : public SqlStatement {
   const SqlStatementPtr statement_;
   const bool analyze_;
   const Type type_;
+};
+
+/// Sets the default catalog and schema for subsequent queries.
+class UseStatement : public SqlStatement {
+ public:
+  UseStatement(std::optional<std::string> catalog, std::string schema)
+      : SqlStatement(SqlStatementKind::kUse),
+        catalog_{std::move(catalog)},
+        schema_{std::move(schema)} {}
+
+  const std::optional<std::string>& catalog() const {
+    return catalog_;
+  }
+
+  const std::string& schema() const {
+    return schema_;
+  }
+
+ private:
+  const std::optional<std::string> catalog_;
+  const std::string schema_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -272,7 +272,14 @@ std::any AstBuilder::visitStatementDefault(
 
 std::any AstBuilder::visitUse(PrestoSqlParser::UseContext* ctx) {
   trace("visitUse");
-  return visitChildren("visitUse", ctx);
+
+  std::shared_ptr<Identifier> catalog;
+  if (ctx->catalog != nullptr) {
+    catalog = visitIdentifier(ctx->catalog);
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<Use>(
+      getLocation(ctx), std::move(catalog), visitIdentifier(ctx->schema)));
 }
 
 std::any AstBuilder::visitCreateSchema(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -758,6 +758,10 @@ void ExplainType::accept(AstVisitor* visitor) {
   visitor->visitExplainType(this);
 }
 
+void Use::accept(AstVisitor* visitor) {
+  visitor->visitUse(this);
+}
+
 void ShowCatalogs::accept(AstVisitor* visitor) {
   visitor->visitShowCatalogs(this);
 }

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -1196,4 +1196,13 @@ void AstPrinter::visitShowFunctions(ShowFunctions* node) {
   printHeader("ShowFunctions", node);
 }
 
+void AstPrinter::visitUse(Use* node) {
+  printHeader("Use", node, [&](std::ostream& out) {
+    if (node->catalog()) {
+      out << node->catalog()->value() << ".";
+    }
+    out << node->schema()->value();
+  });
+}
+
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstPrinter.h
+++ b/axiom/sql/presto/ast/AstPrinter.h
@@ -296,6 +296,8 @@ class AstPrinter : public AstVisitor {
 
   void visitShowFunctions(ShowFunctions* node) override;
 
+  void visitUse(Use* node) override;
+
  private:
   void defaultVisit(Node* node) override {
     printIndent();

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -377,6 +377,31 @@ class CreateType : public Statement {
   std::vector<std::string> enumValues_;
 };
 
+class Use : public Statement {
+ public:
+  Use(NodeLocation location,
+      std::shared_ptr<Identifier> catalog,
+      std::shared_ptr<Identifier> schema)
+      : Statement(NodeType::kUse, location),
+        catalog_(std::move(catalog)),
+        schema_(std::move(schema)) {}
+
+  /// Returns the catalog identifier, or nullptr for schema-only USE.
+  const std::shared_ptr<Identifier>& catalog() const {
+    return catalog_;
+  }
+
+  const std::shared_ptr<Identifier>& schema() const {
+    return schema_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<Identifier> catalog_;
+  std::shared_ptr<Identifier> schema_;
+};
+
 // Drop Statements
 class DropTable : public Statement {
  public:

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -551,6 +551,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitUse(Use* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowCatalogs(ShowCatalogs* node) {
     defaultVisit(node);
   }


### PR DESCRIPTION
Summary:
Allows users to type `USE test.default;` interactively instead of passing `--catalog test --schema default` command line flags.

Supports two forms matching the Presto SQL grammar:
- `USE schema;` — sets the default schema.
- `USE catalog.schema;` — sets the default catalog and schema.

See https://prestodb.io/docs/current/sql/use.html

Differential Revision: D93616975


