### PR TITLE
fix(cli): Only print ROW<...> type line in debug mode

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -155,6 +155,10 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       if (result.message.has_value()) {
         std::cout << result.message.value() << std::endl;
       } else {
+        if (FLAGS_debug && !result.results.empty()) {
+          std::cout << result.results.front()->rowType()->toString()
+                    << std::endl;
+        }
         cli::printResults(result.results, FLAGS_max_rows);
       }
 

--- a/axiom/cli/ResultPrinter.cpp
+++ b/axiom/cli/ResultPrinter.cpp
@@ -51,8 +51,6 @@ int32_t printResults(
   }
 
   const auto type = results.front()->rowType();
-  std::cout << type->toString() << std::endl;
-
   const auto numColumns = type->size();
 
   std::vector<std::vector<std::string>> data;

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -4,7 +4,6 @@
 
 ```scrut
 $ $CLI --query "SELECT count(*) as cnt FROM nation" 2>/dev/null
-ROW<cnt:BIGINT>
 ---
 cnt
 ---
@@ -20,7 +19,6 @@ $ $CLI --query "CREATE TABLE test.default.t(a int, b int, c int); SELECT * FROM 
 Created table: "default"."t"
 (0 rows in 0 batches)
 
-ROW<row_count:BIGINT,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
 row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
@@ -37,21 +35,18 @@ row_count | column_name | nulls_fraction | distinct_values_count | avg_length | 
 ```scrut
 $ $CLI --query "CREATE TABLE test.default.t(a int, b int); INSERT INTO test.default.t VALUES (1, 2); SELECT * FROM test.default.t; SHOW STATS FOR test.default.t" 2>/dev/null
 Created table: "default"."t"
-ROW<rows:BIGINT>
 ----
 rows
 ----
    1
 (1 rows in 1 batches)
 
-ROW<a:INTEGER,b:INTEGER>
 --+--
 a | b
 --+--
 1 | 2
 (1 rows in 1 batches)
 
-ROW<row_count:BIGINT,column_name:VARCHAR,nulls_fraction:DOUBLE,distinct_values_count:BIGINT,avg_length:BIGINT,low_value:VARCHAR,high_value:VARCHAR>
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
 row_count | column_name | nulls_fraction | distinct_values_count | avg_length | low_value | high_value
 ----------+-------------+----------------+-----------------------+------------+-----------+-----------
@@ -67,21 +62,18 @@ row_count | column_name | nulls_fraction | distinct_values_count | avg_length | 
 ```scrut
 $ $CLI --catalog test --schema default --query "CREATE TABLE t(x bigint, y bigint); INSERT INTO t VALUES (10, 20); INSERT INTO t VALUES (30, 40); SELECT * FROM t ORDER BY x" 2>/dev/null
 Created table: "default"."t"
-ROW<rows:BIGINT>
 ----
 rows
 ----
    1
 (1 rows in 1 batches)
 
-ROW<rows:BIGINT>
 ----
 rows
 ----
    1
 (1 rows in 1 batches)
 
-ROW<x:BIGINT,y:BIGINT>
 ---+---
  x |  y
 ---+---
@@ -97,7 +89,6 @@ ROW<x:BIGINT,y:BIGINT>
 $ $CLI --catalog test --schema default --query "CREATE TABLE t(a int); DROP TABLE t; SELECT 1 as ok" 2>/dev/null
 Created table: "default"."t"
 Dropped table: "default"."t"
-ROW<ok:INTEGER>
 --
 ok
 --
@@ -111,7 +102,6 @@ ok
 ```scrut
 $ $CLI --catalog test --schema default --query "DROP TABLE IF EXISTS t; SELECT 1 as ok" 2>/dev/null
 Table doesn't exist: "default"."t"
-ROW<ok:INTEGER>
 --
 ok
 --
@@ -126,14 +116,12 @@ ok
 $ $CLI --query "USE test.default; CREATE TABLE t(x int, y int); INSERT INTO t VALUES (1, 2); SELECT * FROM t" 2>/dev/null
 Using test.default
 Created table: "default"."t"
-ROW<rows:BIGINT>
 ----
 rows
 ----
    1
 (1 rows in 1 batches)
 
-ROW<x:INTEGER,y:INTEGER>
 --+--
 x | y
 --+--

--- a/axiom/cli/tests/TpchgenTest.md
+++ b/axiom/cli/tests/TpchgenTest.md
@@ -79,7 +79,6 @@ $ QUERY="SELECT 'customer' AS tbl, count(*) AS cnt FROM customer UNION ALL SELEC
 
 ```scrut
 $ $CLI --data_path "$TMPDIR/tpch-parquet" --query "$QUERY" 2>/dev/null
-ROW<tbl:VARCHAR,cnt:BIGINT>
 ---------+------
 tbl      |   cnt
 ---------+------
@@ -136,7 +135,6 @@ supplier
 
 ```scrut
 $ $CLI --data_path "$TMPDIR/tpch-dwrf" --data_format dwrf --query "$QUERY" 2>/dev/null
-ROW<tbl:VARCHAR,cnt:BIGINT>
 ---------+------
 tbl      |   cnt
 ---------+------


### PR DESCRIPTION
Summary: The CLI output included a `ROW<...>` type signature line before the result table, which is not useful in normal output. This change gates the type line behind the `--debug` flag so it only appears when debug mode is enabled.

Differential Revision: D96259981


