### PR TITLE
feat(parser): Add support for SHOW STATS FOR <table>

### DIFF
--- a/axiom/cli/ResultPrinter.cpp
+++ b/axiom/cli/ResultPrinter.cpp
@@ -81,11 +81,15 @@ int32_t printResults(
       if (i > 0) {
         std::cout << " | ";
       }
-      std::cout << std::setw(widths[i]);
       if (alignLeft[i]) {
         std::cout << std::left;
+        // Skip padding on the last column to avoid trailing whitespace.
+        if (i < numColumns - 1) {
+          std::cout << std::setw(widths[i]);
+        }
       } else {
         std::cout << std::right;
+        std::cout << std::setw(widths[i]);
       }
       std::cout << row[i];
     }

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -16,16 +16,26 @@ cnt
 ## Create and query table using test connector
 
 ```scrut
-$ $CLI --query "CREATE TABLE test.default.t(a int, b int, c int); SELECT * FROM test.default.t" 2>/dev/null
+$ $CLI --query "CREATE TABLE test.default.t(a int, b int, c int); SELECT * FROM test.default.t; SHOW STATS FOR test.default.t" 2>/dev/null
 Created table: default.t
 (0 rows in 0 batches)
+
+ROW<row_count:DOUBLE,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
+----------+-------------+----------------+-----------------------+------------+-----------+-----------
+row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
+----------+-------------+----------------+-----------------------+------------+-----------+-----------
+     null | a           |           null |                  null |       null | null      | null
+     null | b           |           null |                  null |       null | null      | null
+     null | c           |           null |                  null |       null | null      | null
+        0 | null        |           null |                  null |       null | null      | null
+(4 rows in 1 batches)
 
 ```
 
 ## Insert and select using test connector
 
 ```scrut
-$ $CLI --query "CREATE TABLE test.default.t(a int, b int); INSERT INTO test.default.t VALUES (1, 2); SELECT * FROM test.default.t" 2>/dev/null
+$ $CLI --query "CREATE TABLE test.default.t(a int, b int); INSERT INTO test.default.t VALUES (1, 2); SELECT * FROM test.default.t; SHOW STATS FOR test.default.t" 2>/dev/null
 Created table: default.t
 ROW<rows:BIGINT>
 ----
@@ -40,6 +50,15 @@ a | b
 --+--
 1 | 2
 (1 rows in 1 batches)
+
+ROW<row_count:DOUBLE,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
+----------+-------------+----------------+-----------------------+------------+-----------+-----------
+row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
+----------+-------------+----------------+-----------------------+------------+-----------+-----------
+     null | a           |              0 |                     1 |       null | 1         | 1
+     null | b           |              0 |                     1 |       null | 2         | 2
+        1 | null        |           null |                  null |       null | null      | null
+(3 rows in 1 batches)
 
 ```
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1206,6 +1206,106 @@ SqlStatementPtr parseShowColumns(
           .build());
 }
 
