### PR TITLE
fix: Run constant folding and join sampling synchronously with single-node options (#1268)

### DIFF
--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -153,7 +153,7 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
 
   auto& optimization = queryCtx()->optimization();
   auto plan = optimization->toVelox().toVeloxPlan(
-      filter, optimization->runnerOptions());
+      filter, MultiFragmentPlan::Options::singleNode());
   return std::make_shared<runner::LocalRunner>(
       std::move(plan.plan),
       std::move(plan.finishWrite),

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -173,6 +173,13 @@ class MultiFragmentPlan {
     /// collect results onto a single node. With a single worker, no
     /// additional nodes are added.
     bool remoteOutput{false};
+
+    /// Returns options for single-node, single-threaded local execution.
+    /// Used by constant folding and join sampling which always run via
+    /// LocalRunner regardless of the query's distributed options.
+    static Options singleNode() {
+      return Options{.numWorkers = 1, .numDrivers = 1, .remoteOutput = false};
+    }
   };
 
   MultiFragmentPlan(std::vector<ExecutableFragment> fragments, Options options)

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -317,8 +317,8 @@ lp::ValuesNodePtr tryFoldConstantDt(
   }
 
   auto& optimization = queryCtx()->optimization();
-  auto veloxPlan =
-      optimization->toVelox().toVeloxPlan(plan, optimization->runnerOptions());
+  auto veloxPlan = optimization->toVelox().toVeloxPlan(
+      plan, MultiFragmentPlan::Options::singleNode());
   auto results = runConstantPlan(veloxPlan, pool);
   if (results.empty()) {
     VELOX_CHECK_EQ(1, veloxPlan.plan->fragments().size());

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1993,5 +1993,16 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
   }
 }
 
+TEST_F(SubqueryTest, constantFoldingWithoutExecutor) {
+  auto& ctx = getQueryCtx();
+  ctx = velox::core::QueryCtx::create(nullptr, velox::core::QueryConfig{{}});
+
+  auto logicalPlan =
+      parseSelect("SELECT * FROM nation WHERE n_regionkey > (SELECT 1)");
+
+  auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+  EXPECT_EQ(3, plan.plan->fragments().size());
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -253,6 +253,7 @@ void LocalRunner::start() {
 
   params_.maxDrivers = plan_->options().numDrivers;
   params_.planNode = fragments_.back().fragment.planNode;
+  params_.serialExecution = !params_.queryCtx->isExecutorSupplied();
 
   VELOX_CHECK_LE(fragments_.back().width, 1);
 


### PR DESCRIPTION
Summary:

Constant folding (`evaluateConstantDerivedTable` in `ToGraph.cpp`) and join sampling (`JoinSample.cpp`) always run locally via `LocalRunner`, but were inheriting distributed `RunnerOptions` and `QueryCtx`. In Axel distributed mode this caused:

1. **Wrong plan shape:** `remoteOutput=true` adds a `PartitionedOutputNode` to the constant-folding plan, which `LocalRunner` can't consume.

2. **Missing executor:** Axel creates a `QueryCtx` without an executor (`QueryCtx::create(nullptr, ...)`). `LocalRunner` always used `MultiThreadedTaskCursor`, which requires an executor — crashing with "Executor should be set in parallel task cursor."

Example: `WHERE ds = (SELECT MAX(ds) FROM t)` fails when constant folding inherits `remoteOutput=true` and a null executor from the distributed query context.

Fix:
- Use `MultiFragmentPlan::Options::singleNode()` at both call sites so constant folding and join sampling don't inherit distributed options.
- In `LocalRunner::start()`, use `SingleThreadedTaskCursor` when no executor is supplied (`serialExecution = !queryCtx->isExecutorSupplied()`). This lets constant folding run synchronously in the current thread instead of requiring a thread pool.

T265477247

Differential Revision: D101507986


