### PR TITLE
refactor(test): Replace toString() comparison with structural expression matching (#1291)

### DIFF
--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -729,7 +729,7 @@ TEST_F(PlanBuilderTest, valuesTypeCoercionErrors) {
       buildValues(
           {"x"}, {{"ARRAY[CAST(1 AS integer)]"}, {"MAP(ARRAY[1], ARRAY[2])"}}),
       "Incompatible types in VALUES row 2, column 1: "
-      "expected ARRAY<INTEGER>, got MAP<INTEGER,INTEGER>");
+      "expected ARRAY<INTEGER>, got MAP<BIGINT,BIGINT>");
 
   // Coercions disabled.
   VELOX_ASSERT_THROW(

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -737,7 +737,7 @@ TEST_F(PlanPrinterTest, unnest) {
     EXPECT_THAT(
         lines,
         testing::ElementsAre(
-            testing::Eq("- Unnest: -> ROW<e:INTEGER>"),
+            testing::Eq("- Unnest: -> ROW<e:BIGINT>"),
             testing::Eq("    [e] := [1,2,3]"),
             testing::Eq("  - Values: 1 rows -> ROW<>"),
             testing::Eq("")));
@@ -773,7 +773,7 @@ TEST_F(PlanPrinterTest, unnest) {
     EXPECT_THAT(
         lines,
         testing::ElementsAre(
-            testing::Eq("- Unnest: -> ROW<k:INTEGER,v:INTEGER>"),
+            testing::Eq("- Unnest: -> ROW<k:BIGINT,v:BIGINT>"),
             testing::Eq("    [k, v] := map([1,2,3], [10,20,30])"),
             testing::Eq("  - Values: 1 rows -> ROW<>"),
             testing::Eq("")));
@@ -793,7 +793,7 @@ TEST_F(PlanPrinterTest, unnest) {
         testing::ElementsAre(
             testing::StartsWith("- Project:"),
             testing::StartsWith("    expr := plus(x, y)"),
-            testing::Eq("  - Unnest: -> ROW<x:INTEGER,y:INTEGER>"),
+            testing::Eq("  - Unnest: -> ROW<x:BIGINT,y:BIGINT>"),
             testing::Eq("      [x, y] := map([1,2,3], [10,20,30])"),
             testing::Eq("    - Values: 1 rows -> ROW<>"),
             testing::Eq("")));

--- a/axiom/optimizer/tests/ExprMatcher.cpp
+++ b/axiom/optimizer/tests/ExprMatcher.cpp
@@ -59,7 +59,9 @@ void matchConstant(
     return;
   }
 
-  // DuckDB parses integer literals as BIGINT, but the plan may use INTEGER.
+  // Band-aid: some tests specify expected SQL with bare integer literals
+  // parsed as BIGINT (per parseIntegerAsBigint option), while the plan uses
+  // INTEGER. Many existing tests rely on this tolerance.
   if (actual.type()->isInteger() && expected.type()->isBigint()) {
     EXPECT_EQ(
         static_cast<int64_t>(actual.value().value<int32_t>()),

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -101,7 +101,7 @@ TEST_F(AggregationParserTest, groupByOrdinalWithSelectStar) {
       matchScan()
           .aggregate({"n_nationkey", "n_name", "n_regionkey", "n_comment"}, {})
           .project(
-              {"concat(n_name, _suffix)",
+              {"concat(n_name, '_suffix')",
                "n_nationkey",
                "n_name",
                "n_regionkey",
@@ -786,7 +786,8 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           .aggregate({"b"}, {"sum(a)"})
           .project({"b", "sum", "sum(sum) OVER ()"})
           .project(
-              {"b", "multiply(cast(sum as double), 1) / cast(expr as double)"})
+              {"b",
+               "multiply(cast(sum as double), 1.0) / cast(expr as double)"})
           .output());
 
   // Same as above but with PARTITION BY in the nested window function.
@@ -796,7 +797,8 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           .aggregate({"b"}, {"sum(a)"})
           .project({"b", "sum", "sum(sum) OVER (PARTITION BY b)"})
           .project(
-              {"b", "multiply(cast(sum as double), 1) / cast(expr as double)"})
+              {"b",
+               "multiply(cast(sum as double), 1.0) / cast(expr as double)"})
           .output());
 
   // Same as above but with qualified column references.
@@ -806,7 +808,8 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           .aggregate({"b"}, {"sum(a)"})
           .project({"b", "sum", "sum(sum) OVER ()"})
           .project(
-              {"b", "multiply(cast(sum as double), 1) / cast(expr as double)"})
+              {"b",
+               "multiply(cast(sum as double), 1.0) / cast(expr as double)"})
           .output());
 
   // Window function call with the same signature as a plain aggregate.

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_logical_plan_matcher LogicalPlanMatcher.cpp)
+add_library(axiom_logical_plan_matcher ExprMatcher.cpp LogicalPlanMatcher.cpp)
 
 target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest)
 
@@ -21,6 +21,7 @@ add_executable(
   AggregationParserTest.cpp
   ColumnFilteringTest.cpp
   DdlParserTest.cpp
+  ExprMatcherTest.cpp
   ExpressionParserTest.cpp
   PrestoSqlErrorTest.cpp
   PrestoParserTest.cpp

--- a/axiom/sql/presto/tests/ExprMatcher.cpp
+++ b/axiom/sql/presto/tests/ExprMatcher.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/ExprMatcher.h"
+#include <gtest/gtest.h>
+#include <algorithm>
+#include "axiom/logical_plan/ExprApi.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::axiom::logical_plan::test {
+namespace {
+
+#define AXIOM_RETURN_IF_FAILURE                \
+  if (::testing::Test::HasNonfatalFailure()) { \
+    return;                                    \
+  }
+
+#define AXIOM_RETURN_FALSE_IF_FAILURE          \
+  if (::testing::Test::HasNonfatalFailure()) { \
+    return false;                              \
+  }
+
+bool isWildcard(const velox::core::ExprPtr& expr) {
+  if (!expr->is(velox::core::IExpr::Kind::kCall)) {
+    return false;
+  }
+  const auto* call = expr->as<velox::core::CallExpr>();
+  return call->name() == ExprMatcher::kWildcard && call->inputs().empty();
+}
+
+// Forward declaration for mutual recursion.
+bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected);
+
+void matchChildren(
+    const std::vector<ExprPtr>& actualInputs,
+    const std::vector<velox::core::ExprPtr>& expectedInputs) {
+  EXPECT_EQ(actualInputs.size(), expectedInputs.size());
+  AXIOM_RETURN_IF_FAILURE
+
+  for (size_t i = 0; i < actualInputs.size(); ++i) {
+    SCOPED_TRACE("child " + std::to_string(i));
+    matchImpl(actualInputs[i], expectedInputs[i]);
+    AXIOM_RETURN_IF_FAILURE
+  }
+}
+
+void matchConstant(
+    const ConstantExpr& actual,
+    const velox::core::ConstantExpr& expected) {
+  EXPECT_EQ(actual.isNull(), expected.value().isNull());
+  AXIOM_RETURN_IF_FAILURE
+
+  if (actual.isNull()) {
+    return;
+  }
+
+  if (actual.value()->equalsWithEpsilon(expected.value())) {
+    return;
+  }
+
+  // Band-aid: some tests specify expected SQL with bare integer literals
+  // parsed as BIGINT (per parseIntegerAsBigint option), while the plan uses
+  // INTEGER. Many existing tests rely on this tolerance.
+  if (actual.type()->isInteger() && expected.type()->isBigint()) {
+    EXPECT_EQ(
+        static_cast<int64_t>(actual.value()->value<int32_t>()),
+        expected.value().value<int64_t>());
+    return;
+  }
+
+  if (actual.type()->isBigint() && expected.type()->isInteger()) {
+    EXPECT_EQ(
+        actual.value()->value<int64_t>(),
+        static_cast<int64_t>(expected.value().value<int32_t>()));
+    return;
+  }
+
+  ADD_FAILURE() << "Constant mismatch.";
+}
+
+// Returns the lowercase IExpr call name for a SpecialForm.
+std::string specialFormToCallName(SpecialForm form) {
+  auto name = std::string(SpecialFormName::toName(form));
+  std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+  return name;
+}
+
+void matchDereference(
+    const SpecialFormExpr& actual,
+    const velox::core::ExprPtr& expected) {
+  VELOX_CHECK_EQ(actual.inputs().size(), 2);
+
+  if (expected->is(velox::core::IExpr::Kind::kFieldAccess)) {
+    const auto* field = expected->as<velox::core::FieldAccessExpr>();
+    EXPECT_FALSE(field->isRootColumn()) << "Expected non-root FieldAccessExpr.";
+    AXIOM_RETURN_IF_FAILURE
+
+    // The second input is a constant with the field name or index.
+    const auto* fieldId = actual.inputAt(1)->as<ConstantExpr>();
+    VELOX_CHECK_NOT_NULL(fieldId);
+
+    std::string actualFieldName;
+    if (fieldId->type()->isVarchar()) {
+      actualFieldName =
+          std::string(fieldId->value()->value<velox::TypeKind::VARCHAR>());
+    } else {
+      // Integer index — look up field name from the struct type.
+      VELOX_CHECK(actual.inputAt(0)->type()->isRow());
+      auto index = fieldId->value()->value<velox::TypeKind::INTEGER>();
+      actualFieldName = actual.inputAt(0)->type()->asRow().nameOf(index);
+    }
+
+    EXPECT_EQ(actualFieldName, field->name());
+    AXIOM_RETURN_IF_FAILURE
+
+    matchImpl(actual.inputAt(0), field->inputs()[0]);
+    return;
+  }
+
+  if (expected->is(velox::core::IExpr::Kind::kCall)) {
+    const auto* call = expected->as<velox::core::CallExpr>();
+    if (call->name() == "subscript") {
+      EXPECT_EQ(2, call->inputs().size());
+      AXIOM_RETURN_IF_FAILURE
+
+      EXPECT_TRUE(call->inputs()[1]->is(velox::core::IExpr::Kind::kConstant))
+          << "Expected constant subscript index.";
+      AXIOM_RETURN_IF_FAILURE
+
+      const auto* indexExpr =
+          call->inputs()[1]->as<velox::core::ConstantExpr>();
+      int64_t expectedIndex = 0;
+      if (indexExpr->type()->kind() == velox::TypeKind::INTEGER) {
+        expectedIndex = indexExpr->value().value<velox::TypeKind::INTEGER>();
+      } else if (indexExpr->type()->kind() == velox::TypeKind::BIGINT) {
+        expectedIndex = indexExpr->value().value<velox::TypeKind::BIGINT>();
+      } else {
+        FAIL() << "Expected integer subscript index, got "
+               << indexExpr->type()->toString() << ".";
+      }
+
+      // Logical plan dereference uses 0-based index.
+      const auto* actualIndexExpr = actual.inputAt(1)->as<ConstantExpr>();
+      VELOX_CHECK_NOT_NULL(actualIndexExpr);
+      int64_t actualIndex = 0;
+      if (actualIndexExpr->type()->kind() == velox::TypeKind::INTEGER) {
+        actualIndex =
+            actualIndexExpr->value()->value<velox::TypeKind::INTEGER>();
+      } else if (actualIndexExpr->type()->kind() == velox::TypeKind::BIGINT) {
+        actualIndex =
+            actualIndexExpr->value()->value<velox::TypeKind::BIGINT>();
+      }
+
+      EXPECT_EQ(actualIndex + 1, expectedIndex)
+          << "Subscript index mismatch (0-based vs 1-based).";
+      AXIOM_RETURN_IF_FAILURE
+
+      matchImpl(actual.inputAt(0), call->inputs()[0]);
+      return;
+    }
+  }
+
+  ADD_FAILURE() << "Expected FieldAccessExpr or subscript() for dereference.";
+}
+
+// Matches sort ordering fields.
+void matchOrdering(
+    const std::vector<SortingField>& actualOrdering,
+    const std::vector<velox::core::SortKey>& expectedOrdering) {
+  EXPECT_EQ(actualOrdering.size(), expectedOrdering.size());
+  AXIOM_RETURN_IF_FAILURE
+
+  for (size_t i = 0; i < actualOrdering.size(); ++i) {
+    SCOPED_TRACE("ordering " + std::to_string(i));
+    matchImpl(actualOrdering[i].expression, expectedOrdering[i].expr);
+    AXIOM_RETURN_IF_FAILURE
+
+    EXPECT_EQ(
+        actualOrdering[i].order.isAscending(), expectedOrdering[i].ascending)
+        << "Sort direction mismatch.";
+    AXIOM_RETURN_IF_FAILURE
+
+    EXPECT_EQ(
+        actualOrdering[i].order.isNullsFirst(), expectedOrdering[i].nullsFirst)
+        << "Nulls-first mismatch.";
+    AXIOM_RETURN_IF_FAILURE
+  }
+}
+
+bool matchWindowType(
+    WindowExpr::WindowType actual,
+    velox::core::WindowCallExpr::WindowType expected) {
+  switch (actual) {
+    case WindowExpr::WindowType::kRange:
+      return expected == velox::core::WindowCallExpr::WindowType::kRange;
+    case WindowExpr::WindowType::kRows:
+      return expected == velox::core::WindowCallExpr::WindowType::kRows;
+    case WindowExpr::WindowType::kGroups:
+      return expected == velox::core::WindowCallExpr::WindowType::kGroups;
+  }
+  return false;
+}
+
+bool matchBoundType(
+    WindowExpr::BoundType actual,
+    velox::core::WindowCallExpr::BoundType expected) {
+  switch (actual) {
+    case WindowExpr::BoundType::kUnboundedPreceding:
+      return expected ==
+          velox::core::WindowCallExpr::BoundType::kUnboundedPreceding;
+    case WindowExpr::BoundType::kPreceding:
+      return expected == velox::core::WindowCallExpr::BoundType::kPreceding;
+    case WindowExpr::BoundType::kCurrentRow:
+      return expected == velox::core::WindowCallExpr::BoundType::kCurrentRow;
+    case WindowExpr::BoundType::kFollowing:
+      return expected == velox::core::WindowCallExpr::BoundType::kFollowing;
+    case WindowExpr::BoundType::kUnboundedFollowing:
+      return expected ==
+          velox::core::WindowCallExpr::BoundType::kUnboundedFollowing;
+  }
+  return false;
+}
+
+void matchWindowFrame(
+    const WindowExpr::Frame& actual,
+    const velox::core::WindowCallExpr::Frame& expected) {
+  EXPECT_TRUE(matchWindowType(actual.type, expected.type))
+      << "Window frame type mismatch.";
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_TRUE(matchBoundType(actual.startType, expected.startType))
+      << "Start bound type mismatch.";
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_TRUE(matchBoundType(actual.endType, expected.endType))
+      << "End bound type mismatch.";
+  AXIOM_RETURN_IF_FAILURE
+
+  if (expected.startValue != nullptr) {
+    EXPECT_NE(actual.startValue, nullptr) << "Expected start bound value.";
+    AXIOM_RETURN_IF_FAILURE
+    matchImpl(actual.startValue, expected.startValue);
+    AXIOM_RETURN_IF_FAILURE
+  } else {
+    EXPECT_EQ(actual.startValue, nullptr) << "Unexpected start bound value.";
+    AXIOM_RETURN_IF_FAILURE
+  }
+
+  if (expected.endValue != nullptr) {
+    EXPECT_NE(actual.endValue, nullptr) << "Expected end bound value.";
+    AXIOM_RETURN_IF_FAILURE
+    matchImpl(actual.endValue, expected.endValue);
+    AXIOM_RETURN_IF_FAILURE
+  } else {
+    EXPECT_EQ(actual.endValue, nullptr) << "Unexpected end bound value.";
+    AXIOM_RETURN_IF_FAILURE
+  }
+}
+
+void matchWindow(
+    const WindowExpr& actual,
+    const velox::core::WindowCallExpr& expected) {
+  EXPECT_EQ(actual.name(), expected.name());
+  AXIOM_RETURN_IF_FAILURE
+
+  matchChildren(actual.inputs(), expected.inputs());
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_EQ(actual.partitionKeys().size(), expected.partitionKeys().size());
+  AXIOM_RETURN_IF_FAILURE
+
+  for (size_t i = 0; i < actual.partitionKeys().size(); ++i) {
+    SCOPED_TRACE("partition key " + std::to_string(i));
+    matchImpl(actual.partitionKeys()[i], expected.partitionKeys()[i]);
+    AXIOM_RETURN_IF_FAILURE
+  }
+
+  matchOrdering(actual.ordering(), expected.orderByKeys());
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_TRUE(expected.frame().has_value()) << "Expected window frame.";
+  AXIOM_RETURN_IF_FAILURE
+
+  matchWindowFrame(actual.frame(), expected.frame().value());
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_EQ(actual.ignoreNulls(), expected.isIgnoreNulls())
+      << "IGNORE NULLS mismatch.";
+}
+
+void matchAggregate(
+    const AggregateExpr& actual,
+    const velox::core::AggregateCallExpr& expected) {
+  EXPECT_EQ(actual.name(), expected.name());
+  AXIOM_RETURN_IF_FAILURE
+
+  EXPECT_EQ(actual.isDistinct(), expected.isDistinct()) << "DISTINCT mismatch.";
+  AXIOM_RETURN_IF_FAILURE
+
+  matchChildren(actual.inputs(), expected.inputs());
+  AXIOM_RETURN_IF_FAILURE
+
+  matchOrdering(actual.ordering(), expected.orderBy());
+  AXIOM_RETURN_IF_FAILURE
+
+  if (expected.filter() != nullptr) {
+    EXPECT_NE(actual.filter(), nullptr) << "Expected aggregate filter.";
+    AXIOM_RETURN_IF_FAILURE
+    matchImpl(actual.filter(), expected.filter());
+  } else {
+    EXPECT_EQ(actual.filter(), nullptr) << "Unexpected aggregate filter.";
+  }
+}
+
+void matchSpecialForm(
+    const SpecialFormExpr& actual,
+    const velox::core::ExprPtr& expected) {
+  const auto form = actual.form();
+
+  // Cast/TryCast: expect IExpr::kCast.
+  if (form == SpecialForm::kCast || form == SpecialForm::kTryCast) {
+    EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kCast))
+        << "Expected CastExpr.";
+    AXIOM_RETURN_IF_FAILURE
+
+    const auto* cast = expected->as<velox::core::CastExpr>();
+    EXPECT_EQ(form == SpecialForm::kTryCast, cast->isTryCast())
+        << "CAST vs TRY_CAST mismatch.";
+    AXIOM_RETURN_IF_FAILURE
+
+    EXPECT_TRUE(actual.type()->equivalent(*cast->type()))
+        << "Cast target type: actual " << actual.type()->toString()
+        << ", expected " << cast->type()->toString() << ".";
+    AXIOM_RETURN_IF_FAILURE
+
+    VELOX_CHECK_EQ(actual.inputs().size(), 1);
+    matchImpl(actual.inputAt(0), cast->input());
+    return;
+  }
+
+  // Dereference: expect FieldAccessExpr or subscript call.
+  if (form == SpecialForm::kDereference) {
+    matchDereference(actual, expected);
+    return;
+  }
+
+  // NullIf: the logical plan has 3 inputs (value, comparand, null literal),
+  // but IExpr "nullif" call has only 2 inputs (value, comparand).
+  if (form == SpecialForm::kNullIf) {
+    EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kCall))
+        << "Expected nullif CallExpr.";
+    AXIOM_RETURN_IF_FAILURE
+
+    const auto* expectedCall = expected->as<velox::core::CallExpr>();
+    EXPECT_EQ("nullif", expectedCall->name());
+    AXIOM_RETURN_IF_FAILURE
+
+    EXPECT_GE(actual.inputs().size(), 2);
+    EXPECT_EQ(expectedCall->inputs().size(), 2);
+    AXIOM_RETURN_IF_FAILURE
+
+    for (int32_t i = 0; i < 2; ++i) {
+      SCOPED_TRACE("child " + std::to_string(i));
+      matchImpl(actual.inputAt(i), expectedCall->inputAt(i));
+      AXIOM_RETURN_IF_FAILURE
+    }
+    return;
+  }
+
+  // All other special forms: expect kCall with matching lowercase name.
+  EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kCall))
+      << "Expected CallExpr for special form " << SpecialFormName::toName(form)
+      << ".";
+  AXIOM_RETURN_IF_FAILURE
+
+  const auto callName = specialFormToCallName(form);
+
+  const auto* expectedCall = expected->as<velox::core::CallExpr>();
+  EXPECT_EQ(callName, expectedCall->name());
+  AXIOM_RETURN_IF_FAILURE
+
+  matchChildren(actual.inputs(), expectedCall->inputs());
+}
+
+bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
+  VELOX_CHECK_NOT_NULL(actual);
+  VELOX_CHECK_NOT_NULL(expected);
+
+  if (isWildcard(expected)) {
+    return true;
+  }
+
+  SCOPED_TRACE(
+      "actual: '" + actual->toString() + "', expected: '" +
+      expected->toString() + "'");
+
+  switch (actual->kind()) {
+    case ExprKind::kInputReference: {
+      const auto* inputRef = actual->as<InputReferenceExpr>();
+
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kFieldAccess))
+          << "Expected FieldAccessExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* field = expected->as<velox::core::FieldAccessExpr>();
+      EXPECT_TRUE(field->isRootColumn()) << "Expected root column.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      EXPECT_EQ(inputRef->name(), field->name());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kConstant: {
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kConstant))
+          << "Expected ConstantExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      matchConstant(
+          *actual->as<ConstantExpr>(),
+          *expected->as<velox::core::ConstantExpr>());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kCall: {
+      const auto* call = actual->as<CallExpr>();
+
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kCall))
+          << "Expected CallExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* expectedCall = expected->as<velox::core::CallExpr>();
+      EXPECT_EQ(call->name(), expectedCall->name());
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      matchChildren(call->inputs(), expectedCall->inputs());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kSpecialForm: {
+      matchSpecialForm(*actual->as<SpecialFormExpr>(), expected);
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kAggregate: {
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kAggregate))
+          << "Expected AggregateCallExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      matchAggregate(
+          *actual->as<AggregateExpr>(),
+          *expected->as<velox::core::AggregateCallExpr>());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kWindow: {
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kWindow))
+          << "Expected WindowCallExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      matchWindow(
+          *actual->as<WindowExpr>(),
+          *expected->as<velox::core::WindowCallExpr>());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kLambda: {
+      const auto* lambda = actual->as<LambdaExpr>();
+
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kLambda))
+          << "Expected LambdaExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* expectedLambda = expected->as<velox::core::LambdaExpr>();
+      const auto& actualNames = lambda->signature()->names();
+      const auto& expectedNames = expectedLambda->arguments();
+      EXPECT_EQ(actualNames.size(), expectedNames.size());
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      for (size_t i = 0; i < actualNames.size(); ++i) {
+        EXPECT_EQ(actualNames[i], expectedNames[i])
+            << "Lambda parameter mismatch at index " << i << ".";
+        AXIOM_RETURN_FALSE_IF_FAILURE
+      }
+
+      matchImpl(lambda->body(), expectedLambda->body());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
+    case ExprKind::kSubquery: {
+      EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kSubquery))
+          << "Expected SubqueryExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* actualSubquery = actual->as<SubqueryExpr>();
+      const auto* expectedSubquery = expected->as<velox::core::SubqueryExpr>();
+      EXPECT_EQ(actualSubquery->subquery(), expectedSubquery->subquery());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+  }
+
+  ADD_FAILURE() << "Unsupported expression kind: " << actual->kindName() << ".";
+  return false;
+}
+
+#undef AXIOM_RETURN_IF_FAILURE
+#undef AXIOM_RETURN_FALSE_IF_FAILURE
+
+} // namespace
+
+bool ExprMatcher::match(
+    const ExprPtr& actual,
+    const velox::core::ExprPtr& expected) {
+  return matchImpl(actual, expected);
+}
+
+} // namespace facebook::axiom::logical_plan::test

