### PR TITLE
feat: Wire connector session properties (#1252)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 
 target_link_libraries(
   axiom_cli
+  velox_connector_registry
   velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -37,6 +37,7 @@
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryConfigProvider.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -52,6 +53,28 @@ namespace velox = facebook::velox;
 using namespace facebook::axiom;
 
 namespace {
+
+// Wraps a Velox connector's ConfigProvider pointer into an owned
+// ConfigProvider for use with ConfigRegistry. The underlying connector
+// must outlive this wrapper.
+class ConnectorConfigProvider : public velox::config::ConfigProvider {
+ public:
+  explicit ConnectorConfigProvider(
+      const velox::config::ConfigProvider* provider)
+      : provider_(provider) {}
+
+  std::vector<velox::config::ConfigProperty> properties() const override {
+    return provider_->properties();
+  }
+
+  std::string normalize(std::string_view name, std::string_view value)
+      const override {
+    return provider_->normalize(name, value);
+  }
+
+ private:
+  const velox::config::ConfigProvider* provider_;
+};
 
 // Returns the system's local IANA timezone name. Checks TZ environment variable
 // first, then reads /etc/localtime symlink, falls back to "UTC".
@@ -140,6 +163,15 @@ void SqlQueryRunner::initialize(
   configRegistry_->add(
       kExecutionPrefix,
       std::make_shared<facebook::velox::core::QueryConfigProvider>());
+
+  // Register config providers for connectors that support session properties.
+  for (const auto& [connectorId, connector] :
+       velox::connector::ConnectorRegistry::global().snapshot()) {
+    if (const auto* provider = connector->configProvider()) {
+      configRegistry_->add(
+          connectorId, std::make_shared<ConnectorConfigProvider>(provider));
+    }
+  }
 
   sessionConfig_ =
       std::make_shared<facebook::axiom::SessionConfig>(configRegistry_);
@@ -624,13 +656,29 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   queryConfig[velox::core::QueryConfig::kSessionStartTime] = std::to_string(
       options.sessionStartTimeMs.value_or(velox::getCurrentTimeMs()));
 
+  // Build per-connector session properties.
+  std::unordered_map<std::string, std::shared_ptr<velox::config::ConfigBase>>
+      connectorConfigs;
+  for (const auto& [connectorId, connector] :
+       velox::connector::ConnectorRegistry::global().snapshot()) {
+    if (connector->configProvider()) {
+      auto connectorProps = sessionConfig_->effectiveValues(connectorId);
+      if (!connectorProps.empty()) {
+        connectorConfigs[connectorId] =
+            std::make_shared<velox::config::ConfigBase>(
+                std::unordered_map<std::string, std::string>(
+                    connectorProps.begin(), connectorProps.end()));
+      }
+    }
+  }
+
   return velox::core::QueryCtx::create(
       executor_.get(),
       velox::core::QueryConfig(std::move(queryConfig)),
-      {},
+      std::move(connectorConfigs),
       velox::cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
-      nullptr,
+      /*spillExecutor=*/nullptr,
       queryId,
       options.tokenProvider);
 }

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -106,6 +106,23 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         makeRowVector({"Schema"}, {makeFlatVector(expected)}));
   }
 
+  void assertSessionProperty(
+      std::string_view name,
+      std::string_view expectedValue,
+      std::string_view expectedDefault) {
+    SCOPED_TRACE(name);
+    auto row = fetchSingleRow(fmt::format("SHOW SESSION LIKE '{}'", name));
+    ASSERT_EQ(row->childrenSize(), 5);
+    EXPECT_EQ(
+        row->childAt(0)->as<SimpleVector<StringView>>()->valueAt(0), name);
+    EXPECT_EQ(
+        row->childAt(1)->as<SimpleVector<StringView>>()->valueAt(0),
+        expectedValue);
+    EXPECT_EQ(
+        row->childAt(2)->as<SimpleVector<StringView>>()->valueAt(0),
+        expectedDefault);
+  }
+
   std::unique_ptr<SqlQueryRunner> runner_;
   std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
 
@@ -1073,35 +1090,20 @@ TEST_F(SqlQueryRunnerTest, timingFieldsOnParseError) {
 }
 
 TEST_F(SqlQueryRunnerTest, sessionProperties) {
-  auto assertProperty = [&](std::string_view name,
-                            std::string_view expectedValue,
-                            std::string_view expectedDefault) {
-    SCOPED_TRACE(name);
-    auto row = fetchSingleRow(fmt::format("SHOW SESSION LIKE '{}'", name));
-    // SHOW SESSION returns: Name, Value, Default, Type, Description.
-    ASSERT_EQ(row->childrenSize(), 5);
-    auto nameCol = row->childAt(0)->as<SimpleVector<StringView>>();
-    auto valueCol = row->childAt(1)->as<SimpleVector<StringView>>();
-    auto defaultCol = row->childAt(2)->as<SimpleVector<StringView>>();
-    EXPECT_EQ(nameCol->valueAt(0), name);
-    EXPECT_EQ(valueCol->valueAt(0), expectedValue);
-    EXPECT_EQ(defaultCol->valueAt(0), expectedDefault);
-  };
-
   // Default value.
-  assertProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "true", "true");
 
   // SET changes the value.
   auto result = run("SET SESSION optimizer.sample_joins = false");
   ASSERT_TRUE(result.message.has_value());
   EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' set to 'false'");
-  assertProperty("optimizer.sample_joins", "false", "true");
+  assertSessionProperty("optimizer.sample_joins", "false", "true");
 
   // RESET restores the default.
   result = run("RESET SESSION optimizer.sample_joins");
   ASSERT_TRUE(result.message.has_value());
   EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' reset");
-  assertProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "true", "true");
 
   // Invalid value.
   VELOX_ASSERT_THROW(
@@ -1131,14 +1133,116 @@ TEST_F(SqlQueryRunnerTest, showSession) {
   };
 
   // SHOW SESSION returns all properties.
-  EXPECT_THAT(
-      fetchNames("SHOW SESSION"),
-      ::testing::Contains("optimizer.sample_joins"));
+  auto allNames = fetchNames("SHOW SESSION");
+  EXPECT_THAT(allNames, ::testing::Contains("optimizer.sample_joins"));
+  EXPECT_THAT(allNames, ::testing::Contains("test.collect_column_statistics"));
 
   // SHOW SESSION LIKE filters by prefix.
-  auto names = fetchNames("SHOW SESSION LIKE 'optimizer%'");
-  EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("optimizer.")));
-  EXPECT_THAT(names, ::testing::Contains("optimizer.sample_joins"));
+  {
+    auto names = fetchNames("SHOW SESSION LIKE 'optimizer%'");
+    EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("optimizer.")));
+    EXPECT_THAT(names, ::testing::Contains("optimizer.sample_joins"));
+  }
+
+  {
+    auto names = fetchNames("SHOW SESSION LIKE 'test%'");
+    EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("test.")));
+    EXPECT_THAT(names, ::testing::Contains("test.collect_column_statistics"));
+  }
+}
+
+TEST_F(SqlQueryRunnerTest, connectorSessionProperties) {
+  // Default value.
+  assertSessionProperty("test.collect_column_statistics", "true", "true");
+
+  // SET changes the value.
+  auto result = run("SET SESSION test.collect_column_statistics = false");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(
+      *result.message,
+      "Session 'test.collect_column_statistics' set to 'false'");
+  assertSessionProperty("test.collect_column_statistics", "false", "true");
+
+  // RESET restores the default.
+  result = run("RESET SESSION test.collect_column_statistics");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(*result.message, "Session 'test.collect_column_statistics' reset");
+  assertSessionProperty("test.collect_column_statistics", "true", "true");
+
+  // Invalid value.
+  VELOX_ASSERT_THROW(
+      run("SET SESSION test.collect_column_statistics = 42"),
+      "Expected boolean value");
+}
+
+// Verifies end-to-end flow: SET SESSION for a connector property reaches the
+// connector and affects query behavior.
+TEST_F(SqlQueryRunnerTest, connectorSessionPropertyEffect) {
+  const Variant null;
+
+  const auto statsType = ROW(
+      {
+          "row_count",
+          "column_name",
+          "nulls_fraction",
+          "distinct_values_count",
+          "avg_length",
+          "low_value",
+          "high_value",
+      },
+      {
+          BIGINT(),
+          VARCHAR(),
+          DOUBLE(),
+          BIGINT(),
+          BIGINT(),
+          VARCHAR(),
+          VARCHAR(),
+      });
+
+  // With stats collection enabled (default), SHOW STATS reports per-column
+  // stats.
+  {
+    run("CREATE TABLE t AS SELECT x FROM unnest(sequence(1, 10)) AS _(x)");
+    SCOPE_EXIT {
+      run("DROP TABLE IF EXISTS t");
+    };
+
+    auto expected = BaseVector::createFromVariants(
+        statsType,
+        {
+            Variant::row({10LL, null, null, null, null, null, null}),
+            Variant::row({null, "x", 0.0, 10LL, null, "1", "10"}),
+        },
+        pool());
+
+    auto result = run("SHOW STATS FOR t");
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+  }
+
+  // With stats collection disabled, per-column stats are null.
+  {
+    run("SET SESSION test.collect_column_statistics = false");
+    run("CREATE TABLE t AS SELECT x FROM unnest(sequence(1, 10)) AS _(x)");
+    SCOPE_EXIT {
+      run("DROP TABLE IF EXISTS t");
+    };
+
+    auto expected = BaseVector::createFromVariants(
+        statsType,
+        {
+            Variant::row({10LL, null, null, null, null, null, null}),
+            Variant::row({null, "x", null, null, null, null, null}),
+        },
+        pool());
+
+    auto result = run("SHOW STATS FOR t");
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+  }
 }
 
 } // namespace

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -140,7 +140,9 @@ void TestTable::setStats(
   }
 }
 
