### PR TITLE
fix(optimizer): Scale NDV for non-filtered columns in Filter operator

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,6 +86,7 @@ for the complete guide. Key rules are summarized below.
   - ❌ `// A simple counter.` above `size_t count_{0};`
 - Avoid redundant comments that repeat what the code already says. Comments should explain *why*, not *what*.
 - Use `// TODO: Description.` for future work. Do not include author's username.
+- Do not duplicate comments between `.h` and `.cpp`. Document the function in the header; the implementation should not repeat the same comment. Duplicated comments diverge over time.
 
 ### Naming Conventions
 
@@ -132,8 +133,6 @@ Use conventional commit prefixes with `[Project]` tags:
 [Axiom] feat(optimizer): Add support for window functions
 [Axiom] fix: Validate HAVING column references in SQL parser
 [Axiom] refactor(parser): Extract GroupByPlanner class
-[Axiom] test: Improve LogicalPlanMatcherBuilder API
-[Axiom] docs: Document Query Graphviz CLI
 ```
 
 Format: `[Project] type(scope): Description`
@@ -145,6 +144,14 @@ Format: `[Project] type(scope): Description`
 
 These are frequently violated rules. Check every new or modified line against
 this list before finishing.
+
+### Bug fixes without a failing test first
+
+When fixing a bug, write the test **first**, run it, and confirm it **fails**
+before applying the fix. Then apply the fix and confirm the test passes. If you
+wrote the test after the fix, temporarily revert the fix and verify the test
+fails. A test that passes both with and without the fix proves nothing. This is
+the single most important workflow rule for bug fixes.
 
 ### `///` vs `//` — wrong comment style
 
@@ -164,16 +171,6 @@ namespace {
 // Returns true if 'a' is a prefix of 'b'.
 bool isPrefix(const ExprVector& a, const ExprVector& b);
 } // namespace
-
-// ❌ Wrong — private method is not public API.
- private:
-  /// Recursively replaces window function references.
-  ExprCP resolveWindowRefs(ExprCP expr) const;
-
-// ✅ Correct.
- private:
-  // Recursively replaces window function references.
-  ExprCP resolveWindowRefs(ExprCP expr) const;
 ```
 
 ### One-letter and abbreviated variable names
@@ -186,15 +183,11 @@ variables — must be descriptive.
 // ❌ Wrong — one-letter names and abbreviations.
 bool sameKeys(const ExprVector& a, const ExprVector& b);
 std::sort(groups.begin(), groups.end(), [](const auto& a, const auto& b) { ... });
-for (auto* wf : group.functions) { ... }
-for (size_t gi = 0; gi < groups.size(); ++gi) { ... }
 auto f = [](WindowFunctionCP f) { return f->frame().type == WindowType::kRows; };
 
 // ✅ Correct — descriptive names.
 bool sameKeys(const ExprVector& lhs, const ExprVector& rhs);
 std::sort(groups.begin(), groups.end(), [](const auto& lhs, const auto& rhs) { ... });
-for (auto* windowFunc : group.functions) { ... }
-for (size_t groupIndex = 0; groupIndex < groups.size(); ++groupIndex) { ... }
 auto f = [](WindowFunctionCP func) { return func->frame().type == WindowType::kRows; };
 ```
 
@@ -231,6 +224,33 @@ For optimizer plan tests:
    output into the expected.
 3. Flag suspicious patterns: redundant operators, two gathers with no partition
    keys, extra columns flowing through unnecessary nodes.
+
+### Static analysis instead of CLI experiments
+
+When working on the optimizer, do not spend time reading code and manually
+tracing through logic to predict output (cardinalities, plans, column indices).
+Instead, run a quick CLI experiment:
+
+```bash
+buck run axiom/cli:cli -- --num_workers 1 --num_drivers 1 \
+  --query "EXPLAIN (type optimized) SELECT ..."
+```
+
+Use `--init` with the test connector to create tables with specific data:
+
+```sql
+use test.default;
+create table t as select * from unnest(sequence(1, 100)) as t(a);
+```
+
+A 10-second CLI run is more reliable than 10 minutes of static analysis.
+
+### Working around infrastructure bugs
+
+When you discover a bug in test infrastructure, shared helpers, or common
+utilities, do **not** silently work around it. Stop, report the finding, and
+discuss whether to fix the root cause or work around it. Workarounds accumulate
+into technical debt and mask real problems.
 
 ## Directory Structure
 

