### PR TITLE
fix: Add direct includes for axiom after EnumsDeclare.h split (#1278)

### DIFF
--- a/axiom/common/ConfigRegistry.h
+++ b/axiom/common/ConfigRegistry.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <folly/container/F14Map.h>
+#include "velox/common/config/ConfigProperty.h"
 #include "velox/common/config/ConfigProvider.h"
 
 namespace facebook::axiom {

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -23,6 +23,7 @@
 
 #include "axiom/common/SessionConfig.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::axiom;

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/config/ConfigProperty.h"
 
 namespace facebook::axiom::optimizer {
 


### PR DESCRIPTION
Summary:

After splitting Enums.h into EnumsDeclare.h (D101462826), some axiom files lost transitive includes. Add the direct includes that were previously provided transitively through ConfigProvider.h and ConfigProperty.h:

- ConfigRegistry.h: add ConfigProperty.h include
- OptimizerOptions.cpp: add ConfigProperty.h include
- SessionConfigTest.cpp: add Exceptions.h include
- tests/BUCK: add velox_exception dep

Differential Revision: D101886460


