### PR TITLE
feat: Implement GROUPING() function for GROUPING SETS (#965)

### DIFF
--- a/axiom/optimizer/docs/GroupingSets.md
+++ b/axiom/optimizer/docs/GroupingSets.md
@@ -1,0 +1,165 @@
+# Grouping Sets, GroupId, and GROUPING()
+
+This document describes how Axiom handles queries with multiple grouping
+sets — GROUP BY ROLLUP, CUBE, GROUPING SETS — and the companion GROUPING()
+function that disambiguates rolled-up NULLs from real NULLs.
+
+## Grouping Set Expansion
+
+SQL provides three shorthands for requesting multiple aggregation levels in
+a single query. The parser expands each into an explicit list of grouping
+sets before any planning happens:
+
+```sql
+-- ROLLUP drops columns right to left (hierarchical subtotals)
+GROUP BY ROLLUP(a, b)
+-- expands to: GROUPING SETS ((a, b), (a), ())
+
+-- CUBE generates all 2^n combinations
+GROUP BY CUBE(a, b)
+-- expands to: GROUPING SETS ((a, b), (a), (b), ())
+
+-- GROUPING SETS passes through as-is
+GROUP BY GROUPING SETS ((a), (b))
+-- stays: GROUPING SETS ((a), (b))
+```
+
+Mixed forms are also supported. `GROUP BY a, ROLLUP(b)` computes the
+Cartesian product of the plain key and the rollup expansion, producing
+`GROUPING SETS ((a, b), (a))`.
+
+Duplicate grouping sets are preserved per the SQL standard — each set
+produces its own row group. `GROUP BY DISTINCT` removes duplicates after
+expansion.
+
+The expansion happens in `GroupByPlanner::expandGroupingSets()`, which
+delegates to `expandRollup()`, `expandCube()`, and
+`crossProductGroupingSets()`.
+
+## GroupId Operator
+
+After expansion, the optimizer needs to produce all subtotals in a single
+pass. The naive approach — run a separate GROUP BY for each set and UNION
+the results — scans the input once per set. For CUBE with N columns that
+means 2^N scans, which doesn't scale.
+
+Instead, Axiom inserts a GroupId operator that duplicates each input row
+once per grouping set, NULLing out columns not in the active set and
+tagging each copy with a sequential set ID. A single aggregation then
+groups by all keys plus the set ID, producing detail rows, subtotals, and
+grand totals in one pass.
+
+Consider `SELECT a, sum(b) FROM t GROUP BY ROLLUP(a)` with two rows:
+
+```
+Input:     a=1, b=10
+           a=2, b=20
+
+GroupId output (2 rows × 2 sets = 4 rows):
+           a=1,    b=10, set_id=0    ← set (a): a kept
+           a=NULL, b=10, set_id=1    ← set (): a NULLed
+           a=2,    b=20, set_id=0
+           a=NULL, b=20, set_id=1
+
+Aggregation (GROUP BY a, set_id):
+           a=1,    sum=10, set_id=0  ← detail
+           a=2,    sum=20, set_id=0  ← detail
+           a=NULL, sum=30, set_id=1  ← grand total
+```
+
+### Where GroupId Lives
+
+GroupId is a physical-only operator. The logical plan carries grouping sets
+on AggregateNode — no GroupIdNode in the logical plan. This keeps optimizer
+rules simple: they see AggregateNode with a `groupingSets` field and don't
+need to reason about row duplication.
+
+GroupId is introduced during optimization by
+`AggregationPlanner::addGroupingSetsAggregation()`. For a plain GROUP BY
+(no ROLLUP/CUBE/GROUPING SETS), none of this code runs — a regular
+aggregation is planned as before.
+
+## GROUPING() Function
+
+GROUPING() tells you whether a NULL in the result came from the data or
+from rolling up a grouping set. Without it, a grand total row
+(`a=NULL, sum=30`) is indistinguishable from a row where `a` is genuinely
+NULL.
+
+```sql
+SELECT a, GROUPING(a), sum(b) FROM t GROUP BY ROLLUP(a)
+
+a      grp  sum
+1      0    10     ← a present (0)
+2      0    20     ← a present (0)
+NULL   1    30     ← a rolled up (1)
+```
+
+For multiple columns, GROUPING(a, b) returns a bitmask with the leftmost
+argument as the most significant bit.
+
+### How It Works
+
+ExpressionPlanner emits `Call("grouping", [Col("a"), Col("b")])` — a
+regular function call used as a marker. GroupByPlanner finds these by name
+after grouping set deduplication and rewrites inline to:
+
+```
+element_at(
+    array[bitmask_for_set_0, bitmask_for_set_1, ...],
+    $grouping_set_id + 1
+)
+```
+
+The bitmask for each set is precomputed at plan time. The result is built
+entirely from existing `lp::` primitives (Lit, Col, Call). No new Velox
+types or APIs needed.
+
+By the time the plan reaches the optimizer, GROUPING() has been replaced
+with standard function calls. The optimizer and Velox have no awareness
+of GROUPING().
+
+### Dialect Independence
+
+Only the SQL parser layer is dialect-specific:
+
+- **ExpressionPlanner** (in `axiom/sql/presto/`) creates
+  `Call("grouping", args)` from the Presto GROUPING() AST node.
+- **GroupByPlanner** (in `axiom/sql/presto/`) resolves the marker and
+  builds the element_at expression using `"$grouping_set_id"` as the
+  GroupId column name.
+
+Adding GROUPING() support for a new dialect requires only parser-layer
+changes. The optimizer and Velox require zero modifications.
+
+### Validation
+
+ExpressionPlanner validates GROUPING() via the `ExprOptions.allowGrouping`
+flag, which defaults to `false`. Only the GROUP BY path (SELECT, HAVING,
+ORDER BY) sets it to `true`. This means GROUPING() is automatically
+rejected in all other contexts (WHERE, JOIN ON, standalone queries without
+GROUP BY) without needing per-context checks.
+
+GroupByPlanner validates GROUPING() usage at plan time:
+
+- GROUPING() with plain GROUP BY (no ROLLUP/CUBE/GROUPING SETS) returns
+  0. Every column is always present in the single grouping set.
+- GROUPING() without any GROUP BY clause is rejected (allowGrouping is
+  false by default).
+- GROUPING() referencing a column not in the grouping keys is rejected.
+- GROUPING() arguments must be column references (not expressions).
+- GROUPING() inside aggregate function arguments, FILTER, or ORDER BY
+  is rejected.
+
+## Unsupported Combinations
+
+> **Not yet implemented.** The following query shapes are rejected at plan
+> time with user-facing errors.
+
+- `count(DISTINCT x)` with ROLLUP/CUBE/GROUPING SETS — requires
+  integrating `transformDistinctToGroupBy` with GroupId.
+- `array_agg(x ORDER BY x)` with a global (empty) grouping set
+  ([velox#17312](https://github.com/facebookincubator/velox/issues/17312)).
+- HAVING filter pushdown between GroupId and Aggregation is disabled when
+  grouping sets are present. Queries pass but the aggregation is
+  unoptimized.

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -79,6 +79,42 @@ SELECT a FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
 -- HAVING + ORDER BY with grouping sets.
 SELECT a AS foo FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL ORDER BY a DESC
 ----
+-- GROUPING() returns bitmask: 0 if column present, 1 if aggregated.
+SELECT a, GROUPING(a), sum(b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- GROUPING() with multiple columns.
+SELECT a, b, GROUPING(a, b), sum(b) AS s FROM t GROUP BY CUBE(a, b)
+----
+-- GROUPING() with single grouping set.
+SELECT a, GROUPING(a), count(*) AS c FROM t GROUP BY GROUPING SETS ((a))
+----
+-- GROUPING() with plain GROUP BY returns 0.
+SELECT a, GROUPING(a), count(*) AS c FROM t GROUP BY a
+----
+-- GROUPING() in HAVING.
+SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a) HAVING GROUPING(a) = 0
+----
+-- GROUPING() in ORDER BY.
+-- ordered
+SELECT a, GROUPING(a) AS grp, sum(b) AS s FROM t GROUP BY ROLLUP(a) ORDER BY GROUPING(a), a
+----
+-- GROUPING() with reversed arg order.
+SELECT a, b, GROUPING(b, a), sum(b) AS s FROM t GROUP BY CUBE(a, b)
+----
+-- GROUPING() with empty grouping set.
+SELECT a, GROUPING(a), sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
+----
+-- GROUPING() with duplicate grouping sets.
+SELECT a, GROUPING(a), count(*) AS c FROM t GROUP BY GROUPING SETS ((a), (a), (a, b))
+----
+-- SELECT aliases are not visible in HAVING (standard SQL — HAVING runs before SELECT).
+-- error: HAVING clause cannot reference column
+SELECT a, GROUPING(a) AS grp, sum(b) AS s FROM t GROUP BY ROLLUP(a) HAVING grp = 0
+----
+-- GROUPING() with non-grouping column is rejected.
+-- error: Not a grouping column
+SELECT a, GROUPING(b), count(*) AS c FROM t GROUP BY ROLLUP(a)
+----
 -- error: DISTINCT aggregation with grouping sets is not supported yet
 SELECT b, count(DISTINCT a) AS c FROM t GROUP BY ROLLUP(b)
 ----

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -24,6 +24,7 @@
 
 #include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/sql/presto/GroupByPlanner.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "velox/exec/Aggregate.h"
@@ -702,7 +703,9 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
   return veloxType;
 }
 
-lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
+lp::ExprApi ExpressionPlanner::toExpr(
+    const ExpressionPtr& node,
+    ExprOptions options) {
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());
@@ -768,7 +771,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         }
         return lp::Col(field, lp::Col(qualifier));
       }
