### PR TITLE
feat(optimizer): Skip shuffles for co-bucketed scans (#1302)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -239,6 +239,14 @@ class PartitionType {
   virtual const PartitionType* FOLLY_NULLABLE
   copartition(const PartitionType& other) const = 0;
 
+  /// Returns a PartitionType compatible with this one but with at most
+  /// 'maxPartitions' partitions. The returned partitioning groups together
+  /// rows that this PartitionType would have placed in different partitions,
+  /// so the resulting partition assignment is a coarsening of this one. The
+  /// returned value is always a freshly allocated owned shared_ptr.
+  virtual std::shared_ptr<PartitionType> scaleDown(
+      int32_t maxPartitions) const = 0;
+
   /// Returns a factory that makes partition functions. The function takes a
   /// RowVector and calculates a partition number from the columns identified by
   /// 'channels'. If channels[i] == kConstantChannel then the corresponding
@@ -248,6 +256,9 @@ class PartitionType {
       const std::vector<velox::column_index_t>& channels,
       const std::vector<velox::VectorPtr>& constants,
       bool isLocal) const = 0;
+
+  /// Number of partitions.
+  virtual int32_t numPartitions() const = 0;
 
   virtual std::string toString() const = 0;
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include "axiom/common/Enums.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/common/SchemaTypeName.h"
@@ -50,6 +51,8 @@ using PartitionFunctionSpecPtr =
 /// the above connect to different metadata stores and provide different
 /// metadata, e.g. order, partitioning, bucketing etc.
 namespace facebook::axiom::connector {
+
+class TableLayout;
 
 /// Represents statistics of a column. The statistics may represent the column
 /// across the table or may be calculated over a sample of a layout of the
@@ -228,16 +231,13 @@ class PartitionType {
  public:
   virtual ~PartitionType() = default;
 
-  /// Returns 'this' or '&other' if the partitions are compatible. Partitions
-  /// are compatible if data in one partitioned dataset can only match data in
-  /// the same partition of another dataset if joined on equality of partition
-  /// keys. Compatibility is not strict equality in the case of e.g. Hive where
-  /// a dataset partitioned 8 ways is compatible with one partitioned 16 ways if
-  /// the function is the same. In such a case the partition to use is the 8 way
-  /// one. On the 16 side data from partitions 0 and 1 match 0 on the 8 side and
-  /// 2, 3 match 1 and so on.
-  virtual const PartitionType* FOLLY_NULLABLE
-  copartition(const PartitionType& other) const = 0;
+  /// Returns a PartitionType compatible with both 'this' and 'other', or
+  /// nullptr if they are not compatible. Compatibility is not strict equality:
+  /// for Hive, a table with 8 buckets is compatible with one bucketed 16 ways
+  /// (same hash function); the result has 8 partitions. The returned value
+  /// is always a freshly allocated owned shared_ptr.
+  virtual std::shared_ptr<PartitionType> copartition(
+      const PartitionType& other) const = 0;
 
   /// Returns a PartitionType compatible with this one but with at most
   /// 'maxPartitions' partitions. The returned partitioning groups together
@@ -435,10 +435,10 @@ class TableLayout {
     return partitionColumns_;
   }
 
-  /// Describes how the value in partitionColumns() determines a partition. The
-  /// returned value is owned by 'this'. nullptr if 'partitionColumns_' is
-  /// empty.
-  virtual const PartitionType* partitionType() const {
+  /// Describes how the value in partitionColumns() determines a partition.
+  /// The returned shared_ptr is owned by 'this'; callers may copy it to
+  /// extend lifetime as needed. nullptr if 'partitionColumns_' is empty.
+  virtual std::shared_ptr<const PartitionType> partitionType() const {
     VELOX_CHECK(partitionColumns_.empty());
     return nullptr;
   }

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -17,14 +17,29 @@
 
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
+#include <optional>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
 
+class PartitionType;
+
+/// Wraps a Velox ConnectorSplit with an optional group ID for bucketed
+/// execution routing. Splits with the same groupId are routed to the same
+/// task. When unset, the runtime is free to assign the split to any task.
+struct Split {
+  /// The underlying Velox connector split.
+  std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
+
+  /// Group ID for bucketed routing; splits sharing a groupId are routed to
+  /// the same task. Absent means any task may handle this split.
+  std::optional<int32_t> groupId{std::nullopt};
+};
+
 /// A batch of splits returned by SplitSource::co_getSplits.
 struct SplitBatch {
-  std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
+  std::vector<Split> splits;
 
   /// True when there are no more splits to return.
   bool noMoreSplits{false};
@@ -90,17 +105,22 @@ class ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) = 0;
 
-  /// Returns a SplitSource that covers the contents of 'partitions'. The set of
-  /// partitions is exposed separately so that the caller may process the
-  /// partitions in a specific order or distribute them to specific nodes in a
-  /// cluster. Connector implementations may use 'runtimeStats' to record
-  /// split enumeration metrics (e.g., file listing, Metastore RPCs).
+  /// Returns a SplitSource that covers the contents of 'partitions'. The set
+  /// of partitions is exposed separately so that the caller may process them
+  /// in a specific order or distribute them to specific nodes in a cluster.
+  /// Connector implementations may use 'runtimeStats' to record split
+  /// enumeration metrics (e.g., file listing, Metastore RPCs).
+  ///
+  /// When 'partitionType' is non-null, the connector tags each emitted Split
+  /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
+  /// for the non-bucketed case.
   // TODO: Instrument PrismSplitManager with runtimeStats for split enumeration
   // timing.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) = 0;
 };
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -16,10 +16,10 @@
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
-#include <folly/CppAttributes.h>
 #include <algorithm>
 #include <utility>
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/exec/TableWriter.h"
@@ -27,27 +27,28 @@
 
 namespace facebook::axiom::connector::hive {
 
-const PartitionType* FOLLY_NULLABLE
-HivePartitionType::copartition(const PartitionType& other) const {
-  if (const auto* otherPartitionType = other.as<HivePartitionType>()) {
-    const auto& thisTypes = partitionKeyTypes_;
-    const auto& otherTypes = otherPartitionType->partitionKeyTypes_;
-
-    if (thisTypes.size() == otherTypes.size()) {
-      for (size_t i = 0; i < thisTypes.size(); ++i) {
-        if (!thisTypes[i]->equivalent(*otherTypes[i])) {
-          return nullptr;
-        }
-      }
-
-      if (otherPartitionType->numPartitions_ % numPartitions_ == 0) {
-        return this;
-      }
-
-      if (numPartitions_ % otherPartitionType->numPartitions_ == 0) {
-        return otherPartitionType;
-      }
+std::shared_ptr<PartitionType> HivePartitionType::copartition(
+    const PartitionType& other) const {
+  const auto* otherPartitionType = other.as<HivePartitionType>();
+  if (otherPartitionType == nullptr) {
+    return nullptr;
+  }
+  const auto& thisTypes = partitionKeyTypes_;
+  const auto& otherTypes = otherPartitionType->partitionKeyTypes_;
+  if (thisTypes.size() != otherTypes.size()) {
+    return nullptr;
+  }
+  for (size_t i = 0; i < thisTypes.size(); ++i) {
+    if (!thisTypes[i]->equivalent(*otherTypes[i])) {
+      return nullptr;
     }
+  }
+  const int32_t otherNumPartitions = otherPartitionType->numPartitions_;
+  if (otherNumPartitions % numPartitions_ == 0) {
+    return std::make_shared<HivePartitionType>(numPartitions_, thisTypes);
+  }
+  if (numPartitions_ % otherNumPartitions == 0) {
+    return std::make_shared<HivePartitionType>(otherNumPartitions, otherTypes);
   }
   return nullptr;
 }
@@ -171,10 +172,10 @@ HiveTableLayout::HiveTableLayout(
       numBuckets_(numPartitions),
       partitionType_{
           numPartitions.has_value()
-              ? std::make_optional<HivePartitionType>(
+              ? std::make_shared<const HivePartitionType>(
                     numPartitions.value(),
                     extractPartitionKeyTypes(partitionedByColumns))
-              : std::nullopt} {
+              : nullptr} {
   VELOX_CHECK_EQ(sortedByColumns.size(), sortOrder.size());
 }
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -52,6 +52,17 @@ HivePartitionType::copartition(const PartitionType& other) const {
   return nullptr;
 }
 
+std::shared_ptr<PartitionType> HivePartitionType::scaleDown(
+    int32_t maxPartitions) const {
+  VELOX_CHECK_GT(maxPartitions, 0);
+  int32_t numResultPartitions = std::min(numPartitions_, maxPartitions);
+  while (numResultPartitions > 1 && numPartitions_ % numResultPartitions != 0) {
+    --numResultPartitions;
+  }
+  return std::make_shared<HivePartitionType>(
+      numResultPartitions, partitionKeyTypes_);
+}
+
 velox::core::PartitionFunctionSpecPtr HivePartitionType::makeSpec(
     const std::vector<velox::column_index_t>& channels,
     const std::vector<velox::VectorPtr>& constants,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -48,7 +48,9 @@ class HivePartitionType : public connector::PartitionType {
       int32_t numPartitions,
       std::vector<velox::TypePtr> partitionKeyTypes)
       : numPartitions_(numPartitions),
-        partitionKeyTypes_(std::move(partitionKeyTypes)) {}
+        partitionKeyTypes_(std::move(partitionKeyTypes)) {
+    VELOX_CHECK_GT(numPartitions_, 0);
+  }
 
   /// Types are compatible if numPartitions of one is an interger multiple of
   /// the other. The partition to use for copartitioning is the one with the
@@ -56,10 +58,19 @@ class HivePartitionType : public connector::PartitionType {
   const PartitionType* FOLLY_NULLABLE
   copartition(const PartitionType& any) const override;
 
+  /// Returns the largest divisor of numPartitions() that is <=
+  /// maxPartitions.
+  std::shared_ptr<PartitionType> scaleDown(
+      int32_t maxPartitions) const override;
+
   velox::core::PartitionFunctionSpecPtr makeSpec(
       const std::vector<velox::column_index_t>& channels,
       const std::vector<velox::VectorPtr>& constants,
       bool isLocal) const override;
+
+  int32_t numPartitions() const override {
+    return numPartitions_;
+  }
 
   std::string toString() const override;
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -52,11 +52,8 @@ class HivePartitionType : public connector::PartitionType {
     VELOX_CHECK_GT(numPartitions_, 0);
   }
 
-  /// Types are compatible if numPartitions of one is an interger multiple of
-  /// the other. The partition to use for copartitioning is the one with the
-  /// fewer partitions. If numPartitions is the same, returns 'this'.
-  const PartitionType* FOLLY_NULLABLE
-  copartition(const PartitionType& any) const override;
+  std::shared_ptr<PartitionType> copartition(
+      const PartitionType& any) const override;
 
   /// Returns the largest divisor of numPartitions() that is <=
   /// maxPartitions.
@@ -135,8 +132,8 @@ class HiveTableLayout : public TableLayout {
     return numBuckets_;
   }
 
-  const PartitionType* partitionType() const override {
-    return partitionType_.has_value() ? &partitionType_.value() : nullptr;
+  std::shared_ptr<const PartitionType> partitionType() const override {
+    return partitionType_;
   }
 
   /// Returns SerDe parameters for this layout. Default implementation returns
@@ -167,7 +164,7 @@ class HiveTableLayout : public TableLayout {
   const velox::dwio::common::FileFormat fileFormat_;
   const std::vector<const Column*> hivePartitionColumns_;
   const std::optional<int32_t> numBuckets_;
-  const std::optional<HivePartitionType> partitionType_;
+  const std::shared_ptr<const HivePartitionType> partitionType_;
 };
 
 class HiveConnectorWriteHandle : public ConnectorWriteHandle {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -320,6 +320,7 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& partitionType,
     QueryRuntimeStats& /*runtimeStats*/) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
@@ -344,7 +345,8 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
       std::move(selectedFiles),
       layout->fileFormat(),
       layout->connector()->connectorId(),
-      layout->serdeParameters());
+      layout->serdeParameters(),
+      partitionType);
 }
 
 namespace {
@@ -381,7 +383,14 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
       if (!serdeParameters_.empty()) {
         builder.serdeParameters(serdeParameters_);
       }
-      batch.splits.push_back(builder.build());
+      std::optional<int32_t> groupId;
+      if (partitionType_ != nullptr) {
+        VELOX_CHECK(
+            info->bucketNumber.has_value(),
+            "Bucketed scan requires bucketNumber on every file");
+        groupId = info->bucketNumber.value() % partitionType_->numPartitions();
+      }
+      batch.splits.push_back(Split{builder.build(), groupId});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -37,11 +37,13 @@ class LocalHiveSplitSource : public SplitSource {
       std::vector<const FileInfo*> files,
       velox::dwio::common::FileFormat format,
       const std::string& connectorId,
-      std::unordered_map<std::string, std::string> serdeParameters = {})
+      std::unordered_map<std::string, std::string> serdeParameters,
+      std::shared_ptr<PartitionType> partitionType)
       : format_(format),
         connectorId_(connectorId),
         files_(std::move(files)),
-        serdeParameters_(std::move(serdeParameters)) {}
+        serdeParameters_(std::move(serdeParameters)),
+        partitionType_(std::move(partitionType)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
@@ -53,6 +55,9 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
+  // When non-null, used to assign a groupId to each split for bucketed
+  // execution.
+  const std::shared_ptr<PartitionType> partitionType_;
   size_t fileIdx_{0};
   int64_t splitWithinFile_{0};
 };
@@ -71,6 +76,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
+++ b/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::connector::hive {
+namespace {
+
+using namespace facebook::velox;
+
+HivePartitionType makePartitionType(int32_t numPartitions) {
+  return HivePartitionType{numPartitions, {BIGINT()}};
+}
+
+TEST(HivePartitionTypeTest, scaleDownIdentityWhenWithinLimit) {
+  const auto partitionType = makePartitionType(8);
+
+  auto scaled = partitionType.scaleDown(8);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 8);
+
+  scaled = partitionType.scaleDown(16);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 8);
+}
+
+TEST(HivePartitionTypeTest, scaleDownPicksLargestDivisor) {
+  const auto partitionType = makePartitionType(256);
+
+  auto scaled = partitionType.scaleDown(100);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 64);
+
+  scaled = partitionType.scaleDown(64);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 64);
+
+  scaled = partitionType.scaleDown(63);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 32);
+}
+
+TEST(HivePartitionTypeTest, scaleDownToOne) {
+  const auto partitionType = makePartitionType(16);
+
+  const auto scaled = partitionType.scaleDown(1);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 1);
+}
+
+TEST(HivePartitionTypeTest, scaleDownPrimePartitionCount) {
+  const auto partitionType = makePartitionType(7);
+
+  auto scaled = partitionType.scaleDown(6);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 1);
+
+  scaled = partitionType.scaleDown(7);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 7);
+
+  scaled = partitionType.scaleDown(100);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 7);
+}
+
+TEST(HivePartitionTypeTest, scaleDownRejectsNonPositiveMax) {
+  const auto partitionType = makePartitionType(8);
+
+  VELOX_ASSERT_THROW(partitionType.scaleDown(0), "");
+  VELOX_ASSERT_THROW(partitionType.scaleDown(-1), "");
+}
+
+TEST(HivePartitionTypeTest, ctorRejectsNonPositiveNumPartitions) {
+  VELOX_ASSERT_THROW(HivePartitionType(0, std::vector<TypePtr>{BIGINT()}), "");
+  VELOX_ASSERT_THROW(HivePartitionType(-1, std::vector<TypePtr>{BIGINT()}), "");
+}
+
+TEST(HivePartitionTypeTest, scaleDownPreservesKeyTypes) {
+  HivePartitionType partitionType{
+      12, std::vector<TypePtr>{BIGINT(), VARCHAR()}};
+
+  const auto scaled = partitionType.scaleDown(4);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 4);
+
+  EXPECT_NE(partitionType.copartition(*scaled), nullptr);
+  EXPECT_NE(scaled->copartition(partitionType), nullptr);
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -128,7 +128,7 @@ folly::coro::Task<SplitBatch> SystemSplitSource::co_getSplits(
     uint32_t /*maxSplitCount*/) {
   SplitBatch batch;
   if (!done_) {
-    batch.splits.push_back(std::make_shared<SystemSplit>(connectorId_));
+    batch.splits.push_back(Split{std::make_shared<SystemSplit>(connectorId_)});
     done_ = true;
   }
   batch.noMoreSplits = true;
@@ -147,6 +147,7 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -117,6 +117,7 @@ class SystemSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -332,15 +332,15 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
   EXPECT_EQ(partitions.size(), 1);
 
   QueryRuntimeStats noopStats;
-  auto splitSource =
-      splitManager->getSplitSource(session, tableHandle, partitions, noopStats);
+  auto splitSource = splitManager->getSplitSource(
+      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = folly::coro::blockingWait(splitSource->co_getSplits(1000));
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(axiom_test_connector TestConnector.cpp)
 target_link_libraries(
   axiom_test_connector
   axiom_connectors
+  axiom_hive_connector_metadata
   velox_common_base
   velox_memory
   velox_connector

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -39,6 +39,15 @@ The Test connector is designed for three use cases:
   explicitly without adding actual data, enabling optimizer testing with
   controlled cost estimates (see [Setting Statistics Without Data](#setting-statistics-without-data)).
 
+**Supported:**
+- Hash bucketing. Tables can be created bucketed via the C++ API
+  (`addTable(..., TestBucketSpec{...})`). Rows are routed to buckets via a
+  generic hash partition function on append, and splits are emitted per
+  bucket. When the split manager is asked for splits with a non-null
+  `PartitionType`, each emitted Split is tagged with a `groupId` derived
+  from its bucket, enabling end-to-end exercise of the bucketed-execution
+  scheduling contract.
+
 **Not supported:**
 - Filter pushdown.
 - Hive-style directory partitioning.
@@ -131,6 +140,26 @@ When all columns share the same type, use `ROW(names, type)` instead of
 `ROW(names, {type, type, ...})`.
 
 `setStats()` and `addData()` cannot be combined on the same table.
+
+### Bucketed Tables
+
+Pass a `TestBucketSpec` to `addTable` to mark a table as hash-bucketed. Rows
+appended via `addData` are routed to buckets via a generic hash partition
+function (the test connector defines its own `TestPartitionType` and does
+not depend on the Hive connector). The split manager emits one split per
+non-empty bucket. The optimizer treats the table as bucket-partitioned for
+planning purposes.
+
+```cpp
+auto table = connector->addTable(
+    "orders",
+    ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+    velox::ROW({}),                          // no hidden columns
+    TestBucketSpec{{"customer_id"}, 16});    // 16 buckets on customer_id
+```
+
+`TestBucketSpec::bucketColumns` lists the column names that compose the bucket
+key (must reference visible columns); `numBuckets` is the fixed bucket count.
 
 ### Hidden Columns
 

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -41,7 +41,8 @@ The Test connector is designed for three use cases:
 
 **Not supported:**
 - Filter pushdown.
-- Partitioning and bucketing.
+- Hive-style directory partitioning.
+- Sort-within-bucket.
 - Persistence. All data is lost when the process exits.
 
 ## Usage

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -20,11 +20,60 @@
 #include <utility>
 
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::axiom::connector {
+
+std::shared_ptr<PartitionType> TestPartitionType::copartition(
+    const PartitionType& other) const {
+  const auto* otherTest = other.as<TestPartitionType>();
+  if (otherTest == nullptr) {
+    return nullptr;
+  }
+  if (partitionKeyTypes_.size() != otherTest->partitionKeyTypes_.size()) {
+    return nullptr;
+  }
+  for (size_t i = 0; i < partitionKeyTypes_.size(); ++i) {
+    if (!partitionKeyTypes_[i]->equivalent(*otherTest->partitionKeyTypes_[i])) {
+      return nullptr;
+    }
+  }
+  const auto fewerPartitions =
+      std::min(numPartitions_, otherTest->numPartitions_);
+  const auto morePartitions =
+      std::max(numPartitions_, otherTest->numPartitions_);
+  if (morePartitions % fewerPartitions != 0) {
+    return nullptr;
+  }
+  return std::make_shared<TestPartitionType>(
+      fewerPartitions, partitionKeyTypes_, inputType_);
+}
+
+std::shared_ptr<PartitionType> TestPartitionType::scaleDown(
+    int32_t maxPartitions) const {
+  VELOX_CHECK_GT(maxPartitions, 0);
+  int32_t scaledPartitions = std::min(numPartitions_, maxPartitions);
+  while (scaledPartitions > 1 && numPartitions_ % scaledPartitions != 0) {
+    --scaledPartitions;
+  }
+  return std::make_shared<TestPartitionType>(
+      scaledPartitions, partitionKeyTypes_, inputType_);
+}
+
+velox::core::PartitionFunctionSpecPtr TestPartitionType::makeSpec(
+    const std::vector<velox::column_index_t>& channels,
+    const std::vector<velox::VectorPtr>& constants,
+    bool /*isLocal*/) const {
+  return std::make_shared<velox::exec::HashPartitionFunctionSpec>(
+      inputType_, channels, constants);
+}
+
+std::string TestPartitionType::toString() const {
+  return fmt::format("{} test buckets", numPartitions_);
+}
 
 namespace {
 
@@ -89,15 +138,45 @@ TestTable::TestTable(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
-    const folly::F14FastMap<std::string, velox::Variant>& options)
+    const folly::F14FastMap<std::string, velox::Variant>& options,
+    std::optional<TestBucketSpec> bucketSpec)
     : Table(
           std::move(name),
           makeTestTableColumns(schema, hiddenColumns, options),
           options),
-      connector_(connector) {
+      connector_(connector),
+      bucketSpec_(std::move(bucketSpec)) {
   const auto& label = this->name().table;
-  exportedLayout_ =
-      std::make_unique<TestTableLayout>(label, this, connector_, allColumns());
+  if (bucketSpec_.has_value()) {
+    std::vector<const Column*> partitionColumns;
+    std::vector<velox::TypePtr> partitionKeyTypes;
+    std::vector<velox::column_index_t> bucketChannels;
+    for (const auto& columnName : bucketSpec_->bucketColumns) {
+      auto* column = findColumn(columnName);
+      VELOX_CHECK_NOT_NULL(
+          column, "Bucket column does not exist: {}", columnName);
+      partitionColumns.push_back(column);
+      partitionKeyTypes.push_back(column->type());
+      bucketChannels.push_back(schema->getChildIdx(columnName));
+    }
+
+    auto partitionType = std::make_shared<const TestPartitionType>(
+        bucketSpec_->numBuckets, std::move(partitionKeyTypes), schema);
+    partitionFunction_ =
+        partitionType->makeSpec(bucketChannels, /*constants=*/{}, false)
+            ->create(bucketSpec_->numBuckets, /*localExchange=*/false);
+
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label,
+        this,
+        connector_,
+        allColumns(),
+        std::move(partitionColumns),
+        std::move(partitionType));
+  } else {
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label, this, connector_, allColumns());
+  }
   layouts_.push_back(exportedLayout_.get());
   // Use the connector's parent pool if one was supplied (suite-scoped
   // fixtures with a standalone MemoryManager); otherwise fall back to the
@@ -148,6 +227,62 @@ void TestTable::setStats(
   }
 }
 
+namespace {
+
+struct BucketedRows {
+  velox::RowVectorPtr rows;
+  int32_t bucketId;
+};
+
+std::vector<BucketedRows> splitByBucket(
+    const velox::RowVectorPtr& input,
+    velox::core::PartitionFunction& partitionFunction,
+    int32_t numBuckets,
+    velox::memory::MemoryPool* pool) {
+  std::vector<uint32_t> bucketIds;
+  if (auto single = partitionFunction.partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  VELOX_CHECK_EQ(bucketIds.size(), static_cast<size_t>(input->size()));
+
+  std::vector<std::vector<velox::vector_size_t>> indicesPerBucket(numBuckets);
+  for (velox::vector_size_t row = 0; row < input->size(); ++row) {
+    indicesPerBucket[bucketIds[row]].push_back(row);
+  }
+
+  std::vector<BucketedRows> result;
+  result.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    const auto& rows = indicesPerBucket[bucket];
+    if (rows.empty()) {
+      continue;
+    }
+    const auto rowCount = static_cast<velox::vector_size_t>(rows.size());
+    auto indices = velox::allocateIndices(rowCount, pool);
+    auto* indicesData = indices->asMutable<velox::vector_size_t>();
+    std::copy(rows.begin(), rows.end(), indicesData);
+    std::vector<velox::VectorPtr> wrappedChildren;
+    wrappedChildren.reserve(input->childrenSize());
+    for (auto& child : input->children()) {
+      wrappedChildren.push_back(
+          velox::BaseVector::wrapInDictionary(
+              /*nulls=*/nullptr, indices, rowCount, child));
+    }
+    result.push_back(
+        {std::make_shared<velox::RowVector>(
+             pool,
+             input->type(),
+             /*nulls=*/nullptr,
+             rowCount,
+             std::move(wrappedChildren)),
+         bucket});
+  }
+  return result;
+}
+
+} // namespace
+
 void TestTable::addData(
     const velox::RowVectorPtr& data,
     bool collectColumnStatistics) {
@@ -164,7 +299,15 @@ void TestTable::addData(
   VELOX_CHECK_GT(data->size(), 0, "Cannot append empty RowVector");
   auto copy = std::dynamic_pointer_cast<velox::RowVector>(
       velox::BaseVector::copy(*data, pool_.get()));
-  data_.push_back(copy);
+  if (partitionFunction_ != nullptr) {
+    for (auto& bucketed : splitByBucket(
+             copy, *partitionFunction_, bucketSpec_->numBuckets, pool_.get())) {
+      data_.push_back(std::move(bucketed.rows));
+      dataBucketIds_.push_back(bucketed.bucketId);
+    }
+  } else {
+    data_.push_back(copy);
+  }
   dataRows_ += data->size();
 
   if (!collectColumnStatistics) {
@@ -257,7 +400,12 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
   for (auto i = nextOffset_; i < end; ++i) {
     auto split =
         std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
-    batch.splits.push_back(Split{std::move(split)});
+    std::optional<int32_t> groupId;
+    if (partitionType_ != nullptr) {
+      VELOX_CHECK_LT(i, dataBucketIds_.size());
+      groupId = dataBucketIds_[i] % partitionType_->numPartitions();
+    }
+    batch.splits.push_back(Split{std::move(split), groupId});
   }
   nextOffset_ = end;
   batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
@@ -282,27 +430,60 @@ const TestTable& findTestTableForHandle(
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
-    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
-  co_return std::vector<PartitionHandlePtr>{
-      std::make_shared<PartitionHandle>()};
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  const auto& testTable = findTestTableForHandle(tableHandle);
+  if (!testTable.bucketSpec().has_value()) {
+    co_return std::vector<PartitionHandlePtr>{
+        std::make_shared<PartitionHandle>()};
+  }
+  const auto numBuckets = testTable.bucketSpec()->numBuckets;
+  std::vector<PartitionHandlePtr> partitions;
+  partitions.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    partitions.push_back(std::make_shared<TestPartitionHandle>(bucket));
+  }
+  co_return partitions;
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/,
-    const std::shared_ptr<PartitionType>& /*partitionType*/,
+    const std::vector<PartitionHandlePtr>& partitions,
+    const std::shared_ptr<PartitionType>& partitionType,
     QueryRuntimeStats& /*runtimeStats*/) {
   const auto& testTable = findTestTableForHandle(tableHandle);
 
-  const auto numEntries = testTable.data().size();
   std::vector<size_t> dataIndices;
-  dataIndices.reserve(numEntries);
-  for (size_t i = 0; i < numEntries; ++i) {
-    dataIndices.push_back(i);
+  std::vector<int32_t> dataBucketIds;
+  if (testTable.bucketSpec().has_value()) {
+    folly::F14FastSet<int32_t> selectedBuckets;
+    for (const auto& partition : partitions) {
+      auto testPartition =
+          std::dynamic_pointer_cast<const TestPartitionHandle>(partition);
+      VELOX_CHECK(
+          testPartition != nullptr,
+          "Bucketed scans require TestPartitionHandle");
+      selectedBuckets.insert(testPartition->bucketNumber);
+    }
+    const auto& bucketIds = testTable.dataBucketIds();
+    for (size_t i = 0; i < bucketIds.size(); ++i) {
+      if (selectedBuckets.contains(bucketIds[i])) {
+        dataIndices.push_back(i);
+        dataBucketIds.push_back(bucketIds[i]);
+      }
+    }
+  } else {
+    const auto numEntries = testTable.data().size();
+    dataIndices.reserve(numEntries);
+    for (size_t i = 0; i < numEntries; ++i) {
+      dataIndices.push_back(i);
+    }
   }
   return std::make_shared<TestSplitSource>(
-      tableHandle->connectorId(), std::move(dataIndices));
+      tableHandle->connectorId(),
+      std::move(dataIndices),
+      std::move(dataBucketIds),
+      partitionType);
 }
 
 std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(
@@ -493,14 +674,16 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
   schemas_.insert(tableName.schema);
   auto table = std::make_shared<TestTable>(
       tableName,
       schema,
       hiddenColumns,
       connector_,
-      folly::F14FastMap<std::string, velox::Variant>{});
+      folly::F14FastMap<std::string, velox::Variant>{},
+      std::move(bucketSpec));
   auto [it, ok] = tables_.emplace(std::move(tableName), std::move(table));
   VELOX_CHECK(ok, "Table already exists: {}", it->first.toString());
   return it->second;
@@ -817,8 +1000,10 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
 std::shared_ptr<TestTable> TestConnector::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
-  return metadata_->addTable(std::move(tableName), schema, hiddenColumns);
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
+  return metadata_->addTable(
+      std::move(tableName), schema, hiddenColumns, std::move(bucketSpec));
 }
 
 bool TestConnector::dropTableIfExists(const SchemaTableName& name) {

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,7 +17,9 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <utility>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/ComplexVector.h"
@@ -87,7 +89,7 @@ TestTable::TestTable(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
-    folly::F14FastMap<std::string, velox::Variant> options)
+    const folly::F14FastMap<std::string, velox::Variant>& options)
     : Table(
           std::move(name),
           makeTestTableColumns(schema, hiddenColumns, options),
@@ -250,21 +252,37 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
 folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     uint32_t maxSplitCount) {
   SplitBatch batch;
-  auto end =
-      std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);
-  for (auto i = nextIndex_; i < end; ++i) {
-    batch.splits.push_back(
-        std::make_shared<TestConnectorSplit>(connectorId_, i));
+  const auto end = std::min(
+      nextOffset_ + static_cast<size_t>(maxSplitCount), dataIndices_.size());
+  for (auto i = nextOffset_; i < end; ++i) {
+    auto split =
+        std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
+    batch.splits.push_back(Split{std::move(split)});
   }
-  nextIndex_ = end;
-  batch.noMoreSplits = (nextIndex_ >= splitCount_);
+  nextOffset_ = end;
+  batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
   co_return batch;
 }
+
+namespace {
+
+const TestTable& findTestTableForHandle(
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  auto testHandle =
+      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
+  VELOX_CHECK(testHandle, "Expected TestTableHandle");
+  auto table = ConnectorMetadataRegistry::get(testHandle->connectorId())
+                   ->findTable(testHandle->schemaTableName());
+  VELOX_CHECK(table, "Table does not exist: {}", testHandle->name());
+  return dynamic_cast<const TestTable&>(*table);
+}
+
+} // namespace
 
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
-    const velox::connector::ConnectorTableHandlePtr&) {
+    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
   co_return std::vector<PartitionHandlePtr>{
       std::make_shared<PartitionHandle>()};
 }
@@ -272,13 +290,19 @@ TestSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&,
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
-  auto maybeTableHandle =
-      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
-  VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");
+  const auto& testTable = findTestTableForHandle(tableHandle);
+
+  const auto numEntries = testTable.data().size();
+  std::vector<size_t> dataIndices;
+  dataIndices.reserve(numEntries);
+  for (size_t i = 0; i < numEntries; ++i) {
+    dataIndices.push_back(i);
+  }
   return std::make_shared<TestSplitSource>(
-      tableHandle->connectorId(), maybeTableHandle->size());
+      tableHandle->connectorId(), std::move(dataIndices));
 }
 
 std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -27,6 +27,62 @@ namespace facebook::axiom::connector {
 
 class TestConnector;
 
+/// Hash-bucketing spec for a TestTable. Routes appended rows into buckets
+/// using a generic hash partition function over 'bucketColumns'. The
+/// partitioning is connector-agnostic and does not depend on the Hive
+/// connector.
+struct TestBucketSpec {
+  std::vector<std::string> bucketColumns;
+  int32_t numBuckets;
+};
+
+/// PartitionType used by TestConnector for bucketed tables. Two
+/// TestPartitionTypes are compatible iff their partition-key types match and
+/// one numPartitions divides the other; the result of copartition is the side
+/// with fewer partitions. scaleDown returns the largest divisor of
+/// numPartitions that is <= maxPartitions. makeSpec returns a generic
+/// HashPartitionFunctionSpec.
+class TestPartitionType : public PartitionType {
+ public:
+  TestPartitionType(
+      int32_t numPartitions,
+      std::vector<velox::TypePtr> partitionKeyTypes,
+      velox::RowTypePtr inputType)
+      : numPartitions_(numPartitions),
+        partitionKeyTypes_(std::move(partitionKeyTypes)),
+        inputType_(std::move(inputType)) {}
+
+  std::shared_ptr<PartitionType> copartition(
+      const PartitionType& other) const override;
+
+  std::shared_ptr<PartitionType> scaleDown(
+      int32_t maxPartitions) const override;
+
+  velox::core::PartitionFunctionSpecPtr makeSpec(
+      const std::vector<velox::column_index_t>& channels,
+      const std::vector<velox::VectorPtr>& constants,
+      bool isLocal) const override;
+
+  int32_t numPartitions() const override {
+    return numPartitions_;
+  }
+
+  std::string toString() const override;
+
+ private:
+  const int32_t numPartitions_;
+  const std::vector<velox::TypePtr> partitionKeyTypes_;
+  const velox::RowTypePtr inputType_;
+};
+
+/// PartitionHandle for a single bucket of a bucketed TestTable.
+struct TestPartitionHandle : public PartitionHandle {
+  explicit TestPartitionHandle(int32_t bucketNumber)
+      : bucketNumber(bucketNumber) {}
+
+  const int32_t bucketNumber;
+};
+
 /// The Table and Connector objects to which this layout correspond
 /// are specified explicitly at init time.
 class TestTableLayout : public TableLayout {
@@ -46,6 +102,29 @@ class TestTableLayout : public TableLayout {
             /*sortOrder=*/{},
             /*lookupKeys=*/{},
             /*supportsScan=*/true) {}
+
+  TestTableLayout(
+      const std::string& label,
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::vector<const Column*> partitionColumns,
+      std::shared_ptr<const PartitionType> partitionType)
+      : TableLayout(
+            label,
+            table,
+            connector,
+            std::move(columns),
+            std::move(partitionColumns),
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            /*lookupKeys=*/{},
+            /*supportsScan=*/true),
+        partitionType_(std::move(partitionType)) {}
+
+  std::shared_ptr<const PartitionType> partitionType() const override {
+    return partitionType_;
+  }
 
   /// Records discrete values to use in 'discretePredicateColumns' and
   /// 'discretePredicates' APIs. If called repeatedly, overwrites previous
@@ -78,6 +157,7 @@ class TestTableLayout : public TableLayout {
  private:
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
+  std::shared_ptr<const PartitionType> partitionType_;
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -92,7 +172,8 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
-      const folly::F14FastMap<std::string, velox::Variant>& options);
+      const folly::F14FastMap<std::string, velox::Variant>& options,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -106,11 +187,21 @@ class TestTable : public Table {
     return data_;
   }
 
+  /// Bucket id of the i-th entry in 'data'. Empty for unbucketed tables.
+  const std::vector<int32_t>& dataBucketIds() const {
+    return dataBucketIds_;
+  }
+
+  const std::optional<TestBucketSpec>& bucketSpec() const {
+    return bucketSpec_;
+  }
+
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
   /// memory pool. When 'collectColumnStatistics' is true, computes per-column
   /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
-  /// Cannot be combined with setStats on the same table.
+  /// Cannot be combined with setStats on the same table. For bucketed tables,
+  /// each non-empty bucket of the input becomes one entry in 'data'.
   void addData(
       const velox::RowVectorPtr& data,
       bool collectColumnStatistics = true);
@@ -150,29 +241,45 @@ class TestTable : public Table {
   std::unique_ptr<TestTableLayout> exportedLayout_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<velox::RowVectorPtr> data_;
+  std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
   std::vector<ColumnTracker> columnTrackers_;
+
+  std::optional<TestBucketSpec> bucketSpec_;
+  std::unique_ptr<velox::core::PartitionFunction> partitionFunction_;
 };
 
 /// SplitSource for TestTable. Emits one TestConnectorSplit per index in
-/// 'dataIndices'.
+/// 'dataIndices'. When 'partitionType' is set, tags each Split with
+/// groupId = dataBucketIds[i] % partitionType->numPartitions().
 class TestSplitSource : public SplitSource {
  public:
   TestSplitSource(
       const std::string& connectorId,
-      std::vector<size_t> dataIndices)
-      : connectorId_(connectorId), dataIndices_(std::move(dataIndices)) {}
+      std::vector<size_t> dataIndices,
+      std::vector<int32_t> dataBucketIds = {},
+      std::shared_ptr<PartitionType> partitionType = nullptr)
+      : connectorId_(connectorId),
+        dataIndices_(std::move(dataIndices)),
+        dataBucketIds_(std::move(dataBucketIds)),
+        partitionType_(std::move(partitionType)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;
   const std::vector<size_t> dataIndices_;
+  const std::vector<int32_t> dataBucketIds_;
+  const std::shared_ptr<PartitionType> partitionType_;
   size_t nextOffset_{0};
 };
 
-/// Returns one PartitionHandle covering the whole table.
+class TestConnectorMetadata;
+
+/// Unbucketed: one PartitionHandle covering the whole table.
+/// Bucketed: one TestPartitionHandle per bucket; getSplitSource emits splits
+/// only for the requested buckets' entries.
 class TestSplitManager : public ConnectorSplitManager {
  public:
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
@@ -437,11 +544,12 @@ class TestConnectorMetadata : public ConnectorMetadata {
   }
 
   /// Registers a TestTable in the connector metadata. Throws if the name is
-  /// already taken.
+  /// already taken. When 'bucketSpec' is set, appended rows are hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Appends data to the table with the specified name.
   void appendData(
@@ -685,18 +793,25 @@ class TestConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx* connectorQueryCtx,
       velox::connector::CommitStrategy commitStrategy) override;
 
-  /// Registers a TestTable. Throws if the name is already taken.
+  /// Registers a TestTable. Throws if the name is already taken. When
+  /// 'bucketSpec' is set, the table is hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({}));
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Convenience overload that uses kDefaultSchema as the schema.
   std::shared_ptr<TestTable> addTable(
       const std::string& name,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({})) {
-    return addTable({std::string(kDefaultSchema), name}, schema, hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt) {
+    return addTable(
+        {std::string(kDefaultSchema), name},
+        schema,
+        hiddenColumns,
+        std::move(bucketSpec));
   }
 
   /// Appends data to the table with the specified name.

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -21,6 +21,7 @@
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::axiom::connector {
 
@@ -91,7 +92,7 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
-      folly::F14FastMap<std::string, velox::Variant> options);
+      const folly::F14FastMap<std::string, velox::Variant>& options);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -154,26 +155,24 @@ class TestTable : public Table {
   std::vector<ColumnTracker> columnTrackers_;
 };
 
-/// SplitSource generated via the TestSplitManager embedded in the
-/// TestConnector. Generates one TestConnectorSplit for each RowVector
-/// in the table's data_ vector.
+/// SplitSource for TestTable. Emits one TestConnectorSplit per index in
+/// 'dataIndices'.
 class TestSplitSource : public SplitSource {
  public:
-  TestSplitSource(const std::string& connectorId, size_t splitCount)
-      : connectorId_(connectorId), splitCount_(splitCount) {}
+  TestSplitSource(
+      const std::string& connectorId,
+      std::vector<size_t> dataIndices)
+      : connectorId_(connectorId), dataIndices_(std::move(dataIndices)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;
-  const size_t splitCount_;
-  size_t nextIndex_{0};
+  const std::vector<size_t> dataIndices_;
+  size_t nextOffset_{0};
 };
 
-/// SplitManager embedded in the TestConnector. Returns one
-/// default-initialized PartitionHandle upon call to co_listPartitions.
-/// Generates a TestSplitSource that produces one TestConnectorSplit
-/// per RowVector in the table's data_ vector.
+/// Returns one PartitionHandle covering the whole table.
 class TestSplitManager : public ConnectorSplitManager {
  public:
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
@@ -184,6 +183,7 @@ class TestSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 
@@ -436,9 +436,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return splitManager_.get();
   }
 
-  /// Creates and returns a TestTable with the specified name and schema in the
-  /// in-memory map maintained in the connector metadata. Throws if the table
-  /// already exists.
+  /// Registers a TestTable in the connector metadata. Throws if the name is
+  /// already taken.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
@@ -686,8 +685,7 @@ class TestConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx* connectorQueryCtx,
       velox::connector::CommitStrategy commitStrategy) override;
 
-  /// Adds a TestTable with the specified name and schema. Throws if a table
-  /// with the same name already exists.
+  /// Registers a TestTable. Throws if the name is already taken.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -21,8 +21,10 @@
 #include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <numeric>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -553,6 +555,166 @@ TEST_F(TestConnectorTest, addDataAndSetStatsMutualExclusion) {
     VELOX_ASSERT_THROW(
         table->setStats(100, {{"a", {.numDistinct = 50}}}),
         "Cannot use both setStats and addData on table");
+  }
+}
+
+namespace {
+
+std::vector<uint32_t> referenceBucketIds(
+    const velox::RowVectorPtr& input,
+    const std::vector<velox::column_index_t>& channels,
+    int32_t numBuckets) {
+  velox::exec::HashPartitionFunctionSpec spec(
+      asRowType(input->type()), channels, /*constValues=*/{});
+  std::vector<uint32_t> bucketIds;
+  if (auto single = spec.create(numBuckets, /*localExchange=*/false)
+                        ->partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  return bucketIds;
+}
+
+velox::connector::ConnectorTableHandlePtr makeScanHandle(
+    const TableLayout& layout,
+    const std::vector<std::string>& columnNames) {
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  std::vector<velox::connector::ColumnHandlePtr> columns;
+  columns.reserve(columnNames.size());
+  for (const auto& name : columnNames) {
+    columns.push_back(layout.createColumnHandle(nullptr, name));
+  }
+  std::vector<core::TypedExprPtr> empty;
+  return layout.createTableHandle(
+      nullptr, std::move(columns), *evaluator, empty, empty);
+}
+
+} // namespace
+
+CO_TEST_F(TestConnectorTest, bucketedTable) {
+  constexpr int32_t kNumBuckets = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "bucketed", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  std::vector<int64_t> keys(32);
+  std::iota(keys.begin(), keys.end(), 0);
+  auto input = makeRowVector({makeFlatVector<int64_t>(keys)});
+  connector_->appendData("bucketed", input);
+
+  const auto expected = referenceBucketIds(input, {0}, kNumBuckets);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto* splitManager = metadata_->splitManager();
+  auto partitions =
+      co_await splitManager->co_listPartitions(nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+
+  // Pass a non-null partitionType with numPartitions < numBuckets so the
+  // connector folds buckets into groups and tags each Split with groupId.
+  constexpr int32_t kNumGroups = 2;
+  auto partitionType = std::make_shared<TestPartitionType>(
+      kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
+  QueryRuntimeStats noopStats;
+  auto source = splitManager->getSplitSource(
+      nullptr, tableHandle, partitions, partitionType, noopStats);
+  std::vector<int32_t> observedGroupIds;
+  while (true) {
+    auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
+    for (const auto& split : batch.splits) {
+      CO_ASSERT_TRUE(split.groupId.has_value());
+      EXPECT_GE(*split.groupId, 0);
+      EXPECT_LT(*split.groupId, kNumGroups);
+      auto testSplit = std::dynamic_pointer_cast<const TestConnectorSplit>(
+          split.connectorSplit);
+      CO_ASSERT_NE(testSplit, nullptr);
+      const auto bucket = table->dataBucketIds()[testSplit->index()];
+      EXPECT_EQ(*split.groupId, bucket % kNumGroups);
+      observedGroupIds.push_back(*split.groupId);
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
+  co_await source->co_close();
+  EXPECT_FALSE(observedGroupIds.empty());
+}
+
+TEST_F(TestConnectorTest, bucketedTableNonExistentBucketColumn) {
+  VELOX_ASSERT_THROW(
+      connector_->addTable(
+          "bad_bucket_col",
+          ROW({"a"}, {BIGINT()}),
+          velox::ROW({}),
+          TestBucketSpec{{"missing"}, 4}),
+      "Bucket column does not exist: missing");
+}
+
+CO_TEST_F(TestConnectorTest, bucketedTableNumBucketsExceedsNumRows) {
+  constexpr int32_t kNumBuckets = 16;
+  constexpr int32_t kNumRows = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "sparse", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  auto input = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
+  connector_->appendData("sparse", input);
+
+  EXPECT_LE(table->data().size(), kNumRows);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (const auto& vector : table->data()) {
+    EXPECT_GT(vector->size(), 0);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto partitions = co_await metadata_->splitManager()->co_listPartitions(
+      nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+}
+
+TEST_F(TestConnectorTest, bucketedTableMultiColumnKeys) {
+  constexpr int32_t kNumBuckets = 8;
+  constexpr int32_t kNumRows = 64;
+  auto schema = ROW({"k1", "k2", "v"}, {BIGINT(), VARCHAR(), DOUBLE()});
+  auto table = connector_->addTable(
+      "multi_key",
+      schema,
+      velox::ROW({}),
+      TestBucketSpec{{"k1", "k2"}, kNumBuckets});
+
+  auto& layout = *table->layouts()[0];
+  EXPECT_NE(layout.partitionType(), nullptr);
+  EXPECT_EQ(layout.partitionColumns().size(), 2);
+
+  std::vector<int64_t> k1Values(kNumRows);
+  std::iota(k1Values.begin(), k1Values.end(), 0);
+  std::vector<std::string> k2Values;
+  k2Values.reserve(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    k2Values.push_back(fmt::format("s{}", i));
+  }
+  std::vector<double> vValues(kNumRows, 3.14);
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(k1Values),
+       makeFlatVector<std::string>(k2Values),
+       makeFlatVector<double>(vValues)});
+  connector_->appendData("multi_key", input);
+
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+
+  const auto expected = referenceBucketIds(input, {0, 1}, kNumBuckets);
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
   }
 }
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -157,15 +157,15 @@ CO_TEST_F(TestConnectorTest, splitManager) {
   auto partitions =
       co_await splitManager->co_listPartitions(nullptr, tableHandle);
   QueryRuntimeStats noopStats;
-  auto splitSource =
-      splitManager->getSplitSource(nullptr, tableHandle, partitions, noopStats);
+  auto splitSource = splitManager->getSplitSource(
+      nullptr, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = co_await splitSource->co_getSplits(/*maxSplitCount=*/1000);
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -87,6 +87,7 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const connector::ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
     QueryRuntimeStats& /*runtimeStats*/) {
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
@@ -115,8 +116,8 @@ folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
       std::min(nextSplitIdx_ + static_cast<int64_t>(maxSplitCount), numSplits_);
   for (auto i = nextSplitIdx_; i < end; ++i) {
     batch.splits.push_back(
-        std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
-            connectorId_, numSplits_, i));
+        Split{std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
+            connectorId_, numSplits_, i)});
   }
   nextSplitIdx_ = end;
   batch.noMoreSplits = (nextSplitIdx_ >= numSplits_);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -62,6 +62,7 @@ class TpchSplitManager : public ConnectorSplitManager {
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -212,13 +212,17 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
 
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      /*session=*/nullptr, tableHandle, partitions, noopStats);
+      /*session=*/nullptr,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      noopStats);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {
     auto batch = co_await splitSource->co_getSplits(1000);
     for (auto& split : batch.splits) {
-      splits.push_back(std::move(split));
+      splits.push_back(std::move(split.connectorSplit));
     }
     if (batch.noMoreSplits) {
       break;

--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -207,7 +207,8 @@ MarkDistinctResult addMarkDistinctNodes(
     RelationOpPtr plan,
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
-    bool isSingleWorker) {
+    bool isSingleWorker,
+    PlanState& state) {
   PlanCost totalCost;
   folly::F14FastMap<PlanObjectSet, ColumnCP> markers;
 
@@ -240,7 +241,7 @@ MarkDistinctResult addMarkDistinctNodes(
 
       if (!isSingleWorker) {
         auto [repartitioned, repartitionCost] =
-            maybeRepartition(plan, ExprVector(markDistinctKeys));
+            maybeRepartition(plan, ExprVector(markDistinctKeys), state);
         plan = repartitioned;
         totalCost.add(repartitionCost);
       }
@@ -314,9 +315,32 @@ GroupId* makeGroupIdNode(
 
 } // namespace
 
+std::vector<uint32_t> joinKeyPartition(
+    const RelationOpPtr& op,
+    const ExprVector& keys) {
+  const auto& partitionKeys = op->distribution().partitionKeys();
+  std::vector<uint32_t> positions;
+  positions.reserve(partitionKeys.size());
+  for (const auto& partitionKey : partitionKeys) {
+    bool found = false;
+    for (uint32_t j = 0; j < keys.size(); ++j) {
+      if (keys[j]->sameOrEqual(*partitionKey)) {
+        positions.push_back(j);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return {};
+    }
+  }
+  return positions;
+}
+
 std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     const RelationOpPtr& plan,
-    ExprVector desiredKeys) {
+    ExprVector desiredKeys,
+    PlanState& state) {
   if (plan->distribution().isGather()) {
     return {plan, {}};
   }
@@ -326,6 +350,7 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     auto* gather =
         make<Repartition>(plan, Distribution::gather(), plan->columns());
     cost.add(*gather);
+    commitGroupedLeavesForRepartition(state, gather);
     return {gather, cost};
   }
 
@@ -347,11 +372,12 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
   }
 
   if (shuffle) {
-    Distribution distribution{
-        plan->distribution().partitionType(), std::move(desiredKeys)};
+    Distribution distribution{/*partitionType=*/nullptr,
+                              std::move(desiredKeys)};
     auto* repartition =
         make<Repartition>(plan, std::move(distribution), plan->columns());
     cost.add(*repartition);
+    commitGroupedLeavesForRepartition(state, repartition);
     return {repartition, cost};
   }
 
@@ -360,13 +386,14 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
 
 std::pair<RelationOpPtr, PlanCost> AggregationPlanner::repartitionForAgg(
     const RelationOpPtr& plan,
-    const ColumnVector& partitionKeys) const {
+    const ColumnVector& partitionKeys,
+    PlanState& state) const {
   if (isSingleWorker_ || plan->distribution().isGather()) {
     return {plan, {}};
   }
 
   ExprVector keyExprs(partitionKeys.begin(), partitionKeys.end());
-  return maybeRepartition(plan, std::move(keyExprs));
+  return maybeRepartition(plan, std::move(keyExprs), state);
 }
 
 std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
@@ -376,7 +403,8 @@ std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
     const ColumnVector& intermediateColumns,
     const ColumnVector& outputColumns,
     QGVector<int32_t> globalGroupingSets,
-    ColumnCP groupId) const {
+    ColumnCP groupId,
+    PlanState& state) const {
   PlanCost splitAggCost;
 
   plan = make<Aggregation>(
@@ -393,7 +421,8 @@ std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
       intermediateColumns.begin() + groupingKeys.size());
 
   PlanCost repartitionCost;
-  std::tie(plan, repartitionCost) = repartitionForAgg(plan, partitionKeys);
+  std::tie(plan, repartitionCost) =
+      repartitionForAgg(plan, partitionKeys, state);
   splitAggCost.add(repartitionCost);
 
   ExprVector finalGroupingKeys(partitionKeys.begin(), partitionKeys.end());
@@ -419,14 +448,16 @@ AggregationPlanner::makeSingleAggregationPlan(
     const ColumnVector& intermediateColumns,
     const ColumnVector& outputColumns,
     QGVector<int32_t> globalGroupingSets,
-    ColumnCP groupId) const {
+    ColumnCP groupId,
+    PlanState& state) const {
   PlanCost singleAggCost;
 
   ColumnVector partitionKeys(
       intermediateColumns.begin(),
       intermediateColumns.begin() + groupingKeys.size());
   PlanCost repartitionCost;
-  std::tie(plan, repartitionCost) = repartitionForAgg(plan, partitionKeys);
+  std::tie(plan, repartitionCost) =
+      repartitionForAgg(plan, partitionKeys, state);
   singleAggCost.add(repartitionCost);
 
   auto* singleAgg = make<Aggregation>(
@@ -451,7 +482,14 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
     const ColumnVector& intermediateColumns,
     const ColumnVector& outputColumns,
     QGVector<int32_t> globalGroupingSets,
-    ColumnCP groupId) const {
+    ColumnCP groupId,
+    PlanState& state) const {
+  // Both alternatives may insert Repartitions via maybeRepartition, which
+  // mutates state.currentGroupedLeaves_ via commitGroupedLeavesForRepartition.
+  // Snapshot+restore around each alternative so the second one starts from
+  // the same map the first did, and the chosen alternative's mutations are
+  // re-applied at the end.
+  auto savedMap = state.currentGroupedLeaves();
   auto [splitAggPlan, splitAggCost] = makeSplitAggregationPlan(
       plan,
       groupingKeys,
@@ -459,12 +497,16 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
       intermediateColumns,
       outputColumns,
       globalGroupingSets,
-      groupId);
+      groupId,
+      state);
+  auto splitMap = std::move(state.mutableCurrentGroupedLeaves());
 
   if (groupingKeys.empty() || alwaysPlanPartialAggregation_) {
+    state.mutableCurrentGroupedLeaves() = std::move(splitMap);
     return {std::move(splitAggPlan), splitAggCost};
   }
 
+  state.mutableCurrentGroupedLeaves() = savedMap;
   auto [singleAgg, singleAggCost] = makeSingleAggregationPlan(
       plan,
       groupingKeys,
@@ -472,11 +514,13 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
       intermediateColumns,
       outputColumns,
       std::move(globalGroupingSets),
-      groupId);
+      groupId,
+      state);
 
   if (singleAggCost.cost < splitAggCost.cost) {
     return {std::move(singleAgg), singleAggCost};
   }
+  state.mutableCurrentGroupedLeaves() = std::move(splitMap);
   return {std::move(splitAggPlan), splitAggCost};
 }
 
@@ -487,7 +531,8 @@ AggregationPlanner::makeDistinctToGroupByPlan(
     const ExprVector& distinctArgs,
     const AggregateVector& aggregates,
     AggregationPlanCP aggPlan,
-    bool hasOrderBy) const {
+    bool hasOrderBy,
+    PlanState& state) const {
   // Build inner GROUP BY keys: groupingKeys union distinctArgs. We put
   // groupingKeys at the beginning, followed by distinctArgs not appearing in
   // groupingKeys.
@@ -511,7 +556,14 @@ AggregationPlanner::makeDistinctToGroupByPlan(
 
   PlanCost totalCost;
   auto [innerAgg, innerAggCost] = makeSplitOrSingleAggregationPlan(
-      plan, innerKeys, AggregateVector{}, innerColumns, innerColumns);
+      plan,
+      innerKeys,
+      AggregateVector{},
+      innerColumns,
+      innerColumns,
+      {},
+      nullptr,
+      state);
   totalCost.add(innerAggCost);
   plan = std::move(innerAgg);
 
@@ -524,7 +576,10 @@ AggregationPlanner::makeDistinctToGroupByPlan(
         groupingKeys,
         nonDistinctAggregates,
         aggPlan->intermediateColumns(),
-        aggPlan->columns());
+        aggPlan->columns(),
+        {},
+        nullptr,
+        state);
     plan = std::move(outerPlan);
     totalCost.add(outerCost);
   } else {
@@ -533,7 +588,10 @@ AggregationPlanner::makeDistinctToGroupByPlan(
         groupingKeys,
         nonDistinctAggregates,
         aggPlan->intermediateColumns(),
-        aggPlan->columns());
+        aggPlan->columns(),
+        {},
+        nullptr,
+        state);
     plan = std::move(outerPlan);
     totalCost.add(outerCost);
   }
@@ -547,9 +605,10 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     AggregationPlanCP aggPlan,
-    bool hasOrderBy) const {
-  auto [markedPlan, newAggregates, markCost] =
-      addMarkDistinctNodes(plan, groupingKeys, aggregates, isSingleWorker_);
+    bool hasOrderBy,
+    PlanState& state) const {
+  auto [markedPlan, newAggregates, markCost] = addMarkDistinctNodes(
+      plan, groupingKeys, aggregates, isSingleWorker_, state);
 
   PlanCost totalCost;
   totalCost.add(markCost);
@@ -567,7 +626,10 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
         groupingKeys,
         newAggregates,
         aggPlan->intermediateColumns(),
-        aggPlan->columns());
+        aggPlan->columns(),
+        {},
+        nullptr,
+        state);
     totalCost.add(aggCost);
     return {aggregation, totalCost};
   }
@@ -577,7 +639,10 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
       groupingKeys,
       newAggregates,
       aggPlan->intermediateColumns(),
-      aggPlan->columns());
+      aggPlan->columns(),
+      {},
+      nullptr,
+      state);
   totalCost.add(aggCost);
   return {aggregation, totalCost};
 }
@@ -655,7 +720,8 @@ void AggregationPlanner::addGroupingSetsAggregation(
         aggPlan->intermediateColumns(),
         aggPlan->columns(),
         std::move(globalGroupingSets),
-        aggGroupId);
+        aggGroupId,
+        state);
     state.cost.add(cost);
     plan = std::move(agg);
     return;
@@ -672,7 +738,8 @@ void AggregationPlanner::addGroupingSetsAggregation(
         aggPlan->intermediateColumns(),
         aggPlan->columns(),
         std::move(globalGroupingSets),
-        aggGroupId);
+        aggGroupId,
+        state);
     state.cost.add(cost);
     plan = std::move(agg);
     return;
