### PR TITLE
fix: Use qualified column references for SELECT t.* after JOIN

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -440,17 +440,21 @@ class RelationPlanner : public AstVisitor {
         std::vector<std::string> columnNames;
         if (allColumns->prefix() != nullptr) {
           // SELECT t.*
+          const auto& prefix = allColumns->prefix()->suffix();
           columnNames = builder_->findOrAssignOutputNames(
-              /*includeHiddenColumns=*/false, allColumns->prefix()->suffix());
+              /*includeHiddenColumns=*/false, prefix);
 
+          for (const auto& name : columnNames) {
+            exprs.push_back(lp::Col(name, lp::Col(prefix)));
+          }
         } else {
           // SELECT *
           columnNames =
               builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
-        }
 
-        for (const auto& name : columnNames) {
-          exprs.push_back(lp::Col(name));
+          for (const auto& name : columnNames) {
+            exprs.push_back(lp::Col(name));
+          }
         }
       } else {
         VELOX_CHECK(item->is(NodeType::kSingleColumn));

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -745,6 +745,22 @@ TEST_F(PrestoParserTest, qualifiedStarInUnionAfterJoin) {
       "SELECT a.* FROM (VALUES (1)) a(id) JOIN (VALUES (2)) b(id) ON a.id = b.id");
 }
 
+TEST_F(PrestoParserTest, qualifiedStarWithAmbiguousColumnAfterJoin) {
+  // SELECT t.* after a JOIN where both sides have columns with the same names.
+  // Verifies that t.* correctly resolves ambiguous column names using qualified
+  // references.
+  testSelect(
+      "SELECT n1.* FROM nation n1 JOIN nation n2 ON n1.n_regionkey = n2.n_regionkey",
+      matchScan()
+          .join(matchScan().build())
+          .project({
+              "n_nationkey",
+              "n_name",
+              "n_regionkey",
+              "n_comment",
+          }));
+}
+
 // FETCH FIRST n ROWS ONLY is equivalent to LIMIT n. Each LIMIT query below is
 // paired with a FETCH FIRST query to verify they produce the same plan.
 TEST_F(PrestoParserTest, limit) {


### PR DESCRIPTION
Summary:
After a JOIN where both sides have columns with the same name,
`NameMappings::merge` removes unqualified entries for ambiguous columns.
`SELECT t.*` was generating `lp::Col(name)` (unqualified) which couldn't
resolve. Fix by generating `lp::Col(name, lp::Col(prefix))` (qualified)
when a prefix is present.

Differential Revision: D93990934


