### PR TITLE
refactor(parser): Extract GROUP BY sort utilities

### DIFF
--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   axiom_sql_presto_parser
   ExpressionPlanner.cpp
   GroupByPlanner.cpp
+  SortProjection.cpp
   PrestoParser.cpp
   ShowStatsBuilder.cpp
   SqlStatement.cpp

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/sql/presto/GroupByPlanner.h"
 #include <set>
+#include "axiom/sql/presto/SortProjection.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "folly/container/F14Set.h"
 #include "velox/common/base/BitUtil.h"
@@ -334,14 +335,14 @@ void GroupByPlanner::plan(
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
   // function calls, then add the Aggregate plan node.
   // Populates: aggregates_, aggregateOptionsMap_, projections_, filter_,
-  //   sortingKeys_, outputNames_.
+  //   sortingKeyExprs_, outputNames_.
   collectAggregates(selectItems, having, orderBy);
   addAggregate(groupingSetsIndices_.size() > 1);
 
-  // Rewrite filter_, projections_, and sortingKeys_ to reference the
+  // Rewrite filter_, projections_, and sortingKeyExprs_ to reference the
   // aggregate output columns instead of the original input expressions.
   // Populates: flatInputs_.
-  // Mutates: filter_, projections_, sortingKeys_.
+  // Mutates: filter_, projections_, sortingKeyExprs_.
   rewritePostAggregateExprs();
 
   // Resolve sorting key ordinals before projecting: ORDER BY expressions
@@ -359,7 +360,13 @@ void GroupByPlanner::plan(
   }
 
   // Sort and drop any extra projections added for ORDER BY.
-  addSort(selectItems, sortingKeyOrdinals);
+  if (orderBy != nullptr && !sortingKeyOrdinals.empty()) {
+    SortProjection::sortAndTrim(
+        *builder_,
+        orderBy->sortItems(),
+        sortingKeyOrdinals,
+        selectItems.size());
+  }
 }
 
 bool GroupByPlanner::tryPlanGlobalAgg(
@@ -526,8 +533,7 @@ void GroupByPlanner::collectAggregates(
       auto expr = exprPlanner_.toExpr(item->sortKey(), &aggregateOptionsMap_);
       findAggregates(
           expr.expr(), aggregateOptionsMap_, aggregates_, aggregateSet);
-      sortingKeys_.emplace_back(
-          expr, item->isAscending(), item->isNullsFirst());
+      sortingKeyExprs_.emplace_back(expr);
     }
   }
 }
@@ -608,47 +614,34 @@ void GroupByPlanner::rewritePostAggregateExprs() {
   }
 
   // Replace sorting key expressions too.
