### PR TITLE
refactor(optimizer): Defer filter sampling to initializePlans

### DIFF
--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "axiom/optimizer/RelationOp.h"
+#include "velox/connectors/Connector.h"
+#include "velox/core/ITypedExpr.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -49,13 +51,22 @@ class History {
   /// execution.
   virtual void recordCost(const RelationOp& op, Cost cost) = 0;
 
-  /// Estimates 'filterSelectivity' of 'baseTable' from historical data.
-  /// Considers filters only and does not return a cost since the cost depends
-  /// on the columns extracted. This is used first for coming up with join
-  /// orders. The plan candidates are then made and findCost() is used to access
-  /// historical cost and plan cardinality.
-  virtual bool estimateLeafSelectivity(
+  /// Estimates and sets 'filterSelectivity' on 'baseTable'. Also narrows
+  /// column Value constraints (cardinality, min, max, trueFraction,
+  /// nullFraction, nullable) based on the table's filters. Estimates
+  /// selectivity from column statistics (min/max, NDV, null fraction),
+  /// optionally refined by sampling the table's layout.
+  ///
+  /// Must be called at most once per base table. Calling multiple times
+  /// compounds constraint narrowing, producing incorrect estimates.
+  ///
+  /// 'tableHandle' and 'filters' are the connector-level representation of
+  /// the table's current filters. 'scanType' is the row type for sampled
+  /// columns.
+  virtual void estimateLeafSelectivity(
       BaseTable& baseTable,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const std::vector<velox::core::TypedExprPtr>& filters,
       const velox::RowTypePtr& scanType) = 0;
 
   virtual void recordJoinSample(std::string_view key, float lr, float rl) = 0;

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -317,6 +317,16 @@ MemoKey DerivedTable::memoKey() const {
       this, PlanObjectSet::fromObjects(columns), PlanObjectSet::single(this));
 }
 
+void DerivedTable::estimateBaseTableSelectivity() {
+  auto* optimization = queryCtx()->optimization();
+  for (auto* table : tables) {
+    if (table->is(PlanType::kTableNode)) {
+      auto* baseTable = const_cast<PlanObject*>(table)->as<BaseTable>();
+      optimization->estimateLeafSelectivity(*baseTable);
+    }
+  }
+}
+
 void DerivedTable::initializePlans() {
   // Pre-order (top-down): push conjuncts to children.
   distributeConjuncts();
@@ -344,6 +354,11 @@ void DerivedTable::initializePlans() {
       child->initializePlans();
     }
   }
