### PR TITLE
refactor: Simplify TableLayout::sample API to take only handle

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -252,6 +252,14 @@ utilities, do **not** silently work around it. Stop, report the finding, and
 discuss whether to fix the root cause or work around it. Workarounds accumulate
 into technical debt and mask real problems.
 
+### Verify causation before asserting it
+
+When investigating a test failure or regression, do not attribute it to a
+specific commit based on the commit message alone. Verify empirically by
+checking out the parent commit and running the test. Incorrect attribution
+leads to wrong fixes — e.g., updating test expectations when the real problem
+is a bug introduced by a different commit.
+
 ## Directory Structure
 
 | Directory | Description |

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -324,6 +324,18 @@ class DiscretePredicates {
   const std::vector<const Column*> columns_;
 };
 
+/// Result of sampling a table layout. Both fields are non-negative and
+/// numMatched <= numSampled. numSampled may be zero for empty tables; the
+/// caller treats this as selectivity 1.0.
+struct SampleResult {
+  /// Number of rows sampled. Zero for empty tables.
+  int64_t numSampled;
+
+  /// Number of sampled rows matching the filters in 'handle'. At most
+  /// numSampled.
+  int64_t numMatched;
+};
+
 /// Represents a physical manifestation of a table. There is at least
 /// one layout but for tables that have multiple sort orders, partitionings,
 /// indices, column groups, etc. there is a separate layout for each. The layout
