### PR TITLE
test: Allow test suites to create only the TPC-H tables they need

### DIFF
--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -25,7 +25,16 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class FilterPushdownTest : public test::HiveQueriesTestBase {};
+class FilterPushdownTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_REGION,
+         velox::tpch::Table::TBL_ORDERS});
+  }
+};
 
 TEST_F(FilterPushdownTest, throughAggregation) {
   auto logicalPlan = lp::PlanBuilder()

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -76,6 +76,10 @@ class FiltersTest : public test::HiveQueriesTestBase {
  protected:
   static void SetUpTestCase() {
     HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_LINEITEM,
+         velox::tpch::Table::TBL_ORDERS});
   }
 
   static void TearDownTestCase() {

--- a/axiom/optimizer/tests/HiveAggregationQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveAggregationQueriesTest.cpp
@@ -27,7 +27,13 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveAggregationQueriesTest : public test::HiveQueriesTestBase {};
+class HiveAggregationQueriesTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_NATION});
+  }
+};
 
 TEST_F(HiveAggregationQueriesTest, mask) {
   lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);

--- a/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveLimitQueriesTest.cpp
@@ -24,7 +24,13 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveLimitQueriesTest : public test::HiveQueriesTestBase {};
+class HiveLimitQueriesTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_NATION});
+  }
+};
 
 // LIMIT 10
 TEST_F(HiveLimitQueriesTest, limit) {

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -24,7 +24,14 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveQueriesTest : public test::HiveQueriesTestBase {};
+class HiveQueriesTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_REGION});
+  }
+};
 
 TEST_F(HiveQueriesTest, basic) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -28,7 +28,6 @@ void HiveQueriesTestBase::SetUpTestCase() {
   test::QueryTestBase::SetUpTestCase();
 
   gTempDirectory = common::testutil::TempDirectoryPath::create();
-  test::TpchDataGenerator::createTables(gTempDirectory->getPath());
 
   LocalRunnerTestBase::localDataPath_ = gTempDirectory->getPath();
   LocalRunnerTestBase::localFileFormat_ =
@@ -50,6 +49,13 @@ void HiveQueriesTestBase::SetUp() {
   connector_ = velox::connector::getConnector(exec::test::kHiveConnectorId);
   metadata_ = dynamic_cast<connector::hive::LocalHiveConnectorMetadata*>(
       connector::ConnectorMetadata::metadata(exec::test::kHiveConnectorId));
+}
+
+// static
+void HiveQueriesTestBase::createTpchTables(
+    const std::vector<velox::tpch::Table>& tables) {
+  VELOX_CHECK(gTempDirectory != nullptr, "SetUpTestCase not called");
+  TpchDataGenerator::createTables(tables, gTempDirectory->getPath());
 }
 
 void HiveQueriesTestBase::TearDown() {

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -21,6 +21,7 @@
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/tpch/gen/TpchGen.h"
 
 namespace facebook::axiom::optimizer::test {
 
@@ -28,8 +29,10 @@ class HiveQueriesTestBase : public QueryTestBase {
  protected:
   static void SetUpTestCase();
 
-  /// Creates TPC-H tables in a temp directory using PARQUET file format.
   void SetUp() override;
+
+  /// Creates specified TPC-H tables in the temp directory.
+  static void createTpchTables(const std::vector<velox::tpch::Table>& tables);
 
   void TearDown() override;
 

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -37,6 +37,11 @@ class PlanTest : public test::HiveQueriesTestBase {
 
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_REGION,
+         velox::tpch::Table::TBL_LINEITEM,
+         velox::tpch::Table::TBL_PART});
     test::registerDfFunctions();
   }
 

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -31,6 +31,14 @@ class SetTest : public test::HiveQueriesTestBase {
  protected:
   static constexpr auto kTestConnectorId = "test";
 
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_PART,
+         velox::tpch::Table::TBL_PARTSUPP});
+  }
+
   void SetUp() override {
     test::HiveQueriesTestBase::SetUp();
 

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -30,6 +30,16 @@ class SubqueryTest : public test::HiveQueriesTestBase {
  protected:
   static constexpr auto kTestConnectorId = "test";
 
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_REGION,
+         velox::tpch::Table::TBL_CUSTOMER,
+         velox::tpch::Table::TBL_ORDERS,
+         velox::tpch::Table::TBL_SUPPLIER});
+  }
+
   void SetUp() override {
     test::HiveQueriesTestBase::SetUp();
 

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -18,10 +18,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
-#include "axiom/optimizer/tests/QueryTestBase.h"
-#include "axiom/optimizer/tests/TpchDataGenerator.h"
-#include "axiom/sql/presto/PrestoParser.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::axiom::optimizer {
@@ -30,47 +28,21 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class SyntacticJoinOrderTest : public test::QueryTestBase {
+class SyntacticJoinOrderTest : public test::HiveQueriesTestBase {
  protected:
   static void SetUpTestCase() {
-    test::QueryTestBase::SetUpTestCase();
-
-    gTempDirectory = velox::common::testutil::TempDirectoryPath::create();
-
-    auto path = gTempDirectory->getPath();
-    test::TpchDataGenerator::createTables(path);
-
-    LocalRunnerTestBase::localDataPath_ = path;
-    LocalRunnerTestBase::localFileFormat_ =
-        velox::dwio::common::FileFormat::PARQUET;
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_CUSTOMER,
+         velox::tpch::Table::TBL_LINEITEM,
+         velox::tpch::Table::TBL_ORDERS});
   }
-
-  static void TearDownTestCase() {
-    gTempDirectory.reset();
-    test::QueryTestBase::TearDownTestCase();
-  }
-
-  lp::LogicalPlanNodePtr parseSql(const std::string& sql) const {
-    ::axiom::sql::presto::PrestoParser parser{
-        exec::test::kHiveConnectorId, std::nullopt};
-    auto statement = parser.parse(sql);
-    VELOX_CHECK(statement->isSelect());
-
-    return statement->as<::axiom::sql::presto::SelectStatement>()->plan();
-  }
-
-  inline static std::shared_ptr<velox::common::testutil::TempDirectoryPath>
-      gTempDirectory;
 };
 
 TEST_F(SyntacticJoinOrderTest, innerJoins) {
   lp::PlanBuilder::Context context(exec::test::kHiveConnectorId);
 
   optimizerOptions_.sampleJoins = false;
-
-  auto startMatcher = [](const auto& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
 
   // Cardinalities after filters:
   //  - lineitem - 32.3K
@@ -79,9 +51,9 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
 
   // Optimized join order: lineitem x (orders x customer).
   auto optimizedMatcher =
-      startMatcher("lineitem")
-          .hashJoin(startMatcher("orders")
-                        .hashJoin(startMatcher("customer").build())
+      matchScan("lineitem")
+          .hashJoin(matchScan("orders")
+                        .hashJoin(matchScan("customer").build())
                         .build())
           .aggregation()
           .build();
@@ -159,9 +131,9 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
         optimizerOptions_.syntacticJoinOrder = true;
         auto plan = toSingleNodePlan(logicalPlan);
 
-        auto matcher = startMatcher(order[0])
-                           .hashJoin(startMatcher(order[1]).build())
-                           .hashJoin(startMatcher(order[2]).build())
+        auto matcher = matchScan(order[0])
+                           .hashJoin(matchScan(order[1]).build())
+                           .hashJoin(matchScan(order[2]).build())
                            .aggregation()
                            .build();
         AXIOM_ASSERT_PLAN(plan, matcher);
@@ -217,13 +189,12 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
         optimizerOptions_.syntacticJoinOrder = true;
         auto plan = toSingleNodePlan(logicalPlan);
 
-        auto matcher =
-            startMatcher(order[0])
-                .hashJoin(startMatcher(order[1])
-                              .hashJoin(startMatcher(order[2]).build())
-                              .build())
-                .aggregation()
-                .build();
+        auto matcher = matchScan(order[0])
+                           .hashJoin(matchScan(order[1])
+                                         .hashJoin(matchScan(order[2]).build())
+                                         .build())
+                           .aggregation()
+                           .build();
         AXIOM_ASSERT_PLAN(plan, matcher);
 
         checkSame(logicalPlan, referenceResults);
@@ -235,14 +206,10 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
 TEST_F(SyntacticJoinOrderTest, outerJoins) {
   optimizerOptions_.sampleJoins = false;
 
-  auto startMatcher = [](const auto& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   // Optimized join order: lineitem x orders.
   auto optimizedMatcher =
-      startMatcher("lineitem")
-          .hashJoin(startMatcher("orders").build(), core::JoinType::kLeft)
+      matchScan("lineitem")
+          .hashJoin(matchScan("orders").build(), core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -271,7 +238,7 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
 
   // Syntactic join order: a LEFT JOIN b.
   {
-    auto logicalPlan = parseSql(
+    auto logicalPlan = parseSelect(
         "SELECT count(*) FROM lineitem LEFT JOIN orders ON "
         "l_orderkey = o_orderkey and l_returnflag = 'R'");
 
@@ -294,7 +261,7 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
 
   // Syntactic join order: b RIGHT JOIN a.
   {
-    auto logicalPlan = parseSql(
+    auto logicalPlan = parseSelect(
         "SELECT count(*) FROM orders RIGHT JOIN lineitem ON "
         "l_orderkey = o_orderkey and l_returnflag = 'R'");
 
@@ -311,9 +278,8 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
       auto plan = toSingleNodePlan(logicalPlan);
 
       auto matcher =
-          startMatcher("orders")
-              .hashJoin(
-                  startMatcher("lineitem").build(), core::JoinType::kRight)
+          matchScan("orders")
+              .hashJoin(matchScan("lineitem").build(), core::JoinType::kRight)
               .aggregation()
               .build();
       AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -105,6 +105,7 @@ int64_t TpchDataGenerator::createTable(
 
 //  static
 void TpchDataGenerator::createTables(
+    const std::vector<velox::tpch::Table>& tables,
     std::string_view path,
     double scaleFactor,
     dwio::common::FileFormat format,
@@ -119,7 +120,7 @@ void TpchDataGenerator::createTables(
 
   LOG(INFO) << "Creating TPC-H tables in " << path;
 
-  for (const auto& table : tpch::tables) {
+  for (const auto& table : tables) {
     const auto tableName = tpch::toTableName(table);
     LOG(INFO) << "Creating TPC-H table " << tableName
               << " scaleFactor=" << scaleFactor;

--- a/axiom/optimizer/tests/TpchDataGenerator.h
+++ b/axiom/optimizer/tests/TpchDataGenerator.h
@@ -35,17 +35,15 @@ class TpchDataGenerator {
   static int64_t createTable(
       velox::tpch::Table table,
       std::string_view path,
-      double scaleFactor,
-      velox::dwio::common::FileFormat format,
-      velox::common::CompressionKind compression);
+      double scaleFactor = 0.1,
+      velox::dwio::common::FileFormat format =
+          velox::dwio::common::FileFormat::PARQUET,
+      velox::common::CompressionKind compression =
+          velox::common::CompressionKind::CompressionKind_NONE);
 
-  /// Writes all TPC-H tables to 'path' in the specified format.
-  ///
-  /// @param path Directory to write the tables to. Must exist.
-  /// @param scaleFactor TPC-H scale factor (e.g., 0.1, 1, 10). Controls the
-  /// size of the generated data. SF=1 produces ~6M lineitem rows.
-  /// @param format File format to use (PARQUET or DWRF).
+  /// Writes specified TPC-H tables to 'path'.
   static void createTables(
+      const std::vector<velox::tpch::Table>& tables,
       std::string_view path,
       double scaleFactor = 0.1,
       velox::dwio::common::FileFormat format =

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -38,6 +38,7 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
  protected:
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(velox::tpch::tables);
   }
 
   static void TearDownTestCase() {

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -29,6 +29,12 @@ namespace lp = facebook::axiom::logical_plan;
 
 class WriteTest : public test::HiveQueriesTestBase {
  protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_LINEITEM});
+  }
+
   void SetUp() override {
     HiveQueriesTestBase::SetUp();
     parquet::registerParquetWriterFactory();


### PR DESCRIPTION
Summary:
Remove the upfront creation of all TPC-H tables from
HiveQueriesTestBase::SetUpTestCase. Instead, each test suite
declares the specific tables it needs via createTpchTables().
This avoids generating unused tables and speeds up test suites
that only need a small subset (e.g. nation only).

Differential Revision: D95544115


