### PR TITLE
refactor(optimizer): Replace filterSelectivity with filteredCardinality

### DIFF
--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -51,7 +51,7 @@ class History {
   /// execution.
   virtual void recordCost(const RelationOp& op, Cost cost) = 0;
 
-  /// Estimates and sets 'filterSelectivity' on 'baseTable'. Also narrows
+  /// Estimates and sets 'filteredCardinality' on 'baseTable'. Also narrows
   /// column Value constraints (cardinality, min, max, trueFraction,
   /// nullFraction, nullable) based on the table's filters. Estimates
   /// selectivity from column statistics (min/max, NDV, null fraction),

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -90,10 +90,7 @@ std::string tableName(PlanObjectCP table) {
 
 std::string visitBaseTable(const BaseTable& table) {
   std::stringstream out;
-  out << headerLine(
-      table.cname,
-      table.schemaTable->cardinality * table.filterSelectivity,
-      table.columns);
+  out << headerLine(table.cname, table.filteredCardinality, table.columns);
   out << "  table: " << table.schemaTable->name() << std::endl;
   for (const auto& column : table.columns) {
     out << "    " << column->name() << " " << constraintString(column->value())

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -122,6 +122,7 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
 
   auto base = make<BaseTable>();
   base->schemaTable = table;
+  base->filteredCardinality = table->cardinality;
 
   PlanObjectSet sampleColumns;
   for (auto key : keys) {

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -528,7 +528,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
       if (!state.isPlaced(object) && state.mayConsiderNext(object)) {
         auto fanout = tableCardinality(object);
         if (object->is(PlanType::kTableNode)) {
-          fanout *= object->as<BaseTable>()->filterSelectivity;
+          fanout = object->as<BaseTable>()->filteredCardinality;
         }
         candidates.emplace_back(nullptr, object, fanout);
       }
@@ -1904,7 +1904,8 @@ void Optimization::joinByIndex(
       return;
     }
 
-    auto fanout = info.scanCardinality * rightTable->filterSelectivity;
+    auto fanout = info.scanCardinality * rightTable->filteredCardinality /
+        rightTable->schemaTable->cardinality;
     if (joinType == velox::core::JoinType::kLeft) {
       fanout = std::max<float>(1, fanout);
     } else if (joinType == velox::core::JoinType::kLeftSemiProject) {
@@ -3074,7 +3075,7 @@ PlanP unionPlan(
 float startingScore(PlanObjectCP table) {
   if (table->is(PlanType::kTableNode)) {
     auto* baseTable = table->as<BaseTable>();
-    return baseTable->schemaTable->cardinality * baseTable->filterSelectivity;
+    return baseTable->filteredCardinality;
   }
 
   if (table->is(PlanType::kValuesTableNode)) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -80,7 +80,7 @@ class Optimization {
         baseTable, leafColumns, topColumns, typeMap);
   }
 
-  /// Estimates and sets 'filterSelectivity' on 'baseTable' by sampling the
+  /// Estimates and sets 'filteredCardinality' on 'baseTable' by sampling the
   /// table's layout. Must be called at most once per base table.
   void estimateLeafSelectivity(BaseTable& baseTable);
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -715,7 +715,8 @@ JoinFanout joinFanout(
 
 float baseSelectivity(PlanObjectCP object) {
   if (object->is(PlanType::kTableNode)) {
-    return object->as<BaseTable>()->filterSelectivity;
+    auto* baseTable = object->as<BaseTable>();
+    return baseTable->filteredCardinality / baseTable->schemaTable->cardinality;
   }
   return 1;
 }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -980,9 +980,9 @@ struct BaseTable : public PlanObject {
   /// Multicolumn filters dependent on 'this' alone.
   ExprVector filter;
 
-  /// The fraction of base table rows selected by all filters involving this
-  /// table only.
-  float filterSelectivity{1};
+  /// Estimated number of rows after applying all filters involving this table
+  /// only. Initialized to schemaTable->cardinality (no filtering).
+  float filteredCardinality{0};
 
   SubfieldSet controlSubfields;
 

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -122,7 +122,7 @@ TableScan::TableScan(
           TableScan::outputDistribution(table, index, columns),
           table,
           index,
-          /*fanout=*/index->table->cardinality * table->filterSelectivity,
+          /*fanout=*/table->filteredCardinality,
           columns,
           /*lookupKeys=*/{},
           velox::core::JoinType::kInner,
@@ -177,8 +177,7 @@ TableScan::TableScan(
     return;
   }
 
-  const auto cardinality =
-      index->table->cardinality * baseTable->filterSelectivity;
+  const auto cardinality = baseTable->filteredCardinality;
   updateLeafCost(cardinality, columns_, cost_);
 
   // Cap column cardinalities to the output row count.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2073,8 +2073,7 @@ SubfieldProjections makeSubfieldColumns(
     BaseTable& baseTable,
     ColumnCP column,
     const PathSet& paths) {
-  const float cardinality =
-      baseTable.schemaTable->cardinality * baseTable.filterSelectivity;
+  const float cardinality = baseTable.filteredCardinality;
 
   SubfieldProjections projections;
   paths.forEachPath([&](PathCP path) {
@@ -2109,6 +2108,7 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
   auto* baseTable = make<BaseTable>();
   baseTable->cname = newCName("t");
   baseTable->schemaTable = schemaTable;
+  baseTable->filteredCardinality = schemaTable->cardinality;
   planLeaves_[&tableScan] = baseTable;
 
   auto channels = usedChannels(tableScan);

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -137,7 +137,8 @@ void VeloxHistory::estimateLeafSelectivity(
 
   if (!options.sampleFilters ||
       !runnerTable->layouts()[0]->supportsSampling()) {
-    table.filterSelectivity = conjunctsSelectivityValue;
+    table.filteredCardinality =
+        table.schemaTable->cardinality * conjunctsSelectivityValue;
     return;
   }
 
@@ -145,7 +146,7 @@ void VeloxHistory::estimateLeafSelectivity(
 
   // Return cached sampled selectivity if available to avoid expensive I/O.
   if (auto cached = findSampledLeafSelectivity(string)) {
-    table.filterSelectivity = cached.value();
+    table.filteredCardinality = table.schemaTable->cardinality * cached.value();
     return;
   }
 
@@ -157,23 +158,23 @@ void VeloxHistory::estimateLeafSelectivity(
   VELOX_CHECK_GE(sample.first, 0);
   VELOX_CHECK_GE(sample.first, sample.second);
 
+  float selectivity;
   if (sample.first == 0) {
-    table.filterSelectivity = 1;
+    selectivity = 1;
   } else {
     // When finding no hits, do not make a selectivity of 0 because this
     // makes /0 or *0 and *0 is 0, which makes any subsequent operations 0
     // regardless of cost. Use Selectivity::kLikelyTrue as a floor for the
     // matching row count to ensure a small but non-zero selectivity.
-    table.filterSelectivity =
-        std::max<float>(Selectivity::kLikelyTrue, sample.second) /
+    selectivity = std::max<float>(Selectivity::kLikelyTrue, sample.second) /
         static_cast<float>(sample.first);
   }
-  recordSampledLeafSelectivity(string, table.filterSelectivity, false);
+  table.filteredCardinality = table.schemaTable->cardinality * selectivity;
+  recordSampledLeafSelectivity(string, selectivity, false);
 
   bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;
   if (trace) {
-    std::cout << "Sampled scan " << string << "= " << table.filterSelectivity
-              << " time= "
+    std::cout << "Sampled scan " << string << "= " << selectivity << " time= "
               << velox::succinctMicros(velox::getCurrentTimeMicro() - start)
               << std::endl;
   }


### PR DESCRIPTION
Summary:
Replace `BaseTable::filterSelectivity` (a fraction in [0, 1]) with
`filteredCardinality` (absolute filtered row count). This stores the
estimated number of rows after applying filters directly, rather than
requiring multiplication by `schemaTable->cardinality` at every use site.

This change is needed because not all connectors provide a meaningful
unfiltered cardinality (`schemaTable->cardinality`). For example, Hive
tables may return `numRows() = 0`, making `schemaTable->cardinality = 1` and
any fraction-based selectivity meaningless. Storing the absolute count
avoids needing a valid denominator.

All read sites that previously computed
`schemaTable->cardinality * filterSelectivity` now use
`filteredCardinality` directly. The few sites that need a fraction
(e.g., `baseSelectivity`, index join fanout) derive it via
`filteredCardinality / schemaTable->cardinality`.

Differential Revision: D95338006


