### PR TITLE
feat(parser): Add support for JOIN USING

### DIFF
--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -75,7 +75,7 @@ class LogicalPlanMatcherImpl : public LogicalPlanMatcher {
       onMatch_(plan);
     }
 
-    return true;
+    AXIOM_RETURN_RESULT
   }
 
  protected:
@@ -225,6 +225,14 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::tableScan(
   matcher_ = std::make_shared<LogicalPlanMatcherImpl<TableScanNode>>(
       std::move(onMatch));
   return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::tableScan(
+    const std::string& tableName) {
+  return tableScan([tableName](const LogicalPlanNodePtr& node) {
+    auto scan = std::dynamic_pointer_cast<const TableScanNode>(node);
+    EXPECT_EQ(scan->tableName(), tableName);
+  });
 }
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::values(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -78,6 +78,9 @@ class LogicalPlanMatcherBuilder {
   /// Matches a TableScanNode. Must be the first node in the chain (leaf).
   LogicalPlanMatcherBuilder& tableScan(OnMatchCallback onMatch = nullptr);
 
+  /// Matches a TableScanNode with the specified table name.
+  LogicalPlanMatcherBuilder& tableScan(const std::string& tableName);
+
   /// Matches a ValuesNode. Must be the first node in the chain (leaf).
   LogicalPlanMatcherBuilder& values(OnMatchCallback onMatch = nullptr);
 

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -86,6 +86,14 @@ class PrestoParserTestBase : public testing::Test {
         .tableScan();
   }
 
+  /// Returns a matcher builder starting with a table scan node for the given
+  /// table.
+  static facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder
+  matchScan(const std::string& tableName) {
+    return facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder()
+        .tableScan(tableName);
+  }
+
   /// Returns a matcher builder starting with a values node.
   static facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder
   matchValues() {


### PR DESCRIPTION
Summary:
Add PlanBuilder::joinUsing() method and wire it up in PrestoParser::processJoin() to handle JOIN USING syntax.

joinUsing() builds an equi-join on the named columns, then adds a projection to deduplicate USING columns per SQL semantics:
  - INNER/LEFT: keep the left side's column.
  - RIGHT: keep the right side's column.
  - FULL: COALESCE(left, right).

Output column order: USING columns first, then non-USING columns from both sides in their original order.

Reviewed By: amitkdutta

Differential Revision: D94002650


