### PR TITLE
fix: Remove redundant aggregation for EXCEPT and INTERSECT (#1080)

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -766,7 +766,9 @@ const auto& setOperationNames() {
       {SetOperation::kUnion, "UNION"},
       {SetOperation::kUnionAll, "UNION ALL"},
       {SetOperation::kIntersect, "INTERSECT"},
+      {SetOperation::kIntersectAll, "INTERSECT ALL"},
       {SetOperation::kExcept, "EXCEPT"},
+      {SetOperation::kExceptAll, "EXCEPT ALL"},
   };
   return kNames;
 }

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -578,17 +578,24 @@ using LimitNodePtr = std::shared_ptr<const LimitNode>;
 
 enum class SetOperation {
   /// Returns all rows from all inputs after removing duplicates.
-  kUnion = 0,
+  kUnion,
 
   /// Returns all rows from all inputs.
-  kUnionAll = 1,
+  kUnionAll,
 
-  /// Returns a subset of rows that are present in all inputs.
-  kIntersect = 2,
+  /// Returns distinct rows that are present in all inputs.
+  kIntersect,
 
-  /// Returns a subset of rows in the first input that are not found in any
-  /// other input.
-  kExcept = 3,
+  /// Returns all rows that are present in all inputs, preserving duplicates.
+  kIntersectAll,
+
+  /// Returns distinct rows in the first input that are not found in any other
+  /// input.
+  kExcept,
+
+  /// Returns all rows in the first input that are not found in any other
+  /// input, preserving duplicates.
+  kExceptAll,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SetOperation)

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -393,6 +393,13 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
     for (auto* child : children) {
       child->finalizeJoinsAndMakePlans();
     }
