### PR TITLE
feat(optimizer): Optimize row_number <= N filters

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,23 @@ for the complete guide. Key rules are summarized below.
 - Keep method implementations in `.cpp` except for trivial one-liners.
 - Avoid default arguments when all callers can pass values explicitly.
 
+## Commit Messages
+
+Use conventional commit prefixes with `[Project]` tags:
+
+```
+[Axiom] feat(optimizer): Add support for window functions
+[Axiom] fix: Validate HAVING column references in SQL parser
+[Axiom] refactor(parser): Extract GroupByPlanner class
+[Axiom] test: Improve LogicalPlanMatcherBuilder API
+[Axiom] docs: Document Query Graphviz CLI
+```
+
+Format: `[Project] type(scope): Description`
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`
+- Scope is optional, use for subsystem clarity (e.g., `parser`, `optimizer`)
+- Description starts with a capital letter, no trailing period
+
 ## Common Mistakes
 
 These are frequently violated rules. Check every new or modified line against

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -341,6 +341,15 @@ PlanObjectSet PlanState::computeDownstreamColumns(bool includeFilters) const {
     }
   }
 
+  // Window functions.
+  if (dt->windowPlan) {
+    for (const auto* func : dt->windowPlan->functions()) {
+      if (!placed_.contains(func)) {
+        addExpr(func);
+      }
+    }
+  }
+
   // Filters after aggregation.
   for (const auto* conjunct : dt->having) {
     if (!placed_.contains(conjunct)) {

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -33,6 +33,7 @@ const auto& planTypeNames() {
       {PlanType::kUnnestTableNode, "UnnestTableNode"},
       {PlanType::kDerivedTableNode, "DerivedTableNode"},
       {PlanType::kAggregationNode, "AggregationNode"},
+      {PlanType::kWindowPlanNode, "WindowPlanNode"},
   };
   return kNames;
 }

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -39,6 +39,7 @@ enum class PlanType : uint32_t {
   kUnnestTableNode,
   kDerivedTableNode,
   kAggregationNode,
+  kWindowPlanNode,
   kWriteNode,
 };
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -222,6 +222,17 @@ std::string WindowFunction::toString() const {
   return out.str();
 }
 
+const WindowPlan* WindowPlan::withFunctions(
+    QGVector<WindowFunctionCP> functions,
+    ColumnVector columns) const {
+  auto merged = functions_;
+  auto mergedColumns = columns_;
+  merged.insert(merged.end(), functions.begin(), functions.end());
+  mergedColumns.insert(mergedColumns.end(), columns.begin(), columns.end());
+  return make<WindowPlan>(
+      std::move(merged), std::move(mergedColumns), rankingLimit_);
+}
+
 std::string Field::toString() const {
   std::stringstream out;
   out << base_->toString() << ".";

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -351,6 +351,18 @@ void QueryGraphContext::populateFunctionNames() {
   if (auto isNull = registry->isNull()) {
     functionNames_.isNull = this->toName(isNull.value());
   }
+
+  if (auto rowNumber = registry->rowNumber()) {
+    functionNames_.rowNumber = this->toName(rowNumber.value());
+  }
+
+  if (auto rank = registry->rank()) {
+    functionNames_.rank = this->toName(rank.value());
+  }
+
+  if (auto denseRank = registry->denseRank()) {
+    functionNames_.denseRank = this->toName(denseRank.value());
+  }
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -307,6 +307,11 @@ struct FunctionNames {
   /// Aggregate functions.
   Name arbitrary{nullptr};
   Name count{nullptr};
+
+  /// Window functions.
+  Name rowNumber{nullptr};
+  Name rank{nullptr};
+  Name denseRank{nullptr};
 };
 
 /// Context for making a query plan. Owns all memory associated to

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -5,6 +5,7 @@ See also:
 - [Join Planning](docs/JoinPlanning.md) - Control flow and state management in join order enumeration
 - [Filter Selectivity](docs/FilterSelectivity.md) - How filter selectivity is estimated for cost-based optimization
 - [Cardinality Estimation](docs/CardinalityEstimation.md) - How output cardinality is estimated for each operator
+- [Window Functions](docs/WindowFunctions.md) - Window function support and ranking optimizations
 - [Debugging Tips](docs/DebuggingTips.md) - Using the CLI, generating TPC-H data, speeding up test runs, adding debug logging
 
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -57,12 +57,8 @@ TEST_F(HiveLimitQueriesTest, limit) {
     SCOPED_TRACE("numWorkers: 1, numDrivers: 4");
     auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
-                       .partialLimit(0, 10)
-                       .localPartition()
-                       .finalLimit(0, 10)
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().localLimit(0, 10).build();
 
     checkSingleNodePlan(plan, matcher);
     checkResults(plan, referenceResults);
@@ -76,9 +72,7 @@ TEST_F(HiveLimitQueriesTest, limit) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .partialLimit(0, 10)
-                       .localPartition()
-                       .finalLimit(0, 10)
+                       .localLimit(0, 10)
                        .shuffle()
                        .finalLimit(0, 10)
                        .build();
@@ -120,12 +114,8 @@ TEST_F(HiveLimitQueriesTest, offset) {
     SCOPED_TRACE("numWorkers: 1, numDrivers: 4");
     auto plan = planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = 4});
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
-                       .partialLimit(0, 15)
-                       .localPartition()
-                       .finalLimit(5, 10)
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder().tableScan().localLimit(5, 10).build();
 
     checkSingleNodePlan(plan, matcher);
     checkResults(plan, referenceResults);
@@ -139,9 +129,7 @@ TEST_F(HiveLimitQueriesTest, offset) {
 
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .partialLimit(0, 15)
-                       .localPartition()
-                       .finalLimit(0, 15)
+                       .localLimit(0, 15)
                        .shuffle()
                        .finalLimit(5, 10)
                        .build();

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1655,14 +1655,18 @@ PlanMatcherBuilder& PlanMatcherBuilder::finalLimit(
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::distributedLimit(
+PlanMatcherBuilder& PlanMatcherBuilder::localLimit(
     int64_t offset,
     int64_t count) {
   return partialLimit(0, offset + count)
       .localPartition()
-      .finalLimit(0, offset + count)
-      .gather()
       .finalLimit(offset, count);
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::distributedLimit(
+    int64_t offset,
+    int64_t count) {
+  return localLimit(0, offset + count).gather().finalLimit(offset, count);
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::topN() {

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -349,9 +349,15 @@ class PlanMatcherBuilder {
   /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& finalLimit(int64_t offset, int64_t count);
 
-  /// Matches the distributed limit pattern: partialLimit(0, offset + count) →
-  /// localPartition → finalLimit(0, offset + count) → gather →
-  /// finalLimit(offset, count).
+  /// Matches the local limit pattern: partialLimit(0, offset + count) →
+  /// localPartition → finalLimit(offset, count). Used when data is already on a
+  /// single node and no gather is needed.
+  /// @param offset Number of rows to skip.
+  /// @param count Maximum number of rows to return.
+  PlanMatcherBuilder& localLimit(int64_t offset, int64_t count);
+
+  /// Matches the distributed limit pattern: localLimit(0, offset + count) →
+  /// gather → finalLimit(offset, count).
   /// @param offset Number of rows to skip.
   /// @param count Maximum number of rows to return.
   PlanMatcherBuilder& distributedLimit(int64_t offset, int64_t count);


### PR DESCRIPTION
Summary:
Optimize queries that filter on ranking function output by absorbing the filter
predicate into the ranking operator as a limit, avoiding full window computation.

Supported query shapes:

```sql
-- row_number/rank/dense_rank with upper-bound filter → TopNRowNumber
SELECT * FROM (
  SELECT *, row_number() OVER (ORDER BY b) as rn FROM t
) WHERE rn <= 5

-- row_number without ORDER BY + filter → RowNumber with limit
SELECT * FROM (
  SELECT *, row_number() OVER () as rn FROM t
) WHERE rn <= 5

-- Less-than and equality predicates
WHERE rn < 5   -- limit = 4
WHERE rn = 1   -- limit = 1
```

When additional predicates exist alongside the ranking predicate (e.g.
`rn <= 5 AND a > 10`), the ranking predicate is absorbed into the limit and the
remaining predicates are preserved.

Detection: since a filter on a window function output triggers a DT boundary, the ranking predicate starts in the outer DT. During filter pushdown, addFilter validates the predicate using `isRankingUpperBoundPredicate` and pushes it into the inner DT's conjuncts. In addWindow, `tryExtractRankingLimit` extracts the limit from the conjunct and passes it to `makeWindowOp`, which creates TopNRowNumber or RowNumber with the limit.

Differential Revision: D94566040


