### PR TITLE
fix: Fold unary minus into integer literal to allow INT64_MIN (#1274)

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -18,6 +18,7 @@
 
 #include <unordered_set>
 
+#include <folly/Conv.h>
 #include <folly/Unicode.h>
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "velox/common/base/Exceptions.h"
@@ -230,6 +231,55 @@ extractStarModifiers(
   }
 
   return {std::move(excludeColumns), std::move(replaceItems)};
+}
+
+// Strips underscores from a numeric literal text. If the text contains
+// underscores and friendlySql is false, throws a user error.
+std::string stripDigitSeparators(std::string_view text, bool friendlySql) {
+  if (text.find('_') == std::string_view::npos) {
+    return std::string(text);
+  }
+
+  VELOX_USER_CHECK(
+      friendlySql,
+      "Underscores in numeric literals require Friendly SQL mode: {}",
+      text);
+
+  std::string result;
+  result.reserve(text.size());
+  for (char ch : text) {
+    if (ch != '_') {
+      result.push_back(ch);
+    }
+  }
+  return result;
+}
+
+PrestoSqlParser::IntegerLiteralContext* asIntegerLiteral(
+    PrestoSqlParser::ValueExpressionContext* valueExpr) {
+  auto* defaultCtx =
+      dynamic_cast<PrestoSqlParser::ValueExpressionDefaultContext*>(valueExpr);
+  if (defaultCtx == nullptr) {
+    return nullptr;
+  }
+  auto* numericCtx = dynamic_cast<PrestoSqlParser::NumericLiteralContext*>(
+      defaultCtx->primaryExpression());
+  if (numericCtx == nullptr) {
+    return nullptr;
+  }
+  return dynamic_cast<PrestoSqlParser::IntegerLiteralContext*>(
+      numericCtx->number());
+}
+
+int64_t parseIntegerLiteral(
+    std::string_view text,
+    const NodeLocation& location) {
+  auto result = folly::tryTo<int64_t>(text);
+  if (result.hasError()) {
+    AXIOM_PRESTO_SEMANTIC_FAIL(
+        location, std::string(text), "Integer literal out of range: {}", text);
+  }
+  return result.value();
 }
 
 } // namespace
@@ -1923,17 +1973,39 @@ ArithmeticUnaryExpression::Sign toArithmeticSign(size_t tokenType) {
   }
 }
 
