### PR TITLE
feat(pyspark): Introduce Collagen Spark Connect server for PySpark language (#1280)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(VELOX_BUILD_TESTING OFF)
 set(VELOX_DEPENDENCY_SOURCE AUTO CACHE STRING "Default dependency source: AUTO SYSTEM or BUNDLED.")
 
 option(AXIOM_ENABLE_CCACHE "Use ccache if installed." ON)
+option(AXIOM_ENABLE_COLLAGEN "Build Collagen (Spark Connect server)." OFF)
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
@@ -160,6 +161,18 @@ velox_resolve_dependency(antlr4-runtime)
 
 message(STATUS "Using ANTLR4 runtime from ${ANTLR4_INCLUDE_DIR}")
 
+# Dependencies for the PySpark/Collagen server.
+if(AXIOM_ENABLE_COLLAGEN)
+  velox_set_source(protobuf)
+  velox_resolve_dependency(protobuf)
+
+  velox_set_source(gRPC)
+  velox_resolve_dependency(gRPC)
+
+  velox_set_source(Arrow)
+  velox_resolve_dependency(Arrow)
+endif()
+
 # Use xxhash and xsimd from Velox for now.
 include_directories(.)
 include_directories(${CMAKE_BINARY_DIR})
@@ -181,6 +194,9 @@ add_subdirectory(axiom/runner)
 add_subdirectory(axiom/connectors)
 add_subdirectory(axiom/optimizer)
 add_subdirectory(axiom/cli)
+if(AXIOM_ENABLE_COLLAGEN)
+  add_subdirectory(axiom/pyspark)
+endif()
 
 add_library(axiom_mono INTERFACE)
 add_library(Axiom::axiom ALIAS axiom_mono)
@@ -189,3 +205,7 @@ target_link_libraries(
   axiom_mono
   INTERFACE axiom_connector_metadata axiom_optimizer axiom_runner_local_runner
 )
+
+if(AXIOM_ENABLE_COLLAGEN)
+  target_link_libraries(axiom_mono INTERFACE collagen_service)
+endif()

--- a/axiom/pyspark/ArrowIpcLib.cpp
+++ b/axiom/pyspark/ArrowIpcLib.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/ArrowIpcLib.h"
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
+#include "axiom/pyspark/Exception.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/arrow/Bridge.h"
+
+using namespace facebook;
+
+namespace axiom::collagen {
+
+std::shared_ptr<arrow::Buffer> toArrowIpc(
+    const std::vector<velox::RowVectorPtr>& vectors,
+    uint64_t& rowCount) {
+  rowCount = 0; // Initialize rowCount to zero
+
+  if (vectors.empty()) {
+    // Return empty buffer for empty input
+    COLLAGEN_ARROW_ASSIGN_OR_THROW(
+        auto sink, arrow::io::BufferOutputStream::Create())
+    COLLAGEN_ARROW_ASSIGN_OR_THROW(auto outputBuffer, sink->Finish());
+    return outputBuffer;
+  }
+
+  // Flatten dictionary encoding to avoid null dictionary pointers in
+  // ArrowArray when exporting complex types like MAP<BIGINT, ARRAY<BIGINT>>
+  // from map_zip_with results.
+  const ArrowOptions options{.flattenDictionary = true};
+
+  // Get schema from the first vector (assuming all vectors have the same
+  // schema)
+  ArrowSchema arrowSchema;
+  velox::exportToArrow(vectors[0], arrowSchema, options);
+  COLLAGEN_ARROW_ASSIGN_OR_THROW(
+      auto schema, arrow::ImportSchema(&arrowSchema));
+
+  // Create output stream and writer
+  COLLAGEN_ARROW_ASSIGN_OR_THROW(
+      auto sink, arrow::io::BufferOutputStream::Create())
+
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> arrowWriter;
+  COLLAGEN_ARROW_CHECK(
+      arrow::ipc::MakeStreamWriter(sink.get(), schema).Value(&arrowWriter));
+
+  // Convert each Velox RowVector to Arrow RecordBatch and write to stream
+  for (const auto& vector : vectors) {
+    ArrowArray arrowArray;
+    velox::exportToArrow(vector, arrowArray, vector->pool(), options);
+    COLLAGEN_ARROW_ASSIGN_OR_THROW(
+        auto arrowBatch, arrow::ImportRecordBatch(&arrowArray, schema));
+    COLLAGEN_ARROW_CHECK(arrowWriter->WriteRecordBatch(*arrowBatch));
+
+    // Update rowCount with the number of rows in the current vector
+    LOG(INFO) << "Vector size: " << vector->size();
+    rowCount += vector->size();
+  }
+
+  COLLAGEN_ARROW_CHECK(arrowWriter->Close());
+  COLLAGEN_ARROW_ASSIGN_OR_THROW(auto outputBuffer, sink->Finish());
+  return outputBuffer;
+}
+
+std::vector<velox::RowVectorPtr> fromArrowIpc(
+    const std::shared_ptr<arrow::Buffer>& buffer,
+    velox::memory::MemoryPool* pool) {
+  if (buffer->size() == 0) {
+    return {};
+  }
+
+  COLLAGEN_ARROW_ASSIGN_OR_THROW(
+      auto reader,
+      arrow::ipc::RecordBatchStreamReader::Open(
+          std::make_shared<arrow::io::BufferReader>(buffer)));
+
+  ArrowSchema arrowSchema;
+  COLLAGEN_ARROW_CHECK(arrow::ExportSchema(*reader->schema(), &arrowSchema));
+
+  std::vector<velox::RowVectorPtr> outputVectors;
+
+  // Iterate over each Arrow record batch, convert to Velox vector.
+  while (true) {
+    COLLAGEN_ARROW_ASSIGN_OR_THROW(auto arrowBatch, reader->Next());
+    if (!arrowBatch) {
+      break;
+    }
+
+    ArrowArray arrowArray;
+    COLLAGEN_ARROW_CHECK(ExportRecordBatch(*arrowBatch, &arrowArray));
+
+    auto vector = velox::importFromArrowAsViewer(arrowSchema, arrowArray, pool);
+    outputVectors.emplace_back(
+        std::dynamic_pointer_cast<velox::RowVector>(vector));
+  }
+  return outputVectors;
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/ArrowIpcLib.h
+++ b/axiom/pyspark/ArrowIpcLib.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "arrow/api.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace axiom::collagen {
+
+/// Converts a vector of Velox RowVector into an Arrow Array and serializes it
+/// using Arrow IPC.
+///
+/// Returns the Arrow Buffer containing the serialized IPC payload. Throws
+/// CollagenException on errors.
+std::shared_ptr<arrow::Buffer> toArrowIpc(
+    const std::vector<facebook::velox::RowVectorPtr>& vectors,
+    uint64_t& rowCount);
+
+/// Convert an Arrow IPC payload into Velox Vectors.
+///
+/// This is meant to be used for literals embedded into query plans, not large
+/// datasets.
+std::vector<facebook::velox::RowVectorPtr> fromArrowIpc(
+    const std::shared_ptr<arrow::Buffer>& buffer,
+    facebook::velox::memory::MemoryPool* pool);
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/CMakeLists.txt
+++ b/axiom/pyspark/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(third-party/protos)
+add_subdirectory(runners)
+
+if(AXIOM_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
+
+add_library(collagen_arrow ArrowIpcLib.cpp)
+
+target_link_libraries(collagen_arrow velox_arrow_bridge velox_vector velox_memory Arrow::arrow)
+
+add_library(collagen_spark_velox_converter SparkVeloxConverter.cpp)
+
+target_link_libraries(
+  collagen_spark_velox_converter
+  axiom_logical_plan
+  collagen_proto
+  velox_type
+  Folly::folly
+)
+
+add_library(collagen_converter Optimizer.cpp SparkPlanPrinter.cpp SparkToAxiom.cpp)
+
+target_link_libraries(
+  collagen_converter
+  collagen_arrow
+  collagen_spark_velox_converter
+  collagen_proto
+  axiom_common
+  axiom_connectors
+  axiom_logical_plan
+  axiom_optimizer
+  velox_exec
+  velox_expression
+  velox_function_registry
+  velox_memory
+  velox_type
+  velox_vector
+  Folly::folly
+)
+
+add_library(collagen_service CollagenService.cpp)
+
+target_link_libraries(
+  collagen_service
+  collagen_arrow
+  collagen_converter
+  collagen_proto
+  collagen_runners
+  axiom_optimizer
+  velox_memory
+  Folly::folly
+  gRPC::grpc++
+)
+
+add_library(collagen_main CollagenMain.cpp)
+
+target_link_libraries(
+  collagen_main
+  collagen_service
+  collagen_runners
+  axiom_connectors
+  axiom_hive_connector_metadata
+  axiom_tpch_connector_metadata
+  axiom_test_connector
+  axiom_optimizer
+  velox_connector_registry
+  velox_hive_connector
+  velox_tpch_connector
+  velox_dwio_common
+  velox_dwio_dwrf_reader
+  velox_dwio_dwrf_writer
+  velox_dwio_parquet_reader
+  velox_functions_prestosql
+  velox_aggregates
+  velox_presto_serializer
+  velox_memory
+  Folly::folly
+  gRPC::grpc++
+  gflags::gflags
+)
+
+add_executable(collagen_server CollagenServer.cpp)
+
+target_link_libraries(collagen_server collagen_main Folly::folly gflags::gflags)

--- a/axiom/pyspark/CollagenMain.cpp
+++ b/axiom/pyspark/CollagenMain.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/CollagenMain.h"
+
+#include <folly/io/async/EventBase.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/connectors/tpch/TpchConnectorMetadata.h"
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/pyspark/runners/LocalRunner.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+DEFINE_string(
+    local_hive_data_path,
+    "",
+    "Path for local-hive connector data. If empty, a temp directory is created.");
+
+namespace axiom::collagen {
+namespace {
+
+std::string makeDataDirectory() {
+  char dirname[] = "/tmp/collagen_hive_XXXXXX";
+  char* dir = mkdtemp(dirname);
+  if (dir == nullptr) {
+    LOG(FATAL) << "Failed to create temp directory for LocalHiveConnector";
+  }
+  return std::string(dir);
+}
+
+} // namespace
+
+CollagenMain::CollagenMain(
+    std::string runnerId,
+    std::string catalog,
+    std::string schema,
+    int port)
+    : runnerId_(std::move(runnerId)),
+      catalog_(std::move(catalog)),
+      schema_(std::move(schema)),
+      port_(port) {}
+
+CollagenMain::~CollagenMain() {
+  facebook::axiom::connector::ConnectorMetadata::unregisterMetadata(catalog_);
+  facebook::velox::connector::unregisterConnector(catalog_);
+}
+
+void CollagenMain::init() {
+  LOG(INFO) << "Starting Collagen service with catalog=" << catalog_
+            << ", schema=" << schema_ << ", runner=" << runnerId_;
+
+  initMemory();
+  registerRunner();
+  registerSerde();
+  registerFileSystems();
+  registerConnector();
+  registerFunctions();
+
+  std::string serverAddress(fmt::format("0.0.0.0:{}", port_));
+  service_ = std::make_unique<CollagenService>(runnerId_, catalog_, schema_);
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(serverAddress, grpc::InsecureServerCredentials());
+  builder.RegisterService(service_.get());
+
+  server_ = builder.BuildAndStart();
+}
+
+void CollagenMain::run() {
+  CollagenSignalHandler handler(folly::getEventBase(), server_.get());
+  server_->Wait();
+}
+
+void CollagenMain::initMemory() {
+  facebook::velox::memory::MemoryManager::initialize(
+      facebook::velox::memory::MemoryManager::Options{});
+}
+
+void CollagenMain::registerRunner() {
+  if (runnerId_ == "local") {
+    runner::registerLocalRunnerFactory(runnerId_);
+  } else {
+    LOG(FATAL) << "Unknown runner id: " << runnerId_
+               << ". OSS supported runners: local";
+  }
+}
+
+void CollagenMain::registerSerde() {
+  facebook::velox::core::PlanNode::registerSerDe();
+  facebook::velox::Type::registerSerDe();
+  facebook::velox::common::Filter::registerSerDe();
+  facebook::velox::connector::hive::HiveConnector::registerSerDe();
+  facebook::velox::core::ITypedExpr::registerSerDe();
+}
+
+void CollagenMain::registerFileSystems() {
+  facebook::velox::filesystems::registerLocalFileSystem();
+  facebook::velox::dwio::common::registerFileSinks();
+  facebook::velox::dwrf::registerDwrfReaderFactory();
+  facebook::velox::dwrf::registerDwrfWriterFactory();
+  facebook::velox::parquet::registerParquetReaderFactory();
+  facebook::velox::parquet::registerParquetWriterFactory();
+}
+
+void CollagenMain::registerTestConnector() {
+  auto connector =
+      std::make_shared<facebook::axiom::connector::TestConnector>(catalog_);
+
+  connector->addTable(
+      "training_table",
+      facebook::velox::ROW({"viewer_rid"}, {facebook::velox::BIGINT()}));
+  connector->addTable(
+      "feature_table",
+      facebook::velox::ROW({"primary_rid"}, {facebook::velox::BIGINT()}));
+
+  facebook::velox::connector::registerConnector(connector);
+}
+
+void CollagenMain::registerTpchConnector() {
+  auto emptyConfig = std::make_shared<facebook::velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+
+  facebook::velox::connector::tpch::TpchConnectorFactory factory;
+  auto tpchConnector = factory.newConnector(catalog_, emptyConfig);
+  facebook::velox::connector::registerConnector(tpchConnector);
+
+  facebook::axiom::connector::ConnectorMetadata::registerMetadata(
+      catalog_,
+      std::make_shared<facebook::axiom::connector::tpch::TpchConnectorMetadata>(
+          dynamic_cast<facebook::velox::connector::tpch::TpchConnector*>(
+              tpchConnector.get())));
+}
+
+void CollagenMain::registerLocalHiveConnector() {
+  std::string dataPath = FLAGS_local_hive_data_path.empty()
+      ? makeDataDirectory()
+      : FLAGS_local_hive_data_path;
+
+  std::unordered_map<std::string, std::string> connectorConfig = {
+      {facebook::axiom::connector::hive::HiveMetadataConfig::kLocalDataPath,
+       dataPath},
+      {facebook::axiom::connector::hive::HiveMetadataConfig::kLocalFileFormat,
+       "dwrf"},
+  };
+  auto config = std::make_shared<facebook::velox::config::ConfigBase>(
+      std::move(connectorConfig));
+
+  facebook::velox::connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(catalog_, config);
+  facebook::velox::connector::registerConnector(hiveConnector);
+
+  facebook::axiom::connector::ConnectorMetadata::registerMetadata(
+      catalog_,
+      std::make_shared<
+          facebook::axiom::connector::hive::LocalHiveConnectorMetadata>(
+          dynamic_cast<facebook::velox::connector::hive::HiveConnector*>(
+              hiveConnector.get())));
+}
+
+void CollagenMain::registerConnector() {
+  if (catalog_ == "test") {
+    registerTestConnector();
+  } else if (catalog_ == "tpch") {
+    registerTpchConnector();
+  } else if (catalog_ == "local-hive") {
+    registerLocalHiveConnector();
+  } else {
+    LOG(FATAL) << "Unknown catalog: " << catalog_
+               << ". OSS supported catalogs: test, tpch, local-hive";
+  }
+}
+
+void CollagenMain::registerFunctions() {
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
+  facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
+  facebook::velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  facebook::axiom::optimizer::FunctionRegistry::registerPrestoFunctions();
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/CollagenMain.h
+++ b/axiom/pyspark/CollagenMain.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <grpcpp/grpcpp.h> // @manual=//grpc_fb/cpp:grpc
+#include <memory>
+#include <string>
+
+#include "axiom/pyspark/CollagenService.h"
+
+namespace axiom::collagen {
+
+class CollagenMain {
+ public:
+  CollagenMain(
+      std::string runnerId,
+      std::string catalog,
+      std::string schema,
+      int port);
+
+  virtual ~CollagenMain();
+
+  virtual void init();
+
+  void run();
+
+ protected:
+  virtual void initMemory();
+  virtual void registerRunner();
+  virtual void registerSerde();
+  virtual void registerFileSystems();
+  virtual void registerConnector();
+  virtual void registerFunctions();
+
+  void registerTpchConnector();
+  void registerTestConnector();
+  void registerLocalHiveConnector();
+
+  const std::string runnerId_;
+  const std::string catalog_;
+  const std::string schema_;
+  const int port_;
+
+  std::unique_ptr<CollagenService> service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/CollagenServer.cpp
+++ b/axiom/pyspark/CollagenServer.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "axiom/pyspark/CollagenMain.h"
+
+DEFINE_int32(port, 12345, "TCP port to listen to.");
+DEFINE_string(catalog, "tpch", "Catalog to use: test, tpch, hive");
+DEFINE_string(schema, "", "Schema to use");
+DEFINE_string(runner_id, "local", "Runner id to use, supported: local.");
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  FLAGS_velox_exception_user_stacktrace_enabled = true;
+
+  axiom::collagen::CollagenMain collagenMain(
+      FLAGS_runner_id, FLAGS_catalog, FLAGS_schema, FLAGS_port);
+  collagenMain.init();
+  collagenMain.run();
+
+  return 0;
+}

--- a/axiom/pyspark/CollagenService.cpp
+++ b/axiom/pyspark/CollagenService.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/CollagenService.h"
+
+#include <folly/json.h>
+#include <glog/logging.h>
+
+#include "axiom/optimizer/ToVelox.h"
+#include "axiom/pyspark/ArrowIpcLib.h"
+#include "axiom/pyspark/Exception.h"
+#include "axiom/pyspark/Optimizer.h"
+#include "axiom/pyspark/SparkPlanPrinter.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/runners/Runner.h"
+#include "velox/common/memory/MemoryPool.h"
+
+using namespace ::facebook;
+using facebook::axiom::optimizer::PlanAndStats;
+
+DEFINE_bool(skip_run, false, "Skip running the query and return.");
+
+namespace {
+
+std::vector<facebook::velox::RowVectorPtr> getDummyRowVector(
+    facebook::velox::memory::MemoryPool* pool) {
+  static auto responseType =
+      facebook::velox::ROW({"show_string"}, {facebook::velox::VARCHAR()});
+  static auto response = {
+      facebook::velox::RowVector::createEmpty(responseType, pool)};
+  return response;
+}
+
+} // namespace
+
+namespace axiom::collagen {
+
+CollagenService::CollagenService(
+    std::string runnerId,
+    std::string catalog,
+    std::string schema)
+    : runnerId_(std::move(runnerId)),
+      catalog_(std::move(catalog)),
+      schema_(std::move(schema)) {
+  if (rootPool_->reclaimer() == nullptr) {
+    rootPool_->setReclaimer(facebook::velox::memory::MemoryReclaimer::create());
+  }
+}
+
+// In Spark Connect, Relation represents any execution plan node.
+PlanAndStats CollagenService::plan(
+    const spark::connect::Plan& plan,
+    std::string& logicalPlanStr) {
+  auto startTime = std::chrono::high_resolution_clock::now();
+
+  // TODO: just for debugging for now.
+  LOG(INFO) << "Spark Connect logical plan:\n" << printSparkPlan(plan);
+
+  LOG(INFO) << "Converting to Axiom plan:";
+  SparkToAxiom converter(catalog_, schema_, pool_.get());
+  SparkPlanVisitorContext axiomContext;
+  converter.visit(plan, axiomContext);
+
+  logicalPlanStr = converter.toString();
+  LOG(INFO) << "Axiom logical input:\n" << logicalPlanStr;
+
+  // Optimize it into a Velox physical plan.
+  auto veloxPlanAndStats =
+      optimize(converter.planNode(), catalog_, pool_.get());
+
+  LOG(INFO) << "Generated Velox physical plan with "
+            << veloxPlanAndStats.plan->fragments().size() << " fragments:\n"
+            << veloxPlanAndStats.plan->toString();
+
+  LOG(INFO) << "Plan generation took "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::high_resolution_clock::now() - startTime)
+                   .count()
+            << "ms";
+  return veloxPlanAndStats;
+}
+
+grpc::Status CollagenService::ExecutePlan(
+    grpc::ServerContext* context,
+    const spark::connect::ExecutePlanRequest* request,
+    grpc::ServerWriter<spark::connect::ExecutePlanResponse>* writer) {
+  LOG(INFO) << "Got execute plan request (session_id=" << request->session_id()
+            << ").";
+  // Set execute plan response structure.
+  spark::connect::ExecutePlanResponse planResponse;
+  planResponse.set_session_id(request->session_id());
+
+  std::string logicalPlanStr;
+  PlanAndStats veloxPlanStats;
+
+  try {
+    veloxPlanStats = plan(request->plan(), logicalPlanStr);
+
+    if (veloxPlanStats.plan == nullptr) {
+      return grpc::Status(
+          grpc::StatusCode::INTERNAL,
+          "Failed to generate Velox plan from Spark Connect plan.");
+    }
+  } catch (const CollagenException& e) {
+    LOG(WARNING) << "Request failed:\n" << e.what();
+    return e.status();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Unexpected exception: " << e.what();
+    return grpc::Status(grpc::StatusCode::UNKNOWN, e.what());
+  }
+
+  auto runner = runner::buildRunner(
+      runnerId_,
+      "Test",
+      veloxPlanStats.plan,
+      std::move(veloxPlanStats.finishWrite),
+      rootPool_);
+  std::vector<velox::RowVectorPtr> results;
+
+  // TODO: these configs should be somewhere else. We should also allow clients
+  // to set/overwrite them.
+  std::unordered_map<std::string, std::string> queryConfigs = {
+      {"selective_nimble_reader_enabled", "true"},
+  };
+
+  try {
+    if (FLAGS_skip_run) {
+      results = getDummyRowVector(pool_.get());
+    } else {
+      results = runner->execute(queryConfigs);
+    }
+
+    auto* arrowBatch = planResponse.mutable_arrow_batch();
+    uint64_t rowCount;
+    auto outputBuffer = toArrowIpc(results, rowCount);
+    arrowBatch->set_data(outputBuffer->data(), outputBuffer->size());
+    arrowBatch->set_row_count(rowCount);
+    writer->Write(planResponse);
+    LOG(INFO) << "Executed successfully got " << rowCount << " rows.";
+    return grpc::Status::OK;
+  } catch (const CollagenException& e) {
+    LOG(WARNING) << "Request failed:\n" << e.what();
+    return e.status();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Unexpected exception: " << e.what();
+    return grpc::Status(grpc::StatusCode::UNKNOWN, e.what());
+  }
+}
+
+grpc::Status CollagenService::AnalyzePlan(
+    grpc::ServerContext* context,
+    const spark::connect::AnalyzePlanRequest* request,
+    spark::connect::AnalyzePlanResponse* response) {
+  LOG(INFO) << "Got analyze plan request (session_id=" << request->session_id()
+            << ").";
+  response->set_session_id(request->session_id());
+
+  PlanAndStats veloxPlanStats;
+  try {
+    std::string logicalPlanStr;
+    switch (request->analyze_case()) {
+      case spark::connect::AnalyzePlanRequest::kExplain:
+        veloxPlanStats = plan(request->explain().plan(), logicalPlanStr);
+        break;
+
+      default:
+        break;
+    }
+    auto* explain = response->mutable_explain();
+
+    // Build the complete explain string with both logical and physical plans
+    std::string fullExplainStr = logicalPlanStr;
+
+    // Append the Velox physical plan (MultiFragmentPlan) if available
+    if (veloxPlanStats.plan != nullptr) {
+      std::string veloxPlanStr = veloxPlanStats.plan->toString();
+      fullExplainStr += "\n\n== Velox Physical Plan (MultiFragmentPlan) ==\n";
+      fullExplainStr += veloxPlanStr;
+
+      for (const auto& execFragment : veloxPlanStats.plan->fragments()) {
+        fullExplainStr += "\n\n== Velox Plan JSON ==\n";
+        fullExplainStr +=
+            folly::toJson(execFragment.fragment.planNode->serialize());
+      }
+
+      // Also set the separate field for programmatic access
+      explain->set_velox_plan_string(veloxPlanStr);
+    }
+
+    explain->set_explain_string(fullExplainStr);
+    return grpc::Status::OK;
+  } catch (const CollagenException& e) {
+    veloxPlanStats.plan = nullptr;
+    LOG(WARNING) << "Request failed:\n" << e.what();
+    return e.status();
+  } catch (const std::exception& e) {
+    veloxPlanStats.plan = nullptr;
+    LOG(WARNING) << "Unexpected exception: " << e.what();
+    return grpc::Status(grpc::StatusCode::UNKNOWN, e.what());
+  }
+}
+
+grpc::Status CollagenService::Config(
+    grpc::ServerContext* context,
+    const spark::connect::ConfigRequest* request,
+    spark::connect::ConfigResponse* response) {
+  LOG(INFO) << "Got config request (session_id=" << request->session_id()
+            << ").";
+  return grpc::Status(
+      grpc::StatusCode::UNIMPLEMENTED, "Config() method not implemented yet.");
+}
+
+grpc::Status CollagenService::AddArtifacts(
+    grpc::ServerContext* context,
+    grpc::ServerReader<spark::connect::AddArtifactsRequest>* request,
+    spark::connect::AddArtifactsResponse* response) {
+  LOG(INFO) << "Got add artifacts request.";
+  return grpc::Status(
+      grpc::StatusCode::UNIMPLEMENTED,
+      "AddArtifacts() method not implemented yet.");
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/CollagenService.h
+++ b/axiom/pyspark/CollagenService.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/io/async/AsyncSignalHandler.h>
+#include <grpcpp/grpcpp.h> // @manual=//grpc_fb/cpp:grpc
+#include <signal.h>
+#include <string>
+
+#include "axiom/pyspark/third-party/protos/base.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryPool.h"
+
+namespace facebook::axiom::optimizer {
+struct PlanAndStats;
+}
+
+namespace axiom::collagen {
+
+class CollagenService final
+    : public spark::connect::SparkConnectService::Service {
+ public:
+  CollagenService(
+      std::string runnerId,
+      std::string catalog,
+      std::string schema);
+
+  ~CollagenService() = default;
+
+  // External grpc API:
+  grpc::Status ExecutePlan(
+      grpc::ServerContext* context,
+      const spark::connect::ExecutePlanRequest* request,
+      grpc::ServerWriter<spark::connect::ExecutePlanResponse>* writer) override;
+
+  grpc::Status AnalyzePlan(
+      grpc::ServerContext* context,
+      const spark::connect::AnalyzePlanRequest* request,
+      spark::connect::AnalyzePlanResponse* response) override;
+
+  grpc::Status Config(
+      grpc::ServerContext* context,
+      const spark::connect::ConfigRequest* request,
+      spark::connect::ConfigResponse* response) override;
+
+  grpc::Status AddArtifacts(
+      grpc::ServerContext* context,
+      grpc::ServerReader<spark::connect::AddArtifactsRequest>* request,
+      spark::connect::AddArtifactsResponse* response) override;
+
+ private:
+  using PlanAndStats = facebook::axiom::optimizer::PlanAndStats;
+
+  PlanAndStats plan(
+      const spark::connect::Plan& plan,
+      std::string& logicalPlanStr);
+
+  // Runner id (e.g., "local").
+  const std::string runnerId_;
+  // Catalog name (e.g., "tpch", "local-hive", "test").
+  const std::string catalog_;
+  // Schema to prepend to table names (e.g., "tiny" for TPCH).
+  const std::string schema_;
+
+  using MemoryPool = facebook::velox::memory::MemoryPool;
+
+  std::shared_ptr<MemoryPool> rootPool_{
+      facebook::velox::memory::memoryManager()->addRootPool()};
+  std::shared_ptr<MemoryPool> pool_{rootPool_->addLeafChild("collagen_server")};
+};
+
+class CollagenSignalHandler : public folly::AsyncSignalHandler {
+ public:
+  explicit CollagenSignalHandler(folly::EventBase* eb, grpc::Server* server)
+      : folly::AsyncSignalHandler(eb), server_(server) {
+    // Catch only SIGTERM.
+    registerSignalHandler(SIGTERM);
+  }
+
+  void signalReceived(int signum) noexcept override {
+    LOG(INFO) << "CollagenSignalHandler received signal: " << signum
+              << ". Shutting down...";
+    server_->Shutdown();
+  }
+
+ private:
+  grpc::Server* server_;
+};
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/Exception.h
+++ b/axiom/pyspark/Exception.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <grpcpp/grpcpp.h> // @manual=//grpc_fb/cpp:grpc
+#include <exception>
+#include <string>
+
+namespace axiom::collagen {
+
+// Code adapted from Velox Exception.
+
+#define _COLLAGEN_THROW_IMPL(exprStr, exception, errorCode, ...) \
+  do {                                                           \
+    throw exception(                                             \
+        errorCode,                                               \
+        ::axiom::collagen::errorMessage(__VA_ARGS__),            \
+        exprStr,                                                 \
+        __FILE__,                                                \
+        __LINE__,                                                \
+        __FUNCTION__);                                           \
+  } while (0)
+
+#define _COLLAGEN_THROW(exception, ...) \
+  _COLLAGEN_THROW_IMPL("", exception, ##__VA_ARGS__)
+
+#define _COLLAGEN_CHECK_AND_THROW_IMPL(                                 \
+    expr, exprStr, exception, errorCode, ...)                           \
+  do {                                                                  \
+    if (UNLIKELY(!(expr))) {                                            \
+      _COLLAGEN_THROW_IMPL(exprStr, exception, errorCode, __VA_ARGS__); \
+    }                                                                   \
+  } while (0)
+
+#define _COLLAGEN_CHECK_IMPL(expr, exprStr, ...) \
+  _COLLAGEN_CHECK_AND_THROW_IMPL(                \
+      expr,                                      \
+      exprStr,                                   \
+      ::axiom::collagen::CollagenException,      \
+      ::grpc::StatusCode::UNKNOWN,               \
+      ##__VA_ARGS__)
+
+#define COLLAGEN_FAIL(...)                  \
+  _COLLAGEN_THROW(                          \
+      ::axiom::collagen::CollagenException, \
+      ::grpc::StatusCode::UNKNOWN,          \
+      ##__VA_ARGS__)
+
+#define COLLAGEN_USER_FAIL(...)             \
+  _COLLAGEN_THROW(                          \
+      ::axiom::collagen::CollagenException, \
+      ::grpc::StatusCode::INVALID_ARGUMENT, \
+      ##__VA_ARGS__)
+
+#define COLLAGEN_NYI(...)                   \
+  _COLLAGEN_THROW(                          \
+      ::axiom::collagen::CollagenException, \
+      ::grpc::StatusCode::UNIMPLEMENTED,    \
+      ##__VA_ARGS__)
+
+#define _COLLAGEN_CHECK_OP_WITH_USER_FMT_HELPER( \
+    implmacro, expr1, expr2, op, user_fmt, ...)  \
+  implmacro(                                     \
+      (expr1)op(expr2),                          \
+      #expr1 " " #op " " #expr2,                 \
+      "({} vs. {}) " user_fmt,                   \
+      expr1,                                     \
+      expr2,                                     \
+      ##__VA_ARGS__)
+
+#define _COLLAGEN_CHECK_OP_HELPER(implmacro, expr1, expr2, op, ...) \
+  do {                                                              \
+    if constexpr (FOLLY_PP_DETAIL_NARGS(__VA_ARGS__) > 0) {         \
+      _COLLAGEN_CHECK_OP_WITH_USER_FMT_HELPER(                      \
+          implmacro, expr1, expr2, op, __VA_ARGS__);                \
+    } else {                                                        \
+      implmacro(                                                    \
+          (expr1)op(expr2),                                         \
+          #expr1 " " #op " " #expr2,                                \
+          "({} vs. {})",                                            \
+          expr1,                                                    \
+          expr2);                                                   \
+    }                                                               \
+  } while (0)
+
+#define _COLLAGEN_CHECK_OP(expr1, expr2, op, ...) \
+  _COLLAGEN_CHECK_OP_HELPER(                      \
+      _COLLAGEN_CHECK_IMPL, expr1, expr2, op, ##__VA_ARGS__)
+
+// For all below macros, an additional message can be passed using a
+// format string and arguments, as with `fmt::format`.
+#define COLLAGEN_CHECK(expr, ...) \
+  _COLLAGEN_CHECK_IMPL(expr, #expr, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_GT(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, >, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_GE(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, >=, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_LT(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, <, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_LE(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, <=, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_EQ(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, ==, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_NE(e1, e2, ...) \
+  _COLLAGEN_CHECK_OP(e1, e2, !=, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_NULL(e, ...) COLLAGEN_CHECK(e == nullptr, ##__VA_ARGS__)
+#define COLLAGEN_CHECK_NOT_NULL(e, ...) \
+  COLLAGEN_CHECK(e != nullptr, ##__VA_ARGS__)
+
+#define COLLAGEN_ARROW_CHECK(expr)                       \
+  do {                                                   \
+    ::arrow::Status _s = (expr);                         \
+    _COLLAGEN_CHECK_IMPL(_s.ok(), #expr, _s.ToString()); \
+  } while (false)
+
+#define _COLLAGEN_ARROW_ASSIGN_OR_THROW_IMPL(result_name, lhs, rexpr) \
+  auto&& result_name = (rexpr);                                       \
+  _COLLAGEN_CHECK_IMPL(                                               \
+      result_name.ok(), #rexpr, result_name.status().ToString());     \
+  lhs = std::move(result_name).ValueUnsafe();
+
+#define COLLAGEN_CONCAT_IMPL(x, y) x##y
+#define COLLAGEN_CONCAT(x, y) COLLAGEN_CONCAT_IMPL(x, y)
+
+#define COLLAGEN_ARROW_ASSIGN_OR_THROW(lhs, rexpr) \
+  _COLLAGEN_ARROW_ASSIGN_OR_THROW_IMPL(            \
+      COLLAGEN_CONCAT(_error_or_value, __COUNTER__), lhs, rexpr);
+
+class CollagenException : public std::exception {
+ public:
+  CollagenException(
+      grpc::StatusCode statusCode,
+      std::string_view errorDescription,
+      std::string_view errorExpression,
+      std::string_view sourceFile,
+      size_t sourceLine,
+      std::string_view sourceFunction)
+      : statusCode_(statusCode),
+        errorMessage_(createErrorMessage(
+            errorDescription,
+            errorExpression,
+            sourceFile,
+            sourceLine,
+            sourceFunction)) {}
+
+  const char* what() const noexcept override {
+    return errorMessage_.data();
+  }
+
+  grpc::Status status() const {
+    return grpc::Status(statusCode_, what());
+  }
+
+ private:
+  std::string createErrorMessage(
+      std::string_view errorDescription,
+      std::string_view errorExpression,
+      std::string_view sourceFile,
+      size_t sourceLine,
+      std::string_view sourceFunction) {
+    return fmt::format(
+        "CollagenException: {}\n"
+        "Status code: {}\n"
+        "Expression: {}\n"
+        "File: {}\n"
+        "Line: {}\n"
+        "Function: {}",
+        errorDescription,
+        statusCode_,
+        errorExpression,
+        sourceFile,
+        sourceLine,
+        sourceFunction);
+  }
+
+  const grpc::StatusCode statusCode_;
+  const std::string errorMessage_;
+};
+
+struct StringEmpty {
+  operator std::string_view() const {
+    return "";
+  }
+};
+
+inline StringEmpty errorMessage() {
+  return {};
+}
+
+inline const char* errorMessage(const char* s) {
+  return s;
+}
+
+inline std::string errorMessage(const std::string& str) {
+  return str;
+}
+
+template <typename... Args>
+std::string errorMessage(fmt::string_view fmt, const Args&... args) {
+  return fmt::vformat(fmt, fmt::make_format_args(args...));
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/Optimizer.h"
+
+#include <glog/logging.h>
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/VeloxHistory.h"
+#include "velox/expression/Expr.h"
+
+using namespace facebook;
+
+namespace axiom::collagen {
+namespace {
+
+// Helper to check if the root node of a plan is a CREATE TABLE operation.
+const facebook::axiom::logical_plan::TableWriteNode* FOLLY_NULLABLE
+isCreateTableNode(
+    const facebook::axiom::logical_plan::LogicalPlanNodePtr& plan) {
+  if (!plan) {
+    return nullptr;
+  }
+
+  // We only check the top node of the plan for CREATE TABLE operations.
+  if (auto* writeNode =
+          dynamic_cast<const facebook::axiom::logical_plan::TableWriteNode*>(
+              plan.get())) {
+    if (writeNode->writeKind() ==
+        facebook::axiom::logical_plan::WriteKind::kCreate) {
+      return writeNode;
+    }
+  }
+
+  return nullptr;
+}
+
+// Creates a table with connector metadata.
+facebook::axiom::connector::TablePtr createTable(
+    const facebook::axiom::logical_plan::TableWriteNode& writeNode,
+    const std::string& connectorId) {
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId);
+
+  // Convert string options to velox::Variant options
+  folly::F14FastMap<std::string, velox::Variant> options;
+  for (const auto& [key, value] : writeNode.options()) {
+    options[key] = velox::Variant(value);
+  }
+
+  // Build the table schema from column names and column expressions
+  const auto& columnNames = writeNode.columnNames();
+  const auto& columnExpressions = writeNode.columnExpressions();
+
+  std::vector<std::string> schemaNames;
+  std::vector<velox::TypePtr> schemaTypes;
+  schemaNames.reserve(columnNames.size());
+  schemaTypes.reserve(columnExpressions.size());
+
+  for (size_t i = 0; i < columnNames.size(); ++i) {
+    schemaNames.push_back(columnNames[i]);
+    schemaTypes.push_back(columnExpressions[i]->type());
+  }
+
+  auto tableSchema = velox::ROW(std::move(schemaNames), std::move(schemaTypes));
+
+  auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
+      "pyspark_session");
+  return metadata->createTable(
+      session, writeNode.tableName(), tableSchema, options, /*explain=*/false);
+}
+
+} // namespace
+
+facebook::axiom::optimizer::PlanAndStats optimize(
+    const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
+    const std::string& connectorId,
+    velox::memory::MemoryPool* pool) {
+  // Set up thread local structures.
+  auto allocator = std::make_unique<velox::HashStringAllocator>(pool);
+  auto context =
+      std::make_unique<facebook::axiom::optimizer::QueryGraphContext>(
+          *allocator);
+  facebook::axiom::optimizer::queryCtx() = context.get();
+
+  // Fetch connector and set up schema resolver.
+  auto connector = velox::connector::getConnector(connectorId);
+  auto schemaResolver =
+      std::make_shared<facebook::axiom::connector::SchemaResolver>();
+
+  // Check if this is a CREATE TABLE operation and set up schema resolver.
+  if (auto* createTableNode = isCreateTableNode(logicalPlan)) {
+    auto table = createTable(*createTableNode, connectorId);
+    schemaResolver->setTargetTable(
+        connectorId, createTableNode->tableName(), std::move(table));
+  }
+
+  auto history = std::make_unique<facebook::axiom::optimizer::VeloxHistory>();
+  facebook::axiom::optimizer::OptimizerOptions optimizerOptions;
+  optimizerOptions.sampleJoins = false;
+
+  facebook::axiom::optimizer::MultiFragmentPlan::Options runnerOpts{
+      .numWorkers = 1,
+      .numDrivers = 1,
+  };
+
+  auto queryCtx = velox::core::QueryCtx::create();
+  velox::exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool);
+
+  auto session =
+      std::make_shared<facebook::axiom::Session>(queryCtx->queryId());
+
+  facebook::axiom::optimizer::Optimization opt(
+      session,
+      *logicalPlan,
+      *schemaResolver,
+      *history,
+      queryCtx,
+      evaluator,
+      optimizerOptions,
+      runnerOpts);
+  auto best = opt.bestPlan();
+  LOG(INFO) << "Axiom best plan:\n" << best->toString(false);
+
+  return opt.toVeloxPlan(best->op);
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/Optimizer.h
+++ b/axiom/pyspark/Optimizer.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/ToVelox.h"
+#include "velox/common/memory/Memory.h"
+
+namespace axiom::collagen {
+
+/// Takes an Axiom logical plan as input and returns optimized Velox physical
+/// plan fragments using Axiom (axiom/optimizer).
+///
+/// @param logicalPlan The input logical plan.
+/// @param connectorId Id of the connector to be used to resolve metadata.
+/// @param pool Memory pool to be used for allocating structures required by the
+/// query optimizer.
+::facebook::axiom::optimizer::PlanAndStats optimize(
+    const ::facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
+    const std::string& connectorId,
+    ::facebook::velox::memory::MemoryPool* pool);
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkPlanPrinter.cpp
+++ b/axiom/pyspark/SparkPlanPrinter.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/SparkPlanPrinter.h"
+
+#include <sstream>
+#include "axiom/pyspark/SparkVeloxConverter.h"
+
+namespace axiom::collagen {
+namespace {
+
+struct SparkPlanPrinterContext : public SparkPlanVisitorContext {
+  std::stringstream out;
+  int32_t indent{0};
+};
+
+std::string_view getGroupTypeString(
+    spark::connect::Aggregate::GroupType groupType) {
+  switch (groupType) {
+    case spark::connect::Aggregate::GROUP_TYPE_GROUPBY:
+      return "GROUPBY";
+    case spark::connect::Aggregate::GROUP_TYPE_ROLLUP:
+      return "ROLLUP";
+    case spark::connect::Aggregate::GROUP_TYPE_CUBE:
+      return "CUBE";
+    case spark::connect::Aggregate::GROUP_TYPE_PIVOT:
+      return "PIVOT";
+    case spark::connect::Aggregate::GROUP_TYPE_UNSPECIFIED:
+      return "UNSPECIFIED";
+    default:
+      COLLAGEN_NYI(
+          "Group type to variant not implemented yet for '{}'", groupType);
+  }
+}
+
+class SparkPlanPrinter : public SparkPlanVisitor {
+ public:
+  virtual ~SparkPlanPrinter() = default;
+
+  void visit(
+      const spark::connect::Read_NamedTable& namedTable,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Read[" << context.planId << "]";
+    out << "[" << namedTable.unparsed_identifier() << "] ";
+    out << "(named table)" << std::endl;
+
+    for (const auto& option : namedTable.options()) {
+      out << extraIndent(context) << option.first << " - " << option.second
+          << std::endl;
+    }
+  }
+
+  void visit(
+      const spark::connect::LocalRelation& localRelation,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- LocalRelation[" << context.planId << "]" << std::endl;
+    out << extraIndent(context);
+    out << "Schema: " << localRelation.schema() << std::endl;
+    out << extraIndent(context);
+    out << "Input bytes: " << localRelation.data().size() << std::endl;
+  }
+
+  void visit(
+      const spark::connect::Project& project,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Project[" << context.planId << "]:" << std::endl;
+
+    for (const auto& expression : project.expressions()) {
+      out << extraIndent(context);
+      SparkPlanVisitor::visit(expression, context);
+      out << std::endl;
+    }
+    addIndent(context);
+    SparkPlanVisitor::visit(project, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::Filter& filter,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Filter[" << context.planId << "] ";
+    SparkPlanPrinter::visit(filter.condition(), context);
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(filter, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::Aggregate& aggregate,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Aggregate[" << context.planId << "]:" << std::endl;
+
+    // Print group type.
+    out << extraIndent(context)
+        << "Group Type: " << getGroupTypeString(aggregate.group_type())
+        << std::endl;
+
+    // Print grouping expressions.
+    if (!aggregate.grouping_expressions().empty()) {
+      out << extraIndent(context) << "Grouping Expressions:" << std::endl;
+      for (const auto& groupingExpr : aggregate.grouping_expressions()) {
+        out << extraIndent(context) << "  ";
+        SparkPlanPrinter::visit(groupingExpr, context);
+        out << std::endl;
+      }
+    }
+
+    // Print aggregate expressions.
+    if (!aggregate.aggregate_expressions().empty()) {
+      out << extraIndent(context) << "Aggregate Expressions:" << std::endl;
+      for (const auto& aggExpr : aggregate.aggregate_expressions()) {
+        out << extraIndent(context) << "  ";
+        SparkPlanPrinter::visit(aggExpr, context);
+        out << std::endl;
+      }
+    }
+
+    // Print pivot information if present.
+    if (aggregate.has_pivot()) {
+      const auto& pivot = aggregate.pivot();
+      out << extraIndent(context) << "Pivot:" << std::endl;
+      out << extraIndent(context) << "  Column: ";
+      SparkPlanPrinter::visit(pivot.col(), context);
+      out << std::endl;
+
+      if (!pivot.values().empty()) {
+        out << extraIndent(context) << "  Values: ";
+        bool first = true;
+        for (const auto& value : pivot.values()) {
+          if (!first) {
+            out << ", ";
+          }
+          SparkPlanPrinter::visit(value, context);
+          first = false;
+        }
+        out << std::endl;
+      }
+    }
+  }
+
+  void visit(const spark::connect::Join& join, SparkPlanVisitorContext& context)
+      override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Join[" << context.planId << "] (type=" << join.join_type()
+        << "): ";
+    SparkPlanPrinter::visit(join.join_condition(), context);
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanPrinter::visit(join.left(), context);
+    SparkPlanPrinter::visit(join.right(), context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::Limit& limit,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Limit[" << context.planId << "] ";
+    out << "(" << limit.limit() << ")";
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(limit, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::Offset& offset,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Offset[" << context.planId << "] ";
+    out << "(" << offset.offset() << ")";
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(offset, context);
+    removeIndent(context);
+  }
+
+  void visit(const spark::connect::SQL& sql, SparkPlanVisitorContext& context)
+      override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- SQL[" << context.planId << "]:" << std::endl;
+    out << extraIndent(context) << sql.query() << std::endl;
+  }
+
+  void visit(
+      const spark::connect::SubqueryAlias& subqueryAlias,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Alias [" << context.planId << "]: ";
+    out << subqueryAlias.alias() << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(subqueryAlias, context);
+    removeIndent(context);
+  }
+
+  void visit(const spark::connect::ToDF& toDF, SparkPlanVisitorContext& context)
+      override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- ToDF[" << context.planId << "]:" << std::endl;
+
+    bool first = true;
+    for (const auto& columnName : toDF.column_names()) {
+      if (first) {
+        first = false;
+        out << extraIndent(context);
+      } else {
+        out << ", ";
+      }
+      out << columnName;
+    }
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(toDF, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::ShowString& showString,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- ShowString[" << context.planId << "]:" << std::endl;
+    out << extraIndent(context) << "num_rows: " << showString.num_rows()
+        << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(showString, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::WriteOperation& writeOperation,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- WriteOperation:";
+
+    if (writeOperation.has_source()) {
+      out << " (" << writeOperation.source() << ")";
+    }
+    out << std::endl;
+
+    // Writing to a path or table.
+    out << extraIndent(context);
+    switch (writeOperation.save_type_case()) {
+      case spark::connect::WriteOperation::kPath:
+        out << "path: " << writeOperation.path();
+        break;
+
+      case spark::connect::WriteOperation::kTable:
+        out << "table: " << writeOperation.table().table_name();
+        break;
+
+      case spark::connect::WriteOperation::SAVE_TYPE_NOT_SET:
+        out << "(not set)";
+        break;
+    }
+    out << std::endl;
+
+    addIndent(context);
+    SparkPlanVisitor::visit(writeOperation, context);
+    removeIndent(context);
+  }
+
+  void visit(const spark::connect::Sort& sort, SparkPlanVisitorContext& context)
+      override {
+    auto& out = getOutput(context);
+    out << indent(context);
+    out << "- Sort[" << context.planId << "]:" << std::endl;
+
+    // Print sort orders
+    if (!sort.order().empty()) {
+      out << extraIndent(context) << "Order by:" << std::endl;
+      for (const auto& sortOrder : sort.order()) {
+        out << extraIndent(context) << "  ";
+
+        // Print the expression being sorted
+        SparkPlanPrinter::visit(sortOrder.child(), context);
+
+        // Print sort direction
+        switch (sortOrder.direction()) {
+          case spark::connect::Expression::SortOrder::SORT_DIRECTION_ASCENDING:
+            out << " ASC";
+            break;
+          case spark::connect::Expression::SortOrder::SORT_DIRECTION_DESCENDING:
+            out << " DESC";
+            break;
+          default:
+            out << " ASC"; // Default
+            break;
+        }
+
+        // Print null ordering
+        switch (sortOrder.null_ordering()) {
+          case spark::connect::Expression::SortOrder::SORT_NULLS_FIRST:
+            out << " NULLS FIRST";
+            break;
+          case spark::connect::Expression::SortOrder::SORT_NULLS_LAST:
+            out << " NULLS LAST";
+            break;
+          default:
+            out << " NULLS LAST"; // Default
+            break;
+        }
+
+        out << std::endl;
+      }
+    }
+
+    addIndent(context);
+    SparkPlanVisitor::visit(sort, context);
+    removeIndent(context);
+  }
+
+  void visit(
+      const spark::connect::Relation& relation,
+      SparkPlanVisitorContext& context) override {
+    SparkPlanVisitor::visit(relation, context);
+  }
+
+  void visit(const spark::connect::Plan& plan, SparkPlanVisitorContext& context)
+      override {
+    SparkPlanVisitor::visit(plan, context);
+  }
+
+  // Expressions:
+
+  void visit(
+      const spark::connect::Expression& expression,
+      SparkPlanVisitorContext& context) override {
+    SparkPlanVisitor::visit(expression, context);
+  }
+
+  void visit(
+      const spark::connect::Expression::Literal& literal,
+      SparkPlanVisitorContext& context) override {
+    getOutput(context) << *toVeloxVariant(literal);
+  }
+
+  void visit(
+      const spark::connect::Expression::UnresolvedAttribute&
+          unresolvedAttribute,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << unresolvedAttribute.unparsed_identifier();
+    if (unresolvedAttribute.has_plan_id()) {
+      out << "[plan_id=" << unresolvedAttribute.plan_id() << "]";
+    } else {
+      out << "[none]";
+    }
+  }
+
+  void visit(
+      const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+      SparkPlanVisitorContext& context) override {
+    auto& out = getOutput(context);
+    out << unresolvedFunction.function_name() << "(";
+
+    bool first = true;
+    for (const auto& argument : unresolvedFunction.arguments()) {
+      if (first) {
+        first = false;
+      } else {
+        out << ", ";
+      }
+      visit(argument, context);
+    }
+    out << ")";
+  }
+
+  void visit(
+      const spark::connect::Expression::Alias& alias,
+      SparkPlanVisitorContext& context) override {
+    SparkPlanVisitor::visit(alias.expr(), context);
+
+    auto& out = getOutput(context);
+    bool first = true;
+
+    for (const auto& name : alias.name()) {
+      if (first) {
+        out << " AS ";
+        first = false;
+      } else {
+        out << ", ";
+      }
+      out << name;
+    }
+  }
+
+  void visit(
+      const spark::connect::Expression::UnresolvedExtractValue&
+          unresolvedExtractValue,
+      SparkPlanVisitorContext& context) override {
+    visit(unresolvedExtractValue.child(), context);
+
+    auto& out = getOutput(context);
+    out << "[";
+    visit(unresolvedExtractValue.extraction(), context);
+    out << "]";
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedStar& /*unresolvedStar*/,
+      SparkPlanVisitorContext& context) override {
+    getOutput(context) << "*";
+  }
+
+ private:
+  std::stringstream& getOutput(SparkPlanVisitorContext& context) const {
+    return static_cast<SparkPlanPrinterContext&>(context).out;
+  }
+
+  std::string indent(int32_t size) const {
+    return std::string(size * 2, ' ');
+  }
+
+  std::string indent(const SparkPlanVisitorContext& context) const {
+    return indent(static_cast<const SparkPlanPrinterContext&>(context).indent);
+  }
+
+  std::string extraIndent(const SparkPlanVisitorContext& context) const {
+    return indent(
+        static_cast<const SparkPlanPrinterContext&>(context).indent + 2);
+  }
+
+  void addIndent(SparkPlanVisitorContext& context) const {
+    static_cast<SparkPlanPrinterContext&>(context).indent++;
+  }
+
+  void removeIndent(SparkPlanVisitorContext& context) const {
+    static_cast<SparkPlanPrinterContext&>(context).indent--;
+  }
+};
+
+} // namespace
+
+std::string printSparkPlan(const spark::connect::Plan& plan) {
+  SparkPlanPrinter printer;
+  SparkPlanPrinterContext context;
+  printer.visit(plan, context);
+  return context.out.str();
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkPlanPrinter.h
+++ b/axiom/pyspark/SparkPlanPrinter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/pyspark/SparkPlanVisitor.h"
+#include "axiom/pyspark/third-party/protos/base.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+
+namespace axiom::collagen {
+
+// Returns a human-readable version of the input Spark connect logical plan.
+std::string printSparkPlan(const spark::connect::Plan& plan);
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkPlanVisitor.h
+++ b/axiom/pyspark/SparkPlanVisitor.h
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "axiom/pyspark/Exception.h"
+#include "axiom/pyspark/third-party/protos/base.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "axiom/pyspark/third-party/protos/commands.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "axiom/pyspark/third-party/protos/expressions.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "axiom/pyspark/third-party/protos/relations.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/type/Type.h"
+
+namespace axiom::collagen {
+
+class SparkPlanVisitorContext {
+ public:
+  virtual ~SparkPlanVisitorContext() = default;
+
+  int64_t planId{-1};
+
+  // Spark UnresovedFunction may resolve to either scalar or aggregate function.
+  // This flag is used to track if the current function is aggregate function.
+  bool isAggregate{false};
+
+  /// Lambda variable name to type mapping for resolving lambda body references.
+  /// Managed via LambdaScope RAII to support proper scoping for nested lambdas.
+  std::unordered_map<std::string, facebook::velox::TypePtr> lambdaVariables;
+};
+
+class SparkPlanVisitor {
+ public:
+  virtual ~SparkPlanVisitor() = default;
+
+  // 'Relation' visitor methods:
+
+  virtual void visit(
+      const spark::connect::Read_NamedTable& namedTable,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::Read_DataSource& dataSource,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::Read& read,
+      SparkPlanVisitorContext& context) {
+    switch (read.read_type_case()) {
+      case spark::connect::Read::kNamedTable:
+        visit(read.named_table(), context);
+        break;
+
+      case spark::connect::Read::kDataSource:
+        visit(read.data_source(), context);
+        break;
+
+      case spark::connect::Read::READ_TYPE_NOT_SET:
+        throw std::runtime_error("Read type not set on read relation.");
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::LocalRelation& localRelation,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::Project& project,
+      SparkPlanVisitorContext& context) {
+    visit(project.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Filter& filter,
+      SparkPlanVisitorContext& context) {
+    visit(filter.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Join& join,
+      SparkPlanVisitorContext& context) {
+    visit(join.join_condition(), context);
+    visit(join.left(), context);
+    visit(join.right(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Limit& limit,
+      SparkPlanVisitorContext& context) {
+    visit(limit.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Offset& offset,
+      SparkPlanVisitorContext& context) {
+    visit(offset.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::SQL& sql,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::SubqueryAlias& subqueryAlias,
+      SparkPlanVisitorContext& context) {
+    visit(subqueryAlias.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::ToDF& toDF,
+      SparkPlanVisitorContext& context) {
+    visit(toDF.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::ShowString& showString,
+      SparkPlanVisitorContext& context) {
+    visit(showString.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::WithColumnsRenamed& withColumnsRenamed,
+      SparkPlanVisitorContext& context) {
+    visit(withColumnsRenamed.input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::WithColumns& withColumns,
+      SparkPlanVisitorContext& context) {
+    visit(withColumns.input(), context);
+    for (const auto& alias : withColumns.aliases()) {
+      visit(alias, context);
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::Aggregate& aggregate,
+      SparkPlanVisitorContext& context) {
+    // Visit the input relation first.
+    visit(aggregate.input(), context);
+
+    // Visit all grouping expressions.
+    for (const auto& groupingExpr : aggregate.grouping_expressions()) {
+      visit(groupingExpr, context);
+    }
+
+    // Visit all aggregate expressions.
+    for (const auto& aggExpr : aggregate.aggregate_expressions()) {
+      visit(aggExpr, context);
+    }
+
+    // Visit pivot if present.
+    if (aggregate.has_pivot()) {
+      const auto& pivot = aggregate.pivot();
+
+      // Visit the pivot column expression.
+      visit(pivot.col(), context);
+
+      // Visit all pivot values
+      for (const auto& value : pivot.values()) {
+        visit(value, context);
+      }
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::SetOperation& setOperation,
+      SparkPlanVisitorContext& context) {
+    visit(setOperation.left_input(), context);
+    visit(setOperation.right_input(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Sort& sort,
+      SparkPlanVisitorContext& context) {
+    visit(sort.input(), context);
+    for (const auto& sortOrder : sort.order()) {
+      visit(sortOrder.child(), context);
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::Range& range,
+      SparkPlanVisitorContext& context) {}
+
+  // RAII abstraction to ensure the right planIds are attached to the context
+  // while traversing the plan tree.
+  struct RelationScope {
+    RelationScope(SparkPlanVisitorContext& context, int64_t planId)
+        : context_(context), parentPlanId_(context.planId) {
+      context_.planId = planId;
+    }
+
+    ~RelationScope() {
+      context_.planId = parentPlanId_;
+    }
+
+   private:
+    SparkPlanVisitorContext& context_;
+    const int64_t parentPlanId_;
+  };
+
+  // RAII abstraction to manage lambda variable scoping during lambda body
+  // translation. Supports proper shadowing for nested lambdas by
+  // saving/restoring any pre-existing variable bindings on scope exit.
+  struct LambdaScope {
+    LambdaScope(
+        SparkPlanVisitorContext& context,
+        const std::vector<std::pair<std::string, facebook::velox::TypePtr>>&
+            variables)
+        : context_(context) {
+      for (const auto& [name, type] : variables) {
+        auto it = context_.lambdaVariables.find(name);
+        if (it != context_.lambdaVariables.end()) {
+          savedVariables_.emplace_back(name, it->second);
+          it->second = type;
+        } else {
+          newVariables_.push_back(name);
+          context_.lambdaVariables[name] = type;
+        }
+      }
+    }
+
+    ~LambdaScope() {
+      for (const auto& name : newVariables_) {
+        context_.lambdaVariables.erase(name);
+      }
+      for (const auto& [name, type] : savedVariables_) {
+        context_.lambdaVariables[name] = type;
+      }
+    }
+
+    LambdaScope(const LambdaScope&) = delete;
+    LambdaScope& operator=(const LambdaScope&) = delete;
+
+   private:
+    SparkPlanVisitorContext& context_;
+    std::vector<std::pair<std::string, facebook::velox::TypePtr>>
+        savedVariables_;
+    std::vector<std::string> newVariables_;
+  };
+
+  virtual void visit(
+      const spark::connect::Relation& relation,
+      SparkPlanVisitorContext& context) {
+    RelationScope scope{context, relation.common().plan_id()};
+
+    switch (relation.rel_type_case()) {
+      case spark::connect::Relation::kRead:
+        visit(relation.read(), context);
+        break;
+
+      case spark::connect::Relation::kProject:
+        visit(relation.project(), context);
+        break;
+
+      case spark::connect::Relation::kFilter:
+        visit(relation.filter(), context);
+        break;
+
+      case spark::connect::Relation::kJoin:
+        visit(relation.join(), context);
+        break;
+
+      case spark::connect::Relation::kLimit:
+        visit(relation.limit(), context);
+        break;
+
+      case spark::connect::Relation::kOffset:
+        visit(relation.offset(), context);
+        break;
+
+      case spark::connect::Relation::kLocalRelation:
+        visit(relation.local_relation(), context);
+        break;
+
+      case spark::connect::Relation::kSql:
+        visit(relation.sql(), context);
+        break;
+
+      case spark::connect::Relation::kSubqueryAlias:
+        visit(relation.subquery_alias(), context);
+        break;
+
+      case spark::connect::Relation::kToDf:
+        visit(relation.to_df(), context);
+        break;
+
+      case spark::connect::Relation::kShowString:
+        visit(relation.show_string(), context);
+        break;
+
+      case spark::connect::Relation::kAggregate:
+        visit(relation.aggregate(), context);
+        break;
+
+      case spark::connect::Relation::kSort:
+        visit(relation.sort(), context);
+        break;
+
+      case spark::connect::Relation::kSetOp:
+        visit(relation.set_op(), context);
+        break;
+
+      case spark::connect::Relation::kWithColumnsRenamed:
+        visit(relation.with_columns_renamed(), context);
+        break;
+
+      case spark::connect::Relation::kWithColumns:
+        visit(relation.with_columns(), context);
+        break;
+
+      case spark::connect::Relation::kRange:
+        visit(relation.range(), context);
+        break;
+
+      default:
+        COLLAGEN_NYI(
+            "Relation type not supported yet: {}", relation.rel_type_case());
+    }
+  }
+
+  // 'Plan' visitor methods:
+
+  virtual void visit(
+      const spark::connect::Plan& plan,
+      SparkPlanVisitorContext& context) {
+    switch (plan.op_type_case()) {
+      case spark::connect::Plan::kRoot:
+        visit(plan.root(), context);
+        break;
+
+      case spark::connect::Plan::kCommand:
+        visit(plan.command(), context);
+        break;
+
+      default:
+        COLLAGEN_NYI("Plan type not implemented: {}", plan.op_type_case());
+    }
+  }
+
+  // 'Command' visitor methods:
+
+  virtual void visit(
+      const spark::connect::Command& command,
+      SparkPlanVisitorContext& context) {
+    switch (command.command_type_case()) {
+      case spark::connect::Command::kWriteOperation:
+        visit(command.write_operation(), context);
+        break;
+
+      default:
+        COLLAGEN_NYI(
+            "Command type not implemented: {}", command.command_type_case());
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::WriteOperation& writeOperation,
+      SparkPlanVisitorContext& context) {
+    visit(writeOperation.input(), context);
+  }
+
+  // 'Expression' visitor methods:
+
+  virtual void visit(
+      const spark::connect::Expression& expression,
+      SparkPlanVisitorContext& context) {
+    switch (expression.expr_type_case()) {
+      case spark::connect::Expression::kLiteral:
+        visit(expression.literal(), context);
+        break;
+
+      case spark::connect::Expression::kUnresolvedAttribute:
+        visit(expression.unresolved_attribute(), context);
+        break;
+
+      case spark::connect::Expression::kUnresolvedFunction:
+        visit(expression.unresolved_function(), context);
+        break;
+
+      case spark::connect::Expression::kAlias:
+        visit(expression.alias(), context);
+        break;
+
+      case spark::connect::Expression::kUnresolvedStar:
+        visit(expression.unresolved_star(), context);
+        break;
+
+      case spark::connect::Expression::kUnresolvedExtractValue:
+        visit(expression.unresolved_extract_value(), context);
+        break;
+
+      case spark::connect::Expression::kSortOrder:
+        visit(expression.sort_order(), context);
+        break;
+
+      case spark::connect::Expression::kLambdaFunction:
+        visit(expression.lambda_function(), context);
+        break;
+
+      case spark::connect::Expression::kUnresolvedNamedLambdaVariable:
+        visit(expression.unresolved_named_lambda_variable(), context);
+        break;
+
+      case spark::connect::Expression::kCast:
+        visit(expression.cast(), context);
+        break;
+
+      case spark::connect::Expression::EXPR_TYPE_NOT_SET:
+        COLLAGEN_FAIL(
+            "Expression type not set for plan node '{}'.", context.planId);
+
+      default:
+        COLLAGEN_NYI(
+            "Do not know how to handle expression type '{}'.",
+            expression.expr_type_case());
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::Literal& literal,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedAttribute&
+          unresolvedAttribute,
+      SparkPlanVisitorContext& context) {}
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+      SparkPlanVisitorContext& context) {
+    for (const auto& argument : unresolvedFunction.arguments()) {
+      visit(argument, context);
+    }
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::Alias& alias,
+      SparkPlanVisitorContext& context) {
+    visit(alias.expr(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedStar& /*unresolvedStar*/,
+      SparkPlanVisitorContext& /*context*/) {}
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedExtractValue&
+          unresolvedExtractValue,
+      SparkPlanVisitorContext& context) {
+    visit(unresolvedExtractValue.child(), context);
+    visit(unresolvedExtractValue.extraction(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::SortOrder& sortOrder,
+      SparkPlanVisitorContext& context) {
+    visit(sortOrder.child(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::LambdaFunction& lambdaFunction,
+      SparkPlanVisitorContext& context) {
+    // Visit the lambda body (function expression).
+    visit(lambdaFunction.function(), context);
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::UnresolvedNamedLambdaVariable&
+      /*unresolvedNamedLambdaVariable*/,
+      SparkPlanVisitorContext& /*context*/) {}
+
+  virtual void visit(
+      const spark::connect::Expression::Cast& cast,
+      SparkPlanVisitorContext& context) {
+    // Visit the expression being cast
+    visit(cast.expr(), context);
+  }
+};
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkToAxiom.cpp
+++ b/axiom/pyspark/SparkToAxiom.cpp
@@ -1,0 +1,1348 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/String.h>
+#include <string>
+
+#include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/ExprPrinter.h"
+#include "axiom/logical_plan/PlanPrinter.h"
+#include "axiom/pyspark/ArrowIpcLib.h"
+#include "axiom/pyspark/Exception.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/SparkVeloxConverter.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/type/Type.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook;
+
+namespace axiom::collagen {
+namespace {
+
+// Tries to resolve a function signature. Returns the return type if the
+// signature was found, or throws a descriptive error message.
+velox::TypePtr resolveFunction(
+    const std::string& functionName,
+    const std::vector<velox::TypePtr>& paramTypes,
+    std::vector<velox::TypePtr>& coercions) {
+  if (auto returnType = velox::resolveFunctionWithCoercions(
+          functionName, paramTypes, coercions)) {
+    return returnType;
+  }
+
+  // Signature doesn't exist. Return a descriptive error message.
+  auto availableSignatures = velox::getFunctionSignatures(functionName);
+
+  if (availableSignatures.empty()) {
+    COLLAGEN_USER_FAIL("Scalar function does not exist: '{}'", functionName);
+  }
+
+  std::vector<std::string> strings;
+  strings.reserve(paramTypes.size());
+  for (const auto& type : paramTypes) {
+    strings.push_back(type->toString());
+  }
+  auto signature = folly::join(", ", strings);
+  strings.clear();
+
+  for (const auto& item : availableSignatures) {
+    strings.push_back(item->toString());
+  }
+
+  COLLAGEN_USER_FAIL(
+      "Scalar function signature not supported: '{}({})'. Supported signatures: '{}'",
+      functionName,
+      signature,
+      folly::join(", ", strings));
+}
+
+} // namespace
+
+void SparkToAxiom::setPlanNode(
+    const facebook::axiom::logical_plan::LogicalPlanNodePtr& planNode,
+    int64_t planId) {
+  sparkPlanIdToPlanNode_.emplace(planId, planNode);
+  planNode_ = planNode;
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Read_NamedTable& namedTable,
+    SparkPlanVisitorContext& context) {
+  // This is a leaf, so there should not be an existing plan node.
+  COLLAGEN_CHECK_NULL(planNode_);
+
+  const auto& identifier = namedTable.unparsed_identifier();
+  COLLAGEN_CHECK(
+      identifier.find('.') == std::string::npos,
+      "Schema-qualified table names are not supported: {}",
+      identifier);
+
+  facebook::axiom::SchemaTableName tableName{schema_, identifier};
+
+  LOG(INFO) << "Creating table scan node [" << context.planId << "] for '"
+            << tableName.toString() << "'.";
+
+  // Lookup table metadata on the connector.
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(catalog_);
+  auto table = metadata->findTable(tableName);
+
+  COLLAGEN_CHECK_NOT_NULL(table);
+
+  auto planNode =
+      std::make_shared<facebook::axiom::logical_plan::TableScanNode>(
+          nextId(), table->type(), catalog_, tableName, table->type()->names());
+  setPlanNode(planNode, context.planId);
+  sparkAliasToPlanNode_.emplace(namedTable.unparsed_identifier(), planNode_);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::LocalRelation& localRelation,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "Creating a local relation node [" << context.planId << "]";
+  LOG(INFO) << "      Schema: " << localRelation.schema();
+
+  auto veloxType = velox::asRowType(
+      jsonToVeloxType(std::string_view(localRelation.schema())));
+  if (veloxType == nullptr) {
+    COLLAGEN_USER_FAIL("Top-level type must be a of type 'struct'");
+  }
+
+  // Deserialize the Arrow IPC payload into Velox Vectors.
+  auto arrowBuffer = arrow::Buffer::Wrap(
+      localRelation.data().data(), localRelation.data().size());
+  auto vectorInput = fromArrowIpc(arrowBuffer, pool_);
+
+  // If no data was found in the Arrow input, create one empty vector to
+  // carry the type.
+  if (vectorInput.empty()) {
+    vectorInput.push_back(velox::RowVector::createEmpty(veloxType, pool_));
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ValuesNode>(
+      nextId(), std::move(vectorInput));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Join& join,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "Creating a join node [" << context.planId
+            << "] (type=" << join.join_type() << "):";
+
+  // First traverse and generate the right (build) subtree.
+  SparkPlanVisitor::visit(join.right(), context);
+  auto rightSubtree = std::move(planNode_);
+
+  // Then traverse the left (current) subtree.
+  SparkPlanVisitor::visit(join.left(), context);
+
+  // TODO: Some joins set join.using_columns() instead of join_condition.
+  visit(join.join_condition(), context);
+
+  // Add the actual join node.
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::JoinNode>(
+      nextId(),
+      std::move(planNode_),
+      std::move(rightSubtree),
+      toAxiomJoinType(join.join_type()),
+      std::move(expr_));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Project& project,
+    SparkPlanVisitorContext& context) {
+  // Note that we first visit the project input subtree, before visiting the
+  // expressions themselves. This ensures that by the time we visit the
+  // expressions, we are ready to bind attributes to the output of the current
+  // planNode in `planNode_`.
+  SparkPlanVisitor::visit(project.input(), context);
+
+  LOG(INFO) << "Creating a project node [" << context.planId << "]";
+  std::vector<facebook::axiom::logical_plan::ExprPtr> exprs;
+  std::vector<std::string> exprNames;
+
+  exprs.reserve(project.expressions().size());
+  exprNames.reserve(project.expressions().size());
+
+  for (const auto& expression : project.expressions()) {
+    visit(expression, context);
+
+    // If no expression name is available, PySpark seems to fall back to use the
+    // type as the name.
+    auto exprName = std::move(exprName_);
+    if (exprName.empty()) {
+      exprName = expr_->type()->toString();
+      folly::toLowerAscii(exprName);
+    }
+
+    exprNames.push_back(std::move(exprName));
+    exprs.push_back(std::move(expr_));
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
+      nextId(), std::move(planNode_), std::move(exprNames), std::move(exprs));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Filter& filter,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(filter.input(), context);
+  visit(filter.condition(), context);
+
+  LOG(INFO) << "Creating a filter node [" << context.planId << "]: "
+            << facebook::axiom::logical_plan::ExprPrinter::toText(*expr_);
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::FilterNode>(
+      nextId(), std::move(planNode_), std::move(expr_));
+  COLLAGEN_CHECK_NULL(expr_);
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Aggregate& aggregate,
+    SparkPlanVisitorContext& context) {
+  // First visit the input relation
+  SparkPlanVisitor::visit(aggregate.input(), context);
+
+  LOG(INFO) << "Creating an aggregate node [" << context.planId << "]";
+
+  // init the vectors
+  std::vector<facebook::axiom::logical_plan::ExprPtr> groupingKeys;
+  groupingKeys.reserve(aggregate.grouping_expressions().size());
+
+  std::vector<facebook::axiom::logical_plan::AggregateExprPtr> aggregates;
+  aggregates.reserve(aggregate.aggregate_expressions().size());
+
+  std::vector<std::string> outputNames;
+  outputNames.reserve(
+      aggregate.grouping_expressions().size() +
+      aggregate.aggregate_expressions().size());
+
+  // Clear previous expression and name.
+  expr_.reset();
+  exprName_.clear();
+
+  // Process grouping expressions
+  for (const auto& groupingExpr : aggregate.grouping_expressions()) {
+    visit(groupingExpr, context);
+    groupingKeys.push_back(std::move(expr_));
+    auto exprName = std::move(exprName_);
+    if (exprName.empty()) {
+      // TODO: find out the pyspark convention if exprName is empty
+      exprName = "grouping_key_" + std::to_string(outputNames.size());
+    }
+    outputNames.push_back(std::move(exprName));
+  }
+
+  // Process each aggregate expression
+  COLLAGEN_CHECK_NULL(expr_);
+  COLLAGEN_CHECK(exprName_.empty());
+  for (const auto& aggExpr : aggregate.aggregate_expressions()) {
+    context.isAggregate = true;
+    visit(aggExpr, context);
+    context.isAggregate = false;
+
+    auto resolvedAggrExpr = std::dynamic_pointer_cast<
+        const facebook::axiom::logical_plan::AggregateExpr>(expr_);
+    COLLAGEN_CHECK(
+        resolvedAggrExpr != nullptr,
+        "expr_ must be a facebook::axiom::logical_plan::AggregateExpr, got: {}",
+        expr_ ? facebook::axiom::logical_plan::ExprPrinter::toText(*expr_)
+              : "null");
+    aggregates.push_back(resolvedAggrExpr);
+
+    // Use expression name if available, otherwise use function name
+    auto exprName = std::move(exprName_);
+    if (exprName.empty()) {
+      exprName = resolvedAggrExpr->name();
+    }
+    outputNames.push_back(std::move(exprName));
+
+    // Clear expression after processing
+    expr_.reset();
+    exprName_.clear();
+  }
+
+  // Create the aggregate node
+  // For now, we only support simple GROUP BY (no grouping sets)
+  std::vector<facebook::axiom::logical_plan::AggregateNode::GroupingSet>
+      groupingSets;
+
+  auto planNode =
+      std::make_shared<facebook::axiom::logical_plan::AggregateNode>(
+          nextId(),
+          std::move(planNode_),
+          std::move(groupingKeys),
+          std::move(groupingSets),
+          std::move(aggregates),
+          std::move(outputNames));
+
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Limit& limit,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(limit.input(), context);
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::LimitNode>(
+      nextId(), std::move(planNode_), 0, limit.limit());
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Offset& offset,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(offset.input(), context);
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::LimitNode>(
+      nextId(),
+      std::move(planNode_),
+      offset.offset(),
+      std::numeric_limits<int64_t>::max());
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::ToDF& toDF,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(toDF.input(), context);
+
+  LOG(INFO) << "Creating a project node [" << context.planId
+            << "] for toDF node.";
+  std::vector<ExprPtr> exprs;
+  std::vector<std::string> exprNames;
+
+  exprs.reserve(toDF.column_names().size());
+  exprNames.reserve(toDF.column_names().size());
+
+  for (const auto& columnName : toDF.column_names()) {
+    auto exprType = planNode_->outputType()->findChild(columnName);
+    exprs.push_back(
+        std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+            exprType, columnName));
+    exprNames.push_back(columnName);
+    LOG(INFO) << "    " << columnName;
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
+      nextId(), std::move(planNode_), std::move(exprNames), std::move(exprs));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::Alias& alias,
+    SparkPlanVisitorContext& context) {
+  COLLAGEN_CHECK_EQ(
+      alias.name().size(),
+      1,
+      "Expected exactly one alias name, got {}",
+      alias.name().size());
+  visit(alias.expr(), context);
+  exprName_ = *alias.name().begin();
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::UnresolvedStar& /*unresolvedStar*/,
+    SparkPlanVisitorContext& /*context*/) {
+  // UnresolvedStar represents "*" in expressions like count(*)
+
+  // For aggregate functions like count(*), we create a literal true
+  // expression since count(*) means count all rows regardless of column
+  // values
+  // TODO: handle cases where the "*" needs to actually be expanded to a list
+  // of column references. Fix this when Axiom supports SpecialFormExpr of type
+  // kStar
+  LOG(INFO) << "-- UnresolvedStar (*)";
+  CHECK_EQ(expr_, nullptr);
+
+  // Create a literal TRUE expression to represent * in count(*)
+  expr_ = std::make_shared<facebook::axiom::logical_plan::ConstantExpr>(
+      velox::BOOLEAN(), std::make_shared<velox::variant>(velox::variant(true)));
+
+  exprName_ = "*";
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::SubqueryAlias& subqueryAlias,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(subqueryAlias.input(), context);
+  sparkAliasToPlanNode_.emplace(subqueryAlias.alias(), planNode_);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::WriteOperation& writeOperation,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(writeOperation.input(), context);
+
+  // Only handle write to tables, other options like writing to
+  // path are not supported yet
+  if (writeOperation.save_type_case() !=
+      spark::connect::WriteOperation::kTable) {
+    COLLAGEN_NYI(
+        "Unsupported write operation type: {}",
+        writeOperation.save_type_case());
+  }
+
+  const auto& saveTable = writeOperation.table();
+  const auto& rawTableName = saveTable.table_name();
+  COLLAGEN_CHECK(
+      rawTableName.find('.') == std::string::npos,
+      "Schema-qualified table names are not supported: {}",
+      rawTableName);
+
+  facebook::axiom::SchemaTableName tableName{schema_, rawTableName};
+
+  LOG(INFO) << "Creating table write node [" << context.planId
+            << "] for table '" << tableName.toString() << "'";
+
+  facebook::axiom::logical_plan::WriteKind writeKind;
+  switch (writeOperation.mode()) {
+    case spark::connect::WriteOperation::SAVE_MODE_APPEND:
+      // APPEND mode: Insert rows into existing table
+      writeKind = facebook::axiom::logical_plan::WriteKind::kInsert;
+      break;
+
+    case spark::connect::WriteOperation::SAVE_MODE_ERROR_IF_EXISTS:
+      // ERROR_IF_EXISTS mode: Create new table, error if exists
+      writeKind = facebook::axiom::logical_plan::WriteKind::kCreate;
+      break;
+
+    case spark::connect::WriteOperation::SAVE_MODE_OVERWRITE:
+      // OVERWRITE mode: Not yet implemented
+      COLLAGEN_NYI("SAVE_MODE_OVERWRITE is not yet supported for table writes");
+
+    case spark::connect::WriteOperation::SAVE_MODE_IGNORE:
+      // IGNORE mode: Not yet implemented
+      COLLAGEN_NYI("SAVE_MODE_IGNORE is not yet supported for table writes");
+
+    default:
+      COLLAGEN_NYI("Unknown save mode: {}", writeOperation.mode());
+  }
+
+  // Get the input type to determine column names and create column
+  // expressions
+  const auto inputType = planNode_->outputType();
+  std::vector<std::string> columnNames;
+  std::vector<facebook::axiom::logical_plan::ExprPtr> columnExpressions;
+
+  columnNames.reserve(inputType->size());
+  columnExpressions.reserve(inputType->size());
+
+  for (uint32_t i = 0; i < inputType->size(); ++i) {
+    const auto& columnName = inputType->nameOf(i);
+    auto columnType = inputType->childAt(i);
+
+    columnNames.push_back(columnName);
+    columnExpressions.push_back(
+        std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+            columnType, columnName));
+  }
+
+  // Convert options map
+  folly::F14FastMap<std::string, std::string> options;
+  for (const auto& [key, value] : writeOperation.options()) {
+    options.emplace(key, value);
+  }
+
+  auto planNode =
+      std::make_shared<facebook::axiom::logical_plan::TableWriteNode>(
+          nextId(),
+          std::move(planNode_),
+          catalog_,
+          tableName,
+          writeKind,
+          std::move(columnNames),
+          std::move(columnExpressions),
+          std::move(options));
+
+  setPlanNode(planNode, context.planId);
+
+  // TODO: handle partitioning, bucketing, and sorting.
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Sort& sort,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(sort.input(), context);
+
+  LOG(INFO) << "Creating a sort node [" << context.planId << "]";
+
+  std::vector<facebook::axiom::logical_plan::SortingField> sortKeys;
+  sortKeys.reserve(sort.order().size());
+
+  for (const auto& sortOrder : sort.order()) {
+    visit(sortOrder.child(), context);
+    auto sortKey = expr_;
+
+    // Convert sort direction and null ordering
+    bool ascending = true;
+    bool nullsFirst = false;
+
+    switch (sortOrder.direction()) {
+      case spark::connect::Expression::SortOrder::SORT_DIRECTION_ASCENDING:
+        ascending = true;
+        break;
+      case spark::connect::Expression::SortOrder::SORT_DIRECTION_DESCENDING:
+        ascending = false;
+        break;
+      default:
+        ascending = true;
+        break;
+    }
+
+    switch (sortOrder.null_ordering()) {
+      case spark::connect::Expression::SortOrder::SORT_NULLS_FIRST:
+        nullsFirst = true;
+        break;
+      case spark::connect::Expression::SortOrder::SORT_NULLS_LAST:
+        nullsFirst = false;
+        break;
+      default:
+        nullsFirst = false;
+        break;
+    }
+
+    facebook::axiom::logical_plan::SortOrder order(ascending, nullsFirst);
+    sortKeys.push_back(
+        facebook::axiom::logical_plan::SortingField{sortKey, order});
+    expr_.reset();
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::SortNode>(
+      nextId(), std::move(planNode_), std::move(sortKeys));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Range& range,
+    SparkPlanVisitorContext& context) {
+  // This is a leaf node, so there should not be an existing plan node.
+  COLLAGEN_CHECK_NULL(planNode_);
+
+  // Extract range parameters
+  int64_t start = range.has_start() ? range.start() : 0;
+  int64_t end = range.end();
+  int64_t step = range.step();
+
+  LOG(INFO) << "Creating range node [" << context.planId
+            << "] with start=" << start << ", end=" << end << ", step=" << step;
+
+  // Validate step parameter
+  COLLAGEN_CHECK_NE(step, 0, "Range step cannot be zero");
+
+  // Calculate the number of elements in the range
+  int32_t numElements;
+  if (step > 0) {
+    numElements = (end > start) ? (end - start + step - 1) / step : 0;
+  } else {
+    numElements = (start > end) ? (start - end - step - 1) / (-step) : 0;
+  }
+
+  // Create the output type: single BIGINT column named "id"
+  auto outputType = velox::ROW({"id"}, {velox::BIGINT()});
+
+  // Generate the range values as Velox vectors
+  std::vector<velox::RowVectorPtr> values;
+
+  if (numElements > 0) {
+    // Create a flat vector for the range values
+    auto rangeVector =
+        velox::BaseVector::create(velox::BIGINT(), numElements, pool_);
+    auto flatVector = rangeVector->asFlatVector<int64_t>();
+
+    // Populate the vector with range values
+    int64_t currentValue = start;
+    for (int32_t i = 0; i < numElements; ++i) {
+      flatVector->set(i, currentValue);
+      currentValue += step;
+    }
+
+    // Create a row vector containing the range values
+    std::vector<velox::VectorPtr> children = {rangeVector};
+    auto rowVector = std::make_shared<velox::RowVector>(
+        pool_, outputType, nullptr, numElements, std::move(children));
+    values.push_back(rowVector);
+  } else {
+    // Create an empty vector with the correct type
+    values.push_back(velox::RowVector::createEmpty(outputType, pool_));
+  }
+
+  // Create the ValuesNode
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ValuesNode>(
+      nextId(), std::move(values));
+  setPlanNode(planNode, context.planId);
+}
+
+namespace {
+
+struct Identifier {
+  std::string name;
+  std::string parent;
+  std::string connectorId;
+
+  void updateReference(
+      const facebook::axiom::logical_plan::LogicalPlanNodePtr& planNode) {
+    if (auto tableScan = std::dynamic_pointer_cast<
+            const facebook::axiom::logical_plan::TableScanNode>(planNode)) {
+      parent = tableScan->tableName().toString();
+      connectorId = tableScan->connectorId();
+    }
+  }
+};
+
+Identifier parseIdentifier(const std::string& input) {
+  std::vector<std::string> parts;
+  folly::split('.', input, parts, true); // true = ignore empty tokens
+
+  if (parts.size() == 1) {
+    return {.name = parts[0]};
+  } else if (parts.size() == 2) {
+    return {.name = parts[1], .parent = parts[0]};
+  } else if (parts.size() == 3) {
+    return {.name = parts[2], .parent = parts[1], .connectorId = parts[0]};
+  }
+  COLLAGEN_FAIL("Unable to parse identifier: '{}'", input);
+}
+
+} // namespace
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::UnresolvedAttribute& unresolvedAttribute,
+    SparkPlanVisitorContext& context) {
+  auto referencePlanId = unresolvedAttribute.plan_id();
+  LOG(INFO) << "-- Unresolved attribute: "
+            << unresolvedAttribute.unparsed_identifier() << " - "
+            << referencePlanId;
+  COLLAGEN_CHECK_NULL(
+      expr_,
+      "Found unexpected expression '{}'",
+      facebook::axiom::logical_plan::ExprPrinter::toText(*expr_));
+  COLLAGEN_CHECK_NOT_NULL(planNode_);
+
+  velox::TypePtr exprType;
+  auto identifier = parseIdentifier(unresolvedAttribute.unparsed_identifier());
+  exprName_ = identifier.name;
+
+  // First check if the input tree has an explicit plan id set; if it does,
+  // check the output of that plan node.
+  if (unresolvedAttribute.has_plan_id()) {
+    // Look up the output type of the plan id referenced by this attribute
+    // node.
+    auto it = sparkPlanIdToPlanNode_.find(referencePlanId);
+    if (it == sparkPlanIdToPlanNode_.end()) {
+      COLLAGEN_USER_FAIL(
+          "Unable to find Spark Connect plan id: {}", referencePlanId);
+    }
+    exprType = it->second->outputType()->findChild(exprName_);
+    identifier.updateReference(it->second);
+  } else if (!identifier.parent.empty()) {
+    // Look up the output type of the plan id referenced by the alias name.
+    auto it = sparkAliasToPlanNode_.find(identifier.parent);
+    if (it == sparkAliasToPlanNode_.end()) {
+      COLLAGEN_USER_FAIL(
+          "Unable to find Spark Connect reference: '{}'", identifier.parent);
+    }
+    exprType = it->second->outputType()->findChild(exprName_);
+    identifier.updateReference(it->second);
+  }
+  // If an explicit plan id wasn't set, try to resolve the attribute in the
+  // output of the last plan node.
+  else {
+    if (auto idx = planNode_->outputType()->getChildIdxIfExists(exprName_)) {
+      exprType = planNode_->outputType()->childAt(idx.value());
+    } else {
+      COLLAGEN_USER_FAIL(
+          "Unable to resolve reference '{}'.",
+          unresolvedAttribute.unparsed_identifier());
+    }
+  }
+  expr_ = std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+      exprType, identifier.name);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+    SparkPlanVisitorContext& context) {
+  const auto& functionName = unresolvedFunction.function_name();
+  LOG(INFO) << "-- Unresolved function: " << functionName;
+  CHECK_EQ(expr_, nullptr);
+
+  std::vector<facebook::axiom::logical_plan::ExprPtr> params;
+  std::vector<velox::TypePtr> paramTypes;
+
+  params.reserve(unresolvedFunction.arguments().size());
+  paramTypes.reserve(unresolvedFunction.arguments().size());
+
+  // Check if this is a higher-order function that takes a lambda.
+  // For these functions, we need to infer lambda parameter types from
+  // the array argument before visiting the lambda.
+  // Higher-order functions that take lambda arguments.
+  // These functions are handled specially to infer lambda parameter types
+  // from the array/collection argument types.
+  const bool isHigherOrderFunction = functionName == "transform" ||
+      functionName == "filter" || functionName == "zip_with" ||
+      functionName == "map_zip_with" || functionName == "transform_values" ||
+      functionName == "transform_keys" || functionName == "exists" ||
+      functionName == "forall" || functionName == "map_filter" ||
+      functionName == "find_first_index" || functionName == "aggregate";
+
+  if (isHigherOrderFunction && unresolvedFunction.arguments().size() >= 2) {
+    // For higher-order functions, first visit the array/collection argument
+    // to determine the element type for lambda parameter inference.
+    visitHigherOrderFunction(unresolvedFunction, context, params, paramTypes);
+    return;
+  }
+
+  for (const auto& argument : unresolvedFunction.arguments()) {
+    visit(argument, context);
+    paramTypes.push_back(expr_->type());
+    params.push_back(std::move(expr_));
+  }
+
+  if (context.isAggregate) {
+    // Try to resolve as aggregate function.
+    const auto veloxFunctionName = toVeloxFunctionName(functionName);
+    auto finalType =
+        velox::exec::resolveResultType(veloxFunctionName, paramTypes);
+
+    LOG(INFO) << "Successfully resolved '" << veloxFunctionName
+              << "' as aggregate function";
+    expr_ = std::make_shared<facebook::axiom::logical_plan::AggregateExpr>(
+        finalType, veloxFunctionName, std::move(params));
+    return;
+  }
+
+  // Check if it's a conjunct. Conjuncts (AND/OR) need to generate a special
+  // form expression node.
+  //
+  // TODO: handle other types of special forms.
+  if (functionName == "and") {
+    expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+        velox::BOOLEAN(),
+        facebook::axiom::logical_plan::SpecialForm::kAnd,
+        std::move(params));
+  } else if (functionName == "or") {
+    expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+        velox::BOOLEAN(),
+        facebook::axiom::logical_plan::SpecialForm::kOr,
+        std::move(params));
+  } else if (functionName == "coalesce") {
+    // coalesce returns the first non-null value
+    // The return type is the same as the first argument
+    COLLAGEN_CHECK(!params.empty(), "coalesce requires at least one argument");
+    // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
+    auto resultType = params[0]->type();
+    expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+        resultType,
+        facebook::axiom::logical_plan::SpecialForm::kCoalesce,
+        std::move(params));
+  } else if (functionName == "if" || functionName == "when") {
+    // IF/WHEN expression handling:
+    // Simple: if(condition, then_value, else_value) -> SpecialForm::kIf
+    // Chained: when(c1, v1, c2, v2, ..., else) -> SpecialForm::kSwitch
+    COLLAGEN_CHECK(
+        params.size() >= 2,
+        "if/when requires at least 2 arguments (condition, then_value)");
+
+    // Capture type before move since evaluation order is unspecified
+    // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
+    auto resultType = params[1]->type();
+
+    // Chained when() with more than 3 args uses SWITCH
+    // Format: switch(cond1, val1, cond2, val2, ..., else_val)
+    if (params.size() > 3) {
+      expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+          resultType,
+          facebook::axiom::logical_plan::SpecialForm::kSwitch,
+          std::move(params));
+    } else {
+      // Simple when/otherwise uses IF
+      expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+          resultType,
+          facebook::axiom::logical_plan::SpecialForm::kIf,
+          std::move(params));
+    }
+  } else if (functionName == "isnotnull") {
+    // isnotnull(x) = not(is_null(x))
+    COLLAGEN_CHECK(params.size() == 1, "isnotnull requires exactly 1 argument");
+    auto isNullExpr = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+        velox::BOOLEAN(), "is_null", std::move(params));
+    expr_ = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+        velox::BOOLEAN(),
+        "not",
+        std::vector<facebook::axiom::logical_plan::ExprPtr>{isNullExpr});
+  } else {
+    const auto veloxFunctionName = toVeloxFunctionName(functionName);
+    std::vector<velox::TypePtr> coercions;
+
+    auto returnType =
+        collagen::resolveFunction(veloxFunctionName, paramTypes, coercions);
+
+    if (!coercions.empty()) {
+      for (auto i = 0; i < params.size(); i++) {
+        if (const auto& coercion = coercions.at(i)) {
+          params[i] =
+              std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+                  coercion,
+                  facebook::axiom::logical_plan::SpecialForm::kCast,
+                  params[i]);
+        }
+      }
+    }
+    expr_ = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+        returnType, veloxFunctionName, std::move(params));
+  }
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::UnresolvedExtractValue&
+        unresolvedExtractValue,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "-- Unresolved extract value: ";
+  std::vector<facebook::axiom::logical_plan::ExprPtr> params;
+
+  // First visit the child column.
+  visit(unresolvedExtractValue.child(), context);
+  auto childType = expr_->type();
+  params.emplace_back(std::move(expr_));
+
+  // Then visit the "extract" modifier.
+  visit(unresolvedExtractValue.extraction(), context);
+  params.emplace_back(std::move(expr_));
+
+  // Array subscript will return the type of the array elements.
+  if (childType->isArray()) {
+    expr_ = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+        childType->childAt(0), "subscript", std::move(params));
+  }
+  // Map subscript will return the type of map values.
+  else if (childType->isMap()) {
+    expr_ = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+        childType->childAt(1), "subscript", std::move(params));
+  }
+  // Row field subscript will return the type of the field.
+  else if (childType->isRow()) {
+    if (params.back()->type() == velox::VARCHAR() &&
+        params.back()->kind() ==
+            facebook::axiom::logical_plan::ExprKind::kConstant) {
+      auto constant = std::dynamic_pointer_cast<
+          const facebook::axiom::logical_plan::ConstantExpr>(params.back());
+      COLLAGEN_CHECK_NOT_NULL(constant);
+      auto fieldName = constant->value()->value<velox::TypeKind::VARCHAR>();
+
+      expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+          childType->asRow().findChild(fieldName),
+          facebook::axiom::logical_plan::SpecialForm::kDereference,
+          std::move(params));
+    } else {
+      COLLAGEN_USER_FAIL("Unexpected extract modifier for subfield.");
+    }
+  } else {
+    COLLAGEN_USER_FAIL(
+        "Wrong child type for extract value: '{}'", childType->toString());
+  }
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::WithColumnsRenamed& withColumnsRenamed,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(withColumnsRenamed.input(), context);
+
+  LOG(INFO) << "Creating a project node [" << context.planId
+            << "] for WithColumnsRenamed node.";
+
+  const auto& renameMap = withColumnsRenamed.rename_columns_map();
+  std::vector<ExprPtr> exprs;
+  std::vector<std::string> exprNames;
+
+  const auto inputType = planNode_->outputType();
+  exprs.reserve(inputType->size());
+  exprNames.reserve(inputType->size());
+
+  for (uint32_t i = 0; i < inputType->size(); ++i) {
+    const auto& originalName = inputType->nameOf(i);
+
+    // Check if this column should be renamed
+    std::string newName = originalName;
+    auto it = renameMap.find(originalName);
+    if (it != renameMap.end()) {
+      newName = it->second;
+      LOG(INFO) << "    Renaming column '" << originalName << "' to '"
+                << newName << "'";
+    }
+
+    auto exprType = inputType->childAt(i);
+    exprs.push_back(
+        std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+            exprType, originalName));
+    exprNames.push_back(newName);
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
+      nextId(), std::move(planNode_), std::move(exprNames), std::move(exprs));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::WithColumns& withColumns,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(withColumns.input(), context);
+
+  LOG(INFO) << "Creating a project node [" << context.planId
+            << "] for WithColumns node.";
+
+  std::vector<ExprPtr> exprs;
+  std::vector<std::string> exprNames;
+
+  const auto inputType = planNode_->outputType();
+
+  // Build a map of column names to their new expressions from the aliases.
+  // This allows us to replace existing columns or add new ones.
+  std::unordered_map<std::string, std::pair<ExprPtr, std::string>> newColumns;
+  for (const auto& alias : withColumns.aliases()) {
+    // Visit the expression to get the expr_
+    visit(alias.expr(), context);
+
+    // The alias should have exactly one name
+    COLLAGEN_CHECK(
+        alias.name_size() == 1,
+        "Expected exactly one name in WithColumns alias, got {}",
+        alias.name_size());
+
+    const auto& colName = alias.name(0);
+    newColumns[colName] = {std::move(expr_), colName};
+    LOG(INFO) << "    Adding/replacing column '" << colName << "'";
+  }
+
+  // First, add all existing columns (replacing if there's a new expression)
+  for (uint32_t i = 0; i < inputType->size(); ++i) {
+    const auto& originalName = inputType->nameOf(i);
+
+    auto it = newColumns.find(originalName);
+    if (it != newColumns.end()) {
+      // Replace this column with the new expression
+      exprs.push_back(std::move(it->second.first));
+      exprNames.push_back(it->second.second);
+      newColumns.erase(it); // Remove from map so we don't add it again
+    } else {
+      // Keep the original column
+      auto exprType = inputType->childAt(i);
+      exprs.push_back(
+          std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+              exprType, originalName));
+      exprNames.push_back(originalName);
+    }
+  }
+
+  // Then, add any remaining new columns that weren't replacements
+  for (auto& [colName, colData] : newColumns) {
+    exprs.push_back(std::move(colData.first));
+    exprNames.push_back(colData.second);
+  }
+
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
+      nextId(), std::move(planNode_), std::move(exprNames), std::move(exprs));
+  setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::Literal& literal,
+    SparkPlanVisitorContext& context) {
+  expr_ = std::make_shared<facebook::axiom::logical_plan::ConstantExpr>(
+      toVeloxType(literal), toVeloxVariant(literal));
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::Cast& cast,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "-- Cast expression";
+
+  // First, visit the expression being cast
+  visit(cast.expr(), context);
+  auto inputExpr = std::move(expr_);
+
+  // Determine the target type
+  velox::TypePtr targetType;
+  if (cast.has_type()) {
+    targetType = toVeloxType(cast.type());
+  } else if (cast.has_type_str()) {
+    // Parse the type string (e.g., "long", "string")
+    const auto& typeStr = cast.type_str();
+    if (typeStr == "long" || typeStr == "bigint") {
+      targetType = velox::BIGINT();
+    } else if (typeStr == "int" || typeStr == "integer") {
+      targetType = velox::INTEGER();
+    } else if (typeStr == "short" || typeStr == "smallint") {
+      targetType = velox::SMALLINT();
+    } else if (typeStr == "byte" || typeStr == "tinyint") {
+      targetType = velox::TINYINT();
+    } else if (typeStr == "double") {
+      targetType = velox::DOUBLE();
+    } else if (typeStr == "float" || typeStr == "real") {
+      targetType = velox::REAL();
+    } else if (typeStr == "string" || typeStr == "varchar") {
+      targetType = velox::VARCHAR();
+    } else if (typeStr == "boolean" || typeStr == "bool") {
+      targetType = velox::BOOLEAN();
+    } else if (typeStr == "binary" || typeStr == "varbinary") {
+      targetType = velox::VARBINARY();
+    } else if (typeStr == "date") {
+      targetType = velox::DATE();
+    } else if (typeStr == "timestamp") {
+      targetType = velox::TIMESTAMP();
+    } else {
+      COLLAGEN_NYI("Cast type string not supported: '{}'", typeStr);
+    }
+  } else {
+    COLLAGEN_FAIL("Cast expression must have either type or type_str set");
+  }
+
+  // Create a CAST special form expression
+  expr_ = std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+      targetType, facebook::axiom::logical_plan::SpecialForm::kCast, inputExpr);
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::SetOperation& setOperation,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "Creating a set operation node [" << context.planId
+            << "] (type=" << setOperation.set_op_type() << ")";
+
+  // Visit the left input relation first
+  SparkPlanVisitor::visit(setOperation.left_input(), context);
+  auto leftSubtree = std::move(planNode_);
+
+  // Visit the right input relation
+  SparkPlanVisitor::visit(setOperation.right_input(), context);
+  auto rightSubtree = std::move(planNode_);
+
+  // Create the inputs vector for the set operation
+  std::vector<facebook::axiom::logical_plan::LogicalPlanNodePtr> inputs;
+  inputs.push_back(std::move(leftSubtree));
+  inputs.push_back(std::move(rightSubtree));
+
+  // Determine if it's an ALL operation (preserve duplicates)
+  bool isAll = setOperation.has_is_all() && setOperation.is_all();
+
+  // Convert Spark set operation type to Axiom set operation type
+  auto operation = toAxiomSetOperation(setOperation.set_op_type(), isAll);
+
+  // Create the set operation node
+  auto planNode = std::make_shared<facebook::axiom::logical_plan::SetNode>(
+      nextId(), inputs, operation);
+
+  setPlanNode(planNode, context.planId);
+}
+
+std::string SparkToAxiom::toString() {
+  if (planNode_ == nullptr) {
+    return "<empty>";
+  }
+  return facebook::axiom::logical_plan::PlanPrinter::toText(*planNode_);
+}
+
+namespace {
+
+// Builds a dot-separated variable name from the name_parts of a lambda
+// variable protobuf message.
+std::string buildLambdaVariableName(
+    const spark::connect::Expression::UnresolvedNamedLambdaVariable& var) {
+  std::string name;
+  for (const auto& part : var.name_parts()) {
+    if (!name.empty()) {
+      name += ".";
+    }
+    name += part;
+  }
+  return name;
+}
+
+} // namespace
+
+void SparkToAxiom::visitHigherOrderFunction(
+    const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+    SparkPlanVisitorContext& context,
+    std::vector<facebook::axiom::logical_plan::ExprPtr>& params,
+    std::vector<velox::TypePtr>& paramTypes) {
+  const auto& functionName = unresolvedFunction.function_name();
+  LOG(INFO) << "-- Higher-order function: " << functionName;
+
+  // First, visit the array/collection argument to get its type.
+  const auto& firstArg = unresolvedFunction.arguments(0);
+  visit(firstArg, context);
+  auto arrayType = expr_->type();
+  paramTypes.push_back(arrayType);
+  params.push_back(std::move(expr_));
+
+  // Determine the lambda parameter type(s) based on the function and array
+  // type.
+  velox::TypePtr lambdaElementType = velox::UNKNOWN();
+
+  if (arrayType->isArray()) {
+    // For array functions, the lambda parameter is the array element type.
+    lambdaElementType = arrayType->childAt(0);
+  } else if (arrayType->isMap()) {
+    // For map functions, we'll handle key/value types separately below.
+    lambdaElementType = arrayType->childAt(1); // value type by default
+  }
+
+  // Process remaining arguments, inferring lambda parameter types.
+  int lambdaIndex = 0;
+  for (int i = 1; i < unresolvedFunction.arguments().size(); ++i) {
+    const auto& argument = unresolvedFunction.arguments(i);
+
+    if (argument.has_lambda_function()) {
+      // This is a lambda argument - set up the lambda parameter types before
+      // visiting.
+      const auto& lambdaFunc = argument.lambda_function();
+      const auto numLambdaParams = lambdaFunc.arguments().size();
+
+      // Collect inferred lambda variable types.
+      std::vector<std::pair<std::string, velox::TypePtr>> inferredVars;
+      for (const auto& arg : lambdaFunc.arguments()) {
+        auto paramName = buildLambdaVariableName(arg);
+
+        // Determine the type for this lambda parameter based on the function.
+        // Currently only transform, filter, zip_with, and map_zip_with are
+        // supported.
+        velox::TypePtr paramType = velox::UNKNOWN();
+
+        if (functionName == "transform" || functionName == "filter" ||
+            functionName == "exists" || functionName == "forall" ||
+            functionName == "find_first_index") {
+          // Single-parameter lambdas: element type
+          if (numLambdaParams == 1) {
+            paramType = lambdaElementType;
+          } else if (numLambdaParams == 2) {
+            // Some functions have (element, index) signature
+            // First param is element, second is index (BIGINT)
+            if (&arg == &lambdaFunc.arguments(0)) {
+              paramType = lambdaElementType;
+            } else {
+              paramType = velox::BIGINT();
+            }
+          }
+        } else if (functionName == "zip_with") {
+          // zip_with(array1, array2, (x, y) -> ...)
+          // Lambda takes elements from both arrays
+          if (numLambdaParams == 2 && params.size() >= 2) {
+            auto secondArrayType = params[1]->type();
+            if (&arg == &lambdaFunc.arguments(0)) {
+              paramType = lambdaElementType; // first array element type
+            } else if (secondArrayType->isArray()) {
+              paramType =
+                  secondArrayType->childAt(0); // second array element type
+            }
+          }
+        } else if (functionName == "map_zip_with") {
+          // map_zip_with(map1, map2, (k, v1, v2) -> ...)
+          // Lambda takes key and values from both maps
+          if (numLambdaParams == 3 && params.size() >= 2) {
+            auto firstMapType = arrayType; // First map type
+            auto secondMapType = params[1]->type();
+            if (&arg == &lambdaFunc.arguments(0)) {
+              // First param is key type (from first map)
+              if (firstMapType->isMap()) {
+                paramType = firstMapType->childAt(0);
+              }
+            } else if (&arg == &lambdaFunc.arguments(1)) {
+              // Second param is value from first map
+              if (firstMapType->isMap()) {
+                paramType = firstMapType->childAt(1);
+              }
+            } else {
+              // Third param is value from second map
+              if (secondMapType->isMap()) {
+                paramType = secondMapType->childAt(1);
+              }
+            }
+          }
+        } else if (
+            functionName == "transform_values" ||
+            functionName == "transform_keys") {
+          // transform_values(map, (k, v) -> ...) or transform_keys(map, (k, v)
+          // -> ...) Lambda takes key and value from the map
+          if (numLambdaParams == 2 && arrayType->isMap()) {
+            if (&arg == &lambdaFunc.arguments(0)) {
+              // First param is key type
+              paramType = arrayType->childAt(0);
+            } else {
+              // Second param is value type
+              paramType = arrayType->childAt(1);
+            }
+          }
+        } else if (functionName == "map_filter") {
+          // map_filter(map, (key, value) -> boolean)
+          // Lambda takes key and value from the map, returns boolean
+          if (numLambdaParams == 2 && arrayType->isMap()) {
+            if (&arg == &lambdaFunc.arguments(0)) {
+              // First param is key type
+              paramType = arrayType->childAt(0);
+            } else {
+              // Second param is value type
+              paramType = arrayType->childAt(1);
+            }
+          }
+        } else if (functionName == "aggregate") {
+          // aggregate(array(T), S, function(S, T, S), function(S, R))
+          // PySpark sends "aggregate"; mapped to Velox "reduce".
+          // Lambda 0 (merge): params are (state S, element T)
+          // Lambda 1 (output): param is (state S)
+          // State type S comes from the initial value (params[1]).
+          velox::TypePtr stateType =
+              params.size() >= 2 ? params[1]->type() : velox::UNKNOWN();
+          if (lambdaIndex == 0) {
+            // Merge lambda: (S, T) -> S
+            if (&arg == &lambdaFunc.arguments(0)) {
+              paramType = stateType;
+            } else {
+              paramType = lambdaElementType;
+            }
+          } else {
+            // Output lambda: (S) -> R
+            paramType = stateType;
+          }
+        }
+
+        inferredVars.emplace_back(paramName, paramType);
+        LOG(INFO) << "  Lambda param '" << paramName << "' inferred type: "
+                  << (paramType ? paramType->toString() : "UNKNOWN");
+      }
+
+      // Create scope to pre-register inferred types. The scope ensures
+      // proper cleanup and supports nested lambda shadowing.
+      LambdaScope preScope(context, inferredVars);
+
+      // Now visit the lambda with the types already set up.
+      visit(argument, context);
+      paramTypes.push_back(expr_->type());
+      params.push_back(std::move(expr_));
+      ++lambdaIndex;
+    } else {
+      // Regular argument, visit normally.
+      visit(argument, context);
+      paramTypes.push_back(expr_->type());
+      params.push_back(std::move(expr_));
+    }
+  }
+
+  // Now resolve the function as usual.
+  const auto veloxFunctionName = toVeloxFunctionName(functionName);
+  std::vector<velox::TypePtr> coercions;
+
+  auto returnType =
+      collagen::resolveFunction(veloxFunctionName, paramTypes, coercions);
+
+  if (!coercions.empty()) {
+    for (auto i = 0; i < params.size(); i++) {
+      if (const auto& coercion = coercions.at(i)) {
+        params[i] =
+            std::make_shared<facebook::axiom::logical_plan::SpecialFormExpr>(
+                coercion,
+                facebook::axiom::logical_plan::SpecialForm::kCast,
+                params[i]);
+      }
+    }
+  }
+  expr_ = std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+      returnType, veloxFunctionName, std::move(params));
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::LambdaFunction& lambdaFunction,
+    SparkPlanVisitorContext& context) {
+  LOG(INFO) << "-- Lambda function with " << lambdaFunction.arguments().size()
+            << " arguments";
+  COLLAGEN_CHECK_NULL(
+      expr_,
+      "Found unexpected expression '{}'",
+      facebook::axiom::logical_plan::ExprPrinter::toText(*expr_));
+
+  // Build the lambda signature from the arguments.
+  std::vector<std::string> parameterNames;
+  std::vector<velox::TypePtr> parameterTypes;
+  std::vector<std::pair<std::string, velox::TypePtr>> scopeVars;
+
+  for (const auto& arg : lambdaFunction.arguments()) {
+    auto paramName = buildLambdaVariableName(arg);
+    parameterNames.push_back(paramName);
+
+    // Check if the type was pre-registered by visitHigherOrderFunction.
+    // If not, fall back to UNKNOWN.
+    velox::TypePtr paramType;
+    auto it = context.lambdaVariables.find(paramName);
+    if (it != context.lambdaVariables.end() && it->second != nullptr &&
+        it->second->kind() != velox::TypeKind::UNKNOWN) {
+      paramType = it->second;
+      LOG(INFO) << "  Using pre-inferred type for '" << paramName
+                << "': " << it->second->toString();
+    } else {
+      paramType = velox::UNKNOWN();
+      LOG(INFO) << "  No pre-inferred type for '" << paramName
+                << "', using UNKNOWN";
+    }
+    parameterTypes.push_back(paramType);
+    scopeVars.emplace_back(paramName, paramType);
+  }
+
+  // Create the signature as a RowType.
+  auto signature =
+      velox::ROW(std::move(parameterNames), std::move(parameterTypes));
+
+  // Create a lambda scope for proper variable scoping. This supports nested
+  // lambdas by saving/restoring any shadowed variables on scope exit.
+  LambdaScope scope(context, scopeVars);
+
+  // Visit the lambda body expression.
+  visit(lambdaFunction.function(), context);
+  auto bodyExpr = std::move(expr_);
+
+  // Create the LambdaExpr.
+  expr_ = std::make_shared<facebook::axiom::logical_plan::LambdaExpr>(
+      signature, std::move(bodyExpr));
+}
+
+void SparkToAxiom::visit(
+    const spark::connect::Expression::UnresolvedNamedLambdaVariable&
+        unresolvedNamedLambdaVariable,
+    SparkPlanVisitorContext& context) {
+  auto varName = buildLambdaVariableName(unresolvedNamedLambdaVariable);
+
+  LOG(INFO) << "-- Unresolved named lambda variable: " << varName;
+  COLLAGEN_CHECK_NULL(
+      expr_,
+      "Found unexpected expression '{}'",
+      facebook::axiom::logical_plan::ExprPrinter::toText(*expr_));
+
+  // Look up the variable type from the lambda context.
+  auto it = context.lambdaVariables.find(varName);
+  if (it != context.lambdaVariables.end()) {
+    // Create an InputReferenceExpr for the lambda variable.
+    expr_ = std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+        it->second, varName);
+  } else {
+    COLLAGEN_USER_FAIL(
+        "Lambda variable '{}' not found in current context", varName);
+  }
+  exprName_ = varName;
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkToAxiom.h
+++ b/axiom/pyspark/SparkToAxiom.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/SparkPlanVisitor.h"
+#include "axiom/pyspark/third-party/protos/relations.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/parse/PlanNodeIdGenerator.h"
+
+namespace axiom::collagen {
+
+/// Converts a Spark Connect json type representation into a Velox type.
+facebook::velox::TypePtr jsonToVeloxType(const std::string& jsonInput);
+
+/// Spark visitor implementation that converts the input protobuf Spark Connect
+/// plan into a axiom/logical_plan structure which can serve as an input to the
+/// Axiom optimizer.
+class SparkToAxiom : public SparkPlanVisitor {
+ public:
+  using LogicalPlanNodePtr =
+      ::facebook::axiom::logical_plan::LogicalPlanNodePtr;
+  using ExprPtr = ::facebook::axiom::logical_plan::ExprPtr;
+  using PlanNodeIdGenerator = ::facebook::velox::core::PlanNodeIdGenerator;
+  using MemoryPool = ::facebook::velox::memory::MemoryPool;
+
+  SparkToAxiom(std::string catalog, std::string schema, MemoryPool* pool)
+      : catalog_(std::move(catalog)), schema_(std::move(schema)), pool_(pool) {}
+
+  virtual ~SparkToAxiom() = default;
+
+  void visit(
+      const spark::connect::Read_NamedTable& namedTable,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::LocalRelation& localRelation,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(const spark::connect::Join& join, SparkPlanVisitorContext& context)
+      override;
+
+  void visit(
+      const spark::connect::Project& project,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Filter& filter,
+      SparkPlanVisitorContext& context) override;
+
+  virtual void visit(
+      const spark::connect::Aggregate& aggregate,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Limit& limit,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Offset& offset,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(const spark::connect::ToDF& toDF, SparkPlanVisitorContext& context)
+      override;
+
+  void visit(
+      const spark::connect::SubqueryAlias& subqueryAlias,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression& expression,
+      SparkPlanVisitorContext& context) override {
+    SparkPlanVisitor::visit(expression, context);
+  }
+
+  void visit(
+      const spark::connect::WriteOperation& writeOperation,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(const spark::connect::Sort& sort, SparkPlanVisitorContext& context)
+      override;
+
+  void visit(
+      const spark::connect::Range& range,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(const spark::connect::Plan& plan, SparkPlanVisitorContext& context)
+      override {
+    SparkPlanVisitor::visit(plan, context);
+  }
+
+  void visit(
+      const spark::connect::Relation& relation,
+      SparkPlanVisitorContext& context) override {
+    SparkPlanVisitor::visit(relation, context);
+  }
+
+  virtual void visit(
+      const spark::connect::Expression::Literal& literal,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::UnresolvedAttribute&
+          unresolvedAttribute,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::Alias& alias,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::UnresolvedStar& unresolvedStar,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::UnresolvedExtractValue&
+          unresolvedExtractValue,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::LambdaFunction& lambdaFunction,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::UnresolvedNamedLambdaVariable&
+          unresolvedNamedLambdaVariable,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::Expression::Cast& cast,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::SetOperation& setOperation,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::WithColumnsRenamed& withColumnsRenamed,
+      SparkPlanVisitorContext& context) override;
+
+  void visit(
+      const spark::connect::WithColumns& withColumns,
+      SparkPlanVisitorContext& context) override;
+
+  const LogicalPlanNodePtr& planNode() const {
+    return planNode_;
+  }
+
+  const ExprPtr& expr() const {
+    return expr_;
+  }
+
+  const std::string& exprName() const {
+    return exprName_;
+  }
+
+  std::string toString();
+
+ private:
+  std::string nextId() {
+    return planNodeIdGenerator_->next();
+  }
+
+  void setPlanNode(const LogicalPlanNodePtr& planNode, int64_t planId);
+
+  // Catalog to use for table resolution.
+  const std::string catalog_;
+
+  // Namespace to use for table resolution and creation.
+  const std::string schema_;
+
+  // Current plan node and expr objects being constructed when traversing the
+  // tree.
+  LogicalPlanNodePtr planNode_;
+  ExprPtr expr_;
+  std::string exprName_;
+
+  std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator_{
+      std::make_shared<PlanNodeIdGenerator>()};
+
+  MemoryPool* pool_;
+
+  /// Maintain mappings between the Spark Connect plan id and aliases to the
+  /// Axiom logical plan created as the plan tree is traversed.
+  std::unordered_map<int64_t, LogicalPlanNodePtr> sparkPlanIdToPlanNode_;
+  std::unordered_map<std::string, LogicalPlanNodePtr> sparkAliasToPlanNode_;
+
+  /// Helper method for processing higher-order functions that take lambdas.
+  /// Handles type inference for lambda parameters based on the array/collection
+  /// type before visiting the lambda expression.
+  void visitHigherOrderFunction(
+      const spark::connect::Expression::UnresolvedFunction& unresolvedFunction,
+      SparkPlanVisitorContext& context,
+      std::vector<ExprPtr>& params,
+      std::vector<facebook::velox::TypePtr>& paramTypes);
+};
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkVeloxConverter.cpp
+++ b/axiom/pyspark/SparkVeloxConverter.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/SparkVeloxConverter.h"
+#include <folly/String.h>
+#include <folly/json.h>
+#include <string>
+#include "axiom/pyspark/Exception.h"
+
+using namespace facebook;
+
+namespace axiom::collagen {
+
+std::string toVeloxFunctionName(const std::string& sparkFunctionName) {
+  static std::unordered_map<std::string, std::string> functionMap = {
+      // Arithmetic operators
+      {"+", "plus"},
+      {"-", "minus"},
+      {"*", "multiply"},
+      {"/", "divide"},
+      // Comparison operators
+      {"==", "eq"},
+      // Arithmetic operators (additional)
+      {"%", "mod"},
+      {">", "gt"},
+      {"<", "lt"},
+      {">=", "gte"},
+      {"<=", "lte"},
+      // Higher-order array/map functions (Spark SQL -> Velox/Presto names)
+      {"exists", "any_match"},
+      {"forall", "all_match"},
+      {"aggregate", "reduce"},
+      // Array/collection functions
+      {"size", "cardinality"},
+      {"array_repeat", "repeat"},
+      // Null checking functions
+      {"isnull", "is_null"},
+  };
+
+  auto it = functionMap.find(sparkFunctionName);
+  if (it != functionMap.end()) {
+    return it->second;
+  }
+  return sparkFunctionName;
+}
+
+facebook::axiom::logical_plan::JoinType toAxiomJoinType(
+    const spark::connect::Join::JoinType& joinType) {
+  switch (joinType) {
+    case spark::connect::Join::JOIN_TYPE_INNER:
+      return facebook::axiom::logical_plan::JoinType::kInner;
+
+    case spark::connect::Join::JOIN_TYPE_LEFT_OUTER:
+      return facebook::axiom::logical_plan::JoinType::kLeft;
+
+    case spark::connect::Join::JOIN_TYPE_RIGHT_OUTER:
+      return facebook::axiom::logical_plan::JoinType::kRight;
+
+    case spark::connect::Join::JOIN_TYPE_FULL_OUTER:
+      return facebook::axiom::logical_plan::JoinType::kFull;
+
+    default:
+      COLLAGEN_NYI("Unable to convert join type: {}", joinType);
+  }
+}
+
+facebook::axiom::logical_plan::SetOperation toAxiomSetOperation(
+    const spark::connect::SetOperation::SetOpType& setOpType,
+    bool isAll) {
+  switch (setOpType) {
+    case spark::connect::SetOperation::SET_OP_TYPE_UNION:
+      return isAll ? facebook::axiom::logical_plan::SetOperation::kUnionAll
+                   : facebook::axiom::logical_plan::SetOperation::kUnion;
+
+    case spark::connect::SetOperation::SET_OP_TYPE_INTERSECT:
+      return facebook::axiom::logical_plan::SetOperation::kIntersect;
+
+    case spark::connect::SetOperation::SET_OP_TYPE_EXCEPT:
+      return facebook::axiom::logical_plan::SetOperation::kExcept;
+
+    default:
+      COLLAGEN_NYI("Unable to convert set operation type: {}", setOpType);
+  }
+}
+
+velox::TypePtr toVeloxType(const spark::connect::DataType& sparkType) {
+  static std::unordered_map<int32_t, velox::TypePtr> sparkToVeloxType = {
+      {spark::connect::DataType::kNull, velox::UNKNOWN()},
+      {spark::connect::DataType::kBoolean, velox::BOOLEAN()},
+      {spark::connect::DataType::kByte, velox::TINYINT()},
+      {spark::connect::DataType::kShort, velox::SMALLINT()},
+      {spark::connect::DataType::kInteger, velox::INTEGER()},
+      {spark::connect::DataType::kLong, velox::BIGINT()},
+      {spark::connect::DataType::kFloat, velox::REAL()},
+      {spark::connect::DataType::kDouble, velox::DOUBLE()},
+      {spark::connect::DataType::kBinary, velox::VARBINARY()},
+      {spark::connect::DataType::kString, velox::VARCHAR()},
+      {spark::connect::DataType::kDate, velox::DATE()},
+      {spark::connect::DataType::kTimestamp, velox::TIMESTAMP()},
+  };
+  auto it = sparkToVeloxType.find(sparkType.kind_case());
+  if (it != sparkToVeloxType.end()) {
+    return it->second;
+  }
+
+  switch (sparkType.kind_case()) {
+    default:
+      COLLAGEN_NYI(
+          "Data type conversion not implemented yet for '{}'",
+          sparkType.kind_case());
+  }
+}
+
+// Returns the Velox type for a particular Spark literal.
+velox::TypePtr toVeloxType(const spark::connect::Expression::Literal& literal) {
+  static std::unordered_map<int32_t, velox::TypePtr> literalToType = {
+      {spark::connect::Expression::Literal::kNull, velox::UNKNOWN()},
+      {spark::connect::Expression::Literal::kBoolean, velox::BOOLEAN()},
+      {spark::connect::Expression::Literal::kByte, velox::TINYINT()},
+      {spark::connect::Expression::Literal::kShort, velox::SMALLINT()},
+      {spark::connect::Expression::Literal::kInteger, velox::INTEGER()},
+      {spark::connect::Expression::Literal::kLong, velox::BIGINT()},
+      {spark::connect::Expression::Literal::kFloat, velox::REAL()},
+      {spark::connect::Expression::Literal::kDouble, velox::DOUBLE()},
+      {spark::connect::Expression::Literal::kBinary, velox::VARBINARY()},
+      {spark::connect::Expression::Literal::kString, velox::VARCHAR()},
+      {spark::connect::Expression::Literal::kDate, velox::DATE()},
+      {spark::connect::Expression::Literal::kTimestamp, velox::TIMESTAMP()},
+  };
+  auto it = literalToType.find(literal.literal_type_case());
+  if (it != literalToType.end()) {
+    return it->second;
+  }
+
+  // Special cases:
+  switch (literal.literal_type_case()) {
+    // There is no map literal, as it seems.
+    case spark::connect::Expression::Literal::kArray:
+      return velox::ARRAY(toVeloxType(literal.array().element_type()));
+
+    // Returns the type of the null.
+    case spark::connect::Expression::Literal::kNull:
+      return toVeloxType(literal.null());
+
+    default:
+      COLLAGEN_NYI(
+          "Literal type conversion not implemented yet for '{}'",
+          literal.literal_type_case());
+  }
+}
+
+std::shared_ptr<velox::Variant> toVeloxVariant(
+    const spark::connect::Expression::Literal& literal) {
+  switch (literal.literal_type_case()) {
+    case spark::connect::Expression::Literal::kNull:
+      return std::make_shared<velox::Variant>(
+          velox::Variant::null(toVeloxType(literal.null())->kind()));
+
+    case spark::connect::Expression::Literal::kBinary:
+      return std::make_shared<velox::Variant>(
+          velox::Variant::binary(literal.binary()));
+
+    case spark::connect::Expression::Literal::kBoolean:
+      return std::make_shared<velox::Variant>(literal.boolean());
+
+    case spark::connect::Expression::Literal::kByte:
+      return std::make_shared<velox::Variant>(literal.byte());
+
+    case spark::connect::Expression::Literal::kShort:
+      return std::make_shared<velox::Variant>(literal.short_());
+
+    case spark::connect::Expression::Literal::kInteger:
+      return std::make_shared<velox::Variant>(literal.integer());
+
+    case spark::connect::Expression::Literal::kLong:
+      return std::make_shared<velox::Variant>(literal.long_());
+
+    case spark::connect::Expression::Literal::kFloat:
+      return std::make_shared<velox::Variant>(literal.float_());
+
+    case spark::connect::Expression::Literal::kDouble:
+      return std::make_shared<velox::Variant>(literal.double_());
+
+    case spark::connect::Expression::Literal::kString:
+      return std::make_shared<velox::Variant>(literal.string());
+
+    case spark::connect::Expression::Literal::kDate:
+      return std::make_shared<velox::Variant>(literal.date());
+
+    case spark::connect::Expression::Literal::kTimestamp:
+      return std::make_shared<velox::Variant>(literal.timestamp());
+
+    default:
+      COLLAGEN_NYI(
+          "Literal type to variant not implemented yet for '{}'",
+          literal.literal_type_case());
+  }
+}
+
+namespace {
+
+// This is a simple example of a json type created by Spark Connect:
+// {
+//  "fields":
+//   [
+//     {"metadata":{},"name":"Name","nullable":true,"type":"string"},
+//     {"metadata":{},"name":"Age","nullable":true,"type":"long"},
+//     {"metadata":{},"name":"List","nullable":true,"type":
+//        {"containsNull":true,"elementType":"string","type":"array"}
+//     }
+//   ],
+//  "type":"struct"
+// }
+//
+// The format is a little wonky so it requires a bit more care in the recursion
+// for complex types.
+velox::TypePtr jsonToVeloxType(const folly::dynamic& obj) {
+  // "leaves" are primitive type.
+  if (obj.isString()) {
+    const auto& sparkType = obj.asString();
+
+    if (sparkType == "string") {
+      return velox::VARCHAR();
+    } else if (sparkType == "binary") {
+      return velox::VARBINARY();
+    } else if (sparkType == "byte") {
+      return velox::TINYINT();
+    } else if (sparkType == "short") {
+      return velox::SMALLINT();
+    } else if (sparkType == "integer") {
+      return velox::INTEGER();
+    } else if (sparkType == "long") {
+      return velox::BIGINT();
+    } else if (sparkType == "float") {
+      return velox::REAL();
+    } else if (sparkType == "double") {
+      return velox::DOUBLE();
+    } else if (sparkType == "boolean") {
+      return velox::BOOLEAN();
+    } else if (sparkType == "timestamp") {
+      return velox::TIMESTAMP();
+    } else if (sparkType == "date") {
+      return velox::DATE();
+    }
+  }
+  // Complex types are handled differently. Rows have a string description as
+  // the "type" attributes, while arrays and maps have objects.
+  else if (obj.isObject()) {
+    if (obj["type"].isString()) {
+      const auto& sparkType = obj["type"].asString();
+
+      if (sparkType == "struct") {
+        std::vector<velox::TypePtr> types;
+        std::vector<std::string> names;
+
+        for (const auto& child : obj["fields"]) {
+          types.push_back(jsonToVeloxType(child));
+          names.push_back(child["name"].asString());
+        }
+        return velox::ROW(std::move(names), std::move(types));
+      } else if (sparkType == "array") {
+        return velox::ARRAY(jsonToVeloxType(obj["elementType"]));
+      } else if (sparkType == "map") {
+        return velox::MAP(
+            jsonToVeloxType(obj["keyType"]), jsonToVeloxType(obj["valueType"]));
+      } else {
+        return jsonToVeloxType(obj["type"]);
+      }
+    } else if (obj["type"].isObject()) {
+      return jsonToVeloxType(obj["type"]);
+    }
+  }
+  COLLAGEN_FAIL("Unexpected Spark json type: '{}'", folly::toJson(obj));
+}
+
+} // namespace
+
+velox::TypePtr jsonToVeloxType(std::string_view jsonInput) {
+  return jsonToVeloxType(folly::parseJson(jsonInput));
+}
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/SparkVeloxConverter.h
+++ b/axiom/pyspark/SparkVeloxConverter.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/third-party/protos/commands.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "axiom/pyspark/third-party/protos/expressions.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "axiom/pyspark/third-party/protos/relations.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+
+namespace axiom::collagen {
+
+/// A series of conversion utilities between Spark Connect protobuf structures
+/// and Axiom/Velox.
+
+/// Map Spark scalar function names to Velox.
+///
+/// TODO: We probably want to have the required names registered in Velox
+/// directly, instead of relying on the names registered for Presto.
+std::string toVeloxFunctionName(const std::string& sparkFunctionName);
+
+/// Convert Spark join types to Axiom join types
+facebook::axiom::logical_plan::JoinType toAxiomJoinType(
+    const spark::connect::Join::JoinType& joinType);
+
+/// Convert Spark set operation types to Axiom set operation types
+facebook::axiom::logical_plan::SetOperation toAxiomSetOperation(
+    const spark::connect::SetOperation::SetOpType& setOpType,
+    bool isAll = false);
+
+/// Returns the Velox type for a particular Spark data type.
+facebook::velox::TypePtr toVeloxType(const spark::connect::DataType& sparkType);
+
+/// Returns the Velox type for a particular Spark literal.
+facebook::velox::TypePtr toVeloxType(
+    const spark::connect::Expression::Literal& literal);
+
+/// Convert Spark literals to Velox variants
+std::shared_ptr<facebook::velox::Variant> toVeloxVariant(
+    const spark::connect::Expression::Literal& literal);
+
+/// Convert JSON string type representation to Velox type
+facebook::velox::TypePtr jsonToVeloxType(std::string_view jsonInput);
+
+} // namespace axiom::collagen

--- a/axiom/pyspark/runners/CMakeLists.txt
+++ b/axiom/pyspark/runners/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(collagen_runners Runner.cpp LocalRunner.cpp)
+
+target_link_libraries(
+  collagen_runners
+  axiom_runner_local_runner
+  axiom_optimizer_multifragment_plan
+  velox_memory
+  velox_vector
+  Folly::folly
+)

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/runners/LocalRunner.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "axiom/pyspark/Exception.h"
+#include "axiom/pyspark/runners/Runner.h"
+#include "axiom/runner/LocalRunner.h"
+#include "velox/core/QueryCtx.h"
+
+DEFINE_int32(num_workers, 4, "Number of in-process workers");
+DEFINE_int32(num_drivers, 4, "Number of drivers per worker");
+DEFINE_int64(split_target_bytes, 16 << 20, "Approx bytes covered by one split");
+
+using namespace ::facebook;
+
+namespace axiom::collagen::runner {
+namespace {
+
+void waitForCompletion(
+    const std::shared_ptr<facebook::axiom::runner::LocalRunner>& runner) {
+  if (runner) {
+    try {
+      runner->waitForCompletion(500000);
+    } catch (const std::exception& /*ignore*/) {
+      // Ignore exceptions during wait for completion
+    }
+  }
+}
+
+folly::CPUThreadPoolExecutor* getCPUExecutor() {
+  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
+      FLAGS_num_workers * FLAGS_num_drivers);
+  return executor.get();
+}
+
+/// A runner implementation that executes plans using Velox LocalRunner.
+class LocalRunner : public Runner {
+ public:
+  LocalRunner(
+      const std::string& runId,
+      ::facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+      ::facebook::axiom::optimizer::FinishWrite finishWrite,
+      std::shared_ptr<::facebook::velox::memory::MemoryPool> pool)
+      : Runner(
+            runId,
+            std::move(plan),
+            std::move(finishWrite),
+            std::move(pool)) {
+    aggregatePool_ = rootPool_->addAggregateChild("TestRunner");
+    COLLAGEN_CHECK_NOT_NULL(aggregatePool_, "Failed to create aggregate pool");
+
+    leafPool_ = aggregatePool_->addLeafChild("LocalRunner");
+    COLLAGEN_CHECK_NOT_NULL(leafPool_, "Failed to create leaf pool");
+  }
+
+  ~LocalRunner() override = default;
+
+  std::vector<::facebook::velox::RowVectorPtr> execute(
+      const std::unordered_map<std::string, std::string>& queryConfigs = {})
+      override;
+
+ private:
+  std::shared_ptr<::facebook::velox::memory::MemoryPool> aggregatePool_;
+  std::shared_ptr<::facebook::velox::memory::MemoryPool> leafPool_;
+};
+
+std::vector<velox::RowVectorPtr> LocalRunner::execute(
+    const std::unordered_map<std::string, std::string>& queryConfigs) {
+  std::vector<velox::RowVectorPtr> results;
+
+  auto queryCtx = velox::core::QueryCtx::create(
+      getCPUExecutor(),
+      velox::core::QueryConfig{queryConfigs},
+      {}, // Connector configs
+      velox::cache::AsyncDataCache::getInstance(),
+      aggregatePool_);
+
+  // Todo: pass executor to queryCtx
+  facebook::axiom::connector::SplitOptions splitOptions{
+      .targetSplitCount = FLAGS_num_workers * FLAGS_num_drivers * 2,
+      .fileBytesPerSplit = static_cast<uint64_t>(FLAGS_split_target_bytes)};
+
+  auto splitSourceFactory =
+      std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>(
+          splitOptions);
+
+  auto runner = std::make_shared<facebook::axiom::runner::LocalRunner>(
+      plan_, std::move(finishWrite_), queryCtx, splitSourceFactory, leafPool_);
+  try {
+    while (auto rows = runner->next()) {
+      results.push_back(rows);
+    }
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Query terminated with: " << e.what();
+    waitForCompletion(runner);
+    throw;
+  }
+
+  waitForCompletion(runner);
+  return results;
+}
+
+} // namespace
+
+void registerLocalRunnerFactory(const std::string& runnerId) {
+  registerRunnerFactory(
+      runnerId,
+      [](const std::string& runId,
+         ::facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+         ::facebook::axiom::optimizer::FinishWrite finishWrite,
+         std::shared_ptr<::facebook::velox::memory::MemoryPool> pool) {
+        return std::make_unique<LocalRunner>(
+            runId, std::move(plan), std::move(finishWrite), std::move(pool));
+      });
+}
+
+} // namespace axiom::collagen::runner

--- a/axiom/pyspark/runners/LocalRunner.h
+++ b/axiom/pyspark/runners/LocalRunner.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace axiom::collagen::runner {
+
+void registerLocalRunnerFactory(const std::string& runnerId);
+
+} // namespace axiom::collagen::runner

--- a/axiom/pyspark/runners/Runner.cpp
+++ b/axiom/pyspark/runners/Runner.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/pyspark/runners/Runner.h"
+#include "axiom/pyspark/Exception.h"
+
+namespace axiom::collagen::runner {
+namespace {
+
+std::unordered_map<std::string, TRunnerFactory>& runnerFactories() {
+  static std::unordered_map<std::string, TRunnerFactory> factories;
+  return factories;
+}
+
+} // namespace
+
+Runner::Runner(
+    const std::string& runId,
+    ::facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+    ::facebook::axiom::optimizer::FinishWrite finishWrite,
+    std::shared_ptr<::facebook::velox::memory::MemoryPool> pool)
+    : runId_(runId),
+      plan_(std::move(plan)),
+      finishWrite_(std::move(finishWrite)),
+      rootPool_(std::move(pool)) {
+  COLLAGEN_CHECK_NOT_NULL(rootPool_, "Memory pool cannot be null");
+  COLLAGEN_CHECK_NOT_NULL(plan_, "Plan cannot be null");
+}
+
+void registerRunnerFactory(const std::string runnerId, TRunnerFactory factory) {
+  bool status = runnerFactories().insert({runnerId, factory}).second;
+  COLLAGEN_CHECK(
+      status, "RunnerFactory with name '{}' is already registered.", runnerId);
+}
+
+std::unique_ptr<Runner> buildRunner(
+    const std::string runnerId,
+    const std::string& runId,
+    ::facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+    ::facebook::axiom::optimizer::FinishWrite finishWrite,
+    std::shared_ptr<::facebook::velox::memory::MemoryPool> pool) {
+  auto it = runnerFactories().find(runnerId);
+  VELOX_CHECK(
+      it != runnerFactories().end(),
+      "RunnerFactory with name '{}' not registered.",
+      runnerId);
+  return it->second(
+      runId, std::move(plan), std::move(finishWrite), std::move(pool));
+}
+
+} // namespace axiom::collagen::runner

--- a/axiom/pyspark/runners/Runner.h
+++ b/axiom/pyspark/runners/Runner.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace axiom::collagen::runner {
+
+/// API for executing physical plans.
+class Runner {
+ public:
+  Runner(
+      const std::string& runId,
+      facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+      facebook::axiom::optimizer::FinishWrite finishWrite,
+      std::shared_ptr<::facebook::velox::memory::MemoryPool> pool);
+
+  virtual ~Runner() = default;
+
+  virtual std::vector<::facebook::velox::RowVectorPtr> execute(
+      const std::unordered_map<std::string, std::string>& queryConfigs =
+          {}) = 0;
+
+ protected:
+  const std::string runId_;
+
+  facebook::axiom::optimizer::MultiFragmentPlanPtr plan_;
+
+  facebook::axiom::optimizer::FinishWrite finishWrite_;
+
+  std::shared_ptr<::facebook::velox::memory::MemoryPool> rootPool_;
+};
+
+using TRunnerFactory = std::function<std::unique_ptr<Runner>(
+    const std::string&,
+    facebook::axiom::optimizer::MultiFragmentPlanPtr,
+    facebook::axiom::optimizer::FinishWrite,
+    std::shared_ptr<::facebook::velox::memory::MemoryPool>)>;
+
+/// Registers a factory for a given runnerId.
+void registerRunnerFactory(const std::string runnerId, TRunnerFactory factory);
+
+/// Builds a runner using the respective factory method registered using the
+/// function above.
+std::unique_ptr<Runner> buildRunner(
+    const std::string runnerId,
+    const std::string& runId,
+    facebook::axiom::optimizer::MultiFragmentPlanPtr plan,
+    facebook::axiom::optimizer::FinishWrite finishWrite,
+    std::shared_ptr<::facebook::velox::memory::MemoryPool> pool);
+
+} // namespace axiom::collagen::runner

--- a/axiom/pyspark/tests/CMakeLists.txt
+++ b/axiom/pyspark/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(
+  collagen_spark_velox_converter_test
+  SparkToAxiomLambdaTest.cpp
+  SparkToAxiomSetOperationTest.cpp
+  SparkToAxiomWithColumnsRenamedTest.cpp
+  SparkToAxiomWithColumnsTest.cpp
+  SparkVeloxConverterTest.cpp
+)
+
+target_link_libraries(
+  collagen_spark_velox_converter_test
+  collagen_converter
+  collagen_spark_velox_converter
+  collagen_proto
+  axiom_logical_plan
+  axiom_test_connector
+  velox_connector_registry
+  velox_functions_prestosql
+  velox_memory
+  velox_type
+  GTest::gtest
+  GTest::gtest_main
+)
+
+add_test(NAME collagen_spark_velox_converter_test COMMAND collagen_spark_velox_converter_test)

--- a/axiom/pyspark/tests/SparkToAxiomLambdaTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomLambdaTest.cpp
@@ -1,0 +1,517 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/third-party/protos/relations.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+using facebook::axiom::logical_plan::ExprKind;
+using facebook::axiom::logical_plan::LambdaExpr;
+
+class SparkToAxiomLambdaTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+
+    // Initialize memory manager and create a memory pool for testing
+    velox::memory::MemoryManager::initialize({});
+    pool_ = velox::memory::MemoryManager::getInstance()->addLeafPool();
+
+    // Set up test connector
+    auto connector =
+        std::make_shared<facebook::axiom::connector::TestConnector>(
+            "test_connector");
+    velox::connector::registerConnector(connector);
+  }
+
+  void TearDown() override {
+    // Cleanup is handled by the connector destructor
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+// Helper function to create a simple lambda function expression.
+// Creates: (x) -> x > 10
+spark::connect::Expression createSimpleLambdaExpression(
+    const std::string& paramName) {
+  spark::connect::Expression lambdaExpr;
+  auto* lambdaFunc = lambdaExpr.mutable_lambda_function();
+
+  // Add argument (parameter)
+  auto* arg = lambdaFunc->add_arguments();
+  arg->add_name_parts(paramName);
+
+  // Create the lambda body: x > 10
+  // The body is an unresolved function ">" with arguments x and 10
+  auto* body = lambdaFunc->mutable_function();
+  auto* unresolvedFunc = body->mutable_unresolved_function();
+  unresolvedFunc->set_function_name(">");
+
+  // First argument: the lambda variable reference (x)
+  auto* varArg = unresolvedFunc->add_arguments();
+  auto* lambdaVar = varArg->mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts(paramName);
+
+  // Second argument: literal 10
+  auto* literalArg = unresolvedFunc->add_arguments();
+  auto* literal = literalArg->mutable_literal();
+  literal->set_integer(10);
+
+  return lambdaExpr;
+}
+
+// Helper function to create a lambda with multiple parameters.
+// Creates: (k, v) -> k > v
+spark::connect::Expression createTwoParamLambdaExpression(
+    const std::string& param1,
+    const std::string& param2) {
+  spark::connect::Expression lambdaExpr;
+  auto* lambdaFunc = lambdaExpr.mutable_lambda_function();
+
+  // Add first argument
+  auto* arg1 = lambdaFunc->add_arguments();
+  arg1->add_name_parts(param1);
+
+  // Add second argument
+  auto* arg2 = lambdaFunc->add_arguments();
+  arg2->add_name_parts(param2);
+
+  // Create the lambda body: k > v
+  auto* body = lambdaFunc->mutable_function();
+  auto* unresolvedFunc = body->mutable_unresolved_function();
+  unresolvedFunc->set_function_name(">");
+
+  // First argument: lambda variable k
+  auto* varArg1 = unresolvedFunc->add_arguments();
+  auto* lambdaVar1 = varArg1->mutable_unresolved_named_lambda_variable();
+  lambdaVar1->add_name_parts(param1);
+
+  // Second argument: lambda variable v
+  auto* varArg2 = unresolvedFunc->add_arguments();
+  auto* lambdaVar2 = varArg2->mutable_unresolved_named_lambda_variable();
+  lambdaVar2->add_name_parts(param2);
+
+  return lambdaExpr;
+}
+
+// Test visiting a simple lambda function: (x) -> x > 10
+TEST_F(SparkToAxiomLambdaTest, visitSimpleLambdaFunction) {
+  auto lambdaExpr = createSimpleLambdaExpression("x");
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  // Visit the lambda expression
+  converter.visit(lambdaExpr, context);
+
+  // Verify expr_ is a LambdaExpr with the expected structure.
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+
+  // Verify signature: one parameter named "x".
+  ASSERT_EQ(result->signature()->size(), 1);
+  EXPECT_EQ(result->signature()->nameOf(0), "x");
+
+  // Verify body is a CallExpr for ">" (greaterthan).
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kCall);
+}
+
+// Test visiting a lambda function with two parameters: (k, v) -> k > v
+TEST_F(SparkToAxiomLambdaTest, visitTwoParamLambdaFunction) {
+  auto lambdaExpr = createTwoParamLambdaExpression("k", "v");
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  // Visit the lambda expression
+  converter.visit(lambdaExpr, context);
+
+  // Verify expr_ is a LambdaExpr with two parameters.
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+
+  // Verify signature: two parameters named "k" and "v".
+  ASSERT_EQ(result->signature()->size(), 2);
+  EXPECT_EQ(result->signature()->nameOf(0), "k");
+  EXPECT_EQ(result->signature()->nameOf(1), "v");
+
+  // Verify body is a CallExpr for ">".
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kCall);
+}
+
+// Test visiting an unresolved named lambda variable
+TEST_F(SparkToAxiomLambdaTest, visitUnresolvedNamedLambdaVariable) {
+  // Create a lambda expression that we first visit to register the variable
+  spark::connect::Expression lambdaExpr;
+  auto* lambdaFunc = lambdaExpr.mutable_lambda_function();
+
+  // Add argument
+  auto* arg = lambdaFunc->add_arguments();
+  arg->add_name_parts("x");
+
+  // Create the lambda body: just the variable x
+  auto* body = lambdaFunc->mutable_function();
+  auto* lambdaVar = body->mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts("x");
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(lambdaExpr, context);
+
+  // Verify the result is a LambdaExpr whose body is an InputReferenceExpr
+  // for the lambda variable "x".
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+
+  ASSERT_EQ(result->signature()->size(), 1);
+  EXPECT_EQ(result->signature()->nameOf(0), "x");
+
+  // Body should be an InputReferenceExpr for variable "x".
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kInputReference);
+}
+TEST_F(SparkToAxiomLambdaTest, visitUnregisteredLambdaVariableThrows) {
+  // Create an expression with just an unresolved lambda variable
+  // without being inside a lambda context
+  spark::connect::Expression expr;
+  auto* lambdaVar = expr.mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts("unknown_var");
+
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  // This should throw because the variable is not registered
+  EXPECT_THROW(converter.visit(expr, context), std::exception);
+}
+
+// Test lambda with compound variable name (multiple name_parts)
+TEST_F(SparkToAxiomLambdaTest, visitLambdaWithCompoundVariableName) {
+  spark::connect::Expression lambdaExpr;
+  auto* lambdaFunc = lambdaExpr.mutable_lambda_function();
+
+  // Add argument with compound name (e.g., "struct.field")
+  auto* arg = lambdaFunc->add_arguments();
+  arg->add_name_parts("struct");
+  arg->add_name_parts("field");
+
+  // Create a simple body referencing the compound variable
+  auto* body = lambdaFunc->mutable_function();
+  auto* lambdaVar = body->mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts("struct");
+  lambdaVar->add_name_parts("field");
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(lambdaExpr, context);
+
+  // Verify the result is a LambdaExpr with compound parameter name.
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+
+  // Parameter name should be "struct.field" (joined from name_parts).
+  ASSERT_EQ(result->signature()->size(), 1);
+  EXPECT_EQ(result->signature()->nameOf(0), "struct.field");
+
+  // Body should be an InputReferenceExpr for "struct.field".
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kInputReference);
+}
+
+// Test lambda in the context of a TRANSFORM-like function call
+TEST_F(SparkToAxiomLambdaTest, visitTransformWithLambda) {
+  // Create a function call similar to: transform(array_col, x -> x > 10)
+  spark::connect::Expression transformExpr;
+  auto* unresolvedFunc = transformExpr.mutable_unresolved_function();
+  unresolvedFunc->set_function_name("transform");
+
+  // First argument: would be an array column reference
+  // For this test, we use a literal array
+  auto* arrayArg = unresolvedFunc->add_arguments();
+  auto* literal = arrayArg->mutable_literal();
+  auto* array = literal->mutable_array();
+  array->mutable_element_type()->mutable_integer();
+  auto* elem1 = array->add_elements();
+  elem1->set_integer(1);
+  auto* elem2 = array->add_elements();
+  elem2->set_integer(20);
+  auto* elem3 = array->add_elements();
+  elem3->set_integer(5);
+
+  // Second argument: the lambda function
+  auto lambdaExpr = createSimpleLambdaExpression("x");
+  *unresolvedFunc->add_arguments() = lambdaExpr;
+
+  // Convert to Axiom - should not throw
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  // Note: The actual transform function resolution may fail if not registered,
+  // but the lambda translation itself should succeed
+  try {
+    converter.visit(transformExpr, context);
+  } catch (const std::exception& e) {
+    // Expected if transform function is not registered, but lambda parsing
+    // should have succeeded. Check error is about function resolution, not
+    // lambda.
+    std::string error = e.what();
+    EXPECT_TRUE(error.find("Lambda variable") == std::string::npos)
+        << "Lambda translation failed: " << error;
+  }
+}
+
+// Test nested lambda with shadowed variable names.
+// Verifies that the LambdaScope RAII properly saves/restores outer lambda
+// variables when an inner lambda shadows the same parameter name.
+TEST_F(SparkToAxiomLambdaTest, visitNestedLambdaWithShadowedVariable) {
+  // Simulate being inside an outer lambda scope by pre-populating
+  // context.lambdaVariables with "x" = BIGINT.
+  SparkPlanVisitorContext context;
+  context.lambdaVariables["x"] = velox::BIGINT();
+
+  // Create inner lambda: (x) -> x
+  // This shadows the outer "x" with its own "x" parameter.
+  spark::connect::Expression innerLambdaExpr;
+  auto* lambdaFunc = innerLambdaExpr.mutable_lambda_function();
+  auto* arg = lambdaFunc->add_arguments();
+  arg->add_name_parts("x");
+  auto* body = lambdaFunc->mutable_function();
+  auto* lambdaVar = body->mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts("x");
+
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  converter.visit(innerLambdaExpr, context);
+
+  // Verify the inner lambda correctly used the pre-inferred BIGINT type
+  // from the simulated outer scope.
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->signature()->size(), 1);
+  EXPECT_EQ(result->signature()->nameOf(0), "x");
+  EXPECT_EQ(result->signature()->childAt(0)->kind(), velox::TypeKind::BIGINT);
+
+  // Body should be an InputReferenceExpr for "x".
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kInputReference);
+
+  // CRITICAL: After the inner lambda scope exits, the outer "x" must still
+  // be in the context with its original type. With the old flat-map approach,
+  // the inner lambda's cleanup would erase "x" entirely.
+  auto it = context.lambdaVariables.find("x");
+  ASSERT_NE(it, context.lambdaVariables.end())
+      << "Outer lambda variable 'x' was lost after inner lambda scope exited";
+  EXPECT_EQ(it->second->kind(), velox::TypeKind::BIGINT)
+      << "Outer lambda variable 'x' type was corrupted";
+}
+
+// Test nested lambda with different variable names (no shadowing).
+// Verifies that non-overlapping variable names work correctly across scopes
+// and that inner variables don't leak into the outer scope.
+TEST_F(SparkToAxiomLambdaTest, visitNestedLambdaWithDistinctVariables) {
+  // Simulate outer scope with "x" = BIGINT.
+  SparkPlanVisitorContext context;
+  context.lambdaVariables["x"] = velox::BIGINT();
+
+  // Create inner lambda: (y) -> x
+  // The body references outer "x" (not inner "y"), verifying cross-scope
+  // access.
+  spark::connect::Expression innerLambdaExpr;
+  auto* lambdaFunc = innerLambdaExpr.mutable_lambda_function();
+  auto* arg = lambdaFunc->add_arguments();
+  arg->add_name_parts("y");
+  auto* body = lambdaFunc->mutable_function();
+  auto* lambdaVar = body->mutable_unresolved_named_lambda_variable();
+  lambdaVar->add_name_parts("x");
+
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  converter.visit(innerLambdaExpr, context);
+
+  // Verify the inner lambda has parameter "y" and body referencing "x".
+  ASSERT_NE(converter.expr(), nullptr);
+  ASSERT_EQ(converter.expr()->kind(), ExprKind::kLambda);
+
+  auto result = std::dynamic_pointer_cast<const LambdaExpr>(converter.expr());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->signature()->size(), 1);
+  EXPECT_EQ(result->signature()->nameOf(0), "y");
+
+  // Body should be an InputReferenceExpr for "x" (from outer scope).
+  ASSERT_NE(result->body(), nullptr);
+  EXPECT_EQ(result->body()->kind(), ExprKind::kInputReference);
+
+  // The outer "x" should still be in context after inner lambda exits.
+  auto it = context.lambdaVariables.find("x");
+  ASSERT_NE(it, context.lambdaVariables.end());
+  EXPECT_EQ(it->second->kind(), velox::TypeKind::BIGINT);
+
+  // The inner "y" should NOT be in context after inner lambda exits.
+  EXPECT_EQ(context.lambdaVariables.find("y"), context.lambdaVariables.end())
+      << "Inner lambda variable 'y' leaked into outer scope";
+}
+
+// Test find_first_index higher-order function: find_first_index(array, x -> x >
+// 10) Verifies that find_first_index is recognized as a higher-order function
+// and lambda parameter types are correctly inferred from the array element
+// type.
+TEST_F(SparkToAxiomLambdaTest, visitFindFirstIndexWithLambda) {
+  // Create: find_first_index([1, 20, 5], x -> x > 10)
+  spark::connect::Expression findFirstExpr;
+  auto* unresolvedFunc = findFirstExpr.mutable_unresolved_function();
+  unresolvedFunc->set_function_name("find_first_index");
+
+  // First argument: literal array of integers
+  auto* arrayArg = unresolvedFunc->add_arguments();
+  auto* literal = arrayArg->mutable_literal();
+  auto* array = literal->mutable_array();
+  array->mutable_element_type()->mutable_integer();
+  array->add_elements()->set_integer(1);
+  array->add_elements()->set_integer(20);
+  array->add_elements()->set_integer(5);
+
+  // Second argument: lambda (x) -> x > 10
+  auto lambdaExpr = createSimpleLambdaExpression("x");
+  *unresolvedFunc->add_arguments() = lambdaExpr;
+
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  try {
+    converter.visit(findFirstExpr, context);
+    // If the function resolves, verify the result is a CallExpr.
+    ASSERT_NE(converter.expr(), nullptr);
+    EXPECT_EQ(converter.expr()->kind(), ExprKind::kCall);
+  } catch (const std::exception& e) {
+    // If find_first_index is not registered in the test binary, the lambda
+    // translation should still succeed — verify the error is about function
+    // resolution, not lambda variable inference.
+    std::string error = e.what();
+    EXPECT_TRUE(error.find("Lambda variable") == std::string::npos)
+        << "Lambda type inference failed for find_first_index: " << error;
+    EXPECT_TRUE(
+        error.find("does not exist") != std::string::npos ||
+        error.find("signature") != std::string::npos ||
+        error.find("not implemented") != std::string::npos)
+        << "Unexpected error for find_first_index: " << error;
+  }
+}
+
+// Test aggregate (reduce) higher-order function with two lambdas:
+// aggregate(array, initial, (s, x) -> s + x, (s) -> s)
+// Verifies that aggregate is recognized as a higher-order function and both
+// lambda parameter types are correctly inferred: merge lambda gets (state S,
+// element T) and output lambda gets (state S).
+TEST_F(SparkToAxiomLambdaTest, visitAggregateWithTwoLambdas) {
+  // Create: aggregate([1, 2, 3], 0, (s, x) -> s + x, (s) -> s)
+  spark::connect::Expression aggExpr;
+  auto* unresolvedFunc = aggExpr.mutable_unresolved_function();
+  unresolvedFunc->set_function_name("aggregate");
+
+  // Arg 0: literal array of integers
+  auto* arrayArg = unresolvedFunc->add_arguments();
+  auto* literal = arrayArg->mutable_literal();
+  auto* array = literal->mutable_array();
+  array->mutable_element_type()->mutable_integer();
+  array->add_elements()->set_integer(1);
+  array->add_elements()->set_integer(2);
+  array->add_elements()->set_integer(3);
+
+  // Arg 1: initial value (integer literal 0)
+  auto* initArg = unresolvedFunc->add_arguments();
+  initArg->mutable_literal()->set_integer(0);
+
+  // Arg 2: merge lambda (s, x) -> s + x
+  {
+    spark::connect::Expression mergeLambdaExpr;
+    auto* lambdaFunc = mergeLambdaExpr.mutable_lambda_function();
+    auto* s = lambdaFunc->add_arguments();
+    s->add_name_parts("s");
+    auto* x = lambdaFunc->add_arguments();
+    x->add_name_parts("x");
+    auto* body = lambdaFunc->mutable_function();
+    auto* bodyFunc = body->mutable_unresolved_function();
+    bodyFunc->set_function_name("+");
+    auto* sRef = bodyFunc->add_arguments();
+    sRef->mutable_unresolved_named_lambda_variable()->add_name_parts("s");
+    auto* xRef = bodyFunc->add_arguments();
+    xRef->mutable_unresolved_named_lambda_variable()->add_name_parts("x");
+    *unresolvedFunc->add_arguments() = mergeLambdaExpr;
+  }
+
+  // Arg 3: output lambda (s) -> s
+  {
+    spark::connect::Expression outputLambdaExpr;
+    auto* lambdaFunc = outputLambdaExpr.mutable_lambda_function();
+    auto* s = lambdaFunc->add_arguments();
+    s->add_name_parts("s");
+    auto* body = lambdaFunc->mutable_function();
+    body->mutable_unresolved_named_lambda_variable()->add_name_parts("s");
+    *unresolvedFunc->add_arguments() = outputLambdaExpr;
+  }
+
+  SparkToAxiom converter("test_connector", "", pool_.get());
+  SparkPlanVisitorContext context;
+
+  try {
+    converter.visit(aggExpr, context);
+    ASSERT_NE(converter.expr(), nullptr);
+    EXPECT_EQ(converter.expr()->kind(), ExprKind::kCall);
+  } catch (const std::exception& e) {
+    // Lambda translation should succeed even if function resolution fails.
+    std::string error = e.what();
+    EXPECT_TRUE(error.find("Lambda variable") == std::string::npos)
+        << "Lambda type inference failed for aggregate/reduce: " << error;
+    EXPECT_TRUE(
+        error.find("does not exist") != std::string::npos ||
+        error.find("signature") != std::string::npos ||
+        error.find("not implemented") != std::string::npos)
+        << "Unexpected error for aggregate/reduce: " << error;
+  }
+}
+
+} // namespace
+} // namespace axiom::collagen::test

--- a/axiom/pyspark/tests/SparkToAxiomSetOperationTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomSetOperationTest.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/SparkVeloxConverter.h"
+#include "axiom/pyspark/third-party/protos/relations.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+void registerTestConnector(const std::string& connectorId) {
+  auto connector =
+      std::make_shared<facebook::axiom::connector::TestConnector>(connectorId);
+
+  connector->addTable(
+      "training_table", velox::ROW({"viewer_rid"}, {velox::BIGINT()}));
+  connector->addTable(
+      "feature_table", velox::ROW({"primary_rid"}, {velox::BIGINT()}));
+
+  velox::connector::registerConnector(connector);
+}
+
+class SparkToAxiomSetOperationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+
+    // Initialize memory manager and create a memory pool for testing
+    velox::memory::MemoryManager::initialize({});
+    pool_ = velox::memory::MemoryManager::getInstance()->addLeafPool();
+
+    // Set up test connector
+    registerTestConnector("test_connector");
+  }
+
+  void TearDown() override {
+    // Cleanup is handled by the connector destructor
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+// Test the toAxiomSetOperation conversion function
+TEST_F(SparkToAxiomSetOperationTest, toAxiomSetOperationConversion) {
+  // Test UNION without ALL flag
+  EXPECT_EQ(
+      facebook::axiom::logical_plan::SetOperation::kUnion,
+      toAxiomSetOperation(
+          spark::connect::SetOperation::SET_OP_TYPE_UNION, false));
+
+  // Test UNION with ALL flag
+  EXPECT_EQ(
+      facebook::axiom::logical_plan::SetOperation::kUnionAll,
+      toAxiomSetOperation(
+          spark::connect::SetOperation::SET_OP_TYPE_UNION, true));
+
+  // Test INTERSECT
+  EXPECT_EQ(
+      facebook::axiom::logical_plan::SetOperation::kIntersect,
+      toAxiomSetOperation(
+          spark::connect::SetOperation::SET_OP_TYPE_INTERSECT, false));
+
+  // Test EXCEPT
+  EXPECT_EQ(
+      facebook::axiom::logical_plan::SetOperation::kExcept,
+      toAxiomSetOperation(
+          spark::connect::SetOperation::SET_OP_TYPE_EXCEPT, false));
+}
+
+// Helper function to create a simple table relation for testing
+spark::connect::Relation createTestTableRelation(
+    const std::string& tableName,
+    int64_t planId) {
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(planId);
+
+  auto* read = relation.mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier(tableName);
+
+  return relation;
+}
+
+// Helper function to create a SetOperation relation
+spark::connect::Relation createSetOperationRelation(
+    const spark::connect::Relation& left,
+    const spark::connect::Relation& right,
+    spark::connect::SetOperation::SetOpType opType,
+    bool isAll = false,
+    int64_t planId = 1) {
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(planId);
+
+  auto* setOp = relation.mutable_set_op();
+  *setOp->mutable_left_input() = left;
+  *setOp->mutable_right_input() = right;
+  setOp->set_set_op_type(opType);
+  setOp->set_is_all(isAll);
+
+  return relation;
+}
+
+TEST_F(SparkToAxiomSetOperationTest, visitSetOperationUnion) {
+  // Create left and right table relations
+  auto leftRelation = createTestTableRelation("training_table", 2);
+  auto rightRelation = createTestTableRelation("feature_table", 3);
+
+  // Create UNION operation
+  auto unionRelation = createSetOperationRelation(
+      leftRelation,
+      rightRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_UNION,
+      false, // isAll = false
+      1);
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.SparkPlanVisitor::visit(unionRelation, context);
+
+  // Verify the result
+  auto planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+  EXPECT_EQ(planNode->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto setNode = planNode->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(setNode, nullptr);
+  EXPECT_EQ(
+      setNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kUnion);
+  EXPECT_EQ(setNode->inputs().size(), 2);
+}
+
+TEST_F(SparkToAxiomSetOperationTest, visitSetOperationUnionAll) {
+  // Create left and right table relations
+  auto leftRelation = createTestTableRelation("training_table", 2);
+  auto rightRelation = createTestTableRelation("feature_table", 3);
+
+  // Create UNION ALL operation
+  auto unionAllRelation = createSetOperationRelation(
+      leftRelation,
+      rightRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_UNION,
+      true, // isAll = true
+      1);
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.SparkPlanVisitor::visit(unionAllRelation, context);
+
+  // Verify the result
+  auto planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+  EXPECT_EQ(planNode->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto setNode = planNode->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(setNode, nullptr);
+  EXPECT_EQ(
+      setNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kUnionAll);
+  EXPECT_EQ(setNode->inputs().size(), 2);
+}
+
+TEST_F(SparkToAxiomSetOperationTest, visitSetOperationIntersect) {
+  // Create left and right table relations
+  auto leftRelation = createTestTableRelation("training_table", 2);
+  auto rightRelation = createTestTableRelation("feature_table", 3);
+
+  // Create INTERSECT operation
+  auto intersectRelation = createSetOperationRelation(
+      leftRelation,
+      rightRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_INTERSECT,
+      false,
+      1);
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.SparkPlanVisitor::visit(intersectRelation, context);
+
+  // Verify the result
+  auto planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+  EXPECT_EQ(planNode->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto setNode = planNode->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(setNode, nullptr);
+  EXPECT_EQ(
+      setNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kIntersect);
+  EXPECT_EQ(setNode->inputs().size(), 2);
+}
+
+TEST_F(SparkToAxiomSetOperationTest, visitSetOperationExcept) {
+  // Create left and right table relations
+  auto leftRelation = createTestTableRelation("training_table", 2);
+  auto rightRelation = createTestTableRelation("feature_table", 3);
+
+  // Create EXCEPT operation
+  auto exceptRelation = createSetOperationRelation(
+      leftRelation,
+      rightRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_EXCEPT,
+      false,
+      1);
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.SparkPlanVisitor::visit(exceptRelation, context);
+
+  // Verify the result
+  auto planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+  EXPECT_EQ(planNode->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto setNode = planNode->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(setNode, nullptr);
+  EXPECT_EQ(
+      setNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kExcept);
+  EXPECT_EQ(setNode->inputs().size(), 2);
+}
+
+TEST_F(SparkToAxiomSetOperationTest, visitSetOperationWithComplexInputs) {
+  // Create left table relation
+  auto leftTableRelation = createTestTableRelation("training_table", 3);
+
+  // Create right table relation
+  auto rightTableRelation = createTestTableRelation("feature_table", 4);
+
+  // Create a nested UNION operation as the left input
+  auto nestedUnionRelation = createSetOperationRelation(
+      leftTableRelation,
+      rightTableRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_UNION,
+      false,
+      2);
+
+  // Create another table for the right input
+  auto rightRelation = createTestTableRelation("training_table", 5);
+
+  // Create final INTERSECT operation with nested input
+  auto finalRelation = createSetOperationRelation(
+      nestedUnionRelation,
+      rightRelation,
+      spark::connect::SetOperation::SET_OP_TYPE_INTERSECT,
+      false,
+      1);
+
+  // Convert to Axiom
+  SparkToAxiom converter("test_connector", "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.SparkPlanVisitor::visit(finalRelation, context);
+
+  // Verify the result
+  auto planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+  EXPECT_EQ(planNode->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto setNode = planNode->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(setNode, nullptr);
+  EXPECT_EQ(
+      setNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kIntersect);
+  EXPECT_EQ(setNode->inputs().size(), 2);
+
+  // Verify the left input is also a set operation
+  auto leftInput = setNode->inputs()[0];
+  EXPECT_EQ(leftInput->kind(), facebook::axiom::logical_plan::NodeKind::kSet);
+
+  auto leftSetNode = leftInput->as<facebook::axiom::logical_plan::SetNode>();
+  ASSERT_NE(leftSetNode, nullptr);
+  EXPECT_EQ(
+      leftSetNode->operation(),
+      facebook::axiom::logical_plan::SetOperation::kUnion);
+
+  // Verify the right input is a table scan
+  auto rightInput = setNode->inputs()[1];
+  EXPECT_EQ(
+      rightInput->kind(), facebook::axiom::logical_plan::NodeKind::kTableScan);
+}
+
+} // namespace
+} // namespace axiom::collagen::test

--- a/axiom/pyspark/tests/SparkToAxiomWithColumnsRenamedTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomWithColumnsRenamedTest.cpp
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/third-party/protos/relations.pb.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/connectors/Connector.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+void registerTestConnector(const std::string& connectorId) {
+  auto connector =
+      std::make_shared<facebook::axiom::connector::TestConnector>(connectorId);
+
+  connector->addTable(
+      "training_table", velox::ROW({"viewer_rid"}, {velox::BIGINT()}));
+  connector->addTable(
+      "feature_table", velox::ROW({"primary_rid"}, {velox::BIGINT()}));
+
+  velox::connector::registerConnector(connector);
+}
+
+class SparkToAxiomWithColumnsRenamedTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+    velox::memory::MemoryManager::testingSetInstance({});
+
+    connectorId_ = "test-connector";
+    registerTestConnector(connectorId_);
+
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(connectorId_);
+  }
+
+ protected:
+  std::string connectorId_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, BasicColumnRename) {
+  // Create a basic WithColumnsRenamed plan
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed = relation.mutable_with_columns_renamed();
+
+  // Create input relation (table scan)
+  auto* input = withColumnsRenamed->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* read = input->mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier("training_table");
+
+  // Set up column rename mapping
+  auto& renameMap = *withColumnsRenamed->mutable_rename_columns_map();
+  renameMap["viewer_rid"] = "user_id";
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 1);
+  EXPECT_EQ(outputType->nameOf(0), "user_id");
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+
+  // Verify expressions
+  const auto& expressions = projectNode->expressions();
+  EXPECT_EQ(expressions.size(), 1);
+
+  // Verify the expression is an InputReferenceExpr
+  const auto* inputRefExpr =
+      dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+          expressions[0].get());
+  ASSERT_NE(inputRefExpr, nullptr);
+  EXPECT_EQ(
+      inputRefExpr->name(), "viewer_rid"); // References original column name
+  EXPECT_EQ(inputRefExpr->type(), velox::BIGINT());
+}
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, MultipleColumnRename) {
+  // Create a more complex table with multiple columns
+  // First, we need to create a custom table with multiple columns for this test
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed = relation.mutable_with_columns_renamed();
+
+  // Create input relation using LocalRelation with multiple columns
+  auto* input = withColumnsRenamed->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* localRelation = input->mutable_local_relation();
+
+  // Set schema for multi-column table
+  std::string schema = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "name", "type": "string"},
+      {"name": "age", "type": "integer"},
+      {"name": "active", "type": "boolean"}
+    ]
+  })";
+  localRelation->set_schema(schema);
+
+  // Set up column rename mapping
+  auto& renameMap = *withColumnsRenamed->mutable_rename_columns_map();
+  renameMap["id"] = "user_id";
+  renameMap["name"] = "user_name";
+  // Note: age and active are not renamed (should keep original names)
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 4);
+
+  // Check renamed columns
+  EXPECT_EQ(outputType->nameOf(0), "user_id");
+  EXPECT_EQ(outputType->nameOf(1), "user_name");
+
+  // Check non-renamed columns
+  EXPECT_EQ(outputType->nameOf(2), "age");
+  EXPECT_EQ(outputType->nameOf(3), "active");
+
+  // Verify types are preserved
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+  EXPECT_EQ(outputType->childAt(1), velox::VARCHAR());
+  EXPECT_EQ(outputType->childAt(2), velox::INTEGER());
+  EXPECT_EQ(outputType->childAt(3), velox::BOOLEAN());
+
+  // Verify expressions
+  const auto& expressions = projectNode->expressions();
+  EXPECT_EQ(expressions.size(), 4);
+
+  // Check that all expressions are InputReferenceExpr and reference original
+  // column names
+  for (size_t i = 0; i < expressions.size(); ++i) {
+    const auto* inputRefExpr =
+        dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+            expressions[i].get());
+    ASSERT_NE(inputRefExpr, nullptr);
+  }
+
+  // Verify original column names are referenced in expressions
+  const auto* expr0 =
+      dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+          expressions[0].get());
+  const auto* expr1 =
+      dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+          expressions[1].get());
+  const auto* expr2 =
+      dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+          expressions[2].get());
+  const auto* expr3 =
+      dynamic_cast<const facebook::axiom::logical_plan::InputReferenceExpr*>(
+          expressions[3].get());
+
+  EXPECT_EQ(expr0->name(), "id");
+  EXPECT_EQ(expr1->name(), "name");
+  EXPECT_EQ(expr2->name(), "age");
+  EXPECT_EQ(expr3->name(), "active");
+}
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, NoColumnRename) {
+  // Test case where no columns are renamed (empty rename map)
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed = relation.mutable_with_columns_renamed();
+
+  // Create input relation
+  auto* input = withColumnsRenamed->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* read = input->mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier("training_table");
+
+  // Set up empty column rename mapping
+  // (no entries in the map)
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema (should be the same as input)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 1);
+  EXPECT_EQ(outputType->nameOf(0), "viewer_rid"); // Original name preserved
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+}
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, RenameNonExistentColumn) {
+  // Test case where we try to rename a column that doesn't exist
+  // This should not cause an error but should simply be ignored
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed = relation.mutable_with_columns_renamed();
+
+  // Create input relation
+  auto* input = withColumnsRenamed->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* read = input->mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier("training_table");
+
+  // Set up column rename mapping with non-existent column
+  auto& renameMap = *withColumnsRenamed->mutable_rename_columns_map();
+  renameMap["viewer_rid"] = "user_id"; // Valid rename
+  renameMap["non_existent_column"] =
+      "new_name"; // Invalid rename (should be ignored)
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema (should only have the existing column, renamed)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 1);
+  EXPECT_EQ(outputType->nameOf(0), "user_id");
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+}
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, ChainedWithColumnsRenamed) {
+  // Test chaining multiple WithColumnsRenamed operations
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed2 = relation.mutable_with_columns_renamed();
+
+  // Create first WithColumnsRenamed as input
+  auto* input = withColumnsRenamed2->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* withColumnsRenamed1 = input->mutable_with_columns_renamed();
+
+  // Create base table as input to first WithColumnsRenamed
+  auto* baseInput = withColumnsRenamed1->mutable_input();
+  baseInput->mutable_common()->set_plan_id(3);
+  auto* localRelation = baseInput->mutable_local_relation();
+
+  // Set schema for multi-column table
+  std::string schema = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "string"}
+    ]
+  })";
+  localRelation->set_schema(schema);
+
+  // First rename: a -> x, b -> y
+  auto& renameMap1 = *withColumnsRenamed1->mutable_rename_columns_map();
+  renameMap1["a"] = "x";
+  renameMap1["b"] = "y";
+
+  // Second rename: x -> final_a, y -> final_b
+  auto& renameMap2 = *withColumnsRenamed2->mutable_rename_columns_map();
+  renameMap2["x"] = "final_a";
+  renameMap2["y"] = "final_b";
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode (the outer one)
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify final output schema
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 2);
+  EXPECT_EQ(outputType->nameOf(0), "final_a");
+  EXPECT_EQ(outputType->nameOf(1), "final_b");
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+  EXPECT_EQ(outputType->childAt(1), velox::VARCHAR());
+
+  // Verify the plan structure contains nested ProjectNodes
+  const auto& inputNode = projectNode->inputs()[0];
+  const auto* innerProjectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          inputNode.get());
+  ASSERT_NE(innerProjectNode, nullptr);
+
+  // Verify inner project output schema
+  const auto& innerOutputType = innerProjectNode->outputType();
+  EXPECT_EQ(innerOutputType->size(), 2);
+  EXPECT_EQ(innerOutputType->nameOf(0), "x");
+  EXPECT_EQ(innerOutputType->nameOf(1), "y");
+}
+
+TEST_F(SparkToAxiomWithColumnsRenamedTest, PlanToString) {
+  // Test that the plan can be converted to string representation
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumnsRenamed = relation.mutable_with_columns_renamed();
+
+  // Create input relation
+  auto* input = withColumnsRenamed->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* read = input->mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier("training_table");
+
+  // Set up column rename mapping
+  auto& renameMap = *withColumnsRenamed->mutable_rename_columns_map();
+  renameMap["viewer_rid"] = "user_id";
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  // Test toString method
+  std::string planString = converter.toString();
+  EXPECT_FALSE(planString.empty());
+
+  // Verify the string contains expected information
+  EXPECT_NE(planString.find("Project"), std::string::npos);
+  EXPECT_NE(planString.find("user_id"), std::string::npos);
+}
+
+} // namespace
+} // namespace axiom::collagen::test

--- a/axiom/pyspark/tests/SparkToAxiomWithColumnsTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomWithColumnsTest.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/third-party/protos/relations.pb.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/connectors/Connector.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+void registerTestConnector(const std::string& connectorId) {
+  auto connector =
+      std::make_shared<facebook::axiom::connector::TestConnector>(connectorId);
+
+  connector->addTable(
+      "training_table",
+      velox::ROW(
+          {"viewer_rid", "feature_a"}, {velox::BIGINT(), velox::DOUBLE()}));
+
+  velox::connector::registerConnector(connector);
+}
+
+class SparkToAxiomWithColumnsTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+    velox::memory::MemoryManager::testingSetInstance({});
+
+    connectorId_ = "test-connector-with-columns";
+    registerTestConnector(connectorId_);
+
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  void TearDown() override {
+    velox::connector::unregisterConnector(connectorId_);
+  }
+
+ protected:
+  std::string connectorId_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(SparkToAxiomWithColumnsTest, AddNewColumn) {
+  // Test adding a new column that doesn't exist in input
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumns = relation.mutable_with_columns();
+
+  // Create input relation (table scan)
+  auto* input = withColumns->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* read = input->mutable_read();
+  auto* namedTable = read->mutable_named_table();
+  namedTable->set_unparsed_identifier("training_table");
+
+  // Add a new column: new_col = 42 (literal)
+  auto* alias = withColumns->add_aliases();
+  alias->add_name("new_col");
+  auto* literal = alias->mutable_expr()->mutable_literal();
+  literal->set_long_(42);
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema has 3 columns now (original 2 + new 1)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 3);
+  EXPECT_EQ(outputType->nameOf(0), "viewer_rid");
+  EXPECT_EQ(outputType->nameOf(1), "feature_a");
+  EXPECT_EQ(outputType->nameOf(2), "new_col");
+
+  // Verify types
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+  EXPECT_EQ(outputType->childAt(1), velox::DOUBLE());
+  EXPECT_EQ(outputType->childAt(2), velox::BIGINT());
+}
+
+TEST_F(SparkToAxiomWithColumnsTest, ReplaceExistingColumn) {
+  // Test replacing an existing column with a new expression
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumns = relation.mutable_with_columns();
+
+  // Create input relation using LocalRelation
+  auto* input = withColumns->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* localRelation = input->mutable_local_relation();
+
+  std::string schema = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "value", "type": "integer"}
+    ]
+  })";
+  localRelation->set_schema(schema);
+
+  // Replace 'value' column with literal 100
+  auto* alias = withColumns->add_aliases();
+  alias->add_name("value");
+  auto* literal = alias->mutable_expr()->mutable_literal();
+  literal->set_integer(100);
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema still has 2 columns (replaced, not added)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 2);
+  EXPECT_EQ(outputType->nameOf(0), "id");
+  EXPECT_EQ(outputType->nameOf(1), "value");
+
+  // Verify types - value should now be INTEGER (from the literal)
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+  EXPECT_EQ(outputType->childAt(1), velox::INTEGER());
+
+  // Verify the expression for 'value' is a ConstantExpr
+  const auto& expressions = projectNode->expressions();
+  EXPECT_EQ(expressions.size(), 2);
+
+  const auto* constExpr =
+      dynamic_cast<const facebook::axiom::logical_plan::ConstantExpr*>(
+          expressions[1].get());
+  ASSERT_NE(constExpr, nullptr);
+}
+
+TEST_F(SparkToAxiomWithColumnsTest, AddMultipleColumns) {
+  // Test adding multiple new columns at once
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumns = relation.mutable_with_columns();
+
+  // Create input relation using LocalRelation
+  auto* input = withColumns->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* localRelation = input->mutable_local_relation();
+
+  std::string schema = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "base_col", "type": "string"}
+    ]
+  })";
+  localRelation->set_schema(schema);
+
+  // Add first new column: col_a = 1
+  auto* alias1 = withColumns->add_aliases();
+  alias1->add_name("col_a");
+  auto* literal1 = alias1->mutable_expr()->mutable_literal();
+  literal1->set_long_(1);
+
+  // Add second new column: col_b = 2
+  auto* alias2 = withColumns->add_aliases();
+  alias2->add_name("col_b");
+  auto* literal2 = alias2->mutable_expr()->mutable_literal();
+  literal2->set_long_(2);
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema has 3 columns (1 original + 2 new)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 3);
+  EXPECT_EQ(outputType->nameOf(0), "base_col");
+
+  // Note: The order of new columns may vary since they're stored in a map
+  // Just verify they exist
+  bool hasColA = false;
+  bool hasColB = false;
+  for (uint32_t i = 1; i < outputType->size(); ++i) {
+    if (outputType->nameOf(i) == "col_a") {
+      hasColA = true;
+    }
+    if (outputType->nameOf(i) == "col_b") {
+      hasColB = true;
+    }
+  }
+  EXPECT_TRUE(hasColA);
+  EXPECT_TRUE(hasColB);
+}
+
+TEST_F(SparkToAxiomWithColumnsTest, MixedAddAndReplace) {
+  // Test adding new columns and replacing existing ones in the same operation
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* withColumns = relation.mutable_with_columns();
+
+  // Create input relation using LocalRelation
+  auto* input = withColumns->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  auto* localRelation = input->mutable_local_relation();
+
+  std::string schema = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "string"}
+    ]
+  })";
+  localRelation->set_schema(schema);
+
+  // Replace 'a' with literal 99
+  auto* alias1 = withColumns->add_aliases();
+  alias1->add_name("a");
+  auto* literal1 = alias1->mutable_expr()->mutable_literal();
+  literal1->set_long_(99);
+
+  // Add new column 'c'
+  auto* alias2 = withColumns->add_aliases();
+  alias2->add_name("c");
+  auto* literal2 = alias2->mutable_expr()->mutable_literal();
+  literal2->set_boolean(true);
+
+  // Convert using SparkToAxiom
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  // Verify it's a ProjectNode
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  // Verify output schema has 3 columns (2 original with 1 replaced + 1 new)
+  const auto& outputType = projectNode->outputType();
+  EXPECT_EQ(outputType->size(), 3);
+
+  // First two should be original columns (with 'a' replaced)
+  EXPECT_EQ(outputType->nameOf(0), "a");
+  EXPECT_EQ(outputType->nameOf(1), "b");
+
+  // Third should be the new column 'c'
+  EXPECT_EQ(outputType->nameOf(2), "c");
+
+  // Verify types
+  EXPECT_EQ(outputType->childAt(0), velox::BIGINT());
+  EXPECT_EQ(outputType->childAt(1), velox::VARCHAR());
+  EXPECT_EQ(outputType->childAt(2), velox::BOOLEAN());
+}
+
+} // namespace
+} // namespace axiom::collagen::test

