### PR TITLE
fix(build): Nullable cannot be applied to non-pointer type

### DIFF
--- a/axiom/connectors/ConnectorMetadataRegistry.cpp
+++ b/axiom/connectors/ConnectorMetadataRegistry.cpp
@@ -52,22 +52,20 @@ ConnectorMetadataRegistry::create(const Registry* parent) {
 }
 
 // static
-std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-ConnectorMetadataRegistry::tryGet(
+std::shared_ptr<ConnectorMetadata> ConnectorMetadataRegistry::tryGet(
     const QueryCtx& queryCtx,
     const std::string& connectorId) {
   return registryFor(queryCtx).find(std::string(connectorId));
 }
 
 // static
-std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-ConnectorMetadataRegistry::tryGet(const std::string& connectorId) {
+std::shared_ptr<ConnectorMetadata> ConnectorMetadataRegistry::tryGet(
+    const std::string& connectorId) {
   return global().find(std::string(connectorId));
 }
 
 // static
-std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-ConnectorMetadataRegistry::get(
+std::shared_ptr<ConnectorMetadata> ConnectorMetadataRegistry::get(
     const QueryCtx& queryCtx,
     const std::string& connectorId) {
   auto metadata = tryGet(queryCtx, connectorId);
@@ -77,8 +75,8 @@ ConnectorMetadataRegistry::get(
 }
 
 // static
-std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-ConnectorMetadataRegistry::get(const std::string& connectorId) {
+std::shared_ptr<ConnectorMetadata> ConnectorMetadataRegistry::get(
+    const std::string& connectorId) {
   auto metadata = tryGet(connectorId);
   VELOX_CHECK_NOT_NULL(
       metadata, "ConnectorMetadata not registered: {}", connectorId);

--- a/axiom/connectors/ConnectorMetadataRegistry.h
+++ b/axiom/connectors/ConnectorMetadataRegistry.h
@@ -58,26 +58,27 @@ class ConnectorMetadataRegistry {
   /// Return the metadata connector with the specified ID, or nullptr if
   /// not registered.  Checks per-query override on QueryCtx first, falls back
   /// to the global registry if no override is set.
-  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-  tryGet(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+  static std::shared_ptr<ConnectorMetadata> tryGet(
+      const velox::core::QueryCtx& queryCtx,
+      const std::string& connectorId);
 
   /// Return the metadata connector with the specified ID from the global
   /// registry, or nullptr if not registered.
-  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-  tryGet(const std::string& connectorId);
+  static std::shared_ptr<ConnectorMetadata> tryGet(
+      const std::string& connectorId);
 
   /// Return the metadata connector with the specified ID, or an exception if
   /// not registered.  Checks per-query override on QueryCtx first, falls back
   /// to the global registry if no override is set.
   /// @throws VeloxError if the shared_ptr is null.
-  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-  get(const velox::core::QueryCtx& queryCtx, const std::string& connectorId);
+  static std::shared_ptr<ConnectorMetadata> get(
+      const velox::core::QueryCtx& queryCtx,
+      const std::string& connectorId);
 
   /// Return the metadata connector with the specified ID from the global
   /// registry, or an exception if not registered.
   /// @throws VeloxError if the shared_ptr is null.
-  static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
-  get(const std::string& connectorId);
+  static std::shared_ptr<ConnectorMetadata> get(const std::string& connectorId);
 
   /// Return all metadata connectors whose implementation is of type T. Checks
   /// per-query override on QueryCtx first, falls back to the global registry if


### PR DESCRIPTION
On macos, with clang 16.
```
axiom/connectors/ConnectorMetadataRegistry.h:61:45: error: nullability specifier '_Nullable' cannot be applied to non-pointer type 'std::shared_ptr<ConnectorMetadata>'
   61 |   static std::shared_ptr<ConnectorMetadata> FOLLY_NULLABLE
      |                                             ^
```


Velox System Info v0.0.2
Commit: 92d7304f0ebc51430f93d4d40f810decf9094ed3
CMake Version: 4.3.0
System: Darwin-24.6.0
Arch: arm64
C++ Compiler: /usr/bin/c++
C++ Compiler Version: 16.0.0.16000026
16.0.0.16000026
C Compiler: /usr/bin/cc
C Compiler Version: 16.0.0.16000026
16.0.0.16000026
CMake Prefix Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr;/opt/homebrew;/usr/local;/usr;/;/opt/homebrew;/usr/local;/usr/X11R6;/usr/pkg;/opt;/sw;/opt/local
