### PR TITLE
feat: Add EXPLAIN CTAS support (#1044)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -95,7 +95,8 @@ std::vector<velox::RowVectorPtr> fetchResults(runner::LocalRunner& runner) {
 } // namespace
 
 connector::TablePtr SqlQueryRunner::createTable(
-    const presto::CreateTableStatement& statement) {
+    const presto::CreateTableStatement& statement,
+    bool explain) {
   auto metadata =
       connector::ConnectorMetadata::metadata(statement.connectorId());
 
@@ -107,11 +108,16 @@ connector::TablePtr SqlQueryRunner::createTable(
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
   return metadata->createTable(
-      session, statement.tableName(), statement.tableSchema(), options);
+      session,
+      statement.tableName(),
+      statement.tableSchema(),
+      options,
+      explain);
 }
 
 connector::TablePtr SqlQueryRunner::createTable(
-    const presto::CreateTableAsSelectStatement& statement) {
+    const presto::CreateTableAsSelectStatement& statement,
+    bool explain) {
   auto metadata =
       connector::ConnectorMetadata::metadata(statement.connectorId());
 
@@ -123,7 +129,11 @@ connector::TablePtr SqlQueryRunner::createTable(
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
   return metadata->createTable(
-      session, statement.tableName(), statement.tableSchema(), options);
+      session,
+      statement.tableName(),
+      statement.tableSchema(),
+      options,
+      explain);
 }
 
 std::string SqlQueryRunner::dropTable(
@@ -230,19 +240,33 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     const auto& statement = explain->statement();
 
     logical_plan::LogicalPlanNodePtr logicalPlan;
+    std::shared_ptr<connector::SchemaResolver> schemaResolver;
+
     if (statement->isSelect()) {
       logicalPlan = statement->as<presto::SelectStatement>()->plan();
     } else if (statement->isInsert()) {
       logicalPlan = statement->as<presto::InsertStatement>()->plan();
+    } else if (statement->isCreateTableAsSelect()) {
+      const auto* ctas = statement->as<presto::CreateTableAsSelectStatement>();
+      logicalPlan = ctas->plan();
+
+      // EXPLAIN ANALYZE runs the query for real, so createTable must not
+      // be in explain mode. Regular EXPLAIN must be side-effect-free.
+      auto table = createTable(*ctas, /*explain=*/!explain->isAnalyze());
+      schemaResolver = std::make_shared<connector::SchemaResolver>();
+      schemaResolver->setTargetTable(
+          ctas->connectorId(), ctas->tableName(), table);
     } else {
-      // TODO Add support for EXPLAIN CREATE TABLE AS SELECT ...
       VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
     }
 
     if (explain->isAnalyze()) {
-      return {.message = runExplainAnalyze(logicalPlan, options)};
+      return {
+          .message = runExplainAnalyze(logicalPlan, options, schemaResolver)};
     } else {
-      return {.message = runExplain(logicalPlan, explain->type(), options)};
+      return {
+          .message = runExplain(
+              logicalPlan, explain->type(), options, schemaResolver)};
     }
   }
 
@@ -323,17 +347,27 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
 std::string SqlQueryRunner::runExplain(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     presto::ExplainStatement::Type type,
-    const RunOptions& options) {
+    const RunOptions& options,
+    std::shared_ptr<connector::SchemaResolver> schemaResolver) {
+  const bool explain = schemaResolver != nullptr;
+
   switch (type) {
     case presto::ExplainStatement::Type::kLogical:
       return logical_plan::PlanPrinter::toText(*logicalPlan);
 
     case presto::ExplainStatement::Type::kGraph: {
       std::string text;
-      optimize(logicalPlan, newQuery(options), options, [&](const auto& dt) {
-        text = optimizer::DerivedTablePrinter::toText(dt);
-        return false; // Stop optimization.
-      });
+      optimize(
+          logicalPlan,
+          newQuery(options),
+          options,
+          [&](const auto& dt) {
+            text = optimizer::DerivedTablePrinter::toText(dt);
+            return false; // Stop optimization.
+          },
+          nullptr,
+          schemaResolver,
+          explain);
       return text;
     }
 
@@ -352,12 +386,22 @@ std::string SqlQueryRunner::runExplain(
                     .includeConstraints = options.debugMode,
                 });
             return false; // Stop optimization.
-          });
+          },
+          schemaResolver,
+          explain);
       return text;
     }
 
     case presto::ExplainStatement::Type::kExecutable:
-      return optimize(logicalPlan, newQuery(options), options).toString();
+      return optimize(
+                 logicalPlan,
+                 newQuery(options),
+                 options,
+                 nullptr,
+                 nullptr,
+                 schemaResolver,
+                 explain)
+          .toString();
   }
   VELOX_UNREACHABLE();
 }
@@ -404,9 +448,11 @@ std::string printPlanWithStats(
 
 std::string SqlQueryRunner::runExplainAnalyze(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
-    const RunOptions& options) {
+    const RunOptions& options,
+    std::shared_ptr<connector::SchemaResolver> schemaResolver) {
   auto queryCtx = newQuery(options);
-  auto planAndStats = optimize(logicalPlan, queryCtx, options);
+  auto planAndStats = optimize(
+      logicalPlan, queryCtx, options, nullptr, nullptr, schemaResolver);
 
   auto runner = makeLocalRunner(planAndStats, queryCtx, options);
   SCOPE_EXIT {
@@ -429,9 +475,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     const std::function<bool(const optimizer::DerivedTable&)>&
         checkDerivedTable,
     const std::function<bool(const optimizer::RelationOp&)>& checkBestPlan,
-    std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver
-
-) {
+    std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
+    bool explain) {
   optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
@@ -460,7 +505,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
       *history,
       queryCtx,
       evaluator,
-      {.traceFlags = options.optimizerTraceFlags},
+      {.traceFlags = options.optimizerTraceFlags, .explain = explain},
       opts);
 
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -111,10 +111,12 @@ class SqlQueryRunner {
   }
 
   facebook::axiom::connector::TablePtr createTable(
-      const presto::CreateTableStatement& statement);
+      const presto::CreateTableStatement& statement,
+      bool explain = false);
 
   facebook::axiom::connector::TablePtr createTable(
-      const presto::CreateTableAsSelectStatement& statement);
+      const presto::CreateTableAsSelectStatement& statement,
+      bool explain = false);
 
   std::string dropTable(const presto::DropTableStatement& statement);
 
@@ -135,11 +137,15 @@ class SqlQueryRunner {
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       presto::ExplainStatement::Type type,
-      const RunOptions& options);
+      const RunOptions& options,
+      std::shared_ptr<facebook::axiom::connector::SchemaResolver>
+          schemaResolver = nullptr);
 
   std::string runExplainAnalyze(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
-      const RunOptions& options);
+      const RunOptions& options,
+      std::shared_ptr<facebook::axiom::connector::SchemaResolver>
+          schemaResolver = nullptr);
 
   // Runs SHOW STATS FOR (<query>): optimizes the inner query's logical plan
   // and returns per-column and table-level statistics as a VALUES result.
