### PR TITLE
feat(cli): Plumb per-query token provider through CLI runner

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -108,7 +108,7 @@ void Console::run() {
 }
 
 void Console::runNoThrow(std::string_view sql, bool isInteractive) {
-  const SqlQueryRunner::RunOptions options{
+  const SqlQueryRunner::RunOptions defaultOptions{
       .numWorkers = FLAGS_num_workers,
       .numDrivers = FLAGS_num_drivers,
       .splitTargetBytes = FLAGS_split_target_bytes,
@@ -124,7 +124,9 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       continue;
     }
 
-    auto queryId = queryIdGenerator_->createNextQueryId();
+    const auto queryId = queryIdGenerator_->createNextQueryId();
+    auto options = defaultOptions;
+    options.queryId = queryId;
 
     try {
       cli::Timing parseTiming;
@@ -137,10 +139,10 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       }
 
       // Permission check after parsing, before execution.
-      if (permissionCheck_ != nullptr) {
+      if (permissionCheck_) {
         const auto& schema = options.defaultSchema ? options.defaultSchema
                                                    : runner_.defaultSchema();
-        permissionCheck_(
+        options.tokenProvider = permissionCheck_(
             queryId,
             sqlText,
             options.defaultConnectorId.value_or(runner_.defaultConnectorId()),

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -33,13 +33,15 @@ class QueryIdGenerator;
 namespace axiom::sql {
 
 /// Permission check callback: (queryId, sql, catalog, schema, views) -> throws
-/// on denial. Empty (nullptr) by default -- no permission checking.
-using PermissionCheck = std::function<void(
-    std::string_view queryId,
-    std::string_view sql,
-    std::string_view catalog,
-    std::optional<std::string_view> schema,
-    const presto::ViewMap& views)>;
+/// on denial, and may return a per-query token provider.
+/// Empty (nullptr) by default -- no permission checking.
+using PermissionCheck =
+    std::function<std::shared_ptr<facebook::velox::filesystems::TokenProvider>(
+        std::string_view queryId,
+        std::string_view sql,
+        std::string_view catalog,
+        std::optional<std::string_view> schema,
+        const presto::ViewMap& views)>;
 
 class Console {
  public:

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -300,11 +300,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
 
 std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
     const RunOptions& options) {
-  ++queryCounter_;
-
   executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(std::max<int32_t>(
       folly::available_concurrency() * 2,
       options.numWorkers * options.numDrivers * 2 + 2));
+
+  const auto queryId =
+      options.queryId.value_or(fmt::format("query_{}", ++queryCounter_));
 
   return velox::core::QueryCtx::create(
       executor_.get(),
@@ -313,7 +314,8 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
       velox::cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
       spillExecutor_.get(),
-      fmt::format("query_{}", queryCounter_));
+      queryId,
+      options.tokenProvider);
 }
 
 std::string SqlQueryRunner::runExplain(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/runner/LocalRunner.h"
 #include "axiom/sql/presto/SqlStatement.h"
+#include "velox/common/file/TokenProvider.h"
 
 namespace axiom::sql {
 
@@ -51,6 +52,8 @@ class SqlQueryRunner {
 
     std::optional<std::string> defaultConnectorId;
     std::optional<std::string> defaultSchema;
+    std::optional<std::string> queryId;
+    std::shared_ptr<facebook::velox::filesystems::TokenProvider> tokenProvider;
 
     /// If true, EXPLAIN ANALYZE output includes custom operator stats.
     bool debugMode{false};

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -81,6 +81,7 @@ TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
     called = true;
     capturedSql = std::string(sql);
     capturedCatalog = std::string(catalog);
+    return std::shared_ptr<facebook::velox::filesystems::TokenProvider>{};
   };
 
   Console console{*runner, std::move(check)};


### PR DESCRIPTION
Summary:
Plumb per-query token provider support through the CLI execution path. This is needed for fine grained storage acces control.

Differential Revision: D96202191