--- a/axiom/optimizer/Filters.cpp
+++ b/axiom/optimizer/Filters.cpp
@@ -279,7 +279,7 @@ Selectivity conjunctsSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> conjuncts,
     bool updateConstraints) {
-  // Update constraints for each conjunct before processing.
+  // Derive constraints for all expressions in the conjuncts.
   for (auto* conjunct : conjuncts) {
     exprConstraint(conjunct, constraints, true);
   }

--- a/axiom/optimizer/Filters.h
+++ b/axiom/optimizer/Filters.h
@@ -126,7 +126,27 @@ Value exprConstraint(
 /// BOOLEAN: max 2, TINYINT: max 256, SMALLINT: max 65536.
 Value clampCardinality(const Value& value);
 
-/// Computes selectivity for a conjunction of expressions.
+/// Computes selectivity for a conjunction of filter expressions.
+///
+/// Derives constraints for all expressions in the conjuncts and their
+/// sub-expressions (via exprConstraint). Groups literal-bound comparisons and
+/// IN predicates by left-hand side for combined range analysis; evaluates
+/// everything else individually. Combines selectivities using the independence
+/// assumption.
+///
+/// When 'updateConstraints' is true, refines constraints based on filter
+/// semantics (e.g., x = 5 narrows x's min/max to 5 and sets NDV to 1).
+///
+/// The constraint map may be empty or pre-populated on entry. When empty,
+/// exprConstraint seeds each column's Value from expr->value(). When
+/// pre-populated (e.g., with input operator constraints), existing entries are
+/// used as-is for columns already present; new entries are added for columns
+/// and sub-expressions not yet in the map.
+///
+/// Note: the map is keyed on expr->id() and will contain entries for all
+/// expression nodes visited by exprConstraint (columns, calls, fields), not
+/// just columns. Callers that iterate the map should match entries against
+/// known column IDs.
 Selectivity conjunctsSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> conjuncts,

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1133,6 +1133,22 @@ double sampledNdv(double ndv, double numRows, double fraction) {
   return expectedNumDistincts(numRows * fraction, ndv);
 }
 
+// Scales NDV of all columns in 'constraints' using the coupon collector
+// formula. Models the effect of keeping a fraction of rows on the number of
+// distinct values seen.
+void scaleCardinalities(
+    ConstraintMap& constraints,
+    float inputCardinality,
+    float fanout) {
+  if (fanout >= 1.0) {
+    return;
+  }
+  for (auto& [columnId, constraint] : constraints) {
+    constraint.cardinality = std::max(
+        1.0, sampledNdv(constraint.cardinality, inputCardinality, fanout));
+  }
+}
+
 // Computes a saturating product using rational saturation function. The
 // result behaves like multiplication when far from max, but asymptotically
 // approaches max as the product increases.
@@ -1504,6 +1520,12 @@ Filter::Filter(RelationOpPtr input, ExprVector exprs)
   // Compute selectivity using filter analysis, updating constraints_
   auto selectivity = conjunctsSelectivity(constraints_, exprs_, true);
   cost_.fanout = selectivity.trueFraction;
+
+  // Scale NDV for all columns using the coupon collector formula.
+  // conjunctsSelectivity narrows the value space for filtered columns;
+  // scaleCardinalities narrows the expected count based on the combined row
+  // reduction. See FilterSelectivity.md for why these compose correctly.
+  scaleCardinalities(constraints_, cost_.inputCardinality, cost_.fanout);
 }
 
 const QGString& Filter::historyKey() const {
@@ -1628,18 +1650,8 @@ OrderBy::OrderBy(
   // rows is equivalent to sampling with fraction s = N/M. Use the coupon
   // collector formula to estimate the number of distinct values surviving the
   // sampling.
-  if (cost_.fanout >= 1.0) {
-    constraints_ = input_->constraints();
-  } else {
-    const auto fraction = cost_.fanout;
-    for (const auto& [columnId, constraint] : input_->constraints()) {
-      Value adjusted = constraint;
-      adjusted.cardinality = std::max(
-          1.0,
-          sampledNdv(constraint.cardinality, cost_.inputCardinality, fraction));
-      constraints_.emplace(columnId, adjusted);
-    }
-  }
+  constraints_ = input_->constraints();
+  scaleCardinalities(constraints_, cost_.inputCardinality, cost_.fanout);
 }
 
 void OrderBy::accept(
@@ -1668,14 +1680,8 @@ Limit::Limit(RelationOpPtr input, int64_t limit, int64_t offset)
   // Limit projects all input columns. Keeping N of M rows is equivalent to
   // sampling with fraction s = N/M. Use the coupon collector formula to
   // estimate the number of distinct values surviving the sampling.
-  const auto fraction = cost_.fanout;
-  for (const auto& [columnId, constraint] : input_->constraints()) {
-    Value adjusted = constraint;
-    adjusted.cardinality = std::max(
-        1.0,
-        sampledNdv(constraint.cardinality, cost_.inputCardinality, fraction));
-    constraints_.emplace(columnId, adjusted);
-  }
+  constraints_ = input_->constraints();
+  scaleCardinalities(constraints_, cost_.inputCardinality, cost_.fanout);
 }
 
 void Limit::accept(

--- a/axiom/optimizer/docs/FilterSelectivity.md
+++ b/axiom/optimizer/docs/FilterSelectivity.md
@@ -27,6 +27,106 @@ These constraints are initially derived from table statistics (e.g., Hive
 metastore) and are progressively refined as the optimizer processes filter
 expressions (see [Constraint Propagation](#constraint-propagation) below).
 
+## API
+
+The primary API is `conjunctsSelectivity` in `Filters.h`:
+
+```cpp
+Selectivity conjunctsSelectivity(
+    ConstraintMap& constraints,
+    std::span<const ExprCP> conjuncts,
+    bool updateConstraints);
+```
+
+**Parameters:**
+
+- `constraints` — A map from expression ID to `Value` (min, max, cardinality,
+  nullFraction). May be empty on entry; the function populates it by seeding
+  each column's `Value` from `expr->value()` via `exprConstraint`. Only columns
+  referenced in the conjuncts are added — columns not mentioned in any filter
+  are absent from the map.
+- `conjuncts` — Filter expressions to evaluate.
+- `updateConstraints` — If true, the function refines constraints in the map
+  based on filter semantics (e.g., `x = 5` narrows x's min/max to 5 and sets
+  cardinality to 1). The refined constraints can then be written back to
+  column `Value` objects for downstream cost estimation.
+
+**Returns:** A `Selectivity` with `trueFraction` (fraction of rows passing the
+filter) and `nullFraction` (fraction producing NULL).
+
+**Algorithm:**
+
+1. Seed constraints from column `Value` objects for all expressions in the
+   conjuncts (via `exprConstraint`).
+2. Classify conjuncts:
+   - Literal-bound comparisons (`x > 5`, `x IN (1, 2)`) are grouped by
+     left-hand-side expression for combined range analysis.
+   - Everything else (column-vs-column comparisons, boolean columns, unknown
+     functions) is evaluated individually.
+3. Compute per-conjunct (or per-group) selectivity.
+4. Combine using the independence assumption: `P(TRUE) = product of all
+   trueFractions`.
+
+**Callers:**
+
+- `VeloxHistory::estimateLeafSelectivity` — called with an empty
+  `ConstraintMap`. After the call, `setBaseTableValues(constraints, table)`
+  writes the refined constraints back to the `BaseTable`'s column `Value`
+  objects. Only columns appearing in the filters are updated; other columns
+  retain their original statistics. The downstream `TableScan` constructor
+  caps all column NDVs at `filteredCardinality`.
+- `Filter::Filter` (RelationOp constructor) — called with constraints
+  inherited from the input operator. After computing selectivity, applies
+  `sampledNdv` (coupon collector formula) to scale all column NDVs based on
+  the combined output row count. See below for why this composes correctly
+  with `conjunctsSelectivity`.
+
+**NDV scaling after `conjunctsSelectivity`:**
+
+`conjunctsSelectivity` refines constraints only for columns referenced in
+filter expressions. Each column's NDV reflects its own filter's value-space
+reduction (e.g., `x = 5` sets NDV=1, `y > 200` scales NDV proportionally
+to the range). It does not account for the combined row reduction from all
+conjuncts.
+
+`Filter::Filter` applies `sampledNdv` on top to account for the row
+reduction. This uses the coupon collector formula: given `d` distinct values
+and `n` output rows, the expected distinct values seen is
+`d × (1 − e^(−n/d))`. It is applied to all columns — both filtered and
+unfiltered — using the combined selectivity as the sampling fraction.
+
+The two operations compose correctly because they address orthogonal
+concerns:
+
+1. `conjunctsSelectivity` narrows the **value space** — how many distinct
+   values are possible given the filter predicates on this column.
+2. `sampledNdv` narrows the **expected count** — how many of those possible
+   values will actually appear given the total number of output rows.
+
+**Example:** Table with 1M rows. Filter: `x = 5 AND y > 200`.
+
+- `x = 5`: selectivity = 0.001. conjunctsSelectivity sets x NDV=1.
+- `y > 200`: selectivity = 0.6. conjunctsSelectivity sets y NDV=300
+  (range reduction from 500).
+- `z`: no filter, NDV=10000 unchanged.
+- Combined selectivity: 0.0006. Output: 600 rows.
+
+After `sampledNdv` with fraction=0.0006:
+- x: `sampledNdv(1, 1M, 0.0006)` = 1. Unchanged — a single value always
+  survives.
+- y: `sampledNdv(300, 1M, 0.0006)` ≈ 259. There are 300 possible y values
+  in [200, 499], but with only 600 output rows we expect to see 259 of them.
+- z: `sampledNdv(10000, 1M, 0.0006)` ≈ 582. Capped from 10000 to a value
+  consistent with 600 output rows.
+
+For column y, there is no double-counting despite the fraction including y's
+own selectivity. The math: each of the 300 distinct y values appears ~2000
+times among the 600K rows satisfying `y > 200`. The `x = 5` filter keeps
+each row with probability 0.001. P(a specific y value has zero surviving
+rows) = (1−0.001)^2000 = e^(−2). Expected distinct = 300 × (1−e^(−2)) ≈ 259.
+This matches `sampledNdv`'s computation: `expectedNumDistincts(600, 300)` =
+300 × (1−e^(−600/300)) = 300 × (1−e^(−2)) ≈ 259.
+
 ## Expression Types
 
 The optimizer recognizes and handles the following expression types:

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -116,8 +116,16 @@ class CardinalityEstimationTest : public test::QueryTestBase {
       EXPECT_EQ(dtValue.nullFraction, planValue.nullFraction);
       EXPECT_EQ(dtValue.trueFraction, planValue.trueFraction);
       EXPECT_EQ(dtValue.nullable, planValue.nullable);
-      EXPECT_EQ(dtValue.min, planValue.min);
-      EXPECT_EQ(dtValue.max, planValue.max);
+
+      // Compare min/max by value, not pointer identity.
+      EXPECT_EQ(dtValue.min == nullptr, planValue.min == nullptr);
+      if (dtValue.min && planValue.min) {
+        EXPECT_TRUE(dtValue.min->equals(*planValue.min));
+      }
+      EXPECT_EQ(dtValue.max == nullptr, planValue.max == nullptr);
+      if (dtValue.max && planValue.max) {
+        EXPECT_TRUE(dtValue.max->equals(*planValue.max));
+      }
     }
   }
 
@@ -301,6 +309,107 @@ const T& findOp(const RelationOp& op, RelType relType) {
 
   VELOX_FAIL("Cannot find {}: {}", RelTypeName::toName(relType), op.toString());
   folly::assume_unreachable();
+}
+
+// Verifies that a Filter operator scales NDV of non-filtered columns using
+// the coupon collector formula. Without scaling, column 'b' would retain
+// NDV=3 despite the filter reducing output to ~1 row.
+TEST_F(CardinalityEstimationTest, filterOverValues) {
+  verifyPlan(
+      "SELECT * FROM (VALUES (1, 100), (2, 200), (3, 300)) AS t(a, b) "
+      "WHERE a > 1",
+      [](const Plan& plan) {
+        // Plan structure: Project → Filter → Values.
+        const auto& filter = findOp(*plan.op, RelType::kFilter);
+
+        // Filter 'a > 1' uses default selectivity 0.10 (no min/max on VALUES).
+        // 3 * 0.10 = 0.3, clamped to at least 1 row.
+        EXPECT_NEAR(filter.resultCardinality(), 1, kCardinalityTolerance);
+        ASSERT_EQ(filter.columns().size(), 2);
+
+        // Filtered column 'a': conjunctsSelectivity sets NDV. sampledNdv
+        // preserves it since NDV=1 can't decrease further.
+        auto a = findConstraint(filter, 0);
+        ASSERT_TRUE(a.has_value());
+        EXPECT_NEAR(a->cardinality, 1, kCardinalityTolerance);
+
+        // Non-filtered column 'b': sampledNdv(3, 3, 0.10) scales NDV from 3
+        // to 1.
+        auto b = findConstraint(filter, 1);
+        ASSERT_TRUE(b.has_value());
+        EXPECT_NEAR(b->cardinality, 1, kCardinalityTolerance);
+      });
+}
+
+// Verifies that a Filter operator over Unnest scales NDV of non-filtered
+// columns. The replicate column 'b' has high NDV from the base table;
+// after the filter reduces rows, its NDV should scale down.
+TEST_F(CardinalityEstimationTest, filterOverUnnest) {
+  connector_->addTable("t", ROW({"a", "b"}, {ARRAY(BIGINT()), BIGINT()}))
+      ->setStats(
+          1'000,
+          {
+              {"a", {.numDistinct = 100}},
+              {"b", {.numDistinct = 800}},
+          });
+
+  verifyPlan(
+      "SELECT b, e FROM t CROSS JOIN UNNEST(a) AS u(e) WHERE e > 1",
+      [](const Plan& plan) {
+        // Plan structure: Project → Filter → Unnest → TableScan.
+        const auto& filter = findOp(*plan.op, RelType::kFilter);
+
+        // Unnest produces 10,000 rows (1,000 * fanout 10). Filter 'e > 1'
+        // uses default selectivity 0.10 → 1,000 output rows.
+        EXPECT_NEAR(filter.resultCardinality(), 1'000, kCardinalityTolerance);
+
+        // Non-filtered replicate column 'b': NDV=800 from table scan.
+        // sampledNdv(800, 10000, 0.10) ≈ 571.
+        auto b = findConstraint(filter, 0);
+        ASSERT_TRUE(b.has_value());
+        EXPECT_LT(b->cardinality, 800);
+      });
+}
+
+// Verifies that a Filter operator over a join scales NDV of non-filtered
+// columns. The cross-table WHERE clause becomes a Filter on top of the join.
+// Without scaling, column 'c' would retain its join-output NDV even when
+// the filter reduces the row count below the NDV.
+TEST_F(CardinalityEstimationTest, filterOverJoin) {
+  connector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"a", {.numDistinct = 100}},
+              {"b", {.min = 1LL, .max = 1'000LL, .numDistinct = 1'000}},
+              {"c", {.numDistinct = 800}},
+          });
+
+  connector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          10,
+          {
+              {"x", {.numDistinct = 10}},
+              {"y", {.min = 1LL, .max = 1'000LL, .numDistinct = 10}},
+          });
+
+  verifyPlan(
+      "SELECT a, c, x FROM t JOIN u ON a = x WHERE b > y",
+      [](const Plan& plan) {
+        const auto& filter = findOp(*plan.op, RelType::kFilter);
+
+        // Join on a=x: fanout = 10 / max(100, 10) = 0.1.
+        // resultCardinality = 1'000 * 0.1 = 100.
+        // Filter 'b > y': ~50% selectivity → ~50 rows.
+        EXPECT_NEAR(filter.resultCardinality(), 50, kCardinalityTolerance);
+
+        // Column 'c' is not referenced in any filter or join key. After the
+        // join, c NDV was scaled by sampledNdv to ~94. The Filter should
+        // further scale it: sampledNdv(94, 100, 0.5) ≈ 39.
+        auto c = findConstraint(filter, 1);
+        ASSERT_TRUE(c.has_value());
+        EXPECT_LT(c->cardinality, filter.resultCardinality());
+      });
 }
 
 // Verifies cardinality estimation for inner join: output cardinality


### PR DESCRIPTION
Summary:
The Filter constructor calls conjunctsSelectivity to compute selectivity and
update constraints for columns referenced in filter expressions. However,
columns not referenced in any filter retained their input NDV unchanged, which
could exceed the post-filter row count. For example, a filter reducing 1M rows
to 10K rows left an unfiltered column with NDV=500K.

Add scaleCardinalities helper that applies the coupon collector formula
(sampledNdv) to scale all column NDVs based on the output row count. Apply it
in Filter after conjunctsSelectivity. Refactor OrderBy and Limit to use the
same helper, replacing their inline loops.

Fix verifyDtConstraints in CardinalityEstimationTest to compare min/max
Variant values by value instead of pointer identity.

Add coding style rules: prefer CLI experiments over static analysis, write
tests before fixes, do not work around infrastructure bugs.

Differential Revision: D95386111