@@ -683,7 +750,10 @@ void AggregationPlanner::addGroupingSetsAggregation(
       aggGroupingKeys,
       aggregates,
       aggPlan->intermediateColumns(),
-      aggPlan->columns());
+      aggPlan->columns(),
+      {},
+      nullptr,
+      state);
   state.cost.add(cost);
   plan = std::move(agg);
 }
@@ -694,6 +764,11 @@ void AggregationPlanner::plan(
     PlanState& state) const {
   VELOX_CHECK_NOT_NULL(dt->aggregation);
   const auto* aggPlan = dt->aggregation;
+
+  const bool isBucketedAggregation = !alwaysPlanPartialAggregation_ &&
+      !isSingleWorker_ && !aggPlan->groupingKeys().empty() &&
+      plan->distribution().partitionType() != nullptr &&
+      !joinKeyPartition(plan, aggPlan->groupingKeys()).empty();
 
   PrecomputeProjection precompute(plan, dt, /*projectAllInputs=*/false);
   // When grouping sets are present, don't pass aliases for grouping keys.
@@ -754,11 +829,30 @@ void AggregationPlanner::plan(
     return;
   }
 
+  if (isBucketedAggregation && !hasDistinct && !hasOrderBy) {
+    auto* singleAgg = make<Aggregation>(
+        plan,
+        std::move(groupingKeys),
+        /*preGroupedKeys=*/ExprVector{},
+        std::move(aggregates),
+        velox::core::AggregationNode::Step::kSingle,
+        aggPlan->columns());
+    state.addCost(*singleAgg);
+    plan = singleAgg;
+    return;
+  }
+
   if (hasDistinct) {
     auto distinctArgs = getCommonDistinctArgs(aggregates);
     if (distinctArgs.has_value()) {
       auto [result, cost] = makeDistinctToGroupByPlan(
-          plan, groupingKeys, *distinctArgs, aggregates, aggPlan, hasOrderBy);
+          plan,
+          groupingKeys,
+          *distinctArgs,
+          aggregates,
+          aggPlan,
+          hasOrderBy,
+          state);
       plan = std::move(result);
       state.cost.add(cost);
       return;
@@ -766,7 +860,7 @@ void AggregationPlanner::plan(
 
     if (canMakeMarkDistinctPlan(aggregates)) {
       auto [result, cost] = makeDistinctToMarkDistinctPlan(
-          plan, groupingKeys, aggregates, aggPlan, hasOrderBy);
+          plan, groupingKeys, aggregates, aggPlan, hasOrderBy, state);
       plan = std::move(result);
       state.cost.add(cost);
       return;
@@ -780,7 +874,10 @@ void AggregationPlanner::plan(
         groupingKeys,
         aggregates,
         aggPlan->intermediateColumns(),
-        aggPlan->columns());
+        aggPlan->columns(),
+        {},
+        nullptr,
+        state);
     plan = std::move(result);
     state.cost.add(cost);
     return;
@@ -794,7 +891,10 @@ void AggregationPlanner::plan(
         groupingKeys,
         aggregates,
         aggPlan->intermediateColumns(),
-        aggPlan->columns());
+        aggPlan->columns(),
+        {},
+        nullptr,
+        state);
     plan = singleAgg;
     state.cost.add(singleAggCost);
     return;
@@ -805,7 +905,10 @@ void AggregationPlanner::plan(
       groupingKeys,
       aggregates,
       aggPlan->intermediateColumns(),
-      aggPlan->columns());
+      aggPlan->columns(),
+      {},
+      nullptr,
+      state);
   plan = selectedPlan;
   state.cost.add(selectedCost);
 }

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -28,10 +28,21 @@ struct PlanState;
 /// desiredKeys is empty. Adds a shuffle if existing partition keys are not a
 /// subset of desiredKeys. Does nothing if data is already gathered or
 /// partitioned correctly. Returns the possibly repartitioned plan and cost. If
