### PR TITLE
feat(optimizer): Fold and eliminate constant filters in UNION ALL (#1067)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1701,6 +1701,65 @@ bool DerivedTable::isPartitionKeyFilter(ExprCP imported) const {
   return true;
 }
 
+bool DerivedTable::isZeroRows() const {
+  return tables.size() == 1 && tables[0]->is(PlanType::kValuesTableNode) &&
+      tables[0]->as<ValuesTable>()->cardinality() == 0;
+}
+
+void DerivedTable::clearState() {
+  columns.clear();
+  exprs.clear();
+  outputColumns.clear();
+  tables.clear();
+  tableSet = PlanObjectSet{};
+  joins.clear();
+  conjuncts.clear();
+  having.clear();
+  aggregation = nullptr;
+  windowPlan = nullptr;
+  children.clear();
+  setOp = std::nullopt;
+  orderKeys.clear();
+  orderTypes.clear();
+  limit = -1;
+  offset = 0;
+}
+
+void DerivedTable::makeEmpty() {
+  auto* emptyData = &registerVariant(velox::Variant::array({}))->array();
+
+  // Build ValuesTable matching outputColumns schema.
+  auto savedOutputColumns = outputColumns;
+
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(savedOutputColumns.size());
+  types.reserve(savedOutputColumns.size());
+  for (auto* column : savedOutputColumns) {
+    names.push_back(std::string(column->name()));
+    types.push_back(toTypePtr(column->value().type));
+  }
+
+  auto* rowType = toType(velox::ROW(std::move(names), std::move(types)));
+  auto* valuesTable = make<ValuesTable>(rowType, emptyData);
+  valuesTable->cname = queryCtx()->optimization()->newCName("vt");
+
+  ExprVector newExprs;
+  for (auto* column : savedOutputColumns) {
+    auto* valuesColumn = make<Column>(
+        column->name(), valuesTable, Value(column->value().type, 0));
+    valuesTable->columns.push_back(valuesColumn);
+    newExprs.push_back(valuesColumn);
+  }
+
+  clearState();
+
+  columns = savedOutputColumns;
+  exprs = std::move(newExprs);
+  outputColumns = savedOutputColumns;
+  addTable(valuesTable);
+}
+
 bool DerivedTable::addFilter(ExprCP conjunct) {
   // TODO: Support pushing conjuncts below LIMIT by wrapping in a DT.
   if (dtHasLimit(*this)) {
@@ -1713,10 +1772,35 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
       auto ok = child->addFilter(conjunct);
       VELOX_CHECK(ok);
     }
+
+    if (setOp.value() == logical_plan::SetOperation::kUnionAll) {
+      // Drop children that became zero-rows after filter pushdown.
+      std::erase_if(
+          children, [](const auto* child) { return child->isZeroRows(); });
+
+      if (children.size() == 1) {
+        auto* only = children[0];
+        children.clear();
+        setOp = std::nullopt;
+        flattenDt(only);
+      } else if (children.empty()) {
+        makeEmpty();
+      }
+    }
+
     return true;
   }
 
   auto imported = importExpr(conjunct);
+
+  // Fold constant filters. Eliminate constant-true. Replace the DT with an
+  // empty ValuesTable for constant-false (the branch produces no rows).
+  if (auto* folded = queryCtx()->optimization()->tryFoldConstant(imported)) {
+    if (!isConstantTrue(folded)) {
+      makeEmpty();
+    }
+    return true;
+  }
 
   if (windowPlan) {
     if (isPartitionKeyFilter(imported)) {

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -326,6 +326,10 @@ struct DerivedTable : public PlanObject {
     });
   }
 
+  /// Returns true if this DT is known to produce zero rows (e.g., an empty
+  /// ValuesTable with no data).
+  bool isZeroRows() const;
+
   /// Sets enforceSingleRow flag if this DT doesn't naturally guarantee
   /// single-row output. A global aggregation (no grouping keys) without
   /// HAVING clause guarantees exactly one row; otherwise, runtime validation
@@ -352,6 +356,13 @@ struct DerivedTable : public PlanObject {
   void distributeConjuncts();
 
  private:
+  // Resets all mutable state to empty defaults.
+  void clearState();
+
+  // Replaces this DT's contents with an empty ValuesTable producing zero rows.
+  // Preserves 'outputColumns' (external interface referenced by parent DTs).
+  void makeEmpty();
+
   // Recursively distributes conjuncts across the entire DT tree (top-down).
   // Called as Pass 1 of initializePlans().
   void distributeAllConjuncts();

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -27,6 +27,7 @@
 #include "folly/coro/BlockingWait.h"
 #include "folly/coro/Collect.h"
 #include "folly/coro/Task.h"
+#include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
 
 namespace lp = facebook::axiom::logical_plan;
@@ -3632,6 +3633,37 @@ ExprCP Optimization::combineLeftDeep(Name func, const ExprVector& exprs) {
         result->functions() | copy[i]->functions());
   }
   return result;