@@ -168,7 +174,8 @@ class SqlQueryRunner {
       const std::function<bool(const facebook::axiom::optimizer::RelationOp&)>&
           checkBestPlan = nullptr,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
-          schemaResolver = nullptr);
+          schemaResolver = nullptr,
+      bool explain = false);
 
   std::shared_ptr<facebook::axiom::runner::LocalRunner> makeLocalRunner(
       facebook::axiom::optimizer::PlanAndStats& planAndStats,

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -29,5 +29,6 @@ target_link_libraries(
   velox_exec_test_lib
   velox_vector_test_lib
   GTest::gtest
+  GTest::gmock
   re2
 )

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -16,8 +16,10 @@
 
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/init/Init.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
@@ -142,6 +144,51 @@ TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
   EXPECT_THROW(
       runner_->parseMultiple("SELECT 1; INVALID; SELECT 2", {}),
       std::exception);
+}
+
+TEST_F(SqlQueryRunnerTest, explainCtas) {
+  {
+    auto result = runner_->run(
+        "EXPLAIN (TYPE LOGICAL) CREATE TABLE t AS SELECT 1 AS x", {});
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(
+        result.message.value(),
+        ::testing::HasSubstr("- TableWrite CREATE: -> ROW<rows:BIGINT>"));
+  }
+
+  {
+    auto result = runner_->run(
+        "EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x", {});
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(
+        result.message.value(),
+        ::testing::HasSubstr("TableWrite [1.00 rows] ->"));
+  }
+
+  {
+    auto result = runner_->run("EXPLAIN CREATE TABLE t AS SELECT 1 AS x", {});
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
+  }
+
+  // Table should not exist — EXPLAIN is side-effect-free.
+  VELOX_ASSERT_THROW(runner_->run("SELECT * FROM t", {}), "Table not found: t");
+
+  // EXPLAIN ANALYZE runs the query and creates the table.
+  {
+    auto result =
+        runner_->run("EXPLAIN ANALYZE CREATE TABLE t AS SELECT 1 AS x", {});
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
+  }
+
+  {
+    auto result = runner_->run("SELECT * FROM t", {});
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(
+        result.results[0], makeRowVector({makeFlatVector<int32_t>({1})}));
+  }
 }
 
 TEST_F(SqlQueryRunnerTest, showStats) {

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -815,11 +815,17 @@ class ConnectorMetadata {
   /// returned insert handle, then finishWrite to commit the changes. The table
   /// is not available via the findTable interface until after finishWrite
   /// completes.
+  ///
+  /// When 'explain' is true, the connector must interpret properties and
+  /// return a valid Table with correct layout metadata, but must not create
+  /// directories, write files, or register the table. No cleanup is needed
+  /// after an explain call.
   virtual TablePtr createTable(
       const ConnectorSessionPtr& /*session*/,
       const SchemaTableName& /*tableName*/,
       const velox::RowTypePtr& /*rowType*/,
-      const folly::F14FastMap<std::string, velox::Variant>& /*options*/) {
+      const folly::F14FastMap<std::string, velox::Variant>& /*options*/,
+      bool /*explain*/) {
     VELOX_UNSUPPORTED();
   }
 
@@ -831,10 +837,15 @@ class ConnectorMetadata {
   /// the write handle and call finishWrite. Transaction semantics are
   /// connector-dependent, and ConnectorSession may be null for connectors which
   /// do not require it.
+  ///
+  /// When 'explain' is true, the connector must build and return a valid
+  /// ConnectorWriteHandle for plan display, but must not allocate staging
+  /// directories or acquire resources that need cleanup.
   virtual ConnectorWriteHandlePtr beginWrite(
       const ConnectorSessionPtr& /*session*/,
       const TablePtr& /*table*/,
-      WriteKind /*kind*/) {
+      WriteKind /*kind*/,
+      bool /*explain*/) {
     VELOX_UNSUPPORTED();
   }
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -283,7 +283,8 @@ std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(
 ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
     const ConnectorSessionPtr& session,
     const TablePtr& table,
-    WriteKind kind) {
+    WriteKind kind,
+    bool explain) {
   ensureInitialized();
   VELOX_CHECK(
       kind == WriteKind::kCreate || kind == WriteKind::kInsert,
@@ -352,7 +353,8 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
       std::make_shared<velox::connector::hive::HiveInsertTableHandle>(
           inputColumns,
           makeLocationHandle(
-              tablePath(table->name()), makeStagingDirectory(table->name())),
+              tablePath(table->name()),
+              explain ? std::nullopt : makeStagingDirectory(table->name())),
           storageFormat,
           bucketProperty,
           compressionKind,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -248,7 +248,8 @@ class HiveConnectorMetadata : public ConnectorMetadata {
   ConnectorWriteHandlePtr beginWrite(
       const ConnectorSessionPtr& session,
       const TablePtr& table,
-      WriteKind kind) override;
+      WriteKind kind,
+      bool explain) override;
 
  protected:
   virtual void ensureInitialized() const {}

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1862,17 +1862,27 @@ TablePtr LocalHiveConnectorMetadata::createTable(
     const ConnectorSessionPtr& /*session*/,
     const SchemaTableName& tableName,
     const velox::RowTypePtr& rowType,
-    const folly::F14FastMap<std::string, velox::Variant>& options) {
+    const folly::F14FastMap<std::string, velox::Variant>& options,
+    bool explain) {
   validateOptions(options);
   ensureInitialized();
+  auto createTableOptions = parseCreateTableOptions(options, format_);
+
+  if (explain) {
+    return createLocalTable(
+        tableName.table,
+        rowType,
+        createTableOptions,
+        hiveConnector(),
+        hiveMetadataConfig_);
+  }
+
   auto path = tablePath(tableName);
   if (dirExists(path)) {
     VELOX_USER_FAIL("Table {} already exists", tableName.toString());
   } else {
     createDir(path);
   }
-
-  auto createTableOptions = parseCreateTableOptions(options, format_);
 
   const std::string jsonStr =
       folly::toPrettyJson(toSchemaJson(rowType, createTableOptions));

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -294,7 +294,8 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const ConnectorSessionPtr& session,
       const SchemaTableName& tableName,
       const velox::RowTypePtr& rowType,
-      const folly::F14FastMap<std::string, velox::Variant>& options) override;
+      const folly::F14FastMap<std::string, velox::Variant>& options,
+      bool explain) override;
 
   RowsFuture finishWrite(
       const ConnectorSessionPtr& session,

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -132,7 +132,8 @@ class LocalHiveConnectorMetadataTest
       dwio::common::FileFormat format) {
     std::string outputPath = metadata_->tablePath(table->name());
     auto session = std::make_shared<ConnectorSession>("q-test");
-    auto handle = metadata_->beginWrite(session, table, kind);
+    auto handle =
+        metadata_->beginWrite(session, table, kind, /*explain=*/false);
 
     auto builder = exec::test::PlanBuilder().values({values});
     auto insertHandle = std::make_shared<core::InsertTableHandle>(
@@ -331,7 +332,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
 
   auto session = std::make_shared<ConnectorSession>("q-test");
   auto table = metadata_->createTable(
-      session, {kDefaultSchema, "test"}, tableType, options);
+      session, {kDefaultSchema, "test"}, tableType, options, /*explain=*/false);
 
   constexpr int32_t kTestSize = 2048;
   auto data = makeRowVector(
@@ -409,7 +410,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
       session,
       {kDefaultSchema, "test_empty"},
       tableType,
-      /*options=*/{});
+      /*options=*/{},
+      /*explain=*/false);
 
   auto emptyData = makeRowVector(tableType, 0);
   EXPECT_EQ(emptyData->size(), 0);
@@ -442,8 +444,10 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
       session,
       {kDefaultSchema, "test_insert"},
       tableType,
-      /*options=*/{});
-  auto handle = metadata_->beginWrite(session, staged, WriteKind::kCreate);
+      /*options=*/{},
+      /*explain=*/false);
+  auto handle = metadata_->beginWrite(
+      session, staged, WriteKind::kCreate, /*explain=*/false);
   metadata_->finishWrite(session, handle, /*writeResults=*/{}, nullptr, {})
       .get();
 
@@ -471,10 +475,12 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
       dwio::common::FileFormat::DWRF);
 
   VELOX_ASSERT_THROW(
-      metadata_->beginWrite(session, created, WriteKind::kUpdate),
+      metadata_->beginWrite(
+          session, created, WriteKind::kUpdate, /*explain=*/false),
       "Only CREATE/INSERT supported, not UPDATE");
   VELOX_ASSERT_THROW(
-      metadata_->beginWrite(session, created, WriteKind::kDelete),
+      metadata_->beginWrite(
+          session, created, WriteKind::kDelete, /*explain=*/false),
       "Only CREATE/INSERT supported, not DELETE");
 }
 
