### PR TITLE
feat(parser): Support VARCHAR(n), CHAR(n), VARBINARY(n) parametric types (#1072)

### DIFF
--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -115,6 +115,7 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv, false);
 
   facebook::axiom::optimizer::test::registerQueryFile("basic.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("cast.sql");
   facebook::axiom::optimizer::test::registerQueryFile("join.sql");
   facebook::axiom::optimizer::test::registerQueryFile("subquery.sql");
   facebook::axiom::optimizer::test::registerQueryFile("window.sql");

--- a/axiom/optimizer/tests/sql/cast.sql
+++ b/axiom/optimizer/tests/sql/cast.sql
@@ -1,0 +1,46 @@
+-- Table t(a BIGINT, b BIGINT, c DOUBLE) with 15 rows across 3 splits.
+--
+-- Axiom translates VARCHAR(n) to substr(CAST(x AS VARCHAR), 1, n) and
+-- CHAR(n) to rpad(CAST(x AS VARCHAR), n, ' '). DuckDB does not support
+-- these parametric types, so each query uses an equivalent DuckDB expression
+-- as the reference.
+
+-- VARCHAR(n) truncates long strings.
+-- duckdb: SELECT 'hello'
+SELECT CAST('hello world' AS VARCHAR(5))
+----
+-- VARCHAR(n) returns short strings unchanged.
+-- duckdb: SELECT 'hi'
+SELECT CAST('hi' AS VARCHAR(5))
+----
+-- VARCHAR(n) with exact-length input.
+-- duckdb: SELECT 'hello'
+SELECT CAST('hello' AS VARCHAR(5))
+----
+-- CHAR(n) pads short strings with spaces.
+-- duckdb: SELECT rpad('hi', 5, ' ')
+SELECT CAST('hi' AS CHAR(5))
+----
+-- CHAR(n) truncates long strings.
+-- duckdb: SELECT 'hello'
+SELECT CAST('hello world' AS CHAR(5))
+----
+-- CHAR(n) with exact-length input.
+-- duckdb: SELECT rpad('hello', 5, ' ')
+SELECT CAST('hello' AS CHAR(5))
+----
+-- VARCHAR(n) on integer column truncates to 1 character.
+-- duckdb: SELECT substr(CAST(a AS VARCHAR), 1, 1) FROM t
+SELECT CAST(a AS VARCHAR(1)) FROM t
+----
+-- CHAR(n) on integer column pads to 3 characters.
+-- duckdb: SELECT rpad(CAST(a AS VARCHAR), 3, ' ') FROM t
+SELECT CAST(a AS CHAR(3)) FROM t
+----
+-- typeof on CHAR(n) cast.
+-- duckdb: SELECT 'varchar'
+SELECT typeof(CAST('foo' AS CHAR(10)))
+----
+-- typeof on VARCHAR(n) cast.
+-- duckdb: SELECT 'varchar'
+SELECT typeof(CAST('foo' AS VARCHAR(10)))

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -28,6 +28,13 @@ using namespace facebook::velox;
 
 namespace {
 
+std::string toUpperCase(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+    return std::toupper(c);
+  });
+  return s;
+}
+
 int32_t parseInt(const TypeSignaturePtr& type) {
   VELOX_USER_CHECK_EQ(type->parameters().size(), 0);
   const auto& str = type->baseName();
@@ -219,14 +226,12 @@ std::string canonicalizeIdentifier(const Identifier& identifier) {
 }
 
 TypePtr parseType(const TypeSignaturePtr& type) {
-  auto baseName = type->baseName();
-  std::transform(
-      baseName.begin(), baseName.end(), baseName.begin(), [](char c) {
-        return (std::toupper(c));
-      });
+  auto baseName = toUpperCase(type->baseName());
 
   if (baseName == "INT") {
     baseName = "INTEGER";
+  } else if (baseName == "CHAR") {
+    baseName = "VARCHAR";
   }
 
   std::vector<TypeParameter> parameters;
@@ -260,6 +265,19 @@ TypePtr parseType(const TypeSignaturePtr& type) {
       VELOX_USER_CHECK_EQ(2, numParams);
       parameters.emplace_back(parseInt(type->parameters().at(0)));
       parameters.emplace_back(parseInt(type->parameters().at(1)));
+    } else if (baseName == "VARCHAR" || baseName == "VARBINARY") {
+      // Velox has no parameterized VARCHAR/VARBINARY — accept the syntax,
+      // validate the length, but resolve to the unbounded type.
+      VELOX_USER_CHECK_EQ(
+          1,
+          numParams,
+          "Expected exactly one length parameter: {}(n)",
+          baseName);
+      VELOX_USER_CHECK_GT(
+          parseInt(type->parameters().at(0)),
+          0,
+          "Length must be positive: {}(n)",
+          baseName);
     } else if (baseName == "TDIGEST" || baseName == "QDIGEST") {
       VELOX_USER_CHECK_EQ(1, numParams);
       parameters.emplace_back(parseType(type->parameters().at(0)));
@@ -427,15 +445,29 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kCast: {
       auto* cast = node->as<Cast>();
+      auto targetBaseName = toUpperCase(cast->toType()->baseName());
       const auto type = parseType(cast->toType());
+      auto expr = toExpr(cast->expression(), aggregateOptions, windowOptions);
+      auto result =
+          cast->isSafe() ? lp::TryCast(type, expr) : lp::Cast(type, expr);
 
-      if (cast->isSafe()) {
-        return lp::TryCast(
-            type, toExpr(cast->expression(), aggregateOptions, windowOptions));
-      } else {
-        return lp::Cast(
-            type, toExpr(cast->expression(), aggregateOptions, windowOptions));
+      // Enforce length bounds for VARCHAR(n) and CHAR(n) casts.
+      if (cast->toType()->parameters().size() == 1 &&
+          (targetBaseName == "VARCHAR" || targetBaseName == "CHAR")) {
+        auto maxLength =
+            static_cast<int64_t>(parseInt(cast->toType()->parameters().at(0)));
+        if (targetBaseName == "VARCHAR") {
+          result = lp::Call(
+              "substr",
+              result,
+              lp::Lit(static_cast<int64_t>(1)),
+              lp::Lit(maxLength));
+        } else {
+          result = lp::Call("rpad", result, lp::Lit(maxLength), lp::Lit(" "));
+        }
       }
+
+      return result;
     }
 
     case NodeType::kAtTimeZone: {

--- a/axiom/sql/presto/README.md
+++ b/axiom/sql/presto/README.md
@@ -122,6 +122,20 @@ including named ROW constructors, `EXCEPT ALL` / `INTERSECT ALL`, and
 additional `EXPLAIN` types. See
 [docs/PrestoSqlExtensions.md](docs/PrestoSqlExtensions.md) for details.
 
+## Parametric String Types
+
+The parser accepts `VARCHAR(n)`, `CHAR(n)`, and `VARBINARY(n)` syntax. Velox types are unbounded, so length enforcement is handled at the expression level during `CAST`:
+
+| Cast target | Velox type | Expression wrapper |
+|---|---|---|
+| `VARCHAR(n)` | `VARCHAR` | `substr(cast, 1, n)` — truncates to n |
+| `CHAR(n)` | `VARCHAR` | `rpad(cast, n, ' ')` — pads/truncates to exactly n |
+| `VARBINARY(n)` | `VARBINARY` | None — syntax accepted, length ignored |
+
+`CHAR` without a length parameter resolves to `VARCHAR` (matching Presto behavior). Inside nested types (`ARRAY(VARCHAR(10))`), the length parameter is accepted but dropped — no expression wrapper is added.
+
+See `ExpressionPlanner::toExpr()` (the `kCast` case) for the implementation.
+
 ## Differences from Presto Java
 
 ### No Separate Analysis Phase

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -185,6 +185,12 @@ TEST_F(DdlParserTest, createTable) {
       "t",
       ROW({"price"}, {DECIMAL(10, 2)}));
 
+  // Parametric string types resolve to unbounded Velox types.
+  testCreateTable(
+      "CREATE TABLE t (name VARCHAR(255), code CHAR(10), data VARBINARY(100))",
+      "t",
+      ROW({"name", "code", "data"}, {VARCHAR(), VARCHAR(), VARBINARY()}));
+
   // like clause
   {
     auto likeSchema =

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -112,11 +112,101 @@ TEST_F(ExpressionParserTest, types) {
   test("null as qdigest(real)", QDIGEST(REAL()));
   test("null as qdigest(double)", QDIGEST(DOUBLE()));
 
+  // CHAR without length parameter resolves to VARCHAR.
+  test("null as char", VARCHAR());
+
   test("null as int array", ARRAY(INTEGER()));
   test("null as varchar array", ARRAY(VARCHAR()));
   test("null as map(integer, real)", MAP(INTEGER(), REAL()));
   test("null as row(int, double)", ROW({INTEGER(), DOUBLE()}));
   test("null as row(a int, b double)", ROW({"a", "b"}, {INTEGER(), DOUBLE()}));
+}
+
+// Verifies that VARCHAR(n) wraps the inner cast in substr(expr, 1, n).
+TEST_F(ExpressionParserTest, varcharN) {
+  auto testTruncation = [&](std::string_view sql, int64_t expectedMaxLength) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+    VELOX_EXPECT_EQ_TYPES(expr->type(), VARCHAR());
+    ASSERT_TRUE(expr->isCall());
+    auto* call = expr->as<lp::CallExpr>();
+    EXPECT_EQ(call->name(), "substr");
+    ASSERT_EQ(call->inputs().size(), 3);
+    // First argument is the inner cast.
+    ASSERT_TRUE(call->inputAt(0)->isSpecialForm());
+    // Second argument: start position = 1.
+    auto* startLit = call->inputs()[1]->as<lp::ConstantExpr>();
+    ASSERT_NE(startLit, nullptr);
+    EXPECT_EQ(startLit->value()->value<int64_t>(), 1);
+    // Third argument: max length.
+    auto* lengthLit = call->inputs()[2]->as<lp::ConstantExpr>();
+    ASSERT_NE(lengthLit, nullptr);
+    EXPECT_EQ(lengthLit->value()->value<int64_t>(), expectedMaxLength);
+  };
+
+  testTruncation("cast(null as varchar(10))", 10);
+  testTruncation("cast(null as varchar(255))", 255);
+  testTruncation("try_cast(null as varchar(10))", 10);
+
+  // Nested in complex types — length is dropped, no substr wrapper.
+  auto testType = [&](std::string_view castArgs, const TypePtr& expectedType) {
+    SCOPED_TRACE(castArgs);
+    auto expr = parseExpr(fmt::format("cast({})", castArgs));
+    VELOX_EXPECT_EQ_TYPES(expr->type(), expectedType);
+    // Verify the expression is a plain cast, not wrapped in substr/rpad.
+    ASSERT_TRUE(expr->isSpecialForm());
+    ASSERT_FALSE(expr->isCall());
+  };
+  testType("null as array(varchar(10))", ARRAY(VARCHAR()));
+  testType("null as array(char(10))", ARRAY(VARCHAR()));
+  testType("null as map(varchar(5), integer)", MAP(VARCHAR(), INTEGER()));
+
+  // Zero length is rejected.
+  VELOX_ASSERT_THROW(
+      parseExpr("cast(null as varchar(0))"), "Length must be positive");
+}
+
+// Verifies that CHAR(n) wraps the inner cast in rpad(expr, n, ' ').
+TEST_F(ExpressionParserTest, charN) {
+  auto testPadding = [&](std::string_view sql, int64_t expectedLength) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+    VELOX_EXPECT_EQ_TYPES(expr->type(), VARCHAR());
+    ASSERT_TRUE(expr->isCall());
+    auto* call = expr->as<lp::CallExpr>();
+    EXPECT_EQ(call->name(), "rpad");
+    ASSERT_EQ(call->inputs().size(), 3);
+    // First argument is the inner cast.
+    ASSERT_TRUE(call->inputAt(0)->isSpecialForm());
+    // Second argument: target length.
+    auto* lengthLit = call->inputs()[1]->as<lp::ConstantExpr>();
+    ASSERT_NE(lengthLit, nullptr);
+    EXPECT_EQ(lengthLit->value()->value<int64_t>(), expectedLength);
+    // Third argument: pad character = ' '.
+    auto* padLit = call->inputs()[2]->as<lp::ConstantExpr>();
+    ASSERT_NE(padLit, nullptr);
+    EXPECT_EQ(padLit->value()->value<StringView>(), " ");
+  };
+
+  testPadding("cast(null as char(20))", 20);
+  testPadding("cast(null as char(5))", 5);
+  testPadding("try_cast(null as char(20))", 20);
+
+  // Zero length is rejected.
+  VELOX_ASSERT_THROW(
+      parseExpr("cast(null as char(0))"), "Length must be positive");
+}
+
+// Verifies that VARBINARY(n) resolves to unbounded VARBINARY with no wrapper.
+TEST_F(ExpressionParserTest, varbinaryN) {
+  auto expr = parseExpr("cast(null as varbinary(100))");
+  VELOX_EXPECT_EQ_TYPES(expr->type(), VARBINARY());
+  ASSERT_TRUE(expr->isSpecialForm());
+  ASSERT_FALSE(expr->isCall());
+
+  // Zero length is rejected.
+  VELOX_ASSERT_THROW(
+      parseExpr("cast(null as varbinary(0))"), "Length must be positive");
 }
 
 TEST_F(ExpressionParserTest, intervalDayTime) {


### PR DESCRIPTION
Summary:

Adds bounded string type syntax: `VARCHAR(n)`, `CHAR(n)`, `VARBINARY(n)`. Fixes "Unknown parametric type" errors like `CAST(x AS VARCHAR(255))`.

**What works:**
- `CAST(x AS VARCHAR(n))` truncates to n characters (via `substr` wrapper)
- `CAST(x AS CHAR(n))` produces exactly n characters — pads or truncates (via `rpad` wrapper)
- `CAST(x AS VARBINARY(n))` accepts syntax, validates n > 0, no truncation (Prestissimo-compatible)
- `CREATE TABLE (col VARCHAR(n))` accepts the syntax (see limitations below)
- Bare `CHAR` / `CHAR(n)` normalizes to `VARCHAR`

**Limitations (by design — matches Prestissimo's Velox layer):**
- Velox has no bounded string type, so `parseType()` drops the length and resolves to unbounded `VARCHAR` / `VARBINARY`. Length is only enforced at CAST time via expression wrappers.
- `INSERT INTO` / `UPDATE` on a `VARCHAR(n)` column will **not** truncate — the column is stored as unbounded `VARCHAR`. Presto's Java coordinator adds implicit casts; Axiom does not yet. Follow-up: D99002550.
- `SHOW CREATE TABLE` / `SHOW COLUMNS` will show `VARCHAR` instead of `VARCHAR(n)` — same root cause. Follow-up: D98841937.
- Nested types (e.g. `ARRAY(VARCHAR(10))`) drop the length parameter.
- `typeof()` returns `varchar`, not `varchar(n)`.

All CAST results match Presto. The only observable difference is `typeof()`, which returns `varchar` instead of `varchar(10)` / `char(10)` because Velox's type system is unbounded.

**References:**
- Velox HiveTypeParser discards `VARCHAR(n)` length: facebookincubator/velox#5360
- Presto `CHAR(n)` → `VARCHAR` conversion: prestodb/presto#25843

Differential Revision: D96198587


