### PR TITLE
fix(optimizer): Fix field resolution for nested aggregations across DT boundaries (#1071)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -360,6 +360,34 @@ bool hasConstantFalse(const ExprVector& exprs) {
   return std::ranges::any_of(exprs, isConstantFalse);
 }
 
+// This is a band-aid. Revisit the logic in this method.
+//
+// The problem with current logic is that translated expression may belong
+// to a derived table that's not directly referenced from the currentDt_.
+// When this happens, the downstream processing breaks because the core
+// invariant is broken: all expressions in a derived table must reference
+// relations from DerivedTable::tables.
+ColumnCP tryGetResolvedColumn(
+    const std::string& name,
+    const folly::F14FastMap<std::string, ExprCP>& renames,
+    bool allowCorrelations,
+    const folly::F14FastMap<std::string, ExprCP>* correlations) {
+  auto it = renames.find(name);
+  if (it != renames.end() && it->second->is(PlanType::kColumnExpr)) {
+    return it->second->as<Column>();
+  }
+
+  if (allowCorrelations && correlations != nullptr) {
+    if (auto corrIt = correlations->find(name); corrIt != correlations->end()) {
+      if (corrIt->second->is(PlanType::kColumnExpr)) {
+        return corrIt->second->as<Column>();
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 } // namespace
 
 void ToGraph::translateConjuncts(const lp::ExprPtr& input, ExprVector& flat) {
@@ -465,21 +493,6 @@ void ToGraph::getExprForField(
     const lp::LogicalPlanNode*& context) {
   VELOX_CHECK_NOT_NULL(context);
 
-  auto lookupName = [&](const std::string& name) -> ExprCP {
-    auto it = renames_.find(name);
-    if (it != renames_.end()) {
-      return it->second;
-    }
-
-    if (allowCorrelations_ && correlations_ != nullptr) {
-      if (auto it = correlations_->find(name); it != correlations_->end()) {
-        return it->second;
-      }
-    }
-
-    return nullptr;
-  };
-
   while (context) {
     const auto& name = field->name();
 
@@ -505,21 +518,12 @@ void ToGraph::getExprForField(
       return;
     }
 
-    // This is a band-aid. Revisit the logic in this method.
-    //
-    // The problem with current logic is that translated expression may belong
-    // to a derived table that's not directly referenced from the currentDt_.
-    // When this happens, the downstream processing breaks because the core
-    // invariant is broken: all expressions in a dericed table must reference
-    // relations from DerivedTable::tables.
-    {
-      if (auto expr = lookupName(name)) {
-        if (expr != nullptr && expr->is(PlanType::kColumnExpr)) {
-          resultColumn = expr->as<Column>();
-          resultExpr = nullptr;
-          return;
-        }
-      }
+    // TODO band-aid
+    if (auto column = tryGetResolvedColumn(
+            name, renames_, allowCorrelations_, correlations_)) {
+      resultColumn = column;
+      resultExpr = nullptr;
+      return;
     }
 
     const auto& sources = context->inputs();
@@ -590,20 +594,26 @@ std::optional<ExprCP> ToGraph::translateSubfield(const lp::ExprPtr& inputExpr) {
           column = it->second;
           expr = nullptr;
         } else {
-          if (source == nullptr) {
-            const auto& name = field->name();
+          // TODO band-aid
+          column = tryGetResolvedColumn(
+              field->name(), renames_, allowCorrelations_, correlations_);
 
-            for (const auto* exprSource : exprSources_) {
-              if (exprSource->outputType()->getChildIdxIfExists(name)) {
-                source = exprSource;
-                break;
+          if (column == nullptr) {
+            if (source == nullptr) {
+              const auto& name = field->name();
+
+              for (const auto* exprSource : exprSources_) {
+                if (exprSource->outputType()->getChildIdxIfExists(name)) {
+                  source = exprSource;
+                  break;
+                }
               }
             }
-          }
-          VELOX_CHECK_NOT_NULL(source);
-          getExprForField(field, expr, column, source);
-          if (expr) {
-            continue;
+            VELOX_CHECK_NOT_NULL(source);
+            getExprForField(field, expr, column, source);
+            if (expr) {
+              continue;
+            }
           }
         }
       }

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -118,6 +118,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile("window.sql");
   facebook::axiom::optimizer::test::registerQueryFile("set.sql");
   facebook::axiom::optimizer::test::registerQueryFile("limit.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("nested_aggregation.sql");
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1724,6 +1724,55 @@ TEST_F(SubqueryTest, rightJoinOnSubquery) {
   }
 }
 
+TEST_F(SubqueryTest, innerScopeNestedAggregation) {
+  {
+    auto query =
+        "WITH grouped AS ("
+        "  SELECT id, reverse(array_agg(val)) AS vals "
+        "  FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val) "
+        "  GROUP BY id) "
+        "SELECT id, sum(cardinality(vals)) AS result "
+        "FROM grouped "
+        "GROUP BY id";
+
+    SCOPED_TRACE(query);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .values()
+                       .aggregation()
+                       .project()
+                       .project()
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  {
+    auto query =
+        "WITH grouped AS ("
+        "  SELECT id, CASE WHEN id = 1 THEN array_agg(val) ELSE ARRAY[0] END AS vals "
+        "  FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val) "
+        "  GROUP BY id) "
+        "SELECT sum(cardinality(vals)) AS result "
+        "FROM grouped";
+
+    SCOPED_TRACE(query);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .values()
+                       .aggregation()
+                       .project()
+                       .project()
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
 TEST_F(SubqueryTest, unsupportedSubqueryInJoin) {
   // Left-side subquery in LEFT JOIN ON clause.
   VELOX_ASSERT_THROW(

--- a/axiom/optimizer/tests/sql/nested_aggregation.sql
+++ b/axiom/optimizer/tests/sql/nested_aggregation.sql
@@ -1,0 +1,25 @@
+-- Tests for nested aggregations across DT boundaries
+-- These verify that inner aliased aggregate functions are properly resolved
+-- in outer queries without attempting to re-expand them after the aggregate
+-- no longer exists.
+
+-- Basic nested aggregation with reverse(array_agg())
+-- duckdb: WITH grouped AS (SELECT id, array_agg(val) AS vals FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val) GROUP BY id) SELECT id, sum(array_length(vals)) AS result FROM grouped GROUP BY id
+WITH grouped AS (
+  SELECT id, reverse(array_agg(val)) AS vals
+  FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val)
+  GROUP BY id
+)
+SELECT id, sum(cardinality(vals)) AS result
+FROM grouped
+GROUP BY id
+----
+-- Nested aggregation with CASE expression containing array_agg()
+-- duckdb: WITH grouped AS (SELECT id, CASE WHEN id = 1 THEN array_agg(val) ELSE ARRAY[0] END AS vals FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val) GROUP BY id) SELECT sum(array_length(vals)) AS result FROM grouped
+WITH grouped AS (
+  SELECT id, CASE WHEN id = 1 THEN array_agg(val) ELSE ARRAY[0] END AS vals
+  FROM (VALUES (1, 5), (1, 3), (2, 7)) t(id, val)
+  GROUP BY id
+)
+SELECT sum(cardinality(vals)) AS result
+FROM grouped


### PR DESCRIPTION
Summary:

Adds a check to see if inner aliased aggregate functions have already been resolved, rather than attempting to re-resolve it in the outer query. This will prevent the optimizer from re-expanding the aliases *after* the aggregate no longer exists, resulting in "Field not found" errors.

As an example:
```sql
WITH t AS (
  SELECT reduce(array_agg(ARRAY[v]), null, (s,x)->x, s->s) AS a
  FROM (VALUES (1)) t(v)
)
SELECT sum(cardinality(a)) FROM t;
```
Attempts to resolve `a` in the outer query by expanding it as `reduce(array_agg(col(v)))` which no longer exists.

Differential Revision: D96821235


