### PR TITLE
feat(optimizer): Support stacked IN subqueries (#1074)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -966,6 +966,11 @@ bool DerivedTable::isWrapOnly() const {
       !hasWindow() && exprs.empty();
 }
 
+bool DerivedTable::hasNonInnerJoin() const {
+  return std::ranges::any_of(
+      joins, [](JoinEdgeP join) { return !join->isInner(); });
+}
+
 void DerivedTable::ensureSingleRow() {
   // Global aggregation (no grouping keys) without HAVING clause guarantees
   // exactly one output row.

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -326,6 +326,10 @@ struct DerivedTable : public PlanObject {
     });
   }
 
+  // Returns true if any join in this DT is not an inner join (e.g. semi-join,
+  // anti-join, left join).
+  bool hasNonInnerJoin() const;
+
   /// Returns true if this DT is known to produce zero rows (e.g., an empty
   /// ValuesTable with no data).
   bool isZeroRows() const;

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -431,7 +431,9 @@ A DerivedTable groups together operations that can be planned as a single unit. 
 
 2. **Only inner joins can be flattened together.** Multiple inner joins can be combined into a single DT for join order optimization. Outer joins (LEFT, FULL) cannot be freely reordered, so each outer join and its inputs are wrapped in a nested DT.
 
-3. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order.
+3. **Dependent subquery joins must be in separate DTs.** When a subquery references a column produced by a prior subquery join (e.g., a mark column from an IN semi-join), the prior join is wrapped in a nested DT. Independent subquery joins can coexist in the same DT.
+
+4. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order.
 
 > [!NOTE]
 > Some outer join reorderings are semantically valid. For example, `(a JOIN b) LEFT JOIN c ON f(a, c)` can be reordered to `(a LEFT JOIN c ON f(a, c)) JOIN b`. However, Axiom does not implement this optimization today.
@@ -448,6 +450,6 @@ When a nested DT is needed, there are two patterns:
 
 - **`wrapInDt(node)`**: Converts the logical plan subtree rooted at `node` into a query graph and wraps it in a nested DT. Called when: (1) a node type is not allowed per the `allowedInDt` bitmask, (2) an outer join appears where only inner joins are allowed, (3) for inputs of INTERSECT/EXCEPT set operations, or (4) for inputs of table writes.
 
-- **`finalizeDt`**: Completes `currentDt_` by setting its output columns, nests it inside an outer DT, and updates `currentDt_` to point to the outer DT. Called from `wrapInDt`, but also called directly in cases like adding an aggregation when one already exists, or adding a sort when a limit already exists.
+- **`finalizeDt`**: Completes `currentDt_` by setting its output columns, nests it inside an outer DT, and updates `currentDt_` to point to the outer DT. Called from `wrapInDt`, but also called directly in cases like adding an aggregation when one already exists, adding a sort when a limit already exists, or when `processSubqueries` detects that the DT has non-inner joins, aggregation, or unnest tables before adding new subquery joins.
 
 See `ToGraph::makeQueryGraph` in `ToGraph.cpp` for the full implementation.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1453,19 +1453,39 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
     exprSources_.pop_back();
   };
 
