### PR TITLE
feat: Wire QueryConfigProvider and migrate config_ to SessionConfig (#1245)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 
 target_link_libraries(
   axiom_cli
+  velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan
   axiom_optimizer

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -17,7 +17,7 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <cmath>
-#include <map>
+
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/SchemaResolver.h"
@@ -37,6 +37,8 @@
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/core/QueryConfigProvider.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -120,12 +122,6 @@ void SqlQueryRunner::initialize(
   defaultConnectorId_ = std::move(defaultConnectorId);
   defaultSchema_ = std::move(defaultSchema);
 
-  // Set default session properties to match Presto behavior.
-  config_[velox::core::QueryConfig::kSessionTimezone] = getLocalTimezone();
-  config_[velox::core::QueryConfig::kAdjustTimestampToTimezone] = "true";
-  config_[velox::core::QueryConfig::kSessionStartTime] =
-      std::to_string(velox::getCurrentTimeMs());
-
   permissionCheck_ = std::move(permissionCheck);
 
   if (queryIdGenerator) {
@@ -139,10 +135,22 @@ void SqlQueryRunner::initialize(
 
   configRegistry_ = std::make_shared<facebook::axiom::ConfigRegistry>();
   configRegistry_->add(
-      "optimizer",
+      kOptimizerPrefix,
       std::make_shared<facebook::axiom::optimizer::OptimizerOptions>());
+  configRegistry_->add(
+      kExecutionPrefix,
+      std::make_shared<facebook::velox::core::QueryConfigProvider>());
+
   sessionConfig_ =
       std::make_shared<facebook::axiom::SessionConfig>(configRegistry_);
+  sessionConfig_->set(
+      kExecutionPrefix,
+      velox::core::QueryConfig::kSessionTimezone,
+      getLocalTimezone());
+  sessionConfig_->set(
+      kExecutionPrefix,
+      velox::core::QueryConfig::kAdjustTimestampToTimezone,
+      "true");
 }
 
 namespace {
@@ -563,11 +571,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
   if (sqlStatement.isSetSession()) {
     const auto* setSession = sqlStatement.as<presto::SetSessionStatement>();
     const auto& name = setSession->name();
-    if (name.find('.') != std::string::npos) {
-      sessionConfig_->set(name, setSession->value());
-    } else {
-      config_[name] = setSession->value();
-    }
+    sessionConfig_->set(name, setSession->value());
     return {
         .message =
             fmt::format("Session '{}' set to '{}'", name, setSession->value())};
@@ -605,9 +609,17 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   const auto queryId =
       options.queryId.value_or(fmt::format("query_{}", ++queryCounter_));
 
+  // Build Velox QueryConfig from execution session properties.
+  auto executionProps = sessionConfig_->effectiveValues(kExecutionPrefix);
+  std::unordered_map<std::string, std::string> queryConfig(
+      executionProps.begin(), executionProps.end());
+  // Per-query value, not a session property.
+  queryConfig[velox::core::QueryConfig::kSessionStartTime] = std::to_string(
+      options.sessionStartTimeMs.value_or(velox::getCurrentTimeMs()));
+
   return velox::core::QueryCtx::create(
       executor_.get(),
-      velox::core::QueryConfig(config_),
+      velox::core::QueryConfig(std::move(queryConfig)),
       {},
       velox::cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
@@ -798,7 +810,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     schemaResolver = std::make_shared<connector::SchemaResolver>();
   }
 
-  auto optimizerProps = sessionConfig_->effectiveValues("optimizer");
+  auto optimizerProps = sessionConfig_->effectiveValues(kOptimizerPrefix);
   auto optimizerOptions = optimizer::OptimizerOptions::from(optimizerProps);
   optimizerOptions.explain = explain;
 
@@ -847,24 +859,38 @@ SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
     const RunOptions& options,
     QueryTiming& timing,
     std::string& planString) {
-  std::map<std::string, std::string> sorted(config_.begin(), config_.end());
-  // Include registered session properties.
-  for (const auto& entry : sessionConfig_->all()) {
-    auto qualifiedName = entry.prefix + "." + entry.property.name;
-    sorted[qualifiedName] = entry.currentValue.value_or("");
-  }
+  using facebook::velox::config::ConfigPropertyTypeName;
+
+  // Collect and sort entries by qualified name.
+  auto entries = sessionConfig_->all();
+  std::sort(
+      entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.prefix, lhs.property.name) <
+            std::tie(rhs.prefix, rhs.property.name);
+      });
 
   std::vector<velox::Variant> data;
-  data.reserve(sorted.size());
-  for (const auto& [key, value] : sorted) {
-    data.emplace_back(velox::Variant::row({key, value}));
+  data.reserve(entries.size());
+  for (const auto& entry : entries) {
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    data.emplace_back(
+        velox::Variant::row({
+            qualifiedName,
+            entry.currentValue.value_or(""),
+            entry.property.defaultValue.value_or(""),
+            std::string(ConfigPropertyTypeName::toName(entry.property.type)),
+            entry.property.description,
+        }));
   }
 
   namespace lp = facebook::axiom::logical_plan;
 
   lp::PlanBuilder::Context context(defaultConnectorId_);
   lp::PlanBuilder builder(context);
-  builder.values(ROW({"Name", "Value"}, velox::VARCHAR()), std::move(data));
+  builder.values(
+      ROW({"Name", "Value", "Default", "Type", "Description"},
+          velox::VARCHAR()),
+      std::move(data));
 
   if (statement.likePattern().has_value()) {
     builder.filter(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -99,6 +99,13 @@ using QueryCompletionCallback = std::function<void(const QueryCompletionInfo&)>;
 /// Executes SQL queries.
 class SqlQueryRunner {
  public:
+  /// Prefix for optimizer session properties (e.g., "optimizer.sample_joins").
+  static constexpr const char* kOptimizerPrefix = "optimizer";
+
+  /// Prefix for Velox execution session properties (e.g.,
+  /// "execution.session_timezone").
+  static constexpr const char* kExecutionPrefix = "execution";
+
   virtual ~SqlQueryRunner() = default;
 
   /// Initializes the runner with connectors, an optional permission check, and
@@ -130,6 +137,10 @@ class SqlQueryRunner {
     /// Used by runUnchecked() as-is. Overwritten by run() with the result of
     /// the permission check callback.
     std::shared_ptr<facebook::velox::filesystems::TokenProvider> tokenProvider;
+
+    /// Override for session start time (milliseconds since epoch). If not
+    /// set, uses the current time. Used by tests to verify current_timestamp.
+    std::optional<uint64_t> sessionStartTimeMs;
 
     /// If true, EXPLAIN ANALYZE output includes custom operator stats.
     bool debugMode{false};
@@ -204,8 +215,9 @@ class SqlQueryRunner {
   /// @param sql A single SELECT or EXPLAIN SELECT statement.
   std::string toLogicalPlanDot(std::string_view sql);
 
-  std::unordered_map<std::string, std::string>& sessionConfig() {
-    return config_;
+  /// Returns the session configuration.
+  facebook::axiom::SessionConfig& sessionConfig() {
+    return *sessionConfig_;
   }
 
   facebook::axiom::connector::TablePtr createTable(
@@ -340,7 +352,6 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::velox::memory::MemoryPool> optimizerPool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> executorPool_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
-  std::unordered_map<std::string, std::string> config_;
   std::shared_ptr<facebook::axiom::ConfigRegistry> configRegistry_;
   std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -268,13 +268,13 @@ $ $CLI --query "SELECT from_base64('aGVsbG8=') as bin" 2>/dev/null
 ## SET SESSION and SHOW SESSION
 
 ```scrut
-$ $CLI --query "SET SESSION session_timezone = 'UTC'; SHOW SESSION LIKE '%timezone%'" 2>/dev/null
-Session 'session_timezone' set to 'UTC'
-*-+-* (glob)
-Name*| Value (glob)
-*-+-* (glob)
-adjust_timestamp_to_session_timezone | true
-session_timezone                     | UTC
+$ $CLI --query "SET SESSION execution.session_timezone = 'UTC'; SHOW SESSION LIKE '%timezone%'" 2>/dev/null
+Session 'execution.session_timezone' set to 'UTC'
+*-+-*-+-*-+-* (glob)
+Name*| Value*| Default*| Type*| Description (glob)
+*-+-*-+-*-+-* (glob)
+execution.adjust_timestamp_to_session_timezone*| true*| false*| BOOLEAN*| * (glob)
+execution.session_timezone*| UTC*|*| STRING*| * (glob)
 (2 rows in 1 batches)
 
 ```

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -84,8 +84,10 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     return runner_->run(sql, {});
   }
 
-  RowVectorPtr fetchSingleRow(std::string_view sql) {
-    auto result = run(sql);
+  RowVectorPtr fetchSingleRow(
+      std::string_view sql,
+      const SqlQueryRunner::RunOptions& options = {}) {
+    auto result = runner_->run(sql, options);
     VELOX_CHECK(
         !result.message.has_value(), "Query failed: {}", *result.message);
     VELOX_CHECK_EQ(1, result.results.size());
@@ -715,14 +717,13 @@ TEST_F(SqlQueryRunnerTest, createTableInNonExistentSchema) {
 
 // Verifies that current_timestamp returns the session start time.
 TEST_F(SqlQueryRunnerTest, currentTimestamp) {
-  auto row = fetchSingleRow("SELECT current_timestamp");
+  SqlQueryRunner::RunOptions options;
+  options.sessionStartTimeMs = facebook::velox::getCurrentTimeMs();
 
+  auto row = fetchSingleRow("SELECT current_timestamp", options);
   auto packed = row->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
   auto millis = unpackMillisUtc(packed);
-
-  auto expected = facebook::velox::core::QueryConfig{runner_->sessionConfig()}
-                      .sessionStartTimeMs();
-  EXPECT_EQ(millis, expected);
+  EXPECT_EQ(millis, options.sessionStartTimeMs);
 }
 
 TEST_F(SqlQueryRunnerTest, explainFormatGraphviz) {


### PR DESCRIPTION
Summary:

Register Velox QueryConfigProvider under "execution" prefix, replacing the flat config_ map. Set Presto-specific defaults (session_timezone, adjust_timestamp_to_session_timezone) at startup. All QueryConfig properties are now available as session properties. Per-query values (kSessionStartTime) are injected separately in newQuery().

SHOW SESSION now displays Name, Value, Default, Type, and Description columns.

Users now use prefix-qualified names:
  SET SESSION execution.session_timezone = 'UTC'
  SET SESSION optimizer.sample_joins = false
  SHOW SESSION
  SHOW SESSION LIKE 'optimizer%'

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D100657264
