### PR TITLE
fix(axiom): Relax SchemaResolver validation to pass non-standard table names through to connectors

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -141,6 +141,9 @@ std::pair<std::string, std::string> toConnectorTable(
   }
 
   // connector.schema.name
+  // TODO: This limits table names to exactly 3 dot-separated components.
+  // Same limitation as constructTableName() in TableVisitor.cpp — see the
+  // details there on supporting multi-dot connector paths.
   VELOX_CHECK_EQ(3, parts.size());
   return {parts[0], fmt::format("{}.{}", parts[1], tableName)};
 }

--- a/axiom/sql/presto/TableVisitor.cpp
+++ b/axiom/sql/presto/TableVisitor.cpp
@@ -97,6 +97,14 @@ void TableVisitor::visitDropMaterializedView(DropMaterializedView* node) {
 std::string TableVisitor::constructTableName(const QualifiedName& name) const {
   const auto& parts = name.parts();
   VELOX_CHECK(!parts.empty(), "Table name cannot be empty");
+  // TODO: This limits table names to at most 3 dot-separated components
+  // (catalog.schema.table). Connectors with multi-dot paths (e.g., XDB tier
+  // paths like "ephemeralxdb.on_demand.ftw.784.tasks") require double-quoting
+  // at the SQL layer to collapse them into a single identifier. However, the
+  // resulting dot-joined string loses identifier boundaries downstream. To
+  // fully support multi-dot paths in SQL, this function and toConnectorTable()
+  // in PrestoParser.cpp need to propagate QualifiedName parts instead of a
+  // flat dot-joined string.
   VELOX_CHECK_LE(
       parts.size(),
       3,

--- a/axiom/sql/presto/tests/TableExtractorTest.cpp
+++ b/axiom/sql/presto/tests/TableExtractorTest.cpp
@@ -61,6 +61,14 @@ TEST_F(TableExtractorTest, select) {
   testInput("SELECT * FROM catalog.schema.table1", "catalog.schema.table1");
 }
 
+TEST_F(TableExtractorTest, quotedMultiDotTableName) {
+  // Double-quoted identifiers preserve multi-dot XDB tier paths as a single
+  // component, preventing the parser from splitting them into separate parts.
+  testInput(
+      R"(SELECT * FROM xdb."ephemeralxdb.on_demand_rocksdb.ftw.784.tasks")",
+      "foo.xdb.ephemeralxdb.on_demand_rocksdb.ftw.784.tasks");
+}
+
 TEST_F(TableExtractorTest, joins) {
   testInputs(
       "SELECT * FROM t1 JOIN t2 ON t1.id = t2.id",


### PR DESCRIPTION
Summary:
Axiom's `SchemaResolver::findTable()` resolves table names using the standard *catalog.schema.table* format (up to 3 dot-separated parts) via `TableNameParser`.

**Problem:** 
XDB tier paths like `ephemeralxdb.on_demand_rocksdb.ftw.784.tasks` have 5 parts, causing `TableNameParser` to reject them and throw. This made it impossible to query XDB tables with multi-segment tier paths.

**Solution:** 
When `TableNameParser::valid()` returns false, the raw name is now passed directly to the connector's `findTable()` instead of throwing. The XDB connector already has its own `XdbTierParser` that knows how to handle multi-dot tier paths. At the SQL layer, users wrap the tier path in double quotes (e.g., xdb.`"ephemeralxdb.on_demand_rocksdb.ftw.784.tasks"`) so the parser treats it as a single identifier.

Differential Revision: D93644546