### PR TITLE
fix: Validate existence pushdown join keys that are expressions over subquery columns

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1309,11 +1309,17 @@ bool DerivedTable::validatePushdown(
       auto innerKey = DerivedTableFlattener::replaceInputs(key, outer, inner);
       VELOX_DCHECK(innerKey);
 
-      if (innerKey->is(PlanType::kColumnExpr) &&
-          innerKey->as<Column>()->relation() == &subquery) {
-        if (!validPushdownColumns.contains(innerKey)) {
-          return false;
+      // All columns in innerKey that reference the subquery must be valid
+      // pushdown columns.
+      bool keyValid = true;
+      innerKey->columns().forEach<Column>([&](ColumnCP column) {
+        if (column->relation() == &subquery &&
+            !validPushdownColumns.contains(column)) {
+          keyValid = false;
         }
+      });
+      if (!keyValid) {
+        return false;
       }
 
       auto innerTable = innerKey->singleTable();
@@ -1433,6 +1439,12 @@ void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
 }
 
 void DerivedTable::flattenDt(const DerivedTable* dt) {
+  VELOX_DCHECK(
+      columns.empty() || columns == dt->columns,
+      "flattenDt overwrites columns; caller must have empty columns or "
+      "columns shared with the inner DT: {}",
+      cname);
+
   tables = dt->tables;
   cname = dt->cname;
   tableSet = dt->tableSet;

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -535,17 +535,15 @@ void DerivedTable::checkConsistency() const {
   checkAvailable(having, "having");
 
   // Layer 6: Window inputs must reference only available columns.
-  // Window outputs become available. Process one function at a time so
-  // that dependent windows (function B referencing function A's output)
-  // see A's column as available.
+  // Window functions within a single DT must be independent — none may
+  // reference another's output.
   if (windowPlan) {
-    for (size_t i = 0; i < windowPlan->functions().size(); ++i) {
-      auto* func = windowPlan->functions()[i];
+    for (const auto* func : windowPlan->functions()) {
       checkAvailable(func->partitionKeys(), "window partition key");
       checkAvailable(func->orderKeys(), "window order key");
       checkAvailable(func->args(), "window function arg");
-      availableColumns.add(windowPlan->columns()[i]);
     }
+    availableColumns.unionObjects(windowPlan->columns());
   }
 
   // Layer 7: Exprs and orderKeys must reference only available columns.

--- a/axiom/optimizer/DerivedTableFlattener.cpp
+++ b/axiom/optimizer/DerivedTableFlattener.cpp
@@ -424,23 +424,22 @@ void DerivedTableFlattener::reconstructColumns(
   }
 
   // Layer 6: Window — recreate output columns with relation_ == oldDt,
-  // rewrite window function expressions. Process one function at a time so
-  // that if function B references function A's output column, the mapping
-  // from A is available when B is rewritten.
+  // rewrite window function expressions. Window functions within a DT are
+  // independent (no cross-references).
   if (dt->windowPlan) {
     const auto numMappingsBefore = mapping.size();
 
     WindowFunctionVector newFunctions;
     newFunctions.reserve(dt->windowPlan->functions().size());
+    for (const auto* func : dt->windowPlan->functions()) {
+      newFunctions.push_back(
+          replaceInputs(func, mapping)->as<WindowFunction>());
+    }
+
     ColumnVector newWindowColumns;
     newWindowColumns.reserve(dt->windowPlan->columns().size());
 
-    for (size_t i = 0; i < dt->windowPlan->functions().size(); ++i) {
-      newFunctions.push_back(
-          replaceInputs(dt->windowPlan->functions()[i], mapping)
-              ->as<WindowFunction>());
-
-      auto* column = dt->windowPlan->columns()[i];
+    for (const auto* column : dt->windowPlan->columns()) {
       if (column->relation() == oldDt) {
         newWindowColumns.push_back(recreateColumn(column));
       } else {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3180,7 +3180,7 @@ bool referencesWindowOutput(
     if (it == renames.end() || it->second == nullptr) {
       return false;
     }
-    return windowColumnSet.contains(it->second);
+    return it->second->columns().hasIntersection(windowColumnSet);
   }
   return std::ranges::any_of(expr->inputs(), [&](const auto& input) {
     return referencesWindowOutput(input, renames, windowColumnSet);
@@ -3637,8 +3637,6 @@ void ToGraph::makeProjectQueryGraph(
 
   makeQueryGraph(
       *project.onlyInput(), allowedInDt, excludeOuterJoins, excludeWindows);
-
-  // TODO Handle windows wrapped in scalar expressions.
 
   // Check if this project contains window expressions and apply DT
   // boundary rules.

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -976,5 +976,83 @@ TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
 }
 
+TEST_F(ExistencePushdownTest, functionOfGroupingKey) {
+  // Column grouping key (GROUP BY x): pushdown fires.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT 1 "
+        "FROM t "
+        "LEFT JOIN ("
+        "  SELECT DISTINCT x, y FROM u"
+        ") dt ON abs(dt.x) = abs(t.a)");
+
+    // Semi-join pushdown fires — abs(dt.x) resolves to abs(u.x) which
+    // references a valid pushdown column (grouping key x).
+    auto matcher = matchScan("t")
+                       .project({"abs(a)"})
+                       .hashJoin(
+                           matchScan("u")
+                               .project()
+                               .hashJoin(
+                                   matchScan("t").project().build(),
+                                   core::JoinType::kLeftSemiFilter)
+                               .singleAggregation({"x", "y"}, {})
+                               .project()
+                               .project()
+                               .build(),
+                           core::JoinType::kLeft)
+                       .project()
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Expression grouping key (GROUP BY abs(x)): pushdown skipped.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT 1 "
+        "FROM t "
+        "LEFT JOIN ("
+        "  SELECT DISTINCT x + 2 AS x, y FROM u"
+        ") dt ON abs(dt.x) = abs(t.a)");
+
+    // No semi-join — reversed LEFT JOIN (RIGHT JOIN with u as probe).
+    auto matcher = matchScan("u")
+                       .project({"x + 2 as p", "y"})
+                       .singleAggregation({"p", "y"}, {})
+                       .project()
+                       .project()
+                       .hashJoin(
+                           matchScan("t").project({"abs(a)"}).build(),
+                           core::JoinType::kRight)
+                       .project()
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Join key is a function of a non-grouping key (aggregate output). The
+// existence pushdown must not push a semi-join below the aggregation on
+// a non-grouping column — the aggregation changes the row set, so filtering
+// by an aggregate output before aggregation is invalid.
+TEST_F(ExistencePushdownTest, functionOfAggregate) {
+  auto plan = toSingleNodePlan(
+      "SELECT 1 "
+      "FROM t "
+      "LEFT JOIN ("
+      "  SELECT x, COUNT(*) AS cnt FROM u GROUP BY x"
+      ") dt ON abs(dt.cnt) = abs(t.a)");
+
+  // No semi-join pushdown — reversed LEFT JOIN (RIGHT JOIN with u as probe).
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .project()
+          .project()
+          .hashJoin(matchScan("t").project().build(), core::JoinType::kRight)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1334,12 +1334,13 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
   }
 
   // Verifies each window function call expression and frame. Returns captured
-  // aliases for symbol propagation.
+  // aliases for symbol propagation. Starts with existing symbols since
+  // WindowNode passes through all input columns.
   std::unordered_map<std::string, std::string> verifyWindowFunctions(
       const WindowNode& plan,
       const std::vector<core::WindowCallExprPtr>& expectedWindows,
       const std::unordered_map<std::string, std::string>& symbols) const {
-    std::unordered_map<std::string, std::string> newSymbols;
+    std::unordered_map<std::string, std::string> newSymbols(symbols);
     for (auto i = 0; i < expectedWindows.size(); ++i) {
       const auto& expectedWindow = expectedWindows[i];
       const auto& actualFunc = plan.windowFunctions()[i];

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -565,31 +565,104 @@ TEST_F(WindowTest, windowOutputAsGroupByKey) {
 }
 
 // Dependent window functions must be split into separate Window nodes.
-// When an outer window function's input expression references an inner window
-// function's output, they cannot share a Window node — the inner output isn't
-// available until its Window runs.
+// When a window function's input expression references another window
+// function's output, they cannot share a Window node — the referenced
+// output isn't available until its Window runs.
 TEST_F(WindowTest, dependentWindowFunctions) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
 
-  auto query =
-      "SELECT sum(n) OVER (ORDER BY a) "
-      "FROM ("
-      "    SELECT a, lag(b) OVER (ORDER BY a) + a AS n FROM t"
-      ")";
+  {
+    auto query =
+        "SELECT sum(n) OVER (ORDER BY a) "
+        "FROM ("
+        "    SELECT a, lag(b) OVER (ORDER BY a) + a AS n FROM t"
+        ")";
 
-  auto plan = toSingleNodePlan(query);
+    auto plan = toSingleNodePlan(query);
 
-  // Two separate Window nodes: lag(b) must complete before the expression
-  // lag(b) + a can be computed, so they cannot share a Window node with
-  // sum(lag(b) + a).
-  auto matcher = matchScan("t")
-                     .window({"lag(b) OVER (ORDER BY a) as w"})
-                     .project({"a", "w", "a + w as n"})
-                     .window({"sum(n) OVER (ORDER BY a)"})
-                     .project()
-                     .build();
+    auto matcher = matchScan("t")
+                       .window({"lag(b) OVER (ORDER BY a) as w"})
+                       .project({"a", "a + w as n"})
+                       .window({"sum(n) OVER (ORDER BY a)"})
+                       .project()
+                       .build();
 
-  AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+
+    // No partition keys — all windows gather to a single node.
+    auto distributedPlan = toDistributedPlan(query);
+
+    auto distributedMatcher = matchScan("t")
+                                  .gather()
+                                  .localGather()
+                                  .window({"lag(b) OVER (ORDER BY a) as w"})
+                                  .project({"a", "a + w as n"})
+                                  // TODO: Eliminate redundant local gather.
+                                  .localGather()
+                                  .window({"sum(n) OVER (ORDER BY a)"})
+                                  .project()
+                                  .build();
+
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+  }
+
+  {
+    // lag(pct) references pct, which is a scalar expression over two window
+    // outputs with different specs (one with ORDER BY, one without). The
+    // outer lag shares partition/order keys with the first sum, so without
+    // a DT boundary it would be grouped before the second sum runs.
+    auto query =
+        "SELECT lag(pct) OVER (PARTITION BY a ORDER BY b) "
+        "FROM ("
+        "  SELECT a, b,"
+        "    floor(sum(b) OVER (PARTITION BY a ORDER BY b) * 100.0"
+        "      / sum(b) OVER (PARTITION BY a)) AS pct"
+        "  FROM t"
+        ")";
+
+    auto plan = toSingleNodePlan(query);
+
+    auto matcher =
+        matchScan("t")
+            .window({"sum(b) OVER (PARTITION BY a ORDER BY b) as cum_sum"})
+            .window({"sum(b) OVER (PARTITION BY a) as total_sum"})
+            .project(
+                {"a",
+                 "b",
+                 "floor(cast(cum_sum as double) * 100 / cast(total_sum as double)) as pct"})
+            .window({"lag(pct) OVER (PARTITION BY a ORDER BY b) as lag_pct"})
+            .project({"lag_pct"})
+            .build();
+
+    AXIOM_ASSERT_PLAN(plan, matcher);
+
+    // Distributed plan: single shuffle before the first window (all three
+    // windows share the same partition key). The second and third local
+    // partitions are redundant — data is already partitioned by 'a' from
+    // the first local partition.
+    auto distributedPlan = toDistributedPlan(query);
+
+    auto distributedMatcher =
+        matchScan("t")
+            .shuffle({"a"})
+            .localPartition({"a"})
+            .window({"sum(b) OVER (PARTITION BY a ORDER BY b) as cum_sum"})
+            // TODO: Eliminate redundant local partition.
+            .localPartition({"a"})
+            .window({"sum(b) OVER (PARTITION BY a) as total_sum"})
+            .project(
+                {"a",
+                 "b",
+                 "floor(cast(cum_sum as double) * 100 / cast(total_sum as double)) as pct"})
+            // TODO: Eliminate redundant local partition.
+            .localPartition({"a"})
+            .window({"lag(pct) OVER (PARTITION BY a ORDER BY b) as lag_pct"})
+            .project({"lag_pct"})
+            .gather()
+            .build();
+
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+  }
 }
 
 } // namespace

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -142,3 +142,12 @@ FROM (
     SELECT a, b, a + lag(b) OVER (ORDER BY a, b) AS n
     FROM t
 )
+----
+-- Dependent window via scalar expression over multiple window outputs.
+SELECT lag(pct) OVER (PARTITION BY a ORDER BY b)
+FROM (
+    SELECT a, b,
+        floor(sum(b) OVER (PARTITION BY a ORDER BY b) * 100.0
+            / sum(b) OVER (PARTITION BY a)) AS pct
+    FROM t
+)


### PR DESCRIPTION
Summary:
Previously, validatePushdown only checked plain Column join keys against validPushdownColumns, skipping Call expressions (e.g., abs(dt.x)). This allowed existence pushdown to proceed with expression join keys that reference non-grouping columns (aggregate outputs or expression grouping key outputs), causing "Failed to place a table" during plan generation.

Fix: check ALL columns in the resolved join key that reference the subquery against validPushdownColumns. This catches two previously failing cases:
- Join key is a function of an expression grouping key (e.g., abs(dt.x) where x = x + 2). The DT's columns/exprs mapping is identity for expression grouping keys, so the key can't be resolved to an inner table.
- Join key is a function of an aggregate output (e.g., abs(dt.cnt) where cnt = COUNT(*)). Aggregate outputs are not valid pushdown columns.

Add DCHECK in flattenDt that columns are empty or shared with the inner DT.

Differential Revision: D101573559


