### PR TITLE
refactor(subfield): Unify dereference step extraction in SubfieldTracker and ToGraph

### DIFF
--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -110,6 +110,18 @@ int64_t integerValue(const velox::Variant* variant);
 std::optional<int64_t> maybeIntegerLiteral(
     const logical_plan::ConstantExpr* expr);
 
+/// Returns true if 'expr' points to an instance of 'form'.
+bool isSpecialForm(
+    const logical_plan::ExprPtr& expr,
+    logical_plan::SpecialForm form);
+
+/// Extracts field access information from a DEREFERENCE expression. Throws if
+/// 'expr' is not a DEREFERENCE.
+/// @param expr The DEREFERENCE expression.
+/// @return A Step with kField kind, field name, and field index. For anonymous
+/// structs, the field name will be an empty string.
+Step extractDereferenceStep(const logical_plan::ExprPtr& expr);
+
 std::string conjunctsToString(const ExprVector& conjuncts);
 
 std::string orderByToString(

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -302,13 +302,6 @@ MarkFieldsAccessedContextVector makeContextForLambdaArg(
 
   return {newRowTypes, newSources};
 }
-
-bool isSpecialForm(
-    const logical_plan::ExprPtr& expr,
-    logical_plan::SpecialForm form) {
-  return expr->isSpecialForm() &&
-      expr->as<logical_plan::SpecialFormExpr>()->form() == form;
-}
 } // namespace
 
 void SubfieldTracker::markSubfields(
@@ -334,21 +327,9 @@ void SubfieldTracker::markSubfields(
 
   if (isSpecialForm(expr, lp::SpecialForm::kDereference)) {
     VELOX_CHECK(expr->inputAt(1)->isConstant());
-    const auto* field = expr->inputAt(1)->as<lp::ConstantExpr>();
-    const auto& input = expr->inputAt(0);
-
-    // Always fill the index for a struct getter.
-    auto fieldIndex = maybeIntegerLiteral(field);
-    Name name = nullptr;
-    if (!fieldIndex.has_value()) {
-      const auto& fieldName = field->value()->value<velox::TypeKind::VARCHAR>();
-      fieldIndex = input->type()->asRow().getChildIdx(fieldName);
-      name = toName(fieldName);
-    }
-
-    steps.push_back(
-        {.kind = StepKind::kField, .field = name, .id = fieldIndex.value()});
-    markSubfields(input, steps, isControl, context);
+    auto step = extractDereferenceStep(expr);
+    steps.push_back(step);
+    markSubfields(expr->inputAt(0), steps, isControl, context);
     steps.pop_back();
     return;
   }


### PR DESCRIPTION
Summary:
There are two copies of code that creates a Step of a dereference Expr, in SubfieldTracker::markSubfield and
ToGraph::isSubfield. These two pieces of code are expected to match exactly for subsequent lookup of the
skyline. This diff extracts the common logic into a helper method extractDereferenceStep() to reduce the
maintanence cost.

Differential Revision: D94377781
