### PR TITLE
feat(cli): Pass a query id generator to CLI to generate unique query id for each query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,9 @@ velox_resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 velox_set_source(folly)
 velox_resolve_dependency(folly)
 
+velox_set_source(re2)
+velox_resolve_dependency(re2)
+
 # Add ANTLR4 runtime dependency
 velox_set_source(antlr4-runtime)
 velox_resolve_dependency(antlr4-runtime)

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   axiom_cli
   Connectors.cpp
   Console.cpp
+  QueryIdGenerator.cpp
   SqlQueryRunner.cpp
   ResultPrinter.cpp
   StdinReader.cpp

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -18,6 +18,7 @@
 #include <folly/FileUtil.h>
 #include <iostream>
 #include <optional>
+#include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/cli/ResultPrinter.h"
 #include "axiom/cli/StdinReader.h"
 #include "axiom/cli/Timing.h"
@@ -68,6 +69,16 @@ std::optional<std::string> getHistoryFilePath() {
 
 namespace axiom::sql {
 
+Console::Console(
+    SqlQueryRunner& runner,
+    PermissionCheck permissionCheck,
+    std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator)
+    : runner_{runner},
+      permissionCheck_{std::move(permissionCheck)},
+      queryIdGenerator_{
+          queryIdGenerator ? std::move(queryIdGenerator)
+                           : std::make_shared<cli::QueryIdGenerator>()} {}
+
 void Console::initialize() {
   gflags::SetUsageMessage(
       "Axiom local SQL command line. "
@@ -113,13 +124,16 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       continue;
     }
 
+    auto queryId = queryIdGenerator_->createNextQueryId();
+
     try {
       cli::Timing parseTiming;
       auto statement = cli::time<presto::SqlStatementPtr>(
           [&]() { return runner_.parseSingle(sqlText, options); }, parseTiming);
 
       if (isInteractive) {
-        std::cout << "Parsing: " << parseTiming.toString() << std::endl;
+        std::cout << "Query ID: " << queryId
+                  << " | Parsing: " << parseTiming.toString() << std::endl;
       }
 
       // Permission check after parsing, before execution.
@@ -127,6 +141,7 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
         const auto& schema = options.defaultSchema ? options.defaultSchema
                                                    : runner_.defaultSchema();
         permissionCheck_(
+            queryId,
             sqlText,
             options.defaultConnectorId.value_or(runner_.defaultConnectorId()),
             schema ? std::optional<std::string_view>{*schema} : std::nullopt,
@@ -144,11 +159,12 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       }
 
       if (isInteractive) {
-        std::cout << "Optimizing and Executing: " << statementTiming.toString()
-                  << std::endl;
+        std::cout << "Query ID: " << queryId << " | Optimizing and Executing: "
+                  << statementTiming.toString() << std::endl;
       }
     } catch (std::exception& e) {
-      std::cerr << "Query failed: " << e.what() << std::endl;
+      std::cerr << "Query ID: " << queryId << " | Query failed: " << e.what()
+                << std::endl;
       return;
     }
   }

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <unordered_map>
 #include <utility>
 #include "axiom/cli/SqlQueryRunner.h"
@@ -24,11 +25,16 @@ DECLARE_string(data_path);
 DECLARE_string(data_format);
 DECLARE_bool(debug);
 
+namespace axiom::cli {
+class QueryIdGenerator;
+} // namespace axiom::cli
+
 namespace axiom::sql {
 
-/// Permission check callback: (sql, catalog, schema, views) -> throws on
-/// denial. Empty (nullptr) by default -- no permission checking.
+/// Permission check callback: (queryId, sql, catalog, schema, views) -> throws
+/// on denial. Empty (nullptr) by default -- no permission checking.
 using PermissionCheck = std::function<void(
+    std::string_view queryId,
     std::string_view sql,
     std::string_view catalog,
     std::optional<std::string_view> schema,
@@ -39,11 +45,14 @@ class Console {
  public:
   /// @param permissionCheck Optional callback invoked after each statement is
   /// parsed but before it is executed. Throws on denial.
+  /// @param queryIdGenerator Optional query ID generator. Defaults to a
+  /// generator with a random base-32 suffix.
   explicit Console(
       SqlQueryRunner& runner,
-      PermissionCheck permissionCheck = nullptr)
-      : runner_{runner}, permissionCheck_{std::move(permissionCheck)} {}
+      PermissionCheck permissionCheck = nullptr,
+      std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator = nullptr);
 
+  /// Initializes the CLI with usage message and logging settings.
   void initialize();
 
   /// Runs the CLI, either executing a single query if passed in
@@ -63,6 +72,8 @@ class Console {
 
   SqlQueryRunner& runner_;
   PermissionCheck permissionCheck_;
+  // Generates unique query IDs for each statement execution.
+  std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator_;
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/QueryIdGenerator.cpp
+++ b/axiom/cli/QueryIdGenerator.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/QueryIdGenerator.h"
+#include <fmt/format.h>
+#include <chrono>
+#include <random>
+#include <thread>
+
+namespace axiom::cli {
+
+// Base-32 alphabet: a-z, 2-9, excluding l, o, 0, 1.
+constexpr char kBase32[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+                            'i', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
+                            's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                            '2', '3', '4', '5', '6', '7', '8', '9'};
+
+namespace {
+
+std::string getTimestamp(
+    const std::chrono::system_clock::time_point& timePoint) {
+  time_t rawTime = std::chrono::system_clock::to_time_t(timePoint);
+  char buffer[20];
+  struct tm gmTimeResult{};
+  gmtime_r(&rawTime, &gmTimeResult);
+  strftime(buffer, sizeof(buffer), "%Y%m%d_%H%M%S", &gmTimeResult);
+  return buffer;
+}
+
+} // namespace
+
+QueryIdGenerator::QueryIdGenerator() {
+  std::random_device randomDevice;
+  std::mt19937 engine{randomDevice()};
+  std::uniform_int_distribution<> distribution{0, 31};
+  suffix_.resize(5);
+  for (int i = 0; i < 5; ++i) {
+    suffix_[i] = kBase32[distribution(engine)];
+  }
+}
+
+std::string QueryIdGenerator::createNextQueryId() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (counter_ > 99'999) {
+    while (std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+               .count() == lastTimeInSeconds_) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    counter_ = 0;
+  }
+
+  // Refresh timestamp when the second changes.
+  auto now = std::chrono::system_clock::now();
+  auto nowInSeconds =
+      std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch())
+          .count();
+  if (nowInSeconds != lastTimeInSeconds_) {
+    lastTimeInSeconds_ = nowInSeconds;
+    lastTimestamp_ = getTimestamp(now);
+
+    // Reset counter on day rollover.
+    auto nowInDays =
+        std::chrono::duration_cast<std::chrono::days>(now.time_since_epoch())
+            .count();
+    if (nowInDays != lastTimeInDays_) {
+      lastTimeInDays_ = nowInDays;
+      counter_ = 0;
+    }
+  }
+
+  return fmt::format("{}_{:05d}_{}", lastTimestamp_, counter_++, suffix_);
+}
+
+} // namespace axiom::cli

--- a/axiom/cli/QueryIdGenerator.h
+++ b/axiom/cli/QueryIdGenerator.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <mutex>
+#include <string>
+
+namespace axiom::cli {
+
+/// Generates unique query IDs in the format
+/// `YYYYMMdd_HHmmss_NNNNN_suffix`.
+///
+/// The suffix is a 5-character base-32 string randomly generated at
+/// construction time. The 5-digit counter increments monotonically across
+/// calls and resets to 0 on UTC day rollover. If the counter exceeds 99,999,
+/// `createNextQueryId()` blocks until the next second to avoid overflow. The
+/// timestamp portion reflects the wall-clock time of each call.
+class QueryIdGenerator {
+ public:
+  QueryIdGenerator();
+
+  /// Returns the 5-character base-32 query ID suffix.
+  const std::string& suffix() const {
+    return suffix_;
+  }
+
+  /// Generates the next query ID. Thread-safe.
+  std::string createNextQueryId();
+
+ private:
+  // 5-character base-32 suffix appended to every generated ID.
+  std::string suffix_;
+  // Day of the last generated ID, used to detect day rollover.
+  int64_t lastTimeInDays_{0};
+  // Second of the last generated ID, used to cache the timestamp string.
+  int64_t lastTimeInSeconds_{0};
+  // Cached formatted timestamp for the current second.
+  std::string lastTimestamp_;
+  // Monotonically incrementing counter within the current day.
+  uint32_t counter_{0};
+  // Protects all mutable state for thread safety.
+  std::mutex mutex_;
+};
+
+} // namespace axiom::cli

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_cli_test SqlQueryRunnerTest.cpp StdinReaderTest.cpp ConsoleTest.cpp)
+add_executable(
+  axiom_cli_test
+  SqlQueryRunnerTest.cpp
+  StdinReaderTest.cpp
+  ConsoleTest.cpp
+  QueryIdGeneratorTest.cpp
+)
 
 add_test(NAME axiom_cli_test COMMAND axiom_cli_test)
 
@@ -23,4 +29,5 @@ target_link_libraries(
   velox_exec_test_lib
   velox_vector_test_lib
   GTest::gtest
+  re2
 )

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -70,7 +70,8 @@ TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
   std::string capturedSql;
   std::string capturedCatalog;
 
-  PermissionCheck check = [&](std::string_view sql,
+  PermissionCheck check = [&](std::string_view /*queryId*/,
+                              std::string_view sql,
                               std::string_view catalog,
                               std::optional<std::string_view> /*schema*/,
                               const auto& /*views*/) {

--- a/axiom/cli/tests/QueryIdGeneratorTest.cpp
+++ b/axiom/cli/tests/QueryIdGeneratorTest.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/QueryIdGenerator.h"
+#include <gtest/gtest.h>
+#include <re2/re2.h>
+
+namespace axiom::cli {
+namespace {
+
+// YYYYMMdd_HHmmss_NNNNN_suffix (27 chars).
+static const re2::RE2 kQueryIdPattern(R"(\d{8}_\d{6}_\d{5}_[a-kmn-z2-9]{5})");
+
+TEST(QueryIdGeneratorTest, format) {
+  QueryIdGenerator generator;
+  EXPECT_TRUE(
+      re2::RE2::FullMatch(generator.createNextQueryId(), kQueryIdPattern));
+}
+
+TEST(QueryIdGeneratorTest, counterIncrements) {
+  QueryIdGenerator generator;
+
+  // Counter occupies positions 16..20 in the query ID
+  // (after 8-char date + '_' + 6-char time + '_').
+  auto nextId = [&]() { return generator.createNextQueryId(); };
+
+  EXPECT_EQ(nextId().substr(16, 5), "00000");
+  EXPECT_EQ(nextId().substr(16, 5), "00001");
+  EXPECT_EQ(nextId().substr(16, 5), "00002");
+}
+
+} // namespace
+} // namespace axiom::cli


### PR DESCRIPTION
Add `QueryIdGenerator` that produces unique query IDs in the format
`YYYYMMdd_HHmmss_NNNNN_suffix`. The suffix is a randomly generated
5-character base-32 string created at construction time using
`std::random_device` and `std::mt19937`, identical to the server's
`QueryIdGenerator` implementation.

The query ID format works as follows:
- `YYYYMMdd_HHmmss` — UTC timestamp, refreshed each second
- `NNNNN` — 5-digit zero-padded counter, resets at day boundaries or
  after 99,999 IDs per second
- `suffix` — 5-character randomly generated base-32 string (alphabet:
  a-z excluding l,o; digits 2-9)

Make `Console` accept a pluggable query ID generator function as its 3rd
constructor parameter (`std::function<std::string()>`). When not provided,
defaults to a `QueryIdGenerator` instance with a random suffix.