### PR TITLE
fix: Fix remaining TempDirectoryPath references to use new common/testutil location

### DIFF
--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -35,7 +35,7 @@ class SyntacticJoinOrderTest : public test::QueryTestBase {
   static void SetUpTestCase() {
     test::QueryTestBase::SetUpTestCase();
 
-    gTempDirectory = velox::exec::test::TempDirectoryPath::create();
+    gTempDirectory = velox::common::testutil::TempDirectoryPath::create();
 
     auto path = gTempDirectory->getPath();
     test::TpchDataGenerator::createTables(path);
@@ -59,7 +59,7 @@ class SyntacticJoinOrderTest : public test::QueryTestBase {
     return statement->as<::axiom::sql::presto::SelectStatement>()->plan();
   }
 
-  inline static std::shared_ptr<velox::exec::test::TempDirectoryPath>
+  inline static std::shared_ptr<velox::common::testutil::TempDirectoryPath>
       gTempDirectory;
 };
 

--- a/axiom/runner/tests/LocalRunnerTestBase.h
+++ b/axiom/runner/tests/LocalRunnerTestBase.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include "axiom/runner/LocalRunner.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 namespace facebook::axiom::runner::test {
 


### PR DESCRIPTION
Summary:
Follow-up to D94372595. Update remaining axiom files that still referenced
the old velox/exec/tests/utils/TempDirectoryPath.h include path and
velox::exec::test::TempDirectoryPath namespace after D94032827 moved
TempDirectoryPath to velox/common/testutil/.

Files updated:
- LocalRunnerTestBase.h: fix #include path
- QueryManagerTest.cpp: fix #include path and namespace (3 occurrences)
- SyntacticJoinOrderTest.cpp: fix namespace (2 occurrences)
- PrestoQueryRunnerTest.cpp: fix namespace (2 occurrences)
- BUCK files: update deps from velox_temp_path to velox_test_util

Differential Revision: D94391287