--- a/axiom/sql/presto/tests/ExprMatcher.h
+++ b/axiom/sql/presto/tests/ExprMatcher.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/Expr.h"
+#include "velox/parse/IExpr.h"
+
+namespace facebook::axiom::logical_plan::test {
+
+/// Structurally compares a logical plan expression tree (axiom::logical_plan
+/// ::Expr) against an untyped expression tree (velox::core::IExpr, from DuckDB
+/// parse or ExprApi). Sets gtest failures with descriptive messages on
+/// mismatch.
+class ExprMatcher {
+ public:
+  /// Function name used as a wildcard in expected expressions. A CallExpr
+  /// with this name and zero inputs matches any actual subtree.
+  static constexpr std::string_view kWildcard = "any";
+
+  /// Returns true if the trees match. On mismatch, sets gtest failures
+  /// with SCOPED_TRACE context showing the path through the tree.
+  static bool match(
+      const ExprPtr& actual,
+      const velox::core::ExprPtr& expected);
+};
+
+} // namespace facebook::axiom::logical_plan::test

--- a/axiom/sql/presto/tests/ExprMatcherTest.cpp
+++ b/axiom/sql/presto/tests/ExprMatcherTest.cpp
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/ExprMatcher.h"
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/Expr.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::logical_plan::test {
+namespace {
+
+using namespace facebook::velox;
+
+// Helpers to build lp::Expr nodes.
+
+ExprPtr field(const TypePtr& type, const std::string& name) {
+  return std::make_shared<InputReferenceExpr>(type, name);
+}
+
+ExprPtr constant(const TypePtr& type, const Variant& value) {
+  return std::make_shared<ConstantExpr>(type, std::make_shared<Variant>(value));
+}
+
+ExprPtr constantNull(const TypePtr& type) {
+  return std::make_shared<ConstantExpr>(
+      type, std::make_shared<Variant>(type->kind()));
+}
+
+ExprPtr call(
+    const TypePtr& type,
+    const std::string& name,
+    std::vector<ExprPtr> inputs) {
+  return std::make_shared<CallExpr>(type, name, std::move(inputs));
+}
+
+ExprPtr specialForm(
+    const TypePtr& type,
+    SpecialForm form,
+    std::vector<ExprPtr> inputs) {
+  return std::make_shared<SpecialFormExpr>(type, form, std::move(inputs));
+}
+
+// Helpers to build expected IExpr (untyped) nodes.
+
+velox::core::ExprPtr wildcard() {
+  return std::make_shared<velox::core::CallExpr>(
+      std::string{ExprMatcher::kWildcard},
+      std::vector<velox::core::ExprPtr>{},
+      std::nullopt);
+}
+
+class ExprMatcherTest : public testing::Test {
+ protected:
+  velox::core::ExprPtr parseExpr(const std::string& sql) {
+    return parser_.parseExpr(sql);
+  }
+
+  velox::core::ExprPtr parseAggregateExpr(const std::string& sql) {
+    return parser_.parseAggregateExpr(sql);
+  }
+
+  velox::core::ExprPtr parseWindowExpr(const std::string& sql) {
+    velox::parse::ParseOptions options;
+    options.correctWindowFrameDefault = true;
+    velox::parse::DuckSqlExpressionsParser windowParser(options);
+    return windowParser.parseScalarOrWindowExpr(sql);
+  }
+
+  velox::parse::DuckSqlExpressionsParser parser_;
+};
+
+TEST_F(ExprMatcherTest, inputReference) {
+  ExprMatcher::match(field(BIGINT(), "a"), parseExpr("a"));
+
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(field(BIGINT(), "a"), parseExpr("b")),
+      R"(  inputRef->name()
+    Which is: "a"
+  field->name()
+    Which is: "b")");
+}
+
+TEST_F(ExprMatcherTest, integerConstant) {
+  ExprMatcher::match(constant(BIGINT(), Variant(42LL)), parseExpr("42"));
+}
+
+TEST_F(ExprMatcherTest, integerTypeTolerance) {
+  // Plan uses INTEGER, DuckDB parses as BIGINT.
+  ExprMatcher::match(constant(INTEGER(), Variant(42)), parseExpr("42"));
+}
+
+TEST_F(ExprMatcherTest, doubleEpsilon) {
+  ExprMatcher::match(constant(DOUBLE(), Variant(0.1 + 0.2)), parseExpr("0.3"));
+}
+
+TEST_F(ExprMatcherTest, stringConstant) {
+  ExprMatcher::match(
+      constant(VARCHAR(), Variant("hello")), parseExpr("'hello'"));
+}
+
+TEST_F(ExprMatcherTest, nullConstant) {
+  ExprMatcher::match(constantNull(BIGINT()), parseExpr("null"));
+}
+
+TEST_F(ExprMatcherTest, booleanConstant) {
+  ExprMatcher::match(constant(BOOLEAN(), Variant(true)), parseExpr("true"));
+  ExprMatcher::match(constant(BOOLEAN(), Variant(false)), parseExpr("false"));
+}
+
+TEST_F(ExprMatcherTest, constantMismatch) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(constant(BIGINT(), Variant(42LL)), parseExpr("99")),
+      "Constant mismatch.");
+}
+
+TEST_F(ExprMatcherTest, functionCall) {
+  auto actual =
+      call(BIGINT(), "plus", {field(BIGINT(), "a"), field(BIGINT(), "b")});
+  ExprMatcher::match(actual, parseExpr("a + b"));
+}
+
+TEST_F(ExprMatcherTest, nestedFunctionCall) {
+  auto actual = call(
+      BIGINT(),
+      "mod",
+      {call(
+           BIGINT(),
+           "plus",
+           {field(BIGINT(), "a"), constant(BIGINT(), Variant(1LL))}),
+       constant(BIGINT(), Variant(3LL))});
+  ExprMatcher::match(actual, parseExpr("(a + 1) % 3"));
+}
+
+TEST_F(ExprMatcherTest, functionNameMismatch) {
+  auto actual =
+      call(BIGINT(), "minus", {field(BIGINT(), "a"), field(BIGINT(), "b")});
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(actual, parseExpr("a + b")),
+      R"(  call->name()
+    Which is: "minus"
+  expectedCall->name()
+    Which is: "plus")");
+}
+
+TEST_F(ExprMatcherTest, specialFormAnd) {
+  auto actual = specialForm(
+      BOOLEAN(),
+      SpecialForm::kAnd,
+      {field(BOOLEAN(), "a"), field(BOOLEAN(), "b")});
+  ExprMatcher::match(actual, parseExpr("a AND b"));
+}
+
+TEST_F(ExprMatcherTest, specialFormOr) {
+  auto actual = specialForm(
+      BOOLEAN(),
+      SpecialForm::kOr,
+      {field(BOOLEAN(), "a"), field(BOOLEAN(), "b")});
+  ExprMatcher::match(actual, parseExpr("a OR b"));
+}
+
+TEST_F(ExprMatcherTest, specialFormCast) {
+  auto actual =
+      specialForm(BIGINT(), SpecialForm::kCast, {field(INTEGER(), "a")});
+  ExprMatcher::match(actual, parseExpr("cast(a as bigint)"));
+}
+
+TEST_F(ExprMatcherTest, specialFormTryCast) {
+  auto actual =
+      specialForm(VARCHAR(), SpecialForm::kTryCast, {field(BIGINT(), "a")});
+  ExprMatcher::match(actual, parseExpr("try_cast(a as varchar)"));
+
+  // CAST vs TRY_CAST mismatch.
+  actual = specialForm(BIGINT(), SpecialForm::kCast, {field(INTEGER(), "a")});
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(actual, parseExpr("try_cast(a as bigint)")),
+      "CAST vs TRY_CAST mismatch.");
+}
+
+TEST_F(ExprMatcherTest, specialFormCoalesce) {
+  auto actual = specialForm(
+      BIGINT(),
+      SpecialForm::kCoalesce,
+      {field(BIGINT(), "a"), constant(BIGINT(), Variant(0LL))});
+  ExprMatcher::match(actual, parseExpr("coalesce(a, 0)"));
+}
+
+TEST_F(ExprMatcherTest, specialFormIf) {
+  auto actual = specialForm(
+      BIGINT(),
+      SpecialForm::kIf,
+      {field(BOOLEAN(), "cond"), field(BIGINT(), "a"), field(BIGINT(), "b")});
+  ExprMatcher::match(actual, parseExpr("if(cond, a, b)"));
+}
+
+TEST_F(ExprMatcherTest, specialFormDereference) {
+  auto structType = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  auto actual = specialForm(
+      BIGINT(),
+      SpecialForm::kDereference,
+      {field(structType, "a"), constant(VARCHAR(), Variant("x"))});
+  ExprMatcher::match(actual, parseExpr("(a).x"));
+}
+
+TEST_F(ExprMatcherTest, specialFormDereferenceByIndex) {
+  auto structType = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  auto actual = specialForm(
+      BIGINT(),
+      SpecialForm::kDereference,
+      {field(structType, "a"), constant(INTEGER(), Variant(0))});
+  ExprMatcher::match(actual, parseExpr("(a).x"));
+}
+
+TEST_F(ExprMatcherTest, specialFormNullIf) {
+  auto actual = specialForm(
+      BIGINT(),
+      SpecialForm::kNullIf,
+      {field(BIGINT(), "a"), field(BIGINT(), "b"), constantNull(BIGINT())});
+  ExprMatcher::match(actual, parseExpr("nullif(a, b)"));
+}
+
+TEST_F(ExprMatcherTest, aggregate) {
+  auto actual = std::make_shared<AggregateExpr>(
+      BIGINT(), "sum", std::vector<ExprPtr>{field(BIGINT(), "a")});
+  ExprMatcher::match(actual, parseAggregateExpr("sum(a)"));
+}
+
+TEST_F(ExprMatcherTest, aggregateDistinct) {
+  auto actual = std::make_shared<AggregateExpr>(
+      BIGINT(),
+      "sum",
+      std::vector<ExprPtr>{field(BIGINT(), "a")},
+      nullptr,
+      std::vector<SortingField>{},
+      true);
+  ExprMatcher::match(actual, parseAggregateExpr("sum(DISTINCT a)"));
+}
+
+TEST_F(ExprMatcherTest, aggregateWithFilter) {
+  auto filterExpr = call(
+      BOOLEAN(),
+      "gt",
+      {field(BIGINT(), "a"), constant(BIGINT(), Variant(0LL))});
+
+  auto actual = std::make_shared<AggregateExpr>(
+      BIGINT(), "sum", std::vector<ExprPtr>{field(BIGINT(), "a")}, filterExpr);
+  ExprMatcher::match(actual, parseAggregateExpr("sum(a) FILTER (WHERE a > 0)"));
+}
+
+TEST_F(ExprMatcherTest, window) {
+  WindowExpr::Frame frame;
+  frame.type = WindowExpr::WindowType::kRange;
+  frame.startType = WindowExpr::BoundType::kUnboundedPreceding;
+  frame.endType = WindowExpr::BoundType::kUnboundedFollowing;
+
+  auto actual = std::make_shared<WindowExpr>(
+      BIGINT(),
+      "row_number",
+      std::vector<ExprPtr>{},
+      std::vector<ExprPtr>{field(BIGINT(), "a")},
+      std::vector<SortingField>{},
+      frame,
+      false);
+  ExprMatcher::match(
+      actual, parseWindowExpr("row_number() OVER (PARTITION BY a)"));
+}
+
+TEST_F(ExprMatcherTest, windowWithOrderBy) {
+  WindowExpr::Frame frame;
+  frame.type = WindowExpr::WindowType::kRange;
+  frame.startType = WindowExpr::BoundType::kUnboundedPreceding;
+  frame.endType = WindowExpr::BoundType::kCurrentRow;
+
+  auto actual = std::make_shared<WindowExpr>(
+      BIGINT(),
+      "row_number",
+      std::vector<ExprPtr>{},
+      std::vector<ExprPtr>{},
+      std::vector<SortingField>{
+          {field(BIGINT(), "a"), SortOrder::kAscNullsLast}},
+      frame,
+      false);
+  ExprMatcher::match(
+      actual, parseWindowExpr("row_number() OVER (ORDER BY a ASC NULLS LAST)"));
+}
+
+TEST_F(ExprMatcherTest, lambda) {
+  auto signature = ROW({"x", "y"}, {BIGINT(), BIGINT()});
+  auto body =
+      call(BIGINT(), "plus", {field(BIGINT(), "x"), field(BIGINT(), "y")});
+  auto actual = std::make_shared<LambdaExpr>(signature, body);
+  ExprMatcher::match(actual, parseExpr("(x, y) -> x + y"));
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesInputRef) {
+  ExprMatcher::match(field(BIGINT(), "a"), wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesConstant) {
+  ExprMatcher::match(constant(BIGINT(), Variant(42LL)), wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardMatchesCall) {
+  auto actual =
+      call(BIGINT(), "plus", {field(BIGINT(), "a"), field(BIGINT(), "b")});
+  ExprMatcher::match(actual, wildcard());
+}
+
+TEST_F(ExprMatcherTest, wildcardInSubtree) {
+  auto actual =
+      call(BIGINT(), "plus", {field(BIGINT(), "a"), field(BIGINT(), "b")});
+  ExprMatcher::match(
+      actual,
+      std::make_shared<velox::core::CallExpr>(
+          "plus",
+          std::vector<velox::core::ExprPtr>{parseExpr("a"), wildcard()},
+          std::nullopt));
+}
+
+} // namespace
+} // namespace facebook::axiom::logical_plan::test

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -16,9 +16,8 @@
 
 #include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
 #include <gtest/gtest.h>
