### PR TITLE
feat(connectors): Add Split wrapper and PartitionType API for bucketed scheduling (#1295)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -239,6 +239,14 @@ class PartitionType {
   virtual const PartitionType* FOLLY_NULLABLE
   copartition(const PartitionType& other) const = 0;
 
+  /// Returns a PartitionType compatible with this one but with at most
+  /// 'maxPartitions' partitions. The returned partitioning groups together
+  /// rows that this PartitionType would have placed in different partitions,
+  /// so the resulting partition assignment is a coarsening of this one. The
+  /// returned value is always a freshly allocated owned shared_ptr.
+  virtual std::shared_ptr<PartitionType> scaleDown(
+      int32_t maxPartitions) const = 0;
+
   /// Returns a factory that makes partition functions. The function takes a
   /// RowVector and calculates a partition number from the columns identified by
   /// 'channels'. If channels[i] == kConstantChannel then the corresponding
@@ -248,6 +256,9 @@ class PartitionType {
       const std::vector<velox::column_index_t>& channels,
       const std::vector<velox::VectorPtr>& constants,
       bool isLocal) const = 0;
+
+  /// Number of partitions.
+  virtual int32_t numPartitions() const = 0;
 
   virtual std::string toString() const = 0;
 

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -17,14 +17,29 @@
 
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
+#include <optional>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
 
+class PartitionType;
+
+/// Wraps a Velox ConnectorSplit with an optional group ID for bucketed
+/// execution routing. Splits with the same groupId are routed to the same
+/// task. When unset, the runtime is free to assign the split to any task.
+struct Split {
+  /// The underlying Velox connector split.
+  std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
+
+  /// Group ID for bucketed routing; splits sharing a groupId are routed to
+  /// the same task. Absent means any task may handle this split.
+  std::optional<int32_t> groupId{std::nullopt};
+};
+
 /// A batch of splits returned by SplitSource::co_getSplits.
 struct SplitBatch {
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+  std::vector<Split> splits;
 
   /// True when there are no more splits to return.
   bool noMoreSplits{false};
@@ -90,17 +105,22 @@ class ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) = 0;
 
-  /// Returns a SplitSource that covers the contents of 'partitions'. The set of
-  /// partitions is exposed separately so that the caller may process the
-  /// partitions in a specific order or distribute them to specific nodes in a
-  /// cluster. Connector implementations may use 'runtimeStats' to record
-  /// split enumeration metrics (e.g., file listing, Metastore RPCs).
+  /// Returns a SplitSource that covers the contents of 'partitions'. The set
+  /// of partitions is exposed separately so that the caller may process them
+  /// in a specific order or distribute them to specific nodes in a cluster.
+  /// Connector implementations may use 'runtimeStats' to record split
+  /// enumeration metrics (e.g., file listing, Metastore RPCs).
+  ///
+  /// When 'partitionType' is non-null, the connector tags each emitted Split
+  /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
+  /// for the non-bucketed case.
   // TODO: Instrument PrismSplitManager with runtimeStats for split enumeration
   // timing.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) = 0;
 };
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -52,6 +52,17 @@ HivePartitionType::copartition(const PartitionType& other) const {
   return nullptr;
 }
 
+std::shared_ptr<PartitionType> HivePartitionType::scaleDown(
+    int32_t maxPartitions) const {
+  VELOX_CHECK_GT(maxPartitions, 0);
+  int32_t numResultPartitions = std::min(numPartitions_, maxPartitions);
+  while (numResultPartitions > 1 && numPartitions_ % numResultPartitions != 0) {
+    --numResultPartitions;
+  }
+  return std::make_shared<HivePartitionType>(
+      numResultPartitions, partitionKeyTypes_);
+}
+
 velox::core::PartitionFunctionSpecPtr HivePartitionType::makeSpec(
     const std::vector<velox::column_index_t>& channels,
     const std::vector<velox::VectorPtr>& constants,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -48,7 +48,9 @@ class HivePartitionType : public connector::PartitionType {
       int32_t numPartitions,
       std::vector<velox::TypePtr> partitionKeyTypes)
       : numPartitions_(numPartitions),
-        partitionKeyTypes_(std::move(partitionKeyTypes)) {}
+        partitionKeyTypes_(std::move(partitionKeyTypes)) {
+    VELOX_CHECK_GT(numPartitions_, 0);
+  }
 
   /// Types are compatible if numPartitions of one is an interger multiple of
   /// the other. The partition to use for copartitioning is the one with the
@@ -56,10 +58,19 @@ class HivePartitionType : public connector::PartitionType {
   const PartitionType* FOLLY_NULLABLE
   copartition(const PartitionType& any) const override;
 
+  /// Returns the largest divisor of numPartitions() that is <=
+  /// maxPartitions.
+  std::shared_ptr<PartitionType> scaleDown(
+      int32_t maxPartitions) const override;
+
   velox::core::PartitionFunctionSpecPtr makeSpec(
       const std::vector<velox::column_index_t>& channels,
       const std::vector<velox::VectorPtr>& constants,
       bool isLocal) const override;
+
+  int32_t numPartitions() const override {
+    return numPartitions_;
+  }
 
   std::string toString() const override;
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -320,6 +320,7 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& partitionType,
     QueryRuntimeStats& /*runtimeStats*/) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
@@ -344,7 +345,8 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
       std::move(selectedFiles),
       layout->fileFormat(),
       layout->connector()->connectorId(),
-      layout->serdeParameters());
+      layout->serdeParameters(),
+      partitionType);
 }
 
 namespace {
@@ -381,7 +383,14 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
       if (!serdeParameters_.empty()) {
         builder.serdeParameters(serdeParameters_);
       }
-      batch.splits.push_back(builder.build());
+      std::optional<int32_t> groupId;
+      if (partitionType_ != nullptr) {
+        VELOX_CHECK(
+            info->bucketNumber.has_value(),
+            "Bucketed scan requires bucketNumber on every file");
+        groupId = info->bucketNumber.value() % partitionType_->numPartitions();
+      }
+      batch.splits.push_back(Split{builder.build(), groupId});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -37,11 +37,13 @@ class LocalHiveSplitSource : public SplitSource {
       std::vector<const FileInfo*> files,
       velox::dwio::common::FileFormat format,
       const std::string& connectorId,
-      std::unordered_map<std::string, std::string> serdeParameters = {})
+      std::unordered_map<std::string, std::string> serdeParameters,
+      std::shared_ptr<PartitionType> partitionType)
       : format_(format),
         connectorId_(connectorId),
         files_(std::move(files)),
