### PR TITLE
misc(cli): Add ConsoleTest.cpp to CMakeLists.txt

### DIFF
--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_cli_test SqlQueryRunnerTest.cpp StdinReaderTest.cpp)
+add_executable(axiom_cli_test SqlQueryRunnerTest.cpp StdinReaderTest.cpp ConsoleTest.cpp)
 
 add_test(NAME axiom_cli_test COMMAND axiom_cli_test)
 

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "axiom/cli/Console.h"
-#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 
@@ -93,9 +92,3 @@ TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
 
 } // namespace
 } // namespace axiom::sql
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  folly::Init init(&argc, &argv, false);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Summary:
Add `ConsoleTest.cpp` to the `axiom_cli_test` CMake target. The test was
added to the BUCK file in D95230426 but missed in the corresponding
CMakeLists.txt.

Differential Revision: D95339714