-      return lp::Col(field, toExpr(dereference->base()));
+      return lp::Col(field, toExpr(dereference->base(), options));
     }
 
     case NodeType::kSubqueryExpression: {
@@ -779,23 +782,23 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* comparison = node->as<ComparisonExpression>();
       return lp::Call(
           toFunctionName(comparison->op()),
-          toExpr(comparison->left()),
-          toExpr(comparison->right()));
+          toExpr(comparison->left(), options),
+          toExpr(comparison->right(), options));
     }
 
     case NodeType::kNotExpression: {
       auto* negation = node->as<NotExpression>();
-      return lp::Call("not", toExpr(negation->value()));
+      return lp::Call("not", toExpr(negation->value(), options));
     }
 
     case NodeType::kLikePredicate: {
       auto* like = node->as<LikePredicate>();
 
       std::vector<lp::ExprApi> inputs;
-      inputs.emplace_back(toExpr(like->value()));
-      inputs.emplace_back(toExpr(like->pattern()));
+      inputs.emplace_back(toExpr(like->value(), options));
+      inputs.emplace_back(toExpr(like->pattern(), options));
       if (like->escape()) {
-        inputs.emplace_back(toExpr(like->escape()));
+        inputs.emplace_back(toExpr(like->escape(), options));
       }
 
       return lp::Call("like", std::move(inputs));
@@ -803,8 +806,8 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kLogicalBinaryExpression: {
       auto* logical = node->as<LogicalBinaryExpression>();
-      auto left = toExpr(logical->left());
-      auto right = toExpr(logical->right());
+      auto left = toExpr(logical->left(), options);
+      auto right = toExpr(logical->right(), options);
 
       switch (logical->op()) {
         case LogicalBinaryExpression::Operator::kAnd:
@@ -818,34 +821,34 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     case NodeType::kArithmeticUnaryExpression: {
       auto* unary = node->as<ArithmeticUnaryExpression>();
       if (unary->sign() == ArithmeticUnaryExpression::Sign::kMinus) {
-        return lp::Call("negate", toExpr(unary->value()));
+        return lp::Call("negate", toExpr(unary->value(), options));
       }
 
-      return toExpr(unary->value());
+      return toExpr(unary->value(), options);
     }
 
     case NodeType::kArithmeticBinaryExpression: {
       auto* binary = node->as<ArithmeticBinaryExpression>();
       return lp::Call(
           toFunctionName(binary->op()),
-          toExpr(binary->left()),
-          toExpr(binary->right()));
+          toExpr(binary->left(), options),
+          toExpr(binary->right(), options));
     }
 
     case NodeType::kBetweenPredicate: {
       auto* between = node->as<BetweenPredicate>();
       return lp::Call(
           "between",
-          toExpr(between->value()),
-          toExpr(between->min()),
-          toExpr(between->max()));
+          toExpr(between->value(), options),
+          toExpr(between->min(), options),
+          toExpr(between->max(), options));
     }
 
     case NodeType::kInPredicate: {
       auto* inPredicate = node->as<InPredicate>();
       const auto& valueList = inPredicate->valueList();
 
-      const auto value = toExpr(inPredicate->value());
+      const auto value = toExpr(inPredicate->value(), options);
 
       if (valueList->is(NodeType::kInListExpression)) {
         auto inList = valueList->as<InListExpression>();
@@ -855,14 +858,14 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
         inputs.emplace_back(value);
         for (const auto& expr : inList->values()) {
-          inputs.emplace_back(toExpr(expr));
+          inputs.emplace_back(toExpr(expr, options));
         }
 
         return lp::Call("in", inputs);
       }
 
       if (valueList->is(NodeType::kSubqueryExpression)) {
-        return lp::Call("in", value, toExpr(valueList));
+        return lp::Call("in", value, toExpr(valueList, options));
       }
 
       AXIOM_PRESTO_SEMANTIC_FAIL(
@@ -883,9 +886,9 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       const auto type = resolveType(cast->toType());
 
       if (cast->isSafe()) {
-        return lp::TryCast(type, toExpr(cast->expression()));
+        return lp::TryCast(type, toExpr(cast->expression(), options));
       } else {
-        return lp::Cast(type, toExpr(cast->expression()));
+        return lp::Cast(type, toExpr(cast->expression(), options));
       }
     }
 
@@ -893,25 +896,26 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* atTimeZone = node->as<AtTimeZone>();
       return lp::Call(
           "at_timezone",
-          toExpr(atTimeZone->value()),
-          toExpr(atTimeZone->timeZone()));
+          toExpr(atTimeZone->value(), options),
+          toExpr(atTimeZone->timeZone(), options));
     }
 
     case NodeType::kSimpleCaseExpression: {
       auto* simpleCase = node->as<SimpleCaseExpression>();
 
-      const auto operand = toExpr(simpleCase->operand());
+      const auto operand = toExpr(simpleCase->operand(), options);
 
       std::vector<lp::ExprApi> inputs;
       inputs.reserve(1 + simpleCase->whenClauses().size());
 
       for (const auto& clause : simpleCase->whenClauses()) {
-        inputs.emplace_back(lp::Call("eq", operand, toExpr(clause->operand())));
-        inputs.emplace_back(toExpr(clause->result()));
+        inputs.emplace_back(
+            lp::Call("eq", operand, toExpr(clause->operand(), options)));
+        inputs.emplace_back(toExpr(clause->result(), options));
       }
 
       if (simpleCase->defaultValue()) {
-        inputs.emplace_back(toExpr(simpleCase->defaultValue()));
+        inputs.emplace_back(toExpr(simpleCase->defaultValue(), options));
       }
 
       return lp::Call("switch", inputs);
@@ -928,12 +932,12 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         if (clause->operand()->is(NodeType::kNullLiteral)) {
           continue;
         }
-        inputs.emplace_back(toExpr(clause->operand()));
-        inputs.emplace_back(toExpr(clause->result()));
+        inputs.emplace_back(toExpr(clause->operand(), options));
+        inputs.emplace_back(toExpr(clause->result(), options));
       }
 
       if (searchedCase->defaultValue()) {
-        inputs.emplace_back(toExpr(searchedCase->defaultValue()));
+        inputs.emplace_back(toExpr(searchedCase->defaultValue(), options));
       }
 
       // All WHEN clauses were dropped (all had NULL conditions).
