### PR TITLE
test: Improve LogicalPlanMatcherBuilder API and expand parser test coverage

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -94,6 +94,9 @@ std::any AstBuilder::visitQueryNoWith(
   }
 
   auto limit = getText(ctx->limit);
+  if (!limit.has_value()) {
+    limit = getText(ctx->fetchFirstNRows);
+  }
 
   auto term = visitTyped<QueryBody>(ctx->queryTerm());
   if (auto querySpec = std::dynamic_pointer_cast<QuerySpecification>(term)) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -92,6 +92,11 @@ class LogicalPlanMatcherBuilder {
   /// Matches a ProjectNode.
   LogicalPlanMatcherBuilder& project(OnMatchCallback onMatch = nullptr);
 
+  /// Matches a ProjectNode with the specified expressions. Each expression
+  /// string is compared against expressionAt(i)->toString().
+  LogicalPlanMatcherBuilder& project(
+      const std::vector<std::string>& expressions);
+
   /// Matches an AggregateNode.
   LogicalPlanMatcherBuilder& aggregate(OnMatchCallback onMatch = nullptr);
 


### PR DESCRIPTION
Summary:
Fix FETCH FIRST n ROWS ONLY being silently ignored — the parser accepted the syntax but discarded the row count.

Add project(expressions) overload to LogicalPlanMatcherBuilder that verifies expression strings via expressionAt(i)->toString(), replacing verbose onMatch callbacks.

Tighten expression parser tests to verify actual expression translations instead of only checking plan shape (e.g., matchScan().project()).

Combine cast and try_cast verification in the types test so each entry tests both forms.

Add testNationExpr helper to reduce boilerplate for the common pattern of SELECT <expr> FROM nation with expression verification. 

Add FETCH FIRST support (equivalent to LIMIT) and pair each LIMIT test with a FETCH FIRST test.

Differential Revision: D93979743


