### PR TITLE
refactor(test): Replace toString() expression comparison with structural matching (#1290)

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(
   gtest_main
 )
 
-add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp)
+add_library(axiom_optimizer_tests_plan_matcher ExprMatcher.cpp PlanMatcher.cpp)
 
 target_link_libraries(
   axiom_optimizer_tests_plan_matcher
@@ -106,6 +106,7 @@ add_executable(
   CsvReadWriteTest.cpp
   DerivedTablePrinterTest.cpp
   DomainTest.cpp
+  ExprMatcherTest.cpp
   ExistencePushdownTest.cpp
   FilterPushdownTest.cpp
   FiltersTest.cpp

--- a/axiom/optimizer/tests/ExprMatcher.cpp
+++ b/axiom/optimizer/tests/ExprMatcher.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/ExprMatcher.h"
+#include <gtest/gtest.h>
+#include "velox/core/Expressions.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::core {
+namespace {
+
+#define AXIOM_RETURN_IF_FAILURE                \
+  if (::testing::Test::HasNonfatalFailure()) { \
+    return;                                    \
+  }
+
+#define AXIOM_RETURN_FALSE_IF_FAILURE          \
+  if (::testing::Test::HasNonfatalFailure()) { \
+    return false;                              \
+  }
+
+bool isWildcard(const ExprPtr& expr) {
+  if (!expr->is(IExpr::Kind::kCall)) {
+    return false;
+  }
+  const auto* call = expr->as<CallExpr>();
+  return call->name() == ExprMatcher::kWildcard && call->inputs().empty();
+}
+
+void matchConstant(
+    const ConstantTypedExpr& actual,
+    const ConstantExpr& expected) {
+  EXPECT_EQ(actual.isNull(), expected.value().isNull());
+  AXIOM_RETURN_IF_FAILURE
+
+  if (actual.isNull()) {
+    return;
+  }
+
+  if (actual.hasValueVector()) {
+    EXPECT_EQ(actual.toString(), expected.toString());
+    return;
+  }
+
+  if (actual.value().equalsWithEpsilon(expected.value())) {
+    return;
+  }
+
+  // DuckDB parses integer literals as BIGINT, but the plan may use INTEGER.
+  if (actual.type()->isInteger() && expected.type()->isBigint()) {
+    EXPECT_EQ(
+        static_cast<int64_t>(actual.value().value<int32_t>()),
+        expected.value().value<int64_t>());
+    return;
+  }
+
+  if (actual.type()->isBigint() && expected.type()->isInteger()) {
+    EXPECT_EQ(
+        actual.value().value<int64_t>(),
+        static_cast<int64_t>(expected.value().value<int32_t>()));
+    return;
+  }
+
+  ADD_FAILURE() << "Constant mismatch.";
+}
+
+bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected);
+
+void matchChildren(
+    const std::vector<TypedExprPtr>& actualInputs,
+    const std::vector<ExprPtr>& expectedInputs) {
+  EXPECT_EQ(actualInputs.size(), expectedInputs.size());
+  AXIOM_RETURN_IF_FAILURE
+
+  for (size_t i = 0; i < actualInputs.size(); ++i) {
+    SCOPED_TRACE("child " + std::to_string(i));
+    matchImpl(actualInputs[i], expectedInputs[i]);
+    AXIOM_RETURN_IF_FAILURE
+  }
+}
+
+void matchFieldAccess(
+    const std::string& actualName,
+    const TypedExprPtr& actualInput,
+    const FieldAccessExpr& expected) {
+  EXPECT_FALSE(expected.isRootColumn()) << "Expected non-root FieldAccessExpr.";
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_EQ(actualName, expected.name());
+  AXIOM_RETURN_IF_FAILURE
+
+  matchImpl(actualInput, expected.inputs()[0]);
+}
+
+void matchSubscript(
+    const DereferenceTypedExpr& actual,
+    const CallExpr& expected) {
+  EXPECT_EQ(2, expected.inputs().size());
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_TRUE(expected.inputs()[1]->is(IExpr::Kind::kConstant))
+      << "Expected constant subscript index.";
+  AXIOM_RETURN_IF_FAILURE
+
+  const auto* indexExpr = expected.inputs()[1]->as<ConstantExpr>();
+  int64_t expectedIndex = 0;
+  if (indexExpr->type()->kind() == TypeKind::INTEGER) {
+    expectedIndex = indexExpr->value().value<TypeKind::INTEGER>();
+  } else if (indexExpr->type()->kind() == TypeKind::BIGINT) {
+    expectedIndex = indexExpr->value().value<TypeKind::BIGINT>();
+  } else {
+    FAIL() << "Expected integer subscript index, got "
+           << indexExpr->type()->toString() << ".";
+    return;
+  }
+
+  EXPECT_EQ(static_cast<int64_t>(actual.index() + 1), expectedIndex)
+      << "Subscript index mismatch (0-based vs 1-based).";
+  AXIOM_RETURN_IF_FAILURE
+
+  matchImpl(actual.inputs()[0], expected.inputs()[0]);
+}
+
+bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected) {
+  VELOX_CHECK_NOT_NULL(actual);
+  VELOX_CHECK_NOT_NULL(expected);
+
+  if (isWildcard(expected)) {
+    return true;
+  }
+
+  SCOPED_TRACE(
+      "actual: '" + actual->toString() + "', expected: '" +
+      expected->toString() + "'");
+
+  // InputTypedExpr.
+  if (actual->isInputKind()) {
+    EXPECT_TRUE(expected->is(IExpr::Kind::kInput)) << "Expected InputExpr.";
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // FieldAccessTypedExpr.
+  if (actual->isFieldAccessKind()) {
+    const auto* field = actual->asUnchecked<FieldAccessTypedExpr>();
+
+    if (field->isInputColumn()) {
+      EXPECT_TRUE(expected->is(IExpr::Kind::kFieldAccess))
+          << "Expected FieldAccessExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* expectedField = expected->as<FieldAccessExpr>();
+      EXPECT_TRUE(expectedField->isRootColumn()) << "Expected root column.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      EXPECT_EQ(field->name(), expectedField->name());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    // Struct field access by name.
+    EXPECT_TRUE(expected->is(IExpr::Kind::kFieldAccess))
+        << "Expected FieldAccessExpr for struct field.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    VELOX_CHECK_EQ(field->inputs().size(), 1);
+    matchFieldAccess(
+        field->name(), field->inputs()[0], *expected->as<FieldAccessExpr>());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // DereferenceTypedExpr.
+  if (actual->isDereferenceKind()) {
+    const auto* deref = actual->asUnchecked<DereferenceTypedExpr>();
+    VELOX_CHECK_EQ(deref->inputs().size(), 1);
+
+    if (expected->is(IExpr::Kind::kFieldAccess)) {
+      matchFieldAccess(
+          deref->name(), deref->inputs()[0], *expected->as<FieldAccessExpr>());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    if (expected->is(IExpr::Kind::kCall)) {
+      const auto* expectedCall = expected->as<CallExpr>();
+      if (expectedCall->name() == "subscript") {
+        matchSubscript(*deref, *expectedCall);
+        return !::testing::Test::HasNonfatalFailure();
+      }
+    }
+
+    ADD_FAILURE() << "Expected FieldAccessExpr or subscript() for dereference.";
+    return false;
+  }
+
+  // CallTypedExpr.
+  if (actual->isCallKind()) {
+    const auto* call = actual->asUnchecked<CallTypedExpr>();
+
+    EXPECT_TRUE(expected->is(IExpr::Kind::kCall)) << "Expected CallExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    const auto* expectedCall = expected->as<CallExpr>();
+    EXPECT_EQ(call->name(), expectedCall->name());
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    matchChildren(call->inputs(), expectedCall->inputs());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // ConstantTypedExpr.
+  if (actual->isConstantKind()) {
+    EXPECT_TRUE(expected->is(IExpr::Kind::kConstant))
+        << "Expected ConstantExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    matchConstant(
+        *actual->asUnchecked<ConstantTypedExpr>(),
+        *expected->as<ConstantExpr>());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // CastTypedExpr.
+  if (actual->isCastKind()) {
+    const auto* cast = actual->asUnchecked<CastTypedExpr>();
+
+    EXPECT_TRUE(expected->is(IExpr::Kind::kCast)) << "Expected CastExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    const auto* expectedCast = expected->as<CastExpr>();
+    EXPECT_EQ(cast->isTryCast(), expectedCast->isTryCast());
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    EXPECT_TRUE(cast->type()->equivalent(*expectedCast->type()))
+        << "Cast target type: actual " << cast->type()->toString()
+        << ", expected " << expectedCast->type()->toString() << ".";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    VELOX_CHECK_EQ(cast->inputs().size(), 1);
+    matchImpl(cast->inputs()[0], expectedCast->input());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // ConcatTypedExpr.
+  if (actual->isConcatKind()) {
+    EXPECT_TRUE(expected->is(IExpr::Kind::kCall))
+        << "Expected row_constructor CallExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    const auto* expectedCall = expected->as<CallExpr>();
+    EXPECT_EQ("row_constructor", expectedCall->name());
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    matchChildren(actual->inputs(), expectedCall->inputs());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // LambdaTypedExpr.
+  if (actual->isLambdaKind()) {
+    const auto* lambda = actual->asUnchecked<LambdaTypedExpr>();
+
+    EXPECT_TRUE(expected->is(IExpr::Kind::kLambda)) << "Expected LambdaExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    const auto* expectedLambda = expected->as<LambdaExpr>();
+    const auto& actualNames = lambda->signature()->names();
+    const auto& expectedNames = expectedLambda->arguments();
+    EXPECT_EQ(actualNames.size(), expectedNames.size());
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    for (size_t i = 0; i < actualNames.size(); ++i) {
+      EXPECT_EQ(actualNames[i], expectedNames[i])
+          << "Lambda parameter mismatch at index " << i << ".";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+    }
+
+    matchImpl(lambda->body(), expectedLambda->body());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  // NullIfTypedExpr.
+  if (actual->isNullIfKind()) {
+    EXPECT_TRUE(expected->is(IExpr::Kind::kCall))
+        << "Expected nullif CallExpr.";
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    const auto* expectedCall = expected->as<CallExpr>();
+    EXPECT_EQ("nullif", expectedCall->name());
+    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    matchChildren(actual->inputs(), expectedCall->inputs());
+    return !::testing::Test::HasNonfatalFailure();
+  }
+
+  ADD_FAILURE() << "Unsupported typed expression kind.";
+  return false;
+}
+
+#undef AXIOM_RETURN_IF_FAILURE
+#undef AXIOM_RETURN_FALSE_IF_FAILURE
+
+} // namespace
+
+bool ExprMatcher::match(const TypedExprPtr& actual, const ExprPtr& expected) {
+  return matchImpl(actual, expected);
+}
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/ExprMatcher.h
+++ b/axiom/optimizer/tests/ExprMatcher.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+#include "velox/core/ITypedExpr.h"
+#include "velox/parse/IExpr.h"
+
+namespace facebook::velox::core {
+
+/// Structurally compares a typed expression tree (from a Velox plan) against
+/// an untyped expression tree. Sets gtest failures with descriptive messages
+/// on mismatch.
+class ExprMatcher {
+ public:
+  /// Function name used as a wildcard in expected expressions. A CallExpr
+  /// with this name and zero inputs matches any typed subtree.
+  static constexpr std::string_view kWildcard = "any";
+
+  /// Returns true if the trees match. On mismatch, sets gtest failures
+  /// with SCOPED_TRACE context showing the path through the tree.
+  static bool match(const TypedExprPtr& actual, const core::ExprPtr& expected);
+};
+
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/ExprMatcherTest.cpp
+++ b/axiom/optimizer/tests/ExprMatcherTest.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/ExprMatcher.h"
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+#include "velox/core/Expressions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::core {
+namespace {
+
+TypedExprPtr field(const TypePtr& type, const std::string& name) {
+  return std::make_shared<FieldAccessTypedExpr>(type, name);
+}
+
+TypedExprPtr
+field(const TypePtr& type, const TypedExprPtr& input, const std::string& name) {
+  return std::make_shared<FieldAccessTypedExpr>(type, input, name);
+}
+
+TypedExprPtr constant(const TypePtr& type, const Variant& value) {
+  return std::make_shared<ConstantTypedExpr>(type, value);
+}
+
+TypedExprPtr constantNull(const TypePtr& type) {
+  return ConstantTypedExpr::makeNull(type);
+}
+
+template <typename... Args>
+TypedExprPtr
+call(const TypePtr& type, const std::string& name, Args&&... args) {
+  return std::make_shared<CallTypedExpr>(
+      type, std::vector<TypedExprPtr>{std::forward<Args>(args)...}, name);
+}
+
+TypedExprPtr cast(const TypePtr& type, const TypedExprPtr& input, bool isTry) {
+  return std::make_shared<CastTypedExpr>(type, input, isTry);
+}
+
+TypedExprPtr
+deref(const TypePtr& type, const TypedExprPtr& input, uint32_t index) {
+  return std::make_shared<DereferenceTypedExpr>(type, input, index);
+}
+
+TypedExprPtr concat(
+    const std::vector<std::string>& names,
+    const std::vector<TypedExprPtr>& inputs) {
+  return std::make_shared<ConcatTypedExpr>(names, inputs);
+}
+
+TypedExprPtr lambda(const RowTypePtr& signature, const TypedExprPtr& body) {
+  return std::make_shared<LambdaTypedExpr>(signature, body);
+}
+
+TypedExprPtr nullIf(
+    const TypedExprPtr& value,
+    const TypedExprPtr& comparand,
+    const TypePtr& commonType) {
+  return std::make_shared<NullIfTypedExpr>(value, comparand, commonType);
+}
+
+ExprPtr wildcard() {
+  return std::make_shared<CallExpr>(
+      std::string{ExprMatcher::kWildcard},
+      std::vector<ExprPtr>{},
+      std::nullopt);
+}
+
+class ExprMatcherTest : public testing::Test {
+ protected:
+  ExprPtr parseExpr(const std::string& sql) {
+    return parser_.parseExpr(sql);
+  }
+
+  parse::DuckSqlExpressionsParser parser_;
+};
+
+TEST_F(ExprMatcherTest, rootColumn) {
+  ExprMatcher::match(field(BIGINT(), "a"), parseExpr("a"));
+}
+
+TEST_F(ExprMatcherTest, rootColumnNameMismatch) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(field(BIGINT(), "a"), parseExpr("b")),
+      R"(actual: '"a"', expected: '"b"')");
+}
+
+TEST_F(ExprMatcherTest, functionCall) {
+  ExprMatcher::match(
+      call(BIGINT(), "plus", field(BIGINT(), "a"), field(BIGINT(), "b")),
+      parseExpr("a + b"));
+}
+
+TEST_F(ExprMatcherTest, nestedFunctionCall) {
+  auto expr = call(
+      BIGINT(),
+      "mod",
+      call(BIGINT(), "plus", field(BIGINT(), "a"), constant(BIGINT(), 1LL)),
+      constant(BIGINT(), 3LL));
+  ExprMatcher::match(expr, parseExpr("(a + 1) % 3"));
+}
+
+TEST_F(ExprMatcherTest, functionNameMismatch) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(
+          call(BIGINT(), "minus", field(BIGINT(), "a"), field(BIGINT(), "b")),
+          parseExpr("a + b")),
+      R"(actual: 'minus("a","b")', expected: 'plus("a","b")')");
+}
+
+TEST_F(ExprMatcherTest, integerConstant) {
+  ExprMatcher::match(constant(BIGINT(), 42LL), parseExpr("42"));
+}
+
+TEST_F(ExprMatcherTest, booleanConstant) {
+  ExprMatcher::match(constant(BOOLEAN(), true), parseExpr("true"));
+  ExprMatcher::match(constant(BOOLEAN(), false), parseExpr("false"));
+}
+
+TEST_F(ExprMatcherTest, nullConstant) {
+  ExprMatcher::match(constantNull(BIGINT()), parseExpr("null"));
+}
+
+TEST_F(ExprMatcherTest, stringConstant) {
+  ExprMatcher::match(
+      constant(VARCHAR(), Variant::create<TypeKind::VARCHAR>("hello")),
+      parseExpr("'hello'"));
+}
+
+TEST_F(ExprMatcherTest, doubleEpsilonMatch) {
+  // 0.1 + 0.2 != 0.3 in double precision, but equalsWithEpsilon handles it.
+  ExprMatcher::match(constant(DOUBLE(), Variant(0.1 + 0.2)), parseExpr("0.3"));
+}
+
+TEST_F(ExprMatcherTest, doubleEpsilonMismatch) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(constant(DOUBLE(), 1.0), parseExpr("2.0")),
+      "actual: '1', expected: '2'");
+}
+
+TEST_F(ExprMatcherTest, cast) {
+  ExprMatcher::match(
+      cast(BIGINT(), field(INTEGER(), "a"), false),
+      parseExpr("cast(a as bigint)"));
+}
+
+TEST_F(ExprMatcherTest, tryCast) {
+  ExprMatcher::match(
+      cast(VARCHAR(), field(BIGINT(), "a"), true),
+      parseExpr("try_cast(a as varchar)"));
+}
+
+TEST_F(ExprMatcherTest, castTryCastMismatch) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(
+          cast(BIGINT(), field(INTEGER(), "a"), false),
+          parseExpr("try_cast(a as bigint)")),
+      R"(actual: 'cast("a" as BIGINT)', expected: 'try_cast("a" as BIGINT)')");
+}
+
+TEST_F(ExprMatcherTest, dereferenceExpr) {
+  auto structType = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  ExprMatcher::match(
+      deref(BIGINT(), field(structType, "a"), 0), parseExpr("(a).x"));
+}
+
+TEST_F(ExprMatcherTest, fieldAccessStructField) {
+  auto structType = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  ExprMatcher::match(
+      field(BIGINT(), field(structType, "a"), "x"), parseExpr("(a).x"));
+}
+
+TEST_F(ExprMatcherTest, dereferenceFieldNameMismatch) {
+  auto structType = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(
+          deref(BIGINT(), field(structType, "a"), 0), parseExpr("(a).y")),
+      R"(actual: '"a"[x]', expected: 'dot("a","y")')");
+}
+
+TEST_F(ExprMatcherTest, concatTypedExpr) {
+  ExprMatcher::match(
+      concat({"c0", "c1"}, {constant(BIGINT(), 1LL), constant(BIGINT(), 2LL)}),
+      parseExpr("row_constructor(1, 2)"));
+}
+
+TEST_F(ExprMatcherTest, lambda) {
+  auto signature = ROW({"x", "y"}, {BIGINT(), BIGINT()});
+  auto body =
+      call(BIGINT(), "plus", field(BIGINT(), "x"), field(BIGINT(), "y"));
+  ExprMatcher::match(lambda(signature, body), parseExpr("(x, y) -> x + y"));
+}
+
+TEST_F(ExprMatcherTest, nullIf) {
+  ExprMatcher::match(
+      nullIf(field(BIGINT(), "a"), field(BIGINT(), "b"), BIGINT()),
+      parseExpr("nullif(a, b)"));
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesField) {
+  ExprMatcher::match(field(BIGINT(), "a"), wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesConstant) {
+  ExprMatcher::match(constant(BIGINT(), 42LL), wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesCall) {
+  ExprMatcher::match(
+      call(BIGINT(), "plus", field(BIGINT(), "a"), field(BIGINT(), "b")),
+      wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardInSubtree) {
+  ExprMatcher::match(
+      call(BIGINT(), "plus", field(BIGINT(), "a"), field(BIGINT(), "b")),
+      std::make_shared<CallExpr>(
+          "plus",
+          std::vector<ExprPtr>{parseExpr("a"), wildcard()},
+          std::nullopt));
+}
+
+} // namespace
+} // namespace facebook::velox::core

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/optimizer/tests/ExprMatcher.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -133,79 +134,6 @@ velox::core::ExprPtr rewriteInputNames(
         }
         return e;
       });
