### PR TITLE
feat: Add GROUP BY DISTINCT and grouping set deduplication (#1094)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -978,6 +978,10 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::string& groupingSetIndexName) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Aggregate node cannot be a leaf node");
 
+  VELOX_USER_CHECK(
+      !groupingKeys.empty() || !aggregates.empty(),
+      "Aggregation node must specify at least one aggregate or grouping key");
+
   const auto numKeys = static_cast<int32_t>(groupingKeys.size());
   for (const auto& groupingSet : groupingSets) {
     for (const auto index : groupingSet) {
@@ -1007,8 +1011,14 @@ PlanBuilder& PlanBuilder::aggregate(
 
   resolveAggregates(aggregates, options, outputNames, exprs, *newOutputMapping);
 
-  outputNames.push_back(newName(groupingSetIndexName));
-  newOutputMapping->add(groupingSetIndexName, outputNames.back());
+  auto gidInternalName = newName(groupingSetIndexName);
+  outputNames.push_back(gidInternalName);
+  newOutputMapping->add(groupingSetIndexName, gidInternalName);
+
+  // Grouping sets require a set index column to identify which grouping set
+  // produced each row. Hidden from name resolution so it does not appear in
+  // SELECT results.
+  newOutputMapping->markHidden(gidInternalName);
 
   node_ = std::make_shared<AggregateNode>(
       nextId(),
@@ -2013,19 +2023,22 @@ std::string PlanBuilder::findOrAssignOutputNameAt(size_t index) const {
 }
 
 LogicalPlanNodePtr PlanBuilder::buildOutputNode() {
-  auto defaultNames = findOrAssignOutputNames(/*includeHiddenColumns=*/true);
-  const auto numColumns = defaultNames.size();
+  const auto& inputType = node_->outputType();
+  const auto numColumns = inputType->size();
 
   std::vector<OutputNode::Entry> entries;
   entries.reserve(numColumns);
 
   for (size_t i = 0; i < numColumns; ++i) {
+    const auto& id = inputType->nameOf(i);
+    if (outputMapping_->isHidden(id)) {
+      continue;
+    }
     std::string name;
-    if (auto userName =
-            outputMapping_->userName(node_->outputType()->nameOf(i))) {
+    if (auto userName = outputMapping_->userName(id)) {
       name = *userName;
     } else {
-      name = std::move(defaultNames[i]);
+      name = findOrAssignOutputNameAt(i);
     }
     entries.emplace_back(
         OutputNode::Entry{static_cast<int32_t>(i), std::move(name)});

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -400,7 +400,7 @@ class PlanBuilder {
   /// @param aggregates The aggregate expressions to compute.
   /// @param options Per-aggregate options (filter, orderBy, distinct).
   /// @param groupingSetIndexName Name of the output column that identifies
-  /// which grouping set each row belongs to.
+  /// which grouping set each row belongs to. Hidden from name resolution.
   PlanBuilder& aggregate(
       const std::vector<ExprApi>& groupingKeys,
       const std::vector<std::vector<int32_t>>& groupingSets,

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/GroupByPlanner.h"
+#include <set>
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "folly/container/F14Set.h"
 #include "velox/common/base/BitUtil.h"
@@ -271,20 +272,6 @@ std::vector<std::vector<lp::ExprApi>> expandCube(
   return groupingSets;
 }
 
-bool hasGroupingSets(const std::vector<GroupingElementPtr>& groupingElements) {
-  for (const auto& element : groupingElements) {
-    switch (element->type()) {
-      case NodeType::kRollup:
-      case NodeType::kCube:
-      case NodeType::kGroupingSets:
-        return true;
-      default:
-        break;
-    }
-  }
-  return false;
-}
-
 // Computes Cartesian product of accumulatedSets and newSets.
 std::vector<std::vector<lp::ExprApi>> crossProductGroupingSets(
     const std::vector<std::vector<lp::ExprApi>>& accumulatedSets,
@@ -307,11 +294,30 @@ std::vector<std::vector<lp::ExprApi>> crossProductGroupingSets(
   return combined;
 }
 
+// Removes duplicate grouping sets from 'groupingSetsIndices'. Two sets are
+// duplicates if they contain the same key indices (order-insensitive).
+void deduplicateGroupingSets(
+    std::vector<std::vector<int32_t>>& groupingSetsIndices) {
+  std::set<std::vector<int32_t>> seen;
+  size_t next = 0;
+  for (size_t i = 0; i < groupingSetsIndices.size(); ++i) {
+    std::sort(groupingSetsIndices[i].begin(), groupingSetsIndices[i].end());
+    if (seen.insert(groupingSetsIndices[i]).second) {
+      if (next != i) {
+        groupingSetsIndices[next] = std::move(groupingSetsIndices[i]);
+      }
+      ++next;
+    }
+  }
+  groupingSetsIndices.resize(next);
+}
+
 } // namespace
 
 void GroupByPlanner::plan(
-    const std::vector<SelectItemPtr>& selectItems,
     const std::vector<GroupingElementPtr>& groupingElements,
+    bool distinct,
+    const std::vector<SelectItemPtr>& selectItems,
     const ExpressionPtr& having,
     const OrderByPtr& orderBy) && {
   // Expand ROLLUP, CUBE, GROUPING SETS into a list of grouping sets, then
@@ -319,13 +325,18 @@ void GroupByPlanner::plan(
   // Populates: groupingSets_, groupingKeys_, groupingSetsIndices_.
   groupingSets_ = expandGroupingSets(groupingElements, selectItems);
   deduplicateGroupingKeys();
+  // GROUP BY DISTINCT removes duplicate grouping sets after expansion
+  // (order-insensitive comparison).
+  if (distinct) {
+    deduplicateGroupingSets(groupingSetsIndices_);
+  }
 
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
   // function calls, then add the Aggregate plan node.
   // Populates: aggregates_, aggregateOptionsMap_, projections_, filter_,
   //   sortingKeys_, outputNames_.
   collectAggregates(selectItems, having, orderBy);
-  addAggregate(hasGroupingSets(groupingElements));
+  addAggregate(groupingSetsIndices_.size() > 1);
 
   // Rewrite filter_, projections_, and sortingKeys_ to reference the
   // aggregate output columns instead of the original input expressions.
@@ -378,7 +389,8 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     return false;
   }
 
-  std::move(*this).plan(selectItems, {}, having, /*orderBy=*/nullptr);
+  std::move(*this).plan(
+      {}, /*distinct=*/false, selectItems, having, /*orderBy=*/nullptr);
   return true;
 }
 
@@ -446,7 +458,12 @@ void GroupByPlanner::deduplicateGroupingKeys() {
       if (inserted) {
         groupingKeys_.push_back(expr);
       }
-      indices.push_back(it->second);
+      // Deduplicate keys within a single grouping set: GROUP BY (a, a)
+      // collapses to (a).
+      if (std::find(indices.begin(), indices.end(), it->second) ==
+          indices.end()) {
+        indices.push_back(it->second);
+      }
     }
     groupingSetsIndices_.push_back(std::move(indices));
   }

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -50,9 +50,12 @@ class GroupByPlanner {
       : builder_(builder), exprPlanner_(exprPlanner) {}
 
   /// Plans a GROUP BY clause with optional HAVING and ORDER BY.
+  /// When 'distinct' is true (GROUP BY DISTINCT), duplicate grouping sets
+  /// are removed after expansion.
   void plan(
-      const std::vector<SelectItemPtr>& selectItems,
       const std::vector<GroupingElementPtr>& groupingElements,
+      bool distinct,
+      const std::vector<SelectItemPtr>& selectItems,
       const ExpressionPtr& having,
       const OrderByPtr& orderBy) &&;
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -816,11 +816,12 @@ class RelationPlanner : public AstVisitor {
     const bool distinct = node->select()->isDistinct();
 
     if (auto groupBy = node->groupBy()) {
-      VELOX_USER_CHECK(
-          !groupBy->isDistinct(),
-          "GROUP BY with DISTINCT is not supported yet");
       GroupByPlanner{builder_, exprPlanner_}.plan(
-          selectItems, groupBy->groupingElements(), node->having(), orderBy);
+          groupBy->groupingElements(),
+          groupBy->isDistinct(),
+          selectItems,
+          node->having(),
+          orderBy);
 
       if (distinct) {
         builder_->distinct();

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -108,6 +108,12 @@ TEST_F(AggregationParserTest, groupingSets) {
           testing::ElementsAre(0),
           testing::IsEmpty()));
 
+  // Empty grouping set collapses to global aggregation.
+  testSelect(
+      "SELECT count(1) FROM nation "
+      "GROUP BY GROUPING SETS (())",
+      matchScan().aggregate({}, {"count(1)"}).output());
+
   // Test ordinals in GROUPING SETS: GROUPING SETS ((1, 2), (1))
   testSelect(
       "SELECT n_regionkey, n_name, count(1) FROM nation "
@@ -292,6 +298,93 @@ TEST_F(AggregationParserTest, cubeColumnLimit) {
       columns);
 
   VELOX_ASSERT_THROW(parseSql(sql), "CUBE supports at most 30 columns");
+}
+
+TEST_F(AggregationParserTest, groupByDistinct) {
+  // GROUP BY DISTINCT collapses all-identical sets to regular GROUP BY.
+  // (a, b), (b, a), (a, b) are identical (order-insensitive) → single set.
+  {
+    auto matcher = matchScan()
+                       .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {})
+                       .output();
+    testSelect(
+        "SELECT n_regionkey, n_name, count(1) FROM nation "
+        "GROUP BY DISTINCT GROUPING SETS "
+        "((n_regionkey, n_name), (n_name, n_regionkey), (n_regionkey, n_name))",
+        matcher);
+  }
+
+  // GROUP BY DISTINCT with two genuinely different sets preserves them.
+  {
+    auto matcher =
+        matchScan()
+            .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0}, {1}})
+            .output();
+    testSelect(
+        "SELECT n_regionkey, n_name, count(1) FROM nation "
+        "GROUP BY DISTINCT GROUPING SETS "
+        "((n_regionkey), (n_name), (n_regionkey))",
+        matcher);
+  }
+
+  // Key dedup within sets + DISTINCT across sets collapse to regular GROUP BY.
+  {
+    auto matcher = matchScan()
+                       .aggregate({"n_name", "n_regionkey"}, {"count(1)"}, {})
+                       .output();
+    testSelect(
+        "SELECT n_name, n_regionkey, count(1) FROM nation "
+        "GROUP BY DISTINCT GROUPING SETS "
+        "((n_name, n_regionkey, n_name), (n_regionkey, n_name, n_regionkey))",
+        matcher);
+  }
+
+  // Empty grouping set with DISTINCT collapses to global aggregation.
+  testSelect(
+      "SELECT count(1) FROM nation "
+      "GROUP BY DISTINCT GROUPING SETS (())",
+      matchScan().aggregate({}, {"count(1)"}).output());
+}
+
+TEST_F(AggregationParserTest, groupingSetsDedup) {
+  // All identical grouping sets are preserved without DISTINCT.
+  // The optimizer may collapse them as an optimization.
+  {
+    auto matcher = matchScan()
+                       .aggregate(
+                           {"n_regionkey", "n_name"},
+                           {"count(1)"},
+                           {{0, 1}, {1, 0}, {0, 1}})
+                       .output();
+    testSelect(
+        "SELECT n_regionkey, n_name, count(1) FROM nation "
+        "GROUP BY GROUPING SETS "
+        "((n_regionkey, n_name), (n_name, n_regionkey), (n_regionkey, n_name))",
+        matcher);
+  }
+
+  // Multiple distinct sets with duplicates — preserved per SQL standard.
+  {
+    auto matcher =
+        matchScan()
+            .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0}, {1}, {0}})
+            .output();
+    testSelect(
+        "SELECT n_regionkey, n_name, count(1) FROM nation "
+        "GROUP BY GROUPING SETS ((n_regionkey), (n_name), (n_regionkey))",
+        matcher);
+  }
+
+  // Duplicate keys within a single grouping set are deduplicated.
+  // (n_regionkey, n_regionkey) → (n_regionkey), single set → regular GROUP BY.
+  {
+    auto matcher =
+        matchScan().aggregate({"n_regionkey"}, {"count(1)"}, {}).output();
+    testSelect(
+        "SELECT n_regionkey, count(1) FROM nation "
+        "GROUP BY GROUPING SETS ((n_regionkey, n_regionkey))",
+        matcher);
+  }
 }
 
 TEST_F(AggregationParserTest, distinct) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -395,10 +395,12 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
   AggregateMatcher(
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
       std::vector<std::string> groupingKeys,
-      std::vector<std::string> aggregates)
+      std::vector<std::string> aggregates,
+      std::vector<std::vector<int32_t>> groupingSets = {})
       : LogicalPlanMatcherImpl<AggregateNode>(inputMatcher, nullptr),
         groupingKeys_{std::move(groupingKeys)},
-        aggregates_{std::move(aggregates)} {}
+        aggregates_{std::move(aggregates)},
+        groupingSets_{std::move(groupingSets)} {}
 
  private:
   MatchResult matchDetails(
@@ -422,11 +424,23 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
           << "at aggregate index " << i;
       AXIOM_RETURN_IF_FAILURE;
     }
+
+    EXPECT_EQ(groupingSets_.size(), plan.groupingSets().size())
+        << "grouping sets count mismatch";
+    AXIOM_RETURN_IF_FAILURE;
+
+    for (auto i = 0; i < groupingSets_.size(); ++i) {
+      EXPECT_EQ(groupingSets_[i], plan.groupingSets()[i])
+          << "at grouping set index " << i;
+      AXIOM_RETURN_IF_FAILURE;
+    }
+
     AXIOM_RETURN_RESULT(symbols)
   }
 
   const std::vector<std::string> groupingKeys_;
   const std::vector<std::string> aggregates_;
+  const std::vector<std::vector<int32_t>> groupingSets_;
 };
 
 class DistinctMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
@@ -616,10 +630,11 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
     const std::vector<std::string>& groupingKeys,
-    const std::vector<std::string>& aggregates) {
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::vector<int32_t>>& groupingSets) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ =
-      std::make_shared<AggregateMatcher>(matcher_, groupingKeys, aggregates);
+  matcher_ = std::make_shared<AggregateMatcher>(
+      matcher_, groupingKeys, aggregates, groupingSets);
   return *this;
 }
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -148,11 +148,12 @@ class LogicalPlanMatcherBuilder {
   /// Matches an AggregateNode.
   LogicalPlanMatcherBuilder& aggregate(OnMatchCallback onMatch = nullptr);
 
-  /// Matches an AggregateNode with the specified grouping keys and aggregates.
-  /// Each string is compared against the corresponding expression's toString().
+  /// Matches an AggregateNode with the specified grouping keys, aggregates,
+  /// and optionally grouping sets (as vectors of key indices).
   LogicalPlanMatcherBuilder& aggregate(
       const std::vector<std::string>& groupingKeys,
-      const std::vector<std::string>& aggregates);
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::vector<int32_t>>& groupingSets = {});
 
   /// Matches an AggregateNode used for deduplication (no aggregate functions,
   /// no grouping sets, all output columns are grouping keys).


### PR DESCRIPTION
Summary:

**Summary**  
Adds `GROUP BY DISTINCT` support to the parser to de-duplicate grouping sets produced by `ROLLUP`, `CUBE`, or `GROUPING SETS`.

Also removes duplicate keys within a grouping set (e.g., `GROUP BY (a, a)` → `(a)`). If all grouping sets end up identical, it collapses to a regular `GROUP BY` (avoiding `GroupId` overhead).

Replaces the syntax-based `hasGroupingSets()` check with `groupingSetsIndices_.size() > 1` to correctly handle edge cases (e.g., when all-identical sets collapse).

**Follow-up:** Optimizer-side changes.

**Comparison with Presto:**  
The behavior is the same, difference is architectural:
- **Presto:** `GroupIdNode` exists in the logical plan  
- **Axiom:** `GroupId` is physical-only, `AggregateNode` carries `groupingSets`

Reviewed By: kagamiori

Differential Revision: D97178193


