### PR TITLE
fix(optimizer): Wrap window subquery in nested DT below join

### DIFF
--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -425,7 +425,7 @@ DerivedTable dt2 represents EXCEPT as an ANTI join between dt3 and dt5 with a GR
 
 A DerivedTable groups together operations that can be planned as a single unit. The following rules determine what can be combined into the same DT:
 
-1. **Aggregation, Limit, Sort, and Unnest cannot appear below a join.** These operations must complete before their results can be joined. If any of these appear in a join input, they are wrapped in a nested DT. Operations *above* a join are unaffected — for example, `SELECT ... FROM t1 JOIN t2 GROUP BY ...` produces a single DT containing both the join and the aggregation.
+1. **Aggregation, Limit, Sort, Unnest, and Window cannot appear below a join.** These operations must complete before their results can be joined. If any of these appear in a join input, they are wrapped in a nested DT. Operations *above* a join are unaffected — for example, `SELECT ... FROM t1 JOIN t2 GROUP BY ...` produces a single DT containing both the join and the aggregation. Window functions are detected via the `excludeWindows` flag in `makeQueryGraph` since they are embedded inside Project nodes rather than having their own `NodeKind`.
 
 2. **Only inner joins can be flattened together.** Multiple inner joins can be combined into a single DT for join order optimization. Outer joins (LEFT, FULL) cannot be freely reordered, so each outer join and its inputs are wrapped in a nested DT.
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1730,6 +1730,21 @@ bool hasSubquery(const lp::ExprPtr& expr) {
   return false;
 }
 