-/// no shuffle is added, the returned cost is 0.
+/// no shuffle is added, the returned cost is 0. When a Repartition is added,
+/// snapshots 'state.currentGroupedLeaves_' onto
+/// Optimization::repartitionGroupedLeaves_ and resets the map per the new
+/// Repartition's distribution kind.
 std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     const RelationOpPtr& plan,
-    ExprVector desiredKeys);
+    ExprVector desiredKeys,
+    PlanState& state);
+
+/// Returns the positions in 'keys' of expressions that match 'op's partition
+/// keys, in partition-key order. Returns an empty vector if any partition key
+/// is missing from 'keys'.
+std::vector<uint32_t> joinKeyPartition(
+    const RelationOpPtr& op,
+    const ExprVector& keys);
 
 /// Plans aggregation operators for a derived table.
 class AggregationPlanner {
@@ -57,7 +68,8 @@ class AggregationPlanner {
   // repartition is added, the returned cost is 0.
   std::pair<RelationOpPtr, PlanCost> repartitionForAgg(
       const RelationOpPtr& plan,
-      const ColumnVector& partitionKeys) const;
+      const ColumnVector& partitionKeys,
+      PlanState& state) const;
 
   // Creates a two-phase (partial + final) aggregation plan with repartitioning
   // by groupingKeys in between.
@@ -67,8 +79,9 @@ class AggregationPlanner {
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
       const ColumnVector& outputColumns,
-      QGVector<int32_t> globalGroupingSets = {},
-      ColumnCP groupId = nullptr) const;
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
+      PlanState& state) const;
 
   // Creates a single-phase aggregation plan following repartitioning by
   // groupingKeys.
