### PR TITLE
refactor(optimizer): Extract MemoKey into its own header

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   Filters.cpp
   FunctionRegistry.cpp
   JoinSample.cpp
+  MemoKey.cpp
   Model.cpp
   Optimization.cpp
   ParallelExpr.cpp

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -81,12 +81,12 @@ void fillJoins(
     }
   }
 }
-
-MemoKey memoKey(const DerivedTable& dt) {
-  return MemoKey::create(
-      &dt, PlanObjectSet::fromObjects(dt.columns), PlanObjectSet::single(&dt));
-}
 } // namespace
+
+MemoKey DerivedTable::memoKey() const {
+  return MemoKey::create(
+      this, PlanObjectSet::fromObjects(columns), PlanObjectSet::single(this));
+}
 
 void DerivedTable::initializePlans() {
   // Pre-order (top-down): push conjuncts to children.
@@ -131,12 +131,12 @@ void DerivedTable::initializePlans() {
     auto plan = state.plans.best()->op;
     this->cardinality = plan->resultCardinality();
 
-    MemoKey key = memoKey(*this);
+    MemoKey key = this->memoKey();
     memo.insert(key, std::move(state.plans));
 
   } else {
     for (const auto* childDt : children) {
-      MemoKey childKey = memoKey(*childDt);
+      MemoKey childKey = childDt->memoKey();
 
       auto* plans = memo.find(childKey);
       VELOX_CHECK(
@@ -832,7 +832,7 @@ void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
     if (path.empty()) {
       if (other->is(PlanType::kDerivedTableNode)) {
         queryCtx()->optimization()->memo().erase(
-            memoKey(*other->as<DerivedTable>()));
+            other->as<DerivedTable>()->memoKey());
         const_cast<PlanObject*>(other)->as<DerivedTable>()->makeInitialPlan();
       }
 
@@ -1596,7 +1596,7 @@ void DerivedTable::makeInitialPlan() {
   auto plan = state.plans.best()->op;
   this->cardinality = plan->resultCardinality();
 
-  MemoKey key = memoKey(*this);
+  MemoKey key = this->memoKey();
   optimization->memo().insert(key, std::move(state.plans));
 }
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/MemoKey.h"
 #include "axiom/optimizer/PlanObject.h"
 
 namespace facebook::axiom::optimizer {
@@ -313,6 +314,9 @@ struct DerivedTable : public PlanObject {
   bool isWrapOnly() const;
 
   void addJoinedBy(JoinEdgeP join);
+
+  /// Returns the memo key for this DT.
+  MemoKey memoKey() const;
 
   /// Memoizes plans for 'this' and fills in 'cardinality'. Needed before adding
   /// 'this' as a join side because join sides must have a cardinality guess.

--- a/axiom/optimizer/MemoKey.cpp
+++ b/axiom/optimizer/MemoKey.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/MemoKey.h"
+
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::axiom::optimizer {
+
+size_t MemoKey::hash() const {
+  size_t hash = tables.hash();
+  for (auto& exists : existences) {
+    hash = velox::bits::commutativeHashMix(hash, exists.hash());
+  }
+  return hash;
+}
+
+bool MemoKey::operator==(const MemoKey& other) const {
+  if (firstTable == other.firstTable && columns == other.columns &&
+      tables == other.tables) {
+    if (existences.size() != other.existences.size()) {
+      return false;
+    }
+    for (auto& e : existences) {
+      for (auto& e2 : other.existences) {
+        if (e2 == e) {
+          break;
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+std::string MemoKey::toString() const {
+  return fmt::format(
+      "MemoKey({}, columns: {}, tables: {})",
+      cname(firstTable),
+      columns.toString(true),
+      tables.toString(true));
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/MemoKey.h
+++ b/axiom/optimizer/MemoKey.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/PlanObject.h"
+
+namespace facebook::axiom::optimizer {
+
+/// Key for memoization of partial plans. Identifies a subset of tables
+/// with their required output columns and existence joins.
+struct MemoKey {
+  static MemoKey create(
+      PlanObjectCP firstTable,
+      PlanObjectSet columns,
+      PlanObjectSet tables,
+      std::vector<PlanObjectSet> existences = {}) {
+    VELOX_CHECK_NOT_NULL(firstTable);
+    VELOX_CHECK(tables.contains(firstTable));
+    return MemoKey{
+        firstTable,
+        std::move(columns),
+        std::move(tables),
+        std::move(existences)};
+  }
+
+  bool operator==(const MemoKey& other) const;
+
+  size_t hash() const;
+
+  std::string toString() const;
+
+  const PlanObjectCP firstTable;
+  const PlanObjectSet columns;
+  const PlanObjectSet tables;
+  const std::vector<PlanObjectSet> existences;
+
+ private:
+  MemoKey(
+      PlanObjectCP firstTable,
+      PlanObjectSet columns,
+      PlanObjectSet tables,
+      std::vector<PlanObjectSet> existences)
+      : firstTable(firstTable),
+        columns(std::move(columns)),
+        tables(std::move(tables)),
+        existences(std::move(existences)) {}
+};
+
+} // namespace facebook::axiom::optimizer
+
+namespace std {
+template <>
+struct hash<::facebook::axiom::optimizer::MemoKey> {
+  size_t operator()(const ::facebook::axiom::optimizer::MemoKey& key) const {
+    return key.hash();
+  }
+};
+} // namespace std

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -628,40 +628,6 @@ bool NextJoin::isWorse(const NextJoin& other) const {
   return cost.cost > other.cost.cost + shuffle;
 }
 
-size_t MemoKey::hash() const {
-  size_t hash = tables.hash();
-  for (auto& exists : existences) {
-    hash = velox::bits::commutativeHashMix(hash, exists.hash());
-  }
-  return hash;
-}
-
-bool MemoKey::operator==(const MemoKey& other) const {
-  if (firstTable == other.firstTable && columns == other.columns &&
-      tables == other.tables) {
-    if (existences.size() != other.existences.size()) {
-      return false;
-    }
-    for (auto& e : existences) {
-      for (auto& e2 : other.existences) {
-        if (e2 == e) {
-          break;
-        }
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
-std::string MemoKey::toString() const {
-  return fmt::format(
-      "MemoKey({}, columns: {}, tables: {})",
-      cname(firstTable),
-      columns.toString(true),
-      tables.toString(true));
-}
-
 velox::core::JoinType reverseJoinType(velox::core::JoinType joinType) {
   switch (joinType) {
     case velox::core::JoinType::kLeft:

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/optimizer/DerivedTable.h"
+#include "axiom/optimizer/MemoKey.h"
 #include "axiom/optimizer/RelationOp.h"
 
 /// Planning-time data structures. Represent the state of the planning process
@@ -356,74 +357,6 @@ struct PlanStateSaver {
  private:
   PlanState& state_;
 };
-
-/// Key for collection of memoized partial plans. Any table or derived
-/// table with a particular set of projected out columns and an
-/// optional set of reducing joins and semijoins (existences) is
-/// planned once. The plan is then kept in a memo for future use. The
-/// memo may hold multiple plans with different distribution
-/// properties for one MemoKey. The first table is the table or
-/// derived table to be planned. The 'tables' set is the set of
-/// reducing joins applied to 'firstTable', including the table
-/// itself. 'existences' is another set of reducing joins that are
-/// semijoined to the join of 'tables' in order to restrict the
-/// result. For example, if a reducing join is moved below a group by,
-/// unless it is known never to have duplicates, it must become a
-/// semijoin and the original join must still stay in place in case
-/// there were duplicates.
-///
-/// MemoKey is immutable after construction. Use the static create() method
-/// to construct instances.
-struct MemoKey {
-  static MemoKey create(
-      PlanObjectCP firstTable,
-      PlanObjectSet columns,
-      PlanObjectSet tables,
-      std::vector<PlanObjectSet> existences = {}) {
-    VELOX_CHECK_NOT_NULL(firstTable);
-    VELOX_CHECK(tables.contains(firstTable));
-    return MemoKey{
-        firstTable,
-        std::move(columns),
-        std::move(tables),
-        std::move(existences)};
-  }
-
-  bool operator==(const MemoKey& other) const;
-
-  size_t hash() const;
-
-  std::string toString() const;
-
-  const PlanObjectCP firstTable;
-  const PlanObjectSet columns;
-  const PlanObjectSet tables;
-  const std::vector<PlanObjectSet> existences;
-
- private:
-  MemoKey(
-      PlanObjectCP firstTable,
-      PlanObjectSet columns,
-      PlanObjectSet tables,
-      std::vector<PlanObjectSet> existences)
-      : firstTable(firstTable),
-        columns(std::move(columns)),
-        tables(std::move(tables)),
-        existences(std::move(existences)) {}
-};
-
-} // namespace facebook::axiom::optimizer
-
-namespace std {
-template <>
-struct hash<::facebook::axiom::optimizer::MemoKey> {
-  size_t operator()(const ::facebook::axiom::optimizer::MemoKey& key) const {
-    return key.hash();
-  }
-};
-} // namespace std
-
-namespace facebook::axiom::optimizer {
 
 /// Memoization cache for partial plans. Wraps the underlying map
 /// to provide controlled access for adding entries and looking them up.


### PR DESCRIPTION
Summary:
Extract MemoKey struct and its std::hash specialization from Plan.h
into MemoKey.h/MemoKey.cpp. This breaks the circular dependency between
Plan.h and DerivedTable.h, allowing DerivedTable to include MemoKey.h
directly. Add DerivedTable::memoKey() const method replacing the free
function that was in an anonymous namespace.

Differential Revision: D95046788


