### PR TITLE
fix(optimizer): Deduplicate IN list literals when folding into array constant (#1292)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "axiom/optimizer/ToVelox.h"
+#include <folly/container/F14Set.h>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
@@ -482,6 +483,8 @@ velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
 
   std::vector<velox::Variant> arrayElements;
   arrayElements.reserve(args.size() - 1);
+  folly::F14FastSet<velox::Variant, velox::Variant::Hasher> seen;
+  seen.reserve(args.size() - 1);
   for (size_t i = 1; i < args.size(); ++i) {
     auto arg = args.at(i);
     VELOX_USER_CHECK(
@@ -489,7 +492,10 @@ velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
         "All elements of the IN list must have the same type got {} and {}",
         elementType->toString(),
         arg->value().type->toString());
-    arrayElements.push_back(arg->as<Literal>()->literal());
+    auto& literal = arg->as<Literal>()->literal();
+    if (seen.insert(literal).second) {
+      arrayElements.push_back(literal);
+    }
   }
   auto arrayVector = variantToVector(
       ARRAY(elementType),

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -489,7 +489,11 @@ velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
         "All elements of the IN list must have the same type got {} and {}",
         elementType->toString(),
         arg->value().type->toString());
-    arrayElements.push_back(arg->as<Literal>()->literal());
+    auto& literal = arg->as<Literal>()->literal();
+    if (std::find(arrayElements.begin(), arrayElements.end(), literal) ==
+        arrayElements.end()) {
+      arrayElements.push_back(literal);
+    }
   }
   auto arrayVector = variantToVector(
       ARRAY(elementType),

--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -167,6 +167,20 @@ TEST_F(FilterPushdownTest, throughJoin) {
   }
 }
 
+// Duplicate literals in an IN list should be deduplicated.
+TEST_F(FilterPushdownTest, inListWithDuplicates) {
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("nation")
+                         .filter("n_nationkey in (5, 5)")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher = core::PlanMatcherBuilder()
+                     .hiveScan("nation", test::eq("n_nationkey", 5LL))
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // Verify that OR with a disjunct that is fully subsumed by extracted common
 // factors does not crash. E.g. A OR (A AND B): the first disjunct is fully
 // subsumed, leaving an empty residual. The result should be just A.

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -382,6 +382,15 @@ TEST_F(PlanTest, inList) {
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+  {
+    auto logicalPlan =
+        scan().filter("a in (1, 1, 2, 2, 3)").map({"a + 2"}).build();
+
+    auto matcher = scanMatcher().filter("a in (1, 2, 3)").project().build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
 }
 
 TEST_F(PlanTest, multipleConnectors) {


### PR DESCRIPTION
Summary:

The Astra fuzzer hit a `VELOX_CHECK_LT(min, max)` failure inside `BigintValuesUsingBitmask` when an IN list collapsed to a single unique value through duplicates (e.g. `WHERE a IN (5, 5)`).

`ToVelox.cpp` was building the IN list's array constant by pushing every literal without deduping. `createBigintValuesFilter` then saw `values=[5, 5]` — `size > 1` skips the BigintRange shortcut, but `min == max == 5` so the bitmap constructor's `VELOX_CHECK_LT(min, max)` fires.

Fix: skip a literal that's already in `arrayElements` before pushing.

bypass-github-export-checks

Reviewed By: kagamiori

Differential Revision: D102261646


