### PR TITLE
refactor: VectorSerde named serde API from Kind to string

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -60,7 +60,7 @@ void SqlQueryRunner::initialize(
     velox::exec::ExchangeSource::registerFactory(
         velox::exec::test::createLocalExchangeSource);
     velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
-    if (!isRegisteredNamedVectorSerde(velox::VectorSerde::Kind::kPresto)) {
+    if (!velox::isRegisteredNamedVectorSerde("Presto")) {
       velox::serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
   });

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -305,8 +305,7 @@ class ToVelox {
   runner::ExecutableFragment newFragment();
 
   // TODO Move this into MultiFragmentPlan::Options.
-  const velox::VectorSerde::Kind exchangeSerdeKind_{
-      velox::VectorSerde::Kind::kPresto};
+  const std::string exchangeSerdeKind_{"Presto"};
 
   const SessionPtr session_;
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -167,7 +167,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     exec::ExchangeSource::registerFactory(
         exec::test::createLocalExchangeSource);
     serializer::presto::PrestoVectorSerde::registerVectorSerde();
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
 

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -79,7 +79,7 @@ void DistributedPlanBuilder::addExchange(
     const velox::RowTypePtr& producerType,
     const std::string& producerPrefix,
     runner::ExecutableFragment& fragment) {
-  exchange(producerType, velox::VectorSerde::Kind::kPresto);
+  exchange(producerType, "Presto");
   auto* exchange = as<velox::core::ExchangeNode>(planNode_);
 
   fragment.inputStages.push_back(


### PR DESCRIPTION
Summary:
X-link: https://github.com/prestodb/presto/pull/27229

Change getNamedVectorSerde, registerNamedVectorSerde, deregisterNamedVectorSerde,
and isRegisteredNamedVectorSerde to accept const std::string& instead of
VectorSerde::Kind. Change VectorSerde::kind_ member from Kind to std::string.
Update all callers, PlanNodes, serializers, and tests. Add legacy inline
overloads accepting VectorSerde::Kind for backward compatibility.

Reviewed By: singcha, xiaoxmeng

Differential Revision: D94569860