--- a/axiom/pyspark/tests/SparkVeloxConverterTest.cpp
+++ b/axiom/pyspark/tests/SparkVeloxConverterTest.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/pyspark/SparkVeloxConverter.h"
+#include "velox/type/Type.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+class SparkVeloxConverterTest : public ::testing::Test {};
+
+TEST_F(SparkVeloxConverterTest, toVeloxTypeFromDataType) {
+  // Create and test primitive types
+  spark::connect::DataType dataType;
+
+  dataType.mutable_boolean();
+  EXPECT_EQ(velox::BOOLEAN(), toVeloxType(dataType));
+
+  dataType.mutable_byte();
+  EXPECT_EQ(velox::TINYINT(), toVeloxType(dataType));
+
+  dataType.mutable_short_();
+  EXPECT_EQ(velox::SMALLINT(), toVeloxType(dataType));
+
+  dataType.mutable_integer();
+  EXPECT_EQ(velox::INTEGER(), toVeloxType(dataType));
+
+  dataType.mutable_long_();
+  EXPECT_EQ(velox::BIGINT(), toVeloxType(dataType));
+
+  dataType.mutable_double_();
+  EXPECT_EQ(velox::DOUBLE(), toVeloxType(dataType));
+
+  dataType.mutable_float_();
+  EXPECT_EQ(velox::REAL(), toVeloxType(dataType));
+
+  dataType.mutable_string();
+  EXPECT_EQ(velox::VARCHAR(), toVeloxType(dataType));
+
+  dataType.mutable_date();
+  EXPECT_EQ(velox::DATE(), toVeloxType(dataType));
+
+  dataType.mutable_timestamp();
+  EXPECT_EQ(velox::TIMESTAMP(), toVeloxType(dataType));
+
+  dataType.mutable_binary();
+  EXPECT_EQ(velox::VARBINARY(), toVeloxType(dataType));
+
+  dataType.mutable_null();
+  EXPECT_EQ(velox::UNKNOWN(), toVeloxType(dataType));
+}
+
+TEST_F(SparkVeloxConverterTest, toVeloxTypeFromLiteral) {
+  // Test boolean literal
+  spark::connect::Expression::Literal boolLiteral;
+  boolLiteral.set_boolean(true);
+  EXPECT_EQ(velox::BOOLEAN(), toVeloxType(boolLiteral));
+
+  // Test integer literal
+  spark::connect::Expression::Literal intLiteral;
+  intLiteral.set_integer(42);
+  EXPECT_EQ(velox::INTEGER(), toVeloxType(intLiteral));
+
+  // Test long literal
+  spark::connect::Expression::Literal longLiteral;
+  longLiteral.set_long_(42L);
+  EXPECT_EQ(velox::BIGINT(), toVeloxType(longLiteral));
+
+  // Test double literal
+  spark::connect::Expression::Literal doubleLiteral;
+  doubleLiteral.set_double_(3.14);
+  EXPECT_EQ(velox::DOUBLE(), toVeloxType(doubleLiteral));
+
+  // Test string literal
+  spark::connect::Expression::Literal stringLiteral;
+  stringLiteral.set_string("hello");
+  EXPECT_EQ(velox::VARCHAR(), toVeloxType(stringLiteral));
+
+  // Test binary literal
+  spark::connect::Expression::Literal binaryLiteral;
+  binaryLiteral.set_binary("binary data");
+  EXPECT_EQ(velox::VARBINARY(), toVeloxType(binaryLiteral));
+
+  // Test null literal
+  spark::connect::Expression::Literal nullLiteral;
+  nullLiteral.mutable_null();
+  EXPECT_EQ(velox::UNKNOWN(), toVeloxType(nullLiteral));
+}
+
+TEST_F(SparkVeloxConverterTest, toVeloxVariant) {
+  spark::connect::Expression::Literal literal;
+
+  literal.set_boolean(true);
+  EXPECT_EQ(toVeloxVariant(literal)->kind(), velox::TypeKind::BOOLEAN);
+
+  literal.set_integer(42);
+  EXPECT_EQ(toVeloxVariant(literal)->kind(), velox::TypeKind::INTEGER);
+
+  literal.set_float_(0.99);
+  EXPECT_EQ(toVeloxVariant(literal)->kind(), velox::TypeKind::REAL);
+
+  literal.set_string("hello world");
+  EXPECT_EQ(toVeloxVariant(literal)->kind(), velox::TypeKind::VARCHAR);
+
+  // Variants operate on the pysical type layer, so they don't understand
+  // logical types.
+  literal.set_date(0);
+  EXPECT_EQ(toVeloxVariant(literal)->kind(), velox::TypeKind::INTEGER);
+}
+
+TEST_F(SparkVeloxConverterTest, jsonToVeloxType) {
+  // Test simple primitive type.
+  EXPECT_EQ(velox::VARCHAR(), jsonToVeloxType("\"string\""));
+  EXPECT_EQ(velox::INTEGER(), jsonToVeloxType("\"integer\""));
+  EXPECT_EQ(velox::BIGINT(), jsonToVeloxType("\"long\""));
+
+  // Test struct type.
+  std::string structJson = R"({
+    "type": "struct",
+    "fields": [
+      {"name": "name", "type": "string"},
+      {"name": "age", "type": "integer"},
+      {"name": "active", "type": "boolean"}
+    ]
+  })";
+
+  auto structType = jsonToVeloxType(structJson);
+  EXPECT_TRUE(structType->isRow());
+  const auto& rowType = structType->asRow();
+  EXPECT_EQ(3, rowType.size());
+  EXPECT_EQ("name", rowType.nameOf(0));
+  EXPECT_EQ("age", rowType.nameOf(1));
+  EXPECT_EQ("active", rowType.nameOf(2));
+  EXPECT_EQ(velox::VARCHAR(), rowType.childAt(0));
+  EXPECT_EQ(velox::INTEGER(), rowType.childAt(1));
+  EXPECT_EQ(velox::BOOLEAN(), rowType.childAt(2));
+
+  // Test array type.
+  std::string arrayJson = R"({
+    "type": "array",
+    "elementType": "string",
+    "containsNull": true
+  })";
+
+  auto arrayType = jsonToVeloxType(arrayJson);
+  EXPECT_TRUE(arrayType->isArray());
+  EXPECT_EQ(velox::VARCHAR(), arrayType->asArray().elementType());
+
+  // Test map type.
+  std::string mapJson = R"({
+    "type": "map",
+    "keyType": "string",
+    "valueType": "integer"
+  })";
+
+  auto mapType = jsonToVeloxType(mapJson);
+  EXPECT_TRUE(mapType->isMap());
+  EXPECT_EQ(velox::VARCHAR(), mapType->asMap().keyType());
+  EXPECT_EQ(velox::INTEGER(), mapType->asMap().valueType());
+}
+
+TEST_F(SparkVeloxConverterTest, aggregateMapsToReduce) {
+  EXPECT_EQ(toVeloxFunctionName("aggregate"), "reduce");
+}
+
+} // namespace
+} // namespace axiom::collagen::test