+// Returns true if 'expr' contains a window function at any nesting level.
+bool hasWindow(const lp::ExprPtr& expr) {
+  if (expr->isWindow()) {
+    return true;
+  }
+
+  for (const auto& input : expr->inputs()) {
+    if (hasWindow(input)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // Splits a logical plan expression on AND into leaf conjuncts.
 void flattenConjuncts(const lp::ExprPtr& expr, std::vector<lp::ExprPtr>& out) {
   if (!expr) {
@@ -3389,7 +3404,8 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
 void ToGraph::makeFilterQueryGraph(
     const lp::FilterNode& filter,
     uint64_t allowedInDt,
-    bool excludeOuterJoins) {
+    bool excludeOuterJoins,
+    bool excludeWindows) {
   const auto& input = *filter.onlyInput();
 
   if (hasSubquery(filter.predicate())) {
@@ -3404,7 +3420,7 @@ void ToGraph::makeFilterQueryGraph(
     return;
   }
 
-  makeQueryGraph(input, allowedInDt, excludeOuterJoins);
+  makeQueryGraph(input, allowedInDt, excludeOuterJoins, excludeWindows);
 
   // If the current DT has any window function outputs, finalize the DT
   // so that filters are evaluated in the outer DT after the window.
@@ -3420,16 +3436,28 @@ void ToGraph::makeFilterQueryGraph(
 void ToGraph::makeProjectQueryGraph(
     const lp::ProjectNode& project,
     uint64_t allowedInDt,
-    bool excludeOuterJoins) {
-  makeQueryGraph(*project.onlyInput(), allowedInDt, excludeOuterJoins);
+    bool excludeOuterJoins,
+    bool excludeWindows) {
+  // Window functions cannot appear below a join — filtering rows before
+  // the window changes its computation. Wrap the entire project subtree
+  // in a nested DT when windows are excluded (inside join inputs).
+  const bool hasWindow =
+      std::ranges::any_of(project.expressions(), optimizer::hasWindow);
+  if (hasWindow && excludeWindows) {
+    wrapInDt(project);
+    return;
+  }
+
+  makeQueryGraph(
+      *project.onlyInput(), allowedInDt, excludeOuterJoins, excludeWindows);
+
+  // TODO Handle windows wrapped in scalar expressions.
 
   // Check if this project contains window expressions and apply DT
   // boundary rules.
-  bool hasWindow = false;
   bool windowHasPartitionOrOrderKeys = false;
   for (const auto& expr : project.expressions()) {
     if (expr->isWindow()) {
-      hasWindow = true;
       const auto* window = expr->as<lp::WindowExpr>();
       if (!window->partitionKeys().empty() || !window->ordering().empty()) {
         windowHasPartitionOrOrderKeys = true;
@@ -3451,7 +3479,8 @@ void ToGraph::makeProjectQueryGraph(
 void ToGraph::makeQueryGraph(
     const lp::LogicalPlanNode& node,
     uint64_t allowedInDt,
-    bool excludeOuterJoins) {
+    bool excludeOuterJoins,
+    bool excludeWindows) {
   if (!contains(allowedInDt, node.kind())) {
     wrapInDt(node);
     return;
@@ -3477,11 +3506,17 @@ void ToGraph::makeQueryGraph(
       break;
     case lp::NodeKind::kFilter:
       makeFilterQueryGraph(
-          *node.as<lp::FilterNode>(), allowedInDt, excludeOuterJoins);
+          *node.as<lp::FilterNode>(),
+          allowedInDt,
+          excludeOuterJoins,
+          excludeWindows);
       break;
     case lp::NodeKind::kProject:
       makeProjectQueryGraph(
-          *node.as<lp::ProjectNode>(), allowedInDt, excludeOuterJoins);
+          *node.as<lp::ProjectNode>(),
+          allowedInDt,
+          excludeOuterJoins,
+          excludeWindows);
       break;
     case lp::NodeKind::kAggregate: {
       const auto& input = *node.onlyInput();
@@ -3516,7 +3551,11 @@ void ToGraph::makeQueryGraph(
 
       auto [left, right, joinType] = normalizeLogicalJoin(join);
 
-      makeQueryGraph(*left, allowedInDt, /*excludeOuterJoins=*/true);
+      makeQueryGraph(
+          *left,
+          allowedInDt,
+          /*excludeOuterJoins=*/true,
+          /*excludeWindows=*/true);
 
       // For LEFT JOIN with subquery conjuncts, push subquery predicates into
       // the right side. See Subqueries.md.
@@ -3529,7 +3568,11 @@ void ToGraph::makeQueryGraph(
         if (queryCtx()->optimization()->options().syntacticJoinOrder) {
           allowedInDt = deny(allowedInDt, lp::NodeKind::kJoin);
         }
-        makeQueryGraph(*right, allowedInDt, /*excludeOuterJoins=*/true);
+        makeQueryGraph(
+            *right,
+            allowedInDt,
+            /*excludeOuterJoins=*/true,
+            /*excludeWindows=*/true);
       }
 
       translateJoin(left, right, joinType, remainingCondition, join.joinType());

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -165,21 +165,24 @@ class ToGraph {
   void makeQueryGraph(
       const logical_plan::LogicalPlanNode& node,
       uint64_t allowedInDt,
-      bool excludeOuterJoins = false);
+      bool excludeOuterJoins = false,
+      bool excludeWindows = false);
 
   // Handles kFilter in makeQueryGraph. Creates DT boundaries for
   // nondeterministic filters and filters on window function outputs.
   void makeFilterQueryGraph(
       const logical_plan::FilterNode& filter,
       uint64_t allowedInDt,
-      bool excludeOuterJoins);
+      bool excludeOuterJoins,
+      bool excludeWindows);
 
   // Handles kProject in makeQueryGraph. Creates DT boundaries for
   // window-on-window dependencies and windows over LIMIT.
   void makeProjectQueryGraph(
       const logical_plan::ProjectNode& project,
       uint64_t allowedInDt,
-      bool excludeOuterJoins);
+      bool excludeOuterJoins,
+      bool excludeWindows);
 
   PlanObjectCP findLeaf(const logical_plan::LogicalPlanNode* node) {
     auto* leaf = planLeaves_[node];

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -56,7 +56,7 @@ class WindowTest : public test::QueryTestBase {
   std::shared_ptr<connector::TestConnector> testConnector_;
 };
 
-TEST_F(WindowTest, singleWindowFunction) {
+TEST_F(WindowTest, singleFunction) {
   // No extra columns to drop, so no final project.
   auto plan = toSingleNodePlan(
       "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
@@ -68,7 +68,7 @@ TEST_F(WindowTest, singleWindowFunction) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowWithPartitionBy) {
+TEST_F(WindowTest, partitionBy) {
   // Project drops unused columns (n_nationkey).
   auto plan = toSingleNodePlan(
       "SELECT n_name, n_regionkey, "
@@ -84,7 +84,7 @@ TEST_F(WindowTest, windowWithPartitionBy) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, multipleWindowFunctionsSameSpec) {
+TEST_F(WindowTest, multipleFunctionsSameSpec) {
   // Multiple window functions with the same partition/order spec should be
   // grouped into a single Window operator.
   auto plan = toSingleNodePlan(
@@ -186,7 +186,7 @@ TEST_F(WindowTest, differentOrderTypes) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowWithFrameBounds) {
+TEST_F(WindowTest, frameBounds) {
   // Precompute projection materializes frame bound constant.
   auto plan = toSingleNodePlan(
       "SELECT n_name, "
@@ -214,7 +214,7 @@ TEST_F(WindowTest, windowWithFrameBounds) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowWithExpressionFrameBounds) {
+TEST_F(WindowTest, expressionFrameBounds) {
   // Precompute projection materializes expression frame bounds.
   auto plan = toSingleNodePlan(
       "SELECT n_name, "
@@ -242,7 +242,7 @@ TEST_F(WindowTest, windowWithExpressionFrameBounds) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowWithExpressionInputs) {
+TEST_F(WindowTest, expressionInputs) {
   // All inputs to window function are expressions: function args, partition
   // keys, sorting keys, frame start and end. Partition key and frame end share
   // the expression n_regionkey + 1 which is computed once.
@@ -355,6 +355,27 @@ TEST_F(WindowTest, windowOnWindowInFrameBounds) {
                    "ROWS BETWEEN rn PRECEDING AND CURRENT ROW) as s"})
           .project({"n_name", "s"})
           .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Window subquery as a join input must be wrapped in a nested DT.
+// Without wrapping, the join and window end up in the same DT, and the
+// window computes over the joined result instead of the subquery's rows.
+TEST_F(WindowTest, underJoin) {
+  auto plan = toSingleNodePlan(
+      "SELECT n_name, dt.s "
+      "FROM nation "
+      "JOIN ("
+      "  SELECT n_regionkey, SUM(n_nationkey) OVER (ORDER BY n_regionkey) AS s "
+      "  FROM nation"
+      ") dt ON nation.n_regionkey = dt.n_regionkey");
+
+  // The window must be inside a nested DT (below the join), not above it.
+  auto matcher = matchScan("nation")
+                     .hashJoin(
+                         matchScan("nation").window().project().build(),
+                         core::JoinType::kInner)
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 


### PR DESCRIPTION
Summary:
When a join input contains a window function inside a Project node,
ToGraph::makeQueryGraph did not create a DT boundary. Both the join and
the window ended up in the same DT, causing the window to compute over
the joined result instead of just the subquery's rows — producing wrong
results.

Add an excludeWindows flag to makeQueryGraph, set to true when
processing join inputs. makeProjectQueryGraph wraps the project subtree
in a nested DT when it contains a window and excludeWindows is true.

Also rename redundant 'window' prefixes in WindowTest method names.

Differential Revision: D95079480


