### PR TITLE
feat: Add missing statement kind names for schema and session operations (#1247)

### DIFF
--- a/axiom/connectors/system/CMakeLists.txt
+++ b/axiom/connectors/system/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   axiom_connectors
   velox_connector
   velox_exception
+  velox_serialization
   velox_vector
 )
 

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -87,8 +87,31 @@ SystemTableHandle::SystemTableHandle(
     std::vector<velox::connector::ColumnHandlePtr> columnHandles)
     : ConnectorTableHandle(connectorId),
       name_(layout.table().name().toString()),
-      layout_(layout),
+      layout_(&layout),
       columnHandles_(std::move(columnHandles)) {}
+
+SystemTableHandle::SystemTableHandle(
+    const std::string& connectorId,
+    std::string tableName,
+    std::vector<velox::connector::ColumnHandlePtr> columnHandles)
+    : ConnectorTableHandle(connectorId),
+      name_(std::move(tableName)),
+      layout_(nullptr),
+      columnHandles_(std::move(columnHandles)) {}
+
+velox::connector::ConnectorTableHandlePtr SystemTableHandle::create(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  auto connectorId = obj["connectorId"].asString();
+  auto tableName = obj["tableName"].asString();
+  std::vector<velox::connector::ColumnHandlePtr> handles;
+  for (const auto& handleObj : obj["columnHandles"]) {
+    handles.push_back(
+        velox::ISerializable::deserialize<SystemColumnHandle>(handleObj));
+  }
+  return std::make_shared<SystemTableHandle>(
+      connectorId, std::move(tableName), std::move(handles));
+}
 
 // ===================== SystemDataSource =====================
 

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -84,17 +84,40 @@ class SystemColumnHandle : public velox::connector::ColumnHandle {
     return name_;
   }
 
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = SystemColumnHandle::getClassName();
+    obj["columnName"] = name_;
+    return obj;
+  }
+
+  static std::shared_ptr<SystemColumnHandle> create(const folly::dynamic& obj) {
+    return std::make_shared<SystemColumnHandle>(obj["columnName"].asString());
+  }
+
+  static void registerSerDe() {
+    velox::registerDeserializer<SystemColumnHandle>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SystemColumnHandle)
+
  private:
   const std::string name_;
 };
 
-/// Table handle for the system connector. References the layout
-/// and holds the set of column handles for the query.
+/// Table handle for the system connector. Holds a reference to the layout
+/// and the set of column handles for the query.
 class SystemTableHandle : public velox::connector::ConnectorTableHandle {
  public:
   SystemTableHandle(
       const std::string& connectorId,
       const TableLayout& layout,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles);
+
+  /// Constructor for deserialization. Does not require a layout reference.
+  SystemTableHandle(
+      const std::string& connectorId,
+      std::string tableName,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles);
 
   const std::string& name() const override {
@@ -105,7 +128,7 @@ class SystemTableHandle : public velox::connector::ConnectorTableHandle {
     return name();
   }
 
-  const TableLayout& layout() const {
+  const TableLayout* layout() const {
     return layout_;
   }
 
@@ -113,9 +136,32 @@ class SystemTableHandle : public velox::connector::ConnectorTableHandle {
     return columnHandles_;
   }
 
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = SystemTableHandle::getClassName();
+    obj["connectorId"] = connectorId();
+    obj["tableName"] = name_;
+    folly::dynamic handles = folly::dynamic::array;
+    for (const auto& handle : columnHandles_) {
+      handles.push_back(handle->serialize());
+    }
+    obj["columnHandles"] = handles;
+    return obj;
+  }
+
+  static velox::connector::ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe() {
+    velox::registerDeserializerWithContext<SystemTableHandle>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SystemTableHandle)
+
  private:
   const std::string name_;
-  const TableLayout& layout_;
+  const TableLayout* layout_;
   const std::vector<velox::connector::ColumnHandlePtr> columnHandles_;
 };
 
@@ -124,6 +170,23 @@ class SystemTableHandle : public velox::connector::ConnectorTableHandle {
 struct SystemSplit : public velox::connector::ConnectorSplit {
   explicit SystemSplit(const std::string& connectorId)
       : ConnectorSplit(connectorId) {}
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = SystemSplit::getClassName();
+    obj["connectorId"] = connectorId;
+    return obj;
+  }
+
+  static std::shared_ptr<SystemSplit> create(const folly::dynamic& obj) {
+    return std::make_shared<SystemSplit>(obj["connectorId"].asString());
+  }
+
+  static void registerSerDe() {
+    velox::registerDeserializer<SystemSplit>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SystemSplit)
 };
 
 /// DataSource that reads live query state from a QueryInfoProvider.
@@ -201,6 +264,13 @@ class SystemConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx*,
       velox::connector::CommitStrategy) override {
     VELOX_UNSUPPORTED("SystemConnector does not support writes");
+  }
+
+  /// Registers deserialization functions for all system connector types.
+  static void registerSerDe() {
+    SystemTableHandle::registerSerDe();
+    SystemColumnHandle::registerSerDe();
+    SystemSplit::registerSerDe();
   }
 
  private:

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_system_connector_metadata_test SystemConnectorMetadataTest.cpp)
+add_executable(
+  axiom_system_connector_test
+  SystemConnectorMetadataTest.cpp
+  SystemConnectorSerDeTest.cpp
+)
 
