### PR TITLE
feat(cli): Add query lifecycle callbacks to Console (#1057)

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -23,6 +23,7 @@
 #include "axiom/cli/StdinReader.h"
 #include "axiom/cli/Timing.h"
 #include "axiom/cli/linenoise/linenoise.h"
+#include "velox/common/base/SuccinctPrinter.h"
 
 DEFINE_string(
     data_path,
@@ -72,12 +73,16 @@ namespace axiom::sql {
 Console::Console(
     SqlQueryRunner& runner,
     PermissionCheck permissionCheck,
-    std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator)
+    std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator,
+    QueryStartCallback startCallback,
+    QueryCompletionCallback completionCallback)
     : runner_{runner},
       permissionCheck_{std::move(permissionCheck)},
       queryIdGenerator_{
           queryIdGenerator ? std::move(queryIdGenerator)
-                           : std::make_shared<cli::QueryIdGenerator>()} {}
+                           : std::make_shared<cli::QueryIdGenerator>()},
+      startCallback_{std::move(startCallback)},
+      completionCallback_{std::move(completionCallback)} {}
 
 void Console::initialize() {
   gflags::SetUsageMessage(
@@ -107,6 +112,26 @@ void Console::run() {
   }
 }
 
+void Console::notifyStart(const QueryStartInfo& info) {
+  if (startCallback_) {
+    try {
+      startCallback_(info);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "Start callback failed: " << ex.what();
+    }
+  }
+}
+
+void Console::notifyCompletion(const QueryCompletionInfo& info) {
+  if (completionCallback_) {
+    try {
+      completionCallback_(info);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "Completion callback failed: " << ex.what();
+    }
+  }
+}
+
 void Console::runNoThrow(std::string_view sql, bool isInteractive) {
   const SqlQueryRunner::RunOptions defaultOptions{
       .numWorkers = FLAGS_num_workers,
@@ -127,6 +152,12 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
     const auto queryId = queryIdGenerator_->createNextQueryId();
     auto options = defaultOptions;
     options.queryId = queryId;
+    const auto createTime = std::chrono::system_clock::now();
+
+    // Notify start callback before parse so that every query gets a start
+    // event. Parse or permission failures are handled by completionCallback_
+    // in the catch block.
+    notifyStart({queryId, std::string(sqlText), createTime});
 
     try {
       cli::Timing parseTiming;
@@ -164,11 +195,42 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
         cli::printResults(result.results, FLAGS_max_rows);
       }
 
-      if (isInteractive) {
-        std::cout << "Query ID: " << queryId << " | Optimizing and Executing: "
-                  << statementTiming.toString() << std::endl;
+      // Notify completion callback on success.
+      int64_t numOutputRows{0};
+      for (const auto& rowVector : result.results) {
+        numOutputRows += rowVector->size();
       }
+      uint64_t executionMicros{
+          statementTiming.micros > result.optimizeMicros
+              ? statementTiming.micros - result.optimizeMicros
+              : 0};
+
+      if (isInteractive) {
+        std::cout << "Query ID: " << queryId << " | Optimizing: "
+                  << facebook::velox::succinctNanos(
+                         result.optimizeMicros * 1'000)
+                  << " | Executing: "
+                  << facebook::velox::succinctNanos(executionMicros * 1'000)
+                  << " | Total: " << statementTiming.toString() << std::endl;
+      }
+      notifyCompletion(
+          QueryCompletionInfo{
+              .startInfo = {queryId, std::string(sqlText), createTime},
+              .planString = std::move(result.planString),
+              .parseMicros = parseTiming.micros,
+              .optimizeMicros = result.optimizeMicros,
+              .executionMicros = executionMicros,
+              .numOutputRows = numOutputRows,
+              .endTime = std::chrono::system_clock::now(),
+          });
     } catch (std::exception& e) {
+      // Notify completion callback on failure.
+      notifyCompletion(
+          QueryCompletionInfo{
+              .startInfo = {queryId, std::string(sqlText), createTime},
+              .errorInfo = ErrorInfo{e.what()},
+              .endTime = std::chrono::system_clock::now(),
+          });
       std::cerr << "Query ID: " << queryId << " | Query failed: " << e.what()
                 << std::endl;
       return;

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -15,9 +15,10 @@
  */
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
-#include <unordered_map>
+#include <optional>
 #include <utility>
 #include "axiom/cli/SqlQueryRunner.h"
 #include "axiom/sql/presto/SqlStatement.h"
@@ -43,16 +44,72 @@ using PermissionCheck =
         std::optional<std::string_view> schema,
         const presto::ViewMap& views)>;
 
+/// Holds query metadata captured at query start time.
+struct QueryStartInfo {
+  /// Unique identifier for this query execution.
+  std::string queryId;
+
+  /// SQL text of the query. Owned copy so callbacks can store this safely.
+  std::string query;
+
+  /// Wall-clock time when the query was created.
+  std::chrono::system_clock::time_point createTime;
+};
+
+/// Holds error details when a query fails.
+struct ErrorInfo {
+  /// Human-readable error message from the caught exception.
+  std::string message;
+};
+
+/// Holds query metadata at completion time (success or failure).
+struct QueryCompletionInfo {
+  /// Query identification and timing from start.
+  QueryStartInfo startInfo;
+
+  /// Set when the query fails; std::nullopt on success.
+  std::optional<ErrorInfo> errorInfo;
+
+  /// Human-readable distributed Velox plan with optimizer cardinality and
+  /// memory estimates. Empty for DDL statements.
+  std::optional<std::string> planString;
+
+  /// Time spent parsing the SQL statement, in microseconds.
+  uint64_t parseMicros{0};
+
+  /// Time spent in the optimizer, in microseconds.
+  uint64_t optimizeMicros{0};
+
+  /// Time spent executing the statement (excludes optimization), in
+  /// microseconds.
+  uint64_t executionMicros{0};
+
+  /// Number of rows in the query result.
+  int64_t numOutputRows{0};
+
+  /// Wall-clock time when the query finished.
+  std::chrono::system_clock::time_point endTime;
+};
+
+using QueryStartCallback = std::function<void(const QueryStartInfo&)>;
+using QueryCompletionCallback = std::function<void(const QueryCompletionInfo&)>;
+
 class Console {
  public:
   /// @param permissionCheck Optional callback invoked after each statement is
   /// parsed but before it is executed. Throws on denial.
   /// @param queryIdGenerator Optional query ID generator. Defaults to a
   /// generator with a random base-32 suffix.
+  /// @param startCallback Optional callback invoked before parse, for every
+  /// query.
+  /// @param completionCallback Optional callback invoked after execution
+  /// completes (success or failure).
   explicit Console(
       SqlQueryRunner& runner,
       PermissionCheck permissionCheck = nullptr,
-      std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator = nullptr);
+      std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator = nullptr,
+      QueryStartCallback startCallback = nullptr,
+      QueryCompletionCallback completionCallback = nullptr);
 
   /// Initializes the CLI with usage message and logging settings.
   void initialize();
@@ -69,6 +126,12 @@ class Console {
   // multi-statement queries.
   void runNoThrow(std::string_view sql, bool isInteractive = true);
 
+  // Invokes startCallback_ if set, swallowing any exceptions.
+  void notifyStart(const QueryStartInfo& info);
+
+  // Invokes completionCallback_ if set, swallowing any exceptions.
+  void notifyCompletion(const QueryCompletionInfo& info);
+
   // Reads and executes commands from standard input in interactive mode.
   void readCommands(const std::string& prompt);
 
@@ -76,6 +139,10 @@ class Console {
   PermissionCheck permissionCheck_;
   // Generates unique query IDs for each statement execution.
   std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator_;
+  // Invoked before parse for every query.
+  QueryStartCallback startCallback_;
+  // Invoked after execution completes (success or failure).
+  QueryCompletionCallback completionCallback_;
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -31,6 +31,7 @@
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/time/Timer.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -340,12 +341,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     auto schema = std::make_shared<connector::SchemaResolver>();
     schema->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
-    return {.results = runLogicalPlan(ctas->plan(), options, schema)};
+    return runLogicalPlan(ctas->plan(), options, schema);
   }
 
   if (sqlStatement.isInsert()) {
     const auto* insert = sqlStatement.as<presto::InsertStatement>();
-    return {.results = runLogicalPlan(insert->plan(), options)};
+    return runLogicalPlan(insert->plan(), options);
   }
 
   if (sqlStatement.isDropTable()) {
@@ -388,7 +389,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
 
   const auto logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
 
-  return {.results = runLogicalPlan(logicalPlan, options)};
+  return runLogicalPlan(logicalPlan, options);
 }
 
 std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
@@ -605,21 +606,38 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
       executorPool_);
 }
 
-std::vector<velox::RowVectorPtr> SqlQueryRunner::runLogicalPlan(
+SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
     std::shared_ptr<facebook::axiom::connector::SchemaResolver>
         schemaResolver) {
   auto queryCtx = newQuery(options);
-  auto planAndStats = optimize(
-      logicalPlan, queryCtx, options, nullptr, nullptr, schemaResolver);
+
+  uint64_t optimizeMicros{0};
+  optimizer::PlanAndStats planAndStats;
+  {
+    velox::MicrosecondTimer timer(&optimizeMicros);
+    planAndStats = optimize(
+        logicalPlan,
+        queryCtx,
+        options,
+        nullptr,
+        nullptr,
+        std::move(schemaResolver));
+  }
+
+  auto planString = planAndStats.toString();
 
   auto runner = makeLocalRunner(planAndStats, queryCtx, options);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };
 
-  return fetchResults(*runner);
+  return {
+      .results = fetchResults(*runner),
+      .planString = std::move(planString),
+      .optimizeMicros = optimizeMicros,
+  };
 }
 
 std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -38,6 +38,11 @@ class SqlQueryRunner {
   struct SqlResult {
     std::optional<std::string> message;
     std::vector<facebook::velox::RowVectorPtr> results;
+    /// Human-readable distributed Velox plan with optimizer cardinality and
+    /// memory estimates. Empty for DDL statements.
+    std::optional<std::string> planString;
+    /// Time spent in the optimizer, in microseconds. Zero for DDL statements.
+    uint64_t optimizeMicros{0};
   };
 
   struct RunOptions {
@@ -186,10 +191,9 @@ class SqlQueryRunner {
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
       const RunOptions& options);
 
-  /// Runs a plan and returns the result as a single vector in *resultVector,
-  /// the plan text in *planString and the error message in *errorString.
-  /// *errorString is not set if no error. Any of these may be nullptr.
-  std::vector<facebook::velox::RowVectorPtr> runLogicalPlan(
+  // Optimizes and executes a logical plan, returning results and the
+  // serialized Velox plan string.
+  SqlResult runLogicalPlan(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>


### PR DESCRIPTION
Summary:

Add optional start and completion callbacks to Console so callers can
hook into the query lifecycle for logging, metrics, or other processing.

- startCallback: invoked before parse for every query.
- completionCallback: invoked after execution with query timing, row
  counts, and success/failure status.

Reviewed By: hdikeman, mbasmanova

Differential Revision: D96492425