-#include <algorithm>
 #include <set>
-#include <unordered_set>
+#include "axiom/sql/presto/tests/ExprMatcher.h"
 #include "velox/parse/ExprRewriter.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -40,170 +39,6 @@ namespace {
     return LogicalPlanMatcher::MatchResult::failure(); \
   }                                                    \
   return LogicalPlanMatcher::MatchResult::success(symbols);
-
-// Forward declaration for mutual recursion.
-std::string toExprString(const velox::core::IExpr& expr);
-
-// Formats a function call as "name(arg1, arg2, ...)". Shared by kCall,
-// kAggregate, and the function-call part of kWindow.
-std::string callToString(const velox::core::CallExpr& call) {
-  auto name = call.name();
-  // DuckDB and ExprApi produce lowercase special form names, but
-  // ExprResolver converts these to SpecialFormExprs which print as
-  // uppercase. "if" is not included because ExprResolver resolves it to
-  // "SWITCH".
-  static const std::unordered_set<std::string> kSpecialForms = {
-      "and",
-      "or",
-      "switch",
-      "coalesce",
-      "cast",
-      "try_cast",
-      "try",
-      "dereference",
-      "in",
-      "exists"};
-  if (kSpecialForms.contains(name)) {
-    std::transform(name.begin(), name.end(), name.begin(), ::toupper);
-  }
-  std::string result = name + "(";
-  for (size_t i = 0; i < call.inputs().size(); ++i) {
-    if (i > 0) {
-      result += ", ";
-    }
-    result += toExprString(*call.inputAt(i));
-  }
-  return result + ")";
-}
-
-// Appends ORDER BY keys to a stream.
-void appendOrderBy(
-    const std::vector<velox::core::SortKey>& keys,
-    std::stringstream& out) {
-  out << "ORDER BY ";
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (i > 0) {
-      out << ", ";
-    }
-    out << toExprString(*keys[i].expr);
-    out << (keys[i].ascending ? " ASC" : " DESC");
-    out << (keys[i].nullsFirst ? " NULLS FIRST" : " NULLS LAST");
-  }
-}
-
-// Appends a frame bound to a stream.
-void appendBound(
-    velox::core::WindowCallExpr::BoundType boundType,
-    const velox::core::ExprPtr& value,
-    std::stringstream& out) {
-  if (value) {
-    out << toExprString(*value) << " ";
-  }
-  out << velox::core::WindowCallExpr::toName(boundType);
-}
-
-// Formats a WindowCallExpr as "func(args) OVER (PARTITION BY ... ORDER BY
-// ... ROWS/RANGE/GROUPS BETWEEN ... AND ...)".
-std::string windowToString(const velox::core::WindowCallExpr& window) {
-  std::stringstream out;
-  out << callToString(window) << " OVER (";
-
-  bool needSeparator = false;
-  if (!window.partitionKeys().empty()) {
-    out << "PARTITION BY ";
-    for (size_t i = 0; i < window.partitionKeys().size(); ++i) {
-      if (i > 0) {
-        out << ", ";
-      }
-      out << toExprString(*window.partitionKeys()[i]);
-    }
-    needSeparator = true;
-  }
-
-  if (!window.orderByKeys().empty()) {
-    if (needSeparator) {
-      out << " ";
-    }
-    appendOrderBy(window.orderByKeys(), out);
-    needSeparator = true;
-  }
-
-  if (window.frame().has_value()) {
-    if (needSeparator) {
-      out << " ";
-    }
-    const auto& frame = window.frame().value();
-    out << velox::core::WindowCallExpr::toName(frame.type) << " BETWEEN ";
-    appendBound(frame.startType, frame.startValue, out);
-    out << " AND ";
-    appendBound(frame.endType, frame.endValue, out);
-  }
-
-  out << ")";
-  if (window.isIgnoreNulls()) {
-    out << " IGNORE NULLS";
-  }
-  return out.str();
-}
-
-// Formats an AggregateCallExpr as "name(DISTINCT args ORDER BY ...) FILTER
-// (WHERE ...)".
-std::string aggregateToString(const velox::core::AggregateCallExpr& agg) {
-  std::stringstream out;
-  out << agg.name() << "(";
-  if (agg.isDistinct()) {
-    out << "DISTINCT ";
-  }
-  for (size_t i = 0; i < agg.inputs().size(); ++i) {
-    if (i > 0) {
-      out << ", ";
-    }
-    out << toExprString(*agg.inputs()[i]);
-  }
-  if (!agg.orderBy().empty()) {
-    out << " ";
-    appendOrderBy(agg.orderBy(), out);
-  }
-  out << ")";
-  if (agg.filter() != nullptr) {
-    out << " FILTER (WHERE " << toExprString(*agg.filter()) << ")";
-  }
-  return out.str();
-}
-
-// Prints a velox::core::IExpr tree in the same format as lp::ExprPrinter.
-// This allows comparing DuckDB-parsed expected expressions against actual
-// lp::Expr::toString() output.
-std::string toExprString(const velox::core::IExpr& expr) {
-  using velox::core::IExpr;
-  switch (expr.kind()) {
-    case IExpr::Kind::kFieldAccess:
-      return expr.as<velox::core::FieldAccessExpr>()->name();
-    case IExpr::Kind::kCall:
-      return callToString(*expr.as<velox::core::CallExpr>());
-    case IExpr::Kind::kAggregate:
-      return aggregateToString(*expr.as<velox::core::AggregateCallExpr>());
-    case IExpr::Kind::kWindow:
-      return windowToString(*expr.as<velox::core::WindowCallExpr>());
-    case IExpr::Kind::kCast: {
-      auto* cast = expr.as<velox::core::CastExpr>();
-      return fmt::format(
-          "{}({} AS {})",
-          cast->isTryCast() ? "TRY_CAST" : "CAST",
-          toExprString(*cast->input()),
-          cast->type()->toString());
-    }
-    case IExpr::Kind::kConstant: {
-      auto* constant = expr.as<velox::core::ConstantExpr>();
-      return constant->value().toStringAsVector(constant->type());
-    }
-    case IExpr::Kind::kInput:
-      return "ROW";
-    default:
-      VELOX_UNREACHABLE(
-          "Unsupported IExpr kind in toExprString: {}", expr.toString());
-  }
-}
 
 // Corrects DuckDB's wrong default window frame end bound. DuckDB always
 // defaults to CURRENT_ROW, but the SQL standard specifies UNBOUNDED_FOLLOWING
