### PR TITLE
feat: Add PrestoParser::parseKind()

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -155,6 +155,53 @@ class ParserHelper {
   ErrorListener errorListener_;
 };
 
+// Maps an ANTLR StatementContext subclass to SqlStatementKind.
+std::optional<SqlStatementKind> detectStatementKind(
+    PrestoSqlParser::StatementContext* context) {
+  using P = PrestoSqlParser;
+  using K = SqlStatementKind;
+  if (dynamic_cast<P::StatementDefaultContext*>(context)) {
+    return K::kSelect;
+  }
+  if (dynamic_cast<P::InsertIntoContext*>(context)) {
+    return K::kInsert;
+  }
+  if (dynamic_cast<P::CreateTableAsSelectContext*>(context)) {
+    return K::kCreateTableAsSelect;
+  }
+  if (dynamic_cast<P::CreateTableContext*>(context)) {
+    return K::kCreateTable;
+  }
+  if (dynamic_cast<P::DropTableContext*>(context)) {
+    return K::kDropTable;
+  }
+  if (dynamic_cast<P::CreateSchemaContext*>(context)) {
+    return K::kCreateSchema;
+  }
+  if (dynamic_cast<P::DropSchemaContext*>(context)) {
+    return K::kDropSchema;
+  }
+  if (dynamic_cast<P::ExplainContext*>(context)) {
+    return K::kExplain;
+  }
+  if (dynamic_cast<P::ShowStatsForQueryContext*>(context)) {
+    return K::kShowStatsForQuery;
+  }
+  if (dynamic_cast<P::ShowSessionContext*>(context)) {
+    return K::kShowSession;
+  }
+  if (dynamic_cast<P::SetSessionContext*>(context)) {
+    return K::kSetSession;
+  }
+  if (dynamic_cast<P::ResetSessionContext*>(context)) {
+    return K::kResetSession;
+  }
+  if (dynamic_cast<P::UseContext*>(context)) {
+    return K::kUse;
+  }
+  return std::nullopt;
+}
+
 std::pair<std::string, facebook::axiom::SchemaTableName> toConnectorTable(
     const QualifiedName& name,
     const std::string& defaultConnectorId,
@@ -2225,6 +2272,12 @@ SqlStatementPtr doPlan(
       "Unsupported statement type");
 }
 } // namespace
+
+std::optional<SqlStatementKind> PrestoParser::parseKind(std::string_view sql) {
+  ParserHelper helper(sql);
+  auto* context = helper.parse();
+  return detectStatementKind(context);
+}
 
 SqlStatementPtr PrestoParser::doParse(
     std::string_view sql,

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -50,6 +50,12 @@ class PrestoParser {
 
   SqlStatementPtr parse(std::string_view sql, bool enableTracing = false);
 
+  /// Detects the statement kind by running the ANTLR grammar parse only,
+  /// without building the AST or logical plan. Returns std::nullopt for
+  /// statement types not represented in SqlStatementKind (e.g. ALTER TABLE).
+  /// @throws PrestoSqlError on syntax errors.
+  static std::optional<SqlStatementKind> parseKind(std::string_view sql);
+
   /// Parses multiple semicolon-separated SQL statements.
   /// @param sql SQL text containing one or more statements separated by
   /// semicolons.

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1556,5 +1556,54 @@ TEST_F(PrestoParserTest, friendlySqlFromFirst) {
       "FROM-first syntax requires Friendly SQL mode");
 }
 
+TEST_F(PrestoParserTest, parseKind) {
+  auto parser = makeParser();
+
+  // Verifies parseKind detects the correct kind and that the subsequent
+  // parse(string_view) produces a matching SqlStatement.
+  auto verifyKind = [&](std::string_view sql, SqlStatementKind expectedKind) {
+    SCOPED_TRACE(sql);
+    auto kind = PrestoParser::parseKind(sql);
+    ASSERT_TRUE(kind.has_value());
+    EXPECT_EQ(*kind, expectedKind);
+
+    auto statement = parser.parse(sql);
+    EXPECT_EQ(statement->kind(), expectedKind);
+  };
+
+  verifyKind("SELECT * FROM nation", SqlStatementKind::kSelect);
+  verifyKind(
+      "WITH cte AS (SELECT 1) SELECT * FROM cte", SqlStatementKind::kSelect);
+
+  connector_->addTable("target", ROW({"a"}, {BIGINT()}));
+  verifyKind("INSERT INTO target SELECT 1", SqlStatementKind::kInsert);
+
+  verifyKind(
+      "CREATE TABLE t (a bigint, b varchar)", SqlStatementKind::kCreateTable);
+  verifyKind(
+      "CREATE TABLE t AS SELECT * FROM nation",
+      SqlStatementKind::kCreateTableAsSelect);
+  verifyKind("DROP TABLE t", SqlStatementKind::kDropTable);
+  verifyKind("CREATE SCHEMA s", SqlStatementKind::kCreateSchema);
+  verifyKind("DROP SCHEMA s", SqlStatementKind::kDropSchema);
+  verifyKind("EXPLAIN SELECT * FROM nation", SqlStatementKind::kExplain);
+  verifyKind("USE test.default", SqlStatementKind::kUse);
+  verifyKind("SET SESSION optimize = true", SqlStatementKind::kSetSession);
+  verifyKind("SHOW SESSION", SqlStatementKind::kShowSession);
+  verifyKind("RESET SESSION optimize", SqlStatementKind::kResetSession);
+  verifyKind(
+      "SHOW STATS FOR (SELECT * FROM nation)",
+      SqlStatementKind::kShowStatsForQuery);
+
+  // Unrecognized statement types return nullopt.
+  EXPECT_FALSE(PrestoParser::parseKind("SHOW TABLES").has_value());
+  EXPECT_FALSE(
+      PrestoParser::parseKind("GRANT SELECT ON t TO user1").has_value());
+
+  // Syntax errors throw PrestoSqlError.
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      PrestoParser::parseKind("SELECTT 1"), "mismatched input 'SELECTT'");
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Add PrestoParser::parseKind() static API that detects SqlStatementKind from SQL text using only the ANTLR grammar parse, without building the AST or logical plan. This is a lightweight O(n) operation — it runs the lexer and parser in SLL-first mode but skips the expensive phases (AST construction via AstBuilder, logical plan building via RelationPlanner, and connector metadata resolution).

The motivation is query observability: when a query coordinator rejects a query before full parsing (e.g., due to admission control), the statement type is unknown in completion logs. parseKind() enables coordinators to classify the query cheaply before admission, without running the full parse pipeline. This mirrors the Java Presto coordinator design, where SqlParser.createStatement() runs full ANTLR parsing before resource group submission to determine query type for routing and logging.

The API intentionally does not replace or modify the existing parse() method — it is a separate, independent entry point. The ANTLR grammar parse it performs is a strict subset of what parse() already does.

The Presto has similar behavior.

Differential Revision: D102031202
