### PR TITLE
feat(optimizer): Infer same-table equality filters from equivalence classes. (#1179)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -749,7 +749,182 @@ void collectImpliedPredicates(
   }
 }
 
+// Synthesizes same-table equalities implied by every Equivalence class
+// reachable from columns of 'tables'. Walks each table's columns to find
+// distinct Equivalence pointers, groups each class's members by target
+// table, and emits n-1 anchored (target, equality) pairs for each
+// equivalence-class group of n >= 2 columns on the same target.
+void collectImpliedSameTableEqualities(
+    const QGVector<PlanObjectCP>& tables,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  auto* optimization = queryCtx()->optimization();
+  folly::F14FastSet<const Equivalence*> seenEquivalences;
+
+  auto processEquivalence = [&](const Equivalence* equivalence) {
+    if (!seenEquivalences.insert(equivalence).second) {
+      return;
+    }
+    // Equivalence::columns may contain duplicates when classes merge via
+    // multiple paths (see Column::equals). Dedup per target so we never
+    // synthesize a self-equality like t.a = t.a.
+    folly::F14FastMap<PlanObjectP, folly::F14FastSet<ColumnCP>>
+        tableEquivalences;
+    for (auto* column : equivalence->columns) {
+      auto* memberTable = column->singleTable();
+      if (!memberTable) {
+        continue;
+      }
+      auto it = mutableTables.find(memberTable);
+      if (it == mutableTables.end()) {
+        continue;
+      }
+      tableEquivalences[it->second].insert(column);
+    }
+    for (auto& [target, columns] : tableEquivalences) {
+      if (columns.size() < 2) {
+        continue;
+      }
+      // Sort by Column id so the anchor and member order are stable across
+      // runs.
+      std::vector<ColumnCP> orderedColumns(columns.begin(), columns.end());
+      std::ranges::sort(orderedColumns, [](ColumnCP lhs, ColumnCP rhs) {
+        return lhs->id() < rhs->id();
+      });
+      auto* anchorColumn = orderedColumns[0];
+      for (size_t k = 1; k < orderedColumns.size(); ++k) {
+        impliedPredicatesOut.emplace_back(
+            target,
+            optimization->makeEquality(anchorColumn, orderedColumns[k]));
+      }
+    }
+  };
+
+  for (auto* table : tables) {
+    const ColumnVector* columns = nullptr;
+    if (table->is(PlanType::kTableNode)) {
+      columns = &table->as<BaseTable>()->columns;
+    } else if (table->is(PlanType::kDerivedTableNode)) {
+      columns = &table->as<DerivedTable>()->columns;
+    } else {
+      continue;
+    }
+    for (auto* column : *columns) {
+      if (auto* equivalence = column->equivalence()) {
+        processEquivalence(equivalence);
+      }
+    }
+  }
+}
+
+// Synthesizes same-table equalities on the null-extending side of LEFT and
+// non-null-aware SEMI joins from pairs of right keys paired with the same
+// left key.
+// Example: t LEFT JOIN u ON u.x = t.a AND u.y = t.a → emit u.x = u.y.
+// TODO: Generalize to arbitrary expressions (currently column-only).
+void collectImpliedOuterJoinSlotEqualities(
+    const JoinEdgeVector& joins,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  auto* optimization = queryCtx()->optimization();
+  for (const auto& join : joins) {
+    // Only LEFT and non-null-aware SEMI are sound here.
+    const bool isLeftOuter = join->rightOptional() && !join->leftOptional();
+    const bool isNullRejectingSemi = join->isSemi() && !join->isNullAwareIn();
+    if (!isLeftOuter && !isNullRejectingSemi) {
+      continue;
+    }
+    for (size_t i = 0; i < join->numKeys(); ++i) {
+      auto* leftColI = join->leftKeys()[i];
+      auto* rightColI = join->rightKeys()[i];
+      auto* table = rightColI->singleTable();
+      if (!table) {
+        continue;
+      }
+      // Non-deterministic keys can evaluate differently per row.
+      if (leftColI->containsNonDeterministic() ||
+          rightColI->containsNonDeterministic()) {
+        continue;
+      }
+      auto it = mutableTables.find(table);
+      if (it == mutableTables.end()) {
+        continue;
+      }
+      for (size_t j = i + 1; j < join->numKeys(); ++j) {
+        auto* leftColJ = join->leftKeys()[j];
+        auto* rightColJ = join->rightKeys()[j];
+        if (rightColJ == rightColI) {
+          continue;
+        }
+        if (rightColJ->singleTable() != table) {
+          continue;
+        }
+        if (leftColJ->containsNonDeterministic() ||
+            rightColJ->containsNonDeterministic()) {
+          continue;
+        }
+        if (!leftColI->sameOrEqual(*leftColJ)) {
+          continue;
+        }
+        impliedPredicatesOut.emplace_back(
+            it->second, optimization->makeEquality(rightColI, rightColJ));
+      }
+    }
+  }
+}
+
 } // namespace
