### PR TITLE
fix(optimizer): Avoid null-dereference in UNION queries with exploding functions (#1215)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1292,7 +1292,6 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
     if (!translated.empty()) {
       functionSubfields_[call] =
           SubfieldProjections{.pathToExpr = std::move(translated)};
-      return nullptr;
     }
   }
   auto* callExpr =

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -135,6 +135,79 @@ velox::core::ExprPtr rewriteInputNames(
       });
 }
 
+// Normalizes toStrings to match Velox exprs to DuckDB. Velox uses bracket
+// notation for dereferences while DuckDB uses special forms names explicitly.
+// In addition, Velox constant folds rows into a constant typed expr with curly
+// bracket notation while DuckDB uses "row_constructor".
+std::string toExprString(const TypedExprPtr& expr) {
+  if (auto* deref = dynamic_cast<const DereferenceTypedExpr*>(expr.get())) {
+    return fmt::format(
+        "subscript({},{})",
+        toExprString(expr->inputs()[0]),
+        deref->index() + 1);
+  }
+
+  if (auto* field = dynamic_cast<const FieldAccessTypedExpr*>(expr.get())) {
+    if (!field->inputs().empty() && !field->inputs()[0]->isInputKind()) {
+      return fmt::format(
+          "dot({},\"{}\")", toExprString(field->inputs()[0]), field->name());
+    }
+  }
+
+  if (auto* call = dynamic_cast<const CallTypedExpr*>(expr.get())) {
+    std::string result = call->name() + "(";
+    for (size_t i = 0; i < expr->inputs().size(); ++i) {
+      if (i > 0) {
+        result += ",";
+      }
+      result += toExprString(expr->inputs()[i]);
+    }
+    result += ")";
+    return result;
+  }
+
+  if (auto* cast = dynamic_cast<const CastTypedExpr*>(expr.get())) {
+    return fmt::format(
+        "{}({} as {})",
+        cast->isTryCast() ? "try_cast" : "cast",
+        toExprString(expr->inputs()[0]),
+        cast->type()->toString());
+  }
+
+  if (auto* constant = dynamic_cast<const ConstantTypedExpr*>(expr.get())) {
+    if (constant->type()->isRow()) {
+      std::string result = "row_constructor(";
+      if (constant->hasValueVector()) {
+        const auto& vec = constant->valueVector();
+        const auto* row = vec->wrappedVector()->as<RowVector>();
+        auto idx = vec->wrappedIndex(0);
+        for (vector_size_t i = 0; i < row->childrenSize(); ++i) {
+          if (i > 0) {
+            result += ",";
+          }
+          if (row->childAt(i)->isNullAt(idx)) {
+            result += "null";
+          } else {
+            result += row->childAt(i)->toString(idx);
+          }
+        }
+      } else {
+        const auto& rowValues = constant->value().row();
+        for (size_t i = 0; i < rowValues.size(); ++i) {
+          if (i > 0) {
+            result += ",";
+          }
+          result += rowValues[i].toStringAsVector(constant->type()->childAt(i));
+        }
+      }
+      result += ")";
+      return result;
+    }
+  }
+
+  return expr->toString();
+}
+
 class TableScanMatcher : public PlanMatcherImpl<TableScanNode> {
  public:
   explicit TableScanMatcher() : PlanMatcherImpl<TableScanNode>() {}
@@ -295,7 +368,7 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
       if (!symbols.empty()) {
         expected = rewriteInputNames(expected, symbols);
       }
-      EXPECT_EQ(plan.filter()->toString(), expected->toString());
+      EXPECT_EQ(toExprString(plan.filter()), expected->toString());
     }
 
     AXIOM_TEST_RETURN
@@ -339,7 +412,7 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
         }
 
         EXPECT_EQ(
-            plan.projections()[i]->toString(),
+            toExprString(plan.projections()[i]),
             expected->dropAlias()->toString());
       }
       AXIOM_TEST_RETURN_IF_FAILURE

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1025,6 +1025,75 @@ TEST_F(SetTest, unionAllWithDistinctAndCountStar) {
   }
 }
 
+TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT x.a FROM ("
+        "  SELECT ROW(1 AS a, 2 AS b) AS x"
+        "  UNION ALL"
+        "  SELECT ROW(3 AS a, 4 AS b)"
+        ")");
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchValues(ROW({}))
+            .project({"row_constructor(1, null)"})
+            .localPartition(matchValues(ROW({}))
+                                .project({"row_constructor(3, null)"})
+                                .build())
+            .project({"x.a"})
+            .build());
+  }
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT x[1] FROM ("
+        "  SELECT ROW(1, 2) AS x"
+        "  UNION ALL"
+        "  SELECT ROW(3, 4)"
+        ") WHERE x[1] > 0");
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchValues(ROW({}))
+            .filter()
+            .project({"row_constructor(1, null)"})
+            .localPartition(matchValues(ROW({}))
+                                .filter()
+                                .project({"row_constructor(3, null)"})
+                                .build())
+            .project({"x[1]"})
+            .build());
+  }
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT y FROM ("
+        "  SELECT x[1] AS y FROM ("
+        "    SELECT ROW(1, 2) AS x"
+        "    UNION ALL"
+        "    SELECT ROW(3, 4)"
+        "  )"
+        "  UNION ALL"
+        "  SELECT 5"
+        ")");
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchValues(ROW({}))
+            .project({"row_constructor(1, null)"})
+            .localPartition(matchValues(ROW({}))
+                                .project({"row_constructor(3, null)"})
+                                .build())
+            .project({"x[1]"})
+            .localPartition(matchValues(ROW({})).project({"5 as y"}).build())
+            .build());
+  }
+}
+
 TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
   std::vector<std::string> widthConstrainingInputs = {
       "SELECT 1",

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -184,3 +184,11 @@ SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
 SELECT * FROM (VALUES (1, null, 'a')) t(x, y, z)
 INTERSECT
 SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
+----
+-- ROW subfield access in UNION ALL with positional subscript.
+-- duckdb: VALUES (1), (3)
+SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
+----
+-- ROW subfield access in UNION ALL with named field.
+-- duckdb: VALUES (1), (3)
+SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))


### PR DESCRIPTION
Summary:

Remove explicit nullptr return in translateSubfieldFunction to let code fall through and return a valid Call for exploding functions. As a result, renames_ no longer stores nulls.

Minimal repro: 
```
SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
```
Root cause: 

`translateSubfieldFunction` returns nullptr (an engaged std::optional with null pointer) when explode decomposes a ROW constructor into per-field subfield projections. The caller translateExpr checks has_value(), which is true for nullptr, so it returns the null ExprCP. This null propagates through addProjection into renames_, then translateColumn returns it to translateUnion, which dereferences inner->value() at offset 0x40, causing a SIGSEGV.

Reviewed By: mbasmanova

Differential Revision: D99882408


