### PR TITLE
fix: Improve error template grouping for PrestoSqlError and folly::parseJson

### DIFF
--- a/axiom/connectors/hive/LocalTableMetadata.cpp
+++ b/axiom/connectors/hive/LocalTableMetadata.cpp
@@ -158,7 +158,11 @@ std::optional<PersistedStats> PersistedStats::read(
   std::string content(
       (std::istreambuf_iterator<char>(inputFile)),
       std::istreambuf_iterator<char>());
-  return persistedStatsFromJson(folly::parseJson(content));
+  try {
+    return persistedStatsFromJson(folly::parseJson(content));
+  } catch (const folly::json::parse_error& e) {
+    VELOX_FAIL("Failed to parse persisted stats JSON: {}", e.what());
+  }
 }
 
 void PersistedStats::write(const std::string& directory, PersistedStats stats) {

--- a/axiom/optimizer/JsonUtil.h
+++ b/axiom/optimizer/JsonUtil.h
@@ -40,7 +40,11 @@ inline std::vector<folly::dynamic> readConcatenatedDynamicsFromFile(
       --braceCount;
       if (braceCount == 0) {
         std::string obj = content.substr(start, i - start + 1);
-        result.push_back(folly::parseJson(obj));
+        try {
+          result.push_back(folly::parseJson(obj));
+        } catch (const folly::json::parse_error& e) {
+          VELOX_FAIL("Failed to parse JSON object: {}", e.what());
+        }
       }
     }
   }


### PR DESCRIPTION
Summary:
Two sources of untemplatized `failure_message_template` entries in Scuba on Axiom clusters:

**1. PrestoSqlError (~5,000+ entries/3d):**
`QueryError::create(StandardErrorCode, const std::exception&)` extracts `messageTemplate()` from `VeloxException` for error grouping, but did not handle `PrestoSqlError`. SQL parser/semantic errors (e.g. table-not-found, type resolution failures) are thrown as `PrestoSqlError`, which carries its own `messageTemplate()` — but these fell through to the generic `std::exception` path where `ex.what()` (including line/column/token) became the template.

This caused entries like:
- `Semantic error at 28:5 near 'dfs3_physical_volumes': Table not found: cdb.dfs.dfs3_physical_volumes`
- `Semantic error at 107:9 near 'rack': Table not found: cdb.serf.server.rack`

Fixed by catching `PrestoSqlError` in `AxelQueryContext::handleError` (in `fb_axel/`, where the `axiom/sql/presto` dependency is available) and using `QueryError::createWithTemplate` to preserve the format string. After this fix, all of the above group under `Table not found: {}`.

Also made `QueryError::createWithTemplate` public so callers can set message and template independently.

**2. folly::json::parse_error (7 entries/3d):**
All production `folly::parseJson` call sites across axel/, axiom/, fb_axel/, and fb_axiom/ were uncaught — a `folly::json::parse_error` (e.g. from deeply nested type JSON hitting folly's recursion limit) propagated as raw `std::exception` where `what()` became the template.

This wraps each call site with try-catch that converts to `VELOX_FAIL` with a descriptive format template (e.g. `"Failed to parse plan JSON: {}"`). Two call sites (`QueryPermissionUtils`, `DpasPermissionsClient`) already had try-catch and were left unchanged.

Reviewed By: arhimondr

Differential Revision: D101582194


