### PR TITLE
feat: Add system.metadata.session_properties table (#1253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ with Velox. These components are:
   - top-level “connectors” directory
   - [Hive](axiom/connectors/hive/README.md) — Local filesystem connector for Parquet, DWRF, and TEXT (including CSV) files.
   - [TPC-H](axiom/connectors/tpch/README.md) — Read-only, in-memory TPC-H benchmark data.
+  - [System](axiom/connectors/system/README.md) — Read-only metadata tables for session properties and active queries.
   - [Test](axiom/connectors/tests/README.md) — In-memory read-write connector for unit testing.
 - [CLI](axiom/cli/README.md) - Interactive SQL command line for executing
   queries against in-memory TPC-H dataset and local Hive data.
@@ -316,7 +317,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/24e6ab97ba8015c3b6fae82e8184047cadf521df...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/09c4fb905f0e02b0f334b0e99ff9e8b0c8a5165b...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -39,7 +39,6 @@ int main(int argc, char** argv) {
     auto defaultSchema = "tiny";
 
     connectors.registerTestConnector();
-    connectors.registerSystemConnector();
 
     if (!FLAGS_data_path.empty()) {
       defaultConnector = connectors.registerLocalHiveConnector(
@@ -60,6 +59,9 @@ int main(int argc, char** argv) {
 
     return std::make_pair(connectorId, schema);
   });
+
+  // Register after initialize() so sessionConfig() is available.
+  connectors.registerSystemConnector(runner.sessionConfig());
 
   axiom::sql::Console console{runner};
   console.initialize();

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 
 target_link_libraries(
   axiom_cli
+  velox_connector_registry
   velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -17,6 +17,7 @@
 #include "axiom/cli/Connectors.h"
 
 #include <folly/system/HardwareConcurrency.h>
+#include "axiom/common/SessionConfig.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
@@ -25,6 +26,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
@@ -48,6 +50,38 @@ void initializeFileFormats() {
   velox::text::registerTextWriterFactory();
 }
 
+// Adapts SessionConfig to the SessionPropertiesProvider interface for the
+// system connector's metadata.session_properties table.
+class SessionConfigPropertiesProvider
+    : public connector::system::SessionPropertiesProvider {
+ public:
+  explicit SessionConfigPropertiesProvider(const SessionConfig& sessionConfig)
+      : sessionConfig_(sessionConfig) {}
+
+  std::vector<connector::system::SessionPropertyInfo> getSessionProperties()
+      const override {
+    using velox::config::ConfigPropertyTypeName;
+
+    auto entries = sessionConfig_.all();
+    std::vector<connector::system::SessionPropertyInfo> result;
+    result.reserve(entries.size());
+    for (const auto& entry : entries) {
+      result.push_back({
+          entry.prefix,
+          entry.property.name,
+          std::string(ConfigPropertyTypeName::toName(entry.property.type)),
+          entry.property.defaultValue.value_or(""),
+          entry.currentValue.value_or(""),
+          entry.property.description,
+      });
+    }
+    return result;
+  }
+
+ private:
+  const SessionConfig& sessionConfig_;
+};
+
 } // namespace
 
 Connectors::Connectors() {
@@ -58,7 +92,7 @@ Connectors::~Connectors() {
   for (const auto& connectorId : connectorIds_) {
     // Unregister metadata first since it may reference the connector.
     connector::ConnectorMetadata::unregisterMetadata(connectorId);
-    velox::connector::unregisterConnector(connectorId);
+    velox::connector::ConnectorRegistry::global().erase(connectorId);
   }
 }
 
@@ -77,6 +111,13 @@ void Connectors::initialize() {
   ioExecutor_ = getSharedIoExecutor();
 }
 
+void Connectors::registerConnector(
+    const std::shared_ptr<velox::connector::Connector>& connector) {
+  connectorIds_.push_back(connector->connectorId());
+  velox::connector::ConnectorRegistry::global().insert(
+      connector->connectorId(), connector);
+}
+
 std::shared_ptr<velox::connector::Connector> Connectors::registerTpchConnector(
     const std::string& connectorId) {
   auto emptyConfig = std::make_shared<velox::config::ConfigBase>(
@@ -84,8 +125,7 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerTpchConnector(
 
   velox::connector::tpch::TpchConnectorFactory factory;
   auto connector = factory.newConnector(connectorId, emptyConfig);
-  connectorIds_.push_back(connector->connectorId());
-  velox::connector::registerConnector(connector);
+  registerConnector(connector);
 
   auto tpchConnector =
       dynamic_cast<velox::connector::tpch::TpchConnector*>(connector.get());
@@ -112,8 +152,7 @@ Connectors::registerLocalHiveConnector(
 
   velox::connector::hive::HiveConnectorFactory factory;
   auto connector = factory.newConnector(connectorId, config, ioExecutor());
-  connectorIds_.push_back(connector->connectorId());
-  velox::connector::registerConnector(connector);
+  registerConnector(connector);
 
   auto hiveConnector =
       dynamic_cast<velox::connector::hive::HiveConnector*>(connector.get());
@@ -130,18 +169,25 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(
     const std::string& connectorId) {
   connector::TestConnectorFactory factory(connectorId.c_str());
   auto connector = factory.newConnector(connectorId);
-  connectorIds_.push_back(connector->connectorId());
-  velox::connector::registerConnector(connector);
+  registerConnector(connector);
   return connector;
 }
 
-void Connectors::registerSystemConnector(const std::string& connectorId) {
+void Connectors::registerSystemConnector(
+    const SessionConfig& sessionConfig,
+    const std::string& connectorId) {
+  sessionPropertiesProvider_ =
+      std::make_unique<SessionConfigPropertiesProvider>(sessionConfig);
+
   auto connector = std::make_shared<connector::system::SystemConnector>(
-      connectorId, /*queryInfoProvider=*/nullptr);
-  connectorIds_.push_back(connector->connectorId());
-  velox::connector::registerConnector(connector);
+      connectorId,
+      /*queryInfoProvider=*/nullptr,
+      sessionPropertiesProvider_.get());
+  registerConnector(connector);
   connector::ConnectorMetadata::registerMetadata(
-      connector->connectorId(), connector->metadata());
+      connector->connectorId(),
+      std::make_shared<connector::system::SystemConnectorMetadata>(
+          connector.get()));
 }
 
 } // namespace facebook::axiom

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -20,10 +20,13 @@
 #include <string>
 #include <vector>
 
+#include "axiom/connectors/system/SystemConnector.h"
 #include "folly/executors/IOThreadPoolExecutor.h"
 #include "velox/connectors/Connector.h"
 
 namespace facebook::axiom {
+
+class SessionConfig;
 
 /**
  * Helper class to register connectors for Axiom and Velox.
@@ -72,9 +75,10 @@ class Connectors {
   std::shared_ptr<velox::connector::Connector> registerTestConnector(
       const std::string& connectorId = kTestConnectorId);
 
-  /// Registers the system connector for the runtime.queries table.
-  /// Uses nullptr for QueryInfoProvider since the CLI has no query manager.
+  /// Registers the system connector for the runtime.queries and
+  /// metadata.session_properties tables.
   void registerSystemConnector(
+      const SessionConfig& sessionConfig,
       const std::string& connectorId = kSystemConnectorId);
 
  protected:
@@ -87,12 +91,22 @@ class Connectors {
     return ioExecutor_.get();
   }
 
+  /// Registers a connector in the global registry and tracks it for
+  /// cleanup on destruction.
+  void registerConnector(
+      const std::shared_ptr<velox::connector::Connector>& connector);
+
   // Unregister these on destruction.
   std::vector<std::string> connectorIds_{};
 
  private:
   static std::shared_ptr<folly::IOThreadPoolExecutor> getSharedIoExecutor();
   std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+
+  // Adapts SessionConfig to SessionPropertiesProvider. Stored here to
+  // ensure the provider outlives the system connector.
+  std::unique_ptr<connector::system::SessionPropertiesProvider>
+      sessionPropertiesProvider_;
 };
 
 } // namespace facebook::axiom

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -38,7 +38,7 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 
 ## Connectors
 
-Three connectors are available out of the box. See individual connector READMEs
+Four connectors are available out of the box. See individual connector READMEs
 for detailed documentation.
 
 **[TPC-H](../connectors/tpch/README.md)** (`tpch.tiny`) — Always registered. Read-only. Provides standard TPC-H tables
@@ -66,6 +66,9 @@ default catalog when registered.
 ```
 $ ./axiom_sql --data_path /path/to/data --data_format parquet
 ```
+
+**[System](../connectors/system/README.md)** (`system`) — Always registered. Read-only. Provides metadata tables
+such as session properties (`system.metadata.session_properties`).
 
 **[Test](../connectors/tests/README.md)** (`test.default`) — Always registered. An in-memory connector that supports
 `CREATE TABLE`, `CREATE TABLE AS SELECT`, `INSERT`, and `DROP TABLE`. Tables do

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -37,6 +37,7 @@
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryConfigProvider.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -52,6 +53,28 @@ namespace velox = facebook::velox;
 using namespace facebook::axiom;
 
 namespace {
+
+// Wraps a Velox connector's ConfigProvider pointer into an owned
+// ConfigProvider for use with ConfigRegistry. The underlying connector
+// must outlive this wrapper.
+class ConnectorConfigProvider : public velox::config::ConfigProvider {
+ public:
+  explicit ConnectorConfigProvider(
+      const velox::config::ConfigProvider* provider)
+      : provider_(provider) {}
+
+  std::vector<velox::config::ConfigProperty> properties() const override {
+    return provider_->properties();
+  }
+
+  std::string normalize(std::string_view name, std::string_view value)
+      const override {
+    return provider_->normalize(name, value);
+  }
+
+ private:
+  const velox::config::ConfigProvider* provider_;
+};
 
 // Returns the system's local IANA timezone name. Checks TZ environment variable
 // first, then reads /etc/localtime symlink, falls back to "UTC".
@@ -140,6 +163,15 @@ void SqlQueryRunner::initialize(
   configRegistry_->add(
       kExecutionPrefix,
       std::make_shared<facebook::velox::core::QueryConfigProvider>());
+
+  // Register config providers for connectors that support session properties.
+  for (const auto& [connectorId, connector] :
+       velox::connector::ConnectorRegistry::global().snapshot()) {
+    if (const auto* provider = connector->configProvider()) {
+      configRegistry_->add(
+          connectorId, std::make_shared<ConnectorConfigProvider>(provider));
+    }
+  }
 
   sessionConfig_ =
       std::make_shared<facebook::axiom::SessionConfig>(configRegistry_);
@@ -624,13 +656,29 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   queryConfig[velox::core::QueryConfig::kSessionStartTime] = std::to_string(
       options.sessionStartTimeMs.value_or(velox::getCurrentTimeMs()));
 
+  // Build per-connector session properties.
+  std::unordered_map<std::string, std::shared_ptr<velox::config::ConfigBase>>
+      connectorConfigs;
+  for (const auto& [connectorId, connector] :
+       velox::connector::ConnectorRegistry::global().snapshot()) {
+    if (connector->configProvider()) {
+      auto connectorProps = sessionConfig_->effectiveValues(connectorId);
+      if (!connectorProps.empty()) {
+        connectorConfigs[connectorId] =
+            std::make_shared<velox::config::ConfigBase>(
+                std::unordered_map<std::string, std::string>(
+                    connectorProps.begin(), connectorProps.end()));
+      }
+    }
+  }
+
   return velox::core::QueryCtx::create(
       executor_.get(),
       velox::core::QueryConfig(std::move(queryConfig)),
-      {},
+      std::move(connectorConfigs),
       velox::cache::AsyncDataCache::getInstance(),
       rootPool_->shared_from_this(),
-      nullptr,
+      /*spillExecutor=*/nullptr,
       queryId,
       options.tokenProvider);
 }

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -106,6 +106,23 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         makeRowVector({"Schema"}, {makeFlatVector(expected)}));
   }
 
+  void assertSessionProperty(
+      std::string_view name,
+      std::string_view expectedValue,
+      std::string_view expectedDefault) {
+    SCOPED_TRACE(name);
+    auto row = fetchSingleRow(fmt::format("SHOW SESSION LIKE '{}'", name));
+    ASSERT_EQ(row->childrenSize(), 5);
+    EXPECT_EQ(
+        row->childAt(0)->as<SimpleVector<StringView>>()->valueAt(0), name);
+    EXPECT_EQ(
+        row->childAt(1)->as<SimpleVector<StringView>>()->valueAt(0),
+        expectedValue);
+    EXPECT_EQ(
+        row->childAt(2)->as<SimpleVector<StringView>>()->valueAt(0),
+        expectedDefault);
+  }
+
   std::unique_ptr<SqlQueryRunner> runner_;
   std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
 
@@ -1073,35 +1090,20 @@ TEST_F(SqlQueryRunnerTest, timingFieldsOnParseError) {
 }
 
 TEST_F(SqlQueryRunnerTest, sessionProperties) {
-  auto assertProperty = [&](std::string_view name,
-                            std::string_view expectedValue,
-                            std::string_view expectedDefault) {
-    SCOPED_TRACE(name);
-    auto row = fetchSingleRow(fmt::format("SHOW SESSION LIKE '{}'", name));
-    // SHOW SESSION returns: Name, Value, Default, Type, Description.
-    ASSERT_EQ(row->childrenSize(), 5);
-    auto nameCol = row->childAt(0)->as<SimpleVector<StringView>>();
-    auto valueCol = row->childAt(1)->as<SimpleVector<StringView>>();
-    auto defaultCol = row->childAt(2)->as<SimpleVector<StringView>>();
-    EXPECT_EQ(nameCol->valueAt(0), name);
-    EXPECT_EQ(valueCol->valueAt(0), expectedValue);
-    EXPECT_EQ(defaultCol->valueAt(0), expectedDefault);
-  };
-
   // Default value.
-  assertProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "true", "true");
 
   // SET changes the value.
   auto result = run("SET SESSION optimizer.sample_joins = false");
   ASSERT_TRUE(result.message.has_value());
   EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' set to 'false'");
-  assertProperty("optimizer.sample_joins", "false", "true");
+  assertSessionProperty("optimizer.sample_joins", "false", "true");
 
   // RESET restores the default.
   result = run("RESET SESSION optimizer.sample_joins");
   ASSERT_TRUE(result.message.has_value());
   EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' reset");
-  assertProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "true", "true");
 
   // Invalid value.
   VELOX_ASSERT_THROW(
@@ -1131,14 +1133,116 @@ TEST_F(SqlQueryRunnerTest, showSession) {
   };
 
   // SHOW SESSION returns all properties.
-  EXPECT_THAT(
-      fetchNames("SHOW SESSION"),
-      ::testing::Contains("optimizer.sample_joins"));
+  auto allNames = fetchNames("SHOW SESSION");
+  EXPECT_THAT(allNames, ::testing::Contains("optimizer.sample_joins"));
+  EXPECT_THAT(allNames, ::testing::Contains("test.collect_column_statistics"));
 
   // SHOW SESSION LIKE filters by prefix.
-  auto names = fetchNames("SHOW SESSION LIKE 'optimizer%'");
-  EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("optimizer.")));
-  EXPECT_THAT(names, ::testing::Contains("optimizer.sample_joins"));
+  {
+    auto names = fetchNames("SHOW SESSION LIKE 'optimizer%'");
+    EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("optimizer.")));
+    EXPECT_THAT(names, ::testing::Contains("optimizer.sample_joins"));
+  }
+
+  {
+    auto names = fetchNames("SHOW SESSION LIKE 'test%'");
+    EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("test.")));
+    EXPECT_THAT(names, ::testing::Contains("test.collect_column_statistics"));
+  }
+}
+
+TEST_F(SqlQueryRunnerTest, connectorSessionProperties) {
+  // Default value.
+  assertSessionProperty("test.collect_column_statistics", "true", "true");
+
+  // SET changes the value.
+  auto result = run("SET SESSION test.collect_column_statistics = false");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(
+      *result.message,
+      "Session 'test.collect_column_statistics' set to 'false'");
+  assertSessionProperty("test.collect_column_statistics", "false", "true");
+
+  // RESET restores the default.
+  result = run("RESET SESSION test.collect_column_statistics");
+  ASSERT_TRUE(result.message.has_value());
+  EXPECT_EQ(*result.message, "Session 'test.collect_column_statistics' reset");
+  assertSessionProperty("test.collect_column_statistics", "true", "true");
+
+  // Invalid value.
+  VELOX_ASSERT_THROW(
+      run("SET SESSION test.collect_column_statistics = 42"),
+      "Expected boolean value");
+}
+
+// Verifies end-to-end flow: SET SESSION for a connector property reaches the
+// connector and affects query behavior.
+TEST_F(SqlQueryRunnerTest, connectorSessionPropertyEffect) {
+  const Variant null;
+
+  const auto statsType = ROW(
+      {
+          "row_count",
+          "column_name",
+          "nulls_fraction",
+          "distinct_values_count",
+          "avg_length",
+          "low_value",
+          "high_value",
+      },
+      {
+          BIGINT(),
+          VARCHAR(),
+          DOUBLE(),
+          BIGINT(),
+          BIGINT(),
+          VARCHAR(),
+          VARCHAR(),
+      });
+
+  // With stats collection enabled (default), SHOW STATS reports per-column
+  // stats.
+  {
+    run("CREATE TABLE t AS SELECT x FROM unnest(sequence(1, 10)) AS _(x)");
+    SCOPE_EXIT {
+      run("DROP TABLE IF EXISTS t");
+    };
+
+    auto expected = BaseVector::createFromVariants(
+        statsType,
+        {
+            Variant::row({10LL, null, null, null, null, null, null}),
+            Variant::row({null, "x", 0.0, 10LL, null, "1", "10"}),
+        },
+        pool());
+
+    auto result = run("SHOW STATS FOR t");
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+  }
+
+  // With stats collection disabled, per-column stats are null.
+  {
+    run("SET SESSION test.collect_column_statistics = false");
+    run("CREATE TABLE t AS SELECT x FROM unnest(sequence(1, 10)) AS _(x)");
+    SCOPE_EXIT {
+      run("DROP TABLE IF EXISTS t");
+    };
+
+    auto expected = BaseVector::createFromVariants(
+        statsType,
+        {
+            Variant::row({10LL, null, null, null, null, null, null}),
+            Variant::row({null, "x", null, null, null, null, null}),
+        },
+        pool());
+
+    auto result = run("SHOW STATS FOR t");
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(expected, result.results[0]);
+  }
 }
 
 } // namespace

