### PR TITLE
refactor(cli): Move lifecycle orchestration into SqlQueryRunner (#1182)

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -15,13 +15,13 @@
  */
 
 #include "axiom/cli/Console.h"
+#include <fmt/core.h>
 #include <folly/FileUtil.h>
 #include <unistd.h>
 #include <algorithm>
 #include <iostream>
 #include <optional>
 #include <set>
-#include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/cli/ResultPrinter.h"
 #include "axiom/cli/StdinReader.h"
 #include "axiom/cli/Timing.h"
@@ -88,19 +88,7 @@ std::optional<std::string> getHistoryFilePath() {
 
 namespace axiom::sql {
 
-Console::Console(
-    SqlQueryRunner& runner,
-    PermissionCheck permissionCheck,
-    std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator,
-    QueryStartCallback startCallback,
-    QueryCompletionCallback completionCallback)
-    : runner_{runner},
-      permissionCheck_{std::move(permissionCheck)},
-      queryIdGenerator_{
-          queryIdGenerator ? std::move(queryIdGenerator)
-                           : std::make_shared<cli::QueryIdGenerator>()},
-      startCallback_{std::move(startCallback)},
-      completionCallback_{std::move(completionCallback)} {}
+Console::Console(SqlQueryRunner& runner) : runner_{runner} {}
 
 void Console::initialize() {
   gflags::SetUsageMessage(
@@ -132,35 +120,7 @@ void Console::run() {
   }
 }
 
-void Console::notifyStart(const QueryStartInfo& info) {
-  if (startCallback_) {
-    try {
-      startCallback_(info);
-    } catch (const std::exception& ex) {
-      LOG(WARNING) << "Start callback failed: " << ex.what();
-    }
-  }
-}
-
-void Console::notifyCompletion(const QueryCompletionInfo& info) {
-  if (completionCallback_) {
-    try {
-      completionCallback_(info);
-    } catch (const std::exception& ex) {
-      LOG(WARNING) << "Completion callback failed: " << ex.what();
-    }
-  }
-}
-
 void Console::runNoThrow(std::string_view sql, bool isInteractive) {
-  const SqlQueryRunner::RunOptions defaultOptions{
-      .numWorkers = FLAGS_num_workers,
-      .numDrivers = FLAGS_num_drivers,
-      .splitTargetBytes = FLAGS_split_target_bytes,
-      .optimizerTraceFlags = FLAGS_optimizer_trace,
-      .debugMode = FLAGS_debug,
-  };
-
   // Parse and execute statements one at a time so that DDL statements
   // (e.g. CREATE TABLE) take effect before subsequent statements (e.g.
   // INSERT) are parsed.
@@ -169,52 +129,33 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
       continue;
     }
 
-    const auto queryId = queryIdGenerator_->createNextQueryId();
-    auto options = defaultOptions;
-    options.queryId = queryId;
-    const auto createTime = std::chrono::system_clock::now();
+    // The completion callback captures telemetry for error reporting.
+    QueryCompletionInfo completionInfo;
 
-    // Notify start callback before parse so that every query gets a start
-    // event. Parse or permission failures are handled by completionCallback_
-    // in the catch block.
-    notifyStart({queryId, std::string(sqlText), createTime});
+    SqlQueryRunner::RunOptions options{
+        .numWorkers = FLAGS_num_workers,
+        .numDrivers = FLAGS_num_drivers,
+        .splitTargetBytes = FLAGS_split_target_bytes,
+        .optimizerTraceFlags = FLAGS_optimizer_trace,
+        .debugMode = FLAGS_debug,
+        .onComplete =
+            [&](const QueryCompletionInfo& info) { completionInfo = info; },
+    };
 
+    auto formatTiming = [](const QueryTiming& timing,
+                           const cli::Timing& cpuTiming) {
+      return fmt::format(
+          "Parsing: {} | Optimizing: {} | Executing: {} | Total: {}",
+          facebook::velox::succinctMicros(timing.parse),
+          facebook::velox::succinctMicros(timing.optimize),
+          facebook::velox::succinctMicros(timing.execute),
+          cpuTiming.toString());
+    };
+
+    cli::Timing cpuTiming;
     try {
-      cli::Timing parseTiming;
-      cli::Timing statementTiming;
-      cli::Timing totalTiming;
       auto result = cli::time<SqlQueryRunner::SqlResult>(
-          [&]() {
-            auto statement = cli::time<presto::SqlStatementPtr>(
-                [&]() { return runner_.parseSingle(sqlText, options); },
-                parseTiming);
-
-            if (isInteractive) {
-              std::cout << "Query ID: " << queryId
-                        << " | Parsing: " << parseTiming.toString()
-                        << std::endl;
-            }
-
-            // Permission check after parsing, before execution.
-            if (permissionCheck_) {
-              const auto& schema = options.defaultSchema
-                  ? options.defaultSchema
-                  : runner_.defaultSchema();
-              options.tokenProvider = permissionCheck_(
-                  queryId,
-                  sqlText,
-                  options.defaultConnectorId.value_or(
-                      runner_.defaultConnectorId()),
-                  schema ? std::optional<std::string_view>{*schema}
-                         : std::nullopt,
-                  statement->views());
-            }
-
-            return cli::time<SqlQueryRunner::SqlResult>(
-                [&]() { return runner_.run(*statement, options); },
-                statementTiming);
-          },
-          totalTiming);
+          [&]() { return runner_.run(sqlText, options); }, cpuTiming);
 
       if (result.message.has_value()) {
         std::cout << result.message.value() << std::endl;
@@ -226,44 +167,21 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
         cli::printResults(result.results, FLAGS_max_rows);
       }
 
-      // Notify completion callback on success.
-      int64_t numOutputRows{0};
-      for (const auto& rowVector : result.results) {
-        numOutputRows += rowVector->size();
-      }
-      uint64_t executionMicros{
-          statementTiming.micros > result.optimizeMicros
-              ? statementTiming.micros - result.optimizeMicros
-              : 0};
       if (isInteractive) {
-        std::cout << "Query ID: " << queryId << " | Optimizing: "
-                  << facebook::velox::succinctNanos(
-                         result.optimizeMicros * 1'000)
-                  << " | Executing: "
-                  << facebook::velox::succinctNanos(executionMicros * 1'000)
-                  << " | Total: " << totalTiming.toString() << std::endl;
+        std::cout << "Query ID: " << completionInfo.startInfo.queryId << " | "
+                  << formatTiming(completionInfo.timing, cpuTiming)
+                  << std::endl;
       }
-      notifyCompletion(
-          QueryCompletionInfo{
-              .startInfo = {queryId, std::string(sqlText), createTime},
-              .planString = std::move(result.planString),
-              .parseMicros = parseTiming.micros,
-              .optimizeMicros = result.optimizeMicros,
-              .executionMicros = executionMicros,
-              .totalMicros = totalTiming.micros,
-              .numOutputRows = numOutputRows,
-              .endTime = std::chrono::system_clock::now(),
-          });
-    } catch (std::exception& e) {
-      // Notify completion callback on failure.
-      notifyCompletion(
-          QueryCompletionInfo{
-              .startInfo = {queryId, std::string(sqlText), createTime},
-              .errorInfo = ErrorInfo{e.what()},
-              .endTime = std::chrono::system_clock::now(),
-          });
-      std::cerr << "Query ID: " << queryId << " | Query failed: " << e.what()
+    } catch (const std::exception&) {
+      // run() threw after firing the completion callback, so telemetry
+      // was captured.
+      std::cerr << "Query failed: " << completionInfo.errorInfo->message
                 << std::endl;
+      if (isInteractive) {
+        std::cerr << "Query ID: " << completionInfo.startInfo.queryId << " | "
+                  << formatTiming(completionInfo.timing, cpuTiming)
+                  << std::endl;
+      }
       return;
     }
   }

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -15,106 +15,19 @@
  */
 #pragma once
 
-#include <chrono>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <utility>
 #include "axiom/cli/SqlQueryRunner.h"
-#include "axiom/sql/presto/SqlStatement.h"
 
 DECLARE_string(data_path);
 DECLARE_string(data_format);
 DECLARE_bool(debug);
 
-namespace axiom::cli {
-class QueryIdGenerator;
-} // namespace axiom::cli
-
 namespace axiom::sql {
 
-/// Permission check callback: (queryId, sql, catalog, schema, views) -> throws
-/// on denial, and may return a per-query token provider.
-/// Empty (nullptr) by default -- no permission checking.
-using PermissionCheck =
-    std::function<std::shared_ptr<facebook::velox::filesystems::TokenProvider>(
-        std::string_view queryId,
-        std::string_view sql,
-        std::string_view catalog,
-        std::optional<std::string_view> schema,
-        const presto::ViewMap& views)>;
-
-/// Holds query metadata captured at query start time.
-struct QueryStartInfo {
-  /// Unique identifier for this query execution.
-  std::string queryId;
-
-  /// SQL text of the query. Owned copy so callbacks can store this safely.
-  std::string query;
-
-  /// Wall-clock time when the query was created.
-  std::chrono::system_clock::time_point createTime;
-};
-
-/// Holds error details when a query fails.
-struct ErrorInfo {
-  /// Human-readable error message from the caught exception.
-  std::string message;
-};
-
-/// Holds query metadata at completion time (success or failure).
-struct QueryCompletionInfo {
-  /// Query identification and timing from start.
-  QueryStartInfo startInfo;
-
-  /// Set when the query fails; std::nullopt on success.
-  std::optional<ErrorInfo> errorInfo;
-
-  /// Human-readable distributed Velox plan with optimizer cardinality and
-  /// memory estimates. Empty for DDL statements.
-  std::optional<std::string> planString;
-
-  /// Time spent parsing the SQL statement, in microseconds.
-  uint64_t parseMicros{0};
-
-  /// Time spent in the optimizer, in microseconds.
-  uint64_t optimizeMicros{0};
-
-  /// Time spent executing the statement (excludes optimization), in
-  /// microseconds.
-  uint64_t executionMicros{0};
-
-  /// Total wall-clock time from parse through execution, in microseconds.
-  /// Includes inter-phase time (e.g. permission checks) not captured by the
-  /// per-phase timers.
-  uint64_t totalMicros{0};
-
-  /// Number of rows in the query result.
-  int64_t numOutputRows{0};
-
-  /// Wall-clock time when the query finished.
-  std::chrono::system_clock::time_point endTime;
-};
-
-using QueryStartCallback = std::function<void(const QueryStartInfo&)>;
-using QueryCompletionCallback = std::function<void(const QueryCompletionInfo&)>;
-
+/// SQL console that executes queries from command-line flags, files, or
+/// interactive stdin input.
 class Console {
  public:
-  /// @param permissionCheck Optional callback invoked after each statement is
-  /// parsed but before it is executed. Throws on denial.
-  /// @param queryIdGenerator Optional query ID generator. Defaults to a
-  /// generator with a random base-32 suffix.
-  /// @param startCallback Optional callback invoked before parse, for every
-  /// query.
-  /// @param completionCallback Optional callback invoked after execution
-  /// completes (success or failure).
-  explicit Console(
-      SqlQueryRunner& runner,
-      PermissionCheck permissionCheck = nullptr,
-      std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator = nullptr,
-      QueryStartCallback startCallback = nullptr,
-      QueryCompletionCallback completionCallback = nullptr);
+  explicit Console(SqlQueryRunner& runner);
 
   /// Initializes the CLI with usage message and logging settings.
   void initialize();
@@ -124,30 +37,13 @@ class Console {
   void run();
 
  private:
-  // Executes SQL and prints results, catching any exceptions.
-  // @param sql The SQL text to execute, which may contain multiple
-  // semicolon-separated statements.
-  // @param isInteractive If true, shows timing after each statement for
-  // multi-statement queries.
-  void runNoThrow(std::string_view sql, bool isInteractive = true);
-
-  // Invokes startCallback_ if set, swallowing any exceptions.
-  void notifyStart(const QueryStartInfo& info);
-
-  // Invokes completionCallback_ if set, swallowing any exceptions.
-  void notifyCompletion(const QueryCompletionInfo& info);
+  // Executes SQL, catching any exceptions.
+  void runNoThrow(std::string_view sql, bool isInteractive);
 
   // Reads and executes commands from standard input in interactive mode.
   void readCommands(const std::string& prompt, bool interactive);
 
   SqlQueryRunner& runner_;
-  PermissionCheck permissionCheck_;
-  // Generates unique query IDs for each statement execution.
-  std::shared_ptr<cli::QueryIdGenerator> queryIdGenerator_;
-  // Invoked before parse for every query.
-  QueryStartCallback startCallback_;
-  // Invoked after execution completes (success or failure).
-  QueryCompletionCallback completionCallback_;
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -18,6 +18,7 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <cmath>
 #include <map>
+#include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/LogicalPlanDotPrinter.h"
@@ -84,7 +85,9 @@ namespace axiom::sql {
 
 void SqlQueryRunner::initialize(
     const std::function<std::pair<std::string, std::string>()>&
-        initializeConnectors) {
+        initializeConnectors,
+    PermissionCheck permissionCheck,
+    std::function<std::string()> queryIdGenerator) {
   static folly::once_flag kInitialized;
 
   folly::call_once(kInitialized, []() {
@@ -121,6 +124,17 @@ void SqlQueryRunner::initialize(
   config_[velox::core::QueryConfig::kAdjustTimestampToTimezone] = "true";
   config_[velox::core::QueryConfig::kSessionStartTime] =
       std::to_string(velox::getCurrentTimeMs());
+
+  permissionCheck_ = std::move(permissionCheck);
+
+  if (queryIdGenerator) {
+    queryIdGenerator_ = std::move(queryIdGenerator);
+  } else {
+    auto generator = std::make_shared<cli::QueryIdGenerator>();
+    queryIdGenerator_ = [generator]() {
+      return generator->createNextQueryId();
+    };
+  }
 }
 
 namespace {
@@ -130,6 +144,41 @@ std::vector<velox::RowVectorPtr> fetchResults(runner::LocalRunner& runner) {
     results.push_back(rows);
   }
   return results;
+}
+
+int64_t countRows(const std::vector<velox::RowVectorPtr>& results) {
+  int64_t numRows{0};
+  for (const auto& rowVector : results) {
+    numRows += rowVector->size();
+  }
+  return numRows;
+}
+
+// Fires the start callback if set, swallowing exceptions.
+void onStart(
+    const sql::SqlQueryRunner::RunOptions& options,
+    sql::QueryCompletionInfo& completionInfo) {
+  if (options.onStart) {
+    velox::MicrosecondTimer t(&completionInfo.timing.onStart);
+    try {
+      options.onStart(completionInfo.startInfo);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "Start callback failed: " << ex.what();
+    }
+  }
+}
+
+// Fires the completion callback if set, swallowing exceptions.
+void onComplete(
+    const sql::SqlQueryRunner::RunOptions& options,
+    const sql::QueryCompletionInfo& completionInfo) {
+  if (options.onComplete) {
+    try {
+      options.onComplete(completionInfo);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "Completion callback failed: " << ex.what();
+    }
+  }
 }
 
 } // namespace
@@ -223,8 +272,50 @@ std::string SqlQueryRunner::dropSchema(
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
     std::string_view sql,
     const RunOptions& options) {
-  auto statement = parseSingle(sql, options);
-  return run(*statement, options);
+  auto runOptions = options;
+  runOptions.queryId = options.queryId.value_or(queryIdGenerator_());
+
+  QueryCompletionInfo completionInfo{
+      .startInfo = {
+          *runOptions.queryId,
+          std::string(sql),
+          std::chrono::system_clock::now()}};
+
+  onStart(runOptions, completionInfo);
+
+  auto finalize = [&]() {
+    completionInfo.endTime = std::chrono::system_clock::now();
+    completionInfo.timing.total =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            completionInfo.endTime - completionInfo.startInfo.createTime)
+            .count();
+    onComplete(runOptions, completionInfo);
+  };
+
+  try {
+    presto::SqlStatementPtr statement;
+    {
+      velox::MicrosecondTimer parseTimer(&completionInfo.timing.parse);
+      statement = parseSingle(sql, runOptions);
+    }
+
+    runOptions.tokenProvider =
+        checkPermission(runOptions, completionInfo, statement->views());
+
+    auto result = runUnchecked(
+        *statement,
+        runOptions,
+        completionInfo.timing,
+        completionInfo.planString);
+
+    completionInfo.numOutputRows = countRows(result.results);
+    finalize();
+    return result;
+  } catch (const std::exception& e) {
+    completionInfo.errorInfo = ErrorInfo{e.what()};
+    finalize();
+    throw;
+  }
 }
 
 std::string SqlQueryRunner::toQueryGraphDot(std::string_view sql) {
@@ -297,9 +388,19 @@ presto::SqlStatementPtr SqlQueryRunner::parseSingle(
   return statements.front();
 }
 
-SqlQueryRunner::SqlResult SqlQueryRunner::run(
+SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options) {
+  QueryTiming timing;
+  std::string planString;
+  return runUnchecked(sqlStatement, options, timing, planString);
+}
+
+SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
+    const presto::SqlStatement& sqlStatement,
+    const RunOptions& options,
+    QueryTiming& timing,
+    std::string& planString) {
   if (sqlStatement.isExplain()) {
     const auto* explain = sqlStatement.as<presto::ExplainStatement>();
 
@@ -415,12 +516,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     auto schema = std::make_shared<connector::SchemaResolver>();
     schema->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
-    return runLogicalPlan(ctas->plan(), options, schema);
+    return runLogicalPlan(ctas->plan(), options, timing, planString, schema);
   }
 
   if (sqlStatement.isInsert()) {
     const auto* insert = sqlStatement.as<presto::InsertStatement>();
-    return runLogicalPlan(insert->plan(), options);
+    return runLogicalPlan(insert->plan(), options, timing, planString);
   }
 
   if (sqlStatement.isDropTable()) {
@@ -445,7 +546,10 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
 
   if (sqlStatement.isShowSession()) {
     return showSession(
-        *sqlStatement.as<presto::ShowSessionStatement>(), options);
+        *sqlStatement.as<presto::ShowSessionStatement>(),
+        options,
+        timing,
+        planString);
   }
 
   if (sqlStatement.isSetSession()) {
@@ -478,7 +582,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
 
   const auto logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
 
-  return runLogicalPlan(logicalPlan, options);
+  return runLogicalPlan(logicalPlan, options, timing, planString);
 }
 
 std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
@@ -725,7 +829,9 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
 
 SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
     const presto::ShowSessionStatement& statement,
-    const RunOptions& options) {
+    const RunOptions& options,
+    QueryTiming& timing,
+    std::string& planString) {
   std::map<std::string, std::string> sorted(config_.begin(), config_.end());
 
   std::vector<velox::Variant> data;
@@ -746,20 +852,23 @@ SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
             "like", lp::Col("Name"), lp::Lit(statement.likePattern().value())));
   }
 
-  return runLogicalPlan(builder.build(), options);
+  return runLogicalPlan(builder.build(), options, timing, planString);
 }
 
 SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
+    QueryTiming& timing,
+    std::string& planString,
     std::shared_ptr<facebook::axiom::connector::SchemaResolver>
         schemaResolver) {
   auto queryCtx = newQuery(options);
 
-  uint64_t optimizeMicros{0};
+  SqlResult result;
+
   optimizer::PlanAndStats planAndStats;
   {
-    velox::MicrosecondTimer timer(&optimizeMicros);
+    velox::MicrosecondTimer timer(&timing.optimize);
     planAndStats = optimize(
         logicalPlan,
         queryCtx,
@@ -769,18 +878,19 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         std::move(schemaResolver));
   }
 
-  auto planString = planAndStats.toString();
+  planString = planAndStats.toString();
 
   auto runner = makeLocalRunner(planAndStats, queryCtx, options);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };
 
-  return {
-      .results = fetchResults(*runner),
-      .planString = std::move(planString),
-      .optimizeMicros = optimizeMicros,
-  };
+  {
+    velox::MicrosecondTimer timer(&timing.execute);
+    result.results = fetchResults(*runner);
+  }
+
+  return result;
 }
 
 std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
@@ -823,6 +933,25 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
       velox::BaseVector::createFromVariants(
           presto::ShowStatsBuilder::outputType(), data, optimizerPool_.get()));
   return {result};
+}
+
+std::shared_ptr<velox::filesystems::TokenProvider>
+SqlQueryRunner::checkPermission(
+    const RunOptions& options,
+    QueryCompletionInfo& completionInfo,
+    const presto::ViewMap& views) {
+  if (permissionCheck_) {
+    velox::MicrosecondTimer timer(&completionInfo.timing.checkPermission);
+    return permissionCheck_(
+        completionInfo.startInfo.queryId,
+        completionInfo.startInfo.query,
+        options.defaultConnectorId.value_or(defaultConnectorId_),
+        options.defaultSchema
+            ? std::optional<std::string_view>{*options.defaultSchema}
+            : std::optional<std::string_view>{defaultSchema_},
+        views);
+  }
+  return nullptr;
 }
 
 } // namespace axiom::sql

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <chrono>
+#include <functional>
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/runner/LocalRunner.h"
@@ -24,26 +26,87 @@
 
 namespace axiom::sql {
 
+/// Checks permissions before query execution. Throws on denial and may return
+/// a per-query token provider. No-op (nullptr) by default.
+using PermissionCheck =
+    std::function<std::shared_ptr<facebook::velox::filesystems::TokenProvider>(
+        std::string_view queryId,
+        std::string_view sql,
+        std::string_view catalog,
+        std::optional<std::string_view> schema,
+        const presto::ViewMap& views)>;
+
+/// Holds query metadata captured at query start time.
+struct QueryStartInfo {
+  /// Unique identifier for this query execution.
+  std::string queryId;
+
+  /// SQL text of the query.
+  std::string query;
+
+  /// Wall-clock time when the query was created.
+  std::chrono::system_clock::time_point createTime;
+};
+
+/// Holds error details when a query fails.
+struct ErrorInfo {
+  /// Human-readable error message from the caught exception.
+  std::string message;
+};
+
+/// Per-phase wall-clock timing in microseconds, ordered by lifecycle stage.
+struct QueryTiming {
+  uint64_t onStart{0};
+  uint64_t parse{0};
+  uint64_t checkPermission{0};
+  uint64_t optimize{0};
+  uint64_t execute{0};
+  /// End-to-end time from query creation through execution, excluding
+  /// onComplete. Includes onStart, parse, permission check, optimize,
+  /// and execute.
+  uint64_t total{0};
+};
+
+/// Holds query metadata at completion time (success or failure).
+struct QueryCompletionInfo {
+  /// Carries query ID, SQL text, and creation timestamp from the start event.
+  QueryStartInfo startInfo;
+
+  /// Contains error details when the query fails; std::nullopt on success.
+  std::optional<ErrorInfo> errorInfo;
+
+  /// Serialized Velox execution plan.
+  std::string planString;
+
+  /// Per-phase wall-clock and CPU timing.
+  QueryTiming timing;
+
+  /// Number of rows in the query result.
+  int64_t numOutputRows{0};
+
+  /// Wall-clock time when the query finished, excluding onComplete.
+  std::chrono::system_clock::time_point endTime;
+};
+
+/// Invoked when a query starts, before parsing.
+using QueryStartCallback = std::function<void(const QueryStartInfo&)>;
+
+/// Invoked when a query completes, whether it succeeded or failed.
+using QueryCompletionCallback = std::function<void(const QueryCompletionInfo&)>;
+
+/// Executes SQL queries.
 class SqlQueryRunner {
  public:
-  /// @param initializeConnectors Lambda to call to initialize connectors and
-  /// return a pair of default {connector ID, schema}.
+  virtual ~SqlQueryRunner() = default;
+
+  /// Initializes the runner with connectors, an optional permission check, and
+  /// a query ID generator (defaults to QueryIdGenerator if not provided).
+  /// Call once before running queries.
   void initialize(
       const std::function<std::pair<std::string, std::string>()>&
-          initializeConnectors);
-
-  /// Results of running a query. SELECT queries return a vector of results.
-  /// Other queries return a message. SELECT query that returns no rows returns
-  /// std::nullopt message and empty vector of results.
-  struct SqlResult {
-    std::optional<std::string> message;
-    std::vector<facebook::velox::RowVectorPtr> results;
-    /// Human-readable distributed Velox plan with optimizer cardinality and
-    /// memory estimates. Empty for DDL statements.
-    std::optional<std::string> planString;
-    /// Time spent in the optimizer, in microseconds. Zero for DDL statements.
-    uint64_t optimizeMicros{0};
-  };
+          initializeConnectors,
+      PermissionCheck permissionCheck = {},
+      std::function<std::string()> queryIdGenerator = {});
 
   struct RunOptions {
     int32_t numWorkers{4};
@@ -57,18 +120,47 @@ class SqlQueryRunner {
 
     std::optional<std::string> defaultConnectorId;
     std::optional<std::string> defaultSchema;
+
+    /// Query ID override. If set, run() uses this value instead of generating
+    /// a new one. Useful for correlating queries across systems.
     std::optional<std::string> queryId;
+
+    /// Token provider for authenticated file system access.
+    /// Used by runUnchecked() as-is. Overwritten by run() with the result of
+    /// the permission check callback.
     std::shared_ptr<facebook::velox::filesystems::TokenProvider> tokenProvider;
 
     /// If true, EXPLAIN ANALYZE output includes custom operator stats.
     bool debugMode{false};
+
+    /// Called before parsing. Receives query metadata (query ID, SQL text,
+    /// creation time).
+    QueryStartCallback onStart;
+
+    /// Called after execution completes (success or failure). Carries
+    /// telemetry only: timing, query ID, error info, row counts. Results
+    /// are returned from run(), not passed through callbacks.
+    QueryCompletionCallback onComplete;
   };
 
-  /// Runs a single SQL statement and returns the result.
-  SqlResult run(std::string_view sql, const RunOptions& options);
+  /// Results of running a query. SELECT queries return a vector of results.
+  /// Other queries return a message. SELECT query that returns no rows returns
+  /// std::nullopt message and empty vector of results.
+  struct SqlResult {
+    std::optional<std::string> message;
+    std::vector<facebook::velox::RowVectorPtr> results;
+  };
 
-  /// Runs a single parsed SQL statement and returns the result.
-  SqlResult run(
+  /// Runs a single SQL statement with full lifecycle: generates a query ID,
+  /// fires onStart, parses, checks permissions, executes, fires onComplete,
+  /// and returns the result. On failure, fires onComplete with error telemetry
+  /// then re-throws.
+  virtual SqlResult run(std::string_view sql, const RunOptions& options);
+
+  /// Runs a single parsed SQL statement without lifecycle hooks (no permission
+  /// check, no callbacks). Use run(string_view, RunOptions) for the full
+  /// lifecycle.
+  SqlResult runUnchecked(
       const presto::SqlStatement& statement,
       const RunOptions& options);
 
@@ -140,6 +232,13 @@ class SqlQueryRunner {
   }
 
  private:
+  // Checks permissions for the query via the configured PermissionCheck
+  // callback. Returns a TokenProvider for authenticated file system access.
+  std::shared_ptr<facebook::velox::filesystems::TokenProvider> checkPermission(
+      const RunOptions& options,
+      QueryCompletionInfo& completionInfo,
+      const presto::ViewMap& views);
+
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
       const RunOptions& options);
 
@@ -192,15 +291,27 @@ class SqlQueryRunner {
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
       const RunOptions& options);
 
+  // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
+  // and the serialized Velox plan into 'planString'.
+  SqlResult runUnchecked(
+      const presto::SqlStatement& statement,
+      const RunOptions& options,
+      QueryTiming& timing,
+      std::string& planString);
+
   SqlResult showSession(
       const presto::ShowSessionStatement& statement,
-      const RunOptions& options);
+      const RunOptions& options,
+      QueryTiming& timing,
+      std::string& planString);
 
-  // Optimizes and executes a logical plan, returning results and the
-  // serialized Velox plan string.
+  // Optimizes and executes a logical plan. Writes timing and plan string
+  // directly into the passed-in references so values survive exceptions.
   SqlResult runLogicalPlan(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options,
+      QueryTiming& timing,
+      std::string& planString,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
           schemaResolver = nullptr);
 
@@ -218,6 +329,11 @@ class SqlQueryRunner {
     }
   }
 
+  // Permission check callback invoked before query execution.
+  PermissionCheck permissionCheck_;
+
+  // Generates unique query IDs.
+  std::function<std::string()> queryIdGenerator_;
   std::shared_ptr<facebook::velox::cache::AsyncDataCache> cache_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> optimizerPool_;

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -279,6 +279,13 @@ session_timezone                     | UTC
 
 ```
 
+## Error message for non-existent table
+
+```scrut
+$ $CLI --query "SELECT * FROM nonexistent_table" 2>&1 >/dev/null | grep 'Query failed:'
+Query failed: * (glob)
+```
+
 ## Cleanly log dictionary wrapped result vectors (window functions produce encoded vectors)
 
 ```scrut

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -16,8 +16,8 @@
 
 #include "axiom/cli/Console.h"
 #include <gtest/gtest.h>
-#include <thread>
 #include "axiom/connectors/tests/TestConnector.h"
+#include "velox/connectors/ConnectorRegistry.h"
 
 DECLARE_string(query);
 
@@ -37,28 +37,32 @@ class ConsoleTest : public ::testing::Test {
     // Restore FLAGS_query to avoid polluting other tests.
     FLAGS_query = "";
     for (const auto& id : connectorIds_) {
-      facebook::velox::connector::unregisterConnector(id);
+      facebook::velox::connector::ConnectorRegistry::global().erase(id);
     }
   }
 
-  std::unique_ptr<SqlQueryRunner> makeRunner() {
+  std::unique_ptr<SqlQueryRunner> makeRunner(
+      PermissionCheck permissionCheck = {}) {
     auto runner = std::make_unique<SqlQueryRunner>();
 
-    runner->initialize([&]() {
-      static int32_t kCounter = 0;
+    runner->initialize(
+        [&]() {
+          static int32_t kCounter = 0;
 
-      auto testConnector =
-          std::make_shared<facebook::axiom::connector::TestConnector>(
-              fmt::format("console_test{}", kCounter++));
-      facebook::velox::connector::registerConnector(testConnector);
+          auto testConnector =
+              std::make_shared<facebook::axiom::connector::TestConnector>(
+                  fmt::format("console_test{}", kCounter++));
+          facebook::velox::connector::ConnectorRegistry::global().insert(
+              testConnector->connectorId(), testConnector);
 
-      connectorIds_.emplace_back(testConnector->connectorId());
+          connectorIds_.emplace_back(testConnector->connectorId());
 
-      return std::make_pair(
-          testConnector->connectorId(),
-          std::string(
-              facebook::axiom::connector::TestConnector::kDefaultSchema));
-    });
+          return std::make_pair(
+              testConnector->connectorId(),
+              std::string(
+                  facebook::axiom::connector::TestConnector::kDefaultSchema));
+        },
+        std::move(permissionCheck));
 
     return runner;
   }
@@ -68,24 +72,22 @@ class ConsoleTest : public ::testing::Test {
 };
 
 TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
-  auto runner = makeRunner();
-
   bool called = false;
   std::string capturedSql;
   std::string capturedCatalog;
 
-  PermissionCheck check = [&](std::string_view /*queryId*/,
-                              std::string_view sql,
-                              std::string_view catalog,
-                              std::optional<std::string_view> /*schema*/,
-                              const auto& /*views*/) {
+  auto runner = makeRunner([&](std::string_view /*queryId*/,
+                               std::string_view sql,
+                               std::string_view catalog,
+                               std::optional<std::string_view> /*schema*/,
+                               const auto& /*views*/) {
     called = true;
     capturedSql = std::string(sql);
     capturedCatalog = std::string(catalog);
     return std::shared_ptr<facebook::velox::filesystems::TokenProvider>{};
-  };
+  });
 
-  Console console{*runner, std::move(check)};
+  Console console{*runner};
   console.initialize();
 
   FLAGS_query = "SELECT 1";
@@ -94,137 +96,6 @@ TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
   ASSERT_TRUE(called);
   EXPECT_EQ(capturedSql, "SELECT 1");
   EXPECT_FALSE(capturedCatalog.empty());
-}
-
-TEST_F(ConsoleTest, completionCallbackReceivesTiming) {
-  auto runner = makeRunner();
-
-  QueryCompletionInfo captured;
-  QueryCompletionCallback callback = [&](const QueryCompletionInfo& info) {
-    captured = info;
-  };
-
-  Console console{*runner, nullptr, nullptr, nullptr, std::move(callback)};
-  console.initialize();
-
-  FLAGS_query = "SELECT 1";
-  console.run();
-
-  EXPECT_GT(captured.parseMicros, 0);
-  EXPECT_GT(captured.totalMicros, 0);
-  EXPECT_GE(captured.totalMicros, captured.parseMicros);
-  EXPECT_GE(
-      captured.totalMicros,
-      captured.parseMicros + captured.optimizeMicros +
-          captured.executionMicros);
-}
-
-TEST_F(ConsoleTest, startCallbackFiredBeforeCompletion) {
-  auto runner = makeRunner();
-
-  std::string startQueryId;
-  std::string completionQueryId;
-
-  QueryStartCallback startCallback = [&](const QueryStartInfo& info) {
-    startQueryId = info.queryId;
-    EXPECT_EQ(info.query, "SELECT 1");
-  };
-
-  QueryCompletionCallback completionCallback =
-      [&](const QueryCompletionInfo& info) {
-        completionQueryId = info.startInfo.queryId;
-      };
-
-  Console console{
-      *runner,
-      nullptr,
-      nullptr,
-      std::move(startCallback),
-      std::move(completionCallback)};
-  console.initialize();
-
-  FLAGS_query = "SELECT 1";
-  console.run();
-
-  EXPECT_FALSE(startQueryId.empty());
-  EXPECT_EQ(startQueryId, completionQueryId);
-}
-
-TEST_F(ConsoleTest, completionCallbackOnError) {
-  auto runner = makeRunner();
-
-  QueryCompletionInfo captured;
-  QueryCompletionCallback callback = [&](const QueryCompletionInfo& info) {
-    captured = info;
-  };
-
-  Console console{*runner, nullptr, nullptr, nullptr, std::move(callback)};
-  console.initialize();
-
-  FLAGS_query = "SELECT * FROM nonexistent_table";
-  console.run();
-
-  EXPECT_TRUE(captured.errorInfo.has_value());
-  EXPECT_FALSE(captured.errorInfo->message.empty());
-}
-
-TEST_F(ConsoleTest, multiStatementTimingPerStatement) {
-  auto runner = makeRunner();
-
-  std::vector<QueryCompletionInfo> completions;
-  QueryCompletionCallback callback = [&](const QueryCompletionInfo& info) {
-    completions.push_back(info);
-  };
-
-  Console console{*runner, nullptr, nullptr, nullptr, std::move(callback)};
-  console.initialize();
-
-  FLAGS_query = "SELECT 1; SELECT 2";
-  console.run();
-
-  ASSERT_EQ(completions.size(), 2);
-  for (const auto& info : completions) {
-    EXPECT_GT(info.parseMicros, 0);
-    EXPECT_GT(info.totalMicros, 0);
-    EXPECT_GE(info.totalMicros, info.parseMicros);
-  }
-}
-
-TEST_F(ConsoleTest, totalTimingIncludesAllPhases) {
-  auto runner = makeRunner();
-
-  QueryCompletionInfo captured;
-  QueryCompletionCallback callback = [&](const QueryCompletionInfo& info) {
-    captured = info;
-  };
-
-  // Inject a permission check that sleeps 10ms to create a measurable gap
-  // between parse and execute timers.
-  PermissionCheck slowCheck = [&](std::string_view /*queryId*/,
-                                  std::string_view /*sql*/,
-                                  std::string_view /*catalog*/,
-                                  std::optional<std::string_view> /*schema*/,
-                                  const auto& /*views*/) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    return std::shared_ptr<facebook::velox::filesystems::TokenProvider>{};
-  };
-
-  Console console{
-      *runner, std::move(slowCheck), nullptr, nullptr, std::move(callback)};
-  console.initialize();
-
-  FLAGS_query = "SELECT 1";
-  console.run();
-
-  auto phaseSum =
-      captured.parseMicros + captured.optimizeMicros + captured.executionMicros;
-  EXPECT_GT(captured.totalMicros, 0);
-  EXPECT_GE(captured.totalMicros, phaseSum);
-  // The 10ms sleep in the permission check creates a gap that only the outer
-  // timer captures.
-  EXPECT_GT(captured.totalMicros - phaseSum, 5'000)
-      << "Expected at least 5ms gap from the slow permission check, got "
-      << (captured.totalMicros - phaseSum) << "us";
 }
 
 } // namespace

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -20,9 +20,11 @@
 #include <folly/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <thread>
