### PR TITLE
feat: Add system.metadata.functions table (#1255)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -36,7 +36,9 @@ target_link_libraries(
   axiom_system_connector
   axiom_test_connector
   axiom_sql_presto_parser
+  velox_exec
   velox_exec_test_lib
+  velox_function_registry
   velox_dwio_common
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader

--- a/axiom/connectors/system/CMakeLists.txt
+++ b/axiom/connectors/system/CMakeLists.txt
@@ -18,7 +18,9 @@ target_link_libraries(
   axiom_system_connector
   axiom_connectors
   velox_connector
+  velox_exec
   velox_exception
+  velox_function_registry
   velox_serialization
   velox_vector
 )

--- a/axiom/connectors/system/README.md
+++ b/axiom/connectors/system/README.md
@@ -11,11 +11,13 @@ uses `system`).
 
 ### system.metadata
 
-Configuration metadata, including session-scoped properties.
+Configuration metadata, including session-scoped properties and function
+signatures.
 
 | Table | Description |
 |-------|-------------|
 | `session_properties` | All registered session properties with current values, defaults, and descriptions. |
+| `functions` | All registered function signatures with types, arguments, and metadata. |
 
 ### system.runtime
 
@@ -38,6 +40,14 @@ SELECT component, name, current_value, default_value
 FROM system.metadata.session_properties
 WHERE current_value <> default_value;
 
+-- Distinct function names by kind.
+SELECT DISTINCT name FROM system.metadata.functions
+WHERE kind = 'aggregate' ORDER BY 1;
+
+-- Find functions that accept a variable number of arguments.
+SELECT DISTINCT name FROM system.metadata.functions
+WHERE is_variadic ORDER BY 1;
+
 -- List all active queries.
 SELECT query_id, state, query, elapsed_time_ms
 FROM system.runtime.queries;
@@ -55,6 +65,20 @@ FROM system.runtime.queries;
 | `default_value` | VARCHAR | Default value (empty string if none). |
 | `current_value` | VARCHAR | Current session value (reflects SET SESSION overrides). |
 | `description` | VARCHAR | Human-readable description. |
+
+### system.metadata.functions
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | VARCHAR | Function name. |
+| `kind` | VARCHAR | `scalar`, `aggregate`, or `window`. |
+| `return_type` | VARCHAR | Return type signature (e.g. `bigint`, `array(T)`). |
+| `argument_types` | ARRAY(VARCHAR) | Argument type signatures. |
+| `is_variadic` | BOOLEAN | Whether the function accepts a variable number of arguments. |
+| `owner` | VARCHAR | Responsible team (empty if not set). |
+| `properties` | VARCHAR | Type-specific metadata as JSON (e.g. `{"deterministic": true}`). |
+
+One row per function signature (overload).
 
 <details>
 <summary>system.runtime.queries (30 columns)</summary>
@@ -108,8 +132,9 @@ The system connector has two layers:
 
 Each system table has a corresponding data source class that knows how
 to populate its columns. The data source reads from a **provider
-interface** — `QueryInfoProvider` for the queries table and
-`SessionPropertiesProvider` for session properties. These interfaces
+interface** — `QueryInfoProvider` for the queries table,
+`SessionPropertiesProvider` for session properties, and
+`FunctionsProvider` for function metadata. These interfaces
 decouple the connector from the rest of the system: the connector
 defines what data it needs, and the application supplies it.
 

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -18,8 +18,15 @@
 
 #include <algorithm>
 
+#include <folly/json/json.h>
+
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/WindowFunction.h"
+#include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/FunctionRegistry.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -27,8 +34,8 @@ namespace facebook::axiom::connector::system {
 
 namespace {
 
-/// Indices into the full queries table schema, matching the column order
-/// returned by queriesTableSchema().
+// Indices into the full queries table schema, matching the column order
+// returned by queriesTableSchema().
 enum class QueryColumn : int32_t {
   kQueryId = 0,
   kState,
@@ -63,6 +70,29 @@ enum class QueryColumn : int32_t {
   kNumColumns
 };
 
+// Indices into the session properties table schema, matching the column order
+// returned by sessionPropertiesTableSchema().
+enum class SessionPropertyColumn : int32_t {
+  kComponent = 0,
+  kName,
+  kType,
+  kDefaultValue,
+  kCurrentValue,
+  kDescription,
+};
+
+// Indices into the full functions table schema, matching the column order
+// returned by functionsTableSchema().
+enum class FunctionColumn : int32_t {
+  kName = 0,
+  kKind,
+  kReturnType,
+  kArgumentTypes,
+  kIsVariadic,
+  kOwner,
+  kProperties,
+};
+
 // Converts a system_clock time_point to a Velox Timestamp.
 // Returns a null Timestamp (0, 0) for the epoch (default-constructed
 // time_point), which we treat as "not set".
@@ -79,99 +109,152 @@ bool isEpoch(std::chrono::system_clock::time_point tp) {
   return tp == std::chrono::system_clock::time_point{};
 }
 
-} // namespace
-
 // ===================== Data Sources (internal) =====================
 
+// Base class for system connector data sources. Handles split management
+// and the single-batch read pattern. Subclasses implement buildResults().
+class SystemDataSourceBase : public velox::connector::DataSource {
+ public:
+  SystemDataSourceBase(
+      const velox::RowTypePtr& outputType,
+      const velox::RowTypePtr& fullSchema,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool)
+      : outputType_(outputType), pool_(pool) {
+    outputColumnMappings_.reserve(outputType_->size());
+    for (const auto& name : outputType_->names()) {
+      VELOX_CHECK(
+          columnHandles.contains(name),
+          "No handle for output column '{}'",
+          name);
+      auto handle = columnHandles.find(name)->second;
+      auto idx = fullSchema->getChildIdxIfExists(handle->name());
+      VELOX_CHECK(idx.has_value(), "Column not found: {}", handle->name());
+      outputColumnMappings_.push_back(idx.value());
+    }
+  }
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override {
+    split_ = std::dynamic_pointer_cast<SystemSplit>(split);
+    VELOX_CHECK(split_, "Expected SystemSplit");
+    needData_ = true;
+  }
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t /*size*/,
+      velox::ContinueFuture& /*future*/) override {
+    VELOX_CHECK(split_, "No split added");
+    if (!needData_) {
+      return nullptr;
+    }
+    needData_ = false;
+    auto result = buildResults();
+    if (result) {
+      completedRows_ += result->size();
+    }
+    return result;
+  }
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {}
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ protected:
+  virtual velox::RowVectorPtr buildResults() = 0;
+
+  template <typename T>
+  velox::FlatVectorPtr<T> createFlat(
+      const velox::TypePtr& type,
+      velox::vector_size_t size) {
+    return velox::BaseVector::create<velox::FlatVector<T>>(type, size, pool_);
+  }
+
+  const velox::RowTypePtr outputType_;
+  velox::memory::MemoryPool* pool_;
+  std::vector<velox::column_index_t> outputColumnMappings_;
+  uint64_t completedRows_{0};
+
+ private:
+  std::shared_ptr<SystemSplit> split_;
+  bool needData_{true};
+};
+
 // Reads live query state from a QueryInfoProvider.