@@ -404,8 +239,7 @@ class FilterMatcher : public LogicalPlanMatcherImpl<FilterNode> {
       expected = rewriteInputNames(expected, symbols);
     }
 
-    EXPECT_EQ(
-        toExprString(*expected->dropAlias()), plan.predicate()->toString());
+    ExprMatcher::match(plan.predicate(), expected->dropAlias());
     AXIOM_RETURN_RESULT(symbols)
   }
 
@@ -544,8 +378,8 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
         expectedExpr = rewriteInputNames(expectedExpr, symbols);
       }
 
-      EXPECT_EQ(toExprString(*expectedExpr->dropAlias()), actual->toString())
-          << "at index " << i;
+      SCOPED_TRACE("project expression at index " + std::to_string(i));
+      ExprMatcher::match(actual, expectedExpr->dropAlias());
       AXIOM_RETURN_IF_FAILURE;
     }
 
@@ -603,8 +437,8 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
       }
 
       const auto& actual = plan.aggregateAt(i);
-      EXPECT_EQ(toExprString(*parsed->dropAlias()), actual->toString())
-          << "at aggregate index " << i;
+      SCOPED_TRACE("aggregate at index " + std::to_string(i));
+      ExprMatcher::match(actual, parsed->dropAlias());
       AXIOM_RETURN_IF_FAILURE;
     }
 
