### PR TITLE
fix: Add an overflow check for LIMIT

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -524,7 +524,7 @@ class PlanBuilder {
   }
 
   /// Adds a Limit node returning at most 'count' rows.
-  PlanBuilder& limit(int32_t count) {
+  PlanBuilder& limit(int64_t count) {
     return limit(0, count);
   }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1406,6 +1406,21 @@ TEST_F(PrestoParserTest, limit) {
         matcher);
   }
 
+  {
+    auto matcher = matchScan().limit(0, 2'147'483'647).output(nationColumns);
+    testSelect("SELECT * FROM nation LIMIT 2147483647", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 2'147'483'648).output(nationColumns);
+    testSelect("SELECT * FROM nation LIMIT 2147483648", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 24'859'023'574).output(nationColumns);
+    testSelect("SELECT * FROM nation LIMIT 24859023574", matcher);
+  }
+
   // LIMIT ALL means "no limit" — should not add a LimitNode.
   {
     auto matcher = matchScan().output(nationColumns);


### PR DESCRIPTION
Summary:
Bump limit value type size due to int32_t overflow.
```
SELECT a FROM t ORDER BY a LIMIT 2147483648 -- overflows int32_t maximum
```
Both Axiom's PrestoParser and Java have 64-byte types. PlanBuilder should match to avoid overflow.

Reviewed By: natashasehgal

Differential Revision: D100219633