+
+    // Set initial cardinality as the sum of children's cardinalities so that
+    // makeInitialPlan can use it when estimating groups for makeDistinct.
+    cardinality = 0;
+    for (const auto* child : children) {
+      cardinality += child->cardinality;
+    }
   }
 
   finalizeJoins();

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3309,7 +3309,10 @@ void ToGraph::translateSetJoin(const lp::SetNode& set) {
   const bool exists = set.operation() == lp::SetOperation::kIntersect;
   const bool anti = set.operation() == lp::SetOperation::kExcept;
 
-  VELOX_CHECK(exists || anti);
+  VELOX_USER_CHECK(
+      exists || anti,
+      "Unsupported set operation: {}",
+      lp::SetOperationName::toName(set.operation()));
 
   const auto* left = setDt->tables[0]->as<DerivedTable>();
 

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -694,8 +694,6 @@ TEST_F(SetTest, exceptUnionAll) {
   auto matchExcept = [](const std::string& left, const std::string& right) {
     return matchScan(left)
         .hashJoin(matchScan(right).build(), core::JoinType::kAnti)
-        // TODO Fix the optimizer to remove redundant aggregation.
-        .singleAggregation()
         .singleAggregation();
   };
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -877,33 +877,32 @@ class RelationPlanner : public AstVisitor {
 
   void visitExcept(Except* node) override {
     visitSetOperation(
-        lp::SetOperation::kExcept,
+        node->isDistinct() ? lp::SetOperation::kExcept
+                           : lp::SetOperation::kExceptAll,
         node->left(),
-        node->right(),
-        node->isDistinct());
+        node->right());
   }
 
   void visitIntersect(Intersect* node) override {
     visitSetOperation(
-        lp::SetOperation::kIntersect,
+        node->isDistinct() ? lp::SetOperation::kIntersect
+                           : lp::SetOperation::kIntersectAll,
         node->left(),
-        node->right(),
-        node->isDistinct());
+        node->right());
   }
 
   void visitUnion(Union* node) override {
     visitSetOperation(
-        lp::SetOperation::kUnionAll,
+        node->isDistinct() ? lp::SetOperation::kUnion
+                           : lp::SetOperation::kUnionAll,
         node->left(),
-        node->right(),
-        node->isDistinct());
+        node->right());
   }
 
   void visitSetOperation(
       lp::SetOperation op,
       const std::shared_ptr<QueryBody>& left,
-      const std::shared_ptr<QueryBody>& right,
-      bool distinct) {
+      const std::shared_ptr<QueryBody>& right) {
     left->accept(this);
 
     auto leftBuilder = builder_;
@@ -914,10 +913,6 @@ class RelationPlanner : public AstVisitor {
 
     builder_ = leftBuilder;
     builder_->setOperation(op, *rightBuilder);
-
-    if (distinct) {
-      builder_->distinct();
-    }
   }
 
   std::shared_ptr<lp::PlanBuilder> newBuilder(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -662,6 +662,12 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::setOperation(
   return *this;
 }
 
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::unionDistinct(
+    const std::shared_ptr<LogicalPlanMatcher>& matcher,
+    OnMatchCallback onMatch) {
+  return setOperation(SetOperation::kUnion, matcher, std::move(onMatch));
+}
+
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::unionAll(
     const std::shared_ptr<LogicalPlanMatcher>& matcher,
     OnMatchCallback onMatch) {
@@ -674,10 +680,22 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::except(
   return setOperation(SetOperation::kExcept, matcher, std::move(onMatch));
 }
 
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::exceptAll(
+    const std::shared_ptr<LogicalPlanMatcher>& matcher,
+    OnMatchCallback onMatch) {
+  return setOperation(SetOperation::kExceptAll, matcher, std::move(onMatch));
+}
+
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::intersect(
     const std::shared_ptr<LogicalPlanMatcher>& matcher,
     OnMatchCallback onMatch) {
   return setOperation(SetOperation::kIntersect, matcher, std::move(onMatch));
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::intersectAll(
+    const std::shared_ptr<LogicalPlanMatcher>& matcher,
+    OnMatchCallback onMatch) {
+  return setOperation(SetOperation::kIntersectAll, matcher, std::move(onMatch));
 }
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::sort(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -172,6 +172,12 @@ class LogicalPlanMatcherBuilder {
       const std::shared_ptr<LogicalPlanMatcher>& matcher,
       OnMatchCallback onMatch = nullptr);
 
+  /// Matches a SetNode with kUnion operation. Named 'unionDistinct' because
+  /// 'union' is a C++ reserved keyword.
+  LogicalPlanMatcherBuilder& unionDistinct(
+      const std::shared_ptr<LogicalPlanMatcher>& matcher,
+      OnMatchCallback onMatch = nullptr);
+
   /// Matches a SetNode with kUnionAll operation.
   LogicalPlanMatcherBuilder& unionAll(
       const std::shared_ptr<LogicalPlanMatcher>& matcher,
@@ -182,8 +188,18 @@ class LogicalPlanMatcherBuilder {
       const std::shared_ptr<LogicalPlanMatcher>& matcher,
       OnMatchCallback onMatch = nullptr);
 
+  /// Matches a SetNode with kExceptAll operation.
+  LogicalPlanMatcherBuilder& exceptAll(
+      const std::shared_ptr<LogicalPlanMatcher>& matcher,
+      OnMatchCallback onMatch = nullptr);
+
   /// Matches a SetNode with kIntersect operation.
   LogicalPlanMatcherBuilder& intersect(
+      const std::shared_ptr<LogicalPlanMatcher>& matcher,
+      OnMatchCallback onMatch = nullptr);
+
+  /// Matches a SetNode with kIntersectAll operation.
+  LogicalPlanMatcherBuilder& intersectAll(
       const std::shared_ptr<LogicalPlanMatcher>& matcher,
       OnMatchCallback onMatch = nullptr);
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -832,13 +832,13 @@ TEST_F(PrestoParserTest, unionAllFollowedByInSubqueryCoercion) {
 }
 
 TEST_F(PrestoParserTest, union) {
+  // UNION and UNION DISTINCT are equivalent. Deduplication is part of the
+  // kUnion set operation semantics.
   auto matcher = matchScan()
                      .project()
-                     .unionAll(matchScan().project().build())
-                     .distinct()
+                     .unionDistinct(matchScan().project().build())
                      .output({"n_name"});
 
-  // UNION and UNION DISTINCT are equivalent.
   testSelect(
       "SELECT n_name FROM nation UNION SELECT r_name FROM region", matcher);
   testSelect(
@@ -847,12 +847,11 @@ TEST_F(PrestoParserTest, union) {
 }
 
 TEST_F(PrestoParserTest, except) {
-  // EXCEPT and EXCEPT DISTINCT are equivalent. Both add distinct for
-  // deduplication.
+  // EXCEPT and EXCEPT DISTINCT are equivalent. Deduplication is part of the
+  // kExcept set operation semantics.
   auto matcher = matchScan()
                      .project()
                      .except(matchScan().project().build())
-                     .distinct()
                      .output({"n_name"});
 
   testSelect(
@@ -861,10 +860,10 @@ TEST_F(PrestoParserTest, except) {
       "SELECT n_name FROM nation EXCEPT DISTINCT SELECT r_name FROM region",
       matcher);
 
-  // EXCEPT ALL skips deduplication.
+  // EXCEPT ALL uses kExceptAll which preserves duplicates.
   auto matcherAll = matchScan()
                         .project()
-                        .except(matchScan().project().build())
+                        .exceptAll(matchScan().project().build())
                         .output({"n_name"});
 
   testSelect(
@@ -873,12 +872,11 @@ TEST_F(PrestoParserTest, except) {
 }
 
 TEST_F(PrestoParserTest, intersect) {
-  // INTERSECT and INTERSECT DISTINCT are equivalent. Both add distinct for
-  // deduplication.
+  // INTERSECT and INTERSECT DISTINCT are equivalent. Deduplication is part of
+  // the kIntersect set operation semantics.
   auto matcher = matchScan()
                      .project()
                      .intersect(matchScan().project().build())
-                     .distinct()
                      .output({"n_name"});
 
   testSelect(
@@ -887,10 +885,10 @@ TEST_F(PrestoParserTest, intersect) {
       "SELECT n_name FROM nation INTERSECT DISTINCT SELECT r_name FROM region",
       matcher);
 
-  // INTERSECT ALL skips deduplication.
+  // INTERSECT ALL uses kIntersectAll which preserves duplicates.
   auto matcherAll = matchScan()
                         .project()
-                        .intersect(matchScan().project().build())
+                        .intersectAll(matchScan().project().build())
                         .output({"n_name"});
 
   testSelect(


### PR DESCRIPTION
Summary:

Previously, the SQL parser added an explicit Aggregate node (via distinct())
above EXCEPT and INTERSECT, while translateSetJoin also added its own
aggregation internally. Both performed GROUP BY all columns for deduplication,
resulting in two redundant aggregations in the plan.

Fix by clarifying SetOperation semantics: kExcept and kIntersect include
deduplication (like kUnion), so the parser no longer adds a separate
distinct(). Add kExceptAll and kIntersectAll enum values for future support
of EXCEPT ALL and INTERSECT ALL (currently unsupported by the optimizer).

Also align UNION handling: the parser now emits kUnion directly instead of
kUnionAll + distinct().

Reviewed By: natashasehgal

Differential Revision: D96946555


