### PR TITLE
feat(connectors): Add ScopedRegistry-based scoped metadata registry to ConnectorMetadata (#1249)

### DIFF
--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+
+target_link_libraries(
+  axiom_connectors
+  axiom_common
+  velox_common_base
+  velox_memory
+  velox_connector
+  velox_core
+  Folly::folly
+)
+
 add_subdirectory(system)
 
 if(VELOX_ENABLE_HIVE_CONNECTOR)
@@ -25,14 +37,3 @@ endif()
 if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
-
-add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp)
-
-target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  Folly::folly
-)

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -16,7 +16,7 @@
 
 #include "axiom/connectors/ConnectorMetadata.h"
 
-#include "folly/Synchronized.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 
 namespace facebook::axiom::connector {
 namespace {
@@ -181,28 +181,12 @@ TableLayout::findColumn(std::string_view name) const {
   return nullptr;
 }
 
-namespace {
-
-using MetadataMap = folly::Synchronized<
-    folly::F14FastMap<std::string, std::shared_ptr<ConnectorMetadata>>>;
-
-MetadataMap& metadataRegistry() {
-  static MetadataMap kRegistry;
-  return kRegistry;
-}
-} // namespace
-
 // static
 ConnectorMetadata* FOLLY_NULLABLE
 ConnectorMetadata::tryMetadata(std::string_view connectorId) {
-  return metadataRegistry().withRLock(
-      [&](const auto& registry) -> ConnectorMetadata* {
-        auto it = registry.find(connectorId);
-        if (it != registry.end()) {
-          return it->second.get();
-        }
-        return nullptr;
-      });
+  auto metadata =
+      ConnectorMetadataRegistry::global().find(std::string(connectorId));
+  return metadata == nullptr ? nullptr : metadata.get();
 }
 
 // static
@@ -219,41 +203,31 @@ void ConnectorMetadata::registerMetadata(
     std::shared_ptr<ConnectorMetadata> metadata) {
   VELOX_CHECK_NOT_NULL(metadata);
   VELOX_CHECK(!connectorId.empty());
-  metadataRegistry().withWLock([&](auto& registry) {
-    registry.emplace(connectorId, std::move(metadata));
-  });
+  if (!ConnectorMetadataRegistry::global().find(std::string(connectorId))) {
+    ConnectorMetadataRegistry::global().insert(
+        std::string(connectorId), std::move(metadata));
+  }
 }
 
 // static
 void ConnectorMetadata::unregisterMetadata(std::string_view connectorId) {
-  metadataRegistry().withWLock(
-      [&](auto& registry) { registry.erase(connectorId); });
+  ConnectorMetadataRegistry::global().erase(std::string(connectorId));
 }
 
 // static
 void ConnectorMetadata::unregisterAllMetadata() {
-  // Move entries out of the registry under the lock, then destroy them
-  // outside the lock to avoid holding it during potentially slow destructors.
-  std::vector<std::shared_ptr<ConnectorMetadata>> entries;
-  metadataRegistry().withWLock([&](auto& registry) {
-    entries.reserve(registry.size());
-    for (auto& [_, metadata] : registry) {
-      entries.push_back(std::move(metadata));
-    }
-    registry.clear();
-  });
+  ConnectorMetadataRegistry::global().clear();
 }
 
 // static
 std::vector<std::string> ConnectorMetadata::allMetadataIds() {
-  return metadataRegistry().withRLock([](const auto& registry) {
-    std::vector<std::string> ids;
-    ids.reserve(registry.size());
-    for (const auto& [id, _] : registry) {
-      ids.emplace_back(id);
-    }
-    return ids;
-  });
+  auto entries = ConnectorMetadataRegistry::global().snapshot();
+  std::vector<std::string> ids;
+  ids.reserve(entries.size());
+  for (auto&& [id, _] : entries) {
+    ids.emplace_back(id);
+  }
+  return ids;
 }
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -21,7 +21,6 @@
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
-#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/Connector.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
@@ -786,25 +785,34 @@ using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 class ConnectorMetadata {
  public:
   /// Return the metadata for a given connector ID. Throws if not registered.
+  [[deprecated("Use ConnectorMetadataRegistry::tryGet() instead.")]]
   static ConnectorMetadata* metadata(std::string_view connectorId);
 
   /// Return the metadata for a given connector ID, or nullptr if not
   /// registered.
+  [[deprecated("Use ConnectorMetadataRegistry::tryGet() instead.")]]
   static ConnectorMetadata* FOLLY_NULLABLE
   tryMetadata(std::string_view connectorId);
 
   /// Register metadata for a connector ID.
+  ///
+  /// NOT THREADSAFE: If two processes register the same connector ID, one may
+  /// raise a VeloxError.
+  [[deprecated("Use ConnectorMetadataRegistry::global().insert() instead.")]]
   static void registerMetadata(
       std::string_view connectorId,
       std::shared_ptr<ConnectorMetadata> metadata);
 
   /// Unregister metadata for a connector ID.
+  [[deprecated("Use ConnectorMetadataRegistry::global().erase() instead.")]]
   static void unregisterMetadata(std::string_view connectorId);
 
   /// Unregister all metadata.
+  [[deprecated("Use ConnectorMetadataRegistry::global().clear() instead.")]]
   static void unregisterAllMetadata();
 
   /// Return all registered connector IDs.
+  [[deprecated("Use ConnectorMetadataRegistry::allMetadataIds() instead.")]]
   static std::vector<std::string> allMetadataIds();
 
   virtual ~ConnectorMetadata() = default;

--- a/axiom/connectors/ConnectorMetadataRegistry.cpp
+++ b/axiom/connectors/ConnectorMetadataRegistry.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/core/QueryCtx.h"
+
+namespace facebook::axiom::connector {
+
+using Registry = ConnectorMetadataRegistry::Registry;
+using QueryCtx = velox::core::QueryCtx;
+
+namespace {
+
+Registry& registryFor(const QueryCtx& queryCtx) {
+  auto registry =
+      queryCtx.registry<Registry>(ConnectorMetadataRegistry::kRegistryKey);
+  return registry ? *registry : ConnectorMetadataRegistry::global();
+}
+
+} // namespace
+
+// static
+Registry& ConnectorMetadataRegistry::global() {
+  static Registry kMetadataRegistry;
+  return kMetadataRegistry;
+}
+
+// static
+std::shared_ptr<ConnectorMetadataRegistry::Registry>
+ConnectorMetadataRegistry::create(const Registry* parent) {
+  return std::make_shared<Registry>(parent);
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::tryGet(
+    const QueryCtx& queryCtx,
+    const std::string& connectorId) {
+  return registryFor(queryCtx).find(std::string(connectorId));
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::tryGet(const std::string& connectorId) {
+  return global().find(std::string(connectorId));
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::get(
+    const QueryCtx& queryCtx,
+    const std::string& connectorId) {
+  auto metadata = tryGet(queryCtx, connectorId);
+  VELOX_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::get(const std::string& connectorId) {
+  auto metadata = tryGet(connectorId);
+  VELOX_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
+namespace {
+
+std::vector<std::string> metadataIds(const Registry& registry) {
+  auto entries = registry.snapshot();
+  auto ids = std::vector<std::string>{};
+  ids.reserve(entries.size());
+  for (auto&& [id, _] : entries) {
+    ids.emplace_back(id);
+  }
+  return ids;
+}
+
+} // namespace
+
+// static
+std::vector<std::string> ConnectorMetadataRegistry::allMetadataIds(
+    const QueryCtx& queryCtx) {
+  return metadataIds(registryFor(queryCtx));
+}
+
+// static
+std::vector<std::string> ConnectorMetadataRegistry::allMetadataIds() {
+  return metadataIds(global());
+}
+
+// static
+void ConnectorMetadataRegistry::unregisterAll(const QueryCtx& queryCtx) {
+  auto registry =
+      queryCtx.registry<Registry>(ConnectorMetadataRegistry::kRegistryKey);
+  if (registry) {
+    registry->clear();
+  }
+}
+
+// static
+void ConnectorMetadataRegistry::unregisterAll() {
+  global().clear();
+}
+
+// static
+std::vector<std::pair<std::string, std::shared_ptr<ConnectorMetadata>>>
+ConnectorMetadataRegistry::snapshot(const QueryCtx& queryCtx) {
+  return registryFor(queryCtx).snapshot();
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorMetadataRegistry.h
+++ b/axiom/connectors/ConnectorMetadataRegistry.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/common/ScopedRegistry.h"
+
+namespace facebook::velox::core {
+class QueryCtx;
+} // namespace facebook::velox::core
+
+namespace facebook::axiom::connector {
+
+/// Manages connector metadata registration and lookup. All methods are
+/// thread-safe.
+///
+/// Two groups of APIs:
+///
+/// - Query-scoped APIs take a QueryCtx& and check for per-query registry
+///   overrides before falling back to the global registry. Use these in
+///   operator and expression evaluation code where a QueryCtx is available.
+///
+/// - Global APIs operate directly on the global registry. Use these for
+///   process-level operations: startup registration, shutdown cleanup, and
+///   process-wide lookups (e.g., periodic stats reporting).
+class ConnectorMetadataRegistry {
+ public:
+  /// Type alias for the scoped metadata registry.
+  using Registry = velox::ScopedRegistry<std::string, ConnectorMetadata>;
+
+  /// Registry key for per-query metadata overrides on QueryCtx.
+  static constexpr std::string_view kRegistryKey = "connectorMetadata";
+
+  /// Return the global registry (root scope).
+  static Registry& global();
+
+  /// Create a per-query registry. If 'parent' is provided, lookups fall back
+  /// to it. Pass nullptr for isolation mode (no fallback).
+  static std::shared_ptr<Registry> create(const Registry* parent = nullptr);
+
+  /// Return the metadata connector with the specified ID, or nullptr if
+  /// not registered.  Checks per-query override on QueryCtx first, falls back
+  /// to the global registry if no override is set.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  tryGet(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID from the global
+  /// registry, or nullptr if not registered.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  tryGet(const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID, or an exception if
+  /// not registered.  Checks per-query override on QueryCtx first, falls back
+  /// to the global registry if no override is set.
+  /// @throws VeloxError if the shared_ptr is null.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  get(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID from the global
+  /// registry, or an exception if not registered.
+  /// @throws VeloxError if the shared_ptr is null.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  get(const std::string& connectorId);
+
+  /// Return all metadata connectors whose implementation is of type T. Checks
+  /// per-query override on QueryCtx first, falls back to the global registry if
+  /// no override is set.
+  template <typename T>
+  static std::vector<std::shared_ptr<T>> findAll(
+      const velox::core::QueryCtx& queryCtx) {
+    std::vector<std::shared_ptr<T>> result;
+    for (auto& [_, connectorMetadata] : snapshot(queryCtx)) {
+      if (auto casted = std::dynamic_pointer_cast<T>(connectorMetadata)) {
+        result.push_back(std::move(casted));
+      }
+    }
+    return result;
+  }
+
+  /// Return all metadata connectors from the global registry whose
+  /// implementation is of type T.
+  template <typename T>
+  static std::vector<std::shared_ptr<T>> findAll() {
+    std::vector<std::shared_ptr<T>> result;
+    for (auto& [_, connectorMetadata] : global().snapshot()) {
+      if (auto casted = std::dynamic_pointer_cast<T>(connectorMetadata)) {
+        result.push_back(std::move(casted));
+      }
+    }
+    return result;
+  }
+
+  /// Return all registered ids from the query. Locally registered ids
+  /// override parent or global registrations: each return id will be
+  /// unique.
+  static std::vector<std::string> allMetadataIds(
+      const velox::core::QueryCtx& queryCtx);
+
+  /// Return all registered ids from the global registry.
+  static std::vector<std::string> allMetadataIds();
+
+  /// Unregister all metadata connectors from the registry visible to the given
+  /// query.
+  static void unregisterAll(const velox::core::QueryCtx& queryCtx);
+
+  /// Unregister all metadata connectors from the global registry.
+  static void unregisterAll();
+
+ private:
+  // Return a snapshot of all metadata connectors visible to the given query.
+  // Uses per-query registry if set, otherwise the global registry.
+  static std::vector<std::pair<std::string, std::shared_ptr<ConnectorMetadata>>>
+  snapshot(const velox::core::QueryCtx& queryCtx);
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
   velox_connector
 )
 
-add_executable(axiom_test_connector_test TestConnectorTest.cpp)
+add_executable(axiom_test_connector_test TestConnectorTest.cpp ConnectorMetadataRegistryTest.cpp)
 
 add_test(axiom_test_connector_test axiom_test_connector_test)
 
@@ -43,3 +43,5 @@ add_executable(axiom_connectors_tests SchemaResolverTest.cpp)
 add_test(axiom_connectors_tests axiom_connectors_tests)
 
 target_link_libraries(axiom_connectors_tests axiom_connectors axiom_test_connector gtest gtest_main)
+
+target_link_libraries(axiom_connectors velox_core gtest gtest_main gmock)

--- a/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
+++ b/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/QueryCtx.h"
+
+using namespace facebook::velox;
+using namespace facebook::axiom::connector;
+
+namespace facebook::axiom::connector {
+namespace {
+
+// Implements all pure virtuals with stubs since only registry mechanics are
+// under test.
+class StubConnectorMetadata : public ConnectorMetadata {
+ public:
+  explicit StubConnectorMetadata(std::string label)
+      : label_{std::move(label)} {}
+
+  const std::string& label() const {
+    return label_;
+  }
+
+  TablePtr findTable(const SchemaTableName& /*tableName*/) override {
+    return nullptr;
+  }
+
+  ConnectorSplitManager* splitManager() override {
+    return nullptr;
+  }
+
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& /*session*/) override {
+    return {};
+  }
+
+  bool schemaExists(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return false;
+  }
+
+ private:
+  std::string label_;
+};
+
+class ConnectorMetadataRegistryTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void TearDown() override {
+    ConnectorMetadata::unregisterAllMetadata();
+  }
+};
+
+TEST_F(ConnectorMetadataRegistryTest, queryCtxFallback) {
+  auto globalMetadata = std::make_shared<StubConnectorMetadata>("global");
+  ConnectorMetadataRegistry::global().insert("catalog", globalMetadata);
+
+  auto queryCtx = core::QueryCtx::create();
+  auto queryRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+  auto queryMetadata = std::make_shared<StubConnectorMetadata>("query");
+  queryRegistry->insert("catalog", queryMetadata);
+  queryCtx->setRegistry(ConnectorMetadataRegistry::kRegistryKey, queryRegistry);
+
+  // Per-query registry takes precedence.
+  EXPECT_EQ(
+      ConnectorMetadataRegistry::tryGet(*queryCtx, "catalog"), queryMetadata);
+
+  // Global lookup is unaffected by the query-scoped override.
+  EXPECT_EQ(ConnectorMetadataRegistry::tryGet("catalog"), globalMetadata);
+
+  // QueryCtx without per-query registry falls back to global.
+  auto noRegistryCtx = core::QueryCtx::create();
+  EXPECT_EQ(
+      ConnectorMetadataRegistry::tryGet(*noRegistryCtx, "catalog"),
+      globalMetadata);
+}
+
+TEST_F(ConnectorMetadataRegistryTest, getThrowsOnMissing) {
+  VELOX_ASSERT_THROW(
+      ConnectorMetadataRegistry::get("nonexistent"),
+      "ConnectorMetadata not registered: nonexistent");
+
+  auto queryCtx = core::QueryCtx::create();
+  VELOX_ASSERT_THROW(
+      ConnectorMetadataRegistry::get(*queryCtx, "nonexistent"),
+      "ConnectorMetadata not registered: nonexistent");
+}
+
+TEST_F(ConnectorMetadataRegistryTest, allMetadataIds) {
+  auto globalMetadata = std::make_shared<StubConnectorMetadata>("global");
+  ConnectorMetadataRegistry::global().insert("global-catalog", globalMetadata);
+
+  auto queryCtx = core::QueryCtx::create();
+  auto queryRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+  auto queryMetadata = std::make_shared<StubConnectorMetadata>("query");
+  queryRegistry->insert("query-catalog", queryMetadata);
+  queryCtx->setRegistry(ConnectorMetadataRegistry::kRegistryKey, queryRegistry);
+
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(*queryCtx),
+      testing::UnorderedElementsAre("global-catalog", "query-catalog"));
+
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(),
+      testing::UnorderedElementsAre("global-catalog"));
+
+  // QueryCtx without registry falls back to global.
+  auto noRegistryCtx = core::QueryCtx::create();
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(*noRegistryCtx),
+      testing::UnorderedElementsAre("global-catalog"));
+}
+
+TEST_F(ConnectorMetadataRegistryTest, duplicateRegistration) {
+  auto first = std::make_shared<StubConnectorMetadata>("first");
+  auto second = std::make_shared<StubConnectorMetadata>("second");
+
+  ConnectorMetadata::registerMetadata("catalog", first);
+
+  // Duplicate registration is a no-op — first registration wins.
+  ConnectorMetadata::registerMetadata("catalog", second);
+
+  auto* result = dynamic_cast<StubConnectorMetadata*>(
+      ConnectorMetadata::metadata("catalog"));
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->label(), "first");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector


### PR DESCRIPTION
Summary:

Convert ConnectorMetadata from a global static registry (folly::Synchronized<F14FastMap>) to use Velox's ScopedRegistry, enabling per-query metadata isolation. This mirrors the existing ConnectorRegistry pattern in Velox.

New API additions:
- `Registry` type alias (`ScopedRegistry<string, ConnectorMetadata>`)
- `kRegistryKey` constant for QueryCtx registry storage
- `global()` / `create()` for registry lifecycle
- `metadata(QueryCtx&, connectorId)` / `tryMetadata(QueryCtx&, connectorId)` for query-scoped lookup with global fallback
- `allMetadataIds(const Registry*)` for scoped ID listing

All existing static methods (`metadata()`, `registerMetadata()`, etc.) continue to work unchanged by delegating to the global ScopedRegistry. registerMetadata preserves first-registration-wins semantics.

Includes 8 new unit tests covering: global registration, scoped override, scoped fallback, scoped isolation, QueryCtx fallback, concurrent access, scoped allMetadataIds, and duplicate registration.

Reviewed By: mbasmanova

Differential Revision: D100678748