@@ -488,8 +494,10 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       session,
       SchemaTableName{kDefaultSchema, "test_abort"},
       tableType,
-      /*options=*/{});
-  auto handle = metadata_->beginWrite(session, table, WriteKind::kCreate);
+      /*options=*/{},
+      /*explain=*/false);
+  auto handle = metadata_->beginWrite(
+      session, table, WriteKind::kCreate, /*explain=*/false);
   EXPECT_TRUE(std::filesystem::exists(tablePath));
 
   VELOX_ASSERT_THROW(
@@ -497,7 +505,8 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
           session,
           SchemaTableName{kDefaultSchema, "test_abort"},
           tableType,
-          /*options=*/{}),
+          /*options=*/{},
+          /*explain=*/false),
       "Table \"default\".\"test_abort\" already exists");
   metadata_->abortWrite(session, handle).get();
   EXPECT_FALSE(std::filesystem::exists(tablePath));
@@ -506,8 +515,10 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       session,
       SchemaTableName{kDefaultSchema, "test_abort"},
       tableType,
-      /*options=*/{});
-  handle = metadata_->beginWrite(session, table, WriteKind::kCreate);
+      /*options=*/{},
+      /*explain=*/false);
+  handle = metadata_->beginWrite(
+      session, table, WriteKind::kCreate, /*explain=*/false);
   metadata_->finishWrite(session, handle, /*writeResults=*/{}, nullptr, {})
       .get();
   EXPECT_TRUE(std::filesystem::exists(tablePath));

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -64,7 +64,7 @@ class SchemaResolverTest : public ::testing::Test {
 
 TEST_F(SchemaResolverTest, bareTable) {
   ConnectorMetadata::metadata("base")->createTable(
-      nullptr, {"baseschema", "table"}, ROW({}), {});
+      nullptr, {"baseschema", "table"}, ROW({}), {}, /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"baseschema", "table"});
   ASSERT_NE(table, nullptr);