-        serdeParameters_(std::move(serdeParameters)) {}
+        serdeParameters_(std::move(serdeParameters)),
+        partitionType_(std::move(partitionType)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
@@ -53,6 +55,9 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
+  // When non-null, used to assign a groupId to each split for bucketed
+  // execution.
+  const std::shared_ptr<PartitionType> partitionType_;
   size_t fileIdx_{0};
   int64_t splitWithinFile_{0};
 };
@@ -71,6 +76,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
+++ b/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::connector::hive {
+namespace {
+
+using namespace facebook::velox;
+
+HivePartitionType makePartitionType(int32_t numPartitions) {
+  return HivePartitionType{numPartitions, {BIGINT()}};
+}
+
+TEST(HivePartitionTypeTest, scaleDownIdentityWhenWithinLimit) {
+  const auto partitionType = makePartitionType(8);
+
+  auto scaled = partitionType.scaleDown(8);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 8);
+
+  scaled = partitionType.scaleDown(16);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 8);
+}
+
+TEST(HivePartitionTypeTest, scaleDownPicksLargestDivisor) {
+  const auto partitionType = makePartitionType(256);
+
+  auto scaled = partitionType.scaleDown(100);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 64);
+
+  scaled = partitionType.scaleDown(64);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 64);
+
+  scaled = partitionType.scaleDown(63);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 32);
+}
+
+TEST(HivePartitionTypeTest, scaleDownToOne) {
+  const auto partitionType = makePartitionType(16);
+
+  const auto scaled = partitionType.scaleDown(1);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 1);
+}
+
+TEST(HivePartitionTypeTest, scaleDownPrimePartitionCount) {
+  const auto partitionType = makePartitionType(7);
+
+  auto scaled = partitionType.scaleDown(6);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 1);
+
+  scaled = partitionType.scaleDown(7);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 7);
+
+  scaled = partitionType.scaleDown(100);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 7);
+}
+
+TEST(HivePartitionTypeTest, scaleDownRejectsNonPositiveMax) {
+  const auto partitionType = makePartitionType(8);
+
+  VELOX_ASSERT_THROW(partitionType.scaleDown(0), "");
+  VELOX_ASSERT_THROW(partitionType.scaleDown(-1), "");
+}
+
+TEST(HivePartitionTypeTest, ctorRejectsNonPositiveNumPartitions) {
+  VELOX_ASSERT_THROW(HivePartitionType(0, std::vector<TypePtr>{BIGINT()}), "");
+  VELOX_ASSERT_THROW(HivePartitionType(-1, std::vector<TypePtr>{BIGINT()}), "");
+}
+
+TEST(HivePartitionTypeTest, scaleDownPreservesKeyTypes) {
+  HivePartitionType partitionType{
+      12, std::vector<TypePtr>{BIGINT(), VARCHAR()}};
+
+  const auto scaled = partitionType.scaleDown(4);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 4);
+
+  EXPECT_NE(partitionType.copartition(*scaled), nullptr);
+  EXPECT_NE(scaled->copartition(partitionType), nullptr);
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -128,7 +128,7 @@ folly::coro::Task<SplitBatch> SystemSplitSource::co_getSplits(
     uint32_t /*maxSplitCount*/) {
   SplitBatch batch;
   if (!done_) {
-    batch.splits.push_back(std::make_shared<SystemSplit>(connectorId_));
+    batch.splits.push_back(Split{std::make_shared<SystemSplit>(connectorId_)});
     done_ = true;
   }
   batch.noMoreSplits = true;
@@ -147,6 +147,7 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -117,6 +117,7 @@ class SystemSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -332,15 +332,15 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
   EXPECT_EQ(partitions.size(), 1);
 
   QueryRuntimeStats noopStats;
-  auto splitSource =
-      splitManager->getSplitSource(session, tableHandle, partitions, noopStats);
+  auto splitSource = splitManager->getSplitSource(
+      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = folly::coro::blockingWait(splitSource->co_getSplits(1000));
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(axiom_test_connector TestConnector.cpp)
 target_link_libraries(
   axiom_test_connector
   axiom_connectors
+  axiom_hive_connector_metadata
   velox_common_base
   velox_memory
   velox_connector

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -39,9 +39,15 @@ The Test connector is designed for three use cases:
   explicitly without adding actual data, enabling optimizer testing with
   controlled cost estimates (see [Setting Statistics Without Data](#setting-statistics-without-data)).
 
+**Supported:**
+- Hash bucketing. Tables can be created bucketed via the C++ API
+  (`addTable(..., TestBucketSpec{...})`). Rows are routed to buckets via the
+  Hive partition function on append, and splits are emitted per bucket.
+
 **Not supported:**
 - Filter pushdown.
-- Partitioning and bucketing.
+- Hive-style directory partitioning.
+- Sort-within-bucket.
 - Persistence. All data is lost when the process exits.
 
 ## Usage
@@ -128,6 +134,24 @@ When all columns share the same type, use `ROW(names, type)` instead of
 `ROW(names, {type, type, ...})`.
 
 `setStats()` and `addData()` cannot be combined on the same table.
+
+### Bucketed Tables
+
+Pass a `TestBucketSpec` to `addTable` to mark a table as hash-bucketed. Rows
+appended via `addData` are routed to buckets via the Hive partition function,
+and the split manager emits one split per non-empty bucket. The optimizer
+treats the table as bucket-partitioned for planning purposes.
+
+```cpp
+auto table = connector->addTable(
+    "orders",
+    ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+    velox::ROW({}),                          // no hidden columns
+    TestBucketSpec{{"customer_id"}, 16});    // 16 buckets on customer_id
+```
+
+`TestBucketSpec::bucketColumns` lists the column names that compose the bucket
+key (must reference visible columns); `numBuckets` is the fixed bucket count.
 
 ### Hidden Columns
 

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -41,7 +41,8 @@ The Test connector is designed for three use cases:
 
 **Not supported:**
 - Filter pushdown.
-- Partitioning and bucketing.
+- Hive-style directory partitioning.
+- Sort-within-bucket.
 - Persistence. All data is lost when the process exits.
 
 ## Usage

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,7 +17,9 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <utility>
 
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/ComplexVector.h"
@@ -87,15 +89,45 @@ TestTable::TestTable(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
-    folly::F14FastMap<std::string, velox::Variant> options)
+    folly::F14FastMap<std::string, velox::Variant> options,
+    std::optional<TestBucketSpec> bucketSpec)
     : Table(
           std::move(name),
           makeTestTableColumns(schema, hiddenColumns, options),
           options),
-      connector_(connector) {
+      connector_(connector),
+      bucketSpec_(std::move(bucketSpec)) {
   const auto& label = this->name().table;
-  exportedLayout_ =
-      std::make_unique<TestTableLayout>(label, this, connector_, allColumns());
+  if (bucketSpec_.has_value()) {
+    std::vector<const Column*> partitionColumns;
+    std::vector<velox::TypePtr> partitionKeyTypes;
+    std::vector<velox::column_index_t> bucketChannels;
+    for (const auto& columnName : bucketSpec_->bucketColumns) {
+      auto* column = findColumn(columnName);
+      VELOX_CHECK_NOT_NULL(
+          column, "Bucket column does not exist: {}", columnName);
+      partitionColumns.push_back(column);
+      partitionKeyTypes.push_back(column->type());
+      bucketChannels.push_back(schema->getChildIdx(columnName));
+    }
+
+    auto partitionType = std::make_unique<hive::HivePartitionType>(
+        bucketSpec_->numBuckets, std::move(partitionKeyTypes));
+    partitionFunction_ =
+        partitionType->makeSpec(bucketChannels, /*constants=*/{}, false)
+            ->create(bucketSpec_->numBuckets, /*localExchange=*/false);
+
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label,
+        this,
+        connector_,
+        allColumns(),
+        std::move(partitionColumns),
+        std::move(partitionType));
+  } else {
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label, this, connector_, allColumns());
+  }
   layouts_.push_back(exportedLayout_.get());
   pool_ = velox::memory::memoryManager()->addLeafPool(label + "_table");
   columnTrackers_.resize(schema->size());
@@ -140,6 +172,62 @@ void TestTable::setStats(
   }
 }
 
+namespace {
+
+struct BucketedRows {
+  velox::RowVectorPtr rows;
+  int32_t bucketId;
+};
+
+std::vector<BucketedRows> splitByBucket(
+    const velox::RowVectorPtr& input,
+    velox::core::PartitionFunction& partitionFunction,
+    int32_t numBuckets,
+    velox::memory::MemoryPool* pool) {
+  std::vector<uint32_t> bucketIds;
+  if (auto single = partitionFunction.partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  VELOX_CHECK_EQ(bucketIds.size(), static_cast<size_t>(input->size()));
+
+  std::vector<std::vector<velox::vector_size_t>> indicesPerBucket(numBuckets);
+  for (velox::vector_size_t row = 0; row < input->size(); ++row) {
+    indicesPerBucket[bucketIds[row]].push_back(row);
+  }
+
+  std::vector<BucketedRows> result;
+  result.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    const auto& rows = indicesPerBucket[bucket];
+    if (rows.empty()) {
+      continue;
+    }
+    const auto rowCount = static_cast<velox::vector_size_t>(rows.size());
+    auto indices = velox::allocateIndices(rowCount, pool);
+    auto* indicesData = indices->asMutable<velox::vector_size_t>();
+    std::copy(rows.begin(), rows.end(), indicesData);
+    std::vector<velox::VectorPtr> wrappedChildren;
+    wrappedChildren.reserve(input->childrenSize());
+    for (auto& child : input->children()) {
+      wrappedChildren.push_back(
+          velox::BaseVector::wrapInDictionary(
+              /*nulls=*/nullptr, indices, rowCount, child));
+    }
+    result.push_back(
+        {std::make_shared<velox::RowVector>(
+             pool,
+             input->type(),
+             /*nulls=*/nullptr,
+             rowCount,
+             std::move(wrappedChildren)),
+         bucket});
+  }
+  return result;
+}
+
+} // namespace
+
 void TestTable::addData(
     const velox::RowVectorPtr& data,
     bool collectColumnStatistics) {
@@ -156,7 +244,16 @@ void TestTable::addData(
   VELOX_CHECK_GT(data->size(), 0, "Cannot append empty RowVector");
   auto copy = std::dynamic_pointer_cast<velox::RowVector>(
       velox::BaseVector::copy(*data, pool_.get()));
-  data_.push_back(copy);
+
+  if (partitionFunction_ != nullptr) {
+    for (auto& bucketed : splitByBucket(
+             copy, *partitionFunction_, bucketSpec_->numBuckets, pool_.get())) {
+      data_.push_back(std::move(bucketed.rows));
+      dataBucketIds_.push_back(bucketed.bucketId);
+    }
+  } else {
+    data_.push_back(copy);
+  }
   dataRows_ += data->size();
 
   if (!collectColumnStatistics) {
@@ -245,35 +342,86 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     uint32_t maxSplitCount,
     int32_t /*bucket*/) {
   SplitBatch batch;
-  auto end =
-      std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);
-  for (auto i = nextIndex_; i < end; ++i) {
+  const auto end = std::min(
+      nextOffset_ + static_cast<size_t>(maxSplitCount), dataIndices_.size());
+  for (auto i = nextOffset_; i < end; ++i) {
     batch.splits.push_back(
-        std::make_shared<TestConnectorSplit>(connectorId_, i));
+        std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]));
   }
-  nextIndex_ = end;
-  batch.noMoreSplits = (nextIndex_ >= splitCount_);
+  nextOffset_ = end;
+  batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
   co_return batch;
 }
+
+namespace {
+
+const TestTable& findTestTableForHandle(
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  auto testHandle =
+      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
+  VELOX_CHECK(testHandle, "Expected TestTableHandle");
+  auto table = ConnectorMetadata::metadata(testHandle->connectorId())
+                   ->findTable(testHandle->schemaTableName());
+  VELOX_CHECK(table, "Table does not exist: {}", testHandle->name());
+  return dynamic_cast<const TestTable&>(*table);
+}
+
+} // namespace
 
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
-    const velox::connector::ConnectorTableHandlePtr&) {
-  co_return std::vector<PartitionHandlePtr>{
-      std::make_shared<PartitionHandle>()};
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  const auto& testTable = findTestTableForHandle(tableHandle);
+  if (!testTable.bucketSpec().has_value()) {
+    co_return std::vector<PartitionHandlePtr>{
+        std::make_shared<PartitionHandle>()};
+  }
+  const auto numBuckets = testTable.bucketSpec()->numBuckets;
+  std::vector<PartitionHandlePtr> partitions;
+  partitions.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    partitions.push_back(
+        std::make_shared<hive::HivePartitionHandle>(
+            folly::F14FastMap<std::string, std::optional<std::string>>{},
+            bucket));
+  }
+  co_return partitions;
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&,
+    const std::vector<PartitionHandlePtr>& partitions,
     SplitOptions) {
-  auto maybeTableHandle =
-      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
-  VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");
+  const auto& testTable = findTestTableForHandle(tableHandle);
+
+  std::vector<size_t> dataIndices;
+  if (testTable.bucketSpec().has_value()) {
+    folly::F14FastSet<int32_t> selectedBuckets;
+    for (const auto& partition : partitions) {
+      auto hivePartition =
+          std::dynamic_pointer_cast<const hive::HivePartitionHandle>(partition);
+      VELOX_CHECK(
+          hivePartition && hivePartition->tableBucketNumber.has_value(),
+          "Bucketed scans require HivePartitionHandle with tableBucketNumber");
+      selectedBuckets.insert(hivePartition->tableBucketNumber.value());
+    }
+    const auto& bucketIds = testTable.dataBucketIds();
+    for (size_t i = 0; i < bucketIds.size(); ++i) {
+      if (selectedBuckets.contains(bucketIds[i])) {
+        dataIndices.push_back(i);
+      }
+    }
+  } else {
+    const auto numEntries = testTable.data().size();
+    dataIndices.reserve(numEntries);
+    for (size_t i = 0; i < numEntries; ++i) {
+      dataIndices.push_back(i);
+    }
+  }
   return std::make_shared<TestSplitSource>(
-      tableHandle->connectorId(), maybeTableHandle->size());
+      tableHandle->connectorId(), std::move(dataIndices));
 }
 
 std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(
@@ -436,13 +584,15 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
   auto table = std::make_shared<TestTable>(
       tableName,
       schema,
       hiddenColumns,
       connector_,
-      folly::F14FastMap<std::string, velox::Variant>{});
+      folly::F14FastMap<std::string, velox::Variant>{},
+      std::move(bucketSpec));
   auto [it, ok] = tables_.emplace(std::move(tableName), std::move(table));
   VELOX_CHECK(ok, "Table already exists: {}", it->first.toString());
   return it->second;
