### PR TITLE
fix: Do not create join edges for equality filters on unnested columns

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1931,7 +1931,9 @@ void DerivedTable::distributeConjuncts() {
       // cases, leave the conjunct in place, to be evaluated when its
       // dependences are known.
       if (queryCtx()->optimization()->isJoinEquality(
-              conjunct, tables[0], tables[1], left, right)) {
+              conjunct, tables[0], tables[1], left, right) &&
+          !tables[0]->is(PlanType::kUnnestTableNode) &&
+          !tables[1]->is(PlanType::kUnnestTableNode)) {
         auto join = findJoin(this, tables, true);
         if (join->isInner() && !join->isUnnest()) {
           if (left->is(PlanType::kColumnExpr) &&

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -613,6 +613,11 @@ class JoinEdge {
   }
 
   static JoinEdge* makeInner(PlanObjectCP leftTable, PlanObjectCP rightTable) {
+    VELOX_CHECK(
+        !leftTable->is(PlanType::kUnnestTableNode) &&
+            !rightTable->is(PlanType::kUnnestTableNode),
+        "UnnestTable cannot participate in inner joins. "
+        "Use makeUnnest() instead.");
     return make<JoinEdge>(leftTable, rightTable, Spec{});
   }
 

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1290,5 +1290,25 @@ TEST_F(UnnestTest, multipleTables) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+TEST_F(UnnestTest, unnestWithJoinAndFilter) {
+  testConnector_->addTable("t", ROW("a", ARRAY(INTEGER())));
+  testConnector_->addTable("u", ROW("x", INTEGER()));
+
+  auto query = "SELECT 1 FROM t, u, UNNEST(a) AS _(n) WHERE x = n";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // The filter n = x must not be converted to a join key between
+  // UnnestTable and table u. It must remain as a post-unnest filter.
+  auto matcher = matchScan("u")
+                     .nestedLoopJoin(matchScan("t").build())
+                     .unnest()
+                     .filter("x = n")
+                     .project({"1"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
When a WHERE clause contains an equality between an unnested column and
a column from another table (e.g. WHERE n = x), distributeConjuncts
creates a new inner join edge between the UnnestTable and the other
table. This new join is not directed, so setStartTables does not remove
the UnnestTable from starting table candidates, causing a failure during
join ordering.

Fix by skipping join edge creation in distributeConjuncts when one of
the tables is an UnnestTable. The equality remains as a conjunct and is
evaluated as a filter after the unnest.

Also added a check in JoinEdge::makeInner to catch this class of bugs
earlier.

Differential Revision: D97103127


