### PR TITLE
refactor(optimizer): Remove setTargetExprsForDt (#1284)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -301,11 +301,8 @@ void Optimization::trace(
 }
 
 PlanP Optimization::bestPlan() {
-  PlanObjectSet targetColumns;
-  targetColumns.unionObjects(root_->columns);
-
   topState_.dt = root_;
-  topState_.setTargetExprsForDt(targetColumns);
+  topState_.targetExprs = PlanObjectSet::fromObjects(root_->exprs);
 
   makeJoins(topState_);
 
@@ -3650,7 +3647,11 @@ PlanP Optimization::makeUnionPlan(
         pruneOutputColumns(tmpDt, inputKey.columns);
 
         PlanState inner(*this, tmpDt);
-        inner.setTargetExprsForDt(inputKey.columns);
+        for (size_t i = 0; i < tmpDt->columns.size(); ++i) {
+          if (inputKey.columns.contains(tmpDt->columns[i])) {
+            inner.targetExprs.add(tmpDt->exprs[i]);
+          }
+        }
 
         makeJoins(inner);
         memo_.insert(inputKey, std::move(inner.plans));
@@ -3724,14 +3725,11 @@ PlanP Optimization::makeDtPlan(
     tmpDt->cname = newCName("tmp_dt");
     tmpDt->import(dt, key.tables, key.firstTable, key.existences, existsFanout);
 
+    pruneOutputColumns(tmpDt, key.columns);
+
     PlanState inner(*this, tmpDt);
-    if (key.firstTable->is(PlanType::kDerivedTableNode) &&
-        !tmpDt->columns.empty()) {
-      // tmpDt wraps a subquery DT and has output columns from flattening.
-      // Prune output columns and translate target expressions through the
-      // tmpDt's column-to-expression mapping.
-      pruneOutputColumns(tmpDt, key.columns);
-      inner.setTargetExprsForDt(key.columns);
+    if (!tmpDt->columns.empty()) {
+      inner.targetExprs = PlanObjectSet::fromObjects(tmpDt->exprs);
     } else {
       inner.targetExprs = key.columns;
     }

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3724,15 +3724,13 @@ PlanP Optimization::makeDtPlan(
     tmpDt->cname = newCName("tmp_dt");
     tmpDt->import(dt, key.tables, key.firstTable, key.existences, existsFanout);
 
-    // For subquery DTs, set outputColumns from key.columns rather than
-    // inheriting from the source DT. The temporary DT's output is determined
-    // by the consumer (key.columns), not by the original subquery's output.
-    if (key.firstTable->is(PlanType::kDerivedTableNode)) {
-      pruneOutputColumns(tmpDt, key.columns);
-    }
-
     PlanState inner(*this, tmpDt);
-    if (key.firstTable->is(PlanType::kDerivedTableNode)) {
+    if (key.firstTable->is(PlanType::kDerivedTableNode) &&
+        !tmpDt->columns.empty()) {
+      // tmpDt wraps a subquery DT and has output columns from flattening.
+      // Prune output columns and translate target expressions through the
+      // tmpDt's column-to-expression mapping.
+      pruneOutputColumns(tmpDt, key.columns);
       inner.setTargetExprsForDt(key.columns);
     } else {
       inner.targetExprs = key.columns;

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -209,14 +209,6 @@ void PlanState::addNextJoin(
   }
 }
 
-void PlanState::setTargetExprsForDt(const PlanObjectSet& target) {
-  for (auto i = 0; i < dt->columns.size(); ++i) {
-    if (target.contains(dt->columns[i])) {
-      targetExprs.add(dt->exprs[i]);
-    }
-  }
-}
-
 ExprCP PlanState::isDownstreamFilterOnly(ColumnCP column) const {
   ExprCP result = nullptr;
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -238,10 +238,6 @@ struct PlanState {
     cost.add(op);
   }
 
-  /// Specifies that the plan-to-make only produces 'target' expressions and.
-  /// These refer to 'exprs' of 'dt'.
-  void setTargetExprsForDt(const PlanObjectSet& target);
-
   /// Returns the set of columns referenced in unplaced joins/filters union
   /// targetColumns. Gets smaller as more tables are placed.
   const PlanObjectSet& downstreamColumns() const;

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -53,20 +53,24 @@ class SqlTest : public SqlTestBase {
   }
 
   void TestBody() override {
-    switch (entry_.type) {
-      case QueryEntry::Type::kResults:
-        assertResults(entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
-        break;
-      case QueryEntry::Type::kOrdered:
-        assertOrderedResults(
-            entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
-        break;
-      case QueryEntry::Type::kCount:
-        assertResultCount(entry_.sql, entry_.expectedCount);
-        break;
-      case QueryEntry::Type::kError:
-        assertFailure(entry_.sql, entry_.expectedError);
-        break;
+    try {
+      switch (entry_.type) {
+        case QueryEntry::Type::kResults:
+          assertResults(entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
+          break;
+        case QueryEntry::Type::kOrdered:
+          assertOrderedResults(
+              entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
+          break;
+        case QueryEntry::Type::kCount:
+          assertResultCount(entry_.sql, entry_.expectedCount);
+          break;
+        case QueryEntry::Type::kError:
+          assertFailure(entry_.sql, entry_.expectedError);
+          break;
+      }
+    } catch (const std::exception& e) {
+      FAIL() << "Unexpected exception: " << e.what();
     }
   }
 

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -57,6 +57,21 @@ LEFT JOIN (
 ) AS b ON a.k = b.k
 WHERE b.m = 1
 ----
+-- CROSS JOIN UNNEST with two JOINs that have constant equality filters.
+-- The reducing-join optimization must not prune columns needed by the output.
+-- duckdb: VALUES (1, 2)
+SELECT t.a, t.b
+FROM (
+    SELECT a, b, items
+    FROM (VALUES
+        (1, 2, ARRAY[ROW(10 AS k)]),
+        (3, 4, ARRAY[ROW(20 AS k)])
+    ) _(a, b, items)
+) t
+CROSS JOIN UNNEST(t.items) _(r)
+JOIN (VALUES (1, 10), (1, 20)) u(c, k) ON u.k = r.k AND u.c = 1
+JOIN (VALUES (1, 10)) v(c, k) ON v.k = u.k AND v.c = 1
+----
 -- Chained LEFT JOINs with same-named columns and GROUP BY.
 -- a.ds must group by a's column, not c's.
 SELECT a.ds


### PR DESCRIPTION
Summary:

`setTargetExprsForDt` filtered `dt->exprs` using a `target` set matched
against `dt->columns`. At two of the three call sites (bestPlan and
makeDtPlan), `target` was always a superset of `dt->columns`, making the
filter a no-op. Replace these with direct assignment:
`targetExprs = PlanObjectSet::fromObjects(dt->exprs)`. Inline the filtering
logic at the remaining call site (union inputs) where `target` is a proper
subset and the filter is needed.

Differential Revision: D102072971