+std::shared_ptr<LongLiteral> tryFoldNegatedIntegerLiteral(
+    PrestoSqlParser::ArithmeticUnaryContext* ctx,
+    ArithmeticUnaryExpression::Sign sign,
+    bool friendlySql) {
+  if (sign != ArithmeticUnaryExpression::Sign::kMinus) {
+    return nullptr;
+  }
+  auto* integerCtx = asIntegerLiteral(ctx->valueExpression());
+  if (integerCtx == nullptr) {
+    return nullptr;
+  }
+  auto text = stripDigitSeparators(integerCtx->getText(), friendlySql);
+  auto value = parseIntegerLiteral("-" + text, getLocation(ctx));
+  return std::make_shared<LongLiteral>(getLocation(ctx), value);
+}
+
 } // namespace
 
 std::any AstBuilder::visitArithmeticUnary(
     PrestoSqlParser::ArithmeticUnaryContext* ctx) {
   trace("visitArithmeticUnary");
 
+  auto sign = toArithmeticSign(ctx->op->getType());
+  if (auto folded =
+          tryFoldNegatedIntegerLiteral(ctx, sign, options_.friendlySql)) {
+    return std::static_pointer_cast<Expression>(folded);
+  }
+
   auto expr = visitExpression(ctx->valueExpression());
 
   return std::static_pointer_cast<Expression>(
       std::make_shared<ArithmeticUnaryExpression>(
-          getLocation(ctx), toArithmeticSign(ctx->op->getType()), expr));
+          getLocation(ctx), sign, expr));
 }
 
 std::any AstBuilder::visitAtTimeZone(PrestoSqlParser::AtTimeZoneContext* ctx) {
@@ -2856,30 +2928,6 @@ std::any AstBuilder::visitDigitIdentifier(
   return visitChildren("visitDigitIdentifier", ctx);
 }
 
-namespace {
-// Strips underscores from a numeric literal text. If the text contains
-// underscores and friendlySql is false, throws a user error.
-std::string stripDigitSeparators(std::string_view text, bool friendlySql) {
-  if (text.find('_') == std::string_view::npos) {
-    return std::string(text);
-  }
-
-  VELOX_USER_CHECK(
-      friendlySql,
-      "Underscores in numeric literals require Friendly SQL mode: {}",
-      text);
-
-  std::string result;
-  result.reserve(text.size());
-  for (char ch : text) {
-    if (ch != '_') {
-      result.push_back(ch);
-    }
-  }
-  return result;
-}
-} // namespace
-
 std::any AstBuilder::visitDecimalLiteral(
     PrestoSqlParser::DecimalLiteralContext* ctx) {
   trace("visitDecimalLiteral");
@@ -2906,7 +2954,7 @@ std::any AstBuilder::visitIntegerLiteral(
   trace("visitIntegerLiteral");
 
   auto text = stripDigitSeparators(ctx->getText(), options_.friendlySql);
-  int64_t value = std::stoll(text);
+  auto value = parseIntegerLiteral(text, getLocation(ctx));
 
   return std::static_pointer_cast<Expression>(
       std::make_shared<LongLiteral>(getLocation(ctx), value));

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include <limits>
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
@@ -269,6 +270,13 @@ TEST_F(ExpressionParserTest, digitSeparators) {
   ASSERT_TRUE(expr->isConstant());
   VELOX_EXPECT_EQ_TYPES(expr->type(), INTEGER());
   EXPECT_EQ(expr->as<lp::ConstantExpr>()->value()->value<int32_t>(), 10'000);
+
+  // Negative integer with underscores. Exercises stripDigitSeparators on the
+  // fold path for negative literals (tryFoldNegatedIntegerLiteral).
+  expr = parseExpr("-10_000");
+  ASSERT_TRUE(expr->isConstant());
+  VELOX_EXPECT_EQ_TYPES(expr->type(), INTEGER());
+  EXPECT_EQ(expr->as<lp::ConstantExpr>()->value()->value<int32_t>(), -10'000);
 
   // Double with underscores.
   expr = parseExpr("1_000.5E2");
@@ -584,8 +592,30 @@ TEST_F(ExpressionParserTest, null) {
 }
 
 TEST_F(ExpressionParserTest, unaryArithmetic) {
-  EXPECT_EQ("negate(1)", parseExpr("-1")->toString());
+  EXPECT_EQ("-1", parseExpr("-1")->toString());
   EXPECT_EQ("1", parseExpr("+1")->toString());
+  EXPECT_EQ("negate(plus(1, 1))", parseExpr("-(1+1)")->toString());
+}
+
+TEST_F(ExpressionParserTest, integerLiteralBoundaries) {
+  auto expectInt64 = [&](std::string_view sql, int64_t expected) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+    ASSERT_TRUE(expr->isConstant());
+    VELOX_EXPECT_EQ_TYPES(expr->type(), BIGINT());
+    auto value = expr->as<lp::ConstantExpr>()->value();
+    ASSERT_FALSE(value->isNull());
+    EXPECT_EQ(value->value<int64_t>(), expected);
+  };
+
+  expectInt64("9223372036854775807", std::numeric_limits<int64_t>::max());
+  expectInt64("-9223372036854775808", std::numeric_limits<int64_t>::min());
+  expectInt64("-9223372036854775807", std::numeric_limits<int64_t>::min() + 1);
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("9223372036854775808"), "out of range");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("-99999999999999999999"), "out of range");
 }
 
 TEST_F(ExpressionParserTest, distinctFrom) {

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -375,7 +375,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
       "SELECT a * 2 AS b FROM t ORDER BY b * -1",
       lp::test::LogicalPlanMatcherBuilder()
           .tableScan()
-          .project({"a * 2 as b", "a * 2 * negate(1) as sortFun"})
+          .project({"a * 2 as b", "a * 2 * -1 as sortFun"})
           .sort({"sortFun"})
           .project({"b"})
           .output({"b"}));
@@ -392,9 +392,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
       "SELECT a * -2 AS a FROM t ORDER BY a * -1",
       lp::test::LogicalPlanMatcherBuilder()
           .tableScan()
-          .project(
-              {"a * negate(2) as selectFun",
-               "a * negate(2) * negate(1) as sortFun"})
+          .project({"a * -2 as selectFun", "a * -2 * -1 as sortFun"})
           .sort({"sortFun"})
           .project({"selectFun"})
           .output({"a"}));
@@ -403,8 +401,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
       "SELECT a AS b, a * -2 AS c FROM t ORDER BY b + c",
       lp::test::LogicalPlanMatcherBuilder()
           .tableScan()
-          .project(
-              {"a as b", "a * negate(2) as c", "a + a * negate(2) as sortFun"})
+          .project({"a as b", "a * -2 as c", "a + a * -2 as sortFun"})
           .sort({"sortFun"})
           .project({"b", "c"})
           .output({"b", "c"}));


### PR DESCRIPTION
Summary:

The grammar parses `-9223372036854775808` as "negate the integer 9223372036854775808". But 9223372036854775808 doesn't fit in int64 (it's INT64_MAX + 1), so the parse overflows even though the signed value is valid INT64_MIN.

Fix: when the parser sees `-(integer literal)`, fold them into a single negative literal and parse the string `"-9223372036854775808"` directly via `folly::tryTo<int64_t>`. Also replaces `std::stoll` with `folly::tryTo` so bare overflow like `SELECT 9223372036854775808` produces a clear user error instead of an opaque `std::out_of_range` exception.

## Suggested review order
1. `AstBuilder.cpp` — moved `stripDigitSeparators` to the top anonymous namespace alongside the new `asIntegerLiteral` and `parseIntegerLiteral` helpers; updated `visitArithmeticUnary` and `visitIntegerLiteral`.
2. `ExpressionParserTest.cpp` — new `integerLiteralBoundaries` test exercising INT64_MAX, INT64_MIN, INT64_MIN+1, and the bare/signed overflow error paths. Updated `unaryArithmetic` since `parseExpr("-1")->toString()` now returns `"-1"` instead of `"negate(1)"`.
3. `SortParserTest.cpp` — updated `outputAliasInExpression` plan expectations (`negate(2)` → `-2`, `negate(1)` → `-1`).

Reviewed By: mbasmanova

Differential Revision: D101710099
