### PR TITLE
fix: Failure in planning Unnest followed by a Filter

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1311,7 +1311,7 @@ void DerivedTable::distributeConjuncts() {
       if (queryCtx()->optimization()->isJoinEquality(
               conjunct, tables[0], tables[1], left, right)) {
         auto join = findJoin(this, tables, true);
-        if (join->isInner()) {
+        if (join->isInner() && !join->isUnnest()) {
           if (left->is(PlanType::kColumnExpr) &&
               right->is(PlanType::kColumnExpr)) {
             left->as<Column>()->equals(right->as<Column>());

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -671,6 +671,11 @@ class JoinEdge {
     return make<JoinEdge>(leftTable, rightTable, Spec{.rightNotExists = true});
   }
 
+  /// Creates a JoinEdge for CROSS JOIN UNNEST. Stores 'unnestExprs' in
+  /// leftKeys_. These are the MAP or ARRAY expressions to unnest, not
+  /// equality keys. Equalities from WHERE-clause filters that reference
+  /// unnested columns are left as DT conjuncts and placed as Filter nodes
+  /// during optimization.
   static JoinEdge* makeUnnest(
       PlanObjectCP leftTable,
       PlanObjectCP rightTable,
@@ -777,6 +782,11 @@ class JoinEdge {
   /// True if this is a NOT EXISTS join.
   bool isAnti() const {
     return rightNotExists_;
+  }
+
+  /// True if this is an UNNEST join.
+  bool isUnnest() const {
+    return rightTable_->is(PlanType::kUnnestTableNode);
   }
 
   /// Returns true for IN semantics (nullAware), false for EXISTS semantics.


### PR DESCRIPTION
Summary:
DerivedTable::pushdownConjuncts pushes equality conjuncts (e.g., WHERE x = b) into JoinEdge keys via addEquality. For regular inner joins, this is correct — the equality becomes part of the join condition. However, for UNNEST edges, leftKeys_ stores unnest expressions (MAP/ARRAY columns to unnest), not join equality keys. Pushing an equality into an UNNEST edge causes crossJoinUnnest to treat the equality operand as an unnest expression, resulting in:

>  VeloxRuntimeError: Unexpected type of unnest variable. Expected ARRAY or MAP, but got VARCHAR.

The fix skips UNNEST edges in pushdownConjuncts so the equality stays as a DT conjunct and is placed as a Filter node during optimization.

Differential Revision: D93649955