-  for (auto& key : sortingKeys_) {
+  for (auto& expr : sortingKeyExprs_) {
     auto newExpr = replaceInputs(
-        key.expr.expr(), keyInputs, aggregateInputs, aggregateOptionsMap_);
-    auto newKeyExpr = lp::ExprApi(std::move(newExpr), key.expr.name());
-    if (key.expr.windowSpec()) {
-      newKeyExpr = newKeyExpr.over(*key.expr.windowSpec());
+        expr.expr(), keyInputs, aggregateInputs, aggregateOptionsMap_);
+    const auto windowSpec = expr.windowSpec();
+    expr = lp::ExprApi(newExpr, expr.name());
+    if (windowSpec) {
+      expr = expr.over(*windowSpec);
     }
-    key = lp::SortKey(newKeyExpr, key.ascending, key.nullsFirst);
   }
 }
 
 std::vector<size_t> GroupByPlanner::resolveSortOrdinals(
     const OrderByPtr& orderBy) {
-  std::vector<size_t> sortingKeyOrdinals;
-  if (sortingKeys_.empty()) {
-    return sortingKeyOrdinals;
+  if (sortingKeyExprs_.empty()) {
+    return {};
   }
 
-  ExprMap<size_t> projectionMap;
-  for (size_t i = 0; i < projections_.size(); ++i) {
-    projectionMap.emplace(projections_.at(i).expr(), i + 1);
-  }
-
-  for (size_t i = 0; i < sortingKeys_.size(); ++i) {
+  VELOX_CHECK_EQ(orderBy->sortItems().size(), sortingKeyExprs_.size());
+  std::vector<size_t> preResolved(sortingKeyExprs_.size(), 0);
+  for (size_t i = 0; i < sortingKeyExprs_.size(); ++i) {
     const auto& sortKey = orderBy->sortItems().at(i)->sortKey();
     if (sortKey->is(NodeType::kLongLiteral)) {
-      const auto n = sortKey->as<LongLiteral>()->value();
-      sortingKeyOrdinals.emplace_back(n);
-    } else {
-      auto [it, inserted] = projectionMap.emplace(
-          sortingKeys_.at(i).expr.expr(), projections_.size() + 1);
-      if (inserted) {
-        sortingKeyOrdinals.emplace_back(projections_.size() + 1);
-        projections_.emplace_back(sortingKeys_.at(i).expr);
-      } else {
-        sortingKeyOrdinals.emplace_back(it->second);
-      }
+      preResolved.at(i) = sortKey->as<LongLiteral>()->value();
     }
   }
 
-  return sortingKeyOrdinals;
+  return SortProjection::widenProjections(
+      sortingKeyExprs_, preResolved, projections_);
 }
 
 bool GroupByPlanner::isIdentityProjection() const {
@@ -668,35 +661,6 @@ bool GroupByPlanner::isIdentityProjection() const {
   }
 
   return true;
-}
-
-void GroupByPlanner::addSort(
-    const std::vector<SelectItemPtr>& selectItems,
-    const std::vector<size_t>& sortingKeyOrdinals) {
-  if (sortingKeys_.empty()) {
-    return;
-  }
-
-  for (size_t i = 0; i < sortingKeys_.size(); ++i) {
-    const auto name =
-        builder_->findOrAssignOutputNameAt(sortingKeyOrdinals.at(i) - 1);
-
-    auto& key = sortingKeys_.at(i);
-    key = lp::SortKey(lp::Col(name), key.ascending, key.nullsFirst);
-  }
-
-  builder_->sort(sortingKeys_);
-
-  // Drop projections used only for sorting.
-  if (selectItems.size() < projections_.size()) {
-    std::vector<lp::ExprApi> finalProjections;
-    finalProjections.reserve(selectItems.size());
-    for (size_t i = 0; i < selectItems.size(); ++i) {
-      finalProjections.emplace_back(
-          lp::Col(builder_->findOrAssignOutputNameAt(i)));
-    }
-    builder_->project(finalProjections);
-  }
 }
 
 lp::ExprApi GroupByPlanner::resolveGroupingExpression(

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -78,9 +78,6 @@ class GroupByPlanner {
   void rewritePostAggregateExprs();
   std::vector<size_t> resolveSortOrdinals(const OrderByPtr& orderBy);
   bool isIdentityProjection() const;
-  void addSort(
-      const std::vector<SelectItemPtr>& selectItems,
-      const std::vector<size_t>& sortingKeyOrdinals);
 
   lp::ExprApi resolveGroupingExpression(
       const ExpressionPtr& expr,
@@ -112,7 +109,7 @@ class GroupByPlanner {
   AggregateOptionsMap aggregateOptionsMap_;
 
   std::optional<lp::ExprApi> filter_;
-  std::vector<lp::SortKey> sortingKeys_;
+  std::vector<lp::ExprApi> sortingKeyExprs_;
   std::vector<std::string> outputNames_;
 };
 

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/sql/presto/SortProjection.h"
+
+#include "velox/parse/IExpr.h"
+
+namespace axiom::sql::presto {
+
+namespace lp = facebook::axiom::logical_plan;
+
+std::vector<size_t> SortProjection::widenProjections(
+    const std::vector<lp::ExprApi>& sortKeyExprs,
+    const std::vector<size_t>& preResolvedOrdinals,
+    std::vector<lp::ExprApi>& projections) {
+  VELOX_CHECK_EQ(
+      preResolvedOrdinals.size(),
+      sortKeyExprs.size(),
+      "Must be the same size as sortKeyExprs.");
+  std::vector<size_t> ordinals;
+  ordinals.reserve(sortKeyExprs.size());
+
+  facebook::velox::core::ExprMap<size_t> projectionMap;
+  for (size_t i = 0; i < projections.size(); ++i) {
+    projectionMap.emplace(projections[i].expr(), i + 1);
+  }
+
+  for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
+    // Use pre-resolved ordinal if available.
+    if (preResolvedOrdinals[i] != 0) {
+      ordinals.push_back(preResolvedOrdinals[i]);
+      continue;
+    }
+
+    auto [projectionIt, inserted] =
+        projectionMap.emplace(sortKeyExprs[i].expr(), projections.size() + 1);
+    if (inserted) {
+      ordinals.push_back(projections.size() + 1);
+      projections.push_back(sortKeyExprs[i]);
+    } else {
+      ordinals.push_back(projectionIt->second);
+    }
+  }
+
+  return ordinals;
+}
+
+void SortProjection::sortAndTrim(
+    lp::PlanBuilder& builder,
+    const std::vector<std::shared_ptr<SortItem>>& sortItems,
+    const std::vector<size_t>& sortKeyOrdinals,
+    size_t numOutputColumns) {
+  VELOX_CHECK(!sortItems.empty());
+
+  // Resolve sort key ordinals to output column names.
+  std::vector<lp::SortKey> resolvedKeys;
+  resolvedKeys.reserve(sortItems.size());
+  for (size_t i = 0; i < sortItems.size(); ++i) {
+    const auto name = builder.findOrAssignOutputNameAt(sortKeyOrdinals[i] - 1);
+    const auto& item = sortItems[i];
+    resolvedKeys.emplace_back(
+        lp::Col(name), item->isAscending(), item->isNullsFirst());
+  }
+
+  builder.sort(resolvedKeys);
+
+  // Only trim if extra columns were added for sorting.
+  if (numOutputColumns < builder.numOutput()) {
+    std::vector<lp::ExprApi> finalProjections;
+    finalProjections.reserve(numOutputColumns);
+    for (size_t i = 0; i < numOutputColumns; ++i) {
+      finalProjections.emplace_back(
+          lp::Col(builder.findOrAssignOutputNameAt(i)));
+    }
+    builder.project(finalProjections);
+  }
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/SortProjection.h
+++ b/axiom/sql/presto/SortProjection.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/ast/AstSupport.h"
+
+namespace axiom::sql::presto {
+
+class SortProjection {
+ public:
+  /// Matches sort key expressions against items in the SELECT list. For
+  /// unmatched expressions, appends them to `projections`, widening the
+  /// projection list. Returns a 1-based ordinal for each sort key in the
+  /// widened projection list.
+  ///
+  /// @param sortKeyExprs List of expressions from the ORDER BY list. Keys not
+  /// in the projection list (above) are considered unmatched and used to widen
+  /// the projection list.
+  /// @param preResolvedOrdinals 1-based ordinals for sort keys that are already
+  /// resolved. Must be the same size as sortKeyExprs. A value of 0 means
+  /// unresolved. All non-zero values must map to valid positions in projections
+  /// (1-based).
+  /// @param projections Mutable list of expressions from the SELECT list. This
+  /// is where unmatched sort key expressions are appended. All pre-resolved
+  /// ordinals should match to a projection here.
+  static std::vector<size_t> widenProjections(
+      const std::vector<facebook::axiom::logical_plan::ExprApi>& sortKeyExprs,
+      const std::vector<size_t>& preResolvedOrdinals,
+      std::vector<facebook::axiom::logical_plan::ExprApi>& projections);
+
+  /// Adds a SortNode using sort keys resolved by ordinals, then drops any extra
+  /// columns that were added for sorting.
+  ///
+  /// @param builder The plan builder to add a sort to.
+  /// @param sortItems List of sort items from the ORDER BY clause. This should
+  /// be non-empty.
+  /// @param sortKeyOrdinals 1-based ordinals from the widened projection list,
+  /// used to match the sort key with its corresponding ordinal.
+  /// @param numOutputColumns Number of columns in the final output. Extra
+  /// columns that were appended to the projection list for sorting can be
+  /// trimmed from the end, keeping only numOutputColumns in the final
+  /// projection.
+  static void sortAndTrim(
+      facebook::axiom::logical_plan::PlanBuilder& builder,
+      const std::vector<std::shared_ptr<SortItem>>& sortItems,
+      const std::vector<size_t>& sortKeyOrdinals,
+      size_t numOutputColumns);
+};
+
+} // namespace axiom::sql::presto


### PR DESCRIPTION
Summary:

Extracts GROUP BY sort handling utilities into reusable static functions in `SortProjection` that can be used for ORDER BY refactor:
- `widenProjections()`: resolves sort keys against a projection list and widens it.
- `sortAndTrim()`: adds a sort node and trims the extra projection columns.

Refactored `GroupByPlanner::resolveSortOrdinals()` to use these utilities and removed redundant `addSort()`.

Differential Revision: D96411887


