### PR TITLE
feat: Support ALTER TABLE ADD COLUMN IF NOT EXISTS (#1201)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -291,6 +291,36 @@ std::string SqlQueryRunner::dropTable(
   }
 }
 
+std::string SqlQueryRunner::addColumn(
+    const presto::AddColumnStatement& statement) {
+  auto metadata =
+      connector::ConnectorMetadata::metadata(statement.connectorId());
+
+  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto result = metadata->addColumn(
+      session,
+      statement.tableName(),
+      statement.columnName(),
+      statement.columnType(),
+      statement.ifTableExists(),
+      statement.ifNotExists());
+
+  if (!result.has_value()) {
+    return fmt::format(
+        "Table does not exist: {}.{}",
+        statement.connectorId(),
+        statement.tableName());
+  }
+  if (!result.value()) {
+    return fmt::format(
+        "Column '{}' already exists in {} (no-op)",
+        statement.columnName(),
+        statement.tableName());
+  }
+  return fmt::format(
+      "Added column '{}' to {}", statement.columnName(), statement.tableName());
+}
+
 std::string SqlQueryRunner::createSchema(
     const presto::CreateSchemaStatement& statement) {
   auto metadata =
@@ -505,6 +535,34 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
               drop->ifExists() ? "IF EXISTS " : "",
               drop->connectorId(),
               drop->tableName())};
+    } else if (statement->isAddColumn()) {
+      const auto* add = statement->as<presto::AddColumnStatement>();
+      auto* metadata =
+          connector::ConnectorMetadata::metadata(add->connectorId());
+      auto table = metadata->findTable(add->tableName());
+      if (table == nullptr) {
+        VELOX_USER_CHECK(
+            add->ifTableExists(),
+            "Table does not exist: {}.{}",
+            add->connectorId(),
+            add->tableName());
+      } else if (table->type()->containsChild(add->columnName())) {
+        VELOX_USER_CHECK(
+            add->ifNotExists(),
+            "Column already exists in table {}.{}: {}",
+            add->connectorId(),
+            add->tableName(),
+            add->columnName());
+      }
+      return {
+          .message = fmt::format(
+              "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
+              add->ifTableExists() ? "IF EXISTS " : "",
+              add->connectorId(),
+              add->tableName(),
+              add->ifNotExists() ? "IF NOT EXISTS " : "",
+              add->columnName(),
+              add->columnType()->toString())};
     } else {
       VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
     }
@@ -576,6 +634,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
     return {.message = dropTable(*drop)};
+  }
+
+  if (sqlStatement.isAddColumn()) {
+    const auto* add = sqlStatement.as<presto::AddColumnStatement>();
+
+    return {.message = addColumn(*add)};
   }
 
   if (sqlStatement.isCreateSchema()) {

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -304,6 +304,37 @@ std::string SqlQueryRunner::dropTable(
   }
 }
 
+std::string SqlQueryRunner::addColumn(
+    const presto::AddColumnStatement& statement,
+    bool explain) {
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
+
+  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto result = metadata->addColumn(
+      session,
+      statement.tableName(),
+      statement.columnName(),
+      statement.columnType(),
+      statement.ifTableExists(),
+      statement.ifNotExists(),
+      explain);
+
+  if (!result.has_value()) {
+    return fmt::format(
+        "Table does not exist: {}.{}",
+        statement.connectorId(),
+        statement.tableName());
+  }
+  if (!result.value()) {
+    return fmt::format(
+        "Column '{}' already exists in {} (no-op)",
+        statement.columnName(),
+        statement.tableName());
+  }
+  return fmt::format(
+      "Added column '{}' to {}", statement.columnName(), statement.tableName());
+}
+
 std::string SqlQueryRunner::createSchema(
     const presto::CreateSchemaStatement& statement) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
@@ -545,6 +576,18 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
               drop->ifExists() ? "IF EXISTS " : "",
               drop->connectorId(),
               drop->tableName())};
+    } else if (statement->isAddColumn()) {
+      const auto* add = statement->as<presto::AddColumnStatement>();
+      addColumn(*add, /*explain=*/true);
+      return {
+          .message = fmt::format(
+              "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
+              add->ifTableExists() ? "IF EXISTS " : "",
+              add->connectorId(),
+              add->tableName(),
+              add->ifNotExists() ? "IF NOT EXISTS " : "",
+              add->columnName(),
+              add->columnType()->toString())};
     } else {
       VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
     }
@@ -625,6 +668,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
     return {.message = dropTable(*drop)};
+  }
+
+  if (sqlStatement.isAddColumn()) {
+    const auto* add = sqlStatement.as<presto::AddColumnStatement>();
+
+    return {.message = addColumn(*add)};
   }
 
   if (sqlStatement.isCreateSchema()) {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -230,6 +230,8 @@ class SqlQueryRunner {
 
   std::string dropTable(const presto::DropTableStatement& statement);
 
+  std::string addColumn(const presto::AddColumnStatement& statement);
+
   std::string createSchema(const presto::CreateSchemaStatement& statement);
 
   std::string dropSchema(const presto::DropSchemaStatement& statement);

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -257,6 +257,10 @@ class SqlQueryRunner {
 
   std::string dropTable(const presto::DropTableStatement& statement);
 
+  std::string addColumn(
+      const presto::AddColumnStatement& statement,
+      bool explain = false);
+
   std::string createSchema(const presto::CreateSchemaStatement& statement);
 
   std::string dropSchema(const presto::DropSchemaStatement& statement);

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1245,6 +1245,104 @@ TEST_F(SqlQueryRunnerTest, connectorSessionPropertyEffect) {
   }
 }
 
+TEST_F(SqlQueryRunnerTest, addColumn) {
+  auto findTable = [&]() {
+    auto* metadata = facebook::axiom::connector::ConnectorMetadata::metadata(
+        testConnector_->connectorId());
+    return metadata->findTable({"default", "t"});
+  };
+
+  // basic add + schema verification
+  run("CREATE TABLE t(x BIGINT)");
+  auto result = run("ALTER TABLE t ADD COLUMN y VARCHAR");
+  EXPECT_EQ(result.message.value(), R"(Added column 'y' to "default"."t")");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(), ROW({"x", "y"}, {BIGINT(), VARCHAR()}));
+
+  // multiple sequential adds with complex types
+  run("ALTER TABLE t ADD COLUMN z DOUBLE");
+  run("ALTER TABLE t ADD COLUMN w ARRAY(INTEGER)");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(),
+      ROW({"x", "y", "z", "w"},
+          {BIGINT(), VARCHAR(), DOUBLE(), ARRAY(INTEGER())}));
+
+  // duplicate column without IF NOT EXISTS throws
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE t ADD COLUMN x INTEGER"), "already exists");
+
+  // IF NOT EXISTS is idempotent (name-only check, type mismatch is ignored)
+  result = run("ALTER TABLE t ADD COLUMN IF NOT EXISTS x VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(Column 'x' already exists in "default"."t" (no-op))");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(),
+      ROW({"x", "y", "z", "w"},
+          {BIGINT(), VARCHAR(), DOUBLE(), ARRAY(INTEGER())}));
+
+  // without IF NOT EXISTS still throws after idempotent call
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE t ADD COLUMN x VARCHAR"), "already exists");
+
+  run("DROP TABLE t");
+
+  // IF TABLE EXISTS on missing table is a no-op
+  result = run("ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(Table does not exist: test."default"."no_such_table")");
+
+  // without IF TABLE EXISTS on missing table throws
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
+      "Table does not exist");
+}
+
+TEST_F(SqlQueryRunnerTest, explainAddColumn) {
+  auto findTable = [&]() {
+    auto* metadata = facebook::axiom::connector::ConnectorMetadata::metadata(
+        testConnector_->connectorId());
+    return metadata->findTable({"default", "t"});
+  };
+
+  run("CREATE TABLE t(x BIGINT)");
+
+  auto result = run("EXPLAIN ALTER TABLE t ADD COLUMN y VARCHAR");
+  EXPECT_THAT(result.message.value(), ::testing::HasSubstr("ALTER TABLE"));
+  EXPECT_THAT(result.message.value(), ::testing::HasSubstr("ADD COLUMN"));
+
+  // EXPLAIN must not have side effects.
+  ASSERT_NE(nullptr, findTable());
+  ASSERT_EQ(1, findTable()->type()->size());
+
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
+      "Table does not exist");
+
+  result =
+      run("EXPLAIN ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
+  EXPECT_THAT(result.message.value(), ::testing::HasSubstr("IF EXISTS"));
+
+  // EXPLAIN throws when column already exists and !ifNotExists.
+  run("ALTER TABLE t ADD COLUMN dup VARCHAR");
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE t ADD COLUMN dup INTEGER"),
+      "Column already exists");
+
+  // EXPLAIN with IF NOT EXISTS on existing column is a no-op (no throw).
+  result = run("EXPLAIN ALTER TABLE t ADD COLUMN IF NOT EXISTS dup INTEGER");
+  EXPECT_THAT(result.message.value(), ::testing::HasSubstr("IF NOT EXISTS"));
+
+  // EXPLAIN must not have mutated the column type.
+  auto table = findTable();
+  ASSERT_NE(nullptr, table);
+  auto idx = table->type()->getChildIdx("dup");
+  EXPECT_EQ(*VARCHAR(), *table->type()->childAt(idx));
+
+  run("DROP TABLE t");
+}
+
 } // namespace
 } // namespace axiom::sql
 

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1271,6 +1271,108 @@ TEST_F(SqlQueryRunnerTest, connectorSessionPropertyEffect) {
   }
 }
 
