### PR TITLE
feat(connectors): Add SplitWeight helper

### DIFF
--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -26,7 +26,8 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp)
+add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp
+                             SplitWeight.cpp)
 
 target_link_libraries(
   axiom_connectors

--- a/axiom/connectors/SplitWeight.cpp
+++ b/axiom/connectors/SplitWeight.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/SplitWeight.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector {
+
+namespace {
+// Tolerance used to absorb binary floating-point representation error
+// when scaling fractions to the integer weight scale. Without it,
+// exact-decimal inputs like 0.07 evaluate to 7.000000000000001 and ceil
+// up to 8.
+constexpr double kScaleEpsilon = 1e-9;
+} // namespace
+
+int64_t SplitWeight::normalize(double fraction) {
+  VELOX_USER_CHECK(
+      std::isfinite(fraction) && fraction > 0.0 && fraction <= 1.0,
+      "Split weight fraction must be in (0, 1]: {}",
+      fraction);
+  const double scaled = fraction * kStandard;
+  return std::max<int64_t>(
+      kMin, static_cast<int64_t>(std::ceil(scaled - kScaleEpsilon)));
+}
+
+int64_t SplitWeight::forSize(
+    uint64_t splitSize,
+    uint64_t standardSize,
+    double minFraction) {
+  VELOX_USER_CHECK_GT(standardSize, 0, "Standard split size must be positive");
+  VELOX_USER_CHECK(
+      std::isfinite(minFraction) && minFraction > 0.0 && minFraction <= 1.0,
+      "Minimum split weight fraction must be in (0, 1]: {}",
+      minFraction);
+  const double raw =
+      static_cast<double>(splitSize) / static_cast<double>(standardSize);
+  return normalize(std::clamp(raw, minFraction, 1.0));
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/SplitWeight.h
+++ b/axiom/connectors/SplitWeight.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::axiom::connector {
+
+/// Defines the canonical scale for ConnectorSplit::splitWeight values used
+/// by Axiom-based engines. One full-sized "standard" split has weight
+/// kStandard. Connectors are expected to assign each split a weight in
+/// [kMin, kStandard], roughly proportional to how much work the split
+/// represents (typically size in bytes). The scheduler treats the sum of
+/// weights across pending splits as its work-load proxy, so a connector
+/// that emits weight 0 for every split makes the sum useless and the
+/// scheduler falls back to a count-based cap.
+class SplitWeight {
+ public:
+  /// Represents the weight of a single full-sized standard split. Mirrors
+  /// the UNIT_VALUE constant in com.facebook.presto.spi.SplitWeight so
+  /// that values flowing from Presto-compatible producers retain their
+  /// meaning.
+  static constexpr int64_t kStandard = 100;
+
+  /// Specifies the smallest legal weight. Tiny splits clamp up to this so
+  /// they remain visible to the scheduler instead of collapsing to zero.
+  static constexpr int64_t kMin = 1;
+
+  /// Maps a fractional weight in (0, 1] onto the canonical integer scale
+  /// [kMin, kStandard]. Rounds up so very small fractions don't degenerate
+  /// to 0. Throws if 'fraction' is not finite, not positive, or exceeds 1.
+  static int64_t normalize(double fraction);
+
+  /// Weights a split by its size relative to a standard split size,
+  /// clamped to a configured minimum fraction. Returns kStandard for
+  /// splits at or above standardSize. 'standardSize' must be positive,
+  /// 'minFraction' must be in (0, 1].
+  static int64_t
+  forSize(uint64_t splitSize, uint64_t standardSize, double minFraction);
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(
   GTest::gtest_main
 )
 
-add_executable(axiom_connectors_tests SchemaResolverTest.cpp)
+add_executable(axiom_connectors_tests SchemaResolverTest.cpp SplitWeightTest.cpp)
 
 add_test(axiom_connectors_tests axiom_connectors_tests)
 

--- a/axiom/connectors/tests/SplitWeightTest.cpp
+++ b/axiom/connectors/tests/SplitWeightTest.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/SplitWeight.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::connector {
+namespace {
+
+TEST(SplitWeightTest, normalizeBoundaries) {
+  EXPECT_EQ(SplitWeight::normalize(1.0), SplitWeight::kStandard);
+  EXPECT_EQ(SplitWeight::normalize(0.5), 50);
+  EXPECT_EQ(SplitWeight::normalize(0.05), 5);
+}
+
+TEST(SplitWeightTest, normalizeRoundsUpToMin) {
+  // Tiny fractions ceil up to kMin so they don't collapse to 0.
+  EXPECT_EQ(SplitWeight::normalize(1e-9), SplitWeight::kMin);
+  EXPECT_EQ(SplitWeight::normalize(0.001), SplitWeight::kMin);
+  EXPECT_EQ(SplitWeight::normalize(0.01), SplitWeight::kMin);
+}
+
+TEST(SplitWeightTest, normalizeCeilForNonExactScales) {
+  // 0.011 * 100 = 1.1, ceiled to 2.
+  EXPECT_EQ(SplitWeight::normalize(0.011), 2);
+  // 0.555 * 100 = 55.5, ceiled to 56.
+  EXPECT_EQ(SplitWeight::normalize(0.555), 56);
+}
+
+TEST(SplitWeightTest, normalizeExactDecimals) {
+  // Exact-decimal inputs whose binary representation is slightly above
+  // the integer must not be ceiled up. For example, 0.07 * 100 evaluates
+  // to 7.000000000000001 in IEEE 754, but the canonical mapping is 7.
+  EXPECT_EQ(SplitWeight::normalize(0.07), 7);
+  EXPECT_EQ(SplitWeight::normalize(0.14), 14);
+  EXPECT_EQ(SplitWeight::normalize(0.28), 28);
+  EXPECT_EQ(SplitWeight::normalize(0.55), 55);
+}
+
+TEST(SplitWeightTest, normalizeRejectsInvalid) {
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(0.0), "Split weight fraction must be in (0, 1]");
+  // IEEE 754 -0.0 fails the > 0.0 guard the same way 0.0 does.
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(-0.0), "Split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(-0.1), "Split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(1.5), "Split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(std::numeric_limits<double>::quiet_NaN()),
+      "Split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::normalize(std::numeric_limits<double>::infinity()),
+      "Split weight fraction must be in (0, 1]");
+}
+
+TEST(SplitWeightTest, forSizeStandardAndOver) {
+  // A split exactly at standardSize gets kStandard.
+  EXPECT_EQ(
+      SplitWeight::forSize(256ull << 20, 256ull << 20, 0.05),
+      SplitWeight::kStandard);
+  // A split larger than standardSize is capped at kStandard, not over-weighted.
+  EXPECT_EQ(
+      SplitWeight::forSize(1ull << 30, 256ull << 20, 0.05),
+      SplitWeight::kStandard);
+}
+
+TEST(SplitWeightTest, forSizeProportional) {
+  // 128 MB / 256 MB = 0.5 → 50.
+  EXPECT_EQ(SplitWeight::forSize(128ull << 20, 256ull << 20, 0.05), 50);
+  // 64 MB / 256 MB = 0.25 → 25.
+  EXPECT_EQ(SplitWeight::forSize(64ull << 20, 256ull << 20, 0.05), 25);
+}
+
+TEST(SplitWeightTest, forSizeExactDecimalRatio) {
+  // 7 MB / 100 MB = 0.07, an exact decimal whose binary representation
+  // is 7.000000000000001. Must produce 7, not 8.
+  EXPECT_EQ(SplitWeight::forSize(7ull << 20, 100ull << 20, 0.05), 7);
+}
+
+TEST(SplitWeightTest, forSizeClampToMinFraction) {
+  // 1 KB / 256 MB ~= 3.7e-6, clamped up to 0.05 → 5.
+  EXPECT_EQ(SplitWeight::forSize(1ull << 10, 256ull << 20, 0.05), 5);
+  // Empty split clamps to minFraction as well.
+  EXPECT_EQ(SplitWeight::forSize(0, 256ull << 20, 0.05), 5);
+}
+
+TEST(SplitWeightTest, forSizeRejectsZeroStandardSize) {
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::forSize(1, 0, 0.05), "Standard split size must be positive");
+}
+
+TEST(SplitWeightTest, forSizeRejectsInvalidMinFraction) {
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::forSize(1ull << 10, 256ull << 20, 0.0),
+      "Minimum split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::forSize(1ull << 10, 256ull << 20, -0.1),
+      "Minimum split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::forSize(1ull << 10, 256ull << 20, 1.5),
+      "Minimum split weight fraction must be in (0, 1]");
+  VELOX_ASSERT_USER_THROW(
+      SplitWeight::forSize(
+          1ull << 10, 256ull << 20, std::numeric_limits<double>::quiet_NaN()),
+      "Minimum split weight fraction must be in (0, 1]");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector


### PR DESCRIPTION
Summary:
`velox::connector::ConnectorSplit::splitWeight` is a raw `int64_t` with no established convention for what its values mean. Different connectors emit different scales (some leave it at the default 0, others hardcode 1, others count bytes), making it hard for downstream consumers to compare or aggregate weights consistently.

Adds an `axiom::connector::SplitWeight` value-helper that anchors a canonical scale and centralizes the size→weight math:

- `kStandard` (== 100): weight of one full-sized split. Mirrors `com.facebook.presto.spi.SplitWeight#UNIT_VALUE` so values flowing through Presto-compatible producers retain their meaning.
- `kMin` (== 1): smallest legal weight. Tiny splits clamp to this so they remain visible to consumers instead of degenerating to 0.
- `normalize(fraction)`: maps a fractional weight in (0, 1] onto `[kMin, kStandard]`, rounding up.
- `forSize(splitSize, standardSize, minFraction)`: convenience helper for file-based connectors weighting splits proportional to byte length, clamped to a configured minimum fraction.

Note this is a value-helper, not a wrapper around `ConnectorSplit::splitWeight`. The contract is enforced by convention plus runtime validation downstream (e.g.  scheduler warns when a connector still emits `splitWeight=0`); compile-time enforcement would require typing the field upstream in Velox.

No call sites in this diff.

Reviewed By: arhimondr

Differential Revision: D101397838


