### PR TITLE
feat: Auto-inject table owner from session user in CREATE TABLE

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -243,7 +243,7 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   return metadata->createTable(
       session,
       statement.tableName(),
@@ -264,7 +264,7 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   return metadata->createTable(
       session,
       statement.tableName(),

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -244,6 +244,12 @@ class SqlQueryRunner {
     return defaultSchema_;
   }
 
+  /// Sets the user identity for DDL operations. Used as the default table
+  /// owner in CREATE TABLE when the WITH clause does not specify one.
+  void setUser(std::string user) {
+    user_ = std::move(user);
+  }
+
  private:
   // Checks permissions for the query via the configured PermissionCheck
   // callback. Returns a TokenProvider for authenticated file system access.
@@ -356,6 +362,8 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;
   std::string defaultSchema_;
+  // Identity of the user running queries. Used as table owner in CREATE TABLE.
+  std::string user_;
   std::atomic<int32_t> queryCounter_{0};
 };
 

--- a/axiom/common/Session.cpp
+++ b/axiom/common/Session.cpp
@@ -20,6 +20,6 @@ namespace facebook::axiom {
 
 connector::ConnectorSessionPtr Session::toConnectorSession(
     std::string_view /* connectorId */) const {
-  return std::make_shared<connector::ConnectorSession>(queryId_);
+  return std::make_shared<connector::ConnectorSession>(queryId_, user_);
 }
 } // namespace facebook::axiom

--- a/axiom/common/Session.h
+++ b/axiom/common/Session.h
@@ -23,17 +23,26 @@ namespace facebook::axiom {
 /// Read-only query-specific information.
 class Session final {
  public:
-  Session(std::string queryId) : queryId_{queryId} {}
+  explicit Session(std::string queryId, std::string user = {})
+      : queryId_{std::move(queryId)}, user_{std::move(user)} {}
 
+  /// Returns the query identifier.
   const std::string& queryId() const {
     return queryId_;
   }
 
+  /// Returns the identity of the user who submitted the query.
+  const std::string& user() const {
+    return user_;
+  }
+
+  /// Creates a connector-scoped session carrying the query ID and user.
   connector::ConnectorSessionPtr toConnectorSession(
       std::string_view connectorId) const;
 
  private:
   const std::string queryId_;
+  const std::string user_;
 };
 
 using SessionPtr = std::shared_ptr<Session>;

--- a/axiom/connectors/ConnectorSession.h
+++ b/axiom/connectors/ConnectorSession.h
@@ -21,18 +21,26 @@
 
 namespace facebook::axiom::connector {
 
-/// Read-only query-specific information.
+/// Read-only query-specific information passed to connectors.
 class ConnectorSession final {
  public:
-  explicit ConnectorSession(std::string queryId)
-      : queryId_{std::move(queryId)} {}
+  explicit ConnectorSession(std::string queryId, std::string user = {})
+      : queryId_{std::move(queryId)}, user_{std::move(user)} {}
 
+  /// Returns the query identifier.
   const std::string& queryId() const {
     return queryId_;
   }
 
+  /// Returns the identity of the user who submitted the query. Empty when
+  /// user context is unavailable.
+  const std::string& user() const {
+    return user_;
+  }
+
  private:
   const std::string queryId_;
+  const std::string user_;
 };
 
 using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;


### PR DESCRIPTION
Summary: Adds user identity to ConnectorSession and Session (with default empty string for backward compatibility). Threads user through SqlQueryRunner.setUser() and Session.toConnectorSession(). All existing callers compile unchanged.

Differential Revision: D101488828


