### PR TITLE
feat(parsing): Add structured ParseErrorInfo to PrestoParseError (#1223)

### DIFF
--- a/axiom/sql/presto/PrestoParseError.h
+++ b/axiom/sql/presto/PrestoParseError.h
@@ -22,22 +22,61 @@
 namespace axiom::sql::presto {
 
 /// Exception thrown when parsing a Presto SQL query fails.
-/// The message contains the detailed error message from the parser.
 class PrestoParseError : public std::exception {
  public:
-  /* implicit */ PrestoParseError(std::string_view message)
-      : message_(message) {}
+  PrestoParseError(
+      const std::string& message,
+      size_t line,
+      size_t column,
+      std::string token)
+      : formatted_(
+            "Syntax error at " + std::to_string(line) + ":" +
+            std::to_string(column) + ": " + message),
+        messageLength_(message.size()),
+        line_(line),
+        column_(column),
+        token_(std::move(token)) {}
 
+  /// 0-based line number.
+  size_t line() const {
+    return line_;
+  }
+
+  /// 0-based column number.
+  size_t column() const {
+    return column_;
+  }
+
+  /// Offending token text. May be empty.
+  const std::string& token() const {
+    return token_;
+  }
+
+  /// Raw error description from the parser, without the line:column prefix.
   std::string_view message() const noexcept {
-    return message_;
+    return std::string_view(formatted_)
+        .substr(formatted_.size() - messageLength_);
   }
 
   const char* what() const noexcept override {
-    return message_.data();
+    return formatted_.data();
+  }
+
+  /// Returns a copy with adjusted line and column.
+  PrestoParseError withOffset(size_t lineOffset, size_t columnOffset) const {
+    return PrestoParseError(
+        std::string(message()),
+        line_ + lineOffset,
+        column_ + columnOffset,
+        token_);
   }
 
  private:
-  std::string message_;
+  std::string formatted_;
+  size_t messageLength_;
+  size_t line_;
+  size_t column_;
+  std::string token_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -46,6 +46,26 @@ namespace lp = facebook::axiom::logical_plan;
 
 class ErrorListener : public antlr4::BaseErrorListener {
  public:
+  void reset() {
+    firstError_.reset();
+  }
+
+  const std::string& firstError() const {
+    return firstError_.value();
+  }
+
+  size_t line() const {
+    return line_;
+  }
+
+  size_t column() const {
+    return column_;
+  }
+
+  const std::string& token() const {
+    return token_;
+  }
+
   void syntaxError(
       antlr4::Recognizer* recognizer,
       antlr4::Token* offendingSymbol,
@@ -53,13 +73,22 @@ class ErrorListener : public antlr4::BaseErrorListener {
       size_t charPositionInLine,
       const std::string& msg,
       std::exception_ptr e) override {
-    if (firstError.empty()) {
-      firstError = fmt::format(
-          "Syntax error at {}:{}: {}", line, charPositionInLine, msg);
+    if (firstError_.has_value()) {
+      return; // only capture first error
     }
+
+    line_ = line - 1; // 0-based
+    column_ = charPositionInLine; // 0-based
+    firstError_ = msg;
+    token_ =
+        offendingSymbol != nullptr ? offendingSymbol->getText() : std::string();
   }
 
-  std::string firstError;
+ private:
+  std::optional<std::string> firstError_;
+  size_t line_{};
+  size_t column_{};
+  std::string token_;
 };
 
 class ParserHelper {
@@ -98,13 +127,21 @@ class ParserHelper {
 
     // Fall back to LL mode (slower but handles all valid SQL).
     tokenStream_->seek(0);
+    // Reset both the parser and errorListener so that errors from the SLL
+    // attempt are discarded. Either the LL path succeeds and we return a
+    // valid AST, or it fails and we capture fresh LL error info.
     parser_->reset();
+    errorListener_.reset();
     parser_->getInterpreter<antlr4::atn::ParserATNSimulator>()
         ->setPredictionMode(antlr4::atn::PredictionMode::LL);
 
     auto ctx = parser_->singleStatement();
     if (parser_->getNumberOfSyntaxErrors() > 0) {
-      throw PrestoParseError(errorListener_.firstError);
+      throw PrestoParseError(
+          errorListener_.firstError(),
+          errorListener_.line(),
+          errorListener_.column(),
+          errorListener_.token());
     }
 
     return ctx->statement();
@@ -1194,6 +1231,28 @@ SqlStatementPtr PrestoParser::parse(std::string_view sql, bool enableTracing) {
   return doParse(sql, enableTracing);
 }
 
+namespace {
+
+// Computes line and column offsets for adjusting a parse error that occurred
+// within a sub-statement back to the original multi-statement SQL string.
+// Returns {lineOffset, columnOffset}. columnOffset is non-zero only when the
+// error is on line 0 of the sub-statement (same line as the statement start).
+std::pair<size_t, size_t>
+computeOffset(std::string_view sql, size_t statementOffset, size_t errorLine) {
+  size_t linesBeforeStatement = 0;
+  size_t lastLineStart = 0;
+  for (size_t i = 0; i < statementOffset; ++i) {
+    if (sql[i] == '\n') {
+      ++linesBeforeStatement;
+      lastLineStart = i + 1;
+    }
+  }
+  size_t columnOffset = (errorLine == 0) ? statementOffset - lastLineStart : 0;
+  return {linesBeforeStatement, columnOffset};
+}
+
+} // namespace
+
 std::vector<SqlStatementPtr> PrestoParser::parseMultiple(
     std::string_view sql,
     bool enableTracing) {
@@ -1202,8 +1261,15 @@ std::vector<SqlStatementPtr> PrestoParser::parseMultiple(
   results.reserve(statements.size());
 
   for (const auto& statement : statements) {
-    if (!statement.empty()) {
+    if (statement.empty()) {
+      continue;
+    }
+    try {
       results.push_back(doParse(statement, enableTracing));
+    } catch (const PrestoParseError& e) {
+      auto [lineOffset, columnOffset] =
+          computeOffset(sql, statement.data() - sql.data(), e.line());
+      throw e.withOffset(lineOffset, columnOffset);
     }
   }
 

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -55,10 +55,14 @@ class PrestoParser {
   /// semicolons.
   /// @param enableTracing If true, enables tracing for debugging purposes.
   /// @return Vector of parsed statements.
+  /// @throws PrestoParseError if any statement fails to parse. The error's
+  /// line and column are relative to the full input @p sql, not the individual
+  /// sub-statement.
   std::vector<SqlStatementPtr> parseMultiple(
       std::string_view sql,
       bool enableTracing = false);
 
+  /// @throws PrestoParseError if any statement fails to parse.
   facebook::axiom::logical_plan::ExprPtr parseExpression(
       std::string_view sql,
       bool enableTracing = false);
@@ -68,6 +72,7 @@ class PrestoParser {
   /// do not affect the query output (e.g., an unreferenced CTE).
   /// @param sql SQL query statement
   /// @return input and output tables which the query references.
+  /// @throws PrestoParseError if any statement fails to parse.
   ReferencedTables getReferencedTables(std::string_view sql);
 
   /// Splits SQL text into individual statements by semicolon delimiters.

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ColumnFilteringTest.cpp
   DdlParserTest.cpp
   ExpressionParserTest.cpp
+  PrestoParseErrorTest.cpp
   PrestoParserTest.cpp
   PrestoParserTestBase.cpp
   SortParserTest.cpp

--- a/axiom/sql/presto/tests/PrestoParseErrorTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParseErrorTest.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/PrestoParseError.h"
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+
+namespace axiom::sql::presto::test {
+
+namespace {
+
+class PrestoParseErrorTest : public PrestoParserTestBase {};
+
+auto hasLocation(size_t line, size_t column, const std::string& token) {
+  return testing::AllOf(
+      testing::Property(&PrestoParseError::line, line),
+      testing::Property(&PrestoParseError::column, column),
+      testing::Property(&PrestoParseError::token, token));
+}
+
+auto hasLineAndColumn(size_t line, size_t column) {
+  return testing::AllOf(
+      testing::Property(&PrestoParseError::line, line),
+      testing::Property(&PrestoParseError::column, column));
+}
+
+TEST_F(PrestoParseErrorTest, basic) {
+  auto parser = makeParser();
+  // "SELECT * FROM" is missing the table name — error at the EOF token.
+  EXPECT_THAT(
+      [&]() { parser.parse("SELECT * FROM"); },
+      testing::Throws<PrestoParseError>(hasLocation(0, 13, "<EOF>")));
+}
+
+TEST_F(PrestoParseErrorTest, multiline) {
+  auto parser = makeParser();
+  // Multiline SQL — error on the second line at column 5 (WHERE at end).
+  EXPECT_THAT(
+      [&]() {
+        parser.parse(
+            "SELECT * FROM nation\n"
+            "WHERE");
+      },
+      testing::Throws<PrestoParseError>(hasLocation(1, 5, "<EOF>")));
+}
+
+TEST_F(PrestoParseErrorTest, midToken) {
+  auto parser = makeParser();
+  // Extra closing paren — error on the ')' token at position 30.
+  EXPECT_THAT(
+      [&]() { parser.parse("SELECT * FROM (VALUES 1, 2, 3)) blah..."); },
+      testing::Throws<PrestoParseError>(hasLocation(0, 30, ")")));
+}
+
+TEST_F(PrestoParseErrorTest, unrecognizedChar) {
+  auto parser = makeParser();
+  // A control character (0x01) is not recognized by the Presto SQL lexer.
+  // Error location should still be populated.
+  EXPECT_THAT(
+      [&]() { parser.parse(std::string("SELECT \x01")); },
+      testing::Throws<PrestoParseError>(
+          testing::Property(&PrestoParseError::line, 0)));
+}
+
+TEST_F(PrestoParseErrorTest, multiByteUtf8) {
+  auto parser = makeParser();
+  // 'é' is 2 bytes in UTF-8 but 1 codepoint. PrestoParseError reports
+  // ANTLR's character-based column, not byte offsets.
+  EXPECT_THAT(
+      [&]() { parser.parse("SELECT 'é' AS name FORM"); },
+      testing::Throws<PrestoParseError>(hasLocation(0, 19, "FORM")));
+}
+
+TEST_F(PrestoParseErrorTest, bom) {
+  auto parser = makeParser();
+  // UTF-8 BOM (3 bytes: EF BB BF) followed by "SELECT * FROM".
+  // ANTLR strips the BOM before parsing; line/column are post-BOM.
+  std::string sql =
+      "\xEF\xBB\xBF"
+      "SELECT * FROM";
+  EXPECT_THAT(
+      [&]() { parser.parse(sql); },
+      testing::Throws<PrestoParseError>(hasLocation(0, 13, "<EOF>")));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsLineAdjustment) {
+  auto parser = makeParser();
+  // Error in second statement should report line relative to original SQL.
+  // "select 1;\n" has one newline, so line 0 in the second statement becomes
+  // line 1 in the original SQL.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("select 1;\nSELECT * FROM"); },
+      testing::Throws<PrestoParseError>(hasLocation(1, 13, "<EOF>")));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsMultipleNewlines) {
+  auto parser = makeParser();
+  // Error in the third statement, preceded by two newlines.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("select 1;\nselect 2;\nSELECT * FROM"); },
+      testing::Throws<PrestoParseError>(hasLocation(2, 13, "<EOF>")));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsColumnAdjustment) {
+  auto parser = makeParser();
+  // Second statement has leading whitespace on the same line as the semicolon.
+  // splitStatements trims it, so ANTLR sees column 0. But in the original SQL,
+  // "SELETC" starts at column 12 on line 0.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("select 1;   SELETC 2"); },
+      testing::Throws<PrestoParseError>(hasLineAndColumn(0, 12)));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsFirstStatement) {
+  auto parser = makeParser();
+  // Error in the first statement — no line/column adjustment needed.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("SELETC 1; select 2"); },
+      testing::Throws<PrestoParseError>(hasLineAndColumn(0, 0)));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsMultiLineSubStatement) {
+  auto parser = makeParser();
+  // Error on line 1 of the second sub-statement = line 2 in original SQL.
+  // Column should NOT be adjusted since it's not line 0 of the sub-statement.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("select 1;\nSELECT * FROM nation\nWHERE"); },
+      testing::Throws<PrestoParseError>(hasLineAndColumn(2, 5)));
+}
+
+TEST_F(PrestoParseErrorTest, multipleStatementsColumnOnNewLine) {
+  auto parser = makeParser();
+  // Second statement has leading whitespace on a new line.
+  // "SELETC" starts at column 2 on line 1.
+  EXPECT_THAT(
+      [&]() { parser.parseMultiple("select 1;\n  SELETC 2"); },
+      testing::Throws<PrestoParseError>(hasLineAndColumn(1, 2)));
+}
+
+TEST_F(PrestoParseErrorTest, messageForInvalidDecimalTypeArgs) {
+  auto parser = makeParser();
+  EXPECT_THAT(
+      [&]() { parser.parse("CREATE TABLE t (price DECIMAL('abc', 'xyz'))"); },
+      ThrowsMessage<PrestoParseError>(::testing::HasSubstr(
+          "Syntax error at 0:30: mismatched input ''abc''")));
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -262,33 +262,6 @@ TEST_F(PrestoParserTest, qualifiedColumnAccess) {
   }
 }
 
-TEST_F(PrestoParserTest, syntaxErrors) {
-  auto parser = makeParser();
-  EXPECT_THAT(
-      [&]() { parser.parse("SELECT * FROM"); },
-      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
-          "Syntax error at 1:13: mismatched input '<EOF>'")));
-
-  EXPECT_THAT(
-      [&]() {
-        parser.parse(
-            "SELECT * FROM nation\n"
-            "WHERE");
-      },
-      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
-          "Syntax error at 2:5: mismatched input '<EOF>'")));
-
-  EXPECT_THAT(
-      [&]() { parser.parse("SELECT * FROM (VALUES 1, 2, 3)) blah..."); },
-      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
-          "Syntax error at 1:30: mismatched input ')' expecting <EOF>")));
-
-  EXPECT_THAT(
-      [&]() { parser.parse("CREATE TABLE t (price DECIMAL('abc', 'xyz'))"); },
-      ThrowsMessage<axiom::sql::presto::PrestoParseError>(::testing::HasSubstr(
-          "Syntax error at 1:30: mismatched input ''abc''")));
-}
-
 TEST_F(PrestoParserTest, selectStar) {
   {
     auto matcher = matchScan().output(


### PR DESCRIPTION
Summary:

Add line, column, and token text from ANTLR4 parse errors to PrestoParseError.

Reviewed By: mbasmanova

Differential Revision: D100004842