+TEST_F(SqlQueryRunnerTest, addColumn) {
+  auto findTable = [&]() {
+    auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::get(
+        testConnector_->connectorId());
+    return metadata->findTable({"default", "t"});
+  };
+
+  // Basic add followed by schema verification.
+  run("CREATE TABLE t(x BIGINT)");
+  auto result = run("ALTER TABLE t ADD COLUMN y VARCHAR");
+  EXPECT_EQ(result.message.value(), R"(Added column 'y' to "default"."t")");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(), ROW({"x", "y"}, {BIGINT(), VARCHAR()}));
+
+  // Multiple sequential adds with complex types.
+  run("ALTER TABLE t ADD COLUMN z DOUBLE");
+  run("ALTER TABLE t ADD COLUMN w ARRAY(INTEGER)");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(),
+      ROW({"x", "y", "z", "w"},
+          {BIGINT(), VARCHAR(), DOUBLE(), ARRAY(INTEGER())}));
+
+  // Duplicate column without IF NOT EXISTS throws.
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE t ADD COLUMN x INTEGER"), "already exists");
+
+  // IF NOT EXISTS is idempotent: only the name is checked, and a type mismatch
+  // is ignored.
+  result = run("ALTER TABLE t ADD COLUMN IF NOT EXISTS x VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(Column 'x' already exists in "default"."t" (no-op))");
+  VELOX_ASSERT_EQ_TYPES(
+      findTable()->type(),
+      ROW({"x", "y", "z", "w"},
+          {BIGINT(), VARCHAR(), DOUBLE(), ARRAY(INTEGER())}));
+
+  // Without IF NOT EXISTS, ADD COLUMN still throws after an idempotent call.
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE t ADD COLUMN x VARCHAR"), "already exists");
+
+  run("DROP TABLE t");
+
+  // IF TABLE EXISTS on a missing table is a no-op.
+  result = run("ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(Table does not exist: test."default"."no_such_table")");
+
+  // Without IF TABLE EXISTS, ADD COLUMN on a missing table throws.
+  VELOX_ASSERT_THROW(
+      run("ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
+      "Table does not exist");
+}
+
+TEST_F(SqlQueryRunnerTest, explainAddColumn) {
+  auto findTable = [&]() {
+    auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::get(
+        testConnector_->connectorId());
+    return metadata->findTable({"default", "t"});
+  };
+
+  run("CREATE TABLE t(x BIGINT)");
+
+  auto result = run("EXPLAIN ALTER TABLE t ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE test."default"."t" ADD COLUMN y VARCHAR)");
+
+  // EXPLAIN must not have side effects.
+  ASSERT_NE(nullptr, findTable());
+  VELOX_ASSERT_EQ_TYPES(findTable()->type(), ROW({"x"}, {BIGINT()}));
+
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
+      "Table does not exist");
+
+  result =
+      run("EXPLAIN ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE IF EXISTS test."default"."no_such_table" ADD COLUMN y VARCHAR)");
+
+  // EXPLAIN throws when column already exists and !ifNotExists.
+  run("ALTER TABLE t ADD COLUMN dup VARCHAR");
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE t ADD COLUMN dup INTEGER"),
+      "Column already exists");
+
+  // EXPLAIN with IF NOT EXISTS on existing column is a no-op (no throw).
+  result = run("EXPLAIN ALTER TABLE t ADD COLUMN IF NOT EXISTS dup INTEGER");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE test."default"."t" ADD COLUMN IF NOT EXISTS dup INTEGER)");
+
+  // EXPLAIN must not have mutated the column type.
+  VELOX_EXPECT_EQ_TYPES(
+      findTable()->type(), ROW({"x", "dup"}, {BIGINT(), VARCHAR()}));
+
+  run("DROP TABLE t");
+}
+
 } // namespace
 } // namespace axiom::sql
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -929,6 +929,29 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
+  /// Adds 'columnName' of 'columnType' to an existing table.
+  ///
+  /// Outcomes (combinations of inputs and table state):
+  ///   - Table missing, ifTableExists=false: throws "table missing".
+  ///   - Table missing, ifTableExists=true:  returns std::nullopt (no-op).
+  ///   - Column missing, any flags:          adds column, returns true.
+  ///   - Column exists, ifNotExists=false:   throws "column exists".
+  ///   - Column exists, ifNotExists=true:    returns false (no-op).
+  ///
+  /// Returns:
+  ///   - std::nullopt: table did not exist and 'ifTableExists' is true.
+  ///   - true:         column was added.
+  ///   - false:        column already existed and 'ifNotExists' is true.
+  virtual std::optional<bool> addColumn(
+      const ConnectorSessionPtr& /*session*/,
+      const SchemaTableName& /*tableName*/,
+      const std::string& /*columnName*/,
+      const velox::TypePtr& /*columnType*/,
+      bool /*ifTableExists*/,
+      bool /*ifNotExists*/) {
+    VELOX_UNSUPPORTED();
+  }
+
   /// Returns the list of schema names available in this connector. Some
   /// connectors may return only a representative subset of schemas (e.g.,
   /// TPC-H returns a fixed list of scale-factor schemas). Use schemaExists()

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -943,6 +943,36 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
+  /// Adds 'columnName' of 'columnType' to an existing table.
+  ///
+  /// Outcomes (combinations of inputs and table state):
+  ///   - Table missing, ifTableExists=false: throws "table missing".
+  ///   - Table missing, ifTableExists=true:  returns std::nullopt (no-op).
+  ///   - Column missing, any flags:          adds column, returns true.
+  ///   - Column exists, ifNotExists=false:   throws "column exists".
+  ///   - Column exists, ifNotExists=true:    returns false (no-op).
+  ///
+  /// When 'explain' is true, the connector must perform the same validation
+  /// checks and return the same value (or throw the same user error) as a
+  /// real call, but must not write to disk or mutate in-memory state. No
+  /// cleanup is needed after an explain call.
+  ///
+  /// Returns:
+  ///   - std::nullopt: table did not exist and 'ifTableExists' is true.
+  ///   - true:         column was added (or would be added when 'explain' is
+  ///                   true).
+  ///   - false:        column already existed and 'ifNotExists' is true.
+  virtual std::optional<bool> addColumn(
+      const ConnectorSessionPtr& /*session*/,
+      const SchemaTableName& /*tableName*/,
+      const std::string& /*columnName*/,
+      const velox::TypePtr& /*columnType*/,
+      bool /*ifTableExists*/,
+      bool /*ifNotExists*/,
+      bool /*explain*/) {
+    VELOX_UNSUPPORTED();
+  }
+
   /// Returns the list of schema names available in this connector. Some
   /// connectors may return only a representative subset of schemas (e.g.,
   /// TPC-H returns a fixed list of scale-factor schemas). Use schemaExists()

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1488,4 +1488,55 @@ bool LocalHiveConnectorMetadata::dropTable(
   return tables_.erase(tableName.table) == 1;
 }
 