-}
-
-// Normalizes toStrings to match Velox exprs to DuckDB. Velox uses bracket
-// notation for dereferences while DuckDB uses special forms names explicitly.
-// In addition, Velox constant folds rows into a constant typed expr with curly
-// bracket notation while DuckDB uses "row_constructor".
-std::string toExprString(const TypedExprPtr& expr) {
-  if (auto* deref = dynamic_cast<const DereferenceTypedExpr*>(expr.get())) {
-    return fmt::format(
-        "subscript({},{})",
-        toExprString(expr->inputs()[0]),
-        deref->index() + 1);
-  }
-
-  if (auto* field = dynamic_cast<const FieldAccessTypedExpr*>(expr.get())) {
-    if (!field->inputs().empty() && !field->inputs()[0]->isInputKind()) {
-      return fmt::format(
-          "dot({},\"{}\")", toExprString(field->inputs()[0]), field->name());
-    }
-  }
-
-  if (auto* call = dynamic_cast<const CallTypedExpr*>(expr.get())) {
-    std::string result = call->name() + "(";
-    for (size_t i = 0; i < expr->inputs().size(); ++i) {
-      if (i > 0) {
-        result += ",";
-      }
-      result += toExprString(expr->inputs()[i]);
-    }
-    result += ")";
-    return result;
-  }
-
-  if (auto* cast = dynamic_cast<const CastTypedExpr*>(expr.get())) {
-    return fmt::format(
-        "{}({} as {})",
-        cast->isTryCast() ? "try_cast" : "cast",
-        toExprString(expr->inputs()[0]),
-        cast->type()->toString());
-  }
-
-  if (auto* constant = dynamic_cast<const ConstantTypedExpr*>(expr.get())) {
-    if (constant->type()->isRow()) {
-      std::string result = "row_constructor(";
-      if (constant->hasValueVector()) {
-        const auto& vec = constant->valueVector();
-        const auto* row = vec->wrappedVector()->as<RowVector>();
-        auto idx = vec->wrappedIndex(0);
-        for (vector_size_t i = 0; i < row->childrenSize(); ++i) {
-          if (i > 0) {
-            result += ",";
-          }
-          if (row->childAt(i)->isNullAt(idx)) {
-            result += "null";
-          } else {
-            result += row->childAt(i)->toString(idx);
-          }
-        }
-      } else {
-        const auto& rowValues = constant->value().row();
-        for (size_t i = 0; i < rowValues.size(); ++i) {
-          if (i > 0) {
-            result += ",";
-          }
-          result += rowValues[i].toStringAsVector(constant->type()->childAt(i));
-        }
-      }
-      result += ")";
-      return result;
-    }
-  }
-
-  return expr->toString();
 }
 
 class TableScanMatcher : public PlanMatcherImpl<TableScanNode> {
@@ -368,7 +296,7 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
       if (!symbols.empty()) {
         expected = rewriteInputNames(expected, symbols);
       }
-      EXPECT_EQ(toExprString(plan.filter()), expected->toString());
+      ExprMatcher::match(plan.filter(), expected->dropAlias());
     }
 
     AXIOM_TEST_RETURN
