### PR TITLE
refactor(optimizer): Add FragmentType enum to ExecutableFragment (#1300)

### DIFF
--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -304,6 +304,22 @@ const auto& columnStatFieldNames() {
 
 AXIOM_DEFINE_ENUM_NAME(ColumnStatField, columnStatFieldNames);
 
+namespace {
+
+const auto& fragmentTypeNames() {
+  static const folly::F14FastMap<FragmentType, std::string_view> kNames = {
+      {FragmentType::kSource, "SOURCE"},
+      {FragmentType::kFixed, "FIXED"},
+      {FragmentType::kSingle, "SINGLE"},
+      {FragmentType::kCoordinator, "COORDINATOR"},
+  };
+  return kNames;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(FragmentType, fragmentTypeNames);
+
 FinishWrite::FinishWrite(
     std::shared_ptr<connector::ConnectorMetadata> metadata,
     connector::ConnectorSessionPtr session,
@@ -359,6 +375,22 @@ velox::ContinueFuture FinishWrite::abort() && noexcept {
   return metadata_->abortWrite(session_, handle_);
 }
 
+namespace {
+// Formats the header line for a fragment in toString/toSummaryString.
+std::string formatFragmentHeader(
+    int32_t index,
+    const ExecutableFragment& fragment) {
+  return fmt::format(
+      "Fragment {}: {} {}{}:",
+      index,
+      fragment.taskPrefix,
+      FragmentTypeName::toName(fragment.type),
+      fragment.width.has_value()
+          ? fmt::format(" numWorkers={}", fragment.width.value())
+          : "");
+}
+} // namespace
+
 std::string MultiFragmentPlan::toString(
     bool detailed,
     const std::function<void(
@@ -384,12 +416,7 @@ std::string MultiFragmentPlan::toString(
   std::stringstream out;
   for (auto i = 0; i < fragments_.size(); ++i) {
     const auto& fragment = fragments_[i];
-    out << fmt::format(
-               "Fragment {}: {} numWorkers={}:",
-               i,
-               fragment.taskPrefix,
-               fragment.width)
-        << std::endl;
+    out << formatFragmentHeader(i, fragment) << std::endl;
 
     out << fragment.fragment.planNode->toString(
                detailed,
@@ -421,12 +448,7 @@ std::string MultiFragmentPlan::toSummaryString(
   std::stringstream out;
   for (auto i = 0; i < fragments_.size(); ++i) {
     const auto& fragment = fragments_[i];
-    out << fmt::format(
-               "Fragment {}: {} numWorkers={}:",
-               i,
-               fragment.taskPrefix,
-               fragment.width)
-        << std::endl;
+    out << formatFragmentHeader(i, fragment) << std::endl;
     out << fragment.fragment.planNode->toSummaryString(options) << std::endl;
     if (!fragment.inputStages.empty()) {
       out << "Inputs: ";

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -114,6 +114,20 @@ class FinishWrite {
   WriteStatsMapping statsMapping_;
 };
 
+/// Describes how a fragment's tasks are scheduled.
+enum class FragmentType {
+  /// Parallelism determined by the data source (number of splits).
+  kSource,
+  /// Exactly `width` tasks.
+  kFixed,
+  /// Exactly 1 task, any worker.
+  kSingle,
+  /// Exactly 1 task, on coordinator.
+  kCoordinator,
+};
+
+AXIOM_DECLARE_ENUM_NAME(FragmentType);
+
 /// Describes a fragment of a distributed plan. This allows a run
 /// time to distribute fragments across workers and to set up
 /// exchanges. A complete plan is a vector of these with the last
@@ -123,14 +137,14 @@ class FinishWrite {
 /// parallel execution. Decisions on number of workers, location
 /// of workers and mode of exchange are up to the runtime.
 struct ExecutableFragment {
-  ExecutableFragment() = default;
-
-  explicit ExecutableFragment(std::string taskPrefix)
-      : taskPrefix{std::move(taskPrefix)} {}
-
   std::string taskPrefix;
 
-  int32_t width{0};
+  /// Scheduling type for this fragment.
+  FragmentType type;
+
+  /// Number of tasks. Required for kFixed. std::nullopt for kSource (runtime
+  /// decides actual count), kSingle, and kCoordinator.
+  std::optional<int32_t> width;
 
   velox::core::PlanFragment fragment;
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -204,9 +204,14 @@ void checkStageWidths(const std::vector<ExecutableFragment>& stages) {
       if (partitionedOutput->isBroadcast()) {
         continue;
       }
+      // Skip width check for kSource consumers (task count determined at
+      // runtime by splits).
+      if (consumer.type == FragmentType::kSource) {
+        continue;
+      }
       VELOX_CHECK_EQ(
           partitionedOutput->numPartitions(),
-          consumer.width,
+          consumer.width.value_or(1),
           "Partition count mismatch between producer and consumer stage");
     }
   }
@@ -725,11 +730,10 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
 }
 
 ExecutableFragment ToVelox::newFragment() {
-  ExecutableFragment fragment;
-  fragment.width = options_.numWorkers;
-  fragment.taskPrefix = fmt::format("stage{}", ++stageCounter_);
-
-  return fragment;
+  return ExecutableFragment{
+      .taskPrefix = fmt::format("stage{}", ++stageCounter_),
+      .type = FragmentType::kSource,
+  };
 }
 
 namespace {
@@ -910,7 +914,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   auto merge = std::make_shared<velox::core::MergeExchangeNode>(
       nextId(), node->outputType(), keys, sortOrder, exchangeSerdeKind_);
 
-  fragment.width = 1;
+  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(merge->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -940,7 +944,7 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
 
   auto limitNode = addFinalLimit(nextId(), op.offset, op.limit, exchange);
 
-  fragment.width = 1;
+  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(exchange->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -988,7 +992,7 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
 
   auto finalLimitNode = addFinalLimit(nextId(), op.offset, op.limit, exchange);
 
-  fragment.width = 1;
+  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(exchange->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -1469,7 +1473,7 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
        op.step == velox::core::AggregationNode::Step::kSingle)) {
     input = addLocalPartition(nextId(), input, keys);
     if (keys.empty()) {
-      fragment.width = 1;
+      fragment.type = FragmentType::kSingle;
     }
   }
 
@@ -1660,7 +1664,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
         nextId(), 1, outputType, exchangeSerdeKind_, sourcePlan);
   } else if (distribution.isGather()) {
     VELOX_CHECK_EQ(0, keys.size());
-    fragment.width = 1;
+    fragment.type = FragmentType::kSingle;
     source.fragment.planNode = velox::core::PartitionedOutputNode::single(
         nextId(), outputType, exchangeSerdeKind_, sourcePlan);
   } else {
@@ -1673,7 +1677,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
             nextId(),
             velox::core::PartitionedOutputNode::Kind::kPartitioned,
             keys,
-            fragment.width,
+            options_.numWorkers,
             distribution.isReplicateNullsAndAny(),
             std::move(partitionFunctionFactory),
             outputType,
@@ -1744,7 +1748,7 @@ velox::core::PlanNodePtr ToVelox::makeUnionAll(
 velox::core::PlanNodePtr ToVelox::makeValues(
     const Values& values,
     ExecutableFragment& fragment) {
-  fragment.width = 1;
+  fragment.type = FragmentType::kSingle;
   const auto& newColumns = values.columns();
   const auto newType = makeOutputType(newColumns);
   VELOX_DCHECK_EQ(newColumns.size(), newType->size());
@@ -1902,13 +1906,17 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   auto inputType = ROW(inputNames, inputTypes);
 
   auto numDrivers = options_.numDrivers;
-  if (fragment.width == 1 && numDrivers > 1 &&
-      isSingleThreadedPipeline(input)) {
+  if ((fragment.type == FragmentType::kSingle ||
+       fragment.type == FragmentType::kCoordinator) &&
+      numDrivers > 1 && isSingleThreadedPipeline(input)) {
     numDrivers = 1;
   }
 
+  auto numTasks = fragment.width.value_or(
+      fragment.type == FragmentType::kSource ? options_.numWorkers : 1);
+
   WriteStatsBuilder statsBuilder(
-      table, inputType, *handle, numDrivers, fragment.width);
+      table, inputType, *handle, numDrivers, numTasks);
 
   std::optional<velox::core::ColumnStatsSpec> writeStatsSpec;
   if (statsBuilder.hasStats()) {

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -172,15 +172,14 @@ std::vector<optimizer::ExecutableFragment> topologicalSort(
     }
   }
 
-  auto size = indices.size();
-  VELOX_CHECK_EQ(size, fragments.size());
-  std::vector<optimizer::ExecutableFragment> result(size);
-  auto i = size - 1;
+  VELOX_CHECK_EQ(indices.size(), fragments.size());
+  std::vector<optimizer::ExecutableFragment> result;
+  result.reserve(indices.size());
   while (!indices.empty()) {
-    result[i--] = fragments[indices.top()];
+    result.push_back(fragments[indices.top()]);
     indices.pop();
   }
-  VELOX_CHECK_EQ(result.size(), fragments.size());
+  std::reverse(result.begin(), result.end());
   return result;
 }
 } // namespace
@@ -283,7 +282,10 @@ void LocalRunner::start() {
   params_.planNode = fragments_.back().fragment.planNode;
   params_.serialExecution = !params_.queryCtx->isExecutorSupplied();
 
-  VELOX_CHECK_LE(fragments_.back().width, 1);
+  VELOX_CHECK_LE(
+      fragments_.back().width.value_or(1),
+      1,
+      "Last fragment must be single-task");
 
   auto cursor = velox::exec::TaskCursor::create(params_);
   makeStages(cursor->task());
@@ -429,7 +431,11 @@ void LocalRunner::makeStages(
         stages_.size(), isBroadcast(fragment.fragment)};
     stages_.emplace_back();
 
-    for (auto i = 0; i < fragment.width; ++i) {
+    auto numTasks = fragment.width.value_or(
+        fragment.type == optimizer::FragmentType::kSource
+            ? plan_->options().numWorkers
+            : 1);
+    for (auto i = 0; i < numTasks; ++i) {
       auto taskId = fmt::format(
           "local://{}/{}.{}",
           params_.queryCtx->queryId(),
@@ -481,7 +487,7 @@ void LocalRunner::makeStages(
           sourceSplits.push_back(remoteSplit(task->taskId()));
 
           if (broadcast) {
-            task->updateOutputBuffers(fragment.width, true);
+            task->updateOutputBuffers(static_cast<int>(stage.size()), true);
           }
         }
 

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -50,15 +50,34 @@ optimizer::MultiFragmentPlanPtr DistributedPlanBuilder::build() {
   return std::make_shared<optimizer::MultiFragmentPlan>(fragments(), options_);
 }
 
-void DistributedPlanBuilder::newFragment(int32_t width) {
+void DistributedPlanBuilder::newFragment(std::optional<int32_t> width) {
   if (current_) {
     current_->fragment = velox::core::PlanFragment(std::move(planNode_));
     fragments_.push_back(std::move(*current_));
   }
 
-  current_ = std::make_unique<optimizer::ExecutableFragment>(
-      fmt::format("{}.{}", options_.queryId, root_->fragmentCounter_++));
-  current_->width = width;
+  auto taskPrefix =
+      fmt::format("{}.{}", options_.queryId, root_->fragmentCounter_++);
+  if (width.has_value() && width.value() > 1) {
+    current_ = std::make_unique<optimizer::ExecutableFragment>(
+        optimizer::ExecutableFragment{
+            .taskPrefix = std::move(taskPrefix),
+            .type = optimizer::FragmentType::kFixed,
+            .width = width,
+        });
+  } else if (width.has_value()) {
+    current_ = std::make_unique<optimizer::ExecutableFragment>(
+        optimizer::ExecutableFragment{
+            .taskPrefix = std::move(taskPrefix),
+            .type = optimizer::FragmentType::kSingle,
+        });
+  } else {
+    current_ = std::make_unique<optimizer::ExecutableFragment>(
+        optimizer::ExecutableFragment{
+            .taskPrefix = std::move(taskPrefix),
+            .type = optimizer::FragmentType::kSource,
+        });
+  }
 
   planNode_ = nullptr;
 }
@@ -128,13 +147,18 @@ velox::core::PlanNodePtr DistributedPlanBuilder::shufflePartitionedResult(
   root_->stack_.pop_back(); // Remove self.
 
   auto* consumer = root_->stack_.back();
-  if (consumer->current_->width != 0) {
+  if (consumer->current_->width.has_value()) {
     VELOX_CHECK_EQ(
         numPartitions,
-        consumer->current_->width,
+        consumer->current_->width.value(),
         "The consumer width should match the producer fanout");
   } else {
-    consumer->current_->width = numPartitions;
+    consumer->current_->type = numPartitions > 1
+        ? optimizer::FragmentType::kFixed
+        : optimizer::FragmentType::kSingle;
+    consumer->current_->width = numPartitions > 1
+        ? std::optional<int32_t>{numPartitions}
+        : std::nullopt;
   }
 
   root_->appendFragments(std::move(fragments_));
@@ -155,7 +179,10 @@ velox::core::PlanNodePtr DistributedPlanBuilder::shuffleBroadcastResult() {
   root_->stack_.pop_back(); // Remove self.
   auto* consumer = root_->stack_.back();
 
-  VELOX_CHECK_GE(consumer->current_->width, 1);
+  VELOX_CHECK(
+      consumer->current_->width.has_value() ||
+      consumer->current_->type == optimizer::FragmentType::kSingle ||
+      consumer->current_->type == optimizer::FragmentType::kCoordinator);
 
   root_->appendFragments(std::move(fragments_));
 

--- a/axiom/runner/tests/DistributedPlanBuilder.h
+++ b/axiom/runner/tests/DistributedPlanBuilder.h
@@ -59,7 +59,7 @@ class DistributedPlanBuilder : public velox::exec::test::PlanBuilder {
   optimizer::MultiFragmentPlanPtr build();
 
  private:
-  void newFragment(int32_t width = 0);
+  void newFragment(std::optional<int32_t> width = std::nullopt);
 
   void appendFragments(std::vector<optimizer::ExecutableFragment> fragments);
 

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -164,12 +164,6 @@ std::vector<optimizer::ExecutableFragment> createExecutableFragments(
     const folly::F14FastMap<std::string, PlanFragmentInfo>& planFragments) {
   std::vector<optimizer::ExecutableFragment> executableFragments;
   for (const auto& [taskPrefix, planFragmentInfo] : planFragments) {
-    optimizer::ExecutableFragment executableFragment{taskPrefix};
-    executableFragment.width =
-        (planFragmentInfo.numWorkers > 0) ? planFragmentInfo.numWorkers : 1;
-    executableFragment.fragment =
-        velox::core::PlanFragment{planFragmentInfo.plan};
-
     std::vector<optimizer::InputStage> inputStages;
     const auto& remoteTaskIdMap = planFragmentInfo.remoteTaskIdMap;
     for (const auto& [planNodeId, remoteTaskPrefixes] : remoteTaskIdMap) {
@@ -178,8 +172,24 @@ std::vector<optimizer::ExecutableFragment> createExecutableFragments(
             optimizer::InputStage{planNodeId, remoteTaskPrefix});
       }
     }
-    executableFragment.inputStages = std::move(inputStages);
-    executableFragments.push_back(std::move(executableFragment));
+    if (planFragmentInfo.numWorkers > 1) {
+      executableFragments.push_back(
+          optimizer::ExecutableFragment{
+              .taskPrefix = taskPrefix,
+              .type = optimizer::FragmentType::kFixed,
+              .width = planFragmentInfo.numWorkers,
+              .fragment = velox::core::PlanFragment{planFragmentInfo.plan},
+              .inputStages = std::move(inputStages),
+          });
+    } else {
+      executableFragments.push_back(
+          optimizer::ExecutableFragment{
+              .taskPrefix = taskPrefix,
+              .type = optimizer::FragmentType::kSingle,
+              .fragment = velox::core::PlanFragment{planFragmentInfo.plan},
+              .inputStages = std::move(inputStages),
+          });
+    }
   }
   return executableFragments;
 }


### PR DESCRIPTION
Summary:

Introduce FragmentType enum (kSource, kFixed, kSingle, kCoordinator) to ExecutableFragment, making fragment scheduling intent explicit. Convert width from int32_t to std::optional<int32_t>.

Previously, ExecutableFragment only had width (an integer) to represent all scheduling information. The runtime had to infer scheduling mode from plan shape — whether a fragment has scans, receives hash-partitioned exchange input, or gathers results. This inference is fragile.

FragmentType makes the optimizer's intent explicit:
- kSource: task count determined by splits at runtime
- kFixed: exactly width tasks (hash-partitioned exchange consumer)
- kSingle: exactly 1 task, any worker (gather, Values, global aggregation)
- kCoordinator: exactly 1 task, on coordinator (SystemConnector)

This is a mechanical refactor with no behavior change. FragmentType is populated based on current logic.

Reviewed By: arhimondr, pradeepvaka

Differential Revision: D102630155