-class SystemDataSource : public velox::connector::DataSource {
+class SystemDataSource : public SystemDataSourceBase {
  public:
   SystemDataSource(
       const velox::RowTypePtr& outputType,
       const velox::connector::ColumnHandleMap& columnHandles,
       const QueryInfoProvider* queryInfoProvider,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool)
+      : SystemDataSourceBase(
+            outputType,
+            queriesTableSchema(),
+            columnHandles,
+            pool),
+        queryInfoProvider_(queryInfoProvider) {}
 
-  void addSplit(
-      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
-
-  std::optional<velox::RowVectorPtr> next(
-      uint64_t size,
-      velox::ContinueFuture& future) override;
-
-  void addDynamicFilter(
-      velox::column_index_t,
-      const std::shared_ptr<velox::common::Filter>&) override {}
-
-  uint64_t getCompletedBytes() override {
-    return 0;
-  }
-
-  uint64_t getCompletedRows() override {
-    return completedRows_;
-  }
-
-  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
-      override {
-    return {};
-  }
+ protected:
+  velox::RowVectorPtr buildResults() override;
 
  private:
-  velox::RowVectorPtr buildQueryResults();
-
-  const velox::RowTypePtr outputType_;
   const QueryInfoProvider* queryInfoProvider_;
-  velox::memory::MemoryPool* pool_;
-  std::shared_ptr<SystemSplit> split_;
-  std::vector<velox::column_index_t> outputColumnMappings_;
-  uint64_t completedRows_{0};
-  bool needData_{true};
 };
 
 // Reads session properties from a SessionPropertiesProvider.
-class SessionPropertiesDataSource : public velox::connector::DataSource {
+class SessionPropertiesDataSource : public SystemDataSourceBase {
  public:
   SessionPropertiesDataSource(
       const velox::RowTypePtr& outputType,
       const velox::connector::ColumnHandleMap& columnHandles,
       const SessionPropertiesProvider* provider,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool)
+      : SystemDataSourceBase(
+            outputType,
+            sessionPropertiesTableSchema(),
+            columnHandles,
+            pool),
+        provider_(provider) {}
 
-  void addSplit(
-      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
-
-  std::optional<velox::RowVectorPtr> next(
-      uint64_t size,
-      velox::ContinueFuture& future) override;
-
-  void addDynamicFilter(
-      velox::column_index_t,
-      const std::shared_ptr<velox::common::Filter>&) override {}
-
-  uint64_t getCompletedBytes() override {
-    return 0;
-  }
-
-  uint64_t getCompletedRows() override {
-    return completedRows_;
-  }
-
-  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
-      override {
-    return {};
-  }
+ protected:
+  velox::RowVectorPtr buildResults() override;
 
  private:
-  velox::RowVectorPtr buildResults();
-
-  const velox::RowTypePtr outputType_;
   const SessionPropertiesProvider* provider_;
-  velox::memory::MemoryPool* pool_;
-  std::shared_ptr<SystemSplit> split_;
-  std::vector<velox::column_index_t> outputColumnMappings_;
-  uint64_t completedRows_{0};
-  bool needData_{true};
 };
+
+// Reads function metadata directly from Velox's global function registries.
+class FunctionsDataSource : public SystemDataSourceBase {
+ public:
+  FunctionsDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool)
+      : SystemDataSourceBase(
+            outputType,
+            functionsTableSchema(),
+            columnHandles,
+            pool) {}
+
+ protected:
+  velox::RowVectorPtr buildResults() override;
+};
+
+} // namespace
 
 // ===================== SystemTableHandle =====================
 
@@ -209,50 +292,7 @@ velox::connector::ConnectorTableHandlePtr SystemTableHandle::create(
 
 // ===================== SystemDataSource =====================
 
-SystemDataSource::SystemDataSource(
-    const velox::RowTypePtr& outputType,
-    const velox::connector::ColumnHandleMap& columnHandles,
-    const QueryInfoProvider* queryInfoProvider,
-    velox::memory::MemoryPool* pool)
-    : outputType_(outputType),
-      queryInfoProvider_(queryInfoProvider),
-      pool_(pool) {
-  auto fullSchema = queriesTableSchema();
-  outputColumnMappings_.reserve(outputType_->size());
-  for (const auto& name : outputType_->names()) {
-    VELOX_CHECK(
-        columnHandles.contains(name), "No handle for output column '{}'", name);
-    auto handle = columnHandles.find(name)->second;
-    auto idx = fullSchema->getChildIdxIfExists(handle->name());
-    VELOX_CHECK(
-        idx.has_value(),
-        "Column '{}' not found in system.runtime.queries schema",
-        handle->name());
-    outputColumnMappings_.push_back(idx.value());
-  }
-}
-
-void SystemDataSource::addSplit(
-    std::shared_ptr<velox::connector::ConnectorSplit> split) {
-  split_ = std::dynamic_pointer_cast<SystemSplit>(split);
-  VELOX_CHECK(split_, "Expected SystemSplit");
-  needData_ = true;
-}
-
-std::optional<velox::RowVectorPtr> SystemDataSource::next(
-    uint64_t /*size*/,
-    velox::ContinueFuture& /*future*/) {
-  VELOX_CHECK(split_, "No split added to SystemDataSource");
-
-  if (!needData_) {
-    return nullptr;
-  }
-  needData_ = false;
-
-  return buildQueryResults();
-}
-
-velox::RowVectorPtr SystemDataSource::buildQueryResults() {
+velox::RowVectorPtr SystemDataSource::buildResults() {
   // If no query info provider is available (e.g. CLI mode), return empty
   // results.
   if (!queryInfoProvider_) {
@@ -260,328 +300,287 @@ velox::RowVectorPtr SystemDataSource::buildQueryResults() {
   }
 
   auto queries = queryInfoProvider_->getQueryInfos();
-
   auto numRows = queries.size();
-  completedRows_ += numRows;
 
   if (numRows == 0) {
     return velox::RowVector::createEmpty(outputType_, pool_);
   }
 
-  auto fullSchema = queriesTableSchema();
-  auto numFullColumns = static_cast<int32_t>(QueryColumn::kNumColumns);
+  const auto& fullSchema = queriesTableSchema();
 
-  // Build all columns of the full schema.
-  std::vector<velox::VectorPtr> allColumns(numFullColumns);
+  std::vector<velox::VectorPtr> children;
+  children.reserve(outputType_->size());
+  for (auto fullIdx : outputColumnMappings_) {
+    const auto column = static_cast<QueryColumn>(fullIdx);
+    const auto& type = fullSchema->childAt(fullIdx);
 
-  for (size_t outIdx = 0; outIdx < outputColumnMappings_.size(); ++outIdx) {
-    auto fullIdx = outputColumnMappings_[outIdx];
-
-    // Skip if already built (possible but unlikely with column pruning).
-    if (allColumns[fullIdx]) {
-      continue;
-    }
-
-    auto col = static_cast<QueryColumn>(fullIdx);
-    auto type = fullSchema->childAt(fullIdx);
-
-    switch (col) {
+    switch (column) {
       // VARCHAR columns
       case QueryColumn::kQueryId: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].queryId));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].queryId));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kState: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].state));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].state));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kQuery: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].query));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].query));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kCatalog: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].catalog));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].catalog));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kSchema: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].schema));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].schema));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kUser: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].user));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].user));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kSource: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          if (queries[r].source.has_value()) {
-            flat->set(r, velox::StringView(queries[r].source.value()));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          if (queries[i].source.has_value()) {
+            flat->set(i, velox::StringView(queries[i].source.value()));
           } else {
-            vec->setNull(r, true);
+            flat->setNull(i, true);
           }
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kQueryType: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::StringView>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, velox::StringView(queries[r].queryType));
+        auto flat = createFlat<velox::StringView>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, velox::StringView(queries[i].queryType));
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
 
       // BIGINT columns (time in ms)
       case QueryColumn::kPlanningTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].planningTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].planningTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kOptimizationTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].optimizationTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].optimizationTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kQueueTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].queueTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].queueTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kExecutionTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].executionTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].executionTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kElapsedTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].elapsedTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].elapsedTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kCpuTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].cpuTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].cpuTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kWallTimeMs: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].wallTimeMs);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].wallTimeMs);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
 
       // BIGINT columns (split counts)
       case QueryColumn::kTotalSplits: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].totalSplits);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].totalSplits);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kQueuedSplits: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].queuedSplits);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].queuedSplits);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kRunningSplits: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].runningSplits);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].runningSplits);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kFinishedSplits: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].finishedSplits);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].finishedSplits);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
 
       // BIGINT columns (data volumes)
       case QueryColumn::kOutputRows: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].outputRows);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].outputRows);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kOutputBytes: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].outputBytes);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].outputBytes);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kProcessedRows: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].processedRows);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].processedRows);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kProcessedBytes: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].processedBytes);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].processedBytes);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kWrittenRows: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].writtenRows);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].writtenRows);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kWrittenBytes: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].writtenBytes);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].writtenBytes);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kPeakMemoryBytes: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].peakMemoryBytes);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].peakMemoryBytes);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kSpilledBytes: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<int64_t>();
