### PR TITLE
fix: Handle OFFSET 0 as no-op in parser (#1282)

### DIFF
--- a/axiom/optimizer/tests/sql/limit.sql
+++ b/axiom/optimizer/tests/sql/limit.sql
@@ -30,3 +30,14 @@ SELECT * FROM t LIMIT ALL
 -- count 0
 WITH final AS (SELECT a, SUM(b) AS total FROM t GROUP BY 1 LIMIT 0)
 SELECT x.total FROM final x, final y WHERE x.a = y.a AND x.a = 1
+----
+SELECT a, b FROM t OFFSET 0
+----
+-- ordered
+SELECT a, b FROM t ORDER BY b OFFSET 0
+----
+-- ordered
+SELECT a, b FROM t ORDER BY b OFFSET 0 LIMIT 3
+----
+-- count 0
+SELECT a, b FROM t OFFSET 0 LIMIT 0

--- a/axiom/optimizer/tests/sql/limit.sql
+++ b/axiom/optimizer/tests/sql/limit.sql
@@ -32,3 +32,14 @@ SELECT * FROM t LIMIT ALL
 -- count 0
 WITH final AS (SELECT a, SUM(b) AS total FROM t GROUP BY 1 LIMIT 0)
 SELECT x.total FROM final x, final y WHERE x.a = y.a AND x.a = 1
+----
+SELECT a, b FROM t OFFSET 0
+----
+-- ordered
+SELECT a, b FROM t ORDER BY b OFFSET 0
+----
+-- ordered
+SELECT a, b FROM t ORDER BY b OFFSET 0 LIMIT 3
+----
+-- count 0
+SELECT a, b FROM t OFFSET 0 LIMIT 0

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1057,7 +1057,13 @@ class RelationPlanner : public AstVisitor {
       return;
     }
 
-    builder_->offset(std::atol(offset->offset().c_str()));
+    // OFFSET 0 is a no-op. Skip creating a LimitNode.
+    auto value = std::atol(offset->offset().c_str());
+    if (value == 0) {
+      return;
+    }
+
+    builder_->offset(value);
   }
 
   void addLimit(const std::optional<std::string>& limit) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1095,7 +1095,13 @@ class RelationPlanner : public AstVisitor {
       return;
     }
 
-    builder_->offset(std::atol(offset->offset().c_str()));
+    // OFFSET 0 is a no-op. Skip creating a LimitNode.
+    auto numOffsetRows = std::atol(offset->offset().c_str());
+    if (numOffsetRows == 0) {
+      return;
+    }
+
+    builder_->offset(numOffsetRows);
   }
 
   void addLimit(const std::optional<std::string>& limit) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1426,6 +1426,33 @@ TEST_F(PrestoParserTest, offset) {
     testSelect(
         "SELECT * FROM nation OFFSET 5 FETCH FIRST 10 ROWS ONLY", matcher);
   }
+
+  {
+    auto matcher = matchScan()
+                       .limit(1, std::numeric_limits<int64_t>::max())
+                       .output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 1", matcher);
+  }
+
+  {
+    auto matcher = matchScan().output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0", matcher);
+  }
+
+  {
+    auto matcher = matchScan().sort({"n_name"}).output(nationColumns);
+    testSelect("SELECT * FROM nation ORDER BY n_name OFFSET 0", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 10).output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0 LIMIT 10", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 0).output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0 LIMIT 0", matcher);
+  }
 }
 
 TEST_F(PrestoParserTest, use) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1522,6 +1522,33 @@ TEST_F(PrestoParserTest, offset) {
     testSelect(
         "SELECT * FROM nation OFFSET 5 FETCH FIRST 10 ROWS ONLY", matcher);
   }
+
+  {
+    auto matcher = matchScan()
+                       .limit(1, std::numeric_limits<int64_t>::max())
+                       .output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 1", matcher);
+  }
+
+  {
+    auto matcher = matchScan().output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0", matcher);
+  }
+
+  {
+    auto matcher = matchScan().sort({"n_name"}).output(nationColumns);
+    testSelect("SELECT * FROM nation ORDER BY n_name OFFSET 0", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 10).output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0 LIMIT 10", matcher);
+  }
+
+  {
+    auto matcher = matchScan().limit(0, 0).output(nationColumns);
+    testSelect("SELECT * FROM nation OFFSET 0 LIMIT 0", matcher);
+  }
 }
 
 TEST_F(PrestoParserTest, use) {


### PR DESCRIPTION
Summary:

`SELECT * FROM t OFFSET 0` fails with `VeloxUserError: (0 vs. 0) Offset must be > zero if there is no limit` because the parser creates a `LimitNode(offset=0, count=INT64_MAX)` for every OFFSET clause, even OFFSET 0. The LimitNode constructor correctly rejects this — a node with no limit and no offset is a no-op.

Fix: skip creating the LimitNode in `addOffset()` when offset is 0, matching how `LIMIT ALL` is already handled.

Before:
```
axiom> SELECT * FROM (VALUES (1), (2), (3)) AS t(a) OFFSET 0
Error: (0 vs. 0) Offset must be > zero if there is no limit
```

After:
```
axiom> SELECT * FROM (VALUES (1), (2), (3)) AS t(a) OFFSET 0
1
2
3
(3 rows)
```

Reviewed By: mbasmanova

Differential Revision: D102034348