@@ -435,7 +447,7 @@ class TableLayout {
   /// True if this layout supports sampling for cardinality estimation. If
   /// false, the optimizer skips sampling and falls back to default estimates.
   virtual bool supportsSampling() const {
-    return true;
+    return false;
   }
 
   /// The columns and their names as a RowType.
@@ -448,24 +460,10 @@ class TableLayout {
     return dynamic_cast<const T*>(this);
   }
 
-  /// Samples 'pct' percent of rows. Applies filters in 'handle' before
-  /// sampling. Returns {count of sampled, count matching filters}.
-  /// 'extraFilters' is a list of conjuncts to evaluate in addition to the
-  /// filters in 'handle'. If 'statistics' is non-nullptr, fills it with
-  /// post-filter statistics for the subfields in 'fields'. When sampling on
-  /// demand, it is usually sufficient to look at a subset of all accessed
-  /// columns, so we specify these instead of defaulting to the columns in
-  /// 'handle'. 'allocator' is used for temporary memory in gathering
-  /// statistics. 'outputType' can specify a cast from map to struct. Filter
-  /// expressions see the 'outputType' and 'subfields' are relative to that.
-  virtual std::pair<int64_t, int64_t> sample(
-      const velox::connector::ConnectorTableHandlePtr& /*handle*/,
-      float /*pct*/,
-      const std::vector<velox::core::TypedExprPtr>& /*extraFilters*/,
-      velox::RowTypePtr /*outputType*/ = nullptr,
-      const std::vector<velox::common::Subfield>& /*fields*/ = {},
-      velox::HashStringAllocator* /*allocator*/ = nullptr,
-      std::vector<ColumnStatistics>* /*statistics*/ = nullptr) const {
+  /// Samples a fraction of rows and applies filters from 'handle'. Returns the
+  /// number of rows sampled and the number matching the filters.
+  virtual SampleResult sample(
+      const velox::connector::ConnectorTableHandlePtr& /*handle*/) const {
     VELOX_UNSUPPORTED("Sampling is not supported for this layout");
   }
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -275,31 +275,11 @@ void LocalHiveConnectorMetadata::readTables(std::string_view path) {
   }
 }
 
-std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
-    const velox::connector::ConnectorTableHandlePtr& handle,
-    float pct,
-    const std::vector<velox::core::TypedExprPtr>& extraFilters,
-    velox::RowTypePtr scanType,
-    const std::vector<velox::common::Subfield>& fields,
-    velox::HashStringAllocator* allocator,
-    std::vector<ColumnStatistics>* statistics) const {
-  VELOX_CHECK(extraFilters.empty());
-
+SampleResult LocalHiveTableLayout::sample(
+    const velox::connector::ConnectorTableHandlePtr& handle) const {
   std::vector<std::unique_ptr<StatisticsBuilder>> builders;
-  auto result = sample(handle, pct, scanType, fields, allocator, &builders);
-  if (!statistics) {
-    return result;
-  }
-
-  statistics->resize(builders.size());
-  for (size_t i = 0; i < builders.size(); ++i) {
-    ColumnStatistics runnerStats;
-    if (builders[i]) {
-      builders[i]->build(runnerStats);
-    }
-    (*statistics)[i] = std::move(runnerStats);
-  }
-  return result;
+  auto result = sample(handle, 1, rowType(), {}, nullptr, &builders);
+  return SampleResult{result.first, result.second};
 }
 
 std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -112,14 +112,12 @@ class LocalHiveTableLayout : public HiveTableLayout {
             fileFormat),
         serdeParameters_(std::move(serdeParameters)) {}
 
-  std::pair<int64_t, int64_t> sample(
-      const velox::connector::ConnectorTableHandlePtr& handle,
-      float pct,
-      const std::vector<velox::core::TypedExprPtr>& extraFilters,
-      velox::RowTypePtr outputType,
-      const std::vector<velox::common::Subfield>& fields,
-      velox::HashStringAllocator* allocator,
-      std::vector<ColumnStatistics>* statistics) const override;
+  bool supportsSampling() const override {
+    return true;
+  }
+
+  SampleResult sample(
+      const velox::connector::ConnectorTableHandlePtr& handle) const override;
 
   const std::vector<std::unique_ptr<const FileInfo>>& files() const {
     return files_;

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -246,13 +246,15 @@ TEST_F(LocalHiveConnectorMetadataTest, basic) {
       /*dataColumns=*/nullptr,
       /*lookupKeys=*/{});
   EXPECT_TRUE(rejectedFilters.empty());
-  std::vector<ColumnStatistics> stats;
   std::vector<common::Subfield> fields;
   auto c0 = common::Subfield::create("c0");
   fields.push_back(std::move(*c0));
   HashStringAllocator allocator(pool_.get());
-  auto pair = layout->sample(
-      tableHandle, 100, {}, layout->rowType(), fields, &allocator, &stats);
+  std::vector<std::unique_ptr<StatisticsBuilder>> statsBuilders;
+  auto* localLayout = dynamic_cast<const LocalHiveTableLayout*>(layout);
+  ASSERT_NE(localLayout, nullptr);
+  auto pair = localLayout->sample(
+      tableHandle, 100, layout->rowType(), fields, &allocator, &statsBuilders);
   EXPECT_EQ(250'000, pair.first);
   EXPECT_EQ(250'000, pair.second);
 }
@@ -290,7 +292,6 @@ TEST_F(LocalHiveConnectorMetadataTest, sampleWithPathFilter) {
       /*lookupKeys=*/{});
   EXPECT_TRUE(rejectedFilters.empty());
 
-  std::vector<ColumnStatistics> stats;
   std::vector<common::Subfield> fields;
   auto c0 = common::Subfield::create("c0");
   fields.push_back(std::move(*c0));
@@ -299,8 +300,9 @@ TEST_F(LocalHiveConnectorMetadataTest, sampleWithPathFilter) {
   // sample() should only sample the file matching $path filter.
   // With 5 files and 50,000 rows per file, filtering to 1 file should
   // result in approximately 50,000 rows sampled (not 250,000).
+  std::vector<std::unique_ptr<StatisticsBuilder>> statsBuilders;
   auto pair = layout->sample(
-      tableHandle, 100, {}, layout->rowType(), fields, &allocator, &stats);
+      tableHandle, 100, layout->rowType(), fields, &allocator, &statsBuilders);
   EXPECT_EQ(kRowsPerVector * kNumVectors, pair.first);
   EXPECT_EQ(kRowsPerVector * kNumVectors, pair.second);
 }

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -25,8 +25,7 @@ namespace facebook::axiom::connector {
 class TestConnector;
 
 /// The Table and Connector objects to which this layout correspond
-/// are specified explicitly at init time. The sample API is
-/// overridden to provide placeholder counts.
+/// are specified explicitly at init time.
 class TestTableLayout : public TableLayout {
  public:
   TestTableLayout(
@@ -56,17 +55,6 @@ class TestTableLayout : public TableLayout {
 
   std::unique_ptr<DiscretePredicates> discretePredicates(
       const std::vector<const Column*>& columns) const override;
-
-  std::pair<int64_t, int64_t> sample(
-      const velox::connector::ConnectorTableHandlePtr&,
-      float,
-      const std::vector<velox::core::TypedExprPtr>&,
-      velox::RowTypePtr,
-      const std::vector<velox::common::Subfield>&,
-      velox::HashStringAllocator*,
-      std::vector<ColumnStatistics>*) const override {
-    return std::make_pair(1'000, 1'000);
-  }
 
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -184,19 +184,6 @@ velox::connector::ConnectorTableHandlePtr TpchTableLayout::createTableHandle(
       std::move(filterExpression));
 }
 
-std::pair<int64_t, int64_t> TpchTableLayout::sample(
-    const velox::connector::ConnectorTableHandlePtr& /*handle*/,
-    float /*pct*/,
-    const std::vector<velox::core::TypedExprPtr>& /* extraFilters */,
-    velox::RowTypePtr /* outputType */,
-    const std::vector<velox::common::Subfield>& /* fields */,
-    velox::HashStringAllocator* /* allocator */,
-    std::vector<ColumnStatistics>* /* statistics */) const {
-  // TODO Add support for filter in 'handle' and 'extraFilters'.
-  const auto totalRows = velox::tpch::getRowCount(tpchTable_, scaleFactor_);
-  return std::pair(totalRows, totalRows);
-}
-
 void TpchTable::makeDefaultLayout(TpchConnectorMetadata& metadata) {
   VELOX_CHECK_EQ(0, exportedLayouts_.size());
 

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -101,14 +101,9 @@ class TpchTableLayout : public TableLayout {
     return scaleFactor_;
   }
 
-  std::pair<int64_t, int64_t> sample(
-      const velox::connector::ConnectorTableHandlePtr& handle,
-      float pct,
-      const std::vector<velox::core::TypedExprPtr>& extraFilters,
-      velox::RowTypePtr outputType = nullptr,
-      const std::vector<velox::common::Subfield>& fields = {},
-      velox::HashStringAllocator* allocator = nullptr,
-      std::vector<ColumnStatistics>* statistics = nullptr) const override;
+  bool supportsSampling() const override {
+    return false;
+  }
 
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,

--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -60,14 +60,11 @@ class History {
   /// Must be called at most once per base table. Calling multiple times
   /// compounds constraint narrowing, producing incorrect estimates.
   ///
-  /// 'tableHandle' and 'filters' are the connector-level representation of
-  /// the table's current filters. 'scanType' is the row type for sampled
-  /// columns.
+  /// 'tableHandle' is the connector-level representation of the table's current
+  /// filters.
   virtual void estimateLeafSelectivity(
       BaseTable& baseTable,
-      const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<velox::core::TypedExprPtr>& filters,
-      const velox::RowTypePtr& scanType) = 0;
+      const velox::connector::ConnectorTableHandlePtr& tableHandle) = 0;
 
   virtual void recordJoinSample(std::string_view key, float lr, float rl) = 0;
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -63,12 +63,8 @@ Optimization::Optimization(
 
 void Optimization::estimateLeafSelectivity(BaseTable& baseTable) {
   filterUpdated(&baseTable);
-  auto [tableHandle, filters] = toVelox_.leafHandle(baseTable.id());
-  ColumnVector topColumns;
-  folly::F14FastMap<ColumnCP, velox::TypePtr> typeMap;
-  auto scanType = subfieldPushdownScanType(
-      &baseTable, baseTable.columns, topColumns, typeMap);
-  history_.estimateLeafSelectivity(baseTable, tableHandle, filters, scanType);
+  auto tableHandle = toVelox_.leafHandle(baseTable.id()).first;
+  history_.estimateLeafSelectivity(baseTable, tableHandle);
 }
 
 // static
@@ -2810,6 +2806,13 @@ void Optimization::addJoin(
   }
 
   // If one is much better do not try the other.
+  // TODO: NextJoin::isWorse accounts for probe-side shuffle cost but not for
+  // build-side distribution changes. Flipping a LEFT SEMI to RIGHT SEMI can
+  // turn a cheap broadcast into an expensive shuffle (e.g., when the existence
+  // table is small enough to broadcast as LEFT SEMI build, but RIGHT SEMI
+  // forces both sides to be shuffled). Consider build-side distribution cost
+  // in isWorse() or skip the right variant when the left build is
+  // broadcastable.
   if (toTry.size() == 2 && candidate.tables.size() == 1) {
     if (toTry[0].isWorse(toTry[1])) {
       toTry.erase(toTry.begin());

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -107,9 +107,7 @@ std::pair<float, float> VeloxHistory::sampleJoin(JoinEdge* edge) {
 
 void VeloxHistory::estimateLeafSelectivity(
     BaseTable& table,
-    const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<velox::core::TypedExprPtr>& filters,
-    const velox::RowTypePtr& scanType) {
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
   auto options = queryCtx()->optimization()->options();
 
   float conjunctsSelectivityValue = 1.0f;
@@ -153,21 +151,21 @@ void VeloxHistory::estimateLeafSelectivity(
   // Determine and cache leaf selectivity for the table handle
   // by sampling the layout for the physical table.
   const uint64_t start = velox::getCurrentTimeMicro();
-  auto sample =
-      runnerTable->layouts()[0]->sample(tableHandle, 1, filters, scanType);
-  VELOX_CHECK_GE(sample.first, 0);
-  VELOX_CHECK_GE(sample.first, sample.second);
+  auto sample = runnerTable->layouts()[0]->sample(tableHandle);
+  VELOX_CHECK_GE(sample.numSampled, 0);
+  VELOX_CHECK_GE(sample.numMatched, 0);
+  VELOX_CHECK_GE(sample.numSampled, sample.numMatched);
 
   float selectivity;
-  if (sample.first == 0) {
+  if (sample.numSampled == 0) {
     selectivity = 1;
   } else {
     // When finding no hits, do not make a selectivity of 0 because this
     // makes /0 or *0 and *0 is 0, which makes any subsequent operations 0
     // regardless of cost. Use Selectivity::kLikelyTrue as a floor for the
     // matching row count to ensure a small but non-zero selectivity.
-    selectivity = std::max<float>(Selectivity::kLikelyTrue, sample.second) /
-        static_cast<float>(sample.first);
+    selectivity = std::max<float>(Selectivity::kLikelyTrue, sample.numMatched) /
+        static_cast<float>(sample.numSampled);
   }
   table.filteredCardinality = table.schemaTable->cardinality * selectivity;
   recordSampledLeafSelectivity(string, selectivity, false);

--- a/axiom/optimizer/VeloxHistory.h
+++ b/axiom/optimizer/VeloxHistory.h
@@ -45,9 +45,7 @@ class VeloxHistory : public History {
   /// is available, samples the table to refine the selectivity estimate.
   void estimateLeafSelectivity(
       BaseTable& table,
-      const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<velox::core::TypedExprPtr>& filters,
-      const velox::RowTypePtr& scanType) override;
+      const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 
   /// Stores observed costs and cardinalities from a query execution. If 'op' is
   /// non-null, non-leaf costs from non-leaf levels are recorded. Otherwise only

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -361,8 +361,7 @@ TEST_F(ExistencePushdownTest, multipleTables) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   auto matcher =
-      matchScan("r")
-          .filter("b < 100")
+      matchScan("s")
           .hashJoin(
               matchScan("u")
                   .hashJoin(
@@ -373,7 +372,8 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .singleAggregation({"x", "y"}, {})
                   .build(),
               core::JoinType::kInner)
-          .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -382,8 +382,7 @@ TEST_F(ExistencePushdownTest, multipleTables) {
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("r")
-          .filter("b < 100")
+      matchScan("s")
           .hashJoin(
               matchScan("u")
                   .hashJoin(
@@ -398,7 +397,9 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .broadcast()
                   .build(),
               core::JoinType::kInner)
-          .hashJoin(matchScan("s").broadcast().build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("r").filter("b < 100").broadcast().build(),
+              core::JoinType::kInner)
           .project()
           .gather()
           .project()

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1182,11 +1182,12 @@ TEST_F(JoinTest, impliedJoins) {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.a = t.b";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .filter("a = b")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);


### PR DESCRIPTION
Summary:
Simplify the TableLayout::sample virtual method from 7 parameters to 1.
The only production caller (VeloxHistory::estimateLeafSelectivity) only
needs the handle — it computes a ratio from the returned counts, so the
sample size and other parameters don't matter.

Add SampleResult struct with named fields (numSampled, numMatched) to
replace the anonymous std::pair<int64_t, int64_t> return type.

Change supportsSampling() default from true to false so new connectors
opt out of sampling by default instead of hitting VELOX_UNSUPPORTED at
runtime.

Remove dead parameters:
- pct: caller always passed 1; ratio-based usage makes sample size
irrelevant. Each implementation decides its own sample size.
- extraFilters: LocalHiveTableLayout asserts it empty; no implementation
uses it.
- outputType: not used through the virtual API.
- fields, allocator, statistics: used only by the LocalHive private
overload for column statistics gathering (sampleNumDistincts), never
through the virtual API.

This also simplifies the caller chain:
- VeloxHistory::estimateLeafSelectivity no longer takes filters or
scanType.
- Optimization::estimateLeafSelectivity no longer computes scanType.

Stub implementations (Tpch, TestConnector) that returned hardcoded
values are replaced with supportsSampling() → false.

Differential Revision: D95393244


