### PR TITLE
feat: Convert SplitManager/SplitSource APIs to coroutines (#1152)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,10 @@ include_directories(SYSTEM velox/velox/external/xxhash axiom)
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 include_directories(${ANTLR4_INCLUDE_DIR})
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
+endif()
+
 add_subdirectory(velox)
 add_subdirectory(axiom/common)
 add_subdirectory(axiom/sql/presto)

--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -18,4 +18,4 @@ endif()
 
 add_library(axiom_common SchemaTableName.cpp CatalogSchemaTableName.cpp Session.cpp)
 
-target_link_libraries(axiom_common velox_common_base Folly::folly fmt::fmt)
+target_link_libraries(axiom_common velox_common_base Folly::folly)

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -28,4 +28,11 @@ endif()
 
 add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp)
 
-target_link_libraries(axiom_connectors axiom_common velox_common_base velox_memory velox_connector)
+target_link_libraries(
+  axiom_connectors
+  axiom_common
+  velox_common_base
+  velox_memory
+  velox_connector
+  Folly::folly
+)

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -15,30 +15,38 @@
  */
 #pragma once
 
+#include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
 
+/// A batch of splits returned by SplitSource::co_getSplits.
+struct SplitBatch {
+  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+
+  /// True when there are no more splits to return (for the requested bucket,
+  /// or globally if no bucket was specified).
+  bool noMoreSplits{false};
+};
+
 /// Enumerates splits. The table and partitions to cover are given to
 /// ConnectorSplitManager.
 class SplitSource {
  public:
-  static constexpr uint32_t kUngroupedGroupId =
-      std::numeric_limits<uint32_t>::max();
-
-  /// Result of getSplits. Each split belongs to a group. A nullptr split for
-  /// group means that there are no more splits for the group. In ungrouped
-  /// execution, the group is always kUngroupedGroupId.
-  struct SplitAndGroup {
-    std::shared_ptr<velox::connector::ConnectorSplit> split;
-    uint32_t group{kUngroupedGroupId};
-  };
+  static constexpr int32_t kNoBucket = -1;
 
   virtual ~SplitSource() = default;
 
-  /// Returns a set of splits that cover up to 'targetBytes' of data.
-  virtual std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) = 0;
+  /// Returns up to 'maxSplitCount' splits, or fewer if the source is
+  /// exhausted. Sets SplitBatch::noMoreSplits when no further splits remain.
+  /// If 'bucket' is specified, returns only splits for that bucket.
+  virtual folly::coro::Task<SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t bucket = kNoBucket) = 0;
+
+  /// Cancel the split source and interrupt all background activity.
+  virtual void cancel() {}
 };
 
 /// Options for split generation.
