### PR TITLE
feat: Make getSplits call async (#826)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,15 @@ if(COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
   string(APPEND CMAKE_CXX_FLAGS " -Wno-nullability-completeness")
 endif()
 
+check_cxx_compiler_flag("-fcoroutines" COMPILER_HAS_F_COROUTINES)
+if(COMPILER_HAS_F_COROUTINES)
+  string(APPEND CMAKE_CXX_FLAGS " -fcoroutines")
+  # Explicitly enable folly coroutines when compiler supports them.
+  # This is required for folly::coro::AsyncGenerator to work correctly.
+  # Use CMAKE_CXX_FLAGS to ensure it propagates to all subdirectories including velox.
+  string(APPEND CMAKE_CXX_FLAGS " -DFOLLY_HAS_COROUTINES=1")
+endif()
+
 # Axiom, Velox and folly need to be compiled with the same compiler flags.
 execute_process(
   COMMAND

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -26,4 +26,4 @@ endif()
 
 add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp SchemaUtils.cpp)
 
-target_link_libraries(axiom_connectors velox_common_base velox_memory velox_connector)
+target_link_libraries(axiom_connectors velox_common_base velox_memory velox_connector Folly::folly)

--- a/axiom/connectors/hive/CMakeLists.txt
+++ b/axiom/connectors/hive/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   velox_hdfs
   velox_gcs
   velox_abfs
+  Folly::folly
 )
 
 if(AXIOM_BUILD_TESTING)

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -50,8 +50,7 @@ class LocalHiveSplitSource : public SplitSource {
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const SplitOptions options_;
@@ -59,9 +58,6 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> fileSplits_;
-  int32_t currentFile_{-1};
-  int32_t currentSplit_{0};
 };
 
 class LocalHiveConnectorMetadata;

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   velox_common_base
   velox_memory
   velox_connector
+  Folly::folly
 )
 
 add_executable(axiom_test_connector_test TestConnectorTest.cpp)
@@ -34,8 +35,9 @@ target_link_libraries(
   velox_connector
   velox_exec
   velox_vector_test_lib
-  gtest
-  gtest_main
+  Folly::folly
+  GTest::gtest
+  GTest::gtest_main
 )
 
 add_executable(axiom_connectors_tests SchemaUtilsTest.cpp SchemaResolverTest.cpp)

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -177,20 +177,21 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
   return stats;
 }
 