--- a/axiom/connectors/system/README.md
+++ b/axiom/connectors/system/README.md
@@ -1,0 +1,136 @@
+# System Connector
+
+## Overview
+
+The system connector provides read-only access to runtime metadata —
+active queries, session properties, and other operational state. The
+application registers it under a catalog name of its choice (the CLI
+uses `system`).
+
+## Schemas and Tables
+
+### system.metadata
+
+Configuration metadata, including session-scoped properties.
+
+| Table | Description |
+|-------|-------------|
+| `session_properties` | All registered session properties with current values, defaults, and descriptions. |
+
+### system.runtime
+
+Runtime state that changes as the server operates.
+
+| Table | Description |
+|-------|-------------|
+| `queries` | One row per active or recent query with state, timing, resource usage, and split progress. |
+
+## Usage
+
+```sql
+-- Show all session properties for a component.
+SELECT name, current_value, default_value
+FROM system.metadata.session_properties
+WHERE component = 'optimizer';
+
+-- Find overridden session properties.
+SELECT component, name, current_value, default_value
+FROM system.metadata.session_properties
+WHERE current_value <> default_value;
+
+-- List all active queries.
+SELECT query_id, state, query, elapsed_time_ms
+FROM system.runtime.queries;
+```
+
+## Table Schemas
+
+### system.metadata.session_properties
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `component` | VARCHAR | Namespace prefix (e.g. `optimizer`, `execution`, connector ID). |
+| `name` | VARCHAR | Property name. |
+| `type` | VARCHAR | Property type (BOOLEAN, INTEGER, DOUBLE, STRING). |
+| `default_value` | VARCHAR | Default value (empty string if none). |
+| `current_value` | VARCHAR | Current session value (reflects SET SESSION overrides). |
+| `description` | VARCHAR | Human-readable description. |
+
+<details>
+<summary>system.runtime.queries (30 columns)</summary>
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `query_id` | VARCHAR | Unique query identifier. |
+| `state` | VARCHAR | Current state (QUEUED, RUNNING, FINISHED, FAILED). |
+| `query` | VARCHAR | SQL text. |
+| `catalog` | VARCHAR | Default catalog. |
+| `schema` | VARCHAR | Default schema. |
+| `user` | VARCHAR | User who submitted the query. |
+| `source` | VARCHAR | Client source identifier (nullable). |
+| `query_type` | VARCHAR | Statement type (SELECT, INSERT, etc.). |
+| `planning_time_ms` | BIGINT | Time spent in planning (ms). |
+| `optimization_time_ms` | BIGINT | Time spent in optimization (ms). |
+| `queue_time_ms` | BIGINT | Time spent in queue (ms). |
+| `execution_time_ms` | BIGINT | Time spent in execution (ms). |
+| `elapsed_time_ms` | BIGINT | Total wall-clock time (ms). |
+| `cpu_time_ms` | BIGINT | Total CPU time (ms). |
+| `wall_time_ms` | BIGINT | Total wall time (ms). |
+| `total_splits` | BIGINT | Total number of splits. |
+| `queued_splits` | BIGINT | Splits waiting to run. |
+| `running_splits` | BIGINT | Splits currently executing. |
+| `finished_splits` | BIGINT | Splits completed. |
+| `output_rows` | BIGINT | Rows returned to client. |
+| `output_bytes` | BIGINT | Bytes returned to client. |
+| `processed_rows` | BIGINT | Rows read from storage. |
+| `processed_bytes` | BIGINT | Bytes read from storage. |
+| `written_rows` | BIGINT | Rows written (INSERT queries). |
+| `written_bytes` | BIGINT | Bytes written (INSERT queries). |
+| `peak_memory_bytes` | BIGINT | Peak memory usage. |
+| `spilled_bytes` | BIGINT | Bytes spilled to disk. |
+| `create_time` | TIMESTAMP | When the query was created. |
+| `start_time` | TIMESTAMP | When execution started (nullable). |
+| `end_time` | TIMESTAMP | When execution finished (nullable). |
+
+</details>
+
+## Architecture
+
+The system connector has two layers:
+
+- **Velox layer** (`SystemConnector`): implements the Velox `Connector`
+  interface. Dispatches `createDataSource()` to the appropriate data
+  source based on the table being scanned.
+
+- **Axiom metadata layer** (`SystemConnectorMetadata`): implements the
+  Axiom `ConnectorMetadata` interface. Provides table discovery, column
+  handles, table handles, and split management.
+
+Each system table has a corresponding data source class that knows how
+to populate its columns. The data source reads from a **provider
+interface** — `QueryInfoProvider` for the queries table and
+`SessionPropertiesProvider` for session properties. These interfaces
+decouple the connector from the rest of the system: the connector
+defines what data it needs, and the application supplies it.
+
+At registration time, the application creates provider implementations
+and passes them to `SystemConnector`. For example, the CLI creates an
+adapter that reads from `SessionConfig` and passes it as the
+`SessionPropertiesProvider`:
+
+```
+Registration (startup):
+  Application creates provider adapters
+    → passes them to SystemConnector
+    → creates SystemConnectorMetadata(connector)
+    → registers both globally
+
+Query time:
+  SQL "SELECT ... FROM system.metadata.session_properties"
+    → optimizer resolves table via SystemConnectorMetadata::findTable()
+    → creates SystemTableHandle + SystemColumnHandles
+    → runner calls SystemConnector::createDataSource()
+    → connector dispatches to SessionPropertiesDataSource
+    → data source calls SessionPropertiesProvider::getSessionProperties()
+    → returns rows
+```

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/connectors/system/SystemConnector.h"
 
