### PR TITLE
fix(optimizer): Reconstruct dangling columns in flattenDt (#1263)

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   ConstantExprEvaluator.cpp
   Cost.cpp
   DerivedTable.cpp
+  DerivedTableFlattener.cpp
   DerivedTableDotPrinter.cpp
   DerivedTablePrinter.cpp
   Domain.cpp

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "axiom/optimizer/DerivedTable.h"
+#include "axiom/optimizer/DerivedTableFlattener.h"
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
@@ -186,28 +187,66 @@ void DerivedTable::checkSetOpConsistency() const {
 
   // Union DT cannot have post-processing.
   VELOX_CHECK_NULL(
-      aggregation, "union DT must not have aggregation: {}", cname);
-  VELOX_CHECK_NULL(windowPlan, "union DT must not have windowPlan: {}", cname);
-  VELOX_CHECK(having.empty(), "union DT must not have having: {}", cname);
-  VELOX_CHECK(conjuncts.empty(), "union DT must not have conjuncts: {}", cname);
-  VELOX_CHECK(joins.empty(), "union DT must not have joins: {}", cname);
+      aggregation, "Union DT must not have aggregation: {}", cname);
+  VELOX_CHECK_NULL(windowPlan, "Union DT must not have windowPlan: {}", cname);
+  VELOX_CHECK(having.empty(), "Union DT must not have having: {}", cname);
+  VELOX_CHECK(conjuncts.empty(), "Union DT must not have conjuncts: {}", cname);
+  VELOX_CHECK(joins.empty(), "Union DT must not have joins: {}", cname);
   VELOX_CHECK(
-      startTables.empty(), "union DT must not have startTables: {}", cname);
+      startTables.empty(), "Union DT must not have startTables: {}", cname);
   VELOX_CHECK(
-      singleRowDts.empty(), "union DT must not have singleRowDts: {}", cname);
+      singleRowDts.empty(), "Union DT must not have singleRowDts: {}", cname);
   VELOX_CHECK(
       importedExistences.empty(),
-      "union DT must not have importedExistences: {}",
+      "Union DT must not have importedExistences: {}",
       cname);
 
   // Union DT: outputColumns must equal columns (no intermediate columns).
   VELOX_CHECK(
-      outputColumns.has_value(), "union DT outputColumns not set: {}", cname);
+      outputColumns.has_value(), "Union DT outputColumns not set: {}", cname);
   VELOX_CHECK_EQ(
       outputColumns->size(),
       columns.size(),
-      "union DT outputColumns must match columns: {}",
+      "Union DT outputColumns must match columns: {}",
       cname);
