### PR TITLE
test(optimizer): Add ExpressionMatcher for structural expression comparison (#1200)

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -48,12 +48,13 @@ target_link_libraries(
   gtest_main
 )
 
-add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp)
+add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp ExpressionMatcher.cpp)
 
 target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   velox_hive_connector
   velox_parse_parser
+  velox_type
   GTest::gmock
   glog::glog
   GTest::gtest
@@ -106,6 +107,7 @@ add_executable(
   CsvReadWriteTest.cpp
   DerivedTablePrinterTest.cpp
   DomainTest.cpp
+  ExpressionMatcherTest.cpp
   ExistencePushdownTest.cpp
   FilterPushdownTest.cpp
   FiltersTest.cpp

--- a/axiom/optimizer/tests/ExpressionMatcher.cpp
+++ b/axiom/optimizer/tests/ExpressionMatcher.cpp
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/ExpressionMatcher.h"
+#include <gtest/gtest.h>
+#include "velox/core/Expressions.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::core {
+
+struct ExpressionMatcher::Impl {
+  enum class Kind { kAny, kField, kConstant, kCall, kCast };
+
+  Kind kind{Kind::kAny};
+  std::string name;
+  std::shared_ptr<const ConstantTypedExpr> constantExpr;
+  TypePtr castType;
+  std::vector<ExpressionMatcher> inputs;
+};
+
+bool ExpressionMatcher::matchImpl(
+    const Impl& pattern,
+    const ITypedExpr* actual) {
+  switch (pattern.kind) {
+    case Impl::Kind::kAny:
+      return true;
+
+    case Impl::Kind::kField: {
+      auto* af = dynamic_cast<const FieldAccessTypedExpr*>(actual);
+      if (!af) {
+        return false;
+      }
+      return af->name() == pattern.name;
+    }
+
+    case Impl::Kind::kConstant: {
+      auto* ac = dynamic_cast<const ConstantTypedExpr*>(actual);
+      if (!ac) {
+        return false;
+      }
+      return *ac == *pattern.constantExpr;
+    }
+
+    case Impl::Kind::kCall: {
+      auto* aCall = dynamic_cast<const CallTypedExpr*>(actual);
+      if (!aCall) {
+        return false;
+      }
+      if (aCall->name() != pattern.name) {
+        return false;
+      }
+      if (aCall->inputs().size() != pattern.inputs.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < pattern.inputs.size(); ++i) {
+        if (!matchImpl(*pattern.inputs[i].impl_, aCall->inputs()[i].get())) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    case Impl::Kind::kCast: {
+      auto* aCast = dynamic_cast<const CastTypedExpr*>(actual);
+      if (!aCast) {
+        return false;
+      }
+      if (!aCast->type()->equivalent(*pattern.castType)) {
+        return false;
+      }
+      if (aCast->inputs().size() != pattern.inputs.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < pattern.inputs.size(); ++i) {
+        if (!matchImpl(*pattern.inputs[i].impl_, aCast->inputs()[i].get())) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+std::string ExpressionMatcher::describePattern(const Impl& pattern) {
+  switch (pattern.kind) {
+    case Impl::Kind::kAny:
+      return "<any>";
+    case Impl::Kind::kField:
+      return pattern.name;
+    case Impl::Kind::kConstant:
+      return pattern.constantExpr->toString();
+    case Impl::Kind::kCall: {
+      std::string result = pattern.name + "(";
+      for (size_t i = 0; i < pattern.inputs.size(); ++i) {
+        if (i > 0) {
+          result += ", ";
+        }
+        result += describePattern(*pattern.inputs[i].impl_);
+      }
+      result += ")";
+      return result;
+    }
+    case Impl::Kind::kCast: {
+      std::string result = "cast(";
+      if (!pattern.inputs.empty()) {
+        result += describePattern(*pattern.inputs[0].impl_);
+      }
+      result += " as " + pattern.castType->toString() + ")";
+      return result;
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+ExpressionMatcher::ExpressionMatcher(std::shared_ptr<const Impl> impl)
+    : impl_(std::move(impl)) {}
+
+ExpressionMatcher::ExpressionMatcher(int32_t value)
+    : ExpressionMatcher(constant(value)) {}
+ExpressionMatcher::ExpressionMatcher(int64_t value)
+    : ExpressionMatcher(constant(value)) {}
+ExpressionMatcher::ExpressionMatcher(double value)
+    : ExpressionMatcher(constant(value)) {}
+
+ExpressionMatcher ExpressionMatcher::any() {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kAny;
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::col(const std::string& name) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kField;
+  impl->name = name;
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(int64_t value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(BIGINT(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(int32_t value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(INTEGER(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(float value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(REAL(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(double value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(DOUBLE(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(bool value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(BOOLEAN(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(const std::string& value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  impl->constantExpr =
+      std::make_shared<ConstantTypedExpr>(VARCHAR(), Variant(value));
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(const char* value) {
+  return constant(std::string(value));
+}
+
+ExpressionMatcher ExpressionMatcher::constant(
+    const TypePtr& type,
+    const std::string& value) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kConstant;
+  if (type->isDate()) {
+    impl->constantExpr = std::make_shared<ConstantTypedExpr>(
+        type, Variant(DATE()->toDays(value)));
+  } else {
+    VELOX_UNSUPPORTED(
+        "constant(TypePtr, string) not yet supported for {}", type->toString());
+  }
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::call(
+    const std::string& name,
+    std::vector<ExpressionMatcher> inputs) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kCall;
+  impl->name = name;
+  impl->inputs = std::move(inputs);
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::cast(
+    TypePtr targetType,
+    ExpressionMatcher input) {
+  auto impl = std::make_shared<Impl>();
+  impl->kind = Impl::Kind::kCast;
+  impl->castType = std::move(targetType);
+  impl->inputs = {std::move(input)};
+  return ExpressionMatcher(std::move(impl));
+}
+
+ExpressionMatcher ExpressionMatcher::eq(ExpressionMatcher rhs) const {
+  return call("eq", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::neq(ExpressionMatcher rhs) const {
+  return call("neq", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::lt(ExpressionMatcher rhs) const {
+  return call("lt", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::lte(ExpressionMatcher rhs) const {
+  return call("lte", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::gt(ExpressionMatcher rhs) const {
+  return call("gt", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::gte(ExpressionMatcher rhs) const {
+  return call("gte", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::between(
+    ExpressionMatcher low,
+    ExpressionMatcher high) const {
+  return call("between", {*this, std::move(low), std::move(high)});
+}
+
+ExpressionMatcher ExpressionMatcher::and_(ExpressionMatcher rhs) const {
+  return call("and", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::or_(ExpressionMatcher rhs) const {
+  return call("or", {*this, std::move(rhs)});
+}
+
+ExpressionMatcher ExpressionMatcher::not_() const {
+  return call("not", {*this});
+}
+
+ExpressionMatcher ExpressionMatcher::like(ExpressionMatcher pattern) const {
+  return call("like", {*this, std::move(pattern)});
+}
+
+bool ExpressionMatcher::match(const TypedExprPtr& actual) const {
+  EXPECT_NE(actual, nullptr)
+      << "Expected expression matching: " << describePattern(*impl_);
+  if (actual == nullptr) {
+    return false;
+  }
+  bool result = matchImpl(*impl_, actual.get());
+  EXPECT_TRUE(result) << "Expression mismatch:\n  actual:   "
+                      << actual->toString()
+                      << "\n  expected: " << describePattern(*impl_);
+  return result;
+}
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/ExpressionMatcher.h
+++ b/axiom/optimizer/tests/ExpressionMatcher.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include "velox/core/ITypedExpr.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::core {
+
+/// Structural pattern matcher for typed expression trees (ITypedExpr),
+/// analogous to PlanMatcher for plan nodes.
+///
+/// Replaces the old approach of comparing filter expressions via
+/// DuckDB-parsed toString() equality, which is fragile against float
+/// roundoff (0.06 - 0.01 stringifies as "0.049999999999999996", not
+/// "0.05") and adds an unnecessary DuckDB dependency.
+///
+/// Matching uses ConstantTypedExpr::operator== for constants (strict
+/// type + value equality), dynamic_cast for node-type discrimination,
+/// and recursive child matching.
+///
+/// Factories:
+///   col("name")                - column reference
+///   constant(value)            - typed literal (int32, int64, double, bool,
+///                                string)
+///   constant(type, "value")    - typed literal from string (e.g. DATE)
+///   call("fn", {args...})      - function call
+///   cast(type, input)          - CAST expression with target type
+///   any()                      - wildcard (matches anything)
+///
+/// Fluent operators: eq, neq, lt, lte, gt, gte, between, and_, or_,
+/// not_, like.
+///
+/// Examples (with `using namespace core::em;`):
+///
+///   // Simple comparison
+///   col("a").eq(col("b")).match(actualExpr);
+///
+///   // Compound TPC-H Q6 filter
+///   col("l_shipdate").gte(constant(DATE(), "1994-01-01"))
+///       .and_(col("l_shipdate").lt(constant(DATE(), "1995-01-01")))
+///       .and_(col("l_discount").between(constant(0.05), constant(0.07)))
+///       .and_(col("l_quantity").lt(constant(24.0)))
+///       .match(actualExpr);
+///
+///   // Wildcard for complex constants (e.g. IN-list arrays)
+///   call("in", {col("x"), any()}).match(actualExpr);
+///
+///   // CAST with target type
+///   cast(DATE(), col("x")).match(actualExpr);
+class ExpressionMatcher {
+ public:
+  /// Matches any expression (wildcard).
+  static ExpressionMatcher any();
+
+  static ExpressionMatcher col(const std::string& name);
+
+  static ExpressionMatcher constant(int64_t value);
+  static ExpressionMatcher constant(int32_t value);
+  static ExpressionMatcher constant(float value);
+  static ExpressionMatcher constant(double value);
+  static ExpressionMatcher constant(bool value);
+  static ExpressionMatcher constant(const std::string& value);
+  static ExpressionMatcher constant(const char* value);
+
+  /// Typed constant factory. Parses the string representation according to
+  /// the given type. Currently supports DATE (e.g. "1994-01-01").
+  static ExpressionMatcher constant(
+      const TypePtr& type,
+      const std::string& value);
+
+  static ExpressionMatcher call(
+      const std::string& name,
+      std::vector<ExpressionMatcher> inputs);
+
+  /// Matches a CAST expression with the given target type and input.
+  static ExpressionMatcher cast(TypePtr targetType, ExpressionMatcher input);
+
+  explicit ExpressionMatcher(int32_t value);
+  explicit ExpressionMatcher(int64_t value);
+  explicit ExpressionMatcher(double value);
+
+  ExpressionMatcher eq(ExpressionMatcher rhs) const;
+  ExpressionMatcher neq(ExpressionMatcher rhs) const;
+  ExpressionMatcher lt(ExpressionMatcher rhs) const;
+  ExpressionMatcher lte(ExpressionMatcher rhs) const;
+  ExpressionMatcher gt(ExpressionMatcher rhs) const;
+  ExpressionMatcher gte(ExpressionMatcher rhs) const;
+  ExpressionMatcher between(ExpressionMatcher low, ExpressionMatcher high)
+      const;
+  ExpressionMatcher and_(ExpressionMatcher rhs) const;
+  ExpressionMatcher or_(ExpressionMatcher rhs) const;
+  ExpressionMatcher not_() const;
+  ExpressionMatcher like(ExpressionMatcher pattern) const;
+
+  /// Match this pattern against a typed expression tree. Sets gtest
+  /// EXPECT failures with diagnostics on mismatch.
+  bool match(const TypedExprPtr& actual) const;
+
+ private:
+  struct Impl;
+  std::shared_ptr<const Impl> impl_;
+
+  explicit ExpressionMatcher(std::shared_ptr<const Impl> impl);
+
+  static bool matchImpl(const Impl& pattern, const ITypedExpr* actual);
+  static std::string describePattern(const Impl& pattern);
+};
+
+/// Short aliases for use with `using namespace core::em;` in tests.
+namespace em {
+using ExpressionMatcher = core::ExpressionMatcher;
+inline ExpressionMatcher any() {
+  return ExpressionMatcher::any();
+}
+inline ExpressionMatcher col(const std::string& name) {
+  return ExpressionMatcher::col(name);
+}
+inline ExpressionMatcher constant(int64_t v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(int32_t v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(float v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(double v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(bool v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(const std::string& v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(const char* v) {
+  return ExpressionMatcher::constant(v);
+}
+inline ExpressionMatcher constant(const TypePtr& type, const std::string& v) {
+  return ExpressionMatcher::constant(type, v);
+}
+inline ExpressionMatcher call(
+    const std::string& name,
+    std::vector<ExpressionMatcher> inputs) {
+  return ExpressionMatcher::call(name, std::move(inputs));
+}
+inline ExpressionMatcher cast(TypePtr targetType, ExpressionMatcher input) {
+  return ExpressionMatcher::cast(std::move(targetType), std::move(input));
+}
+} // namespace em
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/ExpressionMatcherTest.cpp
+++ b/axiom/optimizer/tests/ExpressionMatcherTest.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/ExpressionMatcher.h"
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+#include "velox/core/Expressions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::core::em;
+
+namespace {
+
+TypedExprPtr makeConstant(TypePtr type, Variant value) {
+  return std::make_shared<ConstantTypedExpr>(std::move(type), std::move(value));
+}
+
+TypedExprPtr makeField(const std::string& name, TypePtr type) {
+  return std::make_shared<FieldAccessTypedExpr>(std::move(type), name);
+}
+
+TypedExprPtr makeCall(
+    const std::string& name,
+    TypePtr type,
+    std::vector<TypedExprPtr> inputs) {
+  return std::make_shared<CallTypedExpr>(
+      std::move(type), std::move(inputs), name);
+}
+
+} // namespace
+
+TEST(ExpressionMatcherTest, exactConstants) {
+  EXPECT_TRUE(constant(int64_t(42))
+                  .match(makeConstant(BIGINT(), Variant(int64_t(42)))));
+  EXPECT_TRUE(constant(3.14).match(makeConstant(DOUBLE(), Variant(3.14))));
+  EXPECT_TRUE(
+      constant("hello").match(makeConstant(VARCHAR(), Variant("hello"))));
+  EXPECT_TRUE(constant(true).match(makeConstant(BOOLEAN(), Variant(true))));
+  EXPECT_TRUE(
+      constant(int32_t(7)).match(makeConstant(INTEGER(), Variant(int32_t(7)))));
+}
+
+TEST(ExpressionMatcherTest, dateConstant) {
+  auto days = DATE()->toDays("1994-01-01");
+  EXPECT_TRUE(constant(DATE(), "1994-01-01")
+                  .match(makeConstant(DATE(), Variant(days))));
+}
+
+TEST(ExpressionMatcherTest, fieldAccess) {
+  EXPECT_TRUE(col("col_a").match(makeField("col_a", BIGINT())));
+}
+
+TEST(ExpressionMatcherTest, functionCall) {
+  auto a = makeField("a", BIGINT());
+  auto b = makeField("b", BIGINT());
+  EXPECT_TRUE(col("a").eq(col("b")).match(makeCall("eq", BOOLEAN(), {a, b})));
+  EXPECT_TRUE(call("plus", {col("a"), col("b")})
+                  .match(makeCall("plus", BIGINT(), {a, b})));
+}
+
+TEST(ExpressionMatcherTest, fluentOperators) {
+  auto x = makeField("x", BIGINT());
+  auto c = makeConstant(BIGINT(), Variant(int64_t(5)));
+
+  EXPECT_TRUE(col("x")
+                  .neq(constant(int64_t(5)))
+                  .match(makeCall("neq", BOOLEAN(), {x, c})));
+  EXPECT_TRUE(col("x")
+                  .lt(constant(int64_t(5)))
+                  .match(makeCall("lt", BOOLEAN(), {x, c})));
+  EXPECT_TRUE(col("x")
+                  .lte(constant(int64_t(5)))
+                  .match(makeCall("lte", BOOLEAN(), {x, c})));
+  EXPECT_TRUE(col("x")
+                  .gt(constant(int64_t(5)))
+                  .match(makeCall("gt", BOOLEAN(), {x, c})));
+  EXPECT_TRUE(col("x")
+                  .gte(constant(int64_t(5)))
+                  .match(makeCall("gte", BOOLEAN(), {x, c})));
+  EXPECT_TRUE(col("x")
+                  .like(constant("%foo%"))
+                  .match(makeCall(
+                      "like",
+                      BOOLEAN(),
+                      {x, makeConstant(VARCHAR(), Variant("%foo%"))})));
+  EXPECT_TRUE(
+      col("x")
+          .eq(constant(int64_t(1)))
+          .or_(col("x").eq(constant(int64_t(2))))
+          .match(makeCall(
+              "or",
+              BOOLEAN(),
+              {makeCall(
+                   "eq",
+                   BOOLEAN(),
+                   {x, makeConstant(BIGINT(), Variant(int64_t(1)))}),
+               makeCall(
+                   "eq",
+                   BOOLEAN(),
+                   {x, makeConstant(BIGINT(), Variant(int64_t(2)))})})));
+}
+
+TEST(ExpressionMatcherTest, compoundFilter) {
+  auto shipdate = makeField("l_shipdate", DATE());
+  auto discount = makeField("l_discount", DOUBLE());
+  auto quantity = makeField("l_quantity", DOUBLE());
+
+  auto dateDays1 = DATE()->toDays("1994-01-01");
+  auto dateDays2 = DATE()->toDays("1995-01-01");
+
+  auto actual = makeCall(
+      "and",
+      BOOLEAN(),
+      {makeCall(
+           "and",
+           BOOLEAN(),
+           {makeCall(
+                "and",
+                BOOLEAN(),
+                {makeCall(
+                     "gte",
+                     BOOLEAN(),
+                     {shipdate, makeConstant(DATE(), Variant(dateDays1))}),
+                 makeCall(
+                     "lt",
+                     BOOLEAN(),
+                     {shipdate, makeConstant(DATE(), Variant(dateDays2))})}),
+            makeCall(
+                "between",
+                BOOLEAN(),
+                {discount,
+                 makeConstant(DOUBLE(), Variant(0.06 - 0.01)),
+                 makeConstant(DOUBLE(), Variant(0.07))})}),
+       makeCall(
+           "lt",
+           BOOLEAN(),
+           {quantity, makeConstant(DOUBLE(), Variant(24.0))})});
+
+  auto matcher =
+      col("l_shipdate")
+          .gte(constant(DATE(), "1994-01-01"))
+          .and_(col("l_shipdate").lt(constant(DATE(), "1995-01-01")))
+          .and_(
+              col("l_discount").between(constant(0.06 - 0.01), constant(0.07)))
+          .and_(col("l_quantity").lt(constant(24.0)));
+
+  EXPECT_TRUE(matcher.match(actual));
+}
+
+TEST(ExpressionMatcherTest, anyMatcher) {
+  EXPECT_TRUE(any().match(makeConstant(BIGINT(), Variant(int64_t(42)))));
+  EXPECT_TRUE(any().match(makeField("x", DOUBLE())));
+  EXPECT_TRUE(
+      any().match(makeCall("plus", BIGINT(), {makeField("a", BIGINT())})));
+}
+
+TEST(ExpressionMatcherTest, anyInsideCall) {
+  auto actual = makeCall(
+      "in",
+      BOOLEAN(),
+      {makeField("x", BIGINT()), makeConstant(BIGINT(), Variant(int64_t(1)))});
+  EXPECT_TRUE(call("in", {col("x"), any()}).match(actual));
+}
+
+TEST(ExpressionMatcherTest, castExpression) {
+  auto input = makeField("x", VARCHAR());
+  auto castExpr = std::make_shared<CastTypedExpr>(DATE(), input, false);
+  EXPECT_TRUE(cast(DATE(), col("x")).match(castExpr));
+}
+
+TEST(ExpressionMatcherTest, castTypeMismatch) {
+  auto input = makeField("x", VARCHAR());
+  auto castExpr = std::make_shared<CastTypedExpr>(DATE(), input, false);
+  EXPECT_NONFATAL_FAILURE(
+      cast(INTEGER(), col("x")).match(castExpr), "Expression mismatch");
+}
+
+TEST(ExpressionMatcherTest, nullActualExpression) {
+  TypedExprPtr nullExpr = nullptr;
+  EXPECT_NONFATAL_FAILURE(
+      col("x").match(nullExpr), "Expected expression matching");
+}
+
+TEST(ExpressionMatcherTest, mismatchConstantValue) {
+  auto actual = makeConstant(BIGINT(), Variant(int64_t(42)));
+  EXPECT_NONFATAL_FAILURE(constant(99).match(actual), "Expression mismatch");
+}
+
+TEST(ExpressionMatcherTest, mismatchFieldName) {
+  auto actual = makeField("a", BIGINT());
+  EXPECT_NONFATAL_FAILURE(col("b").match(actual), "Expression mismatch");
+}
+
+TEST(ExpressionMatcherTest, mismatchCallName) {
+  auto a = makeField("a", BIGINT());
+  auto b = makeField("b", BIGINT());
+  auto actual = makeCall("eq", BOOLEAN(), {a, b});
+  EXPECT_NONFATAL_FAILURE(
+      call("lt", {col("a"), col("b")}).match(actual), "Expression mismatch");
+}
+
+TEST(ExpressionMatcherTest, mismatchNodeKind) {
+  auto actual = makeField("x", BIGINT());
+  EXPECT_NONFATAL_FAILURE(constant(1).match(actual), "Expression mismatch");
+}
+
+TEST(ExpressionMatcherTest, mismatchCallArity) {
+  auto a = makeField("a", BIGINT());
+  auto actual = makeCall("f", BIGINT(), {a});
+  EXPECT_NONFATAL_FAILURE(
+      call("f", {col("a"), col("b")}).match(actual), "Expression mismatch");
+}

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -259,11 +259,11 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
   HiveScanMatcher(
       const std::string& tableName,
       common::SubfieldFilters subfieldFilters,
-      const std::string& remainingFilter)
+      std::optional<ExpressionMatcher> remainingFilter = std::nullopt)
       : PlanMatcherImpl<TableScanNode>(),
         tableName_{tableName},
         subfieldFilters_{std::move(subfieldFilters)},
-        remainingFilter_{remainingFilter} {}
+        remainingFilterMatcher_{std::move(remainingFilter)} {}
 
   MatchResult matchDetails(
       const TableScanNode& plan,
@@ -299,17 +299,14 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
     }
 
     const auto& remainingFilter = hiveTableHandle->remainingFilter();
-    if (remainingFilter == nullptr) {
-      EXPECT_TRUE(remainingFilter_.empty())
-          << "Expected remaining filter: " << remainingFilter_;
-    } else if (remainingFilter_.empty()) {
+    if (remainingFilterMatcher_) {
+      remainingFilterMatcher_->match(remainingFilter);
+      AXIOM_TEST_RETURN_IF_FAILURE
+    } else {
       EXPECT_TRUE(remainingFilter == nullptr)
           << "Expected no remaining filter, but got "
           << remainingFilter->toString();
-    } else {
-      auto expected =
-          parse::DuckSqlExpressionsParser().parseExpr(remainingFilter_);
-      EXPECT_EQ(remainingFilter->toString(), expected->toString());
+      AXIOM_TEST_RETURN_IF_FAILURE
     }
 
     AXIOM_TEST_RETURN
@@ -318,7 +315,7 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
  private:
   const std::string tableName_;
   const common::SubfieldFilters subfieldFilters_;
-  const std::string remainingFilter_;
+  const std::optional<ExpressionMatcher> remainingFilterMatcher_;
 };
 
 class ValuesMatcher : public PlanMatcherImpl<ValuesNode> {
@@ -1593,10 +1590,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::tableScan(
 PlanMatcherBuilder& PlanMatcherBuilder::hiveScan(
     const std::string& tableName,
     common::SubfieldFilters subfieldFilters,
-    const std::string& remainingFilter) {
+    std::optional<ExpressionMatcher> remainingFilter) {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<HiveScanMatcher>(
-      tableName, std::move(subfieldFilters), remainingFilter);
+      tableName, std::move(subfieldFilters), std::move(remainingFilter));
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/optimizer/tests/ExpressionMatcher.h"
 #include "velox/core/PlanNode.h"
 #include "velox/type/Filter.h"
 
@@ -141,16 +142,16 @@ class PlanMatcherBuilder {
       const RowTypePtr& outputType);
 
   /// Matches a Hive TableScan node with the specified table name, subfield
-  /// filters, and optional remaining filter.
+  /// filters, and an optional structurally matched remaining filter.
   /// @param tableName The name of the table.
   /// @param subfieldFilters Filters pushed down into the scan as subfield
   /// filters.
-  /// @param remainingFilter Optional filter expression that couldn't be pushed
-  /// down into the scan.
+  /// @param remainingFilter Optional ExpressionMatcher for the remaining
+  /// filter. When omitted, asserts that no remaining filter exists.
   PlanMatcherBuilder& hiveScan(
       const std::string& tableName,
       common::SubfieldFilters subfieldFilters,
-      const std::string& remainingFilter = "");
+      std::optional<ExpressionMatcher> remainingFilter = std::nullopt);
 
   /// Matches any Values node regardless of type.
   PlanMatcherBuilder& values();

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -28,6 +28,7 @@ namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace facebook::velox;
+using namespace core::em;
 namespace lp = facebook::axiom::logical_plan;
 
 class PlanTest : public test::HiveQueriesTestBase {
@@ -543,22 +544,30 @@ TEST_F(PlanTest, filterBreakup) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("lineitem", std::move(lineitemFilters))
-            .hashJoin(
-                core::PlanMatcherBuilder()
-                    .hiveScan(
-                        "part",
-                        {},
-                        "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
-                        "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
-                        "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))")
-                    .build())
-            .filter()
-            .project()
-            .singleAggregation()
-            .build();
+    auto brand = [](const char* b, int32_t sizeHi, const char* prefix) {
+      return call(
+          "and",
+          {col("p_size").between(constant(int32_t(1)), constant(sizeHi)),
+           col("p_brand")
+               .eq(constant(b))
+               .and_(col("p_container").like(constant(prefix)))});
+    };
+    auto partFilter = call(
+        "or",
+        {brand("Brand#34", 15, "LG%"),
+         call(
+             "or",
+             {brand("Brand#12", 5, "SM%"), brand("Brand#23", 10, "MED%")})});
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("lineitem", std::move(lineitemFilters))
+                       .hashJoin(
+                           core::PlanMatcherBuilder()
+                               .hiveScan("part", {}, partFilter)
+                               .build())
+                       .filter()
+                       .project()
+                       .singleAggregation()
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -27,6 +27,7 @@ namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace velox;
+using namespace core::em;
 namespace lp = facebook::axiom::logical_plan;
 
 class SetTest : public test::HiveQueriesTestBase {
@@ -60,21 +61,24 @@ TEST_F(SetTest, unionAll) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan(
-                           "nation",
-                           test::lte("n_nationkey", 10),
-                           "(n_regionkey + 1) % 3 = 1")
-                       .localPartition(
-                           core::PlanMatcherBuilder()
-                               .hiveScan(
-                                   "nation",
-                                   test::gte("n_nationkey", 14),
-                                   "(n_regionkey + 1) % 3 = 1")
-                               .project()
-                               .build())
-                       .project()
-                       .build();
+    auto remainingFilter = call(
+        "eq",
+        {call(
+             "mod",
+             {call("plus", {col("n_regionkey"), constant(int64_t(1))}),
+              constant(int64_t(3))}),
+         constant(int64_t(1))});
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .hiveScan("nation", test::lte("n_nationkey", 10), remainingFilter)
+            .localPartition(
+                core::PlanMatcherBuilder()
+                    .hiveScan(
+                        "nation", test::gte("n_nationkey", 14), remainingFilter)
+                    .project()
+                    .build())
+            .project()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -349,11 +353,17 @@ TEST_F(SetTest, intersect) {
           .build();
 
   {
-    auto startMatcher = [&](auto&& filters,
-                            const std::string& remainingFilter = "") {
-      return core::PlanMatcherBuilder().hiveScan(
-          "nation", std::move(filters), remainingFilter);
+    auto startMatcher = [&](auto&& filters) {
+      return core::PlanMatcherBuilder().hiveScan("nation", std::move(filters));
     };
+
+    auto remainingFilter = call(
+        "eq",
+        {call(
+             "mod",
+             {call("plus", {col("n_regionkey"), constant(int64_t(1))}),
+              constant(int64_t(3))}),
+         constant(int64_t(1))});
 
     // TODO Fix this plan to push down (n_regionkey + 1) % 3
     // = 1 to all branches of 'intersect'.
@@ -363,9 +373,11 @@ TEST_F(SetTest, intersect) {
                        .hashJoin(
                            startMatcher(test::gte("n_nationkey", 12))
                                .hashJoin(
-                                   startMatcher(
-                                       test::lte("n_nationkey", 20),
-                                       "(n_regionkey + 1) % 3 = 1")
+                                   core::PlanMatcherBuilder()
+                                       .hiveScan(
+                                           "nation",
+                                           test::lte("n_nationkey", 20),
+                                           remainingFilter)
                                        .build(),
                                    core::JoinType::kRightSemiFilter)
                                .build(),
@@ -414,26 +426,32 @@ TEST_F(SetTest, except) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan(
-                           "nation",
-                           test::lte("n_nationkey", 20),
-                           "(n_regionkey + 1) % 3 = 1")
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               // TODO Fix this plan to push down (n_regionkey +
-                               // 1) % 3 = 1 to all branches of 'except'.
-                               .hiveScan("nation", test::gte("n_nationkey", 17))
-                               .build(),
-                           core::JoinType::kAnti)
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("nation", test::lte("n_nationkey", 5))
-                               .build(),
-                           core::JoinType::kAnti)
-                       .singleAggregation()
-                       .project()
-                       .build();
+    auto exceptRemainingFilter = call(
+        "eq",
+        {call(
+             "mod",
+             {call("plus", {col("n_regionkey"), constant(int64_t(1))}),
+              constant(int64_t(3))}),
+         constant(int64_t(1))});
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .hiveScan(
+                "nation", test::lte("n_nationkey", 20), exceptRemainingFilter)
+            .hashJoin(
+                core::PlanMatcherBuilder()
+                    // TODO Fix this plan to push down (n_regionkey +
+                    // 1) % 3 = 1 to all branches of 'except'.
+                    .hiveScan("nation", test::gte("n_nationkey", 17))
+                    .build(),
+                core::JoinType::kAnti)
+            .hashJoin(
+                core::PlanMatcherBuilder()
+                    .hiveScan("nation", test::lte("n_nationkey", 5))
+                    .build(),
+                core::JoinType::kAnti)
+            .singleAggregation()
+            .project()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -737,11 +755,23 @@ TEST_F(SetTest, filterOnDuplicateExpressionInUnionAll) {
   // on the respective scan branches.
   auto buildMatcher = [&] {
     return core::PlanMatcherBuilder()
-        .hiveScan("t", {}, "x + 1 > 0")
+        .hiveScan(
+            "t",
+            {},
+            call(
+                "gt",
+                {call("plus", {col("x"), constant(int64_t(1))}),
+                 constant(int64_t(0))}))
         .project()
         .localPartition(
             core::PlanMatcherBuilder()
-                .hiveScan("t", {}, "x + 2 > 0")
+                .hiveScan(
+                    "t",
+                    {},
+                    call(
+                        "gt",
+                        {call("plus", {col("x"), constant(int64_t(2))}),
+                         constant(int64_t(0))}))
                 .project()
                 .build());
   };

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -35,6 +35,7 @@ namespace {
 using namespace facebook::velox;
 using namespace facebook::velox::exec::test;
 using namespace facebook::axiom::optimizer::test;
+using namespace core::em;
 namespace lp = facebook::axiom::logical_plan;
 
 template <typename T>
@@ -294,17 +295,39 @@ class SubfieldTest : public HiveQueriesTestBase,
     verifyRequiredSubfields(
         plan, {{"float_features", {subfield("10010"), subfield("10020")}}});
 
-    auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("features", {}, "float_features[10010] + 1 < 10000")
-            .localPartition(
-                core::PlanMatcherBuilder()
-                    .hiveScan(
-                        "features", {}, "float_features[10010] + 1 < 10000")
-                    .project()
-                    .build())
-            .project()
-            .build();
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan(
+                           "features",
+                           {},
+                           call(
+                               "lt",
+                               {call(
+                                    "plus",
+                                    {call(
+                                         "subscript",
+                                         {col("float_features"),
+                                          constant(int32_t(10010))}),
+                                     constant(float(1))}),
+                                constant(float(10000))}))
+                       .localPartition(
+                           core::PlanMatcherBuilder()
+                               .hiveScan(
+                                   "features",
+                                   {},
+                                   call(
+                                       "lt",
+                                       {call(
+                                            "plus",
+                                            {call(
+                                                 "subscript",
+                                                 {col("float_features"),
+                                                  constant(int32_t(10010))}),
+                                             constant(float(1))}),
+                                        constant(float(10000))}))
+                               .project()
+                               .build())
+                       .project()
+                       .build();
 
     ASSERT_TRUE(matcher->match(plan));
   }

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -23,6 +23,7 @@ namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace velox;
+using namespace core::em;
 namespace lp = facebook::axiom::logical_plan;
 
 class SubqueryTest : public test::HiveQueriesTestBase {
@@ -47,14 +48,15 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    auto matcher = matchHiveScan("nation")
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", {}, "r_name like 'AF%'")
-                               .enforceSingleRow()
-                               .build(),
-                           velox::core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchHiveScan("nation")
+            .hashJoin(
+                core::PlanMatcherBuilder()
+                    .hiveScan("region", {}, col("r_name").like(constant("AF%")))
+                    .enforceSingleRow()
+                    .build(),
+                velox::core::JoinType::kInner)
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -33,6 +33,7 @@ namespace facebook::axiom::optimizer {
 namespace {
 
 using namespace facebook::velox;
+using namespace core::em;
 namespace lp = facebook::axiom::logical_plan;
 
 class TpchPlanTest : public virtual test::HiveQueriesTestBase {
@@ -232,21 +233,23 @@ TEST_F(TpchPlanTest, q04) {
   // side. If we had shared key order between lineitem and orders we could look
   // at other plans but in the hash based plan space we have the best outcome.
 
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("lineitem", {}, "l_commitdate < l_receiptdate")
-                     .hashJoin(
-                         core::PlanMatcherBuilder()
-                             .hiveScan(
-                                 "orders",
-                                 test::between(
-                                     "o_orderdate",
-                                     DATE()->toDays("1993-07-01"),
-                                     DATE()->toDays("1993-09-30")))
-                             .build(),
-                         core::JoinType::kRightSemiFilter)
-                     .aggregation()
-                     .orderBy()
-                     .build();
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .hiveScan(
+              "lineitem", {}, col("l_commitdate").lt(col("l_receiptdate")))
+          .hashJoin(
+              core::PlanMatcherBuilder()
+                  .hiveScan(
+                      "orders",
+                      test::between(
+                          "o_orderdate",
+                          DATE()->toDays("1993-07-01"),
+                          DATE()->toDays("1993-09-30")))
+                  .build(),
+              core::JoinType::kRightSemiFilter)
+          .aggregation()
+          .orderBy()
+          .build();
 
   auto plan = planTpch(4);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -450,7 +453,9 @@ TEST_F(TpchPlanTest, q12) {
                   .hiveScan(
                       "lineitem",
                       std::move(subfieldFilters),
-                      "l_commitdate < l_receiptdate AND l_shipdate < l_commitdate")
+                      col("l_commitdate")
+                          .lt(col("l_receiptdate"))
+                          .and_(col("l_shipdate").lt(col("l_commitdate"))))
                   .build(),
               core::JoinType::kInner)
           .project()
@@ -650,23 +655,30 @@ TEST_F(TpchPlanTest, q19) {
           .add("l_quantity", exec::betweenDouble(1.0, 30.0))
           .build();
 
-  auto matcher =
-      core::PlanMatcherBuilder()
-          .hiveScan("lineitem", std::move(lineitemFilters))
-          .hashJoin(
-              core::PlanMatcherBuilder()
-                  .hiveScan(
-                      "part",
-                      {},
-                      "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
-                      "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
-                      "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
-                  .build(),
-              core::JoinType::kInner)
-          .filter()
-          .project()
-          .aggregation()
-          .build();
+  auto brand = [](const char* b, int32_t sizeHi) {
+    return call(
+        "and",
+        {col("p_size").between(constant(int32_t(1)), constant(sizeHi)),
+         col("p_brand")
+             .eq(constant(b))
+             .and_(call("in", {col("p_container"), any()}))});
+  };
+  auto partFilter = call(
+      "or",
+      {brand("Brand#34", 15),
+       call("or", {brand("Brand#12", 5), brand("Brand#23", 10)})});
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .hiveScan("lineitem", std::move(lineitemFilters))
+                     .hashJoin(
+                         core::PlanMatcherBuilder()
+                             .hiveScan("part", {}, partFilter)
+                             .build(),
+                         core::JoinType::kInner)
+                     .filter()
+                     .project()
+                     .aggregation()
+                     .build();
 
   auto plan = planTpch(19);
   AXIOM_ASSERT_PLAN(plan, matcher);


### PR DESCRIPTION
Summary:

Adds ExpressionMatcher, a structural pattern matcher for typed expression
trees (ITypedExpr), analogous to PlanMatcher for plan nodes. Replaces
the old approach of comparing filter expressions via DuckDB-parsed
toString() equality.

**Motivation**: In a follow-up, TpchPlanTest is rewritten to use the
TPCH connector, which pushes the entire filter down as a single
expression rather than decomposing it into subfield filters. The old
toString comparison via DuckDB is fragile:

1. **Float roundoff**: the optimizer constant-folds arithmetic on double
   literals, producing IEEE 754 values that stringify differently from
   the "same" literal written in a test. For example, TPC-H Q6 has the
   filter `l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01`. If the
   optimizer folds `0.06 - 0.01` and a test compares against a
   DuckDB-parsed `"0.05"`, the toString comparison fails:
   ```
   Expected equality of these values:
     folded->toString()
       Which is: "0.049999999999999996"
     literal->toString()
       Which is: "0.05"
   ```
2. **DuckDB dependency**: requiring DuckDB to parse expected filter
   strings adds an unnecessary dependency and limits type support
   (e.g. DATE).
3. **Structural fragility**: any change in Velox's expression
   stringification silently breaks tests.

**How ExpressionMatcher works**: builds a pattern tree from factory
methods (`col`, `constant`, `call`, `cast`, `any`) and fluent operators
(`.eq()`, `.lt()`, `.and_()`, etc.), then structurally matches against
the actual ITypedExpr tree. Uses `ConstantTypedExpr::operator==` for
constant comparison (strict type + value equality).

**Before** (string comparison via DuckDB parsing):
```
hiveScan("lineitem", filters, "l_commitdate < l_receiptdate")
```

**After** (structural matching):
```
hiveScan("lineitem", filters, col("l_commitdate").lt(col("l_receiptdate")))
```

Differential Revision: D99378542