@@ -69,7 +77,7 @@ class ConnectorSplitManager {
 
   /// Returns a list of all partitions that match the filters in
   /// 'tableHandle'. A non-partitioned table returns one partition.
-  virtual std::vector<PartitionHandlePtr> listPartitions(
+  virtual folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) = 0;
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -33,12 +33,14 @@
 
 namespace facebook::axiom::connector::hive {
 
-std::vector<PartitionHandlePtr> LocalHiveSplitManager::listPartitions(
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+LocalHiveSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
   // All tables are unpartitioned.
   folly::F14FastMap<std::string, std::optional<std::string>> empty;
-  return {std::make_shared<HivePartitionHandle>(empty, std::nullopt)};
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<HivePartitionHandle>(empty, std::nullopt)};
 }
 
 namespace {
@@ -353,71 +355,53 @@ T ceil2(T x, T y) {
 }
 } // namespace
 
-std::vector<SplitSource::SplitAndGroup> LocalHiveSplitSource::getSplits(
-    uint64_t targetBytes) {
-  std::vector<SplitAndGroup> result;
-  uint64_t bytes = 0;
-  for (;;) {
-    if (currentFile_ >= static_cast<int32_t>(files_.size())) {
-      result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-      return result;
-    }
-
-    if (currentSplit_ >= fileSplits_.size()) {
-      fileSplits_.clear();
-      ++currentFile_;
-      if (currentFile_ >= files_.size()) {
-        result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-        return result;
-      }
-
-      currentSplit_ = 0;
-      const auto& filePath = files_[currentFile_]->path;
-      const auto fileSize = fs::file_size(filePath);
-      int64_t splitsPerFile =
-          ceil2<uint64_t>(fileSize, options_.fileBytesPerSplit);
-      if (options_.targetSplitCount) {
-        auto numFiles = files_.size();
-        if (splitsPerFile * numFiles < options_.targetSplitCount) {
-          // Divide the file into more splits but still not smaller than 64MB.
-          auto perFile = ceil2<uint64_t>(options_.targetSplitCount, numFiles);
-          int64_t bytesInSplit = ceil2<uint64_t>(fileSize, perFile);
-          splitsPerFile = ceil2<uint64_t>(
-              fileSize, std::max<uint64_t>(bytesInSplit, 32 << 20));
-        }
-      }
-      // Take the upper bound.
-      const int64_t splitSize = ceil2<uint64_t>(fileSize, splitsPerFile);
-      for (int i = 0; i < splitsPerFile; ++i) {
-        auto builder =
-            velox::connector::hive::HiveConnectorSplitBuilder(filePath)
-                .connectorId(connectorId_)
-                .fileFormat(format_)
-                .start(i * splitSize)
-                .length(splitSize);
-
-        auto* info = files_[currentFile_];
-        if (info->bucketNumber.has_value()) {
-          builder.tableBucketNumber(info->bucketNumber.value());
-        }
-        for (auto& pair : info->partitionKeys) {
-          builder.partitionKey(pair.first, pair.second);
-        }
-        if (!serdeParameters_.empty()) {
-          builder.serdeParameters(serdeParameters_);
-        }
-        fileSplits_.push_back(builder.build());
+folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
+    uint32_t maxSplitCount,
+    int32_t /*bucket*/) {
+  SplitBatch batch;
+  const size_t limit = maxSplitCount;
+  while (batch.splits.size() < limit && fileIdx_ < files_.size()) {
+    const auto& filePath = files_[fileIdx_]->path;
+    const auto fileSize = fs::file_size(filePath);
+    int64_t splitsPerFile =
+        ceil2<uint64_t>(fileSize, options_.fileBytesPerSplit);
+    if (options_.targetSplitCount) {
+      auto numFiles = files_.size();
+      if (splitsPerFile * numFiles < options_.targetSplitCount) {
+        auto perFile = ceil2<uint64_t>(options_.targetSplitCount, numFiles);
+        int64_t bytesInSplit = ceil2<uint64_t>(fileSize, perFile);
+        splitsPerFile = ceil2<uint64_t>(
+            fileSize, std::max<uint64_t>(bytesInSplit, 32 << 20));
       }
     }
-    result.push_back(SplitAndGroup{std::move(fileSplits_[currentSplit_++]), 0});
-    bytes +=
-        reinterpret_cast<const velox::connector::hive::HiveConnectorSplit*>(
-            result.back().split.get())
-            ->length;
-    if (bytes > targetBytes) {
-      return result;
+    const int64_t splitSize = ceil2<uint64_t>(fileSize, splitsPerFile);
+    while (splitWithinFile_ < splitsPerFile && batch.splits.size() < limit) {
+      auto builder = velox::connector::hive::HiveConnectorSplitBuilder(filePath)
+                         .connectorId(connectorId_)
+                         .fileFormat(format_)
+                         .start(splitWithinFile_ * splitSize)
+                         .length(splitSize);
+
+      auto* info = files_[fileIdx_];
+      if (info->bucketNumber.has_value()) {
+        builder.tableBucketNumber(info->bucketNumber.value());
+      }
+      for (auto& pair : info->partitionKeys) {
+        builder.partitionKey(pair.first, pair.second);
+      }
+      if (!serdeParameters_.empty()) {
+        builder.serdeParameters(serdeParameters_);
+      }
+      batch.splits.push_back(builder.build());
+      ++splitWithinFile_;
+    }
+    if (splitWithinFile_ >= splitsPerFile) {
+      ++fileIdx_;
+      splitWithinFile_ = 0;
     }
   }
+  batch.noMoreSplits = (fileIdx_ >= files_.size());
+  co_return batch;
 }
 
 LocalHiveConnectorMetadata::LocalHiveConnectorMetadata(

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -45,8 +45,9 @@ class LocalHiveSplitSource : public SplitSource {
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::Task<SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t /*bucket*/) override;
 
  private:
   const SplitOptions options_;
@@ -54,9 +55,8 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> fileSplits_;
-  int32_t currentFile_{-1};
-  int32_t currentSplit_{0};
+  size_t fileIdx_{0};
+  int64_t splitWithinFile_{0};
 };
 
 class LocalHiveConnectorMetadata;
@@ -65,7 +65,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
  public:
   explicit LocalHiveSplitManager(LocalHiveConnectorMetadata* /* metadata */) {}
 
-  std::vector<PartitionHandlePtr> listPartitions(
+  folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -99,25 +99,24 @@ SystemTable::SystemTable(velox::connector::Connector* connector)
 // ===================== SystemSplitSource / SystemSplitManager
 // =====================
 
-std::vector<SplitSource::SplitAndGroup> SystemSplitSource::getSplits(
-    uint64_t /*targetBytes*/) {
-  std::vector<SplitAndGroup> result;
+folly::coro::Task<SplitBatch> SystemSplitSource::co_getSplits(
+    uint32_t /*maxSplitCount*/,
+    int32_t /*bucket*/) {
+  SplitBatch batch;
   if (!done_) {
-    result.push_back(
-        {std::make_shared<SystemSplit>(connectorId_), kUngroupedGroupId});
+    batch.splits.push_back(std::make_shared<SystemSplit>(connectorId_));
     done_ = true;
   }
-  if (result.empty()) {
-    // Signal end-of-splits.
-    result.push_back({nullptr, kUngroupedGroupId});
-  }
-  return result;
+  batch.noMoreSplits = true;
+  co_return batch;
 }
 
-std::vector<PartitionHandlePtr> SystemSplitManager::listPartitions(
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+SystemSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
-  return {std::make_shared<PartitionHandle>()};
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -88,7 +88,9 @@ class SystemSplitSource : public SplitSource {
   explicit SystemSplitSource(const std::string& connectorId)
       : connectorId_(connectorId) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) override;
+  folly::coro::Task<SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t /*bucket*/) override;
 
  private:
   const std::string connectorId_;
@@ -98,7 +100,7 @@ class SystemSplitSource : public SplitSource {
 /// SplitManager that returns a single partition and a single split.
 class SystemSplitManager : public ConnectorSplitManager {
  public:
-  std::vector<PartitionHandlePtr> listPartitions(
+  folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <folly/coro/Task.h>
+#include <folly/coro/BlockingWait.h>
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/ConnectorMetadata.h"
@@ -166,22 +166,26 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
       session, {}, evaluator, std::move(filters), rejectedFilters);
 
   auto* splitManager = metadata_->splitManager();
-  auto partitions = splitManager->listPartitions(session, tableHandle);
+  auto partitions = folly::coro::blockingWait(
+      splitManager->co_listPartitions(session, tableHandle));
   EXPECT_EQ(partitions.size(), 1);
 
   auto splitSource =
       splitManager->getSplitSource(session, tableHandle, partitions);
   ASSERT_NE(splitSource, nullptr);
 
-  // First call should return one split.
-  auto splits1 = splitSource->getSplits(1024);
-  ASSERT_EQ(splits1.size(), 1);
-  ASSERT_NE(splits1[0].split, nullptr);
-
-  // Second call should signal done (nullptr split).
-  auto splits2 = splitSource->getSplits(1024);
-  ASSERT_EQ(splits2.size(), 1);
-  EXPECT_EQ(splits2[0].split, nullptr);
+  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+  while (true) {
+    auto batch = folly::coro::blockingWait(splitSource->co_getSplits(1000));
+    for (auto& split : batch.splits) {
+      splits.push_back(std::move(split));
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
+  ASSERT_EQ(splits.size(), 1);
+  ASSERT_NE(splits[0], nullptr);
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceAllColumns) {

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -34,8 +34,8 @@ target_link_libraries(
   velox_connector
   velox_exec
   velox_vector_test_lib
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
 )
 
 add_executable(axiom_connectors_tests SchemaResolverTest.cpp)

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -235,26 +235,27 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
   return stats;
 }
 
-std::vector<SplitSource::SplitAndGroup> TestSplitSource::getSplits(uint64_t) {
-  std::vector<SplitAndGroup> result;
-  if (!done_) {
-    for (size_t i = 0; i < splitCount_; ++i) {
-      result.push_back(
-          {std::make_shared<TestConnectorSplit>(connectorId_, i),
-           kUngroupedGroupId});
-    }
-    done_ = true;
+folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
+    uint32_t maxSplitCount,
+    int32_t /*bucket*/) {
+  SplitBatch batch;
+  auto end =
+      std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);
+  for (auto i = nextIndex_; i < end; ++i) {
+    batch.splits.push_back(
+        std::make_shared<TestConnectorSplit>(connectorId_, i));
   }
-  if (result.empty()) {
-    result.push_back({nullptr, kUngroupedGroupId});
-  }
-  return result;
+  nextIndex_ = end;
+  batch.noMoreSplits = (nextIndex_ >= splitCount_);
+  co_return batch;
 }
 
-std::vector<PartitionHandlePtr> TestSplitManager::listPartitions(
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr&) {
-  return {std::make_shared<PartitionHandle>()};
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -160,21 +160,23 @@ class TestSplitSource : public SplitSource {
   TestSplitSource(const std::string& connectorId, size_t splitCount)
       : connectorId_(connectorId), splitCount_(splitCount) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t targetBytes) override;
+  folly::coro::Task<SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t /*bucket*/) override;
 
  private:
   const std::string connectorId_;
   const size_t splitCount_;
-  bool done_{false};
+  size_t nextIndex_{0};
 };
 
 /// SplitManager embedded in the TestConnector. Returns one
-/// default-initialized PartitionHandle upon call to listPartitions.
+/// default-initialized PartitionHandle upon call to co_listPartitions.
 /// Generates a TestSplitSource that produces one TestConnectorSplit
 /// per RowVector in the table's data_ vector.
 class TestSplitManager : public ConnectorSplitManager {
  public:
-  std::vector<PartitionHandlePtr> listPartitions(
+  folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -17,6 +17,8 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/common/SchemaTableName.h"
 
+#include <folly/coro/GtestHelpers.h>
+#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -120,7 +122,7 @@ TEST_F(TestConnectorTest, columnHandle) {
   EXPECT_EQ(testColumnHandle->type()->kind(), TypeKind::INTEGER);
 }
 
-TEST_F(TestConnectorTest, splitManager) {
+CO_TEST_F(TestConnectorTest, splitManager) {
   auto schema = ROW({"a"}, {INTEGER()});
   auto table = connector_->addTable("test_table", schema);
 
@@ -143,22 +145,28 @@ TEST_F(TestConnectorTest, splitManager) {
   auto tableHandle = layout.createTableHandle(
       nullptr, std::move(columns), *evaluator, empty, empty);
 
-  auto partitions = splitManager->listPartitions(nullptr, tableHandle);
+  auto partitions =
+      co_await splitManager->co_listPartitions(nullptr, tableHandle);
   auto splitSource =
       splitManager->getSplitSource(nullptr, tableHandle, partitions, {});
   EXPECT_NE(splitSource, nullptr);
 
-  auto splits = splitSource->getSplits(0);
+  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+  while (true) {
+    auto batch = co_await splitSource->co_getSplits(/*maxSplitCount=*/1000);
+    for (auto& split : batch.splits) {
+      splits.push_back(std::move(split));
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
   EXPECT_EQ(splits.size(), kNumSplits);
   for (size_t i = 0; i < kNumSplits; ++i) {
-    auto split = std::dynamic_pointer_cast<TestConnectorSplit>(splits[i].split);
+    auto split = std::dynamic_pointer_cast<TestConnectorSplit>(splits[i]);
     EXPECT_NE(split, nullptr);
     EXPECT_EQ(split->index(), i);
   }
-
-  splits = splitSource->getSplits(0);
-  EXPECT_EQ(splits.size(), 1);
-  EXPECT_EQ(splits[0].split, nullptr);
 }
 
 TEST_F(TestConnectorTest, splits) {

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -75,10 +75,12 @@ double getScaleFactor(const std::string& schema) {
 
 } // namespace
 
-std::vector<PartitionHandlePtr> TpchSplitManager::listPartitions(
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+TpchSplitManager::co_listPartitions(
     const connector::ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
-  return {std::make_shared<connector::PartitionHandle>()};
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<connector::PartitionHandle>()};
 }
 
 std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
@@ -99,53 +101,28 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
       options);
 }
 
-std::vector<SplitSource::SplitAndGroup> TpchSplitSource::getSplits(
-    uint64_t targetBytes) {
-  std::vector<SplitAndGroup> result;
-
-  if (splits_.empty()) {
-    // Generate splits if not already done
+folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
+    uint32_t maxSplitCount,
+    int32_t /*bucket*/) {
+  if (numSplits_ < 0) {
     auto rowType = velox::tpch::getTableSchema(table_);
-    size_t rowSize = 0;
-    for (size_t i = 0; i < rowType->children().size(); i++) {
-      // TODO: use actual size
-      rowSize += 10;
-    }
+    size_t rowSize = rowType->children().size() * 10;
     const auto totalRows = velox::tpch::getRowCount(table_, scaleFactor_);
     const auto rowsPerSplit = options_.fileBytesPerSplit / rowSize;
-    const auto numSplits = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
-
-    // TODO: adjust numSplits based on options_.targetSplitCount
-    for (int64_t i = 0; i < numSplits; ++i) {
-      splits_.push_back(
-          std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
-              connectorId_, numSplits, i));
-    }
+    numSplits_ = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
   }
 
-  if (currentSplit_ >= splits_.size()) {
-    result.push_back(kNoMoreSplits);
-    return result;
+  SplitBatch batch;
+  auto end =
+      std::min(nextSplitIdx_ + static_cast<int64_t>(maxSplitCount), numSplits_);
+  for (auto i = nextSplitIdx_; i < end; ++i) {
+    batch.splits.push_back(
+        std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
+            connectorId_, numSplits_, i));
   }
-
-  uint64_t bytes = 0;
-  while (currentSplit_ < splits_.size()) {
-    auto split = splits_[currentSplit_++];
-    result.emplace_back(SplitAndGroup{split, 0});
-
-    // TODO: use a more accurate size for the split
-    bytes += options_.fileBytesPerSplit;
-
-    if (bytes > targetBytes) {
-      break;
-    }
-  }
-
-  if (result.empty()) {
-    result.push_back(SplitSource::SplitAndGroup{nullptr, 0});
-  }
-
-  return result;
+  nextSplitIdx_ = end;
+  batch.noMoreSplits = (nextSplitIdx_ >= numSplits_);
+  co_return batch;
 }
 
 TpchConnectorMetadata::TpchConnectorMetadata(

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -23,8 +23,6 @@
 
 namespace facebook::axiom::connector::tpch {
 
-inline const SplitSource::SplitAndGroup kNoMoreSplits{nullptr, 0};
-
 class TpchConnectorMetadata;
 
 class TpchSplitSource : public SplitSource {
@@ -39,23 +37,24 @@ class TpchSplitSource : public SplitSource {
         scaleFactor_(scaleFactor),
         connectorId_(connectorId) {}
 
-  std::vector<SplitSource::SplitAndGroup> getSplits(
-      uint64_t targetBytes) override;
+  folly::coro::Task<SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t /*bucket*/) override;
 
  private:
   const SplitOptions options_;
   const velox::tpch::Table table_;
   const double scaleFactor_;
   const std::string connectorId_;
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits_;
-  size_t currentSplit_{0};
+  int64_t nextSplitIdx_{0};
+  int64_t numSplits_{-1};
 };
 
 class TpchSplitManager : public ConnectorSplitManager {
  public:
   explicit TpchSplitManager(TpchConnectorMetadata* /* metadata */) {}
 
-  std::vector<PartitionHandlePtr> listPartitions(
+  folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
+#include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
@@ -155,15 +156,15 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
       tpchTableHandle->getScaleFactor(), tpchLayout->getScaleFactor());
 }
 
-TEST_F(TpchConnectorMetadataTest, splitGeneration) {
+CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
   auto table = metadata_->findTable({"tiny", "lineitem"});
-  ASSERT_NE(table, nullptr);
+  CO_ASSERT_NE(table, nullptr);
 
   const auto& layouts = table->layouts();
-  ASSERT_FALSE(layouts.empty());
+  CO_ASSERT_FALSE(layouts.empty());
 
   auto splitManager = metadata_->splitManager();
-  ASSERT_NE(splitManager, nullptr);
+  CO_ASSERT_NE(splitManager, nullptr);
 
   std::vector<velox::connector::ColumnHandlePtr> columnHandles;
   std::vector<velox::core::TypedExprPtr> empty;
@@ -171,17 +172,26 @@ TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       nullptr, nullptr);
   auto tableHandle = layouts[0]->createTableHandle(
       /*session=*/nullptr, columnHandles, *evaluator, empty, empty);
-  ASSERT_NE(tableHandle, nullptr);
+  CO_ASSERT_NE(tableHandle, nullptr);
 
-  auto partitions =
-      splitManager->listPartitions(/*session=*/nullptr, tableHandle);
-  ASSERT_EQ(partitions.size(), 1);
+  auto partitions = co_await splitManager->co_listPartitions(
+      /*session=*/nullptr, tableHandle);
+  CO_ASSERT_EQ(partitions.size(), 1);
 
   auto splitSource = splitManager->getSplitSource(
       /*session=*/nullptr, tableHandle, partitions);
-  ASSERT_NE(splitSource, nullptr);
-  auto splits = splitSource->getSplits(1024 * 1024); // 1MB target
-  ASSERT_FALSE(splits.empty());
+  CO_ASSERT_NE(splitSource, nullptr);
+  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+  while (true) {
+    auto batch = co_await splitSource->co_getSplits(1000);
+    for (auto& split : batch.splits) {
+      splits.push_back(std::move(split));
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
+  EXPECT_FALSE(splits.empty());
 }
 } // namespace
 } // namespace facebook::axiom::connector::tpch

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "axiom/runner/LocalRunner.h"
+#include <folly/coro/AsyncScope.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Task.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
@@ -31,16 +34,23 @@ class SimpleSplitSource : public connector::SplitSource {
       std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits)
       : splits_(std::move(splits)) {}
 
-  std::vector<SplitAndGroup> getSplits(uint64_t /* targetBytes */) override {
-    if (splitIdx_ >= splits_.size()) {
-      return {{nullptr, 0}};
+  folly::coro::Task<connector::SplitBatch> co_getSplits(
+      uint32_t maxSplitCount,
+      int32_t /*bucket*/) override {
+    connector::SplitBatch batch;
+    auto end = std::min(
+        nextIndex_ + static_cast<size_t>(maxSplitCount), splits_.size());
+    for (auto i = nextIndex_; i < end; ++i) {
+      batch.splits.push_back(std::move(splits_[i]));
     }
-    return {SplitAndGroup{std::move(splits_[splitIdx_++]), 0}};
+    nextIndex_ = end;
+    batch.noMoreSplits = (nextIndex_ >= splits_.size());
+    co_return batch;
   }
 
  private:
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits_;
-  int32_t splitIdx_{0};
+  size_t nextIndex_{0};
 };
 } // namespace
 
@@ -63,7 +73,8 @@ ConnectorSplitSourceFactory::splitSourceForScan(
   auto metadata = connector::ConnectorMetadata::metadata(handle->connectorId());
   auto splitManager = metadata->splitManager();
 
-  auto partitions = splitManager->listPartitions(session, handle);
+  auto partitions = folly::coro::blockingWait(
+      splitManager->co_listPartitions(session, handle));
   return splitManager->getSplitSource(session, handle, partitions, options_);
 }
 
@@ -74,20 +85,33 @@ std::shared_ptr<velox::exec::RemoteConnectorSplit> remoteSplit(
   return std::make_shared<velox::exec::RemoteConnectorSplit>(taskId);
 }
 
-std::vector<velox::exec::Split> listAllSplits(
-    const std::shared_ptr<connector::SplitSource>& source) {
-  std::vector<velox::exec::Split> result;
-  for (;;) {
-    auto splits = source->getSplits(std::numeric_limits<uint64_t>::max());
-    VELOX_CHECK(!splits.empty());
-    for (auto& split : splits) {
-      if (split.split == nullptr) {
-        return result;
+// Streams splits from the source and distributes them round-robin across tasks.
+folly::coro::Task<void> co_generateAndDistributeSplits(
+    std::shared_ptr<connector::SplitSource> source,
+    velox::core::PlanNodeId scanId,
+    std::vector<std::shared_ptr<velox::exec::Task>> tasks,
+    std::function<void(std::exception_ptr)> onError) {
+  try {
+    VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
+
+    size_t taskIdx = 0;
+    for (;;) {
+      auto batch = co_await source->co_getSplits(1);
+      for (auto& split : batch.splits) {
+        tasks[taskIdx]->addSplit(scanId, velox::exec::Split(std::move(split)));
+        taskIdx = (taskIdx + 1) % tasks.size();
       }
-      result.push_back(velox::exec::Split(std::move(split.split)));
+      if (batch.noMoreSplits) {
+        break;
+      }
     }
+    for (auto& task : tasks) {
+      task->noMoreSplits(scanId);
+    }
+  } catch (...) {
+    onError(std::current_exception());
+    throw;
   }
-  VELOX_UNREACHABLE();
 }
 
 void getTopologicalOrder(
@@ -153,6 +177,12 @@ LocalRunner::LocalRunner(
 
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
+}
+
+LocalRunner::~LocalRunner() {
+  if (!splitScopeJoined_) {
+    folly::coro::blockingWait(splitScope_.joinAsync());
+  }
 }
 
 velox::RowVectorPtr LocalRunner::next() {
@@ -284,6 +314,12 @@ void LocalRunner::abort() {
 
 bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
   VELOX_CHECK_NE(state_, State::kInitialized);
+
+  if (!splitScopeJoined_) {
+    folly::coro::blockingWait(splitScope_.joinAsync());
+    splitScopeJoined_ = true;
+  }
+
   std::vector<velox::ContinueFuture> futures;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -398,34 +434,11 @@ void LocalRunner::makeStages(
 
       for (const auto& scan : scans) {
         auto source = splitSourceForScan(/*session=*/nullptr, *scan);
-
-        std::vector<connector::SplitSource::SplitAndGroup> splits;
-        int32_t splitIdx = 0;
-        auto getNextSplit = [&]() {
-          if (splitIdx < splits.size()) {
-            return velox::exec::Split(std::move(splits[splitIdx++].split));
-          }
-          splits = source->getSplits(std::numeric_limits<int64_t>::max());
-          splitIdx = 1;
-          return velox::exec::Split(std::move(splits[0].split));
-        };
-
-        // Distribute splits across tasks using round-robin.
-        bool allDone = false;
-        do {
-          for (auto& task : stage) {
-            auto split = getNextSplit();
-            if (!split.hasConnectorSplit()) {
-              allDone = true;
-              break;
-            }
-            task->addSplit(scan->id(), std::move(split));
-          }
-        } while (!allDone);
-
-        for (auto& task : stage) {
-          task->noMoreSplits(scan->id());
-        }
+        splitScope_.add(
+            folly::coro::co_withExecutor(
+                params_.queryCtx->executor(),
+                co_generateAndDistributeSplits(
+                    source, scan->id(), stage, onError)));
       }
 
       for (const auto& input : fragment.inputStages) {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/coro/AsyncScope.h>
+
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
@@ -85,6 +87,11 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr);
+
+  ~LocalRunner() override;
+
+  LocalRunner(LocalRunner&&) = delete;
+  LocalRunner& operator=(LocalRunner&&) = delete;
 
   /// First call starts execution.
   velox::RowVectorPtr next() override;
@@ -168,6 +175,8 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
+  bool splitScopeJoined_{false};
 };
 
 } // namespace facebook::axiom::runner


### PR DESCRIPTION
Summary:

Making split-related calls non-blocking using coroutines, since some connector implementations may do significant I/O work to construct splits or enumerate partitions and during these long calls may want to release the thread to do other work

Reviewed By: mbasmanova

Differential Revision: D98218415