+
+  // Estimate filter selectivity on base tables after all filters have been
+  // pushed down. This ensures each table is sampled at most once with the
+  // complete filter set.
+  estimateBaseTableSelectivity();
 
   // Post-order (bottom-up): finalize joins and compute plans.
   finalizeJoins();

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -347,6 +347,11 @@ struct DerivedTable : public PlanObject {
   void distributeConjuncts();
 
  private:
+  // Rebuilds connector table handles and estimates filter selectivity for
+  // each base table in this DT. Called by initializePlans() after all
+  // filters have been pushed down, so each table is sampled at most once.
+  void estimateBaseTableSelectivity();
+
   // Asserts invariants specific to union / unionAll DerivedTables.
   void checkSetOpConsistency() const;
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -61,6 +61,16 @@ Optimization::Optimization(
   root_->initializePlans();
 }
 
+void Optimization::estimateLeafSelectivity(BaseTable& baseTable) {
+  filterUpdated(&baseTable);
+  auto [tableHandle, filters] = toVelox_.leafHandle(baseTable.id());
+  ColumnVector topColumns;
+  folly::F14FastMap<ColumnCP, velox::TypePtr> typeMap;
+  auto scanType = subfieldPushdownScanType(
+      &baseTable, baseTable.columns, topColumns, typeMap);
+  history_.estimateLeafSelectivity(baseTable, tableHandle, filters, scanType);
+}
+
 // static
 PlanAndStats Optimization::toVeloxPlan(
     const logical_plan::LogicalPlanNode& logicalPlan,

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -66,13 +66,6 @@ class Optimization {
     return toVelox_;
   }
 
-  std::pair<
-      velox::connector::ConnectorTableHandlePtr,
-      std::vector<velox::core::TypedExprPtr>>
-  leafHandle(int32_t id) {
-    return toVelox_.leafHandle(id);
-  }
-
   /// Translates from Expr to Velox.
   velox::core::TypedExprPtr toTypedExpr(ExprCP expr) {
     return toVelox_.toTypedExpr(expr);
@@ -87,17 +80,13 @@ class Optimization {
         baseTable, leafColumns, topColumns, typeMap);
   }
 
-  /// Estimates 'filterSelectivity' of 'baseTable' from history. Returns true if
-  /// set. 'scanType' is the set of sampled columns with possible map to struct
-  /// cast.
-  bool estimateLeafSelectivity(
-      BaseTable& baseTable,
-      const velox::RowTypePtr& scanType) {
-    return history_.estimateLeafSelectivity(baseTable, scanType);
-  }
+  /// Estimates and sets 'filterSelectivity' on 'baseTable' by sampling the
+  /// table's layout. Must be called at most once per base table.
+  void estimateLeafSelectivity(BaseTable& baseTable);
 
-  void filterUpdated(BaseTableCP baseTable, bool updateSelectivity = true) {
-    toVelox_.filterUpdated(baseTable, updateSelectivity);
+  /// See ToVelox::filterUpdated.
+  void filterUpdated(BaseTableCP baseTable) {
+    toVelox_.filterUpdated(baseTable);
   }
 
   auto& memo() {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2162,16 +2162,6 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
     renames_[type->nameOf(i)] = column;
   }
 
-  auto* optimization = queryCtx()->optimization();
-
-  optimization->filterUpdated(baseTable, false);
-
-  ColumnVector top;
-  folly::F14FastMap<ColumnCP, velox::TypePtr> map;
-  auto scanType = optimization->subfieldPushdownScanType(
-      baseTable, baseTable->columns, top, map);
-
-  optimization->estimateLeafSelectivity(*baseTable, scanType);
   currentDt_->addTable(baseTable);
 }
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -162,11 +162,10 @@ RelationOpPtr addGather(const RelationOpPtr& op) {
 
 } // namespace
 
-void ToVelox::filterUpdated(BaseTableCP table, bool updateSelectivity) {
+void ToVelox::filterUpdated(BaseTableCP table) {
   PlanObjectSet columnSet;
-  for (auto& filter : table->columnFilters) {
-    columnSet.unionSet(filter->columns());
-  }
+  columnSet.unionColumns(table->columnFilters);
+
   auto leafColumns = columnSet.toObjects<Column>();
 
   columnAlteredTypes_.clear();
@@ -218,10 +217,6 @@ void ToVelox::filterUpdated(BaseTableCP table, bool updateSelectivity) {
       rejectedFilters);
 
   setLeafHandle(table->id(), std::move(handle), std::move(rejectedFilters));
-  if (updateSelectivity) {
-    optimization->estimateLeafSelectivity(
-        *const_cast<BaseTable*>(table), scanType);
-  }
 }
 
 velox::core::PlanNodePtr ToVelox::addOutputRenames(
@@ -1114,7 +1109,7 @@ velox::core::PlanNodePtr ToVelox::makeScan(
 
   auto [tableHandle, rejectedFilters] = leafHandle(scan.baseTable->id());
   if (tableHandle == nullptr) {
-    filterUpdated(scan.baseTable, false);
+    filterUpdated(scan.baseTable);
     std::tie(tableHandle, rejectedFilters) = leafHandle(scan.baseTable->id());
     VELOX_CHECK_NOT_NULL(tableHandle, "No table for scan {}", scan.toString());
   }

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -86,7 +86,9 @@ class ToVelox {
     return fmt::format("{}", nodeCounter_++);
   }
 
-  void filterUpdated(BaseTableCP baseTable, bool updateSelectivity = true);
+  /// Rebuilds the connector table handle for 'baseTable' from its current
+  /// filters and column handles.
+  void filterUpdated(BaseTableCP baseTable);
 
  private:
   // Adds a Velox ProjectNode that renames or reorders output columns per the

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -105,12 +105,12 @@ std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
   return pair;
 }
 
-bool VeloxHistory::estimateLeafSelectivity(
+void VeloxHistory::estimateLeafSelectivity(
     BaseTable& table,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    const std::vector<velox::core::TypedExprPtr>& filters,
     const velox::RowTypePtr& scanType) {
   auto options = queryCtx()->optimization()->options();
-  auto [tableHandle, filters] =
-      queryCtx()->optimization()->leafHandle(table.id());
 
   float conjunctsSelectivityValue = 1.0f;
 
@@ -135,48 +135,48 @@ bool VeloxHistory::estimateLeafSelectivity(
   auto* runnerTable = table.schemaTable->connectorTable;
   VELOX_DCHECK_NOT_NULL(runnerTable);
 
-  if (options.sampleFilters && runnerTable->layouts()[0]->supportsSampling()) {
-    const auto string = tableHandle->toString();
-
-    // Return cached sampled selectivity if available to avoid expensive I/O.
-    if (auto cached = findSampledLeafSelectivity(string)) {
-      table.filterSelectivity = cached.value();
-      return true;
-    }
-
-    // Determine and cache leaf selectivity for the table handle
-    // by sampling the layout for the physical table.
-    const uint64_t start = velox::getCurrentTimeMicro();
-    auto sample =
-        runnerTable->layouts()[0]->sample(tableHandle, 1, filters, scanType);
-    VELOX_CHECK_GE(sample.first, 0);
-    VELOX_CHECK_GE(sample.first, sample.second);
-
-    if (sample.first == 0) {
-      table.filterSelectivity = 1;
-    } else {
-      // When finding no hits, do not make a selectivity of 0 because this
-      // makes /0 or *0 and *0 is 0, which makes any subsequent operations 0
-      // regardless of cost. Use Selectivity::kLikelyTrue as a floor for the
-      // matching row count to ensure a small but non-zero selectivity.
-      table.filterSelectivity =
-          std::max<float>(Selectivity::kLikelyTrue, sample.second) /
-          static_cast<float>(sample.first);
-    }
-    recordSampledLeafSelectivity(string, table.filterSelectivity, false);
-
-    bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;
-    if (trace) {
-      std::cout << "Sampled scan " << string << "= " << table.filterSelectivity
-                << " time= "
-                << velox::succinctMicros(velox::getCurrentTimeMicro() - start)
-                << std::endl;
-    }
-    return true;
+  if (!options.sampleFilters ||
+      !runnerTable->layouts()[0]->supportsSampling()) {
+    table.filterSelectivity = conjunctsSelectivityValue;
+    return;
   }
 
-  table.filterSelectivity = conjunctsSelectivityValue;
-  return false;
+  const auto string = tableHandle->toString();
+
+  // Return cached sampled selectivity if available to avoid expensive I/O.
+  if (auto cached = findSampledLeafSelectivity(string)) {
+    table.filterSelectivity = cached.value();
+    return;
+  }
+
+  // Determine and cache leaf selectivity for the table handle
+  // by sampling the layout for the physical table.
+  const uint64_t start = velox::getCurrentTimeMicro();
+  auto sample =
+      runnerTable->layouts()[0]->sample(tableHandle, 1, filters, scanType);
+  VELOX_CHECK_GE(sample.first, 0);
+  VELOX_CHECK_GE(sample.first, sample.second);
+
+  if (sample.first == 0) {
+    table.filterSelectivity = 1;
+  } else {
+    // When finding no hits, do not make a selectivity of 0 because this
+    // makes /0 or *0 and *0 is 0, which makes any subsequent operations 0
+    // regardless of cost. Use Selectivity::kLikelyTrue as a floor for the
+    // matching row count to ensure a small but non-zero selectivity.
+    table.filterSelectivity =
+        std::max<float>(Selectivity::kLikelyTrue, sample.second) /
+        static_cast<float>(sample.first);
+  }
+  recordSampledLeafSelectivity(string, table.filterSelectivity, false);
+
+  bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;
+  if (trace) {
+    std::cout << "Sampled scan " << string << "= " << table.filterSelectivity
+              << " time= "
+              << velox::succinctMicros(velox::getCurrentTimeMicro() - start)
+              << std::endl;
+  }
 }
 
 namespace {

--- a/axiom/optimizer/VeloxHistory.h
+++ b/axiom/optimizer/VeloxHistory.h
@@ -43,10 +43,10 @@ class VeloxHistory : public History {
   /// constraints (cardinality, min, max, trueFraction, nullFraction, nullable)
   /// based on the table's filters. If sampling is enabled and a physical table
   /// is available, samples the table to refine the selectivity estimate.
-  /// Returns true if the estimate is backed by sampling, false if it relies
-  /// solely on statistics-based estimation.
-  bool estimateLeafSelectivity(
+  void estimateLeafSelectivity(
       BaseTable& table,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const std::vector<velox::core::TypedExprPtr>& filters,
       const velox::RowTypePtr& scanType) override;
 
   /// Stores observed costs and cardinalities from a query execution. If 'op' is


### PR DESCRIPTION
Summary:
Previously, BaseTable::addFilter() triggered filterUpdated() with
updateSelectivity=true, which called estimateLeafSelectivity() and
sampled the table on every individual filter addition. If a table
received N filters during optimization, it could be sampled up to N
times, each with a progressively larger filter set.

Move sampling to DerivedTable::initializePlans(), after
distributeConjuncts() has pushed all filters to their final base tables.
This ensures each table is sampled exactly once with the complete filter
set.

Also remove the now-unnecessary updateSelectivity parameter from
filterUpdated(), simplifying it to just rebuild the connector table
handle from the current filters.

Differential Revision: D95234510


