### PR TITLE
fix(docs): Remove incorrect trailing comma rule for function calls

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -126,9 +126,8 @@ for the complete guide. Key rules are summarized below.
 - Use uniform initialization: `size_t size{0}` over `size_t size = 0`.
 - Declare variables in the smallest scope, as close to usage as possible.
 - Use digit separators (`'`) for numeric literals with 4 or more digits: `10'000`, not `10000`.
-- Use trailing commas in multi-line initializer lists, enum definitions, and
-  function-call argument lists that span multiple lines. This produces cleaner
-  diffs when items are added or reordered.
+- Use trailing commas in multi-line initializer lists and enum definitions.
+  This produces cleaner diffs when items are added or reordered.
 
 ### API Design
 


### PR DESCRIPTION
Summary: C++ does not allow trailing commas in function call argument lists. The rule was causing AI assistants to flag valid code as a style violation.

Differential Revision: D101551323


