### PR TITLE
fix: Failure message templates for programmatic error categorization (#1224)

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -24,6 +24,7 @@
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/optimizer/JsonUtil.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -1311,7 +1312,7 @@ bool dirExists(const std::string& path) {
 // Create directory (recursively).
 void createDir(const std::string& path) {
   if (mkdir(path.c_str(), 0755) != 0 && errno != EEXIST) {
-    throw std::runtime_error("Failed to create directory: " + path);
+    VELOX_USER_FAIL("Failed to create directory: {}", path);
   }
 }
 

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -397,8 +397,8 @@ std::any AstBuilder::visitSampledRelation(
   } else if (ctx->sampleType()->SYSTEM() != nullptr) {
     sampleType = SampledRelation::Type::kSystem;
   } else {
-    throw std::runtime_error(
-        "Unsupported table sample type: " + ctx->sampleType()->getText());
+    VELOX_USER_FAIL(
+        "Unsupported table sample type: {}", ctx->sampleType()->getText());
   }
 
   return std::static_pointer_cast<Relation>(std::make_shared<SampledRelation>(
@@ -1097,8 +1097,7 @@ std::string getIntervalFieldType(
   } else if (intervalField->SECOND() != nullptr) {
     return "SECOND";
   } else {
-    throw std::runtime_error(
-        "Unsupported interval field: " + intervalField->getText());
+    VELOX_USER_FAIL("Unsupported interval field: {}", intervalField->getText());
   }
 }
 
@@ -1172,7 +1171,7 @@ TypeSignaturePtr toTypeSignature(
     }
   }
 
-  throw std::runtime_error("Unsupported type specification: " + ctx->getText());
+  VELOX_USER_FAIL("Unsupported type specification: {}", ctx->getText());
 }
 
 TypeSignaturePtr toTypeSignature(
@@ -1187,7 +1186,7 @@ TypeSignaturePtr toTypeSignature(
     return toTypeSignature(ctx->type(), rowFieldName);
   }
 
-  throw std::runtime_error("Unsupported typeParameter: " + ctx->getText());
+  VELOX_USER_FAIL("Unsupported typeParameter: {}", ctx->getText());
 }
 
 } // namespace
@@ -1357,7 +1356,7 @@ std::any AstBuilder::visitSetOperation(
         std::make_shared<Intersect>(getLocation(ctx), left, right, distinct));
   }
 
-  throw std::runtime_error("Unsupported set operation: " + ctx->op->getText());
+  VELOX_USER_FAIL("Unsupported set operation: {}", ctx->op->getText());
 }
 
 std::any AstBuilder::visitQueryPrimaryDefault(
@@ -1553,7 +1552,7 @@ std::any AstBuilder::visitJoinRelation(
       joinCriteria = std::make_shared<JoinUsing>(
           getLocation(ctx->joinCriteria()), columns);
     } else {
-      throw std::runtime_error("Unsupported join criteria");
+      VELOX_USER_FAIL("Unsupported join criteria");
     }
   }
 
@@ -1666,8 +1665,7 @@ ComparisonExpression::Operator toComparisonOperator(size_t tokenType) {
     case PrestoSqlParser::GTE:
       return ComparisonExpression::Operator::kGreaterThanOrEqual;
     default:
-      throw std::runtime_error(
-          "Unsupported comparison operator: " + std::to_string(tokenType));
+      VELOX_USER_FAIL("Unsupported comparison operator: {}", tokenType);
   }
 }
 
@@ -1819,8 +1817,7 @@ ArithmeticBinaryExpression::Operator toArithmeticBinaryOperator(
     case PrestoSqlParser::PERCENT:
       return ArithmeticBinaryExpression::Operator::kModulus;
     default:
-      throw std::runtime_error(
-          "Unsupported arithmetic operator: " + std::to_string(tokenType));
+      VELOX_USER_FAIL("Unsupported arithmetic operator: {}", tokenType);
   }
 }
 
@@ -1848,8 +1845,7 @@ ArithmeticUnaryExpression::Sign toArithmeticSign(size_t tokenType) {
     case PrestoSqlParser::MINUS:
       return ArithmeticUnaryExpression::Sign::kMinus;
     default:
-      throw std::runtime_error(
-          "Unsupported sign: " + std::to_string(tokenType));
+      VELOX_USER_FAIL("Unsupported sign: {}", tokenType);
   }
 }
 
@@ -2238,7 +2234,7 @@ Extract::Field toField(std::string_view name) {
     return Extract::Field::kTimezoneMinute;
   }
 
