### PR TITLE
fix(parser): Fix deduplication of aggregation calls

### DIFF
--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(
   ExprApi.cpp
 )
 
-target_link_libraries(axiom_logical_plan velox_type velox_serialization)
+target_link_libraries(axiom_logical_plan velox_type velox_serialization velox_common_base)
 
 add_library(axiom_logical_plan_builder PlanBuilder.cpp NameAllocator.cpp NameMappings.cpp)
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -364,6 +364,13 @@ class PlanBuilder {
 
     AggregateOptions() = default;
 
+    /// Computes hash based on distinct flag, filter expression, and orderBy.
+    size_t hash() const;
+
+    /// Compare distinct flag, filter expression, and orderBy between 'this' and
+    /// 'other'.
+    bool operator==(const AggregateOptions& other) const;
+
     velox::core::ExprPtr filter;
     std::vector<SortKey> orderBy;
     bool distinct{false};

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   axiom_sql_presto_parser
   axiom_logical_plan_builder
   axiom_sql_presto_ast
+  velox_common_base
   antlr4_shared
 )
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -459,5 +459,73 @@ TEST_F(AggregationParserTest, aggregateOptions) {
   ASSERT_EQ(1, agg->aggregateAt(0)->ordering().size());
 }
 
+// Verifies that aggregation calls with same expression but different options
+// are treated as different aggregates.
+TEST_F(AggregationParserTest, aggregateDeduplication) {
+  // Same expression with different DISTINCT options produces two aggregates.
+  testSelect(
+      "SELECT n_name, sum(n_regionkey) + 1, sum(DISTINCT n_regionkey) * 2 "
+      "FROM nation GROUP BY n_name",
+      matchScan()
+          .aggregate(
+              {"n_name"}, {"sum(n_regionkey)", "sum(DISTINCT n_regionkey)"})
+          .project({
+              "n_name",
+              "plus(sum, CAST(1 AS BIGINT))",
+              "multiply(sum_0, CAST(2 AS BIGINT))",
+          })
+          .output());
+
+  // Same expression with different FILTER clauses produces two aggregates.
+  testSelect(
+      "SELECT n_name, "
+      "sum(n_regionkey) FILTER (WHERE n_nationkey > 5) + 1, "
+      "sum(n_regionkey) FILTER (WHERE n_nationkey < 10) * 2 "
+      "FROM nation GROUP BY n_name",
+      matchScan()
+          .aggregate(
+              {"n_name"},
+              {"sum(n_regionkey) FILTER (WHERE gt(n_nationkey, CAST(5 AS BIGINT)))",
+               "sum(n_regionkey) FILTER (WHERE lt(n_nationkey, CAST(10 AS BIGINT)))"})
+          .project({
+              "n_name",
+              "plus(sum, CAST(1 AS BIGINT))",
+              "multiply(sum_0, CAST(2 AS BIGINT))",
+          })
+          .output());
+
+  // Same expression with different ORDER BY directions produces two
+  // aggregates. No ProjectNode in this plan.
+  testSelect(
+      "SELECT n_name, "
+      "array_agg(n_comment ORDER BY n_nationkey ASC) as agg1, "
+      "array_agg(n_comment ORDER BY n_nationkey DESC) as agg2 "
+      "FROM nation GROUP BY n_name",
+      matchScan()
+          .aggregate(
+              {"n_name"},
+              {"array_agg(n_comment ORDER BY n_nationkey ASC NULLS LAST)",
+               "array_agg(n_comment ORDER BY n_nationkey DESC NULLS LAST)"})
+          .output());
+
+  // Same expression with same options should be deduplicated to one
+  // aggregate. Project references the same column twice.
+  testSelect(
+      "SELECT n_name, "
+      "sum(DISTINCT n_regionkey) FILTER (WHERE n_nationkey > 5) + 1, "
+      "sum(DISTINCT n_regionkey) FILTER (WHERE n_nationkey > 5) * 2 "
+      "FROM nation GROUP BY n_name",
+      matchScan()
+          .aggregate(
+              {"n_name"},
+              {"sum(DISTINCT n_regionkey) FILTER (WHERE gt(n_nationkey, CAST(5 AS BIGINT)))"})
+          .project({
+              "n_name",
+              "plus(sum, CAST(1 AS BIGINT))",
+              "multiply(sum, CAST(2 AS BIGINT))",
+          })
+          .output());
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -390,6 +390,45 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
   const std::vector<std::string> expressions_;
 };
 
+class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
+ public:
+  AggregateMatcher(
+      const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
+      std::vector<std::string> groupingKeys,
+      std::vector<std::string> aggregates)
+      : LogicalPlanMatcherImpl<AggregateNode>(inputMatcher, nullptr),
+        groupingKeys_{std::move(groupingKeys)},
+        aggregates_{std::move(aggregates)} {}
+
+ private:
+  MatchResult matchDetails(
+      const AggregateNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    EXPECT_EQ(groupingKeys_.size(), plan.groupingKeys().size());
+    AXIOM_RETURN_IF_FAILURE;
+
+    for (auto i = 0; i < groupingKeys_.size(); ++i) {
+      EXPECT_EQ(groupingKeys_[i], plan.groupingKeys()[i]->toString())
+          << "at grouping key index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+    }
+
+    EXPECT_EQ(aggregates_.size(), plan.aggregates().size());
+    AXIOM_RETURN_IF_FAILURE;
+
+    for (auto i = 0; i < aggregates_.size(); ++i) {
+      EXPECT_EQ(aggregates_[i], plan.aggregateAt(i)->toString())
+          << "at aggregate index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+    }
+    AXIOM_RETURN_RESULT(symbols)
+  }
+
+  const std::vector<std::string> groupingKeys_;
+  const std::vector<std::string> aggregates_;
+};
+
 class DistinctMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
  public:
   explicit DistinctMatcher(
@@ -524,6 +563,15 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<LogicalPlanMatcherImpl<AggregateNode>>(
       matcher_, std::move(onMatch));
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ =
+      std::make_shared<AggregateMatcher>(matcher_, groupingKeys, aggregates);
   return *this;
 }
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -148,6 +148,12 @@ class LogicalPlanMatcherBuilder {
   /// Matches an AggregateNode.
   LogicalPlanMatcherBuilder& aggregate(OnMatchCallback onMatch = nullptr);
 
+  /// Matches an AggregateNode with the specified grouping keys and aggregates.
+  /// Each string is compared against the corresponding expression's toString().
+  LogicalPlanMatcherBuilder& aggregate(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates);
+
   /// Matches an AggregateNode used for deduplication (no aggregate functions,
   /// no grouping sets, all output columns are grouping keys).
   LogicalPlanMatcherBuilder& distinct();


### PR DESCRIPTION
Summary:
The Axiom parser originally deduplicate aggregation calls only by the call expression. This causes in correct 
results when a query has two aggregation calls with the same expression but different aggregation options, such 
as `select count(x), count(distinct x) from (values 1, 2, 1) as t(x)`. This PR fixes this bug by considering the call 
expression with aggregation option together during the deduplication.

This PR also adds AggregateMatcher for testing logical plan.

This PR fixes https://github.com/facebookincubator/axiom/issues/924.

Differential Revision: D94121698