+std::optional<bool> LocalHiveConnectorMetadata::addColumn(
+    const ConnectorSessionPtr& /* session */,
+    const SchemaTableName& tableName,
+    const std::string& columnName,
+    const velox::TypePtr& columnType,
+    bool ifTableExists,
+    bool ifNotExists) {
+  ensureInitialized();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = tables_.find(tableName.table);
+  if (it == tables_.end()) {
+    if (ifTableExists) {
+      return std::nullopt;
+    }
+    VELOX_USER_FAIL("Table does not exist: {}", tableName);
+  }
+
+  auto existingTable = it->second;
+  auto existingType = existingTable->type();
+
+  if (existingType->containsChild(columnName)) {
+    if (ifNotExists) {
+      return false;
+    }
+    VELOX_USER_FAIL(
+        "Column already exists in table {}: {}", tableName, columnName);
+  }
+
+  auto path = tablePath(tableName);
+  auto schemaFile = schemaPath(path);
+  if (std::filesystem::exists(schemaFile)) {
+    auto jsons = readConcatenatedDynamicsFromFile(schemaFile);
+    if (!jsons.empty()) {
+      auto& schema = jsons[0];
+      folly::dynamic newCol = folly::dynamic::object;
+      newCol["name"] = columnName;
+      newCol["type"] = columnType->serialize();
+      schema["dataColumns"].push_back(newCol);
+
+      std::ofstream outputFile(schemaFile);
+      VELOX_CHECK(outputFile.is_open());
+      outputFile << folly::toPrettyJson(schema);
+      outputFile.close();
+    }
+  }
+
+  loadTable(tableName.table, path);
+  return true;
+}
+
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -897,17 +897,14 @@ folly::dynamic toSchemaJson(
   bool isPartition = false;
   for (auto i = 0; i < rowType->size(); ++i) {
     const auto& name = rowType->nameOf(i);
-
-    folly::dynamic column = folly::dynamic::object();
-    column["name"] = name;
-    column["type"] = rowType->childAt(i)->serialize();
+    auto column = columnToJson(name, rowType->childAt(i));
 
     if (partitionedByColumns.contains(name)) {
-      partitionColumns.push_back(column);
+      partitionColumns.push_back(std::move(column));
       isPartition = true;
     } else {
       VELOX_USER_CHECK(!isPartition, "Partitioning columns must be last");
-      dataColumns.push_back(column);
+      dataColumns.push_back(std::move(column));
     }
   }
 
@@ -1499,6 +1496,67 @@ bool LocalHiveConnectorMetadata::dropTable(
 
   deleteDirectoryRecursive(tablePath(tableName));
   return tables_.erase(tableName.table) == 1;
+}
+
+std::optional<bool> LocalHiveConnectorMetadata::addColumn(
+    const ConnectorSessionPtr& /* session */,
+    const SchemaTableName& tableName,
+    const std::string& columnName,
+    const velox::TypePtr& columnType,
+    bool ifTableExists,
+    bool ifNotExists,
+    bool explain) {
+  ensureInitialized();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = tables_.find(tableName.table);
+  if (it == tables_.end()) {
+    if (ifTableExists) {
+      return std::nullopt;
+    }
+    VELOX_USER_FAIL("Table does not exist: {}", tableName);
+  }
+
+  const auto& existingTable = it->second;
+  const auto& existingType = existingTable->type();
+
+  if (existingType->containsChild(columnName)) {
+    if (ifNotExists) {
+      return false;
+    }
+    VELOX_USER_FAIL(
+        "Column already exists in table {}: {}", tableName, columnName);
+  }
+
+  if (explain) {
+    return true;
+  }
+
+  auto path = tablePath(tableName);
+  auto schemaFile = schemaPath(path);
+  VELOX_CHECK(
+      std::filesystem::exists(schemaFile),
+      "Schema file is missing for table {}: {}",
+      tableName,
+      schemaFile);
+
+  auto jsons = readConcatenatedDynamicsFromFile(schemaFile);
+  VELOX_CHECK(
+      !jsons.empty(),
+      "Schema file is empty for table {}: {}",
+      tableName,
+      schemaFile);
+
+  auto& schema = jsons[0];
+  schema["dataColumns"].push_back(columnToJson(columnName, columnType));
+
+  std::ofstream outputFile(schemaFile);
+  VELOX_CHECK(outputFile.is_open());
+  outputFile << folly::toPrettyJson(schema);
+  outputFile.close();
+
+  loadTable(tableName.table, path);
+  return true;
 }
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -314,6 +314,14 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const SchemaTableName& tableName,
       bool ifExists) override;
 
+  std::optional<bool> addColumn(
+      const ConnectorSessionPtr& session,
+      const SchemaTableName& tableName,
+      const std::string& columnName,
+      const velox::TypePtr& columnType,
+      bool ifTableExists,
+      bool ifNotExists) override;
+
   /// Shortcut for dropTable(session, tableName, true).
   bool dropTableIfExists(const SchemaTableName& tableName) {
     return dropTable(nullptr, tableName, true);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -313,6 +313,15 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       bool ifExists,
       bool explain) override;
 
+  std::optional<bool> addColumn(
+      const ConnectorSessionPtr& session,
+      const SchemaTableName& tableName,
+      const std::string& columnName,
+      const velox::TypePtr& columnType,
+      bool ifTableExists,
+      bool ifNotExists,
+      bool explain) override;
+
   /// Shortcut for dropTable(session, tableName, true, false).
   bool dropTableIfExists(const SchemaTableName& tableName) {
     return dropTable(nullptr, tableName, true, /*explain=*/false);

--- a/axiom/connectors/hive/LocalTableMetadata.cpp
+++ b/axiom/connectors/hive/LocalTableMetadata.cpp
@@ -220,16 +220,21 @@ void FileInfo::listFiles(
   }
 }
 
