### PR TITLE
fix: Fix float-to-int64_t overflow in Aggregation cost estimation

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -747,7 +747,13 @@ JoinFanout joinFanout(
 float baseSelectivity(PlanObjectCP object) {
   if (object->is(PlanType::kTableNode)) {
     auto* baseTable = object->as<BaseTable>();
-    return baseTable->filteredCardinality / baseTable->schemaTable->cardinality;
+    const auto baseCardinality = baseTable->schemaTable->cardinality;
+    // filteredCardinality can exceed baseCardinality when the connector
+    // returns inconsistent statistics, e.g. Table::numRows() returns 0
+    // while co_estimateStats returns the real partition row count.
+    if (baseCardinality > baseTable->filteredCardinality) {
+      return baseTable->filteredCardinality / baseCardinality;
+    }
   }
   return 1;
 }

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1369,7 +1369,7 @@ float sortCost(size_t numKeys, float cardinality) {
 }
 } // namespace
 
-void Aggregation::setCostWithGroups(int64_t inputBeforePartial) {
+void Aggregation::setCostWithGroups(float inputBeforePartial) {
   auto* optimization = queryCtx()->optimization();
   const auto& runnerOptions = optimization->runnerOptions();
 

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -630,7 +630,7 @@ struct Aggregation : public RelationOp {
 
  private:
   void initConstraints();
-  void setCostWithGroups(int64_t inputBeforePartial);
+  void setCostWithGroups(float inputBeforePartial);
 };
 
 /// Represents an order by. The order is given by the distribution.


### PR DESCRIPTION
Summary: Change `setCostWithGroups` parameter type from `int64_t` to `float` to match the caller's type. When input cardinality exceeds int64_t max (~9.2e18), e.g. 2.55e20 from a large join estimate, the implicit float-to-int64_t cast is undefined behavior (caught by UBSAN).

Differential Revision: D100659282


