### PR TITLE
fix: Split Enums.h into lightweight EnumsDeclare.h header

### DIFF
--- a/axiom/common/ConfigRegistry.h
+++ b/axiom/common/ConfigRegistry.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <folly/container/F14Map.h>
+#include "velox/common/config/ConfigProperty.h"
 #include "velox/common/config/ConfigProvider.h"
 
 namespace facebook::axiom {

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -23,6 +23,7 @@
 
 #include "axiom/common/SessionConfig.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::axiom;

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/config/ConfigProperty.h"
 
 namespace facebook::axiom::optimizer {
 


### PR DESCRIPTION
Summary:
Split Enums.h so that the declare macros (VELOX_DECLARE_ENUM_NAME, VELOX_DECLARE_EMBEDDED_ENUM_NAME) live in a lightweight header (EnumsDeclare.h) that only needs <iosfwd>, <optional>, <string_view>. The define macros stay in Enums.h with their heavy transitive includes (folly/container/F14Map.h and velox/common/base/Exceptions.h, together ~8M preprocessed).

Enums.h includes EnumsDeclare.h for backwards compatibility with existing callers. The BUCK targets are separate so new code can depend on just enums_declare for lighter builds. Full usage documentation lives in EnumsDeclare.h.

ConfigProperty.h now includes EnumsDeclare.h instead of Enums.h, cutting ~8M of preprocessed includes. ConfigProvider.h uses a forward declaration of ConfigProperty instead of including ConfigProperty.h, cutting ~10.2M. Axiom consumers updated to add direct includes that were previously provided transitively.

X-link: https://github.com/facebookincubator/velox/pull/17239

Differential Revision: D101462826