--- a/axiom/pyspark/third-party/protos/CMakeLists.txt
+++ b/axiom/pyspark/third-party/protos/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(
+  COLLAGEN_PROTO_SRCS
+  base.proto
+  catalog.proto
+  commands.proto
+  common.proto
+  expressions.proto
+  relations.proto
+  types.proto
+)
+
+set(COLLAGEN_PROTO_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Generate C++ sources from .proto files.
+set(COLLAGEN_PROTO_CXX_SRCS)
+set(COLLAGEN_PROTO_CXX_HDRS)
+set(COLLAGEN_GRPC_CXX_SRCS)
+set(COLLAGEN_GRPC_CXX_HDRS)
+
+foreach(PROTO_FILE ${COLLAGEN_PROTO_SRCS})
+  get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+
+  list(APPEND COLLAGEN_PROTO_CXX_SRCS "${COLLAGEN_PROTO_GENERATED_DIR}/${PROTO_NAME}.pb.cc")
+  list(APPEND COLLAGEN_PROTO_CXX_HDRS "${COLLAGEN_PROTO_GENERATED_DIR}/${PROTO_NAME}.pb.h")
+  list(APPEND COLLAGEN_GRPC_CXX_SRCS "${COLLAGEN_PROTO_GENERATED_DIR}/${PROTO_NAME}.grpc.pb.cc")
+  list(APPEND COLLAGEN_GRPC_CXX_HDRS "${COLLAGEN_PROTO_GENERATED_DIR}/${PROTO_NAME}.grpc.pb.h")
+endforeach()
+
+find_program(PROTOC_EXECUTABLE protoc REQUIRED)
+find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
+
+add_custom_command(
+  OUTPUT
+    ${COLLAGEN_PROTO_CXX_SRCS}
+    ${COLLAGEN_PROTO_CXX_HDRS}
+    ${COLLAGEN_GRPC_CXX_SRCS}
+    ${COLLAGEN_GRPC_CXX_HDRS}
+  COMMAND
+    ${PROTOC_EXECUTABLE} --proto_path=${CMAKE_CURRENT_SOURCE_DIR}
+    --cpp_out=${COLLAGEN_PROTO_GENERATED_DIR} --grpc_out=${COLLAGEN_PROTO_GENERATED_DIR}
+    --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN} ${COLLAGEN_PROTO_SRCS}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${COLLAGEN_PROTO_SRCS}
+  COMMENT "Generating Collagen protobuf/gRPC C++ sources"
+)
+
+add_library(collagen_proto ${COLLAGEN_PROTO_CXX_SRCS} ${COLLAGEN_GRPC_CXX_SRCS})
+
+target_include_directories(collagen_proto PUBLIC ${COLLAGEN_PROTO_GENERATED_DIR})
+
+target_link_libraries(collagen_proto protobuf::libprotobuf gRPC::grpc++)

