### PR TITLE
feat(parser): Add SHOW STATS FOR (<query>) support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -117,6 +117,9 @@ for the complete guide. Key rules are summarized below.
 - Use uniform initialization: `size_t size{0}` over `size_t size = 0`.
 - Declare variables in the smallest scope, as close to usage as possible.
 - Use digit separators (`'`) for numeric literals with 4 or more digits: `10'000`, not `10000`.
+- Use trailing commas in multi-line initializer lists, enum definitions, and
+  function-call argument lists that span multiple lines. This produces cleaner
+  diffs when items are added or reordered.
 
 ### API Design
 

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/system/HardwareConcurrency.h>
+#include <cmath>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/LogicalPlanDotPrinter.h"
@@ -28,6 +29,7 @@
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
+#include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
@@ -269,6 +271,10 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     return {.message = dropTable(*drop)};
   }
 
+  if (sqlStatement.isShowStatsForQuery()) {
+    return {.results = runShowStatsForQuery(sqlStatement, options)};
+  }
+
   if (sqlStatement.isUse()) {
     const auto* use = sqlStatement.as<presto::UseStatement>();
     const auto& connectorId = use->catalog().has_value()
@@ -497,6 +503,48 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runLogicalPlan(
   };
 
   return fetchResults(*runner);
+}
+
+std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
+    const presto::SqlStatement& sqlStatement,
+    const RunOptions& options) {
+  const auto* showStats = sqlStatement.as<presto::ShowStatsForQueryStatement>();
+  const auto& innerStatement = showStats->statement();
+  VELOX_CHECK(innerStatement->isSelect());
+
+  const auto logicalPlan =
+      innerStatement->as<presto::SelectStatement>()->plan();
+
+  std::vector<velox::Variant> data;
+
+  optimize(
+      logicalPlan,
+      newQuery(options),
+      options,
+      [&](const optimizer::DerivedTable& rootDt) {
+        presto::ShowStatsBuilder builder(std::llround(rootDt.cardinality));
+
+        for (const auto* column : rootDt.columns) {
+          const auto& value = column->value();
+
+          builder.addColumn(
+              column->outputName(),
+              *value.type,
+              static_cast<double>(value.nullFraction),
+              static_cast<int64_t>(value.cardinality),
+              /*avgLength=*/std::nullopt,
+              value.min,
+              value.max);
+        }
+
+        data = builder.rows();
+        return false; // Stop optimization.
+      });
+
+  auto result = std::dynamic_pointer_cast<velox::RowVector>(
+      velox::BaseVector::createFromVariants(
+          presto::ShowStatsBuilder::outputType(), data, optimizerPool_.get()));
+  return {result};
 }
 
 } // namespace axiom::sql

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -138,6 +138,12 @@ class SqlQueryRunner {
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options);
 
+  // Runs SHOW STATS FOR (<query>): optimizes the inner query's logical plan
+  // and returns per-column and table-level statistics as a VALUES result.
+  std::vector<facebook::velox::RowVectorPtr> runShowStatsForQuery(
+      const presto::SqlStatement& sqlStatement,
+      const RunOptions& options);
+
   // Parses SQL and returns the logical plan.
   facebook::axiom::logical_plan::LogicalPlanNodePtr toLogicalPlan(
       std::string_view sql);

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -20,14 +20,14 @@ $ $CLI --query "CREATE TABLE test.default.t(a int, b int, c int); SELECT * FROM 
 Created table: default.t
 (0 rows in 0 batches)
 
-ROW<row_count:DOUBLE,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
+ROW<row_count:BIGINT,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
 row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
+        0 | null        |           null |                  null |       null | null      | null
      null | a           |           null |                  null |       null | null      | null
      null | b           |           null |                  null |       null | null      | null
      null | c           |           null |                  null |       null | null      | null
-        0 | null        |           null |                  null |       null | null      | null
 (4 rows in 1 batches)
 
 ```
@@ -51,13 +51,13 @@ a | b
 1 | 2
 (1 rows in 1 batches)
 
-ROW<row_count:DOUBLE,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
+ROW<row_count:BIGINT,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
 row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
+        1 | null        |           null |                  null |       null | null      | null
      null | a           |              0 |                     1 |       null | 1         | 1
      null | b           |              0 |                     1 |       null | 2         | 2
-        1 | null        |           null |                  null |       null | null      | null
 (3 rows in 1 batches)
 
 ```

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -32,7 +32,12 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         facebook::velox::memory::MemoryManager::Options{});
   }
 
