### PR TITLE
fix: Isolate width-constraining inputs in makeUnionAll for distributed execution (#1261)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -212,6 +212,69 @@ void checkStageWidths(const std::vector<ExecutableFragment>& stages) {
   }
 }
 
+// Verifies that no fragment mixes inline table scans with hash-partitioned
+// exchange inputs in a LocalPartition. Hash-partitioned exchanges require
+// exactly width consumer tasks, but scans trigger DYNAMIC scheduling which
+// can create fewer tasks — causing silent data loss for unserved partitions.
+// Round-robin exchanges are safe because they distribute evenly regardless
+// of consumer task count.
+void checkNoMixedScanHashExchange(
+    const std::vector<ExecutableFragment>& stages) {
+  folly::F14FastMap<std::string, const ExecutableFragment*> stageByPrefix;
+  for (const auto& stage : stages) {
+    stageByPrefix[stage.taskPrefix] = &stage;
+  }
+
+  for (const auto& stage : stages) {
+    // Check if this fragment has inline scans.
+    bool hasInlineScan = false;
+    std::function<void(const velox::core::PlanNode*)> findScan;
+    findScan = [&](const velox::core::PlanNode* node) {
+      if (dynamic_cast<const velox::core::TableScanNode*>(node)) {
+        hasInlineScan = true;
+        return;
+      }
+      // Don't recurse into Exchange — those are in other fragments.
+      if (dynamic_cast<const velox::core::ExchangeNode*>(node)) {
+        return;
+      }
+      for (const auto& child : node->sources()) {
+        findScan(child.get());
+      }
+    };
+    findScan(stage.fragment.planNode.get());
+
+    if (!hasInlineScan) {
+      continue;
+    }
+
+    // This fragment has scans → DYNAMIC scheduling. Check if any input
+    // stage uses hash partitioning (not round-robin or broadcast).
+    for (const auto& input : stage.inputStages) {
+      auto it = stageByPrefix.find(input.producerTaskPrefix);
+      if (it == stageByPrefix.end()) {
+        continue;
+      }
+      auto* output = dynamic_cast<const velox::core::PartitionedOutputNode*>(
+          it->second->fragment.planNode.get());
+      if (!output || output->isBroadcast()) {
+        continue;
+      }
+      // Round-robin is safe — data distributes evenly to any task count.
+      if (dynamic_cast<const velox::exec::RoundRobinPartitionFunctionSpec*>(
+              &output->partitionFunctionSpec())) {
+        continue;
+      }
+      VELOX_FAIL(
+          "Stage has inline scans (DYNAMIC scheduling) but receives "
+          "hash-partitioned exchange. This can silently drop data if fewer "
+          "tasks are created than the exchange expects: stage={}, producer={}",
+          stage.taskPrefix,
+          input.producerTaskPrefix);
+    }
+  }
+}
+
 } // namespace
 
 void ToVelox::filterUpdated(BaseTableCP table) {
@@ -390,6 +453,7 @@ PlanAndStats ToVelox::toVeloxPlan(
     velox::core::PlanConsistencyChecker::check(stage.fragment.planNode);
   }
   checkStageWidths(stages);
+  checkNoMixedScanHashExchange(stages);
 
   if (options.remoteOutput) {
     rootPlanNode = velox::core::PartitionedOutputNode::single(
@@ -1694,18 +1758,88 @@ velox::core::PlanNodePtr ToVelox::makeUnionAll(
     const UnionAll& unionAll,
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
-  // If no inputs have a repartition, this is a local exchange. If
-  // some have repartition and more than one have no repartition,
-  // this is a local exchange with a remote exchange as input. All the
-  // inputs with repartition go to one remote exchange.
-  std::vector<velox::core::PlanNodePtr> localSources;
+  // Phase 1: classify inputs.
+  struct LocalInput {
+    velox::core::PlanNodePtr plan; // Root plan node from makeFragment.
+    ExecutableFragment source; // Fragment holding plan, width, inputStages.
+    bool constrained; // True when source.width != fragment.width after
+                      // processing.
+  };
+  std::vector<LocalInput> localInputs;
   std::shared_ptr<velox::core::ExchangeNode> exchange;
+  bool needsIsolation{false}; // Constrained inputs need wrapping.
+  // Snapshot before the loop — makeRepartition can mutate fragment.width.
+  const auto originalWidth = fragment.width;
+
   for (const auto& input : unionAll.inputs) {
     if (input->relType() == RelType::kRepartition) {
       makeRepartition(*input->as<Repartition>(), fragment, stages, exchange);
+      // Repartition creates exchange inputs on the consumer, so any
+      // constrained siblings must be isolated to avoid width contamination.
+      needsIsolation = true;
     } else {
-      localSources.push_back(makeFragment(input, fragment, stages));
+      auto source = newFragment();
+      auto plan = makeFragment(input, source, stages);
+      bool constrained = source.width != originalWidth;
+      if (!constrained || !source.inputStages.empty()) {
+        needsIsolation = true;
+      }
+      localInputs.push_back({std::move(plan), std::move(source), constrained});
     }
+  }
+
+  // Phase 2: build local sources. Wrap constrained inputs (width=1) when
+  // they would contaminate unconstrained siblings, and inputs with sub-stages
+  // (their exchanges need matching partition counts). Plain table scans
+  // stay inline.
+  int32_t constrainedWidth{0};
+  std::vector<velox::core::PlanNodePtr> localSources;
+  for (auto& localInput : localInputs) {
+    bool isolateConstrained = localInput.constrained && needsIsolation;
+    bool hasSubStages = !localInput.source.inputStages.empty();
+    if (isolateConstrained || hasSubStages) {
+      // Wrap in a producer stage (round-robin to fragment.width partitions).
+      VELOX_CHECK_GT(fragment.width, 0);
+      localInput.source.fragment.planNode =
+          std::make_shared<velox::core::PartitionedOutputNode>(
+              nextId(),
+              velox::core::PartitionedOutputNode::Kind::kPartitioned,
+              std::vector<velox::core::TypedExprPtr>{},
+              fragment.width,
+              false,
+              std::make_shared<velox::exec::RoundRobinPartitionFunctionSpec>(),
+              localInput.plan->outputType(),
+              exchangeSerdeKind_,
+              localInput.plan);
+      auto localExchange = std::make_shared<velox::core::ExchangeNode>(
+          nextId(), localInput.plan->outputType(), exchangeSerdeKind_);
+      fragment.inputStages.emplace_back(
+          localExchange->id(), localInput.source.taskPrefix);
+      stages.push_back(std::move(localInput.source));
+      localSources.push_back(localExchange);
+    } else {
+      // Safe to inline — either not constrained or all inputs agree on width.
+      if (localInput.constrained) {
+        VELOX_CHECK(
+            constrainedWidth == 0 ||
+                constrainedWidth == localInput.source.width,
+            "UnionAll has inlined constrained inputs with incompatible widths. "
+            "Consumer fragment can only run with one width: "
+            "existing={}, new={}",
+            constrainedWidth,
+            localInput.source.width);
+        constrainedWidth = localInput.source.width;
+      }
+      for (auto& inputStage : localInput.source.inputStages) {
+        fragment.inputStages.push_back(std::move(inputStage));
+      }
+      localSources.push_back(std::move(localInput.plan));
+    }
+  }
+
+  // Apply the agreed-upon constrained width to the consumer fragment.
+  if (constrainedWidth != 0) {
+    fragment.width = constrainedWidth;
   }
 
   if (localSources.empty()) {

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -210,8 +210,22 @@ class ToVelox {
       std::vector<ExecutableFragment>& stages,
       std::shared_ptr<velox::core::ExchangeNode>& exchange);
 
-  // Makes a union all with a mix of remote and local inputs. Combines all
-  // remote inputs into one ExchangeNode.
+  // Converts a UnionAll into a mix of remote exchanges and local sources.
+  //
+  // Phase 1 — Classify inputs:
+  //   Repartition inputs become a shared remote ExchangeNode.
+  //   Other inputs are collected as local sources.
+  //
+  // Phase 2 — Isolate width-constraining local inputs:
+  //   Width-constraining inputs (Values, Limit, global Aggregation) produce
+  //   fewer rows than the consumer's partition count. If mixed with
+  //   unconstrained siblings (table scans) or remote exchanges, they are
+  //   wrapped in their own producer stages with round-robin distribution to
+  //   match the consumer's width. Inputs with sub-stages (their own exchange
+  //   dependencies) are also isolated so partition counts stay consistent.
+  //   Plain table scans without sub-stages stay inline.
+  //
+  // Phase 3 — Assemble LocalPartitionNode from all local sources + exchange.
   velox::core::PlanNodePtr makeUnionAll(
       const UnionAll& unionAll,
       ExecutableFragment& fragment,

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -694,8 +694,8 @@ TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
   createEmptyTable("t", ROW("x", BIGINT()));
 
   auto sql =
-      "SELECT b FROM ("
-      "  SELECT x as a, x as b FROM t"
+      "SELECT a, b FROM ("
+      "  SELECT x as a, x + 1 as b FROM t"
       "  UNION ALL"
       "  SELECT 2, 3"
       ") WHERE a > 0";
@@ -704,19 +704,29 @@ TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
 
   // Filter is pushed into the HiveScan as a subfield filter on x.
   // The Values child's constant filter (2 > 0) is folded and eliminated.
-  auto buildMatcher = [&] {
-    return core::PlanMatcherBuilder()
-        .hiveScan("t", test::gt("x", int64_t{0}))
-        .project()
-        .localPartition(matchValues().project().build());
-  };
-
+  // Both columns a and b are referenced in the outer SELECT, so neither
+  // is pruned — the project outputs both.
   auto plan = toSingleNodePlan(logicalPlan);
-  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
+  AXIOM_ASSERT_PLAN(
+      plan,
+      core::PlanMatcherBuilder()
+          .hiveScan("t", test::gt("x", int64_t{0}))
+          .project({"x as a", "x + 1 as b"})
+          .localPartition(matchValues().project({"2 as a", "3 as b"}).build())
+          .build());
 
+  // In distributed mode, the constrained Values input is wrapped in a
+  // separate producer stage (shuffle) to prevent width contamination.
   auto distributedPlan = planVelox(logicalPlan);
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+      distributedPlan.plan,
+      core::PlanMatcherBuilder()
+          .hiveScan("t", test::gt("x", int64_t{0}))
+          .project({"x as a", "x + 1 as b"})
+          .localPartition(
+              matchValues().project({"2 as a", "3 as b"}).shuffle({}).build())
+          .gather()
+          .build());
 }
 
 // Same as above but with a non-trivial expression referenced twice
@@ -830,7 +840,7 @@ TEST_F(SetTest, constantFalseFilterInUnionAll) {
   // true. False branch pruned, two surviving branches have no filters.
   {
     auto logicalPlan = parseSelect(
-        "SELECT b FROM ("
+        "SELECT a, b FROM ("
         "  SELECT 5 as a, 1 as b"
         "  UNION ALL"
         "  SELECT 0, 2"
@@ -842,8 +852,8 @@ TEST_F(SetTest, constantFalseFilterInUnionAll) {
     AXIOM_ASSERT_PLAN(
         plan,
         matchValues()
-            .project()
-            .localPartition(matchValues().project().build())
+            .project({"5 as a", "1 as b"})
+            .localPartition(matchValues().project({"3 as a", "3 as b"}).build())
             .build());
   }
 }
@@ -1095,7 +1105,33 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
   }
 }
 
-TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
+TEST_F(SetTest, unionAllWithWidthConstrainingInputs) {
+  // Verify single-node plan shape: DISTINCT (GROUP BY n_regionkey) feeds into
+  // LocalPartition (UNION ALL) alongside the VALUES input, then COUNT(*).
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT DISTINCT n_regionkey FROM nation"
+        "  UNION ALL"
+        "  SELECT 1"
+        ")");
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        core::PlanMatcherBuilder()
+            .hiveScan("nation", {})
+            .singleAggregation({"n_regionkey"}, {})
+            .project()
+            .localPartition(core::PlanMatcherBuilder().values(ROW({})).build())
+            .singleAggregation({}, {"count(*) as cnt"})
+            .build());
+
+    // Verify distributed plan produces the same results as single-node.
+    checkSame(logicalPlan, toSingleNodePlan(logicalPlan));
+  }
+
+  // Each width-constraining input type (previously threw "Partition count
+  // mismatch").
   std::vector<std::string> widthConstrainingInputs = {
       "SELECT 1",
       "SELECT COUNT(*) as n_regionkey FROM nation",
@@ -1110,7 +1146,54 @@ TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
             "  {}"
             ")",
             input));
-    VELOX_ASSERT_THROW(planVelox(plan), "Partition count mismatch");
+    checkSame(plan, toSingleNodePlan(plan));
+  }
+
+  // Multiple constrained inputs in the same UNION ALL.
+  {
+    auto plan = parseSelect(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT DISTINCT n_regionkey FROM nation"
+        "  UNION ALL SELECT 1"
+        "  UNION ALL SELECT 2"
+        ")");
+    checkSame(plan, toSingleNodePlan(plan));
+  }
+
+  // Table scan + constrained input (no repartition in UNION ALL). The
+  // constrained VALUES input must be wrapped in a producer stage to avoid
+  // contaminating the table scan's width.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT n_nationkey FROM nation"
+        "  UNION ALL"
+        "  SELECT 1"
+        ")");
+    // The constrained VALUES input is wrapped in a producer stage (shuffle)
+    // while the table scan stays inline at the original width.
+    checkSame(logicalPlan, toSingleNodePlan(logicalPlan));
+  }
+
+  // All-constrained inputs: no wrapping needed since all agree on width=1.
+  {
+    auto plan = parseSelect(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT 1"
+        "  UNION ALL SELECT 2"
+        ")");
+    checkSame(plan, toSingleNodePlan(plan));
+  }
+
+  // 3 inputs: table scan + VALUES + GROUP BY with internal repartition.
+  {
+    auto plan = parseSelect(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT n_nationkey FROM nation"
+        "  UNION ALL SELECT 123"
+        "  UNION ALL (SELECT n_regionkey FROM nation GROUP BY n_regionkey)"
+        ")");
+    checkSame(plan, toSingleNodePlan(plan));
   }
 }
 

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -192,3 +192,30 @@ SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
 -- ROW subfield access in UNION ALL with named field.
 -- duckdb: VALUES (1), (3)
 SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))
