### PR TITLE
feat: Add CREATE/DROP/SHOW SCHEMAS support (#1053)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -154,6 +154,32 @@ std::string SqlQueryRunner::dropTable(
   }
 }
 
+std::string SqlQueryRunner::createSchema(
+    const presto::CreateSchemaStatement& statement) {
+  auto metadata =
+      connector::ConnectorMetadata::metadata(statement.connectorId());
+
+  folly::F14FastMap<std::string, velox::Variant> properties;
+  for (const auto& [key, value] : statement.properties()) {
+    properties[key] =
+        optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
+  }
+
+  auto session = std::make_shared<connector::ConnectorSession>("test");
+  metadata->createSchema(
+      session, statement.schemaName(), statement.ifNotExists(), properties);
+  return fmt::format("Created schema: {}", statement.schemaName());
+}
+
+std::string SqlQueryRunner::dropSchema(
+    const presto::DropSchemaStatement& statement) {
+  auto metadata =
+      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto session = std::make_shared<connector::ConnectorSession>("test");
+  metadata->dropSchema(session, statement.schemaName(), statement.ifExists());
+  return fmt::format("Dropped schema: {}", statement.schemaName());
+}
+
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
     std::string_view sql,
     const RunOptions& options) {
@@ -295,6 +321,16 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
     return {.message = dropTable(*drop)};
+  }
+
+  if (sqlStatement.isCreateSchema()) {
+    const auto* create = sqlStatement.as<presto::CreateSchemaStatement>();
+    return {.message = createSchema(*create)};
+  }
+
+  if (sqlStatement.isDropSchema()) {
+    const auto* drop = sqlStatement.as<presto::DropSchemaStatement>();
+    return {.message = dropSchema(*drop)};
   }
 
   if (sqlStatement.isShowStatsForQuery()) {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -120,6 +120,10 @@ class SqlQueryRunner {
 
   std::string dropTable(const presto::DropTableStatement& statement);
 
+  std::string createSchema(const presto::CreateSchemaStatement& statement);
+
+  std::string dropSchema(const presto::DropSchemaStatement& statement);
+
   /// Returns the default connector ID set during initialization.
   const std::string& defaultConnectorId() const {
     return defaultConnectorId_;

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -45,6 +45,9 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     }
   }
 
+  inline static const std::string kDefaultSchema{
+      facebook::axiom::connector::TestConnector::kDefaultSchema};
+
   std::unique_ptr<SqlQueryRunner> makeRunner() {
     auto runner = std::make_unique<SqlQueryRunner>();
 
@@ -58,13 +61,19 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
 
       connectorIds_.emplace_back(testConnector->connectorId());
 
-      return std::make_pair(
-          testConnector->connectorId(),
-          std::string(
-              facebook::axiom::connector::TestConnector::kDefaultSchema));
+      return std::make_pair(testConnector->connectorId(), kDefaultSchema);
     });
 
     return runner;
+  }
+
+  void assertSchemas(const std::vector<std::string>& expected) {
+    auto result = runner_->run("SHOW SCHEMAS", {});
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(
+        result.results[0],
+        makeRowVector({"Schema"}, {makeFlatVector(expected)}));
   }
 
   std::unique_ptr<SqlQueryRunner> runner_;
