### PR TITLE
refactor: Improve variable names and test assertions

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -985,6 +985,10 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::string& groupingSetIndexName) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Aggregate node cannot be a leaf node");
 
+  VELOX_USER_CHECK(
+      !groupingKeys.empty() || !aggregates.empty(),
+      "Aggregation node must specify at least one aggregate or grouping key");
+
   const auto numKeys = static_cast<int32_t>(groupingKeys.size());
   for (const auto& groupingSet : groupingSets) {
     for (const auto index : groupingSet) {
@@ -1014,8 +1018,10 @@ PlanBuilder& PlanBuilder::aggregate(
 
   resolveAggregates(aggregates, options, outputNames, exprs, *newOutputMapping);
 
-  outputNames.push_back(newName(groupingSetIndexName));
-  newOutputMapping->add(groupingSetIndexName, outputNames.back());
+  auto gidInternalName = newName(groupingSetIndexName);
+  outputNames.push_back(gidInternalName);
+  newOutputMapping->add(groupingSetIndexName, gidInternalName);
+  newOutputMapping->markHidden(gidInternalName);
 
   node_ = std::make_shared<AggregateNode>(
       nextId(),
@@ -2011,19 +2017,22 @@ std::string PlanBuilder::findOrAssignOutputNameAt(size_t index) const {
 }
 
 LogicalPlanNodePtr PlanBuilder::buildOutputNode() {
-  auto defaultNames = findOrAssignOutputNames(/*includeHiddenColumns=*/true);
-  const auto numColumns = defaultNames.size();
+  const auto& inputType = node_->outputType();
+  const auto numColumns = inputType->size();
 
   std::vector<OutputNode::Entry> entries;
   entries.reserve(numColumns);
 
   for (size_t i = 0; i < numColumns; ++i) {
+    const auto& id = inputType->nameOf(i);
+    if (outputMapping_->isHidden(id)) {
+      continue;
+    }
     std::string name;
-    if (auto userName =
-            outputMapping_->userName(node_->outputType()->nameOf(i))) {
+    if (auto userName = outputMapping_->userName(id)) {
       name = *userName;
     } else {
-      name = std::move(defaultNames[i]);
+      name = findOrAssignOutputNameAt(i);
     }
     entries.emplace_back(
         OutputNode::Entry{static_cast<int32_t>(i), std::move(name)});

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1004,19 +1004,20 @@ PlanBuilder& PlanBuilder::aggregate(
   }
 
   std::vector<std::string> outputNames;
-  outputNames.reserve(groupingKeys.size() + aggregates.size() + 1);
+  outputNames.reserve(numKeys + aggregates.size() + 1);
 
   std::vector<ExprPtr> keyExprs;
-  keyExprs.reserve(groupingKeys.size());
+  keyExprs.reserve(numKeys);
 
   auto newOutputMapping = std::make_shared<NameMappings>();
 
   resolveProjections(groupingKeys, outputNames, keyExprs, *newOutputMapping);
 
-  std::vector<AggregateExprPtr> exprs;
-  exprs.reserve(aggregates.size());
+  std::vector<AggregateExprPtr> aggExprs;
+  aggExprs.reserve(aggregates.size());
 
-  resolveAggregates(aggregates, options, outputNames, exprs, *newOutputMapping);
+  resolveAggregates(
+      aggregates, options, outputNames, aggExprs, *newOutputMapping);
 
   auto gidInternalName = newName(groupingSetIndexName);
   outputNames.push_back(gidInternalName);
@@ -1028,7 +1029,7 @@ PlanBuilder& PlanBuilder::aggregate(
       std::move(node_),
       std::move(keyExprs),
       groupingSets,
-      std::move(exprs),
+      std::move(aggExprs),
       std::move(outputNames));
 
   newOutputMapping->enableUnqualifiedAccess();

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -915,11 +915,18 @@ replaceInputs(AggregationPlanCP aggregation, const T& source, const U& target) {
     return aggregation;
   }
 
+  // Grouping sets contain indices into grouping keys (not column references),
+  // so they don't need replaceInputs treatment. groupIdColumn is an output
+  // column that is also unaffected. inputGroupingKeys reference the original
+  // input columns and must be forwarded as-is.
   return make<AggregationPlan>(
       std::move(newGroupingKeys),
       std::move(newAggregates),
       aggregation->columns(),
-      aggregation->intermediateColumns());
+      aggregation->intermediateColumns(),
+      aggregation->groupingSets(),
+      aggregation->groupIdColumn(),
+      aggregation->inputGroupingKeys());
 }
 } // namespace
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1389,6 +1389,134 @@ std::pair<Aggregation*, PlanCost> makeSplitOrSingleAggregationPlan(
   return {splitAggPlan, splitAggCost};
 }
 
+// Collects unique column references from aggregate functions (args, ORDER BY
+// keys, and filter conditions). Non-column expressions (constants, literals)
+// are embedded in the aggregate and don't need to flow through GroupId.
+ExprVector collectAggregationInputs(const AggregateVector& aggregates) {
+  PlanObjectSet seen;
+  ExprVector inputs;
+  auto maybeAdd = [&](ExprCP expr) {
+    if (expr->is(PlanType::kColumnExpr) && !seen.contains(expr)) {
+      seen.add(expr);
+      inputs.push_back(expr);
+    }
+  };
+  for (const auto* agg : aggregates) {
+    for (const auto* arg : agg->args()) {
+      maybeAdd(arg);
+    }
+    for (const auto* key : agg->orderKeys()) {
+      maybeAdd(key);
+    }
+    if (agg->condition()) {
+      maybeAdd(agg->condition());
+    }
+  }
+  return inputs;
+}
+
+// Handles aggregation with grouping sets (ROLLUP, CUBE, GROUPING SETS).
+// Creates a GroupId node followed by single-step or two-phase aggregation.
+void addGroupingSetsAggregation(
+    const AggregationPlan* aggPlan,
+    RelationOpPtr& plan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    PlanState& state,
+    bool useSingleStep) {
+  ColumnVector groupIdKeys;
+  groupIdKeys.reserve(groupingKeys.size());
+  for (const auto* key : groupingKeys) {
+    groupIdKeys.push_back(key->as<Column>());
+  }
+
+  auto aggregationInputs = collectAggregationInputs(aggregates);
+
+  GroupingSet globalGroupingSets;
+  for (size_t i = 0; i < aggPlan->groupingSets().size(); ++i) {
+    if (aggPlan->groupingSets()[i].empty()) {
+      globalGroupingSets.push_back(static_cast<int32_t>(i));
+    }
+  }
+
+  // Only pass groupIdColumn to the Aggregation when there are global (empty)
+  // grouping sets. Velox uses this pair to produce default output rows for
+  // empty inputs; without global sets, the groupId column is just a regular
+  // grouping key.
+  ColumnCP aggGroupIdColumn =
+      globalGroupingSets.empty() ? nullptr : aggPlan->groupIdColumn();
+
+  auto* groupIdNode = make<GroupId>(
+      plan,
+      aggPlan->groupingSets(),
+      std::move(groupIdKeys),
+      std::move(aggregationInputs),
+      aggPlan->groupIdColumn(),
+      aggPlan->inputGroupingKeys());
+
+  state.addCost(*groupIdNode);
+  plan = groupIdNode;
+
+  const auto numKeys = aggPlan->groupingKeys().size();
+  ExprVector aggGroupingKeys;
+  aggGroupingKeys.reserve(numKeys + 1);
+  for (size_t i = 0; i < numKeys; ++i) {
+    aggGroupingKeys.push_back(groupIdNode->columns()[i]);
+  }
+  aggGroupingKeys.push_back(aggPlan->groupIdColumn());
+
+  auto aggColumns = aggPlan->columns();
+
+  if (useSingleStep) {
+    auto* singleAgg = make<Aggregation>(
+        plan,
+        std::move(aggGroupingKeys),
+        /*preGroupedKeys*/ ExprVector{},
+        aggregates,
+        velox::core::AggregationNode::Step::kSingle,
+        std::move(aggColumns),
+        std::move(globalGroupingSets),
+        aggGroupIdColumn);
+
+    state.addCost(*singleAgg);
+    plan = singleAgg;
+    return;
+  }
+
+  auto intermediateColumns = aggPlan->intermediateColumns();
+
+  auto* partialAgg = make<Aggregation>(
+      plan,
+      aggGroupingKeys,
+      /*preGroupedKeys*/ ExprVector{},
+      aggregates,
+      velox::core::AggregationNode::Step::kPartial,
+      intermediateColumns);
+  state.addCost(*partialAgg);
+
+  plan = partialAgg;
+  repartitionForAgg(plan, aggGroupingKeys, intermediateColumns, state.cost);
+
+  ExprVector finalGroupingKeys;
+  finalGroupingKeys.reserve(numKeys + 1);
+  for (size_t i = 0; i < numKeys; ++i) {
+    finalGroupingKeys.push_back(intermediateColumns[i]);
+  }
+  finalGroupingKeys.push_back(intermediateColumns[numKeys]);
+
+  auto* finalAgg = make<Aggregation>(
+      plan,
+      std::move(finalGroupingKeys),
+      /*preGroupedKeys*/ ExprVector{},
+      aggregates,
+      velox::core::AggregationNode::Step::kFinal,
+      std::move(aggColumns),
+      std::move(globalGroupingSets),
+      aggGroupIdColumn);
+  state.addCost(*finalAgg);
+  plan = finalAgg;
+}
+
 } // namespace
 
 // static
@@ -1479,8 +1607,28 @@ void Optimization::addAggregation(
   plan = std::move(precompute).maybeProject();
   state.place(aggPlan);
 
+  const bool useSingleStep = isSingleWorker_ && isSingleDriver_;
+
+  // ORDER BY aggregates require single-step because partial aggregation
+  // cannot preserve global ordering.
+  const auto hasOrderBy =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return !agg->orderKeys().empty();
+      });
+
+  if (aggPlan->hasGroupingSets()) {
+    addGroupingSetsAggregation(
+        aggPlan,
+        plan,
+        groupingKeys,
+        aggregates,
+        state,
+        useSingleStep || hasOrderBy);
+    return;
+  }
+
   auto preGroupedKeys = computePreGroupedKeys(*plan, groupingKeys);
-  if ((isSingleWorker_ && isSingleDriver_) || !preGroupedKeys.empty()) {
+  if (useSingleStep || !preGroupedKeys.empty()) {
     auto* singleAgg = make<Aggregation>(
         plan,
         std::move(groupingKeys),
@@ -1505,12 +1653,6 @@ void Optimization::addAggregation(
     return;
   }
 
-  // Check if any aggregate has ORDER BY keys. If so, we must use single-step
-  // aggregation because partial aggregation cannot preserve global ordering.
-  const auto hasOrderBy =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return !agg->orderKeys().empty();
-      });
   if (hasOrderBy) {
     const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
         plan,

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -339,6 +339,13 @@ PlanObjectSet PlanState::computeDownstreamColumns(bool includeFilters) const {
     for (auto& aggregate : aggToPlace->aggregates()) {
       addExpr(aggregate);
     }
+    // Grouping-sets renames keys (e.g., a → a$gid) on the DerivedTable. The
+    // renamed columns are not base table columns, so they get filtered out by
+    // indexColumns(). Register the original input columns so the scan includes
+    // them.
+    for (auto* inputKey : aggToPlace->inputGroupingKeys()) {
+      result.add(inputKey);
+    }
   }
 
   // Window functions.

--- a/axiom/optimizer/PlanUtils.cpp
+++ b/axiom/optimizer/PlanUtils.cpp
@@ -166,4 +166,17 @@ std::string exprsToString(const ExprVector& exprs) {
   return out.str();
 }
 
+const logical_plan::AggregateExpr* aggregateForOrdinal(
+    const logical_plan::AggregateNode& agg,
+    size_t ordinal) {
+  if (ordinal < agg.groupingKeys().size()) {
+    return nullptr;
+  }
+  const auto aggregateIndex = ordinal - agg.groupingKeys().size();
+  if (aggregateIndex >= agg.aggregates().size()) {
+    return nullptr;
+  }
+  return agg.aggregates()[aggregateIndex].get();
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -132,4 +132,10 @@ std::string columnsToString(const ColumnVector& columns);
 
 std::string exprsToString(const ExprVector& exprs);
 
+/// Returns the aggregate for an output column ordinal, or nullptr if the
+/// ordinal corresponds to a grouping key or grouping set index column.
+const logical_plan::AggregateExpr* aggregateForOrdinal(
+    const logical_plan::AggregateNode& agg,
+    size_t ordinal);
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -255,6 +255,43 @@ void checkTableReferences(
 }
 } // namespace
 
+AggregationPlan::AggregationPlan(
+    ExprVector groupingKeys,
+    AggregateVector aggregates,
+    ColumnVector columns,
+    ColumnVector intermediateColumns,
+    GroupingSets groupingSets,
+    ColumnCP groupIdColumn,
+    ColumnVector inputGroupingKeys)
+    : PlanObject(PlanType::kAggregationNode),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregates_(std::move(aggregates)),
+      columns_(std::move(columns)),
+      intermediateColumns_(std::move(intermediateColumns)),
+      groupingSets_(std::move(groupingSets)),
+      groupIdColumn_(groupIdColumn),
+      inputGroupingKeys_(std::move(inputGroupingKeys)) {
+  const auto expectedSize = groupingKeys_.size() + aggregates_.size() +
+      (groupIdColumn_ != nullptr ? 1 : 0);
+  VELOX_CHECK_EQ(expectedSize, columns_.size());
+  VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
+
+  for (const auto& set : groupingSets_) {
+    for (size_t i = 0; i < set.size(); ++i) {
+      VELOX_CHECK_LT(
+          set[i],
+          groupingKeys_.size(),
+          "Grouping set index out of bounds: index={}, numKeys={}",
+          set[i],
+          groupingKeys_.size());
+      for (size_t j = i + 1; j < set.size(); ++j) {
+        VELOX_CHECK_NE(
+            set[i], set[j], "Duplicate index in grouping set: {}", set[i]);
+      }
+    }
+  }
+}
+
 void AggregationPlan::checkConsistency(const DerivedTable& dt) const {
   checkTableReferences<ExprCP>(dt, groupingKeys_, "Grouping key");
   checkTableReferences<AggregateCP>(dt, aggregates_, "Aggregate");

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1280,21 +1280,38 @@ using WindowFunctionVector = QGVector<WindowFunctionCP>;
 /// aggregates: columns_[i] corresponds to groupingKeys_[i] for
 /// i < groupingKeys_.size(), and to aggregates_[i - groupingKeys_.size()]
 /// otherwise.
+/// Each grouping set is a list of indices into the grouping keys array.
+using GroupingSet = QGVector<int32_t>;
+using GroupingSets = QGVector<GroupingSet>;
+
 class AggregationPlan : public PlanObject {
  public:
+  /// @param groupingKeys GROUP BY columns referencing the enclosing
+  ///   DerivedTable's tableSet. May be renamed with $gid suffix when grouping
+  ///   sets are present and names collide with aggregate inputs.
+  /// @param aggregates Aggregate functions (sum, count, etc.).
+  /// @param columns Output columns: groupingKeys[i] maps to columns[i], then
+  ///   aggregates. If groupIdColumn is present, it appears after the last
+  ///   aggregate column.
+  /// @param intermediateColumns Columns with intermediate accumulator types for
+  ///   partial aggregation. Same layout as columns.
+  /// @param groupingSets Grouping sets for ROLLUP/CUBE/GROUPING SETS. Each set
+  ///   is a list of indices into groupingKeys. Empty for regular GROUP BY.
+  /// @param groupIdColumn Output column for the grouping set ID. Null when
+  ///   grouping sets are not used.
+  /// @param inputGroupingKeys Original (unrenamed) grouping key columns.
+  ///   Populated when keys are renamed with $gid suffix to avoid collisions
+  ///   with aggregate input names. Used by ToVelox to build
+  ///   GroupingKeyInfo{.output = renamed, .input = original}. Empty when there
+  ///   are no renames.
   AggregationPlan(
       ExprVector groupingKeys,
       AggregateVector aggregates,
       ColumnVector columns,
-      ColumnVector intermediateColumns)
-      : PlanObject(PlanType::kAggregationNode),
-        groupingKeys_(std::move(groupingKeys)),
-        aggregates_(std::move(aggregates)),
-        columns_(std::move(columns)),
-        intermediateColumns_(std::move(intermediateColumns)) {
-    VELOX_CHECK_EQ(groupingKeys_.size() + aggregates_.size(), columns_.size());
-    VELOX_CHECK_EQ(columns_.size(), intermediateColumns_.size());
-  }
+      ColumnVector intermediateColumns,
+      GroupingSets groupingSets = {},
+      ColumnCP groupIdColumn = nullptr,
+      ColumnVector inputGroupingKeys = {});
 
   /// GROUP BY columns. Each references a column from a table in the enclosing
   /// DerivedTable's tableSet or from the DerivedTable itself.
@@ -1327,11 +1344,38 @@ class AggregationPlan : public PlanObject {
   /// reference 'dt'.
   void checkConsistency(const DerivedTable& dt) const;
 
+  /// Returns true if this aggregation uses grouping sets (ROLLUP/CUBE/GROUPING
+  /// SETS).
+  bool hasGroupingSets() const {
+    return !groupingSets_.empty();
+  }
+
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  /// Returns the column for the grouping set ID, or nullptr if no grouping
+  /// sets.
+  ColumnCP groupIdColumn() const {
+    return groupIdColumn_;
+  }
+
+  /// Original (unrenamed) grouping key columns. Used by the physical GroupId
+  /// to produce correct Velox input field references when keys are renamed
+  /// with a $gid suffix to avoid name collisions with aggregate inputs.
+  /// Empty when grouping sets are not used or no renames were needed.
+  const ColumnVector& inputGroupingKeys() const {
+    return inputGroupingKeys_;
+  }
+
  private:
   const ExprVector groupingKeys_;
   const AggregateVector aggregates_;
   const ColumnVector columns_;
   const ColumnVector intermediateColumns_;
+  const GroupingSets groupingSets_;
+  const ColumnCP groupIdColumn_;
+  const ColumnVector inputGroupingKeys_;
 };
 
 using AggregationPlanCP = const AggregationPlan*;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -28,6 +28,10 @@
 
 namespace facebook::axiom::optimizer {
 
+// Minimal per-row cost for operators that do trivial per-row work (e.g.,
+// passing rows through, generating a unique ID, enforcing distinctness).
+constexpr double kMinimalUnitCost = 0.01;
+
 void PlanCost::add(RelationOp& op) {
   cost += op.cost().totalCost();
   cardinality = op.resultCardinality();
@@ -56,6 +60,7 @@ const auto& relTypeNames() {
       {RelType::kWindow, "Window"},
       {RelType::kRowNumber, "RowNumber"},
       {RelType::kTopNRowNumber, "TopNRowNumber"},
+      {RelType::kGroupId, "GroupId"},
   };
 
   return kNames;
@@ -1255,12 +1260,16 @@ Aggregation::Aggregation(
     ExprVector _preGroupedKeys,
     AggregateVector _aggregates,
     velox::core::AggregationNode::Step step,
-    ColumnVector columns)
+    ColumnVector columns,
+    GroupingSet _globalGroupingSets,
+    ColumnCP groupIdColumn)
     : RelationOp{RelType::kAggregation, std::move(input), std::move(columns)},
       groupingKeys{std::move(_groupingKeys)},
       aggregates{std::move(_aggregates)},
       step{step},
-      preGroupedKeys{std::move(_preGroupedKeys)} {
+      preGroupedKeys{std::move(_preGroupedKeys)},
+      globalGroupingSets{std::move(_globalGroupingSets)},
+      groupIdColumn{groupIdColumn} {
 #ifndef NDEBUG
   VELOX_DCHECK_EQ(
       columns_.size(),
@@ -1665,7 +1674,7 @@ Limit::Limit(RelationOpPtr input, int64_t limit, int64_t offset)
       limit{limit},
       offset{offset} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = kMinimalUnitCost;
   const auto cardinality = static_cast<float>(limit);
   if (cost_.inputCardinality <= cardinality) {
     // Input cardinality does not exceed the limit. The limit is no-op.
@@ -1810,7 +1819,7 @@ TableWrite::TableWrite(
       inputColumns{std::move(inputColumns)},
       write{write} {
   cost_.inputCardinality = inputCardinality();
-  cost_.unitCost = 0.01;
+  cost_.unitCost = kMinimalUnitCost;
   VELOX_DCHECK_EQ(
       this->inputColumns.size(), this->write->table().type()->size());
 }
@@ -1880,7 +1889,7 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
       uniqueIdColumn_(uniqueIdColumn) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for generating unique IDs.
+  cost_.unitCost = kMinimalUnitCost; // Minimal cost for generating unique IDs.
 
   // Copy all input constraints (AssignUniqueId projects all input columns).
   constraints_ = input_->constraints();
@@ -1909,7 +1918,7 @@ EnforceDistinct::EnforceDistinct(
       errorMessage_(errorMessage) {
   // Fanout is 1 (cardinality neutral).
   cost_.fanout = 1;
-  cost_.unitCost = 0.01; // Minimal cost for enforcing distinctness.
+  cost_.unitCost = kMinimalUnitCost; // Minimal cost for enforcing distinctness.
 
   // EnforceDistinct projects all input columns.
   constraints_ = input_->constraints();
@@ -2114,4 +2123,101 @@ void TopNRowNumber::accept(
   visitor.visit(*this, context);
 }
 
+namespace {
+
+// Builds the output columns for GroupId from grouping keys, aggregation
+// inputs, and the group ID column.
+ColumnVector makeGroupIdColumns(
+    const ColumnVector& groupingKeys,
+    const ExprVector& aggregationInputs,
+    ColumnCP groupIdColumn) {
+  ColumnVector columns;
+  columns.reserve(groupingKeys.size() + aggregationInputs.size() + 1);
+  for (auto* column : groupingKeys) {
+    columns.push_back(column);
+  }
+  for (auto* expr : aggregationInputs) {
+    VELOX_CHECK(
+        expr->is(PlanType::kColumnExpr),
+        "GroupId aggregation input must be a Column");
+    columns.push_back(expr->as<Column>());
+  }
+  columns.push_back(groupIdColumn);
+  return columns;
+}
+
+// Returns a Value for the group ID column: non-nullable integer in
+// [0, numGroupingSets - 1].
+Value makeGroupIdColumnValue(ColumnCP groupIdColumn, size_t numGroupingSets) {
+  Value value(groupIdColumn->value().type, numGroupingSets);
+  value.nullable = false;
+  value.min = registerVariant(int64_t{0});
+  value.max = registerVariant(static_cast<int64_t>(numGroupingSets - 1));
+  return value;
+}
+
+} // namespace
+
+GroupId::GroupId(
+    RelationOpPtr input,
+    GroupingSets groupingSets,
+    ColumnVector groupingKeys,
+    ExprVector aggregationInputs,
+    ColumnCP groupIdColumn,
+    ColumnVector inputGroupingKeys)
+    : RelationOp(
+          RelType::kGroupId,
+          std::move(input),
+          makeGroupIdColumns(groupingKeys, aggregationInputs, groupIdColumn)),
+      groupingSets_(std::move(groupingSets)),
+      groupingKeys_(std::move(groupingKeys)),
+      aggregationInputs_(std::move(aggregationInputs)),
+      groupIdColumn_(groupIdColumn),
+      inputGroupingKeys_(std::move(inputGroupingKeys)) {
+  VELOX_CHECK_GT(
+      groupingSets_.size(),
+      1,
+      "GroupId requires multiple grouping sets. "
+      "A single grouping set is a regular GROUP BY.");
+
+  for (const auto& set : groupingSets_) {
+    for (size_t i = 0; i < set.size(); ++i) {
+      VELOX_CHECK_LT(
+          set[i],
+          groupingKeys_.size(),
+          "Grouping set index out of bounds: index={}, numKeys={}",
+          set[i],
+          groupingKeys_.size());
+      for (size_t j = i + 1; j < set.size(); ++j) {
+        VELOX_CHECK_NE(
+            set[i], set[j], "Duplicate index in grouping set: {}", set[i]);
+      }
+    }
+  }
+
+  // Fanout equals the number of grouping sets since each input row is
+  // duplicated once per set.
+  cost_.fanout = groupingSets_.size();
+  cost_.unitCost = kMinimalUnitCost * groupingSets_.size();
+
+  constraints_ = input_->constraints();
+
+  // Add constraints for the renamed output key columns. GroupId NULLs out
+  // keys for non-participating grouping sets, so they are always nullable.
+  for (const auto* key : groupingKeys_) {
+    auto value = key->value();
+    value.nullable = true;
+    constraints_.emplace(key->id(), value);
+  }
+
+  constraints_.emplace(
+      groupIdColumn_->id(),
+      makeGroupIdColumnValue(groupIdColumn_, groupingSets_.size()));
+}
+
+void GroupId::accept(
+    const RelationOpVisitor& visitor,
+    RelationOpVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -125,6 +125,7 @@ enum class RelType {
   kWindow,
   kRowNumber,
   kTopNRowNumber,
+  kGroupId,
 };
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
@@ -599,13 +600,17 @@ struct Aggregation : public RelationOp {
   /// @param step Aggregation step (partial, final, single, intermediate).
   /// @param columns Output columns: groupingKeys followed by aggregate result
   ///   columns. Must have size == groupingKeys.size() + aggregates.size().
+  /// @param globalGroupingSets Indices of global (empty) grouping sets, if any.
+  /// @param groupIdColumn The group ID column from upstream GroupId, if any.
   Aggregation(
       RelationOpPtr input,
       ExprVector groupingKeys,
       ExprVector preGroupedKeys,
       AggregateVector aggregates,
       velox::core::AggregationNode::Step step,
-      ColumnVector columns);
+      ColumnVector columns,
+      GroupingSet globalGroupingSets = {},
+      ColumnCP groupIdColumn = nullptr);
 
   const ExprVector groupingKeys;
   const AggregateVector aggregates;
@@ -615,6 +620,17 @@ struct Aggregation : public RelationOp {
   /// that matches the input's clusterKeys. When non-empty, the aggregation
   /// can be executed in streaming manner without building a hash table.
   const ExprVector preGroupedKeys;
+
+  /// Indices of global grouping sets (empty sets) within the grouping sets
+  /// array. Non-empty only for aggregations over GROUPING SETS/ROLLUP/CUBE
+  /// that contain a global (no-key) set. Used to generate a default output row
+  /// for empty inputs.
+  const GroupingSet globalGroupingSets;
+
+  /// The group ID column from the upstream GroupId operator, if present.
+  /// Used to pass grouping set info to the Velox AggregationNode without
+  /// requiring a dynamic_cast of the input.
+  const ColumnCP groupIdColumn{nullptr};
 
   /// Returns true if the aggregation is pre-grouped (streaming).
   bool isPreGrouped() const {
@@ -895,4 +911,59 @@ struct TopNRowNumber : public RelationOp {
 
 using TopNRowNumberCP = const TopNRowNumber*;
 
+/// Duplicates each input row once per grouping set. For each copy, grouping key
+/// columns not participating in that set are set to NULL, and a grouping set ID
+/// column is appended. Used to implement GROUPING SETS, ROLLUP, and CUBE.
+///
+/// Output columns: [grouping keys..., aggregation inputs..., groupIdColumn].
+struct GroupId : public RelationOp {
+  /// @param groupingSets List of grouping sets, each containing indices into
+  ///   groupingKeys that are active for that set.
+  /// @param groupingKeys Input columns for grouping keys. Output names match
+  ///   the column names (possibly renamed with $gid suffix).
+  /// @param aggregationInputs Columns that are inputs to aggregate functions.
+  /// @param groupIdColumn The output column for the grouping set ID.
+  /// @param inputGroupingKeys Original (unrenamed) input key columns. Used by
+  ///   ToVelox to produce correct input field references.
+  GroupId(
+      RelationOpPtr input,
+      GroupingSets groupingSets,
+      ColumnVector groupingKeys,
+      ExprVector aggregationInputs,
+      ColumnCP groupIdColumn,
+      ColumnVector inputGroupingKeys = {});
+
+  const GroupingSets& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  ColumnCP groupIdColumn() const {
+    return groupIdColumn_;
+  }
+
+  const ColumnVector& inputGroupingKeys() const {
+    return inputGroupingKeys_;
+  }
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+
+ private:
+  const GroupingSets groupingSets_;
+  const ColumnVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const ColumnCP groupIdColumn_;
+  const ColumnVector inputGroupingKeys_;
+};
+
+using GroupIdCP = const GroupId*;
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -262,6 +262,44 @@ class ToTextVisitor : public RelationOpVisitor {
     visitDefault(op, context);
   }
 
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+
+    std::stringstream groupingSets;
+    groupingSets << "(";
+    for (size_t i = 0; i < op.groupingSets().size(); ++i) {
+      if (i > 0) {
+        groupingSets << ", ";
+      }
+      // Convert indices to output names for readability.
+      groupingSets << "[";
+      const auto& set = op.groupingSets()[i];
+      for (size_t j = 0; j < set.size(); ++j) {
+        if (j > 0) {
+          groupingSets << ", ";
+        }
+        groupingSets << op.groupingKeys()[set[j]]->name();
+      }
+      groupingSets << "]";
+    }
+    groupingSets << ")";
+
+    printHeader(op, myCtx, groupingSets.str());
+    printConstraints(op, myCtx);
+
+    const auto indentation = toIndentation(myCtx.indent + 2);
+    for (const auto* column : op.groupingKeys()) {
+      myCtx.out << indentation << column->name() << " := " << column->toString()
+                << std::endl;
+    }
+    myCtx.out << indentation
+              << "groupIdColumn: " << op.groupIdColumn()->toString()
+              << std::endl;
+
+    printInput(*op.input(), myCtx);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -488,6 +526,14 @@ class OnelineVisitor : public RelationOpVisitor {
   void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
       const override {
     visitDefault(op, context);
+  }
+
+  void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    myCtx.out << "groupid(";
+    op.input()->accept(*this, context);
+    myCtx.out << ")";
   }
 
  private:

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -87,6 +87,9 @@ class RelationOpVisitor {
 
   virtual void visit(const TopNRowNumber& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(const GroupId& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -158,7 +158,11 @@ void SubfieldTracker::markFieldAccessed(
     return;
   }
 
-  const auto& aggregate = agg.aggregateAt(ordinal - keys.size());
+  const auto* aggregate = aggregateForOrdinal(agg, ordinal);
+  if (!aggregate) {
+    return;
+  }
+
   for (const auto& aggregateInput : aggregate->inputs()) {
     mark(aggregateInput);
   }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -86,6 +86,76 @@ velox::ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   e.arg = ctx;
   return e;
 }
+
+// Detects overlap between grouping key columns and aggregate input columns.
+// When a key appears as a direct aggregate input (e.g., sum(a) GROUP BY
+// ROLLUP(a)), renames the key output with a $gid suffix so the Velox
+// GroupIdNode has distinct output column names. Returns the original
+// (pre-rename) key columns for use in ToVelox GroupingKeyInfo.
+//
+// Only checks direct column args, not leaf columns inside composite
+// expressions. For sum(a+b), the arg is a Call expression —
+// PrecomputeProjection converts it to a new column (e.g., dt1.__p6), so there's
+// no naming conflict in the GroupId output. Checking leaf columns would cause a
+// false rename that crashes downstream (ProjectNode references a$gid before
+// GroupId creates it).
+ColumnVector renameOverlappingGroupingKeys(
+    ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    ColumnVector& columns,
+    ColumnVector& intermediateColumns,
+    folly::F14FastMap<std::string, ExprCP>& renames,
+    DerivedTableCP currentDt) {
+  // Collect direct column references from aggregate inputs — args, ORDER BY
+  // keys, and filter conditions. These pass through the GroupId node as-is and
+  // would conflict with identically-named grouping key outputs.
+  PlanObjectSet aggregateInputColumns;
+  auto maybeAddColumn = [&](ExprCP expr) {
+    if (expr->is(PlanType::kColumnExpr)) {
+      aggregateInputColumns.add(expr);
+    }
+  };
+  for (const auto* aggregate : aggregates) {
+    for (const auto* arg : aggregate->args()) {
+      maybeAddColumn(arg);
+    }
+    for (const auto* key : aggregate->orderKeys()) {
+      maybeAddColumn(key);
+    }
+    if (aggregate->condition()) {
+      maybeAddColumn(aggregate->condition());
+    }
+  }
+
+  bool hasOverlap = false;
+  for (size_t i = 0; i < groupingKeys.size(); ++i) {
+    if (aggregateInputColumns.contains(groupingKeys[i])) {
+      hasOverlap = true;
+      break;
+    }
+  }
+
+  if (!hasOverlap) {
+    return {};
+  }
+
+  ColumnVector inputGroupingKeys(groupingKeys.size());
+  for (size_t i = 0; i < groupingKeys.size(); ++i) {
+    auto* keyColumn = columns[i];
+    inputGroupingKeys[i] = keyColumn;
+    if (aggregateInputColumns.contains(groupingKeys[i])) {
+      auto renamedName = toName(keyColumn->outputName() + "$gid");
+      auto* renamed =
+          make<Column>(renamedName, currentDt, keyColumn->value(), renamedName);
+      groupingKeys[i] = renamed;
+      columns[i] = renamed;
+      intermediateColumns[i] = renamed;
+      renames[keyColumn->name()] = renamed;
+    }
+  }
+  return inputGroupingKeys;
+}
+
 } // namespace
 
 ToGraph::ToGraph(
@@ -1496,6 +1566,28 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
   }
 
+  ColumnCP groupIdColumn = nullptr;
+  GroupingSets qgGroupingSets;
+  if (!agg.groupingSets().empty()) {
+    const auto ordinal = agg.groupingKeys().size() + agg.aggregates().size();
+    auto name = toName(agg.outputNames().at(ordinal));
+    auto groupIdType = agg.outputType()->childAt(ordinal);
+    Value groupIdValue(toType(groupIdType), agg.groupingSets().size());
+    groupIdValue.nullable = false;
+    groupIdValue.min = registerVariant(int64_t{0});
+    groupIdValue.max =
+        registerVariant(static_cast<int64_t>(agg.groupingSets().size() - 1));
+    auto* column = make<Column>(name, currentDt_, groupIdValue, name);
+    newRenames[name] = column;
+    groupIdColumn = column;
+    columns.push_back(column);
+
+    qgGroupingSets.reserve(agg.groupingSets().size());
+    for (const auto& set : agg.groupingSets()) {
+      qgGroupingSets.emplace_back(set.begin(), set.end());
+    }
+  }
+
   AggregateVector deduppedAggregates;
   folly::F14FastMap<AggregateDedupKey, ColumnCP, AggregateDedupHasher>
       uniqueAggregates;
@@ -1507,8 +1599,11 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       continue;
     }
 
-    const auto i = channel - agg.groupingKeys().size();
-    const auto& aggregate = agg.aggregates()[i];
+    const auto* aggregate = aggregateForOrdinal(agg, channel);
+    if (!aggregate) {
+      continue;
+    }
+
     ExprVector args = translateExprs(aggregate->inputs());
 
     FunctionSet funcs;
@@ -1598,13 +1693,27 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     }
   }
 
+  ColumnVector inputGroupingKeys;
+  if (!agg.groupingSets().empty()) {
+    inputGroupingKeys = renameOverlappingGroupingKeys(
+        deduppedGroupingKeys,
+        deduppedAggregates,
+        columns,
+        intermediateColumns,
+        newRenames,
+        currentDt_);
+  }
+
   renames_ = std::move(newRenames);
 
   return make<AggregationPlan>(
       std::move(deduppedGroupingKeys),
       std::move(deduppedAggregates),
       std::move(columns),
-      std::move(intermediateColumns));
+      std::move(intermediateColumns),
+      std::move(qgGroupingSets),
+      groupIdColumn,
+      std::move(inputGroupingKeys));
 }
 
 void ToGraph::addOrderBy(const lp::SortNode& order) {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -226,7 +226,10 @@ void ToVelox::filterUpdated(BaseTableCP table) {
 velox::core::PlanNodePtr ToVelox::addOutputRenames(
     velox::core::PlanNodePtr input,
     const std::vector<logical_plan::OutputNode::Entry>& outputNames) {
-  VELOX_CHECK_EQ(outputNames.size(), input->outputType()->size());
+  VELOX_CHECK_LE(
+      outputNames.size(),
+      input->outputType()->size(),
+      "OutputNode has more entries than input columns");
 
   // If the input is a ProjectNode that only does renames/reorders (all
   // expressions are FieldAccessTypedExpr on input columns), look through it
@@ -1379,6 +1382,14 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
 
   auto preGroupedKeys = toFieldRefs(op.preGroupedKeys);
 
+  std::vector<velox::vector_size_t> globalGroupingSets(
+      op.globalGroupingSets.begin(), op.globalGroupingSets.end());
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  if (op.groupIdColumn != nullptr) {
+    groupId = std::make_shared<velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), op.groupIdColumn->outputName());
+  }
+
   return std::make_shared<velox::core::AggregationNode>(
       nextId(),
       op.step,
@@ -1386,6 +1397,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       preGroupedKeys,
       aggregateNames,
       aggregates,
+      globalGroupingSets,
+      groupId,
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
       input);
@@ -1844,6 +1857,57 @@ velox::core::PlanNodePtr ToVelox::makeEnforceDistinct(
   return node;
 }
 
+velox::core::PlanNodePtr ToVelox::makeGroupId(
+    const GroupId& op,
+    runner::ExecutableFragment& fragment,
+    std::vector<runner::ExecutableFragment>& stages) {
+  auto input = makeFragment(op.input(), fragment, stages);
+
+  std::vector<velox::core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
+  groupingKeyInfos.reserve(op.groupingKeys().size());
+  VELOX_CHECK(
+      op.inputGroupingKeys().empty() ||
+          op.inputGroupingKeys().size() == op.groupingKeys().size(),
+      "inputGroupingKeys size mismatch: {} vs {}",
+      op.inputGroupingKeys().size(),
+      op.groupingKeys().size());
+  for (size_t i = 0; i < op.groupingKeys().size(); ++i) {
+    auto outputName = std::string(op.groupingKeys()[i]->name());
+    auto inputRef = op.inputGroupingKeys().empty()
+        ? toFieldRef(op.groupingKeys()[i])
+        : toFieldRef(op.inputGroupingKeys()[i]);
+    groupingKeyInfos.push_back({
+        .output = std::move(outputName),
+        .input = std::move(inputRef),
+    });
+  }
+
+  // Convert groupingSets from indices to output column names for Velox.
+  std::vector<std::vector<std::string>> groupingSets;
+  groupingSets.reserve(op.groupingSets().size());
+  for (const auto& set : op.groupingSets()) {
+    std::vector<std::string> names;
+    names.reserve(set.size());
+    for (auto keyIndex : set) {
+      names.emplace_back(groupingKeyInfos[keyIndex].output);
+    }
+    groupingSets.emplace_back(std::move(names));
+  }
+
+  auto aggregationInputs = toFieldRefs(op.aggregationInputs());
+
+  auto node = std::make_shared<velox::core::GroupIdNode>(
+      nextId(),
+      std::move(groupingSets),
+      std::move(groupingKeyInfos),
+      std::move(aggregationInputs),
+      op.groupIdColumn()->outputName(),
+      std::move(input));
+
+  makePredictionAndHistory(node->id(), &op);
+  return node;
+}
+
 void ToVelox::makePredictionAndHistory(
     const velox::core::PlanNodeId& id,
     const RelationOp* op) {
@@ -1897,6 +1961,8 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
       return makeRowNumber(*op->as<RowNumber>(), fragment, stages);
     case RelType::kTopNRowNumber:
       return makeTopNRowNumber(*op->as<TopNRowNumber>(), fragment, stages);
+    case RelType::kGroupId:
+      return makeGroupId(*op->as<GroupId>(), fragment, stages);
     default:
       VELOX_FAIL(
           "Unsupported RelationOp {}", static_cast<int32_t>(op->relType()));

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -280,6 +280,12 @@ class ToVelox {
       WindowFunctionCP windowFunc,
       ColumnCP outputColumn);
 
+  // Converts a GroupId operator to a Velox GroupIdNode.
+  velox::core::PlanNodePtr makeGroupId(
+      const GroupId& op,
+      runner::ExecutableFragment& fragment,
+      std::vector<runner::ExecutableFragment>& stages);
+
   // Makes a tree of PlanNode for a tree of
   // RelationOp. 'fragment' is the fragment that 'op'
   // belongs to. If op or children are repartitions then the

--- a/axiom/optimizer/tests/AggregationPlanTest.cpp
+++ b/axiom/optimizer/tests/AggregationPlanTest.cpp
@@ -551,5 +551,72 @@ TEST_F(AggregationPlanTest, unsupportedAggregationOverDistinct) {
   }
 }
 
+TEST_F(AggregationPlanTest, groupingSets) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a", "b"}, {"sum(c) as total"}, "gid")
+                         .build();
+
+  // Single-node plan shape.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    // ROLLUP(a, b) expands to grouping sets: {a, b}, {a}, {}.
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .singleAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .project({"a", "b", "total", "gid"})
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan shape.
+  {
+    auto plan = planVelox(logicalPlan);
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a", "b"}, {"a"}, {}}, {"c"}, "gid")
+            .partialAggregation({"a", "b", "gid"}, {"sum(c) as total"})
+            .shuffle()
+            .localPartition()
+            .finalAggregation()
+            .project({"a", "b", "total", "gid"})
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
+// Verifies that a grouping key can also be an aggregation input.
+// SELECT a, SUM(a) FROM t GROUP BY ROLLUP(a) requires 'a' to appear both as
+// a grouping key (subject to NULL-ing) and as an aggregation input (preserved).
+TEST_F(AggregationPlanTest, groupingSetsKeyIsAggInput) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), DOUBLE()}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"sum(a) as total"}, "gid")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // 'a' appears as both a grouping key and an aggregation input in GroupId.
+  // The key output is renamed to 'a$gid' to avoid ambiguity.
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .groupId({{"a$gid"}, {}}, {"a"}, "gid")
+                     .singleAggregation({"a$gid", "gid"}, {"sum(a) as total"})
+                     .project({"a$gid", "total", "gid"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1442,6 +1442,82 @@ class LocalPartitionTypeMatcher : public PlanMatcherImpl<LocalPartitionNode> {
   const std::vector<std::string> partitionKeys_;
 };
 
+// Matches a GroupIdNode and verifies grouping sets, aggregation inputs, and
+// group ID column name.
+class GroupIdMatcher : public PlanMatcherImpl<GroupIdNode> {
+ public:
+  explicit GroupIdMatcher(const std::shared_ptr<PlanMatcher>& matcher)
+      : PlanMatcherImpl<GroupIdNode>({matcher}) {}
+
+  GroupIdMatcher(
+      const std::shared_ptr<PlanMatcher>& matcher,
+      std::vector<std::vector<std::string>> groupingSets,
+      std::vector<std::string> aggregationInputs,
+      const std::string& groupIdColumnAlias)
+      : PlanMatcherImpl<GroupIdNode>({matcher}),
+        groupingSets_{std::move(groupingSets)},
+        aggregationInputs_{std::move(aggregationInputs)},
+        groupIdColumnAlias_{groupIdColumnAlias} {}
+
+  MatchResult matchDetails(
+      const GroupIdNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+
+    // Capture the groupId column name as a symbol so downstream matchers
+    // can reference it by alias.
+    std::unordered_map<std::string, std::string> newSymbols = symbols;
+    if (groupIdColumnAlias_.has_value()) {
+      newSymbols[groupIdColumnAlias_.value()] = plan.groupIdName();
+    }
+
+    if (groupingSets_.has_value()) {
+      const auto& planSets = plan.groupingSets();
+
+      EXPECT_EQ(planSets.size(), groupingSets_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < groupingSets_->size(); ++i) {
+        const auto& expectedSet = (*groupingSets_)[i];
+        const auto& actualSet = planSets[i];
+
+        EXPECT_EQ(actualSet.size(), expectedSet.size())
+            << "Grouping set " << i << " size mismatch";
+        AXIOM_TEST_RETURN_IF_FAILURE
+
+        for (auto j = 0; j < expectedSet.size(); ++j) {
+          EXPECT_EQ(actualSet[j], expectedSet[j])
+              << "Grouping set " << i << ", key " << j;
+          AXIOM_TEST_RETURN_IF_FAILURE
+        }
+      }
+    }
+
+    if (aggregationInputs_.has_value()) {
+      EXPECT_EQ(plan.aggregationInputs().size(), aggregationInputs_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < aggregationInputs_->size(); ++i) {
+        auto expected = parse::DuckSqlExpressionsParser().parseExpr(
+            (*aggregationInputs_)[i]);
+        if (!newSymbols.empty()) {
+          expected = rewriteInputNames(expected, newSymbols);
+        }
+        EXPECT_EQ(
+            plan.aggregationInputs()[i]->toString(), expected->toString());
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    return MatchResult::success(std::move(newSymbols));
+  }
+
+ private:
+  const std::optional<std::vector<std::vector<std::string>>> groupingSets_;
+  const std::optional<std::vector<std::string>> aggregationInputs_;
+  const std::optional<std::string> groupIdColumnAlias_;
+};
 #undef AXIOM_TEST_RETURN
 #undef AXIOM_TEST_RETURN_IF_FAILURE
 #undef AXIOM_TEST_RETURN_IF_FAILURE_VOID
@@ -1876,6 +1952,22 @@ PlanMatcherBuilder& PlanMatcherBuilder::topNRowNumber(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<TopNRowNumberMatcher>(
       matcher_, partitionKeys, sortingKeys, limit);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::groupId() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<GroupIdMatcher>(matcher_);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::groupId(
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregationInputs,
+    const std::string& groupIdColumnAlias) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<GroupIdMatcher>(
+      matcher_, groupingSets, aggregationInputs, groupIdColumnAlias);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -448,6 +448,23 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& sortingKeys,
       int32_t limit);
 
+  /// Matches any GroupId node regardless of grouping sets or inputs.
+  PlanMatcherBuilder& groupId();
+
+  /// Matches a GroupId node with the specified grouping sets, aggregation
+  /// inputs, and group ID column alias. Each grouping set is a list of output
+  /// column names for the active keys in that set.
+  /// @param groupingSets The expected grouping sets (each set is a list of
+  /// output column names).
+  /// @param aggregationInputs The expected aggregation input expressions.
+  /// @param groupIdColumnAlias Alias for the group ID output column. The actual
+  ///   column name is captured as a symbol so downstream matchers can reference
+  ///   it by this alias.
+  PlanMatcherBuilder& groupId(
+      const std::vector<std::vector<std::string>>& groupingSets,
+      const std::vector<std::string>& aggregationInputs,
+      const std::string& groupIdColumnAlias);
+
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.
   std::shared_ptr<PlanMatcher> build() {

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -390,5 +390,36 @@ TEST_F(RelationOpPrinterTest, maxDepth) {
   }
 }
 
+TEST_F(RelationOpPrinterTest, groupId) {
+  connector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), DOUBLE()}));
+
+  auto lines =
+      toLines("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(
+      lines,
+      testing::ElementsAre(
+          testing::StartsWith("Project"),
+          testing::StartsWith("    "), // dt1.a := t2.a
+          testing::StartsWith("    "), // dt1.b := t2.b
+          testing::StartsWith("    "), // dt1.total := dt1.total
+          testing::StartsWith("    "), // grouping set ID column
+          testing::StartsWith("  Aggregation"),
+          testing::HasSubstr("sum(t2.c)"),
+          testing::AllOf(
+              testing::StartsWith("    GroupId"),
+              testing::HasSubstr("[a, b], [a], []")),
+          testing::HasSubstr("a := "),
+          testing::HasSubstr("b := "),
+          testing::HasSubstr("groupIdColumn:"),
+          testing::StartsWith("      TableScan"),
+          testing::StartsWith("        table: t"),
+          testing::Eq("")));
+
+  auto oneline =
+      toOneline("SELECT a, b, sum(c) AS total FROM t GROUP BY ROLLUP(a, b)");
+  EXPECT_THAT(oneline, testing::HasSubstr("groupid("));
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -115,6 +115,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile("basic.sql");
   facebook::axiom::optimizer::test::registerQueryFile("join.sql");
   facebook::axiom::optimizer::test::registerQueryFile("window.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("groupingsets.sql");
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -1,0 +1,61 @@
+-- Table t(a BIGINT, b BIGINT) with 15 rows across 3 splits:
+--   a |   b
+--  ---+-----
+--   1 |  10
+--   2 |  20
+--   3 |  30
+--   1 |  40
+--   2 |  50
+--   3 |  60
+--   1 |  70
+--   2 |  80
+--   3 |  90
+--   1 | 100
+--   2 | 110
+--   3 | 120
+--   1 | 130
+--   2 | 140
+--   3 | 150
+--
+-- GROUPING SETS / ROLLUP / CUBE queries.
+
+-- Basic ROLLUP with SUM.
+SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- CUBE with SUM (same as ROLLUP for single key).
+SELECT a, sum(b) AS s FROM t GROUP BY CUBE(a)
+----
+-- Explicit GROUPING SETS.
+SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
+----
+-- ROLLUP with multiple keys.
+SELECT a, b, count(*) AS s FROM t GROUP BY ROLLUP(a, b)
+----
+-- Multiple aggregates with ROLLUP.
+SELECT a, sum(b) AS s, count(b) AS c, min(b) AS mn, max(b) AS mx FROM t GROUP BY ROLLUP(a)
+----
+-- Explicit GROUPING SETS with no global (empty) set.
+SELECT a, b, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), (b))
+----
+-- Grouping key is also an aggregation input.
+SELECT a, sum(a) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- Literal aggregate argument.
+SELECT a, count(1) AS c FROM t GROUP BY ROLLUP(a)
+----
+-- Composite aggregate argument with grouping key overlap.
+SELECT a, sum(a + b) AS s FROM t GROUP BY ROLLUP(a)
+----
+-- Duplicate and reordered grouping sets are preserved.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- Duplicate keys within a single grouping set are deduplicated.
+SELECT a, b, count(*) AS c FROM t GROUP BY GROUPING SETS ((a, a), (b, b), (a, b))
+----
+-- GROUP BY DISTINCT removes duplicate grouping sets after expansion.
+-- duckdb: SELECT a, b, count(*) AS c FROM t GROUP BY a, b
+SELECT a, b, count(*) AS c FROM t GROUP BY DISTINCT GROUPING SETS ((a, b), (b, a), (a, b))
+----
+-- GROUP BY DISTINCT with ROLLUP deduplicates expanded sets.
+-- duckdb: SELECT a, sum(b) AS s FROM t GROUP BY ROLLUP(a)
+SELECT a, sum(b) AS s FROM t GROUP BY DISTINCT ROLLUP(a), ROLLUP(a)

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/GroupByPlanner.h"
+#include <set>
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "folly/container/F14Set.h"
 #include "velox/common/base/BitUtil.h"
@@ -307,25 +308,51 @@ std::vector<std::vector<lp::ExprApi>> crossProductGroupingSets(
   return combined;
 }
 
+// Removes duplicate grouping sets from 'groupingSetsIndices'. Two sets are
+// duplicates if they contain the same key indices (order-insensitive).
+// Matches Presto's GROUP BY DISTINCT semantics.
+void deduplicateGroupingSets(
+    std::vector<std::vector<int32_t>>& groupingSetsIndices) {
+  std::vector<std::vector<int32_t>> unique;
+  unique.reserve(groupingSetsIndices.size());
+
+  // Sorted copies used as keys for order-insensitive dedup.
+  std::set<std::vector<int32_t>> seen;
+
+  for (auto& indices : groupingSetsIndices) {
+    auto sorted = indices;
+    std::sort(sorted.begin(), sorted.end());
+
+    if (seen.insert(std::move(sorted)).second) {
+      unique.push_back(std::move(indices));
+    }
+  }
+  groupingSetsIndices = std::move(unique);
+}
+
 } // namespace
 
 void GroupByPlanner::plan(
     const std::vector<SelectItemPtr>& selectItems,
     const std::vector<GroupingElementPtr>& groupingElements,
     const ExpressionPtr& having,
-    const OrderByPtr& orderBy) && {
+    const OrderByPtr& orderBy,
+    bool distinct) && {
   // Expand ROLLUP, CUBE, GROUPING SETS into a list of grouping sets, then
   // extract deduplicated grouping keys and per-set index vectors.
   // Populates: groupingSets_, groupingKeys_, groupingSetsIndices_.
   groupingSets_ = expandGroupingSets(groupingElements, selectItems);
   deduplicateGroupingKeys();
+  if (distinct) {
+    deduplicateGroupingSets(groupingSetsIndices_);
+  }
 
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
   // function calls, then add the Aggregate plan node.
   // Populates: aggregates_, aggregateOptionsMap_, projections_, filter_,
   //   sortingKeys_, outputNames_.
   collectAggregates(selectItems, having, orderBy);
-  addAggregate(hasGroupingSets(groupingElements));
+  addAggregate(groupingSetsIndices_.size() > 1);
 
   // Rewrite filter_, projections_, and sortingKeys_ to reference the
   // aggregate output columns instead of the original input expressions.
@@ -378,7 +405,8 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     return false;
   }
 
-  std::move(*this).plan(selectItems, {}, having, /*orderBy=*/nullptr);
+  std::move(*this).plan(
+      selectItems, {}, having, /*orderBy=*/nullptr, /*distinct=*/false);
   return true;
 }
 
@@ -446,7 +474,12 @@ void GroupByPlanner::deduplicateGroupingKeys() {
       if (inserted) {
         groupingKeys_.push_back(expr);
       }
-      indices.push_back(it->second);
+      // Deduplicate keys within a single grouping set: GROUP BY (a, a)
+      // collapses to (a). Matches Presto behavior.
+      if (std::find(indices.begin(), indices.end(), it->second) ==
+          indices.end()) {
+        indices.push_back(it->second);
+      }
     }
     groupingSetsIndices_.push_back(std::move(indices));
   }

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -50,11 +50,14 @@ class GroupByPlanner {
       : builder_(builder), exprPlanner_(exprPlanner) {}
 
   /// Plans a GROUP BY clause with optional HAVING and ORDER BY.
+  /// When 'distinct' is true (GROUP BY DISTINCT), duplicate grouping sets
+  /// are removed after expansion.
   void plan(
       const std::vector<SelectItemPtr>& selectItems,
       const std::vector<GroupingElementPtr>& groupingElements,
       const ExpressionPtr& having,
-      const OrderByPtr& orderBy) &&;
+      const OrderByPtr& orderBy,
+      bool distinct) &&;
 
   /// Detects implicit global aggregation (e.g. SELECT count(*) FROM t)
   /// and plans it. Returns true if aggregation was added.

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -814,11 +814,12 @@ class RelationPlanner : public AstVisitor {
     const bool distinct = node->select()->isDistinct();
 
     if (auto groupBy = node->groupBy()) {
-      VELOX_USER_CHECK(
-          !groupBy->isDistinct(),
-          "GROUP BY with DISTINCT is not supported yet");
       GroupByPlanner{builder_, exprPlanner_}.plan(
-          selectItems, groupBy->groupingElements(), node->having(), orderBy);
+          selectItems,
+          groupBy->groupingElements(),
+          node->having(),
+          orderBy,
+          groupBy->isDistinct());
 
       if (distinct) {
         builder_->distinct();

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -83,7 +83,7 @@ TEST_F(AggregationParserTest, groupingSets) {
       "SELECT n_regionkey, count(1) FROM nation "
       "GROUP BY GROUPING SETS (n_regionkey, ())",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
@@ -92,7 +92,7 @@ TEST_F(AggregationParserTest, groupingSets) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -105,7 +105,7 @@ TEST_F(AggregationParserTest, groupingSets) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY GROUPING SETS ((1, 2), (1))",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -125,7 +125,7 @@ TEST_F(AggregationParserTest, rollup) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY ROLLUP(n_regionkey, n_name)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -137,7 +137,7 @@ TEST_F(AggregationParserTest, rollup) {
       "SELECT n_regionkey, count(1) FROM nation "
       "GROUP BY ROLLUP(n_regionkey)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
@@ -156,7 +156,7 @@ TEST_F(AggregationParserTest, cube) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY CUBE(n_regionkey, n_name)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -169,7 +169,7 @@ TEST_F(AggregationParserTest, cube) {
       "SELECT n_regionkey, count(1) FROM nation "
       "GROUP BY CUBE(n_regionkey)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(testing::ElementsAre(0), testing::IsEmpty()));
@@ -188,7 +188,7 @@ TEST_F(AggregationParserTest, mixedGroupByWithRollup) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY n_regionkey, ROLLUP(n_name)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -208,7 +208,7 @@ TEST_F(AggregationParserTest, groupingSetsOrdinalCaching) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY GROUPING SETS ((1), (1, 2), (2))",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -220,7 +220,7 @@ TEST_F(AggregationParserTest, groupingSetsOrdinalCaching) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY ROLLUP(1, 2)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -232,7 +232,7 @@ TEST_F(AggregationParserTest, groupingSetsOrdinalCaching) {
       "SELECT n_regionkey, n_name, count(1) FROM nation "
       "GROUP BY CUBE(1, 2)",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -255,7 +255,7 @@ TEST_F(AggregationParserTest, groupingSetsSubqueryOrdinal) {
       "SELECT (SELECT 1), n_name, count(1) FROM nation "
       "GROUP BY GROUPING SETS ((1), (1, 2))",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   EXPECT_THAT(
       agg->groupingSets(),
       testing::ElementsAre(
@@ -416,7 +416,7 @@ TEST_F(AggregationParserTest, aggregateOptions) {
           .output();
 
   testSelect("SELECT array_agg(distinct n_regionkey) FROM nation", matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   ASSERT_EQ(1, agg->aggregates().size());
   ASSERT_TRUE(agg->aggregateAt(0)->isDistinct());
   ASSERT_TRUE(agg->aggregateAt(0)->filter() == nullptr);
@@ -425,7 +425,7 @@ TEST_F(AggregationParserTest, aggregateOptions) {
   testSelect(
       "SELECT array_agg(n_nationkey ORDER BY n_regionkey) FROM nation",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   ASSERT_EQ(1, agg->aggregates().size());
   ASSERT_FALSE(agg->aggregateAt(0)->isDistinct());
   ASSERT_TRUE(agg->aggregateAt(0)->filter() == nullptr);
@@ -434,7 +434,7 @@ TEST_F(AggregationParserTest, aggregateOptions) {
   testSelect(
       "SELECT array_agg(n_nationkey) FILTER (WHERE n_regionkey = 1) FROM nation",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   ASSERT_EQ(1, agg->aggregates().size());
   ASSERT_FALSE(agg->aggregateAt(0)->isDistinct());
   ASSERT_FALSE(agg->aggregateAt(0)->filter() == nullptr);
@@ -443,7 +443,7 @@ TEST_F(AggregationParserTest, aggregateOptions) {
   testSelect(
       "SELECT array_agg(distinct n_regionkey) FILTER (WHERE n_name like 'A%') FROM nation",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   ASSERT_EQ(1, agg->aggregates().size());
   ASSERT_TRUE(agg->aggregateAt(0)->isDistinct());
   ASSERT_FALSE(agg->aggregateAt(0)->filter() == nullptr);
@@ -452,7 +452,7 @@ TEST_F(AggregationParserTest, aggregateOptions) {
   testSelect(
       "SELECT array_agg(n_regionkey ORDER BY n_name) FILTER (WHERE n_name like 'A%') FROM nation",
       matcher);
-  ASSERT_TRUE(agg != nullptr);
+  ASSERT_NE(agg, nullptr);
   ASSERT_EQ(1, agg->aggregates().size());
   ASSERT_FALSE(agg->aggregateAt(0)->isDistinct());
   ASSERT_FALSE(agg->aggregateAt(0)->filter() == nullptr);


### PR DESCRIPTION
Summary: Rename `exprs` to `aggExprs` in PlanBuilder grouping-sets path for clarity, and use pre-computed `numKeys` instead of `groupingKeys.size()`. Replace `ASSERT_TRUE(agg != nullptr)` with `ASSERT_NE(agg, nullptr)` across AggregationParserTest for better failure diagnostics.

Differential Revision: D95964509