@@ -951,7 +955,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kExtract: {
       auto* extract = node->as<Extract>();
-      auto expr = toExpr(extract->expression());
+      auto expr = toExpr(extract->expression(), options);
 
       switch (extract->field()) {
         case Extract::Field::kYear:
@@ -1095,7 +1099,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* array = node->as<ArrayConstructor>();
       std::vector<lp::ExprApi> values;
       for (const auto& value : array->values()) {
-        values.emplace_back(toExpr(value));
+        values.emplace_back(toExpr(value, options));
       }
 
       return lp::Call("array_constructor", values);
@@ -1105,7 +1109,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* row = node->as<Row>();
       std::vector<lp::ExprApi> items;
       for (const auto& item : row->items()) {
-        items.emplace_back(toExpr(item));
+        items.emplace_back(toExpr(item, options));
       }
 
       return lp::Call("row_constructor", items);
@@ -1116,7 +1120,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       std::vector<core::ExprPtr> childExprs;
       childExprs.reserve(row->items().size());
       for (const auto& item : row->items()) {
-        childExprs.push_back(toExpr(item).expr());
+        childExprs.push_back(toExpr(item, options).expr());
       }
       return lp::ExprApi{std::make_shared<core::ConcatExpr>(
           row->fieldNames(), std::move(childExprs))};
@@ -1125,7 +1129,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     case NodeType::kFunctionCall: {
       auto* call = node->as<FunctionCall>();
 
-      auto args = translateArgs(call->arguments());
+      auto args = translateArgs(call->arguments(), options);
 
       const auto& funcName = call->name()->suffix();
       const auto lowerFuncName = canonicalizeName(funcName);
@@ -1141,13 +1145,13 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       }
 
       if (call->isDistinct() || call->filter() || call->orderBy()) {
-        return toAggregateCallExpr(call, funcName, args);
+        return toAggregateCallExpr(call, funcName, args, options);
       }
 
       auto callExpr = lp::Call(funcName, args);
 
       if (call->window() != nullptr) {
-        auto windowSpec = convertWindow(call->window());
+        auto windowSpec = convertWindow(call->window(), options);
         if (call->ignoreNulls()) {
           windowSpec.ignoreNulls();
         }
@@ -1173,23 +1177,26 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         lambdaParamScope_.resize(scopeBegin);
       };
 
-      return lp::Lambda(names, toExpr(lambda->body()));
+      return lp::Lambda(names, toExpr(lambda->body(), options));
     }
 
     case NodeType::kSubscriptExpression: {
       auto* subscript = node->as<SubscriptExpression>();
       return lp::Call(
-          "subscript", toExpr(subscript->base()), toExpr(subscript->index()));
+          "subscript",
+          toExpr(subscript->base(), options),
+          toExpr(subscript->index(), options));
     }
 
     case NodeType::kIsNullPredicate: {
       auto* isNull = node->as<IsNullPredicate>();
-      return lp::Call("is_null", toExpr(isNull->value()));
+      return lp::Call("is_null", toExpr(isNull->value(), options));
     }
 
     case NodeType::kIsNotNullPredicate: {
       auto* isNull = node->as<IsNotNullPredicate>();
-      return lp::Call("not", lp::Call("is_null", toExpr(isNull->value())));
+      return lp::Call(
+          "not", lp::Call("is_null", toExpr(isNull->value(), options)));
     }
 
     case NodeType::kCurrentTime: {
@@ -1214,6 +1221,22 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
           return lp::Call("localtimestamp");
       }
       VELOX_UNREACHABLE();