@@ -78,8 +91,9 @@ class AggregationPlanner {
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
       const ColumnVector& outputColumns,
-      QGVector<int32_t> globalGroupingSets = {},
-      ColumnCP groupId = nullptr) const;
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
+      PlanState& state) const;
 
   // Chooses between split and single aggregation plans based on cost.
   std::pair<RelationOpPtr, PlanCost> makeSplitOrSingleAggregationPlan(
@@ -88,8 +102,9 @@ class AggregationPlanner {
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
       const ColumnVector& outputColumns,
-      QGVector<int32_t> globalGroupingSets = {},
-      ColumnCP groupId = nullptr) const;
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
+      PlanState& state) const;
 
   // Transforms distinct aggregation into a two-level GROUP BY + non-distinct
   // aggregation plan.
@@ -99,7 +114,8 @@ class AggregationPlanner {
       const ExprVector& distinctArgs,
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan,
-      bool hasOrderBy) const;
+      bool hasOrderBy,
+      PlanState& state) const;
 
   // Transforms distinct aggregations into a plan with MarkDistinct and
   // non-distinct masked aggregations.
@@ -108,7 +124,8 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan,
-      bool hasOrderBy) const;
+      bool hasOrderBy,
+      PlanState& state) const;
 
   // Handles aggregation with grouping sets (ROLLUP, CUBE, GROUPING SETS).
   // Creates a GroupId node followed by cost-based split or single aggregation.

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -153,7 +153,7 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
 
   auto& optimization = queryCtx()->optimization();
   auto plan = optimization->toVelox().toVeloxPlan(
-      filter, MultiFragmentPlan::Options::singleNode());
+      filter, MultiFragmentPlan::Options::singleNode(), {}, {});
   static QueryRuntimeStats noopStats;
   return std::make_shared<runner::LocalRunner>(
       std::move(plan.plan),

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -304,6 +304,7 @@ const auto& columnStatFieldNames() {
   };
   return kNames;
 }
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(ColumnStatField, columnStatFieldNames);
@@ -380,18 +381,23 @@ velox::ContinueFuture FinishWrite::abort() && noexcept {
 }
 
 namespace {
-// Formats the header line for a fragment in toString/toSummaryString.
 std::string formatFragmentHeader(
     int32_t index,
     const ExecutableFragment& fragment) {
+  std::string bucketedSuffix;
+  if (!fragment.groupedNodes.empty()) {
+    bucketedSuffix =
+        fmt::format(" bucketed(leaves={})", fragment.groupedNodes.size());
+  }
   return fmt::format(
-      "Fragment {}: {} {}{}:",
+      "Fragment {}: {} {}{}{}:",
       index,
       fragment.taskPrefix,
       FragmentTypeName::toName(fragment.type),
       fragment.width.has_value()
           ? fmt::format(" numWorkers={}", fragment.width.value())
-          : "");
+          : "",
+      bucketedSuffix);
 }
 } // namespace
 
@@ -601,6 +607,48 @@ void checkProducerConsumerLinkage(
   }
 }
 
