### PR TITLE
fix(build): Fix build failure of SessionConfigTest.cpp

### DIFF
--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -23,6 +23,7 @@
 
 #include "axiom/common/SessionConfig.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::axiom;


### PR DESCRIPTION
Summary:
Fix the build error below.
```
axiom/common/tests/SessionConfigTest.cpp:71:5: error: use of undeclared identifier 'VELOX_CHECK'
   71 |     VELOX_CHECK(it != entries.end(), "Property not found: {}", name);
      |     ^
```

Differential Revision: D102193429