-  throw std::runtime_error(fmt::format("Invalid EXTRACT field: {}", name));
+  VELOX_USER_FAIL("Invalid EXTRACT field: {}", name);
 }
 } // namespace
 

--- a/axiom/sql/presto/ast/AstBuilder.h
+++ b/axiom/sql/presto/ast/AstBuilder.h
@@ -22,6 +22,7 @@
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 #include "axiom/sql/presto/grammar/PrestoSqlParser.h"
 #include "axiom/sql/presto/grammar/PrestoSqlVisitor.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace axiom::sql::presto {
 
@@ -670,15 +671,14 @@ class AstBuilder : public PrestoSqlVisitor {
 
   std::any aggregateResult(std::any aggregate, std::any nextResult) override {
     if (aggregate.has_value()) {
-      throw std::runtime_error(
-          "aggregateResult called with non-null aggregate");
+      VELOX_FAIL("aggregateResult called with non-null aggregate");
     }
 
     return nextResult;
   }
 
   std::any visitChildren(antlr4::tree::ParseTree* node) override {
-    throw std::runtime_error("Unexpected call to visitChildren");
+    VELOX_FAIL("Unexpected call to visitChildren");
   }
 
   std::any visitChildren(std::string_view name, antlr4::tree::ParseTree* node) {
@@ -689,11 +689,10 @@ class AstBuilder : public PrestoSqlVisitor {
     }
 
     if (numChildren > 1) {
-      throw std::runtime_error(
-          fmt::format(
-              "visitChildren called with more than one child: {} ({})",
-              numChildren,
-              name));
+      VELOX_FAIL(
+          "visitChildren called with more than one child: {} ({})",
+          numChildren,
+          name);
     }
 
     ++tracingIndent_;

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -17,6 +17,7 @@
 #include "axiom/sql/presto/ast/AstPrinter.h"
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include "velox/common/base/Exceptions.h"
 
 namespace axiom::sql::presto {
 
@@ -94,7 +95,7 @@ std::string toString(ArithmeticBinaryExpression::Operator op) {
     case ArithmeticBinaryExpression::Operator::kModulus:
       return "%";
   }
-  throw std::runtime_error("Unsupported arithmetic operator");
+  VELOX_FAIL("Unsupported arithmetic operator");
 }
 
 std::string toString(LogicalBinaryExpression::Operator op) {
@@ -105,7 +106,7 @@ std::string toString(LogicalBinaryExpression::Operator op) {
       return "or";
   }
 
-  throw std::runtime_error("Unsupported logical operator");
+  VELOX_FAIL("Unsupported logical operator");
 }
 
 std::string toString(ComparisonExpression::Operator op) {
@@ -125,7 +126,7 @@ std::string toString(ComparisonExpression::Operator op) {
     case ComparisonExpression::Operator::kIsDistinctFrom:
       return "IS DISTINCT FROM";
     default:
-      throw std::runtime_error("Unsupported comparison operator");
+      VELOX_FAIL("Unsupported comparison operator");
   }
 }
 
@@ -136,7 +137,7 @@ std::string toString(SortItem::Ordering ordering) {
     case SortItem::Ordering::kDescending:
       return "DESC";
     default:
-      throw std::runtime_error("Unsupported sort ordering");
+      VELOX_FAIL("Unsupported sort ordering");
   }
 }
 
@@ -149,7 +150,7 @@ std::string toString(SortItem::NullOrdering nullOrdering) {
     case SortItem::NullOrdering::kUndefined:
       return "NULLS UNDEFINED";
     default:
-      throw std::runtime_error("Unsupported null ordering");
+      VELOX_FAIL("Unsupported null ordering");
   }
 }
 } // namespace


### PR DESCRIPTION
Summary:

Three fixes in axel (OSS) and axiom to ensure failure message templates are correctly captured for programmatic error categorization:

1. **QueryError template-aware overload**: Add `QueryError::create(errorCode, messageTemplate, args...)` that stores the static format string as the failure template while formatting the full message for display. Add `createWithTemplate` private helper.

2. **VeloxException template fallback**: When VeloxException has an empty messageTemplate (from messageless VELOX_CHECK/VELOX_FAIL), synthesize a groupable template from `failingExpression()` instead of falling back to `ex.what()` (which includes the full stack trace and is ungroupable).

3. **std::runtime_error → VELOX_FAIL/VELOX_USER_FAIL**: Convert `throw std::runtime_error` to `VELOX_FAIL`/`VELOX_USER_FAIL` with format args in axel client, axiom SQL parser, axiom hive connector, and axiom AST printer so that VeloxException captures the template string.

Reviewed By: kagamiori

Differential Revision: D99975400
