### PR TITLE
refactor(test): Move NULLIF tests to dedicated nullif.sql and add scalar subquery test (#1264)

### DIFF
--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -122,6 +122,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile("limit.sql");
   facebook::axiom::optimizer::test::registerQueryFile("aggregation.sql");
   facebook::axiom::optimizer::test::registerQueryFile("subfield.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("nullif.sql");
   facebook::axiom::optimizer::test::registerQueryFile("coercion.sql");
   facebook::axiom::optimizer::test::registerQueryFile(
       "distinctAggregation.sql");

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -85,8 +85,3 @@ SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bi
 ----
 -- error: Grouping sets are not supported yet
 SELECT count(*) FROM t GROUP BY GROUPING SETS ((a), ())
-----
--- NULLIF with non-deterministic expression. Result must contain only NULL and
--- false, never true.
--- duckdb: VALUES (null::boolean), (false)
-SELECT DISTINCT nullif(rand() < 0.5, true) FROM unnest(sequence(1, 1000))

--- a/axiom/optimizer/tests/sql/nullif.sql
+++ b/axiom/optimizer/tests/sql/nullif.sql
@@ -1,0 +1,10 @@
+-- NULLIF tests.
+
+-- NULLIF with non-deterministic expression. Result must contain only NULL and
+-- false, never true.
+-- duckdb: VALUES (null::boolean), (false)
+SELECT DISTINCT nullif(rand() < 0.5, true) FROM unnest(sequence(1, 1000))
+----
+-- NULLIF with scalar subquery.
+-- duckdb: SELECT nullif((SELECT count(*) FROM t), 10)
+SELECT nullif((SELECT count(*) FROM t), 10)


### PR DESCRIPTION
Summary:

Moved the existing NULLIF test from basic.sql to a new nullif.sql file and added a test for NULLIF with a scalar subquery input.

___

bypass-github-export-checks

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: velox

Differential Revision: D101441802