+folly::dynamic columnToJson(std::string_view name, const velox::TypePtr& type) {
+  folly::dynamic column = folly::dynamic::object;
+  column["name"] = std::string(name);
+  column["type"] = type->serialize();
+  return column;
+}
+
 void writeSchemaFile(
     const std::string& tablePath,
     const velox::RowTypePtr& rowType,
     velox::dwio::common::FileFormat fileFormat) {
   folly::dynamic dataColumns = folly::dynamic::array();
   for (auto i = 0; i < rowType->size(); ++i) {
-    folly::dynamic col = folly::dynamic::object();
-    col["name"] = rowType->nameOf(i);
-    col["type"] = rowType->childAt(i)->serialize();
-    dataColumns.push_back(col);
+    dataColumns.push_back(
+        columnToJson(rowType->nameOf(i), rowType->childAt(i)));
   }
 
   folly::dynamic schema = folly::dynamic::object;

--- a/axiom/connectors/hive/LocalTableMetadata.h
+++ b/axiom/connectors/hive/LocalTableMetadata.h
@@ -22,6 +22,8 @@
 #include <string_view>
 #include <vector>
 
+#include <folly/dynamic.h>
+
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "folly/container/F14Map.h"
 #include "velox/dwio/common/Options.h"
@@ -83,5 +85,9 @@ void writeSchemaFile(
     const std::string& tablePath,
     const velox::RowTypePtr& rowType,
     velox::dwio::common::FileFormat fileFormat);
+
+/// Builds the {"name": ..., "type": ...} JSON object used in .schema files for
+/// a single column.
+folly::dynamic columnToJson(std::string_view name, const velox::TypePtr& type);
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -381,6 +381,119 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
       "test", data, {{"ds", partition}}, dwio::common::FileFormat::PARQUET);
 }
 
+TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
+  auto tableType =
+      ROW({{"id", BIGINT()}, {"name", VARCHAR()}, {"ds", VARCHAR()}});
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
+      {HiveWriteOptions::kFileFormat, "parquet"}};
+
+  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      tableType,
+      options,
+      /*explain=*/false);
+
+  // Write some data before adding the column.
+  auto data = makeRowVector(
+      tableType->names(),
+      {
+          makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+          makeFlatVector<StringView>(100, [](auto /*row*/) { return "test"; }),
+          makeFlatVector<StringView>(
+              100, [](auto /*row*/) { return "2025-01-01"; }),
+      });
+  writeToTable(
+      table, data, WriteKind::kCreate, dwio::common::FileFormat::PARQUET);
+
+  // Add a column.
+  auto added = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      "score",
+      DOUBLE(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/false);
+  ASSERT_TRUE(added.has_value());
+  EXPECT_TRUE(*added);
+
+  // Verify schema has the new column.
+  auto updated = metadata_->findTable({kDefaultSchema, "add_col_test"});
+  ASSERT_NE(updated, nullptr);
+  ASSERT_EQ(4, updated->type()->size());
+  EXPECT_EQ("id", updated->type()->nameOf(0));
+  EXPECT_EQ("name", updated->type()->nameOf(1));
+  EXPECT_EQ("score", updated->type()->nameOf(2));
+  EXPECT_EQ("ds", updated->type()->nameOf(3));
+  EXPECT_EQ(*DOUBLE(), *updated->type()->childAt(2));
+
+  // Layout should exist (not empty).
+  ASSERT_FALSE(updated->layouts().empty());
+
+  // Partition columns should be preserved.
+  auto* layout =
+      dynamic_cast<const LocalHiveTableLayout*>(updated->layouts()[0]);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(1, layout->hivePartitionColumns().size());
+  EXPECT_EQ("ds", layout->hivePartitionColumns()[0]->name());
+
+  // Duplicate column without IF NOT EXISTS throws.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          {kDefaultSchema, "add_col_test"},
+          "score",
+          INTEGER(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false),
+      "already exists");
+
+  // IF NOT EXISTS on existing column is a no-op.
+  auto noOp = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      "score",
+      INTEGER(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/true);
+  ASSERT_TRUE(noOp.has_value());
+  EXPECT_FALSE(*noOp);
+  ASSERT_EQ(
+      4,
+      metadata_->findTable({kDefaultSchema, "add_col_test"})->type()->size());
+
+  // Non-existent table throws.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          {kDefaultSchema, "no_such_table"},
+          "col",
+          BIGINT(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false),
+      "does not exist");
+
+  // IF TABLE EXISTS on missing table returns nullopt.
+  auto missing = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "no_such_table"},
+      "col",
+      BIGINT(),
+      /*ifTableExists=*/true,
+      /*ifNotExists=*/false);
+  EXPECT_FALSE(missing.has_value());
+
+  // Schema persists after reload.
+  metadata_->reloadTableFromPath({kDefaultSchema, "add_col_test"});
+  auto reloaded = metadata_->findTable({kDefaultSchema, "add_col_test"});
+  ASSERT_NE(reloaded, nullptr);
+  ASSERT_EQ(4, reloaded->type()->size());
+  EXPECT_EQ("score", reloaded->type()->nameOf(2));
+}
+
 TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
   auto tableType = ROW(
       {{"key1", BIGINT()},

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -398,6 +398,220 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
       "test", data, {{"ds", partition}}, dwio::common::FileFormat::PARQUET);
 }
 
+TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
+  auto tableType =
+      ROW({{"id", BIGINT()}, {"name", VARCHAR()}, {"ds", VARCHAR()}});
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
+      {HiveWriteOptions::kFileFormat, "parquet"}};
+
+  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  // Write some data before adding the column.
+  auto data = makeRowVector(
+      tableType->names(),
+      {
+          makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+          makeFlatVector<StringView>(100, [](auto /*row*/) { return "test"; }),
+          makeFlatVector<StringView>(
+              100, [](auto /*row*/) { return "2025-01-01"; }),
+      });
+  writeToTable(
+      table, data, WriteKind::kCreate, dwio::common::FileFormat::PARQUET);
+
+  // Add a column.
+  auto added = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      "score",
+      DOUBLE(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  ASSERT_TRUE(added.has_value());
+  EXPECT_TRUE(*added);
+
+  // Verify schema has the new column.
+  auto updated = metadata_->findTable({kDefaultSchema, "add_col_test"});
+  ASSERT_NE(updated, nullptr);
+  VELOX_EXPECT_EQ_TYPES(
+      updated->type(),
+      ROW({"id", "name", "score", "ds"},
+          {BIGINT(), VARCHAR(), DOUBLE(), VARCHAR()}));
+
+  // Layout should exist (not empty).
+  ASSERT_FALSE(updated->layouts().empty());
+
+  // Partition columns should be preserved.
+  auto* layout =
+      dynamic_cast<const LocalHiveTableLayout*>(updated->layouts()[0]);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(1, layout->hivePartitionColumns().size());
+  EXPECT_EQ("ds", layout->hivePartitionColumns()[0]->name());
+
+  // Duplicate column without IF NOT EXISTS throws.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          {kDefaultSchema, "add_col_test"},
+          "score",
+          INTEGER(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false,
+          /*explain=*/false),
+      "already exists");
+
+  // IF NOT EXISTS on existing column is a no-op.
+  auto noOp = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "add_col_test"},
+      "score",
+      INTEGER(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/true,
+      /*explain=*/false);
+  ASSERT_TRUE(noOp.has_value());
+  EXPECT_FALSE(*noOp);
+  VELOX_EXPECT_EQ_TYPES(
+      metadata_->findTable({kDefaultSchema, "add_col_test"})->type(),
+      ROW({"id", "name", "score", "ds"},
+          {BIGINT(), VARCHAR(), DOUBLE(), VARCHAR()}));
+
+  // Non-existent table throws.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          {kDefaultSchema, "no_such_table"},
+          "col",
+          BIGINT(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false,
+          /*explain=*/false),
+      "does not exist");
+
+  // IF TABLE EXISTS on missing table returns nullopt.
+  auto missing = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "no_such_table"},
+      "col",
+      BIGINT(),
+      /*ifTableExists=*/true,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  EXPECT_FALSE(missing.has_value());
+
+  // Schema persists after reload.
+  metadata_->reloadTableFromPath({kDefaultSchema, "add_col_test"});
+  auto reloaded = metadata_->findTable({kDefaultSchema, "add_col_test"});
+  ASSERT_NE(reloaded, nullptr);
+  VELOX_EXPECT_EQ_TYPES(
+      reloaded->type(),
+      ROW({"id", "name", "score", "ds"},
+          {BIGINT(), VARCHAR(), DOUBLE(), VARCHAR()}));
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, addColumnExplain) {
+  auto tableType = ROW({{"id", BIGINT()}, {"name", VARCHAR()}});
+
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kFileFormat, "parquet"}};
+
+  auto session = std::make_shared<ConnectorSession>("q-test");
+  metadata_->createTable(
+      session,
+      {kDefaultSchema, "explain_add_col_test"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  const SchemaTableName tableName{kDefaultSchema, "explain_add_col_test"};
+
+  auto originalType = metadata_->findTable(tableName)->type();
+
+  // Explain mode for a valid add returns true and does not mutate the schema
+  // in memory or on disk.
+  auto wouldAdd = metadata_->addColumn(
+      session,
+      tableName,
+      "score",
+      DOUBLE(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/false,
+      /*explain=*/true);
+  ASSERT_TRUE(wouldAdd.has_value());
+  EXPECT_TRUE(*wouldAdd);
+
+  auto afterExplain = metadata_->findTable(tableName);
+  ASSERT_NE(afterExplain, nullptr);
+  EXPECT_EQ(*originalType, *afterExplain->type());
+
+  // Reloading from disk also shows the original schema.
+  metadata_->reloadTableFromPath(tableName);
+  auto afterReload = metadata_->findTable(tableName);
+  ASSERT_NE(afterReload, nullptr);
+  EXPECT_EQ(*originalType, *afterReload->type());
+
+  // Explain mode raises the same user error as a real call when a duplicate
+  // column is added without IF NOT EXISTS.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          tableName,
+          "id",
+          INTEGER(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false,
+          /*explain=*/true),
+      "already exists");
+
+  // Explain mode honors IF NOT EXISTS for an existing column: returns false
+  // (no-op) without mutating state.
+  auto explainNoOp = metadata_->addColumn(
+      session,
+      tableName,
+      "id",
+      INTEGER(),
+      /*ifTableExists=*/false,
+      /*ifNotExists=*/true,
+      /*explain=*/true);
+  ASSERT_TRUE(explainNoOp.has_value());
+  EXPECT_FALSE(*explainNoOp);
+
+  // Explain mode raises the same user error for a missing table when
+  // IF EXISTS is not set.
+  VELOX_ASSERT_THROW(
+      metadata_->addColumn(
+          session,
+          {kDefaultSchema, "no_such_table"},
+          "col",
+          BIGINT(),
+          /*ifTableExists=*/false,
+          /*ifNotExists=*/false,
+          /*explain=*/true),
+      "does not exist");
+
+  // Explain mode honors IF EXISTS on a missing table: returns nullopt
+  // (no-op).
+  auto explainMissing = metadata_->addColumn(
+      session,
+      {kDefaultSchema, "no_such_table"},
+      "col",
+      BIGINT(),
+      /*ifTableExists=*/true,
+      /*ifNotExists=*/false,
+      /*explain=*/true);
+  EXPECT_FALSE(explainMissing.has_value());
+}
+
 TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
   auto tableType = ROW(
       {{"key1", BIGINT()},

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -537,6 +537,64 @@ bool TestConnectorMetadata::dropTable(
   return dropped;
 }
 
+std::optional<bool> TestConnectorMetadata::addColumn(
+    const ConnectorSessionPtr& /* session */,
+    const SchemaTableName& tableName,
+    const std::string& columnName,
+    const velox::TypePtr& columnType,
+    bool ifTableExists,
+    bool ifNotExists) {
+  auto it = tables_.find(tableName);
+  if (it == tables_.end()) {
+    if (ifTableExists) {
+      return std::nullopt;
+    }
+    VELOX_USER_FAIL("Table does not exist: {}", tableName.toString());
+  }
+
+  auto existingType = it->second->type();
+  if (existingType->containsChild(columnName)) {
+    if (ifNotExists) {
+      return false;
+    }
+    VELOX_USER_FAIL(
+        "Column already exists in table {}: {}",
+        tableName.toString(),
+        columnName);
+  }
+
+  VELOX_CHECK(
+      it->second->data().empty(),
+      "Cannot add column to table '{}' that already has data",
+      tableName.toString());
+
+  auto names = existingType->names();
+  auto types = existingType->children();
+  names.push_back(columnName);
+  types.push_back(columnType);
+  auto newType = velox::ROW(std::move(names), std::move(types));
+
+  std::vector<std::string> hiddenNames;
+  for (const auto* col : it->second->allColumns()) {
+    if (col->hidden()) {
+      hiddenNames.push_back(col->name());
+    }
+  }
+  auto hiddenColumns = velox::ROW(std::move(hiddenNames), velox::VARCHAR());
+
+  auto savedOptions = it->second->options();
+  tables_.erase(it);
+
+  auto newTable = std::make_shared<TestTable>(
+      tableName,
+      std::move(newType),
+      std::move(hiddenColumns),
+      connector_,
+      std::move(savedOptions));
+  tables_[tableName] = std::move(newTable);
+  return true;
+}
+
 void TestConnectorMetadata::appendData(
     const SchemaTableName& tableName,
     const velox::RowVectorPtr& data) {

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -561,6 +561,69 @@ bool TestConnectorMetadata::dropTable(
   return dropped;
 }
 
+std::optional<bool> TestConnectorMetadata::addColumn(
+    const ConnectorSessionPtr& /* session */,
+    const SchemaTableName& tableName,
+    const std::string& columnName,
+    const velox::TypePtr& columnType,
+    bool ifTableExists,
+    bool ifNotExists,
+    bool explain) {
+  auto it = tables_.find(tableName);
+  if (it == tables_.end()) {
+    if (ifTableExists) {
+      return std::nullopt;
+    }
+    VELOX_USER_FAIL("Table does not exist: {}", tableName.toString());
+  }
+
+  auto existingType = it->second->type();
+  if (existingType->containsChild(columnName)) {
+    if (ifNotExists) {
+      return false;
+    }
+    VELOX_USER_FAIL(
+        "Column already exists in table {}: {}",
+        tableName.toString(),
+        columnName);
+  }
+
+  VELOX_CHECK(
+      it->second->data().empty(),
+      "Cannot add column to table '{}' that already has data",
+      tableName.toString());
+
+  if (explain) {
+    return true;
+  }
+
+  auto names = existingType->names();
+  auto types = existingType->children();
+  names.push_back(columnName);
+  types.push_back(columnType);
+  auto newType = velox::ROW(std::move(names), std::move(types));
+
+  std::vector<std::string> hiddenNames;
+  for (const auto* col : it->second->allColumns()) {
+    if (col->hidden()) {
+      hiddenNames.push_back(col->name());
+    }
+  }
+  auto hiddenColumns = velox::ROW(std::move(hiddenNames), velox::VARCHAR());
+
+  auto savedOptions = it->second->options();
+  tables_.erase(it);
+
+  auto newTable = std::make_shared<TestTable>(
+      tableName,
+      std::move(newType),
+      std::move(hiddenColumns),
+      connector_,
+      std::move(savedOptions));
+  tables_[tableName] = std::move(newTable);
+  return true;
+}
+
 void TestConnectorMetadata::appendData(
     const SchemaTableName& tableName,
     const velox::RowVectorPtr& data) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -487,6 +487,14 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaTableName& tableName,
       bool ifExists) override;
 
+  std::optional<bool> addColumn(
+      const ConnectorSessionPtr& session,
+      const SchemaTableName& tableName,
+      const std::string& columnName,
+      const velox::TypePtr& columnType,
+      bool ifTableExists,
+      bool ifNotExists) override;
+
   /// Shortcut for dropTable(session, tableName, true).
   bool dropTableIfExists(const SchemaTableName& tableName) {
     return dropTable(nullptr, tableName, true);

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -487,6 +487,15 @@ class TestConnectorMetadata : public ConnectorMetadata {
       bool ifExists,
       bool explain) override;
 
+  std::optional<bool> addColumn(
+      const ConnectorSessionPtr& session,
+      const SchemaTableName& tableName,
+      const std::string& columnName,
+      const velox::TypePtr& columnType,
+      bool ifTableExists,
+      bool ifNotExists,
+      bool explain) override;
+
   /// Shortcut for dropTable(session, tableName, true, false).
   bool dropTableIfExists(const SchemaTableName& tableName) {
     return dropTable(nullptr, tableName, true, /*explain=*/false);

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2031,6 +2031,27 @@ SqlStatementPtr parseDropTable(
       std::move(connectorId), std::move(connectorTable), dropTable.isExists());
 }
 
+SqlStatementPtr parseAddColumn(
+    const AddColumn& addColumn,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  auto [connectorId, connectorTable] = toConnectorTable(
+      *addColumn.tableName(), defaultConnectorId, defaultSchema);
+  auto* colDef = addColumn.column();
+  auto columnType = parseType(colDef->columnType());
+  VELOX_USER_CHECK_NOT_NULL(
+      columnType,
+      "Unknown type specifier: {}",
+      colDef->columnType()->baseName());
+  return std::make_shared<AddColumnStatement>(
+      std::move(connectorId),
+      std::move(connectorTable),
+      colDef->name()->value(),
+      std::move(columnType),
+      addColumn.isTableExists(),
+      addColumn.isColumnNotExists());
+}
+
 SqlStatementPtr parseCreateSchema(
     const CreateSchema& createSchema,
     const std::string& defaultConnectorId) {
@@ -2165,6 +2186,11 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kDropTable)) {
     return parseDropTable(
         *query->as<DropTable>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kAddColumn)) {
+    return parseAddColumn(
+        *query->as<AddColumn>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kCreateSchema)) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2092,6 +2092,28 @@ SqlStatementPtr parseDropTable(
       std::move(connectorId), std::move(connectorTable), dropTable.isExists());
 }
 
+SqlStatementPtr parseAddColumn(
+    const AddColumn& addColumn,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  auto [connectorId, connectorTable] = toConnectorTable(
+      *addColumn.tableName(), defaultConnectorId, defaultSchema);
+  auto* colDef = addColumn.column();
+  auto columnType = parseType(colDef->columnType());
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      columnType != nullptr,
+      colDef->location(),
+      colDef->columnType()->baseName(),
+      "Unknown type specifier");
+  return std::make_shared<AddColumnStatement>(
+      std::move(connectorId),
+      std::move(connectorTable),
+      colDef->name()->value(),
+      std::move(columnType),
+      addColumn.isTableExists(),
+      addColumn.isColumnNotExists());
+}
+
 SqlStatementPtr parseCreateSchema(
     const CreateSchema& createSchema,
     const std::string& defaultConnectorId) {
@@ -2227,6 +2249,11 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kDropTable)) {
     return parseDropTable(
         *query->as<DropTable>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kAddColumn)) {
+    return parseAddColumn(
+        *query->as<AddColumn>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kCreateSchema)) {

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -40,6 +40,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kSetSession, "SET SESSION"},
       {SqlStatementKind::kResetSession, "RESET SESSION"},
       {SqlStatementKind::kUse, "USE"},
