### PR TITLE
fix(optimizer): Support correlated subqueries with nested subquery scopes

### DIFF
--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -142,9 +142,10 @@ void SubfieldTracker::markFieldAccessed(
     const lp::ProjectNode& project,
     int32_t ordinal,
     std::vector<Step>& steps,
-    bool isControl) {
+    bool isControl,
+    const MarkFieldsAccessedContext& context) {
   const auto& input = project.onlyInput();
-  const auto ctx = fromNode(input);
+  const auto ctx = fromNode(input).append(context);
   markSubfields(project.expressionAt(ordinal), steps, isControl, ctx.toCtx());
 }
 
@@ -152,10 +153,11 @@ void SubfieldTracker::markFieldAccessed(
     const lp::UnnestNode& unnest,
     int32_t ordinal,
     std::vector<Step>& steps,
-    bool isControl) {
+    bool isControl,
+    const MarkFieldsAccessedContext& context) {
   const auto& input = unnest.onlyInput();
   if (ordinal < input->outputType()->size()) {
-    const auto ctx = fromNode(input);
+    const auto ctx = fromNode(input).append(context);
     markFieldAccessed(ctx.sources[0], ordinal, steps, isControl, ctx.toCtx());
   }
 }
@@ -187,11 +189,12 @@ void SubfieldTracker::markFieldAccessed(
     const lp::AggregateNode& agg,
     int32_t ordinal,
     std::vector<Step>& steps,
-    bool isControl) {
+    bool isControl,
+    const MarkFieldsAccessedContext& context) {
   const auto& input = agg.onlyInput();
 
   std::vector<Step> subSteps;
-  const auto ctx = fromNode(input);
+  const auto ctx = fromNode(input).append(context);
   auto mark = [&](const lp::ExprPtr& expr) {
     markSubfields(expr, subSteps, isControl, ctx.toCtx());
   };
@@ -236,9 +239,10 @@ void SubfieldTracker::markFieldAccessed(
     const lp::SetNode& set,
     int32_t ordinal,
     std::vector<Step>& steps,
-    bool isControl) {
+    bool isControl,
+    const MarkFieldsAccessedContext& context) {
   for (const auto& input : set.inputs()) {
-    const auto ctx = fromNode(input);
+    const auto ctx = fromNode(input).append(context);
     markFieldAccessed(ctx.sources[0], ordinal, steps, isControl, ctx.toCtx());
   }
 }
@@ -279,13 +283,13 @@ void SubfieldTracker::markFieldAccessed(
   const auto kind = source.planNode->kind();
   if (kind == lp::NodeKind::kProject) {
     const auto* project = source.planNode->as<lp::ProjectNode>();
-    markFieldAccessed(*project, ordinal, steps, isControl);
+    markFieldAccessed(*project, ordinal, steps, isControl, context);
     return;
   }
 
   if (kind == lp::NodeKind::kUnnest) {
     const auto* unnest = source.planNode->as<lp::UnnestNode>();
-    markFieldAccessed(*unnest, ordinal, steps, isControl);
+    markFieldAccessed(*unnest, ordinal, steps, isControl, context);
     return;
   }
 
@@ -296,13 +300,13 @@ void SubfieldTracker::markFieldAccessed(
 
   if (kind == lp::NodeKind::kAggregate) {
     const auto* agg = source.planNode->as<lp::AggregateNode>();
-    markFieldAccessed(*agg, ordinal, steps, isControl);
+    markFieldAccessed(*agg, ordinal, steps, isControl, context);
     return;
   }
 
   if (kind == lp::NodeKind::kSet) {
     const auto* set = source.planNode->as<lp::SetNode>();
-    markFieldAccessed(*set, ordinal, steps, isControl);
+    markFieldAccessed(*set, ordinal, steps, isControl, context);
     return;
   }
 

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -103,25 +103,29 @@ class SubfieldTracker {
       const logical_plan::ProjectNode& project,
       int32_t ordinal,
       std::vector<Step>& steps,
-      bool isControl);
+      bool isControl,
+      const MarkFieldsAccessedContext& context);
 
   void markFieldAccessed(
       const logical_plan::UnnestNode& unnest,
       int32_t ordinal,
       std::vector<Step>& steps,
-      bool isControl);
+      bool isControl,
+      const MarkFieldsAccessedContext& context);
 
   void markFieldAccessed(
       const logical_plan::AggregateNode& agg,
       int32_t ordinal,
       std::vector<Step>& steps,
-      bool isControl);
+      bool isControl,
+      const MarkFieldsAccessedContext& context);
 
   void markFieldAccessed(
       const logical_plan::SetNode& set,
       int32_t ordinal,
       std::vector<Step>& steps,
-      bool isControl);
+      bool isControl,
+      const MarkFieldsAccessedContext& context);
 
   void markFieldAccessed(
       const LogicalContextSource& source,

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2426,9 +2426,16 @@ DerivedTableP ToGraph::translateSubquery(
   auto originalRenames = std::move(renames_);
   renames_.clear();
 
-  correlations_ = &originalRenames;
+  auto mergedCorrelations = originalRenames;
+  if (correlations_ != nullptr) {
+    for (const auto& [name, expr] : *correlations_) {
+      mergedCorrelations.emplace(name, expr);
+    }
+  }
+  auto* savedCorrelations = correlations_;
+  correlations_ = &mergedCorrelations;
   SCOPE_EXIT {
-    correlations_ = nullptr;
+    correlations_ = savedCorrelations;
   };
 
   VELOX_CHECK(correlatedConjuncts_.empty());

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -554,7 +554,7 @@ class ToGraph {
   folly::F14FastMap<std::string, ExprCP> renames_;
 
   // Symbols from the 'outer' query. Used when processing correlated subqueries.
-  const folly::F14FastMap<std::string, ExprCP>* correlations_;
+  const folly::F14FastMap<std::string, ExprCP>* correlations_{nullptr};
 
   // True if expression is allowed to reference symbols from the 'outer' query.
   bool allowCorrelations_{false};

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -35,3 +35,21 @@ SELECT T.* FROM (VALUES (1)) t(a) JOIN (VALUES (2)) u(b) ON true
 -- null-aware semi-project join with extra filter; the optimizer must not flip
 -- this to a right semi-project join that is unsupported in Velox.
 SELECT CASE WHEN a.x IN (SELECT t.a FROM t WHERE t.b < a.y) THEN 'p' ELSE 'f' END FROM ( VALUES ( 1, 100 ) ) a ( x, y )
+----
+-- Correlated scalar subquery referencing a CTE that contains a NOT IN
+-- subquery.
+WITH u AS (
+  SELECT a FROM t WHERE a NOT IN (SELECT 5)
+)
+SELECT (SELECT count(*) FROM u WHERE a > v.a) FROM (SELECT 1 AS a) v
+----
+-- 3 levels with cross-level references and name shadowing.
+-- Level 0 (v): x=20, y=30. Level 1 (u): x=10 (shadows v.x), a=5.
+-- Level 2 references u.a (level 1), v.y (level 0), u.x (level 1 shadow).
+SELECT
+  (SELECT
+    (SELECT count(*)
+     FROM (VALUES (5), (15), (25)) t(b)
+     WHERE b > u.a AND b > u.x AND b < v.y)
+   FROM (SELECT 5 AS a, 10 AS x) u)
+FROM (SELECT 20 AS x, 30 AS y) v


### PR DESCRIPTION
Summary:
Correlated scalar subqueries fail with "Cannot resolve column name" or "Field not found" when the referenced CTE or subquery contains its own subquery (e.g., NOT IN (SELECT ...)), or when subqueries are nested more than 2 levels deep.

Two root causes:

1. translateSubquery unconditionally nulls correlations_ via SCOPE_EXIT, destroying the outer correlation chain when processing nested subqueries. Fix: save and restore correlations_ instead of nulling, and merge outer scope columns into the correlation map so N-level deep subqueries can resolve columns from any enclosing scope.

2. SubfieldTracker::markFieldAccessed for ProjectNode, AggregateNode, UnnestNode, and SetNode drops the outer MarkFieldsAccessedContext. Correlated columns inside subqueries are not found, not marked as used, and get pruned — making them unavailable during later column resolution. Fix: propagate context through all markFieldAccessed overloads.

Also initialize correlations_ to nullptr (was uninitialized).

Differential Revision: D102420383