+#include <algorithm>
+
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/vector/ComplexVector.h"
@@ -78,6 +80,98 @@ bool isEpoch(std::chrono::system_clock::time_point tp) {
 }
 
 } // namespace
+
+// ===================== Data Sources (internal) =====================
+
+// Reads live query state from a QueryInfoProvider.
+class SystemDataSource : public velox::connector::DataSource {
+ public:
+  SystemDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      const QueryInfoProvider* queryInfoProvider,
+      velox::memory::MemoryPool* pool);
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& future) override;
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {}
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ private:
+  velox::RowVectorPtr buildQueryResults();
+
+  const velox::RowTypePtr outputType_;
+  const QueryInfoProvider* queryInfoProvider_;
+  velox::memory::MemoryPool* pool_;
+  std::shared_ptr<SystemSplit> split_;
+  std::vector<velox::column_index_t> outputColumnMappings_;
+  uint64_t completedRows_{0};
+  bool needData_{true};
+};
+
+// Reads session properties from a SessionPropertiesProvider.
+class SessionPropertiesDataSource : public velox::connector::DataSource {
+ public:
+  SessionPropertiesDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      const SessionPropertiesProvider* provider,
+      velox::memory::MemoryPool* pool);
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& future) override;
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {}
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ private:
+  velox::RowVectorPtr buildResults();
+
+  const velox::RowTypePtr outputType_;
+  const SessionPropertiesProvider* provider_;
+  velox::memory::MemoryPool* pool_;
+  std::shared_ptr<SystemSplit> split_;
+  std::vector<velox::column_index_t> outputColumnMappings_;
+  uint64_t completedRows_{0};
+  bool needData_{true};
+};
 
 // ===================== SystemTableHandle =====================
 