@@ -677,8 +827,10 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
 std::shared_ptr<TestTable> TestConnector::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
-  return metadata_->addTable(std::move(tableName), schema, hiddenColumns);
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
+  return metadata_->addTable(
+      std::move(tableName), schema, hiddenColumns, std::move(bucketSpec));
 }
 
 bool TestConnector::dropTableIfExists(const SchemaTableName& name) {

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,7 +17,9 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <utility>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/ComplexVector.h"
@@ -87,7 +89,7 @@ TestTable::TestTable(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
-    folly::F14FastMap<std::string, velox::Variant> options)
+    const folly::F14FastMap<std::string, velox::Variant>& options)
     : Table(
           std::move(name),
           makeTestTableColumns(schema, hiddenColumns, options),
@@ -250,21 +252,37 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
 folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     uint32_t maxSplitCount) {
   SplitBatch batch;
-  auto end =
-      std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);
-  for (auto i = nextIndex_; i < end; ++i) {
-    batch.splits.push_back(
-        std::make_shared<TestConnectorSplit>(connectorId_, i));
+  const auto end = std::min(
+      nextOffset_ + static_cast<size_t>(maxSplitCount), dataIndices_.size());
+  for (auto i = nextOffset_; i < end; ++i) {
+    auto split =
+        std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
+    batch.splits.push_back(Split{std::move(split)});
   }
-  nextIndex_ = end;
-  batch.noMoreSplits = (nextIndex_ >= splitCount_);
+  nextOffset_ = end;
+  batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
   co_return batch;
 }