+SqlStatementPtr parseShowStats(
+    const ShowStats& showStats,
+    const std::string& defaultConnectorId,
+    const std::optional<std::string>& defaultSchema) {
+  const auto table =
+      findTable(*showStats.table(), defaultConnectorId, defaultSchema);
+  const auto schema = table->type();
+
+  static const auto kNullDouble = Variant::null(TypeKind::DOUBLE);
+  static const auto kNullBigint = Variant::null(TypeKind::BIGINT);
+  static const auto kNullVarchar = Variant::null(TypeKind::VARCHAR);
+
+  // Converts a stats Variant (min or max) to a display string using the
+  // column's type for proper formatting (e.g. dates, decimals).
+  auto variantToString = [](const Variant& value,
+                            const TypePtr& type) -> std::string {
+    if (value.kind() == TypeKind::VARCHAR) {
+      return value.value<TypeKind::VARCHAR>();
+    }
+    return value.toJson(type);
+  };
+
+  std::vector<Variant> data;
+  data.reserve(schema->size() + 1);
+
+  for (auto i = 0; i < schema->size(); ++i) {
+    const auto* column = table->columnMap().at(schema->nameOf(i));
+    const auto* stats = column->stats();
+
+    auto nullsFraction = kNullDouble;
+    auto distinctCount = kNullBigint;
+    auto avgLength = kNullBigint;
+    auto lowValue = kNullVarchar;
+    auto highValue = kNullVarchar;
+
+    if (stats != nullptr) {
+      nullsFraction = Variant(static_cast<double>(stats->nullPct) / 100.0);
+
+      if (stats->numDistinct.has_value()) {
+        distinctCount =
+            Variant(static_cast<int64_t>(stats->numDistinct.value()));
+      }
+
+      if (stats->avgLength.has_value()) {
+        avgLength = Variant(static_cast<int64_t>(stats->avgLength.value()));
+      }
+
+      if (stats->min.has_value()) {
+        lowValue = Variant(variantToString(stats->min.value(), column->type()));
+      }
+
+      if (stats->max.has_value()) {
+        highValue =
+            Variant(variantToString(stats->max.value(), column->type()));
+      }
+    }
+
+    data.emplace_back(
+        Variant::row(
+            {kNullDouble,
+             Variant(schema->nameOf(i)),
+             nullsFraction,
+             distinctCount,
+             avgLength,
+             lowValue,
+             highValue}));
+  }
+
+  // Summary row: only row_count is populated.
+  data.emplace_back(
+      Variant::row(
+          {Variant(static_cast<double>(table->numRows())),
+           kNullVarchar,
+           kNullDouble,
+           kNullBigint,
+           kNullBigint,
+           kNullVarchar,
+           kNullVarchar}));
+
+  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  return std::make_shared<SelectStatement>(lp::PlanBuilder(ctx)
+                                               .values(
+                                                   ROW({"row_count",
+                                                        "column_name",
+                                                        "nulls_fraction",
+                                                        "distinct_values_count",
+                                                        "avg_length",
+                                                        "low_value",
+                                                        "high_value"},
+                                                       {DOUBLE(),
+                                                        VARCHAR(),
+                                                        DOUBLE(),
+                                                        BIGINT(),
+                                                        BIGINT(),
+                                                        VARCHAR(),
+                                                        VARCHAR()}),
+                                                   data)
+                                               .build());
+}
+
 SqlStatementPtr parseShowFunctions(
     const ShowFunctions& showFunctions,
     const std::string& defaultConnectorId) {
@@ -1534,6 +1634,11 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kShowColumns)) {
     return parseShowColumns(
         *query->as<ShowColumns>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kShowStats)) {
+    return parseShowStats(
+        *query->as<ShowStats>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kShowFunctions)) {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -716,7 +716,8 @@ std::any AstBuilder::visitShowColumns(
 
 std::any AstBuilder::visitShowStats(PrestoSqlParser::ShowStatsContext* ctx) {
   trace("visitShowStats");
-  return visitChildren("visitShowStats", ctx);
+  return std::static_pointer_cast<Statement>(std::make_shared<ShowStats>(
+      getLocation(ctx), getQualifiedName(ctx->qualifiedName())));
 }
 
 std::any AstBuilder::visitShowStatsForQuery(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -770,6 +770,10 @@ void ShowColumns::accept(AstVisitor* visitor) {
   visitor->visitShowColumns(this);
 }
 
+void ShowStats::accept(AstVisitor* visitor) {
+  visitor->visitShowStats(this);
+}
+
 void ShowFunctions::accept(AstVisitor* visitor) {
   visitor->visitShowFunctions(this);
 }

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -793,6 +793,31 @@ class ShowColumns : public Statement {
   std::shared_ptr<QualifiedName> table_;
 };
 
+/// Represents SHOW STATS FOR <table>. Returns per-column and table-level
+/// statistics as a VALUES plan with the following columns:
+///   row_count (DOUBLE) - total rows, populated only in the summary row.
+///   column_name (VARCHAR) - column name, NULL in the summary row.
+///   nulls_fraction (DOUBLE) - fraction of null values.
+///   distinct_values_count (BIGINT) - number of distinct values.
+///   avg_length (BIGINT) - average length in bytes for varchar and varbinary;
+///     average number of elements for arrays and maps.
+///   low_value (VARCHAR) - minimum value formatted as string.
+///   high_value (VARCHAR) - maximum value formatted as string.
+class ShowStats : public Statement {
+ public:
+  ShowStats(NodeLocation location, const std::shared_ptr<QualifiedName>& table)
+      : Statement(NodeType::kShowStats, location), table_(table) {}
+
+  const std::shared_ptr<QualifiedName>& table() const {
+    return table_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> table_;
+};
+
 class ShowFunctions : public Statement {
  public:
   ShowFunctions(

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -563,6 +563,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowStats(ShowStats* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowFunctions(ShowFunctions* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1045,6 +1045,8 @@ TEST_F(PrestoParserTest, explainShow) {
   testExplain("EXPLAIN SHOW COLUMNS FROM nation", matcher);
 
   testExplain("EXPLAIN SHOW FUNCTIONS", matcher);
+
+  testExplain("EXPLAIN SHOW STATS FOR nation", matcher);
 }
 
 TEST_F(PrestoParserTest, explainInsert) {
@@ -1108,6 +1110,14 @@ TEST_F(PrestoParserTest, showFunctions) {
     auto matcher = matchValues().filter();
     testSelect("SHOW FUNCTIONS LIKE 'array%'", matcher);
   }
+}
+
+TEST_F(PrestoParserTest, showStats) {
+  auto matcher = matchValues();
+  testSelect("SHOW STATS FOR nation", matcher);
+
+  VELOX_ASSERT_USER_THROW(
+      parseSelect("SHOW STATS FOR no_such_table"), "Table not found");
 }
 
 TEST_F(PrestoParserTest, unqualifiedAccessAfterJoin) {


### PR DESCRIPTION
Summary:
Add SHOW STATS FOR <table> SQL command that returns per-column and
table-level statistics.

Output schema:
- row_count (DOUBLE) - total rows (summary row only)
- column_name (VARCHAR) - column name (NULL in summary row)
- nulls_fraction (DOUBLE) - fraction of nulls
- distinct_values_count (DOUBLE) - estimated NDV
- avg_length (DOUBLE) - average length for variable-width types
- low_value (VARCHAR) - minimum value as string
- high_value (VARCHAR) - maximum value as string

Returns one row per non-hidden column plus a summary row at the end.

The SHOW STATS FOR (query) variant is not yet supported.

> buck run axiom/cli:cli -- --query "use test.default;create table t as select * from unnest(sequence(1, 10)) as t(x);show stats for t;"

```
----------+-------------+----------------+-----------------------+------------+-----------+-----------
row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
----------+-------------+----------------+-----------------------+------------+-----------+-----------
     null | x           |              0 |                    10 |       null | 1         | 10        
       10 | null        |           null |                  null |       null | null      | null      
(2 rows in 1 batches)
```

Differential Revision: D95212520


