### PR TITLE
fix(optimizer): Deduplicate scalar subqueries sharing the same plan node (#1228)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2711,7 +2711,21 @@ void ToGraph::processSubqueries(
 void ToGraph::processScalarSubqueries(
     const lp::LogicalPlanNode& input,
     const std::vector<lp::SubqueryExprPtr>& scalars) {
+  // Band-aid:
+  //
+  // NULLIF(x, y) is desugared into IF(eq(x, y), null, x) which
+  // references x twice. When x is a scalar subquery, ExprResolver creates
+  // distinct SubqueryExpr pointers for each reference but they share the same
+  // LogicalPlanNodePtr. Without dedup, we create duplicate cross joins.
+  // https://github.com/facebookincubator/axiom/issues/1229
+  folly::F14FastMap<lp::LogicalPlanNodePtr, ExprCP> processedSubqueries;
   for (const auto& subquery : scalars) {
+    auto it = processedSubqueries.find(subquery->subquery());
+    if (it != processedSubqueries.end()) {
+      subqueries_.emplace(subquery, it->second);
+      continue;
+    }
+
     auto subqueryDt = translateSubquery(*subquery->subquery());
 
     ExprCP column;
@@ -2721,6 +2735,7 @@ void ToGraph::processScalarSubqueries(
       column = processCorrelatedScalarSubquery(input, subqueryDt);
     }
     subqueries_.emplace(subquery, column);
+    processedSubqueries.emplace(subquery->subquery(), column);
   }
 }
 

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -35,3 +35,7 @@ SELECT T.* FROM (VALUES (1)) t(a) JOIN (VALUES (2)) u(b) ON true
 -- null-aware semi-project join with extra filter; the optimizer must not flip
 -- this to a right semi-project join that is unsupported in Velox.
 SELECT CASE WHEN a.x IN (SELECT t.a FROM t WHERE t.b < a.y) THEN 'p' ELSE 'f' END FROM ( VALUES ( 1, 100 ) ) a ( x, y )
+----
+-- NULLIF with scalar subquery. The subquery appears twice in the desugared
+-- IF(eq(x, y), null, x) expression; it must not create duplicate join columns.
+SELECT NULLIF((SELECT 1), 2)


### PR DESCRIPTION
Summary:

Deduplicate scalar subqueries in ToGraph::processScalarSubqueries when the same subquery plan node is referenced multiple times in an expression tree.

Minimal repro:
```
SELECT NULLIF((SELECT 1), 2)
```

Step-by-step failure analysis:

1. ExpressionPlanner desugars `NULLIF(x, y)` into `IF(eq(x, y), null, x)`, referencing `args[0]` (the scalar subquery `(SELECT 1)`) twice — once in the `eq` call and once as the else branch.
2. ExprResolver visits the desugared expression tree and calls `std::make_shared<SubqueryExpr>(subquery->subquery())` for each occurrence. This creates two distinct SubqueryExpr pointers, but both share the same underlying LogicalPlanNodePtr.
3. extractSubqueries walks the expression tree and collects both SubqueryExpr objects into the scalars vector.
4. processScalarSubqueries iterates the vector and calls translateSubquery + processUncorrelatedScalarSubquery for each entry, creating a separate cross join per entry. The second cross join produces a duplicate column name, which triggers a "duplicate names" error.

The fix adds a `folly::F14FastMap<lp::LogicalPlanNodePtr, ExprCP>` to processScalarSubqueries. When a SubqueryExpr's plan node has already been processed, we reuse the column from the first join instead of creating a duplicate.

Reviewed By: mbasmanova

Differential Revision: D100237026
