### PR TITLE
feat: Allow generating plans optimized for remote or local query result consumption

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -304,27 +304,31 @@ PlanAndStats ToVelox::toVeloxPlan(
   prediction_.clear();
   nodeHistory_.clear();
 
-  if (options_.numWorkers > 1) {
+  if (options_.numWorkers > 1 && !options_.remoteOutput) {
     plan = addGather(plan);
   }
 
-  runner::ExecutableFragment top;
+  runner::ExecutableFragment top = newFragment();
   std::vector<runner::ExecutableFragment> stages;
   top.fragment.planNode = makeFragment(plan, top, stages);
-
-  if (!outputNames.empty()) {
-    top.fragment.planNode =
-        addOutputRenames(top.fragment.planNode, outputNames);
-  }
-
   stages.push_back(std::move(top));
 
-  auto finishWrite = std::move(finishWrite_);
-  VELOX_DCHECK(!finishWrite_);
+  auto& rootPlanNode = stages.back().fragment.planNode;
+  if (!outputNames.empty()) {
+    rootPlanNode = addOutputRenames(rootPlanNode, outputNames);
+  }
 
   for (const auto& stage : stages) {
     velox::core::PlanConsistencyChecker::check(stage.fragment.planNode);
   }
+
+  if (options.remoteOutput) {
+    rootPlanNode = velox::core::PartitionedOutputNode::single(
+        nextId(), rootPlanNode->outputType(), exchangeSerdeKind_, rootPlanNode);
+  }
+
+  auto finishWrite = std::move(finishWrite_);
+  VELOX_DCHECK(!finishWrite_);
 
   return PlanAndStats{
       std::make_shared<runner::MultiFragmentPlan>(std::move(stages), options),

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(
   UnnestTest.cpp
   ValuesTest.cpp
   WriteTest.cpp
+  RemoteOutputTest.cpp
 )
 
 add_test(

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1002,6 +1002,37 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
       partitionedOutput->sources()[0], symbols, &producerContext);
 }
 
+class PartitionedOutputMatcher : public PlanMatcherImpl<PartitionedOutputNode> {
+ public:
+  explicit PartitionedOutputMatcher(
+      std::shared_ptr<PlanMatcher> matcher,
+      std::optional<PartitionedOutputNode::Kind> kind = std::nullopt,
+      std::optional<int32_t> numPartitions = std::nullopt)
+      : PlanMatcherImpl<PartitionedOutputNode>({std::move(matcher)}),
+        kind_(kind),
+        numPartitions_(numPartitions) {}
+
+  MatchResult matchDetails(
+      const PartitionedOutputNode& node,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(node.toString(true, false));
+    if (kind_.has_value()) {
+      EXPECT_EQ(node.kind(), kind_.value());
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+    if (numPartitions_.has_value()) {
+      EXPECT_EQ(node.numPartitions(), numPartitions_.value());
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+    return MatchResult::success(symbols);
+  }
+
+ private:
+  const std::optional<PartitionedOutputNode::Kind> kind_;
+  const std::optional<int32_t> numPartitions_;
+};
+
 class AssignUniqueIdMatcher : public PlanMatcherImpl<AssignUniqueIdNode> {
  public:
   AssignUniqueIdMatcher(
@@ -1669,6 +1700,13 @@ PlanMatcherBuilder& PlanMatcherBuilder::exchange() {
 PlanMatcherBuilder& PlanMatcherBuilder::shuffle() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<ShuffleBoundaryMatcher>(matcher_);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::partitionedOutputSingle() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<PartitionedOutputMatcher>(
+      matcher_, PartitionedOutputNode::Kind::kPartitioned, 1);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -325,6 +325,9 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffle();
 
+  /// Matches a PartitionedOutput node with a single partition.
+  PlanMatcherBuilder& partitionedOutputSingle();
+
   /// Marks a shuffle boundary with verification of partition keys.
   /// @param keys Expected partition key column names. Supports symbol rewriting
   /// from child matchers.

--- a/axiom/optimizer/tests/RemoteOutputTest.cpp
+++ b/axiom/optimizer/tests/RemoteOutputTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class RemoteOutputTest : public test::QueryTestBase {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    velox::connector::registerConnector(testConnector_);
+
+    testConnector_->addTpchTables();
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(kTestConnectorId);
+    test::QueryTestBase::TearDown();
+  }
+
+  std::shared_ptr<connector::TestConnector> testConnector_;
+};
+
+TEST_F(RemoteOutputTest, simpleScan) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  lp::PlanBuilder::Context ctx{kTestConnectorId};
+  auto logicalPlan = lp::PlanBuilder{ctx}.tableScan("t").build();
+
+  // Multi-worker with remote output: results stay distributed, each worker
+  // wraps output in a PartitionedOutputNode for remote consumption.
+  auto distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = true});
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan("t")
+                     .partitionedOutputSingle()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+
+  // Multi-worker without remote output: a gather stage is added to collect
+  // results onto a single node.
+  distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = false});
+  matcher = core::PlanMatcherBuilder().tableScan("t").gather().build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+
+  // Single worker with remote output: PartitionedOutputNode is still added
+  // to enable remote consumption even though there is only one worker.
+  distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 1, .numDrivers = 2, .remoteOutput = true});
+  matcher = core::PlanMatcherBuilder()
+                .tableScan("t")
+                .partitionedOutputSingle()
+                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+
+  // Single worker without remote output: no extra nodes are added, results
+  // are consumed locally.
+  distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 1, .numDrivers = 2, .remoteOutput = false});
+  matcher = core::PlanMatcherBuilder().tableScan("t").build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+}
+
+TEST_F(RemoteOutputTest, simpleAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  lp::PlanBuilder::Context ctx{kTestConnectorId};
+  auto logicalPlan =
+      lp::PlanBuilder{ctx}.tableScan("t").aggregate({}, {"sum(b)"}).build();
+
+  // Multi-worker without remote output: partial aggregation on workers,
+  // gather to single node, then final aggregation. No additional gather
+  // needed since the final fragment is already single-worker.
+  auto distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = false});
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan("t")
+                     .partialAggregation({}, {"sum(b)"})
+                     .gather()
+                     .localGather()
+                     .finalAggregation({}, {"sum(sum)"})
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+}
+
+TEST_F(RemoteOutputTest, groupByAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  lp::PlanBuilder::Context ctx{kTestConnectorId};
+  auto logicalPlan =
+      lp::PlanBuilder{ctx}.tableScan("t").aggregate({"a"}, {"sum(b)"}).build();
+
+  // Multi-worker without remote output: shuffle by group-by key, then
+  // single aggregation. A gather stage collects results from multiple
+  // workers onto a single node.
+  auto distributedPlan = planVelox(
+      logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = false});
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan("t")
+                     .shuffle({"a"})
+                     .localPartition({"a"})
+                     .singleAggregation({"a"}, {"sum(b)"})
+                     .gather()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/runner/MultiFragmentPlan.h
+++ b/axiom/runner/MultiFragmentPlan.h
@@ -133,6 +133,21 @@ class MultiFragmentPlan {
     /// Number of threads in a fragment in a worker. If 1, there are no local
     /// exchanges.
     int32_t numDrivers{4};
+
+    /// Controls how query results are delivered from the final plan fragment.
+    ///
+    /// When true, wraps the root of the final fragment in a
+    /// PartitionedOutputNode that serializes results for remote consumption
+    /// via exchange. With multiple workers, results remain distributed across
+    /// worker nodes — no gather is added, so the caller must read from each
+    /// worker independently. Even with a single worker, the
+    /// PartitionedOutputNode is added to enable remote consumption.
+    ///
+    /// When false (default), results are consumed locally from the final
+    /// fragment. With multiple workers, the planner adds a gather stage to
+    /// collect results onto a single node. With a single worker, no
+    /// additional nodes are added.
+    bool remoteOutput{false};
   };
 
   MultiFragmentPlan(std::vector<ExecutableFragment> fragments, Options options)


