### PR TITLE
fix(cli): Fix ioExecutor initialization bug in Connectors (#1248)

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -62,14 +62,19 @@ Connectors::~Connectors() {
   }
 }
 
+// static
+std::shared_ptr<folly::IOThreadPoolExecutor> Connectors::getSharedIoExecutor() {
+  static auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
+      folly::available_concurrency(),
+      std::make_shared<folly::NamedThreadFactory>("io"));
+  return executor;
+}
+
 void Connectors::initialize() {
   static folly::once_flag kInitialized;
-  folly::call_once(kInitialized, [this]() {
-    initializeFileFormats();
-    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
-        folly::available_concurrency(),
-        std::make_shared<folly::NamedThreadFactory>("io"));
-  });
+  folly::call_once(kInitialized, []() { initializeFileFormats(); });
+  // Every instance gets a shared_ptr to the singleton executor.
+  ioExecutor_ = getSharedIoExecutor();
 }
 
 std::shared_ptr<velox::connector::Connector> Connectors::registerTpchConnector(

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -91,7 +91,8 @@ class Connectors {
   std::vector<std::string> connectorIds_{};
 
  private:
-  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  static std::shared_ptr<folly::IOThreadPoolExecutor> getSharedIoExecutor();
+  std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
 };
 
 } // namespace facebook::axiom


### PR DESCRIPTION
Summary:

Connectors::initialize() used a static folly::once_flag with a lambda capturing `this`, meaning only the first Connectors instance ever had its ioExecutor_ set. If that instance was destroyed, connectors registered with it still referenced the dead executor — a use-after-free bug.

Fix by making ioExecutor a shared singleton: a function-local static shared_ptr<IOThreadPoolExecutor> that all Connectors instances share. The executor lives as long as any instance holds a reference. The static once_flag is retained only for initializeFileFormats().

Reviewed By: mbasmanova

Differential Revision: D100689252


