### PR TITLE
refactor(parser): Extract aggregation tests and simplify PrestoParser test helpers

### DIFF
--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest
 
 add_executable(
   axiom_sql_presto_test
+  AggregationParserTest.cpp
   DdlParserTest.cpp
   ExpressionParserTest.cpp
   PrestoParserTest.cpp

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -28,14 +28,12 @@ class DdlParserTest : public PrestoParserTestBase {};
 
 TEST_F(DdlParserTest, insertIntoTable) {
   {
-    auto matcher =
-        lp::test::LogicalPlanMatcherBuilder().tableScan().tableWrite();
+    auto matcher = matchScan().tableWrite();
     testInsert("INSERT INTO nation SELECT * FROM nation", matcher);
   }
 
   {
-    auto matcher =
-        lp::test::LogicalPlanMatcherBuilder().values().project().tableWrite();
+    auto matcher = matchValues().project().tableWrite();
     testInsert(
         "INSERT INTO nation SELECT 100, 'n-100', 2, 'test comment'", matcher);
 
@@ -63,14 +61,12 @@ TEST_F(DdlParserTest, createTableAsSelect) {
             ->findTable("nation")
             ->type();
 
-    auto matcher =
-        lp::test::LogicalPlanMatcherBuilder().tableScan().tableWrite();
+    auto matcher = matchScan().tableWrite();
     testCtas(
         "CREATE TABLE t AS SELECT * FROM nation", "t", nationSchema, matcher);
   }
 
-  auto matcher =
-      lp::test::LogicalPlanMatcherBuilder().tableScan().project().tableWrite();
+  auto matcher = matchScan().project().tableWrite();
 
   testCtas(
       "CREATE TABLE t AS SELECT n_nationkey * 100 as a, n_name as b FROM nation",
@@ -315,14 +311,8 @@ TEST_F(DdlParserTest, view) {
     connector_->dropView("view");
   };
 
-  auto matcher = lp::test::LogicalPlanMatcherBuilder()
-                     .tableScan()
-                     .join(
-                         lp::test::LogicalPlanMatcherBuilder()
-                             .tableScan()
-                             .aggregate()
-                             .project()
-                             .build())
+  auto matcher = matchScan()
+                     .join(matchScan().aggregate().project().build())
                      .filter()
                      .project();
   testSelect(

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -79,6 +79,20 @@ class PrestoParserTestBase : public testing::Test {
       const std::vector<CreateTableStatement::Constraint>& constraints = {});
 
  protected:
+  /// Returns a matcher builder starting with a table scan node.
+  static facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder
+  matchScan() {
+    return facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder()
+        .tableScan();
+  }
+
+  /// Returns a matcher builder starting with a values node.
+  static facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder
+  matchValues() {
+    return facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder()
+        .values();
+  }
+
   /// Creates a PrestoParser configured with the test connector.
   PrestoParser makeParser() {
     return PrestoParser(kConnectorId, std::nullopt);


### PR DESCRIPTION
Summary:
Extract aggregation-related tests from PrestoParserTest.cpp into a new AggregationParserTest.cpp file, continuing the decomposition of the monolithic test file.

Also clean up the test infrastructure:
  - Move testDecimal from PrestoParserTestBase to ExpressionParserTest since it's only used there.
  - Replace makeParser().parseExpression(...) calls in expression tests with the parseExpr helper.
  - Use VELOX_EXPECT_EQ_TYPES in the types test instead of comparing type toString().
  - Add matchScan() and matchValues() helpers to PrestoParserTestBase to replace verbose lp::test::LogicalPlanMatcherBuilder().tableScan() / .values() calls.

Differential Revision: D93975520