+    }
+
+    case NodeType::kGroupingOperation: {
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          options.allowGrouping,
+          node->location(),
+          std::nullopt,
+          "GROUPING() is not allowed in this context");
+      const auto* groupingOp = node->as<GroupingOperation>();
+      std::vector<lp::ExprApi> columnArgs;
+      columnArgs.reserve(groupingOp->groupingColumns().size());
+      for (const auto& column : groupingOp->groupingColumns()) {
+        columnArgs.push_back(lp::Col(canonicalizeName(column->suffix())));
+      }
+      return lp::Call(
+          std::string(GroupByPlanner::kGroupingFunctionName), columnArgs);
     }
 
     default:
@@ -1479,11 +1502,12 @@ std::optional<lp::ExprApi> ExpressionPlanner::tryLiftPureOuterAggregate(
 }
 
 std::vector<lp::ExprApi> ExpressionPlanner::translateArgs(
-    const std::vector<ExpressionPtr>& arguments) {
+    const std::vector<ExpressionPtr>& arguments,
+    ExprOptions options) {
   std::vector<lp::ExprApi> args;
   args.reserve(arguments.size());
   for (const auto& arg : arguments) {
-    args.push_back(toExpr(arg));
+    args.push_back(toExpr(arg, options));
   }
   return args;
 }
@@ -1491,10 +1515,11 @@ std::vector<lp::ExprApi> ExpressionPlanner::translateArgs(
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     const FunctionCall* call,
     const std::string& funcName,
-    const std::vector<lp::ExprApi>& args) {
+    const std::vector<lp::ExprApi>& args,
+    ExprOptions /*options*/) {
   core::ExprPtr filterExpr;
   if (call->filter() != nullptr) {
-    filterExpr = toExpr(call->filter()).expr();
+    filterExpr = toExpr(call->filter(), {}).expr();
   }
 
   std::vector<core::SortKey> sortKeys;
@@ -1504,7 +1529,7 @@ lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
       VELOX_CHECK_NOT_NULL(
           sortingKeyResolver_,
           "Sorting key resolution requires a SortingKeyResolver");
-      auto keyExpr = sortingKeyResolver_(item->sortKey());
+      auto keyExpr = sortingKeyResolver_(item->sortKey(), {});
       sortKeys.push_back(
           {keyExpr.expr(), item->isAscending(), item->isNullsFirst()});
     }
@@ -1520,14 +1545,15 @@ lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
 }
 
 lp::WindowSpec ExpressionPlanner::convertWindow(
-    const std::shared_ptr<Window>& window) {
+    const std::shared_ptr<Window>& window,
+    ExprOptions options) {
   lp::WindowSpec spec;
 
   if (!window->partitionBy().empty()) {
     std::vector<lp::ExprApi> partitionKeys;
     partitionKeys.reserve(window->partitionBy().size());
     for (const auto& key : window->partitionBy()) {
-      partitionKeys.push_back(toExpr(key));
+      partitionKeys.push_back(toExpr(key, options));
     }
     spec.partitionBy(std::move(partitionKeys));
   }
@@ -1538,7 +1564,9 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
     orderByKeys.reserve(sortItems.size());
     for (const auto& item : sortItems) {
       orderByKeys.emplace_back(
-          toExpr(item->sortKey()), item->isAscending(), item->isNullsFirst());
+          toExpr(item->sortKey(), options),
+          item->isAscending(),
+          item->isNullsFirst());
     }
     spec.orderBy(orderByKeys);
   }
@@ -1549,7 +1577,7 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
     auto startType = toWindowBoundType(frame->start()->boundType());
     std::optional<lp::ExprApi> startValue;
     if (frame->start()->value().has_value()) {
-      startValue = toExpr(frame->start()->value().value());
+      startValue = toExpr(frame->start()->value().value(), options);
     }
 
     auto endType = frame->end() != nullptr
@@ -1557,7 +1585,7 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
         : core::WindowCallExpr::BoundType::kCurrentRow;
     std::optional<lp::ExprApi> endValue;
     if (frame->end() != nullptr && frame->end()->value().has_value()) {
-      endValue = toExpr(frame->end()->value().value());
+      endValue = toExpr(frame->end()->value().value(), options);
     }
 
     // For RANGE n PRECEDING / n FOLLOWING the execution engine compares the

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -47,6 +47,13 @@ facebook::velox::TypePtr parseType(const TypeSignaturePtr& type);
 /// subqueries) are rejected.
 bool isOuterScopeAggregateLiftCandidate(Query* query);
 
+/// Options for context-specific validation during expression translation.
+struct ExprOptions {
+  /// Whether GROUPING() expressions are allowed. Defaults to false so that
+  /// GROUPING() is rejected unless explicitly enabled by the GROUP BY path.
+  bool allowGrouping{false};
+};
+
 /// Translates Presto SQL AST expression nodes into logical plan ExprApi
 /// objects. Handles all expression types (literals, comparisons, arithmetic,
 /// function calls, casts, subqueries, etc.).
