### PR TITLE
refactor: Migrate rename to folly::available_concurrency

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -65,7 +65,7 @@ void Connectors::initialize() {
   folly::call_once(kInitialized, [this]() {
     initializeFileFormats();
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
-        folly::hardware_concurrency(),
+        folly::available_concurrency(),
         std::make_shared<folly::NamedThreadFactory>("io"));
   });
 }

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -303,7 +303,7 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   ++queryCounter_;
 
   executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(std::max<int32_t>(
-      folly::hardware_concurrency() * 2,
+      folly::available_concurrency() * 2,
       options.numWorkers * options.numDrivers * 2 + 2));
 
   return velox::core::QueryCtx::create(

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -193,7 +193,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     executor_ =
         std::make_shared<folly::CPUThreadPoolExecutor>(std::max<int32_t>(
-            folly::hardware_concurrency() * 2,
+            folly::available_concurrency() * 2,
             FLAGS_num_workers * FLAGS_num_drivers * 2 + 2));
     spillExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(4);
   }

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -93,7 +93,7 @@ int64_t TpchDataGenerator::createTable(
   }
 
   const int32_t numDrivers =
-      std::min<int32_t>(numSplits, folly::hardware_concurrency());
+      std::min<int32_t>(numSplits, folly::available_concurrency());
 
   auto result = AssertQueryBuilder(plan)
                     .splits(std::move(splits))


### PR DESCRIPTION
Summary: The name `hardware_concurrency`, while parallel to `std::thread::hardware_concurrency`, may be misleading. Migrate to the name `available_concurrency`.

Reviewed By: xiaoxmeng

Differential Revision: D93277186


