### PR TITLE
feat(parser): Add LogicalPlanNode::operator== (#1092)

### DIFF
--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -52,22 +52,6 @@ bool Expr::equalNullableExprs(const ExprPtr& lhs, const ExprPtr& rhs) {
   return *lhs == *rhs;
 }
 
-bool Expr::equalExprVectors(
-    const std::vector<ExprPtr>& lhs,
-    const std::vector<ExprPtr>& rhs) {
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    VELOX_CHECK_NOT_NULL(lhs[i]);
-    VELOX_CHECK_NOT_NULL(rhs[i]);
-    if (*lhs[i] != *rhs[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 bool Expr::operator==(const Expr& other) const {
   if (this == &other) {
     return true;
@@ -131,8 +115,8 @@ bool LambdaExpr::equalTo(const Expr& other) const {
   return *signature_ == *rhs->signature_ && *body_ == *rhs->body_;
 }
 
-bool SubqueryExpr::equalTo(const Expr& /*other*/) const {
-  VELOX_UNSUPPORTED("Equality comparison is not supported for SubqueryExpr.");
+bool SubqueryExpr::equalTo(const Expr& other) const {
+  return *subquery_ == *other.as<SubqueryExpr>()->subquery_;
 }
 
 std::string Expr::toString() const {

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -152,21 +152,35 @@ class Expr : public velox::ISerializable {
   /// Registers deserializers for all Expr subclasses.
   static void registerSerDe();
 
+  /// Compares two ExprPtr values for structural equality. Either or both
+  /// pointers may be null. Two nulls are considered equal; a null and a
+  /// non-null are not.
+  static bool equalNullableExprs(const ExprPtr& lhs, const ExprPtr& rhs);
+
+  /// Compares two vectors of ExprPtr in order for structural equality. All
+  /// elements must be non-null; null elements trigger an error. T should be
+  /// Expr or its subclass.
+  template <typename T>
+  static bool equalExprVectors(
+      const std::vector<std::shared_ptr<const T>>& lhs,
+      const std::vector<std::shared_ptr<const T>>& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      VELOX_CHECK_NOT_NULL(lhs[i]);
+      VELOX_CHECK_NOT_NULL(rhs[i]);
+      if (*lhs[i] != *rhs[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  protected:
   // Returns true if derived-class-specific fields are equal. Called only when
   // kind, type, and inputs already match.
   virtual bool equalTo(const Expr& other) const = 0;
-
-  // Compares two ExprPtr values for structural equality. Either or both
-  // pointers may be null. Two nulls are considered equal; a null and a
-  // non-null are not.
-  static bool equalNullableExprs(const ExprPtr& lhs, const ExprPtr& rhs);
-
-  // Compares two vectors of ExprPtr for structural equality. All elements
-  // must be non-null; null elements trigger an error.
-  static bool equalExprVectors(
-      const std::vector<ExprPtr>& lhs,
-      const std::vector<ExprPtr>& rhs);
 
   // Serializes common base fields (name, type, inputs).
   folly::dynamic serializeBase(std::string_view name) const;

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -108,9 +108,42 @@ std::vector<std::string> deserializeStringVector(
   return result;
 }
 
+// Compares two vectors of LogicalPlanNodePtr for structural equality.
+bool equalNodeVectors(
+    const std::vector<LogicalPlanNodePtr>& lhs,
+    const std::vector<LogicalPlanNodePtr>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    VELOX_CHECK_NOT_NULL(lhs[i]);
+    VELOX_CHECK_NOT_NULL(rhs[i]);
+    if (*lhs[i] != *rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(NodeKind, nodeKindNames)
+
+bool LogicalPlanNode::operator==(const LogicalPlanNode& other) const {
+  if (this == &other) {
+    return true;
+  }
+  if (kind_ != other.kind_) {
+    return false;
+  }
+  if (*outputType_ != *other.outputType_) {
+    return false;
+  }
+  if (!equalNodeVectors(inputs_, other.inputs_)) {
+    return false;
+  }
+  return equalTo(other);
+}
 
 std::string LogicalPlanNode::toString() const {
   return PlanPrinter::toText(*this);
@@ -643,16 +676,72 @@ void ValuesNode::accept(
   visitor.visit(*this, context);
 }
 
+bool ValuesNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<ValuesNode>();
+  if (cardinality_ != rhs->cardinality_) {
+    return false;
+  }
+  if (data_.index() != rhs->data_.index()) {
+    return false;
+  }
+  // TODO: support order-insensitive comparison.
+  return std::visit(
+      [&](const auto& lhsData) -> bool {
+        using T = std::decay_t<decltype(lhsData)>;
+        const auto& rhsData = std::get<T>(rhs->data_);
+        if constexpr (std::is_same_v<T, ValuesNode::Variants>) {
+          return lhsData == rhsData;
+        } else if constexpr (std::is_same_v<T, ValuesNode::Vectors>) {
+          if (lhsData.size() != rhsData.size()) {
+            return false;
+          }
+          for (size_t i = 0; i < lhsData.size(); ++i) {
+            if (lhsData[i]->size() != rhsData[i]->size()) {
+              return false;
+            }
+            for (velox::vector_size_t row = 0; row < lhsData[i]->size();
+                 ++row) {
+              if (!lhsData[i]->equalValueAt(rhsData[i].get(), row, row)) {
+                return false;
+              }
+            }
+          }
+          return true;
+        } else {
+          if (lhsData.size() != rhsData.size()) {
+            return false;
+          }
+          for (size_t i = 0; i < lhsData.size(); ++i) {
+            if (!Expr::equalExprVectors(lhsData[i], rhsData[i])) {
+              return false;
+            }
+          }
+          return true;
+        }
+      },
+      data_);
+}
+
 void TableScanNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
 }
 
+bool TableScanNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<TableScanNode>();
+  return connectorId_ == rhs->connectorId_ && tableName_ == rhs->tableName_ &&
+      columnNames_ == rhs->columnNames_;
+}
+
 void FilterNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool FilterNode::equalTo(const LogicalPlanNode& other) const {
+  return *predicate_ == *other.as<FilterNode>()->predicate_;
 }
 
 // static
@@ -677,6 +766,12 @@ void ProjectNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool ProjectNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<ProjectNode>();
+  return names_ == rhs->names_ &&
+      Expr::equalExprVectors(expressions_, rhs->expressions_);
 }
 
 // static
@@ -717,6 +812,14 @@ void AggregateNode::accept(
   visitor.visit(*this, context);
 }
 
+bool AggregateNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<AggregateNode>();
+  return outputNames_ == rhs->outputNames_ &&
+      groupingSets_ == rhs->groupingSets_ &&
+      Expr::equalExprVectors(groupingKeys_, rhs->groupingKeys_) &&
+      Expr::equalExprVectors(aggregates_, rhs->aggregates_);
+}
+
 namespace {
 const auto& joinTypeNames() {
   static const folly::F14FastMap<JoinType, std::string_view> kNames = {
@@ -748,16 +851,31 @@ void JoinNode::accept(
   visitor.visit(*this, context);
 }
 
+bool JoinNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<JoinNode>();
+  return joinType_ == rhs->joinType_ &&
+      Expr::equalNullableExprs(condition_, rhs->condition_);
+}
+
 void SortNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
 }
 
+bool SortNode::equalTo(const LogicalPlanNode& other) const {
+  return ordering_ == other.as<SortNode>()->ordering_;
+}
+
 void LimitNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool LimitNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<LimitNode>();
+  return offset_ == rhs->offset_ && count_ == rhs->count_;
 }
 
 namespace {
@@ -811,6 +929,10 @@ void SetNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool SetNode::equalTo(const LogicalPlanNode& other) const {
+  return operation_ == other.as<SetNode>()->operation_;
 }
 
 // static
@@ -892,6 +1014,14 @@ void UnnestNode::accept(
   visitor.visit(*this, context);
 }
 
+bool UnnestNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<UnnestNode>();
+  return flattenArrayOfRows_ == rhs->flattenArrayOfRows_ &&
+      ordinalityName_ == rhs->ordinalityName_ &&
+      unnestedNames_ == rhs->unnestedNames_ &&
+      Expr::equalExprVectors(unnestExpressions_, rhs->unnestExpressions_);
+}
+
 TableWriteNode::TableWriteNode(
     std::string id,
     LogicalPlanNodePtr input,
@@ -923,6 +1053,14 @@ void TableWriteNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool TableWriteNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<TableWriteNode>();
+  return connectorId_ == rhs->connectorId_ && tableName_ == rhs->tableName_ &&
+      writeKind_ == rhs->writeKind_ && columnNames_ == rhs->columnNames_ &&
+      options_ == rhs->options_ &&
+      Expr::equalExprVectors(columnExpressions_, rhs->columnExpressions_);
 }
 
 namespace {
@@ -966,6 +1104,12 @@ void SampleNode::accept(
   visitor.visit(*this, context);
 }
 
+bool SampleNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<SampleNode>();
+  return sampleMethod_ == rhs->sampleMethod_ &&
+      *percentage_ == *rhs->percentage_;
+}
+
 namespace {
 velox::RowTypePtr makeOutputType(
     const LogicalPlanNode& input,
@@ -1003,6 +1147,10 @@ void OutputNode::accept(
     const PlanNodeVisitor& visitor,
     PlanNodeVisitorContext& context) const {
   visitor.visit(*this, context);
+}
+
+bool OutputNode::equalTo(const LogicalPlanNode& other) const {
+  return entries_ == other.as<OutputNode>()->entries_;
 }
 
 folly::dynamic OutputNode::serialize() const {

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -121,6 +121,10 @@ class LogicalPlanNode : public velox::ISerializable {
     return outputType_;
   }
 
+  /// Returns true if two plan nodes are structurally equal. Node IDs are
+  /// allowed to differ.
+  bool operator==(const LogicalPlanNode& other) const;
+
   std::string toString() const;
 
   virtual void accept(
@@ -131,6 +135,10 @@ class LogicalPlanNode : public velox::ISerializable {
   static void registerSerDe();
 
  protected:
+  // Returns true if derived-class-specific fields are equal. Called only when
+  // kind, outputType, and inputs already match.
+  virtual bool equalTo(const LogicalPlanNode& other) const = 0;
+
   /// Serializes common base fields (name, id, outputType, inputs).
   folly::dynamic serializeBase(std::string_view name) const;
 
@@ -182,6 +190,8 @@ class ValuesNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const uint64_t cardinality_ = 0;
   const Data data_;
 };
@@ -235,6 +245,8 @@ class TableScanNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const std::string connectorId_;
   const SchemaTableName tableName_;
   const std::vector<std::string> columnNames_;
@@ -266,6 +278,8 @@ class FilterNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const ExprPtr predicate_;
 };
 
@@ -312,6 +326,8 @@ class ProjectNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   static velox::RowTypePtr makeOutputType(
       const std::vector<std::string>& names,
       const std::vector<ExprPtr>& expressions);
@@ -398,6 +414,8 @@ class AggregateNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   static velox::RowTypePtr makeOutputType(
       const std::vector<ExprPtr>& groupingKeys,
       const std::vector<GroupingSet>& groupingSets,
@@ -485,6 +503,8 @@ class JoinNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   static velox::RowTypePtr makeOutputType(
       const LogicalPlanNodePtr& left,
       const LogicalPlanNodePtr& right);
@@ -520,6 +540,8 @@ class SortNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const std::vector<SortingField> ordering_;
 };
 
@@ -570,6 +592,8 @@ class LimitNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const int64_t offset_;
   const int64_t count_;
 };
@@ -630,6 +654,8 @@ class SetNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   static velox::RowTypePtr makeOutputType(
       const std::vector<LogicalPlanNodePtr>& inputs);
 
@@ -715,6 +741,8 @@ class UnnestNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   static velox::RowTypePtr makeOutputType(
       const LogicalPlanNodePtr& input,
       const std::vector<ExprPtr>& unnestExpressions,
@@ -819,6 +847,8 @@ class TableWriteNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const std::string connectorId_;
   const SchemaTableName tableName_;
   const WriteKind writeKind_;
@@ -876,6 +906,8 @@ class SampleNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const ExprPtr percentage_;
   const SampleMethod sampleMethod_;
 };
@@ -896,6 +928,8 @@ class OutputNode : public LogicalPlanNode {
 
     /// Output column name. May be empty or duplicate.
     std::string name;
+
+    bool operator==(const Entry&) const = default;
   };
 
   OutputNode(
@@ -915,6 +949,8 @@ class OutputNode : public LogicalPlanNode {
   static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
   const std::vector<Entry> entries_;
 };
 

--- a/axiom/logical_plan/tests/CMakeLists.txt
+++ b/axiom/logical_plan/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   ExprSerdeTest.cpp
   ExprTest.cpp
   LogicalPlanNodeSerdeTest.cpp
+  LogicalPlanNodeEqualityTest.cpp
   NameAllocatorTest.cpp
   NameMappingsTest.cpp
   ExprApiTest.cpp
@@ -35,6 +36,7 @@ target_link_libraries(
   axiom_test_connector
   velox_functions_prestosql
   velox_aggregates
+  velox_vector_test_lib
   GTest::gtest
   GTest::gtest_main
   GTest::gmock

--- a/axiom/logical_plan/tests/ExprEqualityTest.cpp
+++ b/axiom/logical_plan/tests/ExprEqualityTest.cpp
@@ -18,8 +18,7 @@
 #include "axiom/logical_plan/Expr.h"
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/ExprResolver.h"
-#include "axiom/logical_plan/LogicalPlanNode.h"
-#include "velox/common/base/tests/GTestUtils.h"
+#include "axiom/logical_plan/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
@@ -307,21 +306,59 @@ TEST_F(ExprEqualityTest, lambda) {
 }
 
 TEST_F(ExprEqualityTest, subquery) {
-  auto valuesType = ROW({"x", "y"}, {BIGINT(), BIGINT()});
-  auto makeValues = [this, &valuesType](std::string id) {
-    return std::make_shared<ValuesNode>(
-        std::move(id),
-        valuesType,
-        ValuesNode::Exprs{
-            {resolve(Lit(1LL)), resolve(Lit(10LL))},
-            {resolve(Lit(2LL)), resolve(Lit(20LL))},
-            {resolve(Lit(3LL)), resolve(Lit(30LL))}});
+  // Build a multi-level plan tree: ValuesNode → FilterNode → ProjectNode.
+  std::vector<std::vector<std::string>> rows = {
+      {"1", "10"}, {"2", "20"}, {"3", "30"}};
+  auto makeTree = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .filter("x > 0")
+        .project({"x + y as result"})
+        .planNode();
   };
 
-  VELOX_ASSERT_THROW(
-      *std::make_shared<SubqueryExpr>(makeValues("1")) ==
-          *std::make_shared<SubqueryExpr>(makeValues("1")),
-      "Equality comparison is not supported for SubqueryExpr.");
+  // Two identical complex trees built independently.
+  auto tree = makeTree();
+  auto treeCopy = makeTree();
+  EXPECT_EQ(
+      *std::make_shared<SubqueryExpr>(tree),
+      *std::make_shared<SubqueryExpr>(treeCopy));
+
+  // Different filter threshold deep in the tree.
+  auto treeDifferentFilter = PlanBuilder()
+                                 .values({"x", "y"}, rows)
+                                 .filter("x > 5")
+                                 .project({"x + y as result"})
+                                 .planNode();
+  EXPECT_NE(
+      *std::make_shared<SubqueryExpr>(tree),
+      *std::make_shared<SubqueryExpr>(treeDifferentFilter));
+
+  // Different leaf data.
+  auto treeDifferentValues =
+      PlanBuilder()
+          .values(
+              {"x", "y"},
+              std::vector<std::vector<std::string>>{
+                  {"99", "10"}, {"2", "20"}, {"3", "30"}})
+          .filter("x > 0")
+          .project({"x + y as result"})
+          .planNode();
+  EXPECT_NE(
+      *std::make_shared<SubqueryExpr>(tree),
+      *std::make_shared<SubqueryExpr>(treeDifferentValues));
+
+  // Different node ID.
+  PlanBuilder::Context altCtx;
+  altCtx.planNodeIdGenerator->next();
+  auto treeDifferentId = PlanBuilder(altCtx)
+                             .values({"x", "y"}, rows)
+                             .filter("x > 0")
+                             .project({"x + y as result"})
+                             .planNode();
+  EXPECT_EQ(
+      *std::make_shared<SubqueryExpr>(tree),
+      *std::make_shared<SubqueryExpr>(treeDifferentId));
 }
 
 TEST_F(ExprEqualityTest, crossKind) {

--- a/axiom/logical_plan/tests/LogicalPlanNodeEqualityTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeEqualityTest.cpp
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/ExprApi.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::logical_plan {
+namespace {
+
+class LogicalPlanNodeEqualityTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  test::VectorMaker maker_{pool_.get()};
+};
+
+TEST_F(LogicalPlanNodeEqualityTest, valuesNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder().values({"x", "y"}, rows).planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different id — still equal because id_ is not compared.
+  PlanBuilder::Context ctx;
+  ctx.planNodeIdGenerator->next();
+  auto differentId = PlanBuilder(ctx).values({"x", "y"}, rows).planNode();
+  EXPECT_EQ(*makeNode(), *differentId);
+
+  // Different data.
+  std::vector<std::vector<std::string>> differentRows = {
+      {"99", "10"}, {"2", "20"}};
+  auto differentData =
+      PlanBuilder().values({"x", "y"}, differentRows).planNode();
+  EXPECT_NE(*makeNode(), *differentData);
+
+  // Different cardinality.
+  std::vector<std::vector<std::string>> moreRowsData = {
+      {"1", "10"}, {"2", "20"}, {"3", "30"}};
+  auto moreRows = PlanBuilder().values({"x", "y"}, moreRowsData).planNode();
+  EXPECT_NE(*makeNode(), *moreRows);
+
+  // Variant-based ValuesNode equality.
+  auto makeVariantValues = [] {
+    return PlanBuilder()
+        .values(ROW("a", BIGINT()), {Variant::row({Variant(1L)})})
+        .planNode();
+  };
+  EXPECT_EQ(*makeVariantValues(), *makeVariantValues());
+
+  auto variantValuesDifferent =
+      PlanBuilder()
+          .values(ROW("a", BIGINT()), {Variant::row({Variant(99L)})})
+          .planNode();
+  EXPECT_NE(*makeVariantValues(), *variantValuesDifferent);
+
+  // Vector-based ValuesNode equality.
+  auto makeVectorValues = [this] {
+    auto vec = maker_.rowVector(
+        {"a"}, {maker_.flatVectorNullable<int64_t>({1, std::nullopt, 3})});
+    return PlanBuilder().values({vec}).planNode();
+  };
+  EXPECT_EQ(*makeVectorValues(), *makeVectorValues());
+
+  auto vectorDifferent =
+      maker_.rowVector({"a"}, {maker_.flatVector<int64_t>({99})});
+  auto valuesNodeDifferent = PlanBuilder().values({vectorDifferent}).planNode();
+  EXPECT_NE(*makeVectorValues(), *valuesNodeDifferent);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, tableScanNodeEquality) {
+  auto type = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+  auto makeScan = [&](std::string connectorId = "hive",
+                      std::string tableName = "t",
+                      std::vector<std::string> columns = {"col_a", "col_b"}) {
+    return std::make_shared<TableScanNode>(
+        "1",
+        type,
+        std::move(connectorId),
+        SchemaTableName{"default", std::move(tableName)},
+        std::move(columns));
+  };
+
+  EXPECT_EQ(*makeScan(), *makeScan());
+
+  // Different connector id.
+  EXPECT_NE(*makeScan(), *makeScan("iceberg"));
+
+  // Different table name.
+  EXPECT_NE(*makeScan(), *makeScan("hive", "other"));
+
+  // Different column names.
+  EXPECT_NE(*makeScan(), *makeScan("hive", "t", {"col_x", "col_y"}));
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, filterNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder().values({"x", "y"}, rows).filter("x > 0").planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different predicate.
+  auto filterDifferent =
+      PlanBuilder().values({"x", "y"}, rows).filter("x > 5").planNode();
+  EXPECT_NE(*makeNode(), *filterDifferent);
+
+  // Different input.
+  std::vector<std::vector<std::string>> differentRows = {
+      {"99", "10"}, {"2", "20"}};
+  auto filterDifferentInput = PlanBuilder()
+                                  .values({"x", "y"}, differentRows)
+                                  .filter("x > 0")
+                                  .planNode();
+  EXPECT_NE(*makeNode(), *filterDifferentInput);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, projectNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .project({"x + y as result"})
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different expression.
+  auto projectDifferent = PlanBuilder()
+                              .values({"x", "y"}, rows)
+                              .project({"x - y as result"})
+                              .planNode();
+  EXPECT_NE(*makeNode(), *projectDifferent);
+
+  // Different names.
+  auto projectDifferentName = PlanBuilder()
+                                  .values({"x", "y"}, rows)
+                                  .project({"x + y as other"})
+                                  .planNode();
+  EXPECT_NE(*makeNode(), *projectDifferentName);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, aggregateNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .aggregate({"x"}, {"sum(y) as total"})
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different aggregate function.
+  auto aggregateDifferent = PlanBuilder()
+                                .values({"x", "y"}, rows)
+                                .aggregate({"x"}, {"avg(y) as total"})
+                                .planNode();
+  EXPECT_NE(*makeNode(), *aggregateDifferent);
+
+  // Different output names.
+  auto aggregateDifferentNames = PlanBuilder()
+                                     .values({"x", "y"}, rows)
+                                     .aggregate({"x"}, {"sum(y) as value"})
+                                     .planNode();
+  EXPECT_NE(*makeNode(), *aggregateDifferentNames);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, joinNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  std::vector<std::vector<std::string>> rightRows = {{"1", "2"}};
+
+  auto makeJoin = [&rows, &rightRows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .join(
+            PlanBuilder().values({"a", "b"}, rightRows),
+            "x = a",
+            JoinType::kInner)
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeJoin(), *makeJoin());
+
+  // Different join type.
+  auto joinLeft = PlanBuilder()
+                      .values({"x", "y"}, rows)
+                      .join(
+                          PlanBuilder().values({"a", "b"}, rightRows),
+                          "x = a",
+                          JoinType::kLeft)
+                      .planNode();
+  EXPECT_NE(*makeJoin(), *joinLeft);
+
+  // No condition (cross join) vs with condition.
+  auto makeCrossJoin = [&rows, &rightRows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .crossJoin(PlanBuilder().values({"a", "b"}, rightRows))
+        .planNode();
+  };
+  EXPECT_NE(*makeJoin(), *makeCrossJoin());
+
+  // Two cross joins are equal.
+  EXPECT_EQ(*makeCrossJoin(), *makeCrossJoin());
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, sortNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder().values({"x", "y"}, rows).sort({"x"}).planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different sort order.
+  auto sortDesc =
+      PlanBuilder().values({"x", "y"}, rows).sort({"x DESC"}).planNode();
+  EXPECT_NE(*makeNode(), *sortDesc);
+
+  // Different sort key.
+  auto sortY = PlanBuilder().values({"x", "y"}, rows).sort({"y"}).planNode();
+  EXPECT_NE(*makeNode(), *sortY);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, limitNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder().values({"x", "y"}, rows).limit(0, 10).planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different count.
+  auto limitDifferentCount =
+      PlanBuilder().values({"x", "y"}, rows).limit(0, 20).planNode();
+  EXPECT_NE(*makeNode(), *limitDifferentCount);
+
+  // Different offset.
+  auto limitDifferentOffset =
+      PlanBuilder().values({"x", "y"}, rows).limit(5, 10).planNode();
+  EXPECT_NE(*makeNode(), *limitDifferentOffset);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, setNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .unionAll(PlanBuilder().values({"x", "y"}, rows))
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different operation.
+  auto setIntersect = PlanBuilder()
+                          .values({"x", "y"}, rows)
+                          .intersect(PlanBuilder().values({"x", "y"}, rows))
+                          .planNode();
+  EXPECT_NE(*makeNode(), *setIntersect);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, unnestNodeEquality) {
+  auto makeUnnest = [] {
+    return PlanBuilder()
+        .values(ROW("arr", ARRAY(BIGINT())), std::vector<Variant>{})
+        .unnest({Col("arr").unnestAs("elem")}, Ordinality().as("ord"))
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeUnnest(), *makeUnnest());
+
+  // Different ordinality.
+  auto unnestNoOrd =
+      PlanBuilder()
+          .values(ROW("arr", ARRAY(BIGINT())), std::vector<Variant>{})
+          .unnest({Col("arr").unnestAs("elem")})
+          .planNode();
+  EXPECT_NE(*makeUnnest(), *unnestNoOrd);
+
+  // Different unnested names.
+  auto unnestDifferentNames =
+      PlanBuilder()
+          .values(ROW("arr", ARRAY(BIGINT())), std::vector<Variant>{})
+          .unnest({Col("arr").unnestAs("val")}, Ordinality().as("ord"))
+          .planNode();
+  EXPECT_NE(*makeUnnest(), *unnestDifferentNames);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, tableWriteNodeEquality) {
+  auto type = ROW({"x", "y"}, {BIGINT(), BIGINT()});
+  auto makeInput = [&type] {
+    return std::make_shared<ValuesNode>("1", type, ValuesNode::Variants{});
+  };
+  auto xRef = std::make_shared<InputReferenceExpr>(BIGINT(), "x");
+  auto yRef = std::make_shared<InputReferenceExpr>(BIGINT(), "y");
+
+  auto makeNode =
+      [&](WriteKind kind = WriteKind::kInsert,
+          std::string tableName = "t",
+          folly::F14FastMap<std::string, std::string> options = {}) {
+        return std::make_shared<TableWriteNode>(
+            "2",
+            makeInput(),
+            "hive",
+            SchemaTableName{"default", std::move(tableName)},
+            kind,
+            std::vector<std::string>{"x", "y"},
+            std::vector<ExprPtr>{xRef, yRef},
+            std::move(options));
+      };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different write kind.
+  EXPECT_NE(*makeNode(), *makeNode(WriteKind::kCreate));
+
+  // Different table.
+  EXPECT_NE(*makeNode(), *makeNode(WriteKind::kInsert, "other"));
+
+  // With options vs without.
+  EXPECT_NE(
+      *makeNode(),
+      *makeNode(WriteKind::kInsert, "t", {{"compression", "zstd"}}));
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, sampleNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .sample(50.0, SampleNode::SampleMethod::kBernoulli)
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different percentage.
+  auto sampleDifferentPct =
+      PlanBuilder()
+          .values({"x", "y"}, rows)
+          .sample(25.0, SampleNode::SampleMethod::kBernoulli)
+          .planNode();
+  EXPECT_NE(*makeNode(), *sampleDifferentPct);
+
+  // Different method.
+  auto sampleSystem = PlanBuilder()
+                          .values({"x", "y"}, rows)
+                          .sample(50.0, SampleNode::SampleMethod::kSystem)
+                          .planNode();
+  EXPECT_NE(*makeNode(), *sampleSystem);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, outputNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeNode = [&rows] {
+    return std::make_shared<OutputNode>(
+        "2",
+        PlanBuilder().values({"x", "y"}, rows).planNode(),
+        std::vector<OutputNode::Entry>{{0, "col_x"}, {1, "col_y"}});
+  };
+
+  EXPECT_EQ(*makeNode(), *makeNode());
+
+  // Different entry name.
+  auto outputDifferentName = std::make_shared<OutputNode>(
+      "2",
+      PlanBuilder().values({"x", "y"}, rows).planNode(),
+      std::vector<OutputNode::Entry>{{0, "renamed"}, {1, "col_y"}});
+  EXPECT_NE(*makeNode(), *outputDifferentName);
+
+  // Different entry index.
+  auto outputDifferentIndex = std::make_shared<OutputNode>(
+      "2",
+      PlanBuilder().values({"x", "y"}, rows).planNode(),
+      std::vector<OutputNode::Entry>{{1, "col_x"}, {0, "col_y"}});
+  EXPECT_NE(*makeNode(), *outputDifferentIndex);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, crossKindInequality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto values = PlanBuilder().values({"x", "y"}, rows).planNode();
+  auto filter =
+      PlanBuilder().values({"x", "y"}, rows).filter("x > 0").planNode();
+
+  EXPECT_NE(*values, *filter);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, selfEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto values = PlanBuilder().values({"x", "y"}, rows).planNode();
+
+  EXPECT_EQ(*values, *values);
+}
+
+TEST_F(LogicalPlanNodeEqualityTest, deepTreeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  auto makeTree = [&rows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .filter("x > 0")
+        .project({"x + y as result"})
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeTree(), *makeTree());
+
+  // Different deep in the tree.
+  auto treeDifferentDeep = PlanBuilder()
+                               .values({"x", "y"}, rows)
+                               .filter("x > 5")
+                               .project({"x + y as result"})
+                               .planNode();
+  EXPECT_NE(*makeTree(), *treeDifferentDeep);
+}
+
+} // namespace
+} // namespace facebook::axiom::logical_plan


### PR DESCRIPTION
Summary:

Add custom equality comparison for all logical plan node types.

- Add operator== to LogicalPlanNode base class with virtual equalTo() dispatch.
- Implement equalTo() for all 13 derived classes: ValuesNode, TableScanNode,
  FilterNode, ProjectNode, AggregateNode, JoinNode, SortNode, LimitNode, SetNode,
  UnnestNode, TableWriteNode, SampleNode, OutputNode.
- Implement SubqueryExpr::equalTo() via LogicalPlanNode::operator==.

Reviewed By: natashasehgal

Differential Revision: D97048673