@@ -75,7 +75,7 @@ TEST_F(SchemaResolverTest, bareTable) {
 
 TEST_F(SchemaResolverTest, tablePlusSchema) {
   ConnectorMetadata::metadata("base")->createTable(
-      nullptr, {"newschema", "table"}, ROW({}), {});
+      nullptr, {"newschema", "table"}, ROW({}), {}, /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"newschema", "table"});
   ASSERT_NE(table, nullptr);
@@ -86,12 +86,16 @@ TEST_F(SchemaResolverTest, tablePlusSchema) {
 
 TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
   ConnectorMetadata::metadata("other")->createTable(
-      /*session=*/nullptr, {"otherschema", "other_table"}, ROW({}), {});
+      /*session=*/nullptr,
+      {"otherschema", "other_table"},
+      ROW({}),
+      {},
+      /*explain=*/false);
   auto table = resolver_->findTable("other", {"otherschema", "other_table"});
   ASSERT_NE(table, nullptr);
 
   ConnectorMetadata::metadata("base")->createTable(
-      nullptr, {"baseschema", "base_table"}, ROW({}), {});
+      nullptr, {"baseschema", "base_table"}, ROW({}), {}, /*explain=*/false);
   table = resolver_->findTable("base", {"baseschema", "base_table"});
   ASSERT_NE(table, nullptr);
 }
