### PR TITLE
fix: NameAllocator to preserve trailing underscores in hints

### DIFF
--- a/axiom/logical_plan/NameAllocator.cpp
+++ b/axiom/logical_plan/NameAllocator.cpp
@@ -32,7 +32,7 @@ std::string NameAllocator::newName(std::string_view hint) {
   std::string_view prefix = hint;
 
   auto pos = prefix.rfind('_');
-  if (pos != std::string::npos &&
+  if (pos != std::string::npos && pos + 1 < prefix.size() &&
       isAllDigits({prefix.data() + pos + 1, prefix.size() - pos - 1})) {
     prefix = prefix.substr(0, pos);
   }

--- a/axiom/logical_plan/tests/NameAllocatorTest.cpp
+++ b/axiom/logical_plan/tests/NameAllocatorTest.cpp
@@ -32,6 +32,10 @@ TEST(NameAllocatorTest, basic) {
 
   EXPECT_EQ(allocator.newName("foo_bar"), "foo_bar");
   EXPECT_EQ(allocator.newName("foo_bar"), "foo_bar_3");
+
+  // Trailing underscore is preserved (not stripped as a numeric suffix).
+  EXPECT_EQ(allocator.newName("x_"), "x_");
+  EXPECT_EQ(allocator.newName("x_"), "x__4");
 }
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(
   axiom_runner_tests_utils
   axiom_runner_local_runner
   axiom_hive_connector_metadata
-  velox_temp_path
+  velox_test_util
   velox_exec_test_lib
   velox_exec
   velox_file_test_utils


### PR DESCRIPTION
Summary:
isAllDigits("") returns true (vacuous truth on empty range), causing
newName("x_") to incorrectly strip the trailing underscore and produce "x"
instead of "x_". Add a check that the suffix after the last _ is non-empty
before treating it as a numeric suffix to strip.

Differential Revision: D94240020
