### PR TITLE
fix(optimizer): Fix failure when joining with UNION ALL subquery

### DIFF
--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -466,5 +466,29 @@ TEST_F(SetTest, except) {
   checkSame(logicalPlan, referencePlan);
 }
 
+// Verifies that joining with a UNION ALL subquery does not crash with an
+// assertion failure in importJoinsIntoFirstDt.
+TEST_F(SetTest, joinWithUnionAll) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+  testConnector_->addTable("v", ROW({"x", "y"}, BIGINT()));
+
+  auto sql =
+      "SELECT a FROM t "
+      "JOIN (SELECT x FROM u UNION ALL SELECT x FROM v) w "
+      "ON a = w.x";
+
+  auto logicalPlan = parseSelect(sql, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("u")
+          .localPartition(matchScan("v").project().build())
+          .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+          .build();
+
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -122,6 +122,7 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv, false);
 
   facebook::axiom::optimizer::test::registerQueryFile("basic.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("join.sql");
   facebook::axiom::optimizer::test::registerQueryFile("window.sql");
 
   return RUN_ALL_TESTS();

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -1,0 +1,2 @@
+-- JOIN with UNION ALL subquery.
+SELECT t1.a, t1.b FROM t t1 JOIN (SELECT a FROM t WHERE a = 1 UNION ALL SELECT a FROM t WHERE a = 2) t2 ON t1.a = t2.a


### PR DESCRIPTION
Summary:
In makeUnionPlan, each UNION ALL child's MemoKey was constructed by
copying all tables from the parent key (including reducing bushy join
tables from placeDerivedTable). These extra tables referenced joins
against the UNION ALL DT which don't exist for individual children,
causing an assertion failure in importJoinsIntoFirstDt.

Fix: use only the child DT in each child's MemoKey tables.

Differential Revision: D94799502


