### PR TITLE
refactor: Split PrestoParserTest into focused test files

### DIFF
--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -333,10 +333,27 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return dropTable(nullptr, tableName, true);
   }
 
+  ViewPtr findView(std::string_view name) override;
+
+  /// Register a view with the given name, output schema, and SQL text.
+  void createView(
+      std::string_view name,
+      velox::RowTypePtr type,
+      std::string_view text);
+
+  /// Remove a view by name. Returns true if the view existed.
+  bool dropView(std::string_view name);
+
  private:
   TestConnector* connector_;
   folly::F14FastMap<std::string, std::shared_ptr<TestTable>> tables_;
   std::unique_ptr<TestSplitManager> splitManager_;
+
+  struct ViewDefinition {
+    velox::RowTypePtr type;
+    std::string text;
+  };
+  folly::F14FastMap<std::string, ViewDefinition> views_;
 };
 
 /// At DataSource creation time, the data contained in the corresponding Table
@@ -460,6 +477,15 @@ class TestConnector : public velox::connector::Connector {
 
   /// Registers all 8 TPC-H tables with their canonical schemas.
   void addTpchTables();
+
+  /// Register a view with the given name, output schema, and SQL text.
+  void createView(
+      std::string_view name,
+      velox::RowTypePtr type,
+      std::string_view text);
+
+  /// Remove a view by name. Returns true if the view existed.
+  bool dropView(std::string_view name);
 
  private:
   const std::shared_ptr<TestConnectorMetadata> metadata_;

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -16,7 +16,14 @@ add_library(axiom_logical_plan_matcher LogicalPlanMatcher.cpp)
 
 target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest)
 
-add_executable(axiom_sql_presto_test PrestoParserTest.cpp TableExtractorTest.cpp)
+add_executable(
+  axiom_sql_presto_test
+  DdlParserTest.cpp
+  ExpressionParserTest.cpp
+  PrestoParserTest.cpp
+  PrestoParserTestBase.cpp
+  TableExtractorTest.cpp
+)
 
 add_test(axiom_sql_presto_test axiom_sql_presto_test)
 
