### PR TITLE
fix(tests): Increase waitForCompletion timeout and check return value (#1258)

### DIFF
--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -105,12 +105,13 @@ logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
 }
 
 namespace {
+constexpr int32_t kWaitTimeoutUs = 500'000;
+
 void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner) {
   if (runner) {
-    try {
-      runner->waitForCompletion(50000);
-    } catch (const std::exception& /*ignore*/) {
-    }
+    VELOX_CHECK(
+        runner->waitForCompletion(kWaitTimeoutUs),
+        "Timed out waiting for query completion");
   }
 }
 } // namespace

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -177,7 +177,7 @@ TEST_F(LocalRunnerTest, count) {
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  localRunner->waitForCompletion(kWaitTimeoutUs);
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, error) {
@@ -186,7 +186,7 @@ TEST_F(LocalRunnerTest, error) {
 
   VELOX_ASSERT_THROW(readCursor(localRunner), "division by zero");
   EXPECT_EQ(Runner::State::kError, localRunner->state());
-  localRunner->waitForCompletion(kWaitTimeoutUs);
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, scan) {
@@ -222,7 +222,7 @@ TEST_F(LocalRunnerTest, broadcast) {
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  localRunner->waitForCompletion(kWaitTimeoutUs);
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
@@ -256,7 +256,7 @@ TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
 
   results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  localRunner->waitForCompletion(kWaitTimeoutUs);
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
- Increase `QueryTestBase::waitForCompletion` timeout from 50ms to 500ms to match `LocalRunnerTest`
- Check the return value of `waitForCompletion` instead of silently swallowing timeout exceptions
- Update `LocalRunnerTest` to consistently check the return value

The 50ms timeout was set during the initial repo sync and was never updated when `waitForCompletion` was rewritten in https://github.com/facebookincubator/axiom/issues/835. On loaded CI runners, 50ms can be insufficient for async task cleanup, causing `SharedArbitrator::shutdown` to fail with "Unexpected alive participants on destruction".

Fixes https://github.com/facebookincubator/axiom/issues/1257


Reviewed By: jagill

Differential Revision: D101180582

Pulled By: mbasmanova


