### PR TITLE
fix(GroupByPlanner): Support window functions in GROUP BY queries (#1055)

### DIFF
--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -134,3 +134,15 @@ SELECT a, b, lead(null, 1) OVER (PARTITION BY a ORDER BY b) AS ld FROM t
 ----
 -- Window function output used as GROUP BY key in outer query.
 SELECT a, max_a, sum(b) FROM (SELECT a, b, max(a) OVER (ORDER BY b) AS max_a FROM t) GROUP BY 1, 2
+----
+-- Window function nested inside expression with GROUP BY.
+SELECT a, row_number() OVER (ORDER BY a) + sum(b) FROM t GROUP BY a
+----
+-- Deeply nested window function in arithmetic with GROUP BY.
+SELECT a, 1 + (2 * row_number() OVER (ORDER BY a)) FROM t GROUP BY a
+----
+-- Multiple distinct window functions in same GROUP BY query.
+SELECT a, row_number() OVER (ORDER BY a) + sum(b), rank() OVER (ORDER BY a) FROM t GROUP BY a
+----
+-- Window function sharing a name with an aggregate (sum as window vs sum as aggregate).
+SELECT a, sum(b), sum(a) OVER (ORDER BY a) FROM t GROUP BY a

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -278,7 +278,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
     const ExpressionPtr& node,
     std::unordered_map<const core::IExpr*, lp::PlanBuilder::AggregateOptions>*
         aggregateOptions,
-    std::unordered_map<const core::IExpr*, lp::WindowSpec>* windowOptions) {
+    folly::F14FastMap<const core::IExpr*, lp::WindowSpec>* windowOptions) {
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
@@ -76,7 +77,7 @@ class ExpressionPlanner {
       std::unordered_map<
           const facebook::velox::core::IExpr*,
           lp::PlanBuilder::AggregateOptions>* aggregateOptions = nullptr,
-      std::unordered_map<const facebook::velox::core::IExpr*, lp::WindowSpec>*
+      folly::F14FastMap<const facebook::velox::core::IExpr*, lp::WindowSpec>*
           windowOptions = nullptr);
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -101,19 +101,27 @@ core::ExprPtr replaceInputs(
     const ExprMap<core::ExprPtr>& keyReplacements,
     const AggregateExprMap& aggregateReplacements,
     const AggregateOptionsMap& optionsMap,
+    const folly::F14FastMap<const core::IExpr*, lp::WindowSpec>* windowOptions =
+        nullptr,
     const std::function<void(const core::FieldAccessExpr&)>& onUnreplacedLeaf =
         nullptr) {
+  VELOX_CHECK_NOT_NULL(expr);
   // First try grouping keys.
   auto keyIt = keyReplacements.find(expr);
   if (keyIt != keyReplacements.end()) {
     return keyIt->second;
   }
 
-  // Then try aggregates.
-  AggregateExprWithOptions key{expr, findOptions(expr, optionsMap)};
-  auto aggIt = aggregateReplacements.find(key);
-  if (aggIt != aggregateReplacements.end()) {
-    return aggIt->second;
+  // Skip window function expressions. They should not be replaced with
+  // aggregate column references even if structurally equal to a plain
+  // aggregate. Sub-expressions are still rewritten below.
+  if (windowOptions == nullptr || windowOptions->count(expr.get()) == 0) {
+    // Then try aggregates.
+    AggregateExprWithOptions key{expr, findOptions(expr, optionsMap)};
+    auto aggIt = aggregateReplacements.find(key);
+    if (aggIt != aggregateReplacements.end()) {
+      return aggIt->second;
+    }
   }
 
   std::vector<core::ExprPtr> newInputs;
@@ -124,6 +132,7 @@ core::ExprPtr replaceInputs(
         keyReplacements,
         aggregateReplacements,
         optionsMap,
+        windowOptions,
         onUnreplacedLeaf);
     if (newInput.get() != input.get()) {
       hasNewInput = true;
@@ -143,6 +152,51 @@ core::ExprPtr replaceInputs(
   return expr;
 }
 
+// Finds sub-expressions in an IExpr tree using pointer-identity matching.
+// Walks the expression tree and collects ExprPtrs whose raw pointers are
+// found in targets. Also appends matches to order in traversal order for
+// deterministic plan generation.
+void findExprPtrs(
+    const core::ExprPtr& expr,
+    const folly::F14FastMap<const core::IExpr*, lp::WindowSpec>& targets,
+    folly::F14FastMap<const core::IExpr*, core::ExprPtr>& found,
+    std::vector<const core::IExpr*>& order) {
+  VELOX_CHECK_NOT_NULL(expr);
+  if (targets.count(expr.get())) {
+    if (found.emplace(expr.get(), expr).second) {
+      order.push_back(expr.get());
+    }
+    return;
+  }
+  for (const auto& input : expr->inputs()) {
+    findExprPtrs(input, targets, found, order);
+  }
+}
+
+// Replaces sub-expressions by pointer identity. Used to swap window function
+// call nodes with column references after the window projection is added.
+core::ExprPtr replaceWindowInputs(
+    const core::ExprPtr& expr,
+    const folly::F14FastMap<const core::IExpr*, core::ExprPtr>& replacements) {
+  VELOX_CHECK_NOT_NULL(expr);
+  auto it = replacements.find(expr.get());
+  if (it != replacements.end()) {
+    return it->second;
+  }
+
+  std::vector<core::ExprPtr> newInputs;
+  bool changed = false;
+  for (const auto& input : expr->inputs()) {
+    auto newInput = replaceWindowInputs(input, replacements);
+    if (newInput.get() != input.get()) {
+      changed = true;
+    }
+    newInputs.push_back(std::move(newInput));
+  }
+
+  return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
+}
+
 // Set of aggregation expression with options for deduplication.
 using AggregateExprSet = folly::F14FastSet<
     AggregateExprWithOptions,
@@ -151,9 +205,13 @@ using AggregateExprSet = folly::F14FastSet<
 
 // Walks the expression tree looking for aggregate function calls and appending
 // these calls to 'aggregates' after deduplication through 'aggregateSet'.
+// Skips expressions found in windowOptions. These are window functions that
+// share an aggregate function name (e.g. sum(...) OVER (...)) and should not be
+// collected as aggregates. Nested arguments are still searched.
 void findAggregates(
     const core::ExprPtr& expr,
     const AggregateOptionsMap& optionsMap,
+    const folly::F14FastMap<const core::IExpr*, lp::WindowSpec>* windowOptions,
     std::vector<AggregateWithOptions>& aggregates,
     AggregateExprSet& aggregateSet) {
   switch (expr->kind()) {
@@ -162,6 +220,15 @@ void findAggregates(
     case core::IExpr::Kind::kFieldAccess:
       return;
     case core::IExpr::Kind::kCall: {
+      // Skip window functions even if they share an aggregate function name.
+      // Recurse into their arguments to find nested aggregates.
+      if (windowOptions != nullptr && windowOptions->count(expr.get())) {
+        for (const auto& input : expr->inputs()) {
+          findAggregates(
+              input, optionsMap, windowOptions, aggregates, aggregateSet);
+        }
+        return;
+      }
       if (exec::getAggregateFunctionEntry(expr->as<core::CallExpr>()->name())) {
         auto* options = findOptions(expr, optionsMap);
         AggregateExprWithOptions key{expr, options};
@@ -170,7 +237,8 @@ void findAggregates(
         }
       } else {
         for (const auto& input : expr->inputs()) {
-          findAggregates(input, optionsMap, aggregates, aggregateSet);
+          findAggregates(
+              input, optionsMap, windowOptions, aggregates, aggregateSet);
         }
       }
       return;
@@ -179,6 +247,7 @@ void findAggregates(
       findAggregates(
           expr->as<core::CastExpr>()->input(),
           optionsMap,
+          windowOptions,
           aggregates,
           aggregateSet);
       return;
@@ -192,7 +261,8 @@ void findAggregates(
       return;
     case core::IExpr::Kind::kConcat:
       for (const auto& input : expr->inputs()) {
-        findAggregates(input, optionsMap, aggregates, aggregateSet);
+        findAggregates(
+            input, optionsMap, windowOptions, aggregates, aggregateSet);
       }
       return;
     default:
@@ -354,15 +424,24 @@ void GroupByPlanner::plan(
   // Mutates: filter_, projections_, sortingKeyExprs_.
   rewritePostAggregateExprs();
 
+  // Apply HAVING filter before window projection. HAVING operates on
+  // aggregate results, not window function output, so it must be evaluated
+  // before window functions are materialized.
+  if (filter_.has_value()) {
+    builder_->filter(filter_.value());
+  }
+
+  // Materialize window functions as a separate projection, then replace
+  // window sub-expressions in projections_ and sortingKeys_ with column
+  // references to the window output.
+  if (!windowOptions_.empty()) {
+    addWindowProjection();
+  }
+
   // Resolve sorting key ordinals before projecting: ORDER BY expressions
   // that are not in the SELECT list are appended to projections_ so they
   // are included in the project node. Must happen before builder_->project().
   auto sortingKeyOrdinals = resolveSortOrdinals(orderBy);
-
-  // Apply HAVING filter, then project.
-  if (filter_.has_value()) {
-    builder_->filter(filter_.value());
-  }
 
   if (!isIdentityProjection()) {
     builder_->project(projections_);
@@ -507,11 +586,15 @@ void GroupByPlanner::collectAggregates(
         return it->second;
       }
       return exprPlanner_.toExpr(
-          singleColumn->expression(), &aggregateOptionsMap_);
+          singleColumn->expression(), &aggregateOptionsMap_, &windowOptions_);
     }();
 
     findAggregates(
-        expr.expr(), aggregateOptionsMap_, aggregates_, aggregateSet);
+        expr.expr(),
+        aggregateOptionsMap_,
+        &windowOptions_,
+        aggregates_,
+        aggregateSet);
 
     if (!aggregates_.empty() &&
         aggregates_.back().expr.expr().get() == expr.expr().get()) {
@@ -530,19 +613,34 @@ void GroupByPlanner::collectAggregates(
   }
 
   if (having != nullptr) {
-    lp::ExprApi expr = exprPlanner_.toExpr(having, &aggregateOptionsMap_);
+    // Do not pass windowOptions_ for HAVING. Window functions in HAVING are
+    // invalid SQL, so passing nullptr lets them be rejected with the default
+    // "Window function cannot be an argument to a scalar function" error.
+    lp::ExprApi expr = exprPlanner_.toExpr(
+        having, &aggregateOptionsMap_, /*windowOptions=*/nullptr);
     findAggregates(
-        expr.expr(), aggregateOptionsMap_, aggregates_, aggregateSet);
+        expr.expr(),
+        aggregateOptionsMap_,
+        /*windowOptions=*/nullptr,
+        aggregates_,
+        aggregateSet);
     filter_ = expr;
   }
 
   if (orderBy != nullptr) {
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
-      auto expr = exprPlanner_.toExpr(item->sortKey(), &aggregateOptionsMap_);
+      auto expr = exprPlanner_.toExpr(
+          item->sortKey(), &aggregateOptionsMap_, &windowOptions_);
       findAggregates(
-          expr.expr(), aggregateOptionsMap_, aggregates_, aggregateSet);
+          expr.expr(),
+          aggregateOptionsMap_,
+          &windowOptions_,
+          aggregates_,
+          aggregateSet);
       sortingKeyExprs_.emplace_back(expr);
+      sortingKeys_.emplace_back(
+          expr, item->isAscending(), item->isNullsFirst());
     }
   }
 }
@@ -600,6 +698,7 @@ void GroupByPlanner::rewritePostAggregateExprs() {
         keyInputs,
         aggregateInputs,
         aggregateOptionsMap_,
+        /*windowOptions=*/nullptr,
         [](const core::FieldAccessExpr& expr) {
           VELOX_USER_FAIL(
               "HAVING clause cannot reference column: {}", expr.name());
@@ -613,11 +712,18 @@ void GroupByPlanner::rewritePostAggregateExprs() {
   auto rewriteExpr = [&](lp::ExprApi& item) {
     const auto windowSpec = item.windowSpec();
     if (windowSpec) {
+      // For window function expressions, only rewrite the arguments (not the
+      // call itself). This preserves the window function identity while
+      // replacing aggregate/key sub-expressions with column references.
       std::vector<core::ExprPtr> newInputs;
       bool changed = false;
       for (const auto& input : item.expr()->inputs()) {
         auto newInput = replaceInputs(
-            input, keyInputs, aggregateInputs, aggregateOptionsMap_);
+            input,
+            keyInputs,
+            aggregateInputs,
+            aggregateOptionsMap_,
+            &windowOptions_);
         changed |= (newInput.get() != input.get());
         newInputs.push_back(std::move(newInput));
       }
@@ -626,7 +732,11 @@ void GroupByPlanner::rewritePostAggregateExprs() {
       item = lp::ExprApi(std::move(newExpr), item.name()).over(*windowSpec);
     } else {
       auto newExpr = replaceInputs(
-          item.expr(), keyInputs, aggregateInputs, aggregateOptionsMap_);
+          item.expr(),
+          keyInputs,
+          aggregateInputs,
+          aggregateOptionsMap_,
+          &windowOptions_);
       item = lp::ExprApi(std::move(newExpr), item.name());
     }
   };
@@ -637,13 +747,108 @@ void GroupByPlanner::rewritePostAggregateExprs() {
   // TODO: Verify that SELECT expressions don't depend on anything other
   // than grouping keys and aggregates.
 
+  // Updates windowOptions_ when replaceInputs produces a new IExpr pointer
+  // for a window function (e.g., aggregate sub-expressions inside the window
+  // call were replaced with column references).
+  auto updateWindowKey =
+      [this](const core::IExpr* oldPtr, const core::IExpr* newPtr) {
+        if (oldPtr != newPtr) {
+          auto it = windowOptions_.find(oldPtr);
+          if (it != windowOptions_.end()) {
+            auto spec = std::move(it->second);
+            windowOptions_.erase(it);
+            windowOptions_.emplace(newPtr, std::move(spec));
+          }
+        }
+      };
+
   for (auto& item : projections_) {
+    auto* oldExprPtr = item.expr().get();
     rewriteExpr(item);
+    updateWindowKey(oldExprPtr, item.expr().get());
   }
 
   // Replace sorting key expressions too.
   for (auto& expr : sortingKeyExprs_) {
     rewriteExpr(expr);
+  }
+
+  for (auto& key : sortingKeys_) {
+    auto* oldExprPtr = key.expr.expr().get();
+    rewriteExpr(key.expr);
+    key = lp::SortKey(key.expr, key.ascending, key.nullsFirst);
+    updateWindowKey(oldExprPtr, key.expr.expr().get());
+  }
+}
+
+void GroupByPlanner::addWindowProjection() {
+  auto inputColumns =
+      builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
+
+  // Collect ExprPtrs for the window calls from the expression trees.
+  // windowOrder captures matches in left-to-right traversal order for
+  // deterministic plan generation.
+  folly::F14FastMap<const core::IExpr*, core::ExprPtr> windowExprPtrs;
+  std::vector<const core::IExpr*> windowOrder;
+  for (const auto& expr : projections_) {
+    findExprPtrs(expr.expr(), windowOptions_, windowExprPtrs, windowOrder);
+  }
+  for (const auto& key : sortingKeys_) {
+    findExprPtrs(key.expr.expr(), windowOptions_, windowExprPtrs, windowOrder);
+  }
+
+  // Build window projection: all input columns + window function expressions.
+  std::vector<lp::ExprApi> windowProjection;
+  windowProjection.reserve(inputColumns.size() + windowOrder.size());
+  for (const auto& name : inputColumns) {
+    windowProjection.push_back(lp::Col(name));
+  }
+  for (const auto* exprPtr : windowOrder) {
+    windowProjection.push_back(
+        lp::ExprApi(windowExprPtrs.at(exprPtr))
+            .over(windowOptions_.at(exprPtr)));
+  }
+
+  builder_->project(windowProjection);
+
+  // Build replacement map: window expr pointer to column reference.
+  auto outputNames =
+      builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
+
+  folly::F14FastMap<const core::IExpr*, core::ExprPtr> replacements;
+  for (size_t i = 0; i < windowOrder.size(); ++i) {
+    const auto& name = outputNames.at(inputColumns.size() + i);
+    replacements.emplace(windowOrder[i], lp::Col(name).expr());
+  }
+
+  // Replace window sub-expressions in projections with column references.
+  for (auto& item : projections_) {
+    item = lp::ExprApi(
+        replaceWindowInputs(item.expr(), replacements), item.name());
+  }
+
+  // Replace window sub-expressions in sorting keys with column references.
+  for (auto& key : sortingKeys_) {
+    auto newKeyExpr = lp::ExprApi(
+        replaceWindowInputs(key.expr.expr(), replacements), key.expr.name());
+    key = lp::SortKey(newKeyExpr, key.ascending, key.nullsFirst);
+  }
+
+  // Replace window sub-expressions in sorting key expressions used by
+  // resolveSortOrdinals to map ORDER BY keys to projection indices.
+  for (auto& expr : sortingKeyExprs_) {
+    expr = lp::ExprApi(
+        replaceWindowInputs(expr.expr(), replacements), expr.name());
+  }
+
+  // Refresh flatInputs_ and outputNames_ to reflect the window projection
+  // output, so isIdentityProjection() can detect when the final projection is
+  // identity (e.g., for top-level window functions where no further computation
+  // is needed beyond the window project).
+  flatInputs_.clear();
+  outputNames_ = outputNames;
+  for (const auto& name : outputNames) {
+    flatInputs_.push_back(lp::Col(name));
   }
 }
 
@@ -671,8 +876,9 @@ bool GroupByPlanner::isIdentityProjection() const {
     return false;
   }
 
+  core::IExprEqual exprEqual;
   for (size_t i = 0; i < projections_.size(); ++i) {
-    if (projections_.at(i).expr() != flatInputs_.at(i).expr()) {
+    if (!exprEqual(projections_.at(i).expr(), flatInputs_.at(i).expr())) {
       return false;
     }
 

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -76,6 +76,10 @@ class GroupByPlanner {
       const OrderByPtr& orderBy);
   void addAggregate(bool useGroupingSets);
   void rewritePostAggregateExprs();
+  // Materializes window functions as a separate projection node, then
+  // replaces window sub-expressions in projections_ and sortingKeys_ with
+  // column references to the window output.
+  void addWindowProjection();
   std::vector<size_t> resolveSortOrdinals(const OrderByPtr& orderBy);
   bool isIdentityProjection() const;
 
@@ -108,8 +112,23 @@ class GroupByPlanner {
   // Must outlive aggregates_ since aggregates_ holds pointers into this map.
   AggregateOptionsMap aggregateOptionsMap_;
 
+  // Maps each window function IExpr* to its WindowSpec. Populated by
+  // collectAggregates() via toExpr with windowOptions. Must outlive
+  // addWindowProjection() which reads from this map.
+  folly::F14FastMap<const facebook::velox::core::IExpr*, lp::WindowSpec>
+      windowOptions_;
+
   std::optional<lp::ExprApi> filter_;
+
+  // ORDER BY sorting keys with direction info. Populated by
+  // collectAggregates(). Used in rewritePostAggregateExprs() and
+  // addWindowProjection() for window-aware rewriting.
+  std::vector<lp::SortKey> sortingKeys_;
+
+  // ORDER BY expressions (without direction). Used by resolveSortOrdinals()
+  // and SortProjection::widenProjections().
   std::vector<lp::ExprApi> sortingKeyExprs_;
+
   std::vector<std::string> outputNames_;
 };
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -235,7 +235,7 @@ bool hasNestedWindowFunction(const std::vector<SelectItemPtr>& selectItems) {
 // for deterministic plan generation.
 void findExprPtrs(
     const core::ExprPtr& expr,
-    const std::unordered_map<const core::IExpr*, lp::WindowSpec>& targets,
+    const folly::F14FastMap<const core::IExpr*, lp::WindowSpec>& targets,
     std::unordered_map<const core::IExpr*, core::ExprPtr>& found,
     std::vector<const core::IExpr*>& order) {
   if (targets.count(expr.get())) {
@@ -302,7 +302,7 @@ class RelationPlanner : public AstVisitor {
       const ExpressionPtr& node,
       std::unordered_map<const core::IExpr*, lp::PlanBuilder::AggregateOptions>*
           aggregateOptions = nullptr,
-      std::unordered_map<const core::IExpr*, lp::WindowSpec>* windowOptions =
+      folly::F14FastMap<const core::IExpr*, lp::WindowSpec>* windowOptions =
           nullptr) {
     return exprPlanner_.toExpr(node, aggregateOptions, windowOptions);
   }
@@ -608,7 +608,7 @@ class RelationPlanner : public AstVisitor {
   // window call IExpr* to column reference ExprPtr for replacing window
   // calls in downstream expressions.
   std::unordered_map<const core::IExpr*, core::ExprPtr> addWindowProjection(
-      const std::unordered_map<const core::IExpr*, lp::WindowSpec>&
+      const folly::F14FastMap<const core::IExpr*, lp::WindowSpec>&
           windowOptions,
       const std::vector<lp::ExprApi>& exprs) {
     auto inputColumns =
@@ -670,7 +670,7 @@ class RelationPlanner : public AstVisitor {
     // windowOptions (keyed by IExpr*) and returned as plain function calls.
     // Post-hoc, we extract them and replace with column references, similar
     // to how GroupByPlanner handles aggregates in expressions.
-    std::unordered_map<const core::IExpr*, lp::WindowSpec> windowOptions;
+    folly::F14FastMap<const core::IExpr*, lp::WindowSpec> windowOptions;
 
     // Lateral column alias map: alias name → expression. When friendlySql is
     // enabled, aliases defined in earlier SELECT items can be referenced in

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -655,14 +655,20 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           })
           .output());
 
-  // Window function in ORDER BY with GROUP BY.
+  // Window function in ORDER BY with GROUP BY. The window function is used
+  // only for sorting and does not appear in the SELECT output.
   testSelect(
-      "SELECT a, sum(b) FROM t GROUP BY a ORDER BY row_number() OVER (ORDER BY a)",
+      "SELECT a, sum(b) FROM t GROUP BY a "
+      "ORDER BY row_number() OVER (ORDER BY a)",
       matchScan("t")
           .aggregate({"a"}, {"sum(b)"})
-          .project()
-          .sort()
-          .project()
+          .project({
+              "a",
+              "sum",
+              "row_number() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .sort({"expr ASC NULLS LAST"})
+          .project({"a", "sum"})
           .output());
 
   // TODO: Aggregate references inside window specs are not yet rewritten to
@@ -673,15 +679,121 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
       "Cannot resolve column: a");
 
   // Window function call with the same signature as a plain aggregate.
+  // The window projection adds all input columns plus the window output,
+  // then a final projection selects the output columns in SELECT order.
   testSelect(
       "SELECT sum(a) OVER (ORDER BY b), sum(a) FROM t GROUP BY a, b",
       matchScan("t")
           .aggregate({"a", "b"}, {"sum(a)"})
           .project({
-              "sum(a) OVER (ORDER BY b)",
+              "a",
+              "b",
+              "sum",
+              "sum(a) OVER (ORDER BY b ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .project({
+              "expr",
               "sum",
           })
           .output());
+}
+
+TEST_F(AggregationParserTest, groupByWithNestedWindowFunction) {
+  connector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  // Window function nested inside an expression with GROUP BY.
+  testSelect(
+      "SELECT a, row_number() OVER (ORDER BY a) + sum(b) FROM t GROUP BY a",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b)"})
+          .project({
+              "a",
+              "sum",
+              "row_number() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .project({
+              "a",
+              "plus(expr, sum)",
+          })
+          .output());
+
+  // Deeply nested window function inside arithmetic.
+  testSelect(
+      "SELECT a, 1 + (2 * row_number() OVER (ORDER BY a)) FROM t GROUP BY a",
+      matchScan("t")
+          .aggregate({"a"}, {})
+          .project({
+              "a",
+              "row_number() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .project({
+              "a",
+              "plus(CAST(1 AS BIGINT), multiply(CAST(2 AS BIGINT), expr))",
+          })
+          .output());
+
+  // Window function sharing a name with an aggregate. sum(b) is an aggregate,
+  // sum(a) OVER (...) is a window function — they must not be conflated even
+  // though both use the sum() function name.
+  testSelect(
+      "SELECT a, sum(b), sum(a) OVER (ORDER BY a) FROM t GROUP BY a",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b)"})
+          .project({
+              "a",
+              "sum",
+              "sum(a) OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .output());
+
+  // Nested window function with PARTITION BY and GROUP BY. PARTITION BY adds
+  // additional sub-expressions to the window spec tree, exercising pointer
+  // identity matching in findExprPtrs and replaceWindowInputs.
+  testSelect(
+      "SELECT a, row_number() OVER (PARTITION BY a ORDER BY a) + sum(b) "
+      "FROM t GROUP BY a",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b)"})
+          .project({
+              "a",
+              "sum",
+              "row_number() OVER (PARTITION BY a ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .project({
+              "a",
+              "plus(expr, sum)",
+          })
+          .output());
+
+  // Multiple distinct window functions in same GROUP BY query.
+  testSelect(
+      "SELECT a, row_number() OVER (ORDER BY a) + sum(b), "
+      "rank() OVER (ORDER BY a) FROM t GROUP BY a",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b)"})
+          .project({
+              "a",
+              "sum",
+              "row_number() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+              "rank() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+          })
+          .project({
+              "a",
+              "plus(expr, sum)",
+              "expr_0",
+          })
+          .output());
+}
+
+TEST_F(AggregationParserTest, windowFunctionInHavingRejected) {
+  connector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  // Window functions in HAVING are invalid SQL.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT a, sum(b) FROM t GROUP BY a "
+          "HAVING row_number() OVER (ORDER BY a) > 1"),
+      "Window function cannot be an argument to a scalar function");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Fix GROUP BY queries with window functions nested inside expressions (e.g., `row_number() OVER (...) + sum(b)`). The planner now stashes window specs separately, skips window calls during aggregate collection/replacement, and materializes them via a dedicated projection node — matching PrestoParser's existing window handling.

Also fixes `isIdentityProjection()` to use structural comparison (`IExprEqual`) instead of pointer comparison, passes `windowOptions` through `rewriteExpr` to prevent stale pointer issues during expression rewriting, and fixes `sortingKeyExprs_` to be updated by `addWindowProjection()` so ORDER BY with window functions works correctly.

Follow-up: extract shared `findExprPtrs`/`replaceWindowInputs` helpers into a common header (duplicated with PrestoParser.cpp).

Differential Revision: D96349898


