### PR TITLE
feat: Wire SpillDiskOpts into task creation to enable spilling

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -19,6 +19,8 @@
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Task.h>
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/common/base/SpillConfig.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -83,6 +85,25 @@ namespace {
 std::shared_ptr<velox::exec::RemoteConnectorSplit> remoteSplit(
     const std::string& taskId) {
   return std::make_shared<velox::exec::RemoteConnectorSplit>(taskId);
+}
+
+// Builds per-task SpillDiskOptions under the base spill directory. Each task
+// gets a unique subdirectory created lazily on first spill.
+std::optional<velox::common::SpillDiskOptions> makeSpillDiskOptions(
+    const std::string& baseSpillDirectory,
+    const std::string& taskId) {
+  if (baseSpillDirectory.empty()) {
+    return std::nullopt;
+  }
+  velox::common::SpillDiskOptions options;
+  options.spillDirPath = fmt::format("{}/{}", baseSpillDirectory, taskId);
+  options.spillDirCreated = false;
+  options.spillDirCreateCb = [path = options.spillDirPath]() {
+    auto fileSystem = velox::filesystems::getFileSystem(path, nullptr);
+    fileSystem->mkdir(path);
+    return path;
+  };
+  return options;
 }
 
 // Streams splits from the source and distributes them round-robin across tasks.
@@ -167,13 +188,18 @@ LocalRunner::LocalRunner(
     optimizer::FinishWrite finishWrite,
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
-    std::shared_ptr<velox::memory::MemoryPool> outputPool)
+    std::shared_ptr<velox::memory::MemoryPool> outputPool,
+    std::string baseSpillDirectory)
     : plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
-      splitSourceFactory_{std::move(splitSourceFactory)} {
+      splitSourceFactory_{std::move(splitSourceFactory)},
+      baseSpillDirectory_{std::move(baseSpillDirectory)} {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
+  if (!baseSpillDirectory_.empty()) {
+    params_.spillDirectory = baseSpillDirectory_;
+  }
 
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
@@ -402,19 +428,20 @@ void LocalRunner::makeStages(
     stages_.emplace_back();
 
     for (auto i = 0; i < fragment.width; ++i) {
+      auto taskId = fmt::format(
+          "local://{}/{}.{}",
+          params_.queryCtx->queryId(),
+          fragment.taskPrefix,
+          i);
       auto task = velox::exec::Task::create(
-          fmt::format(
-              "local://{}/{}.{}",
-              params_.queryCtx->queryId(),
-              fragment.taskPrefix,
-              i),
+          taskId,
           fragment.fragment,
           i,
           params_.queryCtx,
           velox::exec::Task::ExecutionMode::kParallel,
           velox::exec::ConsumerSupplier{},
           /*memoryArbitrationPriority=*/0,
-          /*spillDiskOpts=*/std::nullopt,
+          makeSpillDiskOptions(baseSpillDirectory_, taskId),
           onError);
       stages_.back().push_back(task);
 

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -21,6 +21,7 @@
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
+#include "velox/common/base/SpillConfig.h"
 #include "velox/connectors/Connector.h"
 #include "velox/exec/Cursor.h"
 
@@ -80,13 +81,17 @@ class LocalRunner : public Runner,
  public:
   /// @param outputPool Optional memory pool to use for allocating memory for
   /// query results. Required if 'finishWrite' is set.
+  /// @param baseSpillDirectory Base directory for spill files. If non-empty,
+  /// each task gets a unique subdirectory under this path. Empty disables
+  /// spilling at the task level.
   LocalRunner(
       optimizer::MultiFragmentPlanPtr plan,
       optimizer::FinishWrite finishWrite,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
-      std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr);
+      std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr,
+      std::string baseSpillDirectory = "");
 
   ~LocalRunner() override;
 
@@ -175,6 +180,8 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  // Base directory for task spill files. Empty disables spilling.
+  std::string baseSpillDirectory_;
   folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
   bool splitScopeJoined_{false};
 };

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -259,5 +259,26 @@ TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
   ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
+TEST_F(LocalRunnerTest, spillDirectoryWiring) {
+  auto spillDir = velox::common::testutil::TempDirectoryPath::create();
+
+  auto join = makeJoinPlan();
+  const auto queryId = join->options().queryId;
+  auto queryCtx = makeQueryCtx(queryId);
+
+  auto localRunner = std::make_shared<LocalRunner>(
+      std::move(join),
+      optimizer::FinishWrite{},
+      std::move(queryCtx),
+      std::make_shared<ConnectorSplitSourceFactory>(),
+      /*outputPool=*/nullptr,
+      spillDir->getPath());
+
+  auto results = readCursor(localRunner);
+  EXPECT_EQ(1, results.size());
+  EXPECT_EQ(kNumRows, extractSingleInt64(results));
+  EXPECT_EQ(Runner::State::kFinished, localRunner->state());
+}
+
 } // namespace
 } // namespace facebook::axiom::runner


### PR DESCRIPTION
Summary:
**LocalRunner (axiom/runner/):**
- Add `baseSpillDirectory` parameter to constructor
- Add `makeSpillDiskOptions()` helper that builds per-task `SpillDiskOptions` with a lazy directory-creation callback
- Pass `SpillDiskOptions` to `Task::create()` for intermediate-stage tasks
- Set `CursorParameters::spillDirectory` for the last-stage TaskCursor

Differential Revision: D102196225