@@ -82,8 +89,8 @@ class ExpressionPlanner {
   /// functions). Required when the expression may contain aggregate function
   /// calls with ORDER BY clauses. Can be nullptr if aggregates with ORDER BY
   /// are not expected.
-  using SortingKeyResolver =
-      std::function<lp::ExprApi(const ExpressionPtr& expr)>;
+  using SortingKeyResolver = std::function<
+      lp::ExprApi(const ExpressionPtr& expr, ExprOptions options)>;
 
   /// Returns true if the table qualifier should be dropped from a column
   /// reference (e.g. t.col -> col).
@@ -123,7 +130,7 @@ class ExpressionPlanner {
   /// Translates an AST expression into an ExprApi. Aggregate options
   /// (DISTINCT, FILTER, ORDER BY) are embedded in the returned ExprApi via
   /// AggregateCallExpr. Window functions are embedded via WindowCallExpr.
-  lp::ExprApi toExpr(const ExpressionPtr& node);
+  lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {});
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.
   /// When set, Identifier nodes matching an alias key are resolved to the
@@ -155,18 +162,22 @@ class ExpressionPlanner {
       std::vector<const facebook::velox::core::IExpr*>& traversalOrder);
 
   // Converts a Window AST node into a WindowSpec.
-  lp::WindowSpec convertWindow(const std::shared_ptr<Window>& window);
+  lp::WindowSpec convertWindow(
+      const std::shared_ptr<Window>& window,
+      ExprOptions options);
 
   // Translates each AST argument via `toExpr`.
   std::vector<lp::ExprApi> translateArgs(
-      const std::vector<ExpressionPtr>& arguments);
+      const std::vector<ExpressionPtr>& arguments,
+      ExprOptions options = {});
 
   // Builds an AggregateCallExpr from a FunctionCall AST node that has
   // DISTINCT, FILTER, or ORDER BY.
   lp::ExprApi toAggregateCallExpr(
       const FunctionCall* call,
       const std::string& funcName,
-      const std::vector<lp::ExprApi>& args);
+      const std::vector<lp::ExprApi>& args,
+      ExprOptions options);
 
   // Plans `subquery` via `subqueryPlanner_` and wraps the resulting
   // plan as an `lp::Subquery` expression, caching by AST identity.

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -319,6 +319,33 @@ std::vector<std::vector<lp::ExprApi>> crossProductGroupingSets(
   return combined;
 }
 
+constexpr std::string_view kGroupingSetIdColumn = "$grouping_set_id";
+
+const core::CallExpr* FOLLY_NULLABLE asGroupingCall(const core::ExprPtr& expr) {
+  if (expr->is(core::IExpr::Kind::kCall)) {
+    auto* call = expr->as<core::CallExpr>();
+    if (call->name() == GroupByPlanner::kGroupingFunctionName) {
+      return call;
+    }
+  }
+  return nullptr;
+}
+
+// Rejects GROUPING() inside aggregate function arguments.
+void rejectGroupingInAggregates(const core::ExprPtr& expr) {
+  if (asGroupingCall(expr)) {
+    throw PrestoSqlError(
+        "GROUPING() is not allowed in this context",
+        0,
+        0,
+        std::nullopt,
+        PrestoSqlErrorKind::kSemantic);
+  }
+  for (const auto& input : expr->inputs()) {
+    rejectGroupingInAggregates(input);
+  }
+}
+
 // Removes duplicate grouping sets from 'groupingSetsIndices'. Two sets are
 // duplicates if they contain the same key indices (order-insensitive).
 void deduplicateGroupingSets(
@@ -356,11 +383,30 @@ void GroupByPlanner::plan(
     deduplicateGroupingSets(groupingSetsIndices_);
   }
 
+  // Populate groupingColumnToIndex_ for GROUPING() resolution.
+  for (size_t i = 0; i < groupingKeys_.size(); ++i) {
+    if (const auto* fieldAccess =
+            core::FieldAccessExpr::tryAsRootColumn(groupingKeys_[i].expr())) {
+      groupingColumnToIndex_[fieldAccess->name()] = static_cast<int32_t>(i);
+    }
+  }
+
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
   // function calls, then add the Aggregate plan node.
   // Populates: aggregates_, projections_, filter_,
   //   sortingKeyExprs_, outputNames_.
   collectAggregates(selectExprs, having, orderBy);
+
+  for (const auto& agg : aggregates_) {
+    rejectGroupingInAggregates(agg.expr());
+  }
+
+  resolveGroupingCalls(projections_);
+  if (filter_.has_value()) {
+    filter_ =
+        lp::ExprApi(rewriteGroupingMarker(filter_->expr()), filter_->alias());
+  }
+  resolveGroupingCalls(sortingKeyExprs_);
 
   addAggregate(groupingSetsIndices_.size() > 1);
 
@@ -540,7 +586,7 @@ void GroupByPlanner::collectAggregates(
   }
 
   if (having != nullptr) {
-    lp::ExprApi expr = exprPlanner_.toExpr(having);
+    lp::ExprApi expr = exprPlanner_.toExpr(having, {.allowGrouping = true});
     findAggregates(expr.expr(), aggregates_, aggregateSet);
     filter_ = expr;
   }
@@ -548,7 +594,7 @@ void GroupByPlanner::collectAggregates(
   if (orderBy != nullptr) {
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
-      auto expr = exprPlanner_.toExpr(item->sortKey());
+      auto expr = exprPlanner_.toExpr(item->sortKey(), {.allowGrouping = true});
       findAggregates(expr.expr(), aggregates_, aggregateSet);
       sortingKeyExprs_.emplace_back(expr);
     }
@@ -601,7 +647,7 @@ void GroupByPlanner::addAggregate(bool useGroupingSets) {
         groupingKeys_,
         groupingSetsIndices_,
         aggregateExprs,
-        "$grouping_set_id");
+        std::string(kGroupingSetIdColumn));
   } else {
     builder_->aggregate(groupingKeys_, aggregateExprs);
   }