-std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {
-  std::vector<SplitAndGroup> result;
-  if (!done_) {
-    for (size_t i = 0; i < splitCount_; ++i) {
-      result.push_back(
-          {std::make_shared<TestConnectorSplit>(connectorId_, i),
-           kUngroupedGroupId});
-    }
-    done_ = true;
+folly::coro::AsyncGenerator<SplitSource::SplitAndGroup>
+TestSplitSource::getSplitGenerator() {
+  // Keep 'this' alive during coroutine execution.
+  auto self = shared_from_this();
+
+  // Copy member variables to local stack to avoid potential coroutine state
+  // issues when accessing members across suspension points.
+  const auto count = splitCount_;
+  const auto connectorId = connectorId_;
+
+  for (size_t i = 0; i < count; ++i) {
+    co_yield SplitAndGroup{
+        std::make_shared<TestConnectorSplit>(connectorId, i),
+        kUngroupedGroupId};
   }
-  if (result.empty()) {
-    result.push_back({nullptr, kUngroupedGroupId});
-  }
-  return result;
 }
 
 std::vector<PartitionHandlePtr> TestSplitManager::listPartitions(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -168,12 +168,11 @@ class TestSplitSource : public SplitSource {
   TestSplitSource(const std::string& connectorId, size_t splitCount)
       : connectorId_(connectorId), splitCount_(splitCount) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const std::string connectorId_;
   const size_t splitCount_;
-  bool done_{false};
 };
 
 /// SplitManager embedded in the TestConnector. Returns one

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -16,6 +16,9 @@
 
 #include "axiom/connectors/tests/TestConnector.h"
 
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/GtestHelpers.h>
+#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -117,7 +120,7 @@ TEST_F(TestConnectorTest, columnHandle) {
   EXPECT_EQ(testColumnHandle->type()->kind(), TypeKind::INTEGER);
 }
 
-TEST_F(TestConnectorTest, splitManager) {
+CO_TEST_F(TestConnectorTest, splitManager) {
   auto schema = ROW({"a"}, {INTEGER()});
   auto table = connector_->addTable("test_table", schema);
   auto& layout = *table->layouts()[0];
@@ -138,9 +141,14 @@ TEST_F(TestConnectorTest, splitManager) {
       splitManager->getSplitSource(nullptr, tableHandle, partitions, {});
   EXPECT_NE(splitSource, nullptr);
 
-  auto splits = splitSource->getSplits(0);
-  EXPECT_EQ(splits.size(), 1);
-  EXPECT_EQ(splits[0].split, nullptr);
+  {
+    std::vector<SplitSource::SplitAndGroup> splits;
+    auto generator = splitSource->getSplitGenerator();
+    while (auto split = co_await generator.next()) {
+      splits.push_back(std::move(*split));
+    }
+    EXPECT_EQ(splits.size(), 0);
+  }
 
   auto vector = makeRowVector({makeFlatVector<int>({1})});
   constexpr size_t kNumSplits = 1024;
@@ -150,17 +158,20 @@ TEST_F(TestConnectorTest, splitManager) {
 
   splitSource =
       splitManager->getSplitSource(nullptr, tableHandle, partitions, {});
-  splits = splitSource->getSplits(0);
-  EXPECT_EQ(splits.size(), kNumSplits);
-  for (size_t i = 0; i < kNumSplits; ++i) {
-    auto split = std::dynamic_pointer_cast<TestConnectorSplit>(splits[i].split);
-    EXPECT_NE(split, nullptr);
-    EXPECT_EQ(split->index(), i);
+  {
+    std::vector<SplitSource::SplitAndGroup> splits;
+    auto generator = splitSource->getSplitGenerator();
+    while (auto split = co_await generator.next()) {
+      splits.push_back(std::move(*split));
+    }
+    EXPECT_EQ(splits.size(), kNumSplits);
+    for (size_t i = 0; i < kNumSplits; ++i) {
+      auto split =
+          std::dynamic_pointer_cast<TestConnectorSplit>(splits[i].split);
+      EXPECT_NE(split, nullptr);
+      EXPECT_EQ(split->index(), i);
+    }
   }
-
-  splits = splitSource->getSplits(0);
-  EXPECT_EQ(splits.size(), 1);
-  EXPECT_EQ(splits[0].split, nullptr);
 }
 
 TEST_F(TestConnectorTest, splits) {

--- a/axiom/connectors/tpch/CMakeLists.txt
+++ b/axiom/connectors/tpch/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   axiom_connectors
   velox_tpch_connector
   velox_tpch_gen
+  Folly::folly
 )
 
 if(AXIOM_BUILD_TESTING)

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/experimental/coro/AsyncGenerator.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/tpch/TpchConnector.h"
@@ -39,16 +40,13 @@ class TpchSplitSource : public SplitSource {
         scaleFactor_(scaleFactor),
         connectorId_(connectorId) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override;
 
  private:
   const SplitOptions options_;
   const velox::tpch::Table table_;
   const double scaleFactor_;
   const std::string connectorId_;
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits_;
-  size_t currentSplit_{0};
 };
 
 class TpchSplitManager : public ConnectorSplitManager {

--- a/axiom/connectors/tpch/tests/CMakeLists.txt
+++ b/axiom/connectors/tpch/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib
+  Folly::folly
   GTest::gtest
   GTest::gtest_main
 )

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader
+  Folly::folly
   gtest
   gtest_main
 )
@@ -40,6 +41,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader
+  Folly::folly
   gtest
   gtest_main
 )
@@ -66,6 +68,7 @@ target_link_libraries(
   axiom_sql_presto_parser
   axiom_runner_multifragment_plan
   axiom_runner_tests_utils
+  Folly::folly
 )
 
 add_library(axiom_optimizer_tests_tpch_queries TpchQueries.cpp)
@@ -86,6 +89,7 @@ target_link_libraries(
   axiom_optimizer_tests_query_test_base
   axiom_optimizer_tests_hive_queries_test_base
   axiom_runner_tests_utils
+  Folly::folly
 )
 
 add_executable(
@@ -137,6 +141,7 @@ target_link_libraries(
   axiom_test_connector
   velox_dwio_text_reader_register
   velox_dwio_text_writer_register
+  Folly::folly
   GTest::gmock
   glog::glog
   GTest::gtest

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(
   velox_dwio_dwrf_writer
   velox_exec
   velox_cursor
+  Folly::folly
 )

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -15,6 +15,10 @@
  */
 
 #include "axiom/runner/LocalRunner.h"
+#include <folly/coro/AsyncScope.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Task.h>
+#include <folly/experimental/coro/AsyncGenerator.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
@@ -31,16 +35,20 @@ class SimpleSplitSource : public connector::SplitSource {
       std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits)
       : splits_(std::move(splits)) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t /* targetBytes */) override {
-    if (splitIdx_ >= splits_.size()) {
-      return {{nullptr, 0}};
+  folly::coro::AsyncGenerator<SplitAndGroup> getSplitGenerator() override {
+    auto self = shared_from_this();
+
+    // Copy member variable to local stack to avoid potential coroutine state
+    // issues when accessing members across suspension points.
+    auto splits = std::move(splits_);
+
+    for (auto& split : splits) {
+      co_yield SplitAndGroup{std::move(split), 0};
     }
-    return {SplitAndGroup{std::move(splits_[splitIdx_++]), 0}};
   }
 
  private:
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits_;
-  int32_t splitIdx_{0};
 };
 } // namespace
 
@@ -74,20 +82,29 @@ std::shared_ptr<velox::exec::RemoteConnectorSplit> remoteSplit(
   return std::make_shared<velox::exec::RemoteConnectorSplit>(taskId);
 }
 
-std::vector<velox::exec::Split> listAllSplits(
-    const std::shared_ptr<connector::SplitSource>& source) {
-  std::vector<velox::exec::Split> result;
-  for (;;) {
-    auto splits = source->getSplits(std::numeric_limits<uint64_t>::max());
-    VELOX_CHECK(!splits.empty());
-    for (auto& split : splits) {
-      if (split.split == nullptr) {
-        return result;
-      }
-      result.push_back(velox::exec::Split(std::move(split.split)));
+// Streams splits from the source and distributes them round-robin across tasks.
+folly::coro::Task<void> co_generateAndDistributeSplits(
+    std::shared_ptr<connector::SplitSource> source,
+    velox::core::PlanNodeId scanId,
+    std::vector<std::shared_ptr<velox::exec::Task>> tasks,
+    std::function<void(std::exception_ptr)> onError) {
+  try {
+    VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
+
+    size_t taskIdx = 0;
+    auto generator = source->getSplitGenerator();
+    while (auto split = co_await generator.next()) {
+      tasks[taskIdx]->addSplit(
+          scanId, velox::exec::Split(std::move(split->split)));
+      taskIdx = (taskIdx + 1) % tasks.size();
     }
+    for (auto& task : tasks) {
+      task->noMoreSplits(scanId);
+    }
+  } catch (...) {
+    onError(std::current_exception());
+    throw;
   }
-  VELOX_UNREACHABLE();
 }
 
 void getTopologicalOrder(
@@ -153,6 +170,12 @@ LocalRunner::LocalRunner(
 
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
+}
+
+LocalRunner::~LocalRunner() {
+  if (!splitScopeJoined_) {
+    folly::coro::blockingWait(splitScope_.joinAsync());
+  }
 }
 
 velox::RowVectorPtr LocalRunner::next() {
@@ -284,6 +307,12 @@ void LocalRunner::abort() {
 
 bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
   VELOX_CHECK_NE(state_, State::kInitialized);
+
+  if (!splitScopeJoined_) {
+    folly::coro::blockingWait(splitScope_.joinAsync());
+    splitScopeJoined_ = true;
+  }
+
   std::vector<velox::ContinueFuture> futures;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -391,34 +420,11 @@ void LocalRunner::makeStages(
 
       for (const auto& scan : scans) {
         auto source = splitSourceForScan(/*session=*/nullptr, *scan);
-
-        std::vector<connector::SplitSource::SplitAndGroup> splits;
-        int32_t splitIdx = 0;
-        auto getNextSplit = [&]() {
-          if (splitIdx < splits.size()) {
-            return velox::exec::Split(std::move(splits[splitIdx++].split));
-          }
-          splits = source->getSplits(std::numeric_limits<int64_t>::max());
-          splitIdx = 1;
-          return velox::exec::Split(std::move(splits[0].split));
-        };
-
-        // Distribute splits across tasks using round-robin.
-        bool allDone = false;
-        do {
-          for (auto& task : stage) {
-            auto split = getNextSplit();
-            if (!split.hasConnectorSplit()) {
-              allDone = true;
-              break;
-            }
-            task->addSplit(scan->id(), std::move(split));
-          }
-        } while (!allDone);
-
-        for (auto& task : stage) {
-          task->noMoreSplits(scan->id());
-        }
+        splitScope_.add(
+            folly::coro::co_withExecutor(
+                params_.queryCtx->executor(),
+                co_generateAndDistributeSplits(
+                    source, scan->id(), stage, onError)));
       }
 
       for (const auto& input : fragment.inputStages) {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/coro/AsyncScope.h>
+
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/runner/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
@@ -85,6 +87,11 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr);
+
+  ~LocalRunner() override;
+
+  LocalRunner(LocalRunner&&) = delete;
+  LocalRunner& operator=(LocalRunner&&) = delete;
 
   /// First call starts execution.
   velox::RowVectorPtr next() override;
@@ -168,6 +175,8 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
+  bool splitScopeJoined_{false};
 };
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
   velox_file_test_utils
   velox_hive_connector
   velox_tpch_connector
+  Folly::folly
 )
 
 add_executable(axiom_runner_local_runner_test LocalRunnerTest.cpp Main.cpp)
@@ -49,6 +50,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_parse_parser
   velox_parse_expression
+  Folly::folly
   GTest::gtest
 )
 
@@ -59,6 +61,7 @@ target_link_libraries(
   axiom_runner_local_runner
   velox_hive_connector
   velox_exec_test_lib
+  Folly::folly
 )
 
 add_executable(
@@ -74,5 +77,6 @@ target_link_libraries(
   axiom_runner_presto_query_replay_runner_test_utils
   velox_exec_test_lib
   velox_exec
+  Folly::folly
   GTest::gtest
 )


### PR DESCRIPTION
Summary:

Make the getSplits call async via coroutines so that the thread is not blocked while splits are being created/generated.

Differential Revision: D91800596


