### PR TITLE
feat(test): Compute column statistics in TestConnector::addData

### DIFF
--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,6 +17,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
+#include "velox/vector/ComplexVector.h"
 
 namespace facebook::axiom::connector {
 
@@ -46,6 +47,7 @@ TestTable::TestTable(
       std::make_unique<TestTableLayout>(name, this, connector_, allColumns());
   layouts_.push_back(exportedLayout_.get());
   pool_ = velox::memory::memoryManager()->addLeafPool(name + "_table");
+  columnTrackers_.resize(schema->size());
 }
 
 void TestTable::setStats(
@@ -103,6 +105,76 @@ void TestTable::addData(const velox::RowVectorPtr& data) {
       velox::BaseVector::copy(*data, pool_.get()));
   data_.push_back(copy);
   dataRows_ += data->size();
+
+  // Compute per-column statistics incrementally.
+  const auto& rowType = type();
+  for (auto i = 0; i < data->childrenSize(); ++i) {
+    auto& tracker = columnTrackers_[i];
+    tracker.append(*data->childAt(i));
+
+    const auto& columnName = rowType->nameOf(i);
+    const_cast<Column*>(columnMap().at(columnName))
+        ->setStats(
+            tracker.toColumnStatistics(dataRows_, data->childAt(i)->type()));
+  }
+}
+
+void TestTable::ColumnTracker::append(const velox::BaseVector& vector) {
+  const auto& childType = vector.type();
+
+  for (auto i = 0; i < vector.size(); ++i) {
+    if (vector.isNullAt(i)) {
+      ++nullCount;
+      continue;
+    }
+
+    if (childType->isPrimitiveType()) {
+      distinctHashes.insert(vector.hashValueAt(i));
+      auto value = vector.variantAt(i);
+      if (!min.has_value() || value < min.value()) {
+        min = value;
+      }
+      if (!max.has_value() || max.value() < value) {
+        max = value;
+      }
+    }
+
+    if (childType->isVarchar() || childType->isVarbinary()) {
+      auto value =
+          vector.as<velox::SimpleVector<velox::StringView>>()->valueAt(i);
+      maxLength = std::max(maxLength, static_cast<int32_t>(value.size()));
+    } else if (childType->isArray()) {
+      auto* arrayVector = vector.wrappedVector()->as<velox::ArrayVector>();
+      auto wrappedIndex = vector.wrappedIndex(i);
+      maxLength = std::max(maxLength, arrayVector->sizeAt(wrappedIndex));
+    } else if (childType->isMap()) {
+      auto* mapVector = vector.wrappedVector()->as<velox::MapVector>();
+      auto wrappedIndex = vector.wrappedIndex(i);
+      maxLength = std::max(maxLength, mapVector->sizeAt(wrappedIndex));
+    }
+  }
+}
+
+std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
+    uint64_t totalRows,
+    const velox::TypePtr& type) const {
+  auto stats = std::make_unique<ColumnStatistics>();
+  stats->numValues = totalRows - nullCount;
+  stats->nonNull = (nullCount == 0);
+  stats->nullPct = totalRows > 0 ? 100.0f * nullCount / totalRows : 0;
+
+  if (type->isPrimitiveType()) {
+    stats->numDistinct = distinctHashes.size();
+    stats->min = min;
+    stats->max = max;
+  }
+
+  if (type->isVarchar() || type->isVarbinary() || type->isArray() ||
+      type->isMap()) {
+    stats->maxLength = maxLength;
+  }
+
+  return stats;
 }
 
 std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 
 namespace facebook::axiom::connector {
@@ -115,8 +116,8 @@ class TestTable : public Table {
 
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
-  /// memory pool. Tracks numRows only; does not compute per-column statistics
-  /// (min/max, numDistinct, nullPct). Cannot be combined with setStats on the
+  /// memory pool. Computes per-column statistics incrementally (numDistinct,
+  /// min/max, nullPct, maxLength). Cannot be combined with setStats on the
   /// same table.
   void addData(const velox::RowVectorPtr& data);
 
@@ -132,6 +133,23 @@ class TestTable : public Table {
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
 
  private:
+  // Per-column state for incremental stat computation during addData.
+  struct ColumnTracker {
+    // Updates tracker state with values from 'vector'.
+    void append(const velox::BaseVector& vector);
+
+    // Builds ColumnStatistics from accumulated state.
+    std::unique_ptr<ColumnStatistics> toColumnStatistics(
+        uint64_t totalRows,
+        const velox::TypePtr& type) const;
+
+    folly::F14FastSet<uint64_t> distinctHashes;
+    uint64_t nullCount{0};
+    std::optional<velox::Variant> min;
+    std::optional<velox::Variant> max;
+    int32_t maxLength{0};
+  };
+
   velox::connector::Connector* connector_;
   std::vector<const TableLayout*> layouts_;
   std::unique_ptr<TestTableLayout> exportedLayout_;
@@ -139,6 +157,7 @@ class TestTable : public Table {
   std::vector<velox::RowVectorPtr> data_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
+  std::vector<ColumnTracker> columnTrackers_;
 };
 
 /// SplitSource generated via the TestSplitManager embedded in the

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -16,7 +16,6 @@
 
 #include "axiom/connectors/tests/TestConnector.h"
 
-#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -290,11 +289,234 @@ TEST_F(TestConnectorTest, tableLayout) {
   EXPECT_EQ(nonExistent, nullptr);
 }
 
+// Verifies that addData computes per-column statistics incrementally.
+TEST_F(TestConnectorTest, addDataStats) {
+  auto table = connector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+
+  connector_->appendData(
+      "t",
+      makeRowVector(
+          {makeFlatVector<int64_t>({10, 20, 30}),
+           makeFlatVector<int64_t>({1, 1, 2}),
+           makeNullConstant(TypeKind::BIGINT, 3)}));
+
+  EXPECT_EQ(table->numRows(), 3);
+
+  {
+    SCOPED_TRACE("column a");
+    auto* column = table->findColumn("a");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_EQ(stats->numDistinct, 3);
+    EXPECT_EQ(stats->min, Variant(10LL));
+    EXPECT_EQ(stats->max, Variant(30LL));
+  }
+
+  {
+    SCOPED_TRACE("column b");
+    auto* column = table->findColumn("b");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_EQ(stats->numDistinct, 2);
+    EXPECT_EQ(stats->min, Variant(1LL));
+    EXPECT_EQ(stats->max, Variant(2LL));
+  }
+
+  {
+    SCOPED_TRACE("column c - all nulls");
+    auto* column = table->findColumn("c");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 0);
+    EXPECT_EQ(stats->nullPct, 100);
+    EXPECT_FALSE(stats->nonNull);
+    EXPECT_EQ(stats->numDistinct, 0);
+    EXPECT_FALSE(stats->min.has_value());
+    EXPECT_FALSE(stats->max.has_value());
+  }
+}
+
+// Verifies incremental stat computation across multiple addData calls.
+TEST_F(TestConnectorTest, addDataStatsMultipleBatches) {
+  auto table = connector_->addTable("t", ROW("a", BIGINT()));
+
+  connector_->appendData(
+      "t", makeRowVector({makeFlatVector<int64_t>({10, 20})}));
+  connector_->appendData(
+      "t", makeRowVector({makeFlatVector<int64_t>({20, 30})}));
+
+  EXPECT_EQ(table->numRows(), 4);
+
+  auto* column = table->findColumn("a");
+  ASSERT_NE(column, nullptr);
+  auto* stats = column->stats();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->numValues, 4);
+  EXPECT_EQ(stats->nullPct, 0);
+  EXPECT_TRUE(stats->nonNull);
+  // 20 appears in both batches, so numDistinct should be 3.
+  EXPECT_EQ(stats->numDistinct, 3);
+  EXPECT_EQ(stats->min, Variant(10LL));
+  EXPECT_EQ(stats->max, Variant(30LL));
+}
+
+// Verifies null statistics.
+TEST_F(TestConnectorTest, addDataStatsWithNulls) {
+  auto table = connector_->addTable("t", ROW("a", BIGINT()));
+
+  connector_->appendData(
+      "t",
+      makeRowVector({makeNullableFlatVector<int64_t>(
+          {10, std::nullopt, 30, std::nullopt})}));
+
+  auto* column = table->findColumn("a");
+  ASSERT_NE(column, nullptr);
+  auto* stats = column->stats();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->numValues, 2);
+  EXPECT_EQ(stats->nullPct, 50);
+  EXPECT_FALSE(stats->nonNull);
+  EXPECT_EQ(stats->numDistinct, 2);
+  EXPECT_EQ(stats->min, Variant(10LL));
+  EXPECT_EQ(stats->max, Variant(30LL));
+}
+
+// Verifies VARCHAR stats including maxLength.
+TEST_F(TestConnectorTest, addDataStatsVarchar) {
+  auto table = connector_->addTable("t", ROW({"a", "b"}, VARCHAR()));
+
+  connector_->appendData(
+      "t",
+      makeRowVector(
+          {makeFlatVector<std::string>({"abc", "z", "hello"}),
+           makeFlatVector<std::string>({"", "", ""})}));
+
+  {
+    SCOPED_TRACE("non-empty strings");
+    auto* column = table->findColumn("a");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_EQ(stats->numDistinct, 3);
+    EXPECT_EQ(stats->min, Variant("abc"));
+    EXPECT_EQ(stats->max, Variant("z"));
+    EXPECT_EQ(stats->maxLength, 5); // "hello" has 5 bytes
+  }
+
+  {
+    SCOPED_TRACE("empty strings");
+    auto* column = table->findColumn("b");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_EQ(stats->numDistinct, 1);
+    EXPECT_EQ(stats->min, Variant(""));
+    EXPECT_EQ(stats->max, Variant(""));
+    EXPECT_EQ(stats->maxLength, 0);
+  }
+}
+
+// Verifies ARRAY stats: maxLength only, no numDistinct or min/max.
+TEST_F(TestConnectorTest, addDataStatsArray) {
+  auto table = connector_->addTable("t", ROW({"a", "b"}, ARRAY(BIGINT())));
+
+  connector_->appendData(
+      "t",
+      makeRowVector(
+          {makeArrayVector<int64_t>({{1, 2, 3}, {4}, {5, 6}}),
+           makeArrayVector<int64_t>({{}, {}, {}})}));
+
+  {
+    SCOPED_TRACE("non-empty arrays");
+    auto* column = table->findColumn("a");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_FALSE(stats->numDistinct.has_value());
+    EXPECT_FALSE(stats->min.has_value());
+    EXPECT_FALSE(stats->max.has_value());
+    EXPECT_EQ(stats->maxLength, 3); // {1, 2, 3} has 3 elements
+  }
+
+  {
+    SCOPED_TRACE("empty arrays");
+    auto* column = table->findColumn("b");
+    ASSERT_NE(column, nullptr);
+    auto* stats = column->stats();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->numValues, 3);
+    EXPECT_EQ(stats->nullPct, 0);
+    EXPECT_TRUE(stats->nonNull);
+    EXPECT_FALSE(stats->numDistinct.has_value());
+    EXPECT_FALSE(stats->min.has_value());
+    EXPECT_FALSE(stats->max.has_value());
+    EXPECT_EQ(stats->maxLength, 0);
+  }
+}
+
+// Verifies MAP stats: maxLength only, no numDistinct or min/max.
+TEST_F(TestConnectorTest, addDataStatsMap) {
+  auto table = connector_->addTable("t", ROW("m", MAP(BIGINT(), VARCHAR())));
+
+  connector_->appendData(
+      "t",
+      makeRowVector({makeMapVector<int64_t, std::string>({
+          {{1, "a"}, {2, "b"}},
+          {{3, "c"}},
+      })}));
+
+  auto* column = table->findColumn("m");
+  ASSERT_NE(column, nullptr);
+  auto* stats = column->stats();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->numValues, 2);
+  EXPECT_EQ(stats->nullPct, 0);
+  EXPECT_TRUE(stats->nonNull);
+  EXPECT_FALSE(stats->numDistinct.has_value());
+  EXPECT_FALSE(stats->min.has_value());
+  EXPECT_FALSE(stats->max.has_value());
+  EXPECT_EQ(stats->maxLength, 2); // first map has 2 entries
+}
+
+// Verifies that setStats and addData cannot be used on the same table.
+TEST_F(TestConnectorTest, addDataAndSetStatsMutualExclusion) {
+  {
+    SCOPED_TRACE("setStats then addData");
+    auto table = connector_->addTable("t1", ROW("a", BIGINT()));
+    table->setStats(100, {{"a", {.numDistinct = 50}}});
+    VELOX_ASSERT_THROW(
+        connector_->appendData(
+            "t1", makeRowVector({makeFlatVector<int64_t>({1})})),
+        "Cannot use both setStats and addData on table 't1'.");
+  }
+
+  {
+    SCOPED_TRACE("addData then setStats");
+    auto table = connector_->addTable("t2", ROW("a", BIGINT()));
+    connector_->appendData("t2", makeRowVector({makeFlatVector<int64_t>({1})}));
+    VELOX_ASSERT_THROW(
+        table->setStats(100, {{"a", {.numDistinct = 50}}}),
+        "Cannot use both setStats and addData on table 't2'.");
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::connector
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  folly::Init init(&argc, &argv, false);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Summary:
TestTable::addData now computes per-column statistics incrementally as data
is appended, matching the existing pattern for row count tracking. Previously,
tables created via addData (including CREATE TABLE AS SELECT in the CLI) had
no column stats, preventing the optimizer from making cost-based decisions.

Computed stats by type:
- Numeric primitives: numDistinct, min, max, nullPct, numValues.
- VARCHAR/VARBINARY: same + maxLength (byte length).
- ARRAY: nullPct, numValues, maxLength (element count).
- MAP: nullPct, numValues, maxLength (key-value pair count).

The setStats path is unchanged and remains mutually exclusive with addData.

Differential Revision: D94908803