--- a/axiom/pyspark/third-party/protos/base.proto
+++ b/axiom/pyspark/third-party/protos/base.proto
@@ -1,0 +1,553 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+import "google/protobuf/any.proto";
+import "axiom/pyspark/third-party/protos/commands.proto";
+import "axiom/pyspark/third-party/protos/common.proto";
+import "axiom/pyspark/third-party/protos/expressions.proto";
+import "axiom/pyspark/third-party/protos/relations.proto";
+import "axiom/pyspark/third-party/protos/types.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// A [[Plan]] is the structure that carries the runtime information for the execution from the
+// client to the server. A [[Plan]] can either be of the type [[Relation]] which is a reference
+// to the underlying logical plan or it can be of the [[Command]] type that is used to execute
+// commands on the server.
+message Plan {
+  oneof op_type {
+    Relation root = 1;
+    Command command = 2;
+  }
+}
+
+
+
+// User Context is used to refer to one particular user session that is executing
+// queries in the backend.
+message UserContext {
+  string user_id = 1;
+  string user_name = 2;
+
+  // To extend the existing user context message that is used to identify incoming requests,
+  // Spark Connect leverages the Any protobuf type that can be used to inject arbitrary other
+  // messages into this message. Extensions are stored as a `repeated` type to be able to
+  // handle multiple active extensions.
+  repeated google.protobuf.Any extensions = 999;
+}
+
+// Request to perform plan analyze, optionally to explain the plan.
+message AnalyzePlanRequest {
+  // (Required)
+  //
+  // The session_id specifies a spark session for a user id (which is specified
+  // by user_context.user_id). The session_id is set by the client to be able to
+  // collate streaming responses from different queries within the dedicated session.
+  string session_id = 1;
+
+  // (Required) User context
+  UserContext user_context = 2;
+
+  // Provides optional information about the client sending the request. This field
+  // can be used for language or version specific information and is only intended for
+  // logging purposes and will not be interpreted by the server.
+  optional string client_type = 3;
+
+  oneof analyze {
+    Schema schema = 4;
+    Explain explain = 5;
+    TreeString tree_string = 6;
+    IsLocal is_local = 7;
+    IsStreaming is_streaming = 8;
+    InputFiles input_files = 9;
+    SparkVersion spark_version = 10;
+    DDLParse ddl_parse = 11;
+    SameSemantics same_semantics = 12;
+    SemanticHash semantic_hash = 13;
+    Persist persist = 14;
+    Unpersist unpersist = 15;
+    GetStorageLevel get_storage_level = 16;
+  }
+
+  message Schema {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+  }
+
+  // Explains the input plan based on a configurable mode.
+  message Explain {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+
+    // (Required) For analyzePlan rpc calls, configure the mode to explain plan in strings.
+    ExplainMode explain_mode = 2;
+
+    // Plan explanation mode.
+    enum ExplainMode {
+      EXPLAIN_MODE_UNSPECIFIED = 0;
+
+      // Generates only physical plan.
+      EXPLAIN_MODE_SIMPLE = 1;
+
+      // Generates parsed logical plan, analyzed logical plan, optimized logical plan and physical plan.
+      // Parsed Logical plan is a unresolved plan that extracted from the query. Analyzed logical plans
+      // transforms which translates unresolvedAttribute and unresolvedRelation into fully typed objects.
+      // The optimized logical plan transforms through a set of optimization rules, resulting in the
+      // physical plan.
+      EXPLAIN_MODE_EXTENDED = 2;
+
+      // Generates code for the statement, if any and a physical plan.
+      EXPLAIN_MODE_CODEGEN = 3;
+
+      // If plan node statistics are available, generates a logical plan and also the statistics.
+      EXPLAIN_MODE_COST = 4;
+
+      // Generates a physical plan outline and also node details.
+      EXPLAIN_MODE_FORMATTED = 5;
+    }
+  }
+
+  message TreeString {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+  }
+
+  message IsLocal {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+  }
+
+  message IsStreaming {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+  }
+
+  message InputFiles {
+    // (Required) The logical plan to be analyzed.
+    Plan plan = 1;
+  }
+
+  message SparkVersion { }
+
+  message DDLParse {
+    // (Required) The DDL formatted string to be parsed.
+    string ddl_string = 1;
+  }
+
+
+  // Returns `true` when the logical query plans  are equal and therefore return same results.
+  message SameSemantics {
+    // (Required) The plan to be compared.
+    Plan target_plan = 1;
+
+    // (Required) The other plan to be compared.
+    Plan other_plan = 2;
+  }
+
+  message SemanticHash {
+    // (Required) The logical plan to get a hashCode.
+    Plan plan = 1;
+  }
+
+  message Persist {
+    // (Required) The logical plan to persist.
+    Relation relation = 1;
+
+    // (Optional) The storage level.
+    optional StorageLevel storage_level = 2;
+  }
+
+  message Unpersist {
+    // (Required) The logical plan to unpersist.
+    Relation relation = 1;
+
+    // (Optional) Whether to block until all blocks are deleted.
+    optional bool blocking = 2;
+  }
+
+  message GetStorageLevel {
+    // (Required) The logical plan to get the storage level.
+    Relation relation = 1;
+  }
+}
+
+// Response to performing analysis of the query. Contains relevant metadata to be able to
+// reason about the performance.
+message AnalyzePlanResponse {
+  string session_id = 1;
+
+  oneof result {
+    Schema schema = 2;
+    Explain explain = 3;
+    TreeString tree_string = 4;
+    IsLocal is_local = 5;
+    IsStreaming is_streaming = 6;
+    InputFiles input_files = 7;
+    SparkVersion spark_version = 8;
+    DDLParse ddl_parse = 9;
+    SameSemantics same_semantics = 10;
+    SemanticHash semantic_hash = 11;
+    Persist persist = 12;
+    Unpersist unpersist = 13;
+    GetStorageLevel get_storage_level = 14;
+  }
+
+  message Schema {
+    DataType schema = 1;
+  }
+
+  message Explain {
+    string explain_string = 1;
+    // The Velox physical plan string (MultiFragmentPlan.toString())
+    // This is populated when the Axiom optimizer successfully generates a physical plan.
+    string velox_plan_string = 2;
+  }
+
+  message TreeString {
+    string tree_string = 1;
+  }
+
+  message IsLocal {
+    bool is_local = 1;
+  }
+
+  message IsStreaming {
+    bool is_streaming = 1;
+  }
+
+  message InputFiles {
+    // A best-effort snapshot of the files that compose this Dataset
+    repeated string files = 1;
+  }
+
+  message SparkVersion {
+    string version = 1;
+  }
+
+  message DDLParse {
+    DataType parsed = 1;
+  }
+
+  message SameSemantics {
+    bool result = 1;
+  }
+
+  message SemanticHash {
+    int32 result = 1;
+  }
+
+  message Persist { }
+
+  message Unpersist { }
+
+  message GetStorageLevel {
+    // (Required) The StorageLevel as a result of get_storage_level request.
+    StorageLevel storage_level = 1;
+  }
+}
+
+// A request to be executed by the service.
+message ExecutePlanRequest {
+  // (Required)
+  //
+  // The session_id specifies a spark session for a user id (which is specified
+  // by user_context.user_id). The session_id is set by the client to be able to
+  // collate streaming responses from different queries within the dedicated session.
+  string session_id = 1;
+
+  // (Required) User context
+  //
+  // user_context.user_id and session+id both identify a unique remote spark session on the
+  // server side.
+  UserContext user_context = 2;
+
+  // (Required) The logical plan to be executed / analyzed.
+  Plan plan = 3;
+
+  // Provides optional information about the client sending the request. This field
+  // can be used for language or version specific information and is only intended for
+  // logging purposes and will not be interpreted by the server.
+  optional string client_type = 4;
+}
+
+// The response of a query, can be one or more for each request. Responses belonging to the
+// same input query, carry the same `session_id`.
+message ExecutePlanResponse {
+  string session_id = 1;
+
+  // Union type for the different response messages.
+  oneof response_type {
+    ArrowBatch arrow_batch = 2;
+
+    // Special case for executing SQL commands.
+    SqlCommandResult sql_command_result = 5;
+
+    // Support arbitrary result objects.
+    google.protobuf.Any extension = 999;
+  }
+
+  // Metrics for the query execution. Typically, this field is only present in the last
+  // batch of results and then represent the overall state of the query execution.
+  Metrics metrics = 4;
+
+  // The metrics observed during the execution of the query plan.
+  repeated ObservedMetrics observed_metrics = 6;
+
+  // (Optional) The Spark schema. This field is available when `collect` is called.
+  DataType schema = 7;
+
+  // A SQL command returns an opaque Relation that can be directly used as input for the next
+  // call.
+  message SqlCommandResult {
+    Relation relation = 1;
+  }
+
+  // Batch results of metrics.
+  message ArrowBatch {
+    int64 row_count = 1;
+    bytes data = 2;
+  }
+
+  message Metrics {
+
+    repeated MetricObject metrics = 1;
+
+    message MetricObject {
+      string name = 1;
+      int64 plan_id = 2;
+      int64 parent = 3;
+      map<string, MetricValue> execution_metrics = 4;
+    }
+
+    message MetricValue {
+      string name = 1;
+      int64 value = 2;
+      string metric_type = 3;
+    }
+  }
+
+  message ObservedMetrics {
+    string name = 1;
+    repeated Expression.Literal values = 2;
+  }
+}
+
+// The key-value pair for the config request and response.
+message KeyValue {
+  // (Required) The key.
+  string key = 1;
+  // (Optional) The value.
+  optional string value = 2;
+}
+
+// Request to update or fetch the configurations.
+message ConfigRequest {
+  // (Required)
+  //
+  // The session_id specifies a spark session for a user id (which is specified
+  // by user_context.user_id). The session_id is set by the client to be able to
+  // collate streaming responses from different queries within the dedicated session.
+  string session_id = 1;
+
+  // (Required) User context
+  UserContext user_context = 2;
+
+  // (Required) The operation for the config.
+  Operation operation = 3;
+
+  // Provides optional information about the client sending the request. This field
+  // can be used for language or version specific information and is only intended for
+  // logging purposes and will not be interpreted by the server.
+  optional string client_type = 4;
+
+  message Operation {
+    oneof op_type {
+      Set set = 1;
+      Get get = 2;
+      GetWithDefault get_with_default = 3;
+      GetOption get_option = 4;
+      GetAll get_all = 5;
+      Unset unset = 6;
+      IsModifiable is_modifiable = 7;
+    }
+  }
+
+  message Set {
+    // (Required) The config key-value pairs to set.
+    repeated KeyValue pairs = 1;
+  }
+
+  message Get {
+    // (Required) The config keys to get.
+    repeated string keys = 1;
+  }
+
+  message GetWithDefault {
+    // (Required) The config key-value paris to get. The value will be used as the default value.
+    repeated KeyValue pairs = 1;
+  }
+
+  message GetOption {
+    // (Required) The config keys to get optionally.
+    repeated string keys = 1;
+  }
+
+  message GetAll {
+    // (Optional) The prefix of the config key to get.
+    optional string prefix = 1;
+  }
+
+  message Unset {
+    // (Required) The config keys to unset.
+    repeated string keys = 1;
+  }
+
+  message IsModifiable {
+    // (Required) The config keys to check the config is modifiable.
+    repeated string keys = 1;
+  }
+}
+
+// Response to the config request.
+message ConfigResponse {
+  string session_id = 1;
+
+  // (Optional) The result key-value pairs.
+  //
+  // Available when the operation is 'Get', 'GetWithDefault', 'GetOption', 'GetAll'.
+  // Also available for the operation 'IsModifiable' with boolean string "true" and "false".
+  repeated KeyValue pairs = 2;
+
+  // (Optional)
+  //
+  // Warning messages for deprecated or unsupported configurations.
+  repeated string warnings = 3;
+}
+
+// Request to transfer client-local artifacts.
+message AddArtifactsRequest {
+
+  // (Required)
+  //
+  // The session_id specifies a spark session for a user id (which is specified
+  // by user_context.user_id). The session_id is set by the client to be able to
+  // collate streaming responses from different queries within the dedicated session.
+  string session_id = 1;
+
+  // User context
+  UserContext user_context = 2;
+
+  // Provides optional information about the client sending the request. This field
+  // can be used for language or version specific information and is only intended for
+  // logging purposes and will not be interpreted by the server.
+  optional string client_type = 6;
+
+  // A chunk of an Artifact.
+  message ArtifactChunk {
+    // Data chunk.
+    bytes data = 1;
+    // CRC to allow server to verify integrity of the chunk.
+    int64 crc = 2;
+  }
+
+  // An artifact that is contained in a single `ArtifactChunk`.
+  // Generally, this message represents tiny artifacts such as REPL-generated class files.
+  message SingleChunkArtifact {
+    // The name of the artifact is expected in the form of a "Relative Path" that is made up of a
+    // sequence of directories and the final file element.
+    // Examples of "Relative Path"s: "jars/test.jar", "classes/xyz.class", "abc.xyz", "a/b/X.jar".
+    // The server is expected to maintain the hierarchy of files as defined by their name. (i.e
+    // The relative path of the file on the server's filesystem will be the same as the name of
+    // the provided artifact)
+    string name = 1;
+    // A single data chunk.
+    ArtifactChunk data = 2;
+  }
+
+  // A number of `SingleChunkArtifact` batched into a single RPC.
+  message Batch {
+    repeated SingleChunkArtifact artifacts = 1;
+  }
+
+  // Signals the beginning/start of a chunked artifact.
+  // A large artifact is transferred through a payload of `BeginChunkedArtifact` followed by a
+  // sequence of `ArtifactChunk`s.
+  message BeginChunkedArtifact {
+    // Name of the artifact undergoing chunking. Follows the same conventions as the `name` in
+    // the `Artifact` message.
+    string name = 1;
+    // Total size of the artifact in bytes.
+    int64 total_bytes = 2;
+    // Number of chunks the artifact is split into.
+    // This includes the `initial_chunk`.
+    int64 num_chunks = 3;
+    // The first/initial chunk.
+    ArtifactChunk initial_chunk = 4;
+  }
+
+  // The payload is either a batch of artifacts or a partial chunk of a large artifact.
+  oneof payload {
+    Batch batch = 3;
+    // The metadata and the initial chunk of a large artifact chunked into multiple requests.
+    // The server side is notified about the total size of the large artifact as well as the
+    // number of chunks to expect.
+    BeginChunkedArtifact begin_chunk = 4;
+    // A chunk of an artifact excluding metadata. This can be any chunk of a large artifact
+    // excluding the first chunk (which is included in `BeginChunkedArtifact`).
+    ArtifactChunk chunk = 5;
+  }
+}
+
+// Response to adding an artifact. Contains relevant metadata to verify successful transfer of
+// artifact(s).
+message AddArtifactsResponse {
+  // Metadata of an artifact.
+  message ArtifactSummary {
+    string name = 1;
+    // Whether the CRC (Cyclic Redundancy Check) is successful on server verification.
+    // The server discards any artifact that fails the CRC.
+    // If false, the client may choose to resend the artifact specified by `name`.
+    bool is_crc_successful = 2;
+  }
+
+  // The list of artifact(s) seen by the server.
+  repeated ArtifactSummary artifacts = 1;
+}
+
+// Main interface for the SparkConnect service.
+service SparkConnectService {
+
+  // Executes a request that contains the query and returns a stream of [[Response]].
+  //
+  // It is guaranteed that there is at least one ARROW batch returned even if the result set is empty.
+  rpc ExecutePlan(ExecutePlanRequest) returns (stream ExecutePlanResponse) {}
+
+  // Analyzes a query and returns a [[AnalyzeResponse]] containing metadata about the query.
+  rpc AnalyzePlan(AnalyzePlanRequest) returns (AnalyzePlanResponse) {}
+
+  // Update or fetch the configurations and returns a [[ConfigResponse]] containing the result.
+  rpc Config(ConfigRequest) returns (ConfigResponse) {}
+
+  // Add artifacts to the session and returns a [[AddArtifactsResponse]] containing metadata about
+  // the added artifacts.
+  rpc AddArtifacts(stream AddArtifactsRequest) returns (AddArtifactsResponse) {}
+}

