### PR TITLE
fix: Register table in memory on CREATE TABLE (#1081)

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1904,12 +1904,14 @@ TablePtr LocalHiveConnectorMetadata::createTable(
     outputFile << jsonStr;
     outputFile.close();
   }
-  return createLocalTable(
+  auto table = createLocalTable(
       tableName.table,
       rowType,
       createTableOptions,
       hiveConnector(),
       hiveMetadataConfig_);
+  tables_[tableName.table] = table;
+  return table;
 }
 
 RowsFuture LocalHiveConnectorMetadata::finishWrite(

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -309,6 +309,10 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   auto table = metadata_->createTable(
       session, {kDefaultSchema, "test"}, tableType, options, /*explain=*/false);
 
+  // Table should be findable immediately after createTable, before
+  // beginWrite/finishWrite. This is the flow for plain CREATE TABLE (no data).
+  ASSERT_NE(metadata_->findTable({kDefaultSchema, "test"}), nullptr);
+
   constexpr int32_t kTestSize = 2048;
   auto data = makeRowVector(
       tableType->names(),


### PR DESCRIPTION
Summary:

`LocalHiveConnectorMetadata::createTable` writes the table directory and schema
file to disk but does not add the table to the in-memory `tables_` map. For
CTAS, this isn't a problem because `finishWrite` calls `loadTable` which
populates `tables_`. But for a plain `CREATE TABLE` (no data),
`beginWrite`/`finishWrite` is never called, so the table remains invisible to
`findTable`.

This causes multi-statement CLI commands like
`CREATE TABLE t(a int); SELECT * FROM t` to fail with "Table not found".

The fix adds the created table to `tables_` in `createTable`. This is safe
because `abortWrite` already erases the table from `tables_` for kCreate
operations, and `finishWrite` overwrites the entry via `loadTable` with the
fully populated version.

Differential Revision: D96974408
