### PR TITLE
refactor(connectors): Migrate deprecated ConnectorMetadata static methods to ConnectorMetadataRegistry (#1273)

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -19,6 +19,7 @@
 #include <folly/system/HardwareConcurrency.h>
 #include "axiom/common/SessionConfig.h"
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/connectors/system/SystemConnector.h"
@@ -91,7 +92,7 @@ Connectors::Connectors() {
 Connectors::~Connectors() {
   for (const auto& connectorId : connectorIds_) {
     // Unregister metadata first since it may reference the connector.
-    connector::ConnectorMetadata::unregisterMetadata(connectorId);
+    connector::ConnectorMetadataRegistry::global().erase(connectorId);
     velox::connector::ConnectorRegistry::global().erase(connectorId);
   }
 }
@@ -130,7 +131,7 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerTpchConnector(
   auto tpchConnector =
       dynamic_cast<velox::connector::tpch::TpchConnector*>(connector.get());
   VELOX_CHECK_NOT_NULL(tpchConnector);
-  connector::ConnectorMetadata::registerMetadata(
+  connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),
       std::make_shared<connector::tpch::TpchConnectorMetadata>(tpchConnector));
 
@@ -157,7 +158,7 @@ Connectors::registerLocalHiveConnector(
   auto hiveConnector =
       dynamic_cast<velox::connector::hive::HiveConnector*>(connector.get());
   VELOX_CHECK_NOT_NULL(hiveConnector);
-  connector::ConnectorMetadata::registerMetadata(
+  connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),
       std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
           hiveConnector));
@@ -184,7 +185,7 @@ void Connectors::registerSystemConnector(
       /*queryInfoProvider=*/nullptr,
       sessionPropertiesProvider_.get());
   registerConnector(connector);
-  connector::ConnectorMetadata::registerMetadata(
+  connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),
       std::make_shared<connector::system::SystemConnectorMetadata>(
           connector.get()));

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -20,6 +20,7 @@
 
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/LogicalPlanDotPrinter.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -51,6 +52,7 @@
 
 namespace velox = facebook::velox;
 using namespace facebook::axiom;