@@ -26,8 +33,6 @@ target_link_libraries(
   axiom_logical_plan_builder
   axiom_sql_presto_parser
   axiom_test_connector
-  axiom_tpch_connector_metadata
-  velox_tpch_connector
   GTest::gmock
   glog::glog
   GTest::gtest

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+namespace {
+
+class DdlParserTest : public PrestoParserTestBase {};
+
+TEST_F(DdlParserTest, insertIntoTable) {
+  {
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().tableScan().tableWrite();
+    testInsert("INSERT INTO nation SELECT * FROM nation", matcher);
+  }
+
+  {
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().values().project().tableWrite();
+    testInsert(
+        "INSERT INTO nation SELECT 100, 'n-100', 2, 'test comment'", matcher);
+
+    // Omit n_comment. Expect to be filled with default value.
+    testInsert(
+        "INSERT INTO nation(n_nationkey, n_name, n_regionkey) SELECT 100, 'n-100', 2",
+        matcher);
+
+    // Change the order of columns.
+    testInsert(
+        "INSERT INTO nation(n_nationkey, n_regionkey, n_name) SELECT 100, 2, 'n-100'",
+        matcher);
+  }
+
+  // Wrong types.
+  VELOX_ASSERT_THROW(
+      parseSql("INSERT INTO nation SELECT 100, 'n-100', 2, 3"),
+      "Wrong column type: INTEGER vs. VARCHAR, column 'n_comment' in table 'nation'");
+}
+
+TEST_F(DdlParserTest, createTableAsSelect) {
+  {
+    auto nationSchema =
+        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+            ->findTable("nation")
+            ->type();
+
+    auto matcher =
+        lp::test::LogicalPlanMatcherBuilder().tableScan().tableWrite();
+    testCtas(
+        "CREATE TABLE t AS SELECT * FROM nation", "t", nationSchema, matcher);
+  }
+
+  auto matcher =
+      lp::test::LogicalPlanMatcherBuilder().tableScan().project().tableWrite();
+
+  testCtas(
+      "CREATE TABLE t AS SELECT n_nationkey * 100 as a, n_name as b FROM nation",
+      "t",
+      ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+      matcher);
+
+  // Missing column names.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "CREATE TABLE t AS SELECT n_nationkey * 100, n_name FROM nation"),
+      "Column name not specified at position 1");
+
+  testCtas(
+      "CREATE TABLE t(a, b) AS SELECT n_nationkey * 100, n_name FROM nation",
+      "t",
+      ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+      matcher);
+
+  // Table properties.
+  testCtas(
+      "CREATE TABLE t WITH (partitioned_by = ARRAY['ds']) AS "
+      "SELECT n_nationkey, n_name, '2025-10-04' as ds FROM nation",
+      "t",
+      ROW({"n_nationkey", "n_name", "ds"}, {BIGINT(), VARCHAR(), VARCHAR()}),
+      matcher,
+      {
+          {"partitioned_by", "array_constructor(ds)"},
+      });
+
+  testCtas(
+      "CREATE TABLE t WITH (partitioned_by = ARRAY['ds'], bucket_count = 4, bucketed_by = ARRAY['n_nationkey']) AS "
+      "SELECT n_nationkey, n_name, '2025-10-04' as ds FROM nation",
+      "t",
+      ROW({"n_nationkey", "n_name", "ds"}, {BIGINT(), VARCHAR(), VARCHAR()}),
+      matcher,
+      {
+          {"partitioned_by", "array_constructor(ds)"},
+          {"bucket_count", "4"},
+          {"bucketed_by", "array_constructor(n_nationkey)"},
+      });
+}
+
+TEST_F(DdlParserTest, createTable) {
+  testCreateTable("CREATE TABLE t (id INTEGER)", "t", ROW({"id"}, {INTEGER()}));
+
+  // if not exists
+  {
+    auto statement = parseSql("CREATE TABLE IF NOT EXISTS t (id BIGINT)");
+    ASSERT_TRUE(statement->isCreateTable());
+
+    const auto* createTable = statement->as<CreateTableStatement>();
+    ASSERT_EQ("t", createTable->tableName());
+    ASSERT_TRUE(createTable->ifNotExists());
+  }
+
+  // properties
+  testCreateTable(
+      "CREATE TABLE t (id INTEGER, ds VARCHAR) "
+      "WITH (partitioned_by = ARRAY['ds'], format = 'ORC')",
+      "t",
+      ROW({"id", "ds"}, {INTEGER(), VARCHAR()}),
+      /*properties=*/
+      {{"partitioned_by", "array_constructor(ds)"}, {"format", "ORC"}});
+
+  // a variety of different types
+  testCreateTable(
+      "CREATE TABLE t ("
+      "  tiny_col TINYINT,"
+      "  small_col SMALLINT,"
+      "  int_col INT,"
+      "  big_col BIGINT,"
+      "  real_col REAL,"
+      "  double_col DOUBLE,"
+      "  varchar_col VARCHAR,"
+      "  bool_col BOOLEAN"
+      ")",
+      "t",
+      ROW({"tiny_col",
+           "small_col",
+           "int_col",
+           "big_col",
+           "real_col",
+           "double_col",
+           "varchar_col",
+           "bool_col"},
+          {TINYINT(),
+           SMALLINT(),
+           INTEGER(),
+           BIGINT(),
+           REAL(),
+           DOUBLE(),
+           VARCHAR(),
+           BOOLEAN()}));
+
+  // complex types
+  testCreateTable(
+      "CREATE TABLE t (ids ARRAY<INTEGER>)",
+      "t",
+      ROW({"ids"}, {ARRAY(INTEGER())}));
+  testCreateTable(
+      "CREATE TABLE t (kv MAP<VARCHAR, BIGINT>)",
+      "t",
+      ROW({"kv"}, {MAP(VARCHAR(), BIGINT())}));
+  testCreateTable(
+      "CREATE TABLE t (nested_map MAP<VARCHAR, ARRAY<INTEGER>>)",
+      "t",
+      ROW({"nested_map"}, {MAP(VARCHAR(), ARRAY(INTEGER()))}));
+  testCreateTable(
+      "CREATE TABLE t (nested ROW(a INTEGER, b VARCHAR))",
+      "t",
+      ROW({"nested"}, {ROW({"a", "b"}, {INTEGER(), VARCHAR()})}));
+  testCreateTable(
+      "CREATE TABLE t (price DECIMAL(10, 2))",
+      "t",
+      ROW({"price"}, {DECIMAL(10, 2)}));
+
+  // like clause
+  {
+    auto likeSchema =
+        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+            ->findTable("nation")
+            ->type();
+    testCreateTable("CREATE TABLE copy (LIKE nation)", "copy", likeSchema);
+  }
+
+  // like clause + some more columns
+  {
+    auto likeSchema =
+        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+            ->findTable("nation")
+            ->type();
+
+    // should respect the order of (before, LIKE, after)
+    std::vector<std::string> names = {"before"};
+    std::vector<TypePtr> types = {INTEGER()};
+    for (int i = 0; i < likeSchema->size(); ++i) {
+      names.push_back(likeSchema->nameOf(i));
+      types.push_back(likeSchema->childAt(i));
+    }
+    names.push_back("after");
+    types.push_back(DOUBLE());
+
+    testCreateTable(
+        "CREATE TABLE extended (before INTEGER, LIKE nation, after DOUBLE)",
+        "extended",
+        ROW(std::move(names), std::move(types)));
+  }
+
+  // primary key constraint
+  {
+    std::vector<CreateTableStatement::Constraint> constraints = {
+        {.columns = {"id"},
+         .type = CreateTableStatement::Constraint::Type::kPrimaryKey}};
+    testCreateTable(
+        "CREATE TABLE t (id INTEGER, PRIMARY KEY (id))",
+        "t",
+        ROW({"id"}, {INTEGER()}),
+        /*properties=*/{},
+        constraints);
+  }
+
+  // unique key constraint
+  {
+    std::vector<CreateTableStatement::Constraint> constraints = {
+        {.name = "unique_name",
+         .columns = {"name"},
+         .type = CreateTableStatement::Constraint::Type::kUnique}};
+    testCreateTable(
+        "CREATE TABLE t (id INTEGER, name VARCHAR, CONSTRAINT unique_name UNIQUE (name))",
+        "t",
+        ROW({"id", "name"}, {INTEGER(), VARCHAR()}),
+        /*properties=*/{},
+        constraints);
+  }
+
+  // duplicate column names
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id INTEGER, id VARCHAR)"),
+      "Duplicate column name: id");
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id INTEGER, ID VARCHAR)"),
+      "Duplicate column name: ID");
+
+  // unknown type
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id UNKNOWNTYPE)"),
+      "Cannot resolve type: UNKNOWNTYPE");
+
+  // invalid decimal type parameters
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (price DECIMAL(VARCHAR, ARRAY<INTEGER>))"),
+      "'VARCHAR' could not be converted to INTEGER_LITERAL");
+
+  // unknown constraint column
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id INTEGER, PRIMARY KEY (unknown))"),
+      "Constraint on unknown column: unknown");
+
+  // duplicate constraint column
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id INTEGER, PRIMARY KEY (id, id))"),
+      "Duplicate constraint column: id");
+  VELOX_ASSERT_THROW(
+      parseSql("CREATE TABLE t (id INTEGER, PRIMARY KEY (id, ID))"),
+      "Duplicate constraint column: ID");
+
+  // duplicate table property
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "CREATE TABLE t (id INTEGER) WITH (format = 'ORC', format = 'PARQUET')"),
+      "Duplicate property: format");
+}
+
+TEST_F(DdlParserTest, dropTable) {
+  {
+    auto statement = parseSql("DROP TABLE t");
+    ASSERT_TRUE(statement->isDropTable());
+
+    const auto* dropTable = statement->as<DropTableStatement>();
+    ASSERT_EQ("t", dropTable->tableName());
+    ASSERT_FALSE(dropTable->ifExists());
+  }
+
+  {
+    auto statement = parseSql("DROP TABLE IF EXISTS u");
+    ASSERT_TRUE(statement->isDropTable());
+
+    const auto* dropTable = statement->as<DropTableStatement>();
+    ASSERT_EQ("u", dropTable->tableName());
+    ASSERT_TRUE(dropTable->ifExists());
+  }
+}
+
+TEST_F(DdlParserTest, view) {
+  connector_->createView(
+      "view",
+      ROW({"n_nationkey", "cnt"}, {BIGINT(), BIGINT()}),
+      "SELECT n_regionkey as regionkey, count(*) cnt FROM nation GROUP BY 1");
+
+  SCOPE_EXIT {
+    connector_->dropView("view");
+  };
+
+  auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                     .tableScan()
+                     .join(
+                         lp::test::LogicalPlanMatcherBuilder()
+                             .tableScan()
+                             .aggregate()
+                             .project()
+                             .build())
+                     .filter()
+                     .project();
+  testSelect(
+      "SELECT n_name, n_regionkey, cnt FROM nation n, view v "
+      "WHERE n_nationkey = regionkey",
+      matcher,
+      {"view"});
+}
+
+TEST_F(DdlParserTest, createTableAndInsert) {
+  auto parser = makeParser();
+
+  // Parse CREATE TABLE and INSERT statements.
+  const auto statements = parser.parseMultiple(
+      "CREATE TABLE test_table AS SELECT n_nationkey, n_name FROM nation; "
+      "INSERT INTO nation SELECT * FROM nation");
+
+  // Verify both statements parsed correctly with expected write types.
+  ASSERT_EQ(2, statements.size());
+  ASSERT_TRUE(statements[0]->isCreateTableAsSelect());
+  ASSERT_TRUE(statements[1]->isInsert());
+
+  const auto* ctasWrite = statements[0]
+                              ->as<CreateTableAsSelectStatement>()
+                              ->plan()
+                              ->as<lp::TableWriteNode>();
+  ASSERT_EQ(lp::WriteKind::kCreate, ctasWrite->writeKind());
+
+  const auto* insertWrite =
+      statements[1]->as<InsertStatement>()->plan()->as<lp::TableWriteNode>();
+  ASSERT_EQ(lp::WriteKind::kInsert, insertWrite->writeKind());
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+namespace {
+
+class ExpressionParserTest : public PrestoParserTestBase {
+ protected:
+  lp::ExprPtr parseSqlExpression(std::string_view sql) {
+    return makeParser().parseExpression(sql, true);
+  }
+
+  // Parses a decimal literal and verifies its value and type.
+  template <typename T>
+  void testDecimal(std::string_view sql, T value, const TypePtr& type) {
+    SCOPED_TRACE(sql);
+
+    auto parser = makeParser();
+    auto expr = parser.parseExpression(sql);
+
+    ASSERT_TRUE(expr->isConstant());
+    ASSERT_EQ(expr->type()->toString(), type->toString());
+
+    auto v = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(v->isNull());
+    ASSERT_EQ(v->value<T>(), value);
+  }
+};
+
+TEST_F(ExpressionParserTest, types) {
+  auto parser = makeParser();
+
+  auto test = [&](std::string_view sql, const TypePtr& expectedType) {
+    SCOPED_TRACE(sql);
+    auto expr = parser.parseExpression(sql);
+
+    ASSERT_EQ(expr->type()->toString(), expectedType->toString());
+  };
+
+  test("cast(null as boolean)", BOOLEAN());
+  test("cast('1' as tinyint)", TINYINT());
+  test("cast(null as smallint)", SMALLINT());
+  test("cast('2' as int)", INTEGER());
+  test("cast(null as integer)", INTEGER());
+  test("cast('3' as bIgInT)", BIGINT());
+  test("cast('2020-01-01' as date)", DATE());
+  test("cast(null as timestamp)", TIMESTAMP());
+  test("cast(null as decimal(3, 2))", DECIMAL(3, 2));
+  test("cast(null as decimal(33, 10))", DECIMAL(33, 10));
+
+  test("cast(null as int array)", ARRAY(INTEGER()));
+  test("cast(null as varchar array)", ARRAY(VARCHAR()));
+  test("cast(null as map(integer, real))", MAP(INTEGER(), REAL()));
+  test("cast(null as row(int, double))", ROW({INTEGER(), DOUBLE()}));
+  test(
+      "cast(null as row(a int, b double))",
+      ROW({"a", "b"}, {INTEGER(), DOUBLE()}));
+
+  test(
+      R"(cast(json_parse('{"foo": 1, "bar": 2}') as row(foo bigint, "BAR" int)).BAR)",
+      INTEGER());
+}
+
+TEST_F(ExpressionParserTest, intervalDayTime) {
+  auto parser = makeParser();
+
+  auto test = [&](std::string_view sql, int64_t expectedSeconds) {
+    SCOPED_TRACE(sql);
+    auto expr = parser.parseExpression(sql);
+
+    ASSERT_TRUE(expr->isConstant());
+    ASSERT_EQ(expr->type()->toString(), INTERVAL_DAY_TIME()->toString());
+
+    auto value = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(value->isNull());
+    ASSERT_EQ(value->value<int64_t>(), expectedSeconds * 1'000);
+  };
+
+  test("INTERVAL '2' DAY", 2 * 24 * 60 * 60);
+  test("INTERVAL '3' HOUR", 3 * 60 * 60);
+  test("INTERVAL '4' MINUTE", 4 * 60);
+  test("INTERVAL '5' SECOND", 5);
+
+  test("INTERVAL '' DAY", 0);
+  test("INTERVAL '0' HOUR", 0);
+
+  test("INTERVAL '-2' DAY", -2 * 24 * 60 * 60);
+  test("INTERVAL '-3' HOUR", -3 * 60 * 60);
+  test("INTERVAL '-4' MINUTE", -4 * 60);
+  test("INTERVAL '-5' SECOND", -5);
+}
+
+TEST_F(ExpressionParserTest, decimal) {
+  auto parser = makeParser();
+
+  auto testShort =
+      [&](std::string_view sql, int64_t value, const TypePtr& type) {
+        testDecimal<int64_t>(sql, value, type);
+      };
+
+  auto testLong =
+      [&](std::string_view sql, std::string_view value, const TypePtr& type) {
+        testDecimal<int128_t>(sql, folly::to<int128_t>(value), type);
+      };
+
+  // Short decimals.
+  testShort("DECIMAL '1.2'", 12, DECIMAL(2, 1));
+  testShort("DECIMAL '-1.23'", -123, DECIMAL(3, 2));
+  testShort("DECIMAL '+12.3'", 123, DECIMAL(3, 1));
+  testShort("DECIMAL '1.2345'", 12345, DECIMAL(5, 4));
+  testShort("DECIMAL '12'", 12, DECIMAL(2, 0));
+  testShort("DECIMAL '12.'", 12, DECIMAL(2, 0));
+  testShort("DECIMAL '.12'", 12, DECIMAL(2, 2));
+  testShort("DECIMAL '000001.2'", 12, DECIMAL(2, 1));
+  testShort("DECIMAL '-000001.2'", -12, DECIMAL(2, 1));
+
+  // Long decimals.
+  testLong(
+      "decimal '11111222223333344444555556666677777888'",
+      "11111222223333344444555556666677777888",
+      DECIMAL(38, 0));
+  testLong(
+      "decimal '000000011111222223333344444555556666677777888'",
+      "11111222223333344444555556666677777888",
+      DECIMAL(38, 0));
+  testLong(
+      "decimal '11111222223333344444.55'",
+      "1111122222333334444455",
+      DECIMAL(22, 2));
+  testLong(
+      "decimal '00000000000000011111222223333344444.55'",
+      "1111122222333334444455",
+      DECIMAL(22, 2));
+  testLong(
+      "decimal '-11111.22222333334444455555'",
+      "-1111122222333334444455555",
+      DECIMAL(25, 20));
+
+  // Zeros.
+  testShort("DECIMAL '0'", 0, DECIMAL(1, 0));
+  testShort("DECIMAL '00000000000000000000000'", 0, DECIMAL(1, 0));
+  testShort("DECIMAL '0.'", 0, DECIMAL(1, 0));
+  testShort("DECIMAL '0.0'", 0, DECIMAL(1, 1));
+  testShort("DECIMAL '0.000'", 0, DECIMAL(3, 3));
+  testShort("DECIMAL '.0'", 0, DECIMAL(1, 1));
+
+  testLong(
+      "DECIMAL '0.00000000000000000000000000000000000000'",
+      "0",
+      DECIMAL(38, 38));
+}
+
+TEST_F(ExpressionParserTest, intervalYearMonth) {
+  auto parser = makeParser();
+
+  auto test = [&](std::string_view sql, int64_t expected) {
+    auto expr = parser.parseExpression(sql);
+
+    ASSERT_TRUE(expr->isConstant());
+    ASSERT_EQ(expr->type()->toString(), INTERVAL_YEAR_MONTH()->toString());
+
+    auto value = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(value->isNull());
+    ASSERT_EQ(value->value<int32_t>(), expected);
+  };
+
+  test("INTERVAL '2' YEAR", 2 * 12);
+  test("INTERVAL '3' MONTH", 3);
+
+  test("INTERVAL '' YEAR", 0);
+  test("INTERVAL '0' MONTH", 0);
+
+  test("INTERVAL '-2' YEAR", -2 * 12);
+  test("INTERVAL '-3' MONTH", -3);
+}
+
+TEST_F(ExpressionParserTest, doubleLiteral) {
+  auto parser = makeParser();
+
+  auto test = [&](std::string_view sql, double expected) {
+    SCOPED_TRACE(sql);
+    auto expr = parser.parseExpression(sql);
+
+    ASSERT_TRUE(expr->isConstant());
+    ASSERT_EQ(expr->type()->toString(), DOUBLE()->toString());
+
+    auto value = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(value->isNull());
+    ASSERT_DOUBLE_EQ(value->value<double>(), expected);
+  };
+
+  test("1E10", 1e10);
+  test("1.5E10", 1.5e10);
+  test("1.23E-5", 1.23e-5);
+  test(".5E2", 0.5e2);
+  test("1E+5", 1e5);
+}
+
+TEST_F(ExpressionParserTest, timestampLiteral) {
+  auto parser = makeParser();
+
+  auto test = [&](std::string_view sql, const TypePtr& expectedType) {
+    SCOPED_TRACE(sql);
+    auto expr = parser.parseExpression(sql);
+
+    VELOX_ASSERT_EQ_TYPES(expr->type(), expectedType);
+  };
+
+  test("TIMESTAMP '2020-01-01'", TIMESTAMP());
+  test("TIMESTAMP '2020-01-01 00:00:00'", TIMESTAMP());
+  test("TIMESTAMP '2020-01-01 00:00:00.000'", TIMESTAMP());
+  test(
+      "TIMESTAMP '2020-01-01 00:00 America/Los_Angeles'",
+      TIMESTAMP_WITH_TIME_ZONE());
+
+  VELOX_ASSERT_THROW(
+      parser.parseExpression("TIMESTAMP 'foo'"),
+      "Not a valid timestamp literal");
+}
+
+TEST_F(ExpressionParserTest, atTimeZone) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+  testSelect(
+      "SELECT from_unixtime(1700000000, 'UTC') AT TIME ZONE 'America/New_York'",
+      matcher);
+  testSelect(
+      "SELECT date_format(date_trunc('hour', from_unixtime(1700000000, 'UTC') AT TIME ZONE 'GMT'), '%Y-%m-%d+%H:00')",
+      matcher);
+}
+
+TEST_F(ExpressionParserTest, nullif) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+
+  testSelect("SELECT NULLIF(1, 2)", matcher);
+  testSelect("SELECT nullif(1, 1)", matcher);
+  testSelect("SELECT NULLIF('foo', 'bar')", matcher);
+}
+
+TEST_F(ExpressionParserTest, null) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+  testSelect("SELECT 1 is null", matcher);
+  testSelect("SELECT 1 IS NULL", matcher);
+
+  testSelect("SELECT 1 is not null", matcher);
+  testSelect("SELECT 1 IS NOT NULL", matcher);
+}
+
+TEST_F(ExpressionParserTest, unaryArithmetic) {
+  lp::ProjectNodePtr project;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project(
+      [&](const auto& node) {
+        project = std::dynamic_pointer_cast<const lp::ProjectNode>(node);
+      });
+
+  testSelect("SELECT -1", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "negate(1)");
+
+  testSelect("SELECT +1", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "1");
+}
+
+TEST_F(ExpressionParserTest, distinctFrom) {
+  lp::ProjectNodePtr project;
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project(
+      [&](const auto& node) {
+        project = std::dynamic_pointer_cast<const lp::ProjectNode>(node);
+      });
+
+  testSelect("SELECT 1 is distinct from 2", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "distinct_from(1, 2)");
+
+  testSelect("SELECT 1 is not distinct from 2", matcher);
+  ASSERT_EQ(project->expressions().size(), 1);
+  ASSERT_EQ(project->expressionAt(0)->toString(), "not(distinct_from(1, 2))");
+}
+
+TEST_F(ExpressionParserTest, ifClause) {
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+    testSelect("SELECT if (1 > 2, 100)", matcher);
+  }
+
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+    testSelect(
+        "SELECT if (n_nationkey between 10 and 13, 'foo') FROM nation",
+        matcher);
+  }
+}
+
+TEST_F(ExpressionParserTest, switch) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+
+  testSelect(
+      "SELECT case when n_nationkey > 2 then 100 when n_name like 'A%' then 200 end FROM nation",
+      matcher);
+  testSelect(
+      "SELECT case when n_nationkey > 2 then 100 when n_name like 'A%' then 200 else 300 end FROM nation",
+      matcher);
+
+  testSelect(
+      "SELECT case n_nationkey when 1 then 100 when 2 then 200 end FROM nation",
+      matcher);
+
+  testSelect(
+      "SELECT case n_nationkey when 1 then 100 when 2 then 200 else 300 end FROM nation",
+      matcher);
+}
+
+TEST_F(ExpressionParserTest, in) {
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().values().project();
+    testSelect("SELECT 1 in (2,3,4)", matcher);
+    testSelect("SELECT 1 IN (2,3,4)", matcher);
+
+    testSelect("SELECT 1 not in (2,3,4)", matcher);
+    testSelect("SELECT 1 NOT IN (2,3,4)", matcher);
+  }
+
+  // Subquery.
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().filter();
+    testSelect(
+        "SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%')",
+        matcher);
+  }
+
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+    testSelect(
+        "SELECT n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%') FROM nation",
+        matcher);
+  }
+
+  // Coercions.
+  {
+    auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+    testSelect("SELECT n_nationkey in (1, 2, 3) FROM nation", matcher);
+  }
+}
+
+TEST_F(ExpressionParserTest, coalesce) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSelect("SELECT coalesce(n_name, 'foo') FROM nation", matcher);
+  testSelect("SELECT COALESCE(n_name, 'foo') FROM nation", matcher);
+
+  // Coercions.
+  testSelect("SELECT coalesce(n_regionkey, 1) FROM nation", matcher);
+}
+
+TEST_F(ExpressionParserTest, concat) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSelect("SELECT n_name || n_comment FROM nation", matcher);
+}
+
+TEST_F(ExpressionParserTest, position) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSelect("SELECT POSITION('A' IN n_name) FROM nation", matcher);
+  testSelect("SELECT POSITION(n_comment IN n_name) FROM nation", matcher);
+}
+
+TEST_F(ExpressionParserTest, subscript) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSelect("SELECT array[1, 2, 3][1] FROM nation", matcher);
+  testSelect("SELECT row(1,2)[2] FROM nation", matcher);
+}
+
+TEST_F(ExpressionParserTest, dereference) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                     .values()
+                     .unnest()
+                     .project()
+                     .project();
+
+  testSelect("SELECT t.x FROM UNNEST(array[1, 2, 3]) as t(x)", matcher);
+
+  testSelect("SELECT x FROM UNNEST(array[1, 2, 3]) as t(x)", matcher);
+
+  testSelect(
+      "SELECT t.x.a FROM UNNEST(array[cast(row(1, 2) as row(a int, b int))]) as t(x)",
+      matcher);
+
+  testSelect(
+      "SELECT x.a FROM UNNEST(array[cast(row(1, 2) as row(a int, b int))]) as t(x)",
+      matcher);
+
+  testSelect("SELECT t.X FROM UNNEST(array[1, 2, 3]) as t(x)", matcher);
+  testSelect("SELECT T.X FROM UNNEST(array[1, 2, 3]) as t(x)", matcher);
+  testSelect("SELECT t.x FROM UNNEST(array[1, 2, 3]) as t(X)", matcher);
+
+  testSelect(
+      "SELECT t.x.field0 FROM UNNEST(array[row(1, 2)]) as t(x)", matcher);
+  testSelect("SELECT x.field0 FROM UNNEST(array[row(1, 2)]) as t(x)", matcher);
+  testSelect(
+      "SELECT x.field000 FROM UNNEST(array[row(1, 2)]) as t(x)", matcher);
+
+  testSelect("SELECT x.field1 FROM UNNEST(array[row(1, 2)]) as t(x)", matcher);
+  testSelect("SELECT x.field01 FROM UNNEST(array[row(1, 2)]) as t(x)", matcher);
+
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT x.field2 FROM UNNEST(array[row(1, 2)]) as t(x)"),
+      "Invalid legacy field name: field2");
+
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT cast(row(1, 2) as row(a int, b int)).field0"),
+      "Cannot access named field using legacy field name: field0 vs. a");
+}
+
+TEST_F(ExpressionParserTest, row) {
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().project();
+  testSelect("SELECT row(n_regionkey, n_name) FROM nation", matcher);
+}
+
+TEST_F(ExpressionParserTest, lambda) {
+  ASSERT_NO_THROW(parseSqlExpression("filter(array[1,2,3], x -> x > 1)"));
+  ASSERT_NO_THROW(parseSqlExpression("FILTER(array[1,2,3], x -> x > 1)"));
+
+  ASSERT_NO_THROW(parseSqlExpression("filter(array[], x -> true)"));
+
+  ASSERT_NO_THROW(
+      parseSqlExpression("reduce(array[], map(), (s, x) -> s, s -> 123)"));
+
+  ASSERT_NO_THROW(parseSqlExpression(
+      "reduce(array[], map(), (s, x) -> map(array[1], array[2]), s -> 123)"));
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "axiom/logical_plan/ExprPrinter.h"
+#include "axiom/logical_plan/PlanPrinter.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+void PrestoParserTestBase::SetUpTestCase() {
+  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+
+  functions::prestosql::registerAllScalarFunctions();
+  aggregate::prestosql::registerAllAggregateFunctions();
+}
+
+void PrestoParserTestBase::SetUp() {
+  connector_ =
+      std::make_shared<facebook::axiom::connector::TestConnector>(kConnectorId);
+  facebook::velox::connector::registerConnector(connector_);
+  connector_->addTpchTables();
+}
+
+void PrestoParserTestBase::TearDown() {
+  facebook::velox::connector::unregisterConnector(kConnectorId);
+  connector_.reset();
+}
+
+SqlStatementPtr PrestoParserTestBase::parseSql(std::string_view sql) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  return parser.parse(sql, true);
+}
+
+void PrestoParserTestBase::testExplain(
+    std::string_view sql,
+    lp::test::LogicalPlanMatcherBuilder& matcher) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isExplain());
+
+  auto* explainStatement = statement->as<ExplainStatement>();
+  ASSERT_FALSE(explainStatement->isAnalyze());
+  ASSERT_TRUE(explainStatement->type() == ExplainStatement::Type::kExecutable);
+
+  if (explainStatement->statement()->isSelect()) {
+    auto* selectStatement =
+        explainStatement->statement()->as<SelectStatement>();
+
+    auto logicalPlan = selectStatement->plan();
+    ASSERT_TRUE(matcher.build()->match(logicalPlan))
+        << lp::PlanPrinter::toText(*logicalPlan);
+  } else if (explainStatement->statement()->isInsert()) {
+    auto* insertStatement =
+        explainStatement->statement()->as<InsertStatement>();
+
+    auto logicalPlan = insertStatement->plan();
+    ASSERT_TRUE(matcher.build()->match(logicalPlan))
+        << lp::PlanPrinter::toText(*logicalPlan);
+  } else {
+    FAIL() << "Unexpected statement: "
+           << explainStatement->statement()->kindName();
+  }
+}
+
+void PrestoParserTestBase::testSelect(
+    std::string_view sql,
+    lp::test::LogicalPlanMatcherBuilder& matcher,
+    const std::unordered_set<std::string>& views) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql, true);
+  ASSERT_TRUE(statement->isSelect());
+
+  auto* selectStatement = statement->as<SelectStatement>();
+
+  auto logicalPlan = selectStatement->plan();
+  ASSERT_TRUE(matcher.build()->match(logicalPlan))
+      << lp::PlanPrinter::toText(*logicalPlan);
+
+  ASSERT_EQ(views.size(), selectStatement->views().size());
+
+  for (const auto& view : views) {
+    ASSERT_TRUE(selectStatement->views().contains({kConnectorId, view}))
+        << "Missing view: " << view;
+  }
+}
+
+void PrestoParserTestBase::testInsert(
+    std::string_view sql,
+    lp::test::LogicalPlanMatcherBuilder& matcher) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isInsert());
+
+  auto insertStatement = statement->as<InsertStatement>();
+
+  auto logicalPlan = insertStatement->plan();
+  ASSERT_TRUE(matcher.build()->match(logicalPlan))
+      << lp::PlanPrinter::toText(*logicalPlan);
+}
+
+void PrestoParserTestBase::testCtas(
+    std::string_view sql,
+    const std::string& tableName,
+    const RowTypePtr& tableSchema,
+    lp::test::LogicalPlanMatcherBuilder& matcher,
+    const std::unordered_map<std::string, std::string>& properties) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isCreateTableAsSelect());
+
+  auto ctasStatement = statement->as<CreateTableAsSelectStatement>();
+
+  ASSERT_EQ(ctasStatement->tableName(), tableName);
+  ASSERT_TRUE(*ctasStatement->tableSchema() == *tableSchema);
+
+  auto logicalPlan = ctasStatement->plan();
+  ASSERT_TRUE(matcher.build()->match(logicalPlan))
+      << lp::PlanPrinter::toText(*logicalPlan);
+
+  const auto& actualProperties = ctasStatement->properties();
+  ASSERT_EQ(properties.size(), actualProperties.size());
+
+  for (const auto& [key, value] : properties) {
+    ASSERT_TRUE(actualProperties.contains(key));
+    ASSERT_EQ(lp::ExprPrinter::toText(*actualProperties.at(key)), value);
+  }
+}
+
+void PrestoParserTestBase::testCreateTable(
+    std::string_view sql,
+    const std::string& tableName,
+    const RowTypePtr& tableSchema,
+    const std::unordered_map<std::string, std::string>& properties,
+    const std::vector<CreateTableStatement::Constraint>& constraints) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isCreateTable());
+
+  auto* createTable = statement->as<CreateTableStatement>();
+
+  ASSERT_EQ(createTable->tableName(), tableName);
+  ASSERT_TRUE(*createTable->tableSchema() == *tableSchema);
+
+  const auto& actualProperties = createTable->properties();
+  ASSERT_EQ(properties.size(), actualProperties.size());
+  for (const auto& [key, value] : properties) {
+    ASSERT_TRUE(actualProperties.contains(key));
+    ASSERT_EQ(lp::ExprPrinter::toText(*actualProperties.at(key)), value);
+  }
+
+  const auto& actualConstraints = createTable->constraints();
+  ASSERT_EQ(constraints.size(), actualConstraints.size());
+  for (size_t i = 0; i < constraints.size(); ++i) {
+    ASSERT_EQ(constraints[i].name, actualConstraints[i].name);
+    ASSERT_EQ(constraints[i].type, actualConstraints[i].type);
+    ASSERT_EQ(constraints[i].columns, actualConstraints[i].columns);
+  }
+}
+
+} // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/sql/presto/PrestoParser.h"
+#include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
+
+namespace axiom::sql::presto::test {
+
+/// Shared test fixture for PrestoParser tests. Registers scalar and
+/// aggregate functions once per test suite and creates a TestConnector
+/// with TPC-H table schemas for each test.
+class PrestoParserTestBase : public testing::Test {
+ public:
+  static constexpr const char* kConnectorId = "test";
+
+  /// Registers Presto scalar and aggregate functions. Called once per suite.
+  static void SetUpTestCase();
+
+  /// Creates and registers a TestConnector with TPC-H table schemas.
+  void SetUp() override;
+
+  /// Unregisters the connector.
+  void TearDown() override;
+
+  /// Parses a SQL statement with expression optimization enabled.
+  SqlStatementPtr parseSql(std::string_view sql);
+
+  /// Parses an EXPLAIN statement and verifies the underlying plan matches.
+  void testExplain(
+      std::string_view sql,
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher);
+
+  /// Parses a SELECT statement and verifies the logical plan matches.
+  /// Optionally checks that the expected set of views were accessed.
+  void testSelect(
+      std::string_view sql,
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher,
+      const std::unordered_set<std::string>& views = {});
+
+  /// Parses an INSERT statement and verifies the logical plan matches.
+  void testInsert(
+      std::string_view sql,
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher);
+
+  /// Parses a CREATE TABLE AS SELECT statement and verifies the table name,
+  /// schema, logical plan, and optional table properties.
+  void testCtas(
+      std::string_view sql,
+      const std::string& tableName,
+      const facebook::velox::RowTypePtr& tableSchema,
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher,
+      const std::unordered_map<std::string, std::string>& properties = {});
+
+  /// Parses a CREATE TABLE statement and verifies the table name, schema,
+  /// optional properties, and optional constraints.
+  void testCreateTable(
+      std::string_view sql,
+      const std::string& tableName,
+      const facebook::velox::RowTypePtr& tableSchema,
+      const std::unordered_map<std::string, std::string>& properties = {},
+      const std::vector<CreateTableStatement::Constraint>& constraints = {});
+
+ protected:
+  /// Creates a PrestoParser configured with the test connector.
+  PrestoParser makeParser() {
+    return PrestoParser(kConnectorId, std::nullopt);
+  }
+
+  /// Test connector with TPC-H table schemas. Supports addTable, createView,
+  /// and dropView for test-specific customization.
+  std::shared_ptr<facebook::axiom::connector::TestConnector> connector_;
+};
+
+} // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:
Split the monolithic PrestoParserTest.cpp into focused test files by concern:
  - ExpressionParserTest.cpp: expression parsing tests (types, literals, operators, functions)
  - DdlParserTest.cpp: DDL tests (INSERT, CREATE TABLE, DROP TABLE, views)
  - PrestoParserTest.cpp: query parsing tests (SELECT, JOIN, GROUP BY, set ops, EXPLAIN, SHOW)

Extract shared test fixture into PrestoParserTestBase.h/.cpp with single TestConnector (replacing separate TpchConnector + TestConnector setup). 

Add createView/dropView support to TestConnector so the view test no longer requires TpchConnector.

Differential Revision: D93891359