--- a/axiom/pyspark/third-party/protos/catalog.proto
+++ b/axiom/pyspark/third-party/protos/catalog.proto
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+import "axiom/pyspark/third-party/protos/types.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// Catalog messages are marked as unstable.
+message Catalog {
+  oneof cat_type {
+    CurrentDatabase current_database = 1;
+    SetCurrentDatabase set_current_database = 2;
+    ListDatabases list_databases = 3;
+    ListTables list_tables = 4;
+    ListFunctions list_functions = 5;
+    ListColumns list_columns = 6;
+    GetDatabase get_database = 7;
+    GetTable get_table = 8;
+    GetFunction get_function = 9;
+    DatabaseExists database_exists = 10;
+    TableExists table_exists = 11;
+    FunctionExists function_exists = 12;
+    CreateExternalTable create_external_table = 13;
+    CreateTable create_table = 14;
+    DropTempView drop_temp_view = 15;
+    DropGlobalTempView drop_global_temp_view = 16;
+    RecoverPartitions recover_partitions = 17;
+    IsCached is_cached = 18;
+    CacheTable cache_table = 19;
+    UncacheTable uncache_table = 20;
+    ClearCache clear_cache = 21;
+    RefreshTable refresh_table = 22;
+    RefreshByPath refresh_by_path = 23;
+    CurrentCatalog current_catalog = 24;
+    SetCurrentCatalog set_current_catalog = 25;
+    ListCatalogs list_catalogs = 26;
+  }
+}
+
+// See `spark.catalog.currentDatabase`
+message CurrentDatabase { }
+
+// See `spark.catalog.setCurrentDatabase`
+message SetCurrentDatabase {
+  // (Required)
+  string db_name = 1;
+}
+
+// See `spark.catalog.listDatabases`
+message ListDatabases { }
+
+// See `spark.catalog.listTables`
+message ListTables {
+  // (Optional)
+  optional string db_name = 1;
+}
+
+// See `spark.catalog.listFunctions`
+message ListFunctions {
+  // (Optional)
+  optional string db_name = 1;
+}
+
+// See `spark.catalog.listColumns`
+message ListColumns {
+  // (Required)
+  string table_name = 1;
+  // (Optional)
+  optional string db_name = 2;
+}
+
+// See `spark.catalog.getDatabase`
+message GetDatabase {
+  // (Required)
+  string db_name = 1;
+}
+
+// See `spark.catalog.getTable`
+message GetTable {
+  // (Required)
+  string table_name = 1;
+  // (Optional)
+  optional string db_name = 2;
+}
+
+// See `spark.catalog.getFunction`
+message GetFunction {
+  // (Required)
+  string function_name = 1;
+  // (Optional)
+  optional string db_name = 2;
+}
+
+// See `spark.catalog.databaseExists`
+message DatabaseExists {
+  // (Required)
+  string db_name = 1;
+}
+
+// See `spark.catalog.tableExists`
+message TableExists {
+  // (Required)
+  string table_name = 1;
+  // (Optional)
+  optional string db_name = 2;
+}
+
+// See `spark.catalog.functionExists`
+message FunctionExists {
+  // (Required)
+  string function_name = 1;
+  // (Optional)
+  optional string db_name = 2;
+}
+
+// See `spark.catalog.createExternalTable`
+message CreateExternalTable {
+  // (Required)
+  string table_name = 1;
+  // (Optional)
+  optional string path = 2;
+  // (Optional)
+  optional string source = 3;
+  // (Optional)
+  optional DataType schema = 4;
+  // Options could be empty for valid data source format.
+  // The map key is case insensitive.
+  map<string, string> options = 5;
+}
+
+// See `spark.catalog.createTable`
+message CreateTable {
+  // (Required)
+  string table_name = 1;
+  // (Optional)
+  optional string path = 2;
+  // (Optional)
+  optional string source = 3;
+  // (Optional)
+  optional string description = 4;
+  // (Optional)
+  optional DataType schema = 5;
+  // Options could be empty for valid data source format.
+  // The map key is case insensitive.
+  map<string, string> options = 6;
+}
+
+// See `spark.catalog.dropTempView`
+message DropTempView {
+  // (Required)
+  string view_name = 1;
+}
+
+// See `spark.catalog.dropGlobalTempView`
+message DropGlobalTempView {
+  // (Required)
+  string view_name = 1;
+}
+
+// See `spark.catalog.recoverPartitions`
+message RecoverPartitions {
+  // (Required)
+  string table_name = 1;
+}
+
+// See `spark.catalog.isCached`
+message IsCached {
+  // (Required)
+  string table_name = 1;
+}
+
+// See `spark.catalog.cacheTable`
+message CacheTable {
+  // (Required)
+  string table_name = 1;
+}
+
+// See `spark.catalog.uncacheTable`
+message UncacheTable {
+  // (Required)
+  string table_name = 1;
+}
+
+// See `spark.catalog.clearCache`
+message ClearCache { }
+
+// See `spark.catalog.refreshTable`
+message RefreshTable {
+  // (Required)
+  string table_name = 1;
+}
+
+// See `spark.catalog.refreshByPath`
+message RefreshByPath {
+  // (Required)
+  string path = 1;
+}
+
+// See `spark.catalog.currentCatalog`
+message CurrentCatalog { }
+
+// See `spark.catalog.setCurrentCatalog`
+message SetCurrentCatalog {
+  // (Required)
+  string catalog_name = 1;
+}
+
+// See `spark.catalog.listCatalogs`
+message ListCatalogs { }

