### PR TITLE
fix(parser): Convert VeloxUserError to PrestoSqlError in doPlan (#1256)

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1797,6 +1797,21 @@ std::vector<lp::ExprApi> toColumnExprs(
   return exprs;
 }
 
+// Rethrows a VeloxUserError as a PrestoSqlError with kSemantic kind, using
+// the AST node's location for the error position. Callers must check that
+// loc.line > 0 before calling; this is verified with VELOX_CHECK.
+[[noreturn]] void rethrowAsSemanticError(
+    const NodeLocation& loc,
+    const VeloxUserError& e) {
+  VELOX_CHECK_GT(loc.line, 0, "Location must have 1-based line");
+  throw PrestoSqlError(
+      std::string(e.message()),
+      static_cast<size_t>(loc.line - 1),
+      static_cast<size_t>(std::max(0, loc.charPosition)),
+      std::nullopt,
+      PrestoSqlErrorKind::kSemantic);
+}
+
 SqlStatementPtr parseInsert(
     const Insert& insert,
     const std::string& defaultConnectorId,
@@ -1832,18 +1847,27 @@ SqlStatementPtr parseInsert(
   }
 
   RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
-  insert.query()->accept(&planner);
+  try {
+    insert.query()->accept(&planner);
 
-  auto inputColumns = planner.builder().findOrAssignOutputNames();
-  VELOX_CHECK_EQ(inputColumns.size(), columnNames.size());
+    auto inputColumns = planner.builder().findOrAssignOutputNames();
+    VELOX_CHECK_EQ(inputColumns.size(), columnNames.size());
 
-  planner.builder().tableWrite(
-      connectorId,
-      connectorTable.schema,
-      connectorTable.table,
-      lp::WriteKind::kInsert,
-      columnNames,
-      toColumnExprs(inputColumns));
+    planner.builder().tableWrite(
+        connectorId,
+        connectorTable.schema,
+        connectorTable.table,
+        lp::WriteKind::kInsert,
+        columnNames,
+        toColumnExprs(inputColumns));
+  } catch (const VeloxUserError& e) {
+    // No valid SQL location — let the original VeloxUserError propagate
+    // rather than creating a PrestoSqlError with a misleading position.
+    if (insert.location().line <= 0) {
+      throw;
+    }
+    rethrowAsSemanticError(insert.location(), e);
+  }
 
   return std::make_shared<InsertStatement>(planner.plan(), planner.views());
 }
@@ -1876,7 +1900,16 @@ SqlStatementPtr parseCreateTableAsSelect(
       toConnectorTable(*ctas.name(), defaultConnectorId, defaultSchema);
 
   RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
-  ctas.query()->accept(&planner);
+  try {
+    ctas.query()->accept(&planner);
+  } catch (const VeloxUserError& e) {
+    // No valid SQL location — let the original VeloxUserError propagate
+    // rather than creating a PrestoSqlError with a misleading position.
+    if (ctas.location().line <= 0) {
+      throw;
+    }
+    rethrowAsSemanticError(ctas.location(), e);
+  }
 
   auto properties = parseTableProperties(ctas.properties());
 
@@ -2201,7 +2234,16 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kShowStatsForQuery)) {
     auto* showStats = query->as<ShowStatsForQuery>();
     RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
-    showStats->query()->accept(&planner);
+    try {
+      showStats->query()->accept(&planner);
+    } catch (const VeloxUserError& e) {
+      // No valid SQL location — let the original VeloxUserError propagate
+      // rather than creating a PrestoSqlError with a misleading position.
+      if (query->location().line <= 0) {
+        throw;
+      }
+      rethrowAsSemanticError(query->location(), e);
+    }
     auto innerStatement =
         std::make_shared<SelectStatement>(planner.plan(), planner.views());
     return std::make_shared<ShowStatsForQueryStatement>(
@@ -2215,7 +2257,16 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kQuery)) {
     RelationPlanner planner(
         defaultConnectorId, defaultSchema, parseSql, friendlySql);
-    query->accept(&planner);
+    try {
+      query->accept(&planner);
+    } catch (const VeloxUserError& e) {
+      // No valid SQL location — let the original VeloxUserError propagate
+      // rather than creating a PrestoSqlError with a misleading position.
+      if (query->location().line <= 0) {
+        throw;
+      }
+      rethrowAsSemanticError(query->location(), e);
+    }
     return std::make_shared<SelectStatement>(planner.plan(), planner.views());
   }
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -65,7 +66,7 @@ TEST_F(AggregationParserTest, simpleGroupBy) {
   }
 
   // GROUP BY resolves against FROM columns, not SELECT aliases.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT n_name AS x FROM nation GROUP BY x"),
       "Cannot resolve column: x");
 
