### PR TITLE
fix: Handle non-integer MAP keys in subfield tracking (#1087)

### DIFF
--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -358,12 +358,24 @@ void SubfieldTracker::markSubfields(
       }
 
       const auto& value = constant->value();
-      if (value->kind() == velox::TypeKind::VARCHAR) {
-        const auto& str = value->template value<velox::TypeKind::VARCHAR>();
-        steps.push_back({.kind = stepKind, .field = toName(str)});
-      } else {
-        const auto& id = integerValue(value.get());
-        steps.push_back({.kind = stepKind, .id = id});
+      switch (value->kind()) {
+        case velox::TypeKind::VARCHAR: {
+          const auto& str = value->template value<velox::TypeKind::VARCHAR>();
+          steps.push_back({.kind = stepKind, .field = toName(str)});
+          break;
+        }
+        case velox::TypeKind::BIGINT:
+        case velox::TypeKind::INTEGER:
+        case velox::TypeKind::SMALLINT:
+        case velox::TypeKind::TINYINT: {
+          const auto& id = integerValue(value.get());
+          steps.push_back({.kind = stepKind, .id = id});
+          break;
+        }
+        default:
+          // Unsupported key type, cannot narrow to specific subfields.
+          steps.push_back({.kind = stepKind, .allFields = true});
+          break;
       }
 
       markSubfields(expr->inputAt(0), steps, isControl, context);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -442,7 +442,7 @@ bool ToGraph::isSubfield(
             step.id = integerValue(&literal);
             break;
           default:
-            VELOX_UNREACHABLE();
+            return false;
         }
         input = expr->inputAt(0);
         return true;

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -52,3 +52,7 @@ SELECT element_at(filter(ARRAY[1, 2, 3], x -> x > 5), 1)
 ----
 -- error: Array subscript index out of bounds
 SELECT filter(ARRAY[1, 2, 3], x -> x > 5)[1]
+----
+-- Subscript on MAP with DOUBLE key.
+-- duckdb: SELECT 'hello'
+SELECT MAP(ARRAY[CAST(1.0 AS DOUBLE)], ARRAY['hello'])[1.0]


### PR DESCRIPTION
Summary:

The optimizer’s subfield tracking assumes MAP subscript keys are either `VARCHAR` or an integer type. Non-integer numeric keys (e.g. `DOUBLE`) fail during optimization: `integerValue()` gets called on a `DOUBLE` variant, and unsupported key types can reach `VELOX_UNREACHABLE()` unhandled.

**Fix:** switch on key type 
- `VARCHAR` extracts the string field name
-  Integer types call `integerValue()`
- Otherwise fall through to `allFields = true`.

For any unhandled types in the subfield check, return `false` instead of failing.

Differential Revision: D97010779