--- a/axiom/pyspark/third-party/protos/commands.proto
+++ b/axiom/pyspark/third-party/protos/commands.proto
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+import "google/protobuf/any.proto";
+import "axiom/pyspark/third-party/protos/expressions.proto";
+import "axiom/pyspark/third-party/protos/relations.proto";
+
+package spark.connect;
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// A [[Command]] is an operation that is executed by the server that does not directly consume or
+// produce a relational result.
+message Command {
+  oneof command_type {
+    CommonInlineUserDefinedFunction register_function = 1;
+    WriteOperation write_operation = 2;
+    CreateDataFrameViewCommand create_dataframe_view = 3;
+    WriteOperationV2 write_operation_v2 = 4;
+    SqlCommand sql_command = 5;
+
+    // This field is used to mark extensions to the protocol. When plugins generate arbitrary
+    // Commands they can add them here. During the planning the correct resolution is done.
+    google.protobuf.Any extension = 999;
+
+  }
+}
+
+// A SQL Command is used to trigger the eager evaluation of SQL commands in Spark.
+//
+// When the SQL provide as part of the message is a command it will be immediately evaluated
+// and the result will be collected and returned as part of a LocalRelation. If the result is
+// not a command, the operation will simply return a SQL Relation. This allows the client to be
+// almost oblivious to the server-side behavior.
+message SqlCommand {
+  // (Required) SQL Query.
+  string sql = 1;
+
+  // (Optional) A map of parameter names to literal expressions.
+  map<string, Expression.Literal> args = 2;
+}
+
+// A command that can create DataFrame global temp view or local temp view.
+message CreateDataFrameViewCommand {
+  // (Required) The relation that this view will be built on.
+  Relation input = 1;
+
+  // (Required) View name.
+  string name = 2;
+
+  // (Required) Whether this is global temp view or local temp view.
+  bool is_global = 3;
+
+  // (Required)
+  //
+  // If true, and if the view already exists, updates it; if false, and if the view
+  // already exists, throws exception.
+  bool replace = 4;
+}
+
+// As writes are not directly handled during analysis and planning, they are modeled as commands.
+message WriteOperation {
+  // (Required) The output of the `input` relation will be persisted according to the options.
+  Relation input = 1;
+
+  // (Optional) Format value according to the Spark documentation. Examples are: text, parquet, delta.
+  optional string source = 2;
+
+  // (Optional)
+  //
+  // The destination of the write operation can be either a path or a table.
+  // If the destination is neither a path nor a table, such as jdbc and noop,
+  // the `save_type` should not be set.
+  oneof save_type {
+    string path = 3;
+    SaveTable table = 4;
+  }
+
+  // (Required) the save mode.
+  SaveMode mode = 5;
+
+  // (Optional) List of columns to sort the output by.
+  repeated string sort_column_names = 6;
+
+  // (Optional) List of columns for partitioning.
+  repeated string partitioning_columns = 7;
+
+  // (Optional) Bucketing specification. Bucketing must set the number of buckets and the columns
+  // to bucket by.
+  BucketBy bucket_by = 8;
+
+  // (Optional) A list of configuration options.
+  map<string, string> options = 9;
+
+  message SaveTable {
+    // (Required) The table name.
+    string table_name = 1;
+    // (Required) The method to be called to write to the table.
+    TableSaveMethod save_method = 2;
+
+    enum TableSaveMethod {
+      TABLE_SAVE_METHOD_UNSPECIFIED = 0;
+      TABLE_SAVE_METHOD_SAVE_AS_TABLE = 1;
+      TABLE_SAVE_METHOD_INSERT_INTO = 2;
+    }
+  }
+
+  message BucketBy {
+    repeated string bucket_column_names = 1;
+    int32 num_buckets = 2;
+  }
+
+  enum SaveMode {
+    SAVE_MODE_UNSPECIFIED = 0;
+    SAVE_MODE_APPEND = 1;
+    SAVE_MODE_OVERWRITE = 2;
+    SAVE_MODE_ERROR_IF_EXISTS = 3;
+    SAVE_MODE_IGNORE = 4;
+  }
+}
+
+// As writes are not directly handled during analysis and planning, they are modeled as commands.
+message WriteOperationV2 {
+  // (Required) The output of the `input` relation will be persisted according to the options.
+  Relation input = 1;
+
+  // (Required) The destination of the write operation must be either a path or a table.
+  string table_name = 2;
+
+  // (Optional) A provider for the underlying output data source. Spark's default catalog supports
+  // "parquet", "json", etc.
+  optional string provider = 3;
+
+  // (Optional) List of columns for partitioning for output table created by `create`,
+  // `createOrReplace`, or `replace`
+  repeated Expression partitioning_columns = 4;
+
+  // (Optional) A list of configuration options.
+  map<string, string> options = 5;
+
+  // (Optional) A list of table properties.
+  map<string, string> table_properties = 6;
+
+  // (Required) Write mode.
+  Mode mode = 7;
+
+  enum Mode {
+    MODE_UNSPECIFIED = 0;
+    MODE_CREATE = 1;
+    MODE_OVERWRITE = 2;
+    MODE_OVERWRITE_PARTITIONS = 3;
+    MODE_APPEND = 4;
+    MODE_REPLACE = 5;
+    MODE_CREATE_OR_REPLACE = 6;
+  }
+
+  // (Optional) A condition for overwrite saving mode
+  Expression overwrite_condition = 8;
+}

