### PR TITLE
fix(optimizer): Fix existence pushdown bugs and add validation

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -462,7 +462,12 @@ void DerivedTable::import(
   }
 
   if (primaryTable->is(PlanType::kDerivedTableNode)) {
-    pushExistencesIntoSubquery(*primaryTable->as<DerivedTable>());
+    auto& primaryDt = *primaryTable->as<DerivedTable>();
+    if (isWrapOnly()) {
+      flattenDt(&primaryDt);
+    } else {
+      pushExistencesIntoSubquery(primaryDt);
+    }
   }
 
   linkTablesToJoins();
@@ -475,15 +480,6 @@ void eraseFirst(V& set, E element) {
   auto it = std::find(set.begin(), set.end(), element);
   VELOX_CHECK(it != set.end());
   set.erase(it);
-}
-
-JoinEdgeP importedDtJoin(JoinEdgeP join, DerivedTableP dt, ExprCP innerKey) {
-  auto left = innerKey->singleTable();
-  VELOX_CHECK(left);
-  auto otherKey = dt->columns[0];
-  auto* newJoin = JoinEdge::makeExists(left, dt);
-  newJoin->addEquality(innerKey, otherKey);
-  return newJoin;
 }
 
 // Returns a join partner of starting 'joins' where the partner is not in
@@ -517,16 +513,7 @@ void joinChain(
   }
   visited.add(next);
   path.push_back(next);
-  joinChain(next, joins, visited, path);
-}
-
-JoinEdgeP importedJoin(JoinEdgeP join, PlanObjectCP other, ExprCP innerKey) {
-  auto left = innerKey->singleTable();
-  VELOX_CHECK(left);
-  auto otherKey = join->sideOf(other).keys[0];
-  auto* newJoin = JoinEdge::makeExists(left, other);
-  newJoin->addEquality(innerKey, otherKey);
-  return newJoin;
+  joinChain(next, joins, std::move(visited), path);
 }
 
 // Returns a copy of 'expr', replacing instances of columns in 'source' with
@@ -773,86 +760,185 @@ ExprCP DerivedTable::importExpr(ExprCP expr) const {
   return replaceInputs(expr, columns, exprs);
 }
 