@@ -713,10 +547,9 @@ class SortMatcher : public LogicalPlanMatcherImpl<SortNode> {
         expectedExpr = rewriteInputNames(expectedExpr, symbols);
       }
 
-      EXPECT_EQ(
-          toExprString(*expectedExpr->dropAlias()),
-          actualOrdering[i].expression->toString())
-          << "at ordering index " << i;
+      SCOPED_TRACE("ordering at index " + std::to_string(i));
+      ExprMatcher::match(
+          actualOrdering[i].expression, expectedExpr->dropAlias());
       AXIOM_RETURN_IF_FAILURE;
 
       EXPECT_EQ(expected.ascending, actualOrdering[i].order.isAscending())


### PR DESCRIPTION
Summary:

LogicalPlanMatcher compared expressions by converting both sides to strings via a toExprString() normalizer (~165 lines) that patched formatting differences between DuckDB-parsed IExpr trees and lp::Expr::toString() output. This was fragile — it broke on formatting changes, could not handle float epsilon, and required per-case patching for special form casing, window frames, aggregate syntax, etc.

Add ExprMatcher (axiom/sql/presto/tests/ExprMatcher.{h,cpp}) that structurally compares lp::Expr trees against IExpr trees node by node, following the same pattern as the existing ExprMatcher for Velox typed expressions (axiom/optimizer/tests/ExprMatcher.{h,cpp}). Handles all 8 expression kinds: InputReference, Constant, Call, SpecialForm (with cast/dereference/nullif special cases), Aggregate, Window, Lambda, Subquery. Supports any() wildcard and float epsilon via equalsWithEpsilon.

FilterMatcher, ProjectMatcher, AggregateMatcher, and SortMatcher now use ExprMatcher::match() instead of toExprString(). The toExprString normalizer is deleted.

Fixed two pre-existing issues in test expectations that were masked by toString() comparison:
- concat(n_name, _suffix) used an unquoted identifier where a string literal '_suffix' was intended
- multiply(cast(sum as double), 1) used BIGINT literal where DOUBLE 1.0 was intended

Differential Revision: D102331011


