### PR TITLE
fix(optimizer): Error when joining with UNION ALL

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -451,6 +451,7 @@ void DerivedTable::import(
   VELOX_DCHECK(joins.empty());
   VELOX_DCHECK(!superTables.empty());
   VELOX_DCHECK(superTables.contains(primaryTable));
+  VELOX_DCHECK(!super.setOp.has_value(), "Cannot import from a union DT");
 
   copySubset(super, superTables);
 
@@ -470,6 +471,18 @@ void DerivedTable::import(
     }
   }
 
+  linkTablesToJoins();
+  setStartTables();
+}
+
+void DerivedTable::importUnionChild(PlanObjectCP child) {
+  VELOX_DCHECK(tables.empty());
+  VELOX_DCHECK(joins.empty());
+  VELOX_DCHECK(child->is(PlanType::kDerivedTableNode));
+
+  tableSet.add(child);
+  tables = tableSet.toObjects();
+  flattenDt(child->as<DerivedTable>());
   linkTablesToJoins();
   setStartTables();
 }

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -185,10 +185,17 @@ struct DerivedTable : public PlanObject {
   ///
   /// Requires:
   ///   - 'this' must be empty (no tables, no joins).
-  ///   - 'superTables' must not be empty and must be a subset of 'super'
-  ///     tables.
+  ///   - 'super' must not be a union DT (union children are planned
+  ///     individually via importUnionChild).
+  ///   - 'superTables' must not be empty.
   ///   - 'primaryTable' must be in 'superTables'.
   ///
+  /// @param super The outer DerivedTable that owns the tables and joins.
+  /// Joins connecting 'superTables' are copied from 'super'. Must not be a
+  /// set operation (UNION ALL, etc.).
+  /// @param superTables Subset of tables to import. These become 'this'
+  /// DT's tables. Joins from 'super' where both sides are in 'superTables'
+  /// are copied.
   /// @param primaryTable The main table in 'superTables'. Existence semijoins
   /// are attached to this table. If this table is a subquery with aggregation,
   /// existence tables are pushed inside it below the aggregation boundary.
@@ -204,6 +211,13 @@ struct DerivedTable : public PlanObject {
       PlanObjectCP primaryTable,
       const std::vector<PlanObjectSet>& existences,
       float existsFanout);
+
+  /// Populates 'this' by flattening a union child DT. Used when planning
+  /// individual branches of a UNION ALL — the child DT is self-contained
+  /// and does not need tables or joins from an outer DT.
+  ///
+  /// @param child A child from a union DT's 'children' list.
+  void importUnionChild(PlanObjectCP child);
 
   /// Return a copy of 'expr', replacing references to this DT's 'columns' with
   /// corresponding 'exprs'.

--- a/axiom/optimizer/MemoKey.cpp
+++ b/axiom/optimizer/MemoKey.cpp
@@ -46,11 +46,22 @@ bool MemoKey::operator==(const MemoKey& other) const {
 }
 
 std::string MemoKey::toString() const {
-  return fmt::format(
-      "MemoKey({}, columns: {}, tables: {})",
+  auto result = fmt::format(
+      "MemoKey({}, columns: {}, tables: {}",
       cname(firstTable),
       columns.toString(true),
       tables.toString(true));
+  if (!existences.empty()) {
+    result += ", existences: ";
+    for (auto i = 0; i < existences.size(); ++i) {
+      if (i > 0) {
+        result += "; ";
+      }
+      result += existences[i].toString(true);
+    }
+  }
+  result += ")";
+  return result;
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/MemoKey.h
+++ b/axiom/optimizer/MemoKey.h
@@ -20,7 +20,7 @@
 namespace facebook::axiom::optimizer {
 
 /// Key for memoization of partial plans. Identifies a subset of tables
-/// with their required output columns and existence joins.
+/// with their required output columns and optional reducing existence tables.
 struct MemoKey {
   static MemoKey create(
       PlanObjectCP firstTable,
@@ -42,9 +42,18 @@ struct MemoKey {
 
   std::string toString() const;
 
+  /// Starting table for join enumeration. Must be in 'tables'.
   const PlanObjectCP firstTable;
+
+  /// Columns projected out by the plan identified by this key.
   const PlanObjectSet columns;
+
+  /// Tables joined in this partial plan.
   const PlanObjectSet tables;
+
+  /// Groups of reducing tables added as existence semijoins to shrink a hash
+  /// join build side. Each group forms a single existence semijoin. Can be
+  /// empty.
   const std::vector<PlanObjectSet> existences;
 
  private:

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2204,15 +2204,9 @@ void Optimization::joinByHash(
         std::move(buildPartKeys)};
   }
 
-  PlanObjectSet empty;
   bool needsShuffle = false;
   auto buildPlan = makePlan(
-      *state.dt,
-      memoKey,
-      forBuild,
-      empty,
-      candidate.existsFanout,
-      needsShuffle);
+      *state.dt, memoKey, forBuild, candidate.existsFanout, needsShuffle);
 
   PlanState buildState(state.optimization, state.dt, buildPlan);
 
@@ -2406,12 +2400,7 @@ void Optimization::joinByHashRight(
 
   bool needsShuffle = false;
   auto probePlan = makePlan(
-      *state.dt,
-      memoKey,
-      std::nullopt,
-      PlanObjectSet{},
-      candidate.existsFanout,
-      needsShuffle);
+      *state.dt, memoKey, std::nullopt, candidate.existsFanout, needsShuffle);
 
   PlanState probeState(state.optimization, state.dt, probePlan);
 
@@ -2559,15 +2548,9 @@ void Optimization::crossJoin(
   MemoKey memoKey =
       MemoKey::create(table, buildColumns, buildTables, candidate.existences);
 
-  PlanObjectSet empty;
   bool needsShuffle = false;
   auto buildPlan = makePlan(
-      *state.dt,
-      memoKey,
-      std::nullopt,
-      empty,
-      candidate.existsFanout,
-      needsShuffle);
+      *state.dt, memoKey, std::nullopt, candidate.existsFanout, needsShuffle);
 
   PlanState buildState(state.optimization, state.dt, buildPlan);
 
@@ -2841,10 +2824,8 @@ RelationOpPtr Optimization::placeSingleRowDt(
       PlanObjectSet::fromObjects(subquery->columns),
       PlanObjectSet::single(subquery));
 
-  PlanObjectSet empty;
   bool needsShuffle = false;
-  auto rightPlan =
-      makePlan(*state.dt, memoKey, std::nullopt, empty, 1, needsShuffle);
+  auto rightPlan = makePlan(*state.dt, memoKey, std::nullopt, 1, needsShuffle);
 
   auto rightOp = rightPlan->op;
 
@@ -2883,8 +2864,7 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
       MemoKey::create(from, std::move(dtColumns), PlanObjectSet::single(from));
 
   bool ignore = false;
-  auto plan =
-      makePlan(*state.dt, key, std::nullopt, PlanObjectSet{}, 1, ignore);
+  auto plan = makePlan(*state.dt, key, std::nullopt, 1, ignore);
   state.cost = plan->cost;
 
   // Make plans based on the dt alone as first.
@@ -2919,7 +2899,6 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
       *state.dt,
       reducingKey,
       /*distribution=*/std::nullopt,
-      /*boundColumns=*/PlanObjectSet{},
       /*existsFanout=*/result.existenceReduction,
       /*needsShuffle=*/ignore);
   state.cost = plan->cost;
@@ -3279,25 +3258,19 @@ PlanP Optimization::makePlan(
     const DerivedTable& dt,
     const MemoKey& key,
     const std::optional<DesiredDistribution>& distribution,
-    const PlanObjectSet& boundColumns,
     float existsFanout,
     bool& needsShuffle) {
   needsShuffle = false;
   if (key.firstTable->is(PlanType::kDerivedTableNode) &&
       key.firstTable->as<DerivedTable>()->setOp.has_value()) {
-    return makeUnionPlan(
-        dt, key, distribution, boundColumns, existsFanout, needsShuffle);
+    return makeUnionPlan(key, distribution);
   }
   return makeDtPlan(dt, key, distribution, existsFanout, needsShuffle);
 }
 
 PlanP Optimization::makeUnionPlan(
-    const DerivedTable& dt,
     const MemoKey& key,
-    const std::optional<DesiredDistribution>& distribution,
-    const PlanObjectSet& boundColumns,
-    float existsFanout,
-    bool& /*needsShuffle*/) {
+    const std::optional<DesiredDistribution>& distribution) {
   const auto* setDt = key.firstTable->as<DerivedTable>();
 
   RelationOpPtrVector inputs;
@@ -3306,20 +3279,34 @@ PlanP Optimization::makeUnionPlan(
   std::vector<bool> inputNeedsShuffle;
 
   for (auto* inputDt : setDt->children) {
-    MemoKey inputKey = [&]() {
-      PlanObjectSet inputTables = key.tables;
-      inputTables.erase(key.firstTable);
-      inputTables.add(inputDt);
-      return MemoKey::create(
-          inputDt,
-          PlanObjectSet{key.columns},
-          std::move(inputTables),
-          std::vector<PlanObjectSet>{key.existences});
-    }();
+    // Only include the child DT in the input tables. Extra tables from
+    // the parent key (e.g., reducing bushy join tables) reference joins
+    // against the UNION ALL DT which don't exist for individual children.
+    auto inputKey = MemoKey::create(
+        inputDt, PlanObjectSet{key.columns}, PlanObjectSet::single(inputDt));
 
+    PlanP inputPlan;
     bool inputShuffle = false;
-    auto inputPlan = makePlan(
-        dt, inputKey, distribution, boundColumns, existsFanout, inputShuffle);
+    if (inputDt->setOp.has_value()) {
+      // Nested union (e.g., UNION ALL of UNION ALL).
+      // TODO: Flatten nested unions in ToGraph.
+      inputPlan = makeUnionPlan(inputKey, distribution);
+    } else {
+      PlanSet* plans = memo_.find(inputKey);
+      if (plans == nullptr) {
+        auto tmpDt = make<DerivedTable>();
+        tmpDt->cname = newCName("tmp_dt");
+        tmpDt->importUnionChild(inputDt);
+
+        PlanState inner(*this, tmpDt);
+        inner.setTargetExprsForDt(inputKey.columns);
+
+        makeJoins(inner);
+        memo_.insert(inputKey, std::move(inner.plans));
+        plans = memo_.find(inputKey);
+      }
+      inputPlan = plans->best(distribution, inputShuffle);
+    }
     inputPlans.push_back(inputPlan);
     inputStates.emplace_back(*this, setDt, inputPlans.back());
     inputs.push_back(inputPlan->op);

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -196,8 +196,6 @@ class Optimization {
   // @param dt the derived table to plan.
   // @param distribution the desired output distribution or a distribution with
   // no partitioning if this does not matter.
-  // @param boundColumns a set of columns that are lookup keys for an index
-  // based path through the joins in 'key'.
   // @param existsFanout the selectivity for the 'existences' in 'key', i.e.
   // extra reducing joins for a hash join build side, reflecting reducing joins
   // on the probe side. 1 if none.
@@ -207,17 +205,16 @@ class Optimization {
       const DerivedTable& dt,
       const MemoKey& key,
       const std::optional<DesiredDistribution>& distribution,
-      const PlanObjectSet& boundColumns,
       float existsFanout,
       bool& needsShuffle);
 
+  // Plans a set operation (UNION ALL, UNION). Plans each child independently
+  // using importUnionChild, combines them with UnionAll, and optionally adds
+  // a distinct aggregation for UNION. Individual child shuffles are handled
+  // internally.
   PlanP makeUnionPlan(
-      const DerivedTable& dt,
       const MemoKey& key,
-      const std::optional<DesiredDistribution>& distribution,
-      const PlanObjectSet& boundColumns,
-      float existsFanout,
-      bool& needsShuffle);
+      const std::optional<DesiredDistribution>& distribution);
 
   PlanP makeDtPlan(
       const DerivedTable& dt,

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -61,13 +61,15 @@ void PlanObjectSet::unionColumns(const ExprVector& exprs) {
 
 std::string PlanObjectSet::toString(bool names) const {
   std::stringstream out;
+  bool first = true;
   forEach([&](auto object) {
+    if (!first) {
+      out << ", ";
+    }
+    first = false;
     out << object->id();
     if (names) {
-      out << ": " << (object->isTable() ? cname(object) : object->toString())
-          << " ";
-    } else {
-      out << " ";
+      out << ": " << (object->isTable() ? cname(object) : object->toString());
     }
   });
   return out.str();

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -3,6 +3,7 @@
 See also:
 - [Subqueries](docs/Subqueries.md) - How subqueries are implemented in the optimizer
 - [Join Planning](docs/JoinPlanning.md) - Control flow and state management in join order enumeration
+- [Memoization](docs/Memoization.md) - Caching partial plans to avoid redundant work during join enumeration
 - [Filter Selectivity](docs/FilterSelectivity.md) - How filter selectivity is estimated for cost-based optimization
 - [Cardinality Estimation](docs/CardinalityEstimation.md) - How output cardinality is estimated for each operator
 - [Window Functions](docs/WindowFunctions.md) - Window function support and ranking optimizations

--- a/axiom/optimizer/docs/ExistencePushdown.md
+++ b/axiom/optimizer/docs/ExistencePushdown.md
@@ -208,7 +208,7 @@ optimization but not yet implemented; "N/A" means pushdown is always invalid
 | 6 | Inner join | Yes | innerJoinGroupBy | |
 | 7 | Semi-join (IN) | Yes | semiJoin | |
 | 8 | Left/right join (DT is optional side) | Yes | leftJoinDtIsOptional | |
-| 9 | Left/right join (DT is preserved side) | No | leftJoinDtIsPreserved | |
+| 9 | Left/right join (DT is preserved side) | N/A | leftJoinDtIsPreserved | Would incorrectly remove rows that should appear with NULLs |
 | | **What is pushed (`other`)** | | | |
 | 10 | Base table | Yes | innerJoinGroupBy | Added directly to newFirst |
 | 11 | DerivedTable (subquery) | No | otherIsDerivedTable | Optimizer doesn't choose pushdown |
@@ -219,7 +219,7 @@ optimization but not yet implemented; "N/A" means pushdown is always invalid
 | | **What is the DT (subquery)** | | | |
 | 16 | GROUP BY subquery | Yes | innerJoinGroupBy | Core case |
 | 17 | DISTINCT subquery | Yes | distinctSubquery | GROUP BY variant |
-| 18 | UNION ALL subquery | Yes | `SetTest::joinWithUnionAll` | |
+| 18 | UNION ALL subquery | No | | Join keys reference union DT's columns, not children's |
 | 19 | Window function (key is partition key) | Yes | windowSubquery | |
 | 20 | Window function (key is not partition key) | N/A | windowNonPartitionKey | Changes window computation |
 | 21 | Unnest GROUP BY on unnest output | No | unnestGroupBy | Optimizer doesn't choose pushdown |
@@ -368,3 +368,67 @@ fire the optimization.
 
 TODO: Add e2e tests via `SqlTest.cpp` that run queries with DuckDB comparison
 to verify correctness of results (not just plan structure).
+
+## Limitations
+
+### No multi-key join pushdown
+
+When the join between the outer table and the subquery has multiple equality
+keys (e.g., `ON t.a = dt.x AND t.b = dt.y`), the existence is not pushed even
+if all keys map to grouping keys. `validatePushdown` requires a single equality
+key per join edge. Supporting multi-key pushdown would require constructing a
+composite existence semijoin with multiple key pairs.
+
+### No partial pushdown
+
+When multiple tables join the subquery and some are pushable but others are not,
+the entire pushdown is skipped. The existences arrive as a single package with
+a single fanout estimate, so partial pushdown may not achieve the expected
+cardinality reduction. A future enhancement could push what it can and leave
+the rest outside.
+
+### No pushdown when other is a DerivedTable
+
+When the table being pushed is itself a DerivedTable (subquery) or contains an
+unnest, the optimizer does not choose pushdown. The existence mechanism supports
+it structurally, but `findReducingJoins` does not select these cases.
+
+### No recursive pushdown into nested subqueries
+
+Existence pushdown stops at the first aggregation level. If a subquery contains
+a nested subquery with its own aggregation, the existence is not pushed through
+the inner boundary. Each level would need its own discovery and validation pass.
+
+### No existence pushdown into UNION ALL children
+
+When a UNION ALL subquery is joined with a selective table, it would be
+beneficial to push an existence semijoin into each union child independently:
+
+```sql
+SELECT a FROM t
+JOIN (SELECT x FROM u UNION ALL SELECT x FROM v) w ON a = w.x
+WHERE t.a < 100
+```
+
+Ideally, the optimizer would produce:
+
+```
+HashJoin (t.a = w.x)
+├── TableScan t
+└── UnionAll
+    ├── HashJoin LEFT SEMI (u.x = t.a)  ← pushed into child
+    │   ├── TableScan u
+    │   └── TableScan t
+    └── HashJoin LEFT SEMI (v.x = t.a)  ← pushed into child
+        ├── TableScan v
+        └── TableScan t
+```
+
+This is not implemented. The join edge `t ↔ w` references `w`'s columns, not
+the children's columns. Pushing into children would require translating join
+keys from `w`'s column space to each child's column space. Additionally,
+`addExistences` runs before `flattenDt` in `import`, so the child's internal
+columns are not yet visible when existences are processed.
+
+Currently, `makeUnionPlan` creates child MemoKeys without existences, and the
+join with `t` happens above the union.

--- a/axiom/optimizer/docs/Memoization.md
+++ b/axiom/optimizer/docs/Memoization.md
@@ -1,0 +1,125 @@
+# Memoization of Partial Plans
+
+This document describes the memoization mechanism used during plan enumeration
+to avoid redundant work.
+
+## Overview
+
+The optimizer explores different join orderings to find the lowest-cost physical
+plan. During this exploration, the same subset of tables with the same output
+requirements may appear in multiple branches of the search. The `Memo` cache
+stores previously computed plans so they can be reused.
+
+## MemoKey
+
+A `MemoKey` identifies a planning subproblem. It has four fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `firstTable` | `PlanObjectCP` | The primary table (anchor) of the subplan. Must be a member of `tables`. |
+| `columns` | `PlanObjectSet` | The set of output columns required from this subplan. |
+| `tables` | `PlanObjectSet` | All tables that must be joined together in this subplan. |
+| `existences` | `vector<PlanObjectSet>` | Optional existence (semijoin) constraints — see below. |
+
+The key captures the **problem specification**: "produce these columns by
+combining these tables." It does not describe *how* to combine them — that is
+what the cached plans represent.
+
+### Hash and Equality
+
+`MemoKey::hash()` is computed from `tables` and `existences` only
+(order-independent). It deliberately excludes `firstTable` and `columns` for
+efficiency, accepting more hash collisions in exchange for a cheaper hash.
+`operator==` compares all four fields to resolve collisions.
+
+## Memo
+
+The `Memo` class wraps `folly::F14FastMap<MemoKey, PlanSet>`. Each entry maps a
+`MemoKey` to a `PlanSet` — a collection of physical plans (operator trees) that
+satisfy the key's requirements. Different plans in a `PlanSet` may use different
+join orders, join methods (hash vs. index), or data distributions.
+
+## How It Works
+
+The main consumer is `Optimization::makeDtPlan(dt, key, ...)`:
+
+```
+makeDtPlan(dt, key, distribution, existsFanout, needsShuffle)
+    │
+    ├─► memo_.find(key)
+    │     │
+    │     ├─► Cache hit → skip to step 3
+    │     │
+    │     └─► Cache miss:
+    │           1. Create a temporary DerivedTable
+    │           2. Import tables, joins, and existences from 'dt' into it
+    │           3. Call makeJoins() to enumerate join orderings
+    │           4. Store resulting plans: memo_.insert(key, plans)
+    │
+    └─► Return plans->best(distribution, needsShuffle)
+```
+
+The `dt` parameter is the outer (super) DerivedTable that owns the tables and
+joins. On a cache miss, `tmpDt->import(dt, key.tables, ...)` copies the relevant
+subset of tables and joins from `dt` into a temporary DerivedTable, then runs
+join enumeration (`makeJoins`) to produce alternative physical plans. These
+plans are full operator trees containing scans, joins, projections,
+aggregations, etc. The result is stored in the memo for reuse.
+
+On a cache hit, the previously computed plans are returned directly.
+
+`best()` selects the lowest-cost plan from the set, optionally matching a
+desired data distribution.
+
+## Existences in the MemoKey
+
+Existences are **not** part of the logical query specification — they are an
+optimization strategy. An existence represents a decision to push a semijoin
+from the outer query *into* a subplan to filter rows early (see
+[Existence Pushdown](ExistencePushdown.md)).
+
+For example, given:
+
+```sql
+SELECT t.a, dt.cnt
+FROM t
+JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.x
+```
+
+The optimizer may decide to push a semijoin on `t` inside `dt`'s subplan to
+reduce rows before the GROUP BY. This decision is made *before* the MemoKey is
+constructed (by `findReducingJoins` in `placeDerivedTable`). The existences
+field records this decision so the memo distinguishes plans built with different
+optimization strategies:
+
+- `MemoKey{tables={dt}, existences=[]}` → plan `dt` without early filtering.
+- `MemoKey{tables={dt}, existences=[{t}]}` → plan `dt` with a semijoin on `t`.
+
+These are different subproblems because the resulting operator trees are
+structurally different.
+
+### Cross-boundary Nature of Existences
+
+Existences involve tables that are **outside** the current subproblem's scope.
+When `makeJoins` runs on a subplan with tables `{dt}`, it only sees joins
+*within* that DerivedTable. Table `t` belongs to the outer DerivedTable and
+would never be considered during normal join enumeration.
+
+The existence mechanism bridges this boundary: `addExistences` imports the
+cross-boundary join into the child DerivedTable as a semijoin edge. After
+import, `makeJoins` sees the semijoin and incorporates it into join ordering
+like any other join.
+
+## Call Sites
+
+`MemoKey::create` is called in several places in `Optimization.cpp`:
+
+| Context | firstTable | tables | existences |
+|---------|-----------|--------|------------|
+| Hash join build side | Build anchor | Build tables | From candidate |
+| Hash join probe side | Probe anchor | Probe tables | From candidate |
+| Single-table build | Table | {table} | From candidate |
+| Single-row DT | Subquery DT | {subquery} | Empty |
+| `placeDerivedTable` (initial) | DT | {DT} | Empty |
+| `placeDerivedTable` (reducing) | DT | Bushy tables or {DT} | From `findReducingJoins` |
+| UNION ALL child | Child DT | {child} | Empty |

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -113,6 +113,7 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv, false);
 
   facebook::axiom::optimizer::test::registerQueryFile("basic.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("join.sql");
   facebook::axiom::optimizer::test::registerQueryFile("window.sql");
 
   return RUN_ALL_TESTS();

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -1,0 +1,2 @@
+-- JOIN with UNION ALL subquery.
+SELECT t1.a, t1.b FROM t t1 JOIN (SELECT a FROM t WHERE a = 1 UNION ALL SELECT a FROM t WHERE a = 2) t2 ON t1.a = t2.a


### PR DESCRIPTION
Summary:
In makeUnionPlan, each UNION ALL child's MemoKey was constructed by
copying all tables from the parent key (including reducing bushy join
tables from placeDerivedTable). These extra tables referenced joins
against the UNION ALL DT which don't exist for individual children,
causing an assertion failure in importJoinsIntoFirstDt.

Fix: use only the child DT in each child's MemoKey tables.

Differential Revision: D94799435