-void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
-  if (isWrapOnly()) {
-    flattenDt(tables[0]->as<DerivedTable>());
-    return;
+void DerivedTable::removeTables(
+    PlanObjectCP table,
+    const std::vector<PlanObjectCP>& chain) {
+  eraseFirst(tables, table);
+  tableSet.erase(table);
+  for (auto& chainTable : chain) {
+    eraseFirst(tables, chainTable);
+    tableSet.erase(chainTable);
   }
+}
 
-  auto initialTables = tables;
+bool DerivedTable::validatePushdown(
+    const DerivedTable& subquery,
+    JoinEdgeVector& validJoins,
+    ExprVector& innerKeys) {
+  validJoins.clear();
+  innerKeys.clear();
+
   if (subquery.hasLimit() || subquery.hasOrderBy()) {
-    // tables can't be imported but are marked as used so not tried again.
-    for (auto i = 1; i < tables.size(); ++i) {
-      importedExistences.add(tables[i]);
-    }
-    return;
+    return false;
   }
 
-  auto& outer = subquery.columns;
-  auto& inner = subquery.exprs;
+  // Collect valid pushdown columns from the subquery. A join key that
+  // references the subquery must resolve to one of these for pushdown
+  // to be valid. Grouping keys can be filtered before aggregation;
+  // window partition keys can be filtered before the window computation.
+  // When both aggregation and window are present, the valid set is the
+  // intersection (the key must be safe for both operations).
+  PlanObjectSet validPushdownColumns;
+  if (subquery.hasAggregation()) {
+    validPushdownColumns.unionColumns(subquery.aggregation->groupingKeys());
+  }
+  if (subquery.hasWindow()) {
+    // Compute partition keys common to ALL window functions.
+    PlanObjectSet windowKeys;
+    bool first = true;
+    for (const auto* func : subquery.windowPlan->functions()) {
+      if (func->partitionKeys().empty()) {
+        windowKeys.clear();
+        break;
+      }
+      if (first) {
+        windowKeys.unionColumns(func->partitionKeys());
+        first = false;
+      } else {
+        PlanObjectSet funcColumns;
+        funcColumns.unionColumns(func->partitionKeys());
+        windowKeys.intersect(funcColumns);
+      }
+    }
+    if (subquery.hasAggregation()) {
+      // Both agg and window: intersect.
+      validPushdownColumns.intersect(windowKeys);
+    } else {
+      validPushdownColumns = std::move(windowKeys);
+    }
+  }
 
-  auto* newFirst = make<DerivedTable>(subquery);
+  // No valid pushdown columns but the subquery has an operation boundary
+  // (aggregation or window). No join key can be pushed below it.
+  if (validPushdownColumns.empty() &&
+      (subquery.hasAggregation() || subquery.hasWindow())) {
+    return false;
+  }
 
-  const int32_t previousNumJoins = newFirst->joins.size();
+  const auto& outer = subquery.columns;
+  const auto& inner = subquery.exprs;
+
+  // Check if all tables can be pushed. The existences come as a single package
+  // with a single fanout estimate. Partial pushdown may not achieve the
+  // expected cardinality reduction, so we push all or none.
   for (auto& join : joins) {
     auto other = join->otherSide(&subquery);
-    if (!other) {
-      continue;
-    }
-
-    if (!tableSet.contains(other)) {
-      // Already placed in some previous join chain.
+    if (!other || !tableSet.contains(other)) {
       continue;
     }
 
     auto side = join->sideOf(&subquery);
     if (side.keys.size() > 1 || !join->filter().empty()) {
-      continue;
+      return false;
     }
 
-    auto innerKey = replaceInputs(side.keys[0], outer, inner);
+    // Resolve the join key through column mappings to get the inner
+    // expression.
+    auto key = replaceInputs(side.keys[0], columns, exprs);
+    auto innerKey = replaceInputs(key, outer, inner);
     VELOX_DCHECK(innerKey);
-    if (innerKey->containsFunction(FunctionSet::kAggregate)) {
-      // If the join key is an aggregate, the join can't be moved below the
-      // agg.
-      continue;
+
+    // Verify the key is a valid pushdown column.
+    if (innerKey->is(PlanType::kColumnExpr) &&
+        innerKey->as<Column>()->relation() == &subquery) {
+      if (!validPushdownColumns.contains(innerKey)) {
+        return false;
+      }
     }
+
+    auto innerTable = innerKey->singleTable();
+    if (!innerTable) {
+      return false;
+    }
+
+    // Skip if the join key resolves to an unnest table column. To support
+    // this, we would need to wrap the base table and its unnest into a new
+    // DerivedTable and create the existence semijoin on that DT. Not yet
+    // implemented.
+    if (innerTable->is(PlanType::kUnnestTableNode)) {
+      return false;
+    }
+
+    validJoins.push_back(join);
+    innerKeys.push_back(innerKey);
+  }
+
+  return true;
+}
+
+void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
+  JoinEdgeVector validJoins;
+  ExprVector innerKeys;
+  if (!validatePushdown(subquery, validJoins, innerKeys)) {
+    return;
+  }
+
+  auto initialTables = tables;
+  auto* newFirst = make<DerivedTable>(subquery);
+
+  auto* optimization = queryCtx()->optimization();
+  const int32_t previousNumJoins = newFirst->joins.size();
+  for (auto i = 0; i < validJoins.size(); ++i) {
+    auto join = validJoins[i];
+    auto innerKey = innerKeys[i];
 
     auto otherSide = join->sideOf(&subquery, true);
+    auto other = otherSide.table;
+    auto otherKey = otherSide.keys[0];
 
     PlanObjectSet visited;
     visited.add(&subquery);
     visited.add(other);
     std::vector<PlanObjectCP> path;
     joinChain(other, joins, visited, path);
+
+    auto innerTable = innerKey->singleTable();
+    VELOX_DCHECK_NOT_NULL(innerTable);
+
+    auto makeExistsJoin = [&](PlanObjectCP table, ExprCP key) {
+      auto* existsJoin = JoinEdge::makeExists(innerTable, table);
+      existsJoin->addEquality(innerKey, key);
+      return existsJoin;
+    };
+
     if (path.empty()) {
       if (other->is(PlanType::kDerivedTableNode)) {
-        queryCtx()->optimization()->memo().erase(
-            other->as<DerivedTable>()->memoKey());
+        optimization->memo().erase(other->as<DerivedTable>()->memoKey());
         const_cast<PlanObject*>(other)->as<DerivedTable>()->initializePlans();
       }
 
       newFirst->addTable(other);
-      newFirst->joins.push_back(importedJoin(join, other, innerKey));
+      newFirst->joins.push_back(makeExistsJoin(other, otherKey));
     } else {
       auto* chainDt = make<DerivedTable>();
-      chainDt->cname = toName(queryCtx()->optimization()->newCName("rdt"));
+      chainDt->cname = toName(optimization->newCName("rdt"));
 
-      PlanObjectSet chainSet;
+      auto chainSet = PlanObjectSet::fromObjects(path);
       chainSet.add(other);
-      chainSet.unionObjects(path);
-      chainDt->makeProjection(otherSide.keys);
+
+      auto column = make<Column>(
+          optimization->newCName("ec"), chainDt, otherKey->value());
+      chainDt->columns.push_back(column);
+      chainDt->exprs.push_back(otherKey);
+
       chainDt->import(*this, chainSet, other);
       chainDt->initializePlans();
+
       newFirst->addTable(chainDt);
-      newFirst->joins.push_back(importedDtJoin(join, chainDt, innerKey));
+      newFirst->joins.push_back(makeExistsJoin(chainDt, column));
     }
-    eraseFirst(tables, other);
-    tableSet.erase(other);
-    for (auto& table : path) {
-      eraseFirst(tables, table);
-      tableSet.erase(table);
-    }
+
+    removeTables(other, path);
   }
 
   for (auto i = previousNumJoins; i < newFirst->joins.size(); ++i) {
@@ -880,16 +966,6 @@ void DerivedTable::flattenDt(const DerivedTable* dt) {
   having = dt->having;
   limit = dt->limit;
   offset = dt->offset;
-}
-
-void DerivedTable::makeProjection(const ExprVector& exprs) {
-  auto optimization = queryCtx()->optimization();
-  for (auto& expr : exprs) {
-    auto* column =
-        make<Column>(optimization->newCName("ec"), this, expr->value());
-    columns.push_back(column);
-    this->exprs.push_back(expr);
-  }
 }
 
 namespace {

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -349,8 +349,20 @@ struct DerivedTable : public PlanObject {
   // Pushes the other tables in 'this' into 'subquery' as existence semijoins
   // below its aggregation boundary. A table can be pushed when the join key
   // maps to a pre-aggregation expression (not an aggregate result) inside the
-  // subquery. Tables that cannot be pushed remain in 'this'.
+  // subquery. If any table cannot be pushed, the entire pushdown is skipped.
   void pushExistencesIntoSubquery(const DerivedTable& subquery);
+
+  // Checks whether all tables in 'this' can be pushed into 'subquery'. Returns
+  // false if pushdown is blocked (LIMIT, ORDER BY, multi-key join, aggregate
+  // key). On success, populates 'validJoins' and 'innerKeys' with the
+  // validated joins and their translated inner keys.
+  bool validatePushdown(
+      const DerivedTable& subquery,
+      JoinEdgeVector& validJoins,
+      ExprVector& innerKeys);
+
+  // Removes 'table' and all tables in 'chain' from 'tables' and 'tableSet'.
+  void removeTables(PlanObjectCP table, const std::vector<PlanObjectCP>& chain);
 
   // Populates tables, tableSet, joinOrder, and joins from 'super', filtered
   // to 'subsetTables'.
@@ -374,9 +386,6 @@ struct DerivedTable : public PlanObject {
 
   // Sets 'dt' to be the complete contents of 'this'.
   void flattenDt(const DerivedTable* dt);
-
-  // Sets 'columns' and 'exprs'.
-  void makeProjection(const ExprVector& exprs);
 
   // Attempts to convert outer joins to less restrictive join types based on
   // filter predicates. A filter that eliminates NULLs on the optional side of

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -249,18 +249,22 @@ void reducingJoinsRecursive(
   }
 }
 
+// Result of searching for bushy reducing joins from a start table.
+struct BushyJoins {
+  PlanObjectSet tables;
+  float reduction;
+};
+
 // Traverses join edges from 'startTable', skipping tables in
 // 'excludedTables', looking for paths whose cumulative fanout is
-// below kReducingPathThreshold. Populates 'reducingTables' with
-// 'startTable' plus any discovered reducing tables. Returns the
-// cumulative reduction (product of leaf fanouts), or 1 if no reducing
-// path is found.
-float findReducingBushyJoins(
+// below kReducingPathThreshold. Returns the set of tables (including
+// 'startTable') and the cumulative reduction, or std::nullopt if no
+// reducing path is found.
+std::optional<BushyJoins> findReducingBushyJoins(
     const PlanState& state,
     PlanObjectCP startTable,
-    PlanObjectSet& reducingTables,
     const PlanObjectSet& excludedTables = {}) {
-  reducingTables = {};
+  PlanObjectSet reducingTables;
   PlanObjectSet visited = state.placed();
   visited.add(startTable);
   visited.unionSet(excludedTables);
@@ -276,7 +280,10 @@ float findReducingBushyJoins(
       visited,
       reducingTables,
       reduction);
-  return reduction;
+  if (reduction < ReducingJoinsMagic::kReducingPathThreshold) {
+    return BushyJoins{std::move(reducingTables), reduction};
+  }
+  return std::nullopt;
 }
 
 // Traverses join edges from 'startTable', skipping tables in
@@ -321,6 +328,54 @@ float findReducingExistences(
   return existenceReduction;
 }
 
+// Result of the two-pass reducing-join discovery: bushy tables and
+// existences, with their respective reductions.
+struct ReducingJoinsResult {
+  std::vector<PlanObjectCP> bushyTables;
+  std::vector<PlanObjectSet> existences;
+  float bushyReduction{1};
+  float existenceReduction{1};
+};
+
+// Runs both reducing-join passes (bushy inner joins + existences) from
+// 'startTable'. Tables in 'excludedTables' are skipped. Bushy joins are
+// only discovered when 'allowBushyJoins' is true.
+ReducingJoinsResult findReducingJoins(
+    const PlanState& state,
+    PlanObjectCP startTable,
+    const PlanObjectSet& excludedTables,
+    bool allowBushyJoins) {
+  ReducingJoinsResult result;
+
+  // Pass 1: bushy reducing inner joins.
+  PlanObjectSet reducingTables;
+  if (allowBushyJoins) {
+    if (auto bushy =
+            findReducingBushyJoins(state, startTable, excludedTables)) {
+      // startTable must be first in bushyTables (see JoinCandidate::tables).
+      result.bushyTables.push_back(startTable);
+      bushy->tables.forEach([&](auto object) {
+        if (object != startTable) {
+          result.bushyTables.push_back(object);
+        }
+      });
+      result.bushyReduction = bushy->reduction;
+      reducingTables = std::move(bushy->tables);
+    }
+  }
+
+  // Pass 2: reducing existences (semi-joins from probe side).
+  if (state.optimization.options().enableReducingExistences &&
+      !state.dt->noImportOfExists) {
+    reducingTables.add(startTable);
+    reducingTables.unionSet(excludedTables);
+    result.existenceReduction = findReducingExistences(
+        state, startTable, reducingTables, result.existences);
+  }
+
+  return result;
+}
+
 bool allowReducingInnerJoins(const JoinCandidate& candidate) {
   if (!candidate.join->isInner()) {
     return false;
@@ -348,72 +403,37 @@ void checkTables(const JoinCandidate& candidate) {
 // Returns a new JoinCandidate with the expanded table list, accumulated
 // existences, and adjusted fanout. Returns std::nullopt if no reduction is
 // found.
-//
-// Two passes are made using reducingJoinsRecursive:
-//   1. Reducing inner joins — DFS from the candidate table over unplaced
-//      neighbors. If the cumulative reduction is below kReducingPathThreshold,
-//      the discovered tables are bundled into a single bushy candidate.
-//   2. Reducing existences — a second DFS that also traverses already-placed
-//      tables and tables found in pass 1. For every reducing leaf whose
-//      cumulative fanout is below kExistenceReductionThreshold, a semi-join
-//      (existence) is recorded so it can later be imported to the build side.
-//
-// Pass 2 is skipped when 'enableReducingExistences' is false or
-// 'noImportOfExists' is set on the derived table.
 std::optional<JoinCandidate> reducingJoins(
     const PlanState& state,
-    const JoinCandidate& candidate,
-    bool enableReducingExistences) {
+    const JoinCandidate& candidate) {
   checkTables(candidate);
 
   VELOX_DCHECK_EQ(candidate.tables.size(), 1);
   auto startTable = candidate.tables[0];
 
-  std::vector<PlanObjectCP> tables;
-  std::vector<PlanObjectSet> existences;
-  float fanout = candidate.fanout;
+  auto result = findReducingJoins(
+      state,
+      startTable,
+      state.dt->importedExistences,
+      /*allowBushyJoins=*/allowReducingInnerJoins(candidate));
 
-  PlanObjectSet reducingTables;
-  if (allowReducingInnerJoins(candidate)) {
-    auto reduction = findReducingBushyJoins(state, startTable, reducingTables);
-    if (reduction < ReducingJoinsMagic::kReducingPathThreshold) {
-      // Start with the candidate's original table, then append the
-      // reducing tables discovered by the DFS.
-      tables.push_back(startTable);
-      reducingTables.forEach([&](auto object) {
-        if (object != startTable) {
-          tables.push_back(object);
-        }
-      });
-      fanout *= reduction;
-    }
-  }
-
-  float existenceReduction = 1;
-  if (enableReducingExistences && !state.dt->noImportOfExists) {
-    // Look for reducing joins that were not added before, also covering already
-    // placed tables. This may copy reducing joins from a probe to the
-    // corresponding build.
-    reducingTables.add(startTable);
-    reducingTables.unionSet(state.dt->importedExistences);
-    existenceReduction =
-        findReducingExistences(state, startTable, reducingTables, existences);
-  }
-
-  if (tables.empty() && existences.empty()) {
-    // No reduction.
+  if (result.bushyTables.empty() && result.existences.empty()) {
     return std::nullopt;
   }
 
-  if (tables.empty()) {
-    // No reducing joins but reducing existences from probe side.
-    tables = candidate.tables;
+  auto fanout = candidate.fanout;
+  if (!result.bushyTables.empty()) {
+    fanout *= result.bushyReduction;
   }
 
   JoinCandidate reducing(candidate.join, startTable, fanout);
-  reducing.tables = std::move(tables);
-  reducing.existences = std::move(existences);
-  reducing.existsFanout = existenceReduction;
+  if (result.bushyTables.empty()) {
+    reducing.tables = candidate.tables;
+  } else {
+    reducing.tables = std::move(result.bushyTables);
+  }
+  reducing.existences = std::move(result.existences);
+  reducing.existsFanout = result.existenceReduction;
   return reducing;
 }
 
@@ -509,8 +529,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   if (!options_.syntacticJoinOrder && !candidates.empty()) {
     std::vector<JoinCandidate> bushes;
     for (auto& candidate : candidates) {
-      if (auto bush = reducingJoins(
-              state, candidate, options_.enableReducingExistences)) {
+      if (auto bush = reducingJoins(state, candidate)) {
         bushes.push_back(std::move(bush.value()));
         addExtraEdges(state, bushes.back());
       }
@@ -2175,6 +2194,14 @@ void Optimization::joinByHash(
   std::optional<DesiredDistribution> forBuild;
   if (!copartition.empty()) {
     forBuild = {nullptr, copartition};
+  } else if (!partKeys.empty()) {
+    ExprVector buildPartKeys;
+    for (auto i : partKeys) {
+      buildPartKeys.push_back(build.keys[i]);
+    }
+    forBuild = {
+        plan->distribution().distributionType().partitionType(),
+        std::move(buildPartKeys)};
   }
 
   PlanObjectSet empty;
@@ -2848,8 +2875,7 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
 
   state.place(from);
 
-  PlanObjectSet dtColumns;
-  dtColumns.unionObjects(from->columns);
+  auto dtColumns = PlanObjectSet::fromObjects(from->columns);
   dtColumns.intersect(state.downstreamColumns());
   state.placeColumns(dtColumns);
 
@@ -2864,24 +2890,40 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
   // Make plans based on the dt alone as first.
   makeJoins(plan->op, state);
 
-  // We see if there are reducing joins to import inside the dt.
-  PlanObjectSet reducingTables;
-  auto reduction = findReducingBushyJoins(
-      state, from, reducingTables, state.dt->importedExistences);
+  // Look for reducing joins to import inside the DT. Bushy joins are
+  // only allowed when the primary table is a base table — when it is a
+  // subquery DT, bushy tables would be placed inside the MemoKey alongside
+  // the subquery, but they need to join above the subquery's
+  // aggregation/window boundary. The >= 3 threshold requires at least 2
+  // unplaced tables besides 'from' to form a meaningful bushy build side.
+  auto result = findReducingJoins(
+      state,
+      from,
+      state.dt->importedExistences,
+      /*allowBushyJoins=*/!from->is(PlanType::kDerivedTableNode) &&
+          state.dt->tables.size() >= 3);
 
-  if (reduction < ReducingJoinsMagic::kReducingPathThreshold) {
-    MemoKey reducingKey = MemoKey::create(
-        from, state.downstreamColumns(), std::move(reducingTables));
-    plan = makePlan(
-        *state.dt,
-        reducingKey,
-        /*distribution=*/std::nullopt,
-        /*boundColumns=*/PlanObjectSet{},
-        /*existsFanout=*/1,
-        /*needsShuffle=*/ignore);
-    state.cost = plan->cost;
-    makeJoins(plan->op, state);
+  if (result.bushyTables.empty() && result.existences.empty()) {
+    return;
   }
+
+  auto reducingTables = result.bushyTables.empty()
+      ? PlanObjectSet::single(from)
+      : PlanObjectSet::fromObjects(result.bushyTables);
+  MemoKey reducingKey = MemoKey::create(
+      from,
+      state.downstreamColumns(),
+      std::move(reducingTables),
+      std::move(result.existences));
+  plan = makePlan(
+      *state.dt,
+      reducingKey,
+      /*distribution=*/std::nullopt,
+      /*boundColumns=*/PlanObjectSet{},
+      /*existsFanout=*/result.existenceReduction,
+      /*needsShuffle=*/ignore);
+  state.cost = plan->cost;
+  makeJoins(plan->op, state);
 }
 
 bool Optimization::placeConjuncts(

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -6,6 +6,7 @@ See also:
 - [Filter Selectivity](docs/FilterSelectivity.md) - How filter selectivity is estimated for cost-based optimization
 - [Cardinality Estimation](docs/CardinalityEstimation.md) - How output cardinality is estimated for each operator
 - [Window Functions](docs/WindowFunctions.md) - Window function support and ranking optimizations
+- [Existence Pushdown](docs/ExistencePushdown.md) - Pushing semi-joins into subquery aggregations to reduce data before GROUP BY
 - [Debugging Tips](docs/DebuggingTips.md) - Using the CLI, generating TPC-H data, speeding up test runs, adding debug logging
 
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.

--- a/axiom/optimizer/docs/DebuggingTips.md
+++ b/axiom/optimizer/docs/DebuggingTips.md
@@ -226,3 +226,26 @@ buck run axiom/optimizer/tests:tpch_plan -- \
   --gtest_filter="TpchPlanTest.DISABLED_makePlans" \
   --gtest_also_run_disabled_tests
 ```
+
+## 5. Using the CLI with Custom Tables
+
+Use `--init` to create in-memory tables with specific stats for testing
+optimizer behavior outside of TPC-H:
+
+```bash
+buck run fbcode//axiom/cli:cli -- \
+  --num_workers 1 --num_drivers 1 \
+  --init /path/to/init.sql \
+  --query "EXPLAIN SELECT ..."
+```
+
+Example init file:
+```sql
+use test.default;
+create table t as select * from unnest(sequence(1, 100), sequence(1, 100)) as t(a, b);
+create table u as select * from unnest(sequence(1, 10000), sequence(1, 10000)) as t(x, y);
+```
+
+Use `--num_workers 1 --num_drivers 1` to produce single-node plans matching
+`toSingleNodePlan` in C++ tests. Without these flags, the CLI produces
+distributed multi-fragment plans with `LocalPartition` nodes.

--- a/axiom/optimizer/docs/ExistencePushdown.md
+++ b/axiom/optimizer/docs/ExistencePushdown.md
@@ -1,0 +1,370 @@
+# Existence Pushdown into Derived Tables
+
+This document describes the optimization that pushes existence semijoins inside
+derived tables (subqueries) to reduce cardinality before aggregation.
+
+## Motivation
+
+Consider a query that joins a base table with a grouped subquery:
+
+```sql
+SELECT t.a, dt.x, dt.cnt
+FROM t
+JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.x
+```
+
+Without optimization, the executor must:
+1. Scan all rows of `u` and compute `GROUP BY x` over the full table.
+2. Build a hash table on the grouped result.
+3. Probe with `t` to find matching rows.
+
+If `t` has a selective filter (e.g., `WHERE t.a < 100`), the full aggregation
+of `u` is wasteful — most grouped rows will be discarded by the join. The
+optimizer can do better by pushing an existence semijoin on `t.a` *inside* the
+subquery, below the aggregation:
+
+```
+HashJoin (t.a = dt.x)
+├── TableScan t
+└── DerivedTable dt
+    ├── Aggregation (GROUP BY x) → COUNT(*)
+    │   └── HashJoin LEFT SEMI FILTER (u.x = t.a)  ← pushed inside
+    │       ├── TableScan u
+    │       └── TableScan t  ← existence copy
+    └── ...
+```
+
+Now `u` is filtered by a semijoin against `t` before the GROUP BY runs,
+reducing the number of groups and the amount of data aggregated.
+
+This is safe because:
+- The semijoin is on the grouping key (`x`), so it only removes entire groups.
+- Using a semijoin (existence check) rather than a regular join preserves
+  cardinality — no duplicate rows are introduced.
+- The original join remains in place above the aggregation.
+
+## The Optimization in Theory
+
+The optimization applies whenever a derived table is joined to other tables
+and the join key maps to an expression inside the derived table that can
+serve as a filter below some operation boundary (e.g., aggregation).
+
+The following subsections are organized to match the "Current Implementation
+Scope" table below — each category here has a corresponding set of rows in
+the table showing what is and isn't implemented.
+
+### Join key constraints
+
+The join key on the DT side determines whether pushdown is valid:
+
+- **Grouping key**: safe — pushdown removes entire groups.
+- **Aggregate expression**: invalid — can't push below the aggregation
+  boundary on an aggregate result.
+- **Window partition key**: safe — pushdown removes entire partitions, window
+  computation within surviving partitions is unchanged.
+- **Window non-partition key or no PARTITION BY**: invalid — changes the
+  window computation (different row counts, different rankings).
+- **Unnest table column**: invalid — unnest tables have special cross-join
+  semantics that cannot accept arbitrary existence semijoins.
+- **Multiple equality keys**: each conjunct on a grouping key could be pushed
+  independently, or a composite existence could filter on all keys.
+- **Non-equality filter**: a join with `ON dt.x = t.a AND dt.x > t.b` could
+  push the equality part as an existence even if the non-equality filter
+  (which references both sides) stays on the join.
+
+### Join type constraints
+
+- **Inner join, semi-join**: always OK.
+- **Left/right join**: OK only if the DT is the optional side. If the DT is
+  on the preserved side, pushing an existence from the optional table would
+  incorrectly remove DT rows that should appear with NULLs.
+- **Full outer join**: never OK — both sides must preserve unmatched rows.
+
+### What can be pushed (`other`)
+
+Any join partner of the DT can potentially be pushed:
+
+- **Single base table**: added directly inside the DT.
+- **DerivedTable (subquery)**: pushed as-is after re-planning.
+- **Chain of tables**: if the join partner has its own join partners (e.g.,
+  `t JOIN r ON t.fk = r.id`), the entire chain can be wrapped in a sub-DT
+  and pushed as a single existence.
+- **Multiple partners**: if the DT joins multiple tables on grouping keys,
+  each can be pushed independently.
+
+### What is the DT (subquery)
+
+The derived table can be:
+- A subquery with **GROUP BY** — the primary case.
+- A **DISTINCT** subquery (GROUP BY all columns internally).
+- A subquery with **window functions** (pushdown valid on partition keys).
+- A **UNION ALL** subquery.
+- A correlated subquery after decorrelation.
+
+Pushdown is invalid when the subquery has **LIMIT** or **ORDER BY** — these
+change which rows survive, so filtering below them changes the result set.
+
+When multiple tables are joined to the DT, some may be pushable and others
+not (e.g., one join key is a grouping key, another is an aggregate). The
+current implementation uses all-or-nothing semantics: if any table cannot be
+pushed, the entire pushdown is skipped. A future enhancement could push
+what it can and leave the rest outside.
+
+### Query patterns that benefit
+
+In all examples below, the pushed table has a selective filter so the
+existence semijoin meaningfully reduces cardinality inside the DT.
+
+#### Inner join on grouping key
+
+```sql
+SELECT t.a, dt.x, dt.cnt
+FROM t
+JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.x
+WHERE t.b < 100
+```
+
+#### Correlated scalar subquery (after decorrelation)
+
+```sql
+SELECT *
+FROM lineitem l, part p
+WHERE l.l_partkey = p.p_partkey
+  AND p.p_brand = 'Brand#23'
+  AND l.l_quantity < (
+    SELECT 0.2 * AVG(l_quantity) FROM lineitem WHERE l_partkey = p.p_partkey
+  )
+```
+
+After decorrelation, the correlated subquery becomes a DerivedTable with
+`GROUP BY l_partkey`. The outer table `part` (filtered by brand) is pushed as
+an existence semijoin inside the aggregation on `l_partkey`. This is TPC-H
+Q17.
+
+#### Multi-key join
+
+```sql
+SELECT t.a, t.b, dt.cnt
+FROM t
+JOIN (SELECT x, y, COUNT(*) AS cnt FROM u GROUP BY x, y) dt
+  ON t.a = dt.x AND t.b = dt.y
+```
+
+Each equality conjunct on a grouping key could be pushed independently, or a
+composite existence could filter on both keys simultaneously.
+
+### TPC-H queries
+
+#### Q2 — Minimum Cost Supplier
+
+The correlated scalar subquery `ps.ps_supplycost = (SELECT MIN(...) FROM
+partsupp ... WHERE p.p_partkey = ps.ps_partkey)` is decorrelated into a
+DerivedTable with `GROUP BY ps_partkey`. The `part` table is pushed as a
+semijoin inside the aggregation on `ps_partkey`, filtering `partsupp` rows
+before the MIN aggregation.
+
+#### Q17 — Small-Quantity-Order Revenue
+
+The correlated subquery `l.l_quantity < (SELECT 0.2 * AVG(l_quantity) FROM
+lineitem WHERE l_partkey = p.p_partkey)` becomes a DerivedTable with
+`GROUP BY l_partkey`. The `part` table (filtered by brand and container) is
+pushed as a semijoin inside the aggregation. Since only ~0.2% of parts match
+the filter, this dramatically reduces the lineitem rows aggregated.
+
+`TpchPlanTest::q17` verifies plan shape including `kLeftSemiFilter` inside the
+lineitem aggregation. Other TPC-H tests verify query results but not plan
+shape.
+
+#### Q15, Q20 — Potential opportunities
+
+Q15 (`supplier` joined to `revenue` grouped by `l_suppkey`) has the pattern
+but `supplier` is unfiltered, so the cardinality benefit is minimal.
+
+Q20 (`partsupp` joined to lineitem aggregation grouped by `(l_partkey,
+l_suppkey)`) has a multi-key grouping. The `part` table (filtered by
+`p_name LIKE 'forest%'`) could reduce lineitem rows before grouping if
+pushed on `l_partkey`.
+
+## Current Implementation Scope
+
+The current implementation (`DerivedTable::import` and
+`DerivedTable::pushExistencesIntoSubquery`) handles a practical subset of the
+full optimization.
+
+The table below lists optimization opportunities and correctness constraints.
+"Yes" means the current implementation handles it; "No" means it is a valid
+optimization but not yet implemented; "N/A" means pushdown is always invalid
+(correctness constraint).
+
+| # | Aspect | Supported | Test | Notes |
+|---|--------|-----------|------|-------|
+| | **Join key** | | | |
+| 1 | Single equality key on grouping key | Yes | innerJoinGroupBy | Core case |
+| 2 | Multi-key join (each key is a grouping key) | No | multiKeyJoin | Could push each key independently |
+| 3 | Equality key + non-equality filter | Yes | joinWithFilter | Equality pushed, filter stays outside |
+| 4 | Join key maps to aggregate expression | N/A | aggregateKey | Can't push below aggregation boundary |
+| 5 | Join key maps to unnest table column | N/A | unnestKey | Unnest has special cross-join semantics |
+| | **Join type** | | | |
+| 6 | Inner join | Yes | innerJoinGroupBy | |
+| 7 | Semi-join (IN) | Yes | semiJoin | |
+| 8 | Left/right join (DT is optional side) | Yes | leftJoinDtIsOptional | |
+| 9 | Left/right join (DT is preserved side) | No | leftJoinDtIsPreserved | |
+| | **What is pushed (`other`)** | | | |
+| 10 | Base table | Yes | innerJoinGroupBy | Added directly to newFirst |
+| 11 | DerivedTable (subquery) | No | otherIsDerivedTable | Optimizer doesn't choose pushdown |
+| 12 | DerivedTable with unnest | No | otherIsUnnestDerivedTable | Optimizer doesn't choose pushdown |
+| 13 | Chain of tables | Yes | chainJoin | Wrapped in `chainDt` |
+| 14 | Multiple tables in one pass | Yes | multipleTables | Multiple loop iterations |
+| 15 | Partial push (some pushable, some not) | No | partialPush | All-or-nothing: skips entire pushdown |
+| | **What is the DT (subquery)** | | | |
+| 16 | GROUP BY subquery | Yes | innerJoinGroupBy | Core case |
+| 17 | DISTINCT subquery | Yes | distinctSubquery | GROUP BY variant |
+| 18 | UNION ALL subquery | Yes | `SetTest::joinWithUnionAll` | |
+| 19 | Window function (key is partition key) | Yes | windowSubquery | |
+| 20 | Window function (key is not partition key) | N/A | windowNonPartitionKey | Changes window computation |
+| 21 | Unnest GROUP BY on unnest output | No | unnestGroupBy | Optimizer doesn't choose pushdown |
+| 22 | Subquery with LIMIT | N/A | limitOnFirstDt | Filtering changes which rows survive |
+| 23 | Subquery with ORDER BY | N/A | orderByOnFirstDt | Filtering changes which rows survive |
+| 24 | Recursive pushdown into nested subqueries | No | | Existence stops at the first aggregation level |
+
+## Implementation Details
+
+The optimization is split across two layers: a **discovery** layer that
+identifies reducing existence opportunities and a **construction** layer that
+builds the modified DerivedTable with existence semijoins pushed inside.
+
+### Discovery: findReducingJoins
+
+The optimizer discovers reducing joins using `findReducingJoins` in
+`Optimization.cpp`, which runs two passes:
+
+1. **Bushy reducing inner joins** (`findReducingBushyJoins`) — DFS from a
+   start table over unplaced neighbors. If the cumulative fanout is below
+   `kReducingPathThreshold`, the discovered tables are bundled into a bushy
+   build side (`ReducingJoinsResult::bushyTables`).
+
+2. **Reducing existences** (`findReducingExistences`) — a second DFS that
+   also traverses already-placed tables and tables found in pass 1. For
+   every reducing leaf whose cumulative fanout is below
+   `kExistenceReductionThreshold`, a semi-join (existence) is recorded
+   (`ReducingJoinsResult::existences`).
+
+Both `reducingJoins` (called from `nextJoins` during join enumeration) and
+`placeDerivedTable` (called when a DT is the start table) use
+`findReducingJoins`. This ensures bushy tables go into `MemoKey.tables` and
+existences go into `MemoKey.existences` — preventing infinite recursion that
+occurred when existences were placed into `MemoKey.tables`.
+
+The `importedExistences` set on each DerivedTable tracks tables that have
+already been imported as existences, preventing re-discovery in subsequent
+planning rounds. The `noImportOfExists` flag prevents importing existences
+into a DT that was itself created as an existence container.
+
+### Construction: DerivedTable::import
+
+Called from `Optimization::makeDtPlan` when building a plan for a MemoKey.
+Receives `firstTable` (the main table), `superTables` (all tables for this
+plan), `existences` (reducing semijoin groups from discovery), and
+`existsFanout` (cumulative fanout estimate).
+
+Steps:
+1. Copy tables, join order, and joins from the parent DT, filtered to the
+   subset in `superTables` (via `copySubset`).
+2. If `existences` is non-empty, add existence semijoins that filter
+   `firstTable` at the current DT level. Single-table existences are added
+   directly; multi-table existences are wrapped in their own DerivedTable
+   via `makeExistsDtAndJoin`.
+3. Set `noImportOfExists` to prevent recursive re-import.
+4. If `firstTable` is a subquery and `this` is a passthrough DT
+   (`isWrapOnly()`), flatten and return. Otherwise, call
+   `pushExistencesIntoSubquery` to push the existence tables inside the
+   subquery below its aggregation boundary.
+
+### Construction: DerivedTable::pushExistencesIntoSubquery
+
+Takes the other tables in `this` DT (alongside the subquery) and pushes them
+inside the subquery as existence semijoins, below the aggregation boundary.
+
+Uses all-or-nothing semantics: `validatePushdown` checks all tables first,
+and if any table cannot be pushed, the entire pushdown is skipped. The
+existences arrive as a single package with a single fanout estimate, so
+partial pushdown may not achieve the expected cardinality reduction.
+
+**`validatePushdown` checks:**
+
+*DT-level guards* — no tables can be pushed when:
+- The subquery has LIMIT or ORDER BY (these change which rows survive, so
+  filtering below them changes the result set).
+
+*Valid pushdown columns* — computed from the subquery's grouping keys and
+window partition keys. When both aggregation and window are present, the
+valid set is the intersection (the key must be safe for both operations).
+When a window function has no PARTITION BY, it contributes no valid columns.
+
+*Per-table checks* — each table must satisfy:
+- The join has a single equality key (multi-key joins are not yet supported).
+- The translated join key resolves to a valid pushdown column. The key is
+  translated through two levels of `replaceInputs`: first through the outer
+  DT's projection (`this->columns/exprs`), then through the subquery's
+  projection (`subquery.columns/exprs`).
+- The translated join key does not resolve to an unnest table column (unnest
+  tables have special cross-join semantics).
+
+Note: non-equality filters do not block pushdown. The optimizer separates
+equality and non-equality conditions before this code runs, so `join->filter()`
+is empty. The equality gets pushed as the existence key; the non-equality
+filter stays on the outer join.
+
+**Steps:**
+1. Call `validatePushdown`. If it returns false, skip pushdown entirely.
+2. Create a mutable copy of the subquery.
+3. For each validated join:
+   a. Find transitive join partners of `other` via `joinChain`.
+   b. **Simple case** (no chain): add `other` directly to the copy with an
+      existence semijoin. If `other` is a DerivedTable, erase its memo entry
+      and re-plan it first.
+   c. **Chain case**: wrap `other` + its chain partners into a new `chainDt`,
+      call `chainDt->import(...)` recursively, add an existence semijoin
+      to `chainDt`.
+   d. Remove imported tables from `this`.
+4. Mark all initial tables in `importedExistences` to prevent re-discovery.
+5. Replace `tables[0]` with the modified copy and flatten.
+
+### Key helpers
+
+- `makeExists` — creates an existence semijoin edge between two tables.
+- `joinChain` — walks the join graph from `other` to find transitive join
+  partners that must be moved together.
+- `replaceInputs` — translates an expression from outer column references to
+  inner expressions, crossing the DT projection boundary.
+
+### joinChain explained
+
+When pushing `other` inside the subquery, `other` might have its own join
+partners within `this` DT. For example:
+
+```sql
+SELECT ...
+FROM (SELECT x, COUNT(*) FROM big GROUP BY x) dt
+JOIN small_a ON dt.x = small_a.a
+JOIN small_b ON small_a.b = small_b.b
+```
+
+Here `small_a` joins the subquery directly, but `small_b` joins `small_a`
+(not the subquery). `joinChain(small_a, ...)` discovers `small_b`. Both are
+wrapped into a `chainDt` and pushed together as a single existence semijoin.
+
+## Testing
+
+Tests live in `ExistencePushdownTest.cpp` and use SQL queries via
+`parseSelect` + `toSingleNodePlan`, verifying plan structure with
+`AXIOM_ASSERT_PLAN` matchers. For "Yes" rows in the scope table, the test
+asserts that `kLeftSemiFilter` appears inside the subquery's aggregation. For
+"No" rows, the test asserts the query plans without crashing and no
+`kLeftSemiFilter` appears inside the aggregation.
+
+The pushed table should have a selective filter so the optimizer chooses to
+fire the optimization.
+
+TODO: Add e2e tests via `SqlTest.cpp` that run queries with DuckDB comparison
+to verify correctness of results (not just plan structure).

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(
   CardinalityEstimationTest.cpp
   CsvReadWriteTest.cpp
   DerivedTablePrinterTest.cpp
+  ExistencePushdownTest.cpp
   FilterPushdownTest.cpp
   FiltersTest.cpp
   HiveAggregationQueriesTest.cpp

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -1,0 +1,990 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+// Tests for the existence pushdown optimization described in
+// docs/ExistencePushdown.md.
+class ExistencePushdownTest : public test::QueryTestBase {
+ protected:
+  static constexpr auto kTestConnectorId = "test";
+
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    velox::connector::registerConnector(testConnector_);
+
+    // Small table — the pushed table.
+    testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
+        ->setStats(
+            100,
+            {{"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+             {"b", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+             {"c", {.min = 1LL, .max = 100LL, .numDistinct = 100}}});
+    // Large table — inside the GROUP BY subquery.
+    testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()))
+        ->setStats(
+            10'000,
+            {{"x", {.min = 1LL, .max = 10'000LL, .numDistinct = 10'000}},
+             {"y", {.min = 1LL, .max = 10'000LL, .numDistinct = 10'000}},
+             {"z", {.min = 1LL, .max = 10'000LL, .numDistinct = 10'000}}});
+    // Another small table.
+    testConnector_->addTable("r", ROW({"a", "b"}, BIGINT()))
+        ->setStats(
+            100,
+            {{"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+             {"b", {.min = 1LL, .max = 100LL, .numDistinct = 100}}});
+    // Another small table for chain joins.
+    testConnector_->addTable("s", ROW({"a", "b"}, BIGINT()))
+        ->setStats(
+            100,
+            {{"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+             {"b", {.min = 1LL, .max = 100LL, .numDistinct = 100}}});
+    // Table for DerivedTable-as-other.
+    testConnector_->addTable("v", ROW({"a", "b"}, BIGINT()))
+        ->setStats(
+            100,
+            {{"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+             {"b", {.min = 1LL, .max = 100LL, .numDistinct = 100}}});
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(kTestConnectorId);
+    test::QueryTestBase::TearDown();
+  }
+
+  using QueryTestBase::toSingleNodePlan;
+
+  velox::core::PlanNodePtr toSingleNodePlan(const std::string& sql) {
+    return QueryTestBase::toSingleNodePlan(parseSelect(sql, kTestConnectorId));
+  }
+
+  std::shared_ptr<connector::TestConnector> testConnector_;
+};
+
+// --- Yes rows: pushdown should fire ---
+
+// TODO: For each test that verifies pushdown, add a variant that does NOT
+// trigger pushdown — e.g., different stats (pushed table is larger than the
+// grouped table), or join on aggregate key instead of grouping key. This
+// ensures the optimizer only pushes when it's beneficial.
+
+// Row 1, 4, 8, 13.
+TEST_F(ExistencePushdownTest, innerJoinGroupBy) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x, dt.cnt "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  //
+  // TODO: The shuffle before aggregation is suboptimal. See the TODO in the
+  // semiJoin test.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              core::JoinType::kInner)
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 5.
+TEST_F(ExistencePushdownTest, semiJoin) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM t "
+      "WHERE t.b < 100 "
+      "  AND a IN (SELECT x FROM u GROUP BY x HAVING COUNT(*) > 1)",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("u")
+                             .hashJoin(
+                                 matchScan("t").filter("b < 100").build(),
+                                 core::JoinType::kLeftSemiFilter)
+                             .singleAggregation({"x"}, {"count(*) as cnt"})
+                             .filter("cnt > 1")
+                             .project()
+                             .build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  //
+  // TODO: The shuffle before aggregation is suboptimal given the existence
+  // pushdown reduces u from ~10K to ~100 rows. Gather + single aggregation
+  // would be cheaper. The aggregation planner always repartitions by grouping
+  // keys — it does not consider gather as an alternative when the input
+  // cardinality is small.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("t")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .shuffle({"x"})
+                  .localPartition({"x"})
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .filter("cnt > 1")
+                  .project()
+                  .broadcast()
+                  .build(),
+              core::JoinType::kLeftSemiFilter)
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 6.
+TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x, dt.cnt "
+      "FROM t "
+      "LEFT JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt "
+      "  ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("u")
+                             .hashJoin(
+                                 matchScan("t").filter("b < 100").build(),
+                                 core::JoinType::kLeftSemiFilter)
+                             .singleAggregation({"x"}, {"count(*) as cnt"})
+                             .build(),
+                         core::JoinType::kLeft)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              core::JoinType::kRight)
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 9: pushed table is a DerivedTable (subquery).
+// TODO: A more optimal plan would push dt2 as existence inside dt1's
+// aggregation, filtering u before GROUP BY.
+TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
+  auto logicalPlan = parseSelect(
+      "SELECT dt1.x, dt1.cnt, dt2.a "
+      "FROM (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt1 "
+      "JOIN (SELECT DISTINCT a FROM v WHERE a < 10) dt2 ON dt1.x = dt2.a",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("v")
+                             .filter("a < 10")
+                             .singleAggregation({"a"}, {})
+                             .build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher = matchScan("u")
+                                .shuffle({"x"})
+                                .localPartition({"x"})
+                                .singleAggregation({"x"}, {"count(*) as cnt"})
+                                .hashJoin(
+                                    matchScan("v")
+                                        .filter("a < 10")
+                                        .partialAggregation({"a"}, {})
+                                        .shuffle({"a"})
+                                        .localPartition({"a"})
+                                        .finalAggregation({"a"}, {})
+                                        .build(),
+                                    core::JoinType::kInner)
+                                .project()
+                                .gather()
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 10.
+TEST_F(ExistencePushdownTest, chainJoin) {
+  auto logicalPlan = parseSelect(
+      "SELECT dt.cnt "
+      "FROM (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt "
+      "JOIN r ON dt.x = r.a "
+      "JOIN s ON r.b = s.a "
+      "WHERE r.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // r + s wrapped into a chainDt, pushed as existence inside the aggregation.
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("r")
+                  .filter("b < 100")
+                  .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+                  .project()
+                  .build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("r")
+          .filter("b < 100")
+          .hashJoin(matchScan("s").broadcast().build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("r")
+                          .filter("b < 100")
+                          .hashJoin(
+                              matchScan("s").broadcast().build(),
+                              core::JoinType::kInner)
+                          .project()
+                          .broadcast()
+                          .build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .shuffle({"x"})
+                  .localPartition({"x"})
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 11: r and s pushed independently on different grouping keys.
+TEST_F(ExistencePushdownTest, multipleTables) {
+  auto logicalPlan = parseSelect(
+      "SELECT r.a, s.a, dt.x, dt.y "
+      "FROM r "
+      "JOIN (SELECT x, y, COUNT(*) AS cnt FROM u GROUP BY x, y) dt "
+      "  ON r.a = dt.x "
+      "JOIN s ON s.a = dt.y "
+      "WHERE r.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("r")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("r").filter("b < 100").build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .hashJoin(
+                      matchScan("s").build(), core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x", "y"}, {})
+                  .build(),
+              core::JoinType::kInner)
+          .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("r")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("r").filter("b < 100").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .hashJoin(
+                      matchScan("s").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .shuffle({"x", "y"})
+                  .localPartition({"x", "y"})
+                  .singleAggregation({"x", "y"}, {})
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
+          .hashJoin(matchScan("s").broadcast().build(), core::JoinType::kInner)
+          .project()
+          .gather()
+          .project()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 12.
+TEST_F(ExistencePushdownTest, partialPush) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, r.a, dt.x, dt.cnt "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.x "
+      "JOIN r ON dt.cnt = r.a "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // No existence pushdown: dt.cnt (an aggregate result, not a grouping key)
+  // is used in the join with r, so the aggregation cannot be deferred.
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("r").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              core::JoinType::kInner)
+          .hashJoin(matchScan("r").broadcast().build(), core::JoinType::kInner)
+          .project()
+          .gather()
+          .project()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 14.
+TEST_F(ExistencePushdownTest, distinctSubquery) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x "
+      "FROM t "
+      "JOIN (SELECT DISTINCT x FROM u) dt ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("u")
+                             .hashJoin(
+                                 matchScan("t").filter("b < 100").build(),
+                                 core::JoinType::kLeftSemiFilter)
+                             .singleAggregation({"x"}, {})
+                             .build(),
+                         core::JoinType::kInner)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  //
+  // TODO: The shuffle before aggregation is suboptimal. See the TODO in the
+  // semiJoin test.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("t")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .partialAggregation({"x"}, {})
+                  .shuffle({"x"})
+                  .localPartition({"x"})
+                  .finalAggregation({"x"}, {})
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// --- No rows: pushdown should not fire ---
+
+// Row 2.
+TEST_F(ExistencePushdownTest, multiKeyJoin) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, t.b, dt.x, dt.y, dt.cnt "
+      "FROM t "
+      "JOIN (SELECT x, y, COUNT(*) AS cnt FROM u GROUP BY x, y) dt "
+      "  ON t.a = dt.x AND t.b = dt.y "
+      "WHERE t.c < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // No pushdown: multi-key join not yet supported.
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({"x", "y"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .shuffle({"x", "y"})
+          .localPartition({"x", "y"})
+          .singleAggregation({"x", "y"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("c < 100").shuffle({"a", "b"}).build(),
+              core::JoinType::kInner)
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 3: pushdown fires even with non-equality filter — equality part is
+// pushed, filter stays outside.
+TEST_F(ExistencePushdownTest, joinWithFilter) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x, dt.cnt "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt "
+      "  ON t.a = dt.x AND dt.x > t.b "
+      "WHERE t.c < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("c < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
+          .filter("b < x")
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("t")
+          .filter("c < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("c < 100").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .shuffle({"x"})
+                  .localPartition({"x"})
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
+          .filter("b < x")
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 7: no pushdown — DT is the preserved side of LEFT JOIN.
+TEST_F(ExistencePushdownTest, leftJoinDtIsPreserved) {
+  auto logicalPlan = parseSelect(
+      "SELECT dt.x, dt.cnt, t.a "
+      "FROM (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt "
+      "LEFT JOIN t ON dt.x = t.a",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(matchScan("t").build(), core::JoinType::kLeft)
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").shuffle({"a"}).build(), core::JoinType::kLeft)
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Row 16: join key matches window PARTITION BY — pushdown is valid.
+// Correct plan has semijoin below the window, original join above.
+TEST_F(ExistencePushdownTest, windowSubquery) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x, dt.rn "
+      "FROM t "
+      "JOIN ("
+      "  SELECT x, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM u"
+      ") dt ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              core::JoinType::kInner)
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// No pushdown: LIMIT blocks it.
+TEST_F(ExistencePushdownTest, limitOnFirstDt) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x LIMIT 10) dt "
+      "  ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("u")
+                             .singleAggregation({"x"}, {})
+                             .finalLimit(0, 10)
+                             .build(),
+                         core::JoinType::kInner)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher = matchScan("t")
+                                .filter("b < 100")
+                                .hashJoin(
+                                    matchScan("u")
+                                        .partialAggregation({"x"}, {})
+                                        .shuffle({"x"})
+                                        .localPartition({"x"})
+                                        .finalAggregation({"x"}, {})
+                                        .distributedLimit(0, 10)
+                                        .broadcast()
+                                        .build(),
+                                    core::JoinType::kInner)
+                                .gather()
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x ORDER BY cnt) dt "
+      "  ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // No pushdown: ORDER BY blocks it.
+  //
+  // TODO: ORDER BY inside a FROM-clause subquery without LIMIT is semantically
+  // meaningless — the parent join discards the order. Eliminating it early
+  // (e.g., via dropOrderBy() in ToGraph) would unblock existence pushdown here
+  // and simplify the distributed plan (removing shuffleMerge). The check is in
+  // DerivedTable::validatePushdown (DerivedTable.cpp), which rejects subqueries
+  // with hasOrderBy().
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .orderBy({"cnt"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .orderBy({"cnt"})
+          .localMerge()
+          .shuffleMerge()
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kInner)
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+TEST_F(ExistencePushdownTest, aggregateKey) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.cnt "
+      "FROM t "
+      "JOIN (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt ON t.a = dt.cnt "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // No pushdown: join is on aggregate result (cnt), not grouping key.
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kInner)
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Pushed table is a DT with unnest. The join key on firstDt's side is a
+// grouping key (valid). The unnest is inside the pushed table, not firstDt.
+// TODO: A more optimal plan would push w as existence inside dt's
+// aggregation, filtering u before GROUP BY.
+TEST_F(ExistencePushdownTest, otherIsUnnestDerivedTable) {
+  auto logicalPlan = parseSelect(
+      "SELECT dt.x, dt.cnt, w.n "
+      "FROM (SELECT x, COUNT(*) AS cnt FROM u GROUP BY x) dt "
+      "JOIN ("
+      "  SELECT DISTINCT n FROM t CROSS JOIN UNNEST(ARRAY[a, b]) AS v(n)"
+      ") w ON dt.x = w.n",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("t")
+                             .project({"array[a, b] as a"})
+                             .unnest({}, {"a"})
+                             .singleAggregation({"n"}, {})
+                             .build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher = matchScan("u")
+                                .shuffle({"x"})
+                                .localPartition({"x"})
+                                .singleAggregation({"x"}, {"count(*) as cnt"})
+                                .hashJoin(
+                                    matchScan("t")
+                                        .project({"array[a, b] as a"})
+                                        .unnest({}, {"a"})
+                                        .partialAggregation({"n"}, {})
+                                        .shuffle({"n"})
+                                        .localPartition({"n"})
+                                        .finalAggregation({"n"}, {})
+                                        .build(),
+                                    core::JoinType::kInner)
+                                .project()
+                                .gather()
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+// Pushdown into a DT where the grouping key comes from unnest. The semijoin
+// should filter the unnest output, not the unnest table itself.
+// TODO: A more optimal plan would push r as existence below the aggregation,
+// filtering unnested rows before GROUP BY.
+TEST_F(ExistencePushdownTest, unnestGroupBy) {
+  auto logicalPlan = parseSelect(
+      "SELECT r.a, dt.n, dt.cnt "
+      "FROM r "
+      "JOIN ("
+      "  SELECT n, COUNT(*) AS cnt "
+      "  FROM t CROSS JOIN UNNEST(ARRAY[a, b, c]) AS v(n) "
+      "  GROUP BY n"
+      ") dt ON r.a = dt.n "
+      "WHERE r.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("r")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("t")
+                             .project()
+                             .unnest()
+                             .singleAggregation({"n"}, {"count(*) as cnt"})
+                             .build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("r")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("t")
+                  .project()
+                  .unnest()
+                  .partialAggregation({"n"}, {"count(*) as cnt"})
+                  .shuffle({"n"})
+                  .localPartition({"n"})
+                  .finalAggregation({"n"}, {"count(cnt) as cnt"})
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
+          .project()
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+TEST_F(ExistencePushdownTest, unnestKey) {
+  // Use a table with no stats to trigger the code path where
+  // findReducingBushyJoins pushes the base table into the subquery DT.
+  testConnector_->addTable("t_no_stats", ROW("a", INTEGER()));
+
+  auto plan = toSingleNodePlan(
+      "SELECT 1 FROM t_no_stats "
+      "WHERE a IN ("
+      "  SELECT n "
+      "  FROM (VALUES (ARRAY[1, 2]), (ARRAY[3])) AS w(numbers) "
+      "  CROSS JOIN UNNEST(numbers) AS v(n)"
+      ")");
+
+  // The join key 'n' resolves to an unnest table column. Pushdown is skipped.
+  // The plan has a semi-join between the unnest output and t_no_stats.
+  auto matcher =
+      core::PlanMatcherBuilder{}
+          .values()
+          .unnest()
+          .hashJoin(
+              matchScan("t_no_stats").build(), core::JoinType::kRightSemiFilter)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// No PARTITION BY — pushdown below window is invalid. Join must stay above.
+TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
+  auto logicalPlan = parseSelect(
+      "SELECT t.a, dt.x, dt.rn "
+      "FROM t "
+      "JOIN ("
+      "  SELECT x, ROW_NUMBER() OVER (ORDER BY y) AS rn FROM u"
+      ") dt ON t.a = dt.x "
+      "WHERE t.b < 100",
+      kTestConnectorId);
+
+  // Single-node plan.
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // No pushdown: window has no PARTITION BY. Join stays above window.
+  auto matcher =
+      matchScan("u")
+          .window({"row_number() OVER (ORDER BY y)"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Distributed plan.
+  //
+  // Window has no PARTITION BY, so all data must be gathered to a single
+  // worker before the window function can execute.
+  auto distributedPlan = planVelox(logicalPlan);
+
+  auto distributedMatcher =
+      matchScan("u")
+          .gather()
+          .localGather()
+          .window({"row_number() OVER (ORDER BY y)"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kInner)
+          .project()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
Fix several bugs in existence pushdown into derived tables, add documentation and tests.

**Infinite recursion fix**: `placeDerivedTable` conflated bushy joins and
existences, putting both into `MemoKey.tables`. When pushdown failed
(ORDER BY, aggregate key), the reducing table stayed in `tables`,
recreating the same topology and causing infinite recursion. Extract
`findReducingJoins` helper shared by `reducingJoins` and
`placeDerivedTable` that routes bushy tables to `MemoKey.tables` and
existences to `MemoKey.existences`.

**Validation fix**: Extract `validatePushdown` from
`pushExistencesIntoSubquery` with all-or-nothing semantics. Previously,
per-table `continue` statements left unpushed tables in the DT, crashing
on the final `tables.size() == 1` assertion. Now checks all tables
upfront: LIMIT/ORDER BY on subquery, join key maps to aggregate or
unnest table column, multi-key join, window non-partition key. If any
check fails, the entire pushdown is skipped.

**Window partition key support**: Pushdown is now valid when the join key
matches a window PARTITION BY column. When both aggregation and window
are present, the valid pushdown columns are the intersection of grouping
keys and partition keys.

Differential Revision: D95079937


