### PR TITLE
feat: Use Velox NULLIF special form (#1259)

### DIFF
--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -480,6 +480,7 @@ const auto& specialFormNames() {
       {SpecialForm::kStar, "STAR"},
       {SpecialForm::kIn, "IN"},
       {SpecialForm::kExists, "EXISTS"},
+      {SpecialForm::kNullIf, "NULLIF"},
   };
   return kNames;
 }
@@ -701,6 +702,10 @@ SpecialFormExpr::SpecialFormExpr(
       VELOX_USER_CHECK(
           inputs_[0]->isSubquery(),
           "EXISTS input must be a subquery expression");
+      break;
+    case SpecialForm::kNullIf:
+      VELOX_USER_CHECK_EQ(
+          inputs_.size(), 3, "NULLIF must have exactly 3 inputs");
       break;
   }
 }

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -461,6 +461,17 @@ enum class SpecialForm {
   /// Example:
   ///   EXISTS (SELECT * FROM table WHERE condition)
   kExists = 11,
+
+  /// NULLIF(value, comparand). Returns NULL if value equals comparand,
+  /// otherwise returns value.
+  ///
+  /// Takes exactly 3 inputs: value, comparand, and a null literal whose type
+  /// is the common supertype used for comparison. The return type is the type
+  /// of value.
+  ///
+  /// Example:
+  ///   NULLIF(x, 0) => NULL if x = 0, else x
+  kNullIf = 12,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SpecialForm)

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -351,6 +351,30 @@ ExprPtr tryResolveSpecialForm(
         velox::BOOLEAN(), SpecialForm::kExists, resolvedInputs);
   }
 
+  if (name == "nullif") {
+    VELOX_USER_CHECK_EQ(
+        resolvedInputs.size(), 2, "NULLIF requires exactly 2 arguments");
+
+    const auto& valueType = resolvedInputs[0]->type();
+    const auto& comparandType = resolvedInputs[1]->type();
+
+    auto commonType =
+        velox::TypeCoercer::leastCommonSuperType(valueType, comparandType);
+    VELOX_USER_CHECK_NOT_NULL(
+        commonType,
+        "Cannot find common type for NULLIF arguments: {} vs {}",
+        valueType->toString(),
+        comparandType->toString());
+
+    // Append a null literal of the common type to carry the type information.
+    resolvedInputs.push_back(
+        std::make_shared<ConstantExpr>(
+            commonType, std::make_shared<velox::Variant>(commonType->kind())));
+
+    return std::make_shared<SpecialFormExpr>(
+        valueType, SpecialForm::kNullIf, resolvedInputs);
+  }
+
   return nullptr;
 }
 } // namespace

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -427,6 +427,8 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerSpecialForm(
       lp::SpecialForm::kSwitch, velox::expression::kSwitch);
   registry->registerSpecialForm(lp::SpecialForm::kIn, "in");
+  registry->registerSpecialForm(
+      lp::SpecialForm::kNullIf, velox::expression::kNullIf);
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -43,6 +43,8 @@ const char* SpecialFormCallNames::kIf = "__if";
 const char* SpecialFormCallNames::kSwitch = "__switch";
 // static
 const char* SpecialFormCallNames::kIn = "__in";
