### PR TITLE
feat(parser): Add logical_plan::Expr::operator== (#1088)

### DIFF
--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -42,6 +42,99 @@ const auto& exprKindNames() {
 
 AXIOM_DEFINE_ENUM_NAME(ExprKind, exprKindNames);
 
+bool Expr::equalNullableExprs(const ExprPtr& lhs, const ExprPtr& rhs) {
+  if (lhs == nullptr && rhs == nullptr) {
+    return true;
+  }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  return *lhs == *rhs;
+}
+
+bool Expr::equalExprVectors(
+    const std::vector<ExprPtr>& lhs,
+    const std::vector<ExprPtr>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    VELOX_CHECK_NOT_NULL(lhs[i]);
+    VELOX_CHECK_NOT_NULL(rhs[i]);
+    if (*lhs[i] != *rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Expr::operator==(const Expr& other) const {
+  if (this == &other) {
+    return true;
+  }
+  if (kind_ != other.kind_) {
+    return false;
+  }
+  if (*type_ != *other.type_) {
+    return false;
+  }
+  if (!equalExprVectors(inputs_, other.inputs_)) {
+    return false;
+  }
+  return equalTo(other);
+}
+
+bool InputReferenceExpr::equalTo(const Expr& other) const {
+  return name_ == other.as<InputReferenceExpr>()->name_;
+}
+
+bool ConstantExpr::equalTo(const Expr& other) const {
+  return *value_ == *other.as<ConstantExpr>()->value_;
+}
+
+bool CallExpr::equalTo(const Expr& other) const {
+  return name_ == other.as<CallExpr>()->name_;
+}
+
+bool SpecialFormExpr::equalTo(const Expr& other) const {
+  return form_ == other.as<SpecialFormExpr>()->form_;
+}
+
+bool AggregateExpr::equalTo(const Expr& other) const {
+  const auto* rhs = other.as<AggregateExpr>();
+  return name_ == rhs->name_ && distinct_ == rhs->distinct_ &&
+      equalNullableExprs(filter_, rhs->filter_) && ordering_ == rhs->ordering_;
+}
+
+bool WindowExpr::Frame::operator==(const Frame& other) const {
+  return type == other.type && startType == other.startType &&
+      equalNullableExprs(startValue, other.startValue) &&
+      endType == other.endType && equalNullableExprs(endValue, other.endValue);
+}
+
+bool SortingField::operator==(const SortingField& other) const {
+  VELOX_CHECK_NOT_NULL(expression);
+  VELOX_CHECK_NOT_NULL(other.expression);
+  return *expression == *other.expression && order == other.order;
+}
+
+bool WindowExpr::equalTo(const Expr& other) const {
+  const auto* rhs = other.as<WindowExpr>();
+  return name_ == rhs->name_ && ignoreNulls_ == rhs->ignoreNulls_ &&
+      frame_ == rhs->frame_ &&
+      equalExprVectors(partitionKeys_, rhs->partitionKeys_) &&
+      ordering_ == rhs->ordering_;
+}
+
+bool LambdaExpr::equalTo(const Expr& other) const {
+  const auto* rhs = other.as<LambdaExpr>();
+  return *signature_ == *rhs->signature_ && *body_ == *rhs->body_;
+}
+
+bool SubqueryExpr::equalTo(const Expr& /*other*/) const {
+  VELOX_UNSUPPORTED("Equality comparison is not supported for SubqueryExpr.");
+}
+
 std::string Expr::toString() const {
   return ExprPrinter::toText(*this);
 }

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -144,13 +144,31 @@ class Expr : public velox::ISerializable {
   virtual void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
       const = 0;
 
+  /// Returns true if two expressions are structurally equal.
+  bool operator==(const Expr& other) const;
+
   std::string toString() const;
 
   /// Registers deserializers for all Expr subclasses.
   static void registerSerDe();
 
  protected:
-  /// Serializes common base fields (name, type, inputs).
+  // Returns true if derived-class-specific fields are equal. Called only when
+  // kind, type, and inputs already match.
+  virtual bool equalTo(const Expr& other) const = 0;
+
+  // Compares two ExprPtr values for structural equality. Either or both
+  // pointers may be null. Two nulls are considered equal; a null and a
+  // non-null are not.
+  static bool equalNullableExprs(const ExprPtr& lhs, const ExprPtr& rhs);
+
+  // Compares two vectors of ExprPtr for structural equality. All elements
+  // must be non-null; null elements trigger an error.
+  static bool equalExprVectors(
+      const std::vector<ExprPtr>& lhs,
+      const std::vector<ExprPtr>& rhs);
+
+  // Serializes common base fields (name, type, inputs).
   folly::dynamic serializeBase(std::string_view name) const;
 
   const ExprKind kind_;
@@ -182,6 +200,8 @@ class InputReferenceExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const std::string name_;
 };
 
@@ -217,6 +237,8 @@ class ConstantExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const std::shared_ptr<const velox::Variant> value_;
 };
 
@@ -250,6 +272,8 @@ class CallExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const std::string name_;
 };
 
@@ -458,6 +482,8 @@ class SpecialFormExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const SpecialForm form_;
 };
 
@@ -502,6 +528,9 @@ class SortOrder {
 struct SortingField {
   ExprPtr expression;
   SortOrder order;
+
+  /// Returns true if expression and sort order are equal.
+  bool operator==(const SortingField& other) const;
 
   folly::dynamic serialize() const;
 
@@ -577,6 +606,8 @@ class AggregateExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const std::string name_;
   const ExprPtr filter_;
   const std::vector<SortingField> ordering_;
@@ -615,6 +646,9 @@ class WindowExpr : public Expr {
     ExprPtr startValue;
     BoundType endType;
     ExprPtr endValue;
+
+    /// Returns true if frame type, bound types, and bound values are equal.
+    bool operator==(const Frame& other) const;
 
     folly::dynamic serialize() const;
 
@@ -672,6 +706,8 @@ class WindowExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const std::string name_;
   const std::vector<ExprPtr> partitionKeys_;
   const std::vector<SortingField> ordering_;
@@ -722,6 +758,8 @@ class LambdaExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const velox::RowTypePtr signature_;
   const ExprPtr body_;
 };
@@ -749,6 +787,8 @@ class SubqueryExpr : public Expr {
   static ExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const Expr& other) const override;
+
   const LogicalPlanNodePtr subquery_;
 };
 

--- a/axiom/logical_plan/tests/CMakeLists.txt
+++ b/axiom/logical_plan/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   axiom_logical_plan_tests
+  ExprEqualityTest.cpp
   ExprSerdeTest.cpp
   ExprTest.cpp
   LogicalPlanNodeSerdeTest.cpp

--- a/axiom/logical_plan/tests/ExprEqualityTest.cpp
+++ b/axiom/logical_plan/tests/ExprEqualityTest.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/ExprResolver.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/type/Type.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::logical_plan {
+namespace {
+
+class ExprEqualityTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::functions::prestosql::registerAllScalarFunctions();
+    velox::aggregate::prestosql::registerAllAggregateFunctions();
+    velox::window::prestosql::registerAllWindowFunctions();
+  }
+
+  static ExprResolver::InputNameResolver inputResolver(
+      const RowTypePtr& schema) {
+    return [schema](
+               const std::optional<std::string>&,
+               const std::string& name) -> ExprPtr {
+      return std::make_shared<InputReferenceExpr>(
+          schema->findChild(name), name);
+    };
+  }
+
+  ExprPtr resolve(const ExprApi& expr) {
+    return resolve(expr, schema_);
+  }
+
+  ExprPtr resolve(const ExprApi& expr, const RowTypePtr& schema) {
+    return ExprResolver(nullptr, false)
+        .resolveScalarTypes(expr.expr(), inputResolver(schema));
+  }
+
+  RowTypePtr schema_ =
+      ROW({"a", "b", "x", "y", "z"},
+          {BIGINT(), BIGINT(), BIGINT(), BIGINT(), ARRAY(BIGINT())});
+};
+
+TEST_F(ExprEqualityTest, inputReference) {
+  auto x = resolve(Col("x"));
+  auto xCopy = resolve(Col("x"));
+  auto y = resolve(Col("y"));
+  auto xDouble = resolve(Col("x"), ROW("x", DOUBLE()));
+
+  // Same column name and type.
+  EXPECT_EQ(*x, *xCopy);
+  // Different name.
+  EXPECT_NE(*x, *y);
+  // Different type.
+  EXPECT_NE(*x, *xDouble);
+}
+
+TEST_F(ExprEqualityTest, constant) {
+  auto literalOne = resolve(Lit(1LL));
+  auto literalOneCopy = resolve(Lit(1LL));
+  auto literalTwo = resolve(Lit(2LL));
+  auto literalNull = resolve(Lit(Variant::null(TypeKind::BIGINT), BIGINT()));
+  auto literalNullCopy =
+      resolve(Lit(Variant::null(TypeKind::BIGINT), BIGINT()));
+
+  EXPECT_EQ(*literalOne, *literalOneCopy);
+  EXPECT_NE(*literalOne, *literalTwo);
+  EXPECT_EQ(*literalNull, *literalNullCopy);
+  EXPECT_NE(*literalOne, *literalNull);
+
+  // Different types are never equal even if values look similar.
+  EXPECT_NE(*literalOne, *resolve(Lit(1.0)));
+}
+
+TEST_F(ExprEqualityTest, call) {
+  auto plus = resolve(Call("plus", Col("a"), Col("b")));
+  auto plusCopy = resolve(Call("plus", Col("a"), Col("b")));
+  auto minus = resolve(Call("minus", Col("a"), Col("b")));
+
+  // Same name and inputs.
+  EXPECT_EQ(*plus, *plusCopy);
+  // Different function name.
+  EXPECT_NE(*plus, *minus);
+  // Different number of inputs.
+  auto plusOneArg = std::make_shared<CallExpr>(
+      BIGINT(), "plus", std::vector<ExprPtr>{resolve(Col("a"))});
+  EXPECT_NE(*plus, *plusOneArg);
+  // Different input values.
+  EXPECT_NE(*plus, *resolve(Call("plus", Col("b"), Col("a"))));
+}
+
+TEST_F(ExprEqualityTest, specialForm) {
+  auto castA = resolve(Cast(DOUBLE(), Col("a")));
+  auto castACopy = resolve(Cast(DOUBLE(), Col("a")));
+  auto castB = resolve(Cast(DOUBLE(), Col("b")));
+  auto castAInteger = resolve(Cast(INTEGER(), Col("a")));
+
+  EXPECT_EQ(*castA, *castACopy);
+  EXPECT_NE(*castA, *castB);
+  EXPECT_NE(*castA, *castAInteger);
+
+  // Different special form kind.
+  EXPECT_NE(*castA, *resolve(TryCast(DOUBLE(), Col("a"))));
+}
+
+TEST_F(ExprEqualityTest, aggregate) {
+  auto resolveAggregate = [this](
+                              const ExprApi& expr,
+                              const velox::core::ExprPtr& filter,
+                              std::vector<SortKey> ordering,
+                              bool distinct) {
+    return ExprResolver(nullptr, false)
+        .resolveAggregateTypes(
+            expr.expr(), inputResolver(schema_), filter, ordering, distinct);
+  };
+
+  auto sum = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{},
+      /*distinct=*/false);
+  auto sumCopy = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{},
+      /*distinct=*/false);
+  auto avg = resolveAggregate(
+      Call("avg", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{},
+      /*distinct=*/false);
+
+  // Same function, same inputs.
+  EXPECT_EQ(*sum, *sumCopy);
+  // Different function name.
+  EXPECT_NE(*sum, *avg);
+
+  // With distinct flag.
+  auto sumDistinct = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{},
+      /*distinct=*/true);
+  EXPECT_NE(*sum, *sumDistinct);
+
+  // Two distinct aggregates match.
+  auto sumDistinctCopy = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{},
+      /*distinct=*/true);
+  EXPECT_EQ(*sumDistinct, *sumDistinctCopy);
+
+  // With filter.
+  auto sumFiltered = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/Call("gt", Col("x"), Lit(10LL)).expr(),
+      /*ordering=*/{},
+      /*distinct=*/false);
+  auto sumFilteredCopy = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/Call("gt", Col("x"), Lit(10LL)).expr(),
+      /*ordering=*/{},
+      /*distinct=*/false);
+  EXPECT_EQ(*sumFiltered, *sumFilteredCopy);
+  EXPECT_NE(*sum, *sumFiltered);
+
+  // With ordering.
+  auto sumOrdered = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{SortKey(Col("y"))},
+      /*distinct=*/false);
+  auto sumOrderedCopy = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{SortKey(Col("y"))},
+      /*distinct=*/false);
+  EXPECT_EQ(*sumOrdered, *sumOrderedCopy);
+  EXPECT_NE(*sum, *sumOrdered);
+
+  // Different sort order.
+  auto sumOrderedDesc = resolveAggregate(
+      Call("sum", Col("x")),
+      /*filter=*/nullptr,
+      /*ordering=*/{SortKey(Col("y"), DESC)},
+      /*distinct=*/false);
+  EXPECT_NE(*sumOrdered, *sumOrderedDesc);
+}
+
+TEST_F(ExprEqualityTest, window) {
+  auto resolveWindow = [this](const ExprApi& expr) {
+    return ExprResolver(nullptr, false)
+        .resolveWindowTypes(
+            expr.expr(), *expr.windowSpec(), inputResolver(schema_));
+  };
+
+  auto spec = WindowSpec()
+                  .partitionBy({Col("x")})
+                  .orderBy({SortKey(Col("y"))})
+                  .rows(
+                      WindowExpr::BoundType::kUnboundedPreceding,
+                      std::nullopt,
+                      WindowExpr::BoundType::kCurrentRow,
+                      std::nullopt);
+
+  auto rowNum = resolveWindow(Call("row_number").over(spec));
+  auto rowNumCopy = resolveWindow(Call("row_number").over(spec));
+  EXPECT_EQ(*rowNum, *rowNumCopy);
+
+  // Different function name.
+  EXPECT_NE(*rowNum, *resolveWindow(Call("rank").over(spec)));
+
+  // Different partition keys.
+  auto noPartitionSpec = WindowSpec()
+                             .orderBy({SortKey(Col("y"))})
+                             .rows(
+                                 WindowExpr::BoundType::kUnboundedPreceding,
+                                 std::nullopt,
+                                 WindowExpr::BoundType::kCurrentRow,
+                                 std::nullopt);
+  EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(noPartitionSpec)));
+
+  // Different frame type.
+  auto rangeSpec = WindowSpec()
+                       .partitionBy({Col("x")})
+                       .orderBy({SortKey(Col("y"))})
+                       .range(
+                           WindowExpr::BoundType::kUnboundedPreceding,
+                           std::nullopt,
+                           WindowExpr::BoundType::kCurrentRow,
+                           std::nullopt);
+  EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(rangeSpec)));
+
+  // Different ignoreNulls.
+  auto ignoreNullsSpec = WindowSpec()
+                             .partitionBy({Col("x")})
+                             .orderBy({SortKey(Col("y"))})
+                             .rows(
+                                 WindowExpr::BoundType::kUnboundedPreceding,
+                                 std::nullopt,
+                                 WindowExpr::BoundType::kCurrentRow,
+                                 std::nullopt)
+                             .ignoreNulls();
+  EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(ignoreNullsSpec)));
+
+  // Frame with bound values.
+  WindowExpr::Frame frame{
+      WindowExpr::WindowType::kRows,
+      WindowExpr::BoundType::kPreceding,
+      resolve(Lit(5LL)),
+      WindowExpr::BoundType::kFollowing,
+      resolve(Lit(3LL))};
+  WindowExpr::Frame frameCopy{
+      WindowExpr::WindowType::kRows,
+      WindowExpr::BoundType::kPreceding,
+      resolve(Lit(5LL)),
+      WindowExpr::BoundType::kFollowing,
+      resolve(Lit(3LL))};
+  WindowExpr::Frame frameDifferent{
+      WindowExpr::WindowType::kRows,
+      WindowExpr::BoundType::kPreceding,
+      resolve(Lit(10LL)),
+      WindowExpr::BoundType::kFollowing,
+      resolve(Lit(3LL))};
+  EXPECT_EQ(frame, frameCopy);
+  EXPECT_NE(frame, frameDifferent);
+}
+
+TEST_F(ExprEqualityTest, lambda) {
+  auto resolveLambda = [this](const ExprApi& lambda) {
+    return resolve(Call("filter", Col("z"), lambda))->inputAt(1);
+  };
+
+  auto lam = resolveLambda(Lambda({"x"}, Call("gt", Col("x"), Lit(10LL))));
+  auto lamCopy = resolveLambda(Lambda({"x"}, Call("gt", Col("x"), Lit(10LL))));
+  EXPECT_EQ(*lam, *lamCopy);
+
+  // Different body.
+  EXPECT_NE(
+      *lam, *resolveLambda(Lambda({"x"}, Call("lt", Col("x"), Lit(10LL)))));
+
+  // Different signature.
+  EXPECT_NE(
+      *lam, *resolveLambda(Lambda({"y"}, Call("gt", Col("y"), Lit(10LL)))));
+}
+
+TEST_F(ExprEqualityTest, subquery) {
+  auto valuesType = ROW({"x", "y"}, {BIGINT(), BIGINT()});
+  auto makeValues = [this, &valuesType](std::string id) {
+    return std::make_shared<ValuesNode>(
+        std::move(id),
+        valuesType,
+        ValuesNode::Exprs{
+            {resolve(Lit(1LL)), resolve(Lit(10LL))},
+            {resolve(Lit(2LL)), resolve(Lit(20LL))},
+            {resolve(Lit(3LL)), resolve(Lit(30LL))}});
+  };
+
+  VELOX_ASSERT_THROW(
+      *std::make_shared<SubqueryExpr>(makeValues("1")) ==
+          *std::make_shared<SubqueryExpr>(makeValues("1")),
+      "Equality comparison is not supported for SubqueryExpr.");
+}
+
+TEST_F(ExprEqualityTest, crossKind) {
+  auto input = resolve(Col("x"));
+  auto constant = resolve(Lit(1LL));
+  auto callExpr = resolve(Call("abs", Col("x")));
+
+  // Different kinds are never equal.
+  EXPECT_NE(*input, *constant);
+  EXPECT_NE(*input, *callExpr);
+  EXPECT_NE(*constant, *callExpr);
+}
+
+TEST_F(ExprEqualityTest, sortingField) {
+  SortingField sortX{resolve(Col("x")), SortOrder::kAscNullsFirst};
+  SortingField sortXCopy{resolve(Col("x")), SortOrder::kAscNullsFirst};
+  SortingField sortY{resolve(Col("y")), SortOrder::kAscNullsFirst};
+  SortingField sortXDesc{resolve(Col("x")), SortOrder::kDescNullsFirst};
+
+  EXPECT_EQ(sortX, sortXCopy);
+  EXPECT_NE(sortX, sortY);
+  EXPECT_NE(sortX, sortXDesc);
+}
+
+} // namespace
+} // namespace facebook::axiom::logical_plan


### PR DESCRIPTION
Summary:

Add custom equality comparison for all Expr types.

- Add operator== to Expr base class with virtual equalTo() dispatch.
- Implement equalTo() for all derived classes except SubqueryExpr: 
InputReferenceExpr, ConstantExpr, CallExpr, SpecialFormExpr, AggregateExpr, 
WindowExpr, LambdaExpr.
- SubqueryExpr::equalTo() is not implemented and throws in this PR because 
there is no operator== of LocalPlanNode for SubqueryExpr::subquery_. This 
support will be added in https://github.com/facebookincubator/axiom/pull/1092.
- All shared_ptr members are dereferenced for value comparison, not pointer comparison.

Differential Revision: D97048671


