### PR TITLE
fix(axiom): Revert "Relax SchemaResolver validation to pass non-standard table names through to connectors"

### DIFF
--- a/axiom/connectors/SchemaResolver.cpp
+++ b/axiom/connectors/SchemaResolver.cpp
@@ -30,38 +30,29 @@ TablePtr SchemaResolver::findTable(
     std::string_view catalog,
     std::string_view name) const {
   TableNameParser parser(name);
+  VELOX_USER_CHECK(parser.valid(), "Invalid table name: '{}'", name);
 
-  // For standard table names (max 3 parts: catalog.schema.table), use the
-  // parser to validate and extract components.
-  if (parser.valid()) {
-    if (parser.catalog().has_value()) {
-      VELOX_USER_CHECK_EQ(
-          catalog,
-          parser.catalog().value(),
-          "Input catalog must match table catalog specifier");
-    }
-
-    std::string lookupName;
-    if (parser.schema().has_value()) {
-      lookupName =
-          fmt::format("{}.{}", parser.schema().value(), parser.table());
-    } else if (!defaultSchema_.empty()) {
-      lookupName = fmt::format("{}.{}", defaultSchema_, parser.table());
-    } else {
-      lookupName = parser.table();
-    }
-
-    if (targetCatalog_ == catalog && targetTable_->name() == lookupName) {
-      return targetTable_;
-    }
-
-    return ConnectorMetadata::metadata(catalog)->findTable(lookupName);
+  if (parser.catalog().has_value()) {
+    VELOX_USER_CHECK_EQ(
+        catalog,
+        parser.catalog().value(),
+        "Input catalog must match table catalog specifier");
   }
 
-  // For non-standard table names (e.g., XDB tier paths with multiple dots
-  // like "ephemeralxdb.on_demand_rocksdb.ftw.784.tasks"), pass directly to
-  // the connector's findTable which may have its own specialized parser.
-  return ConnectorMetadata::metadata(catalog)->findTable(name);
+  std::string lookupName;
+  if (parser.schema().has_value()) {
+    lookupName = fmt::format("{}.{}", parser.schema().value(), parser.table());
+  } else if (!defaultSchema_.empty()) {
+    lookupName = fmt::format("{}.{}", defaultSchema_, parser.table());
+  } else {
+    lookupName = parser.table();
+  }
+
+  if (targetCatalog_ == catalog && targetTable_->name() == lookupName) {
+    return targetTable_;
+  }
+
+  return ConnectorMetadata::metadata(catalog)->findTable(lookupName);
 }
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -78,24 +78,20 @@ TEST_F(SchemaResolverTest, bareTable) {
 }
 
 TEST_F(SchemaResolverTest, invalidName) {
-  // Names that don't parse as valid catalog.schema.table are passed through
-  // to the connector's findTable, which returns nullptr for unknown tables.
-  ASSERT_EQ(resolver_->findTable("base", "table."), nullptr);
-  ASSERT_EQ(resolver_->findTable("base", "..."), nullptr);
-  ASSERT_EQ(
-      resolver_->findTable("base", "catalog.extra.schema.table"), nullptr);
-}
+  auto lookup = "table.";
+  VELOX_ASSERT_THROW(
+      resolver_->findTable("base", lookup),
+      fmt::format("Invalid table name: '{}'", lookup));
 
-TEST_F(SchemaResolverTest, multiDotNamePassthrough) {
-  // Names with more than 3 dots (e.g., XDB tier paths like
-  // "ephemeralxdb.on_demand.ftw.784.tasks") bypass the standard
-  // catalog.schema.table parser and are passed directly to the connector.
-  auto lookup = "ephemeralxdb.on_demand.ftw.784.tasks";
-  baseCatalog_.connector->addTable(lookup);
+  lookup = "...";
+  VELOX_ASSERT_THROW(
+      resolver_->findTable("base", lookup),
+      fmt::format("Invalid table name: '{}'", lookup));
 
-  auto table = resolver_->findTable("base", lookup);
-  ASSERT_NE(table, nullptr);
-  ASSERT_EQ(table->name(), lookup);
+  lookup = "catalog.extra.schema.table";
+  VELOX_ASSERT_THROW(
+      resolver_->findTable("base", lookup),
+      fmt::format("Invalid table name: '{}'", lookup));
 }
 
 TEST_F(SchemaResolverTest, tablePlusSchema) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -141,9 +141,6 @@ std::pair<std::string, std::string> toConnectorTable(
   }
 
   // connector.schema.name
-  // TODO: This limits table names to exactly 3 dot-separated components.
-  // Same limitation as constructTableName() in TableVisitor.cpp — see the
-  // details there on supporting multi-dot connector paths.
   VELOX_CHECK_EQ(3, parts.size());
   return {parts[0], fmt::format("{}.{}", parts[1], tableName)};
 }

--- a/axiom/sql/presto/TableVisitor.cpp
+++ b/axiom/sql/presto/TableVisitor.cpp
@@ -97,14 +97,6 @@ void TableVisitor::visitDropMaterializedView(DropMaterializedView* node) {
 std::string TableVisitor::constructTableName(const QualifiedName& name) const {
   const auto& parts = name.parts();
   VELOX_CHECK(!parts.empty(), "Table name cannot be empty");
-  // TODO: This limits table names to at most 3 dot-separated components
-  // (catalog.schema.table). Connectors with multi-dot paths (e.g., XDB tier
-  // paths like "ephemeralxdb.on_demand.ftw.784.tasks") require double-quoting
-  // at the SQL layer to collapse them into a single identifier. However, the
-  // resulting dot-joined string loses identifier boundaries downstream. To
-  // fully support multi-dot paths in SQL, this function and toConnectorTable()
-  // in PrestoParser.cpp need to propagate QualifiedName parts instead of a
-  // flat dot-joined string.
   VELOX_CHECK_LE(
       parts.size(),
       3,

--- a/axiom/sql/presto/tests/TableExtractorTest.cpp
+++ b/axiom/sql/presto/tests/TableExtractorTest.cpp
@@ -61,14 +61,6 @@ TEST_F(TableExtractorTest, select) {
   testInput("SELECT * FROM catalog.schema.table1", "catalog.schema.table1");
 }
 
-TEST_F(TableExtractorTest, quotedMultiDotTableName) {
-  // Double-quoted identifiers preserve multi-dot XDB tier paths as a single
-  // component, preventing the parser from splitting them into separate parts.
-  testInput(
-      R"(SELECT * FROM xdb."ephemeralxdb.on_demand_rocksdb.ftw.784.tasks")",
-      "foo.xdb.ephemeralxdb.on_demand_rocksdb.ftw.784.tasks");
-}
-
 TEST_F(TableExtractorTest, joins) {
   testInputs(
       "SELECT * FROM t1 JOIN t2 ON t1.id = t2.id",


### PR DESCRIPTION
Summary:
This diff reverts D93644546
Not an unsafe change but semantically changing the API.

Depends on D93644546

Reviewed By: mbasmanova

Differential Revision: D95418037