@@ -411,11 +339,9 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
           expected = rewriteInputNames(expected, symbols);
         }
 
-        EXPECT_EQ(
-            toExprString(plan.projections()[i]),
-            expected->dropAlias()->toString());
+        ExprMatcher::match(plan.projections()[i], expected->dropAlias());
+        AXIOM_TEST_RETURN_IF_FAILURE
       }
-      AXIOM_TEST_RETURN_IF_FAILURE
     } else {
       // No expressions to verify. Remap symbols through the project's
       // column mapping. For identity projections (field access), update
@@ -464,9 +390,9 @@ class ParallelProjectMatcher : public PlanMatcherImpl<ParallelProjectNode> {
       for (auto i = 0; i < expressions_.size(); ++i) {
         auto expected =
             parse::DuckSqlExpressionsParser().parseExpr(expressions_[i]);
-        EXPECT_EQ(plan.projections()[i]->toString(), expected->toString());
+        ExprMatcher::match(plan.projections()[i], expected->dropAlias());
+        AXIOM_TEST_RETURN_IF_FAILURE
       }
-      AXIOM_TEST_RETURN_IF_FAILURE
     }
 
     return MatchResult::success();
@@ -1265,6 +1191,7 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
     // Parse all window expressions to extract expected values.
     std::vector<core::WindowCallExprPtr> expectedWindows;
     expectedWindows.reserve(windowExprs_.size());
+
     parse::ParseOptions parseOptions;
     parseOptions.correctWindowFrameDefault = true;
     for (const auto& expr : windowExprs_) {

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -143,7 +143,7 @@ TEST_F(PlanTest, rejectedFilters) {
     auto plan = toSingleNodePlan(logicalPlan.build());
 
     auto matcher = matchScan("t", ROW({"a", "b"}, {BIGINT(), DOUBLE()}))
-                       .filter("b > 10")
+                       .filter("b > 10.0")
                        .project()
                        .build();
 
@@ -187,7 +187,7 @@ TEST_F(PlanTest, rejectedFilters) {
     auto plan = toSingleNodePlan(logicalPlan);
 
     auto matcher = matchScan("t", ROW("c", mapType))
-                       .filter("c[1] > 10")
+                       .filter("c[1] > 10.0")
                        .project({"1"})
                        .build();
 
@@ -208,7 +208,7 @@ TEST_F(PlanTest, rejectedFilters) {
     auto plan = toSingleNodePlan(logicalPlan);
 
     auto matcher = matchScan("t", ROW("c", mapType))
-                       .filter("c[1] > 10")
+                       .filter("c[1] > 10.0")
                        .project() // project top-level column c.y
                        .project() // project c.y + 1
                        .build();

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -629,7 +629,7 @@ TEST_F(WindowTest, dependentWindowFunctions) {
             .project(
                 {"a",
                  "b",
-                 "floor(cast(cum_sum as double) * 100 / cast(total_sum as double)) as pct"})
+                 "floor(cast(cum_sum as double) * 100.0 / cast(total_sum as double)) as pct"})
             .window({"lag(pct) OVER (PARTITION BY a ORDER BY b) as lag_pct"})
             .project({"lag_pct"})
             .build();
@@ -653,7 +653,7 @@ TEST_F(WindowTest, dependentWindowFunctions) {
             .project(
                 {"a",
                  "b",
-                 "floor(cast(cum_sum as double) * 100 / cast(total_sum as double)) as pct"})
+                 "floor(cast(cum_sum as double) * 100.0 / cast(total_sum as double)) as pct"})
             // TODO: Eliminate redundant local partition.
             .localPartition({"a"})
             .window({"lag(pct) OVER (PARTITION BY a ORDER BY b) as lag_pct"})

--- a/axiom/optimizer/tests/utils/DfFunctions.cpp
+++ b/axiom/optimizer/tests/utils/DfFunctions.cpp
@@ -55,8 +55,8 @@ std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
       break;
     }
   }
-  VELOX_CHECK(
-      found != -1, "Subfield not found in make_row_from_map: {}", field);
+  VELOX_CHECK_NE(
+      found, -1, "Subfield not found in make_row_from_map: {}", field);
 
   std::vector<Step> newFields(steps.begin(), steps.end());
   newFields.pop_back();
@@ -67,7 +67,7 @@ std::pair<std::vector<Step>, int32_t> makeRowFromMapSubfield(
                     ->as<lp::ConstantExpr>()
                     ->value()
                     ->value<TypeKind::ARRAY>()[found]
-                    .value<int32_t>()});
+                    .value<int64_t>()});
   return std::make_pair(std::move(newFields), 0);
 }
 


### PR DESCRIPTION
Summary:

Replace the fragile toString()-based expression comparison in PlanMatcher with ExprMatcher, a structural tree matcher that walks the typed expression tree (ITypedExpr) and matches each node against the corresponding untyped expression tree (IExpr) parsed from DuckDB SQL.

The old approach used toExprString() to normalize typed expressions to strings and compared against the DuckDB-parsed expression's toString(). This was fragile because formatting differences between the two tree types (struct field access notation, cast syntax, row constructor format) required ongoing point fixes in the normalizer.

ExprMatcher compares tree structure directly, node by node. Formatting differences don't matter because we compare semantics, not strings. Float constants use Variant::equalsWithEpsilon for tolerance. INTEGER vs BIGINT constant mismatches are tolerated since DuckDB parses integer literals as BIGINT while the plan may use narrower types.

Supports all typed node types: FieldAccess (root column and struct field), Dereference (by name or subscript index), Call, Constant, Cast, Concat (row_constructor), Lambda, NullIf. A wildcard `any()` with zero inputs matches any typed subtree, enabling partial matching.

Reviewed By: amitkdutta

Differential Revision: D102272684
