### PR TITLE
refactor(hive): Separate table metadata preparation from query-time loading (#1095)

### DIFF
--- a/axiom/connectors/hive/CMakeLists.txt
+++ b/axiom/connectors/hive/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(
   HiveConnectorMetadata.cpp
   HiveMetadataConfig.cpp
   LocalHiveConnectorMetadata.cpp
+  LocalTableBuilder.cpp
+  LocalTableMetadata.cpp
   StatisticsBuilder.cpp
 )
 

--- a/axiom/connectors/hive/HiveMetadataConfig.cpp
+++ b/axiom/connectors/hive/HiveMetadataConfig.cpp
@@ -27,8 +27,4 @@ std::string HiveMetadataConfig::localFileFormat() const {
   return config_->get<std::string>(kLocalFileFormat, "");
 }
 
-bool HiveMetadataConfig::useWriteTimeStats() const {
-  return config_->get<bool>(kUseWriteTimeStats, true);
-}
-
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/HiveMetadataConfig.h
+++ b/axiom/connectors/hive/HiveMetadataConfig.h
@@ -34,17 +34,9 @@ class HiveMetadataConfig {
   /// The name of the file format to use for processing data at kLocalDataPath.
   static constexpr const char* kLocalFileFormat = "hive_local_file_format";
 
-  /// Whether to use persisted write-time stats (.stats files) instead of
-  /// reading file headers and sampling data. Enabled by default. Disable
-  /// for tables created outside the Axiom write pipeline (e.g. TPC-H data
-  /// generator) which don't have .stats files.
-  static constexpr const char* kUseWriteTimeStats = "hive_use_write_time_stats";
-
   std::string localDataPath() const;
 
   std::string localFileFormat() const;
-
-  bool useWriteTimeStats() const;
 
   /// HiveMetadataConfig may be initialized from a base config which also
   /// contains execution config defined in velox/connectors/hive/HiveConfig.h,

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -22,15 +22,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/optimizer/JsonUtil.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/HivePartitionName.h"
-#include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/Reader.h"
-#include "velox/dwio/common/ReaderFactory.h"
-#include "velox/dwio/common/Statistics.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::axiom::connector::hive {
@@ -44,6 +41,72 @@ std::vector<PartitionHandlePtr> LocalHiveSplitManager::listPartitions(
 }
 
 namespace {
+
+// Merges 'source' into 'target': sums numValues, takes min of mins, max of
+// maxes, and max of numDistinct.
+void mergeColumnStatsValues(
+    ColumnStatistics& target,
+    const ColumnStatistics& source) {
+  target.numValues += source.numValues;
+
+  if (source.min.has_value()) {
+    if (!target.min.has_value() || source.min.value() < target.min.value()) {
+      target.min = source.min;
+    }
+  }
+  if (source.max.has_value()) {
+    if (!target.max.has_value() || target.max.value() < source.max.value()) {
+      target.max = source.max;
+    }
+  }
+
+  if (source.numDistinct.has_value()) {
+    target.numDistinct =
+        std::max(target.numDistinct.value_or(0), source.numDistinct.value());
+  }
+}
+
+// Merges a vector of column stats into an existing vector, matching by name.
+void mergeColumnStats(
+    std::vector<ColumnStatistics>& existing,
+    const std::vector<ColumnStatistics>& incoming) {
+  folly::F14FastMap<std::string, size_t> nameToIndex;
+  for (size_t i = 0; i < existing.size(); ++i) {
+    nameToIndex[existing[i].name] = i;
+  }
+
+  for (const auto& stats : incoming) {
+    auto it = nameToIndex.find(stats.name);
+    if (it == nameToIndex.end()) {
+      nameToIndex[stats.name] = existing.size();
+      existing.push_back(stats);
+      continue;
+    }
+
+    mergeColumnStatsValues(existing[it->second], stats);
+  }
+}
+
+// Extracts the leading digits after the last '/' in the file path.
+int32_t extractDigitsAfterLastSlash(std::string_view path) {
+  size_t lastSlashPos = path.find_last_of('/');
+  VELOX_CHECK(lastSlashPos != std::string::npos, "No slash found in {}", path);
+  std::string digits;
+  for (size_t i = lastSlashPos + 1; i < path.size(); ++i) {
+    char c = path[i];
+    if (std::isdigit(c)) {
+      digits += c;
+    } else {
+      break;
+    }
+  }
+  VELOX_CHECK(
+      !digits.empty(),
+      "Bad bucketed file name: No digits at start of name {}",
+      path);
+  return std::stoi(digits);
+}
+
 velox::common::Filter* FOLLY_NULLABLE findFilter(
     const velox::connector::hive::HiveTableHandle& tableHandle,
     const std::string& columnName) {
@@ -118,34 +181,6 @@ struct MetadataFilter {
   const Column* column{nullptr};
 };
 
-// Tests whether a file passes a metadata filter.
-bool testFileMetadata(
-    const FileInfo& file,
-    const MetadataFilter& metadataFilter) {
-  if (metadataFilter.columnName == HiveTable::kPath) {
-    return metadataFilter.filter->testBytes(
-        file.path.c_str(), static_cast<int32_t>(file.path.size()));
-  }
-
-  if (metadataFilter.columnName == HiveTable::kBucket) {
-    VELOX_CHECK(file.bucketNumber.has_value());
-    return metadataFilter.filter->testInt64(file.bucketNumber.value());
-  }
-
-  // Partition column filter.
-  VELOX_CHECK_NOT_NULL(metadataFilter.column);
-  auto partitionIt = file.partitionKeys.find(metadataFilter.columnName);
-  VELOX_CHECK(
-      partitionIt != file.partitionKeys.end(),
-      "Partition key not found in file {}: {}",
-      file.path,
-      metadataFilter.columnName);
-  return testPartitionValue(
-      *metadataFilter.filter,
-      partitionIt->second,
-      *metadataFilter.column->type());
-}
-
 // Classifies filter conjuncts by converting each to subfieldFilters. Conjuncts
 // fully converted to subfieldFilters on accepted columns are collected in
 // 'metadataFilters'. All others are reported in 'rejectedFilterIndices'. When
@@ -195,109 +230,6 @@ void classifyFilterConjuncts(
               it != partitionColumnsByName.end() ? it->second : nullptr});
     }
   }
-}
-
-// Creates an integer Variant with the TypeKind matching the column type.
-// IntegerColumnStatistics::getMinimum/getMaximum return int64_t regardless of
-// the actual integer width. Constructing Variant(int64_t) always produces
-// BIGINT, which causes a type mismatch when the column is TINYINT, SMALLINT, or
-// INTEGER. This helper narrows the value to the correct type.
-velox::Variant makeIntegerVariant(velox::TypeKind kind, int64_t value) {
-  switch (kind) {
-    case velox::TypeKind::TINYINT:
-      return velox::Variant(static_cast<int8_t>(value));
-    case velox::TypeKind::SMALLINT:
-      return velox::Variant(static_cast<int16_t>(value));
-    case velox::TypeKind::INTEGER:
-      return velox::Variant(static_cast<int32_t>(value));
-    default:
-      return velox::Variant(value);
-  }
-}
-
-// Merges 'source' into 'target': sums numValues, takes min of mins, max of
-// maxes, and max of numDistinct.
-// TODO: Replace numDistinct max with HLL sketch merging for accurate union.
-void mergeColumnStatsValues(
-    ColumnStatistics& target,
-    const ColumnStatistics& source) {
-  target.numValues += source.numValues;
-
-  if (source.min.has_value()) {
-    if (!target.min.has_value() || source.min.value() < target.min.value()) {
-      target.min = source.min;
-    }
-  }
-  if (source.max.has_value()) {
-    if (!target.max.has_value() || target.max.value() < source.max.value()) {
-      target.max = source.max;
-    }
-  }
-
-  if (source.numDistinct.has_value()) {
-    target.numDistinct =
-        std::max(target.numDistinct.value_or(0), source.numDistinct.value());
-  }
-}
-
-// Merges a vector of column stats into an existing vector, matching by name.
-// Columns not yet in 'existing' are appended.
-void mergeColumnStats(
-    std::vector<ColumnStatistics>& existing,
-    const std::vector<ColumnStatistics>& incoming) {
-  folly::F14FastMap<std::string, size_t> nameToIndex;
-  for (size_t i = 0; i < existing.size(); ++i) {
-    nameToIndex[existing[i].name] = i;
-  }
-
-  for (const auto& stats : incoming) {
-    auto it = nameToIndex.find(stats.name);
-    if (it == nameToIndex.end()) {
-      nameToIndex[stats.name] = existing.size();
-      existing.push_back(stats);
-      continue;
-    }
-
-    mergeColumnStatsValues(existing[it->second], stats);
-  }
-}
-
-// Aggregates per-column stats across selected files. Columns missing from a
-// file's columnStats are treated as all-null (numValues = 0, no min/max). This
-// handles schema evolution where a column was added after the file was written.
-std::vector<ColumnStatistics> aggregateColumnStats(
-    const std::vector<const FileInfo*>& files,
-    const std::vector<const Column*>& columns,
-    uint64_t totalRows) {
-  std::vector<ColumnStatistics> result;
-  result.reserve(columns.size());
-
-  for (const auto* column : columns) {
-    ColumnStatistics aggregated;
-
-    for (const auto* file : files) {
-      auto it = file->columnStats.find(column->name());
-      if (it == file->columnStats.end()) {
-        // Column not in this file (schema evolution). All rows are null.
-        continue;
-      }
-      mergeColumnStatsValues(aggregated, it->second);
-    }
-
-    if (column->stats() && column->stats()->numDistinct.has_value()) {
-      aggregated.numDistinct = column->stats()->numDistinct.value();
-    }
-
-    if (totalRows > 0) {
-      aggregated.nullPct = 100.0f *
-          static_cast<float>(totalRows - aggregated.numValues) /
-          static_cast<float>(totalRows);
-    }
-
-    result.push_back(std::move(aggregated));
-  }
-
-  return result;
 }
 
 // Estimates table stats from persisted partition-level stats. Applies partition
