### PR TITLE
feat(parser): Resolve ORDER BY expressions against projection outputs

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -727,6 +727,13 @@ PlanBuilder& PlanBuilder::project(const std::vector<ExprApi>& projections) {
 
   resolveProjections(projections, outputNames, exprs, *newOutputMapping);
 
+  projectionExpressionMap_.clear();
+  for (size_t i = 0; i < projections.size(); ++i) {
+    if (!projections[i].expr()->inputs().empty()) {
+      projectionExpressionMap_.emplace(projections[i].expr(), outputNames[i]);
+    }
+  }
+
   node_ = std::make_shared<ProjectNode>(
       nextId(), std::move(node_), std::move(outputNames), std::move(exprs));
 
@@ -1787,6 +1794,15 @@ ExprPtr PlanBuilder::resolveInputName(
 
 ExprPtr PlanBuilder::resolveScalarTypes(
     const velox::core::ExprPtr& expr) const {
+  if (!projectionExpressionMap_.empty()) {
+    auto it = projectionExpressionMap_.find(expr);
+    if (it != projectionExpressionMap_.end()) {
+      const auto& id = it->second;
+      return std::make_shared<InputReferenceExpr>(
+          node_->outputType()->findChild(id), id);
+    }
+  }
+
   return resolver_.resolveScalarTypes(
       expr, [&](const auto& alias, const auto& name) {
         return resolveInputName(alias, name);

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -839,6 +839,12 @@ class PlanBuilder {
   // Maps user-visible column names to auto-generated internal IDs.
   std::shared_ptr<NameMappings> outputMapping_;
 
+  // Maps unresolved projection expressions to their output column names.
+  // Populated by project() so that resolveScalarTypes() can match a whole
+  // expression (e.g. plus(Col("a"), Col("b"))) to the projection output
+  // that computed it, enabling ORDER BY on expressions that appear in SELECT.
+  velox::core::ExprMap<std::string> projectionExpressionMap_;
+
   // Resolves and type-checks scalar and aggregate expressions.
   ExprResolver resolver_;
 };

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -466,6 +466,65 @@ TEST_F(PrestoParserTest, orderBy) {
   }
 }
 
+TEST_F(PrestoParserTest, orderByExpression) {
+  // Expression in both SELECT and ORDER BY.
+  {
+    auto matcher = matchValues().project().project().sort().output();
+
+    testSelect(
+        "SELECT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b", matcher);
+  }
+
+  // Expression with constant.
+  {
+    auto matcher = matchValues().project().project().sort().output();
+
+    testSelect("SELECT a + 1 FROM ( VALUES (1) ) t(a) ORDER BY a + 1", matcher);
+  }
+
+  // Multiple expressions in SELECT, ORDER BY on one of them.
+  {
+    auto matcher = matchValues().project().project().sort().output();
+
+    testSelect(
+        "SELECT a + b, a - b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b",
+        matcher);
+  }
+
+  // Nested subquery with aliased expression.
+  {
+    auto matcher = matchValues().project().project().project().sort().output();
+
+    testSelect(
+        "SELECT x FROM (SELECT a + b AS x FROM ( VALUES (1, 2) ) t(a, b)) ORDER BY x",
+        matcher);
+  }
+
+  // Simple column ORDER BY (regression check).
+  {
+    auto matcher = matchScan().project().sort().output();
+
+    testSelect("SELECT n_regionkey FROM nation ORDER BY n_regionkey", matcher);
+  }
+
+  // Ordinal ORDER BY with expression in SELECT (regression check).
+  {
+    auto matcher = matchValues().project().project().sort().output();
+
+    testSelect(
+        "SELECT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY 1", matcher);
+  }
+
+  // DISTINCT with expression in both SELECT and ORDER BY.
+  {
+    auto matcher = matchValues().project().project().distinct().sort().output();
+
+    testSelect(
+        "SELECT DISTINCT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b",
+        matcher);
+  }
+}
+
 TEST_F(PrestoParserTest, join) {
   {
     auto matcher = matchScan()


### PR DESCRIPTION
Summary:
When ORDER BY references an expression that also appears in SELECT (e.g. `SELECT a + b FROM t ORDER BY a + b`), the expression needs to resolve against the projected output. However, after `project()`, the result is stored under an auto-generated internal name (e.g. `expr_0`) not registered in `outputMapping_`, so `resolveScalarTypes()` couldn't match it.

This adds a `projectionExpressionMap_` to `PlanBuilder` that maps unresolved projection expressions to their output column names:

- In `project()`, non-trivial expressions are saved into the map.
- In `resolveScalarTypes()`, before leaf-level column resolution, the entire expression is checked against the map. If matched, an `InputReferenceExpr` pointing to the projection output is returned directly.

Resolves https://github.com/facebookincubator/axiom/issues/925

Differential Revision: D94931869