+using connector::ConnectorMetadataRegistry;
 
 namespace {
 
@@ -234,8 +236,7 @@ void onComplete(
 connector::TablePtr SqlQueryRunner::createTable(
     const presto::CreateTableStatement& statement,
     bool explain) {
-  auto metadata =
-      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   folly::F14FastMap<std::string, velox::Variant> options;
   for (const auto& [key, value] : statement.properties()) {
@@ -255,8 +256,7 @@ connector::TablePtr SqlQueryRunner::createTable(
 connector::TablePtr SqlQueryRunner::createTable(
     const presto::CreateTableAsSelectStatement& statement,
     bool explain) {
-  auto metadata =
-      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   folly::F14FastMap<std::string, velox::Variant> options;
   for (const auto& [key, value] : statement.properties()) {
@@ -275,8 +275,7 @@ connector::TablePtr SqlQueryRunner::createTable(
 
 std::string SqlQueryRunner::dropTable(
     const presto::DropTableStatement& statement) {
-  auto metadata =
-      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   const auto& tableName = statement.tableName();
 
@@ -293,8 +292,7 @@ std::string SqlQueryRunner::dropTable(
 
 std::string SqlQueryRunner::createSchema(
     const presto::CreateSchemaStatement& statement) {
-  auto metadata =
-      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   folly::F14FastMap<std::string, velox::Variant> properties;
   for (const auto& [key, value] : statement.properties()) {
@@ -310,8 +308,7 @@ std::string SqlQueryRunner::createSchema(
 
 std::string SqlQueryRunner::dropSchema(
     const presto::DropSchemaStatement& statement) {
-  auto metadata =
-      connector::ConnectorMetadata::metadata(statement.connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
   auto session = std::make_shared<connector::ConnectorSession>("test");
   metadata->dropSchema(session, statement.schemaName(), statement.ifExists());
   return fmt::format("Dropped schema: {}", statement.schemaName());
@@ -474,8 +471,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     } else if (statement->isCreateTable()) {
       const auto* create = statement->as<presto::CreateTableStatement>();
       if (!create->ifNotExists()) {
-        auto* metadata =
-            connector::ConnectorMetadata::metadata(create->connectorId());
+        auto metadata = ConnectorMetadataRegistry::get(create->connectorId());
         VELOX_USER_CHECK(
             !metadata->findTable(create->tableName()),
             "Table already exists: {}.{}",
@@ -491,8 +487,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     } else if (statement->isDropTable()) {
       const auto* drop = statement->as<presto::DropTableStatement>();
       if (!drop->ifExists()) {
-        auto* metadata =
-            connector::ConnectorMetadata::metadata(drop->connectorId());
+        auto metadata = ConnectorMetadataRegistry::get(drop->connectorId());
         VELOX_USER_CHECK(
             metadata->findTable(drop->tableName()),
             "Table does not exist: {}.{}",
@@ -622,7 +617,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
         ? use->catalog().value()
         : defaultConnectorId_;
     VELOX_USER_CHECK(
-        connector::ConnectorMetadata::tryMetadata(connectorId) != nullptr,
+        ConnectorMetadataRegistry::tryGet(connectorId) != nullptr,
         "Catalog does not exist: {}",
         connectorId);
     defaultConnectorId_ = connectorId;

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+
+target_link_libraries(
+  axiom_connectors
+  axiom_common
+  velox_common_base
+  velox_memory
+  velox_connector
+  velox_core
+  Folly::folly
+)
+
 add_subdirectory(system)
 
 if(VELOX_ENABLE_HIVE_CONNECTOR)
@@ -25,14 +37,3 @@ endif()
 if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
-
-add_library(axiom_connectors ConnectorMetadata.cpp SchemaResolver.cpp)
-
-target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  Folly::folly
-)

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -16,7 +16,7 @@
 
 #include "axiom/connectors/ConnectorMetadata.h"
 
-#include "folly/Synchronized.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 
 namespace facebook::axiom::connector {
 namespace {
@@ -181,28 +181,12 @@ TableLayout::findColumn(std::string_view name) const {
   return nullptr;
 }
 
-namespace {
-
-using MetadataMap = folly::Synchronized<
-    folly::F14FastMap<std::string, std::shared_ptr<ConnectorMetadata>>>;
-
-MetadataMap& metadataRegistry() {
-  static MetadataMap kRegistry;
-  return kRegistry;
-}
-} // namespace
-
 // static
 ConnectorMetadata* FOLLY_NULLABLE
 ConnectorMetadata::tryMetadata(std::string_view connectorId) {
-  return metadataRegistry().withRLock(
-      [&](const auto& registry) -> ConnectorMetadata* {
-        auto it = registry.find(connectorId);
-        if (it != registry.end()) {
-          return it->second.get();
-        }
-        return nullptr;
-      });
+  auto metadata =
+      ConnectorMetadataRegistry::global().find(std::string(connectorId));
+  return metadata == nullptr ? nullptr : metadata.get();
 }
 
 // static
@@ -219,41 +203,31 @@ void ConnectorMetadata::registerMetadata(
     std::shared_ptr<ConnectorMetadata> metadata) {
   VELOX_CHECK_NOT_NULL(metadata);
   VELOX_CHECK(!connectorId.empty());
-  metadataRegistry().withWLock([&](auto& registry) {
-    registry.emplace(connectorId, std::move(metadata));
-  });
+  if (!ConnectorMetadataRegistry::global().find(std::string(connectorId))) {
+    ConnectorMetadataRegistry::global().insert(
+        std::string(connectorId), std::move(metadata));
+  }
 }
 
 // static
 void ConnectorMetadata::unregisterMetadata(std::string_view connectorId) {
-  metadataRegistry().withWLock(
-      [&](auto& registry) { registry.erase(connectorId); });
+  ConnectorMetadataRegistry::global().erase(std::string(connectorId));
 }
 
 // static
 void ConnectorMetadata::unregisterAllMetadata() {
-  // Move entries out of the registry under the lock, then destroy them
-  // outside the lock to avoid holding it during potentially slow destructors.
-  std::vector<std::shared_ptr<ConnectorMetadata>> entries;
-  metadataRegistry().withWLock([&](auto& registry) {
-    entries.reserve(registry.size());
-    for (auto& [_, metadata] : registry) {
-      entries.push_back(std::move(metadata));
-    }
-    registry.clear();
-  });
+  ConnectorMetadataRegistry::global().clear();
 }
 
 // static
 std::vector<std::string> ConnectorMetadata::allMetadataIds() {
-  return metadataRegistry().withRLock([](const auto& registry) {
-    std::vector<std::string> ids;
-    ids.reserve(registry.size());
-    for (const auto& [id, _] : registry) {
-      ids.emplace_back(id);
-    }
-    return ids;
-  });
+  auto entries = ConnectorMetadataRegistry::global().snapshot();
+  std::vector<std::string> ids;
+  ids.reserve(entries.size());
+  for (auto&& [id, _] : entries) {
+    ids.emplace_back(id);
+  }
+  return ids;
 }
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -21,7 +21,6 @@
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
-#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/connectors/Connector.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
@@ -786,25 +785,34 @@ using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 class ConnectorMetadata {
  public:
   /// Return the metadata for a given connector ID. Throws if not registered.
+  [[deprecated("Use ConnectorMetadataRegistry::tryGet() instead.")]]
   static ConnectorMetadata* metadata(std::string_view connectorId);
 
   /// Return the metadata for a given connector ID, or nullptr if not
   /// registered.
+  [[deprecated("Use ConnectorMetadataRegistry::tryGet() instead.")]]
   static ConnectorMetadata* FOLLY_NULLABLE
   tryMetadata(std::string_view connectorId);
 
   /// Register metadata for a connector ID.
+  ///
+  /// NOT THREADSAFE: If two processes register the same connector ID, one may
+  /// raise a VeloxError.
+  [[deprecated("Use ConnectorMetadataRegistry::global().insert() instead.")]]
   static void registerMetadata(
       std::string_view connectorId,
       std::shared_ptr<ConnectorMetadata> metadata);
 
   /// Unregister metadata for a connector ID.
+  [[deprecated("Use ConnectorMetadataRegistry::global().erase() instead.")]]
   static void unregisterMetadata(std::string_view connectorId);
 
   /// Unregister all metadata.
+  [[deprecated("Use ConnectorMetadataRegistry::global().clear() instead.")]]
   static void unregisterAllMetadata();
 
   /// Return all registered connector IDs.
+  [[deprecated("Use ConnectorMetadataRegistry::allMetadataIds() instead.")]]
   static std::vector<std::string> allMetadataIds();
 
   virtual ~ConnectorMetadata() = default;

--- a/axiom/connectors/ConnectorMetadataRegistry.cpp
+++ b/axiom/connectors/ConnectorMetadataRegistry.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/core/QueryCtx.h"
+
+namespace facebook::axiom::connector {
+
+using Registry = ConnectorMetadataRegistry::Registry;
+using QueryCtx = velox::core::QueryCtx;
+
+namespace {
+
+Registry& registryFor(const QueryCtx& queryCtx) {
+  auto registry =
+      queryCtx.registry<Registry>(ConnectorMetadataRegistry::kRegistryKey);
+  return registry ? *registry : ConnectorMetadataRegistry::global();
+}
+
+} // namespace
+
+// static
+Registry& ConnectorMetadataRegistry::global() {
+  static Registry kMetadataRegistry;
+  return kMetadataRegistry;
+}
+
+// static
+std::shared_ptr<ConnectorMetadataRegistry::Registry>
+ConnectorMetadataRegistry::create(const Registry* parent) {
+  return std::make_shared<Registry>(parent);
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::tryGet(
+    const QueryCtx& queryCtx,
+    const std::string& connectorId) {
+  return registryFor(queryCtx).find(std::string(connectorId));
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::tryGet(const std::string& connectorId) {
+  return global().find(std::string(connectorId));
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::get(
+    const QueryCtx& queryCtx,
+    const std::string& connectorId) {
+  auto metadata = tryGet(queryCtx, connectorId);
+  VELOX_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
+// static
+std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+ConnectorMetadataRegistry::get(const std::string& connectorId) {
+  auto metadata = tryGet(connectorId);
+  VELOX_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
+namespace {
+
+std::vector<std::string> metadataIds(const Registry& registry) {
+  auto entries = registry.snapshot();
+  auto ids = std::vector<std::string>{};
+  ids.reserve(entries.size());
+  for (auto&& [id, _] : entries) {
+    ids.emplace_back(id);
+  }
+  return ids;
+}
+
+} // namespace
+
+// static
+std::vector<std::string> ConnectorMetadataRegistry::allMetadataIds(
+    const QueryCtx& queryCtx) {
+  return metadataIds(registryFor(queryCtx));
+}
+
+// static
+std::vector<std::string> ConnectorMetadataRegistry::allMetadataIds() {
+  return metadataIds(global());
+}
+
+// static
+void ConnectorMetadataRegistry::unregisterAll(const QueryCtx& queryCtx) {
+  auto registry =
+      queryCtx.registry<Registry>(ConnectorMetadataRegistry::kRegistryKey);
+  if (registry) {
+    registry->clear();
+  }
+}
+
+// static
+void ConnectorMetadataRegistry::unregisterAll() {
+  global().clear();
+}
+
+// static
+std::vector<std::pair<std::string, std::shared_ptr<ConnectorMetadata>>>
+ConnectorMetadataRegistry::snapshot(const QueryCtx& queryCtx) {
+  return registryFor(queryCtx).snapshot();
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorMetadataRegistry.h
+++ b/axiom/connectors/ConnectorMetadataRegistry.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/common/ScopedRegistry.h"
+
+namespace facebook::velox::core {
+class QueryCtx;
+} // namespace facebook::velox::core
+
+namespace facebook::axiom::connector {
+
+/// Manages connector metadata registration and lookup. All methods are
+/// thread-safe.
+///
+/// Two groups of APIs:
+///
+/// - Query-scoped APIs take a QueryCtx& and check for per-query registry
+///   overrides before falling back to the global registry. Use these in
+///   operator and expression evaluation code where a QueryCtx is available.
+///
+/// - Global APIs operate directly on the global registry. Use these for
+///   process-level operations: startup registration, shutdown cleanup, and
+///   process-wide lookups (e.g., periodic stats reporting).
+class ConnectorMetadataRegistry {
+ public:
+  /// Type alias for the scoped metadata registry.
+  using Registry = velox::ScopedRegistry<std::string, ConnectorMetadata>;
+
+  /// Registry key for per-query metadata overrides on QueryCtx.
+  static constexpr std::string_view kRegistryKey = "connectorMetadata";
+
+  /// Return the global registry (root scope).
+  static Registry& global();
+
+  /// Create a per-query registry. If 'parent' is provided, lookups fall back
+  /// to it. Pass nullptr for isolation mode (no fallback).
+  static std::shared_ptr<Registry> create(const Registry* parent = nullptr);
+
+  /// Return the metadata connector with the specified ID, or nullptr if
+  /// not registered.  Checks per-query override on QueryCtx first, falls back
+  /// to the global registry if no override is set.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  tryGet(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID from the global
+  /// registry, or nullptr if not registered.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  tryGet(const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID, or an exception if
+  /// not registered.  Checks per-query override on QueryCtx first, falls back
+  /// to the global registry if no override is set.
+  /// @throws VeloxError if the shared_ptr is null.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  get(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+
+  /// Return the metadata connector with the specified ID from the global
+  /// registry, or an exception if not registered.
+  /// @throws VeloxError if the shared_ptr is null.
+  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
+  get(const std::string& connectorId);
+
+  /// Return all metadata connectors whose implementation is of type T. Checks
+  /// per-query override on QueryCtx first, falls back to the global registry if
+  /// no override is set.
+  template <typename T>
+  static std::vector<std::shared_ptr<T>> findAll(
+      const velox::core::QueryCtx& queryCtx) {
+    std::vector<std::shared_ptr<T>> result;
+    for (auto& [_, connectorMetadata] : snapshot(queryCtx)) {
+      if (auto casted = std::dynamic_pointer_cast<T>(connectorMetadata)) {
+        result.push_back(std::move(casted));
+      }
+    }
+    return result;
+  }
+
+  /// Return all metadata connectors from the global registry whose
+  /// implementation is of type T.
+  template <typename T>
+  static std::vector<std::shared_ptr<T>> findAll() {
+    std::vector<std::shared_ptr<T>> result;
+    for (auto& [_, connectorMetadata] : global().snapshot()) {
+      if (auto casted = std::dynamic_pointer_cast<T>(connectorMetadata)) {
+        result.push_back(std::move(casted));
+      }
+    }
+    return result;
+  }
+
+  /// Return all registered ids from the query. Locally registered ids
+  /// override parent or global registrations: each return id will be
+  /// unique.
+  static std::vector<std::string> allMetadataIds(
+      const velox::core::QueryCtx& queryCtx);
+
+  /// Return all registered ids from the global registry.
+  static std::vector<std::string> allMetadataIds();
+
+  /// Unregister all metadata connectors from the registry visible to the given
+  /// query.
+  static void unregisterAll(const velox::core::QueryCtx& queryCtx);
+
+  /// Unregister all metadata connectors from the global registry.
+  static void unregisterAll();
+
+ private:
+  // Return a snapshot of all metadata connectors visible to the given query.
+  // Uses per-query registry if set, otherwise the global registry.
+  static std::vector<std::pair<std::string, std::shared_ptr<ConnectorMetadata>>>
+  snapshot(const velox::core::QueryCtx& queryCtx);
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/SchemaResolver.cpp
+++ b/axiom/connectors/SchemaResolver.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/connectors/SchemaResolver.h"
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+
 namespace facebook::axiom::connector {
 
 void SchemaResolver::setTargetTable(
@@ -37,7 +39,8 @@ TablePtr SchemaResolver::findTable(
     return targetTable_;
   }
 
-  return ConnectorMetadata::metadata(connectorId)->findTable(tableName);
+  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  return metadata->findTable(tableName);
 }
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -21,6 +21,7 @@
 #include <folly/json.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/optimizer/JsonUtil.h"
@@ -322,7 +323,7 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     SplitOptions options) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
-  auto* metadata = ConnectorMetadata::metadata(tableHandle->connectorId());
+  auto metadata = ConnectorMetadataRegistry::get(tableHandle->connectorId());
   auto table = metadata->findTable(
       {std::string(LocalHiveConnectorMetadata::kDefaultSchema),
        tableHandle->name()});
@@ -535,9 +536,9 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
 
   const auto outputType = ROW(std::move(names), std::move(types));
 
+  auto metadataPtr = ConnectorMetadataRegistry::get(connector()->connectorId());
   auto connectorQueryCtx =
-      reinterpret_cast<LocalHiveConnectorMetadata*>(
-          ConnectorMetadata::metadata(connector()->connectorId()))
+      dynamic_cast<const LocalHiveConnectorMetadata*>(metadataPtr.get())
           ->connectorQueryCtx();
 
   const auto maxRowsToScan = table().numRows() * (pct / 100);
@@ -599,10 +600,10 @@ LocalHiveTableLayout::co_estimateStats(
     partitionColumnsByName[column->name()] = column;
   }
 
-  auto* connectorMetadata =
-      ConnectorMetadata::metadata(connector()->connectorId());
+  auto connectorMetadata =
+      ConnectorMetadataRegistry::get(connector()->connectorId());
   auto* localHiveMetadata =
-      dynamic_cast<const LocalHiveConnectorMetadata*>(connectorMetadata);
+      dynamic_cast<const LocalHiveConnectorMetadata*>(connectorMetadata.get());
   auto& evaluator =
       *localHiveMetadata->connectorQueryCtx()->expressionEvaluator();
 

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
@@ -62,9 +63,20 @@ class LocalHiveConnectorMetadataTest
         }}});
 
     runner::test::LocalRunnerTestBase::SetUp();
-    metadata_ = dynamic_cast<LocalHiveConnectorMetadata*>(
-        ConnectorMetadata::metadata(velox::exec::test::kHiveConnectorId));
+    auto metadataPtr =
+        ConnectorMetadataRegistry::tryGet(velox::exec::test::kHiveConnectorId);
+    VELOX_CHECK_NOT_NULL(
+        metadataPtr,
+        "ConnectorMetadata not registered: {}",
+        velox::exec::test::kHiveConnectorId);
+    metadata_ =
+        std::dynamic_pointer_cast<LocalHiveConnectorMetadata>(metadataPtr);
     ASSERT_TRUE(metadata_ != nullptr);
+  }
+
+  void TearDown() override {
+    metadata_.reset();
+    runner::test::LocalRunnerTestBase::TearDown();
   }
 
   static const LocalHiveTableLayout* getLayout(const TablePtr& table) {
@@ -204,7 +216,7 @@ class LocalHiveConnectorMetadataTest
   }
 
   RowTypePtr rowType_;
-  LocalHiveConnectorMetadata* metadata_{};
+  std::shared_ptr<LocalHiveConnectorMetadata> metadata_;
 };
 
 TEST_F(LocalHiveConnectorMetadataTest, basic) {

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/system/SystemConnector.h"
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
@@ -146,7 +147,7 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     velox::connector::registerConnector(connector_);
 
     metadata_ = std::make_shared<SystemConnectorMetadata>(connector_.get());
-    ConnectorMetadata::registerMetadata(kSystemCatalog, metadata_);
+    ConnectorMetadataRegistry::global().insert(kSystemCatalog, metadata_);
 
     pool_ = velox::memory::memoryManager()->addLeafPool();
     queryCtx_ = velox::core::QueryCtx::create();
@@ -154,7 +155,7 @@ class SystemConnectorMetadataTest : public ::testing::Test {
 
   void TearDown() override {
     metadata_.reset();
-    ConnectorMetadata::unregisterMetadata(kSystemCatalog);
+    ConnectorMetadataRegistry::global().erase(kSystemCatalog);
     velox::connector::unregisterConnector(kSystemCatalog);
     connector_.reset();
   }

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
   velox_connector
 )
 
-add_executable(axiom_test_connector_test TestConnectorTest.cpp)
+add_executable(axiom_test_connector_test TestConnectorTest.cpp ConnectorMetadataRegistryTest.cpp)
 
 add_test(axiom_test_connector_test axiom_test_connector_test)
 
@@ -43,3 +43,5 @@ add_executable(axiom_connectors_tests SchemaResolverTest.cpp)
 add_test(axiom_connectors_tests axiom_connectors_tests)
 
 target_link_libraries(axiom_connectors_tests axiom_connectors axiom_test_connector gtest gtest_main)
+
+target_link_libraries(axiom_connectors velox_core gtest gtest_main gmock)

--- a/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
+++ b/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/QueryCtx.h"
+
+using namespace facebook::velox;
+using namespace facebook::axiom::connector;
+
+namespace facebook::axiom::connector {
+namespace {
+
+// Implements all pure virtuals with stubs since only registry mechanics are
+// under test.
+class StubConnectorMetadata : public ConnectorMetadata {
+ public:
+  explicit StubConnectorMetadata(std::string label)
+      : label_{std::move(label)} {}
+
+  const std::string& label() const {
+    return label_;
+  }
+
+  TablePtr findTable(const SchemaTableName& /*tableName*/) override {
+    return nullptr;
+  }
+
+  ConnectorSplitManager* splitManager() override {
+    return nullptr;
+  }
+
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& /*session*/) override {
+    return {};
+  }
+
+  bool schemaExists(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return false;
+  }
+
+ private:
+  std::string label_;
+};
+
+class ConnectorMetadataRegistryTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void TearDown() override {
+    ConnectorMetadata::unregisterAllMetadata();
+  }
+};
+
+TEST_F(ConnectorMetadataRegistryTest, queryCtxFallback) {
+  auto globalMetadata = std::make_shared<StubConnectorMetadata>("global");
+  ConnectorMetadataRegistry::global().insert("catalog", globalMetadata);
+
+  auto queryCtx = core::QueryCtx::create();
+  auto queryRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+  auto queryMetadata = std::make_shared<StubConnectorMetadata>("query");
+  queryRegistry->insert("catalog", queryMetadata);
+  queryCtx->setRegistry(ConnectorMetadataRegistry::kRegistryKey, queryRegistry);
+
+  // Per-query registry takes precedence.
+  EXPECT_EQ(
+      ConnectorMetadataRegistry::tryGet(*queryCtx, "catalog"), queryMetadata);
+
+  // Global lookup is unaffected by the query-scoped override.
+  EXPECT_EQ(ConnectorMetadataRegistry::tryGet("catalog"), globalMetadata);
+
+  // QueryCtx without per-query registry falls back to global.
+  auto noRegistryCtx = core::QueryCtx::create();
+  EXPECT_EQ(
+      ConnectorMetadataRegistry::tryGet(*noRegistryCtx, "catalog"),
+      globalMetadata);
+}
+
+TEST_F(ConnectorMetadataRegistryTest, getThrowsOnMissing) {
+  VELOX_ASSERT_THROW(
+      ConnectorMetadataRegistry::get("nonexistent"),
+      "ConnectorMetadata not registered: nonexistent");
+
+  auto queryCtx = core::QueryCtx::create();
+  VELOX_ASSERT_THROW(
+      ConnectorMetadataRegistry::get(*queryCtx, "nonexistent"),
+      "ConnectorMetadata not registered: nonexistent");
+}
+
+TEST_F(ConnectorMetadataRegistryTest, allMetadataIds) {
+  auto globalMetadata = std::make_shared<StubConnectorMetadata>("global");
+  ConnectorMetadataRegistry::global().insert("global-catalog", globalMetadata);
+
+  auto queryCtx = core::QueryCtx::create();
+  auto queryRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+  auto queryMetadata = std::make_shared<StubConnectorMetadata>("query");
+  queryRegistry->insert("query-catalog", queryMetadata);
+  queryCtx->setRegistry(ConnectorMetadataRegistry::kRegistryKey, queryRegistry);
+
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(*queryCtx),
+      testing::UnorderedElementsAre("global-catalog", "query-catalog"));
+
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(),
+      testing::UnorderedElementsAre("global-catalog"));
+
+  // QueryCtx without registry falls back to global.
+  auto noRegistryCtx = core::QueryCtx::create();
+  EXPECT_THAT(
+      ConnectorMetadataRegistry::allMetadataIds(*noRegistryCtx),
+      testing::UnorderedElementsAre("global-catalog"));
+}
+
+TEST_F(ConnectorMetadataRegistryTest, duplicateRegistration) {
+  auto first = std::make_shared<StubConnectorMetadata>("first");
+  auto second = std::make_shared<StubConnectorMetadata>("second");
+
+  ConnectorMetadata::registerMetadata("catalog", first);
+
+  // Duplicate registration is a no-op — first registration wins.
+  ConnectorMetadata::registerMetadata("catalog", second);
+
+  auto* result = dynamic_cast<StubConnectorMetadata*>(
+      ConnectorMetadata::metadata("catalog"));
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->label(), "first");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/connectors/tests/TestConnector.h"
 
@@ -50,8 +51,8 @@ class SchemaResolverTest : public ::testing::Test {
       const std::string& schema) {
     auto connector = std::make_shared<connector::TestConnector>(id);
     velox::connector::registerConnector(connector);
-    ConnectorMetadata::metadata(id)->createSchema(
-        nullptr, schema, /*ifNotExists=*/false, {});
+    auto metadata = ConnectorMetadataRegistry::get(id);
+    metadata->createSchema(nullptr, schema, /*ifNotExists=*/false, {});
     return Catalog{
         .id = id,
         .schema = schema,
@@ -65,7 +66,8 @@ class SchemaResolverTest : public ::testing::Test {
 };
 
 TEST_F(SchemaResolverTest, bareTable) {
-  ConnectorMetadata::metadata("base")->createTable(
+  auto metadata = ConnectorMetadataRegistry::get("base");
+  metadata->createTable(
       nullptr, {"baseschema", "table"}, ROW({}), {}, /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"baseschema", "table"});
@@ -76,9 +78,9 @@ TEST_F(SchemaResolverTest, bareTable) {
 }
 
 TEST_F(SchemaResolverTest, tablePlusSchema) {
-  ConnectorMetadata::metadata("base")->createSchema(
-      nullptr, "newschema", /*ifNotExists=*/false, {});
-  ConnectorMetadata::metadata("base")->createTable(
+  auto metadata = ConnectorMetadataRegistry::get("base");
+  metadata->createSchema(nullptr, "newschema", /*ifNotExists=*/false, {});
+  metadata->createTable(
       nullptr, {"newschema", "table"}, ROW({}), {}, /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"newschema", "table"});
@@ -89,7 +91,8 @@ TEST_F(SchemaResolverTest, tablePlusSchema) {
 }
 
 TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
-  ConnectorMetadata::metadata("other")->createTable(
+  auto otherMetadata = ConnectorMetadataRegistry::get("other");
+  otherMetadata->createTable(
       /*session=*/nullptr,
       {"otherschema", "other_table"},
       ROW({}),
@@ -98,7 +101,8 @@ TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
   auto table = resolver_->findTable("other", {"otherschema", "other_table"});
   ASSERT_NE(table, nullptr);
 
-  ConnectorMetadata::metadata("base")->createTable(
+  auto baseMetadata = ConnectorMetadataRegistry::get("base");
+  baseMetadata->createTable(
       nullptr, {"baseschema", "base_table"}, ROW({}), {}, /*explain=*/false);
   table = resolver_->findTable("base", {"baseschema", "base_table"});
   ASSERT_NE(table, nullptr);
@@ -106,7 +110,8 @@ TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
 
 TEST_F(SchemaResolverTest, catalogMismatch) {
   // Table exists in "other" catalog but not in "base".
-  ConnectorMetadata::metadata("other")->createTable(
+  auto metadata = ConnectorMetadataRegistry::get("other");
+  metadata->createTable(
       /*session=*/nullptr,
       {"otherschema", "table"},
       ROW({}),

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -20,6 +20,7 @@
 #include <folly/container/F14Set.h>
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/core/ITypedExpr.h"
 
 namespace facebook::axiom::connector {
@@ -621,11 +622,11 @@ class TestConnector : public velox::connector::Connector {
       : Connector(id, std::move(config)),
         metadata_{std::make_shared<TestConnectorMetadata>(this)} {
     registerSerDe();
-    ConnectorMetadata::registerMetadata(id, metadata_);
+    ConnectorMetadataRegistry::global().insert(id, metadata_);
   }
 
   ~TestConnector() override {
-    ConnectorMetadata::unregisterMetadata(connectorId());
+    ConnectorMetadataRegistry::global().erase(connectorId());
   }
 
   const velox::config::ConfigProvider* configProvider() const override {

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 
 #include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
@@ -42,15 +43,16 @@ class TestConnectorTest : public ::testing::Test, public test::VectorTestBase {
   void SetUp() override {
     connector_ = std::make_shared<TestConnector>("test");
     velox::connector::registerConnector(connector_);
-    metadata_ = ConnectorMetadata::metadata(connector_->connectorId());
+    metadata_ = ConnectorMetadataRegistry::get(connector_->connectorId());
   }
 
   void TearDown() override {
+    metadata_.reset();
     velox::connector::unregisterConnector(connector_->connectorId());
   }
 
   std::shared_ptr<TestConnector> connector_;
-  ConnectorMetadata* metadata_{};
+  std::shared_ptr<ConnectorMetadata> metadata_;
 };
 
 TEST_F(TestConnectorTest, connectorRegister) {
@@ -65,7 +67,7 @@ TEST_F(TestConnectorTest, connectorRegister) {
   registerConnector(connector);
 
   EXPECT_EQ(velox::connector::getConnector(connectorId).get(), connector.get());
-  EXPECT_NE(ConnectorMetadata::metadata(connectorId), nullptr);
+  EXPECT_NE(ConnectorMetadataRegistry::tryGet(connectorId), nullptr);
 
   velox::connector::unregisterConnector(connectorId);
   VELOX_ASSERT_THROW(

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -18,10 +18,13 @@
 #include <numeric>
 #include <vector>
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/NameMappings.h"
 #include "velox/type/TypeCoercer.h"
 
 namespace facebook::axiom::logical_plan {
+
+using connector::ConnectorMetadataRegistry;
 
 PlanBuilder& PlanBuilder::values(
     const velox::RowTypePtr& rowType,
@@ -242,7 +245,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto* metadata = connector::ConnectorMetadata::metadata(connectorId);
+  auto metadata = ConnectorMetadataRegistry::get(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -335,7 +338,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto* metadata = connector::ConnectorMetadata::metadata(connectorId);
+  auto metadata = ConnectorMetadataRegistry::get(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -1611,7 +1614,7 @@ PlanBuilder& PlanBuilder::tableWrite(
 
   if (kind == WriteKind::kInsert) {
     // Check input types.
-    auto* metadata = connector::ConnectorMetadata::metadata(connectorId);
+    auto metadata = ConnectorMetadataRegistry::get(connectorId);
     auto table = metadata->findTable(schemaTableName);
     VELOX_USER_CHECK_NOT_NULL(
         table, "Table not found: {}", schemaTableName.toString());

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -305,11 +305,11 @@ const auto& columnStatFieldNames() {
 AXIOM_DEFINE_ENUM_NAME(ColumnStatField, columnStatFieldNames);
 
 FinishWrite::FinishWrite(
-    connector::ConnectorMetadata* metadata,
+    std::shared_ptr<connector::ConnectorMetadata> metadata,
     connector::ConnectorSessionPtr session,
     connector::ConnectorWriteHandlePtr handle,
     WriteStatsMapping statsMapping)
-    : metadata_{metadata},
+    : metadata_{std::move(metadata)},
       session_{std::move(session)},
       handle_{std::move(handle)},
       statsMapping_{std::move(statsMapping)} {

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -87,7 +87,7 @@ class FinishWrite {
   FinishWrite& operator=(FinishWrite&& other) noexcept = default;
 
   FinishWrite(
-      connector::ConnectorMetadata* metadata,
+      std::shared_ptr<connector::ConnectorMetadata> metadata,
       connector::ConnectorSessionPtr session,
       connector::ConnectorWriteHandlePtr handle,
       WriteStatsMapping statsMapping = {});
@@ -108,7 +108,7 @@ class FinishWrite {
   [[nodiscard]] velox::ContinueFuture abort() && noexcept;
 
  private:
-  connector::ConnectorMetadata* metadata_{nullptr};
+  std::shared_ptr<connector::ConnectorMetadata> metadata_;
   connector::ConnectorSessionPtr session_;
   connector::ConnectorWriteHandlePtr handle_;
   WriteStatsMapping statsMapping_;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "axiom/optimizer/ToVelox.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/WriteStatsBuilder.h"
@@ -1890,7 +1891,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   }
 
   const auto& connectorId = layout->connector()->connectorId();
-  auto* metadata = connector::ConnectorMetadata::metadata(connectorId);
+  auto metadata = connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = session_->toConnectorSession(connectorId);
   auto handle = metadata->beginWrite(
       session,

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -21,6 +21,7 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <iostream>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
@@ -239,7 +240,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     auto connector = factory.newConnector("tpch", emptyConfig);
     velox::connector::registerConnector(connector);
 
-    connector::ConnectorMetadata::registerMetadata(
+    connector::ConnectorMetadataRegistry::global().insert(
         connector->connectorId(),
         std::make_shared<connector::tpch::TpchConnectorMetadata>(
             dynamic_cast<velox::connector::tpch::TpchConnector*>(
@@ -266,7 +267,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         factory.newConnector(kHiveConnectorId, config, ioExecutor_.get());
     velox::connector::registerConnector(connector);
 
-    connector::ConnectorMetadata::registerMetadata(
+    connector::ConnectorMetadataRegistry::global().insert(
         kHiveConnectorId,
         std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
             dynamic_cast<velox::connector::hive::HiveConnector*>(
@@ -315,7 +316,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
   connector::TablePtr createTable(
       const ::axiom::sql::presto::CreateTableAsSelectStatement& statement) {
     auto metadata =
-        connector::ConnectorMetadata::metadata(connector_->connectorId());
+        connector::ConnectorMetadataRegistry::get(connector_->connectorId());
 
     folly::F14FastMap<std::string, velox::Variant> options;
     for (const auto& [key, value] : statement.properties()) {
@@ -334,7 +335,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
   void dropTable(const ::axiom::sql::presto::DropTableStatement& statement) {
     auto metadata =
-        connector::ConnectorMetadata::metadata(connector_->connectorId());
+        connector::ConnectorMetadataRegistry::get(connector_->connectorId());
 
     const auto& tableName = statement.tableName();
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/ConstantExprEvaluator.h"
@@ -73,7 +74,7 @@ void HiveQueriesTestBase::createTpchTables(
 
 void HiveQueriesTestBase::TearDown() {
   hiveMetadata_ = nullptr;
-  connector::ConnectorMetadata::unregisterMetadata(
+  connector::ConnectorMetadataRegistry::global().erase(
       velox::exec::test::kHiveConnectorId);
 
   test::QueryTestBase::TearDown();
@@ -97,7 +98,7 @@ void HiveQueriesTestBase::setupHiveConnector() {
       hiveConnector);
   hiveMetadata_ = metadata.get();
 
-  connector::ConnectorMetadata::registerMetadata(
+  connector::ConnectorMetadataRegistry::global().insert(
       velox::exec::test::kHiveConnectorId, std::move(metadata));
 }
 

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -19,6 +19,7 @@
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Task.h>
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
@@ -72,7 +73,8 @@ ConnectorSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan) {
   const auto& handle = scan.tableHandle();
-  auto metadata = connector::ConnectorMetadata::metadata(handle->connectorId());
+  auto metadata =
+      connector::ConnectorMetadataRegistry::get(handle->connectorId());
   auto splitManager = metadata->splitManager();
 
   auto partitions = folly::coro::blockingWait(

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/connectors/hive/LocalTableMetadata.h"
@@ -44,7 +45,7 @@ void LocalRunnerTestBase::SetUp() {
 }
 
 void LocalRunnerTestBase::TearDown() {
-  connector::ConnectorMetadata::unregisterMetadata(
+  connector::ConnectorMetadataRegistry::global().erase(
       velox::exec::test::kHiveConnectorId);
   velox::exec::ExchangeSource::factories().clear();
   velox::parquet::unregisterParquetWriterFactory();
@@ -82,7 +83,7 @@ void LocalRunnerTestBase::setupConnector() {
   auto hiveConnector =
       velox::connector::getConnector(velox::exec::test::kHiveConnectorId);
 
-  connector::ConnectorMetadata::registerMetadata(
+  connector::ConnectorMetadataRegistry::global().insert(
       velox::exec::test::kHiveConnectorId,
       std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
           dynamic_cast<velox::connector::hive::HiveConnector*>(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ColumnsExpansion.h"
 #include "axiom/sql/presto/ExpressionPlanner.h"
@@ -415,8 +416,9 @@ class RelationPlanner : public AstVisitor {
       const auto [connectorId, connectorTable] = toConnectorTable(
           *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
 
-      auto* metadata =
-          facebook::axiom::connector::ConnectorMetadata::metadata(connectorId);
+      auto metadata =
+          facebook::axiom::connector::ConnectorMetadataRegistry::get(
+              connectorId);
 
       if (metadata->findTable(connectorTable) != nullptr) {
         builder_->tableScan(
@@ -1500,9 +1502,10 @@ static facebook::axiom::connector::TablePtr findTable(
   const auto [connectorId, connectorTable] =
       toConnectorTable(name, defaultConnectorId, defaultSchema);
 
-  auto table =
-      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId)
-          ->findTable(connectorTable);
+  auto metadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+
+  auto table = metadata->findTable(connectorTable);
 
   AXIOM_PRESTO_SEMANTIC_CHECK(
       table != nullptr,
@@ -1533,7 +1536,7 @@ SqlStatementPtr parseShowCatalogs(
     const ShowCatalogs& showCatalogs,
     const std::string& defaultConnectorId) {
   const auto connectorIds =
-      facebook::axiom::connector::ConnectorMetadata::allMetadataIds();
+      facebook::axiom::connector::ConnectorMetadataRegistry::allMetadataIds();
 
   std::vector<Variant> data;
   data.reserve(connectorIds.size());
@@ -1806,9 +1809,10 @@ SqlStatementPtr parseInsert(
   const auto [connectorId, connectorTable] =
       toConnectorTable(*insert.target(), defaultConnectorId, defaultSchema);
 
-  const auto table =
-      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId)
-          ->findTable(connectorTable);
+  auto insertMetadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+
+  const auto table = insertMetadata->findTable(connectorTable);
 
   AXIOM_PRESTO_SEMANTIC_CHECK(
       table != nullptr,
@@ -2088,7 +2092,7 @@ SqlStatementPtr parseShowSchemas(
   const auto connectorId = showSchemas.catalog().value_or(defaultConnectorId);
 
   auto metadata =
-      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId);
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
       "show-schemas");
   auto schemaNames = metadata->listSchemaNames(session);

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -57,8 +58,11 @@ TEST_F(DdlParserTest, insertIntoTable) {
 
 TEST_F(DdlParserTest, createTableAsSelect) {
   {
+    auto ctasMetadata =
+        facebook::axiom::connector::ConnectorMetadataRegistry::get(
+            kConnectorId);
     auto nationSchema =
-        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+        ctasMetadata
             ->findTable(facebook::axiom::SchemaTableName{"default", "nation"})
             ->type();
 
@@ -187,8 +191,11 @@ TEST_F(DdlParserTest, createTable) {
 
   // like clause
   {
+    auto likeMetadata =
+        facebook::axiom::connector::ConnectorMetadataRegistry::get(
+            kConnectorId);
     auto likeSchema =
-        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+        likeMetadata
             ->findTable(facebook::axiom::SchemaTableName{"default", "nation"})
             ->type();
     testCreateTable("CREATE TABLE copy (LIKE nation)", "copy", likeSchema);
@@ -196,8 +203,11 @@ TEST_F(DdlParserTest, createTable) {
 
   // like clause + some more columns
   {
+    auto likeMetadata2 =
+        facebook::axiom::connector::ConnectorMetadataRegistry::get(
+            kConnectorId);
     auto likeSchema =
-        facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId)
+        likeMetadata2
             ->findTable(facebook::axiom::SchemaTableName{"default", "nation"})
             ->type();
 


### PR DESCRIPTION
Summary:

Migrate all ~51 call sites within axiom/ from the deprecated
ConnectorMetadata static methods (metadata(), tryMetadata(),
registerMetadata(), unregisterMetadata(), unregisterAllMetadata(),
allMetadataIds()) to the new ConnectorMetadataRegistry API.

The deprecated wrappers remain in ConnectorMetadata.h/.cpp for
external teams to migrate independently.

Key changes:
- ConnectorMetadata::metadata(id) → ConnectorMetadataRegistry::tryGet(id) + VELOX_CHECK_NOT_NULL
- ConnectorMetadata::tryMetadata(id) → ConnectorMetadataRegistry::tryGet(id)
- ConnectorMetadata::registerMetadata(id, m) → ConnectorMetadataRegistry::global().insert(id, m)
- ConnectorMetadata::unregisterMetadata(id) → ConnectorMetadataRegistry::global().erase(id)
- ConnectorMetadata::allMetadataIds() → ConnectorMetadataRegistry::allMetadataIds()
- FinishWrite now holds shared_ptr<ConnectorMetadata> instead of raw pointer
- Test fixtures store shared_ptr and reset in TearDown before cleanup

Reviewed By: mbasmanova

Differential Revision: D101575629


