### PR TITLE
feat: Optimize LEFT/RIGHT JOIN with constant false ON clause

### DIFF
--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -248,6 +248,14 @@ class ToGraph {
       const logical_plan::ExprPtr& condition,
       logical_plan::JoinType originalJoinType);
 
+  // Eliminates join when the ON clause contains a constant false condition.
+  // Returns true if the join was eliminated.
+  bool eliminateJoinOnConstantFalse(
+      logical_plan::JoinType joinType,
+      const logical_plan::LogicalPlanNodePtr& left,
+      const logical_plan::LogicalPlanNodePtr& right,
+      PlanObjectCP rightTable);
+
   // For LEFT JOIN with subquery conjuncts in the ON clause, processes the right
   // side inside a container DT and applies the subquery conjuncts as filters.
   // Returns the remaining non-subquery condition (possibly nullptr).


### PR DESCRIPTION
Summary:
Optimize LEFT/RIGHT JOIN when the ON clause contains a constant false condition (e.g., `1 > 2`). The join is eliminated: preserved side rows survive with NULL columns for the removed side.

https://github.com/facebookincubator/axiom/issues/919

Differential Revision: D94183175