-  for (const auto& key : agg.groupingKeys()) {
-    processSubqueries(input, key, /*filter=*/false);
+  const auto numGroupingKeys = agg.groupingKeys().size();
+  const auto channels = usedChannels(agg);
+  {
+    bool mayFinalize = true;
+    for (const auto& key : agg.groupingKeys()) {
+      processSubqueries(input, key, mayFinalize);
+    }
+
+    for (auto channel : channels) {
+      if (channel < numGroupingKeys) {
+        continue;
+      }
+
+      const auto& aggregate = agg.aggregates()[channel - numGroupingKeys];
+
+      for (const auto& expr : aggregate->inputs()) {
+        processSubqueries(input, expr, mayFinalize);
+      }
+      if (aggregate->filter()) {
+        processSubqueries(input, aggregate->filter(), mayFinalize);
+      }
+    }
   }
 
   ColumnVector columns;
 
   ExprVector deduppedGroupingKeys;
-  deduppedGroupingKeys.reserve(agg.groupingKeys().size());
+  deduppedGroupingKeys.reserve(numGroupingKeys);
 
   auto newRenames = renames_;
 
   folly::F14FastMap<ExprCP, ColumnCP> uniqueGroupingKeys;
-  for (auto i = 0; i < agg.groupingKeys().size(); ++i) {
+  for (auto i = 0; i < numGroupingKeys; ++i) {
     auto name = toName(agg.outputType()->nameOf(i));
     auto* key = translateExpr(agg.groupingKeys()[i]);
 
@@ -1492,20 +1512,12 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
   // The keys for intermediate are the same as for final.
   ColumnVector intermediateColumns = columns;
-  for (auto channel : usedChannels(agg)) {
-    if (channel < agg.groupingKeys().size()) {
+  for (auto channel : channels) {
+    if (channel < numGroupingKeys) {
       continue;
     }
 
-    const auto i = channel - agg.groupingKeys().size();
-    const auto& aggregate = agg.aggregates()[i];
-
-    for (const auto& argExpr : aggregate->inputs()) {
-      processSubqueries(input, argExpr, /*filter=*/false);
-    }
-    if (aggregate->filter()) {
-      processSubqueries(input, aggregate->filter(), /*filter=*/false);
-    }
+    const auto& aggregate = agg.aggregates()[channel - numGroupingKeys];
 
     ExprVector args = translateExprs(aggregate->inputs());
 
@@ -2249,8 +2261,9 @@ void ToGraph::addProjection(const lp::ProjectNode& project) {
     }
   });
 
+  bool mayFinalize = true;
   for (auto i : channels) {
-    processSubqueries(input, exprs[i], /*filter=*/false);
+    processSubqueries(input, exprs[i], mayFinalize);
   }
 
   QGVector<WindowFunctionCP> windowFunctions;
@@ -2304,6 +2317,29 @@ struct Subqueries {
   }
 };
 
+// Returns true if 'expr' or any of its descendants is a subquery expression.
+bool containsSubquery(const lp::ExprPtr& expr) {
+  if (expr->isSubquery()) {
+    return true;
+  }
+  if (expr->isSpecialForm()) {
+    const auto* specialForm = expr->as<lp::SpecialFormExpr>();
+    if (specialForm->form() == lp::SpecialForm::kExists) {
+      return true;
+    }
+    if (specialForm->form() == lp::SpecialForm::kIn &&
+        specialForm->inputAt(1)->isSubquery()) {
+      return true;
+    }
+  }
+  for (const auto& input : expr->inputs()) {
+    if (containsSubquery(input)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void extractSubqueries(const lp::ExprPtr& expr, Subqueries& subqueries) {
   if (expr->isSubquery()) {
     subqueries.scalars.push_back(
@@ -2315,6 +2351,9 @@ void extractSubqueries(const lp::ExprPtr& expr, Subqueries& subqueries) {
     const auto* specialForm = expr->as<lp::SpecialFormExpr>();
     if (specialForm->form() == lp::SpecialForm::kIn &&
         specialForm->inputAt(1)->isSubquery()) {
+      VELOX_USER_CHECK(
+          !containsSubquery(specialForm->inputAt(0)),
+          "Subqueries nested in the left-hand side of IN <subquery> are not supported");
       subqueries.inPredicates.push_back(expr);
       return;
     }
@@ -2582,24 +2621,35 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(AggregationPlanCP agg) {
 void ToGraph::processSubqueries(
     const lp::LogicalPlanNode& input,
     const lp::ExprPtr& expr,
-    bool filter) {
+    bool& mayFinalize) {
   Subqueries subqueries;
   extractSubqueries(expr, subqueries);
 
-  if (filter && currentDt_->hasLimit()) {
-    // Filter cannot be added after LIMIT.
-    finalizeDt(input);
-  } else if (currentDt_->hasAggregation() && !subqueries.empty()) {
-    // Scalar subqueries are placed as joins. Joins cannot be added after
-    // aggregation.
-    finalizeDt(input);
-  } else if (currentDt_->hasUnnestTable() && !subqueries.empty()) {
-    // Subqueries are placed as joins. Joins cannot be placed directly on unnest
-    // tables because unnest tables are on the right side of directed
-    // cross-joins.
-    // TODO: Optimize to only wrap when subquery actually references an unnest
-    // table column.
-    finalizeDt(input);
+  if (subqueries.empty()) {
+    return;
+  }
+
+  if (mayFinalize) {
+    mayFinalize = false;
+
+    if (currentDt_->hasNonInnerJoin()) {
+      // Subquery joins (semi-joins, left joins) produce columns (mark columns,
+      // scalar subquery results) that belong to the current DT. If a new
+      // subquery references such a column as a join key, it would create a
+      // self-referencing join edge. Wrapping the current DT avoids this.
+      finalizeDt(input);
+    } else if (currentDt_->hasAggregation()) {
+      // Scalar subqueries are placed as joins. Joins cannot be added after
+      // aggregation.
+      finalizeDt(input);
+    } else if (currentDt_->hasUnnestTable()) {
+      // Subqueries are placed as joins. Joins cannot be placed directly on
+      // unnest tables because unnest tables are on the right side of directed
+      // cross-joins.
+      // TODO: Optimize to only wrap when subquery actually references an unnest
+      // table column.
+      finalizeDt(input);
+    }
   }
 
   processScalarSubqueries(input, subqueries.scalars);
@@ -3089,7 +3139,13 @@ void ToGraph::addFilter(
     exprSources_.pop_back();
   };
 
-  processSubqueries(input, predicate, /*filter=*/true);
+  if (currentDt_->hasLimit()) {
+    // Filter cannot be added after LIMIT.
+    finalizeDt(input);
+  }
+
+  bool mayFinalize = true;
+  processSubqueries(input, predicate, mayFinalize);
 
   ExprVector flat;
   {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -419,11 +419,14 @@ class ToGraph {
   //
   // @param input The logical plan node to use when finalizing the DT.
   // @param expr The expression to scan for subqueries.
-  // @param filter If true, indicates this is processing a filter predicate.
+  // @param mayFinalize In/out flag. If true on entry and the current DT has
+  // non-inner joins, aggregation, or unnest tables, wraps the DT before
+  // processing subqueries. Set to false after finalization or after processing
+  // subqueries to prevent subsequent calls from finalizing the DT again.
   void processSubqueries(
       const logical_plan::LogicalPlanNode& input,
       const logical_plan::ExprPtr& expr,
-      bool filter);
+      bool& mayFinalize);
 
   // Processes scalar subqueries, creating DTs and joins for each.
   // Populates subqueries_ with mappings from subquery expressions to columns.

--- a/axiom/optimizer/docs/Subqueries.md
+++ b/axiom/optimizer/docs/Subqueries.md
@@ -476,6 +476,7 @@ EXISTS—in both correlated and uncorrelated forms. Subqueries can appear in:
   null-supplying side are pushed into that side as filters)
 - **SELECT lists** (projections)
 - **GROUP BY keys** (grouping expressions)
+- **Aggregate function arguments and filters**
 
 **Correlation types:**
 - **Equality correlations** of the form `f(outer) = g(inner)` become join keys

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1631,5 +1631,43 @@ TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
   }
 }
 
+TEST_F(SubqueryTest, nestedInSubqueries) {
+  // IN subquery on a column derived from another IN subquery. The inner IN
+  // produces a mark column used to compute 'flag'. The outer IN uses 'flag'
+  // as its left key. The optimizer wraps the inner semi-join in a child DT
+  // so the outer semi-join references the child DT, not the current DT.
+  auto query =
+      "SELECT IF(flag IN (SELECT 1), 'y', 'n') "
+      "FROM ("
+      " SELECT IF(n_regionkey IN (SELECT r_regionkey FROM region), 1, 0) AS flag "
+      " FROM nation"
+      ") t";
+
+  auto matcher =
+      matchHiveScan("nation")
+          .hashJoin(
+              matchHiveScan("region").build(),
+              velox::core::JoinType::kLeftSemiProject,
+              /*nullAware=*/true)
+          .project()
+          .hashJoin(
+              velox::core::PlanMatcherBuilder().values().project().build(),
+              velox::core::JoinType::kLeftSemiProject,
+              /*nullAware=*/true)
+          .project()
+          .build();
+
+  SCOPED_TRACE(query);
+  auto plan = toSingleNodePlan(query);
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // Subqueries nested within a single IN expression are not supported.
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(
+          "SELECT (n_regionkey IN (SELECT r_regionkey FROM region)) "
+          "IN (SELECT true) FROM nation"),
+      "Subqueries nested in the left-hand side of IN <subquery> are not supported");
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

Add support for queries where an IN subquery references a column derived
from another IN subquery processed in an earlier expression. For example:

  SELECT IF(flag IN (SELECT 1), 'y', 'n')
  FROM (SELECT IF(n_regionkey IN (SELECT r_regionkey FROM region), 1, 0) AS flag
        FROM nation) t

Previously, this produced a "Join leftTable is 'this'" error because the
mark column from the inner semi-join belonged to the current
DerivedTable, creating a self-referencing join edge.

Note: subqueries nested within a single expression (e.g., the left key
of an IN is itself a subquery expression) are not supported.

The fix adds a `mayFinalize` in/out flag to `processSubqueries`. On the
first call within a projection or filter, if the current DT already has
non-inner joins (semi-joins, left joins from prior subqueries),
aggregation, or unnest tables, the DT is finalized before adding new
subquery joins. This wraps existing joins into a child DT so new
subqueries reference the child DT rather than the current one.

The flag is set to false after the first finalization or after processing
any subqueries, allowing subsequent independent subquery joins to
coexist in the same DT for join ordering flexibility.

Also:
- Moved "filter after LIMIT" finalization from processSubqueries to
  addFilter where it belongs.
- Consolidated processSubqueries calls in translateAggregation to the
  start of the method.

Differential Revision: D96909030


