### PR TITLE
feat(parser): Add RESET SESSION support (#1250)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 
 target_link_libraries(
   axiom_cli
+  velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan
   axiom_optimizer

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -577,6 +577,13 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
             fmt::format("Session '{}' set to '{}'", name, setSession->value())};
   }
 
+  if (sqlStatement.isResetSession()) {
+    const auto* resetSession = sqlStatement.as<presto::ResetSessionStatement>();
+    const auto& name = resetSession->name();
+    sessionConfig_->reset(name);
+    return {.message = fmt::format("Session '{}' reset", name)};
+  }
+
   if (sqlStatement.isUse()) {
     const auto* use = sqlStatement.as<presto::UseStatement>();
     const auto& connectorId = use->catalog().has_value()

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -17,7 +17,7 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <cmath>
-#include <map>
+
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/SchemaResolver.h"
@@ -37,6 +37,8 @@
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/core/QueryConfigProvider.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -120,12 +122,6 @@ void SqlQueryRunner::initialize(
   defaultConnectorId_ = std::move(defaultConnectorId);
   defaultSchema_ = std::move(defaultSchema);
 
-  // Set default session properties to match Presto behavior.
-  config_[velox::core::QueryConfig::kSessionTimezone] = getLocalTimezone();
-  config_[velox::core::QueryConfig::kAdjustTimestampToTimezone] = "true";
-  config_[velox::core::QueryConfig::kSessionStartTime] =
-      std::to_string(velox::getCurrentTimeMs());
-
   permissionCheck_ = std::move(permissionCheck);
 
   if (queryIdGenerator) {
@@ -139,10 +135,22 @@ void SqlQueryRunner::initialize(
 
   configRegistry_ = std::make_shared<facebook::axiom::ConfigRegistry>();
   configRegistry_->add(
-      "optimizer",
+      kOptimizerPrefix,
       std::make_shared<facebook::axiom::optimizer::OptimizerOptions>());
+  configRegistry_->add(
+      kExecutionPrefix,
+      std::make_shared<facebook::velox::core::QueryConfigProvider>());
+
   sessionConfig_ =
       std::make_shared<facebook::axiom::SessionConfig>(configRegistry_);
+  sessionConfig_->set(
+      kExecutionPrefix,
+      velox::core::QueryConfig::kSessionTimezone,
+      getLocalTimezone());
+  sessionConfig_->set(
+      kExecutionPrefix,
+      velox::core::QueryConfig::kAdjustTimestampToTimezone,
+      "true");
 }
 
 namespace {
@@ -563,11 +571,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
   if (sqlStatement.isSetSession()) {
     const auto* setSession = sqlStatement.as<presto::SetSessionStatement>();
     const auto& name = setSession->name();
-    if (name.find('.') != std::string::npos) {
-      sessionConfig_->set(name, setSession->value());
-    } else {
-      config_[name] = setSession->value();
-    }
+    sessionConfig_->set(name, setSession->value());
     return {
         .message =
             fmt::format("Session '{}' set to '{}'", name, setSession->value())};
@@ -605,9 +609,17 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   const auto queryId =
       options.queryId.value_or(fmt::format("query_{}", ++queryCounter_));
 
+  // Build Velox QueryConfig from execution session properties.
+  auto executionProps = sessionConfig_->effectiveValues(kExecutionPrefix);
+  std::unordered_map<std::string, std::string> queryConfig(
+      executionProps.begin(), executionProps.end());
+  // Per-query value, not a session property.
+  queryConfig[velox::core::QueryConfig::kSessionStartTime] = std::to_string(
+      options.sessionStartTimeMs.value_or(velox::getCurrentTimeMs()));
+
   return velox::core::QueryCtx::create(
       executor_.get(),
-      velox::core::QueryConfig(config_),
+      velox::core::QueryConfig(std::move(queryConfig)),
       {},
       velox::cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
@@ -798,7 +810,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     schemaResolver = std::make_shared<connector::SchemaResolver>();
   }
 
-  auto optimizerProps = sessionConfig_->effectiveValues("optimizer");
+  auto optimizerProps = sessionConfig_->effectiveValues(kOptimizerPrefix);
   auto optimizerOptions = optimizer::OptimizerOptions::from(optimizerProps);
   optimizerOptions.explain = explain;
 
@@ -847,24 +859,38 @@ SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
     const RunOptions& options,
     QueryTiming& timing,
     std::string& planString) {
-  std::map<std::string, std::string> sorted(config_.begin(), config_.end());
-  // Include registered session properties.
-  for (const auto& entry : sessionConfig_->all()) {
-    auto qualifiedName = entry.prefix + "." + entry.property.name;
-    sorted[qualifiedName] = entry.currentValue.value_or("");
-  }
+  using facebook::velox::config::ConfigPropertyTypeName;
+
+  // Collect and sort entries by qualified name.
+  auto entries = sessionConfig_->all();
+  std::sort(
+      entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.prefix, lhs.property.name) <
+            std::tie(rhs.prefix, rhs.property.name);
+      });
 
   std::vector<velox::Variant> data;
-  data.reserve(sorted.size());
-  for (const auto& [key, value] : sorted) {
-    data.emplace_back(velox::Variant::row({key, value}));
+  data.reserve(entries.size());
+  for (const auto& entry : entries) {
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    data.emplace_back(
+        velox::Variant::row({
+            qualifiedName,
+            entry.currentValue.value_or(""),
+            entry.property.defaultValue.value_or(""),
+            std::string(ConfigPropertyTypeName::toName(entry.property.type)),
+            entry.property.description,
+        }));
   }
 
   namespace lp = facebook::axiom::logical_plan;
 
   lp::PlanBuilder::Context context(defaultConnectorId_);
   lp::PlanBuilder builder(context);
-  builder.values(ROW({"Name", "Value"}, velox::VARCHAR()), std::move(data));
+  builder.values(
+      ROW({"Name", "Value", "Default", "Type", "Description"},
+          velox::VARCHAR()),
+      std::move(data));
 
   if (statement.likePattern().has_value()) {
     builder.filter(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -99,6 +99,13 @@ using QueryCompletionCallback = std::function<void(const QueryCompletionInfo&)>;
 /// Executes SQL queries.
 class SqlQueryRunner {
  public:
+  /// Prefix for optimizer session properties (e.g., "optimizer.sample_joins").
+  static constexpr const char* kOptimizerPrefix = "optimizer";
+
+  /// Prefix for Velox execution session properties (e.g.,
+  /// "execution.session_timezone").
+  static constexpr const char* kExecutionPrefix = "execution";
+
   virtual ~SqlQueryRunner() = default;
 
   /// Initializes the runner with connectors, an optional permission check, and
@@ -130,6 +137,10 @@ class SqlQueryRunner {
     /// Used by runUnchecked() as-is. Overwritten by run() with the result of
     /// the permission check callback.
     std::shared_ptr<facebook::velox::filesystems::TokenProvider> tokenProvider;
+
+    /// Override for session start time (milliseconds since epoch). If not
+    /// set, uses the current time. Used by tests to verify current_timestamp.
+    std::optional<uint64_t> sessionStartTimeMs;
 
     /// If true, EXPLAIN ANALYZE output includes custom operator stats.
     bool debugMode{false};
@@ -204,8 +215,9 @@ class SqlQueryRunner {
   /// @param sql A single SELECT or EXPLAIN SELECT statement.
   std::string toLogicalPlanDot(std::string_view sql);
 
-  std::unordered_map<std::string, std::string>& sessionConfig() {
-    return config_;
+  /// Returns the session configuration.
+  facebook::axiom::SessionConfig& sessionConfig() {
+    return *sessionConfig_;
   }
 
   facebook::axiom::connector::TablePtr createTable(
@@ -340,7 +352,6 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::velox::memory::MemoryPool> optimizerPool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> executorPool_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
-  std::unordered_map<std::string, std::string> config_;
   std::shared_ptr<facebook::axiom::ConfigRegistry> configRegistry_;
   std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -268,13 +268,13 @@ $ $CLI --query "SELECT from_base64('aGVsbG8=') as bin" 2>/dev/null
 ## SET SESSION and SHOW SESSION
 
 ```scrut
-$ $CLI --query "SET SESSION session_timezone = 'UTC'; SHOW SESSION LIKE '%timezone%'" 2>/dev/null
-Session 'session_timezone' set to 'UTC'
-*-+-* (glob)
-Name*| Value (glob)
-*-+-* (glob)
-adjust_timestamp_to_session_timezone | true
-session_timezone                     | UTC
+$ $CLI --query "SET SESSION execution.session_timezone = 'UTC'; SHOW SESSION LIKE '%timezone%'" 2>/dev/null
+Session 'execution.session_timezone' set to 'UTC'
+*-+-*-+-*-+-* (glob)
+Name*| Value*| Default*| Type*| Description (glob)
+*-+-*-+-*-+-* (glob)
+execution.adjust_timestamp_to_session_timezone*| true*| false*| BOOLEAN*| * (glob)
+execution.session_timezone*| UTC*|*| STRING*| * (glob)
 (2 rows in 1 batches)
 
 ```

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -722,8 +722,7 @@ TEST_F(SqlQueryRunnerTest, currentTimestamp) {
 
   auto row = fetchSingleRow("SELECT current_timestamp", options);
   auto packed = row->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
-  auto millis = unpackMillisUtc(packed);
-  EXPECT_EQ(millis, options.sessionStartTimeMs);
+  EXPECT_EQ(unpackMillisUtc(packed), options.sessionStartTimeMs);
 }
 
 TEST_F(SqlQueryRunnerTest, explainFormatGraphviz) {
@@ -1067,6 +1066,75 @@ TEST_F(SqlQueryRunnerTest, timingFieldsOnParseError) {
   EXPECT_EQ(captured.timing.execute, 0);
   EXPECT_GT(captured.timing.total, 0);
   EXPECT_GE(captured.timing.total, captured.timing.parse);
+}
+
+TEST_F(SqlQueryRunnerTest, sessionProperties) {
+  auto assertProperty = [&](std::string_view name,
+                            std::string_view expectedValue,
+                            std::string_view expectedDefault) {
+    SCOPED_TRACE(name);
+    auto row = fetchSingleRow(fmt::format("SHOW SESSION LIKE '{}'", name));
+    // SHOW SESSION returns: Name, Value, Default, Type, Description.
+    ASSERT_EQ(row->childrenSize(), 5);
+    auto nameCol = row->childAt(0)->as<SimpleVector<StringView>>();
+    auto valueCol = row->childAt(1)->as<SimpleVector<StringView>>();
+    auto defaultCol = row->childAt(2)->as<SimpleVector<StringView>>();
+    EXPECT_EQ(nameCol->valueAt(0), name);
+    EXPECT_EQ(valueCol->valueAt(0), expectedValue);
+    EXPECT_EQ(defaultCol->valueAt(0), expectedDefault);
+  };
+
+  // Default value.
+  assertProperty("optimizer.sample_joins", "true", "true");
+
+  // SET changes the value.
+  auto result = run("SET SESSION optimizer.sample_joins = false");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' set to 'false'");
+  assertProperty("optimizer.sample_joins", "false", "true");
+
+  // RESET restores the default.
+  result = run("RESET SESSION optimizer.sample_joins");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' reset");
+  assertProperty("optimizer.sample_joins", "true", "true");
+
+  // Invalid value.
+  VELOX_ASSERT_THROW(
+      run("SET SESSION optimizer.sample_joins = 42"), "Expected boolean value");
+
+  // Unknown property.
+  VELOX_ASSERT_THROW(
+      run("SET SESSION optimizer.no_such_property = true"),
+      "Unknown session property");
+}
+
+TEST_F(SqlQueryRunnerTest, showSession) {
+  auto fetchNames = [&](std::string_view query) {
+    auto sqlResult = run(query);
+    VELOX_CHECK(!sqlResult.message.has_value());
+    VELOX_CHECK_EQ(1, sqlResult.results.size());
+
+    auto column =
+        sqlResult.results[0]->childAt(0)->as<SimpleVector<StringView>>();
+
+    std::vector<std::string> names;
+    names.reserve(column->size());
+    for (auto i = 0; i < column->size(); ++i) {
+      names.emplace_back(column->valueAt(i));
+    }
+    return names;
+  };
+
+  // SHOW SESSION returns all properties.
+  EXPECT_THAT(
+      fetchNames("SHOW SESSION"),
+      ::testing::Contains("optimizer.sample_joins"));
+
+  // SHOW SESSION LIKE filters by prefix.
+  auto names = fetchNames("SHOW SESSION LIKE 'optimizer%'");
+  EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("optimizer.")));
+  EXPECT_THAT(names, ::testing::Contains("optimizer.sample_joins"));
 }
 
 } // namespace

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -84,8 +84,10 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     return runner_->run(sql, {});
   }
 
-  RowVectorPtr fetchSingleRow(std::string_view sql) {
-    auto result = run(sql);
+  RowVectorPtr fetchSingleRow(
+      std::string_view sql,
+      const SqlQueryRunner::RunOptions& options = {}) {
+    auto result = runner_->run(sql, options);
     VELOX_CHECK(
         !result.message.has_value(), "Query failed: {}", *result.message);
     VELOX_CHECK_EQ(1, result.results.size());
@@ -715,14 +717,13 @@ TEST_F(SqlQueryRunnerTest, createTableInNonExistentSchema) {
 
 // Verifies that current_timestamp returns the session start time.
 TEST_F(SqlQueryRunnerTest, currentTimestamp) {
-  auto row = fetchSingleRow("SELECT current_timestamp");
+  SqlQueryRunner::RunOptions options;
+  options.sessionStartTimeMs = facebook::velox::getCurrentTimeMs();
 
+  auto row = fetchSingleRow("SELECT current_timestamp", options);
   auto packed = row->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
   auto millis = unpackMillisUtc(packed);
-
-  auto expected = facebook::velox::core::QueryConfig{runner_->sessionConfig()}
-                      .sessionStartTimeMs();
-  EXPECT_EQ(millis, expected);
+  EXPECT_EQ(millis, options.sessionStartTimeMs);
 }
 
 TEST_F(SqlQueryRunnerTest, explainFormatGraphviz) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2187,6 +2187,12 @@ SqlStatementPtr PrestoParser::doParse(
     return parseSetSession(query->as<SetSession>());
   }
 
+  if (query->is(NodeType::kResetSession)) {
+    auto* resetSession = query->as<ResetSession>();
+    return std::make_shared<ResetSessionStatement>(
+        resetSession->name()->fullyQualifiedName());
+  }
+
   if (query->is(NodeType::kUse)) {
     auto* use = query->as<Use>();
     std::optional<std::string> catalog;

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -38,6 +38,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kShowStatsForQuery, "SHOW STATS FOR"},
       {SqlStatementKind::kShowSession, "SHOW SESSION"},
       {SqlStatementKind::kSetSession, "SET SESSION"},
+      {SqlStatementKind::kResetSession, "RESET SESSION"},
       {SqlStatementKind::kUse, "USE"},
   };
 

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -40,6 +40,7 @@ enum class SqlStatementKind {
   kShowStatsForQuery,
   kShowSession,
   kSetSession,
+  kResetSession,
   kUse,
 };
 
@@ -100,6 +101,10 @@ class SqlStatement {
 
   bool isSetSession() const {
     return kind_ == SqlStatementKind::kSetSession;
+  }
+
+  bool isResetSession() const {
+    return kind_ == SqlStatementKind::kResetSession;
   }
 
   bool isUse() const {
@@ -487,6 +492,19 @@ class SetSessionStatement : public SqlStatement {
  private:
   const std::string name_;
   const std::string value_;
+};
+
+class ResetSessionStatement : public SqlStatement {
+ public:
+  explicit ResetSessionStatement(std::string name)
+      : SqlStatement(SqlStatementKind::kResetSession), name_{std::move(name)} {}
+
+  const std::string& name() const {
+    return name_;
+  }
+
+ private:
+  const std::string name_;
 };
 
 class UseStatement : public SqlStatement {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1007,7 +1007,8 @@ std::any AstBuilder::visitSetSession(PrestoSqlParser::SetSessionContext* ctx) {
 std::any AstBuilder::visitResetSession(
     PrestoSqlParser::ResetSessionContext* ctx) {
   trace("visitResetSession");
-  return visitChildren("visitResetSession", ctx);
+  return std::static_pointer_cast<Statement>(std::make_shared<ResetSession>(
+      getLocation(ctx), getQualifiedName(ctx->qualifiedName())));
 }
 
 std::any AstBuilder::visitStartTransaction(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -777,6 +777,10 @@ void SetSession::accept(AstVisitor* visitor) {
   visitor->visitSetSession(this);
 }
 
+void ResetSession::accept(AstVisitor* visitor) {
+  visitor->visitResetSession(this);
+}
+
 void Use::accept(AstVisitor* visitor) {
   visitor->visitUse(this);
 }

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -1277,6 +1277,12 @@ void AstPrinter::visitSetSession(SetSession* node) {
   printChild("Value", node->value());
 }
 
+void AstPrinter::visitResetSession(ResetSession* node) {
+  printHeader("ResetSession", node, [&](std::ostream& out) {
+    out << node->name()->fullyQualifiedName();
+  });
+}
+
 void AstPrinter::visitUse(Use* node) {
   printHeader("Use", node, [&](std::ostream& out) {
     if (node->catalog()) {

--- a/axiom/sql/presto/ast/AstPrinter.h
+++ b/axiom/sql/presto/ast/AstPrinter.h
@@ -304,6 +304,8 @@ class AstPrinter : public AstVisitor {
 
   void visitSetSession(SetSession* node) override;
 
+  void visitResetSession(ResetSession* node) override;
+
   void visitUse(Use* node) override;
 
  private:

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -420,6 +420,21 @@ class SetSession : public Statement {
   ExpressionPtr value_;
 };
 
+class ResetSession : public Statement {
+ public:
+  ResetSession(NodeLocation location, std::shared_ptr<QualifiedName> name)
+      : Statement(NodeType::kResetSession, location), name_(std::move(name)) {}
+
+  const std::shared_ptr<QualifiedName>& name() const {
+    return name_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> name_;
+};
+
 class Use : public Statement {
  public:
   Use(NodeLocation location,

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -567,6 +567,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitResetSession(ResetSession* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitUse(Use* node) {
     defaultVisit(node);
   }


### PR DESCRIPTION
Summary:

Implement RESET SESSION <property> to restore a session property to its
default value. The grammar rule already existed but was not wired up.

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D100752379