-add_test(axiom_system_connector_metadata_test axiom_system_connector_metadata_test)
+add_test(axiom_system_connector_test axiom_system_connector_test)
 
 target_link_libraries(
-  axiom_system_connector_metadata_test
+  axiom_system_connector_test
   axiom_system_connector
   axiom_connectors
   velox_connector

--- a/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
@@ -1,0 +1,82 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include "axiom/connectors/system/SystemConnector.h"
+
+namespace facebook::axiom::connector::system {
+namespace {
+
+class SystemConnectorSerDeTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  SystemConnectorSerDeTest() {
+    SystemConnector::registerSerDe();
+  }
+
+  static void testSerde(const SystemColumnHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone = velox::ISerializable::deserialize<SystemColumnHandle>(obj);
+    ASSERT_EQ(handle.name(), clone->name());
+  }
+
+  static void testSerde(const SystemTableHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone =
+        velox::ISerializable::deserialize<SystemTableHandle>(obj, nullptr);
+    ASSERT_EQ(handle.connectorId(), clone->connectorId());
+    ASSERT_EQ(handle.name(), clone->name());
+    ASSERT_EQ(handle.columnHandles().size(), clone->columnHandles().size());
+    for (size_t i = 0; i < handle.columnHandles().size(); ++i) {
+      auto* original = dynamic_cast<const SystemColumnHandle*>(
+          handle.columnHandles()[i].get());
+      auto* cloned = dynamic_cast<const SystemColumnHandle*>(
+          clone->columnHandles()[i].get());
+      ASSERT_NE(original, nullptr);
+      ASSERT_NE(cloned, nullptr);
+      ASSERT_EQ(original->name(), cloned->name());
+    }
+    // Deserialized handle should have null layout.
+    ASSERT_EQ(clone->layout(), nullptr);
+  }
+
+  static void testSerde(const SystemSplit& split) {
+    auto obj = split.serialize();
+    auto clone = velox::ISerializable::deserialize<SystemSplit>(obj);
+    ASSERT_EQ(split.connectorId, clone->connectorId);
+  }
+};
+
+TEST_F(SystemConnectorSerDeTest, columnHandle) {
+  testSerde(SystemColumnHandle("query_id"));
+  testSerde(SystemColumnHandle("state"));
+  testSerde(SystemColumnHandle(""));
+}
+
+TEST_F(SystemConnectorSerDeTest, tableHandle) {
+  const std::string connectorId = "system";
+
+  // No column handles.
+  auto handle1 = SystemTableHandle(connectorId, "queries", {});
+  testSerde(handle1);
+
+  // With column handles.
+  std::vector<velox::connector::ColumnHandlePtr> columns = {
+      std::make_shared<SystemColumnHandle>("query_id"),
+      std::make_shared<SystemColumnHandle>("state"),
+      std::make_shared<SystemColumnHandle>("user"),
+  };
+  auto handle2 = SystemTableHandle(connectorId, "queries", std::move(columns));
+  testSerde(handle2);
+}
+
+TEST_F(SystemConnectorSerDeTest, connectorSplit) {
+  testSerde(SystemSplit("system"));
+  testSerde(SystemSplit("other"));
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::system

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -32,8 +32,12 @@ const auto& statementKindNames() {
       {SqlStatementKind::kCreateTableAsSelect, "CREATE TABLE AS SELECT"},
       {SqlStatementKind::kInsert, "INSERT"},
       {SqlStatementKind::kDropTable, "DROP TABLE"},
+      {SqlStatementKind::kCreateSchema, "CREATE SCHEMA"},
+      {SqlStatementKind::kDropSchema, "DROP SCHEMA"},
       {SqlStatementKind::kExplain, "EXPLAIN"},
       {SqlStatementKind::kShowStatsForQuery, "SHOW STATS FOR"},
+      {SqlStatementKind::kShowSession, "SHOW SESSION"},
+      {SqlStatementKind::kSetSession, "SET SESSION"},
       {SqlStatementKind::kUse, "USE"},
   };
 


### PR DESCRIPTION
Summary:

CONTEXT: SqlStatement::statementKindNames() was missing entries for kCreateSchema, kDropSchema, kShowSession, and kSetSession, which would cause name lookup failures for these statement types.

WHAT: Add the four missing SqlStatementKind-to-name mappings.

Differential Revision: D100684177


