### PR TITLE
refactor: Use WindowCallExpr instead of WindowSpec side-channel (#1225)

### DIFF
--- a/axiom/logical_plan/ExprApi.cpp
+++ b/axiom/logical_plan/ExprApi.cpp
@@ -142,10 +142,6 @@ ExprApi Call(std::string name, const std::vector<ExprApi>& args) {
   std::vector<velox::core::ExprPtr> argExpr;
   argExpr.reserve(args.size());
   for (auto& arg : args) {
-    VELOX_CHECK_NULL(
-        arg.windowSpec(),
-        "Window function cannot be an argument to a scalar function: {}",
-        name);
     argExpr.push_back(arg.expr());
   }
   return ExprApi{std::make_shared<const velox::core::CallExpr>(
@@ -185,8 +181,8 @@ ExprApi Ordinality() {
 
 ExprApi ExprApi::unnestAs(std::vector<std::string> aliases) const {
   VELOX_USER_CHECK(!aliases.empty(), "UNNEST aliases must not be empty.");
-  VELOX_USER_CHECK_NULL(
-      windowSpec_,
+  VELOX_USER_CHECK(
+      !expr_->is(velox::core::IExpr::Kind::kWindow),
       "UNNEST cannot be combined with OVER: {}",
       expr_->toString());
   return ExprApi(expr_, alias_, std::move(aliases));
@@ -195,18 +191,32 @@ ExprApi ExprApi::unnestAs(std::vector<std::string> aliases) const {
 ExprApi ExprApi::over(const WindowSpec& windowSpec) const {
   VELOX_USER_CHECK(
       expr_->is(velox::core::IExpr::Kind::kCall),
-      "OVER cannot be combined with DISTINCT, FILTER, or ORDER BY: {}",
-      expr_->toString());
-  VELOX_USER_CHECK_NULL(
-      windowSpec_, "OVER clause already specified: {}", expr_->toString());
-  VELOX_USER_CHECK(
-      unnestedAliases_.empty(),
-      "OVER cannot be combined with UNNEST: {}",
+      "OVER can only be applied to a plain function call: {}",
       expr_->toString());
 
-  ExprApi result(expr_, alias_);
-  result.windowSpec_ = std::make_shared<const WindowSpec>(windowSpec);
-  return result;
+  auto* call = expr_->as<velox::core::CallExpr>();
+
+  std::vector<velox::core::ExprPtr> partitionKeys;
+  partitionKeys.reserve(windowSpec.partitionKeys().size());
+  for (const auto& key : windowSpec.partitionKeys()) {
+    partitionKeys.push_back(key.expr());
+  }
+
+  std::vector<velox::core::SortKey> orderByKeys;
+  orderByKeys.reserve(windowSpec.orderByKeys().size());
+  for (const auto& key : windowSpec.orderByKeys()) {
+    orderByKeys.push_back({key.expr.expr(), key.ascending, key.nullsFirst});
+  }
+
+  return ExprApi(
+      std::make_shared<velox::core::WindowCallExpr>(
+          call->name(),
+          call->inputs(),
+          std::move(partitionKeys),
+          std::move(orderByKeys),
+          windowSpec.frame(),
+          windowSpec.isIgnoreNulls()),
+      alias_);
 }
 
 namespace {
@@ -228,8 +238,8 @@ ExprApi ExprApi::distinct() const {
           expr_->is(velox::core::IExpr::Kind::kAggregate),
       "DISTINCT can only be applied to a function call: {}",
       expr_->toString());
-  VELOX_USER_CHECK_NULL(
-      windowSpec_,
+  VELOX_USER_CHECK(
+      !expr_->is(velox::core::IExpr::Kind::kWindow),
       "DISTINCT cannot be combined with OVER: {}",
       expr_->toString());
 
@@ -263,8 +273,8 @@ ExprApi ExprApi::filter(const ExprApi& filterExpr) const {
           expr_->is(velox::core::IExpr::Kind::kAggregate),
       "FILTER can only be applied to a function call: {}",
       expr_->toString());
-  VELOX_USER_CHECK_NULL(
-      windowSpec_,
+  VELOX_USER_CHECK(
+      !expr_->is(velox::core::IExpr::Kind::kWindow),
       "FILTER cannot be combined with OVER: {}",
       expr_->toString());
 
@@ -297,8 +307,8 @@ ExprApi ExprApi::sortBy(const std::vector<SortKey>& keys) const {
           expr_->is(velox::core::IExpr::Kind::kAggregate),
       "ORDER BY can only be applied to a function call: {}",
       expr_->toString());
-  VELOX_USER_CHECK_NULL(
-      windowSpec_,
+  VELOX_USER_CHECK(
+      !expr_->is(velox::core::IExpr::Kind::kWindow),
       "ORDER BY cannot be combined with OVER: {}",
       expr_->toString());
 
@@ -333,42 +343,64 @@ ExprApi ExprApi::sortBy(const std::vector<SortKey>& keys) const {
       alias_);
 }
 
-WindowSpec& WindowSpec::rows(
-    WindowExpr::BoundType startType,
+namespace {
+
+velox::core::WindowCallExpr::Frame makeFrame(
+    velox::core::WindowCallExpr::WindowType type,
+    velox::core::WindowCallExpr::BoundType startType,
     std::optional<ExprApi> startValue,
-    WindowExpr::BoundType endType,
+    velox::core::WindowCallExpr::BoundType endType,
     std::optional<ExprApi> endValue) {
-  frameType_ = WindowExpr::WindowType::kRows;
-  startType_ = startType;
-  startValue_ = std::move(startValue);
-  endType_ = endType;
-  endValue_ = std::move(endValue);
+  return {
+      type,
+      startType,
+      startValue ? startValue->expr() : nullptr,
+      endType,
+      endValue ? endValue->expr() : nullptr,
+  };
+}
+
+} // namespace
+
+WindowSpec& WindowSpec::rows(
+    velox::core::WindowCallExpr::BoundType startType,
+    std::optional<ExprApi> startValue,
+    velox::core::WindowCallExpr::BoundType endType,
+    std::optional<ExprApi> endValue) {
+  frame_ = makeFrame(
+      velox::core::WindowCallExpr::WindowType::kRows,
+      startType,
+      std::move(startValue),
+      endType,
+      std::move(endValue));
   return *this;
 }
 
 WindowSpec& WindowSpec::range(
-    WindowExpr::BoundType startType,
+    velox::core::WindowCallExpr::BoundType startType,
     std::optional<ExprApi> startValue,
-    WindowExpr::BoundType endType,
+    velox::core::WindowCallExpr::BoundType endType,
     std::optional<ExprApi> endValue) {
-  frameType_ = WindowExpr::WindowType::kRange;
-  startType_ = startType;
-  startValue_ = std::move(startValue);
-  endType_ = endType;
-  endValue_ = std::move(endValue);
+  frame_ = makeFrame(
+      velox::core::WindowCallExpr::WindowType::kRange,
+      startType,
+      std::move(startValue),
+      endType,
+      std::move(endValue));
   return *this;
 }
 
 WindowSpec& WindowSpec::groups(
-    WindowExpr::BoundType startType,
+    velox::core::WindowCallExpr::BoundType startType,
     std::optional<ExprApi> startValue,
-    WindowExpr::BoundType endType,
+    velox::core::WindowCallExpr::BoundType endType,
     std::optional<ExprApi> endValue) {
-  frameType_ = WindowExpr::WindowType::kGroups;
-  startType_ = startType;
-  startValue_ = std::move(startValue);
-  endType_ = endType;
-  endValue_ = std::move(endValue);
+  frame_ = makeFrame(
+      velox::core::WindowCallExpr::WindowType::kGroups,
+      startType,
+      std::move(startValue),
+      endType,
+      std::move(endValue));
   return *this;
 }
 

--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -17,6 +17,7 @@
 
 #include <optional>
 #include "axiom/logical_plan/Expr.h"
+#include "velox/parse/Expressions.h"
 #include "velox/parse/IExpr.h"
 #include "velox/type/Variant.h"
 
@@ -242,9 +243,7 @@ class ExprApi {
   }
 
   ExprApi as(std::string alias) const {
-    ExprApi result(expr_, std::move(alias));
-    result.windowSpec_ = windowSpec_;
-    return result;
+    return ExprApi(expr_, std::move(alias));
   }
 
   ExprApi unnestAs(std::vector<std::string> aliases) const;
@@ -255,13 +254,8 @@ class ExprApi {
   }
 
   /// Converts a function call into a window function with the given window
-  /// specification.
+  /// specification. Creates a WindowCallExpr from the underlying CallExpr.
   ExprApi over(const WindowSpec& windowSpec) const;
-
-  /// Returns the window specification, if any.
-  const std::shared_ptr<const WindowSpec>& windowSpec() const {
-    return windowSpec_;
-  }
 
   /// Marks the aggregate function as DISTINCT. Wraps the underlying CallExpr
   /// in an AggregateCallExpr.
@@ -277,7 +271,6 @@ class ExprApi {
   velox::core::ExprPtr expr_;
   std::optional<std::string> alias_;
   std::vector<std::string> unnestedAliases_;
-  std::shared_ptr<const WindowSpec> windowSpec_;
 };
 
 ExprApi Lit(velox::Variant&& val);
@@ -367,8 +360,9 @@ struct SortKey {
   bool nullsFirst;
 };
 
-/// Window specification for use with ExprApi::over(). Follows PySpark's
-/// Window.partitionBy().orderBy() pattern.
+/// Window specification for use with ExprApi::over(). Describes partition keys,
+/// ordering, frame, and ignore nulls. Used as a parameter object — not stored
+/// on ExprApi.
 ///
 /// Usage:
 ///
@@ -396,23 +390,23 @@ class WindowSpec {
 
   /// Specifies a ROWS frame.
   WindowSpec& rows(
-      WindowExpr::BoundType startType,
+      velox::core::WindowCallExpr::BoundType startType,
       std::optional<ExprApi> startValue,
-      WindowExpr::BoundType endType,
+      velox::core::WindowCallExpr::BoundType endType,
       std::optional<ExprApi> endValue);
 
   /// Specifies a RANGE frame.
   WindowSpec& range(
-      WindowExpr::BoundType startType,
+      velox::core::WindowCallExpr::BoundType startType,
       std::optional<ExprApi> startValue,
-      WindowExpr::BoundType endType,
+      velox::core::WindowCallExpr::BoundType endType,
       std::optional<ExprApi> endValue);
 
   /// Specifies a GROUPS frame.
   WindowSpec& groups(
-      WindowExpr::BoundType startType,
+      velox::core::WindowCallExpr::BoundType startType,
       std::optional<ExprApi> startValue,
-      WindowExpr::BoundType endType,
+      velox::core::WindowCallExpr::BoundType endType,
       std::optional<ExprApi> endValue);
 
   /// Sets IGNORE NULLS for the window function.
@@ -429,24 +423,8 @@ class WindowSpec {
     return orderByKeys_;
   }
 
-  const std::optional<WindowExpr::WindowType>& frameType() const {
-    return frameType_;
-  }
-
-  WindowExpr::BoundType startType() const {
-    return startType_;
-  }
-
-  const std::optional<ExprApi>& startValue() const {
-    return startValue_;
-  }
-
-  WindowExpr::BoundType endType() const {
-    return endType_;
-  }
-
-  const std::optional<ExprApi>& endValue() const {
-    return endValue_;
+  const std::optional<velox::core::WindowCallExpr::Frame>& frame() const {
+    return frame_;
   }
 
   bool isIgnoreNulls() const {
@@ -456,11 +434,7 @@ class WindowSpec {
  private:
   std::vector<ExprApi> partitionKeys_;
   std::vector<SortKey> orderByKeys_;
-  std::optional<WindowExpr::WindowType> frameType_;
-  WindowExpr::BoundType startType_{WindowExpr::BoundType::kUnboundedPreceding};
-  std::optional<ExprApi> startValue_;
-  WindowExpr::BoundType endType_{WindowExpr::BoundType::kUnboundedFollowing};
-  std::optional<ExprApi> endValue_;
+  std::optional<velox::core::WindowCallExpr::Frame> frame_;
   bool ignoreNulls_{false};
 };
 

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -940,12 +940,50 @@ AggregateExprPtr ExprResolver::resolveAggregateTypes(
       distinct);
 }
 
+namespace {
+
+// Maps WindowCallExpr::BoundType to WindowExpr::BoundType.
+WindowExpr::BoundType toBoundType(velox::core::WindowCallExpr::BoundType type) {
+  switch (type) {
+    case velox::core::WindowCallExpr::BoundType::kUnboundedPreceding:
+      return WindowExpr::BoundType::kUnboundedPreceding;
+    case velox::core::WindowCallExpr::BoundType::kPreceding:
+      return WindowExpr::BoundType::kPreceding;
+    case velox::core::WindowCallExpr::BoundType::kCurrentRow:
+      return WindowExpr::BoundType::kCurrentRow;
+    case velox::core::WindowCallExpr::BoundType::kFollowing:
+      return WindowExpr::BoundType::kFollowing;
+    case velox::core::WindowCallExpr::BoundType::kUnboundedFollowing:
+      return WindowExpr::BoundType::kUnboundedFollowing;
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Maps WindowCallExpr::WindowType to WindowExpr::WindowType.
+WindowExpr::WindowType toWindowType(
+    velox::core::WindowCallExpr::WindowType type) {
+  switch (type) {
+    case velox::core::WindowCallExpr::WindowType::kRange:
+      return WindowExpr::WindowType::kRange;
+    case velox::core::WindowCallExpr::WindowType::kRows:
+      return WindowExpr::WindowType::kRows;
+    case velox::core::WindowCallExpr::WindowType::kGroups:
+      return WindowExpr::WindowType::kGroups;
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace
+
 WindowExprPtr ExprResolver::resolveWindowTypes(
-    const velox::core::ExprPtr& expr,
-    const WindowSpec& windowSpec,
+    const velox::core::WindowCallExpr& windowCall,
     const InputNameResolver& inputNameResolver) const {
+  // Build a plain CallExpr from the WindowCallExpr for type resolution.
+  auto callExpr = std::make_shared<velox::core::CallExpr>(
+      windowCall.name(), windowCall.inputs(), std::nullopt);
+
   auto resolved = resolveCallTypes(
-      expr,
+      callExpr,
       inputNameResolver,
       *this,
       enableCoercions_,
@@ -955,49 +993,51 @@ WindowExprPtr ExprResolver::resolveWindowTypes(
 
   // Resolve partition keys.
   std::vector<ExprPtr> partitionKeys;
-  partitionKeys.reserve(windowSpec.partitionKeys().size());
-  for (const auto& key : windowSpec.partitionKeys()) {
-    partitionKeys.push_back(resolveScalarTypes(key.expr(), inputNameResolver));
+  partitionKeys.reserve(windowCall.partitionKeys().size());
+  for (const auto& key : windowCall.partitionKeys()) {
+    partitionKeys.push_back(resolveScalarTypes(key, inputNameResolver));
   }
 
   // Resolve ordering.
   std::vector<SortingField> ordering;
-  ordering.reserve(windowSpec.orderByKeys().size());
-  for (const auto& key : windowSpec.orderByKeys()) {
-    auto sortExpr = resolveScalarTypes(key.expr.expr(), inputNameResolver);
+  ordering.reserve(windowCall.orderByKeys().size());
+  for (const auto& key : windowCall.orderByKeys()) {
+    auto sortExpr = resolveScalarTypes(key.expr, inputNameResolver);
     ordering.push_back(
         SortingField{sortExpr, SortOrder(key.ascending, key.nullsFirst)});
   }
 
   // Resolve frame.
-  auto startType = windowSpec.startType();
+  const auto& frame = windowCall.frame();
+  auto startType = frame.has_value()
+      ? toBoundType(frame->startType)
+      : WindowExpr::BoundType::kUnboundedPreceding;
   ExprPtr startValue;
-  if (windowSpec.startValue().has_value()) {
-    startValue =
-        resolveScalarTypes(windowSpec.startValue()->expr(), inputNameResolver);
+  if (frame.has_value() && frame->startValue) {
+    startValue = resolveScalarTypes(frame->startValue, inputNameResolver);
   }
 
-  auto endType = windowSpec.endType();
+  auto endType = frame.has_value() ? toBoundType(frame->endType)
+                                   : WindowExpr::BoundType::kUnboundedFollowing;
   ExprPtr endValue;
-  if (windowSpec.endValue().has_value()) {
-    endValue =
-        resolveScalarTypes(windowSpec.endValue()->expr(), inputNameResolver);
+  if (frame.has_value() && frame->endValue) {
+    endValue = resolveScalarTypes(frame->endValue, inputNameResolver);
   }
 
-  auto windowType = windowSpec.frameType().has_value()
-      ? windowSpec.frameType().value()
-      : WindowExpr::WindowType::kRange;
+  auto windowType = frame.has_value() ? toWindowType(frame->type)
+                                      : WindowExpr::WindowType::kRange;
 
   // SQL standard: when ORDER BY is present and no frame is specified, the
   // default is RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW. When ORDER BY
   // is absent, the default is RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED
   // FOLLOWING (entire partition).
-  if (!windowSpec.frameType().has_value() && !ordering.empty() &&
+  if (!frame.has_value() && !ordering.empty() &&
       endType == WindowExpr::BoundType::kUnboundedFollowing) {
     endType = WindowExpr::BoundType::kCurrentRow;
   }
 
-  WindowExpr::Frame frame{windowType, startType, startValue, endType, endValue};
+  WindowExpr::Frame resolvedFrame{
+      windowType, startType, startValue, endType, endValue};
 
   return std::make_shared<WindowExpr>(
       resolved.type,
@@ -1005,8 +1045,8 @@ WindowExprPtr ExprResolver::resolveWindowTypes(
       std::move(resolved.inputs),
       std::move(partitionKeys),
       std::move(ordering),
-      std::move(frame),
-      windowSpec.isIgnoreNulls());
+      std::move(resolvedFrame),
+      windowCall.isIgnoreNulls());
 }
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/ExprResolver.h
+++ b/axiom/logical_plan/ExprResolver.h
@@ -87,8 +87,7 @@ class ExprResolver {
   /// ordering, and frame bounds, then looks up the window function signature
   /// and produces a WindowExpr.
   WindowExprPtr resolveWindowTypes(
-      const velox::core::ExprPtr& expr,
-      const WindowSpec& windowSpec,
+      const velox::core::WindowCallExpr& windowCall,
       const InputNameResolver& inputNameResolver) const;
 
  private:

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -428,18 +428,19 @@ PlanBuilder& PlanBuilder::filter(const ExprApi& predicate) {
 
 namespace {
 
-WindowExpr::BoundType toBoundType(velox::parse::BoundType type) {
+velox::core::WindowCallExpr::BoundType toBoundType(
+    velox::parse::BoundType type) {
   switch (type) {
     case velox::parse::BoundType::kCurrentRow:
-      return WindowExpr::BoundType::kCurrentRow;
+      return velox::core::WindowCallExpr::BoundType::kCurrentRow;
     case velox::parse::BoundType::kUnboundedPreceding:
-      return WindowExpr::BoundType::kUnboundedPreceding;
+      return velox::core::WindowCallExpr::BoundType::kUnboundedPreceding;
     case velox::parse::BoundType::kUnboundedFollowing:
-      return WindowExpr::BoundType::kUnboundedFollowing;
+      return velox::core::WindowCallExpr::BoundType::kUnboundedFollowing;
     case velox::parse::BoundType::kPreceding:
-      return WindowExpr::BoundType::kPreceding;
+      return velox::core::WindowCallExpr::BoundType::kPreceding;
     case velox::parse::BoundType::kFollowing:
-      return WindowExpr::BoundType::kFollowing;
+      return velox::core::WindowCallExpr::BoundType::kFollowing;
   }
   VELOX_UNREACHABLE();
 }
@@ -664,8 +665,9 @@ void PlanBuilder::resolveProjections(
 
   for (const auto& projection : projections) {
     ExprPtr expr;
-    if (projection.windowSpec() != nullptr) {
-      expr = resolveWindowTypes(projection.expr(), *projection.windowSpec());
+    if (projection.expr()->is(velox::core::IExpr::Kind::kWindow)) {
+      expr = resolveWindowTypes(
+          *projection.expr()->as<velox::core::WindowCallExpr>());
     } else {
       expr = resolveScalarTypes(projection.expr());
     }
@@ -1893,10 +1895,9 @@ AggregateExprPtr PlanBuilder::resolveAggregateTypes(
 }
 
 WindowExprPtr PlanBuilder::resolveWindowTypes(
-    const velox::core::ExprPtr& expr,
-    const WindowSpec& windowSpec) const {
+    const velox::core::WindowCallExpr& windowCallExpr) const {
   return resolver_.resolveWindowTypes(
-      expr, windowSpec, [&](const auto& alias, const auto& name) {
+      windowCallExpr, [&](const auto& alias, const auto& name) {
         return resolveInputName(alias, name);
       });
 }

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -804,8 +804,7 @@ class PlanBuilder {
       bool distinct) const;
 
   WindowExprPtr resolveWindowTypes(
-      const velox::core::ExprPtr& expr,
-      const WindowSpec& windowSpec) const;
+      const velox::core::WindowCallExpr& windowCallExpr) const;
 
   std::vector<ExprApi> parse(const std::vector<std::string>& exprs);
 

--- a/axiom/logical_plan/tests/ExprEqualityTest.cpp
+++ b/axiom/logical_plan/tests/ExprEqualityTest.cpp
@@ -209,19 +209,23 @@ TEST_F(ExprEqualityTest, aggregate) {
 }
 
 TEST_F(ExprEqualityTest, window) {
+  using BoundType = velox::core::WindowCallExpr::BoundType;
+
   auto resolveWindow = [this](const ExprApi& expr) {
+    VELOX_CHECK(expr.expr()->is(velox::core::IExpr::Kind::kWindow));
     return ExprResolver(nullptr, false)
         .resolveWindowTypes(
-            expr.expr(), *expr.windowSpec(), inputResolver(schema_));
+            *expr.expr()->as<velox::core::WindowCallExpr>(),
+            inputResolver(schema_));
   };
 
   auto spec = WindowSpec()
                   .partitionBy({Col("x")})
                   .orderBy({SortKey(Col("y"))})
                   .rows(
-                      WindowExpr::BoundType::kUnboundedPreceding,
+                      BoundType::kUnboundedPreceding,
                       std::nullopt,
-                      WindowExpr::BoundType::kCurrentRow,
+                      BoundType::kCurrentRow,
                       std::nullopt);
 
   auto rowNum = resolveWindow(Call("row_number").over(spec));
@@ -235,9 +239,9 @@ TEST_F(ExprEqualityTest, window) {
   auto noPartitionSpec = WindowSpec()
                              .orderBy({SortKey(Col("y"))})
                              .rows(
-                                 WindowExpr::BoundType::kUnboundedPreceding,
+                                 BoundType::kUnboundedPreceding,
                                  std::nullopt,
-                                 WindowExpr::BoundType::kCurrentRow,
+                                 BoundType::kCurrentRow,
                                  std::nullopt);
   EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(noPartitionSpec)));
 
@@ -246,9 +250,9 @@ TEST_F(ExprEqualityTest, window) {
                        .partitionBy({Col("x")})
                        .orderBy({SortKey(Col("y"))})
                        .range(
-                           WindowExpr::BoundType::kUnboundedPreceding,
+                           BoundType::kUnboundedPreceding,
                            std::nullopt,
-                           WindowExpr::BoundType::kCurrentRow,
+                           BoundType::kCurrentRow,
                            std::nullopt);
   EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(rangeSpec)));
 
@@ -257,9 +261,9 @@ TEST_F(ExprEqualityTest, window) {
                              .partitionBy({Col("x")})
                              .orderBy({SortKey(Col("y"))})
                              .rows(
-                                 WindowExpr::BoundType::kUnboundedPreceding,
+                                 BoundType::kUnboundedPreceding,
                                  std::nullopt,
-                                 WindowExpr::BoundType::kCurrentRow,
+                                 BoundType::kCurrentRow,
                                  std::nullopt)
                              .ignoreNulls();
   EXPECT_NE(*rowNum, *resolveWindow(Call("row_number").over(ignoreNullsSpec)));

--- a/axiom/logical_plan/tests/ExprSerdeTest.cpp
+++ b/axiom/logical_plan/tests/ExprSerdeTest.cpp
@@ -77,11 +77,10 @@ class ExprSerdeTest : public testing::Test {
   // Resolves a window ExprApi expression to an Expr using a schema for column
   // types.
   ExprPtr resolveWindow(const ExprApi& expr, velox::RowTypePtr schema) {
-    VELOX_CHECK_NOT_NULL(expr.windowSpec());
+    VELOX_CHECK(expr.expr()->is(velox::core::IExpr::Kind::kWindow));
     ExprResolver resolver(/*queryCtx=*/nullptr, /*enableCoercions=*/false);
     return resolver.resolveWindowTypes(
-        expr.expr(),
-        *expr.windowSpec(),
+        *expr.expr()->as<velox::core::WindowCallExpr>(),
         [&schema](const std::optional<std::string>&, const std::string& name)
             -> ExprPtr {
           return std::make_shared<InputReferenceExpr>(
@@ -171,6 +170,8 @@ TEST_F(ExprSerdeTest, windowExpr) {
   auto schema =
       velox::ROW({{"x", velox::BIGINT()}, {"category", velox::VARCHAR()}});
 
+  using BoundType = velox::core::WindowCallExpr::BoundType;
+
   // row_number() with ORDER BY.
   testRoundTrip(resolveWindow(
       Call("row_number").over(WindowSpec().orderBy({SortKey(Col("x"), ASC)})),
@@ -193,9 +194,9 @@ TEST_F(ExprSerdeTest, windowExpr) {
                   .partitionBy({Col("category")})
                   .orderBy({SortKey(Col("x"), ASC)})
                   .rows(
-                      WindowExpr::BoundType::kPreceding,
+                      BoundType::kPreceding,
                       Lit(3LL),
-                      WindowExpr::BoundType::kFollowing,
+                      BoundType::kFollowing,
                       Lit(5LL))),
       schema));
 
@@ -207,9 +208,9 @@ TEST_F(ExprSerdeTest, windowExpr) {
                   .partitionBy({Col("category")})
                   .orderBy({SortKey(Col("x"), ASC)})
                   .range(
-                      WindowExpr::BoundType::kUnboundedPreceding,
+                      BoundType::kUnboundedPreceding,
                       {},
-                      WindowExpr::BoundType::kCurrentRow,
+                      BoundType::kCurrentRow,
                       {})),
       schema));
 
@@ -221,9 +222,9 @@ TEST_F(ExprSerdeTest, windowExpr) {
                   .partitionBy({Col("category")})
                   .orderBy({SortKey(Col("x"), ASC)})
                   .groups(
-                      WindowExpr::BoundType::kPreceding,
+                      BoundType::kPreceding,
                       Lit(2LL),
-                      WindowExpr::BoundType::kCurrentRow,
+                      BoundType::kCurrentRow,
                       {})),
       schema));
 }

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -201,48 +201,32 @@ lp::ExprApi parseDecimal(std::string_view value) {
       LongDecimalType::kMaxPrecision);
 }
 
-// Walks the AST looking for window function calls.
-class WindowFunctionFinder : public DefaultTraversalVisitor {
- public:
-  bool hasWindowFunction() const {
-    return hasWindowFunction_;
-  }
-
- protected:
-  void visitFunctionCall(FunctionCall* node) override {
-    if (node->window() != nullptr) {
-      hasWindowFunction_ = true;
-      return;
-    }
-    DefaultTraversalVisitor::visitFunctionCall(node);
-  }
-
-  void visitSubqueryExpression(SubqueryExpression* node) override {}
-
- private:
-  bool hasWindowFunction_{false};
-};
-
 } // namespace
 
-bool ExpressionPlanner::hasNestedWindowFunction(
-    const std::vector<SelectItemPtr>& selectItems) {
-  for (const auto& item : selectItems) {
-    if (item->is(NodeType::kSingleColumn)) {
-      auto* singleColumn = item->as<SingleColumn>();
-      const auto& expr = singleColumn->expression();
-      if (expr->is(NodeType::kFunctionCall) &&
-          expr->as<FunctionCall>()->window() != nullptr) {
-        continue;
-      }
-      WindowFunctionFinder finder;
-      const_cast<Expression*>(expr.get())->accept(&finder);
-      if (finder.hasWindowFunction()) {
-        return true;
-      }
+void ExpressionPlanner::findWindowExprs(
+    const core::ExprPtr& expr,
+    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
+    std::vector<const core::IExpr*>& traversalOrder) {
+  if (expr->is(core::IExpr::Kind::kWindow)) {
+    if (windowExprs.emplace(expr.get(), expr).second) {
+      traversalOrder.push_back(expr.get());
+    }
+    return;
+  }
+  for (const auto& input : expr->inputs()) {
+    findWindowExprs(input, windowExprs, traversalOrder);
+  }
+}
+
+void ExpressionPlanner::findNestedWindowExprs(
+    const std::vector<lp::ExprApi>& exprs,
+    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
+    std::vector<const core::IExpr*>& traversalOrder) {
+  for (const auto& expr : exprs) {
+    if (!expr.expr()->is(core::IExpr::Kind::kWindow)) {
+      findWindowExprs(expr.expr(), windowExprs, traversalOrder);
     }
   }
-  return false;
 }
 
 std::string canonicalizeName(const std::string& name) {
@@ -317,9 +301,7 @@ TypePtr parseType(const TypeSignaturePtr& type) {
   return veloxType;
 }
 
-lp::ExprApi ExpressionPlanner::toExpr(
-    const ExpressionPtr& node,
-    std::unordered_map<const core::IExpr*, lp::WindowSpec>* windowOptions) {
+lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());
@@ -349,7 +331,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
           return lp::Col(field);
         }
       }
-      return lp::Col(field, toExpr(dereference->base(), windowOptions));
+      return lp::Col(field, toExpr(dereference->base()));
     }
 
     case NodeType::kSubqueryExpression: {
@@ -371,23 +353,23 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* comparison = node->as<ComparisonExpression>();
       return lp::Call(
           toFunctionName(comparison->op()),
-          toExpr(comparison->left(), windowOptions),
-          toExpr(comparison->right(), windowOptions));
+          toExpr(comparison->left()),
+          toExpr(comparison->right()));
     }
 
     case NodeType::kNotExpression: {
       auto* negation = node->as<NotExpression>();
-      return lp::Call("not", toExpr(negation->value(), windowOptions));
+      return lp::Call("not", toExpr(negation->value()));
     }
 
     case NodeType::kLikePredicate: {
       auto* like = node->as<LikePredicate>();
 
       std::vector<lp::ExprApi> inputs;
-      inputs.emplace_back(toExpr(like->value(), windowOptions));
-      inputs.emplace_back(toExpr(like->pattern(), windowOptions));
+      inputs.emplace_back(toExpr(like->value()));
+      inputs.emplace_back(toExpr(like->pattern()));
       if (like->escape()) {
-        inputs.emplace_back(toExpr(like->escape(), windowOptions));
+        inputs.emplace_back(toExpr(like->escape()));
       }
 
       return lp::Call("like", std::move(inputs));
@@ -395,8 +377,8 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kLogicalBinaryExpression: {
       auto* logical = node->as<LogicalBinaryExpression>();
-      auto left = toExpr(logical->left(), windowOptions);
-      auto right = toExpr(logical->right(), windowOptions);
+      auto left = toExpr(logical->left());
+      auto right = toExpr(logical->right());
 
       switch (logical->op()) {
         case LogicalBinaryExpression::Operator::kAnd:
@@ -410,34 +392,34 @@ lp::ExprApi ExpressionPlanner::toExpr(
     case NodeType::kArithmeticUnaryExpression: {
       auto* unary = node->as<ArithmeticUnaryExpression>();
       if (unary->sign() == ArithmeticUnaryExpression::Sign::kMinus) {
-        return lp::Call("negate", toExpr(unary->value(), windowOptions));
+        return lp::Call("negate", toExpr(unary->value()));
       }
 
-      return toExpr(unary->value(), windowOptions);
+      return toExpr(unary->value());
     }
 
     case NodeType::kArithmeticBinaryExpression: {
       auto* binary = node->as<ArithmeticBinaryExpression>();
       return lp::Call(
           toFunctionName(binary->op()),
-          toExpr(binary->left(), windowOptions),
-          toExpr(binary->right(), windowOptions));
+          toExpr(binary->left()),
+          toExpr(binary->right()));
     }
 
     case NodeType::kBetweenPredicate: {
       auto* between = node->as<BetweenPredicate>();
       return lp::Call(
           "between",
-          toExpr(between->value(), windowOptions),
-          toExpr(between->min(), windowOptions),
-          toExpr(between->max(), windowOptions));
+          toExpr(between->value()),
+          toExpr(between->min()),
+          toExpr(between->max()));
     }
 
     case NodeType::kInPredicate: {
       auto* inPredicate = node->as<InPredicate>();
       const auto& valueList = inPredicate->valueList();
 
-      const auto value = toExpr(inPredicate->value(), windowOptions);
+      const auto value = toExpr(inPredicate->value());
 
       if (valueList->is(NodeType::kInListExpression)) {
         auto inList = valueList->as<InListExpression>();
@@ -447,14 +429,14 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
         inputs.emplace_back(value);
         for (const auto& expr : inList->values()) {
-          inputs.emplace_back(toExpr(expr, windowOptions));
+          inputs.emplace_back(toExpr(expr));
         }
 
         return lp::Call("in", inputs);
       }
 
       if (valueList->is(NodeType::kSubqueryExpression)) {
-        return lp::Call("in", value, toExpr(valueList, windowOptions));
+        return lp::Call("in", value, toExpr(valueList));
       }
 
       VELOX_USER_FAIL(
@@ -464,7 +446,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kExistsPredicate: {
       auto* exists = node->as<ExistsPredicate>();
-      return lp::Exists(toExpr(exists->subquery(), windowOptions));
+      return lp::Exists(toExpr(exists->subquery()));
     }
 
     case NodeType::kCast: {
@@ -472,9 +454,9 @@ lp::ExprApi ExpressionPlanner::toExpr(
       const auto type = parseType(cast->toType());
 
       if (cast->isSafe()) {
-        return lp::TryCast(type, toExpr(cast->expression(), windowOptions));
+        return lp::TryCast(type, toExpr(cast->expression()));
       } else {
-        return lp::Cast(type, toExpr(cast->expression(), windowOptions));
+        return lp::Cast(type, toExpr(cast->expression()));
       }
     }
 
@@ -482,26 +464,25 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* atTimeZone = node->as<AtTimeZone>();
       return lp::Call(
           "at_timezone",
-          toExpr(atTimeZone->value(), windowOptions),
-          toExpr(atTimeZone->timeZone(), windowOptions));
+          toExpr(atTimeZone->value()),
+          toExpr(atTimeZone->timeZone()));
     }
 
     case NodeType::kSimpleCaseExpression: {
       auto* simpleCase = node->as<SimpleCaseExpression>();
 
-      const auto operand = toExpr(simpleCase->operand(), windowOptions);
+      const auto operand = toExpr(simpleCase->operand());
 
       std::vector<lp::ExprApi> inputs;
       inputs.reserve(1 + simpleCase->whenClauses().size());
 
       for (const auto& clause : simpleCase->whenClauses()) {
-        inputs.emplace_back(
-            lp::Call("eq", operand, toExpr(clause->operand(), windowOptions)));
-        inputs.emplace_back(toExpr(clause->result(), windowOptions));
+        inputs.emplace_back(lp::Call("eq", operand, toExpr(clause->operand())));
+        inputs.emplace_back(toExpr(clause->result()));
       }
 
       if (simpleCase->defaultValue()) {
-        inputs.emplace_back(toExpr(simpleCase->defaultValue(), windowOptions));
+        inputs.emplace_back(toExpr(simpleCase->defaultValue()));
       }
 
       return lp::Call("switch", inputs);
@@ -518,13 +499,12 @@ lp::ExprApi ExpressionPlanner::toExpr(
         if (clause->operand()->is(NodeType::kNullLiteral)) {
           continue;
         }
-        inputs.emplace_back(toExpr(clause->operand(), windowOptions));
-        inputs.emplace_back(toExpr(clause->result(), windowOptions));
+        inputs.emplace_back(toExpr(clause->operand()));
+        inputs.emplace_back(toExpr(clause->result()));
       }
 
       if (searchedCase->defaultValue()) {
-        inputs.emplace_back(
-            toExpr(searchedCase->defaultValue(), windowOptions));
+        inputs.emplace_back(toExpr(searchedCase->defaultValue()));
       }
 
       // All WHEN clauses were dropped (all had NULL conditions).
@@ -542,7 +522,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kExtract: {
       auto* extract = node->as<Extract>();
-      auto expr = toExpr(extract->expression(), windowOptions);
+      auto expr = toExpr(extract->expression());
 
       switch (extract->field()) {
         case Extract::Field::kYear:
@@ -676,7 +656,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* array = node->as<ArrayConstructor>();
       std::vector<lp::ExprApi> values;
       for (const auto& value : array->values()) {
-        values.emplace_back(toExpr(value, windowOptions));
+        values.emplace_back(toExpr(value));
       }
 
       return lp::Call("array_constructor", values);
@@ -686,7 +666,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* row = node->as<Row>();
       std::vector<lp::ExprApi> items;
       for (const auto& item : row->items()) {
-        items.emplace_back(toExpr(item, windowOptions));
+        items.emplace_back(toExpr(item));
       }
 
       return lp::Call("row_constructor", items);
@@ -697,7 +677,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       std::vector<core::ExprPtr> childExprs;
       childExprs.reserve(row->items().size());
       for (const auto& item : row->items()) {
-        childExprs.push_back(toExpr(item, windowOptions).expr());
+        childExprs.push_back(toExpr(item).expr());
       }
       return lp::ExprApi{std::make_shared<core::ConcatExpr>(
           row->fieldNames(), std::move(childExprs))};
@@ -708,7 +688,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
       std::vector<lp::ExprApi> args;
       for (const auto& arg : call->arguments()) {
-        args.push_back(toExpr(arg, windowOptions));
+        args.push_back(toExpr(arg));
       }
 
       const auto& funcName = call->name()->suffix();
@@ -737,10 +717,6 @@ lp::ExprApi ExpressionPlanner::toExpr(
         if (call->ignoreNulls()) {
           windowSpec.ignoreNulls();
         }
-        if (windowOptions != nullptr) {
-          windowOptions->emplace(callExpr.expr().get(), windowSpec);
-          return callExpr;
-        }
         return callExpr.over(windowSpec);
       }
 
@@ -756,26 +732,23 @@ lp::ExprApi ExpressionPlanner::toExpr(
         names.emplace_back(arg->name()->value());
       }
 
-      return lp::Lambda(names, toExpr(lambda->body(), windowOptions));
+      return lp::Lambda(names, toExpr(lambda->body()));
     }
 
     case NodeType::kSubscriptExpression: {
       auto* subscript = node->as<SubscriptExpression>();
       return lp::Call(
-          "subscript",
-          toExpr(subscript->base(), windowOptions),
-          toExpr(subscript->index(), windowOptions));
+          "subscript", toExpr(subscript->base()), toExpr(subscript->index()));
     }
 
     case NodeType::kIsNullPredicate: {
       auto* isNull = node->as<IsNullPredicate>();
-      return lp::Call("is_null", toExpr(isNull->value(), windowOptions));
+      return lp::Call("is_null", toExpr(isNull->value()));
     }
 
     case NodeType::kIsNotNullPredicate: {
       auto* isNull = node->as<IsNotNullPredicate>();
-      return lp::Call(
-          "not", lp::Call("is_null", toExpr(isNull->value(), windowOptions)));
+      return lp::Call("not", lp::Call("is_null", toExpr(isNull->value())));
     }
 
     case NodeType::kCurrentTime: {
@@ -809,18 +782,18 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
 namespace {
 
-lp::WindowExpr::BoundType toWindowBoundType(FrameBound::Type type) {
+core::WindowCallExpr::BoundType toWindowBoundType(FrameBound::Type type) {
   switch (type) {
     case FrameBound::Type::kUnboundedPreceding:
-      return lp::WindowExpr::BoundType::kUnboundedPreceding;
+      return core::WindowCallExpr::BoundType::kUnboundedPreceding;
     case FrameBound::Type::kPreceding:
-      return lp::WindowExpr::BoundType::kPreceding;
+      return core::WindowCallExpr::BoundType::kPreceding;
     case FrameBound::Type::kCurrentRow:
-      return lp::WindowExpr::BoundType::kCurrentRow;
+      return core::WindowCallExpr::BoundType::kCurrentRow;
     case FrameBound::Type::kFollowing:
-      return lp::WindowExpr::BoundType::kFollowing;
+      return core::WindowCallExpr::BoundType::kFollowing;
     case FrameBound::Type::kUnboundedFollowing:
-      return lp::WindowExpr::BoundType::kUnboundedFollowing;
+      return core::WindowCallExpr::BoundType::kUnboundedFollowing;
   }
   VELOX_UNREACHABLE();
 }
@@ -899,7 +872,7 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
 
     auto endType = frame->end() != nullptr
         ? toWindowBoundType(frame->end()->boundType())
-        : lp::WindowExpr::BoundType::kCurrentRow;
+        : core::WindowCallExpr::BoundType::kCurrentRow;
     std::optional<lp::ExprApi> endValue;
     if (frame->end() != nullptr && frame->end()->value().has_value()) {
       endValue = toExpr(frame->end()->value().value());

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -71,17 +71,23 @@ class ExpressionPlanner {
         sortingKeyResolver_(std::move(sortingKeyResolver)),
         shouldDropQualifier_(std::move(shouldDropQualifier)) {}
 
+  /// Finds WindowCallExpr nodes nested inside non-window expressions.
+  /// Skips top-level window projections (where the ExprApi itself is a
+  /// WindowCallExpr). Populates 'windowExprs' with pointers to the found
+  /// WindowCallExpr nodes (raw pointer → shared pointer) and
+  /// 'traversalOrder' with raw pointers in left-to-right order for
+  /// deterministic plan generation.
+  static void findNestedWindowExprs(
+      const std::vector<lp::ExprApi>& exprs,
+      std::unordered_map<
+          const facebook::velox::core::IExpr*,
+          facebook::velox::core::ExprPtr>& windowExprs,
+      std::vector<const facebook::velox::core::IExpr*>& traversalOrder);
+
   /// Translates an AST expression into an ExprApi. Aggregate options
   /// (DISTINCT, FILTER, ORDER BY) are embedded in the returned ExprApi via
-  /// AggregateCallExpr.
-  ///
-  /// @param windowOptions If non-null, collects WindowSpec for nested window
-  /// function calls. Window calls are returned as plain function calls
-  /// (without .over()) and the caller is responsible for extracting them.
-  lp::ExprApi toExpr(
-      const ExpressionPtr& node,
-      std::unordered_map<const facebook::velox::core::IExpr*, lp::WindowSpec>*
-          windowOptions = nullptr);
+  /// AggregateCallExpr. Window functions are embedded via WindowCallExpr.
+  lp::ExprApi toExpr(const ExpressionPtr& node);
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.
   /// When set, Identifier nodes matching an alias key are resolved to the
@@ -102,13 +108,16 @@ class ExpressionPlanner {
     columnNames_ = nullptr;
   }
 
-  /// Returns true if any select item has a window function nested inside a
-  /// non-window expression (e.g. sum(a) / sum(sum(a)) OVER ()). Top-level
-  /// window functions don't need extraction and are excluded.
-  static bool hasNestedWindowFunction(
-      const std::vector<SelectItemPtr>& selectItems);
-
  private:
+  // Walks an IExpr tree collecting WindowCallExpr nodes. Stops recursion at
+  // kWindow nodes (does not descend into window function arguments).
+  static void findWindowExprs(
+      const facebook::velox::core::ExprPtr& expr,
+      std::unordered_map<
+          const facebook::velox::core::IExpr*,
+          facebook::velox::core::ExprPtr>& windowExprs,
+      std::vector<const facebook::velox::core::IExpr*>& traversalOrder);
+
   // Converts a Window AST node into a WindowSpec.
   lp::WindowSpec convertWindow(const std::shared_ptr<Window>& window);
 

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -44,54 +44,43 @@ using AggregateExprSet =
 using AggregateExprMap = folly::
     F14FastMap<core::ExprPtr, core::ExprPtr, core::IExprHash, core::IExprEqual>;
 
-// Rewrites each IExpr in the WindowSpec's PARTITION BY and ORDER BY keys using
-// 'rewrite' and returns the rewritten spec.
-lp::WindowSpec rewriteWindowSpec(
-    const lp::WindowSpec& spec,
-    const std::function<core::ExprPtr(const core::ExprPtr&)>& rewrite) {
-  auto result = spec;
-  if (!result.partitionKeys().empty()) {
-    std::vector<lp::ExprApi> newKeys;
-    for (const auto& key : result.partitionKeys()) {
-      newKeys.push_back(lp::ExprApi(rewrite(key.expr())));
-    }
-    result.partitionBy(std::move(newKeys));
-  }
-
-  if (!result.orderByKeys().empty()) {
-    std::vector<lp::SortKey> newKeys;
-    for (const auto& key : result.orderByKeys()) {
-      newKeys.emplace_back(
-          lp::ExprApi(rewrite(key.expr.expr())), key.ascending, key.nullsFirst);
-    }
-    result.orderBy(std::move(newKeys));
-  }
-  return result;
-}
-
 // Rewrites a window function expression: replaces column references in the
 // function arguments, PARTITION BY keys, and ORDER BY keys using the provided
-// rewrite function.
+// rewrite function. Constructs a new WindowCallExpr directly.
 lp::ExprApi rewriteWindowExpr(
     const lp::ExprApi& item,
     const std::function<core::ExprPtr(const core::ExprPtr&)>& rewriteIExpr) {
-  const auto windowSpec = item.windowSpec();
-  VELOX_CHECK_NOT_NULL(windowSpec);
+  VELOX_CHECK(item.expr()->is(core::IExpr::Kind::kWindow));
+  auto* window = item.expr()->as<core::WindowCallExpr>();
 
   // Rewrite function arguments.
   std::vector<core::ExprPtr> newInputs;
-  bool changed = false;
-  for (const auto& input : item.expr()->inputs()) {
-    auto newInput = rewriteIExpr(input);
-    changed |= (newInput.get() != input.get());
-    newInputs.push_back(std::move(newInput));
+  for (const auto& input : window->inputs()) {
+    newInputs.push_back(rewriteIExpr(input));
   }
 
-  auto newExpr =
-      changed ? item.expr()->replaceInputs(std::move(newInputs)) : item.expr();
+  // Rewrite partition keys.
+  std::vector<core::ExprPtr> newPartitionKeys;
+  for (const auto& key : window->partitionKeys()) {
+    newPartitionKeys.push_back(rewriteIExpr(key));
+  }
 
-  return lp::ExprApi(std::move(newExpr), item.name())
-      .over(rewriteWindowSpec(*windowSpec, rewriteIExpr));
+  // Rewrite order by keys.
+  std::vector<core::SortKey> newOrderByKeys;
+  for (const auto& key : window->orderByKeys()) {
+    newOrderByKeys.push_back(
+        {rewriteIExpr(key.expr), key.ascending, key.nullsFirst});
+  }
+
+  return lp::ExprApi(
+      std::make_shared<core::WindowCallExpr>(
+          window->name(),
+          std::move(newInputs),
+          std::move(newPartitionKeys),
+          std::move(newOrderByKeys),
+          window->frame(),
+          window->isIgnoreNulls()),
+      item.name());
 }
 
 // Given an expression, and pairs of search-and-replace sub-expressions,
@@ -141,33 +130,14 @@ core::ExprPtr replaceInputs(
   return expr;
 }
 
-using WindowOptionsMap = std::unordered_map<const core::IExpr*, lp::WindowSpec>;
-
 // Walks the expression tree looking for aggregate function calls and appending
 // these calls to 'aggregates' after deduplication through 'aggregateSet'.
-// When 'windowOptions' is non-null, expressions found in the map are treated
-// as window functions (not aggregates): their children and WindowSpec keys are
-// searched for real aggregates instead.
+// Window functions (kWindow) are not treated as aggregates — their children
+// and window spec keys are recursed into to find nested aggregates.
 void findAggregates(
     const core::ExprPtr& expr,
     std::vector<lp::ExprApi>& aggregates,
-    AggregateExprSet& aggregateSet,
-    const WindowOptionsMap* windowOptions = nullptr) {
-  // Check if this expression is a window function (not an aggregate).
-  if (windowOptions != nullptr && windowOptions->count(expr.get())) {
-    for (const auto& input : expr->inputs()) {
-      findAggregates(input, aggregates, aggregateSet, windowOptions);
-    }
-    const auto& windowSpec = windowOptions->at(expr.get());
-    for (const auto& key : windowSpec.partitionKeys()) {
-      findAggregates(key.expr(), aggregates, aggregateSet, windowOptions);
-    }
-    for (const auto& key : windowSpec.orderByKeys()) {
-      findAggregates(key.expr.expr(), aggregates, aggregateSet, windowOptions);
-    }
-    return;
-  }
-
+    AggregateExprSet& aggregateSet) {
   switch (expr->kind()) {
     case core::IExpr::Kind::kInput:
       return;
@@ -188,17 +158,14 @@ void findAggregates(
         }
       } else {
         for (const auto& input : expr->inputs()) {
-          findAggregates(input, aggregates, aggregateSet, windowOptions);
+          findAggregates(input, aggregates, aggregateSet);
         }
       }
       return;
     }
     case core::IExpr::Kind::kCast:
       findAggregates(
-          expr->as<core::CastExpr>()->input(),
-          aggregates,
-          aggregateSet,
-          windowOptions);
+          expr->as<core::CastExpr>()->input(), aggregates, aggregateSet);
       return;
     case core::IExpr::Kind::kConstant:
       return;
@@ -208,41 +175,30 @@ void findAggregates(
     case core::IExpr::Kind::kSubquery:
       // TODO: Handle aggregates in subqueries.
       return;
+    case core::IExpr::Kind::kWindow: {
+      // Recurse into function inputs, partition keys, and order by keys
+      // to find nested aggregates.
+      auto* window = expr->as<core::WindowCallExpr>();
+      for (const auto& input : window->inputs()) {
+        findAggregates(input, aggregates, aggregateSet);
+      }
+      for (const auto& key : window->partitionKeys()) {
+        findAggregates(key, aggregates, aggregateSet);
+      }
+      for (const auto& key : window->orderByKeys()) {
+        findAggregates(key.expr, aggregates, aggregateSet);
+      }
+      return;
+    }
     case core::IExpr::Kind::kConcat:
       for (const auto& input : expr->inputs()) {
-        findAggregates(input, aggregates, aggregateSet, windowOptions);
+        findAggregates(input, aggregates, aggregateSet);
       }
       return;
     default:
       VELOX_UNSUPPORTED(
           "Unsupported expression kind in findAggregates: {}",
           expr->toString());
-  }
-}
-
-// Finds aggregates in an ExprApi. For window functions (top-level or nested),
-// recurses into arguments and WindowSpec keys to find real aggregates.
-void findAggregates(
-    const lp::ExprApi& expr,
-    const WindowOptionsMap& windowOptions,
-    std::vector<lp::ExprApi>& aggregates,
-    AggregateExprSet& aggregateSet) {
-  const WindowOptionsMap* windowOptionsPtr =
-      windowOptions.empty() ? nullptr : &windowOptions;
-
-  if (const auto& windowSpec = expr.windowSpec()) {
-    for (const auto& input : expr.expr()->inputs()) {
-      findAggregates(input, aggregates, aggregateSet, windowOptionsPtr);
-    }
-    for (const auto& key : windowSpec->partitionKeys()) {
-      findAggregates(key.expr(), aggregates, aggregateSet, windowOptionsPtr);
-    }
-    for (const auto& key : windowSpec->orderByKeys()) {
-      findAggregates(
-          key.expr.expr(), aggregates, aggregateSet, windowOptionsPtr);
-    }
-  } else {
-    findAggregates(expr.expr(), aggregates, aggregateSet, windowOptionsPtr);
   }
 }
 
@@ -286,69 +242,6 @@ class ExprAnalyzer : public DefaultTraversalVisitor {
   size_t numAggregates_{0};
   std::optional<std::string> aggregateName_;
 };
-
-// Finds sub-expressions in an IExpr tree whose raw pointers match keys in
-// 'targets'. Collects the ExprPtrs and appends matches to 'order' in traversal
-// order for deterministic plan generation.
-void findWindowExprPtrs(
-    const core::ExprPtr& expr,
-    const std::unordered_map<const core::IExpr*, lp::WindowSpec>& targets,
-    std::unordered_map<const core::IExpr*, core::ExprPtr>& found,
-    std::vector<const core::IExpr*>& order) {
-  if (targets.count(expr.get())) {
-    if (found.emplace(expr.get(), expr).second) {
-      order.push_back(expr.get());
-    }
-    return;
-  }
-  for (const auto& input : expr->inputs()) {
-    findWindowExprPtrs(input, targets, found, order);
-  }
-}
-
-// Extracts nested window functions from projections into a separate plan node.
-// For each window function in 'windowOptions':
-// 1. Rewrites its arguments to reference aggregate output columns.
-// 2. Creates a window projection using builder.with().
-// 3. Adds the OLD ExprPtr to 'keyInputs' so replaceInputs substitutes it with
-//    a column reference during the subsequent projection rewrite.
-void extractNestedWindowFunctions(
-    const std::vector<lp::ExprApi>& projections,
-    const WindowOptionsMap& windowOptions,
-    const std::function<core::ExprPtr(const core::ExprPtr&)>& rewriteIExpr,
-    lp::PlanBuilder& builder,
-    ExprMap<core::ExprPtr>& keyInputs) {
-  std::unordered_map<const core::IExpr*, core::ExprPtr> windowExprPtrs;
-  std::vector<const core::IExpr*> windowOrder;
-  for (const auto& item : projections) {
-    findWindowExprPtrs(item.expr(), windowOptions, windowExprPtrs, windowOrder);
-  }
-
-  if (windowOrder.empty()) {
-    return;
-  }
-
-  std::vector<lp::ExprApi> windowExprs;
-  windowExprs.reserve(windowOrder.size());
-  for (const auto* exprPtr : windowOrder) {
-    auto rewrittenExpr = rewriteIExpr(windowExprPtrs.at(exprPtr));
-    auto rewrittenSpec =
-        rewriteWindowSpec(windowOptions.at(exprPtr), rewriteIExpr);
-    windowExprs.push_back(
-        lp::ExprApi(std::move(rewrittenExpr)).over(rewrittenSpec));
-  }
-
-  builder.with(windowExprs);
-
-  auto outputColumns =
-      builder.findOrAssignOutputNames(/*includeHiddenColumns=*/false);
-
-  auto numInputColumns = outputColumns.size() - windowOrder.size();
-  for (size_t i = 0; i < windowOrder.size(); ++i) {
-    const auto& column = outputColumns.at(numInputColumns + i);
-    keyInputs.emplace(windowExprPtrs.at(windowOrder[i]), column.toCol().expr());
-  }
-}
 
 // ROLLUP(a,b,c) -> {(a,b,c), (a,b), (a), ()}
 std::vector<std::vector<lp::ExprApi>> expandRollup(
@@ -514,14 +407,10 @@ bool GroupByPlanner::tryPlanGlobalAgg(
   }
 
   // Resolve SELECT items into ExprApi.
-  const bool hasNestedWindow =
-      ExpressionPlanner::hasNestedWindowFunction(selectItems);
   std::vector<lp::ExprApi> selectExprs;
   for (const auto& item : selectItems) {
     auto* singleColumn = item->as<SingleColumn>();
-    auto expr = exprPlanner_.toExpr(
-        singleColumn->expression(),
-        hasNestedWindow ? &windowOptionsMap_ : nullptr);
+    auto expr = exprPlanner_.toExpr(singleColumn->expression());
     if (singleColumn->alias() != nullptr) {
       expr = expr.as(canonicalizeIdentifier(*singleColumn->alias()));
     }
@@ -621,7 +510,7 @@ void GroupByPlanner::collectAggregates(
 
   AggregateExprSet aggregateSet;
   for (const auto& selectExpr : selectExprs) {
-    findAggregates(selectExpr, windowOptionsMap_, aggregates_, aggregateSet);
+    findAggregates(selectExpr.expr(), aggregates_, aggregateSet);
 
     if (!aggregates_.empty() &&
         aggregates_.back().expr().get() == selectExpr.expr().get()) {
@@ -712,39 +601,66 @@ void GroupByPlanner::rewritePostAggregateExprs() {
     return replaceInputs(expr, keyInputs, aggregateInputs);
   };
 
-  // Rewrites an ExprApi to reference post-aggregate columns. For window
-  // functions, replaces the arguments of the call AND the PARTITION BY /
-  // ORDER BY expressions in the WindowSpec.
+  // Project nested window functions (e.g. sum(sum(a)) OVER () inside
+  // sum(a) / sum(sum(a)) OVER ()) and add replacements to keyInputs.
+  projectNestedWindows(rewriteIExpr, keyInputs);
+
+  // Rewrite projections and sorting keys to reference post-aggregate columns.
+  // Top-level windows need rewriteWindowExpr to rewrite args and
+  // partition/order keys. Non-window expressions use replaceInputs which also
+  // substitutes nested window references added to keyInputs by
+  // projectNestedWindows above.
+
+  // TODO: Verify that SELECT expressions don't depend on anything other
+  // than grouping keys and aggregates.
+
   auto rewriteExpr = [&](lp::ExprApi& item) {
-    const auto windowSpec = item.windowSpec();
-    if (windowSpec) {
+    if (item.expr()->is(core::IExpr::Kind::kWindow)) {
       item = rewriteWindowExpr(item, rewriteIExpr);
     } else {
       item = lp::ExprApi(rewriteIExpr(item.expr()), item.name());
     }
   };
 
-  // Extract nested window functions: project them using builder_->with()
-  // and add replacements to keyInputs so the projection rewrite below
-  // substitutes window sub-expressions with column references.
-  if (!windowOptionsMap_.empty()) {
-    extractNestedWindowFunctions(
-        projections_, windowOptionsMap_, rewriteIExpr, *builder_, keyInputs);
-  }
-
-  // Replace sub-expressions in SELECT projections with column references to
-  // the aggregate output (and window output, if any).
-
-  // TODO: Verify that SELECT expressions don't depend on anything other
-  // than grouping keys and aggregates.
-
   for (auto& item : projections_) {
     rewriteExpr(item);
   }
 
-  // Replace sorting key expressions too.
   for (auto& expr : sortingKeyExprs_) {
     rewriteExpr(expr);
+  }
+}
+
+void GroupByPlanner::projectNestedWindows(
+    const std::function<core::ExprPtr(const core::ExprPtr&)>& rewriteIExpr,
+    ExprMap<core::ExprPtr>& keyInputs) {
+  std::unordered_map<const core::IExpr*, core::ExprPtr> windowExprPtrs;
+  std::vector<const core::IExpr*> windowOrder;
+  ExpressionPlanner::findNestedWindowExprs(
+      projections_, windowExprPtrs, windowOrder);
+
+  if (windowOrder.empty()) {
+    return;
+  }
+
+  std::vector<lp::ExprApi> windowExprs;
+  windowExprs.reserve(windowOrder.size());
+  for (const auto* exprPtr : windowOrder) {
+    // Rewrite aggregate references in function arguments, partition keys,
+    // and order by keys.
+    windowExprs.push_back(rewriteWindowExpr(
+        lp::ExprApi(windowExprPtrs.at(exprPtr)), rewriteIExpr));
+  }
+
+  builder_->with(windowExprs);
+
+  auto outputColumns =
+      builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
+
+  auto numInputColumns = outputColumns.size() - windowOrder.size();
+  for (size_t i = 0; i < windowOrder.size(); ++i) {
+    const auto& column = outputColumns.at(numInputColumns + i);
+    keyInputs.emplace(windowExprPtrs.at(windowOrder[i]), column.toCol().expr());
   }
 }
 

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -21,6 +21,7 @@
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 #include "folly/container/F14Map.h"
+#include "velox/parse/IExpr.h"
 
 namespace axiom::sql::presto {
 
@@ -32,12 +33,8 @@ class GroupByPlanner {
  public:
   GroupByPlanner(
       std::shared_ptr<lp::PlanBuilder>& builder,
-      ExpressionPlanner& exprPlanner,
-      std::unordered_map<const facebook::velox::core::IExpr*, lp::WindowSpec>
-          windowOptions = {})
-      : builder_(builder),
-        exprPlanner_(exprPlanner),
-        windowOptionsMap_(std::move(windowOptions)) {}
+      ExpressionPlanner& exprPlanner)
+      : builder_(builder), exprPlanner_(exprPlanner) {}
 
   /// Plans a GROUP BY clause with optional HAVING and ORDER BY.
   /// When 'distinct' is true (GROUP BY DISTINCT), duplicate grouping sets
@@ -69,6 +66,19 @@ class GroupByPlanner {
       const OrderByPtr& orderBy);
   void addAggregate(bool useGroupingSets);
   void rewritePostAggregateExprs();
+
+  // Projects nested window functions (kWindow nodes inside non-window
+  // expressions) into a separate plan node via builder_->with(). Records
+  // replacement mappings in 'keyInputs' for the caller's projection rewrite.
+  void projectNestedWindows(
+      const std::function<facebook::velox::core::ExprPtr(
+          const facebook::velox::core::ExprPtr&)>& rewriteIExpr,
+      folly::F14FastMap<
+          facebook::velox::core::ExprPtr,
+          facebook::velox::core::ExprPtr,
+          facebook::velox::core::IExprHash,
+          facebook::velox::core::IExprEqual>& keyInputs);
+
   std::vector<size_t> resolveSortOrdinals(const OrderByPtr& orderBy);
   bool isIdentityProjection() const;
 
@@ -97,13 +107,6 @@ class GroupByPlanner {
   // Deduplicated aggregate expressions. Aggregate options are embedded in
   // AggregateCallExpr nodes within the IExpr tree.
   std::vector<lp::ExprApi> aggregates_;
-
-  // Maps window function IExpr* to their WindowSpec. Populated during SELECT
-  // expression resolution when window functions are nested inside scalar
-  // expressions (e.g. sum(a) / sum(sum(a)) OVER ()). Used after aggregate
-  // rewriting to extract window functions into a separate plan node.
-  std::unordered_map<const facebook::velox::core::IExpr*, lp::WindowSpec>
-      windowOptionsMap_;
 
   std::optional<lp::ExprApi> filter_;
   std::vector<lp::ExprApi> sortingKeyExprs_;

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -175,26 +175,6 @@ lp::ExprPtr resolveJoinColumn(
   return leftHas ? leftScope(alias, name) : rightScope(alias, name);
 }
 
-// Finds sub-expressions in an IExpr tree using pointer-identity matching.
-// Walks the expression tree and collects ExprPtrs whose raw pointers are
-// found in 'targets'. Also appends matches to 'order' in traversal order
-// for deterministic plan generation.
-void findExprPtrs(
-    const core::ExprPtr& expr,
-    const std::unordered_map<const core::IExpr*, lp::WindowSpec>& targets,
-    std::unordered_map<const core::IExpr*, core::ExprPtr>& found,
-    std::vector<const core::IExpr*>& order) {
-  if (targets.count(expr.get())) {
-    if (found.emplace(expr.get(), expr).second) {
-      order.push_back(expr.get());
-    }
-    return;
-  }
-  for (const auto& input : expr->inputs()) {
-    findExprPtrs(input, targets, found, order);
-  }
-}
-
 // Recursively replaces expression tree nodes per the replacement map.
 core::ExprPtr replaceInputs(
     const core::ExprPtr& expr,
@@ -245,11 +225,8 @@ class RelationPlanner : public AstVisitor {
     return *builder_;
   }
 
-  lp::ExprApi toExpr(
-      const ExpressionPtr& node,
-      std::unordered_map<const core::IExpr*, lp::WindowSpec>* windowOptions =
-          nullptr) {
-    return exprPlanner_.toExpr(node, windowOptions);
+  lp::ExprApi toExpr(const ExpressionPtr& node) {
+    return exprPlanner_.toExpr(node);
   }
 
  private:
@@ -563,55 +540,6 @@ class RelationPlanner : public AstVisitor {
     }
   }
 
-  // Adds a projection that computes window functions. Returns a map from
-  // window call IExpr* to column reference ExprPtr for replacing window
-  // calls in downstream expressions.
-  std::unordered_map<const core::IExpr*, core::ExprPtr> addWindowProjection(
-      const std::unordered_map<const core::IExpr*, lp::WindowSpec>&
-          windowOptions,
-      const std::vector<lp::ExprApi>& exprs) {
-    // Collect ExprPtrs for the window calls from the expression trees.
-    // 'windowOrder' captures matches in left-to-right traversal order
-    // for deterministic plan generation.
-    std::unordered_map<const core::IExpr*, core::ExprPtr> windowExprPtrs;
-    std::vector<const core::IExpr*> windowOrder;
-    for (const auto& expr : exprs) {
-      findExprPtrs(expr.expr(), windowOptions, windowExprPtrs, windowOrder);
-    }
-
-    // TODO: Deduplicate semantically equivalent window function calls.
-    // Currently, each occurrence of the same window expression (e.g.
-    // sum(b) OVER (PARTITION BY a)) gets a separate entry in windowOptions
-    // and is computed redundantly.
-    std::vector<lp::ExprApi> windowExprs;
-    windowExprs.reserve(windowOrder.size());
-    for (const auto* exprPtr : windowOrder) {
-      windowExprs.push_back(
-          lp::ExprApi(windowExprPtrs.at(exprPtr))
-              .over(windowOptions.at(exprPtr)));
-    }
-
-    // Use with() instead of project() to preserve name mappings (including
-    // table aliases) so that column references built before the window
-    // projection (e.g., from star expansion with qualified names) remain
-    // resolvable.
-    builder_->with(windowExprs);
-
-    auto outputNames =
-        builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
-
-    // Map window call nodes to their output column references. Window
-    // columns are appended after the input columns.
-    auto numInputColumns = outputNames.size() - windowOrder.size();
-    std::unordered_map<const core::IExpr*, core::ExprPtr> replacements;
-    for (size_t i = 0; i < windowOrder.size(); ++i) {
-      const auto& column = outputNames.at(numInputColumns + i);
-      replacements.emplace(windowOrder[i], column.toCol().expr());
-    }
-
-    return replacements;
-  }
-
   // Expands COLUMNS('regex') pseudo-function calls found inside an
   // expression. Delegates to ColumnsExpansion::expand() for the core expansion,
   // then applies the alias. Returns true if expansion happened.
@@ -641,8 +569,6 @@ class RelationPlanner : public AstVisitor {
       std::vector<lp::PlanBuilder::OutputColumnName>& columns,
       const std::vector<std::shared_ptr<Identifier>>& excludeColumns,
       const std::vector<ReplaceItem>& replaceItems,
-      bool hasNestedWindow,
-      std::unordered_map<const core::IExpr*, lp::WindowSpec>& windowOptions,
       std::vector<lp::ExprApi>& exprs) {
     std::unordered_map<std::string, core::ExprPtr> replaceMap;
     if (!excludeColumns.empty() || !replaceItems.empty()) {
@@ -693,8 +619,7 @@ class RelationPlanner : public AstVisitor {
             "Column is ambiguous for REPLACE, use qualified name (e.g., t.{}): {}",
             name,
             name);
-        auto expr = toExpr(
-            replaceItem.expression, hasNestedWindow ? &windowOptions : nullptr);
+        auto expr = toExpr(replaceItem.expression);
         replaceMap[name] = expr.expr();
       }
     }
@@ -711,53 +636,12 @@ class RelationPlanner : public AstVisitor {
     }
   }
 
-  // Like buildSelectProjections, but always returns a result (expands single
-  // SELECT * instead of returning nullopt). Collects window specs into the
-  // caller's map for GroupByPlanner to handle.
-  std::vector<lp::ExprApi> expandSelectExprs(
-      const std::vector<SelectItemPtr>& selectItems,
-      std::unordered_map<const core::IExpr*, lp::WindowSpec>& windowOptions) {
-    auto result = buildSelectProjections(selectItems, windowOptions);
-    if (result.has_value()) {
-      return result.value();
-    }
-    // Single SELECT * — expand to all output columns.
-    std::vector<lp::ExprApi> exprs;
-    for (const auto& column :
-         builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false)) {
-      exprs.push_back(column.toCol());
-    }
-    return exprs;
-  }
-
   // Converts SELECT items to ExprApi projections. Expands AllColumns (*),
   // SelectColumns (COLUMNS(...)), EXCLUDE, and REPLACE. Returns std::nullopt
-  // for a single plain SELECT * (no EXCLUDE/REPLACE).
+  // for a single plain SELECT * (no EXCLUDE/REPLACE). Window functions are
+  // embedded as WindowCallExpr in the IExpr tree.
   std::optional<std::vector<lp::ExprApi>> buildSelectProjections(
       const std::vector<SelectItemPtr>& selectItems) {
-    std::unordered_map<const core::IExpr*, lp::WindowSpec> windowOptions;
-    auto result = buildSelectProjections(selectItems, windowOptions);
-    if (!result.has_value()) {
-      return std::nullopt;
-    }
-
-    if (!windowOptions.empty()) {
-      auto replacements = addWindowProjection(windowOptions, result.value());
-      for (auto& expr : result.value()) {
-        expr =
-            lp::ExprApi(replaceInputs(expr.expr(), replacements), expr.alias());
-      }
-    }
-
-    return result;
-  }
-
-  // Overload that collects window specs into the caller's map instead of
-  // processing them internally. Used by GROUP BY where window function
-  // extraction is handled by GroupByPlanner.
-  std::optional<std::vector<lp::ExprApi>> buildSelectProjections(
-      const std::vector<SelectItemPtr>& selectItems,
-      std::unordered_map<const core::IExpr*, lp::WindowSpec>& windowOptions) {
     // SELECT * FROM ...
     const bool isSingleSelectStar = selectItems.size() == 1 &&
         selectItems.at(0)->is(NodeType::kAllColumns) &&
@@ -767,9 +651,6 @@ class RelationPlanner : public AstVisitor {
     if (isSingleSelectStar) {
       return std::nullopt;
     }
-
-    const bool hasNestedWindow =
-        ExpressionPlanner::hasNestedWindowFunction(selectItems);
 
     // Lateral column alias map: alias name → expression. When friendlySql is
     // enabled, aliases defined in earlier SELECT items can be referenced in
@@ -807,8 +688,6 @@ class RelationPlanner : public AstVisitor {
             selectedColumns,
             allColumns->excludeColumns(),
             allColumns->replaceItems(),
-            hasNestedWindow,
-            windowOptions,
             exprs);
       } else if (item->is(NodeType::kSelectColumns)) {
         auto* selectColumns = item->as<SelectColumns>();
@@ -825,16 +704,12 @@ class RelationPlanner : public AstVisitor {
             selectedColumns,
             selectColumns->excludeColumns(),
             selectColumns->replaceItems(),
-            hasNestedWindow,
-            windowOptions,
             exprs);
       } else {
         VELOX_CHECK(item->is(NodeType::kSingleColumn));
         auto* singleColumn = item->as<SingleColumn>();
 
-        lp::ExprApi expr = toExpr(
-            singleColumn->expression(),
-            hasNestedWindow ? &windowOptions : nullptr);
+        lp::ExprApi expr = toExpr(singleColumn->expression());
 
         std::optional<std::string> alias;
         if (singleColumn->alias() != nullptr) {
@@ -856,6 +731,63 @@ class RelationPlanner : public AstVisitor {
       }
     }
 
+    return exprs;
+  }
+
+  // Extracts nested window functions from the projections. Called after
+  // buildSelectProjections for non-GROUP BY queries. GROUP BY queries
+  // handle window extraction after aggregate rewriting in GroupByPlanner.
+  // Only extracts windows that are nested inside non-window expressions
+  // (e.g., sum(a) / sum(sum(a)) OVER ()). Top-level window projections
+  // are handled by PlanBuilder::project via resolveWindowTypes.
+  void extractNestedWindows(std::vector<lp::ExprApi>& exprs) {
+    std::unordered_map<const core::IExpr*, core::ExprPtr> windowExprPtrs;
+    std::vector<const core::IExpr*> windowOrder;
+    ExpressionPlanner::findNestedWindowExprs(
+        exprs, windowExprPtrs, windowOrder);
+
+    if (windowOrder.empty()) {
+      return;
+    }
+
+    std::vector<lp::ExprApi> windowExprs;
+    windowExprs.reserve(windowOrder.size());
+    for (const auto* exprPtr : windowOrder) {
+      windowExprs.emplace_back(windowExprPtrs.at(exprPtr));
+    }
+
+    builder_->with(windowExprs);
+
+    auto outputNames =
+        builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
+    auto numInputColumns = outputNames.size() - windowOrder.size();
+
+    std::unordered_map<const core::IExpr*, core::ExprPtr> replacements;
+    for (size_t i = 0; i < windowOrder.size(); ++i) {
+      const auto& column = outputNames.at(numInputColumns + i);
+      replacements.emplace(windowOrder[i], column.toCol().expr());
+    }
+
+    for (auto& expr : exprs) {
+      expr =
+          lp::ExprApi(replaceInputs(expr.expr(), replacements), expr.alias());
+    }
+  }
+
+  // Like buildSelectProjections, but always returns a result (expands single
+  // SELECT * instead of returning nullopt). Does NOT extract nested windows —
+  // the caller is responsible for that.
+  std::vector<lp::ExprApi> expandSelectExprs(
+      const std::vector<SelectItemPtr>& selectItems) {
+    auto result = buildSelectProjections(selectItems);
+    if (result.has_value()) {
+      return result.value();
+    }
+    std::vector<lp::ExprApi> exprs;
+    for (const auto& column :
+         builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false)) {
+      exprs.push_back(column.toCol());
+    }
     return exprs;
   }
 
@@ -928,6 +860,7 @@ class RelationPlanner : public AstVisitor {
       builder_->dropHiddenColumns();
       return;
     }
+    extractNestedWindows(projections.value());
     if (orderBy == nullptr) {
       builder_->project(projections.value());
       return;
@@ -962,6 +895,7 @@ class RelationPlanner : public AstVisitor {
       addOrderBy(orderBy);
       return;
     }
+    extractNestedWindows(projections.value());
     if (orderBy == nullptr) {
       builder_->project(projections.value());
       builder_->distinct();
@@ -1106,10 +1040,9 @@ class RelationPlanner : public AstVisitor {
     const bool distinct = node->select()->isDistinct();
 
     if (auto groupBy = node->groupBy()) {
-      std::unordered_map<const core::IExpr*, lp::WindowSpec> windowOptions;
-      auto selectExprs = expandSelectExprs(selectItems, windowOptions);
+      auto selectExprs = expandSelectExprs(selectItems);
 
-      GroupByPlanner{builder_, exprPlanner_, std::move(windowOptions)}.plan(
+      GroupByPlanner{builder_, exprPlanner_}.plan(
           groupBy->groupingElements(),
           groupBy->isDistinct(),
           selectExprs,

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -118,9 +118,6 @@ std::vector<size_t> SortProjection::widenProjections(
         if (inserted) {
           ordinals.push_back(projections.size() + 1);
           lp::ExprApi newProjection(resolved, sortKeyExprs[i].alias());
-          if (sortKeyExprs[i].windowSpec()) {
-            newProjection = newProjection.over(*sortKeyExprs[i].windowSpec());
-          }
           projections.push_back(std::move(newProjection));
         } else {
           ordinals.push_back(projectionIt->second);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1505,7 +1505,9 @@ TEST_F(PrestoParserTest, nestedWindowFunction) {
           .project({"s + 1::bigint", "c * 2::bigint"})
           .output({"s", "c"}));
 
-  // Mix of top-level and nested window functions preserves aliases.
+  // Mix of top-level and nested window functions. Only the nested window
+  // (inside the multiply) is extracted into its own project. The top-level
+  // window stays in the main project alongside the scalar expression.
   testSelect(
       "SELECT row_number() OVER (ORDER BY a) AS rn, "
       "sum(a) OVER (PARTITION BY b) * 2 AS doubled FROM t",
@@ -1513,10 +1515,12 @@ TEST_F(PrestoParserTest, nestedWindowFunction) {
           .project({
               "a",
               "b",
-              "row_number() OVER (ORDER BY a) AS rn",
               "sum(a) OVER (PARTITION BY b) AS w",
           })
-          .project({"rn", "w * 2::bigint"})
+          .project({
+              "row_number() OVER (ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+              "w * 2::bigint",
+          })
           .output({"rn", "doubled"}));
 
   // Window function without alias in expression.


### PR DESCRIPTION
Summary:

Replace the WindowSpec side-channel (windowOptionsMap_) with
WindowCallExpr nodes in the IExpr tree. Previously, toExpr() stored
window specs in a separate map and returned plain CallExprs for nested
windows. Callers had to pass the map around and keep it synchronized.
Now, toExpr() always produces WindowCallExpr directly — the expression
tree is self-describing.

WindowSpec is kept as a parameter object for ExprApi::over() — it
builds the specification, over() creates the WindowCallExpr immediately.
No storage on ExprApi, no side-channel.

- Remove windowOptionsMap_ and windowSpec_ member from ExprApi.
- Simplify toExpr() — remove windowOptions parameter.
- Simplify GroupByPlanner — remove windowOptionsMap_ member and
  constructor parameter.
- Collapse buildSelectProjections from two overloads to one.

Reviewed By: xiaoxmeng

Differential Revision: D100151589
