### PR TITLE
fix: Always allow duplicate column names in JOIN and UNNEST

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -101,11 +101,10 @@ void NameMappings::setAlias(const std::string& alias) {
   }
 }
 
-void NameMappings::merge(const NameMappings& other, bool allowDuplicates) {
+void NameMappings::merge(const NameMappings& other) {
   for (const auto& [name, id] : other.mappings_) {
     if (mappings_.contains(name)) {
       VELOX_CHECK(!name.alias.has_value());
-      VELOX_USER_CHECK(allowDuplicates, "Duplicate name: {}", name.toString());
       mappings_.erase(name);
     } else {
       mappings_.emplace(name, id);

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -70,14 +70,13 @@ class NameMappings {
   void setAlias(const std::string& alias);
 
   /// Merges mappings from 'other' into this. Removes unqualified access to
-  /// non-unique names. If 'allowDuplicates' is false, throws on duplicate
-  /// unqualified names instead of removing access.
+  /// non-unique names.
   ///
   /// @pre IDs are unique across 'this' and 'other'. This expectation is not
   /// verified explicitly. Violations would lead to undefined behavior.
   ///
   /// Used in PlanBuilder::join() and PlanBuilder::unnest() APIs.
-  void merge(const NameMappings& other, bool allowDuplicates = true);
+  void merge(const NameMappings& other);
 
   /// Enables unqualified access to unique names.
   void enableUnqualifiedAccess();

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -999,7 +999,7 @@ PlanBuilder& PlanBuilder::unnest(
       std::move(ordinalityName),
       flattenArrayOfRows);
 
-  outputMapping_->merge(unnestMapping, allowDuplicateAliases_);
+  outputMapping_->merge(unnestMapping);
 
   return *this;
 }
@@ -1054,7 +1054,7 @@ PlanBuilder& PlanBuilder::join(
   // User-facing column names may have duplicates between left and right side.
   // Columns that are unique can be referenced as is. Columns that are not
   // unique must be referenced using an alias.
-  outputMapping_->merge(*right.outputMapping_, allowDuplicateAliases_);
+  outputMapping_->merge(*right.outputMapping_);
 
   auto inputRowType = node_->outputType()->unionWith(right.node_->outputType());
 

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -137,20 +137,12 @@ TEST_F(PlanBuilderTest, duplicateAliasAllowed) {
 }
 
 TEST_F(PlanBuilderTest, duplicateAliasThrows) {
-  // Duplicate aliases throw by default.
+  // Duplicate aliases throw by default in project/aggregate operations.
   VELOX_ASSERT_THROW(
       PlanBuilder()
           .values(ROW({"a", "b"}, BIGINT()), ValuesNode::Variants{})
           .with({"a as x", "b as x"}),
       "Duplicate name: x");
-
-  VELOX_ASSERT_THROW(
-      PlanBuilder()
-          .values(
-              ROW({"a", "arr"}, {BIGINT(), ARRAY(BIGINT())}),
-              ValuesNode::Variants{})
-          .unnest({Col("arr").unnestAs("a")}),
-      "Duplicate name: a");
 }
 
 TEST_F(PlanBuilderTest, setOperationTypeCoercion) {

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -1083,22 +1083,15 @@ TEST_F(PlanPrinterTest, join) {
   };
 
   auto context = PlanBuilder::Context();
-  auto plan =
-      PlanBuilder(
-          context, /*enableCoercions=*/false, /*allowDuplicateAliases=*/true)
-          .values(leftType, leftData)
-          .as("l")
-          .join(
-              PlanBuilder(
-                  context,
-                  /*enableCoercions=*/false,
-                  /*allowDuplicateAliases=*/true)
-                  .values(rightType, rightData)
-                  .as("r"),
-              "l.key = r.key",
-              JoinType::kLeft)
-          .with({"l.v + r.w as z"})
-          .build();
+  auto plan = PlanBuilder(context)
+                  .values(leftType, leftData)
+                  .as("l")
+                  .join(
+                      PlanBuilder(context).values(rightType, rightData).as("r"),
+                      "l.key = r.key",
+                      JoinType::kLeft)
+                  .with({"l.v + r.w as z"})
+                  .build();
 
   auto lines = toLines(plan);
 
@@ -1162,22 +1155,15 @@ TEST_F(PlanPrinterTest, crossJoin) {
   };
 
   PlanBuilder::Context context;
-  auto plan =
-      PlanBuilder(
-          context, /*enableCoercions=*/false, /*allowDuplicateAliases=*/true)
-          .values(leftType, leftData)
-          .as("l")
-          .join(
-              PlanBuilder(
-                  context,
-                  /*enableCoercions=*/false,
-                  /*allowDuplicateAliases=*/true)
-                  .values(rightType, rightData)
-                  .as("r"),
-              "",
-              JoinType::kInner)
-          .with({"l.v + r.w as z"})
-          .build();
+  auto plan = PlanBuilder(context)
+                  .values(leftType, leftData)
+                  .as("l")
+                  .join(
+                      PlanBuilder(context).values(rightType, rightData).as("r"),
+                      "",
+                      JoinType::kInner)
+                  .with({"l.v + r.w as z"})
+                  .build();
 
   auto lines = toLines(plan);
 

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -898,9 +898,7 @@ TEST_F(UnnestTest, limit) {
 
 TEST_F(UnnestTest, join) {
   auto startLogicalPlan = [&](lp::PlanBuilder::Context& ctx) {
-    return lp::PlanBuilder{
-        ctx, /*enableCoercions=*/false, /*allowDuplicateAliases=*/true}
-        .values({rowVector_});
+    return lp::PlanBuilder{ctx}.values({rowVector_});
   };
 
   auto startReferencePlan = [&](auto& planNodeIdGenerator) {


### PR DESCRIPTION
Summary:
Duplicate aliases were allowed in projection in https://github.com/facebookincubator/axiom/pull/869 controlled behind allowDuplicates flag. 

However, this should only be applicable to projections. Duplicates should be silently allowed in JOIN and UNNEST by SQL standards. The behavior is updated to removing unqualified access, allowing qualified access for distinction. 

Note : Also reverted some unnecessary test changes from original PR after fixing JOIN behavior

Differential Revision: D93839525


