### PR TITLE
misc(cli): Add PermissionCheckFn callback to Console and accessors to SqlQueryRunner

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -122,6 +122,17 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
         std::cout << "Parsing: " << parseTiming.toString() << std::endl;
       }
 
+      // Permission check after parsing, before execution.
+      if (permissionCheck_ != nullptr) {
+        const auto& schema = options.defaultSchema ? options.defaultSchema
+                                                   : runner_.defaultSchema();
+        permissionCheck_(
+            sqlText,
+            options.defaultConnectorId.value_or(runner_.defaultConnectorId()),
+            schema ? std::optional<std::string_view>{*schema} : std::nullopt,
+            statement->views());
+      }
+
       cli::Timing statementTiming;
       auto result = cli::time<SqlQueryRunner::SqlResult>(
           [&]() { return runner_.run(*statement, options); }, statementTiming);

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <functional>
+#include <unordered_map>
+#include <utility>
 #include "axiom/cli/SqlQueryRunner.h"
 
 DECLARE_string(data_path);
@@ -23,9 +26,23 @@ DECLARE_bool(debug);
 
 namespace axiom::sql {
 
+/// Permission check callback: (sql, catalog, schema, views) -> throws on
+/// denial. Empty (nullptr) by default -- no permission checking.
+using PermissionCheck = std::function<void(
+    std::string_view sql,
+    std::string_view catalog,
+    std::optional<std::string_view> schema,
+    const std::unordered_map<std::pair<std::string, std::string>, std::string>&
+        views)>;
+
 class Console {
  public:
-  explicit Console(SqlQueryRunner& runner) : runner_{runner} {}
+  /// @param permissionCheck Optional callback invoked after each statement is
+  /// parsed but before it is executed. Throws on denial.
+  explicit Console(
+      SqlQueryRunner& runner,
+      PermissionCheck permissionCheck = nullptr)
+      : runner_{runner}, permissionCheck_{std::move(permissionCheck)} {}
 
   void initialize();
 
@@ -45,6 +62,7 @@ class Console {
   void readCommands(const std::string& prompt);
 
   SqlQueryRunner& runner_;
+  PermissionCheck permissionCheck_;
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -115,6 +115,16 @@ class SqlQueryRunner {
 
   std::string dropTable(const presto::DropTableStatement& statement);
 
+  /// Returns the default connector ID set during initialization.
+  const std::string& defaultConnectorId() const {
+    return defaultConnectorId_;
+  }
+
+  /// Returns the default schema set during initialization.
+  const std::optional<std::string>& defaultSchema() const {
+    return defaultSchema_;
+  }
+
  private:
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
       const RunOptions& options);

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/Console.h"
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+
+DECLARE_string(query);
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+namespace {
+
+class ConsoleTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    facebook::velox::memory::MemoryManager::testingSetInstance(
+        facebook::velox::memory::MemoryManager::Options{});
+  }
+
+  void TearDown() override {
+    // Restore FLAGS_query to avoid polluting other tests.
+    FLAGS_query = "";
+    for (const auto& id : connectorIds_) {
+      facebook::velox::connector::unregisterConnector(id);
+    }
+  }
+
+  std::unique_ptr<SqlQueryRunner> makeRunner() {
+    auto runner = std::make_unique<SqlQueryRunner>();
+
+    runner->initialize([&]() {
+      static int32_t kCounter = 0;
+
+      auto testConnector =
+          std::make_shared<facebook::axiom::connector::TestConnector>(
+              fmt::format("console_test{}", kCounter++));
+      facebook::velox::connector::registerConnector(testConnector);
+
+      connectorIds_.emplace_back(testConnector->connectorId());
+
+      return std::make_pair(testConnector->connectorId(), std::nullopt);
+    });
+
+    return runner;
+  }
+
+ private:
+  std::vector<std::string> connectorIds_;
+};
+
+TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
+  auto runner = makeRunner();
+
+  bool called = false;
+  std::string capturedSql;
+  std::string capturedCatalog;
+
+  PermissionCheck check = [&](std::string_view sql,
+                              std::string_view catalog,
+                              std::optional<std::string_view> /*schema*/,
+                              const auto& /*views*/) {
+    called = true;
+    capturedSql = std::string(sql);
+    capturedCatalog = std::string(catalog);
+  };
+
+  Console console{*runner, std::move(check)};
+  console.initialize();
+
+  FLAGS_query = "SELECT 1";
+  console.run();
+
+  ASSERT_TRUE(called);
+  EXPECT_EQ(capturedSql, "SELECT 1");
+  EXPECT_FALSE(capturedCatalog.empty());
+}
+
+} // namespace
+} // namespace axiom::sql
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Add an optional `PermissionCheck` callback to `Console` that is invoked
between query parsing and execution. The callback defaults to `nullptr`
(no-op), so there is no permission-checking behavior by default.

Also adds read-only accessors `defaultConnectorId()` and `defaultSchema()`
to `SqlQueryRunner` so that `Console` can pass the current catalog and
schema to the permission check callback.