+#include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/common/time/Timer.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -45,7 +47,7 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   void TearDown() override {
     runner_.reset();
     for (const auto& id : connectorIds_) {
-      facebook::velox::connector::unregisterConnector(id);
+      facebook::velox::connector::ConnectorRegistry::global().erase(id);
     }
   }
 
@@ -53,19 +55,27 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
       facebook::axiom::connector::TestConnector::kDefaultSchema};
 
   std::unique_ptr<SqlQueryRunner> makeRunner(
-      const std::string& connectorId = "test") {
+      const std::string& connectorId = "test",
+      std::function<std::string()> queryIdGenerator = {},
+      PermissionCheck permissionCheck = {}) {
     auto runner = std::make_unique<SqlQueryRunner>();
 
-    runner->initialize([&]() {
+    auto initConnectors = [&]() {
       testConnector_ =
           std::make_shared<facebook::axiom::connector::TestConnector>(
               connectorId);
-      facebook::velox::connector::registerConnector(testConnector_);
+      facebook::velox::connector::ConnectorRegistry::global().insert(
+          testConnector_->connectorId(), testConnector_);
 
       connectorIds_.emplace_back(testConnector_->connectorId());
 
       return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
-    });
+    };
+
+    runner->initialize(
+        initConnectors,
+        std::move(permissionCheck),
+        std::move(queryIdGenerator));
 
     return runner;
   }