+
+namespace {
+
+// Returns true if 'target' already has 'expr'. Uses pointer equality to avoid
+// excessive equivalence class deduplication.
+bool targetAlreadyHas(PlanObjectCP target, ExprCP expr) {
+  if (target->is(PlanType::kTableNode)) {
+    auto* baseTable = target->as<BaseTable>();
+    if (std::ranges::any_of(baseTable->columnFilters, [&](ExprCP candidate) {
+          return candidate == expr;
+        })) {
+      return true;
+    }
+    return std::ranges::any_of(
+        baseTable->filter, [&](ExprCP candidate) { return candidate == expr; });
+  }
+  if (target->is(PlanType::kDerivedTableNode)) {
+    const auto& existing = target->as<DerivedTable>()->conjuncts;
+    return std::ranges::any_of(
+        existing, [&](ExprCP candidate) { return candidate == expr; });
+  }
+  return false;
+}
+
+} // namespace
+
+void DerivedTable::attachPredicate(PlanObjectP target, ExprCP expr) {
+  if (targetAlreadyHas(target, expr)) {
+    return;
+  }
+  if (tryPushdownConjunct(expr, target)) {
+    return;
+  }
+  // Pushdown blocked (LIMIT/window DT, ValuesTable, UnnestTable). Land
+  // 'expr' on this DT's conjuncts so it's applied above 'target'.
+  if (std::ranges::any_of(conjuncts, [&](ExprCP candidate) {
+        return candidate->sameOrEqual(*expr);
+      })) {
+    return;
+  }
+  conjuncts.push_back(expr);
+}
+
+void DerivedTable::tryAttachToNullExtendingSide(
+    PlanObjectP target,
+    ExprCP expr) {
+  if (targetAlreadyHas(target, expr)) {
+    return;
+  }
+  tryPushdownConjunct(expr, target);
+}
 
 void DerivedTable::inferImpliedPredicates() {
   folly::F14FastMap<PlanObjectCP, PlanObjectP> mutableTables;
@@ -763,44 +938,28 @@ void DerivedTable::inferImpliedPredicates() {
         collectImpliedPredicates(filter, mutableTables, implied);
       }
     } else if (table->is(PlanType::kDerivedTableNode)) {
-      auto* innerDt = table->as<DerivedTable>();
-      for (auto* filter : innerDt->conjuncts) {
-        if (filter->columns().size() != 1) {
-          continue;
-        }
-        auto* innerColumn = filter->columns().onlyObject<Column>();
-        for (size_t i = 0;
-             i < innerDt->columns.size() && i < innerDt->exprs.size();
-             ++i) {
-          if (innerDt->exprs[i] != innerColumn) {
-            continue;
-          }
-          auto* outerColumn = innerDt->columns[i];
-          auto outerFilter = DerivedTableFlattener::replaceInputs(
-              filter, ColumnVector{innerColumn}, ExprVector{outerColumn});
-          collectImpliedPredicates(outerFilter, mutableTables, implied);
-        }
-      }
+      table->as<DerivedTable>()->forEachExportableSingleColumnConjunct(
+          [&](ColumnCP /*outerColumn*/, ExprCP outerFilter) {
+            collectImpliedPredicates(outerFilter, mutableTables, implied);
+          });
     }
   }
 
