### PR TITLE
feat(optimizer): Add checkConsistency() API to DerivedTable, AggregationPlan, and WindowPlan

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -83,6 +83,235 @@ void fillJoins(
 }
 } // namespace
 
+void DerivedTable::checkSetOpConsistency() const {
+  VELOX_CHECK(
+      setOp.value() == logical_plan::SetOperation::kUnion ||
+          setOp.value() == logical_plan::SetOperation::kUnionAll,
+      "setOp must be union or unionAll: {}, {}",
+      cname,
+      logical_plan::SetOperationName::toName(setOp.value()));
+  VELOX_CHECK_EQ(
+      tables.size(), 0, "tables must be empty for set operation: {}", cname);
+  VELOX_CHECK(
+      exprs.empty(), "exprs must be empty for set operation: {}", cname);
+  VELOX_CHECK_GE(
+      children.size(),
+      2,
+      "set operation must have at least 2 children: {}",
+      cname);
+
+  // Union DT cannot have post-processing.
+  VELOX_CHECK_NULL(
+      aggregation, "union DT must not have aggregation: {}", cname);
+  VELOX_CHECK_NULL(windowPlan, "union DT must not have windowPlan: {}", cname);
+  VELOX_CHECK(having.empty(), "union DT must not have having: {}", cname);
+  VELOX_CHECK(conjuncts.empty(), "union DT must not have conjuncts: {}", cname);
+  VELOX_CHECK(joins.empty(), "union DT must not have joins: {}", cname);
+  VELOX_CHECK(
+      startTables.empty(), "union DT must not have startTables: {}", cname);
+  VELOX_CHECK(
+      singleRowDts.empty(), "union DT must not have singleRowDts: {}", cname);
+  VELOX_CHECK(
+      importedExistences.empty(),
+      "union DT must not have importedExistences: {}",
+      cname);
+}
+
+void DerivedTable::checkConsistency() const {
+  VELOX_CHECK_NOT_NULL(cname);
+
+  if (setOp.has_value()) {
+    checkSetOpConsistency();
+    return;
+  }
+
+  // Verifies that all tables referenced by expressions in 'exprs' are in
+  // tableSet or 'this'.
+  auto checkTableReferences = [&](const ExprVector& expressions,
+                                  const char* context) {
+    for (auto* expr : expressions) {
+      expr->allTables().forEach([&](PlanObjectCP table) {
+        VELOX_CHECK(
+            tableSet.contains(table) || table == this,
+            "{} references table not in tableSet or 'this': {}, {}",
+            context,
+            cname,
+            expr->toString());
+      });
+    }
+  };
+
+  // Columns and exprs must be 1:1 when exprs is non-empty.
+  if (!exprs.empty()) {
+    VELOX_CHECK_EQ(
+        columns.size(),
+        exprs.size(),
+        "Size mismatch between columns and exprs: {}",
+        cname);
+    for (size_t i = 0; i < columns.size(); ++i) {
+      auto columnType = columns[i]->value().type;
+      auto exprType = exprs[i]->value().type;
+      VELOX_CHECK(
+          columnType->equivalent(*exprType),
+          "Type mismatch between column and expr: {}, {}, {} vs {}",
+          cname,
+          i,
+          columnType->toString(),
+          exprType->toString());
+    }
+
+    // exprs must reference only tables in tableSet or 'this'.
+    checkTableReferences(exprs, "expr");
+  }
+
+  VELOX_CHECK_EQ(
+      children.size(),
+      0,
+      "children must be empty for non-set-operation: {}",
+      cname);
+  VELOX_CHECK_GT(
+      tables.size(),
+      0,
+      "tables must not be empty for non-set-operation: {}",
+      cname);
+
+  // All entries in tables must be tables. tableSet must contain exactly the
+  // elements in tables.
+  VELOX_CHECK_EQ(
+      tables.size(),
+      tableSet.size(),
+      "Size mismatch between tables and tableSet: {}",
+      cname);
+  for (auto* table : tables) {
+    VELOX_CHECK(
+        table->isTable(),
+        "Entry in tables is not a table: {}, {}",
+        cname,
+        table->typeName());
+    VELOX_CHECK(
+        tableSet.contains(table),
+        "tableSet is missing a table: {}, {}",
+        cname,
+        optimizer::cname(table));
+  }
+
+  // joinOrder must match tables.
+  VELOX_CHECK_EQ(
+      joinOrder.size(),
+      tables.size(),
+      "Size mismatch between joinOrder and tables: {}",
+      cname);
+  for (auto id : joinOrder) {
+    VELOX_CHECK(
+        tableSet.BitSet::contains(id),
+        "joinOrder references unknown table ID {} in {}",
+        id,
+        cname);
+  }
+
+  // At least one side of each join must be in tableSet. The other side may
+  // reference a table outside this DT via implied joins from equivalence
+  // classes. Neither side can be 'this'.
+  for (auto* join : joins) {
+    VELOX_CHECK(
+        (join->leftTable() && tableSet.contains(join->leftTable())) ||
+            tableSet.contains(join->rightTable()),
+        "Neither side of a join is in tableSet: {}, {}",
+        cname,
+        join->toString());
+    VELOX_CHECK(
+        join->rightTable() != this,
+        "Join rightTable is 'this': {}, {}",
+        cname,
+        join->toString());
+    if (join->leftTable()) {
+      VELOX_CHECK(
+          join->leftTable() != this,
+          "Join leftTable is 'this': {}, {}",
+          cname,
+          join->toString());
+    }
+  }
+
+  // Each entry in joinedBy must have 'this' as an end point.
+  for (auto* join : joinedBy) {
+    VELOX_CHECK(
+        join->leftTable() == this || join->rightTable() == this,
+        "joinedBy entry does not reference this: {}, {}",
+        cname,
+        join->toString());
+  }
+
+  // startTables must be a subset of tableSet.
+  startTables.forEach([&](PlanObjectCP table) {
+    VELOX_CHECK(
+        tableSet.contains(table),
+        "startTables entry not in tableSet: {}, {}",
+        cname,
+        optimizer::cname(table));
+  });
+
+  // singleRowDts must be a subset of tableSet.
+  singleRowDts.forEach([&](PlanObjectCP table) {
+    VELOX_CHECK(
+        tableSet.contains(table),
+        "singleRowDts entry not in tableSet: {}, {}",
+        cname,
+        optimizer::cname(table));
+  });
+
+  // orderKeys and orderTypes must have the same size.
+  VELOX_CHECK_EQ(
+      orderKeys.size(),
+      orderTypes.size(),
+      "Size mismatch between orderKeys and orderTypes: {}",
+      cname);
+
+  // orderKeys must reference only tables in tableSet or 'this'.
+  checkTableReferences(orderKeys, "orderKey");
+
+  // Aggregation and window plan consistency.
+  if (aggregation) {
+    aggregation->checkConsistency(*this);
+  }
+
+  if (windowPlan) {
+    windowPlan->checkConsistency(*this);
+  }
+
+  // having requires aggregation. having must reference only columns produced
+  // by the aggregation.
+  if (!having.empty()) {
+    VELOX_CHECK_NOT_NULL(
+        aggregation, "having is not empty but aggregation is null: {}", cname);
+    auto aggColumns = PlanObjectSet::fromObjects(aggregation->columns());
+    for (auto* expr : having) {
+      VELOX_CHECK(
+          expr->columns().isSubset(aggColumns),
+          "having references columns not produced by aggregation: {}, {}",
+          cname,
+          expr->toString());
+    }
+  }
+
+  // conjuncts must reference only tables in tableSet or 'this'.
+  checkTableReferences(conjuncts, "conjunct");
+
+  // importedExistences must be a subset of tableSet.
+  importedExistences.forEach([&](PlanObjectCP table) {
+    VELOX_CHECK(
+        tableSet.contains(table),
+        "importedExistences entry not in tableSet: {}, {}",
+        cname,
+        optimizer::cname(table));
+  });
+
+  // limit and offset.
+  VELOX_CHECK_GE(limit, -1, "limit must be >= -1: {}", cname);
+  VELOX_CHECK_NE(limit, 0, "limit must not be 0: {}", cname);
+  VELOX_CHECK_GE(offset, 0, "offset must be >= 0: {}", cname);
+}
+
 MemoKey DerivedTable::memoKey() const {
   return MemoKey::create(
       this, PlanObjectSet::fromObjects(columns), PlanObjectSet::single(this));
@@ -119,6 +348,9 @@ void DerivedTable::initializePlans() {
   // Post-order (bottom-up): finalize joins and compute plans.
   finalizeJoins();
 
+#ifndef NDEBUG
+  checkConsistency();
+#endif
   auto plan = queryCtx()->optimization()->makeInitialPlan(*this);
   updateConstraints(*plan);
 }
@@ -339,7 +571,7 @@ void DerivedTable::linkTablesToJoins() {
 }
 
 namespace {
-std::pair<DerivedTableP, JoinEdgeP> makeExistsDtAndJoin(
+std::pair<DerivedTableCP, JoinEdgeP> makeExistsDtAndJoin(
     const DerivedTable& super,
     PlanObjectCP firstTable,
     float existsFanout,
@@ -361,27 +593,31 @@ std::pair<DerivedTableP, JoinEdgeP> makeExistsDtAndJoin(
         PlanObjectSet::fromObjects(existsTables));
   }();
 
-  auto optimization = queryCtx()->optimization();
-  auto it = optimization->existenceDts().find(existsDtKey);
-  DerivedTableP existsDt{};
-  if (it == optimization->existenceDts().end()) {
-    existsDt = make<DerivedTable>();
-    existsDt->cname = optimization->newCName("edt");
-    existsDt->import(super, existsDtKey.tables, existsDtKey.firstTable, {}, 1);
+  auto existsDt = [&]() -> DerivedTableCP {
+    auto optimization = queryCtx()->optimization();
+    auto it = optimization->existenceDts().find(existsDtKey);
+    if (it != optimization->existenceDts().end()) {
+      return it->second;
+    }
+
+    auto newExistsDt = make<DerivedTable>();
+    newExistsDt->cname = optimization->newCName("edt");
+    newExistsDt->import(
+        super, existsDtKey.tables, existsDtKey.firstTable, {}, 1);
     for (auto& key : rightKeys) {
       auto* existsColumn = make<Column>(
-          toName(fmt::format("{}.{}", existsDt->cname, key->toString())),
-          existsDt,
+          toName(fmt::format("{}.{}", newExistsDt->cname, key->toString())),
+          newExistsDt,
           key->value());
-      existsDt->columns.push_back(existsColumn);
-      existsDt->exprs.push_back(key);
+      newExistsDt->columns.push_back(existsColumn);
+      newExistsDt->exprs.push_back(key);
     }
-    existsDt->noImportOfExists = true;
-    existsDt->initializePlans();
-    optimization->existenceDts()[existsDtKey] = existsDt;
-  } else {
-    existsDt = it->second;
-  }
+    newExistsDt->noImportOfExists = true;
+    newExistsDt->initializePlans();
+    optimization->existenceDts()[existsDtKey] = newExistsDt;
+
+    return newExistsDt;
+  }();
 
   auto* joinWithDt = JoinEdge::makeExists(firstTable, existsDt);
   joinWithDt->setFanouts(existsFanout, 1);

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -104,10 +104,12 @@ struct DerivedTable : public PlanObject {
   /// 'tableSet' are not considered.
   PlanObjectSet tableSet;
 
-  /// Set if this is a set operation. If set, 'children' has the operands.
+  /// Set if this is a union or unionAll. If set, 'children' has at least 2
+  /// operands.
   std::optional<logical_plan::SetOperation> setOp;
 
-  /// Operands if 'this' is a set operation, e.g. union.
+  /// Operands if 'this' is a union or unionAll. Has at least 2 entries when
+  /// 'setOp' is set.
   QGVector<DerivedTable*> children;
 
   /// Single row tables from non-correlated scalar subqueries.
@@ -331,6 +333,9 @@ struct DerivedTable : public PlanObject {
 
   void addJoinedBy(JoinEdgeP join);
 
+  /// Asserts invariants about this DerivedTable.
+  void checkConsistency() const;
+
   /// Returns the memo key for this DT.
   MemoKey memoKey() const;
 
@@ -342,6 +347,9 @@ struct DerivedTable : public PlanObject {
   void distributeConjuncts();
 
  private:
+  // Asserts invariants specific to union / unionAll DerivedTables.
+  void checkSetOpConsistency() const;
+
   // Updates cardinality and column constraints from the plan.
   void updateConstraints(const RelationOp& plan);
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3222,7 +3222,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   tryNextJoins(state, nextJoins);
 }
 
-RelationOpPtr Optimization::makeInitialPlan(DerivedTable& dt) {
+RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   const auto key = dt.memoKey();
   PlanState state(*this, &dt);
   RelationOpPtr result;

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -115,7 +115,7 @@ class Optimization {
   /// Makes an initial plan for 'dt' and memoizes it. Handles both union and
   /// non-union DTs. Assumes child DTs already have plans in the memo.
   /// Returns the plan's RelationOp.
-  RelationOpPtr makeInitialPlan(DerivedTable& dt);
+  RelationOpPtr makeInitialPlan(const DerivedTable& dt);
 
   /// Adds single aggregation on top of 'input'.
   /// @param dt Derived table with an aggregation.
@@ -366,7 +366,7 @@ class Optimization {
 
   // Set of previously planned dts for importing probe side reducing joins to a
   // build side
-  folly::F14FastMap<MemoKey, DerivedTableP> existenceDts_;
+  folly::F14FastMap<MemoKey, DerivedTableCP> existenceDts_;
 
   // The top level PlanState. Contains the set of top level interesting plans.
   // Must stay alive as long as the Plans and RelationOps are reeferenced.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/PlanUtils.h"
@@ -231,6 +232,59 @@ const WindowPlan* WindowPlan::withFunctions(
   mergedColumns.insert(mergedColumns.end(), columns.begin(), columns.end());
   return make<WindowPlan>(
       std::move(merged), std::move(mergedColumns), rankingLimit_);
+}
+
+namespace {
+// Verifies that all tables referenced by 'exprs' are in dt.tableSet or 'dt'
+// itself.
+template <typename T>
+void checkTableReferences(
+    const DerivedTable& dt,
+    std::span<const T> exprs,
+    const char* context) {
+  for (auto* expr : exprs) {
+    expr->allTables().forEach([&](PlanObjectCP table) {
+      VELOX_CHECK(
+          dt.tableSet.contains(table) || table == &dt,
+          "{} references table not in tableSet or 'this': {}, {}",
+          context,
+          dt.cname,
+          expr->toString());
+    });
+  }
+}
+} // namespace
+
+void AggregationPlan::checkConsistency(const DerivedTable& dt) const {
+  checkTableReferences<ExprCP>(dt, groupingKeys_, "Grouping key");
+  checkTableReferences<AggregateCP>(dt, aggregates_, "Aggregate");
+
+  // Grouping key columns reference one of dt.tables or 'dt' itself.
+  // Aggregate columns must reference the 'dt'.
+  const auto numKeys = groupingKeys_.size();
+  checkTableReferences<ColumnCP>(
+      dt, std::span(columns_).subspan(0, numKeys), "Grouping key");
+  for (size_t i = numKeys; i < columns_.size(); ++i) {
+    auto* relation = columns_[i]->relation();
+    VELOX_CHECK(
+        relation == &dt,
+        "Aggregate column does not reference DT: {}, {}",
+        dt.cname,
+        columns_[i]->toString());
+  }
+}
+
+void WindowPlan::checkConsistency(const DerivedTable& dt) const {
+  checkTableReferences<WindowFunctionCP>(dt, functions_, "Window function");
+
+  // Window output columns must reference the 'dt'.
+  for (auto* column : columns_) {
+    VELOX_CHECK(
+        column->relation() == &dt,
+        "Window column does not reference DT: {}, {}",
+        dt.cname,
+        column->toString());
+  }
 }
 
 std::string Field::toString() const {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -31,6 +31,8 @@
 /// constant.
 namespace facebook::axiom::optimizer {
 
+struct DerivedTable;
+
 /// Superclass for all expressions.
 class Expr : public PlanObject {
  public:
@@ -1273,6 +1275,11 @@ class WindowFunction : public Call {
 using WindowFunctionCP = const WindowFunction*;
 using WindowFunctionVector = QGVector<WindowFunctionCP>;
 
+/// Stores the GROUP BY keys, aggregate functions, and output columns for a
+/// DerivedTable. Output columns are 1:1 with grouping keys followed by
+/// aggregates: columns_[i] corresponds to groupingKeys_[i] for
+/// i < groupingKeys_.size(), and to aggregates_[i - groupingKeys_.size()]
+/// otherwise.
 class AggregationPlan : public PlanObject {
  public:
   AggregationPlan(
@@ -1289,21 +1296,36 @@ class AggregationPlan : public PlanObject {
     VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
   }
 
+  /// GROUP BY columns. Each references a column from a table in the enclosing
+  /// DerivedTable's tableSet or from the DerivedTable itself.
   const ExprVector& groupingKeys() const {
     return groupingKeys_;
   }
 
+  /// Aggregate functions (e.g., sum, count, min). Each references columns from
+  /// tables in the enclosing DerivedTable's tableSet.
   const AggregateVector& aggregates() const {
     return aggregates_;
   }
 
+  /// Output columns produced by this aggregation. The first
+  /// groupingKeys_.size() entries correspond to grouping keys; the rest
+  /// correspond to aggregate results.
   const ColumnVector& columns() const {
     return columns_;
   }
 
+  /// Output columns with intermediate accumulator types, used for partial
+  /// aggregation. 1:1 with columns().
   const ColumnVector& intermediateColumns() const {
     return intermediateColumns_;
   }
+
+  /// Checks that grouping keys and aggregates reference only tables in
+  /// dt.tableSet or 'dt' itself. Verifies that grouping key output columns
+  /// reference tables in dt.tableSet or 'dt', and aggregate output columns
+  /// reference 'dt'.
+  void checkConsistency(const DerivedTable& dt) const;
 
  private:
   const ExprVector groupingKeys_;
@@ -1314,12 +1336,13 @@ class AggregationPlan : public PlanObject {
 
 using AggregationPlanCP = const AggregationPlan*;
 
-/// Stores the window functions and their output columns in a DerivedTable.
-/// Analogous to AggregationPlan for aggregations.
+/// Stores window functions and their output columns for a DerivedTable.
+/// Each window function produces exactly one output column: functions_[i]
+/// corresponds to columns_[i].
 class WindowPlan : public PlanObject {
  public:
   WindowPlan(
-      QGVector<WindowFunctionCP> functions,
+      WindowFunctionVector functions,
       ColumnVector columns,
       std::optional<int32_t> rankingLimit = std::nullopt)
       : PlanObject(PlanType::kWindowPlanNode),
@@ -1332,10 +1355,13 @@ class WindowPlan : public PlanObject {
     }
   }
 
-  const QGVector<WindowFunctionCP>& functions() const {
+  /// Window function definitions (e.g., row_number, rank, sum). Each
+  /// references columns from tables in the enclosing DerivedTable's tableSet.
+  const WindowFunctionVector& functions() const {
     return functions_;
   }
 
+  /// Output columns produced by window functions. 1:1 with functions().
   const ColumnVector& columns() const {
     return columns_;
   }
@@ -1353,11 +1379,15 @@ class WindowPlan : public PlanObject {
   /// Returns a new WindowPlan with additional window functions and columns
   /// appended. Used when merging windows from stacked project nodes.
   const WindowPlan* withFunctions(
-      QGVector<WindowFunctionCP> functions,
+      WindowFunctionVector functions,
       ColumnVector columns) const;
 
+  /// Checks that window functions reference only tables in dt.tableSet or
+  /// 'dt' itself, and that output columns reference 'dt'.
+  void checkConsistency(const DerivedTable& dt) const;
+
  private:
-  const QGVector<WindowFunctionCP> functions_;
+  const WindowFunctionVector functions_;
   const ColumnVector columns_;
   const std::optional<int32_t> rankingLimit_;
 };


### PR DESCRIPTION
Summary:
Add checkConsistency() to assert structural invariants on DerivedTable,
AggregationPlan, and WindowPlan. For DerivedTable, validates cname,
columns/exprs correspondence, tableSet consistency, join graph, aggregation,
window, having, conjuncts, importedExistences, limit/offset, and joinedBy.
Union DTs are validated separately via checkSetOpConsistency(). For
AggregationPlan and WindowPlan, validates that expressions reference only
tables in the enclosing DT's tableSet.

Also documents AggregationPlan and WindowPlan classes and their accessors.

Differential Revision: D95210075