+void checkGroupedNodes(const ExecutableFragment& fragment) {
+  if (fragment.groupedNodes.empty()) {
+    return;
+  }
+
+  folly::F14FastSet<velox::core::PlanNodeId> leafIds;
+  std::vector<const velox::core::PlanNode*> stack;
+  stack.push_back(fragment.fragment.planNode.get());
+  while (!stack.empty()) {
+    const auto* node = stack.back();
+    stack.pop_back();
+    if (dynamic_cast<const velox::core::TableScanNode*>(node) != nullptr ||
+        dynamic_cast<const velox::core::ExchangeNode*>(node) != nullptr) {
+      leafIds.insert(node->id());
+    }
+    for (const auto& child : node->sources()) {
+      stack.push_back(child.get());
+    }
+  }
+
+  std::optional<int32_t> commonNumPartitions;
+  for (const auto& [planNodeId, partitionType] : fragment.groupedNodes) {
+    VELOX_CHECK(
+        leafIds.contains(planNodeId),
+        "groupedNodes references a PlanNodeId that is not a leaf TableScan or ExchangeNode in fragment '{}': {}",
+        fragment.taskPrefix,
+        planNodeId);
+    if (partitionType == nullptr) {
+      continue;
+    }
+    if (commonNumPartitions.has_value()) {
+      VELOX_CHECK_EQ(
+          commonNumPartitions.value(),
+          partitionType->numPartitions(),
+          "All non-null groupedNodes entries in a fragment must share numPartitions(): {}",
+          fragment.taskPrefix);
+    } else {
+      commonNumPartitions = partitionType->numPartitions();
+    }
+  }
+}
+
 // Checks that the last fragment has a type compatible with local result
 // consumption.
 void checkLastFragment(const ExecutableFragment& last, int32_t numWorkers) {
@@ -621,6 +669,10 @@ void MultiFragmentPlan::checkConsistency() const {
   checkFragmentTypes(fragments_, options_.numWorkers);
 
   checkProducerConsumerLinkage(fragments_);
+
+  for (const auto& fragment : fragments_) {
+    checkGroupedNodes(fragment);
+  }
 
   if (!options_.remoteOutput) {
     checkLastFragment(fragments_.back(), options_.numWorkers);

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include "axiom/common/Enums.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/core/PlanFragment.h"
@@ -151,6 +152,15 @@ struct ExecutableFragment {
   /// Source fragments and Exchange node ids for remote shuffles producing input
   /// for 'this'.
   std::vector<InputStage> inputStages;
+
+  /// PartitionType per scan node for grouped leaf nodes. The connector tags
+  /// each emitted Split with a groupId; the runtime routes by groupId. All
+  /// entries share numPartitions(). Empty when no scan in this fragment is
+  /// bucketed.
+  folly::F14FastMap<
+      velox::core::PlanNodeId,
+      std::shared_ptr<connector::PartitionType>>
+      groupedNodes;
 };
 
 /// Describes a distributed plan handed to a Runner for parallel/distributed

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -277,6 +277,175 @@ void Optimization::applyFilteredStats(
   }
 }
 
+namespace {
+// Coarsens 'groupedLeaves' to the runner's task budget by calling scaleDown on
+// each non-null entry. GroupedLeaves is immutable once taken; this is the only
+// point that locks the per-leaf entries to runner-task partition counts.
+void scaleDownGroupedLeaves(GroupedLeaves& groupedLeaves, int32_t numWorkers) {
+  for (auto& [_, partitionType] : groupedLeaves) {
+    if (partitionType != nullptr) {
+      partitionType = partitionType->scaleDown(numWorkers);
+    }
+  }
+}
+
+// Collects the per-fragment leaves of 'op': TableScans physically inside this
+// fragment plus Repartitions whose consumer-side Exchange lives here.
+// Bounded by Repartition descendants — those are separate fragments.
+void collectFragmentLeaves(
+    const RelationOp* op,
+    folly::F14FastSet<const RelationOp*>& leaves) {
+  if (op == nullptr) {
+    return;
+  }
+  if (op->is(RelType::kTableScan)) {
+    leaves.insert(op);
+    return;
+  }
+  if (op->is(RelType::kRepartition)) {
+    leaves.insert(op);
+    return;
+  }
+  if (op->is(RelType::kJoin)) {
+    const auto& join = *op->as<Join>();
+    collectFragmentLeaves(join.input().get(), leaves);
+    collectFragmentLeaves(join.right.get(), leaves);
+    return;
+  }
+  if (op->is(RelType::kUnionAll)) {
+    for (const auto& input : op->as<UnionAll>()->inputs) {
+      collectFragmentLeaves(input.get(), leaves);
+    }
+    return;
+  }
+  collectFragmentLeaves(op->input().get(), leaves);
+}
+
+// Drops entries from 'groupedLeaves' whose RelationOp* is not in 'leaves'.
+void filterGroupedLeavesToProducerLeaves(
+    GroupedLeaves& groupedLeaves,
+    const folly::F14FastSet<const RelationOp*>& leaves) {
+  for (auto it = groupedLeaves.begin(); it != groupedLeaves.end();) {
+    if (!leaves.contains(it->first)) {
+      it = groupedLeaves.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+} // namespace
+
+void commitGroupedLeavesForRepartition(
+    PlanState& state,
+    const Repartition* repartition) {
+  auto& groupedLeaves =
+      state.optimization.repartitionGroupedLeaves()[repartition];
+  // Overwrite atomically; an entry for 'repartition' may already exist if a
+  // memoized RelationOp was shared across planning candidates.
+  groupedLeaves =
+      std::exchange(state.mutableCurrentGroupedLeaves(), GroupedLeaves{});
+  // Drop entries injected from sibling fragments via mergeFragmentMaps or
+  // PlanStateSaver across planning branches.
+  folly::F14FastSet<const RelationOp*> producerLeaves;
+  collectFragmentLeaves(repartition->input().get(), producerLeaves);
+  filterGroupedLeavesToProducerLeaves(groupedLeaves, producerLeaves);
+  scaleDownGroupedLeaves(
+      groupedLeaves, state.optimization.runnerOptions().numWorkers);
+  const auto& dist = repartition->distribution();
+  if (dist.kind() == Distribution::Kind::kPartitioned &&
+      !dist.partitionKeys().empty()) {
+    state.mutableCurrentGroupedLeaves().emplace(repartition, nullptr);
+  }
+}
+
+namespace {
+// Calls scaleDown(numWorkers) on 'partitionType' and returns the resulting
+// type, pushed onto 'owned' for lifetime management. Passes null through
+// unchanged.
+const connector::PartitionType* FOLLY_NULLABLE scaleDownPartitionType(
+    const connector::PartitionType* partitionType,
+    int32_t numWorkers,
+    std::vector<std::shared_ptr<connector::PartitionType>>& owned) {
+  if (partitionType == nullptr) {
+    return nullptr;
+  }
+  auto scaled = partitionType->scaleDown(numWorkers);
+  const auto* raw = scaled.get();
+  owned.push_back(std::move(scaled));
+  return raw;
+}
+
+// Folds copartition() across all non-null PartitionType values in 'values'.
+// Returns nullptr if 'values' is empty or any pair is incompatible.
+std::shared_ptr<const connector::PartitionType> foldCopartition(
+    const std::vector<std::shared_ptr<const connector::PartitionType>>&
+        values) {
+  if (values.empty()) {
+    return nullptr;
+  }
+  std::shared_ptr<const connector::PartitionType> result = values.front();
+  for (size_t i = 1; result != nullptr && i < values.size(); ++i) {
+    result = result->copartition(*values[i]);
+  }
+  return result;
+}
+
+// Merges 'producer' into 'consumer' with per-leaf coarsening: if both maps
+// contain non-null PartitionTypes, fold copartition() across them to find a
+// common, then replace each non-null value with entry.copartition(*common).
+// Null entries pass through unchanged. Used at every join/union site that
+// combines two PlanStates' current fragment maps.
+void mergeFragmentMaps(GroupedLeaves& consumer, GroupedLeaves&& producer) {
+  std::vector<std::shared_ptr<const connector::PartitionType>> nonNullValues;
+  for (const auto& [_, partitionType] : consumer) {
+    if (partitionType != nullptr) {
+      nonNullValues.push_back(partitionType);
+    }
+  }
+  for (const auto& [_, partitionType] : producer) {
+    if (partitionType != nullptr) {
+      nonNullValues.push_back(partitionType);
+    }
+  }
+
+  if (nonNullValues.size() >= 2) {
+    std::sort(
+        nonNullValues.begin(),
+        nonNullValues.end(),
+        [](const auto& lhs, const auto& rhs) {
+          return lhs->numPartitions() < rhs->numPartitions();
+        });
+    auto result = foldCopartition(nonNullValues);
+    if (result != nullptr) {
+      for (auto& [_, partitionType] : consumer) {
+        if (partitionType != nullptr) {
+          partitionType = partitionType->copartition(*result);
+        }
+      }
+      for (auto& [_, partitionType] : producer) {
+        if (partitionType != nullptr) {
+          partitionType = partitionType->copartition(*result);
+        }
+      }
+    }
+  }
+
+  for (auto& [key, partitionType] : producer) {
+    consumer.emplace(key, std::move(partitionType));
+  }
+  producer.clear();
+}
+} // namespace
+
+PlanAndStats Optimization::toVeloxPlan(RelationOpPtr plan) {
+  return toVelox_.toVeloxPlan(
+      std::move(plan),
+      runnerOptions_,
+      outputColumnMappings_,
+      {repartitionGroupedLeaves_, rootGroupedLeaves_});
+}
+
 // static
 PlanAndStats Optimization::toVeloxPlan(
     const logical_plan::LogicalPlanNode& logicalPlan,
@@ -335,7 +504,18 @@ PlanP Optimization::bestPlan() {
 
   makeJoins(topState_);
 
-  return topState_.plans.best();
+  auto* winner = topState_.plans.best();
+  if (auto it = planGroupedLeaves_.find(winner);
+      it != planGroupedLeaves_.end()) {
+    // Move-out is safe: 'winner' is the single plan ToVelox will emit, no
+    // further consumer of planGroupedLeaves_[winner] exists past this point.
+    rootGroupedLeaves_ = std::move(it->second);
+    folly::F14FastSet<const RelationOp*> rootLeaves;
+    collectFragmentLeaves(winner->op.get(), rootLeaves);
+    filterGroupedLeavesToProducerLeaves(rootGroupedLeaves_, rootLeaves);
+    scaleDownGroupedLeaves(rootGroupedLeaves_, runnerOptions_.numWorkers);
+  }
+  return winner;
 }
 
 namespace {
@@ -887,24 +1067,8 @@ RelationOpPtr repartitionForIndex(
       Distribution{distribution.partitionType(), std::move(keyExprs)},
       plan->columns());
   state.addCost(*repartition);
+  commitGroupedLeavesForRepartition(state, repartition);
   return repartition;
-}
-
-// Returns the positions in 'keys' for the expressions that determine the
-// partition. empty if the partition is not decided by 'keys'
-std::vector<uint32_t> joinKeyPartition(
-    const RelationOpPtr& op,
-    const ExprVector& keys) {
-  const auto& partitionKeys = op->distribution().partitionKeys();
-  std::vector<uint32_t> positions;
-  for (unsigned i = 0; i < partitionKeys.size(); ++i) {
-    auto nthKey = position(keys, *partitionKeys[i]);
-    if (nthKey == kNotFound) {
-      return {};
-    }
-    positions.push_back(nthKey);
-  }
-  return positions;
 }
 
 PlanObjectSet availableColumns(PlanObjectCP object) {
@@ -963,6 +1127,7 @@ void alignJoinSides(
     auto* repartition = make<Repartition>(
         input, std::move(distribution), input->columns(), replicateNullsAndAny);
     state.addCost(*repartition);
+    commitGroupedLeavesForRepartition(state, repartition);
     input = repartition;
   }
 
@@ -978,10 +1143,15 @@ void alignJoinSides(
   }
 
   Distribution distribution{
-      input->distribution().partitionType(), std::move(distColumns)};
+      scaleDownPartitionType(
+          input->distribution().partitionType(),
+          state.optimization.runnerOptions().numWorkers,
+          state.optimization.derivedPartitionTypes()),
+      std::move(distColumns)};
   auto* repartition = make<Repartition>(
       otherInput, std::move(distribution), otherInput->columns());
   otherState.addCost(*repartition);
+  commitGroupedLeavesForRepartition(otherState, repartition);
   otherInput = repartition;
 }
 
@@ -1007,7 +1177,7 @@ const RelationOpPtr& maybeDropProject(const RelationOpPtr& plan) {
   return plan;
 }
 
-const connector::PartitionType* copartitionType(
+std::shared_ptr<connector::PartitionType> copartitionType(
     const connector::PartitionType* first,
     const connector::PartitionType* second) {
   if (first != nullptr && second != nullptr) {
@@ -1051,11 +1221,10 @@ RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
   const auto* planPartitionType = plan->distribution().partitionType();
 
   auto copartition =
-      copartitionType(planPartitionType, layout->partitionType());
+      copartitionType(planPartitionType, layout->partitionType().get());
 
-  // Copartitioning is possible if PartitionTypes are compatible and the table
-  // has no fewer partitions than the plan.
-  bool shuffle = !copartition || copartition != planPartitionType;
+  bool shuffle = !copartition || planPartitionType == nullptr ||
+      copartition->numPartitions() != planPartitionType->numPartitions();
   if (!shuffle) {
     // Check that the partition keys of the plan are assigned pairwise to the
     // partition columns of the layout.
@@ -1072,10 +1241,12 @@ RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
     }
   }
 
-  Distribution distribution(layout->partitionType(), std::move(keyValues));
+  Distribution distribution(
+      layout->partitionType().get(), std::move(keyValues));
   auto* repartition =
       make<Repartition>(plan, std::move(distribution), plan->columns());
   state.addCost(*repartition);
+  commitGroupedLeavesForRepartition(state, repartition);
   return repartition;
 }
 
@@ -1176,8 +1347,11 @@ void Optimization::addPostprocess(
     // EnforceSingleRow requires gather input. Single-worker plans
     // satisfy this by construction; no Repartition needed there.
     if (!isSingleWorker_ && !plan->distribution().isGather()) {
-      plan = make<Repartition>(plan, Distribution::gather(), plan->columns());
-      state.addCost(*plan);
+      auto* gather =
+          make<Repartition>(plan, Distribution::gather(), plan->columns());
+      state.addCost(*gather);
+      commitGroupedLeavesForRepartition(state, gather);
+      plan = gather;
     }
     auto enforceSingleRow = make<EnforceSingleRow>(plan);
     state.addCost(*enforceSingleRow);
@@ -1582,7 +1756,7 @@ bool Optimization::addWindow(
     if (!isSingleWorker_) {
       PlanCost repartitionCost;
       std::tie(plan, repartitionCost) =
-          maybeRepartition(plan, ExprVector(partitionKeys));
+          maybeRepartition(plan, ExprVector(partitionKeys), state);
       state.cost.add(repartitionCost);
     }
 
@@ -1726,6 +1900,10 @@ void Optimization::joinByIndex(
 
     state.placeColumns(c);
     state.addCost(*scan);
+    if (auto partitionType = info.index->layout->partitionType()) {
+      state.mutableCurrentGroupedLeaves().emplace(
+          scan, std::move(partitionType));
+    }
     state.addNextJoin(&candidate, scan, toTry);
   }
 }
@@ -2075,13 +2253,18 @@ void Optimization::joinByHash(
           }
         }
         Distribution distribution{
-            plan->distribution().partitionType(), copartition};
+            scaleDownPartitionType(
+                plan->distribution().partitionType(),
+                runnerOptions_.numWorkers,
+                derivedPartitionTypes_),
+            copartition};
         auto* repartition = make<Repartition>(
             buildInput,
             std::move(distribution),
             buildInput->columns(),
             replicateNullsAndAny);
         buildState.addCost(*repartition);
+        commitGroupedLeavesForRepartition(buildState, repartition);
         buildInput = repartition;
       }
     } else if (
@@ -2090,6 +2273,7 @@ void Optimization::joinByHash(
       auto* broadcast = make<Repartition>(
           buildInput, Distribution::broadcast(), buildInput->columns());
       buildState.addCost(*broadcast);
+      commitGroupedLeavesForRepartition(buildState, broadcast);
       buildInput = broadcast;
     } else {
       // The probe gets shuffled to align with build. If build is not
@@ -2169,6 +2353,9 @@ void Optimization::joinByHash(
 
   state.addCost(*join);
   state.cost.cost += buildState.cost.cost;
+  mergeFragmentMaps(
+      state.mutableCurrentGroupedLeaves(),
+      std::move(buildState.mutableCurrentGroupedLeaves()));
 
   if (enforceDistinctColumn != nullptr) {
     join = make<EnforceDistinct>(
@@ -2358,6 +2545,9 @@ void Optimization::joinByHashRight(
       candidate.fanout,
       projectionBuilder.inputColumns());
   state.addCost(*join);
+  mergeFragmentMaps(
+      state.mutableCurrentGroupedLeaves(),
+      std::move(probeState.mutableCurrentGroupedLeaves()));
 
   if (needsProjection) {
     join = projectionBuilder.build(join);
@@ -2417,12 +2607,17 @@ void Optimization::crossJoin(
   RelationOpPtr buildInput = buildPlan->op;
 
   if (!isSingleWorker_) {
-    buildInput = make<Repartition>(
+    auto* broadcast = make<Repartition>(
         buildInput, Distribution::broadcast(), buildInput->columns());
-    buildState.addCost(*buildInput);
+    buildState.addCost(*broadcast);
+    commitGroupedLeavesForRepartition(buildState, broadcast);
+    buildInput = broadcast;
   }
 
   state.cost.cost += buildState.cost.cost;
+  mergeFragmentMaps(
+      state.mutableCurrentGroupedLeaves(),
+      std::move(buildState.mutableCurrentGroupedLeaves()));
 
   if (candidate.join) {
     auto [build, probe] = candidate.joinSides();
@@ -2703,12 +2898,17 @@ RelationOpPtr Optimization::placeSingleRowDt(
   auto rightOp = rightPlan->op;
 
   if (!isSingleWorker_) {
-    rightOp = make<Repartition>(
+    auto* broadcast = make<Repartition>(
         rightOp, Distribution::broadcast(), rightOp->columns());
-    rightState.addCost(*rightOp);
+    rightState.addCost(*broadcast);
+    commitGroupedLeavesForRepartition(rightState, broadcast);
+    rightOp = broadcast;
   }
 
   state.cost.cost += rightState.cost.cost;
+  mergeFragmentMaps(
+      state.mutableCurrentGroupedLeaves(),
+      std::move(rightState.mutableCurrentGroupedLeaves()));
 
   auto resultColumns = plan->columns();
   resultColumns.insert(
@@ -2788,6 +2988,13 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
   bool ignore = false;
   auto plan = makePlan(*state.dt, key, std::nullopt, 1, ignore);
   state.cost = plan->cost;
+  // Inherit the DT's per-leaf bucketed map so subsequent operators planned
+  // atop this DT see its scans as fragment leaves.
+  auto it = planGroupedLeaves_.find(plan);
+  if (it != planGroupedLeaves_.end()) {
+    mergeFragmentMaps(
+        state.mutableCurrentGroupedLeaves(), GroupedLeaves{it->second});
+  }
 
   // Make plans based on the dt alone as first.
   makeJoins(plan->op, state);
@@ -2928,7 +3135,9 @@ ColumnVector indexColumns(
   return result;
 }
 
-// Adds the costs in the input states to the first state.
+// Adds the costs in the input states to the first state. Also merges the
+// per-leaf currentGroupedLeaves_ from each input state into the first so the
+// resulting Plan.map carries every UnionAll input's bucketed leaves.
 PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
   auto& firstState = states[0];
 
@@ -2937,6 +3146,10 @@ PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
 
     firstState.cost.cost += otherCost.cost;
     firstState.cost.cardinality += otherCost.cardinality;
+
+    mergeFragmentMaps(
+        firstState.mutableCurrentGroupedLeaves(),
+        std::move(states[i].mutableCurrentGroupedLeaves()));
   }
   return make<Plan>(result, states[0]);
 }
@@ -3021,6 +3234,10 @@ void Optimization::makeJoins(PlanState& state) {
 
         auto* scan = make<TableScan>(table, index, columns);
         state.addCost(*scan);
+        if (auto partitionType = index->layout->partitionType()) {
+          state.mutableCurrentGroupedLeaves().emplace(
+              scan, std::move(partitionType));
+        }
         makeJoins(scan, state);
       }
     } else if (from->is(PlanType::kValuesTableNode)) {
@@ -3251,15 +3468,19 @@ PlanP Optimization::makeUnionPlan(
   if (effectiveDistribution.has_value()) {
     // Some inputs need a shuffle to reach the parent's desired distribution;
     // wrap those.
+    const auto* unionPartType = scaleDownPartitionType(
+        effectiveDistribution->partitionType,
+        runnerOptions_.numWorkers,
+        derivedPartitionTypes_);
     for (auto i = 0; i < inputs.size(); ++i) {
       if (inputNeedsShuffle[i]) {
-        inputs[i] = make<Repartition>(
+        auto* repartition = make<Repartition>(
             inputs[i],
-            Distribution{
-                effectiveDistribution->partitionType,
-                effectiveDistribution->partitionKeys},
+            Distribution{unionPartType, effectiveDistribution->partitionKeys},
             inputs[i]->columns());
-        inputStates[i].addCost(*inputs[i]);
+        inputStates[i].addCost(*repartition);
+        commitGroupedLeavesForRepartition(inputStates[i], repartition);
+        inputs[i] = repartition;
       }
     }
   } else {
@@ -3308,7 +3529,11 @@ PlanP Optimization::makeUnionPlan(
         newInputs.emplace_back(wrapped);
       }
       inputs = std::move(newInputs);
-      inputStates[firstSingleIndex].addCost(*wrapped);
+      VELOX_CHECK(wrapEmitted);
+      VELOX_CHECK_LT(firstSingleIndex, inputStates.size());
+      inputStates.at(firstSingleIndex).addCost(*wrapped);
+      commitGroupedLeavesForRepartition(
+          inputStates.at(firstSingleIndex), wrapped);
     }
   }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -59,13 +59,8 @@ class Optimization {
   /// Returns the optimized RelationOp plan for 'plan' given at construction.
   PlanP bestPlan();
 
-  /// Returns a set of per-stage Velox PlanNode trees. If 'historyKeys' is
-  /// given, these can be used to record history data about the execution of
-  /// each relevant node for costing future queries.
-  PlanAndStats toVeloxPlan(RelationOpPtr plan) {
-    return toVelox_.toVeloxPlan(
-        std::move(plan), runnerOptions_, outputColumnMappings_);
-  }
+  /// Returns a set of per-stage Velox PlanNode trees.
+  PlanAndStats toVeloxPlan(RelationOpPtr plan);
 
   ToVelox& toVelox() {
     return toVelox_;
@@ -150,6 +145,11 @@ class Optimization {
     return runnerOptions_;
   }
 
+  std::vector<std::shared_ptr<connector::PartitionType>>&
+  derivedPartitionTypes() {
+    return derivedPartitionTypes_;
+  }
+
   History& history() const {
     return history_;
   }
@@ -177,6 +177,43 @@ class Optimization {
   /// Produces trace output if event matches 'traceFlags_'.
   void trace(uint32_t event, int32_t id, const PlanCost& cost, RelationOp& plan)
       const;
+
+  /// Per-Repartition map from leaf RelationOp to its scaled-down
+  /// PartitionType, captured at fragment commit. ToVelox reads it at
+  /// makeRepartition emission to populate the producer
+  /// ExecutableFragment::groupedNodes.
+  folly::F14FastMap<const Repartition*, GroupedLeaves>&
+  repartitionGroupedLeaves() {
+    return repartitionGroupedLeaves_;
+  }
+
+  const folly::F14FastMap<const Repartition*, GroupedLeaves>&
+  repartitionGroupedLeaves() const {
+    return repartitionGroupedLeaves_;
+  }
+
+  /// Final leaf -> PartitionType map for the root fragment, set by bestPlan()
+  /// and read by ToVelox when emitting the root fragment.
+  GroupedLeaves& rootGroupedLeaves() {
+    return rootGroupedLeaves_;
+  }
+
+  const GroupedLeaves& rootGroupedLeaves() const {
+    return rootGroupedLeaves_;
+  }
+
+  /// Side table of per-Plan bucketed leaf maps, captured at Plan construction.
+  /// Lives on Optimization (not on Plan itself) because some Plans are
+  /// arena-allocated via make<Plan>, where storing an F14FastMap directly on
+  /// Plan would leak its heap storage.
+  folly::F14FastMap<const Plan*, GroupedLeaves>& planGroupedLeaves() {
+    return planGroupedLeaves_;
+  }
+
+  const folly::F14FastMap<const Plan*, GroupedLeaves>& planGroupedLeaves()
+      const {
+    return planGroupedLeaves_;
+  }
 
  private:
   // Lists the possible joins based on 'state.placed' and adds each on top of
@@ -397,7 +434,43 @@ class Optimization {
   // (e.g., via existence pushdown).
   folly::F14FastSet<int32_t> estimatedBaseTables_;
 
+  // PartitionTypes derived during planning (scaleDown for Repartition
+  // distributions). Distribution::partitionType_ is a raw pointer because
+  // RelationOps are arena-allocated and dtors don't run there; this vector
+  // owns the heap-allocated derived types so the raw pointers stay valid
+  // for the lifetime of the planning session.
+  std::vector<std::shared_ptr<connector::PartitionType>> derivedPartitionTypes_;
+
+  // Per-Repartition map from leaf RelationOp to its scaled-down PartitionType,
+  // committed at every make<Repartition>. Consumed by ToVelox at Repartition
+  // emission to populate the producer ExecutableFragment::groupedNodes.
+  folly::F14FastMap<const Repartition*, GroupedLeaves>
+      repartitionGroupedLeaves_;
+
+  // Final leaf -> scaled-down PartitionType map for the root (topmost)
+  // fragment, captured by bestPlan() from the winning Plan's per-leaf map.
+  // Consumed by ToVelox at root emission.
+  GroupedLeaves rootGroupedLeaves_;
+
+  // Per-Plan map from leaf RelationOp to its scaled-down PartitionType,
+  // captured at Plan construction. See planGroupedLeaves() doc.
+  folly::F14FastMap<const Plan*, GroupedLeaves> planGroupedLeaves_;
+
   std::shared_ptr<QueryRuntimeStats> runtimeStats_;
 };
+
+/// Captures the producer-side fragment commit. Moves
+/// 'state.currentGroupedLeaves_' (the producer's per-leaf map of native
+/// PartitionTypes) onto 'state.optimization.repartitionGroupedLeaves_' keyed by
+/// the freshly-created 'repartition', applies scaleDown(numWorkers) to each
+/// non-null entry — that's the optimizer committing the fragment to a
+/// runner-task budget — then resets state's map per the Repartition's
+/// distribution kind: hash-partitioned consumer gets a single
+/// (repartition, nullptr) entry to propagate the exchange into the consumer
+/// fragment's groupedNodes; broadcast/gather/arbitrary leave the consumer
+/// empty. Call immediately after each make<Repartition>.
+void commitGroupedLeavesForRepartition(
+    PlanState& state,
+    const Repartition* repartition);
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -39,7 +39,14 @@ PlanState::PlanState(Optimization& optimization, DerivedTableCP dt, PlanP plan)
     : optimization(optimization),
       dt(dt),
       cost(plan->cost),
-      syntacticJoinOrder_{optimization.options().syntacticJoinOrder} {}
+      syntacticJoinOrder_{optimization.options().syntacticJoinOrder} {
+  if (auto it = optimization.planGroupedLeaves().find(plan);
+      it != optimization.planGroupedLeaves().end()) {
+    // Copy: planGroupedLeaves_[plan] is reused if 'plan' is selected as input
+    // to multiple parents; each consumer needs its own starting map.
+    currentGroupedLeaves_ = GroupedLeaves{it->second};
+  }
+}
 
 #ifndef NDEBUG
 // NOLINTBEGIN
@@ -73,6 +80,7 @@ void PlanState::save(PlanStateSaver& saver) const {
   saver.columns = columns_;
   saver.cost = cost;
   saver.exprToColumn = exprToColumn_;
+  saver.currentGroupedLeaves = currentGroupedLeaves_;
   saver.numDebugPlacedTables = debugPlacedTables.size();
 }
 
@@ -81,6 +89,7 @@ void PlanState::restore(PlanStateSaver& saver) {
   columns_ = std::move(saver.columns);
   cost = saver.cost;
   exprToColumn_ = std::move(saver.exprToColumn);
+  currentGroupedLeaves_ = std::move(saver.currentGroupedLeaves);
   debugPlacedTables.resize(saver.numDebugPlacedTables);
 }
 
@@ -89,6 +98,9 @@ void PlanState::restore(const NextJoin& nextJoin) {
   columns_ = nextJoin.columns;
   cost = nextJoin.cost;
   exprToColumn_.clear();
+  // Copy, not move: NextJoin may be revisited if multiple candidates remain
+  // in toTry and the outer scope iterates them.
+  currentGroupedLeaves_ = nextJoin.currentGroupedLeaves;
 }
 
 void PlanState::place(PlanObjectCP object) {
@@ -160,7 +172,13 @@ Plan::Plan(RelationOpPtr op, const PlanState& state)
       cost(state.cost),
       tables(state.placed()),
       columns(exprColumns(state.targetExprs)),
-      constraints(&this->op->constraints()) {}
+      constraints(&this->op->constraints()) {
+  // Park the per-leaf bucketed map on the Optimization side table keyed by
+  // this Plan's address. Plans are sometimes allocated via the arena
+  // (make<Plan>) where destructors don't run; storing the map externally
+  // avoids leaking the F14FastMap's heap storage.
+  state.optimization.planGroupedLeaves()[this] = state.currentGroupedLeaves();
+}
 
 bool Plan::isStateBetter(const PlanState& state, float margin) const {
   return cost.cost > state.cost.cost + margin;
@@ -203,7 +221,13 @@ void PlanState::addNextJoin(
     std::vector<NextJoin>& toTry) const {
   VELOX_DCHECK(exprToColumn_.empty());
   if (!isOverBest()) {
-    toTry.emplace_back(candidate, std::move(plan), cost, placed_, columns_);
+    toTry.emplace_back(
+        candidate,
+        std::move(plan),
+        cost,
+        placed_,
+        columns_,
+        currentGroupedLeaves_);
   } else {
     optimization.trace(OptimizerOptions::kExceededBest, dt->id(), cost, *plan);
   }
@@ -484,7 +508,7 @@ PlanP PlanSet::best(
 
     update(best, bestCost);
     if (checkDistribution &&
-        plan->op->distribution().isSamePartition(distribution.value())) {
+        plan->op->distribution().isCopartitionedWith(distribution.value())) {
       update(match, matchCost);
     }
   }

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -168,18 +168,25 @@ struct NextJoin {
       RelationOpPtr plan,
       PlanCost cost,
       PlanObjectSet placed,
-      PlanObjectSet columns)
+      PlanObjectSet columns,
+      GroupedLeaves currentGroupedLeaves)
       : candidate{candidate},
         plan{std::move(plan)},
         cost{std::move(cost)},
         placed{std::move(placed)},
-        columns{std::move(columns)} {}
+        columns{std::move(columns)},
+        currentGroupedLeaves{std::move(currentGroupedLeaves)} {}
 
   const JoinCandidate* candidate;
   RelationOpPtr plan;
   PlanCost cost;
   PlanObjectSet placed;
   PlanObjectSet columns;
+
+  /// Frozen copy of PlanState::currentGroupedLeaves_ at the time addNextJoin
+  /// captured this candidate. Restored alongside placed/columns/cost when
+  /// tryNextJoins iterates candidates.
+  GroupedLeaves currentGroupedLeaves;
 
   /// If true, only 'other' should be tried. Use to compare equivalent joins
   /// with different join method or partitioning.
@@ -313,6 +320,16 @@ struct PlanState {
   /// mapping. Returns the original 'expr' if no mapping exists.
   ExprCP toColumn(ExprCP expr) const;
 
+  /// Read-only access to the current fragment's per-leaf PartitionType map.
+  const GroupedLeaves& currentGroupedLeaves() const {
+    return currentGroupedLeaves_;
+  }
+
+  /// Mutable access for in-place updates at scan / join / Repartition sites.
+  GroupedLeaves& mutableCurrentGroupedLeaves() {
+    return currentGroupedLeaves_;
+  }
+
  private:
   PlanObjectSet computeDownstreamColumns(bool includeFilters) const;
 
@@ -336,6 +353,11 @@ struct PlanState {
   /// A mapping of expressions to pre-computed columns. See
   /// PrecomputeProjection.
   folly::F14FastMap<ExprCP, ExprCP> exprToColumn_;
+
+  // Per-leaf PartitionType map for the fragment containing the current top
+  // operator. Updated as scans are placed (insert), as joins fold copartition
+  // (per-leaf coarsening), and as Repartitions are inserted (snapshot+reset).
+  GroupedLeaves currentGroupedLeaves_;
 };
 
 /// A scoped guard that restores fields of PlanState on destruction.
@@ -352,6 +374,7 @@ struct PlanStateSaver {
   PlanObjectSet columns;
   PlanCost cost;
   folly::F14FastMap<ExprCP, ExprCP> exprToColumn;
+  GroupedLeaves currentGroupedLeaves;
   size_t numDebugPlacedTables{0};
 
  private:

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -217,6 +217,7 @@ Distribution TableScan::outputDistribution(
     orderTypes.resize(numPrefix);
     replace(orderKeys, schemaColumns, columns.data());
   }
+
   return Distribution(
       distribution.partitionType(),
       std::move(partitionKeys),

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -440,6 +440,17 @@ class Repartition : public RelationOp {
 
 using RepartitionCP = const Repartition*;
 
+/// Per-leaf PartitionType map for a fragment in flight during planning.
+/// Keys are arena-allocated `const TableScan*` (bucketed scan leaf) or
+/// `const Repartition*` (consumer-side exchange entering this fragment).
+/// Values are non-null for bucketed leaves (the connector emits splits
+/// tagged with groupId and the runtime routes by that groupId) and null for
+/// hash-partitioned exchanges (the producer's hash function does the
+/// alignment, no per-row tagging needed).
+using GroupedLeaves = folly::F14FastMap<
+    const RelationOp*,
+    std::shared_ptr<const connector::PartitionType>>;
+
 /// Represents a usually multitable filter not associated with any non-inner
 /// join. Non-equality constraints over inner joins become Filters.
 class Filter : public RelationOp {

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -227,7 +227,7 @@ SchemaTableCP Schema::findTable(
     VELOX_CHECK_EQ(orderKeys.size(), orderTypes.size());
 
     Distribution distribution(
-        layout->partitionType(),
+        layout->partitionType().get(),
         std::move(partition),
         std::move(orderKeys),
         std::move(orderTypes));
@@ -345,6 +345,32 @@ bool Distribution::isSamePartition(const DesiredDistribution& other) const {
   }
 
   if (partitionKeys().size() != other.partitionKeys.size()) {
+    return false;
+  }
+
+  for (auto i = 0; i < partitionKeys().size(); ++i) {
+    if (!partitionKeys()[i]->sameOrEqual(*other.partitionKeys[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool Distribution::isCopartitionedWith(const DesiredDistribution& other) const {
+  auto* thisPartitionType = partitionType();
+  if (thisPartitionType != other.partitionType) {
+    if (thisPartitionType == nullptr || other.partitionType == nullptr ||
+        thisPartitionType->copartition(*other.partitionType) == nullptr) {
+      return false;
+    }
+  }
+
+  if (partitionKeys().size() != other.partitionKeys.size()) {
+    return false;
+  }
+
+  if (partitionKeys().empty()) {
     return false;
   }
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -215,13 +215,18 @@ struct Distribution {
   }
 
   /// True if 'this' and 'other' have the same number/type of keys and same
-  /// distribution type. Data is copartitioned if both sides have a 1:1
-  /// equality on all partitioning key columns.
+  /// distribution type via strict pointer equality on PartitionType.
   bool isSamePartition(const Distribution& other) const;
 
-  /// Return if 'this' and 'other' have the same number/type of partitioning
-  /// keys and use same partitioning function.
+  /// True if 'this' has the same number/type of partitioning keys and uses
+  /// the same partitioning function (strict pointer equality on
+  /// PartitionType).
   bool isSamePartition(const DesiredDistribution& other) const;
+
+  /// Looser variant of isSamePartition: same partition keys and
+  /// PartitionTypes for which copartition() returns non-null. Returns false
+  /// when both sides have empty partitionKeys.
+  bool isCopartitionedWith(const DesiredDistribution& other) const;
 
   /// True if 'other' has the same ordering columns and order type.
   bool isSameOrder(const Distribution& other) const;
@@ -276,7 +281,10 @@ struct Distribution {
   Kind kind_{Kind::kUnspecified};
 
   // Connector-specific partition function. nullptr means standard Velox hash
-  // (when kind_ is kPartitioned) or no partitioning otherwise.
+  // (when kind_ is kPartitioned) or no partitioning otherwise. Lifetime is
+  // managed externally: layout-owned PartitionTypes live for the connector's
+  // lifetime; PartitionTypes derived during planning (scaleDown, copartition)
+  // are owned by Optimization::derivedPartitionTypes_.
   const connector::PartitionType* partitionType_{nullptr};
 
   // Partitioning columns. The values of these columns determine which

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -535,7 +535,7 @@ lp::ValuesNodePtr tryFoldConstantDt(
 
   auto& optimization = queryCtx()->optimization();
   auto veloxPlan = optimization->toVelox().toVeloxPlan(
-      plan, MultiFragmentPlan::Options::singleNode());
+      plan, MultiFragmentPlan::Options::singleNode(), {}, {});
   auto results = runConstantPlan(veloxPlan, pool);
   if (results.empty()) {
     VELOX_CHECK_EQ(1, veloxPlan.plan->fragments().size());

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -164,7 +164,12 @@ std::vector<velox::common::Subfield> columnSubfields(
   return subfields;
 }
 
-RelationOpPtr addGather(const RelationOpPtr& op) {
+// On return, *outGather is set to the inserted gather Repartition, or
+// nullptr if no gather was added.
+RelationOpPtr addGather(
+    const RelationOpPtr& op,
+    const Repartition** outGather) {
+  *outGather = nullptr;
   if (op->distribution().isGather()) {
     return op;
   }
@@ -172,11 +177,13 @@ RelationOpPtr addGather(const RelationOpPtr& op) {
     const auto& order = op->distribution();
     auto final = Distribution::gather(order.orderKeys(), order.orderTypes());
     auto* gather = make<Repartition>(op, final, op->columns());
+    *outGather = gather;
     auto* orderBy =
         make<OrderBy>(gather, order.orderKeys(), order.orderTypes());
     return orderBy;
   }
   auto* gather = make<Repartition>(op, Distribution::gather(), op->columns());
+  *outGather = gather;
   return gather;
 }
 
@@ -427,20 +434,111 @@ void decideFragmentType(
   }
 }
 
+// First non-null PartitionType's numPartitions in 'groupedLeaves', else
+// 'fallback'. All non-null entries are expected to share numPartitions()
+// (post-foldCopartition invariant) and a mismatch indicates a planning bug.
+int32_t groupedLeavesWidth(
+    const GroupedLeaves& groupedLeaves,
+    int32_t fallback) {
+  int32_t width = -1;
+  for (const auto& [_, pt] : groupedLeaves) {
+    if (pt == nullptr) {
+      continue;
+    }
+    if (width < 0) {
+      width = pt->numPartitions();
+    } else {
+      VELOX_CHECK_EQ(
+          pt->numPartitions(),
+          width,
+          "GroupedLeaves has non-null PartitionTypes with disagreeing numPartitions");
+    }
+  }
+  return width < 0 ? fallback : width;
+}
+
 } // namespace
+
+void ToVelox::applyGroupedLeaves(
+    ExecutableFragment& fragment,
+    const GroupedLeaves& groupedLeaves) {
+  // A fragment is bucketed iff at least one groupedLeaves entry has a non-null
+  // PartitionType. Non-bucketed fragments leave groupedNodes empty: a
+  // fragment that consumes only hash-partitioned exchanges (all-null entries)
+  // doesn't participate in groupId routing.
+  bool anyNonNull = false;
+  for (const auto& [_, pt] : groupedLeaves) {
+    if (pt != nullptr) {
+      anyNonNull = true;
+      break;
+    }
+  }
+  if (!anyNonNull) {
+    return;
+  }
+  for (const auto& [relOp, partitionType] : groupedLeaves) {
+    auto idIt = relationOpToNodeId_.find(relOp);
+    VELOX_CHECK(
+        idIt != relationOpToNodeId_.end(),
+        "GroupedLeaves references a RelationOp not yet emitted by ToVelox");
+    // ExecutableFragment::groupedNodes' contract is non-const PartitionType
+    // (axel/runtime side); groupedLeaves are const for optimizer-side
+    // immutability. Drop-const is safe — neither consumer mutates the type.
+    fragment.groupedNodes.emplace(
+        idIt->second,
+        std::const_pointer_cast<connector::PartitionType>(partitionType));
+  }
+  int32_t width = -1;
+  for (const auto& [_, pt] : fragment.groupedNodes) {
+    if (pt == nullptr) {
+      continue;
+    }
+    if (width < 0) {
+      width = pt->numPartitions();
+    } else {
+      VELOX_CHECK_EQ(
+          pt->numPartitions(),
+          width,
+          "fragment.groupedNodes has non-null PartitionTypes with disagreeing numPartitions");
+    }
+  }
+  if (width >= 0) {
+    fragment.type = FragmentType::kFixed;
+    fragment.width = width;
+  }
+}
 
 PlanAndStats ToVelox::toVeloxPlan(
     RelationOpPtr plan,
     const MultiFragmentPlan::Options& options,
-    const std::vector<OutputColumnNameMapping>& outputNames) {
+    const std::vector<OutputColumnNameMapping>& outputNames,
+    const GroupedLeavesBundle& groupedLeaves) {
   options_ = options;
 
   prediction_.clear();
   nodeHistory_.clear();
+  relationOpToNodeId_.clear();
+  currentConsumerGroupedLeaves_ = nullptr;
+  groupedLeaves_ = &groupedLeaves;
+  gatherRepartition_ = nullptr;
+  SCOPE_EXIT {
+    groupedLeaves_ = nullptr;
+    gatherRepartition_ = nullptr;
+  };
 
+  // If addGather inserts a final gather Repartition, remember it so
+  // makeRepartition's consumer logic can treat it as carrying the root
+  // fragment's GroupedLeaves (the gather was not present at planning time
+  // and so has no entry in groupedLeaves_->perRepartition).
   if (options_.numWorkers > 1 && !options_.remoteOutput) {
-    plan = addGather(plan);
+    plan = addGather(plan, &gatherRepartition_);
   }
+
+  // Top fragment's consumer GroupedLeaves. For non-gather single-task tests
+  // this is groupedLeaves_->root; for the gather case the gather's
+  // PartitionedOutputNode feeds a kSingle root, so the value is unused but
+  // harmless.
+  currentConsumerGroupedLeaves_ = &groupedLeaves_->root;
 
   // The final (root) fragment is not capped by a Repartition. With
   // remoteOutput, the root produces wire output; its type is whatever its
@@ -456,6 +554,17 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   std::vector<ExecutableFragment> stages;
   top.fragment.planNode = makeFragment(plan, top, stages);
+
+  // For the root fragment when no addGather was inserted, apply the
+  // optimizer's root groupedLeaves directly to top.groupedNodes so the
+  // runtime/connector pair sees the root's bucketed-leaf routing.
+  // Skip when top.type is kSingle: a single-task root has no groupId
+  // routing (local consumer) and applyGroupedLeaves would otherwise
+  // overwrite the type with kFixed and trip checkLastFragment.
+  if (gatherRepartition_ == nullptr && top.type != FragmentType::kSingle) {
+    applyGroupedLeaves(top, groupedLeaves_->root);
+  }
+
   stages.push_back(std::move(top));
 
   auto& rootPlanNode = stages.back().fragment.planNode;
@@ -1009,6 +1118,8 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
       nextId(), node->outputType(), exchangeSerdeKind_, node);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
 
+  applyGroupedLeaves(source, groupedLeaves_->root);
+
   auto merge = std::make_shared<velox::core::MergeExchangeNode>(
       nextId(), node->outputType(), keys, sortOrder, exchangeSerdeKind_);
 
@@ -1037,6 +1148,8 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
       nextId(), input->outputType(), exchangeSerdeKind_, input);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
+
+  applyGroupedLeaves(source, groupedLeaves_->root);
 
   auto exchange = std::make_shared<velox::core::ExchangeNode>(
       nextId(), input->outputType(), exchangeSerdeKind_);
@@ -1086,6 +1199,8 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
       nextId(), node->outputType(), exchangeSerdeKind_, node);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
+
+  applyGroupedLeaves(source, groupedLeaves_->root);
 
   auto exchange = std::make_shared<velox::core::ExchangeNode>(
       nextId(), node->outputType(), exchangeSerdeKind_);
@@ -1305,8 +1420,8 @@ velox::core::TypedExprPtr toAndWithAliases(
 
 velox::core::PlanNodePtr ToVelox::makeScan(
     const TableScan& scan,
-    ExecutableFragment& fragment,
-    std::vector<ExecutableFragment>& stages) {
+    ExecutableFragment& /*fragment*/,
+    std::vector<ExecutableFragment>& /*stages*/) {
   columnAlteredTypes_.clear();
 
   const bool isSubfieldPushdown = hasSubfieldPushdown(scan);
@@ -1354,9 +1469,12 @@ velox::core::PlanNodePtr ToVelox::makeScan(
         connectorSession, column->name(), std::move(subfields));
   }
 
+  auto scanId = nextId();
   velox::core::PlanNodePtr result =
       std::make_shared<velox::core::TableScanNode>(
-          nextId(), outputType, tableHandle, assignments);
+          scanId, outputType, tableHandle, assignments);
+
+  relationOpToNodeId_.insert_or_assign(&scan, scanId);
 
   if (filter != nullptr) {
     result =
@@ -1755,7 +1873,30 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   // Repartition's distribution describes the wire output and is independent.
   auto source = newFragment();
   decideFragmentType(*repartition.input(), options_, source);
+
+  // Save the outer consumer's groupedLeaves (used to size our PartitionedOutput
+  // below) and set the inner recursion's consumer context to source's
+  // groupedLeaves. Restore after the recursion returns.
+  const GroupedLeaves* outerConsumerGroupedLeaves =
+      currentConsumerGroupedLeaves_;
+  static const GroupedLeaves kEmptyGroupedLeaves;
+  const GroupedLeaves* sourceGroupedLeaves = nullptr;
+  if (&repartition == gatherRepartition_) {
+    // Synthetic gather Repartition: not present in perRepartition
+    // because it was added after planning. Treat its source-side groupedLeaves
+    // as the root's.
+    sourceGroupedLeaves = &groupedLeaves_->root;
+  } else {
+    auto it = groupedLeaves_->perRepartition.find(&repartition);
+    if (it != groupedLeaves_->perRepartition.end()) {
+      sourceGroupedLeaves = &it->second;
+    }
+  }
+  currentConsumerGroupedLeaves_ = sourceGroupedLeaves != nullptr
+      ? sourceGroupedLeaves
+      : &kEmptyGroupedLeaves;
   auto sourcePlan = makeFragment(repartition.input(), source, stages);
+  currentConsumerGroupedLeaves_ = outerConsumerGroupedLeaves;
 
   // TODO Figure out a cleaner solution to setting 'columns' for TableWrite.
   auto outputType = repartition.columns().empty()
@@ -1780,20 +1921,26 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
         nextId(), outputType, exchangeSerdeKind_, sourcePlan);
   } else {
     VELOX_CHECK_NE(0, keys.size());
-    auto partitionFunctionFactory = createPartitionFunctionSpec(
-        sourcePlan->outputType(), keys, distribution);
-
-    source.fragment.planNode =
-        std::make_shared<velox::core::PartitionedOutputNode>(
-            nextId(),
-            velox::core::PartitionedOutputNode::Kind::kPartitioned,
-            keys,
-            options_.numWorkers,
-            repartition.isReplicateNullsAndAny(),
-            std::move(partitionFunctionFactory),
-            outputType,
-            exchangeSerdeKind_,
-            sourcePlan);
+    const auto numPartitions =
+        groupedLeavesWidth(*outerConsumerGroupedLeaves, options_.numWorkers);
+    if (numPartitions == 1) {
+      source.fragment.planNode = velox::core::PartitionedOutputNode::single(
+          nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+    } else {
+      auto partitionFunctionFactory = createPartitionFunctionSpec(
+          sourcePlan->outputType(), keys, distribution);
+      source.fragment.planNode =
+          std::make_shared<velox::core::PartitionedOutputNode>(
+              nextId(),
+              velox::core::PartitionedOutputNode::Kind::kPartitioned,
+              keys,
+              numPartitions,
+              repartition.isReplicateNullsAndAny(),
+              std::move(partitionFunctionFactory),
+              outputType,
+              exchangeSerdeKind_,
+              sourcePlan);
+    }
   }
   makePredictionAndHistory(source.fragment.planNode->id(), &repartition);
 
@@ -1801,6 +1948,20 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
     exchange = std::make_shared<velox::core::ExchangeNode>(
         nextId(), outputType, exchangeSerdeKind_);
   }
+
+  // Map this Repartition to its consumer-side ExchangeNode id so any later
+  // groupedLeaves lookup that targets &repartition translates to exchange->id()
+  // for the consumer fragment's groupedNodes entry.
+  relationOpToNodeId_.insert_or_assign(&repartition, exchange->id());
+
+  // Apply the optimizer-side groupedLeaves for this Repartition's PRODUCER
+  // fragment. The map was committed in Optimization at every make<Repartition>
+  // and contains the per-leaf PartitionType map for the fragment ending in
+  // this Repartition.
+  if (sourceGroupedLeaves != nullptr) {
+    applyGroupedLeaves(source, *sourceGroupedLeaves);
+  }
+
   fragment.inputStages.emplace_back(exchange->id(), source.taskPrefix);
   stages.push_back(std::move(source));
   return exchange;
@@ -2015,6 +2176,9 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
     numDrivers = 1;
   }
 
+  VELOX_CHECK(
+      fragment.type != FragmentType::kFixed || fragment.width.has_value(),
+      "kFixed fragment must have width set");
   auto numTasks = fragment.width.value_or(
       fragment.type == FragmentType::kSource ? options_.numWorkers : 1);
 

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -57,6 +57,16 @@ struct PlanAndStats {
   std::string toString() const;
 };
 
+/// Per-fragment leaf-PartitionType maps produced by the optimizer and consumed
+/// by ToVelox to populate ExecutableFragment::groupedNodes.
+struct GroupedLeavesBundle {
+  /// One entry per Repartition (fragment boundary).
+  folly::F14FastMap<const Repartition*, GroupedLeaves> perRepartition;
+
+  /// For the root fragment, captured after planning completes.
+  GroupedLeaves root;
+};
+
 class ToVelox {
  public:
   ToVelox(
@@ -66,12 +76,13 @@ class ToVelox {
 
   /// Converts physical plan (a tree of RelationOp) to an executable
   /// multi-fragment Velox plan. If outputNames is non-empty, adds a
-  /// final projection that selects the named source columns from the
-  /// optimized plan's outputType and renames them per outputName.
+  /// final projection to rename or reorder output columns. Pass {} for
+  /// 'groupedLeaves' on plans that don't use bucketed execution.
   PlanAndStats toVeloxPlan(
       RelationOpPtr plan,
       const MultiFragmentPlan::Options& options,
-      const std::vector<OutputColumnNameMapping>& outputNames = {});
+      const std::vector<OutputColumnNameMapping>& outputNames,
+      const GroupedLeavesBundle& groupedLeaves);
 
   /// Per-leaf-table data produced by filterUpdated().
   struct LeafTableData {
@@ -394,6 +405,36 @@ class ToVelox {
   // when numWorkers > 1, consumed by toVeloxPlan to add a
   // TableWriteMerge(kFinal) after the gather exchange.
   std::optional<velox::core::ColumnStatsSpec> finalMergeSpec_;
+
+  // Translates 'groupedLeaves' (keyed by const RelationOp*) into entries in
+  // 'fragment.groupedNodes' (keyed by Velox PlanNodeId) using
+  // 'relationOpToNodeId_'. After translation, if any non-null PartitionType
+  // entry is present, sets fragment.type = kFixed and fragment.width =
+  // numPartitions().
+  void applyGroupedLeaves(
+      ExecutableFragment& fragment,
+      const GroupedLeaves& groupedLeaves);
+
+  // RelationOp identity → minted Velox PlanNodeId. Cleared at the top of
+  // toVeloxPlan.
+  folly::F14FastMap<const RelationOp*, velox::core::PlanNodeId>
+      relationOpToNodeId_;
+
+  // GroupedLeaves of the fragment consuming the Repartition currently being
+  // emitted; read to size that Repartition's PartitionedOutputNode.
+  // Saved/restored across nested makeRepartition calls.
+  const GroupedLeaves* currentConsumerGroupedLeaves_{nullptr};
+
+  // Per-call bundle of optimizer-produced grouped-leaf maps. Set at the top
+  // of toVeloxPlan from the explicit parameter; cleared on exit.
+  const GroupedLeavesBundle* groupedLeaves_{nullptr};
+
+  // The synthetic gather Repartition that addGather inserts at the top of
+  // the plan tree, when applicable. Set by toVeloxPlan. makeRepartition
+  // treats this as carrying the same GroupedLeaves as the root fragment;
+  // it is not present in groupedLeaves_->perRepartition because
+  // it was not in the plan at optimization time.
+  const Repartition* gatherRepartition_{nullptr};
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -698,22 +698,11 @@ for Hive, `bucketId % partitionType->numPartitions()`).
 | Latency | May wait for group completion | Incremental, tasks start immediately |
 | Memory per task | Per-group data | Total data / numTasks |
 
-The optimizer queries the connector to choose the mode:
-
-```cpp
-/// On ConnectorSplitManager. Returns true if the connector can
-/// efficiently enumerate complete groups via GroupedSplitSource.
-virtual bool supportsGroupedSplitSource() const { return false; }
-```
-
-When true, the optimizer sets `groupedExecution = true` on the
-fragment and the runtime uses `GroupedSplitSource` with per-group
-clearing. When false, the optimizer sets `groupedExecution = false`
-and the runtime uses regular `SplitSource` with `groupId` on each
-split — shuffle avoidance without per-group clearing. This applies
-to all cases — aggregations, window functions, and joins (both
-co-bucketed and mixed). A more structured connector capabilities
-system may replace this in the future.
+Shuffle avoidance uses the regular `SplitSource` with `groupId`
+on each split — no per-group clearing. A future grouped-execution
+path may introduce a `GroupedSplitSource` and a corresponding
+capability bit on `ConnectorSplitManager`; the API surface is not
+defined here.
 
 #### Examples
 

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -1,0 +1,677 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class BucketedExecutionTest : public test::QueryTestBase {
+ protected:
+  lp::PlanBuilder::Context makeContext() const {
+    return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
+  }
+
+  void addBucketedTable(
+      const std::string& name,
+      const std::vector<std::string>& bucketColumns,
+      int32_t numBuckets,
+      const RowTypePtr& schema =
+          ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      int64_t numRows = 1'000'000) {
+    testConnector_->addTable(
+        name,
+        schema,
+        velox::ROW({}),
+        connector::TestBucketSpec{bucketColumns, numBuckets});
+    std::unordered_map<std::string, connector::ColumnStatistics> stats;
+    for (const auto& column : schema->names()) {
+      stats[column] = {.numDistinct = numRows / 10};
+    }
+    testConnector_->setStats(name, numRows, stats);
+  }
+
+  void addUnbucketedTable(
+      const std::string& name,
+      const RowTypePtr& schema =
+          ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      int64_t numRows = 1'000'000) {
+    testConnector_->addTable(name, schema);
+    std::unordered_map<std::string, connector::ColumnStatistics> stats;
+    for (const auto& column : schema->names()) {
+      stats[column] = {.numDistinct = numRows / 10};
+    }
+    testConnector_->setStats(name, numRows, stats);
+  }
+
+  PlanAndStats planDistributed(const lp::LogicalPlanNodePtr& logicalPlan) {
+    return planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+  }
+
+  static void expectBucketedFragmentWithWidth(
+      const MultiFragmentPlan& plan,
+      int32_t expectedWidth,
+      int32_t expectedBucketedScans = -1,
+      int32_t expectedHashExchanges = -1) {
+    bool found = false;
+    for (const auto& fragment : plan.fragments()) {
+      if (fragment.groupedNodes.empty()) {
+        continue;
+      }
+      EXPECT_EQ(fragment.type, FragmentType::kFixed);
+      ASSERT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, expectedWidth);
+      int32_t bucketedScans = 0;
+      int32_t hashExchanges = 0;
+      for (const auto& [_, partitionType] : fragment.groupedNodes) {
+        if (partitionType == nullptr) {
+          ++hashExchanges;
+        } else {
+          ++bucketedScans;
+        }
+      }
+      if (expectedBucketedScans >= 0) {
+        EXPECT_EQ(bucketedScans, expectedBucketedScans);
+      }
+      if (expectedHashExchanges >= 0) {
+        EXPECT_EQ(hashExchanges, expectedHashExchanges);
+      }
+      found = true;
+    }
+    EXPECT_TRUE(found) << "Expected at least one bucketed fragment";
+  }
+};
+
+TEST_F(BucketedExecutionTest, join) {
+  addBucketedTable("j_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "j_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders RIGHT JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders FULL OUTER JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  // LEFT join: bucketed fragment preserved on one side.
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders LEFT JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  testConnector_->addTable(
+      "j_unbucketed", ROW({"id", "label"}, {BIGINT(), VARCHAR()}));
+  testConnector_->setStats(
+      "j_unbucketed", 50'000, {{"id", {.numDistinct = 50'000}}});
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM j_orders JOIN j_unbucketed "
+      "ON j_orders.customer_id = j_unbucketed.id",
+      kTestConnectorId));
+  expectBucketedFragmentWithWidth(
+      *plan.plan,
+      /*expectedWidth=*/4,
+      /*expectedBucketedScans=*/1,
+      /*expectedHashExchanges=*/1);
+}
+
+TEST_F(BucketedExecutionTest, semijoin) {
+  addBucketedTable("sj_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "sj_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM sj_orders WHERE customer_id IN "
+        "(SELECT id FROM sj_customers)",
+        kTestConnectorId));
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("sj_orders")
+            .hashJoin(
+                matchScan("sj_customers").build(),
+                core::JoinType::kLeftSemiFilter)
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM sj_orders WHERE customer_id NOT IN "
+        "(SELECT id FROM sj_customers)",
+        kTestConnectorId));
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("sj_orders")
+            .hashJoin(
+                matchScan("sj_customers").build(),
+                core::JoinType::kAnti,
+                {.nullAware = true})
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
+}
+
+TEST_F(BucketedExecutionTest, aggregation) {
+  testConnector_->addTable(
+      "a_orders",
+      ROW({"customer_id", "order_date", "amount"},
+          {BIGINT(), BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 128});
+  testConnector_->setStats(
+      "a_orders",
+      1'000'000,
+      {{"customer_id", {.numDistinct = 100'000}},
+       {"order_date", {.numDistinct = 365}},
+       {"amount", {.numDistinct = 500'000}}});
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id", "order_date"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate(
+                {"customer_id"},
+                {"sum(amount)", "count(*)", "min(amount)", "max(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id"}, {"count(distinct amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) AS total FROM a_orders "
+        "GROUP BY customer_id HAVING sum(amount) > 1000",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext(), /*allowAmbiguousOutputNames=*/true)
+            .tableScan("a_orders")
+            .aggregate(
+                {"customer_id"}, {"array_agg(amount ORDER BY order_date)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  // LIMIT atop a bucketed aggregation keeps the bucketed annotation on
+  // the source fragment.
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id"}, {"sum(amount)"})
+            .limit(0, 100)
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  // Non-bucket grouping key falls through to partial+final.
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"order_date"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+}
+
+TEST_F(BucketedExecutionTest, select) {
+  {
+    addBucketedTable("s_one", {"customer_id"}, 1);
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_one")
+            .aggregate({"customer_id"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 1);
+  }
+
+  // gcd(128, 64) = 64.
+  {
+    addBucketedTable("s_down_a", {"customer_id"}, 128);
+    addBucketedTable(
+        "s_down_b",
+        {"customer_id"},
+        64,
+        ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+        500'000);
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM s_down_a JOIN s_down_b "
+        "ON s_down_a.customer_id = s_down_b.customer_id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  // gcd(16, 9) = 1; copartition rejects. The two sides cannot co-fragment as
+  // a bucketed pair, but each side may independently remain bucketed in its
+  // own fragment.
+  {
+    addBucketedTable("s_incompat_a", {"customer_id"}, 16);
+    addBucketedTable(
+        "s_incompat_b",
+        {"id"},
+        9,
+        ROW({"id", "name"}, {BIGINT(), VARCHAR()}),
+        100'000);
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM s_incompat_a JOIN s_incompat_b "
+        "ON s_incompat_a.customer_id = s_incompat_b.id",
+        kTestConnectorId));
+    for (const auto& fragment : plan.plan->fragments()) {
+      int32_t bucketedScans = 0;
+      for (const auto& [_, partitionType] : fragment.groupedNodes) {
+        if (partitionType != nullptr) {
+          ++bucketedScans;
+        }
+      }
+      EXPECT_LE(bucketedScans, 1)
+          << "Incompatible bucket counts (16/9) should not pair-bucket";
+    }
+  }
+
+  testConnector_->addTable(
+      "s_composite",
+      ROW({"region", "customer_id", "amount"}, {BIGINT(), BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"region", "customer_id"}, 128});
+  testConnector_->setStats(
+      "s_composite",
+      1'000'000,
+      {{"region", {.numDistinct = 10}},
+       {"customer_id", {.numDistinct = 100'000}},
+       {"amount", {.numDistinct = 500'000}}});
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_composite")
+            .aggregate({"region", "customer_id"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+
+  // Strict subset of bucket keys: bucketing on (region, customer_id) doesn't
+  // satisfy aggregation grouped only by region, so it falls through to
+  // partial+shuffle+final. Source fragment may still be bucketed for the
+  // partial aggregation.
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_composite")
+            .aggregate({"region"}, {"sum(amount)"})
+            .build());
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+}
+
+TEST_F(BucketedExecutionTest, unionall) {
+  // gcd(128, 4) = 4.
+  addBucketedTable("u_a", {"customer_id"}, 128);
+  addBucketedTable(
+      "u_b",
+      {"customer_id"},
+      4,
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) FROM ("
+        "  SELECT customer_id, amount FROM u_a"
+        "  UNION ALL"
+        "  SELECT customer_id, amount FROM u_b"
+        ") GROUP BY customer_id",
+        kTestConnectorId));
+    // 2-table union with gcd=4: both scans share the same bucketed fragment.
+    int32_t bucketedFragments = 0;
+    for (const auto& fragment : plan.plan->fragments()) {
+      if (!fragment.groupedNodes.empty()) {
+        ++bucketedFragments;
+        EXPECT_EQ(fragment.type, FragmentType::kFixed);
+        ASSERT_TRUE(fragment.width.has_value());
+        EXPECT_EQ(*fragment.width, 4);
+        int32_t bucketedScans = 0;
+        for (const auto& [_, partitionType] : fragment.groupedNodes) {
+          if (partitionType != nullptr) {
+            ++bucketedScans;
+          }
+        }
+        EXPECT_EQ(bucketedScans, 2);
+      }
+    }
+    EXPECT_GE(bucketedFragments, 1);
+  }
+
+  // Different bucket keys (same type, same count) — TestConnector treats these
+  // as copartition-compatible since it only checks key types and partition
+  // counts, not column names. Both scans land in the same bucketed fragment.
+  // Production connectors that distinguish key identity would not co-fragment.
+  addBucketedTable("u_diff_cust", {"customer_id"}, 16);
+  addBucketedTable(
+      "u_diff_acct",
+      {"account_id"},
+      16,
+      ROW({"account_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) FROM ("
+        "  SELECT customer_id, amount FROM u_diff_cust"
+        "  UNION ALL"
+        "  SELECT account_id AS customer_id, amount FROM u_diff_acct"
+        ") GROUP BY customer_id",
+        kTestConnectorId));
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+  }
+}
+
+TEST_F(BucketedExecutionTest, alwaysPlanPartialAggregation) {
+  addBucketedTable("g_orders", {"customer_id"}, 128);
+
+  auto plan = lp::PlanBuilder(makeContext())
+                  .tableScan("g_orders")
+                  .aggregate({"customer_id"}, {"sum(amount)"})
+                  .build();
+
+  optimizerOptions_.alwaysPlanPartialAggregation = true;
+  auto out = planDistributed(plan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      out.plan,
+      matchScan("g_orders")
+          .partialAggregation()
+          .localPartition({"customer_id"})
+          .finalAggregation()
+          .bucketed()
+          .fragmentWidth(4)
+          .gather()
+          .build());
+}
+
+TEST_F(BucketedExecutionTest, mixedJoinOneBucketed) {
+  addBucketedTable("m_orders", {"customer_id"}, 8);
+  addUnbucketedTable("m_extras");
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM m_orders JOIN m_extras "
+      "ON m_orders.customer_id = m_extras.customer_id",
+      kTestConnectorId));
+  bool foundMixed = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+    if (bucketedScans == 1 && hashExchanges == 1) {
+      foundMixed = true;
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+    }
+  }
+  EXPECT_TRUE(foundMixed);
+}
+
+TEST_F(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
+  addBucketedTable("m2_orders", {"customer_id"}, 8);
+  addBucketedTable(
+      "m2_customers", {"id"}, 8, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+  addUnbucketedTable("m2_extras");
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM m2_orders "
+      "JOIN m2_customers ON m2_orders.customer_id = m2_customers.id "
+      "JOIN m2_extras ON m2_orders.customer_id = m2_extras.customer_id",
+      kTestConnectorId));
+  bool foundMixed = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+    if (bucketedScans == 2 && hashExchanges == 1) {
+      foundMixed = true;
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+    }
+  }
+  EXPECT_TRUE(foundMixed);
+}
+
+TEST_F(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
+  addBucketedTable("m3_orders", {"customer_id"}, 8);
+  addUnbucketedTable("m3_extras1");
+  addUnbucketedTable("m3_extras2");
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM m3_orders "
+      "JOIN m3_extras1 ON m3_orders.customer_id = m3_extras1.customer_id "
+      "JOIN m3_extras2 ON m3_orders.customer_id = m3_extras2.customer_id",
+      kTestConnectorId));
+  bool foundMixed = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+    if (bucketedScans == 1 && hashExchanges == 2) {
+      foundMixed = true;
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+    }
+  }
+  EXPECT_TRUE(foundMixed);
+}
+
+TEST_F(BucketedExecutionTest, windowOnBucketKey) {
+  addBucketedTable("w_orders", {"customer_id"}, 16);
+  auto plan = planDistributed(parseSelect(
+      "SELECT customer_id, amount, "
+      "row_number() OVER (PARTITION BY customer_id ORDER BY amount) AS rn "
+      "FROM w_orders",
+      kTestConnectorId));
+  bool foundBucketed = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    if (!fragment.groupedNodes.empty()) {
+      EXPECT_EQ(fragment.type, FragmentType::kFixed);
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+      foundBucketed = true;
+    }
+  }
+  EXPECT_TRUE(foundBucketed);
+}
+
+TEST_F(BucketedExecutionTest, threeWayCoBucketed) {
+  addBucketedTable("tw_a", {"customer_id"}, 16);
+  addBucketedTable("tw_b", {"customer_id"}, 8);
+  addBucketedTable("tw_c", {"customer_id"}, 4);
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM tw_a "
+      "JOIN tw_b ON tw_a.customer_id = tw_b.customer_id "
+      "JOIN tw_c ON tw_a.customer_id = tw_c.customer_id",
+      kTestConnectorId));
+  bool found = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+    if (bucketedScans == 3 && hashExchanges == 0) {
+      EXPECT_EQ(fragment.type, FragmentType::kFixed);
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST_F(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
+  addBucketedTable("ab_orders", {"customer_id"}, 16);
+  addBucketedTable(
+      "ab_customers", {"id"}, 16, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+  auto plan = planDistributed(parseSelect(
+      "SELECT x.customer_id, x.cnt, ab_customers.name FROM ("
+      "  SELECT customer_id, COUNT(*) AS cnt FROM ab_orders "
+      "  GROUP BY customer_id"
+      ") x JOIN ab_customers ON x.customer_id = ab_customers.id",
+      kTestConnectorId));
+  bool found = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+    if (bucketedScans == 2 && hashExchanges == 0) {
+      EXPECT_TRUE(fragment.width.has_value());
+      EXPECT_EQ(*fragment.width, 4);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST_F(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
+  addBucketedTable("bc_orders", {"customer_id"}, 16);
+  addUnbucketedTable(
+      "bc_dim",
+      ROW({"customer_id", "label"}, {BIGINT(), VARCHAR()}),
+      /*numRows=*/1'000);
+  auto plan = planDistributed(parseSelect(
+      "SELECT x.customer_id, x.cnt, bc_dim.label FROM ("
+      "  SELECT customer_id, COUNT(*) AS cnt FROM bc_orders "
+      "  GROUP BY customer_id"
+      ") x JOIN bc_dim ON x.customer_id = bc_dim.customer_id",
+      kTestConnectorId));
+  bool foundBucketedScan = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType != nullptr) {
+        foundBucketedScan = true;
+      }
+    }
+  }
+  EXPECT_TRUE(foundBucketedScan);
+}
+
+TEST_F(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
+  addBucketedTable("bj_orders", {"customer_id"}, 16);
+  addUnbucketedTable(
+      "bj_dim",
+      ROW({"amount", "label"}, {DOUBLE(), VARCHAR()}),
+      /*numRows=*/1'000);
+  auto plan = planDistributed(parseSelect(
+      "SELECT bj_orders.customer_id, COUNT(*) "
+      "FROM bj_orders JOIN bj_dim ON bj_orders.amount = bj_dim.amount "
+      "GROUP BY bj_orders.customer_id",
+      kTestConnectorId));
+  bool foundBucketedScan = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType != nullptr) {
+        foundBucketedScan = true;
+      }
+    }
+  }
+  EXPECT_TRUE(foundBucketedScan);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -129,6 +129,8 @@ add_executable(
   SyntacticJoinOrderTest.cpp
   FeatureGen.cpp
   Genies.cpp
+  BucketedExecutionPlanTest.cpp
+  HiveBucketedExecutionPlanTest.cpp
   TestConnectorQueryTest.cpp
   TpchConnectorQueryTest.cpp
   UnionAllTest.cpp

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <re2/re2.h>
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class HiveBucketedExecutionTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_CUSTOMER});
+  }
+
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+  }
+
+  void TearDown() override {
+    for (const auto& name : tablesToDrop_) {
+      hiveMetadata().dropTableIfExists({kDefaultSchema, name});
+    }
+    tablesToDrop_.clear();
+    HiveQueriesTestBase::TearDown();
+  }
+
+  void createBucketedTable(const std::string& name, const std::string& sql) {
+    tablesToDrop_.push_back(name);
+    runCtas(sql);
+    verifyBucketed(name, parseBucketCount(sql));
+  }
+
+  void verifyBucketed(const std::string& name, int32_t expectedBuckets) {
+    auto table = hiveMetadata().findTable({kDefaultSchema, name});
+    ASSERT_NE(table, nullptr);
+    ASSERT_FALSE(table->layouts().empty());
+    const auto* layout =
+        table->layouts().at(0)->as<connector::hive::HiveTableLayout>();
+    ASSERT_NE(layout, nullptr);
+    const auto partitionType = layout->partitionType();
+    ASSERT_NE(partitionType, nullptr);
+    EXPECT_EQ(partitionType->numPartitions(), expectedBuckets);
+  }
+
+  static int32_t parseBucketCount(const std::string& sql) {
+    static const re2::RE2 kPattern(R"(bucket_count\s*=\s*(\d+))");
+    int32_t count;
+    VELOX_CHECK(re2::RE2::PartialMatch(sql, kPattern, &count));
+    return count;
+  }
+
+  void assertBucketedExecution(const lp::LogicalPlanNodePtr& logicalPlan) {
+    // Single-node execution produces an unbucketed reference; compare
+    // against the multi-worker bucketed run.
+    auto referencePlan = planVelox(
+        logicalPlan,
+        MultiFragmentPlan::Options::singleNode(),
+        optimizerOptions_);
+    auto reference = runFragmentedPlan(referencePlan).results;
+    ASSERT_GT(reference.size(), 0);
+    checkSame(logicalPlan, reference);
+  }
+
+  std::vector<std::string> tablesToDrop_;
+};
+
+TEST_F(HiveBucketedExecutionTest, join) {
+  createBucketedTable(
+      "j_left",
+      "CREATE TABLE j_left "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "j_right",
+      "CREATE TABLE j_right "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM j_left JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("j_left")
+            .hashJoin(matchHiveScan("j_right").build(), core::JoinType::kInner)
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .project()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  for (std::string_view sql : {
+           "SELECT * FROM j_left RIGHT JOIN j_right "
+           "ON j_left.c_nationkey = j_right.c_nationkey",
+           "SELECT * FROM j_left FULL OUTER JOIN j_right "
+           "ON j_left.c_nationkey = j_right.c_nationkey",
+       }) {
+    SCOPED_TRACE(sql);
+    auto logicalPlan = parseSelect(sql);
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketed = std::any_of(
+        plan.plan->fragments().begin(),
+        plan.plan->fragments().end(),
+        [](const auto& f) { return !f.groupedNodes.empty(); });
+    EXPECT_TRUE(foundBucketed);
+    assertBucketedExecution(logicalPlan);
+  }
+
+  // LEFT join: at least one fragment must be bucketed.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM j_left LEFT JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketed = std::any_of(
+        plan.plan->fragments().begin(),
+        plan.plan->fragments().end(),
+        [](const auto& f) { return !f.groupedNodes.empty(); });
+    EXPECT_TRUE(foundBucketed);
+    assertBucketedExecution(logicalPlan);
+  }
+
+  tablesToDrop_.emplace_back("j_unbucketed");
+  runCtas(
+      "CREATE TABLE j_unbucketed AS "
+      "SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM j_left JOIN j_unbucketed "
+      "ON j_left.c_nationkey = j_unbucketed.c_nationkey");
+  auto plan = planVelox(
+      logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+  int32_t bucketedScans = 0;
+  int32_t hashExchanges = 0;
+  for (const auto& fragment : plan.plan->fragments()) {
+    for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      if (partitionType == nullptr) {
+        ++hashExchanges;
+      } else {
+        ++bucketedScans;
+      }
+    }
+  }
+  EXPECT_EQ(bucketedScans, 1);
+  EXPECT_EQ(hashExchanges, 1);
+  assertBucketedExecution(logicalPlan);
+}
+
+TEST_F(HiveBucketedExecutionTest, semijoin) {
+  createBucketedTable(
+      "sj_left",
+      "CREATE TABLE sj_left "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "sj_right",
+      "CREATE TABLE sj_right "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey FROM customer WHERE c_nationkey < 5");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_custkey, c_nationkey FROM sj_left "
+        "WHERE c_nationkey IN (SELECT c_nationkey FROM sj_right)");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("sj_left")
+            .hashJoin(
+                matchHiveScan("sj_right").build(),
+                core::JoinType::kLeftSemiFilter)
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_custkey, c_nationkey FROM sj_left "
+        "WHERE c_nationkey NOT IN (SELECT c_nationkey FROM sj_right)");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketed = std::any_of(
+        plan.plan->fragments().begin(),
+        plan.plan->fragments().end(),
+        [](const auto& f) { return !f.groupedNodes.empty(); });
+    EXPECT_TRUE(foundBucketed);
+    assertBucketedExecution(logicalPlan);
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, aggregation) {
+  createBucketedTable(
+      "a_customers",
+      "CREATE TABLE a_customers "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT * FROM customer");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, count(*) FROM a_customers GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("a_customers")
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  for (std::string_view sql : {
+           "SELECT c_nationkey, c_mktsegment, count(*) FROM a_customers "
+           "GROUP BY c_nationkey, c_mktsegment",
+           "SELECT c_nationkey, count(*), min(c_acctbal), max(c_acctbal) "
+           "FROM a_customers GROUP BY c_nationkey",
+           "SELECT c_nationkey, count(DISTINCT c_mktsegment) FROM a_customers "
+           "GROUP BY c_nationkey",
+           "SELECT c_nationkey, count(*) AS cnt FROM a_customers "
+           "GROUP BY c_nationkey HAVING count(*) > 100",
+       }) {
+    SCOPED_TRACE(sql);
+    auto logicalPlan = parseSelect(sql);
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketed = std::any_of(
+        plan.plan->fragments().begin(),
+        plan.plan->fragments().end(),
+        [](const auto& f) { return !f.groupedNodes.empty(); });
+    EXPECT_TRUE(foundBucketed);
+    assertBucketedExecution(logicalPlan);
+  }
+
+  // Non-bucket grouping key falls through to partial+final.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_mktsegment, count(*) FROM a_customers GROUP BY c_mktsegment");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketedProducer = false;
+    for (size_t i = 0; i < plan.plan->fragments().size(); ++i) {
+      if (!plan.plan->fragments()[i].groupedNodes.empty()) {
+        foundBucketedProducer = true;
+      } else if (i > 0) {
+        EXPECT_TRUE(plan.plan->fragments()[i].groupedNodes.empty());
+      }
+    }
+    EXPECT_TRUE(foundBucketedProducer);
+    assertBucketedExecution(logicalPlan);
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, select) {
+  createBucketedTable(
+      "s_one",
+      "CREATE TABLE s_one "
+      "WITH (bucket_count = 1, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT * FROM customer");
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, count(*) FROM s_one GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("s_one")
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .bucketed()
+            .fragmentWidth(1)
+            .gather()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  // gcd(16, 8) = 8.
+  createBucketedTable(
+      "s_match",
+      "CREATE TABLE s_match "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "s_down",
+      "CREATE TABLE s_down "
+      "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM s_match JOIN s_down "
+        "ON s_match.c_nationkey = s_down.c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundScaledFragment = false;
+    for (const auto& fragment : plan.plan->fragments()) {
+      if (!fragment.groupedNodes.empty() && fragment.width.has_value() &&
+          *fragment.width == 4) {
+        foundScaledFragment = true;
+      }
+    }
+    EXPECT_TRUE(foundScaledFragment);
+    assertBucketedExecution(logicalPlan);
+  }
+
+  createBucketedTable(
+      "s_composite",
+      "CREATE TABLE s_composite "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey', 'c_mktsegment']) "
+      "AS SELECT * FROM customer");
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, c_mktsegment, count(*) FROM s_composite "
+        "GROUP BY c_nationkey, c_mktsegment");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("s_composite")
+            .localPartition({"c_nationkey", "c_mktsegment"})
+            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  // Strict subset of bucket keys.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, count(*) FROM s_composite "
+        "GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+    assertBucketedExecution(logicalPlan);
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, unionall) {
+  // Different bucket keys (same type) — must not co-fragment.
+  createBucketedTable(
+      "u_diff_a",
+      "CREATE TABLE u_diff_a "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+  createBucketedTable(
+      "u_diff_b",
+      "CREATE TABLE u_diff_b "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_custkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, count(*) FROM ("
+        "  SELECT c_nationkey FROM u_diff_a"
+        "  UNION ALL"
+        "  SELECT c_custkey AS c_nationkey FROM u_diff_b"
+        ") GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+    assertBucketedExecution(logicalPlan);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1109,6 +1109,47 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
   return producerResult;
 }
 
+// Wraps a source matcher and asserts a fragment-level property on the
+// DistributedMatchContext::currentFragment encountered during recursion. The
+// fragment is the one owning the surrounding chain segment between two
+// ShuffleBoundaryMatchers (or the root segment). Structural matching is
+// delegated to the source matcher; this matcher itself does not consume a
+// PlanNode.
+class BucketedAssertionMatcher : public PlanMatcher {
+ public:
+  using AssertionFn =
+      std::function<void(const axiom::optimizer::ExecutableFragment& fragment)>;
+
+  BucketedAssertionMatcher(
+      const std::shared_ptr<PlanMatcher>& sourceMatcher,
+      AssertionFn assertion)
+      : sourceMatcher_{sourceMatcher}, assertion_{std::move(assertion)} {}
+
+  MatchResult match(
+      const PlanNodePtr& plan,
+      const std::unordered_map<std::string, std::string>& symbols,
+      const DistributedMatchContext* context) const override {
+    EXPECT_TRUE(context != nullptr)
+        << "Bucketed assertions require a distributed plan context; use "
+        << "match(MultiFragmentPlan) instead of match(PlanNodePtr).";
+    AXIOM_TEST_RETURN_IF_FAILURE
+    EXPECT_TRUE(context->currentFragment != nullptr)
+        << "Bucketed assertions require currentFragment to be set in context.";
+    AXIOM_TEST_RETURN_IF_FAILURE
+    assertion_(*context->currentFragment);
+    AXIOM_TEST_RETURN_IF_FAILURE
+    return sourceMatcher_->match(plan, symbols, context);
+  }
+
+  int32_t shuffleBoundaryCount() const override {
+    return sourceMatcher_->shuffleBoundaryCount();
+  }
+
+ private:
+  const std::shared_ptr<PlanMatcher> sourceMatcher_;
+  const AssertionFn assertion_;
+};
+
 class PartitionedOutputMatcher : public PlanMatcherImpl<PartitionedOutputNode> {
  public:
   PartitionedOutputMatcher(
@@ -2225,6 +2266,86 @@ PlanMatcherBuilder& PlanMatcherBuilder::groupId(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<GroupIdMatcher>(
       matcher_, groupingSets, aggregationInputs, groupIdAlias, keyAliases);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::bucketed() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [](const axiom::optimizer::ExecutableFragment& fragment) {
+        EXPECT_FALSE(fragment.groupedNodes.empty())
+            << "Expected bucketed fragment but groupedNodes is empty";
+      });
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::notBucketed() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [](const axiom::optimizer::ExecutableFragment& fragment) {
+        EXPECT_TRUE(fragment.groupedNodes.empty())
+            << "Expected non-bucketed fragment but groupedNodes has "
+            << fragment.groupedNodes.size() << " entries";
+      });
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::bucketedScans(int32_t count) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [count](const axiom::optimizer::ExecutableFragment& fragment) {
+        int32_t observed = 0;
+        for (const auto& [_, partitionType] : fragment.groupedNodes) {
+          if (partitionType != nullptr) {
+            ++observed;
+          }
+        }
+        EXPECT_EQ(observed, count)
+            << "Expected " << count << " bucketed scans but found " << observed;
+      });
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::hashExchanges(int32_t count) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [count](const axiom::optimizer::ExecutableFragment& fragment) {
+        int32_t observed = 0;
+        for (const auto& [_, partitionType] : fragment.groupedNodes) {
+          if (partitionType == nullptr) {
+            ++observed;
+          }
+        }
+        EXPECT_EQ(observed, count)
+            << "Expected " << count << " consumer-side hash exchanges but "
+            << "found " << observed;
+      });
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fragmentWidth(int32_t width) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [width](const axiom::optimizer::ExecutableFragment& fragment) {
+        ASSERT_TRUE(fragment.width.has_value())
+            << "Expected fragment.width == " << width
+            << " but width is not set";
+        EXPECT_EQ(*fragment.width, width)
+            << "Expected fragment.width == " << width << " but got "
+            << *fragment.width;
+      });
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fragmentType(
+    axiom::optimizer::FragmentType type) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<BucketedAssertionMatcher>(
+      matcher_, [type](const axiom::optimizer::ExecutableFragment& fragment) {
+        EXPECT_EQ(fragment.type, type)
+            << "Expected fragment.type == " << static_cast<int32_t>(type)
+            << " but got " << static_cast<int32_t>(fragment.type);
+      });
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -548,6 +548,28 @@ class PlanMatcherBuilder {
       const std::string& groupIdAlias,
       const std::vector<std::pair<std::string, std::string>>& keyAliases = {});
 
+  /// Asserts the current fragment has a non-empty groupedNodes map (bucketed
+  /// scheduling is active).
+  PlanMatcherBuilder& bucketed();
+
+  /// Asserts the current fragment has an empty groupedNodes map (no bucketed
+  /// scheduling).
+  PlanMatcherBuilder& notBucketed();
+
+  /// Asserts the current fragment has exactly 'count' entries in groupedNodes
+  /// with a non-null PartitionType (bucketed scans).
+  PlanMatcherBuilder& bucketedScans(int32_t count);
+
+  /// Asserts the current fragment has exactly 'count' entries in groupedNodes
+  /// with a null PartitionType (consumer-side hash exchanges).
+  PlanMatcherBuilder& hashExchanges(int32_t count);
+
+  /// Asserts the current fragment has fragment.width == 'width'.
+  PlanMatcherBuilder& fragmentWidth(int32_t width);
+
+  /// Asserts the current fragment has fragment.type == 'type'.
+  PlanMatcherBuilder& fragmentType(axiom::optimizer::FragmentType type);
+
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.
   std::shared_ptr<PlanMatcher> build() {

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -59,7 +59,8 @@ class SimpleSplitSource : public connector::SplitSource {
 std::shared_ptr<connector::SplitSource>
 SimpleSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& /* session */,
-    const velox::core::TableScanNode& scan) {
+    const velox::core::TableScanNode& scan,
+    const std::shared_ptr<connector::PartitionType>& /*partitionType*/) {
   auto it = nodeSplitMap_.find(scan.id());
   if (it == nodeSplitMap_.end()) {
     VELOX_FAIL("Splits are not provided for scan {}", scan.id());
@@ -70,7 +71,8 @@ SimpleSplitSourceFactory::splitSourceForScan(
 std::shared_ptr<connector::SplitSource>
 ConnectorSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
-    const velox::core::TableScanNode& scan) {
+    const velox::core::TableScanNode& scan,
+    const std::shared_ptr<connector::PartitionType>& partitionType) {
   const auto& handle = scan.tableHandle();
   auto metadata =
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
@@ -93,7 +95,7 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session, handle, partitions, /*partitionType=*/nullptr, runtimeStats_);
+      session, handle, partitions, partitionType, runtimeStats_);
 }
 
 namespace {
@@ -122,7 +124,6 @@ std::optional<velox::common::SpillDiskOptions> makeSpillDiskOptions(
   return options;
 }
 
-// Streams splits from the source and distributes them round-robin across tasks.
 folly::coro::Task<void> co_generateAndDistributeSplits(
     std::shared_ptr<connector::SplitSource> source,
     velox::core::PlanNodeId scanId,
@@ -141,9 +142,18 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     for (;;) {
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
-        tasks[taskIdx]->addSplit(
-            scanId, velox::exec::Split(std::move(split.connectorSplit)));
-        taskIdx = (taskIdx + 1) % tasks.size();
+        size_t targetTask;
+        if (split.groupId.has_value()) {
+          // The connector guarantees groupId is in [0, tasks.size()).
+          VELOX_CHECK_LT(static_cast<size_t>(*split.groupId), tasks.size());
+          targetTask = static_cast<size_t>(*split.groupId);
+        } else {
+          targetTask = taskIdx;
+          taskIdx = (taskIdx + 1) % tasks.size();
+        }
+        tasks.at(targetTask)
+            ->addSplit(
+                scanId, velox::exec::Split(std::move(split.connectorSplit)));
         ++splitCount;
       }
       if (batch.noMoreSplits) {
@@ -345,8 +355,9 @@ void LocalRunner::start() {
 
 std::shared_ptr<connector::SplitSource> LocalRunner::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
-    const velox::core::TableScanNode& scan) {
-  return splitSourceFactory_->splitSourceForScan(session, scan);
+    const velox::core::TableScanNode& scan,
+    const std::shared_ptr<connector::PartitionType>& partitionType) {
+  return splitSourceFactory_->splitSourceForScan(session, scan, partitionType);
 }
 
 void LocalRunner::abort() {
@@ -493,7 +504,6 @@ void LocalRunner::makeStages(
           makeSpillDiskOptions(baseSpillDirectory_, taskId),
           onError);
       stages_.back().push_back(task);
-
       task->start(plan_->options().numDrivers);
     }
   }
@@ -510,7 +520,13 @@ void LocalRunner::makeStages(
       gatherScans(fragment.fragment.planNode, scans);
 
       for (const auto& scan : scans) {
-        auto source = splitSourceForScan(/*session=*/nullptr, *scan);
+        std::shared_ptr<connector::PartitionType> partitionType;
+        if (auto it = fragment.groupedNodes.find(scan->id());
+            it != fragment.groupedNodes.end()) {
+          partitionType = it->second;
+        }
+        auto source =
+            splitSourceForScan(/*session=*/nullptr, *scan, partitionType);
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -43,7 +43,7 @@ class SimpleSplitSource : public connector::SplitSource {
     auto end = std::min(
         nextIndex_ + static_cast<size_t>(maxSplitCount), splits_.size());
     for (auto i = nextIndex_; i < end; ++i) {
-      batch.splits.push_back(std::move(splits_[i]));
+      batch.splits.push_back(connector::Split{std::move(splits_[i])});
     }
     nextIndex_ = end;
     batch.noMoreSplits = (nextIndex_ >= splits_.size());
@@ -93,7 +93,7 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session, handle, partitions, runtimeStats_);
+      session, handle, partitions, /*partitionType=*/nullptr, runtimeStats_);
 }
 
 namespace {
@@ -141,7 +141,8 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     for (;;) {
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
-        tasks[taskIdx]->addSplit(scanId, velox::exec::Split(std::move(split)));
+        tasks[taskIdx]->addSplit(
+            scanId, velox::exec::Split(std::move(split.connectorSplit)));
         taskIdx = (taskIdx + 1) % tasks.size();
         ++splitCount;
       }

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -36,10 +36,12 @@ class SplitSourceFactory {
 
   /// Returns a splitSource for one TableScan across all Tasks of
   /// the fragment. The source will be invoked to produce splits for
-  /// each individual worker running the scan.
+  /// each individual worker running the scan. When 'partitionType' is
+  /// non-null, emitted Splits are tagged with a groupId.
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
-      const velox::core::TableScanNode& scan) = 0;
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType) = 0;
 };
 
 class SimpleSplitSourceFactory : public SplitSourceFactory {
@@ -53,7 +55,8 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
-      const velox::core::TableScanNode& scan) override;
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType) override;
 
  private:
   folly::F14FastMap<
@@ -70,7 +73,8 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
-      const velox::core::TableScanNode& scan) override;
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType) override;
 
  protected:
   QueryRuntimeStats& runtimeStats_;
@@ -165,7 +169,8 @@ class LocalRunner : public Runner,
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
-      const velox::core::TableScanNode& scan);
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType);
 
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;


### PR DESCRIPTION
Summary:

Optimization decides per-leaf PartitionTypes incrementally while planning; ToVelox consumes the decision verbatim. Two new side tables cross the optimizer/runtime boundary: GroupedLeaves (per-fragment `RelationOp* -> shared_ptr<const PartitionType>`, optimizer-side) and ExecutableFragment::groupedNodes (per-fragment `PlanNodeId -> shared_ptr<const PartitionType>`, runtime-side).

End-to-end flow.

ToGraph: unchanged.

Optimization: maintains `PlanState::currentGroupedLeaves_` — the producer fragment's leaf -> native PartitionType map — as new joins are added, with `mergeFragmentMaps` folding `copartition()` to find compatible types and `PlanStateSaver` snapshotting around per-alternative search. At every `make<Repartition>`, `commitGroupedLeavesForRepartition` moves the producer's map into `Optimization::repartitionGroupedLeaves_[Repartition*]`, applies `scaleDown(numWorkers)` to lock in runner-task partition counts, and resets state's map for the consumer. For the root (topmost) fragment, `bestPlan` writes the winning Plan's map into `rootGroupedLeaves_`.

ToVelox: pure translation. The `toVeloxPlan` API takes the optimizer's side tables explicitly as `OptimizationGroupedLeaves {repartitionGroupedLeaves, rootGroupedLeaves}` — no back-pointer reads of planning state. At Repartition emission, `applyGroupedLeaves` translates the snapshot's `RelationOp*` keys to Velox `PlanNodeId`s via the in-pass `relationOpToNodeId_` map and populates `ExecutableFragment::groupedNodes`. If any non-null PartitionType is present, the producer fragment is sized to `kFixed` with `width = numPartitions()`.

Connector: when called with a non-null `PartitionType`, tags each emitted Split with `groupId = nativeBucket % numPartitions` (or the connector's own native mapping). Side table: `connector::Split.groupId`.

Runtime: routes `tasks[*split.groupId]` (no modulo) — alignment is the connector's contract via `scaleDown`.

Plan selection in Plan.cpp now uses `isCopartitionedWith()` (accepting compatible-but-not-identical PartitionTypes via `copartition()`) instead of strict pointer equality, which is the change that enables shuffle skipping for co-bucketed scans.

Reviewed By: mbasmanova

Differential Revision: D100383077