@@ -507,25 +601,153 @@ velox::RowVectorPtr SystemDataSource::buildQueryResults() {
       pool_, outputType_, nullptr, numRows, std::move(children));
 }
 
+// ===================== SessionPropertiesDataSource =====================
+
+SessionPropertiesDataSource::SessionPropertiesDataSource(
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    const SessionPropertiesProvider* provider,
+    velox::memory::MemoryPool* pool)
+    : outputType_(outputType), provider_(provider), pool_(pool) {
+  auto fullSchema = sessionPropertiesTableSchema();
+  outputColumnMappings_.reserve(outputType_->size());
+  for (const auto& name : outputType_->names()) {
+    VELOX_CHECK(
+        columnHandles.contains(name), "No handle for output column '{}'", name);
+    auto handle = columnHandles.find(name)->second;
+    auto idx = fullSchema->getChildIdxIfExists(handle->name());
+    VELOX_CHECK(
+        idx.has_value(),
+        "Column '{}' not found in system.metadata.session_properties schema",
+        handle->name());
+    outputColumnMappings_.push_back(idx.value());
+  }
+}
+
+void SessionPropertiesDataSource::addSplit(
+    std::shared_ptr<velox::connector::ConnectorSplit> split) {
+  split_ = std::dynamic_pointer_cast<SystemSplit>(split);
+  VELOX_CHECK(split_, "Expected SystemSplit");
+  needData_ = true;
+}
+
+std::optional<velox::RowVectorPtr> SessionPropertiesDataSource::next(
+    uint64_t /*size*/,
+    velox::ContinueFuture& /*future*/) {
+  VELOX_CHECK(split_, "No split added to SessionPropertiesDataSource");
+
+  if (!needData_) {
+    return nullptr;
+  }
+  needData_ = false;
+
+  return buildResults();
+}
+
+velox::RowVectorPtr SessionPropertiesDataSource::buildResults() {
+  if (!provider_) {
+    return velox::RowVector::createEmpty(outputType_, pool_);
+  }
+
+  auto properties = provider_->getSessionProperties();
+  auto numRows = properties.size();
+  completedRows_ += numRows;
+
+  if (numRows == 0) {
+    return velox::RowVector::createEmpty(outputType_, pool_);
+  }
+
+  // All 6 columns are VARCHAR. Build only the requested ones.
+  // Column indices: 0=component, 1=name, 2=type, 3=default_value,
+  // 4=current_value, 5=description.
+  auto fullSchema = sessionPropertiesTableSchema();
+
+  // Accessor for each column by index.
+  auto getValue = [&](size_t row,
+                      velox::column_index_t col) -> const std::string& {
+    switch (col) {
+      case 0:
+        return properties[row].component;
+      case 1:
+        return properties[row].name;
+      case 2:
+        return properties[row].type;
+      case 3:
+        return properties[row].defaultValue;
+      case 4:
+        return properties[row].currentValue;
+      case 5:
+        return properties[row].description;
+      default:
+        VELOX_FAIL("Unknown session_properties column index: {}", col);
+    }
+  };
+
+  std::vector<velox::VectorPtr> children;
+  children.reserve(outputType_->size());
+  for (auto fullIdx : outputColumnMappings_) {
+    auto vec =
+        velox::BaseVector::create(fullSchema->childAt(fullIdx), numRows, pool_);
+    auto* flat = vec->asFlatVector<velox::StringView>();
+    for (size_t row = 0; row < numRows; ++row) {
+      flat->set(row, velox::StringView(getValue(row, fullIdx)));
+    }
+    children.push_back(std::move(vec));
+  }
+
+  return std::make_shared<velox::RowVector>(
+      pool_, outputType_, nullptr, numRows, std::move(children));
+}
+
 // ===================== SystemConnector =====================
 
 SystemConnector::SystemConnector(
     const std::string& id,
-    const QueryInfoProvider* queryInfoProvider)
+    const QueryInfoProvider* queryInfoProvider,
+    const SessionPropertiesProvider* sessionPropertiesProvider)
     : Connector(id),
       queryInfoProvider_(queryInfoProvider),
-      metadata_(std::make_shared<SystemConnectorMetadata>(this)) {}
+      sessionPropertiesProvider_(sessionPropertiesProvider) {}
 
 std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
     const velox::RowTypePtr& outputType,
-    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const velox::connector::ColumnHandleMap& columnHandles,
     velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
