### PR TITLE
fix(optimizer): Handle filter pushdown through UNION when child rejects (#1091)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1772,17 +1772,51 @@ void DerivedTable::makeEmpty() {
   addTable(valuesTable);
 }
 
+DerivedTable* DerivedTable::wrapChildWithFilter(
+    DerivedTable* child,
+    ExprCP conjunct) {
+  auto* wrapper = make<DerivedTable>();
+  wrapper->cname = queryCtx()->optimization()->newCName("wdt");
+
+  // In a set operation, all children share Column objects whose relation_
+  // points to the parent set DT. Create new intermediate columns with relation_
+  // = child so that the wrapper's importExpr translates the conjunct into
+  // child-column space. Without this, the conjunct would reference the set DT
+  // (not in the wrapper's tables), causing an infinite pushdown loop between
+  // the wrapper and the set DT.
+  auto sharedColumns = child->columns;
+
+  ColumnVector childColumns;
+  childColumns.reserve(sharedColumns.size());
+  for (const auto* col : sharedColumns) {
+    childColumns.push_back(
+        make<Column>(col->name(), child, col->value(), col->alias()));
+  }
+
+  child->columns = childColumns;
+  child->outputColumns = childColumns;
+
+  wrapper->addTable(child);
+  wrapper->columns = sharedColumns;
+  wrapper->exprs.assign(childColumns.begin(), childColumns.end());
+  wrapper->outputColumns = std::move(sharedColumns);
+  wrapper->conjuncts.push_back(wrapper->importExpr(conjunct));
+  return wrapper;
+}
+
 bool DerivedTable::addFilter(ExprCP conjunct) {
   // TODO: Support pushing conjuncts below LIMIT by wrapping in a DT.
   if (dtHasLimit(*this)) {
     return false;
   }
 
-  // TODO: Handle not being able to pushdown filter through UNION ALL.
   if (setOp.has_value()) {
-    for (auto* child : children) {
-      auto ok = child->addFilter(conjunct);
-      VELOX_CHECK(ok);
+    for (auto i = 0; i < children.size(); ++i) {
+      if (!children[i]->addFilter(conjunct)) {
+        // The child cannot accept the filter (e.g. it has a window or limit).
+        // Wrap the child in a new DT that holds the filter above it.
+        children[i] = wrapChildWithFilter(children[i], conjunct);
+      }
     }
 
     if (setOp.value() == logical_plan::SetOperation::kUnionAll) {

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -360,6 +360,12 @@ struct DerivedTable : public PlanObject {
   void distributeConjuncts();
 
  private:
+  // Wraps a set operation child in a new DT that holds the given filter. Used
+  // when the child cannot accept the filter directly (e.g. due to a window
+  // function or limit). Creates intermediate columns so the wrapper can apply
+  // the filter above the child.
+  DerivedTable* wrapChildWithFilter(DerivedTable* child, ExprCP conjunct);
+
   // Resets all mutable state to empty defaults.
   void clearState();
 

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -694,6 +694,43 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
   const std::vector<std::string> aggregates_;
 };
 
+// Matches an AggregationNode that performs DISTINCT: all input columns as
+// grouping keys and no aggregate functions.
+class DistinctMatcher : public PlanMatcherImpl<AggregationNode> {
+ public:
+  explicit DistinctMatcher(const std::shared_ptr<PlanMatcher>& matcher)
+      : PlanMatcherImpl<AggregationNode>({matcher}) {}
+
+  MatchResult matchDetails(
+      const AggregationNode& plan,
+      const std::unordered_map<std::string, std::string>& /*symbols*/)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+
+    EXPECT_TRUE(plan.aggregates().empty())
+        << "Expected no aggregates for DISTINCT";
+    AXIOM_TEST_RETURN_IF_FAILURE
+
+    // Grouping keys must cover all input columns.
+    const auto& inputType = plan.sources()[0]->outputType();
+    EXPECT_EQ(plan.groupingKeys().size(), inputType->size())
+        << "Expected grouping keys to match all input columns for DISTINCT";
+    AXIOM_TEST_RETURN_IF_FAILURE
+
+    std::unordered_set<std::string> inputColumns;
+    for (const auto& name : inputType->names()) {
+      inputColumns.insert(name);
+    }
+    for (const auto& key : plan.groupingKeys()) {
+      EXPECT_TRUE(inputColumns.contains(key->name()))
+          << "Grouping key " << key->name() << " is not an input column";
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    return MatchResult::success();
+  }
+};
+
 class StreamingAggregationMatcher : public AggregationMatcher {
  public:
   explicit StreamingAggregationMatcher(
@@ -1542,6 +1579,12 @@ PlanMatcherBuilder& PlanMatcherBuilder::unnest(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<UnnestMatcher>(
       matcher_, replicateExprs, unnestExprs, ordinalityName);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::distinct() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<DistinctMatcher>(matcher_);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -202,6 +202,10 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& unnestExprs,
       const std::optional<std::string>& ordinalityName = std::nullopt);
 
+  /// Matches an Aggregation node that performs DISTINCT (all input columns as
+  /// grouping keys, no aggregate functions).
+  PlanMatcherBuilder& distinct();
+
   /// Matches any Aggregation node regardless of step or expressions.
   PlanMatcherBuilder& aggregation();
 

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -675,6 +675,54 @@ TEST_F(SetTest, constantFalseFilterInUnionAll) {
   }
 }
 
+// Verifies that a filter is pushed down below UNION / UNION ALL when one branch
+// has a window function.
+TEST_F(SetTest, filterOnUnionWithWindow) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+
+  // UNION ALL.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM ("
+        "  (SELECT a, row_number() OVER (ORDER BY a) AS r FROM t)"
+        "  UNION ALL"
+        "  (SELECT x, y FROM u)"
+        ") WHERE r > 1",
+        kTestConnectorId);
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher =
+        matchScan("t")
+            .window({"row_number() OVER (ORDER BY a) AS r"})
+            .filter("r > 1")
+            .localPartition(matchScan("u").filter("y > 1").project().build())
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // UNION.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM ("
+        "  (SELECT a, row_number() OVER (ORDER BY a) AS r FROM t)"
+        "  UNION"
+        "  (SELECT x, y FROM u)"
+        ") WHERE r > 1",
+        kTestConnectorId);
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher =
+        matchScan("t")
+            .window({"row_number() OVER (ORDER BY a) AS r"})
+            .filter("r > 1")
+            .localPartition(matchScan("u").filter("y > 1").project().build())
+            .distinct()
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
 // UNION ALL of two EXCEPT branches produces mismatched column names when
 // the same table appears in multiple EXCEPT operands.
 TEST_F(SetTest, exceptUnionAll) {


### PR DESCRIPTION
Summary:

Fix a query failure in DerivedTable::addFilter when pushing a filter
through a UNION / UNION ALL where a child cannot accept the filter (e.g.
because it has a window function).

Previously, addFilter assumed all set operation children would accept the
filter (VELOX_CHECK(ok)), causing a failure when a child returned false.

The fix wraps the rejecting child in a new DT that holds the filter above
it. New intermediate columns with relation_ = child are created so that
importExpr correctly translates the conjunct into child-column space,
avoiding an infinite pushdown loop between the wrapper and the set DT.

Also adds a PlanMatcher::distinct() API that matches an AggregationNode
performing DISTINCT (all input columns as grouping keys, no aggregate
functions).

Reviewed By: amitkdutta

Differential Revision: D97126363