+  void SetUp() override {
+    runner_ = makeRunner();
+  }
+
   void TearDown() override {
+    runner_.reset();
     for (const auto& id : connectorIds_) {
       facebook::velox::connector::unregisterConnector(id);
     }
@@ -57,14 +62,14 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     return runner;
   }
 
+  std::unique_ptr<SqlQueryRunner> runner_;
+
  private:
   std::vector<std::string> connectorIds_;
 };
 
 TEST_F(SqlQueryRunnerTest, runSingleStatement) {
-  auto runner = makeRunner();
-
-  auto result = runner->run("SELECT 1", {});
+  auto result = runner_->run("SELECT 1", {});
 
   ASSERT_FALSE(result.message.has_value());
   ASSERT_EQ(1, result.results.size());
@@ -73,32 +78,28 @@ TEST_F(SqlQueryRunnerTest, runSingleStatement) {
 }
 
 TEST_F(SqlQueryRunnerTest, runRejectsMultipleStatements) {
-  auto runner = makeRunner();
-
   EXPECT_THROW(
-      runner->run("SELECT 1; SELECT 2", {}), facebook::velox::VeloxException);
+      runner_->run("SELECT 1; SELECT 2", {}), facebook::velox::VeloxException);
 }
 
 TEST_F(SqlQueryRunnerTest, parseAndRunMixedStatementTypes) {
-  auto runner = makeRunner();
-
-  auto statements = runner->parseMultiple(
+  auto statements = runner_->parseMultiple(
       "SELECT 42; EXPLAIN (TYPE LOGICAL) SELECT 1; select 7", {});
   ASSERT_EQ(3, statements.size());
 
   // SELECT returns results.
-  auto selectResult = runner->run(*statements[0], {});
+  auto selectResult = runner_->run(*statements[0], {});
   ASSERT_FALSE(selectResult.message.has_value());
   test::assertEqualVectors(
       selectResult.results[0], makeRowVector({makeFlatVector<int32_t>({42})}));
 
   // EXPLAIN returns a message.
-  auto explainResult = runner->run(*statements[1], {});
+  auto explainResult = runner_->run(*statements[1], {});
   ASSERT_TRUE(explainResult.message.has_value());
   ASSERT_FALSE(explainResult.message.value().empty());
 
   // Last SELECT returns 7.
-  auto lastResult = runner->run(*statements[2], {});
+  auto lastResult = runner_->run(*statements[2], {});
   ASSERT_FALSE(lastResult.message.has_value());
   test::assertEqualVectors(
       lastResult.results[0], makeRowVector({makeFlatVector<int32_t>({7})}));
@@ -129,18 +130,115 @@ TEST_F(SqlQueryRunnerTest, multipleRunnerInstances) {
 }
 
 TEST_F(SqlQueryRunnerTest, invalidStatementThrows) {
-  auto runner = makeRunner();
-
   // An invalid query should throw an exception.
-  EXPECT_THROW(runner->run("INVALID SYNTAX HERE", {}), std::exception);
+  EXPECT_THROW(runner_->run("INVALID SYNTAX HERE", {}), std::exception);
 }
 
 TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
-  auto runner = makeRunner();
-
   // Parsing invalid SQL should throw.
   EXPECT_THROW(
-      runner->parseMultiple("SELECT 1; INVALID; SELECT 2", {}), std::exception);
+      runner_->parseMultiple("SELECT 1; INVALID; SELECT 2", {}),
+      std::exception);
+}
+
+TEST_F(SqlQueryRunnerTest, showStats) {
+  // Create a table with 100 rows and 4 columns: x has 100 distinct values,
+  // y has 7 distinct values, z is an array column, w is NULL for every 4th row.
+  runner_->run(
+      "CREATE TABLE t AS "
+      "SELECT x, x % 7 AS y, sequence(1, x % 7 + 1) AS z, "
+      "if(x % 4 <> 0, x + x % 7) AS w "
+      "FROM unnest(sequence(1, 100)) AS _(x)",
+      {});
+
+  {
+    // SHOW STATS FOR <table>: reports raw connector stats.
+    auto expected = makeRowVector({
+        // row_count.
+        makeNullableFlatVector<int64_t>(
+            {100, std::nullopt, std::nullopt, std::nullopt, std::nullopt}),
+        // column_name.
+        makeNullableFlatVector<std::string>({std::nullopt, "x", "y", "z", "w"}),
+        // nulls_fraction: 0.25 for w; 0 for the rest.
+        makeNullableFlatVector<double>({std::nullopt, 0.0, 0.0, 0.0, 0.25}),
+        // distinct_values_count: NULL for z (array).
+        makeNullableFlatVector<int64_t>(
+            {std::nullopt, 100, 7, std::nullopt, 75}),
+        // avg_length: 3 for z (array); NULL for the rest.
+        makeNullableFlatVector<int64_t>(
+            {std::nullopt, std::nullopt, std::nullopt, 3, std::nullopt}),
+        // low_value.
+        makeNullableFlatVector<std::string>(
+            {std::nullopt, "1", "0", std::nullopt, "2"}),
+        // high_value.
+        makeNullableFlatVector<std::string>(
+            {std::nullopt, "100", "6", std::nullopt, "103"}),
+    });
+
+    auto result = runner_->run("SHOW STATS FOR t", {});
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+
+    // SHOW STATS FOR (SELECT * FROM <table>): reports optimizer estimates. The
+    // optimizer always estimates NDV (defaults to numRows when unknown) and
+    // doesn't track avgLength.
+    expected = makeRowVector({
+        expected->childAt(0), // row_count.
+        expected->childAt(1), // column_name.
+        expected->childAt(2), // nulls_fraction.
+        // distinct_values_count: 100 for z (optimizer defaults to numRows).
+        makeNullableFlatVector<int64_t>({std::nullopt, 100, 7, 100, 75}),
+        // avg_length: not tracked by the optimizer.
+        makeNullConstant(TypeKind::BIGINT, 5),
+        expected->childAt(5), // low_value.
+        expected->childAt(6), // high_value.
+    });
+
+    result = runner_->run("SHOW STATS FOR (SELECT * FROM t)", {});
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+  }
+}
+
+// Verifies that SHOW STATS FOR (<query>) reflects optimizer estimates after
+// filter pushdown: reduced row count, tightened min/max, capped NDV.
+TEST_F(SqlQueryRunnerTest, showStatsForQueryWithFilter) {
+  runner_->run(
+      "CREATE TABLE t AS "
+      "SELECT x, x % 7 AS y, sequence(1, x % 7 + 1) AS z, "
+      "if(x % 4 <> 0, x + x % 7) AS w "
+      "FROM unnest(sequence(1, 100)) AS _(x)",
+      {});
+
+  auto expected = makeRowVector({
+      // row_count: 50 (filter x > 50 keeps half the rows).
+      makeNullableFlatVector<int64_t>(
+          {50, std::nullopt, std::nullopt, std::nullopt, std::nullopt}),
+      // column_name.
+      makeNullableFlatVector<std::string>({std::nullopt, "x", "y", "z", "w"}),
+      // nulls_fraction.
+      makeNullableFlatVector<double>({std::nullopt, 0.0, 0.0, 0.0, 0.25}),
+      // distinct_values_count: reduced for x and w; y stays at 7 because the
+      // optimizer assumes column independence — the filter on x doesn't reduce
+      // y's domain (and 7 < 50 filtered rows, so NDV is not capped).
+      makeNullableFlatVector<int64_t>({std::nullopt, 50, 7, 50, 50}),
+      // avg_length: not tracked by the optimizer.
+      makeNullConstant(TypeKind::BIGINT, 5),
+      // low_value: x tightened to 51.
+      makeNullableFlatVector<std::string>(
+          {std::nullopt, "51", "0", std::nullopt, "2"}),
+      // high_value.
+      makeNullableFlatVector<std::string>(
+          {std::nullopt, "100", "6", std::nullopt, "103"}),
+  });
+
+  auto result =
+      runner_->run("SHOW STATS FOR (SELECT * FROM t WHERE x > 50)", {});
+  ASSERT_FALSE(result.message.has_value());
+  ASSERT_EQ(1, result.results.size());
+  test::assertEqualVectors(expected, result.results[0]);
 }
 
 } // namespace

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -139,18 +139,21 @@ void TestTable::ColumnTracker::append(const velox::BaseVector& vector) {
       }
     }
 