--- a/axiom/pyspark/third-party/protos/common.proto
+++ b/axiom/pyspark/third-party/protos/common.proto
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// StorageLevel for persisting Datasets/Tables.
+message StorageLevel {
+  // (Required) Whether the cache should use disk or not.
+  bool use_disk = 1;
+  // (Required) Whether the cache should use memory or not.
+  bool use_memory = 2;
+  // (Required) Whether the cache should use off-heap or not.
+  bool use_off_heap = 3;
+  // (Required) Whether the cached data is deserialized or not.
+  bool deserialized = 4;
+  // (Required) The number of replicas.
+  int32 replication = 5;
+}

--- a/axiom/pyspark/third-party/protos/example_plugins.proto
+++ b/axiom/pyspark/third-party/protos/example_plugins.proto
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+import "axiom/pyspark/third-party/protos/relations.proto";
+import "axiom/pyspark/third-party/protos/expressions.proto";
+
+package spark.connect;
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+message ExamplePluginRelation {
+  Relation input = 1;
+  string custom_field = 2;
+
+}
+
+message ExamplePluginExpression {
+  Expression child = 1;
+  string custom_field = 2;
+}
+
+message ExamplePluginCommand {
+  string custom_field = 1;
+}

--- a/axiom/pyspark/third-party/protos/expressions.proto
+++ b/axiom/pyspark/third-party/protos/expressions.proto
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+import "google/protobuf/any.proto";
+import "axiom/pyspark/third-party/protos/types.proto";
+
+package spark.connect;
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// Expression used to refer to fields, functions and similar. This can be used everywhere
+// expressions in SQL appear.
+message Expression {
+
+  oneof expr_type {
+    Literal literal = 1;
+    UnresolvedAttribute unresolved_attribute = 2;
+    UnresolvedFunction unresolved_function = 3;
+    ExpressionString expression_string = 4;
+    UnresolvedStar unresolved_star = 5;
+    Alias alias = 6;
+    Cast cast = 7;
+    UnresolvedRegex unresolved_regex = 8;
+    SortOrder sort_order = 9;
+    LambdaFunction lambda_function = 10;
+    Window window = 11;
+    UnresolvedExtractValue unresolved_extract_value = 12;
+    UpdateFields update_fields = 13;
+    UnresolvedNamedLambdaVariable unresolved_named_lambda_variable = 14;
+    CommonInlineUserDefinedFunction common_inline_user_defined_function = 15;
+
+    // This field is used to mark extensions to the protocol. When plugins generate arbitrary
+    // relations they can add them here. During the planning the correct resolution is done.
+    google.protobuf.Any extension = 999;
+  }
+
+
+  // Expression for the OVER clause or WINDOW clause.
+  message Window {
+
+    // (Required) The window function.
+    Expression window_function = 1;
+
+    // (Optional) The way that input rows are partitioned.
+    repeated Expression partition_spec = 2;
+
+    // (Optional) Ordering of rows in a partition.
+    repeated SortOrder order_spec = 3;
+
+    // (Optional) Window frame in a partition.
+    //
+    // If not set, it will be treated as 'UnspecifiedFrame'.
+    WindowFrame frame_spec = 4;
+
+    // The window frame
+    message WindowFrame {
+
+      // (Required) The type of the frame.
+      FrameType frame_type = 1;
+
+      // (Required) The lower bound of the frame.
+      FrameBoundary lower = 2;
+
+      // (Required) The upper bound of the frame.
+      FrameBoundary upper = 3;
+
+      enum FrameType {
+        FRAME_TYPE_UNDEFINED = 0;
+
+        // RowFrame treats rows in a partition individually.
+        FRAME_TYPE_ROW = 1;
+
+        // RangeFrame treats rows in a partition as groups of peers.
+        // All rows having the same 'ORDER BY' ordering are considered as peers.
+        FRAME_TYPE_RANGE = 2;
+      }
+
+      message FrameBoundary {
+        oneof boundary {
+          // CURRENT ROW boundary
+          bool current_row = 1;
+
+          // UNBOUNDED boundary.
+          // For lower bound, it will be converted to 'UnboundedPreceding'.
+          // for upper bound, it will be converted to 'UnboundedFollowing'.
+          bool unbounded = 2;
+
+          // This is an expression for future proofing. We are expecting literals on the server side.
+          Expression value = 3;
+        }
+      }
+    }
+  }
+
+  // SortOrder is used to specify the  data ordering, it is normally used in Sort and Window.
+  // It is an unevaluable expression and cannot be evaluated, so can not be used in Projection.
+  message SortOrder {
+    // (Required) The expression to be sorted.
+    Expression child = 1;
+
+    // (Required) The sort direction, should be ASCENDING or DESCENDING.
+    SortDirection direction = 2;
+
+    // (Required) How to deal with NULLs, should be NULLS_FIRST or NULLS_LAST.
+    NullOrdering null_ordering = 3;
+
+    enum SortDirection {
+      SORT_DIRECTION_UNSPECIFIED = 0;
+      SORT_DIRECTION_ASCENDING = 1;
+      SORT_DIRECTION_DESCENDING = 2;
+    }
+
+    enum NullOrdering {
+      SORT_NULLS_UNSPECIFIED = 0;
+      SORT_NULLS_FIRST = 1;
+      SORT_NULLS_LAST = 2;
+    }
+  }
+
+  message Cast {
+    // (Required) the expression to be casted.
+    Expression expr = 1;
+
+    // (Required) the data type that the expr to be casted to.
+    oneof cast_to_type {
+      DataType type = 2;
+      // If this is set, Server will use Catalyst parser to parse this string to DataType.
+      string type_str = 3;
+    }
+  }
+
+  message Literal {
+    oneof literal_type {
+      DataType null = 1;
+      bytes binary = 2;
+      bool boolean = 3;
+
+      int32 byte = 4;
+      int32 short = 5;
+      int32 integer = 6;
+      int64 long = 7;
+      float float = 10;
+      double double = 11;
+      Decimal decimal = 12;
+
+      string string = 13;
+
+      // Date in units of days since the UNIX epoch.
+      int32 date = 16;
+      // Timestamp in units of microseconds since the UNIX epoch.
+      int64 timestamp = 17;
+      // Timestamp in units of microseconds since the UNIX epoch (without timezone information).
+      int64 timestamp_ntz = 18;
+
+      CalendarInterval calendar_interval = 19;
+      int32 year_month_interval = 20;
+      int64 day_time_interval = 21;
+      Array array = 22;
+    }
+
+    message Decimal {
+      // the string representation.
+      string value = 1;
+      // The maximum number of digits allowed in the value.
+      // the maximum precision is 38.
+      optional int32 precision = 2;
+      // declared scale of decimal literal
+      optional int32 scale = 3;
+    }
+
+    message CalendarInterval {
+      int32 months = 1;
+      int32 days = 2;
+      int64 microseconds = 3;
+    }
+
+    message Array {
+      DataType element_type = 1;
+      repeated Literal elements = 2;
+    }
+  }
+
+  // An unresolved attribute that is not explicitly bound to a specific column, but the column
+  // is resolved during analysis by name.
+  message UnresolvedAttribute {
+    // (Required) An identifier that will be parsed by Catalyst parser. This should follow the
+    // Spark SQL identifier syntax.
+    string unparsed_identifier = 1;
+
+    // (Optional) The id of corresponding connect plan.
+    optional int64 plan_id = 2;
+  }
+
+  // An unresolved function is not explicitly bound to one explicit function, but the function
+  // is resolved during analysis following Sparks name resolution rules.
+  message UnresolvedFunction {
+    // (Required) name (or unparsed name for user defined function) for the unresolved function.
+    string function_name = 1;
+
+    // (Optional) Function arguments. Empty arguments are allowed.
+    repeated Expression arguments = 2;
+
+    // (Required) Indicate if this function should be applied on distinct values.
+    bool is_distinct = 3;
+
+    // (Required) Indicate if this is a user defined function.
+    //
+    // When it is not a user defined function, Connect will use the function name directly.
+    // When it is a user defined function, Connect will parse the function name first.
+    bool is_user_defined_function = 4;
+  }
+
+  // Expression as string.
+  message ExpressionString {
+    // (Required) A SQL expression that will be parsed by Catalyst parser.
+    string expression = 1;
+  }
+
+  // UnresolvedStar is used to expand all the fields of a relation or struct.
+  message UnresolvedStar {
+
+    // (Optional) The target of the expansion.
+    //
+    // If set, it should end with '.*' and will be parsed by 'parseAttributeName'
+    // in the server side.
+    optional string unparsed_target = 1;
+  }
+
+  // Represents all of the input attributes to a given relational operator, for example in
+  // "SELECT `(id)?+.+` FROM ...".
+  message UnresolvedRegex {
+    // (Required) The column name used to extract column with regex.
+    string col_name = 1;
+
+    // (Optional) The id of corresponding connect plan.
+    optional int64 plan_id = 2;
+  }
+
+  // Extracts a value or values from an Expression
+  message UnresolvedExtractValue {
+    // (Required) The expression to extract value from, can be
+    // Map, Array, Struct or array of Structs.
+    Expression child = 1;
+
+    // (Required) The expression to describe the extraction, can be
+    // key of Map, index of Array, field name of Struct.
+    Expression extraction = 2;
+  }
+
+  // Add, replace or drop a field of `StructType` expression by name.
+  message UpdateFields {
+    // (Required) The struct expression.
+    Expression struct_expression = 1;
+
+    // (Required) The field name.
+    string field_name = 2;
+
+    // (Optional) The expression to add or replace.
+    //
+    // When not set, it means this field will be dropped.
+    Expression value_expression = 3;
+  }
+
+  message Alias {
+    // (Required) The expression that alias will be added on.
+    Expression expr = 1;
+
+    // (Required) a list of name parts for the alias.
+    //
+    // Scalar columns only has one name that presents.
+    repeated string name = 2;
+
+    // (Optional) Alias metadata expressed as a JSON map.
+    optional string metadata = 3;
+  }
+
+  message LambdaFunction {
+    // (Required) The lambda function.
+    //
+    // The function body should use 'UnresolvedAttribute' as arguments, the sever side will
+    // replace 'UnresolvedAttribute' with 'UnresolvedNamedLambdaVariable'.
+    Expression function = 1;
+
+    // (Required) Function variables. Must contains 1 ~ 3 variables.
+    repeated Expression.UnresolvedNamedLambdaVariable arguments = 2;
+  }
+
+  message UnresolvedNamedLambdaVariable {
+
+    // (Required) a list of name parts for the variable. Must not be empty.
+    repeated string name_parts = 1;
+  }
+}
+
+message CommonInlineUserDefinedFunction {
+  // (Required) Name of the user-defined function.
+  string function_name = 1;
+  // (Optional) Indicate if the user-defined function is deterministic.
+  bool deterministic = 2;
+  // (Optional) Function arguments. Empty arguments are allowed.
+  repeated Expression arguments = 3;
+  // (Required) Indicate the function type of the user-defined function.
+  oneof function {
+    PythonUDF python_udf = 4;
+    ScalarScalaUDF scalar_scala_udf = 5;
+    JavaUDF java_udf = 6;
+  }
+}
+
+message PythonUDF {
+  // (Required) Output type of the Python UDF
+  DataType output_type = 1;
+  // (Required) EvalType of the Python UDF
+  int32 eval_type = 2;
+  // (Required) The encoded commands of the Python UDF
+  bytes command = 3;
+  // (Required) Python version being used in the client.
+  string python_ver = 4;
+}
+
+message ScalarScalaUDF {
+  // (Required) Serialized JVM object containing UDF definition, input encoders and output encoder
+  bytes payload = 1;
+  // (Optional) Input type(s) of the UDF
+  repeated DataType inputTypes = 2;
+  // (Required) Output type of the UDF
+  DataType outputType = 3;
+  // (Required) True if the UDF can return null value
+  bool nullable = 4;
+}
+
+message JavaUDF {
+  // (Required) Fully qualified name of Java class
+  string class_name = 1;
+
+  // (Optional) Output type of the Java UDF
+  optional DataType output_type = 2;
+
+  // (Required) Indicate if the Java user-defined function is an aggregate function
+  bool aggregate = 3;
+}

