### PR TITLE
fix(parser): Preserve windowSpec in GroupByPlanner expression rewriting (#1034)

### DIFF
--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -55,8 +55,18 @@ SELECT a, b, sum(b) OVER (PARTITION BY a ORDER BY b) AS s, count(*) OVER (PARTIT
 -- Multiple window functions with different specifications.
 SELECT a, b, sum(b) OVER (PARTITION BY a) AS s, count(*) OVER () AS c FROM t
 ----
--- Window function with GROUP BY.
+-- Window function with GROUP BY (via subquery).
 SELECT a, sum_b, count(*) OVER () AS cnt FROM (SELECT a, sum(b) AS sum_b FROM t GROUP BY 1)
+----
+-- Window function with GROUP BY in same SELECT.
+SELECT a, sum(b), row_number() OVER (ORDER BY a) FROM t GROUP BY a
+----
+-- Window function with PARTITION BY and GROUP BY.
+SELECT b, sum(a), row_number() OVER (PARTITION BY b ORDER BY a) FROM t GROUP BY b, a
+----
+-- Window function in ORDER BY with GROUP BY.
+-- ordered
+SELECT a, sum(b) FROM t GROUP BY a ORDER BY row_number() OVER (ORDER BY a)
 ----
 -- Subquery with window function and outer filter.
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn = 1

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -583,15 +583,22 @@ void GroupByPlanner::rewritePostAggregateExprs() {
   for (auto& item : projections_) {
     auto newExpr = replaceInputs(
         item.expr(), keyInputs, aggregateInputs, aggregateOptionsMap_);
-    item = lp::ExprApi(newExpr, item.name());
+    const auto windowSpec = item.windowSpec();
+    item = lp::ExprApi(std::move(newExpr), item.name());
+    if (windowSpec) {
+      item = item.over(*windowSpec);
+    }
   }
 
   // Replace sorting key expressions too.
   for (auto& key : sortingKeys_) {
     auto newExpr = replaceInputs(
         key.expr.expr(), keyInputs, aggregateInputs, aggregateOptionsMap_);
-    key = lp::SortKey(
-        lp::ExprApi(newExpr, key.expr.name()), key.ascending, key.nullsFirst);
+    auto newKeyExpr = lp::ExprApi(std::move(newExpr), key.expr.name());
+    if (key.expr.windowSpec()) {
+      newKeyExpr = newKeyExpr.over(*key.expr.windowSpec());
+    }
+    key = lp::SortKey(newKeyExpr, key.ascending, key.nullsFirst);
   }
 }
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -527,5 +527,50 @@ TEST_F(AggregationParserTest, aggregateDeduplication) {
           .output());
 }
 
+TEST_F(AggregationParserTest, groupByWithWindowFunction) {
+  connector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  // Window function in SELECT with GROUP BY.
+  testSelect(
+      "SELECT b, sum(a), row_number() OVER (ORDER BY b) FROM t GROUP BY b",
+      matchScan("t")
+          .aggregate({"b"}, {"sum(a)"})
+          .project({
+              "b",
+              "sum",
+              "row_number() OVER (ORDER BY b ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .output());
+
+  // Window function with PARTITION BY and GROUP BY.
+  testSelect(
+      "SELECT b, sum(a), row_number() OVER (PARTITION BY b ORDER BY b) FROM t GROUP BY b",
+      matchScan("t")
+          .aggregate({"b"}, {"sum(a)"})
+          .project({
+              "b",
+              "sum",
+              "row_number() OVER (PARTITION BY b ORDER BY b ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .output());
+
+  // Window function in ORDER BY with GROUP BY.
+  testSelect(
+      "SELECT a, sum(b) FROM t GROUP BY a ORDER BY row_number() OVER (ORDER BY a)",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b)"})
+          .project()
+          .sort()
+          .project()
+          .output());
+
+  // TODO: Aggregate references inside window specs are not yet rewritten to
+  // post-aggregate output names. This valid Presto SQL should work but doesn't.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT b, sum(a), row_number() OVER (ORDER BY sum(a)) FROM t GROUP BY b"),
+      "Cannot resolve column: a");
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

**Summary:**                                                                                                                                                                         
rewritePostAggregateExprs() rebuilds ExprApi objects after replacing aggregate sub-expressions with column references, but the ExprApi constructor drops windowSpec_. This causes window functions combined with GROUP BY to fail with "Scalar function signature is not supported: row_number()".

**Fix** 
Add ExprApi::withExpr() to replace the underlying expression while preserving alias, windowSpec, and unnestedAliases. Use it in rewritePostAggregateExprs() for both projections and sorting keys.


**Known limitation:** 
Aggregate references in window spec clauses (e.g., `row_number() OVER (ORDER BY sum(a))` with `GROUP BY`) aren’t supported. The planner doesn’t resolve aggregate expressions in window `PARTITION BY`/`ORDER BY` to their post-aggregate output names.

Reviewed By: kagamiori

Differential Revision: D96008935