+----
+-- EXCEPT nested inside UNION ALL.
+SELECT * FROM (
+  SELECT a FROM t WHERE a <= 2
+  EXCEPT
+  SELECT a FROM t WHERE a = 1
+) UNION ALL SELECT 42
+----
+-- INTERSECT nested inside UNION ALL.
+SELECT * FROM (
+  SELECT a FROM t WHERE a <= 2
+  INTERSECT
+  SELECT a FROM t WHERE a = 1
+) UNION ALL SELECT 42
+----
+-- EXCEPT inside UNION ALL with multiple literal inputs.
+SELECT * FROM (
+  SELECT a FROM t WHERE a <= 2
+  EXCEPT
+  SELECT a FROM t WHERE a = 1
+) UNION ALL SELECT 42 UNION ALL SELECT 99
+----
+-- Table scan + literal in UNION ALL.
+SELECT * FROM (
+  SELECT a FROM t
+  UNION ALL SELECT 42
+) ORDER BY 1


### PR DESCRIPTION
Summary:

`makeUnionAll` processes all inputs in the same consumer fragment. This causes two classes of distributed execution failures:

1. **Width contamination** (loud failure): Width-constraining operations (Values, Limit, global Aggregation) set `fragment.width = 1`, contaminating the consumer. When repartitioned inputs (EXCEPT/INTERSECT lowered to semi/anti joins) already created producer stages at width=N, `checkStageWidths` catches the mismatch and throws "Partition count mismatch." The query fails — users can't run it at all.

2. **DYNAMIC vs FIXED scheduling conflict** (silent data loss): When the consumer has both inline scan nodes (triggering DYNAMIC task scheduling, task count = split count) and exchange inputs from sub-stages like GROUP BY (requiring FIXED scheduling, exactly width tasks), the scheduler creates fewer tasks than the exchanges expect, silently dropping data for unserved partitions. `checkStageWidths` does not detect this because the exchange is internal to a local input, not an explicit producer/consumer stage pair.

Fix: two-phase processing in `makeUnionAll`. Phase 1 classifies inputs as constrained or unconstrained and detects whether the consumer would have exchange inputs (from repartition or from local inputs with sub-stages). Phase 2 wraps constrained inputs in their own producer stages to prevent width contamination, and wraps ALL local inputs when the consumer would mix inline scans with exchanges — ensuring the consumer only has exchanges and gets FIXED scheduling.

Complementary to D98981342 (`checkStageWidths`), which adds a general post-plan validator catching any producer/consumer partition count mismatch. This diff fixes the root cause in `makeUnionAll` so the plan is correct in the first place; Peter's validator remains as a safety net for future mismatches beyond UNION ALL.

Differential Revision: D101119620


