### PR TITLE
feat: Add support for queries that return empty or duplicate column names

### DIFF
--- a/axiom/logical_plan/LogicalPlanDotPrinter.cpp
+++ b/axiom/logical_plan/LogicalPlanDotPrinter.cpp
@@ -414,6 +414,29 @@ class DotPrinterVisitor : public PlanNodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const OutputNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    auto& context = static_cast<Context&>(ctx);
+    printNodeStart(context.out, node, "Output", kPalette.header);
+
+    const auto& inputType = node.onlyInput()->outputType();
+    for (const auto& entry : node.entries()) {
+      const auto& inputName = inputType->nameOf(entry.index);
+      if (entry.name != inputName) {
+        printRow(
+            context.out,
+            fmt::format(
+                "{} := {}", escapeHtml(entry.name), escapeHtml(inputName)));
+      } else {
+        printRow(context.out, escapeHtml(entry.name));
+      }
+    }
+
+    printNodeEnd(context.out);
+    printEdgeToInputs(context.out, node);
+    visitInputs(node, ctx);
+  }
+
  private:
   static void printNodeStart(
       std::ostream& out,

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -65,6 +65,9 @@ class PlanNodeVisitor {
   virtual void visit(const SampleNode& node, PlanNodeVisitorContext& context)
       const = 0;
 
+  virtual void visit(const OutputNode& node, PlanNodeVisitorContext& context)
+      const = 0;
+
  protected:
   void visitInputs(const LogicalPlanNode& node, PlanNodeVisitorContext& ctx)
       const {

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -231,6 +231,26 @@ class ToTextVisitor : public PlanNodeVisitor {
         context);
   }
 
+  void visit(const OutputNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    myContext.out << makeIndent(myContext.indent) << "- Output:";
+
+    appendOutputType(node, myContext);
+
+    myContext.out << std::endl;
+
+    const auto& inputType = node.onlyInput()->outputType();
+    const auto indent = makeIndent(myContext.indent + 2);
+
+    for (const auto& entry : node.entries()) {
+      myContext.out << indent << entry.name
+                    << " := " << inputType->nameOf(entry.index) << std::endl;
+    }
+
+    appendInputs(node, myContext);
+  }
+
  private:
   static std::string makeIndent(size_t size) {
     return std::string(size * 2, ' ');
@@ -409,6 +429,11 @@ class CollectExprStatsPlanNodeVisitor : public PlanNodeVisitor {
   }
 
   void visit(const SampleNode& node, PlanNodeVisitorContext& context)
+      const override {
+    visitInputs(node, context);
+  }
+
+  void visit(const OutputNode& node, PlanNodeVisitorContext& context)
       const override {
     visitInputs(node, context);
   }
@@ -713,6 +738,13 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
                     << " " << node.percentage()->toString() << std::endl;
     }
 
+    appendInputs(node, myContext);
+  }
+
+  void visit(const OutputNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    appendHeader(node, myContext);
     appendInputs(node, myContext);
   }
 

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -904,7 +904,7 @@ TEST_F(PlanPrinterTest, subquery) {
   EXPECT_THAT(
       lines,
       testing::ElementsAre(
-          testing::StartsWith("- Project:"),
+          testing::StartsWith("- Output:"),
           testing::StartsWith("    a := a"),
           testing::StartsWith("    expr := expr"),
           testing::StartsWith("    sum := sum_1"),
@@ -921,8 +921,7 @@ TEST_F(PlanPrinterTest, subquery) {
       lines,
       // clang-format off
       testing::ElementsAre(
-          testing::Eq("- PROJECT [5]: 3 fields: a INTEGER, expr INTEGER, sum BIGINT"),
-          testing::Eq("      expressions: field: 3"),
+          testing::Eq("- OUTPUT [5]: 3 fields: a INTEGER, expr INTEGER, sum BIGINT"),
           testing::Eq("  - PROJECT [4]: 3 fields: a INTEGER, expr INTEGER, sum_1 BIGINT"),
           testing::Eq("        expressions: aggregate: 1, call: 2, constant: 1, field: 5, subquery: 1"),
           testing::Eq("        functions: eq: 1, plus: 1, sum: 1"),
@@ -939,7 +938,9 @@ TEST_F(PlanPrinterTest, subquery) {
   EXPECT_THAT(
       lines,
       testing::ElementsAre(
-          testing::Eq("- VALUES [0]: 1 fields"), testing::Eq("")));
+          testing::Eq("- OUTPUT [5]: 3 fields"),
+          testing::Eq("  - VALUES [0]: 1 fields"),
+          testing::Eq("")));
 
   // Subquery in a filter.
   context = PlanBuilder::Context();
@@ -1104,8 +1105,8 @@ TEST_F(PlanPrinterTest, existsSubquery) {
       // clang-format off
       testing::ElementsAre(
           testing::Eq("- FILTER [4]: 1 fields: a INTEGER"),
-          testing::Eq("      predicate: EXISTS(subquery(- Project: -> ROW<a:INTEGER,b:INTE..."),
-          testing::Eq("      expressions: EXISTS: 1, call: 1, field: 4, subquery: 1"),
+          testing::Eq("      predicate: EXISTS(subquery(- Output: -> ROW<a:INTEGER,b:INTEG..."),
+          testing::Eq("      expressions: EXISTS: 1, call: 1, field: 2, subquery: 1"),
           testing::Eq("      functions: eq: 1"),
           testing::Eq("  - VALUES [0]: 1 fields: a INTEGER"),
           testing::Eq("        rows: 3"),
@@ -1300,7 +1301,7 @@ TEST_F(PlanPrinterTest, specialForms) {
   EXPECT_THAT(
       lines,
       testing::ElementsAre(
-          testing::StartsWith("- Project"),
+          testing::StartsWith("- Output"),
           testing::StartsWith("    a := a_0"),
           testing::StartsWith("    b := b_1"),
           testing::StartsWith("    expr "),
@@ -1331,8 +1332,7 @@ TEST_F(PlanPrinterTest, specialForms) {
       lines,
       // clang-format off
       testing::ElementsAre(
-          testing::Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          testing::Eq("      expressions: field: 10"),
+          testing::Eq("- OUTPUT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
           testing::Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
           testing::Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
           testing::Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
@@ -1352,14 +1352,13 @@ TEST_F(PlanPrinterTest, specialForms) {
       lines,
       // clang-format off
       testing::ElementsAre(
-          testing::Eq("- PROJECT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
-          testing::Eq("      expressions: field: 10"),
+          testing::Eq("- OUTPUT [2]: 10 fields: a BOOLEAN, b BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
           testing::Eq("  - PROJECT [1]: 10 fields: a_0 BOOLEAN, b_1 BOOLEAN, expr DOUBLE, expr_2 VARCHAR, expr_3 INTEGER, ..."),
           testing::Eq("        expressions: AND: 1, CAST: 6, COALESCE: 1, DEREFERENCE: 2, IF: 1, OR: 1, SWITCH: 1, TRY: 1, TRY_CAST: 1, call: 10, constant: 11, field: 21"),
           testing::Eq("        functions: divide: 2, eq: 2, gt: 4, lt: 1, multiply: 1"),
           testing::Eq("        constants: BIGINT: 5, DOUBLE: 1, INTEGER: 1, VARCHAR: 4"),
           testing::Eq("        projections: 8 out of 10"),
-          testing::Eq( "          a_0: AND(gt(a, b), gt(b, CAST(10 AS INTEGER)))"),
+          testing::Eq("          a_0: AND(gt(a, b), gt(b, CAST(10 AS INTEGER)))"),
           testing::Eq("          b_1: OR(lt(a, b), gt(b, CAST(0 AS INTEGER)))"),
           testing::Eq("          expr: multiply(CAST(a AS DOUBLE), 1.2)"),
           testing::Eq("          ... 5 more"),
@@ -1377,7 +1376,9 @@ TEST_F(PlanPrinterTest, specialForms) {
   EXPECT_THAT(
       lines,
       testing::ElementsAre(
-          testing::Eq("- VALUES [0]: 3 fields"), testing::Eq("")));
+          testing::Eq("- OUTPUT [2]: 10 fields"),
+          testing::Eq("  - VALUES [0]: 3 fields"),
+          testing::Eq("")));
 }
 
 TEST_F(PlanPrinterTest, lambda) {

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -150,11 +150,13 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
       kSample, velox::BOOLEAN(), hashColumn, bigintLit(mod), bigintLit(lim));
   RelationOpPtr filter = make<Filter>(project, ExprVector{filterExpr});
 
-  auto plan = queryCtx()->optimization()->toVeloxPlan(filter);
+  auto& optimization = queryCtx()->optimization();
+  auto plan = optimization->toVelox().toVeloxPlan(
+      filter, optimization->runnerOptions());
   return std::make_shared<runner::LocalRunner>(
       std::move(plan.plan),
       std::move(plan.finishWrite),
-      sampleQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()));
+      sampleQueryCtx(*optimization->veloxQueryCtx()));
 }
 
 // Maps hash value to number of times it appears in a table.

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -46,7 +46,14 @@ Optimization::Optimization(
       toGraph_{schema, evaluator, options_},
       toVelox_{session_, runnerOptions_, options_} {
   queryCtx()->optimization() = this;
-  root_ = toGraph_.makeQueryGraph(*logicalPlan_);
+
+  const auto* planRoot = logicalPlan_;
+  if (logicalPlan_->is(logical_plan::NodeKind::kOutput)) {
+    outputNames_ = logicalPlan_->as<logical_plan::OutputNode>()->entries();
+    planRoot = logicalPlan_->onlyInput().get();
+  }
+
+  root_ = toGraph_.makeQueryGraph(*planRoot);
   root_->initializePlans();
 }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -59,7 +59,11 @@ class Optimization {
   /// given, these can be used to record history data about the execution of
   /// each relevant node for costing future queries.
   PlanAndStats toVeloxPlan(RelationOpPtr plan) {
-    return toVelox_.toVeloxPlan(std::move(plan), runnerOptions_);
+    return toVelox_.toVeloxPlan(std::move(plan), runnerOptions_, outputNames_);
+  }
+
+  ToVelox& toVelox() {
+    return toVelox_;
   }
 
   std::pair<
@@ -326,6 +330,9 @@ class Optimization {
 
   // Top level plan to optimize.
   const logical_plan::LogicalPlanNode* const logicalPlan_;
+
+  // User-facing output column names from the root OutputNode.
+  std::vector<logical_plan::OutputNode::Entry> outputNames_;
 
   // Source of historical cost/cardinality information.
   History& history_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -315,7 +315,9 @@ lp::ValuesNodePtr tryFoldConstantDt(
         /*redundantProject=*/false);
   }
 
-  auto veloxPlan = queryCtx()->optimization()->toVeloxPlan(plan);
+  auto& optimization = queryCtx()->optimization();
+  auto veloxPlan =
+      optimization->toVelox().toVeloxPlan(plan, optimization->runnerOptions());
   auto results = runConstantPlan(veloxPlan, pool);
   if (results.empty()) {
     VELOX_CHECK_EQ(1, veloxPlan.plan->fragments().size());

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -54,10 +54,12 @@ class ToVelox {
       const OptimizerOptions& optimizerOptions);
 
   /// Converts physical plan (a tree of RelationOp) to an executable
-  /// multi-fragment Velox plan.
+  /// multi-fragment Velox plan. If outputNames is non-empty, adds a
+  /// final projection to rename or reorder output columns.
   PlanAndStats toVeloxPlan(
       RelationOpPtr plan,
-      const runner::MultiFragmentPlan::Options& options);
+      const runner::MultiFragmentPlan::Options& options,
+      const std::vector<logical_plan::OutputNode::Entry>& outputNames = {});
 
   std::pair<
       velox::connector::ConnectorTableHandlePtr,
@@ -87,6 +89,13 @@ class ToVelox {
   void filterUpdated(BaseTableCP baseTable, bool updateSelectivity = true);
 
  private:
+  /// Adds a Velox ProjectNode that renames or reorders output columns per the
+  /// given OutputNode entries. Returns the input unchanged if all names and
+  /// positions already match.
+  velox::core::PlanNodePtr addOutputRenames(
+      velox::core::PlanNodePtr input,
+      const std::vector<logical_plan::OutputNode::Entry>& outputNames);
+
   velox::core::FieldAccessTypedExprPtr toFieldRef(ExprCP expr);
 
   std::vector<velox::core::FieldAccessTypedExprPtr> toFieldRefs(

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -956,6 +956,7 @@ TEST_F(PlanTest, parallelCse) {
                        .tableScan()
                        .parallelProject()
                        .project()
+                       .project()
                        .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -977,6 +978,7 @@ TEST_F(PlanTest, parallelCse) {
                        .tableScan()
                        .parallelProject({"a + b", "c"})
                        .parallelProject()
+                       .project()
                        .project()
                        .build();
 
@@ -1042,6 +1044,27 @@ TEST_F(PlanTest, lambdaArgs) {
 
   auto matcher = core::PlanMatcherBuilder{}.tableScan("t").project().build();
   AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(PlanTest, outputNames) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  auto test = [&](std::string_view sql,
+                  const std::vector<std::string>& expectedNames) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    auto plan = toSingleNodePlan(logicalPlan);
+    EXPECT_THAT(
+        plan->outputType()->names(), testing::ElementsAreArray(expectedNames))
+        << sql;
+  };
+
+  // Duplicate output names.
+  test("SELECT a, a FROM t", {"a", "a"});
+  test("SELECT a AS x, b AS x FROM t", {"x", "x"});
+  test("SELECT *, * FROM t", {"a", "b", "a", "b"});
+
+  // Empty output names.
+  test(R"(SELECT a AS "", b FROM t)", {"", "b"});
 }
 
 } // namespace

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1065,6 +1065,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
                                  "arbitrary(r_name) as r_name",
                              })
                          .project({"length(r_name)", "cnt"})
+                         .project()
                          .build();
 
       auto plan = toSingleNodePlan(logicalPlan);
@@ -1089,6 +1090,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
                              })
                          .project({"length(r_name)", "cnt"})
                          .gather()
+                         .project()
                          .build();
 
       auto distributedPlan = planVelox(logicalPlan);

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -28,7 +28,7 @@ class AggregationParserTest : public PrestoParserTestBase {};
 
 TEST_F(AggregationParserTest, countStar) {
   {
-    auto matcher = matchScan().aggregate();
+    auto matcher = matchScan().aggregate().output();
 
     testSelect("SELECT count(*) FROM nation", matcher);
     testSelect("SELECT count(1) FROM nation", matcher);
@@ -39,27 +39,27 @@ TEST_F(AggregationParserTest, countStar) {
 
   {
     // Global aggregation with HAVING clause.
-    auto matcher = matchScan().aggregate().filter();
+    auto matcher = matchScan().aggregate().filter().output();
     testSelect("SELECT count(*) FROM nation HAVING count(*) > 100", matcher);
   }
 }
 
 TEST_F(AggregationParserTest, aggregateCoercions) {
-  auto matcher = matchScan().aggregate();
+  auto matcher = matchScan().aggregate().output();
 
   testSelect("SELECT corr(n_nationkey, 1.2) FROM nation", matcher);
 }
 
 TEST_F(AggregationParserTest, simpleGroupBy) {
   {
-    auto matcher = matchScan().aggregate();
+    auto matcher = matchScan().aggregate().output();
 
     testSelect("SELECT n_name, count(1) FROM nation GROUP BY 1", matcher);
     testSelect("SELECT n_name, count(1) FROM nation GROUP BY n_name", matcher);
   }
 
   {
-    auto matcher = matchScan().aggregate().project();
+    auto matcher = matchScan().aggregate().project().output();
     testSelect(
         "SELECT count(1) FROM nation GROUP BY n_name, n_regionkey", matcher);
   }
@@ -72,9 +72,12 @@ TEST_F(AggregationParserTest, simpleGroupBy) {
 
 TEST_F(AggregationParserTest, groupingSets) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect(
       "SELECT n_regionkey, count(1) FROM nation "
@@ -111,9 +114,12 @@ TEST_F(AggregationParserTest, groupingSets) {
 
 TEST_F(AggregationParserTest, rollup) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect(
       "SELECT n_regionkey, n_name, count(1) FROM nation "
@@ -139,9 +145,12 @@ TEST_F(AggregationParserTest, rollup) {
 
 TEST_F(AggregationParserTest, cube) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect(
       "SELECT n_regionkey, n_name, count(1) FROM nation "
@@ -168,9 +177,12 @@ TEST_F(AggregationParserTest, cube) {
 
 TEST_F(AggregationParserTest, mixedGroupByWithRollup) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect(
       "SELECT n_regionkey, n_name, count(1) FROM nation "
@@ -185,9 +197,12 @@ TEST_F(AggregationParserTest, mixedGroupByWithRollup) {
 
 TEST_F(AggregationParserTest, groupingSetsOrdinalCaching) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect(
       "SELECT n_regionkey, n_name, count(1) FROM nation "
@@ -234,7 +249,7 @@ TEST_F(AggregationParserTest, groupingSetsSubqueryOrdinal) {
           .aggregate([&](const auto& node) {
             agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
           })
-          .project();
+          .output();
 
   testSelect(
       "SELECT (SELECT 1), n_name, count(1) FROM nation "
@@ -273,27 +288,27 @@ TEST_F(AggregationParserTest, cubeColumnLimit) {
 
 TEST_F(AggregationParserTest, distinct) {
   {
-    auto matcher = matchScan().project().distinct();
+    auto matcher = matchScan().project().distinct().output();
     testSelect("SELECT DISTINCT n_regionkey FROM nation", matcher);
     testSelect(
         "SELECT DISTINCT n_regionkey, length(n_name) FROM nation", matcher);
   }
 
   {
-    auto matcher = matchScan().aggregate().project().distinct();
+    auto matcher = matchScan().aggregate().project().distinct().output();
     testSelect(
         "SELECT DISTINCT count(1) FROM nation GROUP BY n_regionkey", matcher);
   }
 
   {
-    auto matcher = matchScan().distinct();
+    auto matcher = matchScan().distinct().output();
     testSelect("SELECT DISTINCT * FROM nation", matcher);
   }
 }
 
 TEST_F(AggregationParserTest, groupingKeyExpr) {
   {
-    auto matcher = matchScan().aggregate().project();
+    auto matcher = matchScan().aggregate().project().output();
 
     testSelect(
         "SELECT n_name, count(1), length(n_name) FROM nation GROUP BY 1",
@@ -301,7 +316,7 @@ TEST_F(AggregationParserTest, groupingKeyExpr) {
   }
 
   {
-    auto matcher = matchScan().aggregate();
+    auto matcher = matchScan().aggregate().output();
     testSelect(
         "SELECT substr(n_name, 1, 2), count(1) FROM nation GROUP BY 1",
         matcher);
@@ -313,14 +328,14 @@ TEST_F(AggregationParserTest, groupingKeyExpr) {
   }
 
   {
-    auto matcher = matchScan().aggregate().project();
+    auto matcher = matchScan().aggregate().project().output();
     testSelect(
         "SELECT count(1) FROM nation GROUP BY substr(n_name, 1, 2)", matcher);
   }
 }
 
 TEST_F(AggregationParserTest, having) {
-  auto matcher = matchScan().aggregate().filter().project();
+  auto matcher = matchScan().aggregate().filter().project().output();
 
   // HAVING with aggregate expression over a non-selected column.
   testSelect(
@@ -330,12 +345,12 @@ TEST_F(AggregationParserTest, having) {
   // HAVING referencing a grouping key.
   testSelect(
       "SELECT n_regionkey, count(*) FROM nation GROUP BY 1 HAVING n_regionkey > 2",
-      matchScan().aggregate().filter());
+      matchScan().aggregate().filter().output());
 
   // HAVING referencing both a grouping key and an aggregate.
   testSelect(
       "SELECT n_regionkey, count(*) FROM nation GROUP BY 1 HAVING n_regionkey > count(*)",
-      matchScan().aggregate().filter());
+      matchScan().aggregate().filter().output());
 
   // HAVING with count(*) not in SELECT.
   testSelect(
@@ -377,7 +392,7 @@ TEST_F(AggregationParserTest, having) {
 }
 
 TEST_F(AggregationParserTest, scalarOverAgg) {
-  auto matcher = matchScan().aggregate().project();
+  auto matcher = matchScan().aggregate().project().output();
 
   testSelect(
       "SELECT sum(n_regionkey) + count(1), avg(length(n_name)) * 0.3 "
@@ -393,9 +408,12 @@ TEST_F(AggregationParserTest, scalarOverAgg) {
 
 TEST_F(AggregationParserTest, aggregateOptions) {
   lp::AggregateNodePtr agg;
-  auto matcher = matchScan().aggregate([&](const auto& node) {
-    agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
-  });
+  auto matcher =
+      matchScan()
+          .aggregate([&](const auto& node) {
+            agg = std::dynamic_pointer_cast<const lp::AggregateNode>(node);
+          })
+          .output();
 
   testSelect("SELECT array_agg(distinct n_regionkey) FROM nation", matcher);
   ASSERT_TRUE(agg != nullptr);

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -314,7 +314,8 @@ TEST_F(DdlParserTest, view) {
   auto matcher = matchScan()
                      .join(matchScan().aggregate().project().build())
                      .filter()
-                     .project();
+                     .project()
+                     .output();
   testSelect(
       "SELECT n_name, n_regionkey, cnt FROM nation n, view v "
       "WHERE n_nationkey = regionkey",

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -148,12 +148,15 @@ class LogicalPlanMatcherBuilder {
   /// Matches a SampleNode.
   LogicalPlanMatcherBuilder& sample(OnMatchCallback onMatch = nullptr);
 
+  /// Matches an OutputNode.
+  LogicalPlanMatcherBuilder& output(OnMatchCallback onMatch = nullptr);
+
+  /// Matches an OutputNode with the specified output column names.
+  LogicalPlanMatcherBuilder& output(
+      const std::vector<std::string>& expectedNames);
+
   /// Builds and returns the constructed LogicalPlanMatcher.
-  std::shared_ptr<LogicalPlanMatcher> build() {
-    VELOX_USER_CHECK_NOT_NULL(
-        matcher_, "Cannot build an empty LogicalPlanMatcher.");
-    return matcher_;
-  }
+  std::shared_ptr<LogicalPlanMatcher> build();
 
  private:
   std::shared_ptr<LogicalPlanMatcher> matcher_;

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -54,6 +54,12 @@ SqlStatementPtr PrestoParserTestBase::parseSql(std::string_view sql) {
   return parser.parse(sql, true);
 }
 
+lp::LogicalPlanNodePtr PrestoParserTestBase::parseSelect(std::string_view sql) {
+  auto statement = parseSql(sql);
+  VELOX_CHECK(statement->isSelect(), "Expected SELECT statement");
+  return statement->as<SelectStatement>()->plan();
+}
+
 void PrestoParserTestBase::testExplain(
     std::string_view sql,
     lp::test::LogicalPlanMatcherBuilder& matcher) {

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -43,6 +43,10 @@ class PrestoParserTestBase : public testing::Test {
   /// Parses a SQL statement with expression optimization enabled.
   SqlStatementPtr parseSql(std::string_view sql);
 
+  /// Parses a SELECT statement and returns the logical plan.
+  facebook::axiom::logical_plan::LogicalPlanNodePtr parseSelect(
+      std::string_view sql);
+
   /// Parses an EXPLAIN statement and verifies the underlying plan matches.
   void testExplain(
       std::string_view sql,


### PR DESCRIPTION
Add support for SQL queries with duplicate and empty output column names, which were previously silently renamed:

- SELECT a AS x, b AS x FROM t — duplicate aliases preserved as x, x (previously x, x_0)
- SELECT 1 AS "" — empty alias preserved as "" (previously rejected)
- SELECT *, * FROM t — duplicated star expansions preserve original names
- SELECT * FROM (SELECT 1 AS "", 2 AS x, 3 AS x) — propagated through subqueries
- SELECT t.*, t.* FROM t — qualified star duplications
- Cross joins of subqueries with empty/duplicate names
- UNION/EXCEPT/INTERSECT preserve left side's duplicate/empty names

Every logical plan produced by the Presto parser now has an OutputNode at the root. Code that consumes logical plans (optimizer, plan validators, translators) must handle the new node type. The OutputNode is always present, even when output names are unique and match the input column names, providing a consistent contract.

**How It Works**

All plan nodes enforce unique column names internally — this is fundamental to how column resolution works. To support duplicate and empty user-facing names without relaxing this invariant, introduce a root-only OutputNode that sits on top of the plan tree. The OutputNode maps each output position to an input column index and a user-facing name. Unlike ProjectNode, it allows duplicate and empty names.

During plan construction, every column has a unique physical name (e.g. x, x_0, x_1). When the user writes SELECT a AS x, b AS x, the second column gets physical name x_0 internally, but the user-specified name x is recorded in NameMappings::userNames_ keyed by the physical name. These user names propagate automatically through merge(), identity projections, and other operations that rebuild NameMappings. At build() time, user names are read from NameMappings and assembled into OutputNode entries.

The optimizer strips the OutputNode before optimization (since the optimizer works with unique names) and reapplies the output renames as a Velox ProjectNode after producing the physical plan.

**Detailed Logic Split**

Logical Plan:

- OutputNode — new root-only plan node with Entry{index, name} pairs. Allows duplicate and empty names. Cannot appear as a non-root node (enforced by LogicalPlanNode
constructor).

PlanBuilder:

- NameMappings::userNames_ — new map from column ID to user-specified output name. Propagated automatically through merge(), identity projections, dropHiddenColumns(),
with(), and joinUsing().
- resolveProjections() — when allowAmbiguousOutputNames is true, stores user names in NameMappings when physical names differ from aliases (due to dedup or shared
NameAllocator). Empty aliases use the column name (for column references) or "expr" (for expressions) as the physical name hint.
- build() — when allowAmbiguousOutputNames is true, creates an OutputNode at the plan root. Otherwise, creates a renaming ProjectNode as before.
- outputNames() — reads from outputMapping_->userName() first, falls back to reverseLookup().

PrestoSQL Parser:

- The parser is responsible for establishing user-specified output names. Each relation in FROM (table name, table alias, CTE alias, subquery alias) gets its own
PlanBuilder, so column aliases set via .as(alias) are recorded in that builder's NameMappings. When builders merge at joins or unions, user names propagate through
NameMappings::merge(). Column aliases in the final SELECT (e.g. SELECT a AS x) flow through resolveProjections() and propagate automatically through subsequent
operations.

Optimizer (ToVelox::addOutputRenames):

- Strip the OutputNode at the start of optimization and save its entries. After the optimizer produces a Velox plan, apply the output renames as a final ProjectNode.
- Avoid stacking two rename-only projects: if the Velox plan already ends with a project that only does field access (no computation), compose the renames into that
existing project instead of adding a new one.
- Skip the rename entirely when the composed result is a no-op — each output column already maps to the same-named source column at the same index.

Velox (PlanConsistencyChecker):

- Relax the duplicate/empty output name check for the root ProjectNode. The root project may have user-specified aliases that are duplicate or empty. Non-root project
nodes still enforce unique, non-empty output names.

Differential Revision: D94080615


