### PR TITLE
refactor: Move MultiFragmentPlan to optimizer

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(
 target_link_libraries(
   axiom_cli
   axiom_runner_local_runner
-  axiom_runner_multifragment_plan
+  axiom_optimizer_multifragment_plan
   axiom_optimizer
   axiom_hive_connector_metadata
   axiom_tpch_connector_metadata

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -428,7 +428,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver
 
 ) {
-  runner::MultiFragmentPlan::Options opts;
+  optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
   auto allocator =

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -16,6 +16,10 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
+add_library(axiom_optimizer_multifragment_plan MultiFragmentPlan.cpp)
+
+target_link_libraries(axiom_optimizer_multifragment_plan velox_common_base velox_memory velox_core)
+
 add_library(
   axiom_optimizer
   BitSet.cpp
@@ -52,6 +56,6 @@ target_link_libraries(
   axiom_common
   axiom_connectors
   axiom_logical_plan
-  axiom_runner_multifragment_plan
+  axiom_optimizer_multifragment_plan
   velox_connector
 )

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 
-namespace facebook::axiom::runner {
+namespace facebook::axiom::optimizer {
 
 std::string MultiFragmentPlan::toString(
     bool detailed,
@@ -99,4 +99,4 @@ std::string MultiFragmentPlan::toSummaryString(
   return out.str();
 }
 
-} // namespace facebook::axiom::runner
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -20,7 +20,7 @@
 #include "velox/core/PlanFragment.h"
 #include "velox/vector/ComplexVector.h"
 
-namespace facebook::axiom::runner {
+namespace facebook::axiom::optimizer {
 
 /// Describes an exchange source for an ExchangeNode a non-leaf stage.
 struct InputStage {
@@ -185,4 +185,4 @@ class MultiFragmentPlan {
 
 using MultiFragmentPlanPtr = std::shared_ptr<const MultiFragmentPlan>;
 
-} // namespace facebook::axiom::runner
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -41,7 +41,7 @@ Optimization::Optimization(
     std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
     velox::core::ExpressionEvaluator& evaluator,
     OptimizerOptions options,
-    runner::MultiFragmentPlan::Options runnerOptions)
+    MultiFragmentPlan::Options runnerOptions)
     : session_{std::move(session)},
       options_(std::move(options)),
       runnerOptions_(std::move(runnerOptions)),
@@ -253,7 +253,7 @@ PlanAndStats Optimization::toVeloxPlan(
     const logical_plan::LogicalPlanNode& logicalPlan,
     velox::memory::MemoryPool& pool,
     OptimizerOptions options,
-    runner::MultiFragmentPlan::Options runnerOptions) {
+    MultiFragmentPlan::Options runnerOptions) {
   auto allocator = std::make_unique<velox::HashStringAllocator>(&pool);
   auto context = std::make_unique<QueryGraphContext>(*allocator);
   queryCtx() = context.get();

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -18,11 +18,11 @@
 #include "axiom/common/Session.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/Cost.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/ToGraph.h"
 #include "axiom/optimizer/ToVelox.h"
-#include "axiom/runner/MultiFragmentPlan.h"
 #include "velox/core/QueryCtx.h"
 
 namespace facebook::axiom::optimizer {
@@ -41,14 +41,14 @@ class Optimization {
       std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
       velox::core::ExpressionEvaluator& evaluator,
       OptimizerOptions options = {},
-      runner::MultiFragmentPlan::Options runnerOptions = {});
+      MultiFragmentPlan::Options runnerOptions = {});
 
   /// Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
       const logical_plan::LogicalPlanNode& logicalPlan,
       velox::memory::MemoryPool& pool,
       OptimizerOptions options = {},
-      runner::MultiFragmentPlan::Options runnerOptions = {});
+      MultiFragmentPlan::Options runnerOptions = {});
 
   Optimization(const Optimization& other) = delete;
   Optimization& operator=(const Optimization& other) = delete;
@@ -148,7 +148,7 @@ class Optimization {
     return options_;
   }
 
-  const runner::MultiFragmentPlan::Options& runnerOptions() const {
+  const MultiFragmentPlan::Options& runnerOptions() const {
     return runnerOptions_;
   }
 
@@ -347,7 +347,7 @@ class Optimization {
 
   const OptimizerOptions options_;
 
-  const runner::MultiFragmentPlan::Options runnerOptions_;
+  const MultiFragmentPlan::Options runnerOptions_;
 
   const bool isSingleWorker_;
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -46,7 +46,7 @@ std::string PlanAndStats::toString() const {
 
 ToVelox::ToVelox(
     SessionPtr session,
-    const runner::MultiFragmentPlan::Options& options,
+    const MultiFragmentPlan::Options& options,
     const OptimizerOptions& optimizerOptions)
     : session_{std::move(session)},
       options_{options},
@@ -297,7 +297,7 @@ velox::core::PlanNodePtr ToVelox::addOutputRenames(
 
 PlanAndStats ToVelox::toVeloxPlan(
     RelationOpPtr plan,
-    const runner::MultiFragmentPlan::Options& options,
+    const MultiFragmentPlan::Options& options,
     const std::vector<logical_plan::OutputNode::Entry>& outputNames) {
   options_ = options;
 
@@ -308,8 +308,8 @@ PlanAndStats ToVelox::toVeloxPlan(
     plan = addGather(plan);
   }
 
-  runner::ExecutableFragment top = newFragment();
-  std::vector<runner::ExecutableFragment> stages;
+  ExecutableFragment top = newFragment();
+  std::vector<ExecutableFragment> stages;
   top.fragment.planNode = makeFragment(plan, top, stages);
   stages.push_back(std::move(top));
 
@@ -334,7 +334,7 @@ PlanAndStats ToVelox::toVeloxPlan(
   VELOX_DCHECK(!finishWrite_);
 
   return PlanAndStats{
-      std::make_shared<runner::MultiFragmentPlan>(std::move(stages), options),
+      std::make_shared<MultiFragmentPlan>(std::move(stages), options),
       std::move(nodeHistory_),
       std::move(prediction_),
       std::move(finishWrite)};
@@ -633,8 +633,8 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
   }
 }
 
-runner::ExecutableFragment ToVelox::newFragment() {
-  runner::ExecutableFragment fragment;
+ExecutableFragment ToVelox::newFragment() {
+  ExecutableFragment fragment;
   fragment.width = options_.numWorkers;
   fragment.taskPrefix = fmt::format("stage{}", ++stageCounter_);
 
@@ -757,8 +757,8 @@ std::vector<velox::core::FieldAccessTypedExprPtr> ToVelox::toFieldRefs(
 
 velox::core::PlanNodePtr ToVelox::makeOrderBy(
     const OrderBy& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto sortOrder = toSortOrders(op.distribution().orderTypes());
   auto keys = toFieldRefs(op.distribution().orderKeys());
 
@@ -838,8 +838,8 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
 
 velox::core::PlanNodePtr ToVelox::makeOffset(
     const Limit& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   if (isSingle_) {
     auto input = makeFragment(op.input(), fragment, stages);
     return addFinalLimit(nextId(), op.offset, op.limit, input);
@@ -870,8 +870,8 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
 
 velox::core::PlanNodePtr ToVelox::makeLimit(
     const Limit& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   if (op.isNoLimit()) {
     return makeOffset(op, fragment, stages);
   }
@@ -1129,8 +1129,8 @@ velox::core::TypedExprPtr toAndWithAliases(
 
 velox::core::PlanNodePtr ToVelox::makeScan(
     const TableScan& scan,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   columnAlteredTypes_.clear();
 
   const bool isSubfieldPushdown = hasSubfieldPushdown(scan);
@@ -1199,8 +1199,8 @@ velox::core::PlanNodePtr ToVelox::makeScan(
 
 velox::core::PlanNodePtr ToVelox::makeFilter(
     const Filter& filter,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto filterNode = std::make_shared<velox::core::FilterNode>(
       nextId(),
       toAnd(filter.exprs()),
@@ -1211,8 +1211,8 @@ velox::core::PlanNodePtr ToVelox::makeFilter(
 
 velox::core::PlanNodePtr ToVelox::makeProject(
     const Project& project,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(project.input(), fragment, stages);
   if (optimizerOptions_.parallelProjectWidth > 1) {
     auto result = maybeParallelProject(&project, input);
@@ -1243,8 +1243,8 @@ velox::core::PlanNodePtr ToVelox::makeProject(
 
 velox::core::PlanNodePtr ToVelox::makeJoin(
     const Join& join,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto left = makeFragment(join.input(), fragment, stages);
   auto right = makeFragment(join.right, fragment, stages);
   if (join.method == JoinMethod::kCross) {
@@ -1291,8 +1291,8 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
 
 velox::core::PlanNodePtr ToVelox::makeUnnest(
     const Unnest& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
 
   std::vector<std::string> unnestNames;
@@ -1315,8 +1315,8 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
 
 velox::core::PlanNodePtr ToVelox::makeAggregation(
     const Aggregation& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
 
   const bool isRawInput =
@@ -1473,8 +1473,8 @@ velox::core::PlanNodePtr ToVelox::maybeTrimColumns(
 velox::core::PlanNodePtr ToVelox::makeWindowInput(
     const RelationOp& op,
     const ExprVector& partitionKeys,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input =
       maybeTrimColumns(makeFragment(op.input(), fragment, stages), op.input());
   if (options_.numDrivers > 1) {
@@ -1485,8 +1485,8 @@ velox::core::PlanNodePtr ToVelox::makeWindowInput(
 
 velox::core::PlanNodePtr ToVelox::makeWindow(
     const Window& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeWindowInput(op, op.partitionKeys, fragment, stages);
 
   auto partitionKeys = toFieldRefs(op.partitionKeys);
@@ -1519,8 +1519,8 @@ velox::core::PlanNodePtr ToVelox::makeWindow(
 
 velox::core::PlanNodePtr ToVelox::makeRowNumber(
     const RowNumber& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeWindowInput(op, op.partitionKeys, fragment, stages);
 
   return std::make_shared<velox::core::RowNumberNode>(
@@ -1533,8 +1533,8 @@ velox::core::PlanNodePtr ToVelox::makeRowNumber(
 
 velox::core::PlanNodePtr ToVelox::makeTopNRowNumber(
     const TopNRowNumber& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeWindowInput(op, op.partitionKeys, fragment, stages);
 
   return std::make_shared<velox::core::TopNRowNumberNode>(
@@ -1550,8 +1550,8 @@ velox::core::PlanNodePtr ToVelox::makeTopNRowNumber(
 
 velox::core::PlanNodePtr ToVelox::makeRepartition(
     const Repartition& repartition,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages,
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages,
     std::shared_ptr<velox::core::ExchangeNode>& exchange) {
   auto source = newFragment();
   auto sourcePlan = makeFragment(repartition.input(), source, stages);
@@ -1612,8 +1612,8 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
 
 velox::core::PlanNodePtr ToVelox::makeUnionAll(
     const UnionAll& unionAll,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   // If no inputs have a repartition, this is a local exchange. If
   // some have repartition and more than one have no repartition,
   // this is a local exchange with a remote exchaneg as input. All the
@@ -1646,7 +1646,7 @@ velox::core::PlanNodePtr ToVelox::makeUnionAll(
 
 velox::core::PlanNodePtr ToVelox::makeValues(
     const Values& values,
-    runner::ExecutableFragment& fragment) {
+    ExecutableFragment& fragment) {
   fragment.width = 1;
   const auto& newColumns = values.columns();
   const auto newType = makeOutputType(newColumns);
@@ -1730,8 +1730,8 @@ velox::core::PlanNodePtr ToVelox::makeValues(
 
 velox::core::PlanNodePtr ToVelox::makeWrite(
     const TableWrite& tableWrite,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(tableWrite.input(), fragment, stages);
   const auto& write = *tableWrite.write;
   const auto& table = write.table();
@@ -1800,8 +1800,8 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
 
 velox::core::PlanNodePtr ToVelox::makeEnforceSingleRow(
     const EnforceSingleRow& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
   auto node = std::make_shared<velox::core::EnforceSingleRowNode>(
       nextId(), std::move(input));
@@ -1811,8 +1811,8 @@ velox::core::PlanNodePtr ToVelox::makeEnforceSingleRow(
 
 velox::core::PlanNodePtr ToVelox::makeAssignUniqueId(
     const AssignUniqueId& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
 
   // TODO Remove taskUniqueId from AssignUniqueIdNode:
@@ -1829,8 +1829,8 @@ velox::core::PlanNodePtr ToVelox::makeAssignUniqueId(
 
 velox::core::PlanNodePtr ToVelox::makeEnforceDistinct(
     const EnforceDistinct& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
 
   auto node = std::make_shared<velox::core::EnforceDistinctNode>(
@@ -1853,8 +1853,8 @@ void ToVelox::makePredictionAndHistory(
 
 velox::core::PlanNodePtr ToVelox::makeFragment(
     const RelationOpPtr& op,
-    runner::ExecutableFragment& fragment,
-    std::vector<runner::ExecutableFragment>& stages) {
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
   switch (op->relType()) {
     case RelType::kProject:
       return makeProject(*op->as<Project>(), fragment, stages);
@@ -1910,7 +1910,7 @@ extern std::string veloxToString(const velox::core::PlanNode* plan) {
   return plan->toString(true, true);
 }
 
-extern std::string planString(const runner::MultiFragmentPlan* plan) {
+extern std::string planString(const MultiFragmentPlan* plan) {
   return plan->toString(true);
 }
 

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -18,10 +18,10 @@
 
 #include "axiom/common/Session.h"
 #include "axiom/optimizer/Cost.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/RelationOp.h"
-#include "axiom/runner/MultiFragmentPlan.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -36,10 +36,10 @@ using NodePredictionMap =
 /// Plan and specification for recording execution history amd planning ttime
 /// predictions.
 struct PlanAndStats {
-  runner::MultiFragmentPlanPtr plan;
+  MultiFragmentPlanPtr plan;
   NodeHistoryMap history;
   NodePredictionMap prediction;
-  runner::FinishWrite finishWrite;
+  FinishWrite finishWrite;
 
   /// Returns a string representation of the plan annotated with estimates from
   /// 'prediction'.
@@ -50,7 +50,7 @@ class ToVelox {
  public:
   ToVelox(
       SessionPtr session,
-      const runner::MultiFragmentPlan::Options& options,
+      const MultiFragmentPlan::Options& options,
       const OptimizerOptions& optimizerOptions);
 
   /// Converts physical plan (a tree of RelationOp) to an executable
@@ -58,7 +58,7 @@ class ToVelox {
   /// final projection to rename or reorder output columns.
   PlanAndStats toVeloxPlan(
       RelationOpPtr plan,
-      const runner::MultiFragmentPlan::Options& options,
+      const MultiFragmentPlan::Options& options,
       const std::vector<logical_plan::OutputNode::Entry>& outputNames = {});
 
   /// Per-leaf-table data produced by filterUpdated().
@@ -155,108 +155,108 @@ class ToVelox {
   // Makes a Velox UnnestNode for a RelationOp.
   velox::core::PlanNodePtr makeUnnest(
       const Unnest& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes a Velox AggregationNode for a RelationOp.
   velox::core::PlanNodePtr makeAggregation(
       const Aggregation& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes partial + final order by fragments for order by with and without
   // limit.
   velox::core::PlanNodePtr makeOrderBy(
       const OrderBy& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes partial + final limit fragments.
   velox::core::PlanNodePtr makeLimit(
       const Limit& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // @pre op.sNoLimit() is true.
   velox::core::PlanNodePtr makeOffset(
       const Limit& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeScan(
       const TableScan& scan,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeFilter(
       const Filter& filter,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeProject(
       const Project& project,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeJoin(
       const Join& join,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeRepartition(
       const Repartition& repartition,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages,
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages,
       std::shared_ptr<velox::core::ExchangeNode>& exchange);
 
   // Makes a union all with a mix of remote and local inputs. Combines all
   // remote inputs into one ExchangeNode.
   velox::core::PlanNodePtr makeUnionAll(
       const UnionAll& unionAll,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeValues(
       const Values& values,
-      runner::ExecutableFragment& fragment);
+      ExecutableFragment& fragment);
 
   velox::core::PlanNodePtr makeWrite(
       const TableWrite& write,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeEnforceSingleRow(
       const EnforceSingleRow& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeAssignUniqueId(
       const AssignUniqueId& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   velox::core::PlanNodePtr makeEnforceDistinct(
       const EnforceDistinct& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes a Velox WindowNode for a RelationOp.
   velox::core::PlanNodePtr makeWindow(
       const Window& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes a Velox RowNumberNode for a RelationOp.
   velox::core::PlanNodePtr makeRowNumber(
       const RowNumber& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Makes a Velox TopNRowNumberNode for a RelationOp.
   velox::core::PlanNodePtr makeTopNRowNumber(
       const TopNRowNumber& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Adds a ProjectNode to trim extra columns from 'input' if it has more
   // columns than 'inputOp' expects. This handles Velox operators that pass
@@ -272,8 +272,8 @@ class ToVelox {
   velox::core::PlanNodePtr makeWindowInput(
       const RelationOp& op,
       const ExprVector& partitionKeys,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Converts a single WindowFunction to a Velox WindowNode::Function.
   velox::core::WindowNode::Function toVeloxWindowFunction(
@@ -288,8 +288,8 @@ class ToVelox {
   // 'inputStages' and are returned in 'stages'.
   velox::core::PlanNodePtr makeFragment(
       const RelationOpPtr& op,
-      runner::ExecutableFragment& fragment,
-      std::vector<runner::ExecutableFragment>& stages);
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
 
   // Records the prediction for 'node' and a history key to update history
   // after the plan is executed.
@@ -315,7 +315,7 @@ class ToVelox {
       const TableScan& scan,
       const velox::core::PlanNodePtr& scanNode);
 
-  runner::ExecutableFragment newFragment();
+  ExecutableFragment newFragment();
 
   // TODO Move this into MultiFragmentPlan::Options.
   const velox::VectorSerde::Kind exchangeSerdeKind_{
@@ -323,7 +323,7 @@ class ToVelox {
 
   const SessionPtr session_;
 
-  runner::MultiFragmentPlan::Options options_;
+  MultiFragmentPlan::Options options_;
 
   const OptimizerOptions& optimizerOptions_;
 
@@ -362,7 +362,7 @@ class ToVelox {
 
   const std::optional<std::string> subscript_;
 
-  runner::FinishWrite finishWrite_;
+  FinishWrite finishWrite_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -182,7 +182,7 @@ namespace {
 
 const velox::core::TableScanNode* findScan(
     const velox::core::PlanNodeId& id,
-    const runner::MultiFragmentPlanPtr& plan) {
+    const MultiFragmentPlanPtr& plan) {
   for (const auto& fragment : plan->fragments()) {
     if (auto node = velox::core::PlanNode::findFirstNode(
             fragment.fragment.planNode.get(),

--- a/axiom/optimizer/tests/AggregationPlanTest.cpp
+++ b/axiom/optimizer/tests/AggregationPlanTest.cpp
@@ -248,7 +248,7 @@ TEST_F(AggregationPlanTest, orderBy) {
     OptimizerOptions option{.alwaysPlanPartialAggregation = (i == 0)};
     auto plan = planVelox(
         logicalPlan,
-        runner::MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},
+        MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},
         option);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -568,7 +568,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
                 << logical_plan::PlanPrinter::toText(*logicalPlan) << std::endl;
     }
 
-    runner::MultiFragmentPlan::Options opts;
+    optimizer::MultiFragmentPlan::Options opts;
     opts.numWorkers = FLAGS_num_workers;
     opts.numDrivers = FLAGS_num_drivers;
     auto allocator =

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   axiom_optimizer_tests_query_test_base
   axiom_sql_presto_parser
-  axiom_runner_multifragment_plan
+  axiom_optimizer_multifragment_plan
   axiom_runner_tests_utils
 )
 

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -17,7 +17,7 @@
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include <gtest/gtest.h>
 #include <unordered_set>
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -878,7 +878,7 @@ class ShuffleBoundaryMatcher : public PlanMatcher {
 
 // Returns the producer fragment for the given Exchange node, or nullptr if not
 // found.
-const axiom::runner::ExecutableFragment* findProducerFragment(
+const axiom::optimizer::ExecutableFragment* findProducerFragment(
     const PlanNodeId& exchangeNodeId,
     const PlanMatcher::DistributedMatchContext& context) {
   for (const auto& inputStage : context.currentFragment->inputStages) {
@@ -1879,7 +1879,7 @@ PlanMatcherBuilder& PlanMatcherBuilder::topNRowNumber(
   return *this;
 }
 
-bool PlanMatcher::match(const axiom::runner::MultiFragmentPlan& plan) const {
+bool PlanMatcher::match(const axiom::optimizer::MultiFragmentPlan& plan) const {
   const auto& fragments = plan.fragments();
   EXPECT_FALSE(fragments.empty()) << "MultiFragmentPlan has no fragments";
   if (testing::Test::HasNonfatalFailure()) {

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/core/PlanNode.h"
 #include "velox/type/Filter.h"
 
@@ -62,8 +62,8 @@ class PlanMatcher {
   // Context for distributed plan matching. Passed through the match() method
   // to provide fragment information needed by ShuffleBoundaryMatcher.
   struct DistributedMatchContext {
-    const std::vector<axiom::runner::ExecutableFragment>* fragments;
-    const axiom::runner::ExecutableFragment* currentFragment;
+    const std::vector<axiom::optimizer::ExecutableFragment>* fragments;
+    const axiom::optimizer::ExecutableFragment* currentFragment;
     const std::unordered_map<std::string, int32_t>* taskPrefixToFragmentIndex;
   };
 
@@ -100,7 +100,7 @@ class PlanMatcher {
   ///   - PartitionedOutput terminates producer fragments
   ///   - Exchange consumes from correct producer fragments
   ///   - Fragment topology matches shuffle boundary structure
-  bool match(const axiom::runner::MultiFragmentPlan& plan) const;
+  bool match(const axiom::optimizer::MultiFragmentPlan& plan) const;
 
   /// Matches the plan against this matcher with symbol rewriting support.
   /// On mismatch, sets gtest failures with detailed diagnostics.

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -92,17 +92,17 @@ void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner) {
 } // namespace
 
 TestResult QueryTestBase::runVelox(const core::PlanNodePtr& plan) {
-  runner::MultiFragmentPlan::Options options;
+  MultiFragmentPlan::Options options;
   options.numWorkers = 1;
   options.numDrivers = 1;
   options.queryId = fmt::format("q{}", ++gQueryCounter);
 
-  runner::ExecutableFragment fragment(fmt::format("{}.0", options.queryId));
+  ExecutableFragment fragment(fmt::format("{}.0", options.queryId));
   fragment.fragment = core::PlanFragment(plan);
 
   optimizer::PlanAndStats planAndStats = {
-      std::make_shared<runner::MultiFragmentPlan>(
-          std::vector<runner::ExecutableFragment>{std::move(fragment)},
+      std::make_shared<MultiFragmentPlan>(
+          std::vector<ExecutableFragment>{std::move(fragment)},
           std::move(options)),
   };
 
@@ -171,14 +171,14 @@ void QueryTestBase::verifyOptimization(
       veloxQueryCtx,
       evaluator,
       optimizerOptions.value_or(optimizerOptions_),
-      runner::MultiFragmentPlan::Options{.numWorkers = 1, .numDrivers = 1});
+      MultiFragmentPlan::Options{.numWorkers = 1, .numDrivers = 1});
 
   callback(optimization);
 }
 
 optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
-    const runner::MultiFragmentPlan::Options& options,
+    const MultiFragmentPlan::Options& options,
     const std::optional<OptimizerOptions>& optimizerOptions,
     const std::optional<std::string>& planFilePathPrefix) {
   connector::SchemaResolver schemaResolver;
@@ -189,7 +189,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
 optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const connector::SchemaResolver& schemaResolver,
-    const runner::MultiFragmentPlan::Options& options,
+    const MultiFragmentPlan::Options& options,
     const std::optional<OptimizerOptions>& optimizerOptions,
     const std::optional<std::string>& planFilePathPrefix) {
   auto& queryCtx = getQueryCtx();
@@ -251,7 +251,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
 
 TestResult QueryTestBase::runVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
-    const runner::MultiFragmentPlan::Options& options) {
+    const MultiFragmentPlan::Options& options) {
   auto veloxPlan = planVelox(plan, options);
   return runFragmentedPlan(veloxPlan);
 }
@@ -259,7 +259,7 @@ TestResult QueryTestBase::runVelox(
 TestResult QueryTestBase::runVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const connector::SchemaResolver& schemaResolver,
-    const runner::MultiFragmentPlan::Options& options) {
+    const MultiFragmentPlan::Options& options) {
   auto veloxPlan = planVelox(plan, schemaResolver, options);
   return runFragmentedPlan(veloxPlan);
 }
@@ -279,7 +279,7 @@ TestResult QueryTestBase::checkSame(
 void QueryTestBase::checkSame(
     const logical_plan::LogicalPlanNodePtr& planNode,
     const velox::core::PlanNodePtr& referencePlan,
-    const axiom::runner::MultiFragmentPlan::Options& options) {
+    const MultiFragmentPlan::Options& options) {
   VELOX_CHECK_NOT_NULL(planNode);
   VELOX_CHECK_NOT_NULL(referencePlan);
 
@@ -291,10 +291,10 @@ void QueryTestBase::checkSame(
 void QueryTestBase::checkSame(
     const logical_plan::LogicalPlanNodePtr& planNode,
     const std::vector<velox::RowVectorPtr>& referenceResult,
-    const axiom::runner::MultiFragmentPlan::Options& options) {
+    const MultiFragmentPlan::Options& options) {
   VELOX_CHECK_NOT_NULL(planNode);
 
-  std::vector<axiom::runner::MultiFragmentPlan::Options> testOptions = {
+  std::vector<MultiFragmentPlan::Options> testOptions = {
       {.numWorkers = 1, .numDrivers = 1},
   };
 

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -87,7 +87,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   /// and executable plans to files with specified path prefix.
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
-      const runner::MultiFragmentPlan::Options& options =
+      const MultiFragmentPlan::Options& options =
           {
               .numWorkers = 4,
               .numDrivers = 4,
@@ -98,7 +98,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   optimizer::PlanAndStats planVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
       const connector::SchemaResolver& schemaResolver,
-      const runner::MultiFragmentPlan::Options& options =
+      const MultiFragmentPlan::Options& options =
           {
               .numWorkers = 4,
               .numDrivers = 4,
@@ -108,7 +108,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
 
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
-      const runner::MultiFragmentPlan::Options& options = {
+      const MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,
       });
@@ -116,7 +116,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
       const connector::SchemaResolver& schemaResolver,
-      const runner::MultiFragmentPlan::Options& options = {
+      const MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,
       });
@@ -146,7 +146,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const velox::core::PlanNodePtr& referencePlan,
-      const axiom::runner::MultiFragmentPlan::Options& options = {
+      const MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,
       });
@@ -154,7 +154,7 @@ class QueryTestBase : public runner::test::LocalRunnerTestBase {
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const std::vector<velox::RowVectorPtr>& referenceResult,
-      const axiom::runner::MultiFragmentPlan::Options& options = {
+      const MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,
       });

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -50,7 +50,7 @@ class RankingTest : public test::QueryTestBase {
     return QueryTestBase::toSingleNodePlan(logicalPlan, numDrivers);
   }
 
-  runner::MultiFragmentPlanPtr toDistributedPlan(std::string_view sql) {
+  MultiFragmentPlanPtr toDistributedPlan(std::string_view sql) {
     auto logicalPlan = parseSelect(sql, kTestConnectorId);
     return planVelox(logicalPlan).plan;
   }

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
   connector::SchemaResolver schemaResolver;
   VeloxHistory history;
 
-  runner::MultiFragmentPlan::Options options;
+  MultiFragmentPlan::Options options;
   options.numWorkers = numWorkers_;
   options.numDrivers = numDrivers_;
   options.queryId = queryId;

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -46,8 +46,8 @@ class TestConnectorQueryTest : public QueryTestBase {
     QueryTestBase::TearDown();
   }
 
-  runner::MultiFragmentPlanPtr appendTableWrite(
-      const runner::MultiFragmentPlanPtr& plan,
+  MultiFragmentPlanPtr appendTableWrite(
+      const MultiFragmentPlanPtr& plan,
       const RowTypePtr& schema,
       const std::string& tableName) {
     EXPECT_EQ(plan->fragments().size(), 1);
@@ -70,21 +70,19 @@ class TestConnectorQueryTest : public QueryTestBase {
         velox::connector::CommitStrategy::kTaskCommit,
         source);
 
-    runner::ExecutableFragment writeFragment(executableFragment);
+    ExecutableFragment writeFragment(executableFragment);
     writeFragment.fragment = core::PlanFragment(
         write,
         fragment.executionStrategy,
         fragment.numSplitGroups,
         fragment.groupedExecutionLeafNodeIds);
-    std::vector<runner::ExecutableFragment> fragments = {writeFragment};
+    std::vector<ExecutableFragment> fragments = {writeFragment};
 
-    return std::make_shared<runner::MultiFragmentPlan>(fragments, options_);
+    return std::make_shared<MultiFragmentPlan>(fragments, options_);
   }
 
   std::shared_ptr<connector::TestConnector> connector_;
-  const runner::MultiFragmentPlan::Options options_{
-      .numWorkers = 1,
-      .numDrivers = 16};
+  const MultiFragmentPlan::Options options_{.numWorkers = 1, .numDrivers = 16};
 };
 
 TEST_F(TestConnectorQueryTest, selectFiltered) {

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -652,8 +652,7 @@ TEST_F(TpchPlanTest, DISABLED_makePlans) {
   const auto path =
       velox::test::getDataFilePath("axiom/optimizer/tests", "tpch/plans");
 
-  const runner::MultiFragmentPlan::Options options{
-      .numWorkers = 1, .numDrivers = 1};
+  const MultiFragmentPlan::Options options{.numWorkers = 1, .numDrivers = 1};
 
   for (auto q = 1; q <= 22; ++q) {
     LOG(ERROR) << "q" << q;

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -48,7 +48,7 @@ class WindowTest : public test::QueryTestBase {
     return QueryTestBase::toSingleNodePlan(logicalPlan, numDrivers);
   }
 
-  runner::MultiFragmentPlanPtr toDistributedPlan(std::string_view sql) {
+  MultiFragmentPlanPtr toDistributedPlan(std::string_view sql) {
     auto logicalPlan = parseSelect(sql, kTestConnectorId);
     return planVelox(logicalPlan).plan;
   }

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -73,9 +73,9 @@ class WriteTest : public test::HiveQueriesTestBase {
   void runCtas(
       const std::string& sql,
       int64_t writtenRows,
-      const std::function<void(const runner::MultiFragmentPlan& plan)>&
-          verifyPlan = nullptr,
-      const runner::MultiFragmentPlan::Options& options = {
+      const std::function<void(const MultiFragmentPlan& plan)>& verifyPlan =
+          nullptr,
+      const MultiFragmentPlan::Options& options = {
           .numWorkers = 4,
           .numDrivers = 4,
       }) {
@@ -506,13 +506,13 @@ TEST_F(WriteTest, ctasPartitionedSql) {
 }
 
 const velox::core::PlanNodePtr nodeAt(
-    const runner::MultiFragmentPlan& plan,
+    const MultiFragmentPlan& plan,
     size_t index) {
   return plan.fragments().at(index).fragment.planNode;
 }
 
 // Verify that distributed plan has exchange before table write.
-void verifyPartitionedWrite(const runner::MultiFragmentPlan& plan) {
+void verifyPartitionedWrite(const MultiFragmentPlan& plan) {
   auto matcher = core::PlanMatcherBuilder()
                      .tableScan()
                      .project()
@@ -526,7 +526,7 @@ void verifyPartitionedWrite(const runner::MultiFragmentPlan& plan) {
 
 // Verify that table write is collocated with table scan (no exchange between
 // the two).
-void verifyCollocatedWrite(const runner::MultiFragmentPlan& plan) {
+void verifyCollocatedWrite(const MultiFragmentPlan& plan) {
   auto matcher = core::PlanMatcherBuilder()
                      .tableScan()
                      .project()

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -16,15 +16,11 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_runner_multifragment_plan MultiFragmentPlan.cpp)
-
-target_link_libraries(axiom_runner_multifragment_plan velox_common_base velox_memory velox_core)
-
 add_library(axiom_runner_local_runner LocalRunner.cpp Runner.cpp)
 
 target_link_libraries(
   axiom_runner_local_runner
-  axiom_runner_multifragment_plan
+  axiom_optimizer_multifragment_plan
   axiom_connectors
   velox_common_base
   velox_memory

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -91,7 +91,7 @@ std::vector<velox::exec::Split> listAllSplits(
 }
 
 void getTopologicalOrder(
-    const std::vector<ExecutableFragment>& fragments,
+    const std::vector<optimizer::ExecutableFragment>& fragments,
     int32_t index,
     const folly::F14FastMap<std::string, int32_t>& taskPrefixToIndex,
     std::vector<bool>& visited,
@@ -110,8 +110,8 @@ void getTopologicalOrder(
   indices.push(index);
 }
 
-std::vector<ExecutableFragment> topologicalSort(
-    const std::vector<ExecutableFragment>& fragments) {
+std::vector<optimizer::ExecutableFragment> topologicalSort(
+    const std::vector<optimizer::ExecutableFragment>& fragments) {
   folly::F14FastMap<std::string, int32_t> taskPrefixToIndex;
   for (auto i = 0; i < fragments.size(); ++i) {
     taskPrefixToIndex[fragments[i].taskPrefix] = i;
@@ -127,7 +127,7 @@ std::vector<ExecutableFragment> topologicalSort(
 
   auto size = indices.size();
   VELOX_CHECK_EQ(size, fragments.size());
-  std::vector<ExecutableFragment> result(size);
+  std::vector<optimizer::ExecutableFragment> result(size);
   auto i = size - 1;
   while (!indices.empty()) {
     result[i--] = fragments[indices.top()];
@@ -139,8 +139,8 @@ std::vector<ExecutableFragment> topologicalSort(
 } // namespace
 
 LocalRunner::LocalRunner(
-    MultiFragmentPlanPtr plan,
-    FinishWrite finishWrite,
+    optimizer::MultiFragmentPlanPtr plan,
+    optimizer::FinishWrite finishWrite,
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool)

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "axiom/connectors/ConnectorSplitManager.h"
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
 #include "velox/connectors/Connector.h"
 #include "velox/exec/Cursor.h"
@@ -79,8 +79,8 @@ class LocalRunner : public Runner,
   /// @param outputPool Optional memory pool to use for allocating memory for
   /// query results. Required if 'finishWrite' is set.
   LocalRunner(
-      MultiFragmentPlanPtr plan,
-      FinishWrite finishWrite,
+      optimizer::MultiFragmentPlanPtr plan,
+      optimizer::FinishWrite finishWrite,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
@@ -97,7 +97,7 @@ class LocalRunner : public Runner,
   /// appears before B in the sequence. It's essentially a way to arrange tasks
   /// or items with dependencies so that all prerequisites are completed before
   /// the dependent tasks.
-  const std::vector<ExecutableFragment>& fragments() const {
+  const std::vector<optimizer::ExecutableFragment>& fragments() const {
     return fragments_;
   }
 
@@ -156,9 +156,9 @@ class LocalRunner : public Runner,
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;
 
-  const MultiFragmentPlanPtr plan_;
-  const std::vector<ExecutableFragment> fragments_;
-  FinishWrite finishWrite_;
+  const optimizer::MultiFragmentPlanPtr plan_;
+  const std::vector<optimizer::ExecutableFragment> fragments_;
+  optimizer::FinishWrite finishWrite_;
 
   velox::exec::CursorParameters params_;
 

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -19,7 +19,7 @@
 namespace facebook::axiom::runner::test {
 
 DistributedPlanBuilder::DistributedPlanBuilder(
-    const runner::MultiFragmentPlan::Options& options,
+    const optimizer::MultiFragmentPlan::Options& options,
     std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator,
     velox::memory::MemoryPool* pool)
     : PlanBuilder(std::move(planNodeIdGenerator), pool),
@@ -41,13 +41,13 @@ DistributedPlanBuilder::~DistributedPlanBuilder() {
   VELOX_CHECK_EQ(root_->stack_.size(), 1);
 }
 
-std::vector<runner::ExecutableFragment> DistributedPlanBuilder::fragments() {
+std::vector<optimizer::ExecutableFragment> DistributedPlanBuilder::fragments() {
   newFragment();
   return std::move(fragments_);
 }
 
-runner::MultiFragmentPlanPtr DistributedPlanBuilder::build() {
-  return std::make_shared<runner::MultiFragmentPlan>(fragments(), options_);
+optimizer::MultiFragmentPlanPtr DistributedPlanBuilder::build() {
+  return std::make_shared<optimizer::MultiFragmentPlan>(fragments(), options_);
 }
 
 void DistributedPlanBuilder::newFragment(int32_t width) {
@@ -56,7 +56,7 @@ void DistributedPlanBuilder::newFragment(int32_t width) {
     fragments_.push_back(std::move(*current_));
   }
 
-  current_ = std::make_unique<runner::ExecutableFragment>(
+  current_ = std::make_unique<optimizer::ExecutableFragment>(
       fmt::format("{}.{}", options_.queryId, root_->fragmentCounter_++));
   current_->width = width;
 
@@ -78,14 +78,14 @@ const TNode* as(const velox::core::PlanNodePtr& node) {
 void DistributedPlanBuilder::addExchange(
     const velox::RowTypePtr& producerType,
     const std::string& producerPrefix,
-    runner::ExecutableFragment& fragment) {
+    optimizer::ExecutableFragment& fragment) {
   exchange(
       producerType,
       velox::VectorSerde::kindName(velox::VectorSerde::Kind::kPresto));
   auto* exchange = as<velox::core::ExchangeNode>(planNode_);
 
   fragment.inputStages.push_back(
-      runner::InputStage{exchange->id(), producerPrefix});
+      optimizer::InputStage{exchange->id(), producerPrefix});
 }
 
 DistributedPlanBuilder& DistributedPlanBuilder::shufflePartitioned(
@@ -106,7 +106,7 @@ DistributedPlanBuilder& DistributedPlanBuilder::shufflePartitioned(
 }
 
 void DistributedPlanBuilder::appendFragments(
-    std::vector<runner::ExecutableFragment> fragments) {
+    std::vector<optimizer::ExecutableFragment> fragments) {
   for (auto& fragment : fragments) {
     fragments_.emplace_back(std::move(fragment));
   }

--- a/axiom/runner/tests/DistributedPlanBuilder.h
+++ b/axiom/runner/tests/DistributedPlanBuilder.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::axiom::runner::test {
@@ -28,7 +28,7 @@ class DistributedPlanBuilder : public velox::exec::test::PlanBuilder {
  public:
   /// Constructs a top level DistributedPlanBuilder.
   DistributedPlanBuilder(
-      const runner::MultiFragmentPlan::Options& options,
+      const optimizer::MultiFragmentPlan::Options& options,
       std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator,
       velox::memory::MemoryPool* pool = nullptr);
 
@@ -54,21 +54,21 @@ class DistributedPlanBuilder : public velox::exec::test::PlanBuilder {
 
   /// Returns the planned fragments. The builder will be empty after this. This
   /// is only called on the root builder.
-  std::vector<runner::ExecutableFragment> fragments();
+  std::vector<optimizer::ExecutableFragment> fragments();
 
-  runner::MultiFragmentPlanPtr build();
+  optimizer::MultiFragmentPlanPtr build();
 
  private:
   void newFragment(int32_t width = 0);
 
-  void appendFragments(std::vector<runner::ExecutableFragment> fragments);
+  void appendFragments(std::vector<optimizer::ExecutableFragment> fragments);
 
   void addExchange(
       const velox::RowTypePtr& producerType,
       const std::string& producerPrefix,
-      runner::ExecutableFragment& fragment);
+      optimizer::ExecutableFragment& fragment);
 
-  const runner::MultiFragmentPlan::Options& options_;
+  const optimizer::MultiFragmentPlan::Options& options_;
 
   DistributedPlanBuilder* const root_;
 
@@ -84,11 +84,11 @@ class DistributedPlanBuilder : public velox::exec::test::PlanBuilder {
 
   // The fragment being built. Will be moved to the root builder's 'fragments_'
   // when complete.
-  std::unique_ptr<runner::ExecutableFragment> current_;
+  std::unique_ptr<optimizer::ExecutableFragment> current_;
 
   // The fragments gathered under this builder. Moved to the root builder when
   // returning the subplan.
-  std::vector<runner::ExecutableFragment> fragments_;
+  std::vector<optimizer::ExecutableFragment> fragments_;
 };
 
 } // namespace facebook::axiom::runner::test

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -77,8 +77,8 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   // Returns a plan with a table scan. This is a single stage if 'numWorkers' is
   // 1, otherwise this is a scan stage plus shuffle to a stage that gathers the
   // scan results.
-  MultiFragmentPlanPtr makeScanPlan(int32_t numWorkers) {
-    MultiFragmentPlan::Options options = {
+  optimizer::MultiFragmentPlanPtr makeScanPlan(int32_t numWorkers) {
+    optimizer::MultiFragmentPlan::Options options = {
         .queryId = makeQueryId(), .numWorkers = numWorkers, .numDrivers = 2};
 
     test::DistributedPlanBuilder builder(options, idGenerator_, pool_.get());
@@ -89,10 +89,10 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     return builder.build();
   }
 
-  MultiFragmentPlanPtr makeJoinPlan(
+  optimizer::MultiFragmentPlanPtr makeJoinPlan(
       std::string project = "c0",
       bool broadcastBuild = false) {
-    MultiFragmentPlan::Options options = {
+    optimizer::MultiFragmentPlan::Options options = {
         .queryId = makeQueryId(), .numWorkers = 4, .numDrivers = 2};
     const int32_t width = 3;
 
@@ -161,11 +161,12 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
   }
 
-  std::shared_ptr<LocalRunner> makeRunner(MultiFragmentPlanPtr plan) {
+  std::shared_ptr<LocalRunner> makeRunner(
+      optimizer::MultiFragmentPlanPtr plan) {
     const auto queryId = plan->options().queryId;
 
     return std::make_shared<LocalRunner>(
-        std::move(plan), FinishWrite{}, makeQueryCtx(queryId));
+        std::move(plan), optimizer::FinishWrite{}, makeQueryCtx(queryId));
   }
 
   std::shared_ptr<velox::core::PlanNodeIdGenerator> idGenerator_{
@@ -226,7 +227,7 @@ TEST_F(LocalRunnerTest, broadcast) {
 }
 
 TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
-  MultiFragmentPlan::Options options = {
+  optimizer::MultiFragmentPlan::Options options = {
       .queryId = "test.", .numWorkers = 1, .numDrivers = 1};
 
   test::DistributedPlanBuilder rootBuilder(options, idGenerator_, pool_.get());

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -160,21 +160,22 @@ struct PlanFragmentInfo {
   int32_t numWorkers{0};
 };
 
-std::vector<ExecutableFragment> createExecutableFragments(
+std::vector<optimizer::ExecutableFragment> createExecutableFragments(
     const folly::F14FastMap<std::string, PlanFragmentInfo>& planFragments) {
-  std::vector<ExecutableFragment> executableFragments;
+  std::vector<optimizer::ExecutableFragment> executableFragments;
   for (const auto& [taskPrefix, planFragmentInfo] : planFragments) {
-    ExecutableFragment executableFragment{taskPrefix};
+    optimizer::ExecutableFragment executableFragment{taskPrefix};
     executableFragment.width =
         (planFragmentInfo.numWorkers > 0) ? planFragmentInfo.numWorkers : 1;
     executableFragment.fragment =
         velox::core::PlanFragment{planFragmentInfo.plan};
 
-    std::vector<InputStage> inputStages;
+    std::vector<optimizer::InputStage> inputStages;
     const auto& remoteTaskIdMap = planFragmentInfo.remoteTaskIdMap;
     for (const auto& [planNodeId, remoteTaskPrefixes] : remoteTaskIdMap) {
       for (const auto& remoteTaskPrefix : remoteTaskPrefixes) {
-        inputStages.push_back(InputStage{planNodeId, remoteTaskPrefix});
+        inputStages.push_back(
+            optimizer::InputStage{planNodeId, remoteTaskPrefix});
       }
     }
     executableFragment.inputStages = std::move(inputStages);
@@ -245,7 +246,8 @@ std::string findRootTaskPrefix(
 }
 } // namespace
 
-MultiFragmentPlanPtr PrestoQueryReplayRunner::deserializeSupportedPlan(
+optimizer::MultiFragmentPlanPtr
+PrestoQueryReplayRunner::deserializeSupportedPlan(
     const std::string& queryId,
     const std::vector<std::string>& serializedPlanFragments) {
   auto jsonRecords = getJsonRecords(serializedPlanFragments);
@@ -333,8 +335,8 @@ MultiFragmentPlanPtr PrestoQueryReplayRunner::deserializeSupportedPlan(
 
   auto executableFragments = createExecutableFragments(planFragments);
 
-  MultiFragmentPlan::Options options{queryId, width_, maxDrivers_};
-  return std::make_shared<MultiFragmentPlan>(
+  optimizer::MultiFragmentPlan::Options options{queryId, width_, maxDrivers_};
+  return std::make_shared<optimizer::MultiFragmentPlan>(
       std::move(executableFragments), std::move(options));
 }
 
@@ -384,7 +386,7 @@ PrestoQueryReplayRunner::run(
   auto nodeSplitMap = deserializeConnectorSplits(serializedConnectorSplits);
   auto localRunner = std::make_shared<LocalRunner>(
       std::move(multiFragmentPlan),
-      FinishWrite{},
+      optimizer::FinishWrite{},
       makeQueryCtx(queryId, queryRootPool),
       std::make_shared<runner::SimpleSplitSourceFactory>(nodeSplitMap));
 

--- a/axiom/runner/tests/PrestoQueryReplayRunner.h
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "axiom/runner/MultiFragmentPlan.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/QueryCtx.h"
 
@@ -67,9 +67,10 @@ class PrestoQueryReplayRunner {
   std::vector<std::string> getTaskPrefixes(
       const std::vector<folly::dynamic>& jsonRecords);
 
-  /// Deserialize a list of plan fragments into a MultiFragmentPlanPtr. If any
-  /// of the plan fragment is unsupported, return a nullptr.
-  MultiFragmentPlanPtr deserializeSupportedPlan(
+  /// Deserialize a list of plan fragments into a
+  /// optimizer::MultiFragmentPlanPtr. If any of the plan fragment is
+  /// unsupported, return a nullptr.
+  optimizer::MultiFragmentPlanPtr deserializeSupportedPlan(
       const std::string& queryId,
       const std::vector<std::string>& serializedPlanFragments);
 


### PR DESCRIPTION
Summary: To decouple planner from runner in preparation of moving Runner to Axel

While the Runner interface may still be needed for testing purposes, engine utilizing Axiom planner may or may not rely on it. Hence this PR aims to decouple runner from optimizer targets.

Differential Revision: D96022462
