### PR TITLE
fix(optimizer): Fix static storage for kQueryCounter in ToGraph (#1262)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -129,7 +129,7 @@ namespace {
 
 std::shared_ptr<velox::core::QueryCtx> constantQueryCtx(
     const velox::core::QueryCtx& original) {
-  std::atomic<int64_t> kQueryCounter;
+  static std::atomic<int64_t> kQueryCounter{0};
 
   std::unordered_map<std::string, std::string> empty;
   return velox::core::QueryCtx::create(


### PR DESCRIPTION
Summary:

`kQueryCounter` in `constantQueryCtx()` was declared as a local variable, so it was re-initialized on every call and the counter never incremented. Add `static` so query IDs for constant-folding runners are unique across calls.

Reviewed By: amitkdutta, mbasmanova

Differential Revision: D101037563