-        for (size_t r = 0; r < numRows; ++r) {
-          flat->set(r, queries[r].spilledBytes);
+        auto flat = createFlat<int64_t>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          flat->set(i, queries[i].spilledBytes);
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
 
       // TIMESTAMP columns
       case QueryColumn::kCreateTime: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::Timestamp>();
-        for (size_t r = 0; r < numRows; ++r) {
-          auto tp = queries[r].createTime;
+        auto flat = createFlat<velox::Timestamp>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          auto tp = queries[i].createTime;
           if (!isEpoch(tp)) {
-            flat->set(r, toTimestamp(tp));
+            flat->set(i, toTimestamp(tp));
           } else {
-            vec->setNull(r, true);
+            flat->setNull(i, true);
           }
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kStartTime: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::Timestamp>();
-        for (size_t r = 0; r < numRows; ++r) {
-          auto tp = queries[r].startTime;
+        auto flat = createFlat<velox::Timestamp>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          auto tp = queries[i].startTime;
           if (!isEpoch(tp)) {
-            flat->set(r, toTimestamp(tp));
+            flat->set(i, toTimestamp(tp));
           } else {
-            vec->setNull(r, true);
+            flat->setNull(i, true);
           }
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
       case QueryColumn::kEndTime: {
-        auto vec = velox::BaseVector::create(type, numRows, pool_);
-        auto* flat = vec->asFlatVector<velox::Timestamp>();
-        for (size_t r = 0; r < numRows; ++r) {
-          auto tp = queries[r].endTime;
+        auto flat = createFlat<velox::Timestamp>(type, numRows);
+        for (size_t i = 0; i < numRows; ++i) {
+          auto tp = queries[i].endTime;
           if (!isEpoch(tp)) {
-            flat->set(r, toTimestamp(tp));
+            flat->set(i, toTimestamp(tp));
           } else {
-            vec->setNull(r, true);
+            flat->setNull(i, true);
           }
         }
-        allColumns[fullIdx] = std::move(vec);
+        children.push_back(std::move(flat));
         break;
       }
 
@@ -590,59 +589,11 @@ velox::RowVectorPtr SystemDataSource::buildQueryResults() {
     }
   }
 
-  // Build output vector with only the requested columns.
-  std::vector<velox::VectorPtr> children;
-  children.reserve(outputType_->size());
-  for (size_t i = 0; i < outputColumnMappings_.size(); ++i) {
-    children.push_back(allColumns[outputColumnMappings_[i]]);
-  }
-
   return std::make_shared<velox::RowVector>(
       pool_, outputType_, nullptr, numRows, std::move(children));
 }
 
 // ===================== SessionPropertiesDataSource =====================
-
-SessionPropertiesDataSource::SessionPropertiesDataSource(
-    const velox::RowTypePtr& outputType,
-    const velox::connector::ColumnHandleMap& columnHandles,
-    const SessionPropertiesProvider* provider,
-    velox::memory::MemoryPool* pool)
-    : outputType_(outputType), provider_(provider), pool_(pool) {
-  auto fullSchema = sessionPropertiesTableSchema();
-  outputColumnMappings_.reserve(outputType_->size());
-  for (const auto& name : outputType_->names()) {
-    VELOX_CHECK(
-        columnHandles.contains(name), "No handle for output column '{}'", name);
-    auto handle = columnHandles.find(name)->second;
-    auto idx = fullSchema->getChildIdxIfExists(handle->name());
-    VELOX_CHECK(
-        idx.has_value(),
-        "Column '{}' not found in system.metadata.session_properties schema",
-        handle->name());
-    outputColumnMappings_.push_back(idx.value());
-  }
-}
-
-void SessionPropertiesDataSource::addSplit(
-    std::shared_ptr<velox::connector::ConnectorSplit> split) {
-  split_ = std::dynamic_pointer_cast<SystemSplit>(split);
-  VELOX_CHECK(split_, "Expected SystemSplit");
-  needData_ = true;
-}
-
-std::optional<velox::RowVectorPtr> SessionPropertiesDataSource::next(
-    uint64_t /*size*/,
-    velox::ContinueFuture& /*future*/) {
-  VELOX_CHECK(split_, "No split added to SessionPropertiesDataSource");
-
-  if (!needData_) {
-    return nullptr;
-  }
-  needData_ = false;
-
-  return buildResults();
-}
 
 velox::RowVectorPtr SessionPropertiesDataSource::buildResults() {
   if (!provider_) {
@@ -651,48 +602,257 @@ velox::RowVectorPtr SessionPropertiesDataSource::buildResults() {
 
   auto properties = provider_->getSessionProperties();
   auto numRows = properties.size();
-  completedRows_ += numRows;
 
   if (numRows == 0) {
     return velox::RowVector::createEmpty(outputType_, pool_);
   }
 
-  // All 6 columns are VARCHAR. Build only the requested ones.
-  // Column indices: 0=component, 1=name, 2=type, 3=default_value,
-  // 4=current_value, 5=description.
-  auto fullSchema = sessionPropertiesTableSchema();
+  const auto& fullSchema = sessionPropertiesTableSchema();
 
-  // Accessor for each column by index.
   auto getValue = [&](size_t row,
-                      velox::column_index_t col) -> const std::string& {
-    switch (col) {
-      case 0:
+                      SessionPropertyColumn column) -> const std::string& {
+    switch (column) {
+      case SessionPropertyColumn::kComponent:
         return properties[row].component;
-      case 1:
+      case SessionPropertyColumn::kName:
         return properties[row].name;
-      case 2:
+      case SessionPropertyColumn::kType:
         return properties[row].type;
-      case 3:
+      case SessionPropertyColumn::kDefaultValue:
         return properties[row].defaultValue;
-      case 4:
+      case SessionPropertyColumn::kCurrentValue:
         return properties[row].currentValue;
-      case 5:
+      case SessionPropertyColumn::kDescription:
         return properties[row].description;
-      default:
-        VELOX_FAIL("Unknown session_properties column index: {}", col);
     }
+    VELOX_UNREACHABLE();
   };
 
   std::vector<velox::VectorPtr> children;
   children.reserve(outputType_->size());
   for (auto fullIdx : outputColumnMappings_) {
-    auto vec =
-        velox::BaseVector::create(fullSchema->childAt(fullIdx), numRows, pool_);
-    auto* flat = vec->asFlatVector<velox::StringView>();
+    auto column = static_cast<SessionPropertyColumn>(fullIdx);
+    auto vector =
+        createFlat<velox::StringView>(fullSchema->childAt(fullIdx), numRows);
     for (size_t row = 0; row < numRows; ++row) {
-      flat->set(row, velox::StringView(getValue(row, fullIdx)));
+      vector->set(row, velox::StringView(getValue(row, column)));
     }
-    children.push_back(std::move(vec));
+    children.push_back(std::move(vector));
+  }
+
+  return std::make_shared<velox::RowVector>(
+      pool_, outputType_, nullptr, numRows, std::move(children));
+}
+
+// ===================== FunctionsDataSource =====================
+
+namespace {
+
+// Snapshot of a single function signature for building result vectors.
+struct FunctionEntry {
+  std::string name;
+  std::string kind;
+  std::string returnType;
+  std::vector<std::string> argumentTypes;
+  bool isVariadic;
+  std::string owner;
+  std::string properties;
+};
+
+// Serializes a folly::dynamic object to JSON with sorted keys for
+// deterministic output.
+std::string toSortedJson(const folly::dynamic& obj) {
+  folly::json::serialization_opts opts;
+  opts.sort_keys = true;
+  return folly::json::serialize(obj, opts);
+}
+
+// Builds a FunctionEntry from a name, kind, signature, and properties JSON.
+FunctionEntry makeFunctionEntry(
+    const std::string& name,
+    const std::string& kind,
+    const velox::exec::FunctionSignature& signature,
+    std::string owner,
+    std::string properties) {
+  std::vector<std::string> argumentTypes;
+  argumentTypes.reserve(signature.argumentTypes().size());
+  for (const auto& argType : signature.argumentTypes()) {
+    argumentTypes.push_back(argType.toString());
+  }
+  return {
+      name,
+      kind,
+      signature.returnType().toString(),
+      std::move(argumentTypes),
+      signature.variableArity(),
+      std::move(owner),
+      std::move(properties),
+  };
+}
+
+// Reads all function signatures from Velox's global registries. Cached
+// after first call since function registrations are immutable after startup.
+const std::vector<FunctionEntry>& getAllFunctions() {
+  static const auto kFunctions = [] {
+    std::vector<FunctionEntry> result;
+
+    // Vector functions — one metadata per registration, multiple signatures.
+    velox::exec::vectorFunctionFactories().withRLock(
+        [&](const auto& factories) {
+          for (const auto& [name, entry] : factories) {
+            const auto& metadata = entry.metadata;
+            auto properties = toSortedJson(
+                folly::dynamic::object("deterministic", metadata.deterministic)(
+                    "default_null_behavior", metadata.defaultNullBehavior));
+            auto owner = std::string(metadata.owner);
+            for (const auto& signature : entry.signatures) {
+              result.push_back(makeFunctionEntry(
+                  name, "scalar", *signature, owner, properties));
+            }
+          }
+        });
+
+    // Simple functions — per-signature metadata.
+    const auto& simpleRegistry = velox::exec::simpleFunctions();
+    for (const auto& name : simpleRegistry.getFunctionNames()) {
+      for (const auto& [metadata, signature] :
+           simpleRegistry.getFunctionSignaturesAndMetadata(name)) {
+        auto properties = toSortedJson(
+            folly::dynamic::object("deterministic", metadata.deterministic)(
+                "default_null_behavior", metadata.defaultNullBehavior));
+        result.push_back(makeFunctionEntry(
+            name,
+            "scalar",
+            *signature,
+            std::string(metadata.owner),
+            properties));
+      }
+    }
+
+    // Aggregate functions.
+    auto allAggregates = velox::exec::getAggregateFunctionSignatures();
+    for (const auto& [name, signatures] : allAggregates) {
+      auto metadata = velox::exec::getAggregateFunctionMetadata(name);
+      auto properties = toSortedJson(
+          folly::dynamic::object("order_sensitive", metadata.orderSensitive)(
+              "ignore_duplicates", metadata.ignoreDuplicates));
+      for (const auto& signature : signatures) {
+        result.push_back(
+            makeFunctionEntry(name, "aggregate", *signature, "", properties));
+      }
+    }
+
+    // Window functions (excluding those already counted as aggregates).
+    for (const auto& [name, windowEntry] : velox::exec::windowFunctions()) {
+      if (allAggregates.contains(name)) {
+        continue;
+      }
+      for (const auto& signature : windowEntry.signatures) {
+        result.push_back(
+            makeFunctionEntry(name, "window", *signature, "", "{}"));
+      }
+    }
+
+    return result;
+  }();
+
+  return kFunctions;
+}
+
+} // namespace
+
+velox::RowVectorPtr FunctionsDataSource::buildResults() {
+  const auto& functions = getAllFunctions();
+  auto numRows = functions.size();
+
+  if (numRows == 0) {
+    return velox::RowVector::createEmpty(outputType_, pool_);
+  }
+
+  const auto& fullSchema = functionsTableSchema();
+
+  std::vector<velox::VectorPtr> children;
+  children.reserve(outputType_->size());
+  for (auto fullIdx : outputColumnMappings_) {
+    const auto column = static_cast<FunctionColumn>(fullIdx);
+    const auto& type = fullSchema->childAt(fullIdx);
+
+    switch (column) {
+      case FunctionColumn::kName:
+      case FunctionColumn::kKind:
+      case FunctionColumn::kReturnType:
+      case FunctionColumn::kOwner:
+      case FunctionColumn::kProperties: {
+        auto vector = createFlat<velox::StringView>(type, numRows);
+        for (size_t row = 0; row < numRows; ++row) {
+          const std::string* value;
+          switch (column) {
+            case FunctionColumn::kName:
+              value = &functions[row].name;
+              break;
+            case FunctionColumn::kKind:
+              value = &functions[row].kind;
+              break;
+            case FunctionColumn::kReturnType:
+              value = &functions[row].returnType;
+              break;
+            case FunctionColumn::kOwner:
+              value = &functions[row].owner;
+              break;
+            case FunctionColumn::kProperties:
+              value = &functions[row].properties;
+              break;
+            default:
+              VELOX_UNREACHABLE();
+          }
+          vector->set(row, velox::StringView(*value));
+        }
+        children.push_back(std::move(vector));
+        break;
+      }
+      case FunctionColumn::kArgumentTypes: {
+        auto offsets = velox::allocateOffsets(numRows, pool_);
+        auto sizes = velox::allocateSizes(numRows, pool_);
+        auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+        auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+
+        velox::vector_size_t totalElements = 0;
+        for (size_t row = 0; row < numRows; ++row) {
+          totalElements += functions[row].argumentTypes.size();
+        }
+
+        auto elements =
+            createFlat<velox::StringView>(velox::VARCHAR(), totalElements);
+
+        velox::vector_size_t offset = 0;
+        for (size_t row = 0; row < numRows; ++row) {
+          rawOffsets[row] = offset;
+          rawSizes[row] = functions[row].argumentTypes.size();
+          for (const auto& argType : functions[row].argumentTypes) {
+            elements->set(offset++, velox::StringView(argType));
+          }
+        }
+
+        children.push_back(
+            std::make_shared<velox::ArrayVector>(
+                pool_,
+                type,
+                nullptr,
+                numRows,
+                std::move(offsets),
+                std::move(sizes),
+                std::move(elements)));
+        break;
+      }
+      case FunctionColumn::kIsVariadic: {
+        auto vector = createFlat<bool>(type, numRows);
+        for (size_t row = 0; row < numRows; ++row) {
+          vector->set(row, functions[row].isVariadic);
+        }
+        children.push_back(std::move(vector));
+        break;
+      }
+    }
   }
 
   return std::make_shared<velox::RowVector>(
@@ -727,6 +887,10 @@ std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
       SchemaTableName{
           std::string(kMetadataSchema), std::string(kSessionPropertiesTable)}
           .toString();
+  static const auto kFunctionsName =
+      SchemaTableName{
+          std::string(kMetadataSchema), std::string(kFunctionsTable)}
+          .toString();
   static const auto kQueriesName =
       SchemaTableName{std::string(kRuntimeSchema), std::string(kQueriesTable)}
           .toString();
@@ -737,6 +901,11 @@ std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
         columnHandles,
         sessionPropertiesProvider_,
         connectorQueryCtx->memoryPool());
+  }
+
+  if (name == kFunctionsName) {
+    return std::make_unique<FunctionsDataSource>(
+        outputType, columnHandles, connectorQueryCtx->memoryPool());
   }
 
   if (name == kQueriesName) {

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -30,6 +30,7 @@ static constexpr std::string_view kMetadataSchema = "metadata";
 static constexpr std::string_view kQueriesTable = "queries";
 static constexpr std::string_view kSessionPropertiesTable =
     "session_properties";
+static constexpr std::string_view kFunctionsTable = "functions";
 
 /// Snapshot of a single query's state, used by the system connector to
 /// populate the system.runtime.queries table.

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -21,50 +21,65 @@
 
 namespace facebook::axiom::connector::system {
 
-velox::RowTypePtr queriesTableSchema() {
-  static auto schema = velox::ROW(
-      {{"query_id", velox::VARCHAR()},
-       {"state", velox::VARCHAR()},
-       {"query", velox::VARCHAR()},
-       {"catalog", velox::VARCHAR()},
-       {"schema", velox::VARCHAR()},
-       {"user", velox::VARCHAR()},
-       {"source", velox::VARCHAR()},
-       {"query_type", velox::VARCHAR()},
-       {"planning_time_ms", velox::BIGINT()},
-       {"optimization_time_ms", velox::BIGINT()},
-       {"queue_time_ms", velox::BIGINT()},
-       {"execution_time_ms", velox::BIGINT()},
-       {"elapsed_time_ms", velox::BIGINT()},
-       {"cpu_time_ms", velox::BIGINT()},
-       {"wall_time_ms", velox::BIGINT()},
-       {"total_splits", velox::BIGINT()},
-       {"queued_splits", velox::BIGINT()},
-       {"running_splits", velox::BIGINT()},
-       {"finished_splits", velox::BIGINT()},
-       {"output_rows", velox::BIGINT()},
-       {"output_bytes", velox::BIGINT()},
-       {"processed_rows", velox::BIGINT()},
-       {"processed_bytes", velox::BIGINT()},
-       {"written_rows", velox::BIGINT()},
-       {"written_bytes", velox::BIGINT()},
-       {"peak_memory_bytes", velox::BIGINT()},
-       {"spilled_bytes", velox::BIGINT()},
-       {"create_time", velox::TIMESTAMP()},
-       {"start_time", velox::TIMESTAMP()},
-       {"end_time", velox::TIMESTAMP()}});
-  return schema;
+const velox::RowTypePtr& queriesTableSchema() {
+  static auto kSchema = velox::ROW({
+      {"query_id", velox::VARCHAR()},
+      {"state", velox::VARCHAR()},
+      {"query", velox::VARCHAR()},
+      {"catalog", velox::VARCHAR()},
+      {"schema", velox::VARCHAR()},
+      {"user", velox::VARCHAR()},
+      {"source", velox::VARCHAR()},
+      {"query_type", velox::VARCHAR()},
+      {"planning_time_ms", velox::BIGINT()},
+      {"optimization_time_ms", velox::BIGINT()},
+      {"queue_time_ms", velox::BIGINT()},
+      {"execution_time_ms", velox::BIGINT()},
+      {"elapsed_time_ms", velox::BIGINT()},
+      {"cpu_time_ms", velox::BIGINT()},
+      {"wall_time_ms", velox::BIGINT()},
+      {"total_splits", velox::BIGINT()},
+      {"queued_splits", velox::BIGINT()},
+      {"running_splits", velox::BIGINT()},
+      {"finished_splits", velox::BIGINT()},
+      {"output_rows", velox::BIGINT()},
+      {"output_bytes", velox::BIGINT()},
+      {"processed_rows", velox::BIGINT()},
+      {"processed_bytes", velox::BIGINT()},
+      {"written_rows", velox::BIGINT()},
+      {"written_bytes", velox::BIGINT()},
+      {"peak_memory_bytes", velox::BIGINT()},
+      {"spilled_bytes", velox::BIGINT()},
+      {"create_time", velox::TIMESTAMP()},
+      {"start_time", velox::TIMESTAMP()},
+      {"end_time", velox::TIMESTAMP()},
+  });
+  return kSchema;
 }
 
-velox::RowTypePtr sessionPropertiesTableSchema() {
-  static auto schema = velox::ROW(
-      {{"component", velox::VARCHAR()},
-       {"name", velox::VARCHAR()},
-       {"type", velox::VARCHAR()},
-       {"default_value", velox::VARCHAR()},
-       {"current_value", velox::VARCHAR()},
-       {"description", velox::VARCHAR()}});
-  return schema;
+const velox::RowTypePtr& sessionPropertiesTableSchema() {
+  static auto kSchema = velox::ROW({
+      {"component", velox::VARCHAR()},
+      {"name", velox::VARCHAR()},
+      {"type", velox::VARCHAR()},
+      {"default_value", velox::VARCHAR()},
+      {"current_value", velox::VARCHAR()},
+      {"description", velox::VARCHAR()},
+  });
+  return kSchema;
+}
+
+const velox::RowTypePtr& functionsTableSchema() {
+  static auto kSchema = velox::ROW({
+      {"name", velox::VARCHAR()},
+      {"kind", velox::VARCHAR()},
+      {"return_type", velox::VARCHAR()},
+      {"argument_types", velox::ARRAY(velox::VARCHAR())},
+      {"is_variadic", velox::BOOLEAN()},
+      {"owner", velox::VARCHAR()},
+      {"properties", velox::VARCHAR()},
+  });
+  return kSchema;
 }
 
 // ===================== SystemTableLayout =====================
@@ -155,6 +170,15 @@ TablePtr SystemConnectorMetadata::findTable(const SchemaTableName& tableName) {
           tableName, sessionPropertiesTableSchema(), connector_);
     }
     return sessionPropertiesTable_;
+  }
+
+  if (tableName.schema == kMetadataSchema &&
+      tableName.table == kFunctionsTable) {
+    if (!functionsTable_) {
+      functionsTable_ = std::make_shared<SystemTable>(
+          tableName, functionsTableSchema(), connector_);
+    }
+    return functionsTable_;
   }
 
   return nullptr;

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -22,14 +22,17 @@
 namespace facebook::axiom::connector::system {
 
 /// Returns the schema for the system.runtime.queries table.
-velox::RowTypePtr queriesTableSchema();
+const velox::RowTypePtr& queriesTableSchema();
 
 /// Returns the schema for the system.metadata.session_properties table.
-velox::RowTypePtr sessionPropertiesTableSchema();
+const velox::RowTypePtr& sessionPropertiesTableSchema();
+
+/// Returns the schema for the system.metadata.functions table.
+const velox::RowTypePtr& functionsTableSchema();
 
 // ===================== Axiom Metadata Layer =====================
 
-/// Table layout for the system.runtime.queries table.
+/// Table layout for system connector tables.
 class SystemTableLayout : public TableLayout {
  public:
   SystemTableLayout(
@@ -68,7 +71,8 @@ class SystemTableLayout : public TableLayout {
       std::optional<LookupKeys> lookupKeys) const override;
 };
 
-/// Table representing system.runtime.queries.
+/// Table representing a system connector table (e.g., queries,
+/// session_properties, functions).
 class SystemTable : public Table {
  public:
   SystemTable(
@@ -151,6 +155,7 @@ class SystemConnectorMetadata : public ConnectorMetadata {
   std::unique_ptr<SystemSplitManager> splitManager_;
   std::shared_ptr<SystemTable> queriesTable_;
   std::shared_ptr<SystemTable> sessionPropertiesTable_;
+  std::shared_ptr<SystemTable> functionsTable_;
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -26,7 +26,9 @@ target_link_libraries(
   axiom_connectors
   velox_connector
   velox_exec
+  velox_exec_test_lib
   velox_expression
+  velox_function_registry
   velox_vector_test_lib
   GTest::gmock
   GTest::gtest

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <folly/coro/BlockingWait.h>
+#include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -22,11 +23,82 @@
 #include "axiom/connectors/system/SystemConnector.h"
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::axiom::connector::system {
 namespace {
+
+// Test functions for the system.metadata.functions table.
+
+// toss() -> boolean. Non-deterministic coin toss.
+template <typename T>
+struct TossFunction {
+  static constexpr bool is_deterministic = false;
+
+  FOLLY_ALWAYS_INLINE void call(bool& result) {
+    result = folly::Random::rand32(2) == 0;
+  }
+};
+
+// roll() -> integer and roll(integer) -> integer. Non-deterministic dice roll.
+template <typename T>
+struct RollFunction {
+  static constexpr bool is_deterministic = false;
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, int32_t faces = 6) {
+    result = folly::Random::rand32(faces);
+  }
+};
+
+// plus(integer, integer, ...) -> integer and plus(real, real, ...) -> real.
+// Variadic addition.
+template <typename TExec>
+struct PlusFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename T>
+  FOLLY_ALWAYS_INLINE void call(
+      T& result,
+      const T& first,
+      const T& second,
+      const arg_type<velox::Variadic<T>>& remaining) {
+    result = first + second;
+    for (const auto& value : remaining) {
+      if (value.has_value()) {
+        result += value.value();
+      }
+    }
+  }
+};
+
+// Registers the test functions once per process.
+void registerTestFunctions() {
+  static bool kRegistered = false;
+  if (kRegistered) {
+    return;
+  }
+  kRegistered = true;
+
+  velox::registerFunction<TossFunction, bool>({"toss"});
+  velox::registerFunction<RollFunction, int32_t>({"roll"});
+  velox::registerFunction<RollFunction, int32_t, int32_t>({"roll"});
+  velox::registerFunction<
+      PlusFunction,
+      int32_t,
+      int32_t,
+      int32_t,
+      velox::Variadic<int32_t>>({"plus"});
+  velox::registerFunction<
+      PlusFunction,
+      float,
+      float,
+      float,
+      velox::Variadic<float>>({"plus"});
+}
 
 const char* const kSystemCatalog = "test-system";
 
@@ -63,6 +135,7 @@ class MockSessionPropertiesProvider : public SessionPropertiesProvider {
 class SystemConnectorMetadataTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    registerTestFunctions();
     velox::memory::MemoryManager::testingSetInstance({});
 
     queryProvider_ = std::make_unique<MockQueryInfoProvider>();
@@ -161,25 +234,37 @@ class SystemConnectorMetadataTest : public ::testing::Test {
 // ===================== system.runtime.queries tests =====================
 
 TEST_F(SystemConnectorMetadataTest, findTable) {
-  auto table = metadata_->findTable({"runtime", "queries"});
+  auto table = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   ASSERT_NE(table, nullptr);
-  EXPECT_EQ(table->name(), (SchemaTableName{"runtime", "queries"}));
+  EXPECT_EQ(
+      table->name(),
+      (SchemaTableName{
+          std::string(kRuntimeSchema), std::string(kQueriesTable)}));
 }
 
 TEST_F(SystemConnectorMetadataTest, findTableCaching) {
-  auto table1 = metadata_->findTable({"runtime", "queries"});
-  auto table2 = metadata_->findTable({"runtime", "queries"});
+  auto table1 = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
+  auto table2 = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   EXPECT_EQ(table1.get(), table2.get());
 }
 
 TEST_F(SystemConnectorMetadataTest, findTableUnknown) {
-  EXPECT_EQ(metadata_->findTable({"runtime", "nonexistent"}), nullptr);
-  EXPECT_EQ(metadata_->findTable({"runtime", "other"}), nullptr);
+  EXPECT_EQ(
+      metadata_->findTable({std::string(kRuntimeSchema), "nonexistent"}),
+      nullptr);
+  EXPECT_EQ(
+      metadata_->findTable(
+          {std::string(kMetadataSchema), std::string(kQueriesTable)}),
+      nullptr);
   EXPECT_EQ(metadata_->findTable({"", ""}), nullptr);
 }
 
 TEST_F(SystemConnectorMetadataTest, schema) {
-  auto table = metadata_->findTable({"runtime", "queries"});
+  auto table = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   ASSERT_NE(table, nullptr);
 
   auto expectedSchema = queriesTableSchema();
@@ -196,7 +281,8 @@ TEST_F(SystemConnectorMetadataTest, splitManager) {
 }
 
 TEST_F(SystemConnectorMetadataTest, tableLayout) {
-  auto table = metadata_->findTable({"runtime", "queries"});
+  auto table = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   ASSERT_NE(table, nullptr);
 
   const auto& layouts = table->layouts();
@@ -213,7 +299,8 @@ TEST_F(SystemConnectorMetadataTest, tableLayout) {
 }
 
 TEST_F(SystemConnectorMetadataTest, tableHandle) {
-  auto table = metadata_->findTable({"runtime", "queries"});
+  auto table = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   ASSERT_NE(table, nullptr);
 
   const auto& layouts = table->layouts();
@@ -235,7 +322,8 @@ TEST_F(SystemConnectorMetadataTest, tableHandle) {
 }
 
 TEST_F(SystemConnectorMetadataTest, splitSource) {
-  auto table = metadata_->findTable({"runtime", "queries"});
+  auto table = metadata_->findTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)});
   ASSERT_NE(table, nullptr);
 
   auto session = std::make_shared<ConnectorSession>("test-query");
@@ -296,7 +384,9 @@ TEST_F(SystemConnectorMetadataTest, dataSourceAllColumns) {
 
   queryProvider_->addQuery(std::move(snapshot));
 
-  auto vector = readTable({"runtime", "queries"}, queriesTableSchema());
+  auto vector = readTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)},
+      queriesTableSchema());
   ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
 
@@ -336,7 +426,8 @@ TEST_F(SystemConnectorMetadataTest, dataSourceColumnPruning) {
 
   auto outputType =
       velox::ROW({{"query_id", velox::VARCHAR()}, {"state", velox::VARCHAR()}});
-  auto vector = readTable({"runtime", "queries"}, outputType);
+  auto vector = readTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)}, outputType);
   ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
   ASSERT_EQ(vector->type()->size(), 2);
@@ -349,7 +440,9 @@ TEST_F(SystemConnectorMetadataTest, dataSourceColumnPruning) {
 }
 
 TEST_F(SystemConnectorMetadataTest, dataSourceEmpty) {
-  auto vector = readTable({"runtime", "queries"}, queriesTableSchema());
+  auto vector = readTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)},
+      queriesTableSchema());
   ASSERT_NE(vector, nullptr);
   EXPECT_EQ(vector->size(), 0);
 }
@@ -367,7 +460,8 @@ TEST_F(SystemConnectorMetadataTest, dataSourceNullSource) {
   queryProvider_->addQuery(std::move(snapshot));
 
   auto outputType = velox::ROW({{"source", velox::VARCHAR()}});
-  auto vector = readTable({"runtime", "queries"}, outputType);
+  auto vector = readTable(
+      {std::string(kRuntimeSchema), std::string(kQueriesTable)}, outputType);
   ASSERT_NE(vector, nullptr);
   ASSERT_EQ(vector->size(), 1);
 
@@ -376,18 +470,23 @@ TEST_F(SystemConnectorMetadataTest, dataSourceNullSource) {
 }
 
 TEST_F(SystemConnectorMetadataTest, findSessionPropertiesTable) {
-  auto table = metadata_->findTable({"metadata", "session_properties"});
-  ASSERT_NE(table, nullptr);
-  EXPECT_EQ(table->name(), (SchemaTableName{"metadata", "session_properties"}));
-}
+  SchemaTableName tableName{
+      std::string(kMetadataSchema), std::string(kSessionPropertiesTable)};
 
-TEST_F(SystemConnectorMetadataTest, findTableWrongSchema) {
-  EXPECT_EQ(metadata_->findTable({"metadata", "queries"}), nullptr);
-  EXPECT_EQ(metadata_->findTable({"runtime", "session_properties"}), nullptr);
+  auto table = metadata_->findTable(tableName);
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->name(), tableName);
+
+  // Wrong schema.
+  EXPECT_EQ(
+      metadata_->findTable(
+          {std::string(kRuntimeSchema), std::string(kSessionPropertiesTable)}),
+      nullptr);
 }
 
 TEST_F(SystemConnectorMetadataTest, sessionPropertiesSchema) {
-  auto table = metadata_->findTable({"metadata", "session_properties"});
+  auto table = metadata_->findTable(
+      {std::string(kMetadataSchema), std::string(kSessionPropertiesTable)});
   ASSERT_NE(table, nullptr);
 
   auto expectedSchema = sessionPropertiesTableSchema();
@@ -403,9 +502,10 @@ TEST_F(SystemConnectorMetadataTest, schemas) {
   auto session = std::make_shared<ConnectorSession>("test-query");
   EXPECT_THAT(
       metadata_->listSchemaNames(session),
-      testing::UnorderedElementsAre("runtime", "metadata"));
-  EXPECT_TRUE(metadata_->schemaExists(session, "runtime"));
-  EXPECT_TRUE(metadata_->schemaExists(session, "metadata"));
+      testing::UnorderedElementsAre(
+          std::string(kRuntimeSchema), std::string(kMetadataSchema)));
+  EXPECT_TRUE(metadata_->schemaExists(session, std::string(kRuntimeSchema)));
+  EXPECT_TRUE(metadata_->schemaExists(session, std::string(kMetadataSchema)));
   EXPECT_FALSE(metadata_->schemaExists(session, "information_schema"));
 }
 
@@ -423,8 +523,104 @@ TEST_F(SystemConnectorMetadataTest, sessionPropertiesAllColumns) {
       pool_.get());
 
   auto actual = readTable(
-      {"metadata", "session_properties"}, sessionPropertiesTableSchema());
+      {std::string(kMetadataSchema), std::string(kSessionPropertiesTable)},
+      sessionPropertiesTableSchema());
   velox::test::assertEqualVectors(expected, actual);
+}
+
+// ===================== system.metadata.functions tests =====================
+
+TEST_F(SystemConnectorMetadataTest, findFunctionsTable) {
+  SchemaTableName tableName{
+      std::string(kMetadataSchema), std::string(kFunctionsTable)};
+
+  auto table = metadata_->findTable(tableName);
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->name(), tableName);
+
+  // Wrong schema.
+  EXPECT_EQ(
+      metadata_->findTable(
+          {std::string(kRuntimeSchema), std::string(kFunctionsTable)}),
+      nullptr);
+}
+
+TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
+  SchemaTableName tableName{
+      std::string(kMetadataSchema), std::string(kFunctionsTable)};
+
+  auto actual = readTable(tableName, functionsTableSchema());
+  ASSERT_NE(actual, nullptr);
+
+  folly::json::serialization_opts opts;
+  opts.sort_keys = true;
+  auto kDeterministic = folly::json::serialize(
+      folly::dynamic::object("deterministic", true)(
+          "default_null_behavior", true),
+      opts);
+  auto kNonDeterministic = folly::json::serialize(
+      folly::dynamic::object("deterministic", false)(
+          "default_null_behavior", true),
+      opts);
+
+  auto expected = std::dynamic_pointer_cast<velox::RowVector>(
+      velox::BaseVector::createFromVariants(
+          functionsTableSchema(),
+          {
+              // plus(integer, integer, integer...) -> integer.
+              velox::Variant::row({
+                  "plus",
+                  "scalar",
+                  "integer",
+                  velox::Variant::array({"integer", "integer", "integer"}),
+                  true,
+                  "",
+                  kDeterministic,
+              }),
+              // plus(real, real, real...) -> real.
+              velox::Variant::row({
+                  "plus",
+                  "scalar",
+                  "real",
+                  velox::Variant::array({"real", "real", "real"}),
+                  true,
+                  "",
+                  kDeterministic,
+              }),
+              // roll() -> integer.
+              velox::Variant::row({
+                  "roll",
+                  "scalar",
+                  "integer",
+                  velox::Variant::array({}),
+                  false,
+                  "",
+                  kNonDeterministic,
+              }),
+              // roll(integer) -> integer.
+              velox::Variant::row({
+                  "roll",
+                  "scalar",
+                  "integer",
+                  velox::Variant::array({"integer"}),
+                  false,
+                  "",
+                  kNonDeterministic,
+              }),
+              // toss() -> boolean.
+              velox::Variant::row({
+                  "toss",
+                  "scalar",
+                  "boolean",
+                  velox::Variant::array({}),
+                  false,
+                  "",
+                  kNonDeterministic,
+              }),
+          },
+          pool_.get()));
+
+  velox::exec::test::assertEqualResults({expected}, {actual});
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Add a queryable system table that exposes all registered function
signatures:

  -- Schema.
  SQL> desc system.metadata.functions;
  name, kind, return_type, argument_types, is_variadic, owner, properties

  -- Summary: 876 distinct functions, 3319 signature overloads.
  SQL> select kind, count(*) as signatures, count(distinct name) as functions
       from system.metadata.functions group by 1 order by 1;
  aggregate | 1816 | 327
  scalar    | 1488 | 538
  window    |   15 |  11

  -- Non-deterministic functions.
  SQL> select distinct name from system.metadata.functions
       where json_extract_scalar(properties, '$.deterministic') = 'false';
  rand, random, secure_rand, secure_random, shuffle, uuid

One row per function signature (overload). Kind is scalar, aggregate,
or window. Properties is a JSON string with type-specific metadata
(deterministic, default_null_behavior for scalars; order_sensitive,
ignore_duplicates for aggregates).

Function metadata is read directly from Velox's global function
registries and cached on first access.

Also extracts SystemDataSourceBase with shared split/next/createFlat
logic, eliminating duplication across the three data source
implementations.

Reviewed By: amitkdutta

Differential Revision: D101092897
