### PR TITLE
fix(optimizer): Fold EXISTS to false when subquery produces zero rows (#1230)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2989,6 +2989,16 @@ void ToGraph::processExistsSubqueries(const std::vector<lp::ExprPtr>& exists) {
         *existsExpr->inputAt(0)->as<lp::SubqueryExpr>()->subquery(),
         /*finalize=*/false);
 
+    // A subquery that produces zero rows (e.g., LIMIT 0) makes EXISTS false.
+    if (subqueryDt->isZeroRows()) {
+      correlatedConjuncts_.clear();
+      subqueries_.emplace(
+          existsExpr,
+          make<Literal>(
+              toConstantValue(velox::BOOLEAN()), registerVariant(false)));
+      continue;
+    }
+
     // EXISTS (SELECT <expr> WHERE <condition>) with no FROM clause and no
     // LIMIT or aggregation is equivalent to just <condition>. The subquery has
     // a single empty-schema ValuesTable as its source that always produces one

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1873,6 +1873,15 @@ TEST_F(SubqueryTest, existsWithNoFromClause) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// EXISTS (SELECT ... LIMIT 0) should fold to false because the subquery
+// produces zero rows.
+TEST_F(SubqueryTest, existsWithLimitZero) {
+  auto plan = toSingleNodePlan("SELECT EXISTS (SELECT 1 LIMIT 0)");
+
+  auto matcher = matchValues(ROW({})).project({"false"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // IN subquery in a projection combined with a correlated NOT EXISTS in the
 // WHERE clause. The IN subquery creates a semi-join inside the join input,
 // which triggers DT wrapping (excludeOuterJoins). The NOT EXISTS subquery

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -4,6 +4,9 @@ SELECT EXISTS(SELECT 1), EXISTS(SELECT 1), EXISTS(SELECT 3), NOT EXISTS(SELECT 1
 ----
 SELECT (EXISTS(SELECT 1)) = (EXISTS(SELECT 3)) WHERE NOT EXISTS(SELECT 1 WHERE false)
 ----
+-- EXISTS with LIMIT 0 should return false.
+SELECT EXISTS(SELECT 1 LIMIT 0), NOT EXISTS(SELECT 1 LIMIT 0)
+----
 -- IN list with a scalar subquery and a literal.
 -- duckdb: SELECT a, b FROM t WHERE a IN ((SELECT max(a) FROM t), 1)
 SELECT a, b FROM t WHERE a IN ((SELECT max(a) FROM t), 1)


### PR DESCRIPTION
Summary:

EXISTS (SELECT 1 LIMIT 0) was incorrectly folded to true. LIMIT 0
converts the subquery to an empty ValuesTable (zero rows), which the
EXISTS optimization mistook for a "no FROM clause" subquery that always
produces one row.

Check subqueryDt->isZeroRows() before the existing optimization and
fold EXISTS to false when the subquery produces zero rows.

bypass-github-export-checks

Reviewed By: peterenescu

Differential Revision: D100346897