@@ -289,6 +298,70 @@ TEST_F(SqlQueryRunnerTest, showStatsForQueryWithFilter) {
   ASSERT_FALSE(result.message.has_value());
   ASSERT_EQ(1, result.results.size());
   test::assertEqualVectors(expected, result.results[0]);
+}
+
+TEST_F(SqlQueryRunnerTest, createAndDropSchema) {
+  assertSchemas({kDefaultSchema});
+
+  // Create a new schema.
+  auto createResult = runner_->run("CREATE SCHEMA foo", {});
+  EXPECT_EQ("Created schema: foo", createResult.message);
+  assertSchemas({kDefaultSchema, "foo"});
+
+  // Drop the schema.
+  auto dropResult = runner_->run("DROP SCHEMA foo", {});
+  EXPECT_EQ("Dropped schema: foo", dropResult.message);
+  assertSchemas({kDefaultSchema});
+}
+
+TEST_F(SqlQueryRunnerTest, createSchemaErrors) {
+  VELOX_ASSERT_THROW(
+      runner_->run("CREATE SCHEMA default", {}), "Schema already exists");
+
+  // IF NOT EXISTS succeeds silently.
+  auto result = runner_->run("CREATE SCHEMA IF NOT EXISTS default", {});
+  EXPECT_EQ("Created schema: default", result.message);
+}
+
+TEST_F(SqlQueryRunnerTest, dropSchemaErrors) {
+  VELOX_ASSERT_THROW(
+      runner_->run("DROP SCHEMA nonexistent", {}), "Schema does not exist");
+
+  // IF EXISTS succeeds silently.
+  auto result = runner_->run("DROP SCHEMA IF EXISTS nonexistent", {});
+  EXPECT_EQ("Dropped schema: nonexistent", result.message);
+
+  // Cannot drop the default schema.
+  VELOX_ASSERT_THROW(
+      runner_->run("DROP SCHEMA default", {}), "Cannot drop the default");
+  assertSchemas({kDefaultSchema});
+
+  // CASCADE is not supported.
+  VELOX_ASSERT_THROW(
+      runner_->run("DROP SCHEMA default CASCADE", {}),
+      "CASCADE is not supported");
+}
+
+TEST_F(SqlQueryRunnerTest, createTableInNonExistentSchema) {
+  VELOX_ASSERT_THROW(
+      runner_->run("CREATE TABLE nonexistent.t AS SELECT 1 AS x", {}),
+      "Schema does not exist: nonexistent");
+}
+
+TEST_F(SqlQueryRunnerTest, showSchemasWithLike) {
+  runner_->run("CREATE SCHEMA dev", {});
+  runner_->run("CREATE SCHEMA staging", {});
+  SCOPE_EXIT {
+    runner_->run("DROP SCHEMA IF EXISTS dev", {});
+    runner_->run("DROP SCHEMA IF EXISTS staging", {});
+  };
+
+  auto result = runner_->run("SHOW SCHEMAS LIKE 'd%'", {});
+  ASSERT_EQ(1, result.results.size());
+  test::assertEqualVectors(
+      result.results[0],
+      makeRowVector(
+          {"Schema"}, {makeFlatVector<std::string>({kDefaultSchema, "dev"})}));
 }
 
 } // namespace

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -898,6 +898,42 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
+  /// Returns the list of schema names available in this connector. Some
+  /// connectors may return only a representative subset of schemas (e.g.,
+  /// TPC-H returns a fixed list of scale-factor schemas). Use schemaExists()
+  /// to check whether a specific schema exists.
+  virtual std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& session) = 0;
+
+  /// Returns true if the specified schema exists. This may accept schemas
+  /// not listed by listSchemaNames() (e.g., TPC-H accepts any valid
+  /// scale-factor schema like "sf42").
+  virtual bool schemaExists(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) = 0;
+
+  /// Creates a schema with the given name and properties. If 'ifNotExists' is
+  /// true, succeeds silently when the schema already exists. Otherwise, raises
+  /// a user error if the schema already exists.
+  virtual void createSchema(
+      [[maybe_unused]] const ConnectorSessionPtr& session,
+      [[maybe_unused]] const std::string& schemaName,
+      [[maybe_unused]] bool ifNotExists,
+      [[maybe_unused]] const folly::F14FastMap<std::string, velox::Variant>&
+          properties) {
+    VELOX_UNSUPPORTED();
+  }
+
+  /// Drops a schema with the given name. If 'ifExists' is true, succeeds
+  /// silently when the schema does not exist. Otherwise, raises a user error
+  /// if the schema does not exist.
+  virtual void dropSchema(
+      [[maybe_unused]] const ConnectorSessionPtr& session,
+      [[maybe_unused]] const std::string& schemaName,
+      [[maybe_unused]] bool ifExists) {
+    VELOX_UNSUPPORTED();
+  }
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1864,6 +1864,10 @@ TablePtr LocalHiveConnectorMetadata::createTable(
     const velox::RowTypePtr& rowType,
     const folly::F14FastMap<std::string, velox::Variant>& options,
     bool explain) {
+  VELOX_USER_CHECK(
+      schemaExists(nullptr, tableName.schema),
+      "Schema does not exist: {}",
+      tableName.schema);
   validateOptions(options);
   ensureInitialized();
   auto createTableOptions = parseCreateTableOptions(options, format_);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -249,6 +249,17 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
 
   TablePtr findTable(const SchemaTableName& tableName) override;
 
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& session) override {
+    return {std::string(kDefaultSchema)};
+  }
+
+  bool schemaExists(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override {
+    return schemaName == kDefaultSchema;
+  }
+
   ConnectorSplitManager* splitManager() override {
     ensureInitialized();
     return &splitManager_;

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -50,6 +50,8 @@ class SchemaResolverTest : public ::testing::Test {
       const std::string& schema) {
     auto connector = std::make_shared<connector::TestConnector>(id);
     velox::connector::registerConnector(connector);
+    ConnectorMetadata::metadata(id)->createSchema(
+        nullptr, schema, /*ifNotExists=*/false, {});
     return Catalog{
         .id = id,
         .schema = schema,
@@ -74,6 +76,8 @@ TEST_F(SchemaResolverTest, bareTable) {
 }
 
 TEST_F(SchemaResolverTest, tablePlusSchema) {
+  ConnectorMetadata::metadata("base")->createSchema(
+      nullptr, "newschema", /*ifNotExists=*/false, {});
   ConnectorMetadata::metadata("base")->createTable(
       nullptr, {"newschema", "table"}, ROW({}), {}, /*explain=*/false);
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -257,6 +257,40 @@ bool TestConnectorMetadata::dropView(const SchemaTableName& viewName) {
   return views_.erase(viewName) == 1;
 }
 
+std::vector<std::string> TestConnectorMetadata::listSchemaNames(
+    const ConnectorSessionPtr& /*session*/) {
+  return {schemas_.begin(), schemas_.end()};
+}
+
+bool TestConnectorMetadata::schemaExists(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  return schemas_.contains(schemaName);
+}
+
+void TestConnectorMetadata::createSchema(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName,
+    bool ifNotExists,
+    const folly::F14FastMap<std::string, velox::Variant>& /*properties*/) {
+  auto [_, inserted] = schemas_.insert(schemaName);
+  VELOX_USER_CHECK(
+      inserted || ifNotExists, "Schema already exists: {}", schemaName);
+}
+
+void TestConnectorMetadata::dropSchema(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName,
+    bool ifExists) {
+  VELOX_USER_CHECK_NE(
+      schemaName,
+      std::string(kDefaultSchema),
+      "Cannot drop the default schema");
+  auto erased = schemas_.erase(schemaName);
+  VELOX_USER_CHECK(
+      erased == 1 || ifExists, "Schema does not exist: {}", schemaName);
+}
+
 namespace {
 class TestDiscretePredicates : public DiscretePredicates {
  public:
@@ -363,6 +397,10 @@ TablePtr TestConnectorMetadata::createTable(
     const velox::RowTypePtr& rowType,
     const folly::F14FastMap<std::string, velox::Variant>& /*options*/,
     bool explain) {
+  VELOX_USER_CHECK(
+      schemas_.contains(tableName.schema),
+      "Schema does not exist: {}",
+      tableName.schema);
   auto table = std::make_shared<TestTable>(
       tableName, rowType, velox::ROW({}), connector_);
   if (explain) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -287,6 +287,8 @@ class TestInsertTableHandle
 /// layout. Filter pushdown is not supported.
 class TestConnectorMetadata : public ConnectorMetadata {
  public:
+  static constexpr std::string_view kDefaultSchema = "default";
+
   explicit TestConnectorMetadata(TestConnector* connector)
       : connector_(connector),
         splitManager_(std::make_unique<TestSplitManager>()) {}
@@ -366,6 +368,25 @@ class TestConnectorMetadata : public ConnectorMetadata {
   /// Remove a view by name. Returns true if the view existed.
   bool dropView(const SchemaTableName& viewName);
 
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& session) override;
+
+  bool schemaExists(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
+  void createSchema(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName,
+      bool ifNotExists,
+      const folly::F14FastMap<std::string, velox::Variant>& properties)
+      override;
+
+  void dropSchema(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName,
+      bool ifExists) override;
+
  private:
   TestConnector* connector_;
   folly::F14FastMap<
@@ -381,6 +402,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
   };
   folly::F14FastMap<SchemaTableName, ViewDefinition, SchemaTableNameHash>
       views_;
+
+  folly::F14FastSet<std::string> schemas_{"default"};
 };
 
 /// At DataSource creation time, the data contained in the corresponding Table
@@ -438,7 +461,8 @@ class TestDataSource : public velox::connector::DataSource {
 /// the associated table.
 class TestConnector : public velox::connector::Connector {
  public:
-  static constexpr std::string_view kDefaultSchema = "default";
+  static constexpr std::string_view kDefaultSchema =
+      TestConnectorMetadata::kDefaultSchema;
 
   explicit TestConnector(
       const std::string& id,

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -234,6 +234,27 @@ TablePtr TpchConnectorMetadata::findTable(const SchemaTableName& tableName) {
   return table;
 }
 
+std::vector<std::string> TpchConnectorMetadata::listSchemaNames(
+    const ConnectorSessionPtr& /*session*/) {
+  return {
+      kTiny,
+      "sf1",
+      "sf100",
+      "sf300",
+      "sf1000",
+      "sf3000",
+      "sf10000",
+      "sf30000",
+      "sf100000",
+  };
+}
+
+bool TpchConnectorMetadata::schemaExists(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  return isValidTpchSchema(schemaName);
+}
+
 ViewPtr TpchConnectorMetadata::findView(const SchemaTableName& tableName) {
   if (!tableName.schema.empty() && !isValidTpchSchema(tableName.schema)) {
     return nullptr;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -178,6 +178,13 @@ class TpchConnectorMetadata : public ConnectorMetadata {
 
   TablePtr findTable(const SchemaTableName& tableName) override;
 
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& session) override;
+
+  bool schemaExists(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
   ViewPtr findView(const SchemaTableName& tableName) override;
 
   void createView(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1553,6 +1553,79 @@ SqlStatementPtr parseDropTable(
       std::move(connectorId), std::move(connectorTable), dropTable.isExists());
 }
 
+SqlStatementPtr parseCreateSchema(
+    const CreateSchema& createSchema,
+    const std::string& defaultConnectorId) {
+  const auto& parts = createSchema.schemaName()->parts();
+  VELOX_USER_CHECK(
+      parts.size() == 1 || parts.size() == 2,
+      "Invalid schema name: {}",
+      createSchema.schemaName()->fullyQualifiedName());
+
+  std::string connectorId = parts.size() == 2 ? parts[0] : defaultConnectorId;
+  std::string schemaName = parts.size() == 2 ? parts[1] : parts[0];
+
+  auto properties = parseTableProperties(createSchema.properties());
+
+  return std::make_shared<CreateSchemaStatement>(
+      std::move(connectorId),
+      std::move(schemaName),
+      createSchema.isNotExists(),
+      std::move(properties));
+}
+
+SqlStatementPtr parseDropSchema(
+    const DropSchema& dropSchema,
+    const std::string& defaultConnectorId) {
+  const auto& parts = dropSchema.schemaName()->parts();
+  VELOX_USER_CHECK(
+      parts.size() == 1 || parts.size() == 2,
+      "Invalid schema name: {}",
+      dropSchema.schemaName()->fullyQualifiedName());
+
+  VELOX_USER_CHECK(
+      dropSchema.behavior() != DropSchema::DropBehavior::kCascade,
+      "DROP SCHEMA CASCADE is not supported");
+
+  std::string connectorId = parts.size() == 2 ? parts[0] : defaultConnectorId;
+  std::string schemaName = parts.size() == 2 ? parts[1] : parts[0];
+
+  return std::make_shared<DropSchemaStatement>(
+      std::move(connectorId), std::move(schemaName), dropSchema.isExists());
+}
+
+SqlStatementPtr parseShowSchemas(
+    const ShowSchemas& showSchemas,
+    const std::string& defaultConnectorId) {
+  const auto connectorId = showSchemas.catalog().value_or(defaultConnectorId);
+
+  auto metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId);
+  auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
+      "show-schemas");
+  auto schemaNames = metadata->listSchemaNames(session);
+  std::sort(schemaNames.begin(), schemaNames.end());
+
+  std::vector<Variant> data;
+  data.reserve(schemaNames.size());
+  for (const auto& name : schemaNames) {
+    data.emplace_back(Variant::row({name}));
+  }
+
+  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder builder(ctx);
+  builder.values(ROW({"Schema"}, VARCHAR()), std::move(data));
+
+  if (showSchemas.getLikePattern().has_value()) {
+    builder.filter(makeLikeExpr(
+        "Schema",
+        showSchemas.getLikePattern().value(),
+        showSchemas.getEscape()));
+  }
+
+  return std::make_shared<SelectStatement>(builder.build());
+}
+
 SqlStatementPtr doPlan(
     const std::shared_ptr<Statement>& query,
     const std::string& defaultConnectorId,
@@ -1580,6 +1653,18 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kDropTable)) {
     return parseDropTable(
         *query->as<DropTable>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kCreateSchema)) {
+    return parseCreateSchema(*query->as<CreateSchema>(), defaultConnectorId);
+  }
+
+  if (query->is(NodeType::kDropSchema)) {
+    return parseDropSchema(*query->as<DropSchema>(), defaultConnectorId);
+  }
+
+  if (query->is(NodeType::kShowSchemas)) {
+    return parseShowSchemas(*query->as<ShowSchemas>(), defaultConnectorId);
   }
 
   if (query->is(NodeType::kShowCatalogs)) {

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -46,6 +46,8 @@ enum class SqlStatementKind {
   kCreateTableAsSelect,
   kInsert,
   kDropTable,
+  kCreateSchema,
+  kDropSchema,
   kExplain,
   kShowStatsForQuery,
   kUse,
@@ -84,6 +86,14 @@ class SqlStatement {
 
   bool isDropTable() const {
     return kind_ == SqlStatementKind::kDropTable;
+  }
+
+  bool isCreateSchema() const {
+    return kind_ == SqlStatementKind::kCreateSchema;
+  }
+
+  bool isDropSchema() const {
+    return kind_ == SqlStatementKind::kDropSchema;
   }
 
   bool isExplain() const {
@@ -295,6 +305,74 @@ class DropTableStatement : public SqlStatement {
  private:
   const std::string connectorId_;
   const facebook::axiom::SchemaTableName tableName_;
+  const bool ifExists_;
+};
+
+class CreateSchemaStatement : public SqlStatement {
+ public:
+  CreateSchemaStatement(
+      std::string connectorId,
+      std::string schemaName,
+      bool ifNotExists,
+      std::unordered_map<std::string, facebook::axiom::logical_plan::ExprPtr>
+          properties)
+      : SqlStatement(SqlStatementKind::kCreateSchema),
+        connectorId_{std::move(connectorId)},
+        schemaName_{std::move(schemaName)},
+        ifNotExists_{ifNotExists},
+        properties_{std::move(properties)} {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const std::string& schemaName() const {
+    return schemaName_;
+  }
+
+  bool ifNotExists() const {
+    return ifNotExists_;
+  }
+
+  const std::unordered_map<std::string, facebook::axiom::logical_plan::ExprPtr>&
+  properties() const {
+    return properties_;
+  }
+
+ private:
+  const std::string connectorId_;
+  const std::string schemaName_;
+  const bool ifNotExists_;
+  const std::unordered_map<std::string, facebook::axiom::logical_plan::ExprPtr>
+      properties_;
+};
+
+class DropSchemaStatement : public SqlStatement {
+ public:
+  DropSchemaStatement(
+      std::string connectorId,
+      std::string schemaName,
+      bool ifExists)
+      : SqlStatement(SqlStatementKind::kDropSchema),
+        connectorId_{std::move(connectorId)},
+        schemaName_{std::move(schemaName)},
+        ifExists_{ifExists} {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const std::string& schemaName() const {
+    return schemaName_;
+  }
+
+  bool ifExists() const {
+    return ifExists_;
+  }
+
+ private:
+  const std::string connectorId_;
+  const std::string schemaName_;
   const bool ifExists_;
 };
 

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -381,12 +381,32 @@ std::any AstBuilder::visitUse(PrestoSqlParser::UseContext* ctx) {
 std::any AstBuilder::visitCreateSchema(
     PrestoSqlParser::CreateSchemaContext* ctx) {
   trace("visitCreateSchema");
-  return visitChildren("visitCreateSchema", ctx);
+
+  auto schemaName = getQualifiedName(ctx->qualifiedName());
+  bool notExists = ctx->EXISTS() != nullptr;
+
+  std::vector<std::shared_ptr<Property>> properties;
+  if (ctx->properties() != nullptr) {
+    properties = visitTyped<Property>(ctx->properties()->property());
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<CreateSchema>(
+      getLocation(ctx), schemaName, notExists, properties));
 }
 
 std::any AstBuilder::visitDropSchema(PrestoSqlParser::DropSchemaContext* ctx) {
   trace("visitDropSchema");
-  return visitChildren("visitDropSchema", ctx);
+
+  auto schemaName = getQualifiedName(ctx->qualifiedName());
+  bool exists = ctx->EXISTS() != nullptr;
+
+  DropSchema::DropBehavior behavior = DropSchema::DropBehavior::kRestrict;
+  if (ctx->CASCADE() != nullptr) {
+    behavior = DropSchema::DropBehavior::kCascade;
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<DropSchema>(
+      getLocation(ctx), schemaName, exists, behavior));
 }
 
 std::any AstBuilder::visitRenameSchema(
@@ -686,7 +706,26 @@ std::any AstBuilder::visitShowTables(PrestoSqlParser::ShowTablesContext* ctx) {
 std::any AstBuilder::visitShowSchemas(
     PrestoSqlParser::ShowSchemasContext* ctx) {
   trace("visitShowSchemas");
-  return visitChildren("visitShowSchemas", ctx);
+
+  std::optional<std::string> catalog;
+  if (ctx->identifier() != nullptr) {
+    catalog = visitIdentifier(ctx->identifier())->value();
+  }
+
+  std::optional<std::string> likePattern;
+  std::optional<std::string> escape;
+  if (ctx->LIKE() != nullptr) {
+    likePattern = visitExpression(ctx->pattern)->as<StringLiteral>()->value();
+  }
+  if (ctx->ESCAPE() != nullptr) {
+    escape = visitExpression(ctx->escape)->as<StringLiteral>()->value();
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<ShowSchemas>(
+      getLocation(ctx),
+      std::move(catalog),
+      std::move(likePattern),
+      std::move(escape)));
 }
 
 std::any AstBuilder::visitShowCatalogs(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -767,6 +767,10 @@ void ShowCatalogs::accept(AstVisitor* visitor) {
   visitor->visitShowCatalogs(this);
 }
 
+void ShowSchemas::accept(AstVisitor* visitor) {
+  visitor->visitShowSchemas(this);
+}
+
 void ShowColumns::accept(AstVisitor* visitor) {
   visitor->visitShowColumns(this);
 }

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -776,6 +776,38 @@ class ShowCatalogs : public Statement {
   std::optional<std::string> escape_;
 };
 
+class ShowSchemas : public Statement {
+ public:
+  ShowSchemas(
+      NodeLocation location,
+      std::optional<std::string> catalog,
+      std::optional<std::string> likePattern,
+      std::optional<std::string> escape)
+      : Statement(NodeType::kShowSchemas, location),
+        catalog_(std::move(catalog)),
+        likePattern_(std::move(likePattern)),
+        escape_(std::move(escape)) {}
+
+  const std::optional<std::string>& catalog() const {
+    return catalog_;
+  }
+
+  const std::optional<std::string>& getLikePattern() const {
+    return likePattern_;
+  }
+
+  const std::optional<std::string>& getEscape() const {
+    return escape_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::optional<std::string> catalog_;
+  std::optional<std::string> likePattern_;
+  std::optional<std::string> escape_;
+};
+
 class ShowColumns : public Statement {
  public:
   explicit ShowColumns(

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -559,6 +559,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowSchemas(ShowSchemas* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowColumns(ShowColumns* node) {
     defaultVisit(node);
   }


### PR DESCRIPTION
Summary:

Add schema management support.

Connector API: Add listSchemaNames, schemaExists, createSchema, dropSchema
virtual methods to ConnectorMetadata. All default to VELOX_UNSUPPORTED().

TestConnector: Implement all four methods with an in-memory schema set
pre-populated with "default". Validate schema existence in createTable.

SQL: Wire up CREATE SCHEMA [IF NOT EXISTS], DROP SCHEMA [IF EXISTS], and
SHOW SCHEMAS [FROM catalog] [LIKE pattern]. SHOW SCHEMAS resolves at plan
time into a Values node (same pattern as SHOW CATALOGS). DROP SCHEMA
CASCADE raises a user error.

Reviewed By: amitkdutta

Differential Revision: D96479594


