### PR TITLE
feat: Add GroupId operator for GROUPING SETS / ROLLUP / CUBE (#964)

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -406,6 +406,12 @@ class AggregateNode : public LogicalPlanNode {
     return aggregates_[index];
   }
 
+  /// Returns the output index of the grouping set ID column. Only valid when
+  /// groupingSets() is non-empty.
+  size_t groupIdColumnIndex() const {
+    return groupingKeys_.size() + aggregates_.size();
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -406,6 +406,15 @@ class AggregateNode : public LogicalPlanNode {
     return aggregates_[index];
   }
 
+  /// Returns the output index of the grouping set ID column, or std::nullopt
+  /// for regular GROUP BY without grouping sets.
+  std::optional<size_t> groupIdIndex() const {
+    if (groupingSets_.empty()) {
+      return std::nullopt;
+    }
+    return groupingKeys_.size() + aggregates_.size();
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 

--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -257,6 +257,61 @@ MarkDistinctResult addMarkDistinctNodes(
   return {plan, std::move(newAggregates), totalCost};
 }
 
+// Collects unique column references from aggregate functions (args, ORDER BY
+// keys, and filter conditions). Skips literals since they are constants that
+// don't need to flow through GroupId.
+ExprVector collectAggregationInputs(const AggregateVector& aggregates) {
+  PlanObjectSet seen;
+  ExprVector inputs;
+  auto maybeAdd = [&](ExprCP expr) {
+    if (expr->is(PlanType::kColumnExpr) && !seen.contains(expr)) {
+      seen.add(expr);
+      inputs.push_back(expr);
+    }
+  };
+  for (const auto* agg : aggregates) {
+    for (const auto* arg : agg->args()) {
+      maybeAdd(arg);
+    }
+    for (const auto* key : agg->orderKeys()) {
+      maybeAdd(key);
+    }
+    if (agg->condition()) {
+      maybeAdd(agg->condition());
+    }
+  }
+  return inputs;
+}
+
+// Constructs a GroupId node from the aggregation plan's grouping sets,
+// precomputed grouping keys, and aggregate inputs.
+GroupId* makeGroupIdNode(
+    RelationOpPtr& plan,
+    AggregationPlanCP aggPlan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates) {
+  const auto numKeys = groupingKeys.size();
+  ColumnVector outputKeys;
+  outputKeys.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    outputKeys.push_back(aggPlan->columns()[i]);
+  }
+
+  ColumnVector inputKeys;
+  inputKeys.reserve(numKeys);
+  for (const auto* key : groupingKeys) {
+    inputKeys.push_back(key->as<Column>());
+  }
+
+  return make<GroupId>(
+      plan,
+      std::move(inputKeys),
+      collectAggregationInputs(aggregates),
+      aggPlan->groupingSets(),
+      std::move(outputKeys),
+      aggPlan->groupId());
+}
+
 } // namespace
 
 std::pair<RelationOpPtr, PlanCost> maybeRepartition(
@@ -319,7 +374,9 @@ std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
-    const ColumnVector& outputColumns) const {
+    const ColumnVector& outputColumns,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId) const {
   PlanCost splitAggCost;
 
   plan = make<Aggregation>(
@@ -346,7 +403,9 @@ std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kFinal,
-      outputColumns);
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupId);
   splitAggCost.add(*splitAggPlan);
 
   return {splitAggPlan, splitAggCost};
@@ -358,7 +417,9 @@ AggregationPlanner::makeSingleAggregationPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
-    const ColumnVector& outputColumns) const {
+    const ColumnVector& outputColumns,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId) const {
   PlanCost singleAggCost;
 
   ColumnVector partitionKeys(
@@ -374,7 +435,9 @@ AggregationPlanner::makeSingleAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kSingle,
-      outputColumns);
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupId);
   singleAggCost.add(*singleAgg);
 
   return {singleAgg, singleAggCost};
@@ -386,21 +449,35 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
-    const ColumnVector& outputColumns) const {
-  const auto& [splitAggPlan, splitAggCost] = makeSplitAggregationPlan(
-      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+    const ColumnVector& outputColumns,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId) const {
+  auto [splitAggPlan, splitAggCost] = makeSplitAggregationPlan(
+      plan,
+      groupingKeys,
+      aggregates,
+      intermediateColumns,
+      outputColumns,
+      globalGroupingSets,
+      groupId);
 
   if (groupingKeys.empty() || alwaysPlanPartialAggregation_) {
-    return {splitAggPlan, splitAggCost};
+    return {std::move(splitAggPlan), splitAggCost};
   }
 
-  const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
-      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+  auto [singleAgg, singleAggCost] = makeSingleAggregationPlan(
+      plan,
+      groupingKeys,
+      aggregates,
+      intermediateColumns,
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupId);
 
   if (singleAggCost.cost < splitAggCost.cost) {
-    return {singleAgg, singleAggCost};
+    return {std::move(singleAgg), singleAggCost};
   }
-  return {splitAggPlan, splitAggCost};
+  return {std::move(splitAggPlan), splitAggCost};
 }
 
 std::pair<RelationOpPtr, PlanCost>
@@ -433,31 +510,31 @@ AggregationPlanner::makeDistinctToGroupByPlan(
   }
 
   PlanCost totalCost;
-  const auto& [innerAgg, innerAggCost] = makeSplitOrSingleAggregationPlan(
+  auto [innerAgg, innerAggCost] = makeSplitOrSingleAggregationPlan(
       plan, innerKeys, AggregateVector{}, innerColumns, innerColumns);
   totalCost.add(innerAggCost);
-  plan = innerAgg;
+  plan = std::move(innerAgg);
 
   // Make non-distinct aggregation calls for the outer level.
   auto nonDistinctAggregates = dropDistinctFromAggregates(aggregates);
 
   if (hasOrderBy) {
-    const auto& [outerPlan, outerCost] = makeSingleAggregationPlan(
+    auto [outerPlan, outerCost] = makeSingleAggregationPlan(
         plan,
         groupingKeys,
         nonDistinctAggregates,
         aggPlan->intermediateColumns(),
         aggPlan->columns());
-    plan = outerPlan;
+    plan = std::move(outerPlan);
     totalCost.add(outerCost);
   } else {
-    const auto& [outerPlan, outerCost] = makeSplitOrSingleAggregationPlan(
+    auto [outerPlan, outerCost] = makeSplitOrSingleAggregationPlan(
         plan,
         groupingKeys,
         nonDistinctAggregates,
         aggPlan->intermediateColumns(),
         aggPlan->columns());
-    plan = outerPlan;
+    plan = std::move(outerPlan);
     totalCost.add(outerCost);
   }
 
@@ -533,6 +610,84 @@ RelationOpPtr AggregationPlanner::planSingle(
       aggPlan->columns());
 }
 
+void AggregationPlanner::addGroupingSetsAggregation(
+    AggregationPlanCP aggPlan,
+    RelationOpPtr& plan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    PlanState& state,
+    bool useSingleStep,
+    bool hasOrderBy) const {
+  auto* groupIdNode = makeGroupIdNode(plan, aggPlan, groupingKeys, aggregates);
+  state.addCost(*groupIdNode);
+  plan = groupIdNode;
+
+  auto globalGroupingSets = aggPlan->globalGroupingSets();
+
+  // Only pass groupId to the Aggregation when there are global (empty)
+  // grouping sets. Velox uses this pair to produce default output rows for
+  // empty inputs; without global sets, the groupId column is just a regular
+  // grouping key.
+  ColumnCP aggGroupId =
+      globalGroupingSets.empty() ? nullptr : aggPlan->groupId();
+
+  const auto numKeys = groupingKeys.size();
+  ExprVector aggGroupingKeys;
+  aggGroupingKeys.reserve(numKeys + 1);
+  for (size_t i = 0; i < numKeys; ++i) {
+    aggGroupingKeys.push_back(groupIdNode->columns()[i]);
+  }
+  aggGroupingKeys.push_back(aggPlan->groupId());
+
+  // ORDER BY forces single-step aggregation (partial aggregation cannot
+  // preserve ORDER BY semantics), but global grouping sets require split
+  // (partial+final). With kSingle, addLocalPartition creates empty driver
+  // partitions that each emit a spurious default row for the global set.
+  VELOX_USER_CHECK(
+      !hasOrderBy || globalGroupingSets.empty(),
+      "ORDER BY in aggregate functions is not supported with global grouping sets (ROLLUP, CUBE, or GROUPING SETS containing ())");
+
+  if (useSingleStep || hasOrderBy) {
+    auto [agg, cost] = makeSingleAggregationPlan(
+        plan,
+        aggGroupingKeys,
+        aggregates,
+        aggPlan->intermediateColumns(),
+        aggPlan->columns(),
+        std::move(globalGroupingSets),
+        aggGroupId);
+    state.cost.add(cost);
+    plan = std::move(agg);
+    return;
+  }
+
+  // TODO: Remove forced split once Velox handles global grouping sets
+  // in kSingle without spurious default rows from empty partitions.
+  // https://github.com/facebookincubator/velox/issues/17312
+  if (alwaysPlanPartialAggregation_ || !globalGroupingSets.empty()) {
+    auto [agg, cost] = makeSplitAggregationPlan(
+        plan,
+        aggGroupingKeys,
+        aggregates,
+        aggPlan->intermediateColumns(),
+        aggPlan->columns(),
+        std::move(globalGroupingSets),
+        aggGroupId);
+    state.cost.add(cost);
+    plan = std::move(agg);
+    return;
+  }
+
+  auto [agg, cost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      aggGroupingKeys,
+      aggregates,
+      aggPlan->intermediateColumns(),
+      aggPlan->columns());
+  state.cost.add(cost);
+  plan = std::move(agg);
+}
+
 void AggregationPlanner::plan(
     DerivedTableCP dt,
     RelationOpPtr& plan,
@@ -541,15 +696,51 @@ void AggregationPlanner::plan(
   const auto* aggPlan = dt->aggregation;
 
   PrecomputeProjection precompute(plan, dt, /*projectAllInputs=*/false);
-  auto groupingKeys =
-      precompute.toColumns(aggPlan->groupingKeys(), &aggPlan->columns());
+  // When grouping sets are present, don't pass aliases for grouping keys.
+  // This lets them pass through PrecomputeProjection without renaming, so
+  // aggregate args that reference the same column get their own pass-through
+  // entry.
+  auto groupingKeys = precompute.toColumns(
+      aggPlan->groupingKeys(),
+      aggPlan->hasGroupingSets() ? nullptr : &aggPlan->columns());
   auto aggregates = flattenAggregates(aggPlan->aggregates(), precompute);
 
   plan = std::move(precompute).maybeProject();
   state.place(aggPlan);
 
+  const bool useSingleStep = isSingleWorker_ && isSingleDriver_;
+
+  // ORDER BY aggregates force single-step because partial aggregation cannot
+  // preserve ORDER BY semantics.
+  const auto hasOrderBy =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return !agg->orderKeys().empty();
+      });
+
+  const auto hasDistinct =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return agg->isDistinct();
+      });
+
+  if (aggPlan->hasGroupingSets()) {
+    // TODO: Support DISTINCT aggregation with grouping sets. Requires
+    // integrating transformDistinctToGroupBy with GroupId.
+    VELOX_USER_CHECK(
+        !hasDistinct,
+        "DISTINCT aggregation with grouping sets is not supported yet");
+    addGroupingSetsAggregation(
+        aggPlan,
+        plan,
+        groupingKeys,
+        aggregates,
+        state,
+        useSingleStep,
+        hasOrderBy);
+    return;
+  }
+
   auto preGroupedKeys = computePreGroupedKeys(*plan, groupingKeys);
-  if ((isSingleWorker_ && isSingleDriver_) || !preGroupedKeys.empty()) {
+  if (useSingleStep || !preGroupedKeys.empty()) {
     auto* singleAgg = make<Aggregation>(
         plan,
         std::move(groupingKeys),
@@ -563,14 +754,6 @@ void AggregationPlanner::plan(
     return;
   }
 
-  const auto hasDistinct =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return agg->isDistinct();
-      });
-  const auto hasOrderBy =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return !agg->orderKeys().empty();
-      });
   if (hasDistinct) {
     auto distinctArgs = getCommonDistinctArgs(aggregates);
     if (distinctArgs.has_value()) {

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -66,7 +66,9 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
-      const ColumnVector& outputColumns) const;
+      const ColumnVector& outputColumns,
+      QGVector<int32_t> globalGroupingSets = {},
+      ColumnCP groupId = nullptr) const;
 
   // Creates a single-phase aggregation plan following repartitioning by
   // groupingKeys.
@@ -75,7 +77,9 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
-      const ColumnVector& outputColumns) const;
+      const ColumnVector& outputColumns,
+      QGVector<int32_t> globalGroupingSets = {},
+      ColumnCP groupId = nullptr) const;
 
   // Chooses between split and single aggregation plans based on cost.
   std::pair<RelationOpPtr, PlanCost> makeSplitOrSingleAggregationPlan(
@@ -83,7 +87,9 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
-      const ColumnVector& outputColumns) const;
+      const ColumnVector& outputColumns,
+      QGVector<int32_t> globalGroupingSets = {},
+      ColumnCP groupId = nullptr) const;
 
   // Transforms distinct aggregation into a two-level GROUP BY + non-distinct
   // aggregation plan.
@@ -102,6 +108,17 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan,
+      bool hasOrderBy) const;
+
+  // Handles aggregation with grouping sets (ROLLUP, CUBE, GROUPING SETS).
+  // Creates a GroupId node followed by cost-based split or single aggregation.
+  void addGroupingSetsAggregation(
+      AggregationPlanCP aggPlan,
+      RelationOpPtr& plan,
+      const ExprVector& groupingKeys,
+      const AggregateVector& aggregates,
+      PlanState& state,
+      bool useSingleStep,
       bool hasOrderBy) const;
 
   bool isSingleWorker_;

--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -170,6 +170,10 @@ struct Costs {
   // complete cost model will need to consider the count of
   // destinations, number of partition keys etc.
   static constexpr float kByteShuffleCost = 0.3;
+
+  /// Minimal per-row cost for operators that do trivial per-row work (e.g.,
+  /// passing rows through, generating a unique ID).
+  static constexpr double kMinimalUnitCost = 0.01;
 };
 
 /// Returns shuffle cost for a single row. Depends on the number of types of