@@ -523,17 +524,17 @@ TEST_F(AggregationParserTest, having) {
       "SELECT n_name FROM nation GROUP BY 1 HAVING count(*) > 5", matcher);
 
   // HAVING cannot reference SELECT aliases.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT sum(n_regionkey) AS s FROM nation HAVING s > 10"),
       "HAVING clause cannot reference column: s");
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT n_regionkey AS k, count(*) FROM nation GROUP BY 1 HAVING k > 2"),
       "HAVING clause cannot reference column: k");
 
   // HAVING cannot reference non-grouped columns.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT n_regionkey FROM nation GROUP BY 1 HAVING n_comment = 'x'"),
       "HAVING clause cannot reference column: n_comment");
@@ -541,7 +542,7 @@ TEST_F(AggregationParserTest, having) {
   // HAVING with alias-on-aggregate shadowing a FROM column must not silently
   // resolve to the aggregate. 'n_regionkey' in HAVING refers to the FROM
   // column, which is not a grouping key ('n_regionkey + 1' is).
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT n_regionkey + 1, count(*) AS n_regionkey FROM nation "
           "GROUP BY 1 HAVING n_regionkey > 10"),
@@ -550,7 +551,7 @@ TEST_F(AggregationParserTest, having) {
   // HAVING with alias-on-grouping-key shadowing a FROM column must not
   // silently resolve to the grouping key. 'n_nationkey' in HAVING refers to
   // the FROM column, which is not a grouping key ('n_regionkey' is).
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT n_regionkey AS n_nationkey, count(*) FROM nation "
           "GROUP BY 1 HAVING n_nationkey > 10"),
@@ -1015,7 +1016,7 @@ TEST_F(AggregationParserTest, columnCanonicalization) {
     connector_->addTable(
         "st",
         ROW({"x", "s"}, {INTEGER(), ROW({"x", "y"}, {VARCHAR(), DOUBLE()})}));
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql(
             "SELECT s.x, count(*) FROM st "
             "GROUP BY 1 HAVING x > 0"),
@@ -1037,7 +1038,7 @@ TEST_F(AggregationParserTest, columnCanonicalization) {
         "GROUP BY t.a HAVING t.a > 0",
         matchScan().join(matchScan().build()).aggregate().filter().output());
 
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql(
             "SELECT t.a, count(*) FROM t JOIN u ON t.b = u.c "
             "GROUP BY t.a HAVING a > 0"),

--- a/axiom/sql/presto/tests/ColumnFilteringTest.cpp
+++ b/axiom/sql/presto/tests/ColumnFilteringTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -332,7 +333,7 @@ TEST_F(ColumnFilteringTest, multipleColumnsInExpression) {
           .output());
 
   // Mismatched column counts: 'x_.*' matches 3 columns, 'y_a' matches 1.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSelect("SELECT COLUMNS('x_.*') + COLUMNS('y_a') FROM t"),
       "All COLUMNS() calls in a single expression must match the same number "
       "of columns");

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -50,7 +51,7 @@ TEST_F(DdlParserTest, insertIntoTable) {
   }
 
   // Wrong types.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("INSERT INTO nation SELECT 100, 'n-100', 2, 3"),
       "Wrong column type: INTEGER vs. VARCHAR, column 'n_comment' in table \"default\".\"nation\"");
 }

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
@@ -720,10 +721,10 @@ TEST_F(ExpressionParserTest, dereference) {
       "DEREFERENCE(row_constructor(1, 2), 1)",
       parseExpr("row(1, 2).field01")->toString());
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseExpr("row(1, 2).field2"), "Invalid legacy field name: field2");
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseExpr("cast(row(1, 2) as row(a int, b int)).field0"),
       "Cannot access named field using legacy field name: field0 vs. a");
 
@@ -816,17 +817,17 @@ TEST_F(ExpressionParserTest, lateralColumnAlias) {
 
 TEST_F(ExpressionParserTest, lateralColumnAliasErrors) {
   // Forward reference: j is used before it's defined.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT j + 2 AS k, n_regionkey + 1 AS j FROM nation"),
       "Cannot resolve column: j");
 
   // Self-reference: j is not yet in the alias map when the expression is
   // evaluated, so it resolves as a (non-existent) column reference.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT j + 1 AS j FROM nation"), "Cannot resolve column: j");
 
   // Lateral column aliases are not available when Friendly SQL is disabled.
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       makeStrictParser().parse(
           "SELECT n_regionkey + 1 AS j, j + 2 AS k FROM nation", true),
       "Cannot resolve column: j");

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -256,7 +257,7 @@ TEST_F(PrestoParserTest, qualifiedColumnAccess) {
 
     // Struct field 'x' is shadowed by the table-qualified column. Legacy
     // positional access also fails because the struct has named fields.
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql("SELECT t.field0 FROM u AS t"),
         "Cannot access named field using legacy field name");
   }
@@ -312,7 +313,8 @@ TEST_F(PrestoParserTest, selectStar) {
         matcher);
   }
 
-  VELOX_ASSERT_THROW(parseSql("SELECT r.* FROM region"), "Alias not found: r");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT r.* FROM region"), "Alias not found: r");
 }
 
 // Tests for star expansion with duplicate column names from joins.
