### PR TITLE
feat(optimizer): Add support for window functions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,78 @@ for the complete guide. Key rules are summarized below.
 - Keep method implementations in `.cpp` except for trivial one-liners.
 - Avoid default arguments when all callers can pass values explicitly.
 
+## Common Mistakes
+
+These are frequently violated rules. Check every new or modified line against
+this list before finishing.
+
+### `///` vs `//` — wrong comment style
+
+`///` is **only** for public API: public classes, public methods, public member
+variables. Everything else uses `//`: private/protected members, anonymous
+namespace functions and types, comments inside function bodies.
+
+```cpp
+// ❌ Wrong — anonymous-namespace function is not public API.
+namespace {
+/// Returns true if 'a' is a prefix of 'b'.
+bool isPrefix(const ExprVector& a, const ExprVector& b);
+} // namespace
+
+// ✅ Correct.
+namespace {
+// Returns true if 'a' is a prefix of 'b'.
+bool isPrefix(const ExprVector& a, const ExprVector& b);
+} // namespace
+
+// ❌ Wrong — private method is not public API.
+ private:
+  /// Recursively replaces window function references.
+  ExprCP resolveWindowRefs(ExprCP expr) const;
+
+// ✅ Correct.
+ private:
+  // Recursively replaces window function references.
+  ExprCP resolveWindowRefs(ExprCP expr) const;
+```
+
+### One-letter and abbreviated variable names
+
+Do not abbreviate. Use full, descriptive names. Loop indices (`i`, `j`) are
+acceptable. Everything else — function parameters, lambda parameters, local
+variables — must be descriptive.
+
+```cpp
+// ❌ Wrong — one-letter names and abbreviations.
+bool sameKeys(const ExprVector& a, const ExprVector& b);
+std::sort(groups.begin(), groups.end(), [](const auto& a, const auto& b) { ... });
+for (auto* wf : group.functions) { ... }
+for (size_t gi = 0; gi < groups.size(); ++gi) { ... }
+auto f = [](WindowFunctionCP f) { return f->frame().type == WindowType::kRows; };
+
+// ✅ Correct — descriptive names.
+bool sameKeys(const ExprVector& lhs, const ExprVector& rhs);
+std::sort(groups.begin(), groups.end(), [](const auto& lhs, const auto& rhs) { ... });
+for (auto* windowFunc : group.functions) { ... }
+for (size_t groupIndex = 0; groupIndex < groups.size(); ++groupIndex) { ... }
+auto f = [](WindowFunctionCP func) { return func->frame().type == WindowType::kRows; };
+```
+
+### Undocumented APIs in headers
+
+Every class, every non-trivial method declaration, and every member variable in
+a `.h` file must have a comment. Trivial one-liner getters may be left
+undocumented if the name is self-explanatory.
+
+```cpp
+// ❌ Wrong — no comment on method declaration.
+  ExprCP translateWindowExpr(const logical_plan::WindowExpr* window);
+
+// ✅ Correct.
+  // Translates a logical WindowExpr to a QueryGraph WindowFunction.
+  ExprCP translateWindowExpr(const logical_plan::WindowExpr* window);
+```
+
 ## Directory Structure
 
 | Directory | Description |

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -972,6 +972,15 @@ WindowExprPtr ExprResolver::resolveWindowTypes(
       ? windowSpec.frameType().value()
       : WindowExpr::WindowType::kRange;
 
+  // SQL standard: when ORDER BY is present and no frame is specified, the
+  // default is RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW. When ORDER BY
+  // is absent, the default is RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED
+  // FOLLOWING (entire partition).
+  if (!windowSpec.frameType().has_value() && !ordering.empty() &&
+      endType == WindowExpr::BoundType::kUnboundedFollowing) {
+    endType = WindowExpr::BoundType::kCurrentRow;
+  }
+
   WindowExpr::Frame frame{windowType, startType, startValue, endType, endValue};
 
   return std::make_shared<WindowExpr>(

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -259,6 +259,11 @@ struct DerivedTable : public PlanObject {
     return !orderKeys.empty();
   }
 
+  void dropOrderBy() {
+    orderKeys.clear();
+    orderTypes.clear();
+  }
+
   bool hasLimit() const {
     return limit >= 0;
   }

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -43,6 +43,9 @@ class FunctionSet {
   /// may produce non-null result.
   static constexpr uint64_t kNonDefaultNullBehavior = 1UL << 4;
 
+  /// Indicates a window function in the set.
+  static constexpr uint64_t kWindow = 1UL << 5;
+
   FunctionSet() : set_(0) {}
 
   explicit FunctionSet(uint64_t set) : set_(set) {}

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -251,6 +251,11 @@ class Optimization {
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan) const;
 
+  // Adds window function operators to 'plan'. Groups window functions by
+  // specification and emits one Window operator per group.
+  void addWindow(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
+      const;
+
   void addOrderBy(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
       const;
 

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -25,6 +25,7 @@ const auto& planTypeNames() {
       {PlanType::kLiteralExpr, "LiteralExpr"},
       {PlanType::kCallExpr, "CallExpr"},
       {PlanType::kAggregateExpr, "AggregateExpr"},
+      {PlanType::kWindowExpr, "WindowExpr"},
       {PlanType::kFieldExpr, "FieldExpr"},
       {PlanType::kLambdaExpr, "LambdaExpr"},
       {PlanType::kTableNode, "TableNode"},

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -30,6 +30,7 @@ enum class PlanType : uint32_t {
   kLiteralExpr,
   kCallExpr,
   kAggregateExpr,
+  kWindowExpr,
   kFieldExpr,
   kLambdaExpr,
   // Plan nodes.

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -247,6 +247,11 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const Window& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -456,6 +461,11 @@ class OnelineVisitor : public RelationOpVisitor {
   }
 
   void visit(const EnforceDistinct& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const Window& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
   }

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -78,6 +78,9 @@ class RelationOpVisitor {
   virtual void visit(
       const EnforceDistinct& op,
       RelationOpVisitorContext& context) const = 0;
+
+  virtual void visit(const Window& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -225,6 +225,25 @@ class ToVelox {
       runner::ExecutableFragment& fragment,
       std::vector<runner::ExecutableFragment>& stages);
 
+  // Makes a Velox WindowNode for a RelationOp.
+  velox::core::PlanNodePtr makeWindow(
+      const Window& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
+  // Adds a ProjectNode to trim extra columns from 'input' if it has more
+  // columns than 'inputOp' expects. This handles Velox operators that pass
+  // through all input columns (e.g., WindowNode) when the input has extra
+  // columns from rejected scan filters.
+  velox::core::PlanNodePtr maybeTrimColumns(
+      velox::core::PlanNodePtr input,
+      const RelationOpPtr& inputOp);
+
+  // Converts a single WindowFunction to a Velox WindowNode::Function.
+  velox::core::WindowNode::Function toVeloxWindowFunction(
+      WindowFunctionCP windowFunc,
+      ColumnCP outputColumn);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -316,6 +316,11 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffle();
 
+  /// Marks a shuffle boundary with verification of partition keys.
+  /// @param keys Expected partition key column names. Supports symbol rewriting
+  /// from child matchers.
+  PlanMatcherBuilder& shuffle(const std::vector<std::string>& keys);
+
   /// Marks an ordered shuffle boundary (uses MergeExchange instead of
   /// Exchange). In a distributed plan:
   ///   - Producer side expects PartitionedOutput node
@@ -384,6 +389,16 @@ class PlanMatcherBuilder {
   /// syntax). Supports symbol rewriting from child matchers.
   PlanMatcherBuilder& enforceDistinct(
       const std::vector<std::string>& distinctKeys);
+
+  /// Matches any Window node regardless of functions or partitioning.
+  PlanMatcherBuilder& window();
+
+  /// Matches a Window node with the specified SQL window expressions.
+  /// Each expression should be a complete window clause, e.g.
+  /// "row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name) as rn".
+  /// Verifies function names, partition keys, and order by keys.
+  /// @param windowExprs SQL window expressions to match.
+  PlanMatcherBuilder& window(const std::vector<std::string>& windowExprs);
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -269,13 +269,16 @@ TEST_F(PlanTest, specialFormConstantFold) {
                            .map({"a + 2"})
                            .build();
 
-    auto matcher = testCase.expectedExpression.has_value()
-        ? core::PlanMatcherBuilder()
-              .tableScan()
-              .filter(testCase.expectedExpression.value())
-              .project()
-              .build()
-        : core::PlanMatcherBuilder().tableScan().project().build();
+    std::shared_ptr<velox::core::PlanMatcher> matcher;
+    if (!testCase.expectedExpression.has_value()) {
+      matcher = core::PlanMatcherBuilder().tableScan().project().build();
+    } else {
+      matcher = core::PlanMatcherBuilder()
+                    .tableScan()
+                    .filter(testCase.expectedExpression.value())
+                    .project()
+                    .build();
+    }
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -24,6 +24,7 @@
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 
 DECLARE_string(data_path);
 
@@ -53,6 +54,7 @@ void QueryTestBase::SetUp() {
   optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
 
   optimizer::FunctionRegistry::registerPrestoFunctions();
+  velox::window::prestosql::registerAllWindowFunctions();
 }
 
 void QueryTestBase::TearDown() {

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -20,6 +20,7 @@
 #include <gflags/gflags.h>
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/runner/LocalRunner.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
@@ -196,6 +197,11 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   /// Returns the full path to a test data file.
   static std::string getTestDataPath(const std::string& filename);
+
+  static velox::core::PlanMatcherBuilder matchScan(
+      const std::string& tableName) {
+    return velox::core::PlanMatcherBuilder().tableScan(tableName);
+  }
 
   OptimizerOptions optimizerOptions_;
 

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+class WindowTest : public test::QueryTestBase {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    velox::connector::registerConnector(testConnector_);
+
+    testConnector_->addTpchTables();
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(kTestConnectorId);
+    test::QueryTestBase::TearDown();
+  }
+
+  velox::core::PlanNodePtr toSingleNodePlan(
+      std::string_view sql,
+      int32_t numDrivers = 1) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    return QueryTestBase::toSingleNodePlan(logicalPlan, numDrivers);
+  }
+
+  std::shared_ptr<connector::TestConnector> testConnector_;
+};
+
+TEST_F(WindowTest, singleWindowFunction) {
+  // No extra columns to drop, so no final project.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "FROM nation");
+
+  auto matcher = matchScan("nation")
+                     .window({"row_number() OVER (ORDER BY n_name)"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowWithPartitionBy) {
+  // Project drops unused columns (n_nationkey).
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, n_regionkey, "
+      "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s "
+      "FROM nation");
+
+  auto matcher =
+      matchScan("nation")
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s"})
+          .project({"n_name", "n_regionkey", "s"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, multipleWindowFunctionsSameSpec) {
+  // Multiple window functions with the same partition/order spec should be
+  // grouped into a single Window operator.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name) as rn, "
+      "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s "
+      "FROM nation");
+
+  auto matcher =
+      matchScan("nation")
+          .window(
+              {"row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name)",
+               "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, differentPartitionKeys) {
+  // Window functions with different partition keys produce separate Window
+  // operators.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name) as rn, "
+      "sum(n_nationkey) OVER (ORDER BY n_name) as s "
+      "FROM nation");
+
+  // First project drops n_regionkey (not needed by second window).
+  // Second project drops n_nationkey (not in SELECT).
+  auto matcher =
+      matchScan("nation")
+          .window(
+              {"row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .project({"n_nationkey", "n_name", "rn"})
+          .window({"sum(n_nationkey) OVER (ORDER BY n_name)"})
+          .project({"n_name", "rn", "s"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, differentOrderTypes) {
+  // Window functions with same order keys but different sort orders (ASC vs
+  // DESC) must produce separate Window operators.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name ASC) as rn, "
+      "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name DESC) as s "
+      "FROM nation");
+
+  auto matcher =
+      matchScan("nation")
+          .window(
+              {"row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name ASC)"})
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name DESC)"})
+          .project({"n_name", "rn", "s"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowWithFrameBounds) {
+  // Precompute projection materializes frame bound constant.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "sum(n_nationkey) OVER ("
+      "  PARTITION BY n_regionkey ORDER BY n_name "
+      "  ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING"
+      ") as s "
+      "FROM nation");
+
+  // Precompute project materializes the constant frame bounds. Use aliases to
+  // capture the auto-generated column names for symbol propagation.
+  auto matcher =
+      matchScan("nation")
+          .project({
+              "n_nationkey",
+              "n_name",
+              "n_regionkey",
+              "1 as one",
+          })
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name "
+               "ROWS BETWEEN one PRECEDING AND one FOLLOWING)"})
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowWithExpressionFrameBounds) {
+  // Precompute projection materializes expression frame bounds.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "sum(n_nationkey) OVER ("
+      "  PARTITION BY n_regionkey ORDER BY n_name "
+      "  ROWS BETWEEN n_regionkey PRECEDING AND n_regionkey + 1 FOLLOWING"
+      ") as s "
+      "FROM nation");
+
+  // Precompute project materializes expression frame bounds. Use aliases to
+  // capture the auto-generated column names for symbol propagation.
+  auto matcher =
+      matchScan("nation")
+          .project({
+              "n_nationkey",
+              "n_name",
+              "n_regionkey",
+              "n_regionkey + 1 as frameEnd",
+          })
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name "
+               "ROWS BETWEEN n_regionkey PRECEDING AND frameEnd FOLLOWING)"})
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowWithExpressionInputs) {
+  // All inputs to window function are expressions: function args, partition
+  // keys, sorting keys, frame start and end. Partition key and frame end share
+  // the expression n_regionkey + 1 which is computed once.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "sum(n_nationkey * 2) OVER ("
+      "  PARTITION BY n_regionkey + 1 ORDER BY upper(n_name) "
+      "  ROWS BETWEEN n_regionkey PRECEDING AND n_regionkey + 1 FOLLOWING"
+      ") as s "
+      "FROM nation");
+
+  // Precompute project has 6 outputs: 3 pass-through + 3 computed. The
+  // expression n_regionkey + 1 appears once (shared by partition key and frame
+  // end). Use aliases to capture auto-generated names for symbol propagation.
+  auto matcher =
+      matchScan("nation")
+          .project({
+              "n_nationkey",
+              "n_name",
+              "n_regionkey",
+              "n_nationkey * 2 as sumArg",
+              "n_regionkey + 1 as partKey",
+              "upper(n_name) as orderKey",
+          })
+          .window({"sum(sumArg) OVER (PARTITION BY partKey ORDER BY orderKey "
+                   "ROWS BETWEEN n_regionkey PRECEDING AND partKey FOLLOWING)"})
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowAfterFilter) {
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, "
+      "row_number() OVER (ORDER BY n_name) as rn "
+      "FROM nation WHERE n_regionkey = 1");
+
+  // Project drops n_regionkey after filter (not needed by the window).
+  auto matcher = matchScan("nation")
+                     .filter("n_regionkey = 1")
+                     .project({"n_name"})
+                     .window({"row_number() OVER (ORDER BY n_name)"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, filterOnWindowOutput) {
+  // Filter on window output forces a DT boundary.
+  auto plan = toSingleNodePlan(
+      "SELECT * FROM ("
+      "  SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "  FROM nation"
+      ") WHERE rn <= 5");
+
+  auto matcher = matchScan("nation")
+                     .window({"row_number() OVER (ORDER BY n_name) as rn"})
+                     .filter("rn <= 5")
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowOnWindowInArgs) {
+  // Window function that references another window function's output in its
+  // args forces a DT boundary.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, s FROM ("
+      "  SELECT *, "
+      "  sum(rn) OVER (ORDER BY n_name) as s "
+      "  FROM ("
+      "    SELECT n_name, "
+      "    row_number() OVER (ORDER BY n_name) as rn "
+      "    FROM nation"
+      "  )"
+      ")");
+
+  // Two DTs: first computes row_number, second computes sum over rn.
+  auto matcher = matchScan("nation")
+                     .window({"row_number() OVER (ORDER BY n_name)"})
+                     .window({"sum(rn) OVER (ORDER BY n_name) as s"})
+                     .project({"n_name", "s"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, windowOnWindowInFrameBounds) {
+  // Window function that references another window function's output in its
+  // frame bounds forces a DT boundary.
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, s FROM ("
+      "  SELECT *, "
+      "  sum(n_nationkey) OVER ("
+      "    ORDER BY n_name "
+      "    ROWS BETWEEN rn PRECEDING AND CURRENT ROW"
+      "  ) as s "
+      "  FROM ("
+      "    SELECT n_name, n_nationkey, "
+      "    row_number() OVER (ORDER BY n_name) as rn "
+      "    FROM nation"
+      "  )"
+      ")");
+
+  // Two DTs: first computes row_number, second computes sum with frame bound.
+  auto matcher =
+      matchScan("nation")
+          .window({"row_number() OVER (ORDER BY n_name) as rn"})
+          .project({"n_name", "n_nationkey", "rn"})
+          .window({"sum(n_nationkey) OVER (ORDER BY n_name "
+                   "ROWS BETWEEN rn PRECEDING AND CURRENT ROW) as s"})
+          .project({"n_name", "s"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(WindowTest, distributed) {
+  // Distributed plan should have repartitioning for window.
+  auto logicalPlan = parseSelect(
+      "SELECT n_name, "
+      "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s "
+      "FROM nation",
+      kTestConnectorId);
+
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto matcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey"})
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+}
+
+TEST_F(WindowTest, distributedMultipleShuffles) {
+  // Window functions with different partition keys require separate shuffles.
+  auto logicalPlan = parseSelect(
+      "SELECT n_name, "
+      "sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s, "
+      "row_number() OVER (PARTITION BY n_nationkey ORDER BY n_name) as rn "
+      "FROM nation",
+      kTestConnectorId);
+
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto matcher =
+      matchScan("nation")
+          .shuffle({"n_nationkey"})
+          .window(
+              {"row_number() OVER (PARTITION BY n_nationkey ORDER BY n_name)"})
+          .shuffle({"n_regionkey"})
+          .window(
+              {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1309,12 +1309,14 @@ TEST_F(PrestoParserTest, use) {
 }
 
 TEST_F(PrestoParserTest, windowFunction) {
+  // SQL standard default frame when ORDER BY is present without explicit frame
+  // is RANGE UNBOUNDED PRECEDING to CURRENT ROW.
   testSelect(
       "SELECT n_name, row_number() OVER (ORDER BY n_nationkey) FROM nation",
       matchScan()
           .project({
               "n_name",
-              "row_number() OVER (ORDER BY n_nationkey ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+              "row_number() OVER (ORDER BY n_nationkey ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
           })
           .output());
 }


### PR DESCRIPTION
Summary:
Add end-to-end support for window functions in the Axiom optimizer, covering the query graph, optimization, and Velox translation phases. Ranking optimizations (RowNumber, TopNRowNumber) are deferred to a follow-up diff.

**QueryGraph types:**
- Add `WindowFunction` class (extends `Call`) with partition keys, order keys, frame bounds, and `ignoreNulls`. Add `Frame` struct mirroring  `WindowExpr::Frame` with QueryGraph expression pointers.
- Add `kWindowExpr` to `PlanType` and `kWindow` to `RelType`.
- Add `Window` RelationOp.

**ToGraph (logical plan → query graph):**
- Translate `WindowExpr` to `WindowFunction` in `translateExpr`, including partition keys, order keys, frame bounds, and function arguments.
- Add DT boundary rules: finalize DT when a window references another window's output (window-on-window), when a filter references a window output, or when a window appears over a LIMIT. Clear DT order-by when window has its own partition/order keys.

**Optimization (query graph → physical plan):**
- Add `addWindow` in `addPostprocess` (after HAVING, before ORDER BY).
- Group window functions by specification (partition + order keys). Merge
  ROWS-only groups when one group's ORDER BY is a prefix of another's.
- Order groups to maximize sort reuse (`inputsSorted` flag).
- Emit precompute projections for expression arguments, partition keys, order keys, and frame bound expressions.
- Add repartitioning for distributed plans when partition keys differ.

**ToVelox (physical plan → executable plan):**
- Add `makeWindow` to translate `Window` RelationOp to Velox `WindowNode`.
- Add `toVeloxWindowFunction` to convert `WindowFunction` to `WindowNode::Function` with frame translation.
- Add `maybeTrimColumns` helper: inserts a ProjectNode before WindowNode when the input has extra columns (e.g., from rejected scan filters) since Velox WindowNode passes through all input columns.

Differential Revision: D94374980