-  return std::make_unique<SystemDataSource>(
-      outputType,
-      columnHandles,
-      queryInfoProvider_,
-      connectorQueryCtx->memoryPool());
+  auto* systemHandle =
+      dynamic_cast<const SystemTableHandle*>(tableHandle.get());
+  VELOX_CHECK_NOT_NULL(systemHandle, "Expected SystemTableHandle");
+
+  // Dispatch based on which table is being scanned. Use the handle's name
+  // (always available) rather than layout() which is null after
+  // deserialization.
+  const auto& name = systemHandle->name();
+
+  static const auto kSessionPropertiesName =
+      SchemaTableName{
+          std::string(kMetadataSchema), std::string(kSessionPropertiesTable)}
+          .toString();
+  static const auto kQueriesName =
+      SchemaTableName{std::string(kRuntimeSchema), std::string(kQueriesTable)}
+          .toString();
+
+  if (name == kSessionPropertiesName) {
+    return std::make_unique<SessionPropertiesDataSource>(
+        outputType,
+        columnHandles,
+        sessionPropertiesProvider_,
+        connectorQueryCtx->memoryPool());
+  }
+
+  if (name == kQueriesName) {
+    return std::make_unique<SystemDataSource>(
+        outputType,
+        columnHandles,
+        queryInfoProvider_,
+        connectorQueryCtx->memoryPool());
+  }
+
+  VELOX_FAIL("Unknown system table: {}", name);
 }
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -24,6 +24,13 @@
 
 namespace facebook::axiom::connector::system {
 
+/// Schema and table name constants for the system connector.
+static constexpr std::string_view kRuntimeSchema = "runtime";
+static constexpr std::string_view kMetadataSchema = "metadata";
+static constexpr std::string_view kQueriesTable = "queries";
+static constexpr std::string_view kSessionPropertiesTable =
+    "session_properties";
+
 /// Snapshot of a single query's state, used by the system connector to
 /// populate the system.runtime.queries table.
 struct QueryInfo {
@@ -73,7 +80,25 @@ class QueryInfoProvider {
   virtual std::vector<QueryInfo> getQueryInfos() const = 0;
 };
 
-class SystemConnectorMetadata;
+/// Snapshot of a single session property, used by the system connector to
+/// populate the system.metadata.session_properties table.
+struct SessionPropertyInfo {
+  std::string component;
+  std::string name;
+  std::string type;
+  std::string defaultValue;
+  std::string currentValue;
+  std::string description;
+};
+
+/// Provides session property metadata to the system connector.
+class SessionPropertiesProvider {
+ public:
+  virtual ~SessionPropertiesProvider() = default;
+
+  /// Returns all registered session properties with their current values.
+  virtual std::vector<SessionPropertyInfo> getSessionProperties() const = 0;
+};
 
 /// Column handle for the system connector. Wraps a column name.
 class SystemColumnHandle : public velox::connector::ColumnHandle {
@@ -189,68 +214,16 @@ struct SystemSplit : public velox::connector::ConnectorSplit {
   VELOX_DEFINE_CLASS_NAME(SystemSplit)
 };
 
-/// DataSource that reads live query state from a QueryInfoProvider.
-/// On next(), it enumerates all queries and populates a RowVector
-/// with one row per query for the requested columns.
-class SystemDataSource : public velox::connector::DataSource {
- public:
-  SystemDataSource(
-      const velox::RowTypePtr& outputType,
-      const velox::connector::ColumnHandleMap& columnHandles,
-      const QueryInfoProvider* queryInfoProvider,
-      velox::memory::MemoryPool* pool);
-
-  void addSplit(
-      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
-
-  std::optional<velox::RowVectorPtr> next(
-      uint64_t size,
-      velox::ContinueFuture& future) override;
-
-  void addDynamicFilter(
-      velox::column_index_t,
-      const std::shared_ptr<velox::common::Filter>&) override {}
-
-  uint64_t getCompletedBytes() override {
-    return 0;
-  }
-
-  uint64_t getCompletedRows() override {
-    return completedRows_;
-  }
-
-  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
-      override {
-    return {};
-  }
-
- private:
-  velox::RowVectorPtr buildQueryResults();
-
-  const velox::RowTypePtr outputType_;
-  const QueryInfoProvider* queryInfoProvider_;
-  velox::memory::MemoryPool* pool_;
-  std::shared_ptr<SystemSplit> split_;
-  // Maps output column index -> index in the full queries schema.
-  std::vector<velox::column_index_t> outputColumnMappings_;
-  uint64_t completedRows_{0};
-  bool needData_{true};
-};
-
-/// Velox connector for the system catalog. Creates SystemDataSource
-/// instances for reading live query metadata.
+/// Velox connector for the system catalog. Creates data source instances
+/// for reading live query metadata and session properties.
 class SystemConnector : public velox::connector::Connector {
  public:
   SystemConnector(
       const std::string& id,
-      const QueryInfoProvider* queryInfoProvider);
+      const QueryInfoProvider* queryInfoProvider,
+      const SessionPropertiesProvider* sessionPropertiesProvider = nullptr);
 
   ~SystemConnector() override = default;
-
-  /// Returns the Axiom ConnectorMetadata for external registration.
-  const std::shared_ptr<SystemConnectorMetadata>& metadata() const {
-    return metadata_;
-  }
 
   std::unique_ptr<velox::connector::DataSource> createDataSource(
       const velox::RowTypePtr& outputType,
@@ -275,7 +248,7 @@ class SystemConnector : public velox::connector::Connector {
 
  private:
   const QueryInfoProvider* queryInfoProvider_;
-  std::shared_ptr<SystemConnectorMetadata> metadata_;
+  const SessionPropertiesProvider* sessionPropertiesProvider_;
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -56,6 +56,17 @@ velox::RowTypePtr queriesTableSchema() {
   return schema;
 }
 
+velox::RowTypePtr sessionPropertiesTableSchema() {
+  static auto schema = velox::ROW(
+      {{"component", velox::VARCHAR()},
+       {"name", velox::VARCHAR()},
+       {"type", velox::VARCHAR()},
+       {"default_value", velox::VARCHAR()},
+       {"current_value", velox::VARCHAR()},
+       {"description", velox::VARCHAR()}});
+  return schema;
+}
+
 // ===================== SystemTableLayout =====================
 
 velox::connector::ColumnHandlePtr SystemTableLayout::createColumnHandle(
@@ -86,12 +97,11 @@ velox::connector::ConnectorTableHandlePtr SystemTableLayout::createTableHandle(
 
 // ===================== SystemTable =====================
 
-SystemTable::SystemTable(velox::connector::Connector* connector)
-    : Table(
-          SchemaTableName{
-              std::string(SystemConnectorMetadata::kDefaultSchema),
-              "queries"},
-          makeColumns(queriesTableSchema())) {
+SystemTable::SystemTable(
+    const SchemaTableName& tableName,
+    const velox::RowTypePtr& schema,
+    velox::connector::Connector* connector)
+    : Table(tableName, makeColumns(schema)) {
   layout_ = std::make_unique<SystemTableLayout>(this, connector, allColumns());
   layouts_.push_back(layout_.get());
 }
@@ -130,13 +140,24 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
 // ===================== SystemConnectorMetadata =====================
 
 TablePtr SystemConnectorMetadata::findTable(const SchemaTableName& tableName) {
-  if (tableName.schema != kDefaultSchema || tableName.table != "queries") {
-    return nullptr;
+  if (tableName.schema == kRuntimeSchema && tableName.table == kQueriesTable) {
+    if (!queriesTable_) {
+      queriesTable_ = std::make_shared<SystemTable>(
+          tableName, queriesTableSchema(), connector_);
+    }
+    return queriesTable_;
   }
-  if (!queriesTable_) {
-    queriesTable_ = std::make_shared<SystemTable>(connector_);
+
+  if (tableName.schema == kMetadataSchema &&
+      tableName.table == kSessionPropertiesTable) {
+    if (!sessionPropertiesTable_) {
+      sessionPropertiesTable_ = std::make_shared<SystemTable>(
+          tableName, sessionPropertiesTableSchema(), connector_);
+    }
+    return sessionPropertiesTable_;
   }
-  return queriesTable_;
+
+  return nullptr;
 }
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -17,11 +17,15 @@
 #pragma once
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/system/SystemConnector.h"
 
 namespace facebook::axiom::connector::system {
 
 /// Returns the schema for the system.runtime.queries table.
 velox::RowTypePtr queriesTableSchema();
+
+/// Returns the schema for the system.metadata.session_properties table.
+velox::RowTypePtr sessionPropertiesTableSchema();
 
 // ===================== Axiom Metadata Layer =====================
 
@@ -67,7 +71,10 @@ class SystemTableLayout : public TableLayout {
 /// Table representing system.runtime.queries.
 class SystemTable : public Table {
  public:
-  explicit SystemTable(velox::connector::Connector* connector);
+  SystemTable(
+      const SchemaTableName& tableName,
+      const velox::RowTypePtr& schema,
+      velox::connector::Connector* connector);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -112,10 +119,11 @@ class SystemSplitManager : public ConnectorSplitManager {
 };
 
 /// Axiom ConnectorMetadata for the system connector.
-/// Provides the runtime.queries table and split management.
+/// Provides the runtime.queries and metadata.session_properties tables.
 class SystemConnectorMetadata : public ConnectorMetadata {
  public:
-  static constexpr std::string_view kDefaultSchema = "runtime";
+  /// Keep for backward compatibility.
+  static constexpr std::string_view kDefaultSchema = kRuntimeSchema;
 
   explicit SystemConnectorMetadata(velox::connector::Connector* connector)
       : connector_(connector),
@@ -125,13 +133,13 @@ class SystemConnectorMetadata : public ConnectorMetadata {
 
   std::vector<std::string> listSchemaNames(
       const ConnectorSessionPtr& session) override {
-    return {std::string(kDefaultSchema)};
+    return {std::string(kRuntimeSchema), std::string(kMetadataSchema)};
   }
 
   bool schemaExists(
       const ConnectorSessionPtr& session,
       const std::string& schemaName) override {
-    return schemaName == kDefaultSchema;
+    return schemaName == kRuntimeSchema || schemaName == kMetadataSchema;
   }
 
   ConnectorSplitManager* splitManager() override {
@@ -142,6 +150,7 @@ class SystemConnectorMetadata : public ConnectorMetadata {
   velox::connector::Connector* connector_;
   std::unique_ptr<SystemSplitManager> splitManager_;
   std::shared_ptr<SystemTable> queriesTable_;
+  std::shared_ptr<SystemTable> sessionPropertiesTable_;
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -27,6 +27,8 @@ target_link_libraries(
   velox_connector
   velox_exec
   velox_expression
+  velox_vector_test_lib
+  GTest::gmock
   GTest::gtest
   GTest::gtest_main
 )

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <folly/coro/BlockingWait.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/ConnectorMetadata.h"
@@ -22,6 +23,7 @@
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
 #include "velox/expression/Expr.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::axiom::connector::system {
 namespace {
@@ -43,21 +45,35 @@ class MockQueryInfoProvider : public QueryInfoProvider {
   std::vector<QueryInfo> snapshots_;
 };
 
+/// In-memory mock that returns a fixed set of session properties.
+class MockSessionPropertiesProvider : public SessionPropertiesProvider {
+ public:
+  void addProperty(SessionPropertyInfo property) {
+    properties_.push_back(std::move(property));
+  }
+
+  std::vector<SessionPropertyInfo> getSessionProperties() const override {
+    return properties_;
+  }
+
+ private:
+  std::vector<SessionPropertyInfo> properties_;
+};
+
 class SystemConnectorMetadataTest : public ::testing::Test {
  protected:
   void SetUp() override {
     velox::memory::MemoryManager::testingSetInstance({});
 
-    mockProvider_ = std::make_unique<MockQueryInfoProvider>();
+    queryProvider_ = std::make_unique<MockQueryInfoProvider>();
+    sessionProvider_ = std::make_unique<MockSessionPropertiesProvider>();
 
-    // SystemConnector no longer auto-registers metadata.
-    connector_ =
-        std::make_shared<SystemConnector>(kSystemCatalog, mockProvider_.get());
+    connector_ = std::make_shared<SystemConnector>(
+        kSystemCatalog, queryProvider_.get(), sessionProvider_.get());
     velox::connector::registerConnector(connector_);
-    ConnectorMetadata::registerMetadata(kSystemCatalog, connector_->metadata());
 
-    // Create a separate metadata instance for direct testing.
     metadata_ = std::make_shared<SystemConnectorMetadata>(connector_.get());
+    ConnectorMetadata::registerMetadata(kSystemCatalog, metadata_);
 
     pool_ = velox::memory::memoryManager()->addLeafPool();
     queryCtx_ = velox::core::QueryCtx::create();
@@ -70,12 +86,79 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     connector_.reset();
   }
 
-  std::unique_ptr<MockQueryInfoProvider> mockProvider_;
+  // Creates a DataSource for the given schema/table through the connector,
+  // adds a split, and returns the first batch of results.
+  velox::RowVectorPtr readTable(
+      const SchemaTableName& tableName,
+      const velox::RowTypePtr& outputType) {
+    auto table = metadata_->findTable(tableName);
+    VELOX_CHECK_NOT_NULL(table);
+
+    auto session = std::make_shared<ConnectorSession>("test-query");
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        queryCtx_.get(), pool_.get());
+
+    velox::connector::ColumnHandleMap columnHandles;
+    std::vector<velox::connector::ColumnHandlePtr> handleList;
+    for (const auto& name : outputType->names()) {
+      auto handle = table->layouts()[0]->createColumnHandle(session, name);
+      columnHandles[name] = handle;
+      handleList.push_back(handle);
+    }
+
+    std::vector<velox::core::TypedExprPtr> filters;
+    std::vector<velox::core::TypedExprPtr> rejectedFilters;
+    auto tableHandle = table->layouts()[0]->createTableHandle(
+        session,
+        std::move(handleList),
+        evaluator,
+        std::move(filters),
+        rejectedFilters);
+
+    auto emptyConfig = std::make_shared<velox::config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{});
+    auto connectorQueryCtx =
+        std::make_unique<velox::connector::ConnectorQueryCtx>(
+            pool_.get(),
+            pool_.get(),
+            emptyConfig.get(),
+            /*spillConfig=*/nullptr,
+            velox::common::PrefixSortConfig{},
+            /*expressionEvaluator=*/nullptr,
+            /*cache=*/nullptr,
+            "test-query",
+            "test-task",
+            "test-plan-node",
+            /*driverId=*/0,
+            /*sessionTimezone=*/"UTC");
+
+    auto dataSource = connector_->createDataSource(
+        outputType, tableHandle, columnHandles, connectorQueryCtx.get());
+
+    auto split = std::make_shared<SystemSplit>(kSystemCatalog);
+    dataSource->addSplit(split);
+
+    velox::ContinueFuture future;
+    auto result = dataSource->next(1024, future);
+    VELOX_CHECK(result.has_value());
+
+    // Verify the data source is exhausted.
+    auto next = dataSource->next(1024, future);
+    VELOX_CHECK(next.has_value());
+    VELOX_CHECK_NULL(next.value());
+
+    return result.value();
+  }
+
+  std::unique_ptr<MockQueryInfoProvider> queryProvider_;
+  std::unique_ptr<MockSessionPropertiesProvider> sessionProvider_;
   std::shared_ptr<SystemConnector> connector_;
   std::shared_ptr<SystemConnectorMetadata> metadata_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::shared_ptr<velox::core::QueryCtx> queryCtx_;
 };
+
+// ===================== system.runtime.queries tests =====================
 
 TEST_F(SystemConnectorMetadataTest, findTable) {
   auto table = metadata_->findTable({"runtime", "queries"});
@@ -189,9 +272,6 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceAllColumns) {
-  // Set up test data.
-  auto now = std::chrono::system_clock::now();
-
   QueryInfo snapshot;
   snapshot.queryId = "q1";
   snapshot.state = "RUNNING";
@@ -204,82 +284,43 @@ TEST_F(SystemConnectorMetadataTest, dataSourceAllColumns) {
   snapshot.planningTimeMs = 100;
   snapshot.totalSplits = 10;
   snapshot.outputRows = 1000;
-  snapshot.createTime = now;
+  snapshot.createTime = std::chrono::system_clock::now();
 
-  mockProvider_->addQuery(std::move(snapshot));
+  auto expectedSeconds = std::chrono::duration_cast<std::chrono::seconds>(
+                             snapshot.createTime.time_since_epoch())
+                             .count();
+  auto expectedNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           snapshot.createTime.time_since_epoch())
+                           .count() %
+      1'000'000'000;
 
-  auto fullSchema = queriesTableSchema();
+  queryProvider_->addQuery(std::move(snapshot));
 
-  // Build column handles for all columns.
-  velox::connector::ColumnHandleMap columnHandles;
-  for (const auto& name : fullSchema->names()) {
-    columnHandles[name] = std::make_shared<SystemColumnHandle>(name);
-  }
-
-  auto dataSource = std::make_unique<SystemDataSource>(
-      fullSchema, columnHandles, mockProvider_.get(), pool_.get());
-
-  auto split = std::make_shared<SystemSplit>(kSystemCatalog);
-  dataSource->addSplit(split);
-
-  velox::ContinueFuture future;
-  auto result = dataSource->next(1024, future);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_NE(result.value(), nullptr);
-  auto vector = result.value();
+  auto vector = readTable({"runtime", "queries"}, queriesTableSchema());
+  ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
 
-  // query_id (column 0)
-  auto* queryIdVec = vector->childAt(0)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(queryIdVec->valueAt(0).str(), "q1");
+  auto values = vector->variantAt(0).row();
 
-  // state (column 1)
-  auto* stateVec = vector->childAt(1)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(stateVec->valueAt(0).str(), "RUNNING");
+  // VARCHAR columns.
+  EXPECT_EQ(values[0].value<std::string>(), "q1");
+  EXPECT_EQ(values[1].value<std::string>(), "RUNNING");
+  EXPECT_EQ(values[2].value<std::string>(), "SELECT * FROM t");
+  EXPECT_EQ(values[3].value<std::string>(), "cat");
+  EXPECT_EQ(values[5].value<std::string>(), "testuser");
+  EXPECT_EQ(values[6].value<std::string>(), "testsource");
+  EXPECT_EQ(values[7].value<std::string>(), "SELECT");
 
-  // query (column 2)
-  auto* queryVec = vector->childAt(2)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(queryVec->valueAt(0).str(), "SELECT * FROM t");
+  // BIGINT columns.
+  EXPECT_EQ(values[8].value<int64_t>(), 100); // planning_time_ms
+  EXPECT_EQ(values[15].value<int64_t>(), 10); // total_splits
+  EXPECT_EQ(values[19].value<int64_t>(), 1000); // output_rows
 
-  // catalog (column 3)
-  auto* catalogVec = vector->childAt(3)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(catalogVec->valueAt(0).str(), "cat");
-
-  // user (column 5)
-  auto* userVec = vector->childAt(5)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(userVec->valueAt(0).str(), "testuser");
-
-  // source (column 6) — should not be null
-  EXPECT_FALSE(vector->childAt(6)->isNullAt(0));
-  auto* sourceVec = vector->childAt(6)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(sourceVec->valueAt(0).str(), "testsource");
-
-  // query_type (column 7)
-  auto* qtVec = vector->childAt(7)->asFlatVector<velox::StringView>();
-  EXPECT_EQ(qtVec->valueAt(0).str(), "SELECT");
-
-  // planning_time_ms (column 8)
-  auto* planVec = vector->childAt(8)->asFlatVector<int64_t>();
-  EXPECT_EQ(planVec->valueAt(0), 100);
-
-  // total_splits (column 15)
-  auto* splitVec = vector->childAt(15)->asFlatVector<int64_t>();
-  EXPECT_EQ(splitVec->valueAt(0), 10);
-
-  // output_rows (column 19)
-  auto* outVec = vector->childAt(19)->asFlatVector<int64_t>();
-  EXPECT_EQ(outVec->valueAt(0), 1000);
-
-  // create_time (column 27) — should not be null
-  EXPECT_FALSE(vector->childAt(27)->isNullAt(0));
-
-  // end_time (column 29) — should be null (epoch = not set)
-  EXPECT_TRUE(vector->childAt(29)->isNullAt(0));
-
-  // Second call returns no more data.
-  auto result2 = dataSource->next(1024, future);
-  ASSERT_TRUE(result2.has_value());
-  EXPECT_EQ(result2.value(), nullptr);
+  // TIMESTAMP columns.
+  auto ts = values[27].value<velox::Timestamp>();
+  EXPECT_EQ(ts.getSeconds(), expectedSeconds);
+  EXPECT_EQ(ts.getNanos(), expectedNanos);
+  EXPECT_TRUE(values[29].isNull()); // end_time (epoch = not set)
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceColumnPruning) {
@@ -291,26 +332,12 @@ TEST_F(SystemConnectorMetadataTest, dataSourceColumnPruning) {
   snapshot.schema = "s";
   snapshot.user = "u";
 
-  mockProvider_->addQuery(std::move(snapshot));
+  queryProvider_->addQuery(std::move(snapshot));
 
-  // Request only query_id and state.
   auto outputType =
       velox::ROW({{"query_id", velox::VARCHAR()}, {"state", velox::VARCHAR()}});
-  velox::connector::ColumnHandleMap columnHandles;
-  columnHandles["query_id"] = std::make_shared<SystemColumnHandle>("query_id");
-  columnHandles["state"] = std::make_shared<SystemColumnHandle>("state");
-
-  auto dataSource = std::make_unique<SystemDataSource>(
-      outputType, columnHandles, mockProvider_.get(), pool_.get());
-
-  auto split = std::make_shared<SystemSplit>(kSystemCatalog);
-  dataSource->addSplit(split);
-
-  velox::ContinueFuture future;
-  auto result = dataSource->next(1024, future);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_NE(result.value(), nullptr);
-  auto vector = result.value();
+  auto vector = readTable({"runtime", "queries"}, outputType);
+  ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
   ASSERT_EQ(vector->type()->size(), 2);
 
@@ -322,24 +349,9 @@ TEST_F(SystemConnectorMetadataTest, dataSourceColumnPruning) {
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceEmpty) {
-  // No queries in the mock.
-  auto fullSchema = queriesTableSchema();
-  velox::connector::ColumnHandleMap columnHandles;
-  for (const auto& name : fullSchema->names()) {
-    columnHandles[name] = std::make_shared<SystemColumnHandle>(name);
-  }
-
-  auto dataSource = std::make_unique<SystemDataSource>(
-      fullSchema, columnHandles, mockProvider_.get(), pool_.get());
-
-  auto split = std::make_shared<SystemSplit>(kSystemCatalog);
-  dataSource->addSplit(split);
-
-  velox::ContinueFuture future;
-  auto result = dataSource->next(1024, future);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_NE(result.value(), nullptr);
-  EXPECT_EQ(result.value()->size(), 0);
+  auto vector = readTable({"runtime", "queries"}, queriesTableSchema());
+  ASSERT_NE(vector, nullptr);
+  EXPECT_EQ(vector->size(), 0);
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceNullSource) {
@@ -352,28 +364,67 @@ TEST_F(SystemConnectorMetadataTest, dataSourceNullSource) {
   snapshot.user = "u";
   // source is not set (std::nullopt by default).
 
-  mockProvider_->addQuery(std::move(snapshot));
+  queryProvider_->addQuery(std::move(snapshot));
 
-  // Request only the source column.
   auto outputType = velox::ROW({{"source", velox::VARCHAR()}});
-  velox::connector::ColumnHandleMap columnHandles;
-  columnHandles["source"] = std::make_shared<SystemColumnHandle>("source");
-
-  auto dataSource = std::make_unique<SystemDataSource>(
-      outputType, columnHandles, mockProvider_.get(), pool_.get());
-
-  auto split = std::make_shared<SystemSplit>(kSystemCatalog);
-  dataSource->addSplit(split);
-
-  velox::ContinueFuture future;
-  auto result = dataSource->next(1024, future);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_NE(result.value(), nullptr);
-  auto vector = result.value();
+  auto vector = readTable({"runtime", "queries"}, outputType);
+  ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
 
   // source should be null since snapshot.source is std::nullopt.
   EXPECT_TRUE(vector->childAt(0)->isNullAt(0));
+}
+
+TEST_F(SystemConnectorMetadataTest, findSessionPropertiesTable) {
+  auto table = metadata_->findTable({"metadata", "session_properties"});
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->name(), (SchemaTableName{"metadata", "session_properties"}));
+}
+
+TEST_F(SystemConnectorMetadataTest, findTableWrongSchema) {
+  EXPECT_EQ(metadata_->findTable({"metadata", "queries"}), nullptr);
+  EXPECT_EQ(metadata_->findTable({"runtime", "session_properties"}), nullptr);
+}
+
+TEST_F(SystemConnectorMetadataTest, sessionPropertiesSchema) {
+  auto table = metadata_->findTable({"metadata", "session_properties"});
+  ASSERT_NE(table, nullptr);
+
+  auto expectedSchema = sessionPropertiesTableSchema();
+  ASSERT_EQ(table->type()->size(), expectedSchema->size());
+  for (size_t i = 0; i < expectedSchema->size(); ++i) {
+    EXPECT_EQ(table->type()->nameOf(i), expectedSchema->nameOf(i));
+    EXPECT_EQ(
+        table->type()->childAt(i)->kind(), expectedSchema->childAt(i)->kind());
+  }
+}
+
+TEST_F(SystemConnectorMetadataTest, schemas) {
+  auto session = std::make_shared<ConnectorSession>("test-query");
+  EXPECT_THAT(
+      metadata_->listSchemaNames(session),
+      testing::UnorderedElementsAre("runtime", "metadata"));
+  EXPECT_TRUE(metadata_->schemaExists(session, "runtime"));
+  EXPECT_TRUE(metadata_->schemaExists(session, "metadata"));
+  EXPECT_FALSE(metadata_->schemaExists(session, "information_schema"));
+}
+
+TEST_F(SystemConnectorMetadataTest, sessionPropertiesAllColumns) {
+  sessionProvider_->addProperty(
+      {"a", "x", "boolean", "true", "false", "First."});
+  sessionProvider_->addProperty({"b", "y", "string", "", "hello", "Second."});
+
+  auto expected = velox::BaseVector::createFromVariants(
+      sessionPropertiesTableSchema(),
+      {
+          velox::Variant::row({"a", "x", "boolean", "true", "false", "First."}),
+          velox::Variant::row({"b", "y", "string", "", "hello", "Second."}),
+      },
+      pool_.get());
+
+  auto actual = readTable(
+      {"metadata", "session_properties"}, sessionPropertiesTableSchema());
+  velox::test::assertEqualVectors(expected, actual);
 }
 
 } // namespace

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -140,7 +140,9 @@ void TestTable::setStats(
   }
 }
 
-void TestTable::addData(const velox::RowVectorPtr& data) {
+void TestTable::addData(
+    const velox::RowVectorPtr& data,
+    bool collectColumnStatistics) {
   VELOX_CHECK_EQ(
       numRows_,
       0,
@@ -156,6 +158,10 @@ void TestTable::addData(const velox::RowVectorPtr& data) {
       velox::BaseVector::copy(*data, pool_.get()));
   data_.push_back(copy);
   dataRows_ += data->size();
+
+  if (!collectColumnStatistics) {
+    return;
+  }
 
   // Compute per-column statistics incrementally.
   const auto& rowType = type();
@@ -651,7 +657,7 @@ std::unique_ptr<velox::connector::DataSource> TestConnector::createDataSource(
 std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
     velox::RowTypePtr,
     velox::connector::ConnectorInsertTableHandlePtr tableHandle,
-    velox::connector::ConnectorQueryCtx*,
+    velox::connector::ConnectorQueryCtx* connectorQueryCtx,
     velox::connector::CommitStrategy) {
   VELOX_CHECK(tableHandle, "table handle must be non-null");
   auto* testHandle =
@@ -662,7 +668,10 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
       table,
       "cannot create data sink for nonexistent table {}",
       testHandle->tableName().toString());
-  return std::make_unique<TestDataSink>(table);
+  auto collectColumnStatistics =
+      connectorQueryCtx->sessionProperties()->get<bool>(
+          TestConfigProvider::kCollectColumnStatistics, true);
+  return std::make_unique<TestDataSink>(table, collectColumnStatistics);
 }
 
 std::shared_ptr<TestTable> TestConnector::addTable(
@@ -736,7 +745,7 @@ std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(
 
 void TestDataSink::appendData(velox::RowVectorPtr vector) {
   if (vector) {
-    table_->addData(vector);
+    table_->addData(vector, collectColumnStatistics_);
   }
 }
 

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -107,10 +107,12 @@ class TestTable : public Table {
 
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
-  /// memory pool. Computes per-column statistics incrementally (numDistinct,
-  /// min/max, nullPct, maxLength). Cannot be combined with setStats on the
-  /// same table.
-  void addData(const velox::RowVectorPtr& data);
+  /// memory pool. When 'collectColumnStatistics' is true, computes per-column
+  /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
+  /// Cannot be combined with setStats on the same table.
+  void addData(
+      const velox::RowVectorPtr& data,
+      bool collectColumnStatistics = true);
 
   TestTableLayout* mutableLayout() {
     return exportedLayout_.get();
@@ -581,6 +583,27 @@ class TestDataSource : public velox::connector::DataSource {
   bool more_{false};
 };
 
+/// ConfigProvider for TestConnector session properties.
+class TestConfigProvider : public velox::config::ConfigProvider {
+ public:
+  static constexpr const char* kCollectColumnStatistics =
+      "collect_column_statistics";
+
+  std::vector<velox::config::ConfigProperty> properties() const override {
+    return {
+        {kCollectColumnStatistics,
+         velox::config::ConfigPropertyType::kBoolean,
+         "true",
+         "Collect per-column statistics when writing data to a table."},
+    };
+  }
+
+  std::string normalize(std::string_view /*name*/, std::string_view value)
+      const override {
+    return std::string(value);
+  }
+};
+
 /// Contains an embedded TestConnectorMetadata to which TestTables are
 /// added at runtime using the addTable API. Data is appended to a
 /// TestTable via the appendData method. createDataSource creates a
@@ -603,6 +626,11 @@ class TestConnector : public velox::connector::Connector {
 
   ~TestConnector() override {
     ConnectorMetadata::unregisterMetadata(connectorId());
+  }
+
+  const velox::config::ConfigProvider* configProvider() const override {
+    static const TestConfigProvider kProvider;
+    return &kProvider;
   }
 
   bool supportsSplitPreload() const override {
@@ -720,7 +748,8 @@ class TestConnectorFactory : public velox::connector::ConnectorFactory {
 /// contained in the corresponding table.
 class TestDataSink : public velox::connector::DataSink {
  public:
-  explicit TestDataSink(std::shared_ptr<Table> table) {
+  TestDataSink(std::shared_ptr<Table> table, bool collectStats)
+      : collectColumnStatistics_(collectStats) {
     table_ = std::dynamic_pointer_cast<TestTable>(table);
     VELOX_CHECK(table_, "table {} not a TestTable", table->name().toString());
   }
@@ -748,6 +777,7 @@ class TestDataSink : public velox::connector::DataSink {
 
  private:
   std::shared_ptr<TestTable> table_;
+  bool collectColumnStatistics_;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -182,8 +182,28 @@ TEST_F(TestConnectorTest, dataSink) {
   auto table = connector_->addTable("table", schema);
   EXPECT_EQ(table->numRows(), 0);
 
+  auto emptyConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto connectorQueryCtx =
+      std::make_unique<velox::connector::ConnectorQueryCtx>(
+          pool_.get(),
+          pool_.get(),
+          emptyConfig.get(),
+          /*spillConfig=*/nullptr,
+          velox::common::PrefixSortConfig{},
+          /*expressionEvaluator=*/nullptr,
+          /*cache=*/nullptr,
+          "test-query",
+          "test-task",
+          "test-plan-node",
+          /*driverId=*/0,
+          /*sessionTimezone=*/"UTC");
+
   auto dataSink = connector_->createDataSink(
-      schema, handle, nullptr, velox::connector::CommitStrategy::kNoCommit);
+      schema,
+      handle,
+      connectorQueryCtx.get(),
+      velox::connector::CommitStrategy::kNoCommit);
   EXPECT_NE(dataSink, nullptr);
 
   auto vector = makeRowVector({makeFlatVector<int>({0, 1, 2})});


### PR DESCRIPTION
Summary:

Add a queryable system table that exposes all registered session
properties, making them discoverable via standard SQL:

  SELECT * FROM system.metadata.session_properties
  WHERE component = 'optimizer';

Columns: component, name, type, default_value, current_value, description.

The table reads from SessionConfig at query time, so current_value
reflects any SET SESSION overrides in the active session.

Fixes https://github.com/facebookincubator/axiom/issues/1238

Reviewed By: jagill

Differential Revision: D101006261
