### PR TITLE
fix(parser): Support tdigest/qdigest parametric types

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -257,7 +257,9 @@ TypePtr parseType(const TypeSignaturePtr& type) {
       VELOX_USER_CHECK_EQ(2, numParams);
       parameters.emplace_back(parseInt(type->parameters().at(0)));
       parameters.emplace_back(parseInt(type->parameters().at(1)));
-
+    } else if (baseName == "TDIGEST" || baseName == "QDIGEST") {
+      VELOX_USER_CHECK_EQ(1, numParams);
+      parameters.emplace_back(parseType(type->parameters().at(0)));
     } else {
       VELOX_USER_FAIL("Unknown parametric type: {}", baseName);
     }

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -17,6 +17,10 @@
 #include <fmt/format.h>
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/QDigestRegistration.h"
+#include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/TDigestRegistration.h"
+#include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace axiom::sql::presto::test {
@@ -95,6 +99,14 @@ TEST_F(ExpressionParserTest, types) {
   test("null as timestamp", TIMESTAMP());
   test("null as decimal(3, 2)", DECIMAL(3, 2));
   test("null as decimal(33, 10)", DECIMAL(33, 10));
+
+  facebook::velox::registerTDigestType();
+  facebook::velox::registerQDigestType();
+
+  test("null as tdigest(double)", TDIGEST(DOUBLE()));
+  test("null as qdigest(bigint)", QDIGEST(BIGINT()));
+  test("null as qdigest(real)", QDIGEST(REAL()));
+  test("null as qdigest(double)", QDIGEST(DOUBLE()));
 
   test("null as int array", ARRAY(INTEGER()));
   test("null as varchar array", ARRAY(VARCHAR()));


### PR DESCRIPTION
Summary:
Add logic in `parseType()` to handle `tdigest(double)` and `qdigest(bigint/real/double)`. These custom Velox types have type parameters that need to be parsed recursively, like ARRAY and MAP.

Note: The parametric type handling for these types is intentionally added as explicit branches because types like VARCHAR(n) and CHAR(n) have integer parameters with different semantics which is not handled yet.

Differential Revision: D96183685


