### PR TITLE
feat(optimizer): Add OptimizerConfigProvider and wire SET/SHOW SESSION

### DIFF
--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -38,8 +38,6 @@ DEFINE_uint64(
     16 << 20,
     "Approx bytes covered by one split");
 
-DEFINE_uint32(optimizer_trace, 0, "Optimizer trace level");
-
 DEFINE_int32(max_rows, 100, "Max number of printed result rows");
 
 DEFINE_int32(num_workers, 4, "Number of in-process workers");
@@ -136,7 +134,6 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
         .numWorkers = FLAGS_num_workers,
         .numDrivers = FLAGS_num_drivers,
         .splitTargetBytes = FLAGS_split_target_bytes,
-        .optimizerTraceFlags = FLAGS_optimizer_trace,
         .debugMode = FLAGS_debug,
         .onComplete =
             [&](const QueryCompletionInfo& info) { completionInfo = info; },
@@ -235,8 +232,7 @@ void Console::readCommands(const std::string& prompt, bool interactive) {
           "Useful flags:\n\n"
           "  num_workers      - Number of workers for distributed plans (1 = single node).\n"
           "  num_drivers      - Number of drivers (threads) per pipeline per worker.\n"
-          "  max_rows         - Maximum number of printed result rows.\n"
-          "  optimizer_trace  - Optimizer trace level (0 = off).\n\n";
+          "  max_rows         - Maximum number of printed result rows.\n\n";
 
       std::cout << helpText << std::flush;
       continue;
@@ -312,7 +308,6 @@ void Console::readCommands(const std::string& prompt, bool interactive) {
           "num_workers",
           "num_drivers",
           "max_rows",
-          "optimizer_trace",
       };
       for (const auto& name : kFlagNames) {
         gflags::CommandLineFlagInfo info;

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -34,7 +34,6 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 | `--num_workers` | `4` | Number of in-process workers. |
 | `--num_drivers` | `4` | Number of drivers per worker (parallelism). |
 | `--max_rows` | `100` | Maximum number of printed result rows. |
-| `--optimizer_trace` | `0` | Optimizer trace level. |
 | `--debug` | `false` | Enable debug mode (logging to stderr). |
 
 ## Connectors
@@ -164,7 +163,7 @@ Dot-commands do not require a semicolon terminator.
 |---------|-------------|
 | `.help` | Print help text. |
 | `.run <file>` | Execute SQL statements from a file. |
-| `.set <name> <value>` | Set a gflag at runtime (e.g., `num_workers`, `num_drivers`, `max_rows`, `optimizer_trace`). |
+| `.set <name> <value>` | Set a gflag at runtime (e.g., `num_workers`, `num_drivers`, `max_rows`). |
 | `.clear <name>` | Reset a flag to its default value. |
 | `.flags` | List modified flags. |
 | `.exit` or `.quit` | Exit the CLI. |

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -29,6 +29,7 @@
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/ExplainIo.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
@@ -135,6 +136,13 @@ void SqlQueryRunner::initialize(
       return generator->createNextQueryId();
     };
   }
+
+  configRegistry_ = std::make_shared<facebook::axiom::ConfigRegistry>();
+  configRegistry_->add(
+      "optimizer",
+      std::make_shared<facebook::axiom::optimizer::OptimizerOptions>());
+  sessionConfig_ =
+      std::make_shared<facebook::axiom::SessionConfig>(configRegistry_);
 }
 
 namespace {
@@ -554,12 +562,15 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
   if (sqlStatement.isSetSession()) {
     const auto* setSession = sqlStatement.as<presto::SetSessionStatement>();
-    config_[setSession->name()] = setSession->value();
+    const auto& name = setSession->name();
+    if (name.find('.') != std::string::npos) {
+      sessionConfig_->set(name, setSession->value());
+    } else {
+      config_[name] = setSession->value();
+    }
     return {
-        .message = fmt::format(
-            "Session '{}' set to '{}'",
-            setSession->name(),
-            setSession->value())};
+        .message =
+            fmt::format("Session '{}' set to '{}'", name, setSession->value())};
   }
 
   if (sqlStatement.isUse()) {
@@ -787,6 +798,10 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     schemaResolver = std::make_shared<connector::SchemaResolver>();
   }
 
