### PR TITLE
fix: Strict weak ordering violation in Path::operator<

### DIFF
--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -177,6 +177,9 @@ bool Path::operator<(const Path& other) const {
     if (steps_[i] < other.steps_[i]) {
       return true;
     }
+    if (steps_[i] > other.steps_[i]) {
+      return false;
+    }
   }
   return steps_.size() < other.steps_.size();
 }

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -189,6 +189,14 @@ struct Step {
 
   bool operator<(const Step& other) const;
 
+  bool operator>=(const Step& other) const {
+    return !(*this < other);
+  }
+
+  bool operator>(const Step& other) const {
+    return other < *this;
+  }
+
   size_t hash() const;
 };
 
@@ -255,6 +263,14 @@ class Path {
   bool operator==(const Path& other) const;
 
   bool operator<(const Path& other) const;
+
+  bool operator>=(const Path& other) const {
+    return !(*this < other);
+  }
+
+  bool operator>(const Path& other) const {
+    return other < *this;
+  }
 
   size_t hash() const;
 

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/QueryGraphContext.h"
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "velox/common/memory/Memory.h"
 #include "velox/type/Type.h"
 
@@ -141,6 +142,97 @@ TEST_F(QueryGraphContextTest, toType) {
                     ->cardinality();
   auto interned2 = queryCtx()->toPath(path2);
   EXPECT_EQ(interned2, interned);
+}
+
+TEST_F(QueryGraphContextTest, stepOrdering) {
+  // Steps with different kinds.
+  {
+    Step a{.kind = StepKind::kField, .field = toName("a")};
+    Step b{.kind = StepKind::kSubscript, .field = toName("b")};
+    Step c{.kind = StepKind::kCardinality};
+
+    // kField < kSubscript < kCardinality (enum order).
+    // Verify ordering and asymmetry: if A < B then B > A.
+    EXPECT_LT(a, b);
+    EXPECT_GT(b, a);
+    EXPECT_LT(b, c);
+    EXPECT_GT(c, b);
+
+    // Irreflexivity for <, > and reflexivity for >=.
+    EXPECT_FALSE(a < a);
+    EXPECT_FALSE(a > a);
+    EXPECT_GE(a, a);
+    EXPECT_EQ(a, a);
+    EXPECT_FALSE(b < b);
+    EXPECT_FALSE(b > b);
+    EXPECT_GE(b, b);
+    EXPECT_EQ(b, b);
+  }
+
+  // Steps with same kind but different fields.
+  {
+    Step a{.kind = StepKind::kField, .field = toName("a")};
+    Step b{.kind = StepKind::kField, .field = toName("b")};
+    // kField steps compare by id, not field pointer.
+    // Both have id=0, so neither is less than the other.
+    EXPECT_GE(a, b);
+    EXPECT_GE(b, a);
+    EXPECT_FALSE(a > b);
+    EXPECT_FALSE(b > a);
+  }
+
+  // Steps with same kind but different ids.
+  {
+    Step a{.kind = StepKind::kSubscript, .id = 1};
+    Step b{.kind = StepKind::kSubscript, .id = 2};
+    EXPECT_LT(a, b);
+    EXPECT_GT(b, a);
+    EXPECT_GE(b, a);
+    EXPECT_GE(a, a);
+    EXPECT_FALSE(a > a);
+  }
+}
+
+TEST_F(QueryGraphContextTest, pathOrdering) {
+  // Use subscript steps with different ids so that steps have distinct values
+  // under operator<.
+  auto* a = make<Path>()->subscript(1)->subscript(3);
+  auto* b = make<Path>()->subscript(3)->subscript(1);
+  auto* c = make<Path>()->subscript(1);
+  auto* d = make<Path>()->subscript(1)->subscript(3)->subscript(5);
+
+  // Irreflexivity for < and reflexivity for >=.
+  EXPECT_FALSE(*a < *a);
+  EXPECT_GE(*a, *a);
+  EXPECT_EQ(*a, *a);
+  EXPECT_FALSE(*b < *b);
+  EXPECT_GE(*b, *b);
+  EXPECT_EQ(*b, *b);
+  EXPECT_FALSE(*c < *c);
+  EXPECT_GE(*c, *c);
+  EXPECT_EQ(*c, *c);
+
+  // Asymmetry: if A < B then B >= A.
+  // c (1 step) < a (2 steps, same prefix).
+  EXPECT_LT(*c, *a);
+  EXPECT_GE(*a, *c);
+
+  // a (2 steps) < d (3 steps, same prefix).
+  EXPECT_LT(*a, *d);
+  EXPECT_GE(*d, *a);
+
+  // Asymmetry: a [sub(1), sub(3)] < b [sub(3), sub(1)] because
+  // the first step differs (1 < 3). Verify the reverse does not hold.
+  EXPECT_LT(*a, *b);
+  EXPECT_GE(*b, *a);
+
+  // Verify std::sort works properly.
+  std::vector<Path> pathValues = {*a, *b, *c, *d};
+  std::sort(pathValues.begin(), pathValues.end());
+  for (size_t i = 1; i < pathValues.size(); ++i) {
+    EXPECT_FALSE(pathValues[i] < pathValues[i - 1])
+        << "Sort result not ordered at index " << i;
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Fix strict weak ordering violation in Path::operator<. The comparator was missing an early return false when other.steps_[i] < steps_[i], causing the loop to fall through and compare subsequent steps. This meant both A < B and B < A could return true for paths with different step values, which violates the contract required by std::sort and caused crashes (SIGSEGV).

Differential Revision: D95458598