+      {SqlStatementKind::kAddColumn, "ALTER TABLE ADD COLUMN"},
   };
 
   return kNames;

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -40,6 +40,7 @@ enum class SqlStatementKind {
   kSetSession,
   kResetSession,
   kUse,
+  kAddColumn,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SqlStatementKind);
@@ -122,6 +123,10 @@ class SqlStatement {
 
   bool isUse() const {
     return kind_ == SqlStatementKind::kUse;
+  }
+
+  bool isAddColumn() const {
+    return kind_ == SqlStatementKind::kAddColumn;
   }
 
   template <typename T>
@@ -358,6 +363,62 @@ class DropTableStatement : public SqlStatement {
   const std::string connectorId_;
   const facebook::axiom::SchemaTableName tableName_;
   const bool ifExists_;
+};
+
+class AddColumnStatement : public SqlStatement {
+ public:
+  AddColumnStatement(
+      std::string connectorId,
+      facebook::axiom::SchemaTableName tableName,
+      std::string columnName,
+      facebook::velox::TypePtr columnType,
+      bool ifTableExists,
+      bool ifNotExists)
+      : SqlStatement(
+            SqlStatementKind::kAddColumn,
+            /*views=*/{},
+            ReferencedTables{/*inputTables=*/{},
+                             facebook::axiom::CatalogSchemaTableName{
+                                 connectorId,
+                                 tableName}}),
+        connectorId_{std::move(connectorId)},
+        tableName_{std::move(tableName)},
+        columnName_{std::move(columnName)},
+        columnType_{std::move(columnType)},
+        ifTableExists_{ifTableExists},
+        ifNotExists_{ifNotExists} {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const facebook::axiom::SchemaTableName& tableName() const {
+    return tableName_;
+  }
+
+  const std::string& columnName() const {
+    return columnName_;
+  }
+
+  const facebook::velox::TypePtr& columnType() const {
+    return columnType_;
+  }
+
+  bool ifTableExists() const {
+    return ifTableExists_;
+  }
+
+  bool ifNotExists() const {
+    return ifNotExists_;
+  }
+
+ private:
+  const std::string connectorId_;
+  const facebook::axiom::SchemaTableName tableName_;
+  const std::string columnName_;
+  const facebook::velox::TypePtr columnType_;
+  const bool ifTableExists_;
+  const bool ifNotExists_;
 };
 
 class CreateSchemaStatement : public SqlStatement {

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -42,6 +42,7 @@ enum class SqlStatementKind {
   kSetSession,
   kResetSession,
   kUse,
+  kAddColumn,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SqlStatementKind);
@@ -109,6 +110,10 @@ class SqlStatement {
 
   bool isUse() const {
     return kind_ == SqlStatementKind::kUse;
+  }
+
+  bool isAddColumn() const {
+    return kind_ == SqlStatementKind::kAddColumn;
   }
 
   template <typename T>
@@ -309,6 +314,56 @@ class DropTableStatement : public SqlStatement {
   const std::string connectorId_;
   const facebook::axiom::SchemaTableName tableName_;
   const bool ifExists_;
+};
+
+class AddColumnStatement : public SqlStatement {
+ public:
+  AddColumnStatement(
+      std::string connectorId,
+      facebook::axiom::SchemaTableName tableName,
+      std::string columnName,
+      facebook::velox::TypePtr columnType,
+      bool ifTableExists,
+      bool ifNotExists)
+      : SqlStatement(SqlStatementKind::kAddColumn),
+        connectorId_{std::move(connectorId)},
+        tableName_{std::move(tableName)},
+        columnName_{std::move(columnName)},
+        columnType_{std::move(columnType)},
+        ifTableExists_{ifTableExists},
+        ifNotExists_{ifNotExists} {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const facebook::axiom::SchemaTableName& tableName() const {
+    return tableName_;
+  }
+
+  const std::string& columnName() const {
+    return columnName_;
+  }
+
+  const facebook::velox::TypePtr& columnType() const {
+    return columnType_;
+  }
+
+  bool ifTableExists() const {
+    return ifTableExists_;
+  }
+
+  bool ifNotExists() const {
+    return ifNotExists_;
+  }
+
+ private:
+  const std::string connectorId_;
+  const facebook::axiom::SchemaTableName tableName_;
+  const std::string columnName_;
+  const facebook::velox::TypePtr columnType_;
+  const bool ifTableExists_;
+  const bool ifNotExists_;
 };
 
 class CreateSchemaStatement : public SqlStatement {

--- a/axiom/sql/presto/TableVisitor.cpp
+++ b/axiom/sql/presto/TableVisitor.cpp
@@ -82,6 +82,11 @@ void TableVisitor::visitDropTable(DropTable* node) {
   DefaultTraversalVisitor::visitDropTable(node);
 }
 
+void TableVisitor::visitAddColumn(AddColumn* node) {
+  setOutputTable(*node->tableName());
+  DefaultTraversalVisitor::visitAddColumn(node);
+}
+
 void TableVisitor::visitDropView(DropView* node) {
   setOutputTable(*node->viewName());
   DefaultTraversalVisitor::visitDropView(node);

--- a/axiom/sql/presto/TableVisitor.h
+++ b/axiom/sql/presto/TableVisitor.h
@@ -52,6 +52,7 @@ class TableVisitor : public DefaultTraversalVisitor {
   void visitCreateView(CreateView* node) override;
   void visitCreateMaterializedView(CreateMaterializedView* node) override;
   void visitDropTable(DropTable* node) override;
+  void visitAddColumn(AddColumn* node) override;
   void visitDropView(DropView* node) override;
   void visitDropMaterializedView(DropMaterializedView* node) override;
 

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -20,6 +20,7 @@
 
 #include <folly/Conv.h>
 #include <folly/Unicode.h>
+#include <algorithm>
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -807,7 +808,31 @@ std::any AstBuilder::visitDropColumn(PrestoSqlParser::DropColumnContext* ctx) {
 
 std::any AstBuilder::visitAddColumn(PrestoSqlParser::AddColumnContext* ctx) {
   trace("visitAddColumn");
-  return visitChildren("visitAddColumn", ctx);
+  auto column = std::any_cast<std::shared_ptr<TableElement>>(
+      visit(ctx->columnDefinition()));
+  // Grammar: ALTER TABLE (IF EXISTS)? name ADD COLUMN (IF NOT EXISTS)? col
+  // Disambiguate by position relative to COLUMN: EXISTS before COLUMN belongs
+  // to the table clause, EXISTS after COLUMN belongs to the column clause.
+  auto columnIndex = ctx->COLUMN()->getSymbol()->getTokenIndex();
+  auto existsTokens = ctx->EXISTS();
+  bool ifTableExists = std::any_of(
+      existsTokens.begin(),
+      existsTokens.end(),
+      [columnIndex](antlr4::tree::TerminalNode* node) {
+        return node->getSymbol()->getTokenIndex() < columnIndex;
+      });
+  bool ifNotExists = std::any_of(
+      existsTokens.begin(),
+      existsTokens.end(),
+      [columnIndex](antlr4::tree::TerminalNode* node) {
+        return node->getSymbol()->getTokenIndex() > columnIndex;
+      });
+  return std::static_pointer_cast<Statement>(std::make_shared<AddColumn>(
+      getLocation(ctx),
+      getQualifiedName(ctx->qualifiedName()),
+      column,
+      ifTableExists,
+      ifNotExists));
 }
 
 std::any AstBuilder::visitAddConstraint(

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -19,6 +19,7 @@
 #include <unordered_set>
 
 #include <folly/Unicode.h>
+#include <algorithm>
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -742,7 +743,31 @@ std::any AstBuilder::visitDropColumn(PrestoSqlParser::DropColumnContext* ctx) {
 
 std::any AstBuilder::visitAddColumn(PrestoSqlParser::AddColumnContext* ctx) {
   trace("visitAddColumn");
-  return visitChildren("visitAddColumn", ctx);
+  auto column = std::any_cast<std::shared_ptr<TableElement>>(
+      visit(ctx->columnDefinition()));
+  // Grammar: ALTER TABLE (IF EXISTS)? name ADD COLUMN (IF NOT EXISTS)? col
+  // Disambiguate by position relative to COLUMN: EXISTS before COLUMN belongs
+  // to the table clause, EXISTS after COLUMN belongs to the column clause.
+  auto columnIndex = ctx->COLUMN()->getSymbol()->getTokenIndex();
+  auto existsTokens = ctx->EXISTS();
+  bool ifTableExists = std::any_of(
+      existsTokens.begin(),
+      existsTokens.end(),
+      [columnIndex](antlr4::tree::TerminalNode* node) {
+        return node->getSymbol()->getTokenIndex() < columnIndex;
+      });
+  bool ifNotExists = std::any_of(
+      existsTokens.begin(),
+      existsTokens.end(),
+      [columnIndex](antlr4::tree::TerminalNode* node) {
+        return node->getSymbol()->getTokenIndex() > columnIndex;
+      });
+  return std::static_pointer_cast<Statement>(std::make_shared<AddColumn>(
+      getLocation(ctx),
+      getQualifiedName(ctx->qualifiedName()),
+      column,
+      ifTableExists,
+      ifNotExists));
 }
 
 std::any AstBuilder::visitAddConstraint(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -648,6 +648,16 @@ void DropSchema::accept(AstVisitor* visitor) {
   visitor->visitDropSchema(this);
 }
 
+void AddColumn::accept(AstVisitor* visitor) {
+  visitor->visitAddColumn(this);
+}
+
+ColumnDefinition* AddColumn::column() const {
+  auto* result = column_->as<ColumnDefinition>();
+  VELOX_DCHECK_NOT_NULL(result);
+  return result;
+}
+
 // DML Statement implementations
 void Insert::accept(AstVisitor* visitor) {
   visitor->visitInsert(this);

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -1055,6 +1055,23 @@ void AstPrinter::visitDropSchema(DropSchema* node) {
   });
 }
 
+// ALTER TABLE Statements
+void AstPrinter::visitAddColumn(AddColumn* node) {
+  printHeader("AddColumn", node, [&](std::ostream& out) {
+    out << node->tableName()->suffix();
+    if (node->isTableExists()) {
+      out << " IF EXISTS";
+    }
+    if (node->isColumnNotExists()) {
+      out << " IF NOT EXISTS";
+    }
+  });
+
+  indent_++;
+  node->columnElement()->accept(this);
+  indent_--;
+}
+
 // DML Statements
 void AstPrinter::visitInsert(Insert* node) {
   printHeader("Insert", node, [&](std::ostream& out) {

--- a/axiom/sql/presto/ast/AstPrinter.h
+++ b/axiom/sql/presto/ast/AstPrinter.h
@@ -233,6 +233,9 @@ class AstPrinter : public AstVisitor {
 
   void visitDropSchema(DropSchema* node) override;
 
+  // ALTER TABLE Statements
+  void visitAddColumn(AddColumn* node) override;
+
   // DML Statements
   void visitInsert(Insert* node) override;
 

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -570,6 +570,48 @@ class DropSchema : public Statement {
   DropBehavior behavior_;
 };
 
+// ALTER TABLE Statements
+class AddColumn : public Statement {
+ public:
+  AddColumn(
+      NodeLocation location,
+      const std::shared_ptr<QualifiedName>& tableName,
+      const std::shared_ptr<TableElement>& column,
+      bool ifTableExists,
+      bool ifNotExists)
+      : Statement(NodeType::kAddColumn, location),
+        tableName_(tableName),
+        column_(column),
+        ifTableExists_(ifTableExists),
+        ifNotExists_(ifNotExists) {}
+
+  const std::shared_ptr<QualifiedName>& tableName() const {
+    return tableName_;
+  }
+
+  const std::shared_ptr<TableElement>& columnElement() const {
+    return column_;
+  }
+
+  ColumnDefinition* column() const;
+
+  bool isTableExists() const {
+    return ifTableExists_;
+  }
+
+  bool isColumnNotExists() const {
+    return ifNotExists_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> tableName_;
+  std::shared_ptr<TableElement> column_;
+  bool ifTableExists_;
+  bool ifNotExists_;
+};
+
 // DML Statements
 class Insert : public Statement {
  public:

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -438,6 +438,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitAddColumn(AddColumn* node) {
+    defaultVisit(node);
+  }
+
   // DML Statements
   virtual void visitInsert(Insert* node) {
     defaultVisit(node);

--- a/axiom/sql/presto/ast/DefaultTraversalVisitor.h
+++ b/axiom/sql/presto/ast/DefaultTraversalVisitor.h
@@ -475,6 +475,15 @@ class DefaultTraversalVisitor : public AstVisitor {
     }
   }
 
+  void visitAddColumn(AddColumn* node) override {
+    if (node->tableName()) {
+      node->tableName()->accept(this);
+    }
+    if (node->columnElement()) {
+      node->columnElement()->accept(this);
+    }
+  }
+
   void visitExplain(Explain* node) override {
     if (node->statement()) {
       node->statement()->accept(this);

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -349,5 +349,83 @@ TEST_F(DdlParserTest, createTableAndInsert) {
   ASSERT_EQ(lp::WriteKind::kInsert, insertWrite->writeKind());
 }
 
+TEST_F(DdlParserTest, addColumn) {
+  // basic
+  {
+    auto statement = parseSql("ALTER TABLE t ADD COLUMN c BIGINT");
+    ASSERT_TRUE(statement->isAddColumn());
+
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("c", add->columnName());
+    ASSERT_EQ(*BIGINT(), *add->columnType());
+    ASSERT_FALSE(add->ifTableExists());
+    ASSERT_FALSE(add->ifNotExists());
+  }
+
+  // IF NOT EXISTS on column
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN IF NOT EXISTS c VARCHAR");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_FALSE(add->ifTableExists());
+    ASSERT_TRUE(add->ifNotExists());
+  }
+
+  // IF EXISTS on table
+  {
+    auto statement = parseSql("ALTER TABLE IF EXISTS t ADD COLUMN c DOUBLE");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_TRUE(add->ifTableExists());
+    ASSERT_FALSE(add->ifNotExists());
+  }
+
+  // both IF clauses
+  {
+    auto statement =
+        parseSql("ALTER TABLE IF EXISTS t ADD COLUMN IF NOT EXISTS c INTEGER");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_TRUE(add->ifTableExists());
+    ASSERT_TRUE(add->ifNotExists());
+  }
+
+  // complex types
+  {
+    auto statement = parseSql("ALTER TABLE t ADD COLUMN c ARRAY<INTEGER>");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*ARRAY(INTEGER()), *add->columnType());
+  }
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN c MAP<VARCHAR, BIGINT>");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*MAP(VARCHAR(), BIGINT()), *add->columnType());
+  }
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN c ROW(a INTEGER, b VARCHAR)");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*ROW({"a", "b"}, {INTEGER(), VARCHAR()}), *add->columnType());
+  }
+
+  // schema-qualified table name
+  {
+    auto statement = parseSql("ALTER TABLE myschema.t ADD COLUMN c BIGINT");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("myschema", add->tableName().schema);
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("test", add->connectorId());
+  }
+
+  // catalog.schema.table
+  {
+    auto statement = parseSql("ALTER TABLE cat.myschema.t ADD COLUMN c BIGINT");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("myschema", add->tableName().schema);
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("cat", add->connectorId());
+  }
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -359,5 +359,83 @@ TEST_F(DdlParserTest, createTableAndInsert) {
   ASSERT_EQ(lp::WriteKind::kInsert, insertWrite->writeKind());
 }
 
+TEST_F(DdlParserTest, addColumn) {
+  // Basic ALTER TABLE ADD COLUMN.
+  {
+    auto statement = parseSql("ALTER TABLE t ADD COLUMN c BIGINT");
+    ASSERT_TRUE(statement->isAddColumn());
+
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("c", add->columnName());
+    ASSERT_EQ(*BIGINT(), *add->columnType());
+    ASSERT_FALSE(add->ifTableExists());
+    ASSERT_FALSE(add->ifNotExists());
+  }
+
+  // IF NOT EXISTS on the column.
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN IF NOT EXISTS c VARCHAR");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_FALSE(add->ifTableExists());
+    ASSERT_TRUE(add->ifNotExists());
+  }
+
+  // IF EXISTS on the table.
+  {
+    auto statement = parseSql("ALTER TABLE IF EXISTS t ADD COLUMN c DOUBLE");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_TRUE(add->ifTableExists());
+    ASSERT_FALSE(add->ifNotExists());
+  }
+
+  // Both IF clauses.
+  {
+    auto statement =
+        parseSql("ALTER TABLE IF EXISTS t ADD COLUMN IF NOT EXISTS c INTEGER");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_TRUE(add->ifTableExists());
+    ASSERT_TRUE(add->ifNotExists());
+  }
+
+  // Complex column types.
+  {
+    auto statement = parseSql("ALTER TABLE t ADD COLUMN c ARRAY<INTEGER>");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*ARRAY(INTEGER()), *add->columnType());
+  }
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN c MAP<VARCHAR, BIGINT>");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*MAP(VARCHAR(), BIGINT()), *add->columnType());
+  }
+  {
+    auto statement =
+        parseSql("ALTER TABLE t ADD COLUMN c ROW(a INTEGER, b VARCHAR)");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ(*ROW({"a", "b"}, {INTEGER(), VARCHAR()}), *add->columnType());
+  }
+
+  // Schema-qualified table name.
+  {
+    auto statement = parseSql("ALTER TABLE myschema.t ADD COLUMN c BIGINT");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("myschema", add->tableName().schema);
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("test", add->connectorId());
+  }
+
+  // Catalog-, schema-, and table-qualified name.
+  {
+    auto statement = parseSql("ALTER TABLE cat.myschema.t ADD COLUMN c BIGINT");
+    const auto* add = statement->as<AddColumnStatement>();
+    ASSERT_EQ("myschema", add->tableName().schema);
+    ASSERT_EQ("t", add->tableName().table);
+    ASSERT_EQ("cat", add->connectorId());
+  }
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Adds support for `ALTER TABLE [IF EXISTS] t ADD COLUMN [IF NOT EXISTS] c <type>`:

- **AST**: `AddColumn` node in `AstStatements.h`, `AstBuilder::visitAddColumn` with IF/EXISTS/NOT token disambiguation, visitor + traversal support
- **SqlStatement**: `kAddColumn` enum, `AddColumnStatement` (connectorId, tableName, columnName, columnType, ifTableExists, ifNotExists)
- **PrestoParser**: `parseAddColumn()` with type resolution via `parseType()`, dispatch in `doPlan()`
- **ConnectorMetadata**: `addColumn()` virtual method (connector handles column-level `ifNotExists`; runner/server handles table-level `ifTableExists`)
- **LocalHive**: Reconstructs `LocalTable` with augmented `RowType`, preserves bucketed flag
- **TestConnector**: Reconstructs `TestTable`, preserves hidden columns, guards against data loss
- **TableVisitor**: `visitAddColumn` sets output table
- **SqlQueryRunner**: `addColumn()` method with `ifTableExists` check, `EXPLAIN` path, `run()` dispatch

Reviewed By: mbasmanova

Differential Revision: D99237701