### PR DESCRIPTION
### Execution Modes Considered

**1. In process planning and execution on a single machine**

This model is similar to a model DuckDB employes. Plan is created, executed and results are returned all within the same process. No network communication involved.

**2. Planning in one process and execution by a single different process**

This model usually involves a server accepting a query, generating a plan and sending it for execution to a different process (machine).

This model can be employed by a deployed service with many coordinators accepting queries and many workers processing them. For queries determined to be "small" the service may decide to process the whole query on a single worker and streaming results back to the client. 

**3. Planning in one process and executing by multiple other processes**

This model can be employed for "larger" queries that require large scale, distributed processing by employing multiple physical machines.

### Performance Considerations

To minimize the performance impact of the results transfer back to the client the planner must allow two things:

1. For in process planning and execution avoid any form of serialization all together
2. For remote execution minimize the impact of serialization / deserialization by reducing the number of times it is performed.

The current implementation of adding a `gather` exchange when the number of workers is greater than 1 does not satisfy the second requirements. Due to the Exchange operator implementation adding a remote exchange forces the engine to serialize query results and deserialize them back on the receiver end. 

When the result set is large it can be costly. In case of a large data set it can be highly beneficial to ask the engine to serialize results in a format that a client can understand and stream them back using zero copy mechanisms. The streaming results back can be further optimized by asking the client to pull results directly from a select set of workers to avoid utilizing coordinator CPU and Network bandwidth altogether.

### Proposed Change

This chance introduces a new flag, `remoteOutput` that allows a user of the Axiom planner to chose the behavior desired. 

To generate plan for in process execution mode the user needs to set the `.numWorkers` to `1` and instruct the planner that no remote transfer of query results is necessary by setting the `.remoteOutput` flag to `false`.

To generate plan for single node, remote execution the user needs to set the `.numWorkers` to `1` and instruct the planner that remote transfer of query results is needed by setting the `.remoteOutput` flag to `true`.

To generate plan for distributed execution the user needs to set the `.numWorkers` to `X > 1` and instruct the planner that remote transfer of query results is needed by setting the `.remoteOutput` flag to `true`.

It is also allowed to generated distributed plans with the `.remoteOutput` flag set to `flase`. In this case the planner will add an additional Exchange only fragment if necessary (if the last fragment is not a single node fragment already).


Differential Revision: D94688349