+// static
+const char* SpecialFormCallNames::kNullIf = "__nullif";
 
 void Column::equals(ColumnCP other) const {
   if (!equivalence_ && !other->equivalence_) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -331,6 +331,7 @@ struct SpecialFormCallNames {
   static const char* kIf;
   static const char* kSwitch;
   static const char* kIn;
+  static const char* kNullIf;
 
   static const char* toCallName(const logical_plan::SpecialForm& form) {
     switch (form) {
@@ -352,6 +353,8 @@ struct SpecialFormCallNames {
         return SpecialFormCallNames::kSwitch;
       case logical_plan::SpecialForm::kIn:
         return SpecialFormCallNames::kIn;
+      case logical_plan::SpecialForm::kNullIf:
+        return SpecialFormCallNames::kNullIf;
       default:
         VELOX_FAIL(
             "No function call name for special form: {}",
@@ -387,6 +390,9 @@ struct SpecialFormCallNames {
     }
     if (name == kIn) {
       return logical_plan::SpecialForm::kIn;
+    }
+    if (name == kNullIf) {
+      return logical_plan::SpecialForm::kNullIf;
     }
 
     return std::nullopt;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -665,6 +665,14 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
               toTypePtr(expr->value().type), std::move(inputs), true);
         }
 
+        if (form == lp::SpecialForm::kNullIf) {
+          // Third input is a null literal carrying the common type.
+          VELOX_CHECK_EQ(inputs.size(), 3);
+          const auto& commonType = inputs[2]->type();
+          return std::make_shared<velox::core::NullIfTypedExpr>(
+              std::move(inputs[0]), std::move(inputs[1]), commonType);
+        }
+
         return std::make_shared<velox::core::CallTypedExpr>(
             toTypePtr(expr->value().type),
             std::move(inputs),

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -85,3 +85,8 @@ SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bi
 ----
 -- error: Grouping sets are not supported yet
 SELECT count(*) FROM t GROUP BY GROUPING SETS ((a), ())
+----
+-- NULLIF with non-deterministic expression. Result must contain only NULL and
+-- false, never true.
+-- duckdb: VALUES (null::boolean), (false)
+SELECT DISTINCT nullif(rand() < 0.5, true) FROM unnest(sequence(1, 1000))

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -748,8 +748,6 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       const auto& funcName = call->name()->suffix();
       const auto lowerFuncName = canonicalizeName(funcName);
 
-      // TODO: Verify that NULLIF is semantically equivalent with IF(a = b,
-      // null, a). https://github.com/prestodb/presto/issues/27024
       if (lowerFuncName == "nullif") {
         AXIOM_PRESTO_SEMANTIC_CHECK(
             args.size() == 2,
@@ -757,11 +755,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
             lowerFuncName,
             "NULLIF requires exactly 2 arguments, got {}",
             args.size());
-        return lp::Call(
-            "if",
-            lp::Call("eq", args[0], args[1]),
-            lp::Lit(Variant::null(TypeKind::UNKNOWN)),
-            args[0]);
+        return lp::Call("nullif", args[0], args[1]);
       }
 
       if (call->isDistinct() || call->filter() || call->orderBy()) {

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -531,16 +531,48 @@ TEST_F(ExpressionParserTest, specialDateTimeFunctions) {
 }
 
 TEST_F(ExpressionParserTest, nullif) {
-  // NULLIF(a, b) translates to IF(eq(a, b), null, a).
-  EXPECT_EQ(
-      "IF(eq(1, 2), CAST(null AS INTEGER), 1)",
-      parseExpr("NULLIF(1, 2)")->toString());
-  EXPECT_EQ(
-      "IF(eq(1, 1), CAST(null AS INTEGER), 1)",
-      parseExpr("nullif(1, 1)")->toString());
-  EXPECT_EQ(
-      "IF(eq(foo, bar), CAST(null AS VARCHAR), foo)",
-      parseExpr("NULLIF('foo', 'bar')")->toString());
+  auto verifyNullIf = [&](const std::string& sql,
+                          const TypePtr& expectedType,
+                          const TypePtr& expectedCommonType) {
+    auto expr = parseExpr(sql);
+    ASSERT_TRUE(expr->isSpecialForm());
+
+    auto* nullIf = expr->as<lp::SpecialFormExpr>();
+    ASSERT_EQ(nullIf->form(), lp::SpecialForm::kNullIf);
+    ASSERT_EQ(nullIf->inputs().size(), 3);
+
+    VELOX_ASSERT_EQ_TYPES(expr->type(), expectedType);
+    VELOX_EXPECT_EQ_TYPES(nullIf->inputAt(2)->type(), expectedCommonType);
+  };
+
+  // Same types.
+  verifyNullIf("NULLIF(1, 2)", INTEGER(), INTEGER());
+  verifyNullIf("nullif(1, 1)", INTEGER(), INTEGER());
+  verifyNullIf("NULLIF('foo', 'bar')", VARCHAR(), VARCHAR());
+
+  // Different types: return type is first arg's type, common type is the
+  // least common supertype.
+  verifyNullIf("NULLIF(TINYINT '1', 2)", TINYINT(), INTEGER());
+  verifyNullIf("NULLIF(SMALLINT '1', BIGINT '2')", SMALLINT(), BIGINT());
+
+  // Complex type: ARRAY(TINYINT) vs ARRAY(BIGINT) → common type is
+  // ARRAY(BIGINT).
+  verifyNullIf(
+      "NULLIF(ARRAY[TINYINT '1'], ARRAY[BIGINT '2'])",
+      ARRAY(TINYINT()),
+      ARRAY(BIGINT()));
+
+  // ROW with fields coerced in opposite directions. Neither ROW is coercible
+  // to the other, but leastCommonSuperType produces ROW(BIGINT, BIGINT).
+  verifyNullIf(
+      "NULLIF(ROW(TINYINT '1', BIGINT '2'), ROW(BIGINT '1', TINYINT '2'))",
+      ROW({TINYINT(), BIGINT()}),
+      ROW({BIGINT(), BIGINT()}));
+
+  // No common type.
+  VELOX_ASSERT_THROW(
+      parseExpr("NULLIF(1, 'a')"),
+      "Cannot find common type for NULLIF arguments");
 }
 
 TEST_F(ExpressionParserTest, null) {


### PR DESCRIPTION
Summary:

Replace the IF(eq(a, b), null, a) rewrite for NULLIF with the new
Velox NullIfTypedExpr special form that evaluates each input once.

The ExpressionPlanner emits nullif(a, b) as a regular call. The
ExprResolver computes the common type via leastCommonSuperType and
appends a null literal of that type as a third input to carry the
type information. ToVelox converts this to NullIfTypedExpr.

This fixes wrong results for non-deterministic expressions. For
example:

  SELECT DISTINCT nullif(rand() < 0.5, true)
  FROM unnest(sequence(1, 1000))

Before (wrong):  true, false, NULL
After (correct): false, NULL

Reviewed By: xiaoxmeng

Differential Revision: D101170682
