### PR TITLE
fix(optimizer): Handle inconsistent connector statistics in baseSelectivity

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -747,7 +747,13 @@ JoinFanout joinFanout(
 float baseSelectivity(PlanObjectCP object) {
   if (object->is(PlanType::kTableNode)) {
     auto* baseTable = object->as<BaseTable>();
-    return baseTable->filteredCardinality / baseTable->schemaTable->cardinality;
+    const auto baseCardinality = baseTable->schemaTable->cardinality;
+    // filteredCardinality can exceed baseCardinality when the connector
+    // returns inconsistent statistics, e.g. Table::numRows() returns 0
+    // while co_estimateStats returns the real partition row count.
+    if (baseCardinality > baseTable->filteredCardinality) {
+      return baseTable->filteredCardinality / baseCardinality;
+    }
   }
   return 1;
 }


### PR DESCRIPTION
Summary:
baseSelectivity computes filteredCardinality / schemaTable->cardinality, which should be <= 1. When a connector returns inconsistent statistics — Table::numRows() returns 0 (clamped to 1 by SchemaTable) while co_estimateStats returns the real partition row count (e.g. 7e11) — the ratio overflows. Across multiple joins, fanouts multiplied by these selectivities overflow float to infinity, causing a VELOX_CHECK(std::isfinite(inputCardinality)) failure.

Return 1 (no selectivity reduction) when filteredCardinality >= baseCardinality.

Differential Revision: D100616000


