### PR TITLE
fix(optimizer): Fix signed integer overflow in rangeCardinality (#1254)

### DIFF
--- a/axiom/optimizer/Filters.cpp
+++ b/axiom/optimizer/Filters.cpp
@@ -537,11 +537,14 @@ std::pair<VariantCP, VariantCP> findArrayMinMax(
 }
 
 // Computes the maximum cardinality for an integer range: 1 + (max - min).
+// Operands are cast to double to avoid signed integer overflow when the
+// range spans a large portion of the integer domain.
 template <velox::TypeKind KIND>
 float rangeCardinality(VariantCP minPtr, VariantCP maxPtr) {
   auto upperVal = maxPtr->value<KIND>();
   auto lowerVal = minPtr->value<KIND>();
-  return 1.0f + static_cast<float>(upperVal - lowerVal);
+  return static_cast<float>(
+      1.0 + static_cast<double>(upperVal) - static_cast<double>(lowerVal));
 }
 
 // Returns true if the given TypeKind represents an integer type

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -534,6 +534,43 @@ TEST_F(FiltersTest, rangeSelectivity) {
       });
 }
 
+TEST_F(FiltersTest, rangeCardinalityMaxMin) {
+  static constexpr auto kTestConnectorId = "test_range_overflow";
+
+  auto testConnector =
+      std::make_shared<connector::TestConnector>(kTestConnectorId);
+  velox::connector::registerConnector(testConnector);
+
+  SCOPE_EXIT {
+    velox::connector::unregisterConnector(kTestConnectorId);
+  };
+
+  testConnector->addTable("t_overflow", ROW({"x"}, BIGINT()));
+  testConnector->setStats(
+      "t_overflow",
+      10'000,
+      {{"x",
+        {.nonNull = true,
+         .min = velox::Variant::create<int64_t>(
+             std::numeric_limits<int64_t>::min()),
+         .max = velox::Variant::create<int64_t>(
+             std::numeric_limits<int64_t>::max()),
+         .numDistinct = 1000}}});
+
+  verifyQueryGraph(
+      "SELECT * FROM t_overflow WHERE x > 0",
+      [&](DerivedTableCP rootDt) {
+        auto allFilters = getAllFilters(rootDt, "t_overflow");
+        ASSERT_FALSE(allFilters.empty());
+
+        auto constraints = makeSchemaConstraints(allFilters);
+        auto selectivity = conjunctsSelectivity(constraints, allFilters, true);
+
+        EXPECT_NEAR(selectivity.trueFraction, 0.5, 0.1);
+      },
+      kTestConnectorId);
+}
+
 TEST_F(FiltersTest, strictInequalityIntegerBounds) {
   // n_nationkey is BIGINT with min=0, max=24, cardinality=25.
   verifyFilterTestCases(


### PR DESCRIPTION
Summary:

A query fuzzer discovered a signed integer overflow (UBSAN) in the optimizer's range cardinality estimation.

`rangeCardinality<BIGINT>` computes `upperVal - lowerVal` as a signed int64 subtraction, which overflows when column statistics span near INT64 boundaries (e.g., min=INT64_MIN, max=INT64_MAX). The result feeds into `makeConstraint` to cap cardinality estimates.

Cast operands to double before subtraction, matching the established convention in `rangeSelectivityImpl` and `computeRangeSelectivity`. Double arithmetic avoids the overflow and provides sufficient precision for selectivity estimation.

Reviewed By: natashasehgal

Differential Revision: D100906326