@@ -373,56 +305,6 @@ FilteredTableStats estimateStatsFromPartitionStats(
       columnStats.push_back(std::move(stats));
     }
   }
-
-  return FilteredTableStats{
-      totalRows, std::move(columnStats), std::move(rejectedFilterIndices)};
-}
-
-// Estimates table stats from per-file header metadata. Applies metadata filters
-// (partition keys, $path, $bucket), aggregates per-file column stats. Returns
-// nullopt if any file lacks row count metadata.
-std::optional<FilteredTableStats> estimateStatsFromFileStats(
-    const std::vector<std::unique_ptr<const FileInfo>>& files,
-    const std::vector<velox::core::TypedExprPtr>& filterConjuncts,
-    velox::core::ExpressionEvaluator& evaluator,
-    const folly::F14FastMap<std::string, const Column*>& partitionColumnsByName,
-    const std::vector<const Column*>& requestedColumns) {
-  std::vector<MetadataFilter> metadataFilters;
-  std::vector<int32_t> rejectedFilterIndices;
-  classifyFilterConjuncts(
-      filterConjuncts,
-      evaluator,
-      partitionColumnsByName,
-      /*allowPathAndBucket=*/true,
-      metadataFilters,
-      rejectedFilterIndices);
-
-  std::vector<const FileInfo*> selectedFiles;
-  for (const auto& file : files) {
-    if (!file->numRows.has_value()) {
-      return std::nullopt;
-    }
-    bool pass = true;
-    for (const auto& metadataFilter : metadataFilters) {
-      if (!testFileMetadata(*file, metadataFilter)) {
-        pass = false;
-        break;
-      }
-    }
-    if (!pass) {
-      continue;
-    }
-    selectedFiles.push_back(file.get());
-  }
-
-  uint64_t totalRows{0};
-  for (const auto* file : selectedFiles) {
-    VELOX_CHECK(file->numRows.has_value());
-    totalRows += file->numRows.value();
-  }
-
-  auto columnStats =
-      aggregateColumnStats(selectedFiles, requestedColumns, totalRows);
 
   return FilteredTableStats{
       totalRows, std::move(columnStats), std::move(rejectedFilterIndices)};
@@ -745,17 +627,8 @@ LocalHiveTableLayout::co_estimateStats(
     requestedColumns.push_back(column);
   }
 
-  if (hiveMetadataConfig_ && hiveMetadataConfig_->useWriteTimeStats()) {
-    co_return estimateStatsFromPartitionStats(
-        partitionStats_,
-        filterConjuncts,
-        evaluator,
-        partitionColumnsByName,
-        requestedColumns);
-  }
-
-  co_return estimateStatsFromFileStats(
-      files_,
+  co_return estimateStatsFromPartitionStats(
+      partitionStats_,
       filterConjuncts,
       evaluator,
       partitionColumnsByName,
@@ -793,66 +666,6 @@ LocalHiveTableLayout* LocalTable::makeDefaultLayout(
 }
 
 namespace {
-
-// Extracts the digits after the last / in the file path and returns them as an
-// integer.
-int32_t extractDigitsAfterLastSlash(std::string_view path) {
-  size_t lastSlashPos = path.find_last_of('/');
-  VELOX_CHECK(lastSlashPos != std::string::npos, "No slash found in {}", path);
-  std::string digits;
-  for (size_t i = lastSlashPos + 1; i < path.size(); ++i) {
-    char c = path[i];
-    if (std::isdigit(c)) {
-      digits += c;
-    } else {
-      break;
-    }
-  }
-  VELOX_CHECK(
-      !digits.empty(),
-      "Bad bucketed file name: No digits at start of name {}",
-      path);
-  return std::stoi(digits);
-}
-
-void listFiles(
-    std::string_view path,
-    const std::function<int32_t(std::string_view)>& parseBucketNumber,
-    int32_t prefixSize,
-    std::vector<std::unique_ptr<const FileInfo>>& result) {
-  for (auto const& dirEntry : fs::directory_iterator{path}) {
-    // Ignore hidden files.
-    if (dirEntry.path().filename().c_str()[0] == '.') {
-      continue;
-    }
-
-    if (dirEntry.is_directory()) {
-      listFiles(
-          fmt::format("{}/{}", path, dirEntry.path().filename().c_str()),
-          parseBucketNumber,
-          prefixSize,
-          result);
-    }
-    if (!dirEntry.is_regular_file()) {
-      continue;
-    }
-    auto file = std::make_unique<FileInfo>();
-    file->path = fmt::format("{}/{}", path, dirEntry.path().filename().c_str());
-    if (parseBucketNumber) {
-      file->bucketNumber = parseBucketNumber(file->path);
-    }
-    std::vector<std::string> dirs;
-    folly::split('/', path.substr(prefixSize, path.size()), dirs);
-    for (auto& dir : dirs) {
-      std::vector<std::string> parts;
-      folly::split('=', dir, parts);
-      if (parts.size() == 2) {
-        file->partitionKeys[parts.at(0)] = parts.at(1);
-      }
-    }
-    result.push_back(std::move(file));
-  }
-}
 
 struct CreateTableOptions {
   std::optional<velox::common::CompressionKind> compressionKind;
@@ -1216,124 +1029,6 @@ std::shared_ptr<LocalTable> createLocalTable(
   return table;
 }
 
-std::string schemaPath(std::string_view path) {
-  return fmt::format("{}/.schema", path);
-}
-
-std::string statsPath(const std::string& path) {
-  return fmt::format("{}/.stats", path);
-}
-
-folly::dynamic columnStatsToJson(const ColumnStatistics& stats) {
-  folly::dynamic json = folly::dynamic::object;
-  json["name"] = stats.name;
-  json["numValues"] = stats.numValues;
-  json["nullPct"] = stats.nullPct;
-  if (stats.min.has_value()) {
-    json["min"] = stats.min->serialize();
-  }
-  if (stats.max.has_value()) {
-    json["max"] = stats.max->serialize();
-  }
-  if (stats.numDistinct.has_value()) {
-    json["numDistinct"] = stats.numDistinct.value();
-  }
-  if (stats.maxLength.has_value()) {
-    json["maxLength"] = stats.maxLength.value();
-  }
-  if (stats.avgLength.has_value()) {
-    json["avgLength"] = stats.avgLength.value();
-  }
-  return json;
-}
-
-struct PersistedStats {
-  uint64_t numRows{0};
-  std::vector<ColumnStatistics> columns;
-};
-
-folly::dynamic persistedStatsToJson(const PersistedStats& stats) {
-  folly::dynamic columns = folly::dynamic::array;
-  for (const auto& colStats : stats.columns) {
-    columns.push_back(columnStatsToJson(colStats));
-  }
-  folly::dynamic json = folly::dynamic::object;
-  json["numRows"] = stats.numRows;
-  json["columns"] = std::move(columns);
-  return json;
-}
-
-ColumnStatistics columnStatsFromJson(const folly::dynamic& json) {
-  ColumnStatistics stats;
-  stats.name = json["name"].asString();
-  stats.numValues = json["numValues"].asInt();
-  stats.nullPct = json["nullPct"].asDouble();
-  if (json.count("min")) {
-    stats.min = velox::Variant::create(json["min"]);
-  }
-  if (json.count("max")) {
-    stats.max = velox::Variant::create(json["max"]);
-  }
-  if (json.count("numDistinct")) {
-    stats.numDistinct = json["numDistinct"].asInt();
-  }
-  if (json.count("maxLength")) {
-    stats.maxLength = json["maxLength"].asInt();
-  }
-  if (json.count("avgLength")) {
-    stats.avgLength = json["avgLength"].asInt();
-  }
-  return stats;
-}
-
-PersistedStats persistedStatsFromJson(const folly::dynamic& json) {
-  PersistedStats result;
-  result.numRows = json["numRows"].asInt();
-  for (const auto& colJson : json["columns"]) {
-    result.columns.push_back(columnStatsFromJson(colJson));
-  }
-  return result;
-}
-
-// Reads persisted stats from the .stats file. Returns std::nullopt if the
-// file doesn't exist.
-std::optional<PersistedStats> readPersistedStats(const std::string& directory) {
-  const auto file = statsPath(directory);
-  if (!std::filesystem::exists(file)) {
-    return std::nullopt;
-  }
-  std::ifstream inputFile(file);
-  if (!inputFile.is_open()) {
-    return std::nullopt;
-  }
-  std::string content(
-      (std::istreambuf_iterator<char>(inputFile)),
-      std::istreambuf_iterator<char>());
-  return persistedStatsFromJson(folly::parseJson(content));
-}
-
-// Writes stats to a .stats file in 'directory', merging with any existing
-// stats from prior writes.
-void persistStats(
-    const std::string& directory,
-    uint64_t numRows,
-    std::vector<ColumnStatistics> columns) {
-  auto existing = readPersistedStats(directory);
-  if (existing.has_value()) {
-    numRows += existing->numRows;
-    mergeColumnStats(existing->columns, columns);
-    columns = std::move(existing->columns);
-  }
-
-  const auto file = statsPath(directory);
-  std::ofstream outputFile(file);
-  VELOX_CHECK(outputFile.is_open(), "Failed to open stats file: {}", file);
-  outputFile << folly::toPrettyJson(
-      persistedStatsToJson({numRows, std::move(columns)}));
-  outputFile.close();
-  VELOX_CHECK(!outputFile.fail(), "Failed to write stats file: {}", file);
-}
-
 std::shared_ptr<LocalTable> createTableFromSchema(
     std::string_view name,
     std::string_view path,
@@ -1355,79 +1050,6 @@ std::shared_ptr<LocalTable> createTableFromSchema(
       name, schema, options, connector, std::move(hiveMetadataConfig));
 }
 
-// Reads column statistics from file headers (min, max, count, null
-// percentage) and populates both table-level Column stats and per-file
-// FileInfo stats.
-void populateFileStats(
-    Table& table,
-    const velox::dwio::common::Reader& reader,
-    const velox::RowType& fileType,
-    FileInfo* fileInfo,
-    std::optional<uint64_t> numRows) {
-  for (auto i = 0; i < fileType.size(); ++i) {
-    const auto& name = fileType.nameOf(i);
-
-    const auto* column = table.findColumn(name);
-    VELOX_CHECK_NOT_NULL(column, "Column not found: {}", name);
-
-    const auto& typeWithId = reader.typeWithId()->childByName(name);
-    auto readerStats = reader.columnStatistics(typeWithId->id());
-    if (!readerStats) {
-      continue;
-    }
-
-    auto* stats = const_cast<Column*>(column)->mutableStats();
-    stats->numValues += readerStats->getNumberOfValues().value_or(0);
-
-    const auto numValues = readerStats->getNumberOfValues();
-    if (numRows.has_value() && numRows.value() > 0 && numValues.has_value()) {
-      stats->nullPct =
-          100 * (numRows.value() - numValues.value()) / numRows.value();
-    }
-
-    ColumnStatistics fileColStats;
-    fileColStats.numValues = numValues.value_or(0);
-
-    if (auto* intStats =
-            dynamic_cast<const velox::dwio::common::IntegerColumnStatistics*>(
-                readerStats.get())) {
-      auto columnKind = column->type()->kind();
-      if (intStats->getMinimum().has_value()) {
-        fileColStats.min =
-            makeIntegerVariant(columnKind, intStats->getMinimum().value());
-      }
-      if (intStats->getMaximum().has_value()) {
-        fileColStats.max =
-            makeIntegerVariant(columnKind, intStats->getMaximum().value());
-      }
-    } else if (
-        auto* dblStats =
-            dynamic_cast<const velox::dwio::common::DoubleColumnStatistics*>(
-                readerStats.get())) {
-      if (dblStats->getMinimum().has_value()) {
-        fileColStats.min = velox::Variant(dblStats->getMinimum().value());
-      }
-      if (dblStats->getMaximum().has_value()) {
-        fileColStats.max = velox::Variant(dblStats->getMaximum().value());
-      }
-    } else if (
-        auto* strStats =
-            dynamic_cast<const velox::dwio::common::StringColumnStatistics*>(
-                readerStats.get())) {
-      if (strStats->getMinimum().has_value()) {
-        fileColStats.min = velox::Variant::create<velox::TypeKind::VARCHAR>(
-            strStats->getMinimum().value());
-      }
-      if (strStats->getMaximum().has_value()) {
-        fileColStats.max = velox::Variant::create<velox::TypeKind::VARCHAR>(
-            strStats->getMaximum().value());
-      }
-    }
-
-    fileInfo->columnStats[name] = std::move(fileColStats);
-  }
-}
-
 } // namespace
 
 // Loads persisted write-time stats from .stats files and stores them in the
@@ -1438,7 +1060,7 @@ void LocalHiveConnectorMetadata::loadTableWithWriteTimeStats(
     LocalHiveTableLayout* layout,
     const fs::path& tablePath) {
   std::vector<PartitionStats> allPartitionStats;
-  auto persistedStats = readPersistedStats(tablePath.string());
+  auto persistedStats = PersistedStats::read(tablePath.string());
   if (persistedStats.has_value()) {
     // Unpartitioned table: single entry with empty partition keys.
     PartitionStats partitionEntry;
@@ -1463,7 +1085,7 @@ void LocalHiveConnectorMetadata::loadTableWithWriteTimeStats(
       if (!entry.is_directory()) {
         continue;
       }
-      auto persisted = readPersistedStats(entry.path().string());
+      auto persisted = PersistedStats::read(entry.path().string());
       if (!persisted.has_value()) {
         continue;
       }
@@ -1488,73 +1110,6 @@ void LocalHiveConnectorMetadata::loadTableWithWriteTimeStats(
   layout->setPartitionStats(std::move(allPartitionStats));
 }
 
-// Reads file headers to discover schema (if no .schema file), row counts, and
-// per-file column stats. Samples NDVs after loading.
-void LocalHiveConnectorMetadata::loadTableFromFileHeaders(
-    std::string_view tableName,
-    std::shared_ptr<LocalTable> table,
-    std::vector<std::unique_ptr<const FileInfo>> files,
-    const fs::path& tablePath) {
-  velox::RowTypePtr tableType;
-  if (table) {
-    tableType = table->type();
-  }
-
-  for (auto& info : files) {
-    velox::dwio::common::ReaderOptions readerOptions{schemaPool_.get()};
-    auto fileFormat = table == nullptr || table->layouts().empty()
-        ? format_
-        : reinterpret_cast<const HiveTableLayout*>(table->layouts()[0])
-              ->fileFormat();
-    readerOptions.setFileFormat(fileFormat);
-
-    if (fileFormat == velox::dwio::common::FileFormat::TEXT && tableType) {
-      readerOptions.setFileSchema(tableType);
-    }
-
-    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
-        std::make_shared<velox::LocalReadFile>(info->path),
-        readerOptions.memoryPool());
-    std::unique_ptr<velox::dwio::common::Reader> reader =
-        velox::dwio::common::getReaderFactory(readerOptions.fileFormat())
-            ->createReader(std::move(input), readerOptions);
-
-    const auto& fileType = reader->rowType();
-    if (!tableType) {
-      tableType = fileType;
-    } else if (fileType->size() > tableType->size()) {
-      tableType = fileType;
-    }
-
-    if (!table) {
-      tables_[tableName] = std::make_shared<LocalTable>(
-          SchemaTableName{std::string(kDefaultSchema), std::string{tableName}},
-          tableType,
-          /*bucketed=*/false,
-          /*options=*/folly::F14FastMap<std::string, velox::Variant>{});
-      table = tables_[tableName];
-    }
-
-    const auto rows = reader->numberOfRows();
-    if (rows.has_value()) {
-      table->incrementNumRows(rows.value());
-    }
-    auto* mutableInfo = const_cast<FileInfo*>(info.get());
-    mutableInfo->numRows = rows;
-
-    populateFileStats(*table, *reader, *fileType, mutableInfo, rows);
-  }
-  VELOX_CHECK_NOT_NULL(table, "Table directory {} is empty", tablePath);
-
-  table->makeDefaultLayout(std::move(files), *this);
-
-  float pct = 10;
-  if (table->numRows() > 1'000'000) {
-    pct = 100 * 100'000 / table->numRows();
-  }
-  table->sampleNumDistincts(pct, schemaPool_.get());
-}
-
 void LocalHiveConnectorMetadata::loadTable(
     std::string_view tableName,
     const fs::path& tablePath) {
@@ -1564,78 +1119,26 @@ void LocalHiveConnectorMetadata::loadTable(
       format_,
       hiveConnector(),
       hiveMetadataConfig_);
+  VELOX_CHECK_NOT_NULL(
+      table,
+      "Schema file (.schema) not found for table: {}. "
+      "Run LocalTableBuilder::build() first.",
+      tablePath);
 
-  if (table) {
-    tables_[tableName] = table;
-  }
-
-  const bool useWriteTimeStats = hiveMetadataConfig_->useWriteTimeStats();
-  if (useWriteTimeStats) {
-    VELOX_CHECK_NOT_NULL(
-        table, "Schema file required for write-time stats: {}", tablePath);
-  }
+  tables_[tableName] = table;
 
   std::function<int32_t(std::string_view)> parseBucketNumber = nullptr;
-  if (table && !table->layouts()[0]->partitionColumns().empty()) {
+  if (!table->layouts()[0]->partitionColumns().empty()) {
     parseBucketNumber = extractDigitsAfterLastSlash;
   }
 
   std::vector<std::unique_ptr<const FileInfo>> files;
   std::string pathString = tablePath;
-  listFiles(
-      pathString,
-      parseBucketNumber,
-      static_cast<int32_t>(pathString.size()),
-      files);
+  FileInfo::listFiles(pathString, parseBucketNumber, pathString.size(), files);
 
-  if (useWriteTimeStats) {
-    auto* layout = table->makeDefaultLayout(std::move(files), *this);
-    loadTableWithWriteTimeStats(table, layout, tablePath);
-  } else {
-    loadTableFromFileHeaders(tableName, table, std::move(files), tablePath);
-  }
+  auto* layout = table->makeDefaultLayout(std::move(files), *this);
+  loadTableWithWriteTimeStats(table, layout, tablePath);
 }
-
-namespace {
-
-bool isMixedOrder(const ColumnStatistics& stats) {
-  return stats.ascendingPct.has_value() && stats.descendingPct.has_value() &&
-      stats.ascendingPct.value() > 0 && stats.descendingPct.value() > 0;
-}
-
-bool isInteger(velox::TypeKind kind) {
-  switch (kind) {
-    case velox::TypeKind::TINYINT:
-    case velox::TypeKind::SMALLINT:
-    case velox::TypeKind::INTEGER:
-    case velox::TypeKind::BIGINT:
-      return true;
-    default:
-      return false;
-  }
-}
-
-template <typename T>
-T numericValue(const velox::Variant& v) {
-  switch (v.kind()) {
-    case velox::TypeKind::TINYINT:
-      return static_cast<T>(v.value<velox::TypeKind::TINYINT>());
-    case velox::TypeKind::SMALLINT:
-      return static_cast<T>(v.value<velox::TypeKind::SMALLINT>());
-    case velox::TypeKind::INTEGER:
-      return static_cast<T>(v.value<velox::TypeKind::INTEGER>());
-    case velox::TypeKind::BIGINT:
-      return static_cast<T>(v.value<velox::TypeKind::BIGINT>());
-    case velox::TypeKind::REAL:
-      return static_cast<T>(v.value<velox::TypeKind::REAL>());
-    case velox::TypeKind::DOUBLE:
-      return static_cast<T>(v.value<velox::TypeKind::DOUBLE>());
-    default:
-      VELOX_UNREACHABLE();
-  }
-}
-
-} // namespace
 
 LocalTable::LocalTable(
     SchemaTableName name,
@@ -1648,90 +1151,6 @@ LocalTable::LocalTable(
           bucketed,
           /*includeHiddenColumns=*/true,
           std::move(options)) {}
-
-void LocalTable::sampleNumDistincts(
-    float samplePct,
-    velox::memory::MemoryPool* pool) {
-  std::vector<velox::connector::ColumnHandlePtr> columns;
-  columns.reserve(type()->size());
-
-  std::vector<velox::common::Subfield> fields;
-  fields.reserve(type()->size());
-
-  auto* layout = layouts_[0].get();
-  for (const auto& name : type()->names()) {
-    columns.push_back(layout->createColumnHandle(
-        /*session=*/nullptr, name));
-    fields.emplace_back(name);
-  }
-
-  // Sample the table. Adjust distinct values according to the samples.
-  auto allocator = std::make_unique<velox::HashStringAllocator>(pool);
-
-  auto* metadata = ConnectorMetadata::metadata(layout->connector());
-  auto* localHiveMetadata =
-      dynamic_cast<const LocalHiveConnectorMetadata*>(metadata);
-  auto& evaluator =
-      *localHiveMetadata->connectorQueryCtx()->expressionEvaluator();
-
-  std::vector<velox::core::TypedExprPtr> rejectedFilters;
-  auto handle = layout->createTableHandle(
-      /*session=*/nullptr, columns, evaluator, /*filters=*/{}, rejectedFilters);
-
-  auto* localLayout = dynamic_cast<LocalHiveTableLayout*>(layout);
-  VELOX_CHECK_NOT_NULL(localLayout, "Expecting a local hive layout");
-
-  std::vector<std::unique_ptr<StatisticsBuilder>> statsBuilders;
-  auto [sampled, passed] = localLayout->sample(
-      handle, samplePct, fields, allocator.get(), &statsBuilders);
-
-  numSampledRows_ = sampled;
-  for (size_t i = 0; i < statsBuilders.size(); ++i) {
-    if (const auto& builder = statsBuilders[i]) {
-      auto columnIdx = static_cast<uint32_t>(i);
-      auto* column = findColumn(type()->nameOf(columnIdx));
-      VELOX_CHECK_NOT_NULL(
-          column, "Column not found: {}", type()->nameOf(columnIdx));
-
-      ColumnStatistics& stats = *const_cast<Column*>(column)->mutableStats();
-      builder->build(stats);
-
-      auto estimate = stats.numDistinct;
-      int64_t approxNumDistinct =
-          estimate.has_value() ? estimate.value() : numRows_;
-
-      // For tiny tables the sample is 100% and the approxNumDistinct is
-      // accurate. For partial samples, the distinct estimate is left to be the
-      // distinct estimate of the sample if there are few distincts. This is an
-      // enumeration where values in unsampled rows are likely the same. If
-      // there are many distincts, we multiply by 1/sample rate assuming that
-      // unsampled rows will mostly have new values.
-      if (numSampledRows_ < numRows_) {
-        if (approxNumDistinct > sampled / 50) {
-          float numDups =
-              numSampledRows_ / static_cast<float>(approxNumDistinct);
-          approxNumDistinct = std::min<float>(numRows_, numRows_ / numDups);
-
-          // If the type is an integer type, num distincts cannot be larger than
-          // max - min.
-
-          if (isInteger(builder->type()->kind())) {
-            auto min = stats.min;
-            auto max = stats.max;
-            if (min.has_value() && max.has_value() && isMixedOrder(stats)) {
-              auto range = numericValue<float>(max.value()) -
-                  numericValue<float>(min.value());
-              approxNumDistinct = std::min<float>(approxNumDistinct, range);
-            }
-          }
-        }
-
-        const_cast<Column*>(column)->mutableStats()->numDistinct =
-            approxNumDistinct;
-      }
-    }
-  }
-}
 
 TablePtr LocalHiveConnectorMetadata::findTable(
     const SchemaTableName& tableName) {
@@ -1969,21 +1388,20 @@ RowsFuture LocalHiveConnectorMetadata::finishWrite(
       auto partitionDirName =
           velox::connector::hive::HivePartitionName::partitionName(
               i, partitionKeys, /*partitionKeyAsLowerCase=*/true);
-      persistStats(
+      PersistedStats::write(
           fmt::format("{}/{}", targetPath, partitionDirName),
-          partitionRows,
-          std::move(groupStats[i]));
+          {static_cast<uint64_t>(partitionRows), std::move(groupStats[i])});
     }
   } else {
-    persistStats(
+    PersistedStats::write(
         targetPath,
-        rows,
-        groupStats.empty() ? std::vector<ColumnStatistics>{}
-                           : std::move(groupStats[0]));
+        {rows,
+         groupStats.empty() ? std::vector<ColumnStatistics>{}
+                            : std::move(groupStats[0])});
   }
 
-  // loadTable reads file headers, samples for NDV, and applies persisted
-  // .stats — populating in-memory Column stats.
+  // loadTable reads the .schema and .stats files, populating in-memory
+  // Column stats.
   loadTable(hiveHandle->table()->name().table, targetPath);
 
   return rows;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -20,6 +20,7 @@
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/connectors/hive/StatisticsBuilder.h"
 #include "folly/experimental/coro/Task.h"
 #include "velox/common/base/Fs.h"
@@ -29,19 +30,6 @@
 #include "velox/dwio/common/Options.h"
 
 namespace facebook::axiom::connector::hive {
-
-/// Describes a file in a table. Input to split enumeration.
-struct FileInfo {
-  std::string path;
-  folly::F14FastMap<std::string, std::optional<std::string>> partitionKeys;
-  std::optional<int32_t> bucketNumber;
-
-  /// Row count from file header metadata.
-  std::optional<uint64_t> numRows;
-
-  /// Per-column stats from file header metadata keyed by column name.
-  folly::F14FastMap<std::string, ColumnStatistics> columnStats;
-};
 
 class LocalHiveSplitSource : public SplitSource {
  public:
@@ -179,13 +167,12 @@ class LocalHiveTableLayout : public HiveTableLayout {
       std::vector<velox::core::TypedExprPtr> filterConjuncts) const override;
 
  private:
-  // Configuration for local Hive metadata, including useWriteTimeStats flag.
+  // Configuration for local Hive metadata.
   std::shared_ptr<HiveMetadataConfig> hiveMetadataConfig_;
   std::vector<std::unique_ptr<const FileInfo>> files_;
   std::vector<std::unique_ptr<const FileInfo>> ownedFiles_;
   // Per-partition (or per-table for unpartitioned) write-time stats loaded
-  // from persisted .stats files. Populated during loadTable when
-  // useWriteTimeStats is enabled.
+  // from persisted .stats files. Populated during loadTable.
   std::vector<PartitionStats> partitionStats_;
   std::unordered_map<std::string, std::string> serdeParameters_;
 };
@@ -221,10 +208,6 @@ class LocalTable : public HiveTable {
     numRows_ += n;
   }
 
-  /// Samples  'samplePct' % rows of the table and sets the num distincts
-  /// estimate for the columns. uses 'pool' for temporary data.
-  void sampleNumDistincts(float samplePct, velox::memory::MemoryPool* pool);
-
  private:
   // Serializes initialization, e.g. exportedColumns_.
   mutable std::mutex mutex_;
@@ -237,7 +220,6 @@ class LocalTable : public HiveTable {
   std::vector<const TableLayout*> exportedLayouts_;
 
   int64_t numRows_{0};
-  int64_t numSampledRows_{0};
 };
 
 class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
@@ -278,8 +260,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
     return hiveConnector_;
   }
 
-  /// Returns the metadata configuration (data path, file format,
-  /// useWriteTimeStats flag, etc.).
+  /// Returns the metadata configuration (data path, file format, etc.).
   const std::shared_ptr<HiveMetadataConfig>& hiveMetadataConfig() const {
     return hiveMetadataConfig_;
   }
@@ -361,14 +342,6 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   void loadTableWithWriteTimeStats(
       std::shared_ptr<LocalTable> table,
       LocalHiveTableLayout* layout,
-      const fs::path& tablePath);
-
-  // Reads file headers to discover schema, row counts, and per-file column
-  // stats. Samples NDVs after loading.
-  void loadTableFromFileHeaders(
-      std::string_view tableName,
-      std::shared_ptr<LocalTable> table,
-      std::vector<std::unique_ptr<const FileInfo>> files,
       const fs::path& tablePath);
 
   std::shared_ptr<LocalTable> findTableLocked(std::string_view name) const;

--- a/axiom/connectors/hive/LocalTableBuilder.cpp
+++ b/axiom/connectors/hive/LocalTableBuilder.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/LocalTableBuilder.h"
+
+#include <fstream>
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+
+#include "axiom/connectors/hive/LocalTableMetadata.h"
+#include "axiom/connectors/hive/StatisticsBuilder.h"
+#include "axiom/optimizer/JsonUtil.h"
+#include "velox/common/base/Fs.h"
+#include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Reader.h"
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/common/Statistics.h"
+
+namespace facebook::axiom::connector::hive {
+
+namespace {
+
+std::string statsPath(const std::string& path) {
+  return fmt::format("{}/.stats", path);
+}
+
+// Merges 'source' into 'target': sums numValues, takes min of mins, max of
+// maxes, and max of numDistinct.
+void mergeColumnStatsValues(
+    ColumnStatistics& target,
+    const ColumnStatistics& source) {
+  target.numValues += source.numValues;
+
+  if (source.min.has_value()) {
+    if (!target.min.has_value() || source.min.value() < target.min.value()) {
+      target.min = source.min;
+    }
+  }
+  if (source.max.has_value()) {
+    if (!target.max.has_value() || target.max.value() < source.max.value()) {
+      target.max = source.max;
+    }
+  }
+
+  if (source.numDistinct.has_value()) {
+    target.numDistinct =
+        std::max(target.numDistinct.value_or(0), source.numDistinct.value());
+  }
+}
+
+folly::dynamic columnStatsToJson(const ColumnStatistics& stats) {
+  folly::dynamic json = folly::dynamic::object;
+  json["name"] = stats.name;
+  json["numValues"] = stats.numValues;
+  json["nullPct"] = stats.nullPct;
+  if (stats.min.has_value()) {
+    json["min"] = stats.min->serialize();
+  }
+  if (stats.max.has_value()) {
+    json["max"] = stats.max->serialize();
+  }
+  if (stats.numDistinct.has_value()) {
+    json["numDistinct"] = stats.numDistinct.value();
+  }
+  if (stats.maxLength.has_value()) {
+    json["maxLength"] = stats.maxLength.value();
+  }
+  if (stats.avgLength.has_value()) {
+    json["avgLength"] = stats.avgLength.value();
+  }
+  return json;
+}
+
+folly::dynamic persistedStatsToJson(const PersistedStats& stats) {
+  folly::dynamic columns = folly::dynamic::array;
+  for (const auto& colStats : stats.columns) {
+    columns.push_back(columnStatsToJson(colStats));
+  }
+  folly::dynamic json = folly::dynamic::object;
+  json["numRows"] = stats.numRows;
+  json["columns"] = std::move(columns);
+  return json;
+}
+
+// Creates an integer Variant with the TypeKind matching the column type.
+// IntegerColumnStatistics::getMinimum/getMaximum return int64_t regardless of
+// the actual integer width. Constructing Variant(int64_t) always produces
+// BIGINT, which causes a type mismatch when the column is TINYINT, SMALLINT, or
+// INTEGER. This helper narrows the value to the correct type.
+velox::Variant makeIntegerVariant(velox::TypeKind kind, int64_t value) {
+  switch (kind) {
+    case velox::TypeKind::TINYINT:
+      return velox::Variant(static_cast<int8_t>(value));
+    case velox::TypeKind::SMALLINT:
+      return velox::Variant(static_cast<int16_t>(value));
+    case velox::TypeKind::INTEGER:
+      return velox::Variant(static_cast<int32_t>(value));
+    default:
+      return velox::Variant(value);
+  }
+}
+
+// Reads per-column min/max/count from DWIO reader and populates
+// fileInfo->columnStats.
+void populateFileColumnStats(
+    const velox::dwio::common::Reader& reader,
+    const velox::RowType& fileType,
+    FileInfo* fileInfo,
+    std::optional<uint64_t> numRows) {
+  for (auto i = 0; i < fileType.size(); ++i) {
+    const auto& name = fileType.nameOf(i);
+    const auto& columnType = fileType.childAt(i);
+
+    const auto& typeWithId = reader.typeWithId()->childByName(name);
+    auto readerStats = reader.columnStatistics(typeWithId->id());
+    if (!readerStats) {
+      continue;
+    }
+
+    const auto numValues = readerStats->getNumberOfValues();
+
+    ColumnStatistics fileColStats;
+    fileColStats.name = name;
+    fileColStats.numValues = numValues.value_or(0);
+
+    if (numRows.has_value() && numRows.value() > 0 && numValues.has_value()) {
+      fileColStats.nullPct =
+          100 * (numRows.value() - numValues.value()) / numRows.value();
+    }
+
+    auto columnKind = columnType->kind();
+
+    if (auto* intStats =
+            dynamic_cast<const velox::dwio::common::IntegerColumnStatistics*>(
+                readerStats.get())) {
+      if (intStats->getMinimum().has_value()) {
+        fileColStats.min =
+            makeIntegerVariant(columnKind, intStats->getMinimum().value());
+      }
+      if (intStats->getMaximum().has_value()) {
+        fileColStats.max =
+            makeIntegerVariant(columnKind, intStats->getMaximum().value());
+      }
+    } else if (
+        auto* dblStats =
+            dynamic_cast<const velox::dwio::common::DoubleColumnStatistics*>(
+                readerStats.get())) {
+      if (dblStats->getMinimum().has_value()) {
+        fileColStats.min = velox::Variant(dblStats->getMinimum().value());
+      }
+      if (dblStats->getMaximum().has_value()) {
+        fileColStats.max = velox::Variant(dblStats->getMaximum().value());
+      }
+    } else if (
+        auto* strStats =
+            dynamic_cast<const velox::dwio::common::StringColumnStatistics*>(
+                readerStats.get())) {
+      if (strStats->getMinimum().has_value()) {
+        fileColStats.min = velox::Variant::create<velox::TypeKind::VARCHAR>(
+            strStats->getMinimum().value());
+      }
+      if (strStats->getMaximum().has_value()) {
+        fileColStats.max = velox::Variant::create<velox::TypeKind::VARCHAR>(
+            strStats->getMaximum().value());
+      }
+    }
+
+    fileInfo->columnStats[name] = std::move(fileColStats);
+  }
+}
+
+velox::RowTypePtr parseSchema(const folly::dynamic& obj) {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+
+  auto parseColumn = [&](const auto& column) {
+    names.push_back(column["name"].asString());
+    types.push_back(
+        velox::ISerializable::deserialize<velox::Type>(column["type"]));
+  };
+
+  for (const auto& column : obj["dataColumns"]) {
+    parseColumn(column);
+  }
+
+  for (const auto& column : obj["partitionColumns"]) {
+    parseColumn(column);
+  }
+
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+bool isMixedOrder(const ColumnStatistics& stats) {
+  return stats.ascendingPct.has_value() && stats.descendingPct.has_value() &&
+      stats.ascendingPct.value() > 0 && stats.descendingPct.value() > 0;
+}
+
+bool isInteger(velox::TypeKind kind) {
+  switch (kind) {
+    case velox::TypeKind::TINYINT:
+    case velox::TypeKind::SMALLINT:
+    case velox::TypeKind::INTEGER:
+    case velox::TypeKind::BIGINT:
+      return true;
+    default:
+      return false;
+  }
+}
+
+template <typename T>
+T numericValue(const velox::Variant& v) {
+  switch (v.kind()) {
+    case velox::TypeKind::TINYINT:
+      return static_cast<T>(v.value<velox::TypeKind::TINYINT>());
+    case velox::TypeKind::SMALLINT:
+      return static_cast<T>(v.value<velox::TypeKind::SMALLINT>());
+    case velox::TypeKind::INTEGER:
+      return static_cast<T>(v.value<velox::TypeKind::INTEGER>());
+    case velox::TypeKind::BIGINT:
+      return static_cast<T>(v.value<velox::TypeKind::BIGINT>());
+    case velox::TypeKind::REAL:
+      return static_cast<T>(v.value<velox::TypeKind::REAL>());
+    case velox::TypeKind::DOUBLE:
+      return static_cast<T>(v.value<velox::TypeKind::DOUBLE>());
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+} // namespace
+
+LocalTableBuilder::LocalTableBuilder(
+    velox::memory::MemoryPool* pool,
+    velox::dwio::common::FileFormat fileFormat,
+    velox::connector::hive::HiveConnector* connector,
+    float samplePct)
+    : pool_(pool),
+      fileFormat_(fileFormat),
+      connector_(connector),
+      samplePct_(samplePct) {}
+
+void LocalTableBuilder::build(const std::string& tablePath) {
+  velox::RowTypePtr tableType;
+
+  // Check if .schema already exists and read it.
+  const auto schemaFile = schemaPath(tablePath);
+  const bool hasSchema = std::filesystem::exists(schemaFile);
+  if (hasSchema) {
+    auto dynamics = readConcatenatedDynamicsFromFile(schemaFile);
+    VELOX_CHECK(!dynamics.empty(), "Empty schema file: {}", schemaFile);
+    tableType = parseSchema(dynamics[0]);
+  }
+
+  // List all data files.
+  std::vector<std::unique_ptr<const FileInfo>> files;
+  FileInfo::listFiles(
+      tablePath, /*parseBucketNumber=*/nullptr, tablePath.size(), files);
+  VELOX_CHECK(!files.empty(), "Table directory is empty: {}", tablePath);
+
+  uint64_t totalRows{0};
+
+  // Aggregate per-column stats across all files, keyed by column name.
+  folly::F14FastMap<std::string, ColumnStatistics> aggregatedStats;
+
+  for (auto& info : files) {
+    velox::dwio::common::ReaderOptions readerOptions{pool_};
+    readerOptions.setFileFormat(fileFormat_);
+
+    if (fileFormat_ == velox::dwio::common::FileFormat::TEXT && tableType) {
+      readerOptions.setFileSchema(tableType);
+    }
+
+    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+        std::make_shared<velox::LocalReadFile>(info->path),
+        readerOptions.memoryPool());
+    std::unique_ptr<velox::dwio::common::Reader> reader =
+        velox::dwio::common::getReaderFactory(readerOptions.fileFormat())
+            ->createReader(std::move(input), readerOptions);
+
+    const auto& fileType = reader->rowType();
+
+    // Merge schema: take the widest (most columns).
+    if (!tableType) {
+      tableType = fileType;
+    } else if (fileType->size() > tableType->size()) {
+      tableType = fileType;
+    }
+
+    const auto rows = reader->numberOfRows();
+    if (rows.has_value()) {
+      totalRows += rows.value();
+    }
+
+    auto* mutableInfo = const_cast<FileInfo*>(info.get());
+    mutableInfo->numRows = rows;
+
+    populateFileColumnStats(*reader, *fileType, mutableInfo, rows);
+
+    // Merge file-level column stats into aggregated stats.
+    for (const auto& [name, colStats] : mutableInfo->columnStats) {
+      auto it = aggregatedStats.find(name);
+      if (it == aggregatedStats.end()) {
+        aggregatedStats[name] = colStats;
+      } else {
+        mergeColumnStatsValues(it->second, colStats);
+      }
+    }
+  }
+
+  // Write .schema if it doesn't exist.
+  if (!hasSchema) {
+    writeSchemaFile(tablePath, tableType, fileFormat_);
+  }
+
+  // Build ordered column stats vector matching the schema column order.
+  std::vector<ColumnStatistics> orderedStats;
+  orderedStats.reserve(tableType->size());
+  for (auto i = 0; i < tableType->size(); ++i) {
+    const auto& name = tableType->nameOf(i);
+    auto it = aggregatedStats.find(name);
+    if (it != aggregatedStats.end()) {
+      orderedStats.push_back(it->second);
+    } else {
+      ColumnStatistics empty;
+      empty.name = name;
+      orderedStats.push_back(empty);
+    }
+  }
+
+  // Remove any existing .stats file and write fresh stats.
+  const auto statsFile = statsPath(tablePath);
+  if (std::filesystem::exists(statsFile)) {
+    std::filesystem::remove(statsFile);
+  }
+  PersistedStats::write(tablePath, {totalRows, std::move(orderedStats)});
+
+  // Sample for NDV estimates if configured.
+  if (connector_ != nullptr) {
+    sampleNumDistincts(tablePath, tableType, totalRows);
+  }
+}
+
+void LocalTableBuilder::sampleNumDistincts(
+    const std::string& tablePath,
+    const velox::RowTypePtr& schema,
+    uint64_t totalRows) {
+  if (totalRows == 0) {
+    return;
+  }
+
+  float pct = samplePct_;
+  if (totalRows > 1'000'000) {
+    pct = std::min(pct, 100.0f * 100'000 / totalRows);
+  }
+
+  // Build column handles for all columns.
+  velox::connector::ColumnHandleMap columnHandles;
+  for (auto i = 0; i < schema->size(); ++i) {
+    const auto& name = schema->nameOf(i);
+    const auto& type = schema->childAt(i);
+    columnHandles[name] =
+        std::make_shared<velox::connector::hive::HiveColumnHandle>(
+            name,
+            velox::connector::hive::HiveColumnHandle::ColumnType::kRegular,
+            type,
+            type);
+  }
+
+  // Create a table handle with no filters.
+  auto tableHandle = std::make_shared<velox::connector::hive::HiveTableHandle>(
+      connector_->connectorId(),
+      "local_table_builder",
+      velox::common::SubfieldFilters{},
+      /*remainingFilter=*/nullptr);
+
+  // Create a ConnectorQueryCtx for sampling.
+  velox::common::SpillConfig spillConfig;
+  velox::common::PrefixSortConfig prefixSortConfig;
+  // Use an empty config for session properties during sampling.
+  auto sessionProperties = std::make_shared<velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto connectorQueryCtx =
+      std::make_shared<velox::connector::ConnectorQueryCtx>(
+          pool_,
+          pool_,
+          sessionProperties.get(),
+          &spillConfig,
+          prefixSortConfig,
+          /*expressionEvaluator=*/nullptr,
+          /*cache=*/nullptr,
+          "local_table_builder",
+          "local_table_builder",
+          "N/a",
+          0,
+          "");
+
+  // Create statistics builders for each column.
+  auto allocator = std::make_unique<velox::HashStringAllocator>(pool_);
+  StatisticsBuilderOptions builderOptions = {
+      .maxStringLength = 100,
+      .countDistincts = true,
+      .allocator = allocator.get()};
+
+  std::vector<std::unique_ptr<connector::StatisticsBuilder>> builders;
+  builders.reserve(schema->size());
+  for (auto i = 0; i < schema->size(); ++i) {
+    builders.push_back(
+        connector::StatisticsBuilder::create(
+            schema->childAt(i), builderOptions));
+  }
+
+  // List files and scan them.
+  std::vector<std::unique_ptr<const FileInfo>> files;
+  FileInfo::listFiles(
+      tablePath, /*parseBucketNumber=*/nullptr, tablePath.size(), files);
+
+  const auto maxRowsToScan = static_cast<int64_t>(totalRows * (pct / 100));
+  int64_t scannedRows{0};
+  int64_t numSampledRows{0};
+
+  for (const auto& file : files) {
+    auto dataSource = connector_->createDataSource(
+        schema, tableHandle, columnHandles, connectorQueryCtx.get());
+
+    auto split = velox::connector::hive::HiveConnectorSplitBuilder(file->path)
+                     .fileFormat(fileFormat_)
+                     .connectorId(connector_->connectorId())
+                     .build();
+    dataSource->addSplit(split);
+
+    constexpr int32_t kBatchSize = 1'000;
+    for (;;) {
+      velox::ContinueFuture ignore{velox::ContinueFuture::makeEmpty()};
+      auto data = dataSource->next(kBatchSize, ignore).value();
+      if (data == nullptr) {
+        scannedRows += dataSource->getCompletedRows();
+        break;
+      }
+
+      numSampledRows += data->size();
+      connector::StatisticsBuilder::updateBuilders(data, builders);
+
+      if (scannedRows + dataSource->getCompletedRows() > maxRowsToScan) {
+        scannedRows += dataSource->getCompletedRows();
+        break;
+      }
+    }
+  }
+
+  // Read existing stats, add NDV estimates, and write back.
+  auto existingStats = PersistedStats::read(tablePath);
+  VELOX_CHECK(existingStats.has_value(), "Stats file not found: {}", tablePath);
+
+  for (size_t i = 0; i < builders.size(); ++i) {
+    if (!builders[i]) {
+      continue;
+    }
+
+    ColumnStatistics builderStats;
+    builders[i]->build(builderStats);
+
+    auto estimate = builderStats.numDistinct;
+    int64_t approxNumDistinct =
+        estimate.has_value() ? estimate.value() : totalRows;
+
+    // For tiny tables the sample is 100% and the approxNumDistinct is
+    // accurate. For partial samples, the distinct estimate is left to be the
+    // distinct estimate of the sample if there are few distincts. This is an
+    // enumeration where values in unsampled rows are likely the same. If
+    // there are many distincts, we multiply by 1/sample rate assuming that
+    // unsampled rows will mostly have new values.
+    if (numSampledRows < static_cast<int64_t>(totalRows)) {
+      if (approxNumDistinct > numSampledRows / 50) {
+        float numDups = numSampledRows / static_cast<float>(approxNumDistinct);
+        approxNumDistinct = std::min<float>(totalRows, totalRows / numDups);
+
+        // If the type is an integer type, num distincts cannot be larger than
+        // max - min.
+        if (isInteger(builders[i]->type()->kind())) {
+          auto min = builderStats.min;
+          auto max = builderStats.max;
+          if (min.has_value() && max.has_value() &&
+              isMixedOrder(builderStats)) {
+            auto range = numericValue<float>(max.value()) -
+                numericValue<float>(min.value());
+            approxNumDistinct = std::min<float>(approxNumDistinct, range);
+          }
+        }
+      }
+    }
+
+    // Find matching column in persisted stats and update numDistinct.
+    const auto& name = schema->nameOf(i);
+    for (auto& colStats : existingStats->columns) {
+      if (colStats.name == name) {
+        colStats.numDistinct = approxNumDistinct;
+        break;
+      }
+    }
+  }
+
+  // Write back the updated stats (overwrite, not merge).
+  const auto statsFile = statsPath(tablePath);
+  std::ofstream outputFile(statsFile);
+  VELOX_CHECK(outputFile.is_open(), "Failed to open stats file: {}", statsFile);
+  outputFile << folly::toPrettyJson(persistedStatsToJson(*existingStats));
+  outputFile.close();
+  VELOX_CHECK(!outputFile.fail(), "Failed to write stats file: {}", statsFile);
+}
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalTableBuilder.h
+++ b/axiom/connectors/hive/LocalTableBuilder.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::axiom::connector::hive {
+
+/// Scans a directory of data files to produce .schema and .stats metadata
+/// artifacts. After building, the table directory contains everything
+/// LocalHiveConnectorMetadata needs to serve queries without reading file
+/// headers at init time.
+///
+/// Usage:
+///   LocalTableBuilder builder(pool, fileFormat, connector);
+///   builder.build("/path/to/table_dir");
+///
+/// Reads all data files, infers schema from file headers, collects
+/// per-column statistics (min, max, null count), estimates NDV by
+/// sampling, and writes .schema and .stats files.
+class LocalTableBuilder {
+ public:
+  /// Constructs a builder. 'pool' is used for DWIO readers and sampling.
+  /// 'fileFormat' is the file format (e.g., DWRF, PARQUET); all data files in
+  /// the table directory are expected to use this format. 'connector' is used
+  /// for creating data sources during NDV sampling (only public APIs are used).
+  /// Pass nullptr to skip NDV sampling. 'samplePct' is the percentage of rows
+  /// to sample (automatically reduced for tables > 1M rows).
+  LocalTableBuilder(
+      velox::memory::MemoryPool* pool,
+      velox::dwio::common::FileFormat fileFormat,
+      velox::connector::hive::HiveConnector* connector = nullptr,
+      float samplePct = 10.0f);
+
+  /// Scans data files in 'tablePath', infers schema from file headers and
+  /// computes column statistics. Writes .schema and .stats files. If .schema
+  /// already exists, uses it instead of inferring from file headers. Overwrites
+  /// any existing .stats file. All files must have the same schema. Currently
+  /// supports unpartitioned tables only.
+  void build(const std::string& tablePath);
+
+ private:
+  // Samples data to estimate NDV for each column. Uses the connector's
+  // public createDataSource() API. Updates the .stats file with NDV estimates.
+  void sampleNumDistincts(
+      const std::string& tablePath,
+      const velox::RowTypePtr& schema,
+      uint64_t totalRows);
+
+  // Memory pool for DWIO readers and sampling.
+  velox::memory::MemoryPool* const pool_;
+
+  // File format for reading data files. All files are expected to use the
+  // same format.
+  const velox::dwio::common::FileFormat fileFormat_;
+
+  // Hive connector for creating data sources during NDV sampling.
+  velox::connector::hive::HiveConnector* const connector_;
+
+  // Percentage of rows to sample for NDV estimation.
+  const float samplePct_;
+};
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalTableMetadata.cpp
+++ b/axiom/connectors/hive/LocalTableMetadata.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/LocalTableMetadata.h"
+
+#include <fstream>
+
+#include <folly/Conv.h>
+#include <folly/json.h>
+
+#include "velox/common/base/Fs.h"
+
+namespace facebook::axiom::connector::hive {
+
+std::string schemaPath(std::string_view path) {
+  return fmt::format("{}/.schema", path);
+}
+
+namespace {
+
+std::string statsPath(const std::string& path) {
+  return fmt::format("{}/.stats", path);
+}
+
+folly::dynamic columnStatsToJson(const ColumnStatistics& stats) {
+  folly::dynamic json = folly::dynamic::object;
+  json["name"] = stats.name;
+  json["numValues"] = stats.numValues;
+  json["nullPct"] = stats.nullPct;
+  if (stats.min.has_value()) {
+    json["min"] = stats.min->serialize();
+  }
+  if (stats.max.has_value()) {
+    json["max"] = stats.max->serialize();
+  }
+  if (stats.numDistinct.has_value()) {
+    json["numDistinct"] = stats.numDistinct.value();
+  }
+  if (stats.maxLength.has_value()) {
+    json["maxLength"] = stats.maxLength.value();
+  }
+  if (stats.avgLength.has_value()) {
+    json["avgLength"] = stats.avgLength.value();
+  }
+  return json;
+}
+
+folly::dynamic persistedStatsToJson(const PersistedStats& stats) {
+  folly::dynamic columns = folly::dynamic::array;
+  for (const auto& colStats : stats.columns) {
+    columns.push_back(columnStatsToJson(colStats));
+  }
+  folly::dynamic json = folly::dynamic::object;
+  json["numRows"] = stats.numRows;
+  json["columns"] = std::move(columns);
+  return json;
+}
+
+ColumnStatistics columnStatsFromJson(const folly::dynamic& json) {
+  ColumnStatistics stats;
+  stats.name = json["name"].asString();
+  stats.numValues = json["numValues"].asInt();
+  stats.nullPct = json["nullPct"].asDouble();
+  if (json.count("min")) {
+    stats.min = velox::Variant::create(json["min"]);
+  }
+  if (json.count("max")) {
+    stats.max = velox::Variant::create(json["max"]);
+  }
+  if (json.count("numDistinct")) {
+    stats.numDistinct = json["numDistinct"].asInt();
+  }
+  if (json.count("maxLength")) {
+    stats.maxLength = json["maxLength"].asInt();
+  }
+  if (json.count("avgLength")) {
+    stats.avgLength = json["avgLength"].asInt();
+  }
+  return stats;
+}
+
+PersistedStats persistedStatsFromJson(const folly::dynamic& json) {
+  PersistedStats result;
+  result.numRows = json["numRows"].asInt();
+  for (const auto& colJson : json["columns"]) {
+    result.columns.push_back(columnStatsFromJson(colJson));
+  }
+  return result;
+}
+
+void mergeColumnStatsValues(
+    ColumnStatistics& target,
+    const ColumnStatistics& source) {
+  target.numValues += source.numValues;
+
+  if (source.min.has_value()) {
+    if (!target.min.has_value() || source.min.value() < target.min.value()) {
+      target.min = source.min;
+    }
+  }
+  if (source.max.has_value()) {
+    if (!target.max.has_value() || target.max.value() < source.max.value()) {
+      target.max = source.max;
+    }
+  }
+
+  if (source.numDistinct.has_value()) {
+    target.numDistinct =
+        std::max(target.numDistinct.value_or(0), source.numDistinct.value());
+  }
+}
+
+void mergeColumnStats(
+    std::vector<ColumnStatistics>& existing,
+    const std::vector<ColumnStatistics>& incoming) {
+  folly::F14FastMap<std::string, size_t> nameToIndex;
+  for (size_t i = 0; i < existing.size(); ++i) {
+    nameToIndex[existing[i].name] = i;
+  }
+
+  for (const auto& stats : incoming) {
+    auto it = nameToIndex.find(stats.name);
+    if (it == nameToIndex.end()) {
+      nameToIndex[stats.name] = existing.size();
+      existing.push_back(stats);
+      continue;
+    }
+
+    mergeColumnStatsValues(existing[it->second], stats);
+  }
+}
+
+} // namespace
+
+std::optional<PersistedStats> PersistedStats::read(
+    const std::string& directory) {
+  const auto file = statsPath(directory);
+  if (!std::filesystem::exists(file)) {
+    return std::nullopt;
+  }
+  std::ifstream inputFile(file);
+  if (!inputFile.is_open()) {
+    return std::nullopt;
+  }
+  std::string content(
+      (std::istreambuf_iterator<char>(inputFile)),
+      std::istreambuf_iterator<char>());
+  return persistedStatsFromJson(folly::parseJson(content));
+}
+
+void PersistedStats::write(const std::string& directory, PersistedStats stats) {
+  auto existing = PersistedStats::read(directory);
+  if (existing.has_value()) {
+    stats.numRows += existing->numRows;
+    mergeColumnStats(existing->columns, stats.columns);
+    stats.columns = std::move(existing->columns);
+  }
+
+  const auto file = statsPath(directory);
+  std::ofstream outputFile(file);
+  VELOX_CHECK(outputFile.is_open(), "Failed to open stats file: {}", file);
+  outputFile << folly::toPrettyJson(persistedStatsToJson(stats));
+  outputFile.close();
+  VELOX_CHECK(!outputFile.fail(), "Failed to write stats file: {}", file);
+}
+
+void FileInfo::listFiles(
+    std::string_view path,
+    const std::function<int32_t(std::string_view)>& parseBucketNumber,
+    int32_t prefixSize,
+    std::vector<std::unique_ptr<const FileInfo>>& result) {
+  for (auto const& dirEntry : fs::directory_iterator{path}) {
+    // Ignore hidden files.
+    if (dirEntry.path().filename().c_str()[0] == '.') {
+      continue;
+    }
+
+    if (dirEntry.is_directory()) {
+      listFiles(
+          fmt::format("{}/{}", path, dirEntry.path().filename().c_str()),
+          parseBucketNumber,
+          prefixSize,
+          result);
+    }
+    if (!dirEntry.is_regular_file()) {
+      continue;
+    }
+    auto file = std::make_unique<FileInfo>();
+    file->path = fmt::format("{}/{}", path, dirEntry.path().filename().c_str());
+    if (parseBucketNumber) {
+      file->bucketNumber = parseBucketNumber(file->path);
+    }
+    std::vector<std::string> dirs;
+    folly::split('/', path.substr(prefixSize, path.size()), dirs);
+    for (auto& dir : dirs) {
+      std::vector<std::string> parts;
+      folly::split('=', dir, parts);
+      if (parts.size() == 2) {
+        file->partitionKeys[parts.at(0)] = parts.at(1);
+      }
+    }
+    result.push_back(std::move(file));
+  }
+}
+
+void writeSchemaFile(
+    const std::string& tablePath,
+    const velox::RowTypePtr& rowType,
+    velox::dwio::common::FileFormat fileFormat) {
+  folly::dynamic dataColumns = folly::dynamic::array();
+  for (auto i = 0; i < rowType->size(); ++i) {
+    folly::dynamic col = folly::dynamic::object();
+    col["name"] = rowType->nameOf(i);
+    col["type"] = rowType->childAt(i)->serialize();
+    dataColumns.push_back(col);
+  }
+
+  folly::dynamic schema = folly::dynamic::object;
+  schema["dataColumns"] = dataColumns;
+  schema["partitionColumns"] = folly::dynamic::array();
+  schema["fileFormat"] = std::string(velox::dwio::common::toString(fileFormat));
+
+  const auto file = schemaPath(tablePath);
+  std::ofstream outputFile(file);
+  VELOX_CHECK(outputFile.is_open(), "Failed to open schema file: {}", file);
+  outputFile << folly::toPrettyJson(schema);
+  outputFile.close();
+  VELOX_CHECK(!outputFile.fail(), "Failed to write schema file: {}", file);
+}
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalTableMetadata.h
+++ b/axiom/connectors/hive/LocalTableMetadata.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "folly/container/F14Map.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::connector::hive {
+
+/// Describes a file in a table. Used for split enumeration and stats
+/// collection.
+struct FileInfo {
+  /// Absolute path to the data file.
+  std::string path;
+
+  /// Partition key=value pairs parsed from parent directory names.
+  folly::F14FastMap<std::string, std::optional<std::string>> partitionKeys;
+
+  /// Bucket number extracted from the file name, if bucketed.
+  std::optional<int32_t> bucketNumber;
+
+  /// Row count from file header metadata.
+  std::optional<uint64_t> numRows;
+
+  /// Per-column stats from file header metadata, keyed by column name.
+  folly::F14FastMap<std::string, ColumnStatistics> columnStats;
+
+  /// Recursively lists files under 'path', populating FileInfo entries with
+  /// partition keys parsed from directory names (key=value format) and optional
+  /// bucket numbers.
+  static void listFiles(
+      std::string_view path,
+      const std::function<int32_t(std::string_view)>& parseBucketNumber,
+      int32_t prefixSize,
+      std::vector<std::unique_ptr<const FileInfo>>& result);
+};
+
+/// Table-level statistics persisted in .stats files.
+struct PersistedStats {
+  /// Total number of rows in the table or partition.
+  uint64_t numRows{0};
+
+  /// Per-column statistics (min, max, numValues, numDistinct, etc.).
+  std::vector<ColumnStatistics> columns;
+
+  /// Reads persisted stats from the .stats file in 'directory'. Returns
+  /// std::nullopt if the file doesn't exist.
+  static std::optional<PersistedStats> read(const std::string& directory);
+
+  /// Writes stats to a .stats file in 'directory', merging with any existing
+  /// stats from prior writes.
+  static void write(const std::string& directory, PersistedStats stats);
+};
+
+/// Returns the path to the .schema file in the given directory.
+std::string schemaPath(std::string_view path);
+
+/// Writes a minimal .schema file for the given row type and file format.
+/// All columns are treated as data columns (no partitioning or bucketing).
+void writeSchemaFile(
+    const std::string& tablePath,
+    const velox::RowTypePtr& rowType,
+    velox::dwio::common::FileFormat fileFormat);
+
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -109,8 +109,8 @@ For partitioned tables, data files are organized into subdirectories named
 ```
 /data/
 ├── orders/
-│   ├── .schema              # optional: schema and table properties
-│   ├── .stats               # optional: persisted write-time statistics
+│   ├── .schema              # schema and table properties
+│   ├── .stats               # persisted write-time statistics
 │   ├── file1.parquet
 │   └── file2.parquet
 ├── lineitem/
@@ -122,13 +122,16 @@ For partitioned tables, data files are organized into subdirectories named
 │       ├── .stats
 │       └── data.parquet
 └── users/
-    └── data.parquet          # no .schema: schema inferred from files
+    ├── .schema               # required: schema and table properties
+    ├── .stats                # required: persisted statistics
+    └── data.parquet
 ```
 
-If a table directory contains a `.schema` file, column definitions, partition
-and bucketing information, and file format are read from it. Otherwise, the
-schema is inferred from data files, file format defaults to `--data_format`,
-and no bucketing or Hive partitioning is assumed.
+Every table directory must contain a `.schema` file with column definitions,
+partition and bucketing information, and file format. A `.stats` file with
+row counts and per-column statistics is also required. Both files are produced
+automatically by the write pipeline (`CREATE TABLE`, `INSERT INTO`) or by
+`LocalTableBuilder::build()` for externally created data.
 
 ## .schema File Format
 
@@ -188,8 +191,7 @@ CLI flag.
 ## .stats File Format
 
 The `.stats` file is JSON with per-table or per-partition statistics. It is
-written by `INSERT INTO` and `CREATE TABLE AS SELECT` and read at load time
-when `hive_use_write_time_stats` is enabled (default).
+written by `INSERT INTO` and `CREATE TABLE AS SELECT` and read at load time.
 
 For unpartitioned tables, a single `.stats` file is placed in the table
 directory. For partitioned tables, each partition directory has its own
@@ -317,38 +319,30 @@ DROP TABLE t;
 
 ## Statistics
 
-The local implementation supports two statistics paths, controlled by the
-`hive_use_write_time_stats` config (default: `true`).
+Tables require `.schema` and `.stats` metadata files. These are produced in
+two ways:
 
-### Write-time stats (default)
+### Write pipeline (CREATE TABLE, INSERT INTO)
 
 Tables created through the write pipeline (`CREATE TABLE`, `INSERT INTO`)
-produce `.stats` files alongside the data. These files store per-partition
-row counts and per-column statistics (min, max, count, NDV). At load time,
-statistics are read directly from `.stats` files without opening data files.
-
-This path requires a `.schema` file.
+produce `.schema` and `.stats` files automatically. The `.stats` files store
+per-partition row counts and per-column statistics (min, max, count, NDV).
+At load time, statistics are read directly from these files without opening
+data files.
 
 - **Cost estimation**: The optimizer applies partition key filters to the
   persisted partition stats, merges column stats across matching partitions,
   and computes null percentages. NDV is merged using max across partitions.
   TODO: Replace NDV max with HLL sketch merging for accurate union.
 
-### File-header stats
+### LocalTableBuilder (external data)
 
-When write-time stats are disabled (`hive_use_write_time_stats = false`),
-statistics are collected from file headers at load time:
+For tables created outside the write pipeline (e.g., data files dropped into
+a directory), use `LocalTableBuilder` to generate `.schema` and `.stats`
+files. The builder reads file headers to infer schema and collect per-column
+statistics, and optionally samples data to estimate NDV.
 
-- **File-header stats**: Row counts are read from file metadata without
-  reading the data itself. DWRF files also provide per-column stats: null
-  counts and min/max values. Parquet files currently provide only row counts
-  at the file level. TODO: implement file-level `columnStatistics()` in the
-  Parquet reader.
-- **Sampling**: A percentage of rows is read from each table to estimate NDV
-  and other column-level statistics. For tables with more than 1M rows,
-  approximately 100K rows are sampled; for smaller tables, 10% of rows are
-  sampled. This can slow down startup significantly for large datasets.
-  TODO: defer sampling until the optimizer needs it.
-- **Cost estimation**: The optimizer uses partition key filters and `$path` /
-  `$bucket` filters to skip irrelevant files, then aggregates per-file stats
-  to produce cost estimates without reading data.
+```cpp
+LocalTableBuilder builder(pool, fileFormat, connector);
+builder.build("/path/to/table_dir");
+```

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
+#include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/tests/FeatureGen.h"
@@ -106,10 +107,6 @@ class SubfieldTest : public HiveQueriesTestBase,
                      public testing::WithParamInterface<int32_t> {
  protected:
   static void SetUpTestCase() {
-    // Disable write-time stats because this test creates tables by writing
-    // files directly (not via CTAS), so no .stats files are produced.
-    hiveConfig_[connector::hive::HiveMetadataConfig::kUseWriteTimeStats] =
-        "false";
     HiveQueriesTestBase::SetUpTestCase();
 
     localFileFormat_ = velox::dwio::common::FileFormat::DWRF;
@@ -316,11 +313,22 @@ class SubfieldTest : public HiveQueriesTestBase,
       const std::shared_ptr<dwrf::Config>& config =
           std::make_shared<dwrf::Config>()) {
     auto fs = filesystems::getFileSystem(localDataPath_, {});
-    fs->mkdir(fmt::format("{}/{}", localDataPath_, name));
+    const auto tablePath = fmt::format("{}/{}", localDataPath_, name);
+    fs->mkdir(tablePath);
 
-    const auto filePath =
-        fmt::format("{}/{}/{}.dwrf", localDataPath_, name, name);
+    const auto filePath = fmt::format("{}/{}.dwrf", tablePath, name);
     writeToFile(filePath, vectors, config);
+
+    // Write .schema and .stats metadata so that
+    // LocalHiveConnectorMetadata::loadTable() can load the table.
+    connector::hive::writeSchemaFile(
+        tablePath, vectors[0]->rowType(), dwio::common::FileFormat::DWRF);
+
+    uint64_t totalRows = 0;
+    for (const auto& vector : vectors) {
+      totalRows += vector->size();
+    }
+    connector::hive::PersistedStats::write(tablePath, {totalRows, {}});
 
     // Re-read the data directory to pick up the new table.
     hiveMetadata().reinitialize();

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -17,6 +17,7 @@
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
@@ -75,10 +76,6 @@ void LocalRunnerTestBase::setupConnector() {
       tempDirectory_->getPath();
   configs[connector::hive::HiveMetadataConfig::kLocalFileFormat] =
       velox::dwio::common::toString(velox::dwio::common::FileFormat::DWRF);
-  // Disable write-time stats since makeTables() generates data files without
-  // .schema or .stats files.
-  configs[connector::hive::HiveMetadataConfig::kUseWriteTimeStats] = "false";
-
   resetHiveConnector(
       std::make_shared<velox::config::ConfigBase>(std::move(configs)));
 
@@ -114,6 +111,18 @@ void LocalRunnerTestBase::makeTables(const std::vector<TableSpec>& specs) {
       auto filePath = fmt::format("{}/f{}", tablePath, i);
       writeToFile(filePath, vectors);
     }
+  }
+
+  // Write .schema and .stats metadata for each table so that
+  // LocalHiveConnectorMetadata can load them.
+  for (const auto& spec : specs) {
+    const auto tablePath = fmt::format("{}/{}", dataPath, spec.name);
+    connector::hive::writeSchemaFile(
+        tablePath, spec.columns, velox::dwio::common::FileFormat::DWRF);
+
+    const uint64_t totalRows = static_cast<uint64_t>(spec.rowsPerVector) *
+        spec.numVectorsPerFile * spec.numFiles;
+    connector::hive::PersistedStats::write(tablePath, {totalRows, {}});
   }
 }
 


### PR DESCRIPTION
Summary:

Extract file-discovery, schema-inference, and stats-collection logic from
LocalHiveConnectorMetadata into two new classes:

- LocalTableMetadata — shared utilities for .schema/.stats file I/O, file
  listing, stats merging (PersistedStats, FileInfo, schemaPath, statsPath,
  persistStats, readPersistedStats, listFiles, etc.).

- LocalTableBuilder — scans a directory of data files, infers schema from
  file headers, collects per-column statistics, estimates NDV by sampling,
  and writes .schema + .stats metadata artifacts.

LocalHiveConnectorMetadata::loadTable() is simplified to always read
pre-built .schema + .stats artifacts. It no longer infers schema from file
headers or samples for NDV at load time. The write pipeline (createTable +
finishWrite) continues to produce these artifacts as before.

The useWriteTimeStats config option is removed since all tables now use
write-time stats.

Reviewed By: xiaoxmeng

Differential Revision: D97187939