@@ -99,7 +103,11 @@ TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
 TEST_F(SchemaResolverTest, catalogMismatch) {
   // Table exists in "other" catalog but not in "base".
   ConnectorMetadata::metadata("other")->createTable(
-      /*session=*/nullptr, {"otherschema", "table"}, ROW({}), {});
+      /*session=*/nullptr,
+      {"otherschema", "table"},
+      ROW({}),
+      {},
+      /*explain=*/false);
   auto table = resolver_->findTable("base", {"otherschema", "table"});
   ASSERT_EQ(table, nullptr);
 }

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -361,9 +361,13 @@ TablePtr TestConnectorMetadata::createTable(
     const ConnectorSessionPtr& /*session*/,
     const SchemaTableName& tableName,
     const velox::RowTypePtr& rowType,
-    const folly::F14FastMap<std::string, velox::Variant>& /*options*/) {
+    const folly::F14FastMap<std::string, velox::Variant>& /*options*/,
+    bool explain) {
   auto table = std::make_shared<TestTable>(
       tableName, rowType, velox::ROW({}), connector_);
+  if (explain) {
+    return table;
+  }
   auto [it, ok] = tables_.emplace(tableName, std::move(table));
   VELOX_CHECK(ok, "Table already exists: {}", tableName.toString());
   return it->second;
@@ -372,7 +376,8 @@ TablePtr TestConnectorMetadata::createTable(
 ConnectorWriteHandlePtr TestConnectorMetadata::beginWrite(
     const ConnectorSessionPtr& /*session*/,
     const TablePtr& table,
-    WriteKind /*kind*/) {
+    WriteKind /*kind*/,
+    bool /*explain*/) {
   auto insertHandle = std::make_shared<TestInsertTableHandle>(table->name());
   return std::make_shared<ConnectorWriteHandle>(
       std::move(insertHandle),

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -329,12 +329,14 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const SchemaTableName& tableName,
       const velox::RowTypePtr& rowType,
-      const folly::F14FastMap<std::string, velox::Variant>& options) override;
+      const folly::F14FastMap<std::string, velox::Variant>& options,
+      bool explain) override;
 
   ConnectorWriteHandlePtr beginWrite(
       const ConnectorSessionPtr& session,
       const TablePtr& table,
-      WriteKind kind) override;
+      WriteKind kind,
+      bool explain) override;
 
   RowsFuture finishWrite(
       const ConnectorSessionPtr& session,

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -77,6 +77,10 @@ struct OptimizerOptions {
   /// partial + final or not.
   bool alwaysPlanPartialAggregation = false;
 
+  /// When true, connectors skip side effects in createTable() and
+  /// beginWrite(). Used for EXPLAIN queries.
+  bool explain{false};
+
   bool isMapAsStruct(const SchemaTableName& tableName, std::string_view column)
       const {
     if (allMapsAsStruct) {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1792,8 +1792,11 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   auto* connector = layout->connector();
   auto* metadata = connector::ConnectorMetadata::metadata(connector);
   auto session = session_->toConnectorSession(connector->connectorId());
-  auto handle =
-      metadata->beginWrite(session, table.shared_from_this(), write.kind());
+  auto handle = metadata->beginWrite(
+      session,
+      table.shared_from_this(),
+      write.kind(),
+      optimizerOptions_.explain);
 
   auto inputType = ROW(inputNames, inputTypes);
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -328,7 +328,11 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
     return metadata->createTable(
-        session, statement.tableName(), statement.tableSchema(), options);
+        session,
+        statement.tableName(),
+        statement.tableSchema(),
+        options,
+        /*explain=*/false);
   }
 
   void dropTable(const ::axiom::sql::presto::DropTableStatement& statement) {

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -138,9 +138,9 @@ void HiveQueriesTestBase::createEmptyTable(
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
   auto table = metadata_->createTable(
-      session, {kDefaultSchema, name}, tableType, options);
-  auto handle =
-      metadata_->beginWrite(session, table, connector::WriteKind::kCreate);
+      session, {kDefaultSchema, name}, tableType, options, /*explain=*/false);
+  auto handle = metadata_->beginWrite(
+      session, table, connector::WriteKind::kCreate, /*explain=*/false);
   metadata_->finishWrite(session, handle, {}, nullptr, {}).get();
 }
 
@@ -166,7 +166,11 @@ void HiveQueriesTestBase::createTableFromFiles(
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
   metadata_->createTable(
-      session, {kDefaultSchema, tableName}, tableType, options);
+      session,
+      {kDefaultSchema, tableName},
+      tableType,
+      options,
+      /*explain=*/false);
 
   auto tablePath = metadata_->tablePath({kDefaultSchema, tableName});
   for (const auto& filePath : filePaths) {
@@ -200,7 +204,8 @@ void HiveQueriesTestBase::runCtas(const std::string& sql) {
       session,
       ctasStatement->tableName(),
       ctasStatement->tableSchema(),
-      options);
+      options,
+      /*explain=*/false);
 
   connector::SchemaResolver schemaResolver;
   schemaResolver.setTargetTable(

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -49,9 +49,9 @@ class WriteTest : public test::HiveQueriesTestBase {
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
     auto table = metadata.createTable(
-        session, {kDefaultSchema, name}, tableType, options);
-    auto handle =
-        metadata.beginWrite(session, table, connector::WriteKind::kCreate);
+        session, {kDefaultSchema, name}, tableType, options, /*explain=*/false);
+    auto handle = metadata.beginWrite(
+        session, table, connector::WriteKind::kCreate, /*explain=*/false);
     metadata.finishWrite(session, handle, {}, nullptr, {}).get();
   }
 
@@ -67,7 +67,11 @@ class WriteTest : public test::HiveQueriesTestBase {
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
     return metadata.createTable(
-        session, statement.tableName(), statement.tableSchema(), options);
+        session,
+        statement.tableName(),
+        statement.tableSchema(),
+        options,
+        /*explain=*/false);
   }
 
   void runCtas(


### PR DESCRIPTION
Summary:

Previously, EXPLAIN CTAS was blocked with VELOX_NYI because planning
CTAS requires calling ConnectorMetadata::createTable() and beginWrite(),
both of which can have side effects (directory creation, file writes,
metastore registration). EXPLAIN must be side-effect-free.

The fix adds a `bool explain` parameter to createTable() and beginWrite()
in the ConnectorMetadata API. When true, connectors interpret table
properties and return valid metadata for plan display, but skip all side
effects. No cleanup is needed if the process crashes during EXPLAIN.

The flag is threaded via OptimizerOptions::explain, which is set to true
when the optimizer runs under an EXPLAIN query. EXPLAIN runs the regular
CTAS flow and stops after optimization — no finishWrite() is called.

Reviewed By: amitkdutta

Differential Revision: D96339691