+  auto optimizerProps = sessionConfig_->effectiveValues("optimizer");
+  auto optimizerOptions = optimizer::OptimizerOptions::from(optimizerProps);
+  optimizerOptions.explain = explain;
+
   optimizer::Optimization optimization(
       session,
       *logicalPlan,
@@ -794,7 +809,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
       *history,
       queryCtx,
       evaluator,
-      {.traceFlags = options.optimizerTraceFlags, .explain = explain},
+      optimizerOptions,
       opts);
 
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {
@@ -833,6 +848,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
     QueryTiming& timing,
     std::string& planString) {
   std::map<std::string, std::string> sorted(config_.begin(), config_.end());
+  // Include registered session properties.
+  for (const auto& entry : sessionConfig_->all()) {
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    sorted[qualifiedName] = entry.currentValue.value_or("");
+  }
 
   std::vector<velox::Variant> data;
   data.reserve(sorted.size());

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -18,6 +18,8 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <chrono>
 #include <functional>
+#include "axiom/common/ConfigRegistry.h"
+#include "axiom/common/SessionConfig.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/runner/LocalRunner.h"
@@ -112,7 +114,6 @@ class SqlQueryRunner {
     int32_t numWorkers{4};
     int32_t numDrivers{4};
     uint64_t splitTargetBytes{16 << 20};
-    uint32_t optimizerTraceFlags{0};
 
     /// Microseconds to wait for query to complete. 0 means check for completion
     /// then timeout immediately if not complete.
@@ -340,6 +341,8 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::velox::memory::MemoryPool> executorPool_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::unordered_map<std::string, std::string> config_;
+  std::shared_ptr<facebook::axiom::ConfigRegistry> configRegistry_;
+  std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;
   std::string defaultSchema_;
   std::atomic<int32_t> queryCounter_{0};

--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -16,6 +16,13 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_common SchemaTableName.cpp CatalogSchemaTableName.cpp Session.cpp)
+add_library(
+  axiom_common
+  CatalogSchemaTableName.cpp
+  ConfigRegistry.cpp
+  SchemaTableName.cpp
+  Session.cpp
+  SessionConfig.cpp
+)
 
-target_link_libraries(axiom_common velox_common_base Folly::folly)
+target_link_libraries(axiom_common velox_common_base velox_config_property Folly::folly)

--- a/axiom/common/ConfigRegistry.cpp
+++ b/axiom/common/ConfigRegistry.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/common/ConfigRegistry.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom {
+
+using velox::config::ConfigProperty;
+using velox::config::ConfigProvider;
+
+void ConfigRegistry::add(
+    std::string_view prefix,
+    std::shared_ptr<ConfigProvider> provider) {
+  const auto key = std::string(prefix);
+  VELOX_USER_CHECK(
+      providers_.find(key) == providers_.end(),
+      "Config prefix already registered: {}",
+      prefix);
+
+  folly::F14FastMap<std::string, ConfigProperty> propertyMap;
+  for (auto& prop : provider->properties()) {
+    auto name = prop.name;
+    VELOX_CHECK(
+        propertyMap.emplace(name, std::move(prop)).second,
+        "Duplicate config property: {}.{}",
+        prefix,
+        name);
+  }
+  providers_[key] = ProviderEntry{std::move(provider), std::move(propertyMap)};
+}
+
+ConfigRegistry::Resolution ConfigRegistry::resolve(
+    std::string_view qualifiedName) const {
+  auto dot = qualifiedName.find('.');
+  VELOX_USER_CHECK(
+      dot != std::string_view::npos,
+      "Session property must be prefix-qualified (e.g., "
+      "'optimizer.sample_joins'): {}",
+      qualifiedName);
+
+  const auto prefix = std::string(qualifiedName.substr(0, dot));
+  auto it = providers_.find(prefix);
+  VELOX_USER_CHECK(
+      it != providers_.end(), "Unknown session property prefix: {}", prefix);
+
+  const auto name = std::string(qualifiedName.substr(dot + 1));
+  auto propIt = it->second.properties.find(name);
+  VELOX_USER_CHECK(
+      propIt != it->second.properties.end(),
+      "Unknown session property: {}.{}",
+      prefix,
+      name);
+  return {it->second.provider.get(), propIt->second};
+}
+
+std::vector<ConfigRegistry::Entry> ConfigRegistry::all() const {
+  std::vector<Entry> result;
+  for (const auto& [prefix, entry] : providers_) {
+    for (const auto& [name, prop] : entry.properties) {
+      result.push_back({prefix, prop});
+    }
+  }
+  return result;
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/ConfigRegistry.h
+++ b/axiom/common/ConfigRegistry.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+#include "velox/common/config/ConfigProvider.h"
+
+namespace facebook::axiom {
+
+/// Maps namespace prefixes to ConfigProviders. Built once at startup and
+/// shared across sessions. Immutable after assembly.
+class ConfigRegistry {
+ public:
+  /// Registers a provider under a namespace prefix. Takes a snapshot
+  /// of the provider's properties at registration time; later changes
+  /// to the provider's property list are not reflected. Throws if the
+  /// prefix is already registered. Not thread-safe — call only during
+  /// single-threaded startup before sharing the registry.
+  void add(
+      std::string_view prefix,
+      std::shared_ptr<velox::config::ConfigProvider> provider);
+
+  /// Result of resolving a prefix-qualified property name.
+  struct Resolution {
+    /// Provider that owns the property (for validation).
+    const velox::config::ConfigProvider* provider;
+
+    /// Property descriptor.
+    velox::config::ConfigProperty property;
+  };
+
+  /// Looks up provider and property for a prefix-qualified name
+  /// (e.g., "optimizer.sample_joins"). Throws if not found.
+  Resolution resolve(std::string_view qualifiedName) const;
+
+  /// A property with its namespace prefix.
+  struct Entry {
+    std::string prefix;
+    velox::config::ConfigProperty property;
+  };
+
+  /// Returns all properties across all providers.
+  std::vector<Entry> all() const;
+
+ private:
+  struct ProviderEntry {
+    std::shared_ptr<velox::config::ConfigProvider> provider;
+    folly::F14FastMap<std::string, velox::config::ConfigProperty> properties;
+  };
+
+  folly::F14FastMap<std::string, ProviderEntry> providers_;
+};
+
+} // namespace facebook::axiom

--- a/axiom/common/SessionConfig.cpp
+++ b/axiom/common/SessionConfig.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/common/SessionConfig.h"
+
+#include <fmt/format.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom {
+
+using velox::config::ConfigPropertyType;
+
+SessionConfig::SessionConfig(std::shared_ptr<const ConfigRegistry> registry)
+    : registry_(std::move(registry)) {}
+
+bool SessionConfig::set(
+    std::string_view qualifiedName,
+    std::string_view value) {
+  auto resolved = registry_->resolve(qualifiedName);
+  auto normalized = normalizeType(qualifiedName, resolved.property.type, value);
+  normalized = resolved.provider->normalize(resolved.property.name, normalized);
+
+  auto key = std::string(qualifiedName);
+
+  // If the normalized value equals the default, clear any override.
+  if (normalized == resolved.property.defaultValue) {
+    return overrides_.erase(key) > 0;
+  }
+
+  // Check if value is same as current override.
+  auto it = overrides_.find(key);
+  if (it != overrides_.end() && it->second == normalized) {
+    return false;
+  }
+
+  overrides_[std::move(key)] = std::move(normalized);
+  return true;
+}
+
+bool SessionConfig::set(
+    std::string_view prefix,
+    std::string_view name,
+    std::string_view value) {
+  return set(fmt::format("{}.{}", prefix, name), value);
+}
+
+bool SessionConfig::reset(std::string_view qualifiedName) {
+  // Verify property exists.
+  registry_->resolve(qualifiedName);
+  return overrides_.erase(qualifiedName) > 0;
+}
+
+std::optional<std::string> SessionConfig::effectiveValue(
+    std::string_view qualifiedName) const {
+  auto it = overrides_.find(qualifiedName);
+  if (it != overrides_.end()) {
+    return it->second;
+  }
+  auto resolved = registry_->resolve(qualifiedName);
+  return resolved.property.defaultValue;
+}
+
+folly::F14FastMap<std::string, std::string> SessionConfig::effectiveValues(
+    std::string_view prefix) const {
+  folly::F14FastMap<std::string, std::string> result;
+  for (const auto& entry : registry_->all()) {
+    if (entry.prefix != prefix) {
+      continue;
+    }
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    auto it = overrides_.find(qualifiedName);
+    if (it != overrides_.end()) {
+      result[entry.property.name] = it->second;
+    } else if (entry.property.defaultValue.has_value()) {
+      result[entry.property.name] = entry.property.defaultValue.value();
+    }
+  }
+  return result;
+}
+
+std::vector<SessionConfig::Entry> SessionConfig::all() const {
+  std::vector<Entry> result;
+  for (const auto& registryEntry : registry_->all()) {
+    auto qualifiedName =
+        registryEntry.prefix + "." + registryEntry.property.name;
+    auto it = overrides_.find(qualifiedName);
+    std::optional<std::string> currentValue;
+    if (it != overrides_.end()) {
+      currentValue = it->second;
+    } else {
+      currentValue = registryEntry.property.defaultValue;
+    }
+    result.push_back(
+        {registryEntry.prefix,
+         registryEntry.property,
+         currentValue,
+         it != overrides_.end()});
+  }
+  return result;
+}
+
+namespace {
+
+// Returns true if 'value' is a valid integer string (optional leading '-'
+// followed by one or more digits).
+bool isInteger(std::string_view value) {
+  auto start = !value.empty() && value[0] == '-' ? 1u : 0u;
+  return value.size() > start &&
+      std::all_of(value.begin() + start, value.end(), [](char c) {
+           return std::isdigit(c);
+         });
+}
+
+// Returns true if 'value' is a valid double string.
+bool isDouble(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+  auto str = std::string(value);
+  char* end = nullptr;
+  std::strtod(str.c_str(), &end);
+  return end != nullptr && *end == '\0';
+}
+
+} // namespace
+
+std::string SessionConfig::normalizeType(
+    std::string_view qualifiedName,
+    ConfigPropertyType type,
+    std::string_view value) {
+  switch (type) {
+    case ConfigPropertyType::kBoolean: {
+      auto lower = std::string(value);
+      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+      VELOX_USER_CHECK(
+          lower == "true" || lower == "false",
+          "Expected boolean value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return lower;
+    }
+    case ConfigPropertyType::kInteger:
+      VELOX_USER_CHECK(
+          isInteger(value),
+          "Expected integer value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kDouble:
+      VELOX_USER_CHECK(
+          isDouble(value),
+          "Expected double value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kString:
+      return std::string(value);
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/SessionConfig.h
+++ b/axiom/common/SessionConfig.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <folly/container/F14Map.h>
+#include "axiom/common/ConfigRegistry.h"
+
+namespace facebook::axiom {
+
+/// Per-session mutable state. Holds a reference to the shared
+/// ConfigRegistry and a map of property overrides. Reads check the
+/// override map first, then fall back to the provider's default.
+class SessionConfig {
+ public:
+  explicit SessionConfig(std::shared_ptr<const ConfigRegistry> registry);
+
+  /// Sets a property by prefix-qualified name. Validates type and
+  /// delegates to provider for domain validation. Returns true if
+  /// the value changed.
+  bool set(std::string_view qualifiedName, std::string_view value);
+
+  /// Convenience overload: set("prefix", "name", "value") is equivalent to
+  /// set("prefix.name", "value").
+  bool
+  set(std::string_view prefix, std::string_view name, std::string_view value);
+
+  /// Resets a property to its default. Returns true if the value
+  /// changed.
+  bool reset(std::string_view qualifiedName);
+
+  /// Returns effective value (override or default) for a single
+  /// property. Returns nullopt if no default and not set.
+  std::optional<std::string> effectiveValue(
+      std::string_view qualifiedName) const;
+
+  /// Returns effective values (override or default) for all properties
+  /// under a component prefix as a flat map.
+  folly::F14FastMap<std::string, std::string> effectiveValues(
+      std::string_view prefix) const;
+
+  /// A property with its current effective value for SHOW SESSION output.
+  struct Entry {
+    std::string prefix;
+
+    velox::config::ConfigProperty property;
+
+    /// Override or default value. Nullopt if no default and not set.
+    std::optional<std::string> currentValue;
+
+    /// True if the value was explicitly set to a non-default value.
+    bool isOverridden;
+  };
+
+  /// Returns all properties with current values.
+  std::vector<Entry> all() const;
+
+ private:
+  // Validates and normalizes 'value' for 'type'. Lowercases booleans,
+  // passes through integers, doubles, and strings. Throws on invalid values.
+  static std::string normalizeType(
+      std::string_view qualifiedName,
+      velox::config::ConfigPropertyType type,
+      std::string_view value);
+
+  std::shared_ptr<const ConfigRegistry> registry_;
+  folly::F14FastMap<std::string, std::string> overrides_;
+};
+
+} // namespace facebook::axiom

--- a/axiom/common/tests/CMakeLists.txt
+++ b/axiom/common/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_common_tests CatalogSchemaTableNameTest.cpp SchemaTableNameTest.cpp)
+add_executable(
+  axiom_common_tests
+  CatalogSchemaTableNameTest.cpp
+  SchemaTableNameTest.cpp
+  SessionConfigTest.cpp
+)
 
 add_test(axiom_common_tests axiom_common_tests)
 

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for ConfigRegistry and SessionConfig.
+//
+// Uses a TestConfigProvider that declares a few properties of
+// different types to exercise:
+// - Registry: add, resolve, all, duplicate prefix, unknown property
+// - SessionConfig: set, get, reset, getAll, type validation, all()
+
+#include "axiom/common/SessionConfig.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::axiom;
+using namespace facebook::velox::config;
+
+namespace {
+
+class TestConfigProvider : public ConfigProvider {
+ public:
+  std::vector<ConfigProperty> properties() const override {
+    return {
+        {"flag_a", ConfigPropertyType::kBoolean, "true", "A boolean flag."},
+        {"count", ConfigPropertyType::kInteger, "10", "An integer count."},
+        {"ratio", ConfigPropertyType::kDouble, "0.5", "A double ratio."},
+        {"label", ConfigPropertyType::kString, std::nullopt, "A string label."},
+    };
+  }
+
+  std::string normalize(std::string_view name, std::string_view value)
+      const override {
+    // Normalize label to lowercase (simulates enum-like normalization).
+    if (name == "label") {
+      auto lower = std::string(value);
+      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+      return lower;
+    }
+    return std::string(value);
+  }
+};
+
+class SessionConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto registry = std::make_shared<ConfigRegistry>();
+    registry->add("test", std::make_shared<TestConfigProvider>());
+    registry_ = registry;
+    config_ = std::make_unique<SessionConfig>(registry_);
+  }
+
+  // Finds an entry by property name in the all() result.
+  SessionConfig::Entry findEntry(std::string_view name) const {
+    auto entries = config_->all();
+    auto it = std::find_if(entries.begin(), entries.end(), [&](const auto& e) {
+      return e.property.name == name;
+    });
+    VELOX_CHECK(it != entries.end(), "Property not found: {}", name);
+    return *it;
+  }
+
+  std::shared_ptr<const ConfigRegistry> registry_;
+  std::unique_ptr<SessionConfig> config_;
+};
+
+TEST_F(SessionConfigTest, getDefault) {
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+  EXPECT_EQ(config_->effectiveValue("test.count"), "10");
+  EXPECT_EQ(config_->effectiveValue("test.ratio"), "0.5");
+  EXPECT_EQ(config_->effectiveValue("test.label"), std::nullopt);
+}
+
+TEST_F(SessionConfigTest, setAndGet) {
+  EXPECT_TRUE(config_->set("test.flag_a", "false"));
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "false");
+
+  // Setting same value returns false.
+  EXPECT_FALSE(config_->set("test.flag_a", "false"));
+}
+
+TEST_F(SessionConfigTest, resetToDefault) {
+  config_->set("test.flag_a", "false");
+  EXPECT_TRUE(config_->reset("test.flag_a"));
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+
+  // Reset when not overridden returns false.
+  EXPECT_FALSE(config_->reset("test.flag_a"));
+}
+
+TEST_F(SessionConfigTest, typeValidation) {
+  VELOX_ASSERT_THROW(
+      config_->set("test.flag_a", "banana"), "Expected boolean value");
+  VELOX_ASSERT_THROW(
+      config_->set("test.count", "abc"), "Expected integer value");
+  VELOX_ASSERT_THROW(
+      config_->set("test.ratio", "xyz"), "Expected double value");
+
+  // String accepts anything.
+  EXPECT_NO_THROW(config_->set("test.label", "anything"));
+}
+
+TEST_F(SessionConfigTest, unknownProperty) {
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("test.nonexistent"), "Unknown session property");
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("unknown.flag"),
+      "Unknown session property prefix");
+  VELOX_ASSERT_THROW(
+      config_->effectiveValue("noDotPrefix"),
+      "Session property must be prefix-qualified");
+}
+
+TEST_F(SessionConfigTest, effective) {
+  config_->set("test.flag_a", "false");
+  auto props = config_->effectiveValues("test");
+
+  EXPECT_EQ(props["flag_a"], "false"); // overridden
+  EXPECT_EQ(props["count"], "10"); // default
+  EXPECT_EQ(props["ratio"], "0.5"); // default
+  // "label" has no default, not set — absent from map.
+  EXPECT_EQ(props.find("label"), props.end());
+}
+
+TEST_F(SessionConfigTest, allEntries) {
+  config_->set("test.count", "42");
+  EXPECT_EQ(config_->all().size(), 4);
+
+  auto entry = findEntry("count");
+  EXPECT_EQ(entry.currentValue, "42");
+  EXPECT_TRUE(entry.isOverridden);
+}
+
+TEST_F(SessionConfigTest, normalize) {
+  // Boolean normalization: normalizeType lowercases booleans.
+  config_->set("test.flag_a", "FALSE");
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "false");
+
+  // Setting to the default (after normalization) clears the override.
+  config_->set("test.flag_a", "TRUE");
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+
+  // Verify the override was actually cleared, not just storing "true".
+  EXPECT_FALSE(findEntry("flag_a").isOverridden);
+
+  // Provider normalization: label is lowercased by the provider.
+  config_->set("test.label", "Hello");
+  EXPECT_EQ(config_->effectiveValue("test.label"), "hello");
+}
+
+TEST_F(SessionConfigTest, duplicatePrefix) {
+  auto registry = std::make_shared<ConfigRegistry>();
+  registry->add("test", std::make_shared<TestConfigProvider>());
+  VELOX_ASSERT_THROW(
+      registry->add("test", std::make_shared<TestConfigProvider>()),
+      "Config prefix already registered");
+}
+
+} // namespace

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
   MemoKey.cpp
   Model.cpp
   Optimization.cpp
+  OptimizerOptions.cpp
   ParallelExpr.cpp
   Plan.cpp
   PlanObject.cpp

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/OptimizerOptions.h"
+
+#include <fmt/format.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer {
+
+using velox::config::ConfigProperty;
+using velox::config::ConfigPropertyType;
+
+std::vector<ConfigProperty> OptimizerOptions::properties() const {
+  // Defaults come from field initializers on a default-constructed instance.
+  OptimizerOptions defaults;
+  return {
+      {
+          std::string(kSampleJoins),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.sampleJoins),
+          "Sample joins to determine optimal join order.",
+      },
+      {
+          std::string(kSampleFilters),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.sampleFilters),
+          "Sample filters to estimate scan selectivity.",
+      },
+      {
+          std::string(kUseFilteredTableStats),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.useFilteredTableStats),
+          "Use connector-provided table statistics for cardinality estimation.",
+      },
+      {
+          std::string(kPushdownSubfields),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.pushdownSubfields),
+          "Extract accessed subfields of complex columns in table scan.",
+      },
+      {
+          std::string(kAllMapsAsStruct),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.allMapsAsStruct),
+          "Project maps with known key subsets as structs.",
+      },
+      {
+          std::string(kSyntacticJoinOrder),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.syntacticJoinOrder),
+          "Disable cost-based join ordering; use query order.",
+      },
+      {
+          std::string(kAlwaysPlanPartialAggregation),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.alwaysPlanPartialAggregation),
+          "Always split aggregation into partial + final.",
+      },
+      {
+          std::string(kEnableReducingExistences),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.enableReducingExistences),
+          "Enable reducing semi joins.",
+      },
+      {
+          std::string(kParallelProjectWidth),
+          ConfigPropertyType::kInteger,
+          std::to_string(defaults.parallelProjectWidth),
+          "Number of threads for parallel projection. 1 disables.",
+      },
+      {
+          std::string(kTraceFlags),
+          ConfigPropertyType::kInteger,
+          std::to_string(defaults.traceFlags),
+          "Bit mask for optimizer trace output: 1=retained, 2=exceeded best, 4=sample, 8=preprocess.",
+      },
+  };
+}
+
+std::string OptimizerOptions::normalize(
+    std::string_view name,
+    std::string_view value) const {
+  if (name == kParallelProjectWidth) {
+    auto width = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        width, 1, "parallel_project_width must be >= 1: {}", value);
+  }
+  return std::string(value);
+}
+
+OptimizerOptions OptimizerOptions::from(
+    const folly::F14FastMap<std::string, std::string>& properties) {
+  // Sets 'field' from the property map if present, otherwise keeps default.
+  auto setBool = [&](std::string_view key, bool& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = it->second == "true";
+    }
+  };
+
+  auto setInt = [&](std::string_view key, int32_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = std::stoi(it->second);
+    }
+  };
+
+  OptimizerOptions options;
+  setBool(kSampleJoins, options.sampleJoins);
+  setBool(kSampleFilters, options.sampleFilters);
+  setBool(kUseFilteredTableStats, options.useFilteredTableStats);
+  setBool(kPushdownSubfields, options.pushdownSubfields);
+  setBool(kAllMapsAsStruct, options.allMapsAsStruct);
+  setBool(kSyntacticJoinOrder, options.syntacticJoinOrder);
+  setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
+  setBool(kEnableReducingExistences, options.enableReducingExistences);
+  setInt(kParallelProjectWidth, options.parallelProjectWidth);
+
+  auto setUint = [&](std::string_view key, uint32_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = static_cast<uint32_t>(std::stoul(it->second));
+    }
+  };
+  setUint(kTraceFlags, options.traceFlags);
+  return options;
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -20,19 +20,36 @@
 #include <cstdint>
 
 #include "axiom/common/SchemaTableName.h"