+}
+
+ExprCP Optimization::tryFoldConstant(ExprCP expr) {
+  if (expr->is(PlanType::kLiteralExpr)) {
+    return expr;
+  }
+
+  if (!expr->columns().empty()) {
+    return nullptr;
+  }
+
+  try {
+    auto typedExpr = toTypedExpr(expr);
+    auto exprSet = evaluator()->compile(typedExpr);
+    const auto& first = *exprSet->exprs().front();
+    if (!first.isConstant()) {
+      return nullptr;
+    }
+    const auto& constantExpr =
+        static_cast<const velox::exec::ConstantExpr&>(first);
+    auto variant = constantExpr.value()->variantAt(0);
+    Value value(toType(constantExpr.type()), 1);
+    auto* registered = registerVariant(std::move(variant));
+    if (constantExpr.type()->isPrimitiveType()) {
+      value.min = registered;
+      value.max = registered;
+    }
+    return make<Literal>(value, registered);
+  } catch (const std::exception&) {
+    return nullptr;
+  }
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -166,6 +166,11 @@ class Optimization {
     return cnamesInExpr_;
   }
 
+  /// Tries to evaluate a constant expression (one with no column references).
+  /// Returns the result as a Literal, or nullptr if the expression is not
+  /// constant or evaluation fails.
+  ExprCP tryFoldConstant(ExprCP expr);
+
   /// Returns a dedupped left deep reduction with 'func' for the
   /// elements in 'expr'. The elements are sorted on plan object
   /// id and then combined into a left deep reduction on 'func'.

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -122,6 +122,26 @@ bool isSpecialForm(
 /// structs, the field name will be an empty string.
 Step extractDereferenceStep(const logical_plan::ExprPtr& expr);
 
+/// Returns true if 'expr' is a boolean literal with the given value.
+inline bool isConstantBool(ExprCP expr, bool expected) {
+  if (expr->isNot(PlanType::kLiteralExpr)) {
+    return false;
+  }
+  const auto& variant = expr->as<Literal>()->literal();
+  return variant.kind() == velox::TypeKind::BOOLEAN && !variant.isNull() &&
+      variant.value<bool>() == expected;
+}
+
+/// Returns true if 'expr' is a boolean literal with value true.
+inline bool isConstantTrue(ExprCP expr) {
+  return isConstantBool(expr, true);
+}
+
+/// Returns true if 'expr' is a boolean literal with value false.
+inline bool isConstantFalse(ExprCP expr) {
+  return isConstantBool(expr, false);
+}
+
 std::string conjunctsToString(const ExprVector& conjuncts);
 
 std::string orderByToString(

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -356,24 +356,6 @@ std::vector<int32_t> ToGraph::usedChannels(const lp::LogicalPlanNode& node) {
 
 namespace {
 
-bool isConstantBool(ExprCP expr, bool expected) {
-  if (expr->isNot(PlanType::kLiteralExpr)) {
-    return false;
-  }
-
-  const auto& variant = expr->as<Literal>()->literal();
-  return variant.kind() == velox::TypeKind::BOOLEAN && !variant.isNull() &&
-      variant.value<bool>() == expected;
-}
-
-bool isConstantTrue(ExprCP expr) {
-  return isConstantBool(expr, true);
-}
-
-bool isConstantFalse(ExprCP expr) {
-  return isConstantBool(expr, false);
-}
-
 bool hasConstantFalse(const ExprVector& exprs) {
   return std::ranges::any_of(exprs, isConstantFalse);
 }
@@ -416,26 +398,18 @@ ExprCP ToGraph::tryFoldConstant(
     const velox::TypePtr& returnType,
     std::string_view callName,
     const ExprVector& literals) {
-  try {
-    auto* call = make<Call>(
-        toName(callName), toConstantValue(returnType), literals, FunctionSet());
-    auto typedExpr = queryCtx()->optimization()->toTypedExpr(call);
-    auto exprSet = evaluator_.compile(typedExpr);
-    const auto& first = *exprSet->exprs().front();
-    if (!first.isConstant()) {
-      return nullptr;
-    }
-    const auto& constantExpr =
-        static_cast<const velox::exec::ConstantExpr&>(first);
-    auto typed = std::make_shared<lp::ConstantExpr>(
-        constantExpr.type(),
-        std::make_shared<velox::Variant>(constantExpr.value()->variantAt(0)));
-    return makeConstant(*typed);
-  } catch (const std::exception&) {
-    // Swallow exception.
+  auto* call = make<Call>(
+      toName(callName), toConstantValue(returnType), literals, FunctionSet());
+  auto* folded = queryCtx()->optimization()->tryFoldConstant(call);
+  if (!folded) {
+    return nullptr;
   }
 
-  return nullptr;
+  // Re-create through makeConstant for deduplication.
+  auto typed = lp::ConstantExpr(
+      returnType,
+      std::make_shared<velox::Variant>(folded->as<Literal>()->literal()));
+  return makeConstant(typed);
 }
 
 bool ToGraph::isSubfield(

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -500,19 +500,10 @@ TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
 
   auto logicalPlan = parseSelect(sql);
 
-  // Constant filters ('x' <> '' and 'y' <> '') remain as Filter nodes.
-  // TODO: Fold and eliminate these constant filters.
+  // Constant filters ('x' <> '' and 'y' <> '') are folded and eliminated.
   auto buildMatcher = [&] {
-    return core::PlanMatcherBuilder()
-        .values()
-        .filter("'x' <> ''")
-        .project()
-        .localPartition(
-            core::PlanMatcherBuilder()
-                .values()
-                .filter("'y' <> ''")
-                .project()
-                .build());
+    return core::PlanMatcherBuilder().values().project().localPartition(
+        core::PlanMatcherBuilder().values().project().build());
   };
 
   auto plan = toSingleNodePlan(logicalPlan);
@@ -540,17 +531,12 @@ TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
   auto logicalPlan = parseSelect(sql);
 
   // Filter is pushed into the HiveScan as a subfield filter on x.
-  // TODO: Constant filter (2 > 0) should be folded and eliminated.
+  // The Values child's constant filter (2 > 0) is folded and eliminated.
   auto buildMatcher = [&] {
     return core::PlanMatcherBuilder()
         .hiveScan("t", test::gt("x", 0L))
         .project()
-        .localPartition(
-            core::PlanMatcherBuilder()
-                .values()
-                .filter("2 > 0")
-                .project()
-                .build());
+        .localPartition(core::PlanMatcherBuilder().values().project().build());
   };
 
   auto plan = toSingleNodePlan(logicalPlan);
@@ -627,6 +613,66 @@ TEST_F(SetTest, filterColumnPruningInUnionAll) {
   auto distributedPlan = planVelox(logicalPlan);
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       distributedPlan.plan, buildMatcher().gather().build());
+}
+
+// Constant-false filters on UNION ALL branches cause them to be replaced with
+// empty ValuesTable (zero rows) and pruned. Tests three cases:
+// - One branch false, one survives: UNION ALL dissolved.
+// - All branches false: entire UNION ALL becomes empty ValuesTable.
+// - Mix of true/false: false branch pruned, true branches survive without
+//   filters.
+TEST_F(SetTest, constantFalseFilterInUnionAll) {
+  createEmptyTable("t", ROW({"x", "y"}, BIGINT()));
+
+  // One constant-false branch (0 > 0), one table scan branch survives.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT y FROM ("
+        "  SELECT x, y FROM t"
+        "  UNION ALL"
+        "  SELECT 0, 3"
+        ") WHERE x > 0");
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        core::PlanMatcherBuilder().hiveScan("t", test::gt("x", 0L)).build());
+  }
+
+  // All branches constant-false (0 > 0 and -1 > 0).
+  auto matchValues = [&]() { return core::PlanMatcherBuilder().values(); };
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT b FROM ("
+        "  SELECT 0 as a, 1 as b"
+        "  UNION ALL"
+        "  SELECT -1, 2"
+        ") WHERE a > 0");
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matchValues().project().build());
+  }
+
+  // Mix: branch 1 (5 > 0) true, branch 2 (0 > 0) false, branch 3 (3 > 0)
+  // true. False branch pruned, two surviving branches have no filters.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT b FROM ("
+        "  SELECT 5 as a, 1 as b"
+        "  UNION ALL"
+        "  SELECT 0, 2"
+        "  UNION ALL"
+        "  SELECT 3, 3"
+        ") WHERE a > 0");
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchValues()
+            .project()
+            .localPartition(matchValues().project().build())
+            .build());
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

When a filter is pushed through UNION ALL, column references are remapped to
each child's expressions. If a child is a VALUES node with constants (e.g.,
SELECT 2, 3), the filter becomes a constant expression (e.g., 2 > 0) that
was previously left unevaluated.

This diff adds constant folding during filter pushdown:
- Constant-true filters are eliminated.
- Constant not-true filters cause the branch to be replaced with an empty
  ValuesTable (zero rows).
- UNION ALL parents prune zero-rows children. If only one child remains, the
  set operation is dissolved.

Reviewed By: amitkdutta

Differential Revision: D96750046