--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -170,6 +170,10 @@ struct Costs {
   // complete cost model will need to consider the count of
   // destinations, number of partition keys etc.
   static constexpr float kByteShuffleCost = 0.3;
+
+  /// Minimal per-row cost for operators that do trivial per-row work (e.g.,
+  /// passing rows through, generating a unique ID, enforcing distinctness).
+  static constexpr double kMinimalUnitCost = 0.01;
 };
 
 /// Returns shuffle cost for a single row. Depends on the number of types of

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1067,11 +1067,16 @@ void DerivedTable::replaceJoinOutputs(
 
     if (newGroupingKeys != aggregation->groupingKeys() ||
         newAggregates != aggregation->aggregates()) {
+      // groupingSets: Indices into grouping keys, not column references —
+      // unaffected by input replacement.
+      // groupIdColumn: Output column, unaffected by input replacement.
       aggregation = make<AggregationPlan>(
           std::move(newGroupingKeys),
           std::move(newAggregates),
           aggregation->columns(),
-          aggregation->intermediateColumns());
+          aggregation->intermediateColumns(),
+          aggregation->groupingSets(),
+          aggregation->groupIdColumn());
     }
   }
 
@@ -2073,7 +2078,12 @@ void DerivedTable::distributeConjuncts() {
       // aggregation. Translate from names after agg to pre-agg
       // names. Pre/post agg names may differ for dts in set
       // operations. If already in pre-agg names, no-op.
-      if (having[i]->columns().isSubset(grouping)) {
+      //
+      // With GROUPING SETS, GroupId NULLs keys not in the active set,
+      // so HAVING filters on grouping keys must stay above aggregation
+      // to see the NULLed values.
+      if (!aggregation->hasGroupingSets() &&
+          having[i]->columns().isSubset(grouping)) {
         conjuncts.push_back(
             DerivedTableFlattener::replaceInputs(
                 having[i],

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1161,11 +1161,16 @@ void DerivedTable::replaceJoinOutputs(
 
     if (newGroupingKeys != aggregation->groupingKeys() ||
         newAggregates != aggregation->aggregates()) {
+      // groupingSets: Indices into grouping keys, not column references —
+      // unaffected by input replacement.
+      // groupId: Output column, unaffected by input replacement.
       aggregation = make<AggregationPlan>(
           std::move(newGroupingKeys),
           std::move(newAggregates),
           aggregation->columns(),
-          aggregation->intermediateColumns());
+          aggregation->intermediateColumns(),
+          aggregation->groupingSets(),
+          aggregation->groupId());
     }
   }
 
@@ -2232,7 +2237,15 @@ void DerivedTable::distributeConjuncts() {
       // aggregation. Translate from names after agg to pre-agg
       // names. Pre/post agg names may differ for dts in set
       // operations. If already in pre-agg names, no-op.
-      if (having[i]->columns().isSubset(grouping)) {
+      //
+      // With GROUPING SETS, GroupId NULLs keys not in the active set,
+      // so HAVING filters on grouping keys must stay above aggregation
+      // to see the NULLed values.
+      // TODO: Push HAVING between GroupId and Aggregation instead of
+      // disabling pushdown entirely.
+      // https://github.com/facebookincubator/axiom/issues/1338
+      if (!aggregation->hasGroupingSets() &&
+          having[i]->columns().isSubset(grouping)) {
         conjuncts.push_back(
             DerivedTableFlattener::replaceInputs(
                 having[i],

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1324,7 +1324,9 @@ std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
-    const ColumnVector& outputColumns) {
+    const ColumnVector& outputColumns,
+    GroupingSet globalGroupingSets = {},
+    ColumnCP groupIdColumn = nullptr) {
   PlanCost splitAggCost;
   Aggregation* splitAggPlan;
 
@@ -1353,21 +1355,24 @@ std::pair<Aggregation*, PlanCost> makeSplitAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kFinal,
-      outputColumns);
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupIdColumn);
   splitAggCost.add(*splitAggPlan);
 
   return {splitAggPlan, splitAggCost};
 }
 
-// Creates a single-phase aggregation plan where data is first repartitioned by
-// grouping keys and then aggregated in one step. Returns a pair of the root to
-// the aggregation plan and the cost of this aggregation.
+// Creates a single-phase aggregation plan. Repartitions data by grouping
+// keys, then aggregates in one step. Returns the aggregation root and cost.
 std::pair<Aggregation*, PlanCost> makeSingleAggregationPlan(
     RelationOpPtr plan,
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
-    const ColumnVector& outputColumns) {
+    const ColumnVector& outputColumns,
+    GroupingSet globalGroupingSets = {},
+    ColumnCP groupIdColumn = nullptr) {
   PlanCost singleAggCost;
   repartitionForAgg(plan, groupingKeys, intermediateColumns, singleAggCost);
   auto* singleAgg = make<Aggregation>(
@@ -1376,7 +1381,9 @@ std::pair<Aggregation*, PlanCost> makeSingleAggregationPlan(
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kSingle,
-      outputColumns);
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupIdColumn);
   singleAggCost.add(*singleAgg);
 
   return {singleAgg, singleAggCost};
@@ -1393,21 +1400,175 @@ std::pair<Aggregation*, PlanCost> makeSplitOrSingleAggregationPlan(
     const AggregateVector& aggregates,
     const ColumnVector& intermediateColumns,
     const ColumnVector& outputColumns,
-    bool alwaysPlanPartialAggregation) {
+    bool alwaysPlanPartialAggregation = false,
+    GroupingSet globalGroupingSets = {},
+    ColumnCP groupIdColumn = nullptr) {
   const auto& [splitAggPlan, splitAggCost] = makeSplitAggregationPlan(
-      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+      plan,
+      groupingKeys,
+      aggregates,
+      intermediateColumns,
+      outputColumns,
+      globalGroupingSets,
+      groupIdColumn);
 
   if (groupingKeys.empty() || alwaysPlanPartialAggregation) {
     return {splitAggPlan, splitAggCost};
   }
 
   const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
-      plan, groupingKeys, aggregates, intermediateColumns, outputColumns);
+      plan,
+      groupingKeys,
+      aggregates,
+      intermediateColumns,
+      outputColumns,
+      std::move(globalGroupingSets),
+      groupIdColumn);
 
   if (singleAggCost.cost < splitAggCost.cost) {
     return {singleAgg, singleAggCost};
   }
   return {splitAggPlan, splitAggCost};
+}
+
+// Collects unique column references from aggregate functions (args, ORDER BY
+// keys, and filter conditions). Skips literals since they are constants that
+// don't need to flow through GroupId.
+ExprVector collectAggregationInputs(const AggregateVector& aggregates) {
+  PlanObjectSet seen;
+  ExprVector inputs;
+  auto maybeAdd = [&](ExprCP expr) {
+    if (expr->is(PlanType::kColumnExpr) && !seen.contains(expr)) {
+      seen.add(expr);
+      inputs.push_back(expr);
+    }
+  };
+  for (const auto* agg : aggregates) {
+    for (const auto* arg : agg->args()) {
+      maybeAdd(arg);
+    }
+    for (const auto* key : agg->orderKeys()) {
+      maybeAdd(key);
+    }
+    if (agg->condition()) {
+      maybeAdd(agg->condition());
+    }
+  }
+  return inputs;
+}
+
+// Handles aggregation with grouping sets (ROLLUP, CUBE, GROUPING SETS).
+// Creates a GroupId node followed by cost-based split or single aggregation
+// via makeSplitOrSingleAggregationPlan.
+void addGroupingSetsAggregation(
+    const AggregationPlan* aggPlan,
+    RelationOpPtr& plan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    PlanState& state,
+    bool useSingleStep,
+    bool hasOrderBy,
+    bool alwaysPlanPartialAggregation) {
+  const auto numKeys = groupingKeys.size();
+  // GroupId output keys are the auto-generated columns from AggregationPlan.
+  ColumnVector groupIdOutputKeys;
+  groupIdOutputKeys.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    groupIdOutputKeys.push_back(aggPlan->columns()[i]);
+  }
+
+  // GroupId input keys are the precomputed grouping keys from the input plan.
+  ColumnVector groupIdInputKeys;
+  groupIdInputKeys.reserve(numKeys);
+  for (const auto* key : groupingKeys) {
+    groupIdInputKeys.push_back(key->as<Column>());
+  }
+
+  auto aggregationInputs = collectAggregationInputs(aggregates);
+
+  auto* groupIdNode = make<GroupId>(
+      plan,
+      aggPlan->groupingSets(),
+      std::move(groupIdOutputKeys),
+      std::move(aggregationInputs),
+      aggPlan->groupIdColumn(),
+      std::move(groupIdInputKeys));
+
+  state.addCost(*groupIdNode);
+  plan = groupIdNode;
+
+  QGVector<int32_t> globalGroupingSets;
+  for (size_t i = 0; i < aggPlan->groupingSets().size(); ++i) {
+    if (aggPlan->groupingSets()[i].empty()) {
+      globalGroupingSets.push_back(static_cast<int32_t>(i));
+    }
+  }
+
+  // Only pass groupIdColumn to the Aggregation when there are global (empty)
+  // grouping sets. Velox uses this pair to produce default output rows for
+  // empty inputs; without global sets, the groupId column is just a regular
+  // grouping key.
+  ColumnCP aggGroupIdColumn =
+      globalGroupingSets.empty() ? nullptr : aggPlan->groupIdColumn();
+
+  ExprVector aggGroupingKeys;
+  aggGroupingKeys.reserve(numKeys + 1);
+  for (size_t i = 0; i < numKeys; ++i) {
+    aggGroupingKeys.push_back(groupIdNode->columns()[i]);
+  }
+  aggGroupingKeys.push_back(aggPlan->groupIdColumn());
+
+  // ORDER BY forces single-step aggregation (partial aggregation cannot
+  // preserve ORDER BY semantics), but global grouping sets require split
+  // (partial+final). With kSingle, addLocalPartition creates empty driver
+  // partitions that each emit a spurious default row for the global set.
+  VELOX_USER_CHECK(
+      !hasOrderBy || globalGroupingSets.empty(),
+      "ORDER BY in aggregate functions is not supported with global grouping sets (ROLLUP, CUBE, or GROUPING SETS containing ())");
+
+  if (useSingleStep || hasOrderBy) {
+    const auto& [agg, cost] = makeSingleAggregationPlan(
+        plan,
+        aggGroupingKeys,
+        aggregates,
+        aggPlan->intermediateColumns(),
+        aggPlan->columns(),
+        std::move(globalGroupingSets),
+        aggGroupIdColumn);
+    state.cost.add(cost);
+    plan = agg;
+    return;
+  }
+
+  // When globalGroupingSets is non-empty or partial aggregation is forced,
+  // always use split (partial + final) aggregation. The kSingle path combined
+  // with addLocalPartition in ToVelox causes each empty driver partition to
+  // emit a spurious default row for the global grouping set, producing
+  // incorrect extra rows. The split path avoids this because partial
+  // aggregation has no globalGroupingSets, and the final aggregation runs
+  // after repartitioning where data is properly consolidated.
+  if (alwaysPlanPartialAggregation || !globalGroupingSets.empty()) {
+    const auto& [agg, cost] = makeSplitAggregationPlan(
+        plan,
+        aggGroupingKeys,
+        aggregates,
+        aggPlan->intermediateColumns(),
+        aggPlan->columns(),
+        std::move(globalGroupingSets),
+        aggGroupIdColumn);
+    state.cost.add(cost);
+    plan = agg;
+    return;
+  }
+
+  const auto& [agg, cost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      aggGroupingKeys,
+      aggregates,
+      aggPlan->intermediateColumns(),
+      aggPlan->columns());
+  state.cost.add(cost);
+  plan = agg;
 }
 
 } // namespace
@@ -1511,15 +1672,53 @@ void Optimization::addAggregation(
   const auto* aggPlan = dt->aggregation;
 
   PrecomputeProjection precompute(plan, dt, /*projectAllInputs=*/false);
-  auto groupingKeys =
-      precompute.toColumns(aggPlan->groupingKeys(), &aggPlan->columns());
+  // When grouping sets are present, don't pass aliases for grouping keys.
+  // This lets them pass through PrecomputeProjection without renaming, so
+  // aggregate args that reference the same column get their own pass-through
+  // entry. GroupId handles the renaming to auto-generated output columns.
+  auto groupingKeys = precompute.toColumns(
+      aggPlan->groupingKeys(),
+      aggPlan->hasGroupingSets() ? nullptr : &aggPlan->columns());
   auto aggregates = flattenAggregates(aggPlan->aggregates(), precompute);
 
   plan = std::move(precompute).maybeProject();
   state.place(aggPlan);
 
+  const bool useSingleStep = isSingleWorker_ && isSingleDriver_;
+
+  // ORDER BY aggregates force single-step because partial aggregation cannot
+  // preserve ORDER BY semantics. This limits scalability for ORDER BY +
+  // grouping sets queries to a single node.
+  const auto hasOrderBy =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return !agg->orderKeys().empty();
+      });
+
+  const auto hasDistinct =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return agg->isDistinct();
+      });
+
+  if (aggPlan->hasGroupingSets()) {
+    // TODO: Support DISTINCT aggregation with grouping sets. Requires
+    // integrating transformDistinctToGroupBy with GroupId.
+    VELOX_USER_CHECK(
+        !hasDistinct,
+        "DISTINCT aggregation with grouping sets is not supported yet");
+    addGroupingSetsAggregation(
+        aggPlan,
+        plan,
+        groupingKeys,
+        aggregates,
+        state,
+        useSingleStep,
+        hasOrderBy,
+        options_.alwaysPlanPartialAggregation);
+    return;
+  }
+
   auto preGroupedKeys = computePreGroupedKeys(*plan, groupingKeys);
