### PR TITLE
fix(parser): Fix stack overflow when CTE has the same name as a base table

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -429,8 +429,17 @@ class RelationPlanner : public AstVisitor {
     }
 
     if (withIt != withQueries_.end()) {
-      // TODO Change WithQuery to store Query and not Statement.
-      processQuery(dynamic_cast<Query*>(withIt->second->query().get()));
+      // Temporarily remove the CTE from the map while processing its body
+      // to prevent infinite recursion when a CTE has the same name as a
+      // base table it references (e.g. WITH t AS (SELECT * FROM t)).
+      // Non-recursive CTEs cannot reference themselves in Presto.
+      auto withEntry = std::move(withIt->second);
+      withQueries_.erase(withIt);
+      SCOPE_EXIT {
+        withQueries_.insert_or_assign(tableName, std::move(withEntry));
+      };
+      // TODO: Change WithQuery to store Query and not Statement.
+      processQuery(dynamic_cast<Query*>(withEntry->query().get()));
     } else {
       const auto& [connectorId, qualifiedName] = toConnectorTable(
           *table.name(), context_.defaultConnectorId, defaultSchema_);
@@ -766,6 +775,7 @@ class RelationPlanner : public AstVisitor {
     };
 
     if (const auto& with = query->with()) {
+      VELOX_USER_CHECK(!with->isRecursive(), "WITH RECURSIVE is not supported");
       for (const auto& query : with->queries()) {
         withQueries_.insert_or_assign(
             canonicalizeIdentifier(*query->name()), query);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -385,7 +385,7 @@ TEST_F(PrestoParserTest, mixedCaseColumnNames) {
   }
 }
 
-TEST_F(PrestoParserTest, with) {
+TEST_F(PrestoParserTest, withBasic) {
   {
     auto matcher = matchValues().project().output({"x"});
     testSelect("WITH a as (SELECT 1 as x) SELECT * FROM a", matcher);
@@ -399,7 +399,7 @@ TEST_F(PrestoParserTest, with) {
   }
 }
 
-TEST_F(PrestoParserTest, withShadowing) {
+TEST_F(PrestoParserTest, withShadowingCte) {
   // Inner CTE shadows outer CTE with the same name. The inner CTE uses a table
   // scan (producing a Scan node) while the outer uses VALUES. Without proper
   // shadowing, the subquery would resolve to the outer CTE and produce a Values
@@ -418,6 +418,45 @@ TEST_F(PrestoParserTest, withNoLeaking) {
           "SELECT * FROM (WITH t AS (SELECT 1 AS x) SELECT * FROM t) sub "
           "CROSS JOIN t"),
       "Table not found: t");
+}
+
+TEST_F(PrestoParserTest, withShadowingBaseTable) {
+  // CTE with the same name as a base table it references. The inner reference
+  // to 'nation' inside the CTE body must resolve to the base table, not recurse
+  // into the CTE itself.
+  auto matcher = matchScan().project().output({"n_nationkey"});
+  testSelect(
+      "WITH nation AS (SELECT n_nationkey FROM nation) "
+      "SELECT * FROM nation",
+      matcher);
+}
+
+TEST_F(PrestoParserTest, withMultipleCtes) {
+  // Later CTE references earlier CTE.
+  testSelect(
+      "WITH a AS (SELECT n_nationkey, n_name FROM nation), "
+      "     b AS (SELECT * FROM a) "
+      "SELECT * FROM b",
+      matchScan().project().output({"n_nationkey", "n_name"}));
+}
+
+TEST_F(PrestoParserTest, withReferencedMultipleTimes) {
+  // Same CTE referenced twice in a JOIN.
+  auto matcher = matchScan()
+                     .project()
+                     .join(matchScan().project().build())
+                     .project()
+                     .output({"n_nationkey"});
+  testSelect(
+      "WITH a AS (SELECT n_nationkey FROM nation) "
+      "SELECT x.n_nationkey FROM a x JOIN a y ON x.n_nationkey = y.n_nationkey",
+      matcher);
+}
+
+TEST_F(PrestoParserTest, withRecursiveNotSupported) {
+  VELOX_ASSERT_THROW(
+      parseSql("WITH RECURSIVE t AS (SELECT 1 AS x) SELECT * FROM t"),
+      "WITH RECURSIVE is not supported");
 }
 
 TEST_F(PrestoParserTest, orderBy) {


### PR DESCRIPTION
Summary:
When a CTE (WITH clause) has the same name as a base table it references
(e.g. `WITH nation AS (SELECT n_nationkey FROM nation)`), the parser would
infinitely recurse because processTable found the CTE name in withQueries_
and re-planned the CTE body, which again found the same CTE name.

Fix by temporarily removing the CTE from withQueries_ while processing its
body, so self-references fall through to the base table lookup. Use
SCOPE_EXIT to ensure the CTE is re-inserted even if processing throws.

Also add VELOX_USER_CHECK to reject WITH RECURSIVE (not supported).

Differential Revision: D95802949