@@ -523,7 +525,7 @@ TEST_F(PrestoParserTest, join) {
         "t3", ROW({"x", "y", "z"}, {INTEGER(), INTEGER(), VARCHAR()}));
 
     // Unqualified reference to a column on both sides is ambiguous.
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql("SELECT * FROM t1 JOIN t2 ON id = id"),
         "Cannot resolve column");
 
@@ -533,7 +535,7 @@ TEST_F(PrestoParserTest, join) {
     testSelect("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id", matcher);
 
     // Non-existent column in ON clause.
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql("SELECT * FROM t1 JOIN t2 ON t1.id = no_such_column"),
         "Cannot resolve column");
 
@@ -541,7 +543,7 @@ TEST_F(PrestoParserTest, join) {
     // that exists on both sides of the join is ambiguous. This exercises the
     // joinScope lambda (resolveJoinColumn) rather than the NameMappings::merge
     // path used for simple ON conditions.
-    VELOX_ASSERT_THROW(
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
         parseSql(
             "SELECT * FROM t1 JOIN t2 "
             "ON t1.id = (SELECT max(x) FROM t3 WHERE t3.y = id)"),
@@ -1201,8 +1203,8 @@ TEST_F(PrestoParserTest, duplicateAliases) {
         matcher);
   }
 
-  // Referencing a duplicate column shoud fail.
-  VELOX_ASSERT_THROW(
+  // Referencing a duplicate column should fail.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT x FROM (SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b))"),
       "Cannot resolve column: x");

--- a/axiom/sql/presto/tests/PrestoSqlErrorTest.cpp
+++ b/axiom/sql/presto/tests/PrestoSqlErrorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 
 namespace axiom::sql::presto::test {
@@ -159,6 +160,25 @@ TEST_F(PrestoSqlErrorTest, messageForInvalidDecimalTypeArgs) {
           testing::Property(
               &PrestoSqlError::what,
               testing::HasSubstr("mismatched input ''abc''")))));
+}
+
+TEST_F(PrestoSqlErrorTest, typeErrorThrowsSemanticError) {
+  auto parser = makeParser();
+  // Type mismatch: integer + varchar. ExprResolver throws VeloxUserError;
+  // doPlan() should catch it and rethrow as PrestoSqlError with kSemantic kind.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parser.parse("SELECT 1 + 'a' FROM nation"),
+      "Scalar function signature is not supported");
+}
+
+TEST_F(PrestoSqlErrorTest, insertTypeErrorThrowsSemanticError) {
+  auto parser = makeParser();
+  // Column type mismatch in INSERT sub-query. tableWrite() throws
+  // VeloxUserError; parseInsert() should catch it and rethrow as
+  // PrestoSqlError with kSemantic kind.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parser.parse("INSERT INTO nation SELECT 100, 'n-100', 2, 3"),
+      "Wrong column type");
 }
 
 } // namespace

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/logical_plan/ExprApi.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -134,7 +135,7 @@ TEST_F(SortParserTest, groupBy) {
     testSelect("SELECT a AS b, sum(b) FROM t GROUP BY a ORDER BY b", matcher);
   }
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT a, sum(b) FROM t GROUP BY a ORDER BY b"),
       "Cannot resolve column: b");
 }
@@ -189,7 +190,7 @@ TEST_F(SortParserTest, nonSelectedColumn) {
 TEST_F(SortParserTest, ambiguousAlias) {
   connector_->addTable("t", ROW({"a", "b", "c"}, INTEGER()));
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT a as b, b FROM t ORDER BY b"), "Column is ambiguous: b");
 
   testSelect(
@@ -303,7 +304,7 @@ TEST_F(SortParserTest, distinct) {
           "ORDER BY 2 DESC"),
       "ORDER BY position is not in the select list: 2");
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
           "SELECT a + b "
           "FROM (VALUES (1, 2), (3, 4)) AS t(a, b) "
@@ -418,7 +419,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
           .project({"x"})
           .output({"x"}));
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT 1 AS a, a FROM t2 ORDER BY a + 1"),
       "Column is ambiguous: a");
 


### PR DESCRIPTION
Summary:

SQL type errors (e.g., `1 + 'a'`, `lower(false)`) and other semantic errors from RelationPlanner (column resolution, ambiguous columns, etc.) produced `CompileError` instead of `SqlParseError` downstream because `ExprResolver` throws `VeloxUserError` which lacks SQL source location, causing `AxiomConnector::parseSql()` to classify the error incorrectly.

Added `rethrowAsSemanticError()` helper and try/catch blocks around all four RelationPlanner callsites in PrestoParser.cpp (kQuery, kShowStatsForQuery, parseInsert, parseCreateTableAsSelect) to catch VeloxUserError and rethrow as PrestoSqlError with kSemantic kind and the AST node's location. Extended parseInsert's catch scope to also cover tableWrite() for INSERT column type mismatches.

Differential Revision: D101168987