+    auto addLength = [&](int32_t length) {
+      totalLength += length;
+      maxLength = std::max(maxLength, length);
+    };
+
     if (childType->isVarchar() || childType->isVarbinary()) {
       auto value =
           vector.as<velox::SimpleVector<velox::StringView>>()->valueAt(i);
-      maxLength = std::max(maxLength, static_cast<int32_t>(value.size()));
+      addLength(static_cast<int32_t>(value.size()));
     } else if (childType->isArray()) {
       auto* arrayVector = vector.wrappedVector()->as<velox::ArrayVector>();
-      auto wrappedIndex = vector.wrappedIndex(i);
-      maxLength = std::max(maxLength, arrayVector->sizeAt(wrappedIndex));
+      addLength(arrayVector->sizeAt(vector.wrappedIndex(i)));
     } else if (childType->isMap()) {
       auto* mapVector = vector.wrappedVector()->as<velox::MapVector>();
-      auto wrappedIndex = vector.wrappedIndex(i);
-      maxLength = std::max(maxLength, mapVector->sizeAt(wrappedIndex));
+      addLength(mapVector->sizeAt(vector.wrappedIndex(i)));
     }
   }
 }
@@ -172,6 +175,10 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
   if (type->isVarchar() || type->isVarbinary() || type->isArray() ||
       type->isMap()) {
     stats->maxLength = maxLength;
+    auto numNonNull = totalRows - nullCount;
+    if (numNonNull > 0) {
+      stats->avgLength = totalLength / numNonNull;
+    }
   }
 
   return stats;

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -135,6 +135,7 @@ class TestTable : public Table {
     uint64_t nullCount{0};
     std::optional<velox::Variant> min;
     std::optional<velox::Variant> max;
+    int64_t totalLength{0};
     int32_t maxLength{0};
   };
 

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -59,7 +59,9 @@ float Value::byteSize() const {
     return static_cast<float>(type->cppSizeInBytes());
   }
   switch (type->kind()) {
-      // Add complex types here.
+      // TODO: Use avgLength from connector stats to replace this hardcoded
+      // estimate. Needed for strings, arrays, and maps to properly estimate
+      // memory usage and shuffle volume.
     default:
       return 16;
   }