@@ -633,6 +679,13 @@ void GroupByPlanner::rewritePostAggregateExprs() {
     flatInputs_.emplace_back(lp::Col(outputNames_.at(index)));
     aggregateInputs.emplace(agg.expr(), flatInputs_.back().expr());
     ++index;
+  }
+
+  // GROUPING() resolution introduces Col(kGroupingSetIdColumn) references.
+  // Add an identity mapping so replaceInputs passes them through.
+  if (groupingSetsIndices_.size() > 1) {
+    auto groupingSetIdCol = lp::Col(std::string(kGroupingSetIdColumn)).expr();
+    keyInputs.emplace(groupingSetIdCol, groupingSetIdCol);
   }
 
   if (filter_.has_value()) {
@@ -808,6 +861,89 @@ std::vector<lp::ExprApi> GroupByPlanner::resolveWithCache(
     }
   }
   return result;
+}
+
+core::ExprPtr GroupByPlanner::rewriteGroupingMarker(const core::ExprPtr& expr) {
+  if (auto* call = asGroupingCall(expr)) {
+    std::vector<int32_t> columnIndices;
+    columnIndices.reserve(call->inputs().size());
+    for (const auto& input : call->inputs()) {
+      auto* field = core::FieldAccessExpr::tryAsRootColumn(input);
+      VELOX_USER_CHECK_NOT_NULL(
+          field, "GROUPING() arguments must be column references");
+      auto it = groupingColumnToIndex_.find(field->name());
+      VELOX_USER_CHECK(
+          it != groupingColumnToIndex_.end(),
+          "Not a grouping column: {}",
+          field->name());
+      columnIndices.push_back(it->second);
+    }
+
+    VELOX_USER_CHECK(
+        !columnIndices.empty(),
+        "GROUPING() requires at least one column argument");
+    // Bitmask is int64, so at most 63 columns (sign bit excluded).
+    VELOX_USER_CHECK_LE(
+        columnIndices.size(),
+        63,
+        "GROUPING() supports up to 63 column arguments");
+
+    if (groupingSetsIndices_.size() == 1) {
+      return lp::Lit(static_cast<int64_t>(0)).expr();
+    }
+
+    // MSB = leftmost arg. Bit is 0 when column is present in the
+    // active set, 1 when rolled up (absent).
+    folly::F14FastSet<int32_t> setIndices;
+    std::vector<Variant> bitmaskValues;
+    bitmaskValues.reserve(groupingSetsIndices_.size());
+    for (const auto& groupingSet : groupingSetsIndices_) {
+      int64_t bitmask =
+          static_cast<int64_t>((1ULL << columnIndices.size()) - 1);
+      setIndices.clear();
+      setIndices.insert(groupingSet.begin(), groupingSet.end());
+      for (size_t i = 0; i < columnIndices.size(); ++i) {
+        if (setIndices.contains(columnIndices[i])) {
+          bitmask &=
+              ~static_cast<int64_t>(1ULL << (columnIndices.size() - 1 - i));
+        }
+      }
+      bitmaskValues.emplace_back(bitmask);
+    }
+
+    // element_at is 1-indexed; $grouping_set_id is 0-based.
+    return lp::Call(
+               "element_at",
+               lp::Lit(Variant::array(std::move(bitmaskValues))),
+               lp::Call(
+                   "plus",
+                   lp::Col(std::string(kGroupingSetIdColumn)),
+                   lp::Lit(static_cast<int64_t>(1))))
+        .expr();
+  }
+
+  std::vector<core::ExprPtr> newInputs;
+  bool changed = false;
+  for (const auto& input : expr->inputs()) {
+    auto resolved = rewriteGroupingMarker(input);
+    if (resolved != input) {
+      changed = true;
+    }
+    newInputs.push_back(std::move(resolved));
+  }
+  if (changed) {
+    return expr->replaceInputs(std::move(newInputs));
+  }
+  return expr;
+}
+
+void GroupByPlanner::resolveGroupingCalls(std::vector<lp::ExprApi>& exprs) {
+  for (auto& expr : exprs) {
+    auto resolved = rewriteGroupingMarker(expr.expr());
+    if (resolved != expr.expr()) {
+      expr = lp::ExprApi(std::move(resolved), expr.alias());
+    }
+  }
 }
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -31,6 +31,10 @@ namespace lp = facebook::axiom::logical_plan;
 /// per-query to hold intermediate state during aggregation planning.
 class GroupByPlanner {
  public:
+  /// Marker function name emitted by ExpressionPlanner for GROUPING() AST
+  /// nodes.
+  static constexpr std::string_view kGroupingFunctionName = "grouping";
+
   GroupByPlanner(
       std::shared_ptr<lp::PlanBuilder>& builder,
       ExpressionPlanner& exprPlanner)
@@ -92,6 +96,15 @@ class GroupByPlanner {
       const std::vector<ExpressionPtr>& exprs,
       const std::vector<lp::ExprApi>& selectExprs);
 
+  // Replaces `grouping(...)` marker calls in 'exprs' with
+  // `element_at(array[bitmasks...], $grouping_set_id + 1)`.
+  void resolveGroupingCalls(std::vector<lp::ExprApi>& exprs);
+
+  // Replaces a single `grouping(...)` marker in 'expr' (recursively) with
+  // the bitmask lookup expression. Returns the original expr if unchanged.
+  facebook::velox::core::ExprPtr rewriteGroupingMarker(
+      const facebook::velox::core::ExprPtr& expr);
+
   // Injected dependencies.
   std::shared_ptr<lp::PlanBuilder>& builder_;
   ExpressionPlanner& exprPlanner_;
@@ -102,6 +115,9 @@ class GroupByPlanner {
   std::vector<std::vector<lp::ExprApi>> groupingSets_;
   std::vector<lp::ExprApi> groupingKeys_;
   std::vector<std::vector<int32_t>> groupingSetsIndices_;
+  // Maps grouping key column name → index in groupingKeys_ for GROUPING()
+  // resolution.
+  folly::F14FastMap<std::string, int32_t> groupingColumnToIndex_;
   std::vector<lp::ExprApi> projections_;
 
   // Deduplicated aggregate expressions. Aggregate options are embedded in

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -293,17 +293,17 @@ class RelationPlanner : public AstVisitor {
     return *builder_;
   }
 
-  lp::ExprApi toExpr(const ExpressionPtr& node) {
-    return exprPlanner_.toExpr(node);
+  lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {}) {
+    return exprPlanner_.toExpr(node, options);
   }
 
  private:
-  void addFilter(const ExpressionPtr& filter) {
+  void addFilter(const ExpressionPtr& filter, ExprOptions options = {}) {
     if (filter == nullptr) {
       return;
     }
 
-    auto expr = toExpr(filter);
+    auto expr = toExpr(filter, options);
     auto expanded =
         ColumnsExpansion::expand(expr, *builder_, filter->location());
     if (expanded.empty()) {
@@ -765,7 +765,8 @@ class RelationPlanner : public AstVisitor {
   // for a single plain SELECT * (no EXCLUDE/REPLACE). Window functions are
   // embedded as WindowCallExpr in the IExpr tree.
   std::optional<std::vector<lp::ExprApi>> buildSelectProjections(
-      const std::vector<SelectItemPtr>& selectItems) {
+      const std::vector<SelectItemPtr>& selectItems,
+      ExprOptions options = {}) {
     // Previous SELECT's display names must not leak into this scope.
     displayNames_.lastNames.clear();
 
@@ -859,7 +860,7 @@ class RelationPlanner : public AstVisitor {
         VELOX_CHECK(item->is(NodeType::kSingleColumn));
         auto* singleColumn = item->as<SingleColumn>();
 
-        lp::ExprApi expr = toExpr(singleColumn->expression());
+        lp::ExprApi expr = toExpr(singleColumn->expression(), options);
 
         std::optional<std::string> alias;
         if (singleColumn->alias() != nullptr) {
@@ -932,8 +933,9 @@ class RelationPlanner : public AstVisitor {
   // SELECT * instead of returning nullopt). Does NOT extract nested windows —
   // the caller is responsible for that.
   std::vector<lp::ExprApi> expandSelectExprs(
-      const std::vector<SelectItemPtr>& selectItems) {
-    auto result = buildSelectProjections(selectItems);
+      const std::vector<SelectItemPtr>& selectItems,
+      ExprOptions options = {}) {
+    auto result = buildSelectProjections(selectItems, options);
     if (result.has_value()) {
       return result.value();
     }
@@ -1089,7 +1091,7 @@ class RelationPlanner : public AstVisitor {
         projectedExprs.size());
   }
 
-  lp::ExprApi toSortingKey(const ExpressionPtr& expr) {
+  lp::ExprApi toSortingKey(const ExpressionPtr& expr, ExprOptions options) {
     if (expr->is(NodeType::kLongLiteral)) {
       const auto n = expr->as<LongLiteral>()->value();
       AXIOM_PRESTO_SEMANTIC_CHECK_GE(
@@ -1109,7 +1111,7 @@ class RelationPlanner : public AstVisitor {
       return column.toCol();
     }
 
-    return toExpr(expr);
+    return toExpr(expr, options);
   }
 
   // Plans 'query' as a subquery in a fresh builder, reporting whether it
@@ -1150,7 +1152,7 @@ class RelationPlanner : public AstVisitor {
 
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
-      auto expr = toSortingKey(item->sortKey());
+      auto expr = toSortingKey(item->sortKey(), {});
 
       // Expand COLUMNS() calls to multiple sort keys with the same
       // ordering direction.
@@ -1261,7 +1263,8 @@ class RelationPlanner : public AstVisitor {
     const bool distinct = node->select()->isDistinct();
 
     if (auto groupBy = node->groupBy()) {
-      auto selectExprs = expandSelectExprs(selectItems);
+      auto selectExprs =
+          expandSelectExprs(selectItems, {.allowGrouping = true});
 
       // When DISTINCT is also present, skip ORDER BY in the GROUP BY
       // planner so the Sort lands ABOVE the DISTINCT aggregate.
@@ -1390,7 +1393,9 @@ class RelationPlanner : public AstVisitor {
   std::shared_ptr<lp::PlanBuilder> builder_;
   ExpressionPlanner exprPlanner_{
       [this](Query* query) { return planSubquery(query); },
-      [this](const ExpressionPtr& expr) { return toSortingKey(expr); },
+      [this](const ExpressionPtr& expr, ExprOptions options) {
+        return toSortingKey(expr, options);
+      },
       [this](const std::string& qualifier, const std::string& name) {
         // Only canonicalize if the qualifier resolves as a table alias (not a
         // struct field dereference) and the unqualified name is unambiguous.

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -306,18 +308,167 @@ TEST_F(AggregationParserTest, groupingSets) {
 }
 
 TEST_F(AggregationParserTest, groupingFunction) {
-  // GROUPING(col) is rejected with a clear unsupported-expression error.
-  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
-      parseSql(
-          "SELECT GROUPING(n_regionkey), count(1) FROM nation "
-          "GROUP BY GROUPING SETS ((n_regionkey), ())"),
-      "Unsupported expression type: GroupingOperation");
+  auto grouping = [](std::initializer_list<int64_t> bitmasks) {
+    return fmt::format(
+        "element_at([{}], plus($grouping_set_id, 1))",
+        fmt::join(bitmasks, ","));
+  };
 
-  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
-      parseSql(
-          "SELECT GROUPING(n_regionkey, n_name), count(1) FROM nation "
-          "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())"),
-      "Unsupported expression type: GroupingOperation");
+  // DuckDB can't parse "$grouping_set_id", so use callback-based project
+  // matching to compare expression toString() directly.
+  using MatcherBuilder =
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder;
+  auto projectExprs =
+      [](std::vector<std::string> expected) -> MatcherBuilder::OnMatchCallback {
+    return
+        [expected = std::move(expected)](const lp::LogicalPlanNodePtr& node) {
+          auto& project = *node->as<lp::ProjectNode>();
+          ASSERT_EQ(expected.size(), project.expressions().size());
+          for (auto i = 0; i < expected.size(); ++i) {
+            EXPECT_EQ(expected[i], project.expressionAt(i)->toString())
+                << "at index " << i;
+          }
+        };
+  };
+
+  // GROUPING() with two grouping sets.
+  testSelect(
+      "SELECT GROUPING(n_regionkey), count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((n_regionkey), ())",
+      matchScan()
+          .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
+          .project(projectExprs({grouping({0, 1}), "count"}))
+          .output());
+
+  // GROUPING() with two columns, three grouping sets.
+  testSelect(
+      "SELECT GROUPING(n_regionkey, n_name), count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())",
+      matchScan()
+          .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0, 1}, {0}, {}})
+          .project(projectExprs({grouping({0, 1, 3}), "count"}))
+          .output());
+
+  // GROUPING() in SELECT with other columns (ROLLUP).
+  testSelect(
+      "SELECT n_regionkey, n_name, GROUPING(n_regionkey, n_name), count(1) "
+      "FROM nation GROUP BY ROLLUP(n_regionkey, n_name)",
+      matchScan()
+          .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0, 1}, {0}, {}})
+          .project(projectExprs(
+              {"n_regionkey", "n_name", grouping({0, 1, 3}), "count"}))
+          .output());
+
+  // Two separate GROUPING() calls (CUBE).
+  testSelect(
+      "SELECT n_regionkey, n_name, GROUPING(n_regionkey), GROUPING(n_name), "
+      "count(1) FROM nation GROUP BY CUBE(n_regionkey, n_name)",
+      matchScan()
+          .aggregate(
+              {"n_regionkey", "n_name"}, {"count(1)"}, {{0, 1}, {0}, {1}, {}})
+          .project(projectExprs(
+              {"n_regionkey",
+               "n_name",
+               grouping({0, 0, 1, 1}),
+               grouping({0, 1, 0, 1}),
+               "count"}))
+          .output());
+
+  // GROUPING() with plain GROUP BY resolves to constant 0 (single set).
+  testSelect(
+      "SELECT n_regionkey, GROUPING(n_regionkey), count(1) "
+      "FROM nation GROUP BY n_regionkey",
+      matchScan()
+          .aggregate({"n_regionkey"}, {"count(1)"})
+          .project(projectExprs({"n_regionkey", "0", "count"}))
+          .output());
+
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT n_regionkey, GROUPING(n_name), count(1) "
+          "FROM nation GROUP BY ROLLUP(n_regionkey)"),
+      "Not a grouping column: n_name");
+
+  // Duplicate columns are allowed.
+  testSelect(
+      "SELECT n_regionkey, GROUPING(n_regionkey, n_regionkey), count(1) "
+      "FROM nation GROUP BY ROLLUP(n_regionkey)",
+      matchScan()
+          .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
+          .project(projectExprs({"n_regionkey", grouping({0, 3}), "count"}))
+          .output());
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT n_regionkey, count(1) "
+          "FROM nation "
+          "WHERE GROUPING(n_regionkey) = 0 "
+          "GROUP BY ROLLUP(n_regionkey)"),
+      "not allowed in this context");
+
+  // Multiple GROUPING() calls in WHERE.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT n_regionkey, n_name, count(1) "
+          "FROM nation "
+          "WHERE GROUPING(n_regionkey) = 0 OR GROUPING(n_name) = 1 "
+          "GROUP BY ROLLUP(n_regionkey, n_name)"),
+      "not allowed in this context");
+
+  // Zero-arg GROUPING().
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT n_regionkey, GROUPING(), count(1) "
+          "FROM nation GROUP BY ROLLUP(n_regionkey)"),
+      "GROUPING() requires at least one column argument");
+
+  // GROUPING() inside aggregate arguments is rejected.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT sum(GROUPING(n_regionkey)) "
+          "FROM nation GROUP BY ROLLUP(n_regionkey)"),
+      "GROUPING() is not allowed in this context");
+
+  // Qualified column reference.
+  testSelect(
+      "SELECT GROUPING(nation.n_regionkey), count(1) FROM nation "
+      "GROUP BY GROUPING SETS ((n_regionkey), ())",
+      matchScan()
+          .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
+          .project(projectExprs({grouping({0, 1}), "count"}))
+          .output());
+
+  // GROUPING() in FILTER clause of aggregate.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT sum(n_regionkey) FILTER (WHERE GROUPING(n_regionkey) = 0), "
+          "count(1) FROM nation GROUP BY ROLLUP(n_regionkey)"),
+      "not allowed in this context");
+
+  // GROUPING() in ORDER BY of aggregate.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT array_agg(n_name ORDER BY GROUPING(n_regionkey)), "
+          "count(1) FROM nation GROUP BY ROLLUP(n_regionkey)"),
+      "not allowed in this context");
+
+  // GROUPING() without GROUP BY.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect("SELECT GROUPING(n_regionkey) FROM nation"),
+      "not allowed in this context");
+
+  // GROUPING() in standalone ORDER BY without GROUP BY.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT n_regionkey FROM nation ORDER BY GROUPING(n_regionkey)"),
+      "not allowed in this context");
+
+  // GROUPING() in JOIN ON.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT n_regionkey FROM nation n1 "
+          "JOIN nation n2 ON GROUPING(n1.n_regionkey) = 0"),
+      "not allowed in this context");
 }
 
 TEST_F(AggregationParserTest, rollup) {


### PR DESCRIPTION
Summary:

Implement GROUPING() function for ROLLUP, CUBE, and GROUPING SETS queries.

GROUPING(col) returns 0 when the column is present, 1 when rolled up. Multiple args give a bitmask — GROUPING(a, b) returns 0-3.

  SELECT a, GROUPING(a), sum(b) FROM t GROUP BY ROLLUP(a)

Here, GROUPING(a) returns 0 when a is grouped and 1 for the rolled-up total.

ExpressionPlanner emits a marker Call("grouping", [cols]) for GroupingOperation nodes. GroupByPlanner resolves the markers after grouping set deduplication — precomputes a constant bitmask array at plan time and rewrites to element_at({bitmask0, bitmask1, ...}, $grouping_set_id + 1). No new Velox types needed.

Validation: ExprOptions.allowGrouping defaults to false, so GROUPING() is rejected everywhere unless the GROUP BY path explicitly enables it. This covers WHERE, JOIN ON, standalone queries without GROUP BY, and aggregate arguments. Error messages match Presto Java.

Single grouping set: resolves to constant 0, no gid lookup.

Reviewed By: mbasmanova

Differential Revision: D94242997