+
+  // Each child's columns must contain the parent's columns (shared Column
+  // objects) and have 1:1 exprs. Exprs must reference only the child's own
+  // tables or the child itself.
+  for (const auto* child : children) {
+    VELOX_CHECK_GE(
+        child->columns.size(),
+        columns.size(),
+        "Union child has fewer columns than parent: {}, child {}",
+        cname,
+        child->cname);
+    auto childColumnSet = PlanObjectSet::fromObjects(child->columns);
+    for (const auto* column : columns) {
+      VELOX_CHECK(
+          childColumnSet.contains(column),
+          "Union child missing parent column: {}, child {}, {}",
+          cname,
+          child->cname,
+          column->toString());
+    }
+    VELOX_CHECK_EQ(
+        child->exprs.size(),
+        child->columns.size(),
+        "Union child exprs/columns size mismatch: {}, child {}",
+        cname,
+        child->cname);
+    for (auto* expr : child->exprs) {
+      expr->allTables().forEach([&](PlanObjectCP table) {
+        VELOX_CHECK(
+            child->tableSet.contains(table) || table == child,
+            "Union child expr references table not in child's tableSet: "
+            "{}, child {}, {}",
+            cname,
+            child->cname,
+            expr->toString());
+      });
+    }
+  }
 }
 
 void DerivedTable::checkConsistency() const {
@@ -423,6 +462,98 @@ void DerivedTable::checkConsistency() const {
   VELOX_CHECK_GE(limit, -1, "limit must be >= -1: {}", cname);
   VELOX_CHECK_NE(limit, 0, "limit must not be 0: {}", cname);
   VELOX_CHECK_GE(offset, 0, "offset must be >= 0: {}", cname);
+
+  // Verify layer dependency direction: each layer's expressions must
+  // reference only columns available from lower layers.
+  PlanObjectSet availableColumns;
+
+  // Layer 1: Base table columns are available.
+  for (auto* table : tables) {
+    if (table->is(PlanType::kDerivedTableNode)) {
+      availableColumns.unionObjects(table->as<DerivedTable>()->columns);
+    } else if (table->is(PlanType::kTableNode)) {
+      availableColumns.unionObjects(table->as<BaseTable>()->columns);
+    } else if (table->is(PlanType::kValuesTableNode)) {
+      availableColumns.unionObjects(table->as<ValuesTable>()->columns);
+    } else if (table->is(PlanType::kUnnestTableNode)) {
+      auto* unnest = table->as<UnnestTable>();
+      availableColumns.unionObjects(unnest->columns);
+      if (unnest->ordinalityColumn) {
+        availableColumns.add(unnest->ordinalityColumn);
+      }
+    }
+  }
+
+  auto checkExprAvailable = [&](ExprCP expr, const char* layerName) {
+    expr->columns().forEach([&](PlanObjectCP column) {
+      VELOX_CHECK(
+          availableColumns.contains(column),
+          "{} references column not available at this layer: {}, {}",
+          layerName,
+          cname,
+          column->toString());
+    });
+  };
+
+  auto checkAvailable = [&](const ExprVector& expressions,
+                            const char* layerName) {
+    for (auto* expr : expressions) {
+      checkExprAvailable(expr, layerName);
+    }
+  };
+
+  // Layer 2: Join columns become available.
+  for (auto* join : joins) {
+    availableColumns.unionObjects(join->leftColumns());
+    availableColumns.unionObjects(join->rightColumns());
+    if (join->markColumn()) {
+      availableColumns.add(join->markColumn());
+    }
+    if (join->rowNumberColumn()) {
+      availableColumns.add(join->rowNumberColumn());
+    }
+  }
+
+  // Layer 3: Conjuncts must reference only available columns.
+  checkAvailable(conjuncts, "conjunct");
+
+  // Layer 4: Aggregation inputs must reference only available columns.
+  // Aggregation outputs become available.
+  if (aggregation) {
+    checkAvailable(aggregation->groupingKeys(), "grouping key");
+    for (auto* aggregate : aggregation->aggregates()) {
+      checkAvailable(aggregate->args(), "aggregate input");
+      checkAvailable(aggregate->orderKeys(), "aggregate order key");
+      if (aggregate->condition()) {
+        checkExprAvailable(aggregate->condition(), "aggregate condition");
+      }
+    }
+    availableColumns = PlanObjectSet::fromObjects(aggregation->columns());
+  }
+
+  // Layer 5: Having must reference only available columns.
+  checkAvailable(having, "having");
+
+  // Layer 6: Window inputs must reference only available columns.
+  // Window outputs become available. Process one function at a time so
+  // that dependent windows (function B referencing function A's output)
+  // see A's column as available.
+  if (windowPlan) {
+    for (size_t i = 0; i < windowPlan->functions().size(); ++i) {
+      auto* func = windowPlan->functions()[i];
+      checkAvailable(func->partitionKeys(), "window partition key");
+      checkAvailable(func->orderKeys(), "window order key");
+      checkAvailable(func->args(), "window function arg");
+      availableColumns.add(windowPlan->columns()[i]);
+    }
+  }
+
+  // Layer 7: Exprs and orderKeys must reference only available columns.
+  // The DT's own columns (relation_ == this) are also available — exprs
+  // can cross-reference other output columns (e.g., SELECT a, a + 1).
+  availableColumns.unionObjects(columns);
+  checkAvailable(exprs, "expr");
+  checkAvailable(orderKeys, "orderKey");
 }
 
 MemoKey DerivedTable::memoKey() const {
@@ -913,187 +1044,38 @@ void joinChain(
   joinChain(next, joins, std::move(visited), path);
 }
 
-// Unions function flags from children into 'functions'.
-void unionChildFunctions(FunctionSet& functions, const ExprVector& children) {
-  for (const auto& child : children) {
-    if (child->isFunction()) {
-      functions = functions | child->as<Call>()->functions();
-    }
-  }
-}
-
-// Returns the function flags for a scalar Call with the given name and new
-// children. Recomputes the call's own flags using functionBits and combines
-// with flags accumulated from new children.
-FunctionSet computeCallFunctions(CallCP call, const ExprVector& newChildren) {
-  FunctionSet functions = functionBits(
-      call->name(), SpecialFormCallNames::isSpecialForm(call->name()));
-  unionChildFunctions(functions, newChildren);
-  return functions;
-}
-
-// Returns the function flags for an Aggregate with new children.
-// Aggregate-specific flags (kIgnoreDuplicatesAggregate,
-// kOrderSensitiveAggregate) are determined by the aggregate name and don't
-// come from children, so they are preserved from the original aggregate.
-// kAggregate is added by the Aggregate constructor automatically.
-FunctionSet computeAggregateFunctions(
-    const Aggregate* aggregate,
-    const ExprVector& newChildren) {
-  FunctionSet functions;
-  if (aggregate->functions().contains(
-          FunctionSet::kIgnoreDuplicatesAggregate)) {
-    functions = functions | FunctionSet::kIgnoreDuplicatesAggregate;
-  }
-  if (aggregate->functions().contains(FunctionSet::kOrderSensitiveAggregate)) {
-    functions = functions | FunctionSet::kOrderSensitiveAggregate;
-  }
-  unionChildFunctions(functions, newChildren);
-  return functions;
-}
-
-// Returns a copy of 'expr', replacing instances of columns in 'source' with
-// the corresponding expression from 'target'
-// @tparam T ColumnVector or ExprVector
-// @tparam U ColumnVector or ExprVector
-// @param source Columns to replace. 1:1 with 'target.
-// @param target Replacements.
-template <typename T, typename U>
-ExprCP replaceInputs(ExprCP expr, const T& source, const U& target) {
-  if (!expr) {
-    return nullptr;
-  }
-
-  switch (expr->type()) {
-    case PlanType::kColumnExpr:
-      for (auto i = 0; i < source.size(); ++i) {
-        if (source[i] == expr) {
-          return target[i];
-        }
-      }
-      return expr;
-    case PlanType::kLiteralExpr:
-      return expr;
-    case PlanType::kCallExpr:
-    case PlanType::kAggregateExpr: {
-      auto children = expr->children();
-      ExprVector newChildren(children.size());
-      bool anyChange = false;
-      for (auto i = 0; i < children.size(); ++i) {
-        newChildren[i] = replaceInputs(children[i]->as<Expr>(), source, target);
-        anyChange |= newChildren[i] != children[i];
-      }
-
-      if (expr->type() == PlanType::kAggregateExpr) {
-        const auto* aggregate = expr->as<Aggregate>();
-        auto* newCondition =
-            replaceInputs(aggregate->condition(), source, target);
-
-        ExprVector newOrderKeys;
-        newOrderKeys.reserve(aggregate->orderKeys().size());
-        for (const auto* orderKey : aggregate->orderKeys()) {
-          newOrderKeys.push_back(replaceInputs(orderKey, source, target));
-        }
-
-        anyChange |= newCondition != aggregate->condition();
-        anyChange |= newOrderKeys != aggregate->orderKeys();
-
-        if (!anyChange) {
-          return expr;
-        }
-
-        auto functions = computeAggregateFunctions(aggregate, newChildren);
-        return make<Aggregate>(
-            aggregate->name(),
-            aggregate->value(),
-            std::move(newChildren),
-            std::move(functions),
-            aggregate->isDistinct(),
-            newCondition,
-            aggregate->intermediateType(),
-            std::move(newOrderKeys),
-            aggregate->orderTypes());
-      }
-
-      if (!anyChange) {
-        return expr;
-      }
-
-      const auto* call = expr->as<Call>();
-      auto functions = computeCallFunctions(call, newChildren);
-      return make<Call>(
-          call->name(),
-          call->value(),
-          std::move(newChildren),
-          std::move(functions));
-    }
-    case PlanType::kFieldExpr: {
-      auto* field = expr->as<Field>();
-      auto* newBase = replaceInputs(field->base(), source, target);
-      if (newBase != field->base()) {
-        return make<Field>(field->value().type, newBase, field->field());
-      }
-
-      return expr;
-    }
-    case PlanType::kLambdaExpr: {
-      auto* lambda = expr->as<Lambda>();
-      auto* body = lambda->body();
-      auto* newBody = replaceInputs(body, source, target);
-      if (body == newBody) {
-        return expr;
-      }
-
-      return make<Lambda>(lambda->args(), lambda->value().type, newBody);
-    }
-    default:
-      VELOX_UNREACHABLE(
-          "Unexpected expression: {} - {}", expr->typeName(), expr->toString());
-  }
-}
-
-template <typename T, typename U>
-void replaceInputs(ExprVector& exprs, const T& source, const U& target) {
-  for (auto i = 0; i < exprs.size(); ++i) {
-    exprs[i] = replaceInputs(exprs[i], source, target);
-  }
-}
-
-template <typename T, typename U>
-AggregationPlanCP
-replaceInputs(AggregationPlanCP aggregation, const T& source, const U& target) {
-  if (!aggregation) {
-    return nullptr;
-  }
-
-  ExprVector newGroupingKeys = aggregation->groupingKeys();
-  replaceInputs(newGroupingKeys, source, target);
-
-  AggregateVector newAggregates;
-  newAggregates.reserve(aggregation->aggregates().size());
-  for (const auto* aggregate : aggregation->aggregates()) {
-    newAggregates.push_back(
-        replaceInputs(aggregate, source, target)->template as<Aggregate>());
-  }
-
-  if (newGroupingKeys == aggregation->groupingKeys() &&
-      newAggregates == aggregation->aggregates()) {
-    return aggregation;
-  }
-
-  return make<AggregationPlan>(
-      std::move(newGroupingKeys),
-      std::move(newAggregates),
-      aggregation->columns(),
-      aggregation->intermediateColumns());
-}
 } // namespace
 
 void DerivedTable::replaceJoinOutputs(
     const ColumnVector& source,
     const ExprVector& target) {
-  replaceInputs(conjuncts, source, target);
-  aggregation = replaceInputs(aggregation, source, target);
+  for (auto& conjunct : conjuncts) {
+    conjunct = DerivedTableFlattener::replaceInputs(conjunct, source, target);
+  }
+
+  if (aggregation) {
+    ExprVector newGroupingKeys = aggregation->groupingKeys();
+    for (auto& key : newGroupingKeys) {
+      key = DerivedTableFlattener::replaceInputs(key, source, target);
+    }
+
+    AggregateVector newAggregates;
+    newAggregates.reserve(aggregation->aggregates().size());
+    for (const auto* aggregate : aggregation->aggregates()) {
+      newAggregates.push_back(
+          DerivedTableFlattener::replaceInputs(aggregate, source, target)
+              ->as<Aggregate>());
+    }
+
+    if (newGroupingKeys != aggregation->groupingKeys() ||
+        newAggregates != aggregation->aggregates()) {
+      aggregation = make<AggregationPlan>(
+          std::move(newGroupingKeys),
+          std::move(newAggregates),
+          aggregation->columns(),
+          aggregation->intermediateColumns());
+    }
+  }
 
   // Post-aggregation fields (exprs, orderKeys) reference aggregation output
   // columns, not the join output columns being replaced. When a grouping key
@@ -1104,8 +1086,12 @@ void DerivedTable::replaceJoinOutputs(
   // pre-aggregation expression, which is invalid above the aggregation
   // boundary.
   if (!aggregation) {
-    replaceInputs(exprs, source, target);
-    replaceInputs(orderKeys, source, target);
+    for (auto& expr : exprs) {
+      expr = DerivedTableFlattener::replaceInputs(expr, source, target);
+    }
+    for (auto& key : orderKeys) {
+      key = DerivedTableFlattener::replaceInputs(key, source, target);
+    }
   }
 }
 
@@ -1220,7 +1206,7 @@ ExprCP DerivedTable::exportExpr(ExprCP expr) {
     }
   });
 