-  if ((isSingleWorker_ && isSingleDriver_) || !preGroupedKeys.empty()) {
+  if (useSingleStep || !preGroupedKeys.empty()) {
     auto* singleAgg = make<Aggregation>(
         plan,
         std::move(groupingKeys),
@@ -1533,14 +1732,6 @@ void Optimization::addAggregation(
     return;
   }
 
-  const auto hasDistinct =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return agg->isDistinct();
-      });
-  const auto hasOrderBy =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return !agg->orderKeys().empty();
-      });
   if (hasDistinct) {
     auto distinctArgs = getSingleDistinctArgs(aggregates);
     transformDistinctToGroupBy(

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -262,6 +262,40 @@ void checkTableReferences(
 }
 } // namespace
 
+AggregationPlan::AggregationPlan(
+    ExprVector groupingKeys,
+    AggregateVector aggregates,
+    ColumnVector columns,
+    ColumnVector intermediateColumns,
+    GroupingSets groupingSets,
+    ColumnCP groupIdColumn)
+    : PlanObject(PlanType::kAggregationNode),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregates_(std::move(aggregates)),
+      columns_(std::move(columns)),
+      intermediateColumns_(std::move(intermediateColumns)),
+      groupingSets_(std::move(groupingSets)),
+      groupIdColumn_(groupIdColumn) {
+  const auto expectedSize = groupingKeys_.size() + aggregates_.size() +
+      (groupIdColumn_ != nullptr ? 1 : 0);
+  VELOX_CHECK_EQ(expectedSize, columns_.size());
+  VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
+
+  for (const auto& set : groupingSets_) {
+    folly::F14FastSet<int32_t> seen;
+    for (const auto idx : set) {
+      VELOX_CHECK_LT(
+          idx,
+          groupingKeys_.size(),
+          "Grouping set index out of bounds: index={}, numKeys={}",
+          idx,
+          groupingKeys_.size());
+      VELOX_CHECK(
+          seen.insert(idx).second, "Duplicate index in grouping set: {}", idx);
+    }
+  }
+}
+
 void AggregationPlan::checkConsistency(const DerivedTable& dt) const {
   checkTableReferences<ExprCP>(dt, groupingKeys_, "Grouping key");
   checkTableReferences<AggregateCP>(dt, aggregates_, "Aggregate");

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -277,6 +277,45 @@ void checkTableReferences(
 }
 } // namespace
 
+AggregationPlan::AggregationPlan(
+    ExprVector groupingKeys,
+    AggregateVector aggregates,
+    ColumnVector columns,
+    ColumnVector intermediateColumns,
+    GroupingSets groupingSets,
+    ColumnCP groupId)
+    : PlanObject(PlanType::kAggregationNode),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregates_(std::move(aggregates)),
+      columns_(std::move(columns)),
+      intermediateColumns_(std::move(intermediateColumns)),
+      groupingSets_(std::move(groupingSets)),
+      groupId_(groupId) {
+  const auto expectedSize =
+      groupingKeys_.size() + aggregates_.size() + (groupId_ != nullptr ? 1 : 0);
+  VELOX_CHECK_EQ(expectedSize, columns_.size());
+  VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
+
+  VELOX_CHECK_EQ(
+      groupingSets_.empty(),
+      groupId_ == nullptr,
+      "groupingSets and groupId must both be set or both be empty");
+
+  for (const auto& set : groupingSets_) {
+    folly::F14FastSet<int32_t> seen;
+    for (const auto idx : set) {
+      VELOX_CHECK_LT(
+          idx,
+          groupingKeys_.size(),
+          "Grouping set index out of bounds: index={}, numKeys={}",
+          idx,
+          groupingKeys_.size());
+      VELOX_CHECK(
+          seen.insert(idx).second, "Duplicate index in grouping set: {}", idx);
+    }
+  }
+}
+
 void AggregationPlan::checkConsistency(const DerivedTable& dt) const {
   checkTableReferences<ExprCP>(dt, groupingKeys_, "Grouping key");
   checkTableReferences<AggregateCP>(dt, aggregates_, "Aggregate");
@@ -457,6 +496,16 @@ JoinEdge* JoinEdge::reverse(JoinEdge& join) {
   reversed->setFanouts(join.rlFanout_, join.lrFanout_);
 
   return reversed;
+}
+
+QGVector<int32_t> AggregationPlan::globalGroupingSets() const {
+  QGVector<int32_t> result;
+  for (int32_t i = 0; i < groupingSets_.size(); ++i) {
+    if (groupingSets_[i].empty()) {
+      result.push_back(i);
+    }
+  }
+  return result;
 }
 
 std::pair<std::string, bool> JoinEdge::sampleKey() const {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1297,21 +1297,32 @@ using WindowFunctionVector = QGVector<WindowFunctionCP>;
 /// aggregates: columns_[i] corresponds to groupingKeys_[i] for
 /// i < groupingKeys_.size(), and to aggregates_[i - groupingKeys_.size()]
 /// otherwise.
+/// Each grouping set is a list of indices into the grouping keys array.
+using GroupingSet = QGVector<int32_t>;
+using GroupingSets = QGVector<GroupingSet>;
+
 class AggregationPlan : public PlanObject {
  public:
+  /// @param groupingKeys GROUP BY columns referencing the enclosing
+  ///   DerivedTable's tableSet. When grouping sets are present, these are
+  ///   new columns with auto-generated names (no alias).
+  /// @param aggregates Aggregate functions (sum, count, etc.).
+  /// @param columns Output columns: groupingKeys[i] maps to columns[i], then
+  ///   aggregates. If groupIdColumn is present, it appears after the last
+  ///   aggregate column.
+  /// @param intermediateColumns Columns with intermediate accumulator types for
+  ///   partial aggregation. Same layout as columns.
+  /// @param groupingSets Grouping sets for ROLLUP/CUBE/GROUPING SETS. Each set
+  ///   is a list of indices into groupingKeys. Empty for regular GROUP BY.
+  /// @param groupIdColumn Output column for the grouping set ID. Null when
+  ///   grouping sets are not used.
   AggregationPlan(
       ExprVector groupingKeys,
       AggregateVector aggregates,
       ColumnVector columns,
-      ColumnVector intermediateColumns)
-      : PlanObject(PlanType::kAggregationNode),
-        groupingKeys_(std::move(groupingKeys)),
-        aggregates_(std::move(aggregates)),
-        columns_(std::move(columns)),
-        intermediateColumns_(std::move(intermediateColumns)) {
-    VELOX_CHECK_EQ(groupingKeys_.size() + aggregates_.size(), columns_.size());
-    VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
-  }
+      ColumnVector intermediateColumns,
+      GroupingSets groupingSets = {},
+      ColumnCP groupIdColumn = nullptr);
 
   /// GROUP BY columns. Each references a column from a table in the enclosing
   /// DerivedTable's tableSet or from the DerivedTable itself.
@@ -1344,11 +1355,30 @@ class AggregationPlan : public PlanObject {
   /// reference 'dt'.
   void checkConsistency(const DerivedTable& dt) const;
 
+  /// Returns true if this aggregation uses grouping sets (ROLLUP/CUBE/GROUPING
+  /// SETS).
+  bool hasGroupingSets() const {
+    return !groupingSets_.empty();
+  }
+
+  /// Grouping sets for ROLLUP/CUBE/GROUPING SETS. Empty for regular GROUP BY.
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  /// Returns the column for the grouping set ID, or nullptr if no grouping
+  /// sets.
+  ColumnCP groupIdColumn() const {
+    return groupIdColumn_;
+  }
+
  private:
   const ExprVector groupingKeys_;
   const AggregateVector aggregates_;
   const ColumnVector columns_;
   const ColumnVector intermediateColumns_;
+  const GroupingSets groupingSets_;
+  const ColumnCP groupIdColumn_;
 };
 
 using AggregationPlanCP = const AggregationPlan*;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1316,25 +1316,36 @@ using WindowFunctionCP = const WindowFunction*;
 using WindowFunctionVector = QGVector<WindowFunctionCP>;
 
 /// Stores the GROUP BY keys, aggregate functions, and output columns for a
-/// DerivedTable. Output columns are 1:1 with grouping keys followed by
-/// aggregates: columns_[i] corresponds to groupingKeys_[i] for
-/// i < groupingKeys_.size(), and to aggregates_[i - groupingKeys_.size()]
-/// otherwise.
+/// DerivedTable. Output column layout: [groupingKeys, groupId (optional),
+/// aggregates]. columns_[i] corresponds to groupingKeys_[i] for
+/// i < groupingKeys_.size(). When groupId is present, columns_[numKeys] is
+/// the groupId column and aggregates start at numKeys + 1. Without groupId,
+/// aggregates start immediately after keys.
+/// Each grouping set is a list of indices into the grouping keys array.
+using GroupingSet = QGVector<int32_t>;
+using GroupingSets = QGVector<GroupingSet>;
+
 class AggregationPlan : public PlanObject {
  public:
+  /// @param groupingKeys GROUP BY columns referencing the enclosing
+  ///   DerivedTable's tableSet. When grouping sets are present, these are
+  ///   new columns with auto-generated names (no alias).
+  /// @param aggregates Aggregate functions (sum, count, etc.).
+  /// @param columns Output columns: groupingKeys[i] maps to columns[i],
+  ///   followed by groupId (if present), then aggregate result columns.
+  /// @param intermediateColumns Columns with intermediate accumulator types for
+  ///   partial aggregation. Same layout as columns.
+  /// @param groupingSets Grouping sets for ROLLUP/CUBE/GROUPING SETS. Each set
+  ///   is a list of indices into groupingKeys. Empty for regular GROUP BY.
+  /// @param groupId Output column for the grouping set ID. Null when
+  ///   grouping sets are not used.
   AggregationPlan(
       ExprVector groupingKeys,
       AggregateVector aggregates,
       ColumnVector columns,
-      ColumnVector intermediateColumns)
-      : PlanObject(PlanType::kAggregationNode),
-        groupingKeys_(std::move(groupingKeys)),
-        aggregates_(std::move(aggregates)),
-        columns_(std::move(columns)),
-        intermediateColumns_(std::move(intermediateColumns)) {
-    VELOX_CHECK_EQ(groupingKeys_.size() + aggregates_.size(), columns_.size());
-    VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
-  }
+      ColumnVector intermediateColumns,
+      GroupingSets groupingSets = {},
+      ColumnCP groupId = nullptr);
 
   /// GROUP BY columns. Each references a column from a table in the enclosing
   /// DerivedTable's tableSet or from the DerivedTable itself.
@@ -1348,9 +1359,7 @@ class AggregationPlan : public PlanObject {
     return aggregates_;
   }
 
-  /// Output columns produced by this aggregation. The first
-  /// groupingKeys_.size() entries correspond to grouping keys; the rest
-  /// correspond to aggregate results.
+  /// Output columns: [groupingKeys, groupId (if present), aggregates].
   const ColumnVector& columns() const {
     return columns_;
   }
@@ -1367,11 +1376,33 @@ class AggregationPlan : public PlanObject {
   /// reference 'dt'.
   void checkConsistency(const DerivedTable& dt) const;
 
+  /// Returns true if this aggregation uses grouping sets (ROLLUP/CUBE/GROUPING
+  /// SETS).
+  bool hasGroupingSets() const {
+    return !groupingSets_.empty();
+  }
+
+  /// Grouping sets for ROLLUP/CUBE/GROUPING SETS. Empty for regular GROUP BY.
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  /// Returns the column for the grouping set ID, or nullptr if no grouping
+  /// sets.
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  /// Returns indices of global (empty) grouping sets within groupingSets().
+  QGVector<int32_t> globalGroupingSets() const;
+
  private:
   const ExprVector groupingKeys_;
   const AggregateVector aggregates_;
   const ColumnVector columns_;
   const ColumnVector intermediateColumns_;
+  const GroupingSets groupingSets_;
+  const ColumnCP groupId_;
 };
 
 using AggregationPlanCP = const AggregationPlan*;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -56,6 +56,7 @@ const auto& relTypeNames() {
       {RelType::kWindow, "Window"},
       {RelType::kRowNumber, "RowNumber"},
       {RelType::kTopNRowNumber, "TopNRowNumber"},
+      {RelType::kGroupId, "GroupId"},
   };
 
   return kNames;
@@ -1263,12 +1264,21 @@ Aggregation::Aggregation(
     ExprVector _preGroupedKeys,
     AggregateVector _aggregates,
     velox::core::AggregationNode::Step step,
-    ColumnVector columns)
+    ColumnVector columns,
+    GroupingSet _globalGroupingSets,
+    ColumnCP _groupIdColumn)
     : RelationOp{RelType::kAggregation, std::move(input), std::move(columns)},
       groupingKeys{std::move(_groupingKeys)},
       aggregates{std::move(_aggregates)},
       step{step},
-      preGroupedKeys{std::move(_preGroupedKeys)} {
+      preGroupedKeys{std::move(_preGroupedKeys)},
+      globalGroupingSets{std::move(_globalGroupingSets)},
+      groupIdColumn{_groupIdColumn} {
+  if (!globalGroupingSets.empty()) {
+    VELOX_CHECK_NOT_NULL(
+        groupIdColumn,
+        "groupIdColumn must be set when globalGroupingSets is non-empty");
+  }
 #ifndef NDEBUG
   VELOX_DCHECK_EQ(
       columns_.size(),
@@ -1673,7 +1683,7 @@ Limit::Limit(RelationOpPtr input, int64_t limit, int64_t offset)
       limit{limit},
       offset{offset} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = Costs::kMinimalUnitCost;
   const auto cardinality = static_cast<float>(limit);
   if (cost_.inputCardinality <= cardinality) {
     // Input cardinality does not exceed the limit. The limit is no-op.
@@ -1820,7 +1830,7 @@ TableWrite::TableWrite(
       inputColumns{std::move(inputColumns)},
       write{write} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = Costs::kMinimalUnitCost;
   VELOX_DCHECK_EQ(
       this->inputColumns.size(), this->write->table().type()->size());
 }
@@ -1890,7 +1900,8 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
       uniqueIdColumn_(uniqueIdColumn) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for generating unique IDs.
+  cost_.unitCost =
+      Costs::kMinimalUnitCost; // Minimal cost for generating unique IDs.
 
   // Copy all input constraints (AssignUniqueId projects all input columns).
   constraints_ = input_->constraints();
@@ -1919,7 +1930,8 @@ EnforceDistinct::EnforceDistinct(
       errorMessage_(errorMessage) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for enforcing distinctness.
+  cost_.unitCost =
+      Costs::kMinimalUnitCost; // Minimal cost for enforcing distinctness.
 
   // EnforceDistinct projects all input columns.
   constraints_ = input_->constraints();
@@ -2124,4 +2136,86 @@ void TopNRowNumber::accept(
   visitor.visit(*this, context);
 }
 
+namespace {
+
+// Builds the output columns for GroupId from grouping keys, aggregation
+// inputs, and the group ID column.
+ColumnVector makeGroupIdColumns(
+    const ColumnVector& groupingKeys,
+    const ExprVector& aggregationInputs,
+    ColumnCP groupIdColumn) {
+  ColumnVector columns;
+  columns.reserve(groupingKeys.size() + aggregationInputs.size() + 1);
+  for (auto* column : groupingKeys) {
+    columns.push_back(column);
+  }
+  for (auto* expr : aggregationInputs) {
+    VELOX_CHECK(
+        expr->is(PlanType::kColumnExpr),
+        "GroupId aggregation input must be a Column");
+    columns.push_back(expr->as<Column>());
+  }
+  columns.push_back(groupIdColumn);
+  return columns;
+}
+
+} // namespace
+
+GroupId::GroupId(
+    RelationOpPtr input,
+    GroupingSets groupingSets,
+    ColumnVector groupingKeys,
+    ExprVector aggregationInputs,
+    ColumnCP groupIdColumn,
+    ColumnVector inputGroupingKeys)
+    : RelationOp(
+          RelType::kGroupId,
+          std::move(input),
+          makeGroupIdColumns(groupingKeys, aggregationInputs, groupIdColumn)),
+      groupingSets_(std::move(groupingSets)),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregationInputs_(std::move(aggregationInputs)),
+      groupIdColumn_(groupIdColumn),
+      inputGroupingKeys_(std::move(inputGroupingKeys)) {
+  VELOX_CHECK_GT(
+      groupingSets_.size(),
+      1,
+      "GroupId requires multiple grouping sets. "
+      "A single grouping set is a regular GROUP BY.");
+  // Bounds and duplicate checks on grouping set indices are validated
+  // upstream in AggregationPlan's constructor.
+
+  // Fanout equals the number of grouping sets since each input row is
+  // duplicated once per set.
+  cost_.fanout = groupingSets_.size();
+  cost_.unitCost = Costs::kMinimalUnitCost * groupingSets_.size();
+
+  constraints_ = input_->constraints();
+
+  // Add constraints for the renamed output key columns. GroupId NULLs out
+  // keys for non-participating grouping sets, so they are always nullable.
+  const auto numSets = groupingSets_.size();
+  std::vector<size_t> setsPerKey(groupingKeys_.size(), 0);
+  for (const auto& set : groupingSets_) {
+    for (auto idx : set) {
+      ++setsPerKey[idx];
+    }
+  }
+
+  for (size_t keyIdx = 0; keyIdx < groupingKeys_.size(); ++keyIdx) {
+    auto value = groupingKeys_[keyIdx]->value();
+    value.nullable = true;
+    value.nullFraction = static_cast<float>(numSets - setsPerKey[keyIdx]) /
+        static_cast<float>(numSets);
+    constraints_.emplace(groupingKeys_[keyIdx]->id(), value);
+  }
+
+  constraints_.emplace(groupIdColumn_->id(), groupIdColumn_->value());
+}
+
+void GroupId::accept(
+    const RelationOpVisitor& visitor,
+    RelationOpVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -57,6 +57,7 @@ const auto& relTypeNames() {
       {RelType::kRowNumber, "RowNumber"},
       {RelType::kTopNRowNumber, "TopNRowNumber"},
       {RelType::kMarkDistinct, "MarkDistinct"},
+      {RelType::kGroupId, "GroupId"},
   };
 
   return kNames;
@@ -1293,12 +1294,26 @@ Aggregation::Aggregation(
     ExprVector _preGroupedKeys,
     AggregateVector _aggregates,
     velox::core::AggregationNode::Step step,
-    ColumnVector columns)
+    ColumnVector columns,
+    QGVector<int32_t> _globalGroupingSets,
+    ColumnCP _groupId)
     : RelationOp{RelType::kAggregation, std::move(input), std::move(columns)},
       groupingKeys{std::move(_groupingKeys)},
       aggregates{std::move(_aggregates)},
       step{step},
-      preGroupedKeys{std::move(_preGroupedKeys)} {
+      preGroupedKeys{std::move(_preGroupedKeys)},
+      globalGroupingSets{std::move(_globalGroupingSets)},
+      groupId{_groupId} {
+  if (!globalGroupingSets.empty()) {
+    VELOX_CHECK_NOT_NULL(
+        groupId, "groupId must be set when globalGroupingSets is non-empty");
+  }
+  if (groupId != nullptr) {
+    VELOX_CHECK(
+        std::find(groupingKeys.begin(), groupingKeys.end(), groupId) !=
+            groupingKeys.end(),
+        "groupId must appear in groupingKeys");
+  }
 #ifndef NDEBUG
   VELOX_DCHECK_EQ(
       columns_.size(),
@@ -1703,7 +1718,7 @@ Limit::Limit(RelationOpPtr input, int64_t limit, int64_t offset)
       limit{limit},
       offset{offset} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = Costs::kMinimalUnitCost;
   const auto cardinality = static_cast<float>(limit);
   if (cost_.inputCardinality <= cardinality) {
     // Input cardinality does not exceed the limit. The limit is no-op.
@@ -1888,7 +1903,7 @@ TableWrite::TableWrite(
       inputColumns{std::move(inputColumns)},
       write{write} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = Costs::kMinimalUnitCost;
   VELOX_DCHECK_EQ(
       this->inputColumns.size(), this->write->table().type()->size());
 }
@@ -1959,7 +1974,7 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
       uniqueIdColumn_(uniqueIdColumn) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for generating unique IDs.
+  cost_.unitCost = Costs::kMinimalUnitCost;
 
   // Copy all input constraints (AssignUniqueId projects all input columns).
   constraints_ = input_->constraints();
@@ -1988,7 +2003,8 @@ EnforceDistinct::EnforceDistinct(
       errorMessage_(errorMessage) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for enforcing distinctness.
+  // TODO: Review cost for EnforceDistinct.
+  cost_.unitCost = 0.01;
 
   // EnforceDistinct projects all input columns.
   constraints_ = input_->constraints();
@@ -2248,4 +2264,84 @@ void MarkDistinct::accept(
   visitor.visit(*this, context);
 }
 
+namespace {
+
+// Builds the output columns for GroupId from grouping keys, aggregation
+// inputs, and the group ID column.
+ColumnVector makeGroupIdColumns(
+    const ColumnVector& groupingKeyColumns,
+    const ExprVector& aggregationInputs,
+    ColumnCP groupId) {
+  ColumnVector columns;
+  columns.reserve(groupingKeyColumns.size() + aggregationInputs.size() + 1);
+  for (auto* column : groupingKeyColumns) {
+    columns.push_back(column);
+  }
+  for (auto* expr : aggregationInputs) {
+    VELOX_CHECK(
+        expr->is(PlanType::kColumnExpr),
+        "GroupId aggregation input must be a Column");
+    columns.push_back(expr->as<Column>());
+  }
+  columns.push_back(groupId);
+  return columns;
+}
+
+} // namespace
+
+GroupId::GroupId(
+    RelationOpPtr input,
+    ColumnVector groupingKeys,
+    ExprVector aggregationInputs,
+    GroupingSets groupingSets,
+    ColumnVector groupingKeyColumns,
+    ColumnCP groupId)
+    : RelationOp(
+          RelType::kGroupId,
+          std::move(input),
+          makeGroupIdColumns(groupingKeyColumns, aggregationInputs, groupId)),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregationInputs_(std::move(aggregationInputs)),
+      groupingSets_(std::move(groupingSets)),
+      groupingKeyColumns_(std::move(groupingKeyColumns)),
+      groupId_(groupId) {
+  VELOX_CHECK_GT(
+      groupingSets_.size(),
+      1,
+      "GroupId requires multiple grouping sets. "
+      "A single grouping set is a regular GROUP BY.");
+
+  // Each input row is duplicated once per set.
+  cost_.fanout = groupingSets_.size();
+  cost_.unitCost = Costs::kMinimalUnitCost * groupingSets_.size();
+
+  constraints_ = input_->constraints();
+
+  // Add constraints for the renamed output key columns. GroupId NULLs out
+  // keys for non-participating grouping sets, so they are always nullable.
+  const auto numSets = groupingSets_.size();
+  std::vector<size_t> setsPerKey(groupingKeyColumns_.size(), 0);
+  for (const auto& set : groupingSets_) {
+    for (auto idx : set) {
+      VELOX_CHECK_LT(idx, groupingKeyColumns_.size());
+      ++setsPerKey[idx];
+    }
+  }
+
+  for (size_t keyIdx = 0; keyIdx < groupingKeyColumns_.size(); ++keyIdx) {
+    auto value = groupingKeyColumns_[keyIdx]->value();
+    value.nullable = true;
+    value.nullFraction = static_cast<float>(numSets - setsPerKey[keyIdx]) /
+        static_cast<float>(numSets);
+    constraints_.emplace(groupingKeyColumns_[keyIdx]->id(), value);
+  }
+
+  constraints_.emplace(groupId_->id(), groupId_->value());
+}
+
+void GroupId::accept(
+    const RelationOpVisitor& visitor,
+    RelationOpVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -125,6 +125,7 @@ enum class RelType {
   kWindow,
   kRowNumber,
   kTopNRowNumber,
+  kGroupId,
 };
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
@@ -601,13 +602,17 @@ struct Aggregation : public RelationOp {
   /// @param step Aggregation step (partial, final, single, intermediate).
   /// @param columns Output columns: groupingKeys followed by aggregate result
   ///   columns. Must have size == groupingKeys.size() + aggregates.size().
+  /// @param globalGroupingSets Indices of global (empty) grouping sets, if any.
+  /// @param groupIdColumn The group ID column from upstream GroupId, if any.
   Aggregation(
       RelationOpPtr input,
       ExprVector groupingKeys,
       ExprVector preGroupedKeys,
       AggregateVector aggregates,
       velox::core::AggregationNode::Step step,
-      ColumnVector columns);
+      ColumnVector columns,
+      GroupingSet globalGroupingSets = {},
+      ColumnCP groupIdColumn = nullptr);
 
   const ExprVector groupingKeys;
   const AggregateVector aggregates;
@@ -617,6 +622,17 @@ struct Aggregation : public RelationOp {
   /// that matches the input's clusterKeys. When non-empty, the aggregation
   /// can be executed in streaming manner without building a hash table.
   const ExprVector preGroupedKeys;
+
+  /// Indices of global grouping sets (empty sets) within the grouping sets
+  /// array. Non-empty only for aggregations over GROUPING SETS/ROLLUP/CUBE
+  /// that contain a global (no-key) set. Used to generate a default output row
+  /// for empty inputs.
+  const GroupingSet globalGroupingSets;
+
+  /// The group ID column from the upstream GroupId operator, if present.
+  /// Used to pass grouping set info to the Velox AggregationNode without
+  /// requiring a dynamic_cast of the input.
+  const ColumnCP groupIdColumn{nullptr};
 
   /// Returns true if the aggregation is pre-grouped (streaming).
   bool isPreGrouped() const {
@@ -897,4 +913,60 @@ struct TopNRowNumber : public RelationOp {
 
 using TopNRowNumberCP = const TopNRowNumber*;
 
+/// Duplicates each input row once per grouping set. For each copy, grouping key
+/// columns not participating in that set are set to NULL, and a grouping set ID
+/// column is appended. Used to implement GROUPING SETS, ROLLUP, and CUBE.
+///
+/// Output columns: [grouping keys..., aggregation inputs..., groupIdColumn].
+struct GroupId : public RelationOp {
+  /// @param groupingSets List of grouping sets, each containing indices into
+  ///   groupingKeys that are active for that set.
+  /// @param groupingKeys Output columns for grouping keys with auto-generated
+  ///   names.
+  /// @param aggregationInputs Columns that are inputs to aggregate functions.
+  /// @param groupIdColumn The output column for the grouping set ID.
+  /// @param inputGroupingKeys Original input key columns before replacement
+  ///   with auto-generated output columns. Used by ToVelox to produce correct
+  ///   input field references.
+  GroupId(
+      RelationOpPtr input,
+      GroupingSets groupingSets,
+      ColumnVector groupingKeys,
+      ExprVector aggregationInputs,
+      ColumnCP groupIdColumn,
+      ColumnVector inputGroupingKeys);
+
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  ColumnCP groupIdColumn() const {
+    return groupIdColumn_;
+  }
+
+  const ColumnVector& inputGroupingKeys() const {
+    return inputGroupingKeys_;
+  }
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+
+ private:
+  const GroupingSets groupingSets_;
+  const ColumnVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const ColumnCP groupIdColumn_;
+  const ColumnVector inputGroupingKeys_;
+};
+
+using GroupIdCP = const GroupId*;
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -126,6 +126,7 @@ enum class RelType {
   kRowNumber,
   kTopNRowNumber,
   kMarkDistinct,
+  kGroupId,
 };
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
@@ -631,14 +632,19 @@ struct Aggregation : public RelationOp {
   ///   (columns[groupingKeys.size()..]).
   /// @param step Aggregation step (partial, final, single, intermediate).
   /// @param columns Output columns: groupingKeys followed by aggregate result
-  ///   columns. Must have size == groupingKeys.size() + aggregates.size().
+  ///   columns. Size includes groupId when present.
+  /// @param globalGroupingSets Indices of global (empty) grouping sets, if any.
+  /// @param groupId The group ID column from upstream GroupId, if any.
+  ///   When set, must appear in groupingKeys.
   Aggregation(
       RelationOpPtr input,
       ExprVector groupingKeys,
       ExprVector preGroupedKeys,
       AggregateVector aggregates,
       velox::core::AggregationNode::Step step,
-      ColumnVector columns);
+      ColumnVector columns,
+      QGVector<int32_t> globalGroupingSets = {},
+      ColumnCP groupId = nullptr);
 
   const ExprVector groupingKeys;
   const AggregateVector aggregates;
@@ -648,6 +654,17 @@ struct Aggregation : public RelationOp {
   /// that matches the input's clusterKeys. When non-empty, the aggregation
   /// can be executed in streaming manner without building a hash table.
   const ExprVector preGroupedKeys;
+
+  /// Indices of global grouping sets (empty sets) within the grouping sets
+  /// array. Non-empty only for aggregations over GROUPING SETS/ROLLUP/CUBE
+  /// that contain a global (no-key) set. Used to generate a default output row
+  /// for empty inputs.
+  const QGVector<int32_t> globalGroupingSets;
+
+  /// The group ID column from the upstream GroupId operator, if present.
+  /// Must appear in groupingKeys when set. Carries grouping set info to
+  /// ToVelox for Velox AggregationNode construction.
+  const ColumnCP groupId{nullptr};
 
   /// Returns true if the aggregation is pre-grouped (streaming).
   bool isPreGrouped() const {
@@ -956,4 +973,60 @@ struct MarkDistinct : public RelationOp {
 
 using MarkDistinctCP = const MarkDistinct*;
 
+/// Duplicates each input row once per grouping set. For each copy, grouping key
+/// columns not participating in that set are set to NULL, and a grouping set ID
+/// column is appended. Used to implement GROUPING SETS, ROLLUP, and CUBE.
+///
+/// Output columns: [groupingKeyColumns..., aggregation inputs..., groupId].
+struct GroupId : public RelationOp {
+  /// @param groupingKeys Original input key columns before replacement
+  ///   with auto-generated output columns. Used by ToVelox to produce correct
+  ///   input field references.
+  /// @param aggregationInputs Columns that are inputs to aggregate functions.
+  /// @param groupingSets List of grouping sets, each containing indices into
+  ///   groupingKeyColumns that are active for that set.
+  /// @param groupingKeyColumns Output columns for grouping keys with
+  ///   auto-generated names.
+  /// @param groupId The output column for the grouping set ID.
+  GroupId(
+      RelationOpPtr input,
+      ColumnVector groupingKeys,
+      ExprVector aggregationInputs,
+      GroupingSets groupingSets,
+      ColumnVector groupingKeyColumns,
+      ColumnCP groupId);
+
+  const ColumnVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeyColumns() const {
+    return groupingKeyColumns_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+
+ private:
+  const ColumnVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const GroupingSets groupingSets_;
+  const ColumnVector groupingKeyColumns_;
+  const ColumnCP groupId_;
+};
+
+using GroupIdCP = const GroupId*;
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -262,6 +262,44 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+
+    std::stringstream groupingSets;
+    groupingSets << "(";
+    for (size_t i = 0; i < op.groupingSets().size(); ++i) {
+      if (i > 0) {
+        groupingSets << ", ";
+      }
+      // Convert indices to output names for readability.
+      groupingSets << "[";
+      const auto& set = op.groupingSets()[i];
+      for (size_t j = 0; j < set.size(); ++j) {
+        if (j > 0) {
+          groupingSets << ", ";
+        }
+        groupingSets << op.groupingKeys()[set[j]]->name();
+      }
+      groupingSets << "]";
+    }
+    groupingSets << ")";
+
+    printHeader(op, myCtx, groupingSets.str());
+    printConstraints(op, myCtx);
+
+    const auto indentation = toIndentation(myCtx.indent + 2);
+    for (const auto* column : op.groupingKeys()) {
+      myCtx.out << indentation << column->name() << " := " << column->toString()
+                << std::endl;
+    }
+    myCtx.out << indentation
+              << "groupIdColumn: " << op.groupIdColumn()->toString()
+              << std::endl;
+
+    printInput(*op.input(), myCtx);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -488,6 +526,14 @@ class OnelineVisitor : public RelationOpVisitor {
   void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
+  }
+
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    myCtx.out << "groupid(";
+    op.input()->accept(*this, context);
+    myCtx.out << ")";
   }
 
  private:

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -267,6 +267,43 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+
+    std::stringstream groupingSets;
+    groupingSets << "(";
+    for (size_t i = 0; i < op.groupingSets().size(); ++i) {
+      if (i > 0) {
+        groupingSets << ", ";
+      }
+      // Convert indices to output names for readability.
+      groupingSets << "[";
+      const auto& set = op.groupingSets()[i];
+      for (size_t j = 0; j < set.size(); ++j) {
+        if (j > 0) {
+          groupingSets << ", ";
+        }
+        groupingSets << op.groupingKeyColumns()[set[j]]->name();
+      }
+      groupingSets << "]";
+    }
+    groupingSets << ")";
+
+    printHeader(op, myCtx, groupingSets.str());
+    printConstraints(op, myCtx);
+
+    const auto indentation = toIndentation(myCtx.indent + 2);
+    for (const auto* column : op.groupingKeyColumns()) {
+      myCtx.out << indentation << column->name() << " := " << column->toString()
+                << std::endl;
+    }
+    myCtx.out << indentation << "groupId: " << op.groupId()->toString()
+              << std::endl;
+
+    printInput(*op.input(), myCtx);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -498,6 +535,14 @@ class OnelineVisitor : public RelationOpVisitor {
   void visit(const MarkDistinct& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
+  }
+
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    myCtx.out << "groupid(";
+    op.input()->accept(*this, context);
+    myCtx.out << ")";
   }
 
  private:

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -87,6 +87,9 @@ class RelationOpVisitor {
 
   virtual void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -90,6 +90,9 @@ class RelationOpVisitor {
 
   virtual void visit(const MarkDistinct& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -202,7 +202,13 @@ void SubfieldTracker::markFieldAccessed(
     return;
   }
 
-  const auto& aggregate = agg.aggregateAt(ordinal - keys.size());
+  const auto numKeys = keys.size();
+  if (ordinal >= numKeys + agg.aggregates().size()) {
+    return;
+  }
+
+  const auto& aggregate = agg.aggregates()[ordinal - numKeys];
+
   for (auto i = 0; i < aggregate->inputs().size(); ++i) {
     const auto& aggregateInput = aggregate->inputAt(i);
     if (aggregateInput->isLambda()) {

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -213,7 +213,13 @@ void SubfieldTracker::markFieldAccessed(
     return;
   }
 
-  const auto& aggregate = agg.aggregateAt(ordinal - keys.size());
+  const auto numKeys = keys.size();
+  if (ordinal >= numKeys + agg.aggregates().size()) {
+    return;
+  }
+
+  const auto& aggregate = agg.aggregates()[ordinal - numKeys];
+
   for (auto i = 0; i < aggregate->inputs().size(); ++i) {
     const auto& aggregateInput = aggregate->inputAt(i);
     if (aggregateInput->isLambda()) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -86,6 +86,29 @@ velox::ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   e.arg = ctx;
   return e;
 }
+
+// Remaps grouping set indices through keyIndexMap (which maps original key
+// positions to deduped positions) and deduplicates within each set.
+GroupingSets dedupAndRemapGroupingSets(
+    const std::vector<std::vector<int32_t>>& logicalGroupingSets,
+    const std::vector<int32_t>& keyIndexMap) {
+  GroupingSets result;
+  result.reserve(logicalGroupingSets.size());
+  for (const auto& set : logicalGroupingSets) {
+    GroupingSet remapped;
+    remapped.reserve(set.size());
+    folly::F14FastSet<int32_t> seen;
+    for (auto idx : set) {
+      auto mappedIdx = keyIndexMap[idx];
+      if (seen.insert(mappedIdx).second) {
+        remapped.push_back(mappedIdx);
+      }
+    }
+    result.emplace_back(std::move(remapped));
+  }
+  return result;
+}
+
 } // namespace
 
 ToGraph::ToGraph(
@@ -1450,11 +1473,19 @@ struct AggregateDedupHasher {
 };
 } // namespace
 
+ColumnCP ToGraph::createGroupIdColumn(
+    Name name,
+    const velox::TypePtr& type,
+    size_t numGroupingSets) {
+  Value value(toType(type), numGroupingSets);
+  value.nullable = false;
+  value.min = registerVariant(int64_t{0});
+  value.max = registerVariant(static_cast<int64_t>(numGroupingSets - 1));
+  return make<Column>(name, currentDt_, value, name);
+}
+
 AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   const auto& input = *agg.onlyInput();
-
-  VELOX_USER_CHECK_EQ(
-      0, agg.groupingSets().size(), "Grouping sets are not supported yet");
 
   exprSources_.push_back(&input);
   SCOPE_EXIT {
@@ -1470,7 +1501,8 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
 
     for (auto channel : channels) {
-      if (channel < numGroupingKeys) {
+      if (channel < numGroupingKeys ||
+          channel >= numGroupingKeys + agg.aggregates().size()) {
         continue;
       }
 
@@ -1485,6 +1517,7 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
   }
 
+  const bool hasGroupingSets = !agg.groupingSets().empty();
   ColumnVector columns;
 
   ExprVector deduppedGroupingKeys;
@@ -1492,26 +1525,59 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
   auto newRenames = renames_;
 
-  folly::F14FastMap<ExprCP, ColumnCP> uniqueGroupingKeys;
+  // Maps each original grouping key index to its deduped index. Used to
+  // remap grouping set indices after key deduplication.
+  std::vector<int32_t> keyIndexMap(numGroupingKeys);
+  folly::F14FastMap<ExprCP, std::pair<ColumnCP, int32_t>> uniqueGroupingKeys;
   for (auto i = 0; i < numGroupingKeys; ++i) {
     auto name = toName(agg.outputType()->nameOf(i));
     auto* key = translateExpr(agg.groupingKeys()[i]);
 
     auto it = uniqueGroupingKeys.try_emplace(key).first;
-    if (it->second) {
-      newRenames[name] = it->second;
+    if (it->second.first) {
+      newRenames[name] = it->second.first;
+      keyIndexMap[i] = it->second.second;
     } else {
+      ColumnCP inputColumn;
       if (key->is(PlanType::kColumnExpr)) {
-        columns.push_back(key->as<Column>());
+        inputColumn = key->as<Column>();
       } else {
-        auto* column = make<Column>(name, currentDt_, key->value(), name);
-        columns.push_back(column);
+        inputColumn = make<Column>(name, currentDt_, key->value(), name);
       }
 
+      if (hasGroupingSets) {
+        // GroupId reads original key columns and produces nullable output
+        // columns with auto-generated names that can be nulled per set.
+        auto groupKeyName = newCName("gk");
+        auto* outputColumn = make<Column>(
+            groupKeyName, currentDt_, inputColumn->value(), groupKeyName);
+        columns.push_back(outputColumn);
+        newRenames[name] = outputColumn;
+      } else {
+        columns.push_back(inputColumn);
+        newRenames[name] = inputColumn;
+      }
+
+      const auto dedupedIdx = static_cast<int32_t>(deduppedGroupingKeys.size());
       deduppedGroupingKeys.emplace_back(key);
-      it->second = columns.back();
-      newRenames[name] = columns.back();
+      it->second = {columns.back(), dedupedIdx};
+      keyIndexMap[i] = dedupedIdx;
     }
+  }
+
+  ColumnCP groupIdColumn = nullptr;
+  GroupingSets queryGraphGroupingSets;
+  if (hasGroupingSets) {
+    const auto ordinal = agg.groupIdColumnIndex();
+    groupIdColumn = createGroupIdColumn(
+        toName(agg.outputNames().at(ordinal)),
+        agg.outputType()->childAt(ordinal),
+        agg.groupingSets().size());
+    newRenames[groupIdColumn->name()] = groupIdColumn;
+    columns.push_back(groupIdColumn);
+
+    queryGraphGroupingSets =
+        dedupAndRemapGroupingSets(agg.groupingSets(), keyIndexMap);
   }
 
   AggregateVector deduppedAggregates;
@@ -1521,7 +1587,8 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   // The keys for intermediate are the same as for final.
   ColumnVector intermediateColumns = columns;
   for (auto channel : channels) {
-    if (channel < numGroupingKeys) {
+    if (channel < numGroupingKeys ||
+        channel >= numGroupingKeys + agg.aggregates().size()) {
       continue;
     }
 
@@ -1617,7 +1684,9 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       std::move(deduppedGroupingKeys),
       std::move(deduppedAggregates),
       std::move(columns),
-      std::move(intermediateColumns));
+      std::move(intermediateColumns),
+      std::move(queryGraphGroupingSets),
+      groupIdColumn);
 }
 
 void ToGraph::addOrderBy(const lp::SortNode& order) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -131,6 +131,29 @@ velox::ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   e.arg = ctx;
   return e;
 }
+
+// Remaps grouping set indices through keyIndexMap (which maps original key
+// positions to deduped positions) and deduplicates within each set.
+GroupingSets dedupAndRemapGroupingSets(
+    const std::vector<std::vector<int32_t>>& logicalGroupingSets,
+    const std::vector<int32_t>& keyIndexMap) {
+  GroupingSets result;
+  result.reserve(logicalGroupingSets.size());
+  for (const auto& set : logicalGroupingSets) {
+    GroupingSet remapped;
+    remapped.reserve(set.size());
+    folly::F14FastSet<int32_t> seen;
+    for (auto idx : set) {
+      auto mappedIdx = keyIndexMap[idx];
+      if (seen.insert(mappedIdx).second) {
+        remapped.push_back(mappedIdx);
+      }
+    }
+    result.emplace_back(std::move(remapped));
+  }
+  return result;
+}
+
 } // namespace
 
 size_t SubqueryExprHash::operator()(const lp::ExprPtr& expr) const {
@@ -1687,11 +1710,20 @@ struct AggregateDedupHasher {
 };
 } // namespace
 
+ColumnCP ToGraph::createGroupIdColumn(
+    Name name,
+    const velox::TypePtr& type,
+    size_t numGroupingSets) {
+  VELOX_CHECK_GT(numGroupingSets, 0);
+  Value value(toType(type), numGroupingSets);
+  value.nullable = false;
+  value.min = registerVariant(int64_t{0});
+  value.max = registerVariant(static_cast<int64_t>(numGroupingSets - 1));
+  return make<Column>(name, currentDt_, value, name);
+}
+
 AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   const auto& input = *agg.onlyInput();
-
-  VELOX_USER_CHECK_EQ(
-      0, agg.groupingSets().size(), "Grouping sets are not supported yet");
 
   exprSources_.push_back(&input);
   SCOPE_EXIT {
@@ -1711,7 +1743,8 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
 
     for (auto channel : channels) {
-      if (channel < numGroupingKeys) {
+      if (channel < numGroupingKeys ||
+          channel >= numGroupingKeys + agg.aggregates().size()) {
         continue;
       }
 
@@ -1726,6 +1759,7 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
   }
 
+  const bool hasGroupingSets = !agg.groupingSets().empty();
   ColumnVector columns;
 
   ExprVector deduppedGroupingKeys;
@@ -1733,26 +1767,60 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
   auto newRenames = renames_;
 
-  folly::F14FastMap<ExprCP, ColumnCP> uniqueGroupingKeys;
+  // Maps each original grouping key index to its deduped index. Used to
+  // remap grouping set indices after key deduplication.
+  std::vector<int32_t> keyIndexMap(numGroupingKeys);
+  folly::F14FastMap<ExprCP, std::pair<ColumnCP, int32_t>> uniqueGroupingKeys;
   for (auto i = 0; i < numGroupingKeys; ++i) {
     auto name = toName(agg.outputType()->nameOf(i));
     auto* key = translateExpr(agg.groupingKeys()[i]);
 
     auto it = uniqueGroupingKeys.try_emplace(key).first;
-    if (it->second) {
-      newRenames[name] = it->second;
+    if (it->second.first) {
+      newRenames[name] = it->second.first;
+      keyIndexMap[i] = it->second.second;
     } else {
+      ColumnCP inputColumn;
       if (key->is(PlanType::kColumnExpr)) {
-        columns.push_back(key->as<Column>());
+        inputColumn = key->as<Column>();
       } else {
-        auto* column = make<Column>(name, currentDt_, key->value(), name);
-        columns.push_back(column);
+        inputColumn = make<Column>(name, currentDt_, key->value(), name);
       }
 
+      if (hasGroupingSets) {
+        // GroupId produces nullable output columns with auto-generated names.
+        // Replace the original key in renames so downstream references resolve
+        // to the GroupId output column instead of the original input column.
+        auto groupKeyName = newCName("gk");
+        auto* outputColumn = make<Column>(
+            groupKeyName, currentDt_, inputColumn->value(), groupKeyName);
+        columns.push_back(outputColumn);
+        newRenames[name] = outputColumn;
+      } else {
+        columns.push_back(inputColumn);
+        newRenames[name] = inputColumn;
+      }
+
+      const auto dedupedIdx = static_cast<int32_t>(deduppedGroupingKeys.size());
       deduppedGroupingKeys.emplace_back(key);
-      it->second = columns.back();
-      newRenames[name] = columns.back();
+      it->second = {columns.back(), dedupedIdx};
+      keyIndexMap[i] = dedupedIdx;
     }
+  }
+
+  ColumnCP groupId = nullptr;
+  GroupingSets queryGraphGroupingSets;
+  if (hasGroupingSets) {
+    const auto ordinal = agg.groupIdIndex().value();
+    groupId = createGroupIdColumn(
+        toName(agg.outputNames().at(ordinal)),
+        agg.outputType()->childAt(static_cast<uint32_t>(ordinal)),
+        agg.groupingSets().size());
+    newRenames[groupId->name()] = groupId;
+    columns.push_back(groupId);
+
+    queryGraphGroupingSets =
+        dedupAndRemapGroupingSets(agg.groupingSets(), keyIndexMap);
   }
 
   AggregateVector deduppedAggregates;
@@ -1772,7 +1840,8 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   // The keys for intermediate are the same as for final.
   ColumnVector intermediateColumns = columns;
   for (auto channel : channels) {
-    if (channel < numGroupingKeys) {
+    if (channel < numGroupingKeys ||
+        channel >= numGroupingKeys + agg.aggregates().size()) {
       continue;
     }
 
@@ -1909,7 +1978,9 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       std::move(deduppedGroupingKeys),
       std::move(deduppedAggregates),
       std::move(columns),
-      std::move(intermediateColumns));
+      std::move(intermediateColumns),
+      std::move(queryGraphGroupingSets),
+      groupId);
 }
 
 void ToGraph::addOrderBy(const lp::SortNode& order) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -302,6 +302,13 @@ class ToGraph {
 
   void addUnnest(const logical_plan::UnnestNode& unnest);
 
+  // Creates a Column for the grouping set ID with the given name, type, and
+  // number of grouping sets.
+  ColumnCP createGroupIdColumn(
+      Name name,
+      const velox::TypePtr& type,
+      size_t numGroupingSets);
+
   AggregationPlanCP translateAggregation(
       const logical_plan::AggregateNode& aggregation);
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -481,6 +481,13 @@ class ToGraph {
 
   void addUnnest(const logical_plan::UnnestNode& unnest);
 
+  // Creates a Column for the grouping set ID with the given name, type, and
+  // number of grouping sets.
+  ColumnCP createGroupIdColumn(
+      Name name,
+      const velox::TypePtr& type,
+      size_t numGroupingSets);
+
   AggregationPlanCP translateAggregation(
       const logical_plan::AggregateNode& aggregation);
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -277,7 +277,14 @@ void ToVelox::filterUpdated(BaseTableCP table) {
 velox::core::PlanNodePtr ToVelox::addOutputRenames(
     velox::core::PlanNodePtr input,
     const std::vector<logical_plan::OutputNode::Entry>& outputNames) {
-  VELOX_CHECK_EQ(outputNames.size(), input->outputType()->size());
+  // LE because the Velox AggregationNode includes groupIdColumn as a grouping
+  // key in its output, but the Axiom Aggregation's columns_ does not. The
+  // groupIdColumn flows through intermediate operators (repartition, final
+  // aggregation) and can only be safely dropped at the output boundary.
+  VELOX_CHECK_LE(
+      outputNames.size(),
+      input->outputType()->size(),
+      "OutputNode has more entries than input columns");
 
   // If the input is a ProjectNode that only does renames/reorders (all
   // expressions are FieldAccessTypedExpr on input columns), look through it
@@ -1474,6 +1481,14 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
 
   auto preGroupedKeys = toFieldRefs(op.preGroupedKeys);
 
+  std::vector<velox::vector_size_t> globalGroupingSets(
+      op.globalGroupingSets.begin(), op.globalGroupingSets.end());
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  if (op.groupIdColumn != nullptr) {
+    groupId = std::make_shared<velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), op.groupIdColumn->outputName());
+  }
+
   return std::make_shared<velox::core::AggregationNode>(
       nextId(),
       op.step,
@@ -1481,6 +1496,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       preGroupedKeys,
       aggregateNames,
       aggregates,
+      globalGroupingSets,
+      groupId,
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
       input);
@@ -2012,6 +2029,53 @@ velox::core::PlanNodePtr ToVelox::makeEnforceDistinct(
   return node;
 }
 
+velox::core::PlanNodePtr ToVelox::makeGroupId(
+    const GroupId& op,
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
+  auto input = makeFragment(op.input(), fragment, stages);
+
+  std::vector<velox::core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
+  groupingKeyInfos.reserve(op.groupingKeys().size());
+  VELOX_CHECK_EQ(
+      op.inputGroupingKeys().size(),
+      op.groupingKeys().size(),
+      "inputGroupingKeys size mismatch");
+  for (size_t i = 0; i < op.groupingKeys().size(); ++i) {
+    auto outputName = op.groupingKeys()[i]->outputName();
+    auto inputRef = toFieldRef(op.inputGroupingKeys()[i]);
+    groupingKeyInfos.push_back({
+        .output = std::move(outputName),
+        .input = std::move(inputRef),
+    });
+  }
+
+  // Convert groupingSets from indices to output column names for Velox.
+  std::vector<std::vector<std::string>> groupingSets;
+  groupingSets.reserve(op.groupingSets().size());
+  for (const auto& set : op.groupingSets()) {
+    std::vector<std::string> names;
+    names.reserve(set.size());
+    for (auto keyIndex : set) {
+      names.emplace_back(groupingKeyInfos[keyIndex].output);
+    }
+    groupingSets.emplace_back(std::move(names));
+  }
+
+  auto aggregationInputs = toFieldRefs(op.aggregationInputs());
+
+  auto node = std::make_shared<velox::core::GroupIdNode>(
+      nextId(),
+      std::move(groupingSets),
+      std::move(groupingKeyInfos),
+      std::move(aggregationInputs),
+      op.groupIdColumn()->outputName(),
+      std::move(input));
+
+  makePredictionAndHistory(node->id(), &op);
+  return node;
+}
+
 void ToVelox::makePredictionAndHistory(
     const velox::core::PlanNodeId& id,
     const RelationOp* op) {
@@ -2065,6 +2129,8 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
       return makeRowNumber(*op->as<RowNumber>(), fragment, stages);
     case RelType::kTopNRowNumber:
       return makeTopNRowNumber(*op->as<TopNRowNumber>(), fragment, stages);
+    case RelType::kGroupId:
+      return makeGroupId(*op->as<GroupId>(), fragment, stages);
     default:
       VELOX_FAIL(
           "Unsupported RelationOp {}", static_cast<int32_t>(op->relType()));

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1575,6 +1575,13 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
 
   auto preGroupedKeys = toFieldRefs(op.preGroupedKeys);
 
+  std::vector<velox::vector_size_t> globalGroupingSets(
+      op.globalGroupingSets.begin(), op.globalGroupingSets.end());
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  if (op.groupId != nullptr) {
+    groupId = toFieldRef(op.groupId);
+  }
+
   return std::make_shared<velox::core::AggregationNode>(
       nextId(),
       op.step,
@@ -1582,6 +1589,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       preGroupedKeys,
       aggregateNames,
       aggregates,
+      globalGroupingSets,
+      groupId,
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
       input);
@@ -2121,11 +2130,7 @@ velox::core::PlanNodePtr ToVelox::makeMarkDistinct(
     std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
   if (options_.numDrivers > 1) {
-    // If the input is a repartition, always add a local partition after it. If
-    // the input is not a repartition, check if the input's distribution
-    // partition keys are a subset of MarkDistinct's keys. If so, rows with the
-    // same MarkDistinct keys are already co-located, so no need for an
-    // additional local partition.
+    // Add local partition unless keys are already co-located.
     bool needsLocalPartition = true;
     if (op.input()->relType() != RelType::kRepartition) {
       const auto& existingKeys = op.input()->distribution().partitionKeys();
@@ -2144,6 +2149,54 @@ velox::core::PlanNodePtr ToVelox::makeMarkDistinct(
       nextId(),
       op.marker()->outputName(),
       toFieldRefs(op.keys()),
+      std::move(input));
+
+  makePredictionAndHistory(node->id(), &op);
+  return node;
+}
+
+velox::core::PlanNodePtr ToVelox::makeGroupId(
+    const GroupId& op,
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
+  auto input = makeFragment(op.input(), fragment, stages);
+
+  std::vector<velox::core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
+  groupingKeyInfos.reserve(op.groupingKeyColumns().size());
+  VELOX_CHECK_EQ(
+      op.groupingKeys().size(),
+      op.groupingKeyColumns().size(),
+      "groupingKeys size mismatch");
+  for (size_t i = 0; i < op.groupingKeyColumns().size(); ++i) {
+    auto outputName = op.groupingKeyColumns()[i]->outputName();
+    auto inputRef = toFieldRef(op.groupingKeys()[i]);
+    groupingKeyInfos.push_back({
+        .output = std::move(outputName),
+        .input = std::move(inputRef),
+    });
+  }
+
+  // Convert groupingSets from indices to output column names for Velox.
+  std::vector<std::vector<std::string>> groupingSets;
+  groupingSets.reserve(op.groupingSets().size());
+  for (const auto& set : op.groupingSets()) {
+    std::vector<std::string> names;
+    names.reserve(set.size());
+    for (auto keyIndex : set) {
+      VELOX_CHECK_LT(keyIndex, groupingKeyInfos.size());
+      names.emplace_back(groupingKeyInfos[keyIndex].output);
+    }
+    groupingSets.emplace_back(std::move(names));
+  }
+
+  auto aggregationInputs = toFieldRefs(op.aggregationInputs());
+
+  auto node = std::make_shared<velox::core::GroupIdNode>(
+      nextId(),
+      std::move(groupingSets),
+      std::move(groupingKeyInfos),
+      std::move(aggregationInputs),
+      op.groupId()->outputName(),
       std::move(input));
 
   makePredictionAndHistory(node->id(), &op);
@@ -2228,6 +2281,9 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
       break;
     case RelType::kMarkDistinct:
       result = makeMarkDistinct(*op->as<MarkDistinct>(), fragment, stages);
+      break;
+    case RelType::kGroupId:
+      result = makeGroupId(*op->as<GroupId>(), fragment, stages);
       break;
     default:
       VELOX_FAIL(

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -103,7 +103,8 @@ class ToVelox {
  private:
   // Adds a Velox ProjectNode that renames or reorders output columns per the
   // given OutputNode entries. Returns the input unchanged if all names and
-  // positions already match.
+  // positions already match. input->outputType() may contain more columns than
+  // outputNames; extra columns are dropped by the projection.
   velox::core::PlanNodePtr addOutputRenames(
       velox::core::PlanNodePtr input,
       const std::vector<logical_plan::OutputNode::Entry>& outputNames);
@@ -280,6 +281,12 @@ class ToVelox {
   velox::core::WindowNode::Function toVeloxWindowFunction(
       WindowFunctionCP windowFunc,
       ColumnCP outputColumn);
+
+  // Converts a GroupId operator to a Velox GroupIdNode.
+  velox::core::PlanNodePtr makeGroupId(
+      const GroupId& op,
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -114,7 +114,8 @@ class ToVelox {
  private:
   // Adds a Velox ProjectNode that selects 'outputNames' from 'input' by
   // source name and renames them per outputName. Returns 'input' unchanged
-  // when all names and positions already match.
+  // when all names and positions already match. input->outputType() may contain
+  // more columns than outputNames; extra columns are dropped by the projection.
   velox::core::PlanNodePtr addOutputRenames(
       velox::core::PlanNodePtr input,
       const std::vector<OutputColumnNameMapping>& outputNames);
@@ -295,6 +296,12 @@ class ToVelox {
   // Makes a Velox MarkDistinctNode for a RelationOp.
   velox::core::PlanNodePtr makeMarkDistinct(
       const MarkDistinct& op,
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
+
+  // Converts a GroupId operator to a Velox GroupIdNode.
+  velox::core::PlanNodePtr makeGroupId(
+      const GroupId& op,
       ExecutableFragment& fragment,
       std::vector<ExecutableFragment>& stages);
 

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -323,5 +323,228 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   }
 }
 
+TEST_F(AggregationTest, groupingSets) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a", "b"}, {"sum(c) as total"}, "gid")
+                         .build();
+
+  // Single-node plan shape.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    // ROLLUP(a, b) expands to grouping sets: {a, b}, {a}, {}.
+    // Grouping keys get auto-generated output names in GroupId.
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .singleAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .project({"a", "b", "total", "gid"})
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan shape.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .partialAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .shuffle()
+            .localPartition()
+            .finalAggregation({"a", "b", "gid"}, {"sum(total) as total"})
+            .project({"a", "b", "total", "gid"})
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
+// Verifies that a grouping key can also be an aggregation input.
+// SELECT a, SUM(a) FROM t GROUP BY ROLLUP(a) requires 'a' to appear both as
+// a grouping key (subject to NULL-ing) and as an aggregation input (preserved).
+TEST_F(AggregationTest, groupingSetsKeyIsAggInput) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"sum(a) as total"}, "gid")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // 'a' is both a grouping key (renamed to gk3) and an aggregate input
+  // (passed through as 'a'). Use gk3 explicitly — symbol propagation
+  // skips overlapping keys to avoid rewriting sum(a) to sum(gk3).
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .groupId({{"a"}, {}}, {"a"}, "gid")
+                     .singleAggregation({"gk3", "gid"}, {"sum(a) as total"})
+                     .project({"gk3 as a", "total", "gid"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// TODO: Identical grouping sets compute separately today. Follow-up
+// optimization: detect identical sets, compute once, and replicate rows.
+TEST_F(AggregationTest, groupingSetsCrossSetOptimization) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  // GROUP BY GROUPING SETS ((a, b), (b, a), (a, b)) — all three sets are
+  // order-insensitively identical but treated as separate sets today.
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate(
+              {{"a", "b"}, {"b", "a"}, {"a", "b"}}, {"count(1) as c"}, "gid")
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // Three separate grouping sets in GroupId. Follow-up: collapse to one set
+  // with row replication.
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .groupId({{"a", "b"}, {"b", "a"}, {"a", "b"}}, {}, "gid")
+                     .singleAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                     .project({"a", "b", "c", "gid"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// No global (empty) grouping set — all sets have at least one key.
+// This exercises the globalGroupingSets.empty() branch where aggGroupIdColumn
+// is nullptr and forcePartial is not triggered by global sets.
+TEST_F(AggregationTest, groupingSetsNoGlobalSet) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  // GROUPING SETS ((a), (b)) — no empty set.
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({{"a"}, {"b"}}, {"count(1) as c"}, "gid")
+                         .build();
+
+  // Single-node plan.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {"b"}}, {}, "gid")
+                       .singleAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                       .project({"a", "b", "c", "gid"})
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan — without global sets, the optimizer chooses
+  // split (partial + final) aggregation based on cost.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {"b"}}, {}, "gid")
+                       .partialAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                       .shuffle()
+                       .localPartition()
+                       .finalAggregation({"a", "b", "gid"}, {"count(c) as c"})
+                       .project({"a", "b", "c", "gid"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
+// ORDER BY in aggregates requires single-step aggregation (partial aggregation
+// cannot preserve ORDER BY semantics), but global grouping sets require
+// partial+final. With kSingle, empty driver partitions emit spurious default
+// rows for the global set.
+TEST_F(AggregationTest, groupingSetsOrderByWithGlobalSet) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"array_agg(b ORDER BY b)"}, "gid")
+                         .build();
+
+  VELOX_ASSERT_THROW(
+      planVelox(
+          logicalPlan,
+          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
+      "ORDER BY in aggregate functions is not supported with global grouping sets");
+}
+
+TEST_F(AggregationTest, groupingSetsDistinctAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"count(DISTINCT b)"}, "gid")
+                         .build();
+
+  VELOX_ASSERT_THROW(
+      planVelox(
+          logicalPlan,
+          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
+      "DISTINCT aggregation with grouping sets is not supported yet");
+}
+
+// Literal-only aggregate args (count(1)) — aggregation inputs list passed to
+// GroupId should be empty since literals are not column references.
+TEST_F(AggregationTest, groupingSetsLiteralArgs) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"count(1) as c"}, "gid")
+                         .build();
+
+  // Single-node plan — GroupId has empty aggregation inputs.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {}}, {}, "gid")
+                       .singleAggregation({"a", "gid"}, {"count(1) as c"})
+                       .project({"a", "c", "gid"})
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {}}, {}, "gid")
+                       .partialAggregation({"a", "gid"}, {"count(1) as c"})
+                       .shuffle()
+                       .localPartition()
+                       .finalAggregation({"a", "gid"}, {"count(c) as c"})
+                       .project({"a", "c", "gid"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -322,5 +322,219 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
 // optimizationCost() helper is available for verifying cost differences between
 // plans with and without projections.
 
+TEST_F(AggregationTest, groupingSets) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a", "b"}, {"sum(c) as total"}, "gid")
+                         .build();
+
+  // Single-node plan shape.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    // ROLLUP(a, b) expands to grouping sets: {a, b}, {a}, {}.
+    // Grouping keys get auto-generated output names in GroupId.
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .singleAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .project({"a", "b", "total", "gid"})
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan shape.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .distributedAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .project({"a", "b", "total", "gid"})
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
+// Verifies that a grouping key can also be an aggregation input.
+// SELECT a, SUM(a) FROM t GROUP BY ROLLUP(a) requires 'a' to appear both as
+// a grouping key (subject to NULL-ing) and as an aggregation input (preserved).
+TEST_F(AggregationTest, groupingSetsKeyIsAggInput) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"sum(a) as total"}, "gid")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .groupId({{"a"}, {}}, {"a"}, "gid", {{"a", "key_a"}})
+                     .singleAggregation({"key_a", "gid"}, {"sum(a) as total"})
+                     .project({"key_a as a", "total", "gid"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// TODO: Identical grouping sets compute separately today. Follow-up
+// optimization: detect identical sets, compute once, and replicate rows.
+TEST_F(AggregationTest, groupingSetsCrossSetOptimization) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  // GROUP BY GROUPING SETS ((a, b), (b, a), (a, b)) — all three sets are
+  // order-insensitively identical but treated as separate sets today.
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate(
+              {{"a", "b"}, {"b", "a"}, {"a", "b"}}, {"count(1) as c"}, "gid")
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .groupId({{"a", "b"}, {"b", "a"}, {"a", "b"}}, {}, "gid")
+                     .singleAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                     .project({"a", "b", "c", "gid"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Verifies aggregation with GROUPING SETS that contain no empty set —
+// exercises both single-node and distributed plan shapes.
+TEST_F(AggregationTest, groupingSetsNoGlobalSet) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  // GROUPING SETS ((a), (b)) — no empty set.
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({{"a"}, {"b"}}, {"count(1) as c"}, "gid")
+                         .build();
+
+  // Single-node plan.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {"b"}}, {}, "gid")
+                       .singleAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                       .project({"a", "b", "c", "gid"})
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan — without global sets, the optimizer chooses
+  // split (partial + final) aggregation based on cost.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {"b"}}, {}, "gid")
+                       .partialAggregation({"a", "b", "gid"}, {"count(1) as c"})
+                       .shuffle()
+                       .localPartition()
+                       .finalAggregation({"a", "b", "gid"}, {"count(c) as c"})
+                       .project({"a", "b", "c", "gid"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
+// ORDER BY in aggregates requires single-step aggregation (partial aggregation
+// cannot preserve ORDER BY semantics), but global grouping sets require
+// partial+final. With kSingle, empty driver partitions emit spurious default
+// rows for the global set.
+TEST_F(AggregationTest, groupingSetsOrderByWithGlobalSet) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"array_agg(b ORDER BY b)"}, "gid")
+                         .build();
+
+  VELOX_ASSERT_THROW(
+      planVelox(
+          logicalPlan,
+          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
+      "ORDER BY in aggregate functions is not supported with global grouping sets");
+}
+
+TEST_F(AggregationTest, groupingSetsDistinctAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"count(DISTINCT b)"}, "gid")
+                         .build();
+
+  VELOX_ASSERT_THROW(
+      planVelox(
+          logicalPlan,
+          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
+      "DISTINCT aggregation with grouping sets is not supported yet");
+}
+
+// Literal-only aggregate args (count(1)) — aggregation inputs list passed to
+// GroupId should be empty since literals are not column references.
+TEST_F(AggregationTest, groupingSetsLiteralArgs) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"count(1) as c"}, "gid")
+                         .build();
+
+  // Single-node plan — GroupId has empty aggregation inputs.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {}}, {}, "gid")
+                       .singleAggregation({"a", "gid"}, {"count(1) as c"})
+                       .project({"a", "c", "gid"})
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .groupId({{"a"}, {}}, {}, "gid")
+                       .partialAggregation({"a", "gid"}, {"count(1) as c"})
+                       .shuffle()
+                       .localPartition()
+                       .finalAggregation({"a", "gid"}, {"count(c) as c"})
+                       .project({"a", "c", "gid"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1564,6 +1564,101 @@ class LocalPartitionTypeMatcher : public PlanMatcherImpl<LocalPartitionNode> {
   const std::vector<std::string> partitionKeys_;
 };
 
+// Matches a GroupIdNode and verifies grouping sets, aggregation inputs, and
+// group ID column name.
+class GroupIdMatcher : public PlanMatcherImpl<GroupIdNode> {
+ public:
+  explicit GroupIdMatcher(const std::shared_ptr<PlanMatcher>& matcher)
+      : PlanMatcherImpl<GroupIdNode>({matcher}) {}
+
+  GroupIdMatcher(
+      const std::shared_ptr<PlanMatcher>& matcher,
+      std::vector<std::vector<std::string>> groupingSets,
+      std::vector<std::string> aggregationInputs,
+      const std::string& groupIdColumnAlias)
+      : PlanMatcherImpl<GroupIdNode>({matcher}),
+        groupingSets_{std::move(groupingSets)},
+        aggregationInputs_{std::move(aggregationInputs)},
+        groupIdColumnAlias_{groupIdColumnAlias} {}
+
+  MatchResult matchDetails(
+      const GroupIdNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+
+    std::unordered_map<std::string, std::string> newSymbols = symbols;
+    if (groupIdColumnAlias_.has_value()) {
+      newSymbols[groupIdColumnAlias_.value()] = plan.groupIdName();
+    }
+
+    // Propagate input→output key mappings so downstream matchers can use
+    // original column names (e.g., "a" instead of "gk3"). Skip keys that
+    // also appear as aggregate inputs — those pass through as-is.
+    std::unordered_set<std::string> aggInputNames;
+    for (const auto& input : plan.aggregationInputs()) {
+      aggInputNames.insert(input->name());
+    }
+    for (const auto& info : plan.groupingKeyInfos()) {
+      if (!aggInputNames.contains(info.input->name())) {
+        newSymbols[info.input->name()] = info.output;
+      }
+    }
+
+    if (groupingSets_.has_value()) {
+      const auto& planSets = plan.groupingSets();
+
+      EXPECT_EQ(planSets.size(), groupingSets_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < groupingSets_->size(); ++i) {
+        const auto& expectedSet = (*groupingSets_)[i];
+        const auto& actualSet = planSets[i];
+
+        EXPECT_EQ(actualSet.size(), expectedSet.size())
+            << "Grouping set " << i << " size mismatch";
+        AXIOM_TEST_RETURN_IF_FAILURE
+
+        for (auto j = 0; j < expectedSet.size(); ++j) {
+          // Resolve input column name → output key name via groupingKeyInfos.
+          auto expected = expectedSet[j];
+          for (const auto& info : plan.groupingKeyInfos()) {
+            if (info.input->name() == expected) {
+              expected = info.output;
+              break;
+            }
+          }
+          EXPECT_EQ(actualSet[j], expected)
+              << "Grouping set " << i << ", key " << j;
+          AXIOM_TEST_RETURN_IF_FAILURE
+        }
+      }
+    }
+
+    if (aggregationInputs_.has_value()) {
+      EXPECT_EQ(plan.aggregationInputs().size(), aggregationInputs_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < aggregationInputs_->size(); ++i) {
+        auto expected = parse::DuckSqlExpressionsParser().parseExpr(
+            (*aggregationInputs_)[i]);
+        if (!symbols.empty()) {
+          expected = rewriteInputNames(expected, symbols);
+        }
+        EXPECT_EQ(
+            plan.aggregationInputs()[i]->toString(), expected->toString());
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    return MatchResult::success(std::move(newSymbols));
+  }
+
+ private:
+  const std::optional<std::vector<std::vector<std::string>>> groupingSets_;
+  const std::optional<std::vector<std::string>> aggregationInputs_;
+  const std::optional<std::string> groupIdColumnAlias_;
+};
 #undef AXIOM_TEST_RETURN
 #undef AXIOM_TEST_RETURN_IF_FAILURE
 #undef AXIOM_TEST_RETURN_IF_FAILURE_VOID
@@ -2011,6 +2106,16 @@ PlanMatcherBuilder& PlanMatcherBuilder::topNRowNumber(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<TopNRowNumberMatcher>(
       matcher_, partitionKeys, sortingKeys, limit);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::groupId(
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregationInputs,
+    const std::string& groupIdColumnAlias) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<GroupIdMatcher>(
+      matcher_, groupingSets, aggregationInputs, groupIdColumnAlias);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1591,6 +1591,112 @@ class MarkDistinctMatcher : public PlanMatcherImpl<MarkDistinctNode> {
   const std::optional<std::string> markerAlias_;
 };
 
+// Matches a GroupIdNode and verifies grouping sets, aggregation inputs, and
+// group ID column name.
+class GroupIdMatcher : public PlanMatcherImpl<GroupIdNode> {
+ public:
+  GroupIdMatcher(
+      const std::shared_ptr<PlanMatcher>& matcher,
+      std::vector<std::vector<std::string>> groupingSets,
+      std::vector<std::string> aggregationInputs,
+      const std::string& groupIdAlias,
+      std::vector<std::pair<std::string, std::string>> keyAliases = {})
+      : PlanMatcherImpl<GroupIdNode>({matcher}),
+        groupingSets_{std::move(groupingSets)},
+        aggregationInputs_{std::move(aggregationInputs)},
+        groupIdAlias_{groupIdAlias},
+        keyAliases_{std::move(keyAliases)} {}
+
+  MatchResult matchDetails(
+      const GroupIdNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+
+    std::unordered_map<std::string, std::string> newSymbols = symbols;
+    if (groupIdAlias_.has_value()) {
+      newSymbols[groupIdAlias_.value()] = plan.groupIdName();
+    }
+
+    // Propagate input→output key mappings so downstream matchers can use
+    // original column names (e.g., "a" instead of "gk3"). Skip keys that
+    // also appear as aggregate inputs — those pass through as-is.
+    std::unordered_set<std::string> aggInputNames;
+    for (const auto& input : plan.aggregationInputs()) {
+      aggInputNames.insert(input->name());
+    }
+    for (const auto& info : plan.groupingKeyInfos()) {
+      if (!aggInputNames.contains(info.input->name())) {
+        newSymbols[info.input->name()] = info.output;
+      }
+    }
+
+    // Propagate explicit key aliases for keys that overlap with aggregate
+    // inputs (where automatic symbol propagation is skipped).
+    for (const auto& [inputName, alias] : keyAliases_) {
+      for (const auto& info : plan.groupingKeyInfos()) {
+        if (info.input->name() == inputName) {
+          newSymbols[alias] = info.output;
+          break;
+        }
+      }
+    }
+
+    if (groupingSets_.has_value()) {
+      const auto& planSets = plan.groupingSets();
+
+      EXPECT_EQ(planSets.size(), groupingSets_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < groupingSets_->size(); ++i) {
+        const auto& expectedSet = (*groupingSets_)[i];
+        const auto& actualSet = planSets[i];
+
+        EXPECT_EQ(actualSet.size(), expectedSet.size())
+            << "Grouping set " << i << " size mismatch";
+        AXIOM_TEST_RETURN_IF_FAILURE
+
+        for (auto j = 0; j < expectedSet.size(); ++j) {
+          // Resolve input column name → output key name via groupingKeyInfos.
+          auto expected = expectedSet[j];
+          for (const auto& info : plan.groupingKeyInfos()) {
+            if (info.input->name() == expected) {
+              expected = info.output;
+              break;
+            }
+          }
+          EXPECT_EQ(actualSet[j], expected)
+              << "Grouping set " << i << ", key " << j;
+          AXIOM_TEST_RETURN_IF_FAILURE
+        }
+      }
+    }
+
+    if (aggregationInputs_.has_value()) {
+      EXPECT_EQ(plan.aggregationInputs().size(), aggregationInputs_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < aggregationInputs_->size(); ++i) {
+        auto expected = parse::DuckSqlExpressionsParser().parseExpr(
+            (*aggregationInputs_)[i]);
+        if (!symbols.empty()) {
+          expected = rewriteInputNames(expected, symbols);
+        }
+        EXPECT_EQ(
+            plan.aggregationInputs()[i]->toString(), expected->toString());
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    return MatchResult::success(std::move(newSymbols));
+  }
+
+ private:
+  const std::optional<std::vector<std::vector<std::string>>> groupingSets_;
+  const std::optional<std::vector<std::string>> aggregationInputs_;
+  const std::optional<std::string> groupIdAlias_;
+  const std::vector<std::pair<std::string, std::string>> keyAliases_;
+};
 #undef AXIOM_TEST_RETURN
 #undef AXIOM_TEST_RETURN_IF_FAILURE
 #undef AXIOM_TEST_RETURN_IF_FAILURE_VOID
@@ -2126,6 +2232,17 @@ PlanMatcherBuilder& PlanMatcherBuilder::markDistinct(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<MarkDistinctMatcher>(
       matcher_, distinctKeys, std::move(markerAlias));
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::groupId(
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregationInputs,
+    const std::string& groupIdAlias,
+    const std::vector<std::pair<std::string, std::string>>& keyAliases) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<GroupIdMatcher>(
+      matcher_, groupingSets, aggregationInputs, groupIdAlias, keyAliases);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -459,6 +459,20 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& sortingKeys,
       int32_t limit);
 
+  /// Matches a GroupId node with the specified grouping sets, aggregation
+  /// inputs, and group ID column alias. Each grouping set is a list of output
+  /// column names for the active keys in that set.
+  /// @param groupingSets The expected grouping sets (each set is a list of
+  /// output column names).
+  /// @param aggregationInputs The expected aggregation input expressions.
+  /// @param groupIdColumnAlias Alias for the group ID output column. The actual
+  ///   column name is captured as a symbol so downstream matchers can reference
+  ///   it by this alias.
+  PlanMatcherBuilder& groupId(
+      const std::vector<std::vector<std::string>>& groupingSets,
+      const std::vector<std::string>& aggregationInputs,
+      const std::string& groupIdColumnAlias);
+
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.
   std::shared_ptr<PlanMatcher> build() {

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -553,6 +553,24 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& distinctKeys,
       std::optional<std::string> markerAlias = std::nullopt);
 
+  /// Matches a GroupId node with the specified grouping sets, aggregation
+  /// inputs, and group ID column alias. Each grouping set is a list of output
+  /// column names for the active keys in that set.
+  /// @param groupingSets The expected grouping sets (each set is a list of
+  /// output column names).
+  /// @param aggregationInputs The expected aggregation input expressions.
+  /// @param groupIdAlias Alias for the group ID output column. The actual
+  ///   column name is captured as a symbol so downstream matchers can reference
+  ///   it by this alias.
+  /// @param keyAliases Maps input column names to test aliases for keys that
+  ///   also appear as aggregate inputs. Downstream matchers can use the alias
+  ///   to reference the auto-generated output key name.
+  PlanMatcherBuilder& groupId(
+      const std::vector<std::vector<std::string>>& groupingSets,
+      const std::vector<std::string>& aggregationInputs,
+      const std::string& groupIdAlias,
+      const std::vector<std::pair<std::string, std::string>>& keyAliases = {});
+
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.
   std::shared_ptr<PlanMatcher> build() {

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -395,5 +395,36 @@ TEST_F(RelationOpPrinterTest, maxDepth) {
   }
 }
 
+TEST_F(RelationOpPrinterTest, groupId) {
+  connector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto lines =
+      toLines("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("Project"),
+          testing::StartsWith("    "), // dt1.a := t2.a
+          testing::StartsWith("    "), // dt1.b := t2.b
+          testing::StartsWith("    "), // dt1.total := dt1.total
+          testing::StartsWith("    "), // grouping set ID column
+          testing::StartsWith("  Aggregation"),
+          testing::HasSubstr("sum(t2.c)"),
+          testing::AllOf(
+              testing::StartsWith("    GroupId"),
+              testing::HasSubstr("[gk3, gk4], [gk3], []")),
+          testing::HasSubstr("gk3 := "),
+          testing::HasSubstr("gk4 := "),
+          testing::HasSubstr("groupIdColumn:"),
+          testing::StartsWith("      TableScan"),
+          testing::HasSubstr("table:"),
+          testing::Eq("")));
+
+  auto oneline =
+      toOneline("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(oneline, testing::HasSubstr("groupid("));
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -460,5 +460,35 @@ TEST_F(RelationOpPrinterTest, maxDepth) {
   }
 }
 
+TEST_F(RelationOpPrinterTest, groupId) {
+  connector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto lines =
+      toLines("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("Project"),
+          testing::StartsWith("    "), // dt1.a := dt1.gk3
+          testing::StartsWith("    "), // dt1.b := dt1.gk4
+          testing::StartsWith("    "), // dt1.total := dt1.total
+          testing::StartsWith("  Aggregation"),
+          testing::HasSubstr("sum(t2.c)"),
+          testing::AllOf(
+              testing::StartsWith("    GroupId"),
+              testing::HasSubstr("[gk3, gk4], [gk3], []")),
+          testing::HasSubstr("gk3 := "),
+          testing::HasSubstr("gk4 := "),
+          testing::HasSubstr("groupId:"),
+          testing::StartsWith("      TableScan"),
+          testing::HasSubstr("table:"),
+          testing::Eq("")));
+
+  auto oneline =
+      toOneline("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(oneline, testing::HasSubstr("groupid("));
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -127,6 +127,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile(
       "distinctAggregation.sql");
   facebook::axiom::optimizer::test::registerQueryFile("unionAllFlatten.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("groupingsets.sql");
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -271,6 +271,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"distinctAggregation">();
   registerQueryFile<"unionAll">();
   registerQueryFile<"unionAllFlatten">();
+  registerQueryFile<"groupingsets">();
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -83,5 +83,7 @@ SELECT * FROM (VALUES ROW(1), ROW(CAST(2 AS bigint))) AS t(x)
 -- duckdb: VALUES (MAP {1::bigint: 1.0}), (MAP {2::bigint: 2.0})
 SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)]))) AS t(x)
 ----
--- error: Grouping sets are not supported yet
-SELECT count(*) FROM t GROUP BY GROUPING SETS ((a), ())
+-- NULLIF with non-deterministic expression. Result must contain only NULL and
+-- false, never true.
+-- duckdb: VALUES (null::boolean), (false)
+SELECT DISTINCT nullif(rand() < 0.5, true) FROM unnest(sequence(1, 1000))

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -89,5 +89,3 @@ SELECT * FROM (VALUES ROW(1), ROW(CAST(2 AS bigint))) AS t(x)
 -- duckdb: VALUES (MAP {1::bigint: 1.0}), (MAP {2::bigint: 2.0})
 SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)]))) AS t(x)
 ----
--- error: Grouping sets are not supported yet
-SELECT count(*) FROM t GROUP BY GROUPING SETS ((a), ())

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -1,0 +1,89 @@
+-- Table t(a BIGINT, b BIGINT) with 15 rows across 3 splits:
+--   a |   b
+--  ---+-----
+--   1 |  10
+--   2 |  20
+--   3 |  30
+--   1 |  40
+--   2 |  50
+--   3 |  60
+--   1 |  70
+--   2 |  80
+--   3 |  90
+--   1 | 100
+--   2 | 110
+--   3 | 120
+--   1 | 130
+--   2 | 140
+--   3 | 150
+--
+-- GROUPING SETS / ROLLUP / CUBE queries.
+
+-- Basic ROLLUP with SUM.
+SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- CUBE with SUM (same as ROLLUP for single key).
+SELECT a, sum(b) AS s FROM t GROUP BY CUBE(a)
+----
+-- Explicit GROUPING SETS.
+SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
+----
+-- ROLLUP with multiple keys.
+SELECT a, b, count(*) AS s FROM t GROUP BY ROLLUP(a, b)
+----
+-- Multiple aggregates with ROLLUP.
+SELECT a, sum(b) AS s, count(b) AS c, min(b) AS mn, max(b) AS mx FROM t GROUP BY ROLLUP(a)
+----
+-- Explicit GROUPING SETS with no global (empty) set.
+SELECT a, b, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), (b))
+----
+-- Grouping key is also an aggregation input.
+SELECT a, sum(a) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- Literal aggregate argument.
+SELECT a, count(1) AS c FROM t GROUP BY ROLLUP(a)
+----
+-- Composite aggregate argument with grouping key overlap.
+SELECT a, sum(a + b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- All identical grouping sets — each set computes separately per SQL standard.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- Multiple distinct sets with duplicates — preserved per SQL standard.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a), (b), (a))
+----
+-- Duplicate keys within a single grouping set are deduplicated.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, a), (b, b), (a, b))
+----
+-- GROUP BY DISTINCT removes duplicate grouping sets after expansion.
+-- duckdb: SELECT a, b, count(*) AS c FROM t GROUP BY a, b
+SELECT a, b, count(*) AS c FROM t GROUP BY DISTINCT GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- GROUP BY DISTINCT with ROLLUP deduplicates expanded sets.
+-- duckdb: SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+SELECT a, sum(b) AS s FROM t GROUP BY DISTINCT ROLLUP(a), ROLLUP(a)
+----
+-- Multi-key CUBE expands to all subsets: {a,b}, {a}, {b}, {}.
+SELECT a, b, sum(b) AS s FROM t GROUP BY CUBE(a, b)
+----
+-- WHERE filter with grouping sets.
+SELECT a, sum(b) AS s FROM t WHERE a > 1 GROUP BY ROLLUP(a)
+----
+-- HAVING filter with grouping sets (with aggregate).
+SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
+----
+-- HAVING filter with grouping sets (no aggregate, keys only).
+SELECT a FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
+----
+-- HAVING + ORDER BY with grouping sets.
+SELECT a AS foo FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL ORDER BY a DESC
+----
+-- TODO: Support DISTINCT aggregation with grouping sets.
+-- error: DISTINCT aggregation with grouping sets
+SELECT b, count(DISTINCT a) AS c FROM t GROUP BY ROLLUP(b)
+----
+-- TODO: Support ORDER BY in aggregates with global grouping sets. kSingle
+-- emits spurious default rows from empty driver partitions for the global set.
+-- error: ORDER BY in aggregate functions is not supported with global grouping sets
+SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)
+----

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -1,0 +1,90 @@
+-- setup_file: common_setup.sql
+-- Table t(a BIGINT, b BIGINT, c DOUBLE) with 15 rows across 3 splits:
+--   a |   b |    c
+--  ---+-----+------
+--   1 |  10
+--   2 |  20
+--   3 |  30
+--   1 |  40
+--   2 |  50
+--   3 |  60
+--   1 |  70
+--   2 |  80
+--   3 |  90
+--   1 | 100
+--   2 | 110
+--   3 | 120
+--   1 | 130
+--   2 | 140
+--   3 | 150
+--
+-- GROUPING SETS / ROLLUP / CUBE queries.
+
+-- Basic ROLLUP with SUM.
+SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- CUBE with SUM (same as ROLLUP for single key).
+SELECT a, sum(b) AS s FROM t GROUP BY CUBE(a)
+----
+-- Explicit GROUPING SETS.
+SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
+----
+-- ROLLUP with multiple keys.
+SELECT a, b, count(*) AS s FROM t GROUP BY ROLLUP(a, b)
+----
+-- Multiple aggregates with ROLLUP.
+SELECT a, sum(b) AS s, count(b) AS c, min(b) AS mn, max(b) AS mx FROM t GROUP BY ROLLUP(a)
+----
+-- Explicit GROUPING SETS with no global (empty) set.
+SELECT a, b, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), (b))
+----
+-- Grouping key is also an aggregation input.
+SELECT a, sum(a) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- Literal aggregate argument.
+SELECT a, count(1) AS c FROM t GROUP BY ROLLUP(a)
+----
+-- Composite aggregate argument with grouping key overlap.
+SELECT a, sum(a + b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- All identical grouping sets — each set computes separately per SQL standard.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- Multiple distinct sets with duplicates — preserved per SQL standard.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a), (b), (a))
+----
+-- Duplicate keys within a single grouping set are deduplicated.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, a), (b, b), (a, b))
+----
+-- GROUP BY DISTINCT removes duplicate grouping sets after expansion.
+-- duckdb: SELECT a, b, count(*) AS c FROM t GROUP BY a, b
+SELECT a, b, count(*) AS c FROM t GROUP BY DISTINCT GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- GROUP BY DISTINCT with ROLLUP deduplicates expanded sets.
+-- duckdb: SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+SELECT a, sum(b) AS s FROM t GROUP BY DISTINCT ROLLUP(a), ROLLUP(a)
+----
+-- Multi-key CUBE expands to all subsets: {a,b}, {a}, {b}, {}.
+SELECT a, b, sum(b) AS s FROM t GROUP BY CUBE(a, b)
+----
+-- WHERE filter with grouping sets.
+SELECT a, sum(b) AS s FROM t WHERE a > 1 GROUP BY ROLLUP(a)
+----
+-- HAVING filter with grouping sets (with aggregate).
+SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
+----
+-- HAVING filter with grouping sets (no aggregate, keys only).
+SELECT a FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
+----
+-- HAVING + ORDER BY with grouping sets.
+SELECT a AS foo FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL ORDER BY a DESC
+----
+-- TODO: Support DISTINCT aggregation with grouping sets.
+-- error: DISTINCT aggregation with grouping sets
+SELECT b, count(DISTINCT a) AS c FROM t GROUP BY ROLLUP(b)
+----
+-- TODO: Support ORDER BY in aggregates with global grouping sets. kSingle
+-- emits spurious default rows from empty driver partitions for the global set.
+-- error: ORDER BY in aggregate functions is not supported with global grouping sets
+SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)
+----


### PR DESCRIPTION
Summary:

Adds the physical GroupId operator that materializes GROUPING SETS semantics during plan optimization. The logical representation (AggregateNode with groupingSets) is established by the parser; this diff translates it into an executable physical plan.

GroupId duplicates each input row once per grouping set, NULLing out columns not in the active set and tagging each copy with a set ID. A single aggregation then groups by all keys + set ID to produce detail rows, subtotals, and grand totals in one pass.

```sql
SELECT a, b, SUM(x) FROM t GROUP BY ROLLUP(a, b)
-- Produces grouping sets: (a, b), (a), ()

SELECT a, b, SUM(x) FROM t GROUP BY CUBE(a, b)
-- Produces grouping sets: (a, b), (a), (b), ()
```

**Design Decisions:**
- GroupId is physical-only — `AggregateNode` with `groupingSets` captures the logical semantics, the optimizer materializes GroupId during plan generation.
- Grouping keys get auto-generated output column names. When a key is also an aggregate input (e.g. `sum(a) GROUP BY ROLLUP(a)`), GroupId produces a nullable output key and a separate pass-through for the aggregate — no overlap detection needed.
- When GROUP BY DISTINCT collapses to a single set, Axiom skips GroupId and uses regular GROUP BY.
- Global grouping sets require split (partial + final) aggregation (https://github.com/facebookincubator/velox/issues/17312). Single-step parallel aggregation duplicates the default row.
- Duplicate grouping sets produce duplicate output rows per SQL:2011 (S7.12). The current implementation computes each duplicate set independently. A future optimization can compute once and replicate rows.

**Not yet supported (subsequent PRs):**
- ORDER BY + global grouping sets: Partial aggregation cannot preserve ORDER BY semantics, and global grouping sets (from ROLLUP, CUBE, or GROUPING SETS containing `()`) require partial+final. Currently rejected at plan time.
- DISTINCT + grouping sets: Requires integrating transformDistinctToGroupBy with GroupId.
- HAVING pushdown for grouping sets (https://github.com/facebookincubator/axiom/issues/1338): HAVING filters on grouping keys stay above aggregation when grouping sets are present. A follow-up will push them between GroupId and Aggregation.
- Cross-set computation de-dup: Identical grouping sets (e.g., (a, b) and (b, a)) compute separately today. A future optimization can compute once and replicate rows.
- GroupIdNode: identify groupId column by index instead of name.

Reviewed By: mbasmanova

Differential Revision: D94281152


