### PR TITLE
feat: Add ConfigRegistry and SessionConfig

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -16,6 +16,13 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_common SchemaTableName.cpp CatalogSchemaTableName.cpp Session.cpp)
+add_library(
+  axiom_common
+  CatalogSchemaTableName.cpp
+  ConfigRegistry.cpp
+  SchemaTableName.cpp
+  Session.cpp
+  SessionConfig.cpp
+)
 
-target_link_libraries(axiom_common velox_common_base Folly::folly)
+target_link_libraries(axiom_common velox_common_base velox_config_property Folly::folly)

--- a/axiom/common/ConfigRegistry.cpp
+++ b/axiom/common/ConfigRegistry.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/common/ConfigRegistry.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom {
+
+using velox::config::ConfigProperty;
+using velox::config::ConfigProvider;
+
+void ConfigRegistry::add(
+    std::string_view prefix,
+    std::shared_ptr<ConfigProvider> provider) {
+  const auto key = std::string(prefix);
+  VELOX_USER_CHECK(
+      providers_.find(key) == providers_.end(),
+      "Config prefix already registered: {}",
+      prefix);
+
+  folly::F14FastMap<std::string, ConfigProperty> propertyMap;
+  for (auto& prop : provider->properties()) {
+    auto name = prop.name;
+    VELOX_CHECK(
+        propertyMap.emplace(name, std::move(prop)).second,
+        "Duplicate config property: {}.{}",
+        prefix,
+        name);
+  }
+  providers_[key] = ProviderEntry{std::move(provider), std::move(propertyMap)};
+}
+
+ConfigRegistry::Resolution ConfigRegistry::resolve(
+    std::string_view qualifiedName) const {
+  auto dot = qualifiedName.find('.');
+  VELOX_USER_CHECK(
+      dot != std::string_view::npos,
+      "Session property must be prefix-qualified (e.g., "
+      "'optimizer.sample_joins'): {}",
+      qualifiedName);
+
+  const auto prefix = std::string(qualifiedName.substr(0, dot));
+  auto it = providers_.find(prefix);
+  VELOX_USER_CHECK(
+      it != providers_.end(), "Unknown session property prefix: {}", prefix);
+
+  const auto name = std::string(qualifiedName.substr(dot + 1));
+  auto propIt = it->second.properties.find(name);
+  VELOX_USER_CHECK(
+      propIt != it->second.properties.end(),
+      "Unknown session property: {}.{}",
+      prefix,
+      name);
+  return {it->second.provider.get(), propIt->second};
+}
+
+std::vector<ConfigRegistry::Entry> ConfigRegistry::all() const {
+  std::vector<Entry> result;
+  for (const auto& [prefix, entry] : providers_) {
+    for (const auto& [name, prop] : entry.properties) {
+      result.push_back({prefix, prop});
+    }
+  }
+  return result;
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/ConfigRegistry.h
+++ b/axiom/common/ConfigRegistry.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+#include "velox/common/config/ConfigProvider.h"
+
+namespace facebook::axiom {
+
+/// Maps namespace prefixes to ConfigProviders. Built once at startup and
+/// shared across sessions. Immutable after assembly.
+class ConfigRegistry {
+ public:
+  /// Registers a provider under a namespace prefix. Takes a snapshot
+  /// of the provider's properties at registration time; later changes
+  /// to the provider's property list are not reflected. Throws if the
+  /// prefix is already registered. Not thread-safe — call only during
+  /// single-threaded startup before sharing the registry.
+  void add(
+      std::string_view prefix,
+      std::shared_ptr<velox::config::ConfigProvider> provider);
+
+  /// Result of resolving a prefix-qualified property name.
+  struct Resolution {
+    /// Provider that owns the property (for validation).
+    const velox::config::ConfigProvider* provider;
+
+    /// Property descriptor.
+    velox::config::ConfigProperty property;
+  };
+
+  /// Looks up provider and property for a prefix-qualified name
+  /// (e.g., "optimizer.sample_joins"). Throws if not found.
+  Resolution resolve(std::string_view qualifiedName) const;
+
+  /// A property with its namespace prefix.
+  struct Entry {
+    std::string prefix;
+    velox::config::ConfigProperty property;
+  };
+
+  /// Returns all properties across all providers.
+  std::vector<Entry> all() const;
+
+ private:
+  struct ProviderEntry {
+    std::shared_ptr<velox::config::ConfigProvider> provider;
+    folly::F14FastMap<std::string, velox::config::ConfigProperty> properties;
+  };
+
+  folly::F14FastMap<std::string, ProviderEntry> providers_;
+};
+
+} // namespace facebook::axiom

--- a/axiom/common/SessionConfig.cpp
+++ b/axiom/common/SessionConfig.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/common/SessionConfig.h"
+
+#include <fmt/format.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom {
+
+using velox::config::ConfigPropertyType;
+
+SessionConfig::SessionConfig(std::shared_ptr<const ConfigRegistry> registry)
+    : registry_(std::move(registry)) {}
+
+bool SessionConfig::set(
+    std::string_view qualifiedName,
+    std::string_view value) {
+  auto resolved = registry_->resolve(qualifiedName);
+  auto normalized = normalizeType(qualifiedName, resolved.property.type, value);
+  normalized = resolved.provider->normalize(resolved.property.name, normalized);
+
+  auto key = std::string(qualifiedName);
+
+  // If the normalized value equals the default, clear any override.
+  if (normalized == resolved.property.defaultValue) {
+    return overrides_.erase(key) > 0;
+  }
+
+  // Check if value is same as current override.
+  auto it = overrides_.find(key);
+  if (it != overrides_.end() && it->second == normalized) {
+    return false;
+  }
+
+  overrides_[std::move(key)] = std::move(normalized);
+  return true;
+}
+
+bool SessionConfig::set(
+    std::string_view prefix,
+    std::string_view name,
+    std::string_view value) {
+  return set(fmt::format("{}.{}", prefix, name), value);
+}
+
+bool SessionConfig::reset(std::string_view qualifiedName) {
+  // Verify property exists.
+  registry_->resolve(qualifiedName);
+  return overrides_.erase(qualifiedName) > 0;
+}
+
+std::optional<std::string> SessionConfig::effectiveValue(
+    std::string_view qualifiedName) const {
+  auto it = overrides_.find(qualifiedName);
+  if (it != overrides_.end()) {
+    return it->second;
+  }
+  auto resolved = registry_->resolve(qualifiedName);
+  return resolved.property.defaultValue;
+}
+
+folly::F14FastMap<std::string, std::string> SessionConfig::effectiveValues(
+    std::string_view prefix) const {
+  folly::F14FastMap<std::string, std::string> result;
+  for (const auto& entry : registry_->all()) {
+    if (entry.prefix != prefix) {
+      continue;
+    }
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    auto it = overrides_.find(qualifiedName);
+    if (it != overrides_.end()) {
+      result[entry.property.name] = it->second;
+    } else if (entry.property.defaultValue.has_value()) {
+      result[entry.property.name] = entry.property.defaultValue.value();
+    }
+  }
+  return result;
+}
+
+std::vector<SessionConfig::Entry> SessionConfig::all() const {
+  std::vector<Entry> result;
+  for (const auto& registryEntry : registry_->all()) {
+    auto qualifiedName =
+        registryEntry.prefix + "." + registryEntry.property.name;
+    auto it = overrides_.find(qualifiedName);
+    std::optional<std::string> currentValue;
+    if (it != overrides_.end()) {
+      currentValue = it->second;
+    } else {
+      currentValue = registryEntry.property.defaultValue;
+    }
+    result.push_back(
+        {registryEntry.prefix,
+         registryEntry.property,
+         currentValue,
+         it != overrides_.end()});
+  }
+  return result;
+}
+
+namespace {
+
+// Returns true if 'value' is a valid integer string (optional leading '-'
+// followed by one or more digits).
+bool isInteger(std::string_view value) {
+  auto start = !value.empty() && value[0] == '-' ? 1u : 0u;
+  return value.size() > start &&
+      std::all_of(value.begin() + start, value.end(), [](char c) {
+           return std::isdigit(c);
+         });
+}
+
+// Returns true if 'value' is a valid double string.
+bool isDouble(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+  auto str = std::string(value);
+  char* end = nullptr;
+  std::strtod(str.c_str(), &end);
+  return end != nullptr && *end == '\0';
+}
+
+} // namespace
+
+std::string SessionConfig::normalizeType(
+    std::string_view qualifiedName,
+    ConfigPropertyType type,
+    std::string_view value) {
+  switch (type) {
+    case ConfigPropertyType::kBoolean: {
+      auto lower = std::string(value);
+      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+      VELOX_USER_CHECK(
+          lower == "true" || lower == "false",
+          "Expected boolean value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return lower;
+    }
+    case ConfigPropertyType::kInteger:
+      VELOX_USER_CHECK(
+          isInteger(value),
+          "Expected integer value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kDouble:
+      VELOX_USER_CHECK(
+          isDouble(value),
+          "Expected double value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kString:
+      return std::string(value);
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/SessionConfig.h
+++ b/axiom/common/SessionConfig.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <folly/container/F14Map.h>
+#include "axiom/common/ConfigRegistry.h"
+
+namespace facebook::axiom {
+
+/// Per-session mutable state. Holds a reference to the shared
+/// ConfigRegistry and a map of property overrides. Reads check the
+/// override map first, then fall back to the provider's default.
+class SessionConfig {
+ public:
+  explicit SessionConfig(std::shared_ptr<const ConfigRegistry> registry);
+
+  /// Sets a property by prefix-qualified name. Validates type and
+  /// delegates to provider for domain validation. Returns true if
+  /// the value changed.
+  bool set(std::string_view qualifiedName, std::string_view value);
+
+  /// Convenience overload: set("prefix", "name", "value") is equivalent to
+  /// set("prefix.name", "value").
+  bool
+  set(std::string_view prefix, std::string_view name, std::string_view value);
+
+  /// Resets a property to its default. Returns true if the value
+  /// changed.
+  bool reset(std::string_view qualifiedName);
+
+  /// Returns effective value (override or default) for a single
+  /// property. Returns nullopt if no default and not set.
+  std::optional<std::string> effectiveValue(
+      std::string_view qualifiedName) const;
+
+  /// Returns effective values (override or default) for all properties
+  /// under a component prefix as a flat map.
+  folly::F14FastMap<std::string, std::string> effectiveValues(
+      std::string_view prefix) const;
+
+  /// A property with its current effective value for SHOW SESSION output.
+  struct Entry {
+    std::string prefix;
+
+    velox::config::ConfigProperty property;
+
+    /// Override or default value. Nullopt if no default and not set.
+    std::optional<std::string> currentValue;
+
+    /// True if the value was explicitly set to a non-default value.
+    bool isOverridden;
+  };
+
+  /// Returns all properties with current values.
+  std::vector<Entry> all() const;
+
+ private:
+  // Validates and normalizes 'value' for 'type'. Lowercases booleans,
+  // passes through integers, doubles, and strings. Throws on invalid values.
+  static std::string normalizeType(
+      std::string_view qualifiedName,
+      velox::config::ConfigPropertyType type,
+      std::string_view value);
+
+  std::shared_ptr<const ConfigRegistry> registry_;
+  folly::F14FastMap<std::string, std::string> overrides_;
+};
+
+} // namespace facebook::axiom

--- a/axiom/common/tests/CMakeLists.txt
+++ b/axiom/common/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_common_tests CatalogSchemaTableNameTest.cpp SchemaTableNameTest.cpp)
+add_executable(
+  axiom_common_tests
+  CatalogSchemaTableNameTest.cpp
+  SchemaTableNameTest.cpp
+  SessionConfigTest.cpp
+)
 
 add_test(axiom_common_tests axiom_common_tests)
 

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for ConfigRegistry and SessionConfig.
+//
+// Uses a TestConfigProvider that declares a few properties of
+// different types to exercise:
+// - Registry: add, resolve, all, duplicate prefix, unknown property
+// - SessionConfig: set, get, reset, getAll, type validation, all()
+
+#include "axiom/common/SessionConfig.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::axiom;
+using namespace facebook::velox::config;
+
+namespace {
+
+class TestConfigProvider : public ConfigProvider {
+ public:
+  std::vector<ConfigProperty> properties() const override {
+    return {
+        {"flag_a", ConfigPropertyType::kBoolean, "true", "A boolean flag."},
+        {"count", ConfigPropertyType::kInteger, "10", "An integer count."},
+        {"ratio", ConfigPropertyType::kDouble, "0.5", "A double ratio."},
+        {"label", ConfigPropertyType::kString, std::nullopt, "A string label."},
+    };
+  }
+
+  std::string normalize(std::string_view name, std::string_view value)
+      const override {
+    // Normalize label to lowercase (simulates enum-like normalization).
+    if (name == "label") {
+      auto lower = std::string(value);
+      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+      return lower;
+    }
+    return std::string(value);
+  }
+};
+
+class SessionConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto registry = std::make_shared<ConfigRegistry>();
+    registry->add("test", std::make_shared<TestConfigProvider>());
+    registry_ = registry;
+    config_ = std::make_unique<SessionConfig>(registry_);
+  }
+
+  // Finds an entry by property name in the all() result.
+  SessionConfig::Entry findEntry(std::string_view name) const {
+    auto entries = config_->all();
+    auto it = std::find_if(entries.begin(), entries.end(), [&](const auto& e) {
+      return e.property.name == name;
+    });
+    VELOX_CHECK(it != entries.end(), "Property not found: {}", name);
+    return *it;
+  }
+
+  std::shared_ptr<const ConfigRegistry> registry_;
+  std::unique_ptr<SessionConfig> config_;
+};
+
+TEST_F(SessionConfigTest, getDefault) {
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+  EXPECT_EQ(config_->effectiveValue("test.count"), "10");
+  EXPECT_EQ(config_->effectiveValue("test.ratio"), "0.5");
+  EXPECT_EQ(config_->effectiveValue("test.label"), std::nullopt);
+}
+
+TEST_F(SessionConfigTest, setAndGet) {
+  EXPECT_TRUE(config_->set("test.flag_a", "false"));
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "false");
+
+  // Setting same value returns false.
+  EXPECT_FALSE(config_->set("test.flag_a", "false"));
+}
+
+TEST_F(SessionConfigTest, resetToDefault) {
+  config_->set("test.flag_a", "false");
+  EXPECT_TRUE(config_->reset("test.flag_a"));
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+
+  // Reset when not overridden returns false.
+  EXPECT_FALSE(config_->reset("test.flag_a"));
+}
+
+TEST_F(SessionConfigTest, typeValidation) {
+  VELOX_ASSERT_THROW(
+      config_->set("test.flag_a", "banana"), "Expected boolean value");
+  VELOX_ASSERT_THROW(
+      config_->set("test.count", "abc"), "Expected integer value");
+  VELOX_ASSERT_THROW(
+      config_->set("test.ratio", "xyz"), "Expected double value");
+
+  // String accepts anything.
+  EXPECT_NO_THROW(config_->set("test.label", "anything"));
+}
+
+TEST_F(SessionConfigTest, unknownProperty) {
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("test.nonexistent"), "Unknown session property");
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("unknown.flag"),
+      "Unknown session property prefix");
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("noDotPrefix"),
+      "Session property must be prefix-qualified");
+}
+
+TEST_F(SessionConfigTest, effective) {
+  config_->set("test.flag_a", "false");
+  auto props = config_->effectiveValues("test");
+
+  EXPECT_EQ(props["flag_a"], "false"); // overridden
+  EXPECT_EQ(props["count"], "10"); // default
+  EXPECT_EQ(props["ratio"], "0.5"); // default
+  // "label" has no default, not set — absent from map.
+  EXPECT_EQ(props.find("label"), props.end());
+}
+
+TEST_F(SessionConfigTest, allEntries) {
+  config_->set("test.count", "42");
+  EXPECT_EQ(config_->all().size(), 4);
+
+  auto entry = findEntry("count");
+  EXPECT_EQ(entry.currentValue, "42");
+  EXPECT_TRUE(entry.isOverridden);
+}
+
+TEST_F(SessionConfigTest, normalize) {
+  // Boolean normalization: normalizeType lowercases booleans.
+  config_->set("test.flag_a", "FALSE");
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "false");
+
+  // Setting to the default (after normalization) clears the override.
+  config_->set("test.flag_a", "TRUE");
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+
+  // Verify the override was actually cleared, not just storing "true".
+  EXPECT_FALSE(findEntry("flag_a").isOverridden);
+
+  // Provider normalization: label is lowercased by the provider.
+  config_->set("test.label", "Hello");
+  EXPECT_EQ(config_->effectiveValue("test.label"), "hello");
+}
+
+TEST_F(SessionConfigTest, duplicatePrefix) {
+  auto registry = std::make_shared<ConfigRegistry>();
+  registry->add("test", std::make_shared<TestConfigProvider>());
+  VELOX_ASSERT_THROW(
+      registry->add("test", std::make_shared<TestConfigProvider>()),
+      "Config prefix already registered");
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
ConfigRegistry maps namespace prefixes (e.g. "optimizer", "execution") to ConfigProviders and resolves prefix-qualified property names. SessionConfig holds per-session overrides with type validation and normalization.

Both use ConfigProperty and ConfigProvider types from velox/common/config/.

Reviewed By: xiaoxmeng

Differential Revision: D100639562