+
+namespace {
+
+const TestTable& findTestTableForHandle(
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  auto testHandle =
+      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
+  VELOX_CHECK(testHandle, "Expected TestTableHandle");
+  auto table = ConnectorMetadataRegistry::get(testHandle->connectorId())
+                   ->findTable(testHandle->schemaTableName());
+  VELOX_CHECK(table, "Table does not exist: {}", testHandle->name());
+  return dynamic_cast<const TestTable&>(*table);
+}
+
+} // namespace
 
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
-    const velox::connector::ConnectorTableHandlePtr&) {
+    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
   co_return std::vector<PartitionHandlePtr>{
       std::make_shared<PartitionHandle>()};
 }
@@ -272,13 +290,19 @@ TestSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&,
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
-  auto maybeTableHandle =
-      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
-  VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");
+  const auto& testTable = findTestTableForHandle(tableHandle);
+
+  const auto numEntries = testTable.data().size();
+  std::vector<size_t> dataIndices;
+  dataIndices.reserve(numEntries);
+  for (size_t i = 0; i < numEntries; ++i) {
+    dataIndices.push_back(i);
+  }
   return std::make_shared<TestSplitSource>(
-      tableHandle->connectorId(), maybeTableHandle->size());
+      tableHandle->connectorId(), std::move(dataIndices));
 }
 
 std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -22,10 +22,18 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::axiom::connector {
 
 class TestConnector;
+
+/// Hash-bucketing spec for a TestTable. Routes appended rows into buckets
+/// using the Hive partition function over 'bucketColumns'.
+struct TestBucketSpec {
+  std::vector<std::string> bucketColumns;
+  int32_t numBuckets;
+};
 
 /// The Table and Connector objects to which this layout correspond
 /// are specified explicitly at init time.
@@ -46,6 +54,29 @@ class TestTableLayout : public TableLayout {
             /*sortOrder=*/{},
             /*lookupKeys=*/{},
             /*supportsScan=*/true) {}
+
+  TestTableLayout(
+      const std::string& label,
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::vector<const Column*> partitionColumns,
+      std::unique_ptr<PartitionType> partitionType)
+      : TableLayout(
+            label,
+            table,
+            connector,
+            std::move(columns),
+            std::move(partitionColumns),
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            /*lookupKeys=*/{},
+            /*supportsScan=*/true),
+        partitionType_(std::move(partitionType)) {}
+
+  const PartitionType* partitionType() const override {
+    return partitionType_.get();
+  }
 
   /// Records discrete values to use in 'discretePredicateColumns' and
   /// 'discretePredicates' APIs. If called repeatedly, overwrites previous
@@ -78,6 +109,7 @@ class TestTableLayout : public TableLayout {
  private:
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
+  std::unique_ptr<PartitionType> partitionType_;
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -92,7 +124,8 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
-      folly::F14FastMap<std::string, velox::Variant> options);
+      folly::F14FastMap<std::string, velox::Variant> options,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -106,11 +139,21 @@ class TestTable : public Table {
     return data_;
   }
 
+  /// Bucket id of the i-th entry in 'data'. Empty for unbucketed tables.
+  const std::vector<int32_t>& dataBucketIds() const {
+    return dataBucketIds_;
+  }
+
+  const std::optional<TestBucketSpec>& bucketSpec() const {
+    return bucketSpec_;
+  }
+
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
   /// memory pool. When 'collectColumnStatistics' is true, computes per-column
   /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
-  /// Cannot be combined with setStats on the same table.
+  /// Cannot be combined with setStats on the same table. For bucketed tables,
+  /// each non-empty bucket of the input becomes one entry in 'data'.
   void addData(
       const velox::RowVectorPtr& data,
       bool collectColumnStatistics = true);
@@ -150,18 +193,23 @@ class TestTable : public Table {
   std::unique_ptr<TestTableLayout> exportedLayout_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<velox::RowVectorPtr> data_;
+  std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
   std::vector<ColumnTracker> columnTrackers_;
+
+  std::optional<TestBucketSpec> bucketSpec_;
+  std::unique_ptr<velox::core::PartitionFunction> partitionFunction_;
 };
 
-/// SplitSource generated via the TestSplitManager embedded in the
-/// TestConnector. Generates one TestConnectorSplit for each RowVector
-/// in the table's data_ vector.
+/// Emits one TestConnectorSplit per index in 'dataIndices'. Each index points
+/// into the table's data_ vector.
 class TestSplitSource : public SplitSource {
  public:
-  TestSplitSource(const std::string& connectorId, size_t splitCount)
-      : connectorId_(connectorId), splitCount_(splitCount) {}
+  TestSplitSource(
+      const std::string& connectorId,
+      std::vector<size_t> dataIndices)
+      : connectorId_(connectorId), dataIndices_(std::move(dataIndices)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(
       uint32_t maxSplitCount,
@@ -169,14 +217,13 @@ class TestSplitSource : public SplitSource {
 
  private:
   const std::string connectorId_;
-  const size_t splitCount_;
-  size_t nextIndex_{0};
+  const std::vector<size_t> dataIndices_;
+  size_t nextOffset_{0};
 };
 
-/// SplitManager embedded in the TestConnector. Returns one
-/// default-initialized PartitionHandle upon call to co_listPartitions.
-/// Generates a TestSplitSource that produces one TestConnectorSplit
-/// per RowVector in the table's data_ vector.
+/// Unbucketed: one PartitionHandle covering the whole table.
+/// Bucketed: one HivePartitionHandle per bucket; getSplitSource emits splits
+/// only for the requested buckets' entries.
 class TestSplitManager : public ConnectorSplitManager {
  public:
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
@@ -439,13 +486,13 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return splitManager_.get();
   }
 
-  /// Creates and returns a TestTable with the specified name and schema in the
-  /// in-memory map maintained in the connector metadata. Throws if the table
-  /// already exists.
+  /// Registers a TestTable in the connector metadata. Throws if the name is
+  /// already taken. When 'bucketSpec' is set, appended rows are hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Appends data to the table with the specified name.
   void appendData(
@@ -655,19 +702,25 @@ class TestConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx* connectorQueryCtx,
       velox::connector::CommitStrategy commitStrategy) override;
 
-  /// Adds a TestTable with the specified name and schema. Throws if a table
-  /// with the same name already exists.
+  /// Registers a TestTable. Throws if the name is already taken. When
+  /// 'bucketSpec' is set, the table is hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({}));
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Convenience overload that uses kDefaultSchema as the schema.
   std::shared_ptr<TestTable> addTable(
       const std::string& name,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({})) {
-    return addTable({std::string(kDefaultSchema), name}, schema, hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt) {
+    return addTable(
+        {std::string(kDefaultSchema), name},
+        schema,
+        hiddenColumns,
+        std::move(bucketSpec));
   }
 
   /// Appends data to the table with the specified name.

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -21,6 +21,7 @@
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::axiom::connector {
 
@@ -91,7 +92,7 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
-      folly::F14FastMap<std::string, velox::Variant> options);
+      const folly::F14FastMap<std::string, velox::Variant>& options);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -154,26 +155,24 @@ class TestTable : public Table {
   std::vector<ColumnTracker> columnTrackers_;
 };
 
-/// SplitSource generated via the TestSplitManager embedded in the
-/// TestConnector. Generates one TestConnectorSplit for each RowVector
-/// in the table's data_ vector.
+/// SplitSource for TestTable. Emits one TestConnectorSplit per index in
+/// 'dataIndices'.
 class TestSplitSource : public SplitSource {
  public:
-  TestSplitSource(const std::string& connectorId, size_t splitCount)
-      : connectorId_(connectorId), splitCount_(splitCount) {}
+  TestSplitSource(
+      const std::string& connectorId,
+      std::vector<size_t> dataIndices)
+      : connectorId_(connectorId), dataIndices_(std::move(dataIndices)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;
-  const size_t splitCount_;
-  size_t nextIndex_{0};
+  const std::vector<size_t> dataIndices_;
+  size_t nextOffset_{0};
 };
 
-/// SplitManager embedded in the TestConnector. Returns one
-/// default-initialized PartitionHandle upon call to co_listPartitions.
-/// Generates a TestSplitSource that produces one TestConnectorSplit
-/// per RowVector in the table's data_ vector.
+/// Returns one PartitionHandle covering the whole table.
 class TestSplitManager : public ConnectorSplitManager {
  public:
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
@@ -184,6 +183,7 @@ class TestSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 
@@ -436,9 +436,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return splitManager_.get();
   }
 
-  /// Creates and returns a TestTable with the specified name and schema in the
-  /// in-memory map maintained in the connector metadata. Throws if the table
-  /// already exists.
+  /// Registers a TestTable in the connector metadata. Throws if the name is
+  /// already taken.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
@@ -686,8 +685,7 @@ class TestConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx* connectorQueryCtx,
       velox::connector::CommitStrategy commitStrategy) override;
 
-  /// Adds a TestTable with the specified name and schema. Throws if a table
-  /// with the same name already exists.
+  /// Registers a TestTable. Throws if the name is already taken.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -17,12 +17,15 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
 #include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <numeric>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -544,6 +547,153 @@ TEST_F(TestConnectorTest, addDataAndSetStatsMutualExclusion) {
     VELOX_ASSERT_THROW(
         table->setStats(100, {{"a", {.numDistinct = 50}}}),
         "Cannot use both setStats and addData on table");
+  }
+}
+
+namespace {
+
+std::vector<uint32_t> referenceBucketIds(
+    const velox::RowVectorPtr& input,
+    const std::vector<velox::column_index_t>& channels,
+    int32_t numBuckets) {
+  velox::connector::hive::HivePartitionFunctionSpec spec(
+      numBuckets, channels, /*constValues=*/{});
+  std::vector<uint32_t> bucketIds;
+  if (auto single = spec.create(numBuckets, /*localExchange=*/false)
+                        ->partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  return bucketIds;
+}
+
+velox::connector::ConnectorTableHandlePtr makeScanHandle(
+    const TableLayout& layout,
+    const std::vector<std::string>& columnNames) {
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  std::vector<velox::connector::ColumnHandlePtr> columns;
+  columns.reserve(columnNames.size());
+  for (const auto& name : columnNames) {
+    columns.push_back(layout.createColumnHandle(nullptr, name));
+  }
+  std::vector<core::TypedExprPtr> empty;
+  return layout.createTableHandle(
+      nullptr, std::move(columns), *evaluator, empty, empty);
+}
+
+} // namespace
+
+CO_TEST_F(TestConnectorTest, bucketedTable) {
+  constexpr int32_t kNumBuckets = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "bucketed", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  std::vector<int64_t> keys(32);
+  std::iota(keys.begin(), keys.end(), 0);
+  auto input = makeRowVector({makeFlatVector<int64_t>(keys)});
+  connector_->appendData("bucketed", input);
+
+  const auto expected = referenceBucketIds(input, {0}, kNumBuckets);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto* splitManager = metadata_->splitManager();
+  auto partitions =
+      co_await splitManager->co_listPartitions(nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+
+  constexpr int32_t kSelectedBucket = 2;
+  auto source = splitManager->getSplitSource(
+      nullptr, tableHandle, {partitions[kSelectedBucket]}, {});
+  while (true) {
+    auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
+    for (const auto& split : batch.splits) {
+      auto testSplit =
+          std::dynamic_pointer_cast<const TestConnectorSplit>(split);
+      CO_ASSERT_NE(testSplit, nullptr);
+      EXPECT_EQ(table->dataBucketIds()[testSplit->index()], kSelectedBucket);
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
+}
+
+TEST_F(TestConnectorTest, bucketedTableNonExistentBucketColumn) {
+  VELOX_ASSERT_THROW(
+      connector_->addTable(
+          "bad_bucket_col",
+          ROW({"a"}, {BIGINT()}),
+          velox::ROW({}),
+          TestBucketSpec{{"missing"}, 4}),
+      "Bucket column does not exist: missing");
+}
+
+CO_TEST_F(TestConnectorTest, bucketedTableNumBucketsExceedsNumRows) {
+  constexpr int32_t kNumBuckets = 16;
+  constexpr int32_t kNumRows = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "sparse", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  auto input = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
+  connector_->appendData("sparse", input);
+
+  EXPECT_LE(table->data().size(), kNumRows);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (const auto& vector : table->data()) {
+    EXPECT_GT(vector->size(), 0);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto partitions = co_await metadata_->splitManager()->co_listPartitions(
+      nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+}
+
+TEST_F(TestConnectorTest, bucketedTableMultiColumnKeys) {
+  constexpr int32_t kNumBuckets = 8;
+  constexpr int32_t kNumRows = 64;
+  auto schema = ROW({"k1", "k2", "v"}, {BIGINT(), VARCHAR(), DOUBLE()});
+  auto table = connector_->addTable(
+      "multi_key",
+      schema,
+      velox::ROW({}),
+      TestBucketSpec{{"k1", "k2"}, kNumBuckets});
+
+  auto& layout = *table->layouts()[0];
+  EXPECT_NE(layout.partitionType(), nullptr);
+  EXPECT_EQ(layout.partitionColumns().size(), 2);
+
+  std::vector<int64_t> k1Values(kNumRows);
+  std::iota(k1Values.begin(), k1Values.end(), 0);
+  std::vector<std::string> k2Values;
+  k2Values.reserve(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    k2Values.push_back(fmt::format("s{}", i));
+  }
+  std::vector<double> vValues(kNumRows, 3.14);
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(k1Values),
+       makeFlatVector<std::string>(k2Values),
+       makeFlatVector<double>(vValues)});
+  connector_->appendData("multi_key", input);
+
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+
+  const auto expected = referenceBucketIds(input, {0, 1}, kNumBuckets);
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
   }
 }
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -157,15 +157,15 @@ CO_TEST_F(TestConnectorTest, splitManager) {
   auto partitions =
       co_await splitManager->co_listPartitions(nullptr, tableHandle);
   QueryRuntimeStats noopStats;
-  auto splitSource =
-      splitManager->getSplitSource(nullptr, tableHandle, partitions, noopStats);
+  auto splitSource = splitManager->getSplitSource(
+      nullptr, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = co_await splitSource->co_getSplits(/*maxSplitCount=*/1000);
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -87,6 +87,7 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const connector::ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
@@ -115,8 +116,8 @@ folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
       std::min(nextSplitIdx_ + static_cast<int64_t>(maxSplitCount), numSplits_);
   for (auto i = nextSplitIdx_; i < end; ++i) {
     batch.splits.push_back(
-        std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
-            connectorId_, numSplits_, i));
+        Split{std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
+            connectorId_, numSplits_, i)});
   }
   nextSplitIdx_ = end;
   batch.noMoreSplits = (nextSplitIdx_ >= numSplits_);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -62,6 +62,7 @@ class TpchSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -212,13 +212,17 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
 
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      /*session=*/nullptr, tableHandle, partitions, noopStats);
+      /*session=*/nullptr,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      noopStats);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = co_await splitSource->co_getSplits(1000);
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -698,22 +698,11 @@ for Hive, `bucketId % partitionType->numPartitions()`).
 | Latency | May wait for group completion | Incremental, tasks start immediately |
 | Memory per task | Per-group data | Total data / numTasks |
 
-The optimizer queries the connector to choose the mode:
-
-```cpp
-/// On ConnectorSplitManager. Returns true if the connector can
-/// efficiently enumerate complete groups via GroupedSplitSource.
-virtual bool supportsGroupedSplitSource() const { return false; }
-```
-
-When true, the optimizer sets `groupedExecution = true` on the
-fragment and the runtime uses `GroupedSplitSource` with per-group
-clearing. When false, the optimizer sets `groupedExecution = false`
-and the runtime uses regular `SplitSource` with `groupId` on each
-split — shuffle avoidance without per-group clearing. This applies
-to all cases — aggregations, window functions, and joins (both
-co-bucketed and mixed). A more structured connector capabilities
-system may replace this in the future.
+Shuffle avoidance uses the regular `SplitSource` with `groupId`
+on each split — no per-group clearing. A future grouped-execution
+path may introduce a `GroupedSplitSource` and a corresponding
+capability bit on `ConnectorSplitManager`; the API surface is not
+defined here.
 
 #### Examples
 

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -43,7 +43,7 @@ class SimpleSplitSource : public connector::SplitSource {
     auto end = std::min(
         nextIndex_ + static_cast<size_t>(maxSplitCount), splits_.size());
     for (auto i = nextIndex_; i < end; ++i) {
-      batch.splits.push_back(std::move(splits_[i]));
+      batch.splits.push_back(connector::Split{std::move(splits_[i])});
     }
     nextIndex_ = end;
     batch.noMoreSplits = (nextIndex_ >= splits_.size());
@@ -93,7 +93,7 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session, handle, partitions, runtimeStats_);
+      session, handle, partitions, /*partitionType=*/nullptr, runtimeStats_);
 }
 
 namespace {
@@ -141,7 +141,8 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     for (;;) {
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
-        tasks[taskIdx]->addSplit(scanId, velox::exec::Split(std::move(split)));
+        tasks[taskIdx]->addSplit(
+            scanId, velox::exec::Split(std::move(split.connectorSplit)));
         taskIdx = (taskIdx + 1) % tasks.size();
         ++splitCount;
       }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/27

Adds the connector contract that the optimizer (D100383077) uses to ask connectors for group-tagged splits. Specifically, the additions match the Section 3 'Shuffle avoidance without per-group processing' surface in axiom/optimizer/docs/DistributedExecution.md.

Surface:

- `axiom::connector::Split` wraps a `velox::connector::ConnectorSplit` with `optional<int32_t> groupId`. `SplitBatch::splits` is now `vector<Split>` instead of `vector<shared_ptr<ConnectorSplit>>`. Velox's `ConnectorSplit` cannot carry `groupId` itself, so the wrapper carries it for the runner.
- `ConnectorSplitManager::getSplitSource` gains a required `shared_ptr<PartitionType>` parameter (no default — defaults on virtual functions resolve statically and silently disagree across overrides). When non-null, the connector tags each emitted `Split` with `groupId` computed by the `PartitionType` (e.g. for Hive: `bucket % numPartitions`). When null, splits are emitted with `groupId=nullopt` and the runner falls back to round-robin.
- `PartitionType::numPartitions()` virtual; `HivePartitionType` implements it.
- `PartitionType::scaleDown(maxPartitions)`: returns a coarsened `PartitionType` with at most `maxPartitions` partitions, suitable for collapsing native bucket counts onto a runner-task budget. `HivePartitionType::scaleDown` picks the largest divisor of `numPartitions()` that is `<= maxPartitions`. Tested in `axiom/connectors/hive/tests:hive_partition_type_test`.
- `TestConnector` / `TestSplitManager` / `TestSplitSource`: bucketed support so the optimizer tests in this stack can exercise the new contract end to end. `addTable` accepts a `TestBucketSpec`, `addData` routes rows into per-bucket sub-vectors, `getSplitSource` emits one `HivePartitionHandle` per bucket, and `TestSplitSource` tags `Split`s with `groupId = dataBucketIds[i] % partitionType->numPartitions()` when `partitionType` is set.
- `LocalHiveSplitSource` computes `groupId = HiveConnectorSplit::tableBucketNumber % partitionType->numPartitions()` when constructed with a non-null `PartitionType`.

Out of scope (per design doc Section 3 'Status: design proposal — not yet implemented' and explicit in this stack):

- `GroupedSplitSource` and `getGroupedSplitSource` (no per-group state clearing here).
- `TableLayout::getPartitionTypes` / `TableLayout::copartition` (the multi-PartitionType selection API). Single applicable PartitionType per table is enough for v1.
- `groupedExecution=true` path on `ExecutableFragment` (added in D100383077, always set to false).

Updates 9 connector implementations to accept the new `getSplitSource` parameter (Hive, System, Tpch, Test, plus fb_axiom Prism, Impulse, Configerator, Xdb, and the `MockImpulseSplitManager` test helper). Updates 2 production consumers (LocalRunner, StreamingStageScheduler in axel) and 8 test sites to wrap/unwrap `Split`.


Reviewed By: mbasmanova

Differential Revision: D100383075