+  collectImpliedSameTableEqualities(tables, mutableTables, implied);
+  // Land each implied predicate. attachPredicate guarantees enforcement
+  // somewhere (scan or this DT's conjuncts); JoinEdge::addEquality relies
+  // on that invariant when dropping equivalence-class-redundant keys.
   for (auto& [target, expr] : implied) {
-    if (target->is(PlanType::kTableNode)) {
-      const auto& existing = target->as<BaseTable>()->columnFilters;
-      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
-            return candidate->sameOrEqual(*expr);
-          })) {
-        continue;
-      }
-    } else if (target->is(PlanType::kDerivedTableNode)) {
-      const auto& existing = target->as<DerivedTable>()->conjuncts;
-      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
-            return candidate->sameOrEqual(*expr);
-          })) {
-        continue;
-      }
-    }
-    tryPushdownConjunct(expr, target);
+    attachPredicate(target, expr);
+  }
+
+  // Outer-join slot equalities are only valid on matched rows; use
+  // tryAttachToNullExtendingSide which drops silently if pushdown fails.
+  std::vector<std::pair<PlanObjectP, ExprCP>> outerSlotEqualities;
+  collectImpliedOuterJoinSlotEqualities(
+      joins, mutableTables, outerSlotEqualities);
+  for (auto& [target, expr] : outerSlotEqualities) {
+    tryAttachToNullExtendingSide(target, expr);
   }
 }
 
