### PR TITLE
test: Add ordering verification to LogicalPlanMatcher sort

### DIFF
--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -489,6 +489,54 @@ class OutputNamesMatcher : public LogicalPlanMatcherImpl<OutputNode> {
   const std::vector<std::string> expectedNames_;
 };
 
+class SortMatcher : public LogicalPlanMatcherImpl<SortNode> {
+ public:
+  SortMatcher(
+      const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
+      std::vector<std::string> ordering,
+      std::function<void(const LogicalPlanNodePtr&)> onMatch)
+      : LogicalPlanMatcherImpl<SortNode>(inputMatcher, std::move(onMatch)),
+        ordering_{std::move(ordering)} {}
+
+ private:
+  MatchResult matchDetails(
+      const SortNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    const auto& actualOrdering = plan.ordering();
+    EXPECT_EQ(actualOrdering.size(), ordering_.size());
+    AXIOM_RETURN_IF_FAILURE;
+
+    velox::parse::DuckSqlExpressionsParser parser;
+    for (size_t i = 0; i < ordering_.size(); ++i) {
+      auto expected = parser.parseOrderByExpr(ordering_[i]);
+      auto expectedExpr = expected.expr;
+
+      if (!symbols.empty()) {
+        expectedExpr = rewriteInputNames(expectedExpr, symbols);
+      }
+
+      EXPECT_EQ(
+          toExprString(*expectedExpr->dropAlias()),
+          actualOrdering[i].expression->toString())
+          << "at ordering index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+
+      EXPECT_EQ(expected.ascending, actualOrdering[i].order.isAscending())
+          << "sort direction mismatch at ordering index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+
+      EXPECT_EQ(expected.nullsFirst, actualOrdering[i].order.isNullsFirst())
+          << "nulls-first mismatch at ordering index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+    }
+
+    AXIOM_RETURN_RESULT(symbols)
+  }
+
+  const std::vector<std::string> ordering_;
+};
+
 #undef AXIOM_RETURN_IF_FAILURE
 #undef AXIOM_RETURN_RESULT
 
@@ -637,6 +685,15 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::sort(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<LogicalPlanMatcherImpl<SortNode>>(
       matcher_, std::move(onMatch));
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::sort(
+    const std::vector<std::string>& ordering,
+    OnMatchCallback onMatch) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ =
+      std::make_shared<SortMatcher>(matcher_, ordering, std::move(onMatch));
   return *this;
 }
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -190,6 +190,12 @@ class LogicalPlanMatcherBuilder {
   /// Matches a SortNode.
   LogicalPlanMatcherBuilder& sort(OnMatchCallback onMatch = nullptr);
 
+  /// Matches a SortNode with the specified ordering. Each entry in 'ordering'
+  /// is a sorting expression in DuckDB SQL syntax.
+  LogicalPlanMatcherBuilder& sort(
+      const std::vector<std::string>& ordering,
+      OnMatchCallback onMatch = nullptr);
+
   /// Matches any LimitNode.
   LogicalPlanMatcherBuilder& limit(OnMatchCallback onMatch = nullptr);
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -461,16 +461,16 @@ TEST_F(PrestoParserTest, withRecursiveNotSupported) {
 
 TEST_F(PrestoParserTest, orderBy) {
   {
-    auto matcher =
-        matchScan().aggregate().sort().project().output({"n_regionkey"});
+    auto matcher = matchScan().aggregate().sort({"count"}).project().output(
+        {"n_regionkey"});
 
     testSelect(
         "select n_regionkey from nation group by 1 order by count(1)", matcher);
   }
 
   {
-    auto matcher =
-        matchScan().aggregate().sort().output({"n_regionkey", "count"});
+    auto matcher = matchScan().aggregate().sort({"count"}).output(
+        {"n_regionkey", "count"});
 
     testSelect(
         "select n_regionkey, count(1) from nation group by 1 order by count(1)",
@@ -482,11 +482,15 @@ TEST_F(PrestoParserTest, orderBy) {
 
     testSelect(
         "select n_regionkey, count(1) as c from nation group by 1 order by c",
-        matchScan().aggregate().sort().output({"n_regionkey", "c"}));
+        matchScan().aggregate().sort({"c"}).output({"n_regionkey", "c"}));
   }
 
   {
-    auto matcher = matchScan().aggregate().project().sort().output();
+    auto matcher = matchScan()
+                       .aggregate()
+                       .project({"n_regionkey", "count * 2::bigint as x"})
+                       .sort({"x"})
+                       .output();
 
     testSelect(
         "select n_regionkey, count(1) * 2 from nation group by 1 order by 2",
@@ -498,17 +502,38 @@ TEST_F(PrestoParserTest, orderBy) {
   }
 
   {
-    auto matcher = matchScan().aggregate().project().sort().project().output();
+    auto matcher = matchScan()
+                       .aggregate()
+                       .project(
+                           {"n_regionkey",
+                            "count * 2::bigint as x",
+                            "count * 3::bigint as y"})
+                       .sort({"y"})
+                       .project()
+                       .output();
+
     testSelect(
         "select n_regionkey, count(1) * 2 from nation group by 1 order by count(1) * 3",
         matcher);
+  }
+
+  // Multiple sort keys with mixed directions.
+  {
+    auto matcher =
+        matchScan()
+            .sort({"n_regionkey", "n_name desc"})
+            .output({"n_nationkey", "n_name", "n_regionkey", "n_comment"});
+
+    testSelect(
+        "SELECT * FROM nation ORDER BY n_regionkey, n_name DESC", matcher);
   }
 }
 
 TEST_F(PrestoParserTest, orderByExpression) {
   // Expression in both SELECT and ORDER BY.
   {
-    auto matcher = matchValues().project().project().sort().output();
+    auto matcher =
+        matchValues().project().project({"a + b as x"}).sort({"x"}).output();
 
     testSelect(
         "SELECT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b", matcher);
@@ -516,14 +541,19 @@ TEST_F(PrestoParserTest, orderByExpression) {
 
   // Expression with constant.
   {
-    auto matcher = matchValues().project().project().sort().output();
+    auto matcher =
+        matchValues().project().project({"a + 1 as x"}).sort({"x"}).output();
 
     testSelect("SELECT a + 1 FROM ( VALUES (1) ) t(a) ORDER BY a + 1", matcher);
   }
 
   // Multiple expressions in SELECT, ORDER BY on one of them.
   {
-    auto matcher = matchValues().project().project().sort().output();
+    auto matcher = matchValues()
+                       .project()
+                       .project({"a + b as x", "a - b as y"})
+                       .sort({"x"})
+                       .output();
 
     testSelect(
         "SELECT a + b, a - b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b",
@@ -532,7 +562,8 @@ TEST_F(PrestoParserTest, orderByExpression) {
 
   // Nested subquery with aliased expression.
   {
-    auto matcher = matchValues().project().project().project().sort().output();
+    auto matcher =
+        matchValues().project().project().project().sort({"x"}).output();
 
     testSelect(
         "SELECT x FROM (SELECT a + b AS x FROM ( VALUES (1, 2) ) t(a, b)) ORDER BY x",
@@ -541,14 +572,15 @@ TEST_F(PrestoParserTest, orderByExpression) {
 
   // Simple column ORDER BY (regression check).
   {
-    auto matcher = matchScan().project().sort().output();
+    auto matcher = matchScan().project().sort({"n_regionkey"}).output();
 
     testSelect("SELECT n_regionkey FROM nation ORDER BY n_regionkey", matcher);
   }
 
   // Ordinal ORDER BY with expression in SELECT (regression check).
   {
-    auto matcher = matchValues().project().project().sort().output();
+    auto matcher =
+        matchValues().project().project({"a + b as x"}).sort({"x"}).output();
 
     testSelect(
         "SELECT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY 1", matcher);
@@ -556,11 +588,28 @@ TEST_F(PrestoParserTest, orderByExpression) {
 
   // DISTINCT with expression in both SELECT and ORDER BY.
   {
-    auto matcher = matchValues().project().project().distinct().sort().output();
+    auto matcher = matchValues()
+                       .project()
+                       .project({"a + b as x"})
+                       .distinct()
+                       .sort({"x"})
+                       .output();
 
     testSelect(
         "SELECT DISTINCT a + b FROM ( VALUES (1, 2) ) t(a, b) ORDER BY a + b",
         matcher);
+  }
+
+  // Ordinal ORDER BY with multiple expressions in SELECT.
+  {
+    connector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+    testSelect(
+        "SELECT a + b, b * 2, b + 4 FROM t ORDER BY 1, 3 DESC, 2",
+        matchScan("t")
+            .project({"a + b as x", "b * 2::bigint as y", "b + 4::bigint as z"})
+            .sort({"x", "z desc", "y"})
+            .output());
   }
 }
 
@@ -1008,7 +1057,7 @@ TEST_F(PrestoParserTest, everything) {
                      .join(matchScan().build())
                      .filter()
                      .aggregate()
-                     .sort()
+                     .sort({"count desc"})
                      .output({"r_name", "count"});
 
   testSelect(
@@ -1395,7 +1444,8 @@ TEST_F(PrestoParserTest, limit) {
   }
 
   {
-    auto matcher = matchScan().sort().limit(0, 100).output(nationColumns);
+    auto matcher =
+        matchScan().sort({"n_name"}).limit(0, 100).output(nationColumns);
     testSelect("SELECT * FROM nation ORDER BY n_name LIMIT 100", matcher);
     testSelect(
         "SELECT * FROM nation ORDER BY n_name FETCH FIRST 100 ROWS ONLY",


### PR DESCRIPTION
Summary:
Add a new `sort(ordering)` overload to `LogicalPlanMatcherBuilder` that
verifies sort keys in the logical plan. The existing `sort()` method only
checks that a `SortNode` exists; the new overload also validates the
ordering expressions match expected values.

- Add `SortMatcher` class that parses expected ordering expressions and
  compares them against the actual `SortNode` ordering.
- Add `sort(ordering, onMatch)` overload to `LogicalPlanMatcherBuilder`.
- Update existing `orderBy`, `orderByExpression`, and related tests to
  use the new overload for stronger assertions.

Differential Revision: D95269850


