### PR TITLE
fix: Use leastCommonSuperType for VALUES type coercion (#1251)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -167,22 +167,31 @@ PlanBuilder& PlanBuilder::values(
   }
 
   if (enableCoercions_) {
-    for (auto i = 0; i < numRows; ++i) {
-      auto& row = exprs[i];
+    for (auto i = 1; i < numRows; ++i) {
       for (auto j = 0; j < numColumns; ++j) {
-        const auto& type = row[j]->type();
-        if (types[j]->equivalent(*type)) {
+        const auto& colType = exprs[i][j]->type();
+        if (types[j]->equivalent(*colType)) {
           continue;
         }
 
-        if (velox::TypeCoercer::coercible(type, types[j])) {
-          row[j] = applyCoercion(row[j], types[j]);
-        } else if (velox::TypeCoercer::coercible(types[j], type)) {
-          types[j] = type;
+        auto common =
+            velox::TypeCoercer::leastCommonSuperType(types[j], colType);
+        VELOX_USER_CHECK_NOT_NULL(
+            common,
+            "Incompatible types in VALUES row {}, column {}: expected {}, got {}",
+            i + 1,
+            j + 1,
+            types[j]->toString(),
+            colType->toString());
+        types[j] = common;
+      }
+    }
 
-          for (auto k = 0; k < i; ++k) {
-            exprs[k][j] = applyCoercion(exprs[k][j], types[j]);
-          }
+    // Coerce expressions whose type differs from the resolved column type.
+    for (auto& row : exprs) {
+      for (auto j = 0; j < numColumns; ++j) {
+        if (!row[j]->type()->equivalent(*types[j])) {
+          row[j] = applyCoercion(row[j], types[j]);
         }
       }
     }

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -669,5 +669,76 @@ TEST_F(PlanBuilderTest, cubeThreeKeys) {
           std::vector<int32_t>{}));
 }
 
+namespace {
+LogicalPlanNodePtr buildValues(
+    const std::vector<std::string>& columns,
+    const std::vector<std::vector<std::string>>& rows,
+    bool enableCoercions = true) {
+  PlanBuilder::Context context;
+  return PlanBuilder(context, enableCoercions).values(columns, rows).build();
+}
+} // namespace
+
+TEST_F(PlanBuilderTest, valuesTypeCoercion) {
+  // Scalar: BIGINT + INTEGER → BIGINT, with nulls.
+  EXPECT_EQ(
+      *buildValues(
+           {"a", "b"},
+           {{"CAST(123 AS bigint)", "CAST(1 AS integer)"},
+            {"CAST(null AS integer)", "CAST(null AS bigint)"}})
+           ->outputType(),
+      *ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+
+  // Progressive widening: INTEGER → BIGINT → DOUBLE.
+  EXPECT_EQ(
+      *buildValues(
+           {"x"},
+           {{"CAST(1 AS integer)"},
+            {"CAST(2 AS bigint)"},
+            {"CAST(3.0 AS double)"}})
+           ->outputType(),
+      *ROW({"x"}, {DOUBLE()}));
+
+  // Complex type with mixed-direction coercion per child.
+  // MAP(INTEGER, DOUBLE) + MAP(BIGINT, REAL): key widens INT→BIGINT,
+  // value widens REAL→DOUBLE. leastCommonSuperType picks direction per child.
+  EXPECT_EQ(
+      *buildValues(
+           {"x"},
+           {{"MAP(ARRAY[CAST(1 AS integer)], ARRAY[CAST(1.0 AS double)])"},
+            {"MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)])"}})
+           ->outputType(),
+      *ROW({"x"}, {MAP(BIGINT(), DOUBLE())}));
+}
+
+TEST_F(PlanBuilderTest, valuesTypeCoercionErrors) {
+  // Incompatible scalar types.
+  VELOX_ASSERT_THROW(
+      buildValues({"x"}, {{"true"}, {"CAST(123 AS bigint)"}}),
+      "Incompatible types in VALUES row 2, column 1: "
+      "expected BOOLEAN, got BIGINT");
+
+  // Incompatible null types.
+  VELOX_ASSERT_THROW(
+      buildValues({"x"}, {{"CAST(null AS boolean)"}, {"CAST(null AS bigint)"}}),
+      "Incompatible types in VALUES row 2, column 1: "
+      "expected BOOLEAN, got BIGINT");
+
+  // Incompatible complex types.
+  VELOX_ASSERT_THROW(
+      buildValues(
+          {"x"}, {{"ARRAY[CAST(1 AS integer)]"}, {"MAP(ARRAY[1], ARRAY[2])"}}),
+      "Incompatible types in VALUES row 2, column 1: "
+      "expected ARRAY<INTEGER>, got MAP<INTEGER,INTEGER>");
+
+  // Coercions disabled.
+  VELOX_ASSERT_THROW(
+      buildValues(
+          {"x"},
+          {{"CAST(null AS boolean)"}, {"CAST(null AS bigint)"}},
+          /*enableCoercions=*/false),
+      "All values should have equivalent types: BIGINT vs. ROW<x:BOOLEAN>");
+}
+
 } // namespace
 } // namespace facebook::axiom::logical_plan

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -75,5 +75,13 @@ SELECT MAP(ARRAY[CAST(1.0 AS DOUBLE)], ARRAY['hello'])[1.0]
 -- duckdb: SELECT true FROM t
 SELECT ROW(a, CAST(null AS BIGINT)) IS NOT NULL FROM t
 ----
+-- VALUES with compatible types coerced to common supertype.
+-- duckdb: VALUES (1::bigint), (2::bigint)
+SELECT * FROM (VALUES ROW(1), ROW(CAST(2 AS bigint))) AS t(x)
+----
+-- VALUES with complex types requiring mixed-direction coercion per child.
+-- duckdb: VALUES (MAP {1::bigint: 1.0}), (MAP {2::bigint: 2.0})
+SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)]))) AS t(x)
+----
 -- error: Grouping sets are not supported yet
 SELECT count(*) FROM t GROUP BY GROUPING SETS ((a), ())


### PR DESCRIPTION
Summary:

Replace the `coercible()` two-way check in VALUES type coercion with `TypeCoercer::leastCommonSuperType`. This enables coercion for complex types where children require different coercion directions — previously, these queries failed with a confusing error.

`coercible(a, b)` is directional: for MAP(INTEGER, DOUBLE) vs MAP(BIGINT, REAL), the key needs INT→BIGINT and the value needs REAL→DOUBLE. Since children coerce in opposite directions, both `coercible(a, b)` and `coercible(b, a)` return false. `leastCommonSuperType` resolves each child independently, matching the pattern already used by UNION in `setOperationImpl()`.

Previously failed, now works:

  SELECT * FROM (VALUES
    ROW(MAP(ARRAY[CAST(1 AS integer)], ARRAY[CAST(1.0 AS double)])),
    ROW(MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)]))
  ) AS t(x)

  -- Before: "All values should have equivalent types: MAP(INTEGER,DOUBLE) vs. MAP(BIGINT,REAL)"
  -- After:  coerces to MAP(BIGINT, DOUBLE), returns {1=1.0}, {2=2.0}

For genuinely incompatible types, the error now includes row/column context:

  -- Before: "All values should have equivalent types: BIGINT vs. BOOLEAN"
  -- After:  "Incompatible types in VALUES row 2, column 1: expected BOOLEAN, got BIGINT"

Reviewed By: mbasmanova

Differential Revision: D100726579


