### PR TITLE
feat: Add ranking function optimizations (RowNumber and TopNRowNumber)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -196,6 +196,25 @@ undocumented if the name is self-explanatory.
   ExprCP translateWindowExpr(const logical_plan::WindowExpr* window);
 ```
 
+### `goto` statements
+
+Never use `goto`. Restructure the code using early returns, helper functions, or
+duplicated code paths instead. `goto` makes control flow hard to follow and is
+never necessary in C++.
+
+### Fitting tests to buggy code
+
+When a test fails, **never** update the test expectation to match what the code
+produces without first verifying that the code is correct. The default
+assumption should be that the code is wrong, not the test.
+
+For optimizer plan tests:
+1. Derive the expected plan from query semantics before running the test.
+2. When a test fails, investigate the mismatch — do not blindly copy the actual
+   output into the expected.
+3. Flag suspicious patterns: redundant operators, two gathers with no partition
+   keys, extra columns flowing through unnecessary nodes.
+
 ## Directory Structure
 
 | Directory | Description |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,32 @@ of the connectors is a separate CMake target.
 - connectors/hive
 
 Avoid introducing new CMake targets unless there is a clear reason to do so.
+
+## Design guidelines
+
+### Keep Axiom generic
+
+Axiom is designed to work with different SQL dialects, not just Presto. Avoid
+hard-coding function names, type names, or dialect-specific behavior directly
+in the optimizer or runner. Instead, use the `FunctionRegistry` to register
+well-known functions by their semantic role and look them up at optimization
+time.
+
+```cpp
+// ❌ Wrong — hard-coded function name.
+if (name == "row_number") {
+  return RankFunction::kRowNumber;
+}
+
+// ✅ Correct — use registered name from FunctionRegistry.
+const auto* registry = FunctionRegistry::instance();
+if (registry->rowNumber().has_value() && name == *registry->rowNumber()) {
+  return RankFunction::kRowNumber;
+}
+```
+
+When adding a new optimization that depends on recognizing a specific function,
+add a registration method to `FunctionRegistry` (e.g., `registerRowNumber`) and
+register the function in `registerPrestoFunctions` (or the equivalent for other
+dialects). This ensures the optimization works regardless of the function name
+used by a particular dialect.

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -136,6 +136,33 @@ bool FunctionRegistry::registerIsNull(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerRowNumber(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (rowNumber_.has_value() && rowNumber_.value() != name) {
+    return false;
+  }
+  rowNumber_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerRank(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (rank_.has_value() && rank_.value() != name) {
+    return false;
+  }
+  rank_ = name;
+  return true;
+}
+
+bool FunctionRegistry::registerDenseRank(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (denseRank_.has_value() && denseRank_.value() != name) {
+    return false;
+  }
+  denseRank_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerSpecialForm(
     lp::SpecialForm specialForm,
     std::string_view name) {
@@ -314,6 +341,9 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerGreaterThan(fullName("gt"));
   registry->registerGreaterThanOrEqual(fullName("gte"));
   registry->registerIsNull(fullName("is_null"));
+  registry->registerRowNumber(fullName("row_number"));
+  registry->registerRank(fullName("rank"));
+  registry->registerDenseRank(fullName("dense_rank"));
 
   registry->registerAggregateEmptyResultResolver(
       {fullName("count_if"), fullName("approx_distinct")},

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -360,6 +360,39 @@ class FunctionRegistry {
     return isNull_;
   }
 
+  /// Registers function 'name' that has semantics of 'row_number' window
+  /// function, i.e. assigns sequential numbers to rows within a partition.
+  /// @return true if successfully registered, false if a different
+  /// 'rowNumber' function is already registered.
+  bool registerRowNumber(std::string_view name);
+
+  /// Returns the name of the 'row_number' window function.
+  const std::optional<std::string>& rowNumber() const {
+    return rowNumber_;
+  }
+
+  /// Registers function 'name' that has semantics of 'rank' window function,
+  /// i.e. assigns rank with gaps for ties within a partition.
+  /// @return true if successfully registered, false if a different
+  /// 'rank' function is already registered.
+  bool registerRank(std::string_view name);
+
+  /// Returns the name of the 'rank' window function.
+  const std::optional<std::string>& rank() const {
+    return rank_;
+  }
+
+  /// Registers function 'name' that has semantics of 'dense_rank' window
+  /// function, i.e. assigns rank without gaps for ties within a partition.
+  /// @return true if successfully registered, false if a different
+  /// 'denseRank' function is already registered.
+  bool registerDenseRank(std::string_view name);
+
+  /// Returns the name of the 'dense_rank' window function.
+  const std::optional<std::string>& denseRank() const {
+    return denseRank_;
+  }
+
   bool registerSpecialForm(
       logical_plan::SpecialForm specialForm,
       std::string_view name);
@@ -428,18 +461,28 @@ class FunctionRegistry {
 
  private:
   folly::F14FastMap<std::string, std::unique_ptr<FunctionMetadata>> metadata_;
+
+  // Scalar functions.
   std::string equality_{"eq"};
   std::string negation_{"not"};
   std::optional<std::string> elementAt_;
   std::optional<std::string> subscript_;
   std::optional<std::string> cardinality_;
-  std::optional<std::string> arbitrary_;
-  std::optional<std::string> count_;
   std::optional<std::string> lessThan_;
   std::optional<std::string> lessThanOrEqual_;
   std::optional<std::string> greaterThan_;
   std::optional<std::string> greaterThanOrEqual_;
   std::optional<std::string> isNull_;
+
+  // Aggregate functions.
+  std::optional<std::string> arbitrary_;
+  std::optional<std::string> count_;
+
+  // Window functions.
+  std::optional<std::string> rowNumber_;
+  std::optional<std::string> rank_;
+  std::optional<std::string> denseRank_;
+
   folly::F14FastMap<std::string, std::string> reversibleFunctions_;
   folly::F14FastMap<logical_plan::SpecialForm, std::string> specialForms_;
   folly::F14FastMap<std::string, AggregateEmptyResultResolver>

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -252,8 +252,10 @@ class Optimization {
       AggregationPlanCP aggPlan) const;
 
   // Adds window function operators to 'plan'. Groups window functions by
-  // specification and emits one Window operator per group.
-  void addWindow(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
+  // specification and emits one Window operator per group. Returns true if the
+  // DT's limit was consumed by a ranking optimization and should not be
+  // created separately by addPostprocess.
+  bool addWindow(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
       const;
 
   void addOrderBy(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -252,6 +252,16 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const RowNumber& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -466,6 +476,16 @@ class OnelineVisitor : public RelationOpVisitor {
   }
 
   void visit(const Window& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const RowNumber& op, RelationOpVisitorContext& context)
+      const override {
+    visitDefault(op, context);
+  }
+
+  void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
   }

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -81,6 +81,12 @@ class RelationOpVisitor {
 
   virtual void visit(const Window& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(const RowNumber& op, RelationOpVisitorContext& context)
+      const = 0;
+
+  virtual void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -231,6 +231,18 @@ class ToVelox {
       runner::ExecutableFragment& fragment,
       std::vector<runner::ExecutableFragment>& stages);
 
+  // Makes a Velox RowNumberNode for a RelationOp.
+  velox::core::PlanNodePtr makeRowNumber(
+      const RowNumber& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
+  // Makes a Velox TopNRowNumberNode for a RelationOp.
+  velox::core::PlanNodePtr makeTopNRowNumber(
+      const TopNRowNumber& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
   // Adds a ProjectNode to trim extra columns from 'input' if it has more
   // columns than 'inputOp' expects. This handles Velox operators that pass
   // through all input columns (e.g., WindowNode) when the input has extra

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -349,6 +349,13 @@ class PlanMatcherBuilder {
   /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& finalLimit(int64_t offset, int64_t count);
 
+  /// Matches the distributed limit pattern: partialLimit(0, offset + count) →
+  /// localPartition → finalLimit(0, offset + count) → gather →
+  /// finalLimit(offset, count).
+  /// @param offset Number of rows to skip.
+  /// @param count Maximum number of rows to return.
+  PlanMatcherBuilder& distributedLimit(int64_t offset, int64_t count);
+
   /// Matches any TopN node.
   PlanMatcherBuilder& topN();
 
@@ -399,6 +406,29 @@ class PlanMatcherBuilder {
   /// Verifies function names, partition keys, and order by keys.
   /// @param windowExprs SQL window expressions to match.
   PlanMatcherBuilder& window(const std::vector<std::string>& windowExprs);
+
+  /// Matches any RowNumber node.
+  PlanMatcherBuilder& rowNumber();
+
+  /// Matches a RowNumber node with the specified partition keys and limit.
+  /// @param partitionKeys Expected partition key column names.
+  /// @param limit Expected per-partition limit.
+  PlanMatcherBuilder& rowNumber(
+      const std::vector<std::string>& partitionKeys,
+      std::optional<int32_t> limit = std::nullopt);
+
+  /// Matches any TopNRowNumber node.
+  PlanMatcherBuilder& topNRowNumber();
+
+  /// Matches a TopNRowNumber node with the specified partition keys, sorting
+  /// keys, and limit.
+  /// @param partitionKeys Expected partition key column names.
+  /// @param sortingKeys Expected sorting key column names.
+  /// @param limit Expected per-partition row limit.
+  PlanMatcherBuilder& topNRowNumber(
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<std::string>& sortingKeys,
+      int32_t limit);
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+class RankingTest : public test::QueryTestBase {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    velox::connector::registerConnector(testConnector_);
+
+    testConnector_->addTpchTables();
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(kTestConnectorId);
+    test::QueryTestBase::TearDown();
+  }
+
+  velox::core::PlanNodePtr toSingleNodePlan(
+      std::string_view sql,
+      int32_t numDrivers = 1) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    return QueryTestBase::toSingleNodePlan(logicalPlan, numDrivers);
+  }
+
+  runner::MultiFragmentPlanPtr toDistributedPlan(std::string_view sql) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    return planVelox(logicalPlan).plan;
+  }
+
+  std::shared_ptr<connector::TestConnector> testConnector_;
+};
+
+TEST_F(RankingTest, rowNumberWithoutOrderBy) {
+  // row_number() without ORDER BY uses a specialized RowNumberNode.
+  constexpr auto sql = "SELECT n_name, row_number() OVER () as rn FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation").rowNumber({}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather to single node, then RowNumber.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation").gather().rowNumber({}).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithPartitionByWithoutOrderBy) {
+  // row_number() with PARTITION BY but no ORDER BY uses RowNumberNode.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER (PARTITION BY n_regionkey) as rn "
+      "FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .rowNumber({"n_regionkey"})
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through gather unnecessarily. Drop it after
+  // RowNumber once https://github.com/facebookincubator/velox/issues/16551 is
+  // fixed.
+  // Shuffle by partition keys before RowNumber.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .shuffle({"n_regionkey"})
+                                .rowNumber({"n_regionkey"})
+                                .project({"n_name", "rn"})
+                                .gather()
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithLimit) {
+  // row_number() without ORDER BY + LIMIT. LIMIT is pushed below RowNumber
+  // because the row numbering is non-deterministic.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER () as rn FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation").finalLimit(0, 10).rowNumber({}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed: partial limit → local gather → final limit → gather →
+  // final limit → RowNumber.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation").distributedLimit(0, 10).rowNumber({}).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithPartitionByAndLimit) {
+  // LIMIT pushed below RowNumber.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER (PARTITION BY n_regionkey) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .finalLimit(0, 10)
+                     .rowNumber({"n_regionkey"})
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through the limit chain and gather
+  // unnecessarily. Drop it after RowNumber once
+  // https://github.com/facebookincubator/velox/issues/16551 is fixed.
+  // Distributed: limit pushed below RowNumber, gather to single node.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .distributedLimit(0, 10)
+                                .rowNumber({"n_regionkey"})
+                                .project({"n_name", "rn"})
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithOrderByAndLimit) {
+  // row_number() with ORDER BY + LIMIT → TopNRowNumber. No partition keys and
+  // row_number never produces ties, so the LIMIT is fully absorbed.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation").topNRowNumber({}, {"n_name"}, 10).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then TopNRowNumber.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation").gather().topNRowNumber({}, {"n_name"}, 10).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rankWithOrderByAndLimit) {
+  // rank() with ORDER BY + LIMIT → TopNRowNumber with LIMIT on top because
+  // rank() may produce ties.
+  constexpr auto sql =
+      "SELECT n_name, rank() OVER (ORDER BY n_name) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({}, {"n_name"}, 10)
+                     .finalLimit(0, 10)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then TopNRowNumber + finalLimit.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .gather()
+                                .topNRowNumber({}, {"n_name"}, 10)
+                                .partialLimit(0, 10)
+                                .localPartition()
+                                .finalLimit(0, 10)
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, denseRankWithOrderByAndLimit) {
+  // dense_rank() behaves like rank() — LIMIT preserved on top.
+  constexpr auto sql =
+      "SELECT n_name, dense_rank() OVER (ORDER BY n_name) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({}, {"n_name"}, 10)
+                     .finalLimit(0, 10)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then TopNRowNumber + finalLimit.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .gather()
+                                .topNRowNumber({}, {"n_name"}, 10)
+                                .partialLimit(0, 10)
+                                .localPartition()
+                                .finalLimit(0, 10)
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithPartitionAndOrderByAndLimit) {
+  // With partition keys, LIMIT stays on top because per-partition limit differs
+  // from global limit.
+  constexpr auto sql =
+      "SELECT n_name, "
+      "row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({"n_regionkey"}, {"n_name"}, 10)
+                     .finalLimit(0, 10)
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through the limit chain and gather
+  // unnecessarily. Drop it after TopNRowNumber once
+  // https://github.com/facebookincubator/velox/issues/16551 is fixed.
+  // Shuffle by partition keys, then TopNRowNumber + limit + gather + limit +
+  // project.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .shuffle({"n_regionkey"})
+                                .topNRowNumber({"n_regionkey"}, {"n_name"}, 10)
+                                .distributedLimit(0, 10)
+                                .project({"n_name", "rn"})
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, multipleWindowFunctionsWithLimitNoOptimization) {
+  // Multiple window functions in the same group — no ranking optimization.
+  constexpr auto sql =
+      "SELECT n_name, "
+      "   row_number() OVER (ORDER BY n_name) as rn, "
+      "   sum(n_regionkey) OVER (ORDER BY n_name) as s "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .window(
+                         {"row_number() OVER (ORDER BY n_name)",
+                          "sum(n_regionkey) OVER (ORDER BY n_name)"})
+                     .finalLimit(0, 10)
+                     .project({"n_name", "rn", "s"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then Window + limit + project.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .gather()
+                                .window(
+                                    {"row_number() OVER (ORDER BY n_name)",
+                                     "sum(n_regionkey) OVER (ORDER BY n_name)"})
+                                .partialLimit(0, 10)
+                                .localPartition()
+                                .finalLimit(0, 10)
+                                .project({"n_name", "rn", "s"})
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rankWithoutOrderBy) {
+  // rank() without ORDER BY stays as generic Window — only row_number() gets
+  // the RowNumber optimization.
+  constexpr auto sql =
+      "SELECT n_name, rank() OVER (PARTITION BY n_regionkey) as rn "
+      "FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .window({"rank() OVER (PARTITION BY n_regionkey)"})
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through gather unnecessarily. Drop it after
+  // the Window once https://github.com/facebookincubator/velox/issues/16551 is
+  // fixed.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey"})
+          .window({"rank() OVER (PARTITION BY n_regionkey)"})
+          .project({"n_name", "rn"})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, denseRankWithoutOrderBy) {
+  // dense_rank() without ORDER BY stays as generic Window.
+  constexpr auto sql =
+      "SELECT n_name, dense_rank() OVER (PARTITION BY n_regionkey) as rn "
+      "FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .window({"dense_rank() OVER (PARTITION BY n_regionkey)"})
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through gather unnecessarily. Drop it after
+  // the Window once https://github.com/facebookincubator/velox/issues/16551 is
+  // fixed.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey"})
+          .window({"dense_rank() OVER (PARTITION BY n_regionkey)"})
+          .project({"n_name", "rn"})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rankWithLimitWithoutOrderBy) {
+  // rank() with LIMIT but without ORDER BY — Pattern 2 does NOT apply (only
+  // row_number qualifies). LIMIT stays on top.
+  constexpr auto sql =
+      "SELECT n_name, rank() OVER (PARTITION BY n_regionkey) as rn "
+      "FROM nation LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .window({"rank() OVER (PARTITION BY n_regionkey)"})
+                     .finalLimit(0, 10)
+                     .project({"n_name", "rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // TODO: n_regionkey is carried through the limit chain and gather
+  // unnecessarily. Drop it after the Window once
+  // https://github.com/facebookincubator/velox/issues/16551 is fixed.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey"})
+          .window({"rank() OVER (PARTITION BY n_regionkey)"})
+          .distributedLimit(0, 10)
+          .project({"n_name", "rn"})
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithOrderByNoLimit) {
+  // row_number() with ORDER BY but no LIMIT stays as generic Window — no TopN
+  // optimization without LIMIT.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .window({"row_number() OVER (ORDER BY n_name)"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then Window.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .gather()
+                                .window({"row_number() OVER (ORDER BY n_name)"})
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rankWithOrderByNoLimit) {
+  // rank() with ORDER BY but no LIMIT stays as generic Window.
+  constexpr auto sql =
+      "SELECT n_name, rank() OVER (ORDER BY n_name) as rn "
+      "FROM nation";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher =
+      matchScan("nation").window({"rank() OVER (ORDER BY n_name)"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then Window.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .gather()
+                                .window({"rank() OVER (ORDER BY n_name)"})
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_F(RankingTest, rowNumberWithRedundantQueryOrderBy) {
+  // Query ORDER BY matches window ORDER BY — ORDER BY is redundant, absorbed
+  // into TopNRowNumber.
+  constexpr auto sql =
+      "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "FROM nation ORDER BY n_name LIMIT 10";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation").topNRowNumber({}, {"n_name"}, 10).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // No partition keys — gather, then TopNRowNumber.
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation").gather().topNRowNumber({}, {"n_name"}, 10).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
Optimize queries with ranking functions (row_number(), rank(), dense_rank()) to use specialized Velox operators instead of the generic WindowNode.

Pattern 1: row_number() without ORDER BY → RowNumberNode

> SELECT row_number() OVER () FROM t
> SELECT row_number() OVER (PARTITION BY k) FROM t

No sorting needed — just hashing by partition keys.

Pattern 2: row_number() without ORDER BY + LIMIT → push LIMIT below RowNumber

> SELECT row_number() OVER () FROM t LIMIT 10
> SELECT row_number() OVER (PARTITION BY k) FROM t LIMIT 10

Row numbering is non-deterministic (no ORDER BY), so computing row numbers on a smaller input is valid. Plan: Scan → Limit → RowNumber instead of Scan → RowNumber → Limit.

Pattern 4: ranking function with ORDER BY + LIMIT → TopNRowNumberNode

> SELECT row_number() OVER (ORDER BY x) FROM t LIMIT 10
> SELECT rank() OVER (ORDER BY x) FROM t LIMIT 10
> SELECT dense_rank() OVER (PARTITION BY k ORDER BY x) FROM t LIMIT 10

Only keeps the top N rows per partition instead of sorting the full input. For row_number() without partition keys, LIMIT is fully absorbed. For rank()/dense_rank() or with partition keys, LIMIT is preserved on top.

Not included (follow-up): Pattern 3 — ranking function + filter on output (e.g., WHERE rn <= 10). Requires cross-DT optimization.

Differential Revision: D94508813


