### PR TITLE
fix(optimizer): Guard null exploded expressions in addJoinColumns

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1714,6 +1714,7 @@ void ToGraph::addJoinColumns(
   for (auto channel : usedChannels(joinSide)) {
     const auto& name = names[channel];
     auto* expr = translateColumn(name);
+    VELOX_CHECK_NOT_NULL(expr, "Null expression for join column: {}", name);
 
     // Check if we already created a column for this expression (e.g., two
     // aliases of the same source column: v AS x, v AS y).

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1715,6 +1715,9 @@ void ToGraph::addJoinColumns(
   for (auto channel : usedChannels(joinSide)) {
     const auto& name = names[channel];
     auto* expr = translateColumn(name);
+    // TODO: Remove once https://github.com/facebookincubator/axiom/issues/1325
+    // is fixed.
+    VELOX_CHECK_NOT_NULL(expr, "Null expression for join column: {}", name);
 
     // Check if we already created a column for this expression (e.g., two
     // aliases of the same source column: v AS x, v AS y).

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -1353,6 +1354,30 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+}
+
+TEST_F(JoinTest, leftJoinWithUnmaterializedSubfield) {
+  testConnector_->addTable("t", ROW({"k", "v"}, {INTEGER(), INTEGER()}));
+  testConnector_->addTable(
+      "u",
+      ROW({"k", "m"}, {INTEGER(), MAP(INTEGER(), MAP(INTEGER(), REAL()))}));
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .project({"k", "v"})
+                         .join(
+                             lp::PlanBuilder(makeContext())
+                                 .tableScan("u")
+                                 .project({"k as uk", "m[100::int] as nested"}),
+                             "k = uk",
+                             lp::JoinType::kLeft)
+                         .project({"v", "nested[1::int] as val"})
+                         .build();
+  SCOPED_TRACE("leftJoinWithUnmaterializedSubfield");
+
+  optimizerOptions_.pushdownSubfields = true;
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(logicalPlan), "Null expression for join column: nested");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -957,6 +957,23 @@ TEST_P(SubfieldTest, subfieldAcrossDtBoundary) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+TEST_P(SubfieldTest, leftJoinWithUnmaterializedSubfield) {
+  testConnector_->addTable("t", ROW({"k", "v"}, INTEGER()));
+  testConnector_->addTable(
+      "u",
+      ROW({"k", "m"}, {INTEGER(), MAP(INTEGER(), MAP(INTEGER(), REAL()))}));
+
+  auto logicalPlan = parseSelect(
+      "SELECT v, nested[1] "
+      "FROM t "
+      "LEFT JOIN (SELECT k, m[100] as nested FROM u) u ON t.k = u.k",
+      kTestConnectorId);
+
+  optimizerOptions_.pushdownSubfields = true;
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(logicalPlan), "Null expression for join column: nested");
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SubfieldTests,
     SubfieldTest,


### PR DESCRIPTION
Summary:
When subfield pushdown is enabled and the optional side of an outer join projects a map subscript, the skyline-based subfield tracking can produce a null entry in renames_. This happens because makeGettersOverSkyline returns nullptr when the intermediate subfield path is not materialized — only the fully-resolved leaf path exists in the skyline. addJoinColumns then retrieves this null via translateColumn and dereferences it at expr->isColumn(), causing a SIGSEGV.

Add a VELOX_CHECK_NOT_NULL guard in addJoinColumns to convert the SIGSEGV into a clear error message identifying which join column has a null expression.

Crash path:
1. addProjection translates m[100] via translateExpr -> translateSubfield -> makeGettersOverSkyline
2. The skyline has path [100][1] but intersectWithSkyline fails for the intermediate [100] prefix
3. makeGettersOverSkyline returns nullptr, stored as renames_["nested"] = nullptr
4. translateJoin calls addJoinColumns for the optional right side
5. addJoinColumns calls translateColumn("nested"), gets nullptr from renames_
6. expr->isColumn() dereferences null pointer, SIGSEGV

Reviewed By: mbasmanova

Differential Revision: D101229030


