### PR TITLE
fix: Preserve element_at semantics in subfield path rewriting (#1083)

### DIFF
--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -23,6 +23,20 @@
 
 namespace facebook::axiom::optimizer {
 
+namespace {
+const auto& stepKindNames() {
+  static const folly::F14FastMap<StepKind, std::string_view> kNames = {
+      {StepKind::kField, "FIELD"},
+      {StepKind::kSubscript, "SUBSCRIPT"},
+      {StepKind::kElementAt, "ELEMENT_AT"},
+      {StepKind::kCardinality, "CARDINALITY"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(StepKind, stepKindNames);
+
 QueryGraphContext::QueryGraphContext(velox::HashStringAllocator& allocator)
     : allocator_(allocator), cache_(allocator_) {
   auto addName = [&](const char* name) {
@@ -231,6 +245,7 @@ std::string Path::toString() const {
         out << fmt::format("__{}", step.id);
         break;
       case StepKind::kSubscript:
+      case StepKind::kElementAt:
         if (step.field) {
           out << "[" << step.field << "]";
         } else {

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include "axiom/common/Enums.h"
 #include "axiom/optimizer/ArenaCache.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/type/Variant.h"
@@ -170,7 +171,14 @@ using QGF14FastSet =
 
 /// Elements of subfield paths. The QueryGraphContext holds a dedupped
 /// collection of distinct paths.
-enum class StepKind : uint8_t { kField, kSubscript, kCardinality };
+enum class StepKind : uint8_t {
+  kField,
+  kSubscript,
+  kElementAt,
+  kCardinality,
+};
+
+AXIOM_DECLARE_ENUM_NAME(StepKind);
 
 struct Step {
   StepKind kind;

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -344,12 +344,14 @@ void SubfieldTracker::markSubfields(
     }
 
     if (name == subscript_ || name == elementAt_) {
+      const auto stepKind =
+          (name == elementAt_) ? StepKind::kElementAt : StepKind::kSubscript;
       auto constant = tryFoldConstant_(expr->inputAt(1));
       if (!constant) {
         std::vector<Step> subSteps;
         markSubfields(expr->inputAt(1), subSteps, isControl, context);
 
-        steps.push_back({.kind = StepKind::kSubscript, .allFields = true});
+        steps.push_back({.kind = stepKind, .allFields = true});
         markSubfields(expr->inputAt(0), steps, isControl, context);
         steps.pop_back();
         return;
@@ -358,10 +360,10 @@ void SubfieldTracker::markSubfields(
       const auto& value = constant->value();
       if (value->kind() == velox::TypeKind::VARCHAR) {
         const auto& str = value->template value<velox::TypeKind::VARCHAR>();
-        steps.push_back({.kind = StepKind::kSubscript, .field = toName(str)});
+        steps.push_back({.kind = stepKind, .field = toName(str)});
       } else {
         const auto& id = integerValue(value.get());
-        steps.push_back({.kind = StepKind::kSubscript, .id = id});
+        steps.push_back({.kind = stepKind, .id = id});
       }
 
       markSubfields(expr->inputAt(0), steps, isControl, context);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -428,7 +428,8 @@ bool ToGraph::isSubfield(
     if (name == functionNames_.subscript || name == functionNames_.elementAt) {
       auto subscript = translateExpr(call->inputAt(1));
       if (subscript->is(PlanType::kLiteralExpr)) {
-        step.kind = StepKind::kSubscript;
+        step.kind = (name == functionNames_.elementAt) ? StepKind::kElementAt
+                                                       : StepKind::kSubscript;
         auto& literal = subscript->as<Literal>()->literal();
         switch (subscript->value().type->kind()) {
           case velox::TypeKind::VARCHAR:
@@ -441,7 +442,7 @@ bool ToGraph::isSubfield(
             step.id = integerValue(&literal);
             break;
           default:
-            return false;
+            VELOX_UNREACHABLE();
         }
         input = expr->inputAt(0);
         return true;
@@ -743,7 +744,8 @@ ExprCP ToGraph::makeGetter(const Step& step, ExprCP base) {
       }
     }
 
-    case StepKind::kSubscript: {
+    case StepKind::kSubscript:
+    case StepKind::kElementAt: {
       // Type of array element or map value.
       auto valueType = inputType->childAt(inputType->isArray() ? 0 : 1);
 
@@ -759,7 +761,8 @@ ExprCP ToGraph::makeGetter(const Step& step, ExprCP base) {
       };
 
       return make<Call>(
-          functionNames_.subscript,
+          step.kind == StepKind::kElementAt ? functionNames_.elementAt
+                                            : functionNames_.subscript,
           toConstantValue(valueType),
           std::move(args),
           FunctionSet());
@@ -2069,6 +2072,7 @@ const velox::Type* pathType(const velox::Type* type, PathCP path) {
         type = type->childAt(step.id).get();
         break;
       case StepKind::kSubscript:
+      case StepKind::kElementAt:
         type =
             type->childAt(type->kind() == velox::TypeKind::ARRAY ? 0 : 1).get();
         break;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -55,7 +55,8 @@ ToVelox::ToVelox(
       options_{options},
       optimizerOptions_{optimizerOptions},
       isSingle_{options.numWorkers == 1},
-      subscript_{FunctionRegistry::instance()->subscript()} {}
+      subscript_{FunctionRegistry::instance()->subscript()},
+      elementAt_{FunctionRegistry::instance()->elementAt()} {}
 
 namespace {
 
@@ -125,6 +126,7 @@ std::vector<velox::common::Subfield> columnSubfields(
                   step.field));
           break;
         case StepKind::kSubscript:
+        case StepKind::kElementAt:
           if (step.allFields) {
             elements.push_back(
                 std::make_unique<velox::common::Subfield::AllSubscripts>());
@@ -475,7 +477,8 @@ velox::core::TypedExprPtr stepToMapSubscript(
 velox::core::TypedExprPtr stepToGetter(
     Step step,
     velox::core::TypedExprPtr arg,
-    const std::string& subscript) {
+    const std::string& subscript,
+    const std::string& elementAt) {
   switch (step.kind) {
     case StepKind::kField: {
       if (step.field) {
@@ -496,15 +499,18 @@ velox::core::TypedExprPtr stepToGetter(
       return std::make_shared<velox::core::DereferenceTypedExpr>(
           type, arg, step.id);
     }
-    case StepKind::kSubscript: {
+    case StepKind::kSubscript:
+    case StepKind::kElementAt: {
       auto& type = arg->type();
+      auto& funcName =
+          step.kind == StepKind::kElementAt ? elementAt : subscript;
       if (type->isMap()) {
-        return stepToMapSubscript(step, arg, subscript);
+        return stepToMapSubscript(step, arg, funcName);
       }
 
       return std::make_shared<velox::core::CallTypedExpr>(
           type->childAt(0),
-          subscript,
+          funcName,
           arg,
           makeKey(velox::INTEGER(), static_cast<int32_t>(step.id)));
     }
@@ -520,35 +526,35 @@ velox::core::TypedExprPtr ToVelox::pathToGetter(
     ColumnCP column,
     PathCP path,
     velox::core::TypedExprPtr field) {
-  bool first = true;
   // If this is a path over a map that is retrieved as struct, the first getter
   // becomes a struct getter.
-  auto alterStep = [&](ColumnCP, const Step& step, Step& newStep) {
-    auto* rel = column->relation();
-    if (rel->is(PlanType::kTableNode) &&
+  const auto alterStep = [&](ColumnCP, const Step& step, Step& newStep) {
+    auto* relation = column->relation();
+    if (relation->is(PlanType::kTableNode) &&
         isMapAsStruct(
-            rel->as<BaseTable>()->schemaTable->name(), column->name())) {
+            relation->as<BaseTable>()->schemaTable->name(), column->name())) {
       // This column is a map to project out as struct.
       newStep.kind = StepKind::kField;
       if (step.field) {
         newStep.field = step.field;
       } else {
-        newStep.field = toName(fmt::format("{}", step.id));
+        newStep.field = toName(fmt::to_string(step.id));
       }
       return true;
     }
     return false;
   };
 
+  bool first = true;
   for (auto& step : path->steps()) {
     Step newStep;
     if (first && alterStep(column, step, newStep)) {
-      field = stepToGetter(newStep, field, subscript_.value());
-      first = false;
-      continue;
+      field =
+          stepToGetter(newStep, field, subscript_.value(), elementAt_.value());
+    } else {
+      field = stepToGetter(step, field, subscript_.value(), elementAt_.value());
     }
     first = false;
-    field = stepToGetter(step, field, subscript_.value());
   }
   return field;
 }

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -362,6 +362,7 @@ class ToVelox {
   int32_t stageCounter_{0};
 
   const std::optional<std::string> subscript_;
+  const std::optional<std::string> elementAt_;
 
   FinishWrite finishWrite_;
 

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -204,7 +204,7 @@ TEST_F(QueryGraphContextTest, stepOrdering) {
     Step b{.kind = StepKind::kSubscript, .field = toName("b")};
     Step c{.kind = StepKind::kCardinality};
 
-    // kField < kSubscript < kCardinality (enum order).
+    // kField < kSubscript < kElementAt < kCardinality (enum order).
     // Verify ordering and asymmetry: if A < B then B > A.
     EXPECT_LT(a, b);
     EXPECT_GT(b, a);

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/tests/SqlTestBase.h"
 #include "axiom/common/Session.h"
 #include "axiom/connectors/SchemaResolver.h"
+#include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/LocalRunner.h"
@@ -39,6 +40,7 @@ void SqlTestBase::SetUpTestCase() {
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   window::prestosql::registerAllWindowFunctions();
+  FunctionRegistry::registerPrestoFunctions();
 }
 
 void SqlTestBase::SetUp() {

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -60,11 +60,14 @@ lp::ExprPtr stepToLogicalPlanGetter(Step step, const lp::ExprPtr& arg) {
           *type, lp::SpecialForm::kDereference, arg, key);
     }
 
-    case StepKind::kSubscript: {
+    case StepKind::kSubscript:
+    case StepKind::kElementAt: {
+      const auto* funcName =
+          step.kind == StepKind::kElementAt ? "element_at" : "subscript";
       if (argType->kind() == TypeKind::ARRAY) {
         return std::make_shared<lp::CallExpr>(
             argType->childAt(0),
-            "subscript",
+            funcName,
             arg,
             makeKey(INTEGER(), static_cast<int32_t>(step.id)));
       }
@@ -91,7 +94,7 @@ lp::ExprPtr stepToLogicalPlanGetter(Step step, const lp::ExprPtr& arg) {
       }
 
       return std::make_shared<lp::CallExpr>(
-          argType->childAt(1), "subscript", arg, key);
+          argType->childAt(1), funcName, arg, key);
     }
 
     default:

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -47,6 +47,8 @@ SELECT a FROM t UNION ALL SELECT b FROM t
 -- CAST to different types on the same column must not be deduplicated.
 SELECT ROW(CAST(a AS varchar), CAST(a AS double)) FROM t
 ----
--- Subscript on MAP with DOUBLE key.
--- count 1
-SELECT m[1.0] FROM (VALUES (MAP(ARRAY[CAST(1.0 AS DOUBLE)], ARRAY['hello']))) AS t(m)
+-- duckdb: SELECT NULL
+SELECT element_at(filter(ARRAY[1, 2, 3], x -> x > 5), 1)
+----
+-- error: Array subscript index out of bounds
+SELECT filter(ARRAY[1, 2, 3], x -> x > 5)[1]


### PR DESCRIPTION
Summary:

The optimizer's subfield tracking converts both `element_at` and `subscript`
function calls into `StepKind::kSubscript` path steps. When converting back
to Velox expressions, it always emits `subscript`, losing the `element_at`
semantics. This causes queries using `element_at` on arrays to throw
"Array subscript index out of bounds" instead of returning NULL when the
index is out of bounds.

Added `StepKind::kElementAt` enum value to preserve the distinction between
the two functions throughout the optimizer pipeline:
- `isSubfield` (ToGraph.cpp) now sets `kElementAt` for `element_at` calls.
- `makeGetter` (ToGraph.cpp) uses the correct function name based on StepKind.
- `stepToGetter` (ToVelox.cpp) emits the correct function name.
- `SubfieldTracker.cpp` preserves the distinction during subfield marking.

Also added `FunctionRegistry::registerPrestoFunctions()` to SqlTestBase
so SQL tests exercise the same code paths as production.

Differential Revision: D96987814