@@ -114,16 +124,16 @@ TEST_F(SqlQueryRunnerTest, parseAndRunMixedStatementTypes) {
       "SELECT 42; EXPLAIN (TYPE LOGICAL) SELECT 1; select 7", {});
   ASSERT_EQ(3, statements.size());
 
-  auto selectResult = runner_->run(*statements[0], {});
+  auto selectResult = runner_->runUnchecked(*statements[0], {});
   ASSERT_FALSE(selectResult.message.has_value());
   test::assertEqualVectors(
       selectResult.results[0], makeRowVector({makeFlatVector<int32_t>({42})}));
 
-  auto explainResult = runner_->run(*statements[1], {});
+  auto explainResult = runner_->runUnchecked(*statements[1], {});
   ASSERT_TRUE(explainResult.message.has_value());
   ASSERT_FALSE(explainResult.message.value().empty());
 
-  auto lastResult = runner_->run(*statements[2], {});
+  auto lastResult = runner_->runUnchecked(*statements[2], {});
   ASSERT_FALSE(lastResult.message.has_value());
   test::assertEqualVectors(
       lastResult.results[0], makeRowVector({makeFlatVector<int32_t>({7})}));
@@ -798,6 +808,264 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
   // Non-existent table.
   VELOX_ASSERT_USER_THROW(
       run("SHOW CREATE TABLE no_such_table"), "Table not found");
