### PR TITLE
fix(optimizer): Preserve custom types in type deduplication (#1078)

### DIFF
--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -73,12 +73,27 @@ velox::TypePtr QueryGraphContext::dedupType(const velox::TypePtr& type) {
   if (it != deduppedTypes_.end()) {
     return *it;
   }
-  auto size = type->size();
+
+  const auto size = type->size();
   if (size == 0) {
     deduppedTypes_.insert(type);
     toTypePtr_[type.get()] = type;
     return type;
   }
+
+  // Custom types (e.g., IPPREFIX) extend built-in types like RowType.
+  // Reconstructing them as a plain built-in type would lose their identity.
+  // Preserve the original type.
+  if (velox::customTypeExists(type->name())) {
+    VELOX_USER_CHECK(
+        type->parameters().empty(),
+        "Custom types with type parameters are not supported: {}",
+        type->toString());
+    deduppedTypes_.insert(type);
+    toTypePtr_[type.get()] = type;
+    return type;
+  }
+
   std::vector<velox::TypePtr> children;
   children.reserve(size);
   for (auto i = 0; i < size; ++i) {

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -144,6 +144,59 @@ TEST_F(QueryGraphContextTest, toType) {
   EXPECT_EQ(interned2, interned);
 }
 
+class TestCustomType : public RowType {
+ public:
+  TestCustomType() : RowType({"f1", "f2"}, {INTEGER(), VARCHAR()}) {}
+
+  const char* name() const override {
+    return "TEST_CUSTOM";
+  }
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  std::span<const TypeParameter> parameters() const override {
+    return {};
+  }
+};
+
+class TestCustomTypeFactory : public CustomTypeFactory {
+ public:
+  explicit TestCustomTypeFactory(TypePtr type) : type_(std::move(type)) {}
+
+  TypePtr getType(
+      const std::vector<TypeParameter>& /*parameters*/) const override {
+    return type_;
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig&) const override {
+    return nullptr;
+  }
+
+ private:
+  TypePtr type_;
+};
+
+// Custom types (e.g., IPPREFIX) must be preserved by toType, not
+// reconstructed as plain ROW.
+TEST_F(QueryGraphContextTest, customType) {
+  auto customType = std::make_shared<const TestCustomType>();
+  registerCustomType(
+      customType->name(), std::make_unique<TestCustomTypeFactory>(customType));
+  SCOPE_EXIT {
+    unregisterCustomType(customType->name());
+  };
+
+  auto* deduped = toType(customType);
+  EXPECT_EQ(deduped, customType.get());
+}
+
 TEST_F(QueryGraphContextTest, stepOrdering) {
   // Steps with different kinds.
   {


### PR DESCRIPTION
Summary:

Custom types like IPPREFIX extend RowType but have their own identity
(e.g., singleton instances, custom equivalent()). The type deduplication
in QueryGraphContext::dedupType reconstructed all ROW types as plain
ROW, losing the custom type identity. This caused a runtime error when
Velox's ExprCompiler compared the deduped plain ROW against the expected
custom type:

>  SELECT ip_prefix(CAST('1.2.3.4' AS ipaddress), 24)

```
Found incompatible return types for 'ip_prefix' (IPPREFIX vs. ROW<ip:IPADDRESS,prefix:TINYINT>)
```

The fix checks customTypeExists() before reconstructing and preserves
the original type.

Reviewed By: xiaoxmeng

Differential Revision: D96924043