+#include "velox/common/config/ConfigProvider.h"
 
 namespace facebook::axiom::optimizer {
 
-struct OptimizerOptions {
+struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Bit masks for use in 'traceFlags'.
   static constexpr uint32_t kRetained = 1;
   static constexpr uint32_t kExceededBest = 2;
   static constexpr uint32_t kSample = 4;
   static constexpr uint32_t kPreprocess = 8;
 
+  static constexpr std::string_view kSampleJoins = "sample_joins";
+  static constexpr std::string_view kSampleFilters = "sample_filters";
+  static constexpr std::string_view kUseFilteredTableStats =
+      "use_filtered_table_stats";
+  static constexpr std::string_view kPushdownSubfields = "pushdown_subfields";
+  static constexpr std::string_view kAllMapsAsStruct = "all_maps_as_struct";
+  static constexpr std::string_view kSyntacticJoinOrder =
+      "syntactic_join_order";
+  static constexpr std::string_view kAlwaysPlanPartialAggregation =
+      "always_plan_partial_aggregation";
+  static constexpr std::string_view kEnableReducingExistences =
+      "enable_reducing_existences";
+  static constexpr std::string_view kParallelProjectWidth =
+      "parallel_project_width";
+  static constexpr std::string_view kTraceFlags = "trace_flags";
+
   /// Parallelizes independent projections over this many threads. 1 means no
   /// parallel projection.
-  int32_t parallelProjectWidth = 1;
+  int32_t parallelProjectWidth{1};
 
   /// Produces skyline subfield sets of complex type columns as top level
   /// columns in table scan.
@@ -42,7 +59,7 @@ struct OptimizerOptions {
   /// be projected out as structs.
   bool allMapsAsStruct{false};
 
-  /// Map from table name to  list of map columns to be read as structs unless
+  /// Map from table name to list of map columns to be read as structs unless
   /// the whole map is accessed as a map.
   folly::F14FastMap<std::string, std::vector<std::string>> mapAsStruct;
 
@@ -70,16 +87,27 @@ struct OptimizerOptions {
 
   /// Disable cost-based join order selection. Perform the joins in the exact
   /// sequence specified in the query.
-  /// TODO Make this work for non-inner joins.
-  bool syntacticJoinOrder = false;
+  /// TODO: Make this work for non-inner joins.
+  bool syntacticJoinOrder{false};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.
-  bool alwaysPlanPartialAggregation = false;
+  bool alwaysPlanPartialAggregation{false};
 
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.
   bool explain{false};
+
+  /// Constructs options from session property name-value pairs.
+  /// Keys are unqualified property names (e.g., "sample_joins").
+  /// Missing keys use struct defaults.
+  static OptimizerOptions from(
+      const folly::F14FastMap<std::string, std::string>& properties);
+
+  // ConfigProvider implementation.
+  std::vector<velox::config::ConfigProperty> properties() const override;
+  std::string normalize(std::string_view name, std::string_view value)
+      const override;
 
   bool isMapAsStruct(const SchemaTableName& tableName, std::string_view column)
       const {

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -225,7 +225,8 @@ TEST_F(AggregationTest, orderBy) {
           .build();
 
   for (auto i = 0; i < 2; ++i) {
-    OptimizerOptions option{.alwaysPlanPartialAggregation = (i == 0)};
+    OptimizerOptions option;
+    option.alwaysPlanPartialAggregation = (i == 0);
     auto plan = planVelox(
         logicalPlan,
         MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -586,6 +586,9 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     auto session = std::make_shared<Session>(queryCtx->queryId());
 
+    optimizer::OptimizerOptions optimizerOptions;
+    optimizerOptions.traceFlags = FLAGS_optimizer_trace;
+
     optimizer::Optimization optimization(
         session,
         *logicalPlan,
@@ -593,7 +596,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         *history_,
         queryCtx,
         evaluator,
-        {.traceFlags = FLAGS_optimizer_trace},
+        optimizerOptions,
         opts);
 
     if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -73,7 +73,12 @@ class CardinalityEstimationTest : public test::QueryTestBase {
 
           verifyDtConstraints(*optimization.rootDt(), *plan->op);
         },
-        OptimizerOptions{.sampleJoins = false, .sampleFilters = false});
+        [] {
+          OptimizerOptions options;
+          options.sampleJoins = false;
+          options.sampleFilters = false;
+          return options;
+        }());
   }
 
   // Verifies that the DT's column constraints match the plan's constraints.

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -97,7 +97,12 @@ class DerivedTablePrinterTest : public ::testing::Test {
         history,
         veloxQueryCtx,
         evaluator,
-        {.sampleJoins = false, .sampleFilters = false},
+        [] {
+          OptimizerOptions options;
+          options.sampleJoins = false;
+          options.sampleFilters = false;
+          return options;
+        }(),
         {.numWorkers = 1, .numDrivers = 1}};
 
     const auto dtString = DerivedTablePrinter::toText(*opt.rootDt());

--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -89,7 +89,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupBy) {
 
   // Builds a logical plan, optimizes it, and asserts it matches the expected
   // distributed plan.
-  OptimizerOptions options{.alwaysPlanPartialAggregation = true};
+  OptimizerOptions options;
+  options.alwaysPlanPartialAggregation = true;
   auto assertPlan =
       [&](const std::vector<std::string>& groupingKeys,
           const std::vector<std::string>& aggregates,

--- a/axiom/optimizer/tests/FilteredTableStatsTest.cpp
+++ b/axiom/optimizer/tests/FilteredTableStatsTest.cpp
@@ -65,7 +65,12 @@ class FilteredTableStatsTest : public test::HiveQueriesTestBase {
 
           callback(*plan);
         },
-        OptimizerOptions{.sampleJoins = false, .sampleFilters = false});
+        [] {
+          OptimizerOptions options;
+          options.sampleJoins = false;
+          options.sampleFilters = false;
+          return options;
+        }());
   }
 };
 

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -124,7 +124,12 @@ class RelationOpPrinterTest : public ::testing::Test {
         history,
         veloxQueryCtx,
         evaluator,
-        {.sampleJoins = false, .sampleFilters = false},
+        [] {
+          OptimizerOptions options;
+          options.sampleJoins = false;
+          options.sampleFilters = false;
+          return options;
+        }(),
         {.numWorkers = 1, .numDrivers = 1}};
 
     auto* plan = opt.bestPlan();

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -120,10 +120,12 @@ class SubfieldTest : public HiveQueriesTestBase,
         optimizerOptions_ = OptimizerOptions();
         break;
       case 2:
-        optimizerOptions_ = OptimizerOptions{.pushdownSubfields = true};
+        optimizerOptions_ = OptimizerOptions{};
+        optimizerOptions_.pushdownSubfields = true;
         break;
       case 3:
-        optimizerOptions_ = OptimizerOptions{.pushdownSubfields = true};
+        optimizerOptions_ = OptimizerOptions{};
+        optimizerOptions_.pushdownSubfields = true;
         optimizerOptions_.mapAsStruct["features"] = {
             "float_features", "id_list_features", "id_score_list_features"};
         break;

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -32,8 +32,12 @@ const auto& statementKindNames() {
       {SqlStatementKind::kCreateTableAsSelect, "CREATE TABLE AS SELECT"},
       {SqlStatementKind::kInsert, "INSERT"},
       {SqlStatementKind::kDropTable, "DROP TABLE"},
+      {SqlStatementKind::kCreateSchema, "CREATE SCHEMA"},
+      {SqlStatementKind::kDropSchema, "DROP SCHEMA"},
       {SqlStatementKind::kExplain, "EXPLAIN"},
       {SqlStatementKind::kShowStatsForQuery, "SHOW STATS FOR"},
+      {SqlStatementKind::kShowSession, "SHOW SESSION"},
+      {SqlStatementKind::kSetSession, "SET SESSION"},
       {SqlStatementKind::kUse, "USE"},
   };
 


### PR DESCRIPTION
Summary: OptimizerOptions implements ConfigProvider, declaring optimizer session properties (sample_joins, sample_filters, etc.) with property names and defaults defined once. Wire SET SESSION and SHOW SESSION through SessionConfig for prefix-qualified properties (e.g., optimizer.sample_joins). Add missing entries to statementKindNames map (kShowSession, kSetSession, kCreateSchema, kDropSchema).

Reviewed By: xiaoxmeng

Differential Revision: D100639563