--- a/axiom/pyspark/third-party/protos/relations.proto
+++ b/axiom/pyspark/third-party/protos/relations.proto
@@ -1,0 +1,852 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+import "google/protobuf/any.proto";
+import "axiom/pyspark/third-party/protos/expressions.proto";
+import "axiom/pyspark/third-party/protos/types.proto";
+import "axiom/pyspark/third-party/protos/catalog.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// The main [[Relation]] type. Fundamentally, a relation is a typed container
+// that has exactly one explicit relation type set.
+//
+// When adding new relation types, they have to be registered here.
+message Relation {
+  RelationCommon common = 1;
+  oneof rel_type {
+    Read read = 2;
+    Project project = 3;
+    Filter filter = 4;
+    Join join = 5;
+    SetOperation set_op = 6;
+    Sort sort = 7;
+    Limit limit = 8;
+    Aggregate aggregate = 9;
+    SQL sql = 10;
+    LocalRelation local_relation = 11;
+    Sample sample = 12;
+    Offset offset = 13;
+    Deduplicate deduplicate = 14;
+    Range range = 15;
+    SubqueryAlias subquery_alias = 16;
+    Repartition repartition = 17;
+    ToDF to_df = 18;
+    WithColumnsRenamed with_columns_renamed = 19;
+    ShowString show_string = 20;
+    Drop drop = 21;
+    Tail tail = 22;
+    WithColumns with_columns = 23;
+    Hint hint = 24;
+    Unpivot unpivot = 25;
+    ToSchema to_schema = 26;
+    RepartitionByExpression repartition_by_expression = 27;
+    MapPartitions map_partitions = 28;
+    CollectMetrics collect_metrics = 29;
+    Parse parse = 30;
+    GroupMap group_map = 31;
+    CoGroupMap co_group_map = 32;
+
+    // NA functions
+    NAFill fill_na = 90;
+    NADrop drop_na = 91;
+    NAReplace replace = 92;
+
+    // stat functions
+    StatSummary summary = 100;
+    StatCrosstab crosstab = 101;
+    StatDescribe describe = 102;
+    StatCov cov = 103;
+    StatCorr corr = 104;
+    StatApproxQuantile approx_quantile = 105;
+    StatFreqItems freq_items = 106;
+    StatSampleBy sample_by = 107;
+
+    // Catalog API (experimental / unstable)
+    Catalog catalog = 200;
+
+    // This field is used to mark extensions to the protocol. When plugins generate arbitrary
+    // relations they can add them here. During the planning the correct resolution is done.
+    google.protobuf.Any extension = 998;
+    Unknown unknown = 999;
+  }
+}
+
+// Used for testing purposes only.
+message Unknown {}
+
+// Common metadata of all relations.
+message RelationCommon {
+  // (Required) Shared relation metadata.
+  string source_info = 1;
+
+  // (Optional) A per-client globally unique id for a given connect plan.
+  optional int64 plan_id = 2;
+}
+
+// Relation that uses a SQL query to generate the output.
+message SQL {
+  // (Required) The SQL query.
+  string query = 1;
+
+  // (Optional) A map of parameter names to literal expressions.
+  map<string, Expression.Literal> args = 2;
+}
+
+// Relation that reads from a file / table or other data source. Does not have additional
+// inputs.
+message Read {
+  oneof read_type {
+    NamedTable named_table = 1;
+    DataSource data_source = 2;
+  }
+
+  message NamedTable {
+    // (Required) Unparsed identifier for the table.
+    string unparsed_identifier = 1;
+
+    // Options for the named table. The map key is case insensitive.
+    map<string, string> options = 2;
+  }
+
+  message DataSource {
+    // (Optional) Supported formats include: parquet, orc, text, json, parquet, csv, avro.
+    //
+    // If not set, the value from SQL conf 'spark.sql.sources.default' will be used.
+    optional string format = 1;
+
+    // (Optional) If not set, Spark will infer the schema.
+    //
+    // This schema string should be either DDL-formatted or JSON-formatted.
+    optional string schema = 2;
+
+    // Options for the data source. The context of this map varies based on the
+    // data source format. This options could be empty for valid data source format.
+    // The map key is case insensitive.
+    map<string, string> options = 3;
+
+    // (Optional) A list of path for file-system backed data sources.
+    repeated string paths = 4;
+
+    // (Optional) Condition in the where clause for each partition.
+    //
+    // This is only supported by the JDBC data source.
+    repeated string predicates = 5;
+  }
+}
+
+// Projection of a bag of expressions for a given input relation.
+//
+// The input relation must be specified.
+// The projected expression can be an arbitrary expression.
+message Project {
+  // (Optional) Input relation is optional for Project.
+  //
+  // For example, `SELECT ABS(-1)` is valid plan without an input plan.
+  Relation input = 1;
+
+  // (Required) A Project requires at least one expression.
+  repeated Expression expressions = 3;
+}
+
+// Relation that applies a boolean expression `condition` on each row of `input` to produce
+// the output result.
+message Filter {
+  // (Required) Input relation for a Filter.
+  Relation input = 1;
+
+  // (Required) A Filter must have a condition expression.
+  Expression condition = 2;
+}
+
+// Relation of type [[Join]].
+//
+// `left` and `right` must be present.
+message Join {
+  // (Required) Left input relation for a Join.
+  Relation left = 1;
+
+  // (Required) Right input relation for a Join.
+  Relation right = 2;
+
+  // (Optional) The join condition. Could be unset when `using_columns` is utilized.
+  //
+  // This field does not co-exist with using_columns.
+  Expression join_condition = 3;
+
+  // (Required) The join type.
+  JoinType join_type = 4;
+
+  // Optional. using_columns provides a list of columns that should present on both sides of
+  // the join inputs that this Join will join on. For example A JOIN B USING col_name is
+  // equivalent to A JOIN B on A.col_name = B.col_name.
+  //
+  // This field does not co-exist with join_condition.
+  repeated string using_columns = 5;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_FULL_OUTER = 2;
+    JOIN_TYPE_LEFT_OUTER = 3;
+    JOIN_TYPE_RIGHT_OUTER = 4;
+    JOIN_TYPE_LEFT_ANTI = 5;
+    JOIN_TYPE_LEFT_SEMI = 6;
+    JOIN_TYPE_CROSS = 7;
+  }
+}
+
+// Relation of type [[SetOperation]]
+message SetOperation {
+  // (Required) Left input relation for a Set operation.
+  Relation left_input = 1;
+
+  // (Required) Right input relation for a Set operation.
+  Relation right_input = 2;
+
+  // (Required) The Set operation type.
+  SetOpType set_op_type = 3;
+
+  // (Optional) If to remove duplicate rows.
+  //
+  // True to preserve all results.
+  // False to remove duplicate rows.
+  optional bool is_all = 4;
+
+  // (Optional) If to perform the Set operation based on name resolution.
+  //
+  // Only UNION supports this option.
+  optional bool by_name = 5;
+
+  // (Optional) If to perform the Set operation and allow missing columns.
+  //
+  // Only UNION supports this option.
+  optional bool allow_missing_columns = 6;
+
+  enum SetOpType {
+    SET_OP_TYPE_UNSPECIFIED = 0;
+    SET_OP_TYPE_INTERSECT = 1;
+    SET_OP_TYPE_UNION = 2;
+    SET_OP_TYPE_EXCEPT = 3;
+  }
+}
+
+// Relation of type [[Limit]] that is used to `limit` rows from the input relation.
+message Limit {
+  // (Required) Input relation for a Limit.
+  Relation input = 1;
+
+  // (Required) the limit.
+  int32 limit = 2;
+}
+
+// Relation of type [[Offset]] that is used to read rows staring from the `offset` on
+// the input relation.
+message Offset {
+  // (Required) Input relation for an Offset.
+  Relation input = 1;
+
+  // (Required) the limit.
+  int32 offset = 2;
+}
+
+// Relation of type [[Tail]] that is used to fetch `limit` rows from the last of the input relation.
+message Tail {
+  // (Required) Input relation for an Tail.
+  Relation input = 1;
+
+  // (Required) the limit.
+  int32 limit = 2;
+}
+
+// Relation of type [[Aggregate]].
+message Aggregate {
+  // (Required) Input relation for a RelationalGroupedDataset.
+  Relation input = 1;
+
+  // (Required) How the RelationalGroupedDataset was built.
+  GroupType group_type = 2;
+
+  // (Required) Expressions for grouping keys
+  repeated Expression grouping_expressions = 3;
+
+  // (Required) List of values that will be translated to columns in the output DataFrame.
+  repeated Expression aggregate_expressions = 4;
+
+  // (Optional) Pivots a column of the current `DataFrame` and performs the specified aggregation.
+  Pivot pivot = 5;
+
+  enum GroupType {
+    GROUP_TYPE_UNSPECIFIED = 0;
+    GROUP_TYPE_GROUPBY = 1;
+    GROUP_TYPE_ROLLUP = 2;
+    GROUP_TYPE_CUBE = 3;
+    GROUP_TYPE_PIVOT = 4;
+  }
+
+  message Pivot {
+    // (Required) The column to pivot
+    Expression col = 1;
+
+    // (Optional) List of values that will be translated to columns in the output DataFrame.
+    //
+    // Note that if it is empty, the server side will immediately trigger a job to collect
+    // the distinct values of the column.
+    repeated Expression.Literal values = 2;
+  }
+}
+
+// Relation of type [[Sort]].
+message Sort {
+  // (Required) Input relation for a Sort.
+  Relation input = 1;
+
+  // (Required) The ordering expressions
+  repeated Expression.SortOrder order = 2;
+
+  // (Optional) if this is a global sort.
+  optional bool is_global = 3;
+}
+
+
+// Drop specified columns.
+message Drop {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) columns to drop.
+  repeated Expression columns = 2;
+
+  // (Optional) names of columns to drop.
+  repeated string column_names = 3;
+}
+
+
+// Relation of type [[Deduplicate]] which have duplicate rows removed, could consider either only
+// the subset of columns or all the columns.
+message Deduplicate {
+  // (Required) Input relation for a Deduplicate.
+  Relation input = 1;
+
+  // (Optional) Deduplicate based on a list of column names.
+  //
+  // This field does not co-use with `all_columns_as_keys`.
+  repeated string column_names = 2;
+
+  // (Optional) Deduplicate based on all the columns of the input relation.
+  //
+  // This field does not co-use with `column_names`.
+  optional bool all_columns_as_keys = 3;
+}
+
+// A relation that does not need to be qualified by name.
+message LocalRelation {
+  // (Optional) Local collection data serialized into Arrow IPC streaming format which contains
+  // the schema of the data.
+  optional bytes data = 1;
+
+  // (Optional) The schema of local data.
+  // It should be either a DDL-formatted type string or a JSON string.
+  //
+  // The server side will update the column names and data types according to this schema.
+  // If the 'data' is not provided, then this schema will be required.
+  optional string schema = 2;
+}
+
+// Relation of type [[Sample]] that samples a fraction of the dataset.
+message Sample {
+  // (Required) Input relation for a Sample.
+  Relation input = 1;
+
+  // (Required) lower bound.
+  double lower_bound = 2;
+
+  // (Required) upper bound.
+  double upper_bound = 3;
+
+  // (Optional) Whether to sample with replacement.
+  optional bool with_replacement = 4;
+
+  // (Optional) The random seed.
+  optional int64 seed = 5;
+
+  // (Required) Explicitly sort the underlying plan to make the ordering deterministic or cache it.
+  // This flag is true when invoking `dataframe.randomSplit` to randomly splits DataFrame with the
+  // provided weights. Otherwise, it is false.
+  bool deterministic_order = 6;
+}
+
+// Relation of type [[Range]] that generates a sequence of integers.
+message Range {
+  // (Optional) Default value = 0
+  optional int64 start = 1;
+
+  // (Required)
+  int64 end = 2;
+
+  // (Required)
+  int64 step = 3;
+
+  // Optional. Default value is assigned by 1) SQL conf "spark.sql.leafNodeDefaultParallelism" if
+  // it is set, or 2) spark default parallelism.
+  optional int32 num_partitions = 4;
+}
+
+// Relation alias.
+message SubqueryAlias {
+  // (Required) The input relation of SubqueryAlias.
+  Relation input = 1;
+
+  // (Required) The alias.
+  string alias = 2;
+
+  // (Optional) Qualifier of the alias.
+  repeated string qualifier = 3;
+}
+
+// Relation repartition.
+message Repartition {
+  // (Required) The input relation of Repartition.
+  Relation input = 1;
+
+  // (Required) Must be positive.
+  int32 num_partitions = 2;
+
+  // (Optional) Default value is false.
+  optional bool shuffle = 3;
+}
+
+// Compose the string representing rows for output.
+// It will invoke 'Dataset.showString' to compute the results.
+message ShowString {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) Number of rows to show.
+  int32 num_rows = 2;
+
+  // (Required) If set to more than 0, truncates strings to
+  // `truncate` characters and all cells will be aligned right.
+  int32 truncate = 3;
+
+  // (Required) If set to true, prints output rows vertically (one line per column value).
+  bool vertical = 4;
+}
+
+// Computes specified statistics for numeric and string columns.
+// It will invoke 'Dataset.summary' (same as 'StatFunctions.summary')
+// to compute the results.
+message StatSummary {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) Statistics from to be computed.
+  //
+  // Available statistics are:
+  //  count
+  //  mean
+  //  stddev
+  //  min
+  //  max
+  //  arbitrary approximate percentiles specified as a percentage (e.g. 75%)
+  //  count_distinct
+  //  approx_count_distinct
+  //
+  // If no statistics are given, this function computes 'count', 'mean', 'stddev', 'min',
+  // 'approximate quartiles' (percentiles at 25%, 50%, and 75%), and 'max'.
+  repeated string statistics = 2;
+}
+
+// Computes basic statistics for numeric and string columns, including count, mean, stddev, min,
+// and max. If no columns are given, this function computes statistics for all numerical or
+// string columns.
+message StatDescribe {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) Columns to compute statistics on.
+  repeated string cols = 2;
+}
+
+// Computes a pair-wise frequency table of the given columns. Also known as a contingency table.
+// It will invoke 'Dataset.stat.crosstab' (same as 'StatFunctions.crossTabulate')
+// to compute the results.
+message StatCrosstab {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The name of the first column.
+  //
+  // Distinct items will make the first item of each row.
+  string col1 = 2;
+
+  // (Required) The name of the second column.
+  //
+  // Distinct items will make the column names of the DataFrame.
+  string col2 = 3;
+}
+
+// Calculate the sample covariance of two numerical columns of a DataFrame.
+// It will invoke 'Dataset.stat.cov' (same as 'StatFunctions.calculateCov') to compute the results.
+message StatCov {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The name of the first column.
+  string col1 = 2;
+
+  // (Required) The name of the second column.
+  string col2 = 3;
+}
+
+// Calculates the correlation of two columns of a DataFrame. Currently only supports the Pearson
+// Correlation Coefficient. It will invoke 'Dataset.stat.corr' (same as
+// 'StatFunctions.pearsonCorrelation') to compute the results.
+message StatCorr {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The name of the first column.
+  string col1 = 2;
+
+  // (Required) The name of the second column.
+  string col2 = 3;
+
+  // (Optional) Default value is 'pearson'.
+  //
+  // Currently only supports the Pearson Correlation Coefficient.
+  optional string method = 4;
+}
+
+// Calculates the approximate quantiles of numerical columns of a DataFrame.
+// It will invoke 'Dataset.stat.approxQuantile' (same as 'StatFunctions.approxQuantile')
+// to compute the results.
+message StatApproxQuantile {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The names of the numerical columns.
+  repeated string cols = 2;
+
+  // (Required) A list of quantile probabilities.
+  //
+  // Each number must belong to [0, 1].
+  // For example 0 is the minimum, 0.5 is the median, 1 is the maximum.
+  repeated double probabilities = 3;
+
+  // (Required) The relative target precision to achieve (greater than or equal to 0).
+  //
+  // If set to zero, the exact quantiles are computed, which could be very expensive.
+  // Note that values greater than 1 are accepted but give the same result as 1.
+  double relative_error = 4;
+}
+
+// Finding frequent items for columns, possibly with false positives.
+// It will invoke 'Dataset.stat.freqItems' (same as 'StatFunctions.freqItems')
+// to compute the results.
+message StatFreqItems {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The names of the columns to search frequent items in.
+  repeated string cols = 2;
+
+  // (Optional) The minimum frequency for an item to be considered `frequent`.
+  // Should be greater than 1e-4.
+  optional double support = 3;
+}
+
+
+// Returns a stratified sample without replacement based on the fraction
+// given on each stratum.
+// It will invoke 'Dataset.stat.freqItems' (same as 'StatFunctions.freqItems')
+// to compute the results.
+message StatSampleBy {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The column that defines strata.
+  Expression col = 2;
+
+  // (Required) Sampling fraction for each stratum.
+  //
+  // If a stratum is not specified, we treat its fraction as zero.
+  repeated Fraction fractions = 3;
+
+  // (Optional) The random seed.
+  optional int64 seed = 5;
+
+  message Fraction {
+    // (Required) The stratum.
+    Expression.Literal stratum = 1;
+
+    // (Required) The fraction value. Must be in [0, 1].
+    double fraction = 2;
+  }
+}
+
+
+// Replaces null values.
+// It will invoke 'Dataset.na.fill' (same as 'DataFrameNaFunctions.fill') to compute the results.
+// Following 3 parameter combinations are supported:
+//  1, 'values' only contains 1 item, 'cols' is empty:
+//    replaces null values in all type-compatible columns.
+//  2, 'values' only contains 1 item, 'cols' is not empty:
+//    replaces null values in specified columns.
+//  3, 'values' contains more than 1 items, then 'cols' is required to have the same length:
+//    replaces each specified column with corresponding value.
+message NAFill {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) Optional list of column names to consider.
+  repeated string cols = 2;
+
+  // (Required) Values to replace null values with.
+  //
+  // Should contain at least 1 item.
+  // Only 4 data types are supported now: bool, long, double, string
+  repeated Expression.Literal values = 3;
+}
+
+
+// Drop rows containing null values.
+// It will invoke 'Dataset.na.drop' (same as 'DataFrameNaFunctions.drop') to compute the results.
+message NADrop {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) Optional list of column names to consider.
+  //
+  // When it is empty, all the columns in the input relation will be considered.
+  repeated string cols = 2;
+
+  // (Optional) The minimum number of non-null and non-NaN values required to keep.
+  //
+  // When not set, it is equivalent to the number of considered columns, which means
+  // a row will be kept only if all columns are non-null.
+  //
+  // 'how' options ('all', 'any') can be easily converted to this field:
+  //   - 'all' -> set 'min_non_nulls' 1;
+  //   - 'any' -> keep 'min_non_nulls' unset;
+  optional int32 min_non_nulls = 3;
+}
+
+
+// Replaces old values with the corresponding values.
+// It will invoke 'Dataset.na.replace' (same as 'DataFrameNaFunctions.replace')
+// to compute the results.
+message NAReplace {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Optional) List of column names to consider.
+  //
+  // When it is empty, all the type-compatible columns in the input relation will be considered.
+  repeated string cols = 2;
+
+  // (Optional) The value replacement mapping.
+  repeated Replacement replacements = 3;
+
+  message Replacement {
+    // (Required) The old value.
+    //
+    // Only 4 data types are supported now: null, bool, double, string.
+    Expression.Literal old_value = 1;
+
+    // (Required) The new value.
+    //
+    // Should be of the same data type with the old value.
+    Expression.Literal new_value = 2;
+  }
+}
+
+
+// Rename columns on the input relation by the same length of names.
+message ToDF {
+  // (Required) The input relation of RenameColumnsBySameLengthNames.
+  Relation input = 1;
+
+  // (Required)
+  //
+  // The number of columns of the input relation must be equal to the length
+  // of this field. If this is not true, an exception will be returned.
+  repeated string column_names = 2;
+}
+
+
+// Rename columns on the input relation by a map with name to name mapping.
+message WithColumnsRenamed {
+  // (Required) The input relation.
+  Relation input = 1;
+
+
+  // (Required)
+  //
+  // Renaming column names of input relation from A to B where A is the map key
+  // and B is the map value. This is a no-op if schema doesn't contain any A. It
+  // does not require that all input relation column names to present as keys.
+  // duplicated B are not allowed.
+  map<string, string> rename_columns_map = 2;
+}
+
+// Adding columns or replacing the existing columns that have the same names.
+message WithColumns {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required)
+  //
+  // Given a column name, apply the corresponding expression on the column. If column
+  // name exists in the input relation, then replace the column. If the column name
+  // does not exist in the input relation, then adds it as a new column.
+  //
+  // Only one name part is expected from each Expression.Alias.
+  //
+  // An exception is thrown when duplicated names are present in the mapping.
+  repeated Expression.Alias aliases = 2;
+}
+
+// Specify a hint over a relation. Hint should have a name and optional parameters.
+message Hint {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) Hint name.
+  //
+  // Supported Join hints include BROADCAST, MERGE, SHUFFLE_HASH, SHUFFLE_REPLICATE_NL.
+  //
+  // Supported partitioning hints include COALESCE, REPARTITION, REPARTITION_BY_RANGE.
+  string name = 2;
+
+  // (Optional) Hint parameters.
+  repeated Expression parameters = 3;
+}
+
+// Unpivot a DataFrame from wide format to long format, optionally leaving identifier columns set.
+message Unpivot {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) Id columns.
+  repeated Expression ids = 2;
+
+  // (Optional) Value columns to unpivot.
+  optional Values values = 3;
+
+  // (Required) Name of the variable column.
+  string variable_column_name = 4;
+
+  // (Required) Name of the value column.
+  string value_column_name = 5;
+
+  message Values {
+    repeated Expression values = 1;
+  }
+}
+
+message ToSchema {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The user provided schema.
+  //
+  // The Sever side will update the dataframe with this schema.
+  DataType schema = 2;
+}
+
+message RepartitionByExpression {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) The partitioning expressions.
+  repeated Expression partition_exprs = 2;
+
+  // (Optional) number of partitions, must be positive.
+  optional int32 num_partitions = 3;
+}
+
+message MapPartitions {
+  // (Required) Input relation for a mapPartitions-equivalent API: mapInPandas, mapInArrow.
+  Relation input = 1;
+
+  // (Required) Input user-defined function.
+  CommonInlineUserDefinedFunction func = 2;
+}
+
+message GroupMap {
+  // (Required) Input relation for Group Map API: apply, applyInPandas.
+  Relation input = 1;
+
+  // (Required) Expressions for grouping keys.
+  repeated Expression grouping_expressions = 2;
+
+  // (Required) Input user-defined function.
+  CommonInlineUserDefinedFunction func = 3;
+}
+
+message CoGroupMap {
+  // (Required) One input relation for CoGroup Map API - applyInPandas.
+  Relation input = 1;
+
+  // Expressions for grouping keys of the first input relation.
+  repeated Expression input_grouping_expressions = 2;
+
+  // (Required) The other input relation.
+  Relation other = 3;
+
+  // Expressions for grouping keys of the other input relation.
+  repeated Expression other_grouping_expressions = 4;
+
+  // (Required) Input user-defined function.
+  CommonInlineUserDefinedFunction func = 5;
+}
+
+// Collect arbitrary (named) metrics from a dataset.
+message CollectMetrics {
+  // (Required) The input relation.
+  Relation input = 1;
+
+  // (Required) Name of the metrics.
+  string name = 2;
+
+  // (Required) The metric sequence.
+  repeated Expression metrics = 3;
+}
+
+message Parse {
+  // (Required) Input relation to Parse. The input is expected to have single text column.
+  Relation input = 1;
+  // (Required) The expected format of the text.
+  ParseFormat format = 2;
+
+  // (Optional) DataType representing the schema. If not set, Spark will infer the schema.
+  optional DataType schema = 3;
+
+  // Options for the csv/json parser. The map key is case insensitive.
+  map<string, string> options = 4;
+  enum ParseFormat {
+    PARSE_FORMAT_UNSPECIFIED = 0;
+    PARSE_FORMAT_CSV = 1;
+    PARSE_FORMAT_JSON = 2;
+  }
+}

--- a/axiom/pyspark/third-party/protos/types.proto
+++ b/axiom/pyspark/third-party/protos/types.proto
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+
+// This message describes the logical [[DataType]] of something. It does not carry the value
+// itself but only describes it.
+message DataType {
+  oneof kind {
+    NULL null = 1;
+
+    Binary binary = 2;
+
+    Boolean boolean = 3;
+
+    // Numeric types
+    Byte byte = 4;
+    Short short = 5;
+    Integer integer = 6;
+    Long long = 7;
+
+    Float float = 8;
+    Double double = 9;
+    Decimal decimal = 10;
+
+    // String types
+    String string = 11;
+    Char char = 12;
+    VarChar var_char = 13;
+
+    // Datatime types
+    Date date = 14;
+    Timestamp timestamp = 15;
+    TimestampNTZ timestamp_ntz = 16;
+
+    // Interval types
+    CalendarInterval calendar_interval = 17;
+    YearMonthInterval year_month_interval = 18;
+    DayTimeInterval day_time_interval = 19;
+
+    // Complex types
+    Array array = 20;
+    Struct struct = 21;
+    Map map = 22;
+
+    // UserDefinedType
+    UDT udt = 23;
+
+    // UnparsedDataType
+    Unparsed unparsed = 24;
+  }
+
+  message Boolean {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Byte {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Short {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Integer {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Long {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Float {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Double {
+    uint32 type_variation_reference = 1;
+  }
+
+  message String {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Binary {
+    uint32 type_variation_reference = 1;
+  }
+
+  message NULL {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Timestamp {
+    uint32 type_variation_reference = 1;
+  }
+
+  message Date {
+    uint32 type_variation_reference = 1;
+  }
+
+  message TimestampNTZ {
+    uint32 type_variation_reference = 1;
+  }
+
+  message CalendarInterval {
+    uint32 type_variation_reference = 1;
+  }
+
+  message YearMonthInterval {
+    optional int32 start_field = 1;
+    optional int32 end_field = 2;
+    uint32 type_variation_reference = 3;
+  }
+
+  message DayTimeInterval {
+    optional int32 start_field = 1;
+    optional int32 end_field = 2;
+    uint32 type_variation_reference = 3;
+  }
+
+  // Start compound types.
+  message Char {
+    int32 length = 1;
+    uint32 type_variation_reference = 2;
+  }
+
+  message VarChar {
+    int32 length = 1;
+    uint32 type_variation_reference = 2;
+  }
+
+  message Decimal {
+    optional int32 scale = 1;
+    optional int32 precision = 2;
+    uint32 type_variation_reference = 3;
+  }
+
+  message StructField {
+    string name = 1;
+    DataType data_type = 2;
+    bool nullable = 3;
+    optional string metadata = 4;
+  }
+
+  message Struct {
+    repeated StructField fields = 1;
+    uint32 type_variation_reference = 2;
+  }
+
+  message Array {
+    DataType element_type = 1;
+    bool contains_null = 2;
+    uint32 type_variation_reference = 3;
+  }
+
+  message Map {
+    DataType key_type = 1;
+    DataType value_type = 2;
+    bool value_contains_null = 3;
+    uint32 type_variation_reference = 4;
+  }
+
+  message UDT {
+    string type = 1;
+    optional string jvm_class = 2;
+    optional string python_class = 3;
+    optional string serialized_python_class = 4;
+    DataType sql_type = 5;
+  }
+
+  message Unparsed {
+    // (Required) The unparsed data type string
+    string data_type_string = 1;
+  }
+}


### PR DESCRIPTION
Summary:

Introducing "Collagen", a Spark Connect implementation for the Axiom query 
framework. It translates PySpark DataFrame operations into Axiom logical plans,
optimizes them, and executes them on Velox.

Protecting the new code by a compilation flag AXIOM_ENABLE_COLLAGEN,
and leaving if off by default. CI support will be added in the next diff.

Reviewed By: kKPulla

Differential Revision: D101921050
