### PR TITLE
feat(optimizer): Eliminate redundant nested DISTINCT-only aggregations

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3714,16 +3714,104 @@ void ToGraph::makeQueryGraph(
     case lp::NodeKind::kAggregate: {
       const auto& input = *node.onlyInput();
       makeQueryGraph(input, allowedInDt, excludeOuterJoins);
-      if (currentDt_->hasAggregation() || currentDt_->hasLimit() ||
-          currentDt_->windowPlan) {
-        finalizeDtWithCorrelatedConjuncts(input);
-      } else if (currentDt_->hasOrderBy()) {
-        currentDt_->dropOrderBy();
+
+      // Eliminate redundant nested DISTINCT-only aggregations. When both the
+      // existing and new aggregations have no aggregate functions, one of them
+      // may be unnecessary:
+      // - If outer keys ⊆ inner keys, the inner aggregation is redundant.
+      // - If inner keys ⊂ outer keys and the extra outer keys are deterministic
+      //   functions of the inner keys, the outer aggregation is redundant.
+      bool skipOuterAggregation = false;
+      if (currentDt_->hasAggregation() && !currentDt_->hasLimit() &&
+          !currentDt_->windowPlan && correlatedConjuncts_.empty()) {
+        const auto* existingAgg = currentDt_->aggregation;
+        const auto* aggNode = node.as<lp::AggregateNode>();
+        if (existingAgg->aggregates().empty() &&
+            aggNode->aggregates().empty()) {
+          folly::F14FastSet<std::string> innerKeyNames;
+          for (const auto* key : existingAgg->groupingKeys()) {
+            if (key->is(PlanType::kColumnExpr)) {
+              innerKeyNames.insert(std::string(key->as<Column>()->name()));
+            }
+          }
+
+          folly::F14FastSet<std::string> outerKeyNames;
+          bool allOuterAreColumnRefs = true;
+          for (const auto& key : aggNode->groupingKeys()) {
+            const auto* inputRef =
+                dynamic_cast<const lp::InputReferenceExpr*>(key.get());
+            if (inputRef != nullptr) {
+              outerKeyNames.insert(inputRef->name());
+            } else {
+              allOuterAreColumnRefs = false;
+              break;
+            }
+          }
+
+          if (allOuterAreColumnRefs && !innerKeyNames.empty()) {
+            // Check if outer keys ⊆ inner keys → inner is redundant.
+            bool outerIsSubsetOfInner = true;
+            for (const auto& name : outerKeyNames) {
+              if (!innerKeyNames.contains(name)) {
+                outerIsSubsetOfInner = false;
+                break;
+              }
+            }
+
+            if (outerIsSubsetOfInner) {
+              currentDt_->aggregation = nullptr;
+            } else {
+              // Check if inner keys ⊂ outer keys → outer may be redundant.
+              bool innerIsSubsetOfOuter = true;
+              for (const auto& name : innerKeyNames) {
+                if (!outerKeyNames.contains(name)) {
+                  innerIsSubsetOfOuter = false;
+                  break;
+                }
+              }
+
+              if (innerIsSubsetOfOuter) {
+                // Extra outer keys are deterministic functions of inner keys
+                // because after an aggregation, only grouping keys are
+                // available as columns. Verify the extra keys exist in the
+                // rename map and are deterministic.
+                bool allExtraAreValid = true;
+                for (const auto& name : outerKeyNames) {
+                  if (innerKeyNames.contains(name)) {
+                    continue;
+                  }
+                  auto it = renames_.find(name);
+                  if (it == renames_.end()) {
+                    allExtraAreValid = false;
+                    break;
+                  }
+                  if (it->second->containsNonDeterministic()) {
+                    allExtraAreValid = false;
+                    break;
+                  }
+                }
+
+                if (allExtraAreValid) {
+                  skipOuterAggregation = true;
+                }
+              }
+            }
+          }
+        }
       }
 
-      auto* agg = translateAggregation(*node.as<lp::AggregateNode>());
-      if (auto* result = processCorrelatedAggregation(agg)) {
-        currentDt_->aggregation = result;
+      if (!skipOuterAggregation) {
+        if (currentDt_->hasAggregation() || currentDt_->hasLimit() ||
+            currentDt_->windowPlan) {
+          finalizeDtWithCorrelatedConjuncts(input);
+        } else if (currentDt_->hasOrderBy()) {
+          currentDt_->dropOrderBy();
+        }
+
+        auto* agg = translateAggregation(*node.as<lp::AggregateNode>());
+        if (auto* result = processCorrelatedAggregation(agg)) {
+          currentDt_->aggregation = result;
+        }
       }
 
     } break;

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -273,9 +273,9 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   {
     auto logicalPlan = lp::PlanBuilder(makeContext())
                            .tableScan("t")
-                           .aggregate({"a", "b"}, {})
+                           .aggregate({"a", "b"}, {"sum(v) as sv"})
                            .with({"a + b as d"})
-                           .aggregate({"a", "b", "d"}, {})
+                           .aggregate({"a", "b", "d"}, {"sum(sv)"})
                            .build();
     auto plan = planVelox(logicalPlan);
 
@@ -286,11 +286,11 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
                        .tableScan()
                        .shuffle()
                        .localPartition()
-                       .singleAggregation({"a", "b"}, {})
+                       .singleAggregation({"a", "b"}, {"sum(v)"})
                        .project()
                        // No shuffle here - partitionKeys ⊆ groupingKeys
                        .localPartition()
-                       .singleAggregation({"a", "b", "d"}, {})
+                       .singleAggregation({"a", "b", "d"}, {"sum(sv)"})
                        .shuffle()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
@@ -300,8 +300,8 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   {
     auto logicalPlan = lp::PlanBuilder(makeContext())
                            .tableScan("t")
-                           .aggregate({"a", "b", "c"}, {})
-                           .aggregate({"a", "b"}, {})
+                           .aggregate({"a", "b", "c"}, {"sum(v) as sv"})
+                           .aggregate({"a", "b"}, {"sum(sv)"})
                            .build();
     auto plan = planVelox(logicalPlan);
 
@@ -312,15 +312,76 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
                        .tableScan()
                        .shuffle()
                        .localPartition()
-                       .singleAggregation({"a", "b", "c"}, {})
+                       .singleAggregation({"a", "b", "c"}, {"sum(v)"})
                        .project()
                        .shuffle()
                        .localPartition()
-                       .singleAggregation({"a", "b"}, {})
+                       .singleAggregation({"a", "b"}, {"sum(sv)"})
                        .shuffle()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
+}
+
+// Verifies that a redundant outer DISTINCT-only aggregation is eliminated
+// when the inner aggregation already deduplicates by a subset of the outer's
+// grouping keys and the extra keys are deterministic expressions of the
+// inner keys.
+TEST_F(AggregationTest, eliminateRedundantOuterDistinct) {
+  auto schema = ROW({"a", "b", "c"}, BIGINT());
+  testConnector_->addTable("t", schema);
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({"a", "b"}, {})
+                         .with({"a + b as d"})
+                         .aggregate({"a", "b", "d"}, {})
+                         .build();
+  auto plan = planVelox(logicalPlan);
+
+  // The 2nd aggregation is unnecessary because the 1st aggregation already
+  // deduplicates (a, b), and d = a + b is deterministic. So the plan should
+  // have only one aggregation on {a, b}.
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .shuffle()
+                     .localPartition()
+                     .singleAggregation({"a", "b"}, {})
+                     .project({"a", "b", "a + b as d"})
+                     .shuffle()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// Verifies that a redundant inner DISTINCT-only aggregation is eliminated
+// when the outer aggregation groups by a subset of the inner's grouping keys.
+TEST_F(AggregationTest, eliminateRedundantInnerDistinct) {
+  auto schema = ROW({"a", "b", "c"}, BIGINT());
+  testConnector_->addTable("t", schema);
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({"a", "b", "c"}, {})
+                         .aggregate({"a", "b"}, {})
+                         .build();
+  auto plan = planVelox(logicalPlan);
+
+  // The 1st aggregation is unnecessary because grouping by (a, b, c) and
+  // then by (a, b) is equivalent to just grouping by (a, b).
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .shuffle()
+                     .localPartition()
+                     .singleAggregation({"a", "b"}, {})
+                     .shuffle()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
 }
 
 } // namespace


### PR DESCRIPTION
When two DISTINCT-only aggregations (no aggregate functions) are nested, one of them is often redundant. If the outer grouping keys are a subset of the inner keys, the inner aggregation is unnecessary. If the inner grouping keys are a subset of the outer keys and the extra outer keys are deterministic functions, the outer aggregation is unnecessary.

The existing repartitionForAggPartitionSubset test was modified to use aggregate functions (sum(v)) in both nested aggregations. This ensures the aggregations are preserved (not eliminated by the new optimization) so the test continues to verify the repartitionForAgg shuffle logic as originally intended.

Fixes #886