-  return replaceInputs(expr, exprs, columns);
+  return DerivedTableFlattener::replaceInputs(expr, exprs, columns);
 }
 
 void DerivedTable::exportExprs(ExprVector& exprs) {
@@ -1230,7 +1216,7 @@ void DerivedTable::exportExprs(ExprVector& exprs) {
 }
 
 ExprCP DerivedTable::importExpr(ExprCP expr) const {
-  return replaceInputs(expr, columns, exprs);
+  return DerivedTableFlattener::replaceInputs(expr, columns, exprs);
 }
 
 void DerivedTable::removeTables(
@@ -1320,8 +1306,9 @@ bool DerivedTable::validatePushdown(
     ExprVector resolvedKeys;
     PlanObjectCP resolvedTable{nullptr};
     for (size_t keyIdx = 0; keyIdx < side.keys.size(); ++keyIdx) {
-      auto key = replaceInputs(side.keys[keyIdx], columns, exprs);
-      auto innerKey = replaceInputs(key, outer, inner);
+      auto key = DerivedTableFlattener::replaceInputs(
+          side.keys[keyIdx], columns, exprs);
+      auto innerKey = DerivedTableFlattener::replaceInputs(key, outer, inner);
       VELOX_DCHECK(innerKey);
 
       if (innerKey->is(PlanType::kColumnExpr) &&
@@ -1368,6 +1355,7 @@ void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
 
   auto initialTables = tables;
   auto* newFirst = make<DerivedTable>(subquery);
+  DerivedTableFlattener::reconstructColumns(newFirst, &subquery);
 
   auto* optimization = queryCtx()->optimization();
   const size_t previousNumJoins = newFirst->joins.size();
@@ -1462,6 +1450,8 @@ void DerivedTable::flattenDt(const DerivedTable* dt) {
   having = dt->having;
   limit = dt->limit;
   offset = dt->offset;
+
+  DerivedTableFlattener::reconstructColumns(this, dt);
 }
 
 namespace {
@@ -2074,8 +2064,11 @@ void DerivedTable::distributeConjuncts() {
       // names. Pre/post agg names may differ for dts in set
       // operations. If already in pre-agg names, no-op.
       if (having[i]->columns().isSubset(grouping)) {
-        conjuncts.push_back(replaceInputs(
-            having[i], aggregation->columns(), aggregation->groupingKeys()));
+        conjuncts.push_back(
+            DerivedTableFlattener::replaceInputs(
+                having[i],
+                aggregation->columns(),
+                aggregation->groupingKeys()));
         having.erase(having.begin() + i);
         --i;
       }

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -61,11 +61,14 @@ using WindowPlanCP = const WindowPlan*;
 ///   2. WHERE (filters)
 ///   3. GROUP BY (aggregation)
 ///   4. HAVING (more filters)
-///   5. SELECT (projections)
-///   6. ORDER BY (sort)
-///   7. OFFSET and LIMIT (limit)
-///   8. WRITE (create/insert/delete/update)
+///   5. Window functions
+///   6. SELECT (projections)
+///   7. ORDER BY (sort)
+///   8. OFFSET and LIMIT (limit)
+///   9. WRITE (create/insert/delete/update)
 ///
+/// See docs/DerivedTableLayers.md for the layered column ownership model
+/// and dependency rules validated by checkConsistency.
 struct DerivedTable : public PlanObject {
   DerivedTable() : PlanObject(PlanType::kDerivedTableNode) {}
 
@@ -112,7 +115,31 @@ struct DerivedTable : public PlanObject {
   PlanObjectSet tableSet;
 
   /// Set if this is a union or unionAll. If set, 'children' has at least 2
-  /// operands.
+  /// operands. When setOp is set, 'tables' and 'joins' are empty and 'exprs'
+  /// is empty. The children hold the per-leg expressions.
+  // TODO: Rename setOp -> unionOp. Only UNION and UNION ALL use this
+  // structure. INTERSECT and EXCEPT are translated to joins.
+  ///
+  /// A UNION ALL produces a single result set — each leg contributes rows
+  /// to the same output columns. The output schema is defined once on the
+  /// parent, and all children feed into it. No child "owns" the output
+  /// columns; the parent does. Each child's 'exprs' describes how that
+  /// child populates the shared output columns.
+  ///
+  /// Column structure:
+  ///
+  ///   setDt (parent):
+  ///     columns = [col_a, col_b, ...]  (relation_ == setDt)
+  ///     exprs = {}                     (empty — setOp DTs have no exprs)
+  ///     outputColumns = columns
+  ///
+  ///   child DTs:
+  ///     columns contains setDt->columns (shared Column objects from parent,
+  ///             plus possibly the child's own columns from makeQueryGraph)
+  ///     exprs = [expr_a, expr_b, ...]  (1:1 with columns, reference child's
+  ///                                     internal tables or child's own
+  ///                                     aggregation/window output columns)
+  ///     outputColumns = setDt->columns
   std::optional<logical_plan::SetOperation> setOp;
 
   /// Operands if 'this' is a union or unionAll. Has at least 2 entries when
@@ -442,7 +469,10 @@ struct DerivedTable : public PlanObject {
       const PlanObjectSet& superTables,
       PlanObjectCP primaryTable);
 
-  // Sets 'dt' to be the complete contents of 'this'.
+  // Replaces 'this' with the contents of 'dt', effectively removing one
+  // level of DT nesting. Reconstructs columns that have relation_ == dt
+  // (aggregation, window, outer join outputs) so they reference 'this'
+  // instead, since 'dt' will no longer be in tableSet after flattening.
   void flattenDt(const DerivedTable* dt);
 
   // Attempts to convert outer joins to less restrictive join types based on

--- a/axiom/optimizer/DerivedTableFlattener.cpp
+++ b/axiom/optimizer/DerivedTableFlattener.cpp
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/DerivedTableFlattener.h"
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+// Unions function flags from children into 'functions'.
+void unionChildFunctions(FunctionSet& functions, const ExprVector& children) {
+  for (const auto& child : children) {
+    if (child->isFunction()) {
+      functions = functions | child->as<Call>()->functions();
+    }
+  }
+}
+
+// Returns the function flags for a scalar Call with new children.
+FunctionSet computeCallFunctions(CallCP call, const ExprVector& newChildren) {
+  FunctionSet functions = functionBits(
+      call->name(), SpecialFormCallNames::isSpecialForm(call->name()));
+  unionChildFunctions(functions, newChildren);
+  return functions;
+}
+
+// Returns the function flags for an Aggregate with new children.
+// Aggregate-specific flags (kIgnoreDuplicatesAggregate,
+// kOrderSensitiveAggregate) are preserved from the original aggregate.
+FunctionSet computeAggregateFunctions(
+    const Aggregate* aggregate,
+    const ExprVector& newChildren) {
+  FunctionSet functions;
+  if (aggregate->functions().contains(
+          FunctionSet::kIgnoreDuplicatesAggregate)) {
+    functions = functions | FunctionSet::kIgnoreDuplicatesAggregate;
+  }
+  if (aggregate->functions().contains(FunctionSet::kOrderSensitiveAggregate)) {
+    functions = functions | FunctionSet::kOrderSensitiveAggregate;
+  }
+  unionChildFunctions(functions, newChildren);
+  return functions;
+}
+
+ExprCP replaceInputs(ExprCP expr, const ExprMapping& mapping) {
+  if (!expr) {
+    return nullptr;
+  }
+
+  switch (expr->type()) {
+    case PlanType::kColumnExpr: {
+      auto it = mapping.find(expr);
+      return it != mapping.end() ? it->second : expr;
+    }
+    case PlanType::kLiteralExpr:
+      return expr;
+    case PlanType::kCallExpr:
+    case PlanType::kAggregateExpr: {
+      auto children = expr->children();
+      ExprVector newChildren(children.size());
+      bool anyChange = false;
+      for (auto i = 0; i < children.size(); ++i) {
+        newChildren[i] = replaceInputs(children[i]->as<Expr>(), mapping);
+        anyChange |= newChildren[i] != children[i];
+      }
+
+      if (expr->type() == PlanType::kAggregateExpr) {
+        const auto* aggregate = expr->as<Aggregate>();
+        auto* newCondition = replaceInputs(aggregate->condition(), mapping);
+
+        ExprVector newOrderKeys;
+        newOrderKeys.reserve(aggregate->orderKeys().size());
+        for (const auto* orderKey : aggregate->orderKeys()) {
+          newOrderKeys.push_back(replaceInputs(orderKey, mapping));
+        }
+
+        anyChange |= newCondition != aggregate->condition();
+        anyChange |= newOrderKeys != aggregate->orderKeys();
+
+        if (!anyChange) {
+          return expr;
+        }
+
+        auto functions = computeAggregateFunctions(aggregate, newChildren);
+        return make<Aggregate>(
+            aggregate->name(),
+            aggregate->value(),
+            std::move(newChildren),
+            std::move(functions),
+            aggregate->isDistinct(),
+            newCondition,
+            aggregate->intermediateType(),
+            std::move(newOrderKeys),
+            aggregate->orderTypes());
+      }
+
+      if (!anyChange) {
+        return expr;
+      }
+
+      const auto* call = expr->as<Call>();
+      auto functions = computeCallFunctions(call, newChildren);
+      return make<Call>(
+          call->name(),
+          call->value(),
+          std::move(newChildren),
+          std::move(functions));
+    }
+    case PlanType::kFieldExpr: {
+      auto* field = expr->as<Field>();
+      auto* newBase = replaceInputs(field->base(), mapping);
+      if (newBase != field->base()) {
+        return make<Field>(field->value().type, newBase, field->field());
+      }
+
+      return expr;
+    }
+    case PlanType::kLambdaExpr: {
+      auto* lambda = expr->as<Lambda>();
+      auto* body = lambda->body();
+      auto* newBody = replaceInputs(body, mapping);
+      if (body == newBody) {
+        return expr;
+      }
+
+      return make<Lambda>(lambda->args(), lambda->value().type, newBody);
+    }
+    case PlanType::kWindowExpr: {
+      auto* window = expr->as<WindowFunction>();
+      auto children = expr->children();
+      ExprVector newArgs(children.size());
+      bool anyChange = false;
+      for (auto i = 0; i < children.size(); ++i) {
+        newArgs[i] = replaceInputs(children[i]->as<Expr>(), mapping);
+        anyChange |= newArgs[i] != children[i];
+      }
+
+      ExprVector newPartitionKeys;
+      newPartitionKeys.reserve(window->partitionKeys().size());
+      for (const auto* key : window->partitionKeys()) {
+        newPartitionKeys.push_back(replaceInputs(key, mapping));
+      }
+      anyChange |= newPartitionKeys != window->partitionKeys();
+
+      ExprVector newOrderKeys;
+      newOrderKeys.reserve(window->orderKeys().size());
+      for (const auto* key : window->orderKeys()) {
+        newOrderKeys.push_back(replaceInputs(key, mapping));
+      }
+      anyChange |= newOrderKeys != window->orderKeys();
+
+      Frame newFrame = window->frame();
+      newFrame.startValue = replaceInputs(newFrame.startValue, mapping);
+      newFrame.endValue = replaceInputs(newFrame.endValue, mapping);
+      anyChange |= newFrame.startValue != window->frame().startValue;
+      anyChange |= newFrame.endValue != window->frame().endValue;
+
+      if (!anyChange) {
+        return expr;
+      }
+
+      FunctionSet functions;
+      unionChildFunctions(functions, newArgs);
+      return make<WindowFunction>(
+          window->name(),
+          window->value(),
+          std::move(newArgs),
+          functions,
+          std::move(newPartitionKeys),
+          std::move(newOrderKeys),
+          window->orderTypes(),
+          newFrame,
+          window->ignoreNulls());
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected expression: {} - {}", expr->typeName(), expr->toString());
+  }
+}
+
+void replaceInputs(ExprVector& exprs, const ExprMapping& mapping) {
+  for (auto i = 0; i < exprs.size(); ++i) {
+    exprs[i] = replaceInputs(exprs[i], mapping);
+  }
+}
+
+AggregationPlanCP replaceInputs(
+    AggregationPlanCP aggregation,
+    const ExprMapping& mapping) {
+  if (!aggregation) {
+    return nullptr;
+  }
+
+  ExprVector newGroupingKeys = aggregation->groupingKeys();
+  replaceInputs(newGroupingKeys, mapping);
+
+  AggregateVector newAggregates;
+  newAggregates.reserve(aggregation->aggregates().size());
+  for (const auto* aggregate : aggregation->aggregates()) {
+    newAggregates.push_back(replaceInputs(aggregate, mapping)->as<Aggregate>());
+  }
+
+  if (newGroupingKeys == aggregation->groupingKeys() &&
+      newAggregates == aggregation->aggregates()) {
+    return aggregation;
+  }
+
+  return make<AggregationPlan>(
+      std::move(newGroupingKeys),
+      std::move(newAggregates),
+      aggregation->columns(),
+      aggregation->intermediateColumns());
+}
+
+// Returns a new JoinEdge with columns and expressions remapped via
+// 'mapping'. Copies fanouts from the original. Uniqueness is left as
+// default (recomputed by guessFanout during finalizeJoins).
+JoinEdge* remapJoinColumns(const JoinEdge* join, const ExprMapping& mapping) {
+  auto remapColumn = [&](ColumnCP column) -> ColumnCP {
+    if (!column) {
+      return nullptr;
+    }
+    auto it = mapping.find(column);
+    return it != mapping.end() ? it->second->as<Column>() : column;
+  };
+
+  auto remapExprs = [&](const ExprVector& exprs) {
+    ExprVector result;
+    result.reserve(exprs.size());
+    for (auto* expr : exprs) {
+      result.push_back(replaceInputs(expr, mapping));
+    }
+    return result;
+  };
+
+  auto remapColumns = [&](const ColumnVector& columns) {
+    ColumnVector result;
+    result.reserve(columns.size());
+    for (auto* column : columns) {
+      result.push_back(remapColumn(column));
+    }
+    return result;
+  };
+
+  auto* edge = make<JoinEdge>(
+      join->leftTable(),
+      join->rightTable(),
+      JoinEdge::Spec{
+          .filter = remapExprs(join->filter()),
+          .joinType = join->joinType(),
+          .nullAwareIn = join->isNullAwareIn(),
+          .nullAsValue = join->isNullAsValue(),
+          .markColumn = remapColumn(join->markColumn()),
+          .rowNumberColumn = remapColumn(join->rowNumberColumn()),
+          .multipleMatchesError = join->multipleMatchesError(),
+          .leftColumns = remapColumns(join->leftColumns()),
+          .leftExprs = remapExprs(join->leftExprs()),
+          .rightColumns = remapColumns(join->rightColumns()),
+          .rightExprs = remapExprs(join->rightExprs()),
+          .directed = join->directed(),
+      },
+      join->originalJoinType());
+
+  for (size_t i = 0; i < join->numKeys(); ++i) {
+    edge->addEquality(
+        replaceInputs(join->leftKeys()[i], mapping),
+        replaceInputs(join->rightKeys()[i], mapping));
+  }
+  edge->setFanouts(join->lrFanout(), join->rlFanout());
+  return edge;
+}
+
+} // namespace
+
+ExprCP DerivedTableFlattener::replaceInputs(
+    ExprCP expr,
+    const ExprMapping& mapping) {
+  return ::facebook::axiom::optimizer::replaceInputs(expr, mapping);
+}
+
+ExprCP DerivedTableFlattener::replaceInputs(
+    ExprCP expr,
+    const ColumnVector& source,
+    const ExprVector& target) {
+  ExprMapping mapping;
+  auto size = std::min(source.size(), target.size());
+  mapping.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    mapping[source[i]] = target[i];
+  }
+  return replaceInputs(expr, mapping);
+}
+
+ExprCP DerivedTableFlattener::replaceInputs(
+    ExprCP expr,
+    const ExprVector& source,
+    const ColumnVector& target) {
+  ExprMapping mapping;
+  auto size = std::min(source.size(), target.size());
+  mapping.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    mapping[source[i]] = target[i];
+  }
+  return replaceInputs(expr, mapping);
+}
+
+void DerivedTableFlattener::reconstructColumns(
+    DerivedTable* dt,
+    const DerivedTable* oldDt) {
+  // Import the anonymous-namespace replaceInputs overloads (map-based).
+  // Without this, the compiler resolves to the public 3-arg overload.
+  using ::facebook::axiom::optimizer::replaceInputs;
+
+  // Reconstruct columns with relation_ == oldDt. These reference an object
+  // no longer in dt's tableSet. Process bottom-up through the DT layers so
+  // that each layer's expressions are rewritten before the next layer's
+  // outputs are created.
+  ExprMapping mapping;
+
+  // Recreates a column with relation_ == dt. Registers the old->new
+  // mapping so that expressions referencing the old column get rewritten.
+  auto recreateColumn = [&](ColumnCP column) -> ColumnCP {
+    auto* newColumn =
+        make<Column>(column->name(), dt, column->value(), column->alias());
+    mapping[column] = newColumn;
+    return newColumn;
+  };
+
+  // Layer 2: Joins — recreate output columns with relation_ == oldDt, then
+  // rebuild affected edges.
+  bool hasJoinColumns = false;
+  for (auto* join : dt->joins) {
+    for (auto* column : join->leftColumns()) {
+      recreateColumn(column);
+      hasJoinColumns = true;
+    }
+    for (auto* column : join->rightColumns()) {
+      recreateColumn(column);
+      hasJoinColumns = true;
+    }
+    if (join->markColumn()) {
+      recreateColumn(join->markColumn());
+      hasJoinColumns = true;
+    }
+    if (join->rowNumberColumn()) {
+      recreateColumn(join->rowNumberColumn());
+      hasJoinColumns = true;
+    }
+  }
+  if (hasJoinColumns) {
+    for (auto*& join : dt->joins) {
+      join = remapJoinColumns(join, mapping);
+    }
+  }
+
+  // Layer 3: Filters — rewrite conjuncts referencing remapped join columns.
+  if (!mapping.empty()) {
+    replaceInputs(dt->conjuncts, mapping);
+  }
+
+  // Layer 4: Aggregation — recreate output columns with
+  // relation_ == oldDt, rewrite grouping keys and aggregate inputs.
+  // Grouping key output columns may reference base tables
+  // (relation_ != oldDt) and are left unchanged.
+  if (dt->aggregation) {
+    auto* rewritten = replaceInputs(dt->aggregation, mapping);
+    const auto numMappingsBefore = mapping.size();
+
+    const auto numKeys = rewritten->groupingKeys().size();
+
+    ColumnVector newAggregationColumns;
+    newAggregationColumns.reserve(rewritten->columns().size());
+    for (auto* column : rewritten->columns()) {
+      if (column->relation() == oldDt) {
+        newAggregationColumns.push_back(recreateColumn(column));
+      } else {
+        newAggregationColumns.push_back(column);
+      }
+    }
+
+    // Grouping key entries in intermediateColumns share the same Column
+    // objects as columns (see ToGraph.cpp translateAggregation). Reuse the
+    // already-recreated columns for the grouping key prefix. Aggregate
+    // entries have distinct Column objects and are recreated independently.
+    ColumnVector newIntermediateColumns;
+    newIntermediateColumns.reserve(rewritten->intermediateColumns().size());
+    for (size_t i = 0; i < rewritten->intermediateColumns().size(); ++i) {
+      if (i < numKeys) {
+        newIntermediateColumns.push_back(newAggregationColumns[i]);
+      } else {
+        auto* column = rewritten->intermediateColumns()[i];
+        if (column->relation() == oldDt) {
+          newIntermediateColumns.push_back(recreateColumn(column));
+        } else {
+          newIntermediateColumns.push_back(column);
+        }
+      }
+    }
+
+    if (rewritten != dt->aggregation || mapping.size() != numMappingsBefore) {
+      dt->aggregation = make<AggregationPlan>(
+          rewritten->groupingKeys(),
+          rewritten->aggregates(),
+          std::move(newAggregationColumns),
+          std::move(newIntermediateColumns));
+    }
+  }
+
+  // Layer 5: Having — rewrite expressions referencing remapped agg columns.
+  if (!dt->having.empty() && !mapping.empty()) {
+    replaceInputs(dt->having, mapping);
+  }
+
+  // Layer 6: Window — recreate output columns with relation_ == oldDt,
+  // rewrite window function expressions. Process one function at a time so
+  // that if function B references function A's output column, the mapping
+  // from A is available when B is rewritten.
+  if (dt->windowPlan) {
+    const auto numMappingsBefore = mapping.size();
+
+    WindowFunctionVector newFunctions;
+    newFunctions.reserve(dt->windowPlan->functions().size());
+    ColumnVector newWindowColumns;
+    newWindowColumns.reserve(dt->windowPlan->columns().size());
+
+    for (size_t i = 0; i < dt->windowPlan->functions().size(); ++i) {
+      newFunctions.push_back(
+          replaceInputs(dt->windowPlan->functions()[i], mapping)
+              ->as<WindowFunction>());
+
+      auto* column = dt->windowPlan->columns()[i];
+      if (column->relation() == oldDt) {
+        newWindowColumns.push_back(recreateColumn(column));
+      } else {
+        newWindowColumns.push_back(column);
+      }
+    }
+
+    if (newFunctions != dt->windowPlan->functions() ||
+        mapping.size() != numMappingsBefore) {
+      dt->windowPlan = make<WindowPlan>(
+          std::move(newFunctions),
+          std::move(newWindowColumns),
+          dt->windowPlan->rankingLimit());
+    }
+  }
+
+  // Layer 7: Rewrite expressions that reference remapped columns.
+  if (!mapping.empty()) {
+    replaceInputs(dt->exprs, mapping);
+    replaceInputs(dt->orderKeys, mapping);
+  }
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTableFlattener.h
+++ b/axiom/optimizer/DerivedTableFlattener.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/DerivedTable.h"
+#include "folly/container/F14Map.h"
+
+namespace facebook::axiom::optimizer {
+
+using ExprMapping = folly::F14FastMap<ExprCP, ExprCP>;
+
+/// Supports inlining one DerivedTable into another. When a DT is a trivial
+/// wrapper around a single child (e.g., after UNION ALL collapses to one
+/// leg, or when isWrapOnly), the child's fields can be copied directly into
+/// the parent to eliminate unnecessary nesting. After the copy, columns that
+/// referenced the child DT become dangling. This class fixes those
+/// references.
+class DerivedTableFlattener {
+ public:
+  /// Reconstructs columns in 'dt' that have relation_ == 'oldDt' so they
+  /// reference 'dt' instead. Columns produced by aggregation, window, and
+  /// outer join layers may have relation_ pointing to oldDt (the DT that
+  /// originally owned them). After inlining, oldDt is no longer in dt's
+  /// tableSet, so these columns become dangling. This method recreates
+  /// them with relation_ == dt and rewrites all expressions that reference
+  /// the old columns.
+  ///
+  /// Processes DT layers bottom-up: joins (2), filters (3),
+  /// aggregation (4), having (5), window (6), projection expressions (7).
+  static void reconstructColumns(DerivedTable* dt, const DerivedTable* oldDt);
+
+  /// Replaces column references in an expression tree. Columns found in
+  /// 'source' are replaced with the corresponding entry in 'target'.
+  /// Handles all expression types including WindowFunction.
+  static ExprCP replaceInputs(
+      ExprCP expr,
+      const ColumnVector& source,
+      const ExprVector& target);
+
+  static ExprCP replaceInputs(
+      ExprCP expr,
+      const ExprVector& source,
+      const ColumnVector& target);
+
+ private:
+  static ExprCP replaceInputs(ExprCP expr, const ExprMapping& mapping);
+};
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -824,6 +824,11 @@ class JoinEdge {
     return originalJoinType_;
   }
 
+  /// Returns the join type (inner, left, right, full, semi, anti, etc.).
+  velox::core::JoinType joinType() const {
+    return joinType_;
+  }
+
   /// True if all tables referenced from 'leftKeys' must be placed before
   /// placing this.
   bool isNonCommutative() const {

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -9,6 +9,7 @@ See also:
 - [Window Functions](docs/WindowFunctions.md) - Window function support and ranking optimizations
 - [Existence Pushdown](docs/ExistencePushdown.md) - Pushing semi-joins into subquery aggregations to reduce data before GROUP BY
 - [Testing](docs/Testing.md) - PlanMatcher for plan shape, SqlTest for correctness, test coverage guidelines
+- [DerivedTable Layers](docs/DerivedTableLayers.md) - Layered column ownership model and dependency rules
 - [Debugging Tips](docs/DebuggingTips.md) - Using the CLI, generating TPC-H data, speeding up test runs, adding debug logging
 
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.
@@ -116,9 +117,13 @@ The order of operations in a DerivedTable follows SQL order:
 1. Filters
 1. Aggregation
 1. Having clause
+1. Window functions
 1. Order By
 1. Offset
 1. Limit
+
+See [DerivedTable Layers](docs/DerivedTableLayers.md) for the column
+ownership model and dependency rules.
 
 Consider a simple count(*) query.
 

--- a/axiom/optimizer/docs/DerivedTableLayers.md
+++ b/axiom/optimizer/docs/DerivedTableLayers.md
@@ -1,0 +1,72 @@
+# DerivedTable Layers
+
+A DerivedTable (DT) represents a query block. Internally it has a layered
+structure that mirrors SQL's logical order of operations. Each layer can
+consume columns from lower layers and produce new columns.
+
+## Layers (bottom-up)
+
+| Layer | Fields | Produces columns? | Column `relation_` |
+|-------|--------|-------------------|---------------------|
+| 1. Base Tables | `tables`, `tableSet` | Yes | base table or sub-DT |
+| 2. Joins | `joins` (JoinEdge) | Yes | this DT |
+| 3. Filters | `conjuncts` | No | — |
+| 4. Aggregation | `aggregation` | Yes (replaces) | this DT |
+| 5. Having | `having` | No | — |
+| 6. Window | `windowPlan` | Yes | this DT |
+| 7. Projection | `exprs`, `columns` | Yes | this DT |
+| 8. Order By | `orderKeys`, `orderTypes` | No | — |
+| 9. Output | `outputColumns` | No | — |
+
+## Column Ownership
+
+Columns with `relation_ == thisDt` are produced by the Joins, Aggregation,
+Window, and Projection layers:
+
+- **Joins:** Columns stored on JoinEdge: `leftColumns`, `rightColumns`
+  (nullable columns from outer joins), `markColumn` (semi-join existence
+  flag), `rowNumberColumn` (unique ID for decorrelation).
+- **Aggregation:** `aggregation->columns()` and
+  `aggregation->intermediateColumns()`. Grouping key columns in
+  `intermediateColumns()` share the same Column objects as `columns()`.
+  Aggregation replaces the available column set — columns from lower
+  layers are no longer directly accessible.
+- **Window:** `windowPlan->columns()`.
+- **Projection:** `columns` (the DT's output columns).
+
+## Dependency Rules
+
+Dependencies flow upward. Each layer's expressions may reference columns
+produced by lower layers but never by higher layers. `checkConsistency`
+validates these rules.
+
+- **Filters:** `conjuncts` reference columns from Base Tables and Joins.
+- **Aggregation:** `groupingKeys` and `aggregates` reference columns from
+  Base Tables and Joins.
+- **Having:** `having` references Aggregation output columns.
+- **Window:** `partitionKeys`, `orderKeys`, and `args` reference columns
+  available after Aggregation (or from Base Tables and Joins if there is
+  no aggregation). Within a `WindowPlan`,
+  dependent window functions (function B referencing function A's output)
+  are ordered so that A appears before B.
+- **Projection:** `exprs` may reference any available column.
+- **Order By:** `orderKeys` may reference any available column.
+
+## Flattening
+
+When a DT is inlined into another (e.g., UNION ALL collapses to one child,
+or a wrapper DT contains a single child with no additional operations),
+the inner DT's fields are copied into the outer DT.
+Columns with `relation_` pointing to the inner DT become dangling —
+they reference an object that is neither `this` nor in `tableSet`.
+
+`DerivedTableFlattener::reconstructColumns` fixes these references by
+processing layers bottom-up:
+
+1. For column-producing layers (Joins, Aggregation, Window): recreate
+   columns with `relation_ == innerDt` so they reference the outer DT.
+   Register the old-to-new mapping.
+2. For expression-only layers (Filters, Having, Projection, Order By):
+   rewrite expressions using the accumulated column mapping.
+
+See `DerivedTableFlattener.h` for the API.

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -372,6 +372,7 @@ TEST_F(SetTest, intersect) {
                            core::JoinType::kRightSemiFilter)
                        .singleAggregation()
                        .project()
+                       .project()
                        .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -125,6 +125,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile("coercion.sql");
   facebook::axiom::optimizer::test::registerQueryFile(
       "distinctAggregation.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("unionAllFlatten.sql");
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/sql/unionAllFlatten.sql
+++ b/axiom/optimizer/tests/sql/unionAllFlatten.sql
@@ -1,0 +1,196 @@
+-- Tests for UNION ALL single-child collapse (flattenDt).
+-- Each test uses a CTE with a specific layer, wraps it in UNION ALL with a
+-- constant boolean column, and applies an outer WHERE that eliminates one leg.
+-- Filter pushdown removes the constant-false leg, leaving a single child that
+-- gets flattened into the parent. The tests verify that column reconstruction
+-- during flattening preserves correctness.
+--
+-- See docs/DerivedTableLayers.md for the DT layer model.
+
+-- Layer 2: Outer join — LEFT JOIN produces nullable columns.
+WITH t AS (
+    SELECT a.x, b.y
+    FROM (VALUES (1), (2)) a (x)
+    LEFT JOIN (VALUES (1, 10)) b (x, y) ON a.x = b.x
+)
+SELECT x, y FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 3: Filter only (no column-producing layers above base tables).
+WITH t AS (
+    SELECT x FROM (VALUES (1), (2), (3)) v (x) WHERE x > 1
+)
+SELECT x FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 4: Aggregation with simple grouping key.
+WITH t AS (
+    SELECT x, count(*) cnt
+    FROM (VALUES (1), (1), (2)) v (x)
+    GROUP BY 1
+)
+SELECT x, cnt FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 4: Aggregation with computed grouping key (the original bug).
+WITH t AS (
+    SELECT upper(x) a
+    FROM (VALUES ('cat1'), ('cat2')) v (x)
+    GROUP BY 1
+)
+SELECT a FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 4: Aggregation with multiple grouping keys and aggregates.
+WITH t AS (
+    SELECT x, y, sum(z) total, count(*) cnt
+    FROM (VALUES (1, 'a', 10), (1, 'a', 20), (2, 'b', 30)) v (x, y, z)
+    GROUP BY 1, 2
+)
+SELECT x, y, total, cnt FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 5: Aggregation with HAVING.
+WITH t AS (
+    SELECT x, count(*) cnt
+    FROM (VALUES (1), (1), (2)) v (x)
+    GROUP BY 1
+    HAVING count(*) > 1
+)
+SELECT x, cnt FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 6: Window function (row_number).
+WITH t AS (
+    SELECT x, row_number() OVER (ORDER BY x) rn
+    FROM (VALUES (1), (2), (3)) v (x)
+)
+SELECT x, rn FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 6: Window function (rank with partition).
+WITH t AS (
+    SELECT x, y, rank() OVER (PARTITION BY x ORDER BY y) rnk
+    FROM (VALUES (1, 10), (1, 20), (2, 30)) v (x, y)
+)
+SELECT x, y, rnk FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 6: Window function with running sum.
+WITH t AS (
+    SELECT x, y, sum(y) OVER (PARTITION BY x ORDER BY y) running_sum
+    FROM (VALUES (1, 10), (1, 20), (2, 30)) v (x, y)
+)
+SELECT x, y, running_sum FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layers 2+4: Outer join + aggregation.
+WITH t AS (
+    SELECT a.x, count(b.y) cnt
+    FROM (VALUES (1), (2)) a (x)
+    LEFT JOIN (VALUES (1, 10), (1, 20)) b (x, y) ON a.x = b.x
+    GROUP BY 1
+)
+SELECT x, cnt FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layers 4+6: Aggregation + window.
+WITH t AS (
+    SELECT x, cnt, row_number() OVER (ORDER BY cnt DESC, x) rn
+    FROM (
+        SELECT x, count(*) cnt
+        FROM (VALUES (1), (1), (2), (3)) v (x)
+        GROUP BY 1
+    )
+)
+SELECT x, cnt, rn FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layers 2+4+6: Outer join + aggregation + window.
+WITH t AS (
+    SELECT x, cnt, row_number() OVER (ORDER BY cnt DESC) rn
+    FROM (
+        SELECT a.x, count(b.y) cnt
+        FROM (VALUES (1), (2)) a (x)
+        LEFT JOIN (VALUES (1, 10), (1, 20)) b (x, y) ON a.x = b.x
+        GROUP BY 1
+    )
+)
+SELECT x, cnt, rn FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 6: Dependent window functions. rank() orders by rn, which is the
+-- output of row_number(). After window merging, both functions are in the
+-- same WindowPlan and must be processed sequentially during flattening.
+WITH t AS (
+    SELECT x, rn, rank() OVER (ORDER BY rn) rnk
+    FROM (
+        SELECT x, row_number() OVER (ORDER BY x) rn
+        FROM (VALUES (1), (2), (3)) v (x)
+    )
+)
+SELECT x, rn, rnk FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+----
+-- Layer 7: Order by on surviving child.
+WITH t AS (
+    SELECT x FROM (VALUES (3), (1), (2)) v (x)
+)
+SELECT x FROM (
+    SELECT *, FALSE f FROM t
+    UNION ALL
+    SELECT *, TRUE f FROM t
+) WHERE f = FALSE
+ORDER BY x
+----
+-- Multiple surviving children (no flattening). Both legs survive.
+-- Verifies non-flattening path still works.
+WITH t AS (
+    SELECT upper(x) a
+    FROM (VALUES ('cat1'), ('cat2')) v (x)
+    GROUP BY 1
+)
+SELECT a FROM (
+    SELECT *, 1 f FROM t
+    UNION ALL
+    SELECT *, 2 f FROM t
+) WHERE f IN (1, 2)


### PR DESCRIPTION
Summary:

When a UNION ALL collapses to a single child after filter pushdown, flattenDt copies the child's fields into the parent. Columns produced by the child's internal layers (aggregation, window, outer joins) have relation_ == child. After flattening, these references dangle because the child is no longer in tableSet, producing an invalid query graph.

Fix: after copying fields, call DerivedTableFlattener::reconstructColumns to recreate columns with relation_ == dt bottom-up through the DT layers. At each layer, recreate output columns with relation_ == this, then rewrite expressions referencing the old columns.

Extract expression rewriting into DerivedTableFlattener with map-based (O(1)) column lookup. Move replaceInputs and supporting helpers from DerivedTable.cpp to DerivedTableFlattener static methods.

Add layer dependency checks to checkConsistency: verify each layer's expressions reference only columns available from lower layers. Add union child validation to checkSetOpConsistency.

Add SQL tests covering UNION ALL single-child collapse for all DT layers: outer joins, aggregation, HAVING, window functions (including dependent windows), and layer combinations.

Fix a related bug in pushExistencesIntoSubquery where the copy constructor copies a DT without recreating columns, leaving dangling relation_ pointers on aggregation output columns and join markColumns. The fix calls reconstructColumns after the copy.

Differential Revision: D101395241