-void TestTable::addData(const velox::RowVectorPtr& data) {
+void TestTable::addData(
+    const velox::RowVectorPtr& data,
+    bool collectColumnStatistics) {
   VELOX_CHECK_EQ(
       numRows_,
       0,
@@ -156,6 +158,10 @@ void TestTable::addData(const velox::RowVectorPtr& data) {
       velox::BaseVector::copy(*data, pool_.get()));
   data_.push_back(copy);
   dataRows_ += data->size();
+
+  if (!collectColumnStatistics) {
+    return;
+  }
 
   // Compute per-column statistics incrementally.
   const auto& rowType = type();
@@ -651,7 +657,7 @@ std::unique_ptr<velox::connector::DataSource> TestConnector::createDataSource(
 std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
     velox::RowTypePtr,
     velox::connector::ConnectorInsertTableHandlePtr tableHandle,
-    velox::connector::ConnectorQueryCtx*,
+    velox::connector::ConnectorQueryCtx* connectorQueryCtx,
     velox::connector::CommitStrategy) {
   VELOX_CHECK(tableHandle, "table handle must be non-null");
   auto* testHandle =
@@ -662,7 +668,10 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
       table,
       "cannot create data sink for nonexistent table {}",
       testHandle->tableName().toString());
-  return std::make_unique<TestDataSink>(table);
+  auto collectColumnStatistics =
+      connectorQueryCtx->sessionProperties()->get<bool>(
+          TestConfigProvider::kCollectColumnStatistics, true);
+  return std::make_unique<TestDataSink>(table, collectColumnStatistics);
 }
 
 std::shared_ptr<TestTable> TestConnector::addTable(
@@ -736,7 +745,7 @@ std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(
 
 void TestDataSink::appendData(velox::RowVectorPtr vector) {
   if (vector) {
-    table_->addData(vector);
+    table_->addData(vector, collectColumnStatistics_);
   }
 }
 

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -107,10 +107,12 @@ class TestTable : public Table {
 
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
-  /// memory pool. Computes per-column statistics incrementally (numDistinct,
-  /// min/max, nullPct, maxLength). Cannot be combined with setStats on the
-  /// same table.
-  void addData(const velox::RowVectorPtr& data);
+  /// memory pool. When 'collectColumnStatistics' is true, computes per-column
+  /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
+  /// Cannot be combined with setStats on the same table.
+  void addData(
+      const velox::RowVectorPtr& data,
+      bool collectColumnStatistics = true);
 
   TestTableLayout* mutableLayout() {
     return exportedLayout_.get();
@@ -581,6 +583,27 @@ class TestDataSource : public velox::connector::DataSource {
   bool more_{false};
 };
 
+/// ConfigProvider for TestConnector session properties.
+class TestConfigProvider : public velox::config::ConfigProvider {
+ public:
+  static constexpr const char* kCollectColumnStatistics =
+      "collect_column_statistics";
+
+  std::vector<velox::config::ConfigProperty> properties() const override {
+    return {
+        {kCollectColumnStatistics,
+         velox::config::ConfigPropertyType::kBoolean,
+         "true",
+         "Collect per-column statistics when writing data to a table."},
+    };
+  }
+
+  std::string normalize(std::string_view /*name*/, std::string_view value)
+      const override {
+    return std::string(value);
+  }
+};
+
 /// Contains an embedded TestConnectorMetadata to which TestTables are
 /// added at runtime using the addTable API. Data is appended to a
 /// TestTable via the appendData method. createDataSource creates a
@@ -603,6 +626,11 @@ class TestConnector : public velox::connector::Connector {
 
   ~TestConnector() override {
     ConnectorMetadata::unregisterMetadata(connectorId());
+  }
+
+  const velox::config::ConfigProvider* configProvider() const override {
+    static const TestConfigProvider kProvider;
+    return &kProvider;
   }
 
   bool supportsSplitPreload() const override {
@@ -720,7 +748,8 @@ class TestConnectorFactory : public velox::connector::ConnectorFactory {
 /// contained in the corresponding table.
 class TestDataSink : public velox::connector::DataSink {
  public:
-  explicit TestDataSink(std::shared_ptr<Table> table) {
+  TestDataSink(std::shared_ptr<Table> table, bool collectStats)
+      : collectColumnStatistics_(collectStats) {
     table_ = std::dynamic_pointer_cast<TestTable>(table);
     VELOX_CHECK(table_, "table {} not a TestTable", table->name().toString());
   }
@@ -748,6 +777,7 @@ class TestDataSink : public velox::connector::DataSink {
 
  private:
   std::shared_ptr<TestTable> table_;
+  bool collectColumnStatistics_;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -182,8 +182,28 @@ TEST_F(TestConnectorTest, dataSink) {
   auto table = connector_->addTable("table", schema);
   EXPECT_EQ(table->numRows(), 0);
 
+  auto emptyConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto connectorQueryCtx =
+      std::make_unique<velox::connector::ConnectorQueryCtx>(
+          pool_.get(),
+          pool_.get(),
+          emptyConfig.get(),
+          /*spillConfig=*/nullptr,
+          velox::common::PrefixSortConfig{},
+          /*expressionEvaluator=*/nullptr,
+          /*cache=*/nullptr,
+          "test-query",
+          "test-task",
+          "test-plan-node",
+          /*driverId=*/0,
+          /*sessionTimezone=*/"UTC");
+
   auto dataSink = connector_->createDataSink(
-      schema, handle, nullptr, velox::connector::CommitStrategy::kNoCommit);
+      schema,
+      handle,
+      connectorQueryCtx.get(),
+      velox::connector::CommitStrategy::kNoCommit);
   EXPECT_NE(dataSink, nullptr);
 
   auto vector = makeRowVector({makeFlatVector<int>({0, 1, 2})});


### PR DESCRIPTION
Summary:

Register connector config providers with ConfigRegistry at startup. Iterates ConnectorRegistry::global().snapshot() and registers a ConfigProvider for each connector that supports session properties (e.g., Hive connector).

Users can now SET/SHOW/RESET SESSION for connector properties using the connector ID as the prefix:
  SET SESSION hive.max_partitions_per_writers = 256
  SHOW SESSION LIKE 'hive%'

Connector session properties are passed to QueryCtx::create() as connectorConfigs, enabling per-query overrides of connector behavior.

Reviewed By: natashasehgal

Differential Revision: D100999184