@@ -1331,6 +1490,25 @@ void DerivedTable::exportExprs(ExprVector& exprs) {
 
 ExprCP DerivedTable::importExpr(ExprCP expr) const {
   return DerivedTableFlattener::replaceInputs(expr, columns, exprs);
+}
+
+void DerivedTable::forEachExportableSingleColumnConjunct(
+    folly::FunctionRef<void(ColumnCP, ExprCP)> cb) const {
+  for (auto* filter : conjuncts) {
+    if (filter->columns().size() != 1) {
+      continue;
+    }
+    auto* innerColumn = filter->columns().onlyObject<Column>();
+    for (size_t i = 0; i < columns.size() && i < exprs.size(); ++i) {
+      if (exprs[i] != innerColumn) {
+        continue;
+      }
+      auto* outerColumn = columns[i];
+      auto* outerFilter = DerivedTableFlattener::replaceInputs(
+          filter, ColumnVector{innerColumn}, ExprVector{outerColumn});
+      cb(outerColumn, outerFilter);
+    }
+  }
 }
 
 void DerivedTable::removeTables(

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/Function.h>
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/MemoKey.h"
 #include "axiom/optimizer/PlanObject.h"
@@ -278,6 +279,13 @@ struct DerivedTable : public PlanObject {
   /// corresponding 'exprs'.
   ExprCP importExpr(ExprCP expr) const;
 
+  /// Invokes 'cb(outerColumn, translatedFilter)' for each single-column
+  /// conjunct in this DT whose underlying source column maps to one of
+  /// this DT's output 'columns'. 'translatedFilter' is the conjunct with
+  /// the inner source column substituted by the corresponding outer column.
+  void forEachExportableSingleColumnConjunct(
+      folly::FunctionRef<void(ColumnCP, ExprCP)> cb) const;
+
   /// Adds a filter conjunct to this DT. Handles LIMIT (returns false),
   /// aggregation (adds to 'having'), and set operations (adds to all children).
   /// Returns true if the conjunct was successfully added, false otherwise.
@@ -461,12 +469,24 @@ struct DerivedTable : public PlanObject {
   // Updates cardinality and column constraints from the plan.
   void updateConstraints(const RelationOp& plan);
 
-  // Synthesizes single-column predicates implied by inner-join
-  // column equivalences. For each single-column filter on a
-  // BaseTable or inner DerivedTable, clones it to other columns
-  // in the same equivalence class. Skips non-deterministic and
-  // multi-column filters; see implementation for rationale.
+  // Adds same-table equality filters that hold on a single table because of
+  // its column equivalences. Three paths:
+  //   1. Per-column propagation of single-column deterministic filters to
+  //      other members of the same equivalence class.
+  //   2. Same-table synthesis: for each equivalence class with 2+ members
+  //      on the same table (e.g. ON t.a = u.x AND t.b = u.x), emits
+  //      anchored equalities (t.a = t.b) on that table.
+  //   3. Outer-join slot synthesis: for LEFT and non-null-aware LEFT SEMI
+  //      joins, when two right-side join keys belong to the same null-
+  //      supplying table and pair with the same left key, emits their
+  //      equality on that table.
   void inferImpliedPredicates();
+
+  // Enforces 'expr' on 'target': existing scan filter, pushdown via
+  // tryPushdownConjunct, or fallback to this DT's conjuncts above the
+  // refusing target. The always-attaches invariant lets JoinEdge::addEquality
+  // drop equivalence-class-redundant join keys unconditionally.
+  void attachPredicate(PlanObjectP target, ExprCP expr);
 
   // Completes 'joins' with edges implied by column equivalences.
   void addImpliedJoins();
@@ -561,6 +581,10 @@ struct DerivedTable : public PlanObject {
   // @param table The target table (BaseTable, DerivedTable, etc.).
   // @return true if the conjunct was successfully pushed down, false otherwise.
   bool tryPushdownConjunct(ExprCP conjunct, PlanObjectP table);
+
+  // Pushes 'expr' to the null-extending side. Drops if target refuses —
+  // post-join fallback would filter NULL-padded unmatched rows incorrectly.
+  void tryAttachToNullExtendingSide(PlanObjectP target, ExprCP expr);
 
   // Returns true if 'imported' depends only on columns that are partition keys
   // of every window function in windowPlan.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -470,8 +470,11 @@ bool JoinEdge::isBroadcastableType() const {
 }
 
 void JoinEdge::addEquality(ExprCP left, ExprCP right, bool update) {
-  for (auto i = 0; i < leftKeys_.size(); ++i) {
-    if (leftKeys_[i] == left && rightKeys_[i] == right) {
+  // Drop equivalence-class-redundant keys; sound via attachPredicate's
+  // always-attaches invariant.
+  for (size_t i = 0; i < leftKeys_.size(); ++i) {
+    if (leftKeys_[i]->sameOrEqual(*left) &&
+        rightKeys_[i]->sameOrEqual(*right)) {
       return;
     }
   }
@@ -705,6 +708,13 @@ void BaseTable::addFilter(ExprCP expr) {
   if (columns.size() == 1) {
     columnFilters.push_back(expr);
   } else {
+    // Pointer equality suffices: equality calls are interned by ToGraph,
+    // so a duplicate insert resolves to the same Call*.
+    for (auto* existing : filter) {
+      if (existing == expr) {
+        return;
+      }
+    }
     filter.push_back(expr);
   }
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1132,7 +1132,8 @@ TEST_F(JoinTest, impliedJoins) {
 
   // Same-table columns in one equivalence class: t.a = u.x AND t.a = t.b puts
   // t.a and t.b (both from t) in the same class. addImpliedJoins must skip
-  // same-table pairs. t.a = t.b becomes a filter on t.
+  // same-table pairs. t.a = t.b becomes a filter on t, and the redundant
+  // implied key (t.b, u.x) is removed.
   {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.a = t.b";
     SCOPED_TRACE(query);
@@ -1148,17 +1149,85 @@ TEST_F(JoinTest, impliedJoins) {
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
-  // Same as above, but the same-table equivalence arises indirectly through
-  // transitivity: t.a = u.x AND t.b = u.x implies t.a = t.b. The optimizer
-  // keeps both as join keys.
-  // TODO(https://github.com/facebookincubator/axiom/issues/909): Optimal plan
-  // would filter t on a = b, then join on a single key.
+  // Same-table equality dedup: ON t.a = u.x AND t.b = u.x merges {t.a, t.b,
+  // u.x}, so an explicit WHERE t.a = t.b becomes the same interned Call as
+  // the inferred one and is added only once.
+  {
+    auto query =
+        "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.x WHERE t.a = t.b";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
   {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.x";
     SCOPED_TRACE(query);
 
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Separate equivalence classes: no same-table filter.
+  {
+    auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.y";
+    SCOPED_TRACE(query);
+
     auto matcher = matchScan("t")
                        .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // LEFT JOIN: no same-table filter on preserved side; both keys preserved.
+  {
+    auto query =
+        "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.x";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Three tables with same-table filter on t.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x "
+        "JOIN v ON u.x = v.n";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("u")
+                       .hashJoin(
+                           matchScan("v")
+                               .hashJoin(
+                                   matchScan("t").filter("a = b").build(),
+                                   core::JoinType::kInner)
+                               .build(),
+                           core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1351,6 +1420,308 @@ TEST_F(JoinTest, impliedFilters) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+}
+
+// Three or more columns from the same table in one equivalence class.
+TEST_F(JoinTest, impliedSameTableEquality) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // Three same-table columns produce a = b and a = c filters.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x AND t.c = u.x";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("u")
+                       .hashJoin(
+                           matchScan("t").filter("a = b AND a = c").build(),
+                           core::JoinType::kInner)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Equivalence class with same-table columns on both sides of the join.
+TEST_F(JoinTest, impliedSameTableEqualityBothSides) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // t.a = u.x AND t.b = u.x AND t.a = u.y creates equivalence class
+  // {t.a, t.b, u.x, u.y}. Pushes a = b on t and x = y on u.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x AND t.a = u.y";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("t")
+            .filter("a = b")
+            .hashJoin(
+                matchScan("u").filter("x = y").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// With GROUP BY a, b, the synthesized a = b references only grouping keys
+// and is pushed below the aggregation onto t's scan.
+TEST_F(JoinTest, impliedSameTableEqualityBelowAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t GROUP BY a, b) AS gb "
+      "JOIN u ON gb.a = u.x AND gb.b = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t")
+                             .filter("a = b")
+                             .singleAggregation({"a", "b"}, {})
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Synthesis into HAVING: when an equivalence class member is an aggregate
+// output, the implied equality can't push below the aggregation and stays
+// as a post-aggregation Filter (HAVING).
+TEST_F(JoinTest, impliedSameTableEqualityInHaving) {
+  testConnector_->addTable("t", ROW({"k"}, BIGINT()))
+      ->setStats(10'000, {{"k", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT k, COUNT(*) AS c FROM t GROUP BY k) AS agg "
+      "JOIN u ON agg.k = u.x AND agg.c = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t")
+                             .singleAggregation({"k"}, {"count(*) as c"})
+                             .filter("k = c")
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// With a LIMIT in the way, the synthesized equality lands as a Filter
+// above the Limit. The redundant join key is still dropped.
+TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimit) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
+      "JOIN u ON lim.a = u.x AND lim.b = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .limit()
+                     .filter("a = b")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Explicit WHERE and synthesized equality converge on the same LIMIT DT
+// target. The filter appears exactly once above the Limit.
+TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
+      "JOIN u ON lim.a = u.x AND lim.b = u.x "
+      "WHERE lim.a = lim.b";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .limit()
+                     .filter("a = b")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// The null-supplying (right) side of a LEFT join gets same-table equality
+// filters when multiple ON-clause conditions pair different right-side
+// columns with the same left-side column. For t LEFT JOIN u ON u.x = t.a
+// AND u.y = t.a, any u row in the output must satisfy both conditions, so
+// u.x = u.y holds.
+TEST_F(JoinTest, impliedSameTableEqualityOuterJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // u.x = t.a AND u.y = t.a implies u.x = u.y, which can be pushed
+  // to u's scan since unmatched u rows never appear in the result.
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// SEMI join (EXISTS) gets slot-pattern same-table eq synthesis on its
+// subquery side: surviving left rows require a matching right row, so the
+// same-table eq on the right side is sound.
+TEST_F(JoinTest, impliedSameTableEqualitySemiJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t WHERE EXISTS ("
+      "  SELECT 1 FROM u WHERE u.x = t.a AND u.y = t.a)";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u").filter("x = y").build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// RIGHT JOIN is normalized to LEFT JOIN; same-table synthesis fires on
+// the (now-right) u side, producing u.x = u.y.
+TEST_F(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM u RIGHT JOIN t ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// FULL OUTER slot synthesis is unsound on either side (unmatched rows on
+// both sides survive with NULLs; a filter would drop them). u must NOT
+// get u.x = u.y.
+TEST_F(JoinTest, impliedSameTableEqualityFullOuterJoinSkipped) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t FULL OUTER JOIN u ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  // u must have no filter — slot synthesis is unsound for FULL OUTER.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kFull)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table equalities must NOT be inferred for the null-supplying side
+// when the right-side keys are paired with *different* left-side keys. For
+// t LEFT JOIN u ON t.a = u.x AND t.b = u.y, u.x = u.y does not follow
+// because t.a and t.b can differ.
+TEST_F(JoinTest, impliedSameTableEqualityMismatchedLeftKeys) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y";
+  SCOPED_TRACE(query);
+
+  // u must have no filter — u.x = u.y must not be inferred.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table equalities must NOT be pushed to the preserved (left) side of a
+// left join. t rows can appear in the output without matching any u row, so
+// t.a = t.b cannot be inferred from ON t.a = u.x AND t.b = u.x.
+TEST_F(JoinTest, impliedSameTableEqualityPreservedSide) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.x";
+  SCOPED_TRACE(query);
+
+  // t must have no filter — t.a = t.b must not be inferred.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // LEFT JOIN with no equalities when the DT has 3+ tables. The comma join

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -81,3 +81,26 @@ FROM (VALUES ('d1'), ('d2')) a(ds)
 LEFT JOIN (VALUES ('d3')) b(ds) ON (a.ds = b.ds)
 LEFT JOIN (SELECT 'x' as ds WHERE false) c ON (a.ds = c.ds)
 GROUP BY 1
+----
+-- Same-table equality from equivalence class: a = b is inferred and pushed
+-- as a filter on the left side. Only rows where a = b survive, projecting
+-- (a, b): (1, 1), (3, 3), (5, 5).
+SELECT t.a, t.b
+FROM (VALUES (1, 1), (2, 20), (3, 3), (4, 40), (5, 5)) AS t(a, b)
+JOIN (SELECT DISTINCT a FROM (VALUES (1), (2), (3), (4), (5)) AS v(a)) AS u(a)
+  ON t.a = u.a AND t.b = u.a
+----
+-- LEFT JOIN slot synthesis: u.x = u.y inferred from u.x = t.a AND u.y = t.a.
+SELECT t.a, u.x
+FROM (VALUES (1), (2), (3)) AS t(a)
+LEFT JOIN (VALUES (1, 1), (3, 3), (4, 5)) AS u(x, y)
+  ON u.x = t.a AND u.y = t.a
+----
+-- SEMI join slot synthesis: u.x = u.y inferred, so only rows where x = y
+-- survive the semi-join filter. t.a = 2 has no matching u row (2, 3 fails).
+SELECT t.a
+FROM (VALUES (1), (2), (3)) AS t(a)
+WHERE EXISTS (
+  SELECT 1 FROM (VALUES (1, 1), (2, 3), (3, 3)) AS u(x, y)
+  WHERE u.x = t.a AND u.y = t.a
+)


### PR DESCRIPTION
Summary:
For the query below:
```
SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.x
```
Before: t.a = u.x AND t.b = u.x kept both join keys and inferred no additional filter (t.a = t.b).
After: pushes a = b as a filter on t and removes the redundant key b = x.

Same-table equalities are discovered from equivalence classes of inner join
keys. For n same-table columns, the anchor-per-table algorithm produces a
minimal spanning set of n-1 equality filters. Redundant inner-join keys are
removed. Infers same-table filters for both inner and outer joins.

Resolves https://github.com/facebookincubator/axiom/issues/909


Reviewed By: mbasmanova

Differential Revision: D98079885