+}
+
+TEST_F(SqlQueryRunnerTest, generateQueryIdDefault) {
+  // Default generator produces non-empty, unique IDs via run().
+  std::string queryId1;
+  std::string queryId2;
+  SqlQueryRunner::RunOptions options;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    queryId1 = info.startInfo.queryId;
+  };
+  runner_->run("SELECT 1", options);
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    queryId2 = info.startInfo.queryId;
+  };
+  runner_->run("SELECT 2", options);
+  EXPECT_FALSE(queryId1.empty());
+  EXPECT_FALSE(queryId2.empty());
+  EXPECT_NE(queryId1, queryId2);
+}
+
+TEST_F(SqlQueryRunnerTest, generateQueryIdCustomGenerator) {
+  auto generator = std::make_shared<cli::QueryIdGenerator>();
+  auto runner = makeRunner("test_custom_gen", [generator]() {
+    return generator->createNextQueryId();
+  });
+
+  std::string queryId;
+  SqlQueryRunner::RunOptions options;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    queryId = info.startInfo.queryId;
+  };
+  runner->run("SELECT 1", options);
+  EXPECT_FALSE(queryId.empty());
+  // Custom generator's suffix should appear in the generated ID.
+  EXPECT_THAT(queryId, ::testing::HasSubstr(generator->suffix()));
+}
+
+TEST_F(SqlQueryRunnerTest, completionCallbackReceivesTiming) {
+  QueryCompletionInfo captured;
+  runner_->run("SELECT 1", {.onComplete = [&](const QueryCompletionInfo& info) {
+                 captured = info;
+               }});
+
+  EXPECT_GT(captured.timing.parse, 0);
+  EXPECT_GT(captured.timing.total, 0);
+  EXPECT_GE(captured.timing.total, captured.timing.parse);
+  EXPECT_GE(
+      captured.timing.total,
+      captured.timing.parse + captured.timing.optimize +
+          captured.timing.execute);
+}
+
+TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletion) {
+  std::string startQueryId;
+  std::string completionQueryId;
+
+  runner_->run(
+      "SELECT 1",
+      {.onStart =
+           [&](const QueryStartInfo& info) {
+             startQueryId = info.queryId;
+             EXPECT_EQ(info.query, "SELECT 1");
+           },
+       .onComplete =
+           [&](const QueryCompletionInfo& info) {
+             completionQueryId = info.startInfo.queryId;
+           }});
+
+  EXPECT_FALSE(startQueryId.empty());
+  EXPECT_EQ(startQueryId, completionQueryId);
+}
+
+TEST_F(SqlQueryRunnerTest, completionCallbackOnError) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM nonexistent_table",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  EXPECT_TRUE(captured.errorInfo.has_value());
+  EXPECT_FALSE(captured.errorInfo->message.empty());
+}
+
+TEST_F(SqlQueryRunnerTest, multiStatementTimingPerStatement) {
+  std::vector<QueryCompletionInfo> completions;
+
+  for (const auto& sqlText : runner_->splitStatements("SELECT 1; SELECT 2")) {
+    if (sqlText.empty()) {
+      continue;
+    }
+    runner_->run(sqlText, {.onComplete = [&](const QueryCompletionInfo& info) {
+                   completions.push_back(info);
+                 }});
+  }
+
+  ASSERT_EQ(completions.size(), 2);
+  for (const auto& info : completions) {
+    EXPECT_GT(info.timing.parse, 0);
+    EXPECT_GT(info.timing.total, 0);
+    EXPECT_GE(info.timing.total, info.timing.parse);
+  }
+}
+
+TEST_F(SqlQueryRunnerTest, totalTimingIncludesAllPhases) {
+  QueryCompletionInfo captured;
+
+  // Inject a permission check that sleeps 10ms to create a measurable gap
+  // between parse and execute timers.
+  auto runner = makeRunner(
+      "test_timing",
+      {},
+      [&](std::string_view /*queryId*/,
+          std::string_view /*sql*/,
+          std::string_view /*catalog*/,
+          std::optional<std::string_view> /*schema*/,
+          const auto& /*views*/) {
+        // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        return std::shared_ptr<facebook::velox::filesystems::TokenProvider>{};
+      });
+
+  runner->run("SELECT 1", {.onComplete = [&](const QueryCompletionInfo& info) {
+                captured = info;
+              }});
+
+  auto phaseSum = captured.timing.parse + captured.timing.optimize +
+      captured.timing.execute;
+  EXPECT_GT(captured.timing.total, 0);
+  EXPECT_GE(captured.timing.total, phaseSum);
+  // The permission check timing is now tracked explicitly.
+  EXPECT_GT(captured.timing.checkPermission, 5'000)
+      << "Expected at least 5ms from the slow permission check, got "
+      << captured.timing.checkPermission << "us";
+}
+
+TEST_F(SqlQueryRunnerTest, onStartExceptionSwallowed) {
+  QueryCompletionInfo captured;
+  bool completionFired = false;
+
+  auto result = runner_->run(
+      "SELECT 1",
+      {.onStart =
+           [](const QueryStartInfo&) {
+             throw std::runtime_error("start error");
+           },
+       .onComplete =
+           [&](const QueryCompletionInfo& info) {
+             captured = info;
+             completionFired = true;
+           }});
+
+  // Query should still succeed despite onStart throwing.
+  EXPECT_FALSE(result.message.has_value());
+  ASSERT_EQ(result.results.size(), 1);
+  EXPECT_TRUE(completionFired);
+  EXPECT_FALSE(captured.errorInfo.has_value());
+}
+
+TEST_F(SqlQueryRunnerTest, completionCallbackOnParseFailure) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "INVALID SYNTAX HERE",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  EXPECT_TRUE(captured.errorInfo.has_value());
+  EXPECT_GT(captured.timing.parse, 0);
+  EXPECT_EQ(captured.timing.optimize, 0);
+  EXPECT_EQ(captured.timing.execute, 0);
+}
+
+TEST_F(SqlQueryRunnerTest, completionCallbackOnPermissionCheckFailure) {
+  QueryCompletionInfo captured;
+
+  auto runner = makeRunner(
+      "test_perm_fail",
+      {},
+      [](std::string_view,
+         std::string_view,
+         std::string_view,
+         std::optional<std::string_view>,
+         const auto&)
+          -> std::shared_ptr<facebook::velox::filesystems::TokenProvider> {
+        throw std::runtime_error("permission denied");
+      });
+
+  EXPECT_THROW(
+      runner->run(
+          "SELECT 1",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  EXPECT_TRUE(captured.errorInfo.has_value());
+  EXPECT_THAT(captured.errorInfo->message, ::testing::HasSubstr("permission"));
+  EXPECT_GT(captured.timing.parse, 0);
+  EXPECT_GT(captured.timing.checkPermission, 0);
+  EXPECT_EQ(captured.timing.optimize, 0);
+  EXPECT_EQ(captured.timing.execute, 0);
+}
+
+TEST_F(SqlQueryRunnerTest, completionCallbackOnOptimizationFailure) {
+  // SELECT * FROM nonexistent_table fails during optimization (table not
+  // found). Verify onComplete fires with error info and partial timing.
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM nonexistent_table",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  EXPECT_TRUE(captured.errorInfo.has_value());
+  EXPECT_GT(captured.timing.parse, 0);
+  // Optimization started but failed — timing may be > 0.
+  EXPECT_EQ(captured.timing.execute, 0);
+  EXPECT_GT(captured.timing.total, 0);
+}
+
+TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletionOrdering) {
+  int counter = 0;
+  int startOrder = -1;
+  int completeOrder = -1;
+
+  runner_->run(
+      "SELECT 1",
+      {.onStart = [&](const QueryStartInfo&) { startOrder = counter++; },
+       .onComplete =
+           [&](const QueryCompletionInfo&) { completeOrder = counter++; }});
+
+  EXPECT_EQ(startOrder, 0);
+  EXPECT_EQ(completeOrder, 1);
+}
+
+TEST_F(SqlQueryRunnerTest, timingFieldsOnParseError) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "TOTALLY INVALID SQL",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  EXPECT_TRUE(captured.errorInfo.has_value());
+  EXPECT_GT(captured.timing.parse, 0);
+  EXPECT_EQ(captured.timing.checkPermission, 0);
+  EXPECT_EQ(captured.timing.optimize, 0);
+  EXPECT_EQ(captured.timing.execute, 0);
+  EXPECT_GT(captured.timing.total, 0);
+  EXPECT_GE(captured.timing.total, captured.timing.parse);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Console previously orchestrated the query lifecycle (generating query IDs,
calling onQueryStart, checking permissions, calling onQueryCompletion) and
owned the callback configuration. This forced direct SqlQueryRunner callers
to duplicate the same call pattern.

This diff moves lifecycle orchestration into SqlQueryRunner and introduces
per-query callbacks via RunOptions:

**SqlQueryRunner changes:**

- `run(string_view, RunOptions)` is now virtual and handles the full lifecycle: generates a query ID, fires the start callback, parses (timed), checks permissions (timed), executes (timed), fires the completion callback, and returns the result. On error, the completion callback receives error details and the exception is rethrown.
- `runUnchecked(SqlStatement, RunOptions)` is the low-level execution method without lifecycle hooks (renamed from `run` to make explicit that it bypasses permission checks, callbacks, and timing).
- `initialize()` takes connectors, an optional `PermissionCheck`, and a query ID generator (defaults to `QueryIdGenerator` if not provided).
- Per-query callbacks are passed via `RunOptions.onStart` and `RunOptions.onComplete`. Each fires exactly once per `run()` call, avoiding the concurrency issues of global callback registration. Exceptions from callbacks are logged and swallowed.
- Callbacks carry telemetry only (query ID, timing, error info, row counts). Results are returned exclusively from `run()` via `SqlResult`.
- `SqlResult` is a nested struct inside `SqlQueryRunner` with just `{message, results}` — lifecycle metadata (query ID, timing, plan string) flows through the `onComplete` callback via `QueryCompletionInfo`, not the return value.
- `QueryTiming` tracks per-phase wall-clock timing in microseconds, ordered by lifecycle stage: onStart, parse, checkPermission, optimize, execute, total.
- `QueryCompletionInfo` is built once before try-catch. A `finalize` lambda computes total timing from `endTime - createTime` and fires `onComplete` on both success and error paths.
- Timing and plan string are written directly into `QueryCompletionInfo` via references passed through `runUnchecked` and `runLogicalPlan`, so values survive exceptions.

**Console changes:**

- Console holds a `SqlQueryRunner&` and calls `runner_.run()`. Virtual dispatch routes to `FbSqlQueryRunner::run()` in the FB path.
- CPU timing (getrusage) moved from SqlQueryRunner to Console via `cli::time`/`cli::Timing`, since it measures the entire process and is a CLI presentation concern.
- `runNoThrow()` captures telemetry via the `onComplete` callback. On success, prints results from `SqlResult` and timing from `QueryCompletionInfo`. On failure, prints error and timing from `QueryCompletionInfo`.
- Interactive output now includes parse timing: `Parsing: ... | Optimizing: ... | Executing: ... | Total: ...`
- Timing is printed on failed queries too (to stderr).
- `isInteractive` restored as a parameter (not a member variable).

Reviewed By: mbasmanova

Differential Revision: D98851321


