### PR TITLE
docs: Add known limitation for unaliased projected expression

### DIFF
--- a/axiom/sql/presto/README.md
+++ b/axiom/sql/presto/README.md
@@ -476,5 +476,13 @@ them today). Contributions to close these gaps are welcome.
   narrows the scope to only the SELECT list columns. Referencing a FROM
   column not in SELECT will fail with "Cannot resolve column".
 
+- **ORDER BY cannot reference un-aliased expressions in SELECT.**
+  In standard SQL, `SELECT a + b FROM t ORDER BY a + b` is valid — ORDER BY
+  can reference expressions that also appear in the SELECT list even if these
+  columns are not projected outside of the expression. Axiom currently only
+  propagates projected columns to ORDER BY, not expressions, so this query
+  will fail with "Cannot resolve column" if "a" and "b" are not projected
+  outside of the expression. Expressions are aliased as "expr_0", etc.
+
 [SLL]: https://www.antlr.org/api/Java/org/antlr/v4/runtime/atn/PredictionMode.html "SLL — Simple LL. A faster but less powerful prediction mode that ignores the parser call stack (full context). Falls back to LL on ambiguity."
 [LL]: https://en.wikipedia.org/wiki/LL_parser "LL — a top-down parsing strategy that reads input Left-to-right and produces a Leftmost derivation"


### PR DESCRIPTION
Summary:
Add a known gap entry for queries where ORDER BY references expressions
(e.g. `a + b`) that also appear in the SELECT list. The planner crashes
due to unfound mappings.

Bug detailed in https://github.com/facebookincubator/axiom/issues/925

AI-assisted change.

Differential Revision: D94947384


