### PR TITLE
feat(optimizer): Support lambda arguments in aggregate functions

### DIFF
--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -84,6 +84,35 @@ bool SpecialFormExpr::equalTo(const Expr& other) const {
   return form_ == other.as<SpecialFormExpr>()->form_;
 }
 
+namespace {
+bool hasCaptures(const Expr& expr, const velox::RowType& signature) {
+  if (expr.isInputReference()) {
+    return !signature.containsChild(expr.as<InputReferenceExpr>()->name());
+  }
+  if (expr.isLambda()) {
+    return false;
+  }
+  for (const auto& input : expr.inputs()) {
+    if (hasCaptures(*input, signature)) {
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
+void AggregateExpr::rejectLambdaCaptures() const {
+  for (const auto& input : inputs_) {
+    if (input->isLambda()) {
+      const auto* lambda = input->as<LambdaExpr>();
+      VELOX_USER_CHECK(
+          !hasCaptures(*lambda->body(), *lambda->signature()),
+          "Lambda captures are not supported in aggregate functions: {}",
+          name_);
+    }
+  }
+}
+
 bool AggregateExpr::equalTo(const Expr& other) const {
   const auto* rhs = other.as<AggregateExpr>();
   return name_ == rhs->name_ && distinct_ == rhs->distinct_ &&

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -600,6 +600,8 @@ class AggregateExpr : public Expr {
         distinct_{distinct} {
     VELOX_USER_CHECK(!name_.empty());
 
+    rejectLambdaCaptures();
+
     if (filter_ != nullptr) {
       VELOX_USER_CHECK_EQ(filter_->typeKind(), velox::TypeKind::BOOLEAN);
     }
@@ -648,6 +650,8 @@ class AggregateExpr : public Expr {
 
  private:
   bool equalTo(const Expr& other) const override;
+
+  void rejectLambdaCaptures() const;
 
   const std::string name_;
   const ExprPtr filter_;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1236,8 +1236,15 @@ AggregateVector flattenAggregates(
     if (agg->condition()) {
       condition = precompute.toColumn(agg->condition());
     }
-    auto args = precompute.toColumns(
-        agg->args(), /*aliases=*/nullptr, /*preserveLiterals=*/true);
+    ExprVector args;
+    args.reserve(agg->args().size());
+    for (const auto& arg : agg->args()) {
+      if (arg->is(PlanType::kLambdaExpr)) {
+        args.push_back(arg);
+      } else {
+        args.push_back(precompute.toColumn(arg, nullptr, true));
+      }
+    }
     auto orderKeys = precompute.toColumns(agg->orderKeys());
     flatAggregates.emplace_back(
         make<Aggregate>(

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -160,6 +160,29 @@ void SubfieldTracker::markFieldAccessed(
   }
 }
 
+namespace {
+MarkFieldsAccessedContextVector makeContextForLambdaArg(
+    const lp::LambdaExpr& lambda,
+    const LogicalContextSource& source,
+    const MarkFieldsAccessedContext& context) {
+  const auto& argType = lambda.signature();
+
+  std::vector<const velox::RowType*> newRowTypes;
+  newRowTypes.reserve(context.rowTypes.size() + 1);
+  newRowTypes.push_back(argType.get());
+  newRowTypes.insert(
+      newRowTypes.end(), context.rowTypes.begin(), context.rowTypes.end());
+
+  std::vector<LogicalContextSource> newSources;
+  newSources.reserve(context.sources.size() + 1);
+  newSources.push_back(source);
+  newSources.insert(
+      newSources.end(), context.sources.begin(), context.sources.end());
+
+  return {newRowTypes, newSources};
+}
+} // namespace
+
 void SubfieldTracker::markFieldAccessed(
     const lp::AggregateNode& agg,
     int32_t ordinal,
@@ -180,7 +203,23 @@ void SubfieldTracker::markFieldAccessed(
   }
 
   const auto& aggregate = agg.aggregateAt(ordinal - keys.size());
-  for (const auto& aggregateInput : aggregate->inputs()) {
+  for (auto i = 0; i < aggregate->inputs().size(); ++i) {
+    const auto& aggregateInput = aggregate->inputAt(i);
+    if (aggregateInput->isLambda()) {
+      const auto* lambda = aggregateInput->as<lp::LambdaExpr>();
+      auto lambdaContext = makeContextForLambdaArg(
+          *lambda,
+          {.callName = aggregate->name(),
+           .callExpr = aggregate.get(),
+           .lambdaOrdinal = static_cast<int32_t>(i)},
+          ctx.toCtx());
+
+      std::vector<Step> lambdaSteps;
+      markSubfields(
+          lambda->body(), lambdaSteps, isControl, lambdaContext.toCtx());
+      VELOX_DCHECK(lambdaSteps.empty());
+      continue;
+    }
     mark(aggregateInput);
   }
 
@@ -213,13 +252,13 @@ void SubfieldTracker::markFieldAccessed(
   if (!source.planNode) {
     // The source is a lambda arg. We apply the path to the corresponding
     // container arg of the 2nd order function call that has the lambda.
-    const auto* metadata = functionMetadata(toName(source.call->name()));
+    const auto* metadata = functionMetadata(toName(source.callName));
     if (metadata != nullptr) {
       const auto* lambdaInfo = metadata->lambdaInfo(source.lambdaOrdinal);
       const auto nth = lambdaInfo->argOrdinal[ordinal];
 
       markSubfields(
-          source.call->inputAt(nth),
+          source.callExpr->inputAt(nth),
           steps,
           isControl,
           {context.rowTypes.subspan(1), context.sources.subspan(1)});
@@ -302,29 +341,6 @@ std::optional<int32_t> SubfieldTracker::stepToArg(
   return std::nullopt;
 }
 
-namespace {
-MarkFieldsAccessedContextVector makeContextForLambdaArg(
-    const lp::LambdaExpr* lambda,
-    const LogicalContextSource& source,
-    const MarkFieldsAccessedContext& context) {
-  const auto& argType = lambda->signature();
-
-  std::vector<const velox::RowType*> newRowTypes;
-  newRowTypes.reserve(context.rowTypes.size() + 1);
-  newRowTypes.push_back(argType.get());
-  newRowTypes.insert(
-      newRowTypes.end(), context.rowTypes.begin(), context.rowTypes.end());
-
-  std::vector<LogicalContextSource> newSources;
-  newSources.reserve(context.sources.size() + 1);
-  newSources.push_back(source);
-  newSources.insert(
-      newSources.end(), context.sources.begin(), context.sources.end());
-
-  return {newRowTypes, newSources};
-}
-} // namespace
-
 void SubfieldTracker::markSubfields(
     const lp::ExprPtr& expr,
     std::vector<Step>& steps,
@@ -398,7 +414,9 @@ void SubfieldTracker::markSubfields(
         if (input->isLambda()) {
           const auto* lambda = input->as<lp::LambdaExpr>();
           auto lambdaContext = makeContextForLambdaArg(
-              lambda, {.call = call, .lambdaOrdinal = i}, context);
+              *lambda,
+              {.callName = call->name(), .callExpr = call, .lambdaOrdinal = i},
+              context);
 
           std::vector<Step> lambdaSteps;
           markSubfields(
@@ -467,7 +485,9 @@ void SubfieldTracker::markSubfields(
       if (metadata->lambdaInfo(i)) {
         const auto* lambda = expr->inputAt(i)->as<lp::LambdaExpr>();
         auto lambdaContext = makeContextForLambdaArg(
-            lambda, {.call = call, .lambdaOrdinal = i}, context);
+            *lambda,
+            {.callName = call->name(), .callExpr = call, .lambdaOrdinal = i},
+            context);
 
         std::vector<Step> lambdaSteps;
         markSubfields(

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -48,10 +48,11 @@ struct PlanSubfields {
 
 /// Struct for resolving which logical PlanNode or Lambda defines which
 /// field for column and subfield tracking.
-/// Only one of planNode or call + lambdaOrdinal is set.
+/// Only one of planNode or callName + callExpr + lambdaOrdinal is set.
 struct LogicalContextSource {
   const logical_plan::LogicalPlanNode* planNode{nullptr};
-  const logical_plan::CallExpr* call{nullptr};
+  std::string_view callName;
+  const logical_plan::Expr* callExpr{nullptr};
   int32_t lambdaOrdinal{-1};
 };
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1448,11 +1448,17 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
           .distinct = aggregate->isDistinct(),
       });
     } else {
-      auto call = std::make_shared<velox::core::CallTypedExpr>(
-          type,
-          aggregate->name(),
+      std::vector<velox::core::TypedExprPtr> inputs;
+      inputs.push_back(
           std::make_shared<velox::core::FieldAccessTypedExpr>(
               toTypePtr(aggregate->intermediateType()), aggregateNames.back()));
+      for (const auto& arg : aggregate->args()) {
+        if (arg->is(PlanType::kLambdaExpr)) {
+          inputs.push_back(toTypedExpr(arg));
+        }
+      }
+      auto call = std::make_shared<velox::core::CallTypedExpr>(
+          type, std::move(inputs), aggregate->name());
       aggregates.push_back({.call = call, .rawInputTypes = rawInputTypes});
     }
   }

--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -48,3 +48,26 @@ SELECT a, b, a + b AS d FROM (SELECT a, b FROM t GROUP BY a, b) GROUP BY 1, 2, 3
 ----
 -- Nested aggregation: partition keys not subset (extra shuffle needed).
 SELECT a, b FROM (SELECT a, b, c FROM t GROUP BY a, b, c) GROUP BY a, b
+----
+-- Lambda aggregate function.
+-- duckdb: SELECT sum(a) FROM t
+SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2) FROM t
+----
+-- duckdb: SELECT b, sum(a) FROM t GROUP BY 1
+SELECT b, reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2) FROM t GROUP BY 1
+----
+-- Lambda aggregate with FILTER.
+-- duckdb: SELECT sum(a) FROM t WHERE b > 50
+SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2) FILTER (WHERE b > 50) FROM t
+----
+-- Lambda aggregate with GROUP BY on VALUES (single step).
+-- duckdb: VALUES (3), (7)
+SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2) FROM (VALUES (1, 'x'), (2, 'x'), (3, 'y'), (4, 'y')) AS t(a, k) GROUP BY k
+----
+-- Multiple lambda aggregates in same query.
+-- duckdb: VALUES (10, 24)
+SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2), reduce_agg(a, 1, (s, x) -> s * x, (s1, s2) -> s1 * s2) FROM (VALUES (1), (2), (3), (4)) AS t(a)
+----
+-- Lambda aggregate functions with lambda captures are not supported.
+-- error: Lambda captures are not supported in aggregate functions
+SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2 + b) FROM t GROUP BY b


### PR DESCRIPTION
Summary:
Add support for aggregate functions with lambda arguments such as
reduce_agg. Four changes:

1. Teach SubfieldTracker to handle lambda inputs in aggregate functions
by creating a lambda context for proper parameter resolution, mirroring
the existing scalar call pattern. Generalize LogicalContextSource to
store callName + callExpr instead of CallExpr*, since AggregateExpr is
not a CallExpr.

2. Keep lambda arguments inline in the Velox plan by skipping
PrecomputeProjection for them in flattenAggregates. Velox expects
LambdaTypedExpr in the aggregate call, not FieldAccessTypedExpr
referencing projected columns.

3. Pass lambda expressions to the final/intermediate aggregation step.
Velox requires lambdas in both partial and final aggregate calls.

4. Reject lambda captures in aggregate functions early in AggregateExpr
construction, since Velox does not support captures in aggregate
lambdas.

Differential Revision: D101519375


