### PR TITLE
fix(optimizer): Handle unsupported subscript key types in isSubfield (#1073)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -441,7 +441,7 @@ bool ToGraph::isSubfield(
             step.id = integerValue(&literal);
             break;
           default:
-            VELOX_UNREACHABLE();
+            return false;
         }
         input = expr->inputAt(0);
         return true;

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -46,3 +46,7 @@ SELECT a FROM t UNION ALL SELECT b FROM t
 ----
 -- CAST to different types on the same column must not be deduplicated.
 SELECT ROW(CAST(a AS varchar), CAST(a AS double)) FROM t
+----
+-- Subscript on MAP with DOUBLE key.
+-- count 1
+SELECT m[1.0] FROM (VALUES (MAP(ARRAY[CAST(1.0 AS DOUBLE)], ARRAY['hello']))) AS t(m)


### PR DESCRIPTION
Summary:

**Issue**
- `ToGraph::isSubfield` can crash with `VELOX_UNREACHABLE()` when a `subscript` uses a **literal key** whose type isn’t `VARCHAR`, `BIGINT`, `INTEGER`, `SMALLINT`, or `TINYINT` (e.g., `DOUBLE`).  
- This appears in Deltoid queries on `MAP` columns with non-integer/non-string key types.  

**Fix**
- Change `VELOX_UNREACHABLE()` to `return false`, so the subscript is treated as a normal function call via `translateExpr` instead of forcing subfield access.  
- When `isSubfield` is false, `translateSubfield` returns `std::nullopt`, and `translateExpr` falls back to standard expression translation.

Reviewed By: amitkdutta

Differential Revision: D96836852


