### PR TITLE
feat: Support binary literal expressions (X'...') (#1045)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/ExpressionPlanner.h"
+#include <folly/String.h>
 #include <algorithm>
 #include <cctype>
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -546,6 +547,22 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kStringLiteral:
       return lp::Lit(node->as<StringLiteral>()->value());
+
+    case NodeType::kBinaryLiteral: {
+      auto hexString = node->as<BinaryLiteral>()->value();
+      std::erase_if(hexString, [](char c) { return std::isspace(c); });
+      std::string bytes;
+      VELOX_USER_CHECK_EQ(
+          hexString.size() % 2,
+          0,
+          "Binary literal must contain an even number of digits: X'{}'",
+          hexString);
+      VELOX_USER_CHECK(
+          folly::unhexlify(hexString, bytes),
+          "Binary literal can only contain hexadecimal digits: X'{}'",
+          hexString);
+      return lp::Lit(Variant::binary(std::move(bytes)));
+    }
 
     case NodeType::kIntervalLiteral: {
       const auto interval = node->as<IntervalLiteral>();

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1873,7 +1873,10 @@ std::any AstBuilder::visitSubqueryExpression(
 std::any AstBuilder::visitBinaryLiteral(
     PrestoSqlParser::BinaryLiteralContext* ctx) {
   trace("visitBinaryLiteral");
-  return visitChildren("visitBinaryLiteral", ctx);
+
+  auto token = ctx->BINARY_LITERAL()->getText();
+  return std::static_pointer_cast<Expression>(std::make_shared<BinaryLiteral>(
+      getLocation(ctx), token.substr(2, token.size() - 3)));
 }
 
 std::any AstBuilder::visitCurrentUser(

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -242,6 +242,37 @@ TEST_F(ExpressionParserTest, doubleLiteral) {
   test("1E+5", 1e5);
 }
 
+TEST_F(ExpressionParserTest, binaryLiteral) {
+  auto test = [&](std::string_view sql, std::string_view expectedBytes) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+
+    ASSERT_TRUE(expr->isConstant());
+    ASSERT_EQ(*expr->type(), *VARBINARY());
+
+    auto value = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(value->isNull());
+    EXPECT_EQ(value->value<TypeKind::VARBINARY>(), expectedBytes);
+  };
+
+  test("X'48454C4C4F'", "HELLO");
+  test(
+      "X'abcdef1234567890ABCDEF'",
+      "\xab\xcd\xef\x12\x34\x56\x78\x90\xAB\xCD\xEF");
+  test("X'00'", std::string("\x00", 1));
+  test("X''", "");
+
+  test("x''", "");
+  test("x' '", "");
+  test("X'AB CD'", "\xAB\xCD");
+
+  // Odd number of hex digits.
+  VELOX_ASSERT_THROW(parseExpr("X'a b c'"), "even number of digits");
+
+  // Non-hexadecimal character.
+  VELOX_ASSERT_THROW(parseExpr("X'az'"), "hexadecimal digits");
+}
+
 TEST_F(ExpressionParserTest, unicodeStringLiteral) {
   auto test = [&](std::string_view sql, std::string_view expected) {
     SCOPED_TRACE(sql);


### PR DESCRIPTION
Summary:

**Summary:**
Add parser support for binary literals . E.g

```sql
SELECT from_utf8(X'48454C4C4F')
```

**Changes**
- Build a proper `BinaryLiteral` AST node in `AstBuilder::visitBinaryLiteral`
- Decode hex to VARBINARY via `folly::unhexlify` in `ExpressionPlanner`
- Strip whitespace inside binary literals per SQL standard.

Reviewed By: amitkdutta

Differential Revision: D96331806


