### PR TITLE
fix(optimizer): Fix DT columns when finalizing window operation in filter (#1054)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3440,7 +3440,7 @@ void ToGraph::makeFilterQueryGraph(
   // Window functions compute over the full input; pushing any filter below
   // them changes their semantics.
   if (currentDt_->hasWindow()) {
-    finalizeDt(filter);
+    finalizeDt(input);
   }
 
   addFilter(input, filter.predicate());

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -471,6 +471,33 @@ TEST_F(RankingTest, filterOnRowNumberEquals1) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
+TEST_F(RankingTest, filterOnRowNumberGreaterThan) {
+  constexpr auto sql =
+      "SELECT count(1) FROM ("
+      "  SELECT n_name, row_number() OVER () as rn "
+      "  FROM nation"
+      ") WHERE rn > 1";
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .rowNumber({})
+                     .filter("rn > 1")
+                     .singleAggregation({}, {"count(1) as count"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation")
+                                .shuffle()
+                                .localGather()
+                                .rowNumber({})
+                                .filter("rn > 1")
+                                .partialAggregation({}, {"count(1)"})
+                                .localPartition()
+                                .finalAggregation()
+                                .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
 TEST_F(RankingTest, filterWithAdditionalPredicates) {
   // The ranking predicate (rn <= 5) is absorbed as a TopNRowNumber limit. The
   // non-window predicate (n_regionkey > 2) stays as a filter above because it

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -64,6 +64,9 @@ SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn 
 -- Filter on ranking function output (rn <= N).
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn <= 1
 ----
+-- Filter on ranking function output (rn > N).
+SELECT a, b FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn > 1
+----
 -- Window function combined with ORDER BY and LIMIT.
 -- ordered
 SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t ORDER BY a, b LIMIT 3


### PR DESCRIPTION
Summary:

Previously in ToGraph::makeFilterQueryGraph, when the current DT contains a
window plan, it finalize the DT with the filter node's used channels and then
adding the filter to the outer DT. However, the filter node's used channels may
not include all input columns of the filter. This would cause 
Optimization::placeConjuncts later failed to place the filter conjunct.

To fix this problem, this PR makes ToGraph::makeFilterQueryGraph to finalize
the DT with the filter's input node whose used channels are guaranteed to 
include all input columns of the filter.

Reviewed By: peterenescu

Differential Revision: D96413832


