### PR TITLE
fix(optimizer): Fix column pruning in reducing-join exploration

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3724,15 +3724,13 @@ PlanP Optimization::makeDtPlan(
     tmpDt->cname = newCName("tmp_dt");
     tmpDt->import(dt, key.tables, key.firstTable, key.existences, existsFanout);
 
-    // For subquery DTs, set outputColumns from key.columns rather than
-    // inheriting from the source DT. The temporary DT's output is determined
-    // by the consumer (key.columns), not by the original subquery's output.
-    if (key.firstTable->is(PlanType::kDerivedTableNode)) {
-      pruneOutputColumns(tmpDt, key.columns);
-    }
-
     PlanState inner(*this, tmpDt);
-    if (key.firstTable->is(PlanType::kDerivedTableNode)) {
+    if (key.firstTable->is(PlanType::kDerivedTableNode) &&
+        !tmpDt->columns.empty()) {
+      // tmpDt wraps a subquery DT and has output columns from flattening.
+      // Prune output columns and translate target expressions through the
+      // tmpDt's column-to-expression mapping.
+      pruneOutputColumns(tmpDt, key.columns);
       inner.setTargetExprsForDt(key.columns);
     } else {
       inner.targetExprs = key.columns;

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -53,20 +53,24 @@ class SqlTest : public SqlTestBase {
   }
 
   void TestBody() override {
-    switch (entry_.type) {
-      case QueryEntry::Type::kResults:
-        assertResults(entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
-        break;
-      case QueryEntry::Type::kOrdered:
-        assertOrderedResults(
-            entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
-        break;
-      case QueryEntry::Type::kCount:
-        assertResultCount(entry_.sql, entry_.expectedCount);
-        break;
-      case QueryEntry::Type::kError:
-        assertFailure(entry_.sql, entry_.expectedError);
-        break;
+    try {
+      switch (entry_.type) {
+        case QueryEntry::Type::kResults:
+          assertResults(entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
+          break;
+        case QueryEntry::Type::kOrdered:
+          assertOrderedResults(
+              entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
+          break;
+        case QueryEntry::Type::kCount:
+          assertResultCount(entry_.sql, entry_.expectedCount);
+          break;
+        case QueryEntry::Type::kError:
+          assertFailure(entry_.sql, entry_.expectedError);
+          break;
+      }
+    } catch (const std::exception& e) {
+      FAIL() << "Unexpected exception: " << e.what();
     }
   }
 

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -57,6 +57,21 @@ LEFT JOIN (
 ) AS b ON a.k = b.k
 WHERE b.m = 1
 ----
+-- CROSS JOIN UNNEST with two JOINs that have constant equality filters.
+-- The reducing-join optimization must not prune columns needed by the output.
+-- duckdb: VALUES (1, 2)
+SELECT t.a, t.b
+FROM (
+    SELECT a, b, items
+    FROM (VALUES
+        (1, 2, ARRAY[ROW(10 AS k)]),
+        (3, 4, ARRAY[ROW(20 AS k)])
+    ) _(a, b, items)
+) t
+CROSS JOIN UNNEST(t.items) _(r)
+JOIN (VALUES (1, 10), (1, 20)) u(c, k) ON u.k = r.k AND u.c = 1
+JOIN (VALUES (1, 10)) v(c, k) ON v.k = u.k AND v.c = 1
+----
 -- Chained LEFT JOINs with same-named columns and GROUP BY.
 -- a.ds must group by a's column, not c's.
 SELECT a.ds


### PR DESCRIPTION
Summary:
When the optimizer explores a reducing-join (existence) optimization for a
subquery, `makeDtPlan` creates a temporary DerivedTable via `import()`.
`import()` only populates `tmpDt->columns` when `isWrapOnly()` is true and
the inner DT is flattened. When `isWrapOnly()` is false (because
`addExistences` added tables), `tmpDt->columns` remains empty. The
subsequent call to `setTargetExprsForDt` iterates these empty columns and
produces empty `targetExprs`. This causes `computeDownstreamColumns` to miss
columns needed by the query output but not referenced by join conditions.
These columns are incorrectly pruned, and the final Project fails with
"Field not found".

Fix: when `tmpDt->columns` is empty (no flattening occurred), skip
`setTargetExprsForDt` and assign `key.columns` directly to `targetExprs`.
This preserves the outer column references so downstream column tracking
correctly includes them.

Also fix SqlTest to catch unexpected exceptions in TestBody and report them
as clean test failures instead of crashing the test process.

Differential Revision: D102064968


