### PR TITLE
fix: Support lambda arguments in aggregate and window function resolution (#1246)

### DIFF
--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -849,59 +849,89 @@ ExprPtr ExprResolver::resolveScalarTypes(
   VELOX_NYI("Can't resolve {}", expr->toString());
 }
 
-namespace {
-
-// Resolves function call arguments to typed expressions and determines the
-// return type using the provided resolve functions.
-struct ResolvedCall {
-  std::string name;
-  std::vector<ExprPtr> inputs;
-  velox::TypePtr type;
-};
-
-using ResolveFunc =
-    velox::TypePtr (*)(const std::string&, const std::vector<velox::TypePtr>&);
-
-using ResolveWithCoercionsFunc = velox::TypePtr (*)(
-    const std::string&,
-    const std::vector<velox::TypePtr>&,
-    std::vector<velox::TypePtr>&);
-
-ResolvedCall resolveCallTypes(
+ExprResolver::ResolvedCall ExprResolver::resolveCallTypes(
     const velox::core::ExprPtr& expr,
-    const ExprResolver::InputNameResolver& inputNameResolver,
-    const ExprResolver& resolver,
-    bool enableCoercions,
+    const InputNameResolver& inputNameResolver,
     const char* label,
     ResolveFunc resolveFunc,
-    ResolveWithCoercionsFunc resolveWithCoercionsFunc) {
+    ResolveWithCoercionsFunc resolveWithCoercionsFunc) const {
   const auto* call = dynamic_cast<const velox::core::CallExpr*>(expr.get());
   VELOX_USER_CHECK_NOT_NULL(
       call, "{} must be a call expression: {}", label, expr->toString());
 
   auto name = velox::exec::sanitizeName(call->name());
 
+  // Find the matching lambda signature if any arguments are lambdas.
+  const velox::exec::FunctionSignature* lambdaSignature{nullptr};
+  if (std::ranges::any_of(call->inputs(), [](const auto& input) {
+        return input->is(velox::core::IExpr::Kind::kLambda);
+      })) {
+    auto callExpr = std::static_pointer_cast<const velox::core::CallExpr>(expr);
+    lambdaSignature = findLambdaSignature(callExpr);
+    VELOX_CHECK_NOT_NULL(
+        lambdaSignature,
+        "Cannot resolve {} with lambda arguments: {}",
+        label,
+        call->toString());
+  }
+
+  // Resolve arguments.
+  const auto numArgs = call->inputs().size();
   std::vector<ExprPtr> inputs;
-  inputs.reserve(expr->inputs().size());
-  for (const auto& input : expr->inputs()) {
-    inputs.push_back(resolver.resolveScalarTypes(input, inputNameResolver));
-  }
-
-  auto inputTypes = toTypes(inputs);
-
-  velox::TypePtr type;
-  if (enableCoercions) {
-    std::vector<velox::TypePtr> coercions;
-    type = resolveWithCoercionsFunc(name, inputTypes, coercions);
-    applyCoercions(inputs, coercions);
+  if (lambdaSignature == nullptr) {
+    inputs.reserve(numArgs);
+    for (const auto& input : call->inputs()) {
+      inputs.push_back(resolveScalarTypes(input, inputNameResolver));
+    }
   } else {
-    type = resolveFunc(name, inputTypes);
+    // Resolve non-lambda arguments first, then infer lambda parameter types
+    // from the function signature.
+    inputs.resize(numArgs);
+    for (size_t i = 0; i < numArgs; ++i) {
+      if (!isLambdaArgument(lambdaSignature->argumentTypes()[i])) {
+        inputs[i] = resolveScalarTypes(call->inputAt(i), inputNameResolver);
+      }
+    }
+    VELOX_CHECK(
+        resolveLambdaArguments(
+            call->inputs(), *lambdaSignature, inputs, inputNameResolver),
+        "Cannot resolve lambda arguments for {}",
+        call->toString());
   }
 
-  return {std::move(name), std::move(inputs), type};
-}
+  // Resolve return type.
+  if (!enableCoercions_) {
+    auto returnType = resolveFunc(name, toTypes(inputs));
+    return {std::move(name), std::move(inputs), returnType};
+  }
+  // Apply implicit type widening. For lambda-bearing calls, null out lambda
+  // coercions (lambdas can't be cast) and re-resolve lambdas if non-lambda
+  // inputs were coerced.
+  std::vector<velox::TypePtr> coercions;
+  auto returnType = resolveWithCoercionsFunc(name, toTypes(inputs), coercions);
+  bool reResolveLambdas = false;
+  if (lambdaSignature != nullptr && !coercions.empty()) {
+    for (size_t i = 0; i < numArgs; ++i) {
+      if (isLambdaArgument(lambdaSignature->argumentTypes()[i])) {
+        coercions[i] = nullptr;
+      } else if (coercions[i] != nullptr) {
+        reResolveLambdas = true;
+      }
+    }
+  }
+  applyCoercions(inputs, coercions);
 
-} // namespace
+  if (reResolveLambdas) {
+    VELOX_CHECK(
+        resolveLambdaArguments(
+            call->inputs(), *lambdaSignature, inputs, inputNameResolver),
+        "Cannot re-resolve lambda arguments after coercion for {}",
+        call->toString());
+    returnType = resolveFunc(name, toTypes(inputs));
+  }
+
+  return {std::move(name), std::move(inputs), returnType};
+}
 
 AggregateExprPtr ExprResolver::resolveAggregateTypes(
     const velox::core::ExprPtr& expr,
@@ -912,8 +942,6 @@ AggregateExprPtr ExprResolver::resolveAggregateTypes(
   auto resolved = resolveCallTypes(
       expr,
       inputNameResolver,
-      *this,
-      enableCoercions_,
       "Aggregate",
       velox::exec::resolveResultType,
       velox::exec::resolveResultTypeWithCoercions);
@@ -985,8 +1013,6 @@ WindowExprPtr ExprResolver::resolveWindowTypes(
   auto resolved = resolveCallTypes(
       callExpr,
       inputNameResolver,
-      *this,
-      enableCoercions_,
       "Window function",
       velox::exec::resolveWindowResultType,
       velox::exec::resolveWindowResultTypeWithCoercions);

--- a/axiom/logical_plan/ExprResolver.h
+++ b/axiom/logical_plan/ExprResolver.h
@@ -91,6 +91,31 @@ class ExprResolver {
       const InputNameResolver& inputNameResolver) const;
 
  private:
+  using ResolveFunc = velox::TypePtr (*)(
+      const std::string&,
+      const std::vector<velox::TypePtr>&);
+
+  using ResolveWithCoercionsFunc = velox::TypePtr (*)(
+      const std::string&,
+      const std::vector<velox::TypePtr>&,
+      std::vector<velox::TypePtr>&);
+
+  struct ResolvedCall {
+    std::string name;
+    std::vector<ExprPtr> inputs;
+    velox::TypePtr type;
+  };
+
+  // Resolves function call arguments (including lambdas) and determines the
+  // return type using the provided resolve functions. Used by both
+  // resolveAggregateTypes and resolveWindowTypes.
+  ResolvedCall resolveCallTypes(
+      const velox::core::ExprPtr& expr,
+      const InputNameResolver& inputNameResolver,
+      const char* label,
+      ResolveFunc resolveFunc,
+      ResolveWithCoercionsFunc resolveWithCoercionsFunc) const;
+
   ExprPtr resolveLambdaExpr(
       const velox::core::LambdaExpr& lambdaExpr,
       const std::vector<velox::TypePtr>& lambdaInputTypes,

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -69,14 +69,14 @@ TEST_F(ExprTest, looksConstant) {
 
 TEST_F(ExprTest, aggregateExprDistinctOrderBy) {
   auto makeAggregate =
-      [this](const ExprApi& expr, std::vector<SortKey> ordering = {}) {
+      [this](const ExprApi& expr, const std::vector<SortKey>& ordering = {}) {
         return ExprResolver(nullptr, false)
             .resolveAggregateTypes(
                 expr.expr(), inputResolver(schema_), nullptr, ordering, false);
       };
 
   auto makeDistinctAggregate =
-      [this](const ExprApi& expr, std::vector<SortKey> ordering = {}) {
+      [this](const ExprApi& expr, const std::vector<SortKey>& ordering = {}) {
         return ExprResolver(nullptr, false)
             .resolveAggregateTypes(
                 expr.expr(), inputResolver(schema_), nullptr, ordering, true);
@@ -124,6 +124,104 @@ TEST_F(ExprTest, aggregateExprDistinctOrderBy) {
           {SortKey(Col("x"), ASC_NULLS_FIRST),
            SortKey(Col("y"), ASC_NULLS_FIRST)}),
       "For DISTINCT aggregations, ORDER BY keys must appear in aggregation arguments");
+}
+
+TEST_F(ExprTest, aggregateWithLambda) {
+  auto makeAggregate = [this](const ExprApi& expr) {
+    return ExprResolver(nullptr, false)
+        .resolveAggregateTypes(
+            expr.expr(), inputResolver(schema_), nullptr, {}, false);
+  };
+
+  // reduce_agg(x, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2).
+  auto reduceAgg = makeAggregate(Call(
+      "reduce_agg",
+      Col("x"),
+      Lit(0LL),
+      Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))),
+      Lambda({"s1", "s2"}, Call("plus", Col("s1"), Col("s2")))));
+
+  EXPECT_EQ(*reduceAgg->type(), *BIGINT());
+  EXPECT_EQ(reduceAgg->inputs().size(), 4);
+  EXPECT_TRUE(reduceAgg->inputAt(2)->isLambda());
+  EXPECT_TRUE(reduceAgg->inputAt(3)->isLambda());
+}
+
+TEST_F(ExprTest, aggregateWithLambdaEquality) {
+  auto makeAggregate = [this](const ExprApi& expr) {
+    return ExprResolver(nullptr, false)
+        .resolveAggregateTypes(
+            expr.expr(), inputResolver(schema_), nullptr, {}, false);
+  };
+
+  auto reduceAgg = makeAggregate(Call(
+      "reduce_agg",
+      Col("x"),
+      Lit(0LL),
+      Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))),
+      Lambda({"s1", "s2"}, Call("plus", Col("s1"), Col("s2")))));
+
+  auto reduceAggCopy = makeAggregate(Call(
+      "reduce_agg",
+      Col("x"),
+      Lit(0LL),
+      Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))),
+      Lambda({"s1", "s2"}, Call("plus", Col("s1"), Col("s2")))));
+
+  EXPECT_EQ(*reduceAgg, *reduceAggCopy);
+
+  // Different lambda body.
+  auto reduceAggDifferent = makeAggregate(Call(
+      "reduce_agg",
+      Col("x"),
+      Lit(0LL),
+      Lambda({"s", "x"}, Call("minus", Col("s"), Col("x"))),
+      Lambda({"s1", "s2"}, Call("plus", Col("s1"), Col("s2")))));
+
+  EXPECT_NE(*reduceAgg, *reduceAggDifferent);
+}
+
+TEST_F(ExprTest, aggregateWithLambdaCoercion) {
+  auto schema = ROW({"a", "b"}, {BIGINT(), SMALLINT()});
+
+  auto makeAggregate = [&](const ExprApi& expr) {
+    return ExprResolver(nullptr, true)
+        .resolveAggregateTypes(
+            expr.expr(), inputResolver(schema), nullptr, {}, false);
+  };
+
+  // reduce_agg with coercions enabled and mixed types (SMALLINT input,
+  // BIGINT initial state). Since reduce_agg has independent type variables
+  // (T, S), no inter-argument coercion is needed. This exercises the
+  // coercion-enabled code path but not the lambda re-resolution sub-path
+  // (no known aggregate function with lambdas currently triggers it).
+  auto reduceAgg = makeAggregate(Call(
+      "reduce_agg",
+      Col("b"),
+      Lit(0LL),
+      Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))),
+      Lambda({"s1", "s2"}, Call("plus", Col("s1"), Col("s2")))));
+
+  EXPECT_EQ(*reduceAgg->type(), *BIGINT());
+  EXPECT_EQ(reduceAgg->inputs().size(), 4);
+  EXPECT_EQ(*reduceAgg->inputAt(0)->type(), *SMALLINT());
+  EXPECT_TRUE(reduceAgg->inputAt(2)->isLambda());
+  EXPECT_TRUE(reduceAgg->inputAt(3)->isLambda());
+}
+
+TEST_F(ExprTest, aggregateWithLambdaUnknownFunction) {
+  auto makeAggregate = [this](const ExprApi& expr) {
+    return ExprResolver(nullptr, false)
+        .resolveAggregateTypes(
+            expr.expr(), inputResolver(schema_), nullptr, {}, false);
+  };
+
+  VELOX_ASSERT_THROW(
+      makeAggregate(Call(
+          "nonexistent_agg",
+          Col("x"),
+          Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))))),
+      "Cannot resolve Aggregate with lambda arguments: nonexistent_agg");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Axiom's `ExprResolver::resolveCallTypes` resolves each function argument individually via `resolveScalarTypes`, which fails on bare `LambdaExpr` nodes that need parent function context to infer parameter types. This causes `VELOX_NYI("Can't resolve ...")` errors for aggregate functions like `reduce_agg` that take lambda arguments.

Add lambda detection to `resolveCallTypes` (shared by both aggregate and window resolution paths). When lambda arguments are present, find the matching function signature, resolve non-lambda arguments first, then resolve lambdas via `resolveLambdaArguments` with proper type inference from `SignatureBinder`. Handles coercion re-resolution when non-lambda inputs are coerced. Refactor `resolveCallTypes` from a free function in the anonymous namespace to a private method of `ExprResolver`, keeping `resolveLambdaArguments` private.

Reviewed By: natashasehgal

Differential Revision: D99525864