--- a/axiom/optimizer/docs/CardinalityEstimation.md
+++ b/axiom/optimizer/docs/CardinalityEstimation.md
@@ -304,6 +304,11 @@ TODO: Compute fanout from unnest expression array size statistics when available
 5. **Unnest heuristic**: Array/map unnest uses a hardcoded fanout of 10
    regardless of actual array sizes.
 
+6. **No average length tracking**: The optimizer does not propagate average
+   length (avgLength) for variable-length types (strings, arrays, maps).
+   `Value::byteSize()` returns a hardcoded 16 bytes for all such types.
+   This affects memory usage and shuffle volume estimates.
+
 ## Sampling
 
 The optimizer can sample actual data to improve cardinality estimates beyond

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ExpressionPlanner.cpp
   GroupByPlanner.cpp
   PrestoParser.cpp
+  ShowStatsBuilder.cpp
   SqlStatement.cpp
   TableVisitor.cpp
 )

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -22,6 +22,7 @@
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
 #include "axiom/sql/presto/PrestoParseError.h"
+#include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "axiom/sql/presto/TableVisitor.h"
 #include "axiom/sql/presto/ast/AstBuilder.h"
 #include "axiom/sql/presto/ast/AstPrinter.h"
@@ -1211,96 +1212,46 @@ SqlStatementPtr parseShowStats(
       findTable(*showStats.table(), defaultConnectorId, defaultSchema);
   const auto schema = table->type();
 
-  static const auto kNullDouble = Variant::null(TypeKind::DOUBLE);
-  static const auto kNullBigint = Variant::null(TypeKind::BIGINT);
-  static const auto kNullVarchar = Variant::null(TypeKind::VARCHAR);
-
-  // Converts a stats Variant (min or max) to a display string using the
-  // column's type for proper formatting (e.g. dates, decimals).
-  auto variantToString = [](const Variant& value,
-                            const TypePtr& type) -> std::string {
-    if (value.kind() == TypeKind::VARCHAR) {
-      return value.value<TypeKind::VARCHAR>();
-    }
-    return value.toJson(type);
-  };
-
-  std::vector<Variant> data;
-  data.reserve(schema->size() + 1);
-
+  ShowStatsBuilder builder(static_cast<int64_t>(table->numRows()));
   for (auto i = 0; i < schema->size(); ++i) {
     const auto* column = table->columnMap().at(schema->nameOf(i));
     const auto* stats = column->stats();
 
-    auto nullsFraction = kNullDouble;
-    auto distinctCount = kNullBigint;
-    auto avgLength = kNullBigint;
-    auto lowValue = kNullVarchar;
-    auto highValue = kNullVarchar;
+    std::optional<double> nullsFraction;
+    std::optional<int64_t> distinctCount;
+    std::optional<int64_t> avgLength;
+    const Variant* min{nullptr};
+    const Variant* max{nullptr};
 
     if (stats != nullptr) {
-      nullsFraction = Variant(static_cast<double>(stats->nullPct) / 100.0);
-
+      nullsFraction = static_cast<double>(stats->nullPct) / 100.0;
       if (stats->numDistinct.has_value()) {
-        distinctCount =
-            Variant(static_cast<int64_t>(stats->numDistinct.value()));
+        distinctCount = static_cast<int64_t>(stats->numDistinct.value());
       }
-
-      if (stats->avgLength.has_value()) {
-        avgLength = Variant(static_cast<int64_t>(stats->avgLength.value()));
-      }
-
+      avgLength = stats->avgLength;
       if (stats->min.has_value()) {
-        lowValue = Variant(variantToString(stats->min.value(), column->type()));
+        min = &stats->min.value();
       }
-
       if (stats->max.has_value()) {
-        highValue =
-            Variant(variantToString(stats->max.value(), column->type()));
+        max = &stats->max.value();
       }
     }
 
-    data.emplace_back(
-        Variant::row(
-            {kNullDouble,
-             Variant(schema->nameOf(i)),
-             nullsFraction,
-             distinctCount,
-             avgLength,
-             lowValue,
-             highValue}));
+    builder.addColumn(
+        schema->nameOf(i),
+        *column->type(),
+        nullsFraction,
+        distinctCount,
+        avgLength,
+        min,
+        max);
   }
 
-  // Summary row: only row_count is populated.
-  data.emplace_back(
-      Variant::row(
-          {Variant(static_cast<double>(table->numRows())),
-           kNullVarchar,
-           kNullDouble,
-           kNullBigint,
-           kNullBigint,
-           kNullVarchar,
-           kNullVarchar}));
-
   lp::PlanBuilder::Context ctx(defaultConnectorId);
-  return std::make_shared<SelectStatement>(lp::PlanBuilder(ctx)
-                                               .values(
-                                                   ROW({"row_count",
-                                                        "column_name",
-                                                        "nulls_fraction",
-                                                        "distinct_values_count",
-                                                        "avg_length",
-                                                        "low_value",
-                                                        "high_value"},
-                                                       {DOUBLE(),
-                                                        VARCHAR(),
-                                                        DOUBLE(),
-                                                        BIGINT(),
-                                                        BIGINT(),
-                                                        VARCHAR(),
-                                                        VARCHAR()}),
-                                                   data)
-                                               .build());
+  return std::make_shared<SelectStatement>(
+      lp::PlanBuilder(ctx)
+          .values(ShowStatsBuilder::outputType(), builder.rows())
+          .build());
 }
 
 SqlStatementPtr parseShowFunctions(
@@ -1636,6 +1587,16 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kShowStats)) {
     return parseShowStats(
         *query->as<ShowStats>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kShowStatsForQuery)) {
+    auto* showStats = query->as<ShowStatsForQuery>();
+    RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+    showStats->query()->accept(&planner);
+    auto innerStatement =
+        std::make_shared<SelectStatement>(planner.plan(), planner.views());
+    return std::make_shared<ShowStatsForQueryStatement>(
+        std::move(innerStatement));
   }
 
   if (query->is(NodeType::kShowFunctions)) {

--- a/axiom/sql/presto/ShowStatsBuilder.cpp
+++ b/axiom/sql/presto/ShowStatsBuilder.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/ShowStatsBuilder.h"
+
+namespace axiom::sql::presto {
+
+using namespace facebook::velox;
+
+namespace {
+const auto kNullBigint = Variant::null(TypeKind::BIGINT);
+const auto kNullDouble = Variant::null(TypeKind::DOUBLE);
+const auto kNullVarchar = Variant::null(TypeKind::VARCHAR);
+
+Variant toVariant(const std::optional<double>& value) {
+  return value.has_value() ? Variant(*value) : kNullDouble;
+}
+
+Variant toVariant(const std::optional<int64_t>& value) {
+  return value.has_value() ? Variant(*value) : kNullBigint;
+}
+
+// Formats a Variant value for display. Returns the raw string for VARCHAR,
+// otherwise uses type-aware formatting.
+std::string formatValue(const Variant& value, const Type& type) {
+  if (value.kind() == TypeKind::VARCHAR) {
+    return value.value<TypeKind::VARCHAR>();
+  }
+  return value.toJson(type);
+}
+} // namespace
+
+ShowStatsBuilder::ShowStatsBuilder(int64_t rowCount) {
+  rows_.emplace_back(
+      Variant::row({
+          Variant(rowCount),
+          kNullVarchar,
+          kNullDouble,
+          kNullBigint,
+          kNullBigint,
+          kNullVarchar,
+          kNullVarchar,
+      }));
+}
+
+ShowStatsBuilder& ShowStatsBuilder::addColumn(
+    std::string_view name,
+    const Type& type,
+    std::optional<double> nullsFraction,
+    std::optional<int64_t> distinctCount,
+    std::optional<int64_t> avgLength,
+    const Variant* min,
+    const Variant* max) {
+  auto lowValue = (min != nullptr && !min->isNull())
+      ? Variant(formatValue(*min, type))
+      : kNullVarchar;
+  auto highValue = (max != nullptr && !max->isNull())
+      ? Variant(formatValue(*max, type))
+      : kNullVarchar;
+
+  rows_.emplace_back(
+      Variant::row({
+          kNullBigint,
+          Variant(std::string(name)),
+          toVariant(nullsFraction),
+          toVariant(distinctCount),
+          toVariant(avgLength),
+          lowValue,
+          highValue,
+      }));
+  return *this;
+}
+
+const RowTypePtr& ShowStatsBuilder::outputType() {
+  static const auto kType = ROW(
+      {
+          "row_count",
+          "column_name",
+          "nulls_fraction",
+          "distinct_values_count",
+          "avg_length",
+          "low_value",
+          "high_value",
+      },
+      {
+          BIGINT(),
+          VARCHAR(),
+          DOUBLE(),
+          BIGINT(),
+          BIGINT(),
+          VARCHAR(),
+          VARCHAR(),
+      });
+  return kType;
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/ShowStatsBuilder.h
+++ b/axiom/sql/presto/ShowStatsBuilder.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+
+namespace axiom::sql::presto {
+
+/// Builds the result rows for SHOW STATS statements. The constructor adds the
+/// summary row with the total row count, then addColumn appends per-column
+/// stats rows. The result can be used to construct a VALUES plan or a RowVector
+/// via BaseVector::createFromVariants.
+///
+/// Output schema:
+///   row_count (BIGINT) - estimated rows, populated only in the summary row.
+///   column_name (VARCHAR) - column name, NULL in the summary row.
+///   nulls_fraction (DOUBLE) - fraction of null values.
+///   distinct_values_count (BIGINT) - number of distinct values.
+///   avg_length (BIGINT) - average length in bytes for varchar and varbinary;
+///     average number of elements for arrays and maps.
+///   low_value (VARCHAR) - minimum value formatted as string.
+///   high_value (VARCHAR) - maximum value formatted as string.
+class ShowStatsBuilder {
+ public:
+  /// @param rowCount Total row count for the summary row.
+  explicit ShowStatsBuilder(int64_t rowCount);
+
+  /// Adds a per-column stats row. Min/max Variant values are formatted using
+  /// the column type (raw string for VARCHAR, toJson for other types). Null
+  /// Variant pointers produce NULL. Returns *this for chaining.
+  ShowStatsBuilder& addColumn(
+      std::string_view name,
+      const facebook::velox::Type& type,
+      std::optional<double> nullsFraction,
+      std::optional<int64_t> distinctCount,
+      std::optional<int64_t> avgLength,
+      const facebook::velox::Variant* min,
+      const facebook::velox::Variant* max);
+
+  /// Returns the output schema shared by all SHOW STATS variants.
+  static const facebook::velox::RowTypePtr& outputType();
+
+  /// Returns the accumulated rows: summary row followed by per-column rows.
+  const std::vector<facebook::velox::Variant>& rows() const {
+    return rows_;
+  }
+
+ private:
+  // Summary row followed by per-column stats rows.
+  std::vector<facebook::velox::Variant> rows_;
+};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -33,6 +33,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kInsert, "INSERT"},
       {SqlStatementKind::kDropTable, "DROP TABLE"},
       {SqlStatementKind::kExplain, "EXPLAIN"},
+      {SqlStatementKind::kShowStatsForQuery, "SHOW STATS FOR"},
       {SqlStatementKind::kUse, "USE"},
   };
 

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -30,6 +30,7 @@ enum class SqlStatementKind {
   kInsert,
   kDropTable,
   kExplain,
+  kShowStatsForQuery,
   kUse,
 };
 
@@ -73,6 +74,10 @@ class SqlStatement {
 
   bool isExplain() const {
     return kind_ == SqlStatementKind::kExplain;
+  }
+
+  bool isShowStatsForQuery() const {
+    return kind_ == SqlStatementKind::kShowStatsForQuery;
   }
 
   bool isUse() const {
@@ -325,6 +330,22 @@ class ExplainStatement : public SqlStatement {
   const SqlStatementPtr statement_;
   const bool analyze_;
   const Type type_;
+};
+
+/// Wraps a SELECT statement whose logical plan should be optimized to extract
+/// per-column and table-level statistics from the optimizer.
+class ShowStatsForQueryStatement : public SqlStatement {
+ public:
+  explicit ShowStatsForQueryStatement(SqlStatementPtr statement)
+      : SqlStatement(SqlStatementKind::kShowStatsForQuery),
+        statement_{std::move(statement)} {}
+
+  const SqlStatementPtr& statement() const {
+    return statement_;
+  }
+
+ private:
+  const SqlStatementPtr statement_;
 };
 
 /// Sets the default catalog and schema for subsequent queries.

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -723,7 +723,12 @@ std::any AstBuilder::visitShowStats(PrestoSqlParser::ShowStatsContext* ctx) {
 std::any AstBuilder::visitShowStatsForQuery(
     PrestoSqlParser::ShowStatsForQueryContext* ctx) {
   trace("visitShowStatsForQuery");
-  return visitChildren("visitShowStatsForQuery", ctx);
+  auto queryBody = std::any_cast<std::shared_ptr<QueryBody>>(
+      visitQuerySpecification(ctx->querySpecification()));
+  auto query = std::static_pointer_cast<Statement>(
+      std::make_shared<Query>(getLocation(ctx), nullptr, queryBody));
+  return std::static_pointer_cast<Statement>(
+      std::make_shared<ShowStatsForQuery>(getLocation(ctx), query));
 }
 
 std::any AstBuilder::visitShowRoles(PrestoSqlParser::ShowRolesContext* ctx) {

--- a/axiom/sql/presto/ast/AstNode.h
+++ b/axiom/sql/presto/ast/AstNode.h
@@ -182,6 +182,7 @@ enum class NodeType {
   kShowCreateFunction,
   kShowSession,
   kShowStats,
+  kShowStatsForQuery,
   kShowGrants,
   kShowRoles,
   kShowRoleGrants,

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -182,6 +182,7 @@ const auto& nodeTypeNames() {
       {NodeType::kShowCreateFunction, "ShowCreateFunction"},
       {NodeType::kShowSession, "ShowSession"},
       {NodeType::kShowStats, "ShowStats"},
+      {NodeType::kShowStatsForQuery, "ShowStatsForQuery"},
       {NodeType::kShowGrants, "ShowGrants"},
       {NodeType::kShowRoles, "ShowRoles"},
       {NodeType::kShowRoleGrants, "ShowRoleGrants"},
@@ -772,6 +773,10 @@ void ShowColumns::accept(AstVisitor* visitor) {
 
 void ShowStats::accept(AstVisitor* visitor) {
   visitor->visitShowStats(this);
+}
+
+void ShowStatsForQuery::accept(AstVisitor* visitor) {
+  visitor->visitShowStatsForQuery(this);
 }
 
 void ShowFunctions::accept(AstVisitor* visitor) {

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -795,7 +795,7 @@ class ShowColumns : public Statement {
 
 /// Represents SHOW STATS FOR <table>. Returns per-column and table-level
 /// statistics as a VALUES plan with the following columns:
-///   row_count (DOUBLE) - total rows, populated only in the summary row.
+///   row_count (BIGINT) - total rows, populated only in the summary row.
 ///   column_name (VARCHAR) - column name, NULL in the summary row.
 ///   nulls_fraction (DOUBLE) - fraction of null values.
 ///   distinct_values_count (BIGINT) - number of distinct values.
@@ -816,6 +816,25 @@ class ShowStats : public Statement {
 
  private:
   std::shared_ptr<QualifiedName> table_;
+};
+
+/// Represents SHOW STATS FOR (<query>). Same output schema as ShowStats, but
+/// statistics are estimated by the optimizer for the result of the query.
+class ShowStatsForQuery : public Statement {
+ public:
+  ShowStatsForQuery(
+      NodeLocation location,
+      const std::shared_ptr<Statement>& query)
+      : Statement(NodeType::kShowStatsForQuery, location), query_(query) {}
+
+  const std::shared_ptr<Statement>& query() const {
+    return query_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<Statement> query_;
 };
 
 class ShowFunctions : public Statement {

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -567,6 +567,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowStatsForQuery(ShowStatsForQuery* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowFunctions(ShowFunctions* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1129,6 +1129,25 @@ TEST_F(PrestoParserTest, showStats) {
 
   VELOX_ASSERT_USER_THROW(
       parseSelect("SHOW STATS FOR no_such_table"), "Table not found");
+
+  // SHOW STATS FOR (<query>) returns a ShowStatsForQueryStatement wrapping
+  // the inner SELECT's logical plan.
+  {
+    auto statement = parseSql("SHOW STATS FOR (SELECT * FROM nation)");
+    ASSERT_TRUE(statement->isShowStatsForQuery());
+
+    auto* showStats = statement->as<ShowStatsForQueryStatement>();
+    ASSERT_TRUE(showStats->statement()->isSelect());
+  }
+
+  {
+    auto statement = parseSql(
+        "SHOW STATS FOR (SELECT n_nationkey FROM nation WHERE n_regionkey = 1)");
+    ASSERT_TRUE(statement->isShowStatsForQuery());
+
+    auto* showStats = statement->as<ShowStatsForQueryStatement>();
+    ASSERT_TRUE(showStats->statement()->isSelect());
+  }
 }
 
 TEST_F(PrestoParserTest, unqualifiedAccessAfterJoin) {


### PR DESCRIPTION
Summary:
Add support for `SHOW STATS FOR (<query>)` which shows per-column
statistics (NDV, min, max, null fraction) and row count from the
optimizer's cardinality estimates after filter pushdown. This
complements the existing `SHOW STATS FOR <table>` which reads
static connector-level stats.

> SHOW STATS FOR (SELECT * FROM t WHERE k = 2)

Implementation follows the EXPLAIN pattern: the parser produces a
ShowStatsForQueryStatement wrapper, the runner optimizes the inner
query's logical plan and reads statistics from the optimizer's
DerivedTable.

Extract ShowStatsBuilder class to share output schema and row
construction between SHOW STATS FOR <table> (parser) and
SHOW STATS FOR (<query>) (runner).

Differential Revision: D95577804


