### PR TITLE
feat(optimizer): Add outputColumns to DerivedTable for explicit output projection (#1066)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -115,6 +115,13 @@ void DerivedTable::checkSetOpConsistency() const {
       importedExistences.empty(),
       "union DT must not have importedExistences: {}",
       cname);
+
+  // Union DT: outputColumns must equal columns (no intermediate columns).
+  VELOX_CHECK_EQ(
+      outputColumns.size(),
+      columns.size(),
+      "union DT outputColumns must match columns: {}",
+      cname);
 }
 
 void DerivedTable::checkConsistency() const {
@@ -162,6 +169,26 @@ void DerivedTable::checkConsistency() const {
 
     // exprs must reference only tables in tableSet or 'this'.
     checkTableReferences(exprs, "expr");
+  }
+
+  // outputColumns must be a subset of columns with no duplicates.
+  {
+    PlanObjectSet columnSet;
+    columnSet.unionObjects(columns);
+    PlanObjectSet seen;
+    for (const auto* column : outputColumns) {
+      VELOX_CHECK(
+          columnSet.contains(column),
+          "outputColumn not found in columns: {}, {}",
+          column->toString(),
+          cname);
+      VELOX_CHECK(
+          !seen.contains(column),
+          "Duplicate in outputColumns: {}, {}",
+          column->toString(),
+          cname);
+      seen.add(column);
+    }
   }
 
   VELOX_CHECK_EQ(
@@ -388,20 +415,20 @@ void DerivedTable::updateConstraints(const RelationOp& plan) {
 
   // A DT may have zero output columns (e.g. a child DT whose parent only
   // needs a row count). Only cardinality is useful for such DTs.
-  if (columns.empty()) {
+  if (outputColumns.empty()) {
     return;
   }
 
   const auto& planColumns = plan.columns();
   const auto& constraints = plan.constraints();
-  VELOX_CHECK_EQ(columns.size(), planColumns.size());
-  for (size_t i = 0; i < columns.size(); ++i) {
+  VELOX_CHECK_EQ(outputColumns.size(), planColumns.size());
+  for (size_t i = 0; i < outputColumns.size(); ++i) {
     auto it = constraints.find(planColumns[i]->id());
     VELOX_CHECK(
         it != constraints.end(),
         "Missing constraint for column: {}",
         planColumns[i]->toString());
-    const_cast<Value&>(columns[i]->value()) = it->second;
+    const_cast<Value&>(outputColumns[i]->value()) = it->second;
   }
 }
 
@@ -633,6 +660,7 @@ std::pair<DerivedTableCP, JoinEdgeP> makeExistsDtAndJoin(
           key->value());
       newExistsDt->columns.push_back(existsColumn);
       newExistsDt->exprs.push_back(key);
+      newExistsDt->outputColumns.push_back(existsColumn);
     }
     newExistsDt->noImportOfExists = true;
     newExistsDt->initializePlans();
@@ -965,6 +993,12 @@ AggregateCP DerivedTable::exportSingleAggregate(Name markName) {
   VELOX_CHECK(!hasLimit());
   VELOX_CHECK(!hasOrderBy());
 
+  // Clear outputColumns before export. The old output columns (aggregate
+  // results) become invalid once aggregation is cleared. exportExpr and the
+  // mark column addition below will repopulate outputColumns with only the
+  // columns this DT can produce post-export.
+  outputColumns.clear();
+
   const Value constantBoolean{toType(velox::BOOLEAN()), 1};
 
   auto* markColumn = make<Column>(markName, this, constantBoolean);
@@ -973,6 +1007,7 @@ AggregateCP DerivedTable::exportSingleAggregate(Name markName) {
       make<Literal>(constantBoolean, registerVariant(velox::Variant(true)));
   columns.push_back(markColumn);
   exprs.push_back(trueLiteral);
+  outputColumns.push_back(markColumn);
 
   const auto* onlyAgg = aggregation->aggregates().front();
 
@@ -1008,12 +1043,20 @@ AggregateCP DerivedTable::exportSingleAggregate(Name markName) {
 }
 
 ExprCP DerivedTable::exportExpr(ExprCP expr) {
+  // Only update outputColumns if it has been initialized (by setDtUsedOutput or
+  // exportSingleAggregate). When uninitialized (empty), adding a single column
+  // would create a partial output specification missing the other columns.
+  const bool hasOutputColumns = !outputColumns.empty();
+
   expr->columns().forEach<Column>([&](auto* column) {
     if (tableSet.contains(column->relation())) {
       if (pushBackUnique(exprs, column)) {
         auto outer = make<Column>(
             column->name(), this, column->value(), column->alias());
         columns.push_back(outer);
+        if (hasOutputColumns) {
+          outputColumns.push_back(outer);
+        }
       }
     }
   });
@@ -1203,6 +1246,7 @@ void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
       chainDt->exprs.push_back(otherKey);
 
       chainDt->import(*this, chainSet, other);
+      chainDt->outputColumns = chainDt->columns;
       chainDt->initializePlans();
 
       newFirst->addTable(chainDt);
@@ -1231,6 +1275,7 @@ void DerivedTable::flattenDt(const DerivedTable* dt) {
   conjuncts = dt->conjuncts;
   columns = dt->columns;
   exprs = dt->exprs;
+  outputColumns = dt->outputColumns;
   importedExistences.unionSet(dt->importedExistences);
   aggregation = dt->aggregation;
   windowPlan = dt->windowPlan;

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -78,12 +78,17 @@ struct DerivedTable : public PlanObject {
   /// Correlation name.
   Name cname{nullptr};
 
-  /// Columns projected out. Visible in the enclosing query.
+  /// All columns defined by this DT, including intermediate columns needed for
+  /// HAVING, ORDER BY, etc.
   ColumnVector columns;
 
   /// Exprs projected out. 1:1 to 'columns' or empty if 'this' represents a set
   /// operation (setOp is set).
   ExprVector exprs;
+
+  /// Ordered list of columns this DT produces as output. Subset of 'columns'.
+  /// Determines the schema visible to the enclosing query.
+  ColumnVector outputColumns;
 
   /// True if this DT is expected to produce exactly 1 row and must be validated
   /// at runtime. Set for scalar subqueries that don't naturally guarantee

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1177,22 +1177,25 @@ void Optimization::addPostprocess(
     plan = limit;
   }
 
-  if (!dt->columns.empty()) {
-    ColumnVector usedColumns;
-    ExprVector usedExprs;
-    for (auto i = 0; i < dt->exprs.size(); ++i) {
-      const auto* expr = dt->exprs[i];
-      if (state.targetExprs.contains(expr)) {
-        usedColumns.emplace_back(dt->columns[i]);
-        usedExprs.emplace_back(state.toColumn(expr));
+  if (!dt->outputColumns.empty()) {
+    ExprVector outputExprs;
+    for (auto* column : dt->outputColumns) {
+      bool found = false;
+      for (size_t i = 0; i < dt->columns.size(); ++i) {
+        if (dt->columns[i] == column) {
+          outputExprs.emplace_back(state.toColumn(dt->exprs[i]));
+          found = true;
+          break;
+        }
       }
+      VELOX_CHECK(found, "outputColumn not in columns: {}", column->toString());
     }
 
     plan = make<Project>(
         maybeDropProject(plan),
-        usedExprs,
-        usedColumns,
-        Project::isRedundant(plan, usedExprs, usedColumns));
+        outputExprs,
+        dt->outputColumns,
+        Project::isRedundant(plan, outputExprs, dt->outputColumns));
   }
 
   if (!limitConsumedByWindow && !dt->hasOrderBy() &&
@@ -3173,6 +3176,17 @@ bool Optimization::placeConjuncts(
 
 namespace {
 
+// Restricts dt->outputColumns to only those present in 'needed'.
+void pruneOutputColumns(DerivedTableP dt, const PlanObjectSet& needed) {
+  ColumnVector output;
+  for (auto* column : dt->outputColumns) {
+    if (needed.contains(column)) {
+      output.push_back(column);
+    }
+  }
+  dt->outputColumns = std::move(output);
+}
+
 // Returns a subset of 'downstream' that exist in 'index' of 'table'.
 ColumnVector indexColumns(
     const PlanObjectSet& downstream,
@@ -3498,6 +3512,13 @@ PlanP Optimization::makeUnionPlan(
         tmpDt->cname = newCName("tmp_dt");
         tmpDt->importUnionChild(inputDt);
 
+        // Restrict outputColumns to only the columns needed by the
+        // parent. The child DT inherits all union columns in
+        // outputColumns, but the parent may need only a subset.
+        // Without this, addPostprocess creates a Project that
+        // references columns pruned from the scan.
+        pruneOutputColumns(tmpDt, inputKey.columns);
+
         PlanState inner(*this, tmpDt);
         inner.setTargetExprsForDt(inputKey.columns);
 
@@ -3574,6 +3595,13 @@ PlanP Optimization::makeDtPlan(
     auto tmpDt = make<DerivedTable>();
     tmpDt->cname = newCName("tmp_dt");
     tmpDt->import(dt, key.tables, key.firstTable, key.existences, existsFanout);
+
+    // For subquery DTs, set outputColumns from key.columns rather than
+    // inheriting from the source DT. The temporary DT's output is determined
+    // by the consumer (key.columns), not by the original subquery's output.
+    if (key.firstTable->is(PlanType::kDerivedTableNode)) {
+      pruneOutputColumns(tmpDt, key.columns);
+    }
 
     PlanState inner(*this, tmpDt);
     if (key.firstTable->is(PlanType::kDerivedTableNode)) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -340,6 +340,7 @@ void ToGraph::setDtUsedOutput(
   for (auto i : usedChannels(node)) {
     addDtColumn(dt, type.nameOf(i));
   }
+  dt->outputColumns = dt->columns;
 }
 
 std::vector<int32_t> ToGraph::usedChannels(const lp::LogicalPlanNode& node) {
@@ -2052,6 +2053,7 @@ ColumnCP ToGraph::makeCountStarWrapper(DerivedTableP inputDt) {
 
   wrapperDt->columns = {countColumn};
   wrapperDt->exprs = {countColumn};
+  wrapperDt->outputColumns = wrapperDt->columns;
 
   currentDt_->addTable(wrapperDt);
 
@@ -3278,6 +3280,7 @@ void ToGraph::translateSetJoin(const lp::SetNode& set) {
     setDt->exprs.push_back(c);
   }
   setDt->columns = columns;
+  setDt->outputColumns = columns;
 }
 
 namespace {
@@ -3361,6 +3364,11 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
   };
 
   translateSetOperationInput(set, shouldFlatten, translateUnionInput);
+
+  setDt->outputColumns = setDt->columns;
+  for (auto* child : setDt->children) {
+    child->outputColumns = setDt->columns;
+  }
 
   renames_ = std::move(renames);
   for (const auto* column : setDt->columns) {

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -488,5 +488,146 @@ TEST_F(SetTest, joinWithUnionAll) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// Verifies that filtering a UNION ALL works when two columns in a child branch
+// map to the same expression object (e.g., SELECT 'x' as a, 'x' as b).
+TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
+  auto sql =
+      "SELECT b FROM ("
+      "  SELECT 'x' as a, 'x' as b"
+      "  UNION ALL"
+      "  SELECT 'y', 'z'"
+      ") WHERE a <> ''";
+
+  auto logicalPlan = parseSelect(sql);
+
+  // Constant filters ('x' <> '' and 'y' <> '') remain as Filter nodes.
+  // TODO: Fold and eliminate these constant filters.
+  auto buildMatcher = [&] {
+    return core::PlanMatcherBuilder()
+        .values()
+        .filter("'x' <> ''")
+        .project()
+        .localPartition(
+            core::PlanMatcherBuilder()
+                .values()
+                .filter("'y' <> ''")
+                .project()
+                .build());
+  };
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
+
+  // TODO: The distributed plan has a redundant gather since there are no
+  // table scans. Check isSingleThreadedPipeline in ToVelox.
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan, buildMatcher().gather().build());
+}
+
+// Same as above but with a table column referenced twice (SELECT x as a, x as
+// b) instead of constant expressions.
+TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
+  createEmptyTable("t", ROW("x", BIGINT()));
+
+  auto sql =
+      "SELECT b FROM ("
+      "  SELECT x as a, x as b FROM t"
+      "  UNION ALL"
+      "  SELECT 2, 3"
+      ") WHERE a > 0";
+
+  auto logicalPlan = parseSelect(sql);
+
+  // Filter is pushed into the HiveScan as a subfield filter on x.
+  // TODO: Constant filter (2 > 0) should be folded and eliminated.
+  auto buildMatcher = [&] {
+    return core::PlanMatcherBuilder()
+        .hiveScan("t", test::gt("x", 0L))
+        .project()
+        .localPartition(
+            core::PlanMatcherBuilder()
+                .values()
+                .filter("2 > 0")
+                .project()
+                .build());
+  };
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
+
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan, buildMatcher().gather().build());
+}
+
+// Same as above but with a non-trivial expression referenced twice
+// (SELECT x + 1 as a, x + 1 as b). The expression deduplication produces a
+// single expression object shared by both columns.
+TEST_F(SetTest, filterOnDuplicateExpressionInUnionAll) {
+  createEmptyTable("t", ROW("x", BIGINT()));
+
+  auto sql =
+      "SELECT b FROM ("
+      "  SELECT x + 1 as a, x + 1 as b FROM t"
+      "  UNION ALL"
+      "  SELECT x + 2, x + 3 FROM t"
+      ") WHERE a > 0";
+
+  auto logicalPlan = parseSelect(sql);
+
+  // Filter 'a > 0' becomes remaining filters 'x + 1 > 0' and 'x + 2 > 0'
+  // on the respective scan branches.
+  auto buildMatcher = [&] {
+    return core::PlanMatcherBuilder()
+        .hiveScan("t", {}, "x + 1 > 0")
+        .project()
+        .localPartition(
+            core::PlanMatcherBuilder()
+                .hiveScan("t", {}, "x + 2 > 0")
+                .project()
+                .build());
+  };
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
+
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan, buildMatcher().gather().build());
+}
+
+// Verifies that filtering a UNION ALL on a column not included in the outer
+// SELECT works correctly when the filter is pushed into the scan.
+TEST_F(SetTest, filterColumnPruningInUnionAll) {
+  createEmptyTable("t", ROW({"x", "y"}, BIGINT()));
+
+  auto sql =
+      "SELECT y FROM ("
+      "  SELECT x, y FROM t"
+      "  UNION ALL"
+      "  SELECT x, y FROM t"
+      ") WHERE x > 0";
+
+  auto logicalPlan = parseSelect(sql);
+
+  auto buildMatcher = [&] {
+    return core::PlanMatcherBuilder()
+        .hiveScan("t", test::gt("x", 0L))
+        .localPartition(
+            core::PlanMatcherBuilder()
+                .hiveScan("t", test::gt("x", 0L))
+                .project()
+                .build());
+  };
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
+
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan, buildMatcher().gather().build());
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

Add ColumnVector outputColumns to DerivedTable — an explicit ordered list of
columns the DT produces as output. addPostprocess projects exactly
outputColumns instead of filtering by targetExprs.

The previous approach used targetExprs (pointer identity) to decide which
columns to project. This broke when two DT columns shared the same expression
pointer (e.g., SELECT 'x' as a, 'x' as b), producing mismatched column counts
across UNION ALL children.

outputColumns is initialized by ToGraph (setDtUsedOutput, translateUnion,
makeCountStarWrapper, translateDistinct) and propagated by flattenDt. During
optimization, makeDtPlan computes outputColumns for temporary subproblem DTs
from key.columns — the consumer determines what the subproblem must produce.

Mutations that add columns after outputColumns is initialized (exportExpr,
exportSingleAggregate, makeExistsDtAndJoin, pushExistencesIntoSubquery chainDt)
update outputColumns to keep it in sync.

Reviewed By: amitkdutta

Differential Revision: D96738400


