### PR TITLE
fix(cli): Remove wrapper encoding debug info from query output (#1033)

### DIFF
--- a/axiom/cli/ResultPrinter.cpp
+++ b/axiom/cli/ResultPrinter.cpp
@@ -17,6 +17,7 @@
 #include "axiom/cli/ResultPrinter.h"
 #include <iomanip>
 #include <iostream>
+#include "velox/vector/DecodedVector.h"
 
 using namespace facebook::velox;
 
@@ -114,14 +115,19 @@ int32_t printResults(
     printFooter();
   };
 
+  std::vector<DecodedVector> decodedColumns(numColumns);
   for (const auto& result : results) {
+    for (auto column = 0; column < numColumns; ++column) {
+      decodedColumns[column].decode(*result->childAt(column));
+    }
+
     for (auto row = 0; row < result->size(); ++row) {
       data.emplace_back();
 
       auto& rowData = data.back();
       rowData.resize(numColumns);
       for (auto column = 0; column < numColumns; ++column) {
-        rowData[column] = result->childAt(column)->toString(row);
+        rowData[column] = decodedColumns[column].toString(row);
         widths[column] = std::max(widths[column], rowData[column].size());
       }
 

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -136,3 +136,16 @@ x | y
 $ $CLI --query "USE blah.default" 2>&1 | grep Reason
 Reason: Catalog does not exist: blah
 ```
+
+## Cleanly log dictionary wrapped result vectors (window functions produce encoded vectors)
+
+```scrut
+$ $CLI --query "SELECT * FROM (SELECT x, count(*) OVER () as cnt, row_number() OVER () AS rn FROM unnest(array[1,2,3]) AS t(x)) WHERE rn <= 2" 2>/dev/null
+--+-----+---
+x | cnt | rn
+--+-----+---
+1 |   3 |  1
+2 |   3 |  2
+(2 rows in 1 batches)
+
+```


### PR DESCRIPTION
Summary:

Window function results are typically wrapped using DictionaryVector, whose toString outputs debug information like `[0->0] 3` instead of just `3`. This can make deciphering output information difficult for the reader.

By using DecodedVector and decoding each column once per batch, we can solve this verbose wrapping information and homogenize the output.

Resolves: https://github.com/facebookincubator/axiom/issues/972

Differential Revision: D95984334


