### PR TITLE
fix(parser): Add type coercion for JOIN USING with mismatched column types

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -142,6 +142,19 @@ ExprPtr applyCoercion(const ExprPtr& input, const velox::TypePtr& type) {
   return std::make_shared<SpecialFormExpr>(type, SpecialForm::kCast, input);
 }
 
+// Creates an InputRef for the given column, casting to targetType if it
+// differs from the column's actual type.
+ExprPtr makeCoercedRef(
+    const velox::TypePtr& columnType,
+    const std::string& name,
+    const velox::TypePtr& targetType) {
+  auto ref = makeInputRef(columnType, name);
+  if (targetType != nullptr && !columnType->equivalent(*targetType)) {
+    return applyCoercion(ref, targetType);
+  }
+  return ref;
+}
+
 std::vector<velox::TypePtr> toTypes(const std::vector<ExprPtr>& exprs) {
   std::vector<velox::TypePtr> types;
   types.reserve(exprs.size());
@@ -1328,19 +1341,17 @@ PlanBuilder& PlanBuilder::joinUsing(
   auto leftType = node_->outputType();
   auto rightType = right.node_->outputType();
 
+  auto commonTypes = computeCommonTypes(usingColumns, leftType, rightType);
+
   std::vector<ExprPtr> eqExprs;
   eqExprs.reserve(usingColumns.size());
-  for (const auto& column : usingColumns) {
-    auto leftColumnType = leftType->findChild(column.leftId);
-    auto rightColumnType = rightType->findChild(column.rightId);
-    VELOX_USER_CHECK(
-        leftColumnType->equivalent(*rightColumnType),
-        "USING column has different types on left and right sides of the join: {} ({} vs {})",
-        column.name,
-        leftColumnType->toString(),
-        rightColumnType->toString());
-    auto leftRef = makeInputRef(leftColumnType, column.leftId);
-    auto rightRef = makeInputRef(rightColumnType, column.rightId);
+  for (size_t i = 0; i < usingColumns.size(); ++i) {
+    const auto& column = usingColumns[i];
+    auto leftRef = makeCoercedRef(
+        leftType->findChild(column.leftId), column.leftId, commonTypes[i]);
+    auto rightRef = makeCoercedRef(
+        rightType->findChild(column.rightId), column.rightId, commonTypes[i]);
+
     eqExprs.push_back(
         std::make_shared<CallExpr>(
             velox::BOOLEAN(), "eq", std::vector<ExprPtr>{leftRef, rightRef}));
@@ -1361,40 +1372,87 @@ PlanBuilder& PlanBuilder::joinUsing(
       nextId(), std::move(node_), right.node_, joinType, std::move(condition));
 
   // Add projection to deduplicate USING columns.
-  addJoinUsingProjection(usingColumns, joinType);
+  addJoinUsingProjection(usingColumns, joinType, commonTypes);
 
   return *this;
 }
 
+std::vector<velox::TypePtr> PlanBuilder::computeCommonTypes(
+    const std::vector<UsingColumn>& usingColumns,
+    const velox::RowTypePtr& leftType,
+    const velox::RowTypePtr& rightType) {
+  std::vector<velox::TypePtr> commonTypes;
+  commonTypes.reserve(usingColumns.size());
+
+  for (const auto& column : usingColumns) {
+    auto leftColumnType = leftType->findChild(column.leftId);
+    auto rightColumnType = rightType->findChild(column.rightId);
+
+    if (leftColumnType->equivalent(*rightColumnType)) {
+      commonTypes.push_back(nullptr);
+      continue;
+    }
+
+    if (!enableCoercions_) {
+      VELOX_USER_FAIL(
+          "USING column has different types on left and right sides of the join: ({} vs {}) for {}",
+          leftColumnType->toString(),
+          rightColumnType->toString(),
+          column.name);
+    }
+
+    auto commonType = velox::TypeCoercer::leastCommonSuperType(
+        leftColumnType, rightColumnType);
+    VELOX_USER_CHECK_NOT_NULL(
+        commonType,
+        "USING column has incompatible types on left and right sides of the join: ({} vs {}) for {}",
+        leftColumnType->toString(),
+        rightColumnType->toString(),
+        column.name);
+    commonTypes.push_back(commonType);
+  }
+  return commonTypes;
+}
+
 void PlanBuilder::addJoinUsingProjection(
     const std::vector<UsingColumn>& usingColumns,
-    JoinType joinType) {
+    JoinType joinType,
+    const std::vector<velox::TypePtr>& commonTypes) {
   auto joinOutputType = node_->outputType();
 
   std::vector<std::string> outputNames;
   std::vector<ExprPtr> exprs;
+  outputNames.reserve(joinOutputType->size());
+  exprs.reserve(joinOutputType->size());
   auto newOutputMapping = std::make_shared<NameMappings>();
 
   // Emit USING columns first (one copy each).
-  for (const auto& column : usingColumns) {
-    const auto& type = joinOutputType->findChild(column.leftId);
+  for (size_t i = 0; i < usingColumns.size(); ++i) {
+    const auto& column = usingColumns[i];
+    auto leftColumnType = joinOutputType->findChild(column.leftId);
+    auto rightColumnType = joinOutputType->findChild(column.rightId);
+
     if (joinType == JoinType::kFull) {
       // Coalesce left and right for FULL OUTER joins.
-      auto leftRef = makeInputRef(type, column.leftId);
-      auto rightRef = makeInputRef(type, column.rightId);
+      auto leftRef =
+          makeCoercedRef(leftColumnType, column.leftId, commonTypes[i]);
+      auto rightRef =
+          makeCoercedRef(rightColumnType, column.rightId, commonTypes[i]);
       exprs.push_back(
           std::make_shared<SpecialFormExpr>(
-              type,
+              leftRef->type(),
               SpecialForm::kCoalesce,
               std::vector<ExprPtr>{leftRef, rightRef}));
       outputNames.push_back(newName(column.name));
     } else if (joinType == JoinType::kRight) {
       // Use the right side's column for RIGHT joins.
-      exprs.push_back(makeInputRef(type, column.rightId));
+      exprs.push_back(
+          makeCoercedRef(rightColumnType, column.rightId, commonTypes[i]));
       outputNames.push_back(column.rightId);
     } else {
       // Pass through the left side's column for INNER/LEFT joins.
-      exprs.push_back(makeInputRef(type, column.leftId));
+      exprs.push_back(
+          makeCoercedRef(leftColumnType, column.leftId, commonTypes[i]));
       outputNames.push_back(column.leftId);
     }
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -768,11 +768,19 @@ class PlanBuilder {
     }
   };
 
+  // Computes the common supertype for each pair of USING columns from the left
+  // and right sides of a join. Returns nullptr for columns that already match.
+  std::vector<velox::TypePtr> computeCommonTypes(
+      const std::vector<UsingColumn>& usingColumns,
+      const velox::RowTypePtr& leftType,
+      const velox::RowTypePtr& rightType);
+
   // Adds a projection to deduplicate USING columns after a join. Emits a
   // single copy of each USING column followed by all non-USING columns.
   void addJoinUsingProjection(
       const std::vector<UsingColumn>& usingColumns,
-      JoinType joinType);
+      JoinType joinType,
+      const std::vector<velox::TypePtr>& commonTypes);
 
   std::string nextId() {
     return planNodeIdGenerator_->next();

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -296,6 +296,143 @@ TEST_F(PlanBuilderTest, setOperationTypeCoercion) {
   }
 }
 
+TEST_F(PlanBuilderTest, joinUsingTypeCoercion) {
+  auto startMatcher = [] { return test::LogicalPlanMatcherBuilder().values(); };
+
+  auto makeBuilders = [](PlanBuilder::Context& context,
+                         const velox::RowTypePtr& leftType,
+                         const velox::RowTypePtr& rightType,
+                         bool enableCoercions = true) {
+    auto left = PlanBuilder(context, enableCoercions)
+                    .values(leftType, ValuesNode::Variants{});
+    auto right = PlanBuilder(context).values(rightType, ValuesNode::Variants{});
+    return std::make_pair(std::move(left), std::move(right));
+  };
+
+  // INTEGER vs BIGINT -> BIGINT.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {INTEGER(), VARCHAR()}),
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
+
+    auto plan = left.joinUsing(right, {"c0"}, JoinType::kInner).build();
+
+    VELOX_EXPECT_EQ_TYPES(
+        plan->outputType(),
+        ROW({"c0", "c1", "c1_1"}, {BIGINT(), VARCHAR(), VARCHAR()}));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+
+  // Same types on both sides.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
+
+    auto plan = left.joinUsing(right, {"c0"}, JoinType::kInner).build();
+
+    VELOX_EXPECT_EQ_TYPES(
+        plan->outputType(),
+        ROW({"c0", "c1", "c1_1"}, {BIGINT(), VARCHAR(), VARCHAR()}));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+
+  // Incompatible types (VARCHAR vs INTEGER) fail even with coercions enabled.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {VARCHAR(), BIGINT()}),
+        ROW({"c0", "c1"}, {INTEGER(), BIGINT()}));
+
+    VELOX_ASSERT_THROW(
+        left.joinUsing(right, {"c0"}, JoinType::kInner),
+        "USING column has incompatible types");
+  }
+
+  // Mismatched types fail when coercions are disabled.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {INTEGER(), VARCHAR()}),
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
+        /*enableCoercions=*/false);
+
+    VELOX_ASSERT_THROW(
+        left.joinUsing(right, {"c0"}, JoinType::kInner),
+        "USING column has different types");
+  }
+
+  // RIGHT JOIN with coercion.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {INTEGER(), VARCHAR()}),
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
+
+    auto plan = left.joinUsing(right, {"c0"}, JoinType::kRight).build();
+
+    VELOX_EXPECT_EQ_TYPES(
+        plan->outputType(),
+        ROW({"c0", "c1", "c1_1"}, {BIGINT(), VARCHAR(), VARCHAR()}));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+
+  // FULL OUTER JOIN with coercion.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1"}, {INTEGER(), VARCHAR()}),
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
+
+    auto plan = left.joinUsing(right, {"c0"}, JoinType::kFull).build();
+
+    VELOX_EXPECT_EQ_TYPES(
+        plan->outputType(),
+        ROW({"c0", "c1", "c1_1"}, {BIGINT(), VARCHAR(), VARCHAR()}));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+
+  // Multiple USING columns with mixed match/mismatch.
+  {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW({"c0", "c1", "c2"}, {INTEGER(), VARCHAR(), REAL()}),
+        ROW({"c0", "c1", "c2"}, {BIGINT(), VARCHAR(), DOUBLE()}));
+
+    auto plan = left.joinUsing(right, {"c0", "c1"}, JoinType::kInner).build();
+
+    VELOX_EXPECT_EQ_TYPES(
+        plan->outputType(),
+        ROW({"c0", "c1", "c2", "c2_2"},
+            {BIGINT(), VARCHAR(), REAL(), DOUBLE()}));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+}
+
 TEST_F(PlanBuilderTest, groupingSetsEmptyAggregatesAndKeys) {
   auto rowType = ROW({"a", "b"}, INTEGER());
   std::vector<Variant> data{

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -732,6 +732,17 @@ TEST_F(PrestoParserTest, joinUsing) {
         "SELECT * FROM t4 AS r(id, a, a) JOIN t5 AS t(id, b, b) USING (id)",
         matcher);
   }
+
+  // JOIN USING with type coercion (INTEGER vs BIGINT).
+  {
+    connector_->addTable("t_int", ROW({"id", "a"}, {INTEGER(), VARCHAR()}));
+    connector_->addTable("t_big", ROW({"id", "b"}, {BIGINT(), VARCHAR()}));
+    auto matcher = matchScan("t_int")
+                       .join(matchScan("t_big").build())
+                       .project()
+                       .output({"id", "a", "b"});
+    testSelect("SELECT * FROM t_int JOIN t_big USING (id)", matcher);
+  }
 }
 
 TEST_F(PrestoParserTest, joinOnSubquery) {


### PR DESCRIPTION
Summary:
When a `JOIN ... USING (col)` has compatible but non-identical types on the left and right sides (e.g., BIGINT vs INTEGER), Axiom fails with: `USING column has different types on left and right sides of the join`

Fix is similar to Presto. When `enableCoercions_` is true, use `TypeCoercer::leastCommonSuperType()` to find the common type and wrap the appropriate join input(s) in CAST ProjectNodes. When `enableCoercions_` is false, behavior is unchanged (fails). Similar coercion is done in `setOperation()`.

Also added .reserve() to addJoinUsingProjection vectors (pre-existing nit)

Differential Revision: D95242150


