### PR TITLE
feat(runner): Wire bucket-aware split scheduling in LocalRunner (#1303)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include "axiom/common/Enums.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorSession.h"
@@ -49,6 +50,8 @@ using PartitionFunctionSpecPtr =
 /// the above connect to different metadata stores and provide different
 /// metadata, e.g. order, partitioning, bucketing etc.
 namespace facebook::axiom::connector {
+
+class TableLayout;
 
 /// Represents statistics of a column. The statistics may represent the column
 /// across the table or may be calculated over a sample of a layout of the
@@ -250,6 +253,23 @@ class PartitionType {
 
   virtual std::string toString() const = 0;
 
+  /// Returns the fixed partition (bucket) count. Must be a positive integer.
+  virtual int32_t numPartitions() const = 0;
+
+  /// Function mapping a split for 'layout' to a worker index in
+  /// [0, numWorkers).
+  using SplitToWorkerFn =
+      std::function<int32_t(const velox::connector::ConnectorSplit&)>;
+
+  /// Builds a closure that routes a split from a scan with 'layout' to a
+  /// worker index in [0, numWorkers). 'common' is the PartitionType produced
+  /// by chaining copartition() across the bucketed scans in the fragment;
+  /// implementations decide how (or whether) to use it.
+  virtual SplitToWorkerFn makeSplitToWorkerFn(
+      const TableLayout& layout,
+      const PartitionType& common,
+      int32_t numWorkers) const = 0;
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
@@ -429,6 +449,13 @@ class TableLayout {
   virtual const PartitionType* partitionType() const {
     VELOX_CHECK(partitionColumns_.empty());
     return nullptr;
+  }
+
+  /// Returns the bucket index for 'split' as defined by this layout. Layouts
+  /// that participate in bucketed scheduling must override.
+  virtual int32_t splitBucket(
+      const velox::connector::ConnectorSplit& /*split*/) const {
+    VELOX_UNSUPPORTED("Bucketed scheduling is not supported for this layout");
   }
 
   /// Columns on which content is ordered within the range of rows covered by a

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <utility>
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/exec/TableWriter.h"
@@ -203,6 +204,34 @@ void extractInputFields(
 }
 
 } // namespace
+
+int32_t HiveTableLayout::splitBucket(
+    const velox::connector::ConnectorSplit& split) const {
+  const auto& hiveSplit =
+      dynamic_cast<const velox::connector::hive::HiveConnectorSplit&>(split);
+  VELOX_USER_CHECK(
+      hiveSplit.tableBucketNumber.has_value(),
+      "Bucketed scheduling requires a bucketed split");
+  VELOX_USER_CHECK_GE(
+      *hiveSplit.tableBucketNumber,
+      0,
+      "Bucketed split has negative tableBucketNumber");
+  return *hiveSplit.tableBucketNumber;
+}
+
+PartitionType::SplitToWorkerFn HivePartitionType::makeSplitToWorkerFn(
+    const TableLayout& layout,
+    const PartitionType& common,
+    int32_t numWorkers) const {
+  VELOX_CHECK_GT(numWorkers, 0);
+  const int32_t modulus = common.numPartitions();
+  VELOX_CHECK_GT(modulus, 0);
+  auto tablePtr = layout.table().shared_from_this();
+  return [tablePtr = std::move(tablePtr), modulus, numWorkers](
+             const velox::connector::ConnectorSplit& split) -> int32_t {
+    return (tablePtr->layouts()[0]->splitBucket(split) % modulus) % numWorkers;
+  };
+}
 
 velox::connector::ColumnHandlePtr HiveTableLayout::createColumnHandle(
     const ConnectorSessionPtr& /*session*/,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -63,6 +63,15 @@ class HivePartitionType : public connector::PartitionType {
 
   std::string toString() const override;
 
+  int32_t numPartitions() const override {
+    return numPartitions_;
+  }
+
+  SplitToWorkerFn makeSplitToWorkerFn(
+      const connector::TableLayout& layout,
+      const PartitionType& common,
+      int32_t numWorkers) const override;
+
  private:
   const int32_t numPartitions_;
   const std::vector<velox::TypePtr> partitionKeyTypes_;
@@ -127,6 +136,9 @@ class HiveTableLayout : public TableLayout {
   const PartitionType* partitionType() const override {
     return partitionType_.has_value() ? &partitionType_.value() : nullptr;
   }
+
+  int32_t splitBucket(
+      const velox::connector::ConnectorSplit& split) const override;
 
   /// Returns SerDe parameters for this layout. Default implementation returns
   /// empty map. Derived classes can override to provide actual parameters.

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(axiom_test_connector TestConnector.cpp)
 target_link_libraries(
   axiom_test_connector
   axiom_connectors
+  axiom_hive_connector_metadata
   velox_common_base
   velox_memory
   velox_connector

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -39,9 +39,15 @@ The Test connector is designed for three use cases:
   explicitly without adding actual data, enabling optimizer testing with
   controlled cost estimates (see [Setting Statistics Without Data](#setting-statistics-without-data)).
 
+**Supported:**
+- Hash bucketing. Tables can be created bucketed via the C++ API
+  (`addTable(..., TestBucketSpec{...})`). Rows are routed to buckets via the
+  Hive partition function on append, and splits are emitted per bucket.
+
 **Not supported:**
 - Filter pushdown.
-- Partitioning and bucketing.
+- Hive-style directory partitioning.
+- Sort-within-bucket.
 - Persistence. All data is lost when the process exits.
 
 ## Usage
@@ -128,6 +134,24 @@ When all columns share the same type, use `ROW(names, type)` instead of
 `ROW(names, {type, type, ...})`.
 
 `setStats()` and `addData()` cannot be combined on the same table.
+
+### Bucketed Tables
+
+Pass a `TestBucketSpec` to `addTable` to mark a table as hash-bucketed. Rows
+appended via `addData` are routed to buckets via the Hive partition function,
+and the split manager emits one split per non-empty bucket. The optimizer
+treats the table as bucket-partitioned for planning purposes.
+
+```cpp
+auto table = connector->addTable(
+    "orders",
+    ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+    velox::ROW({}),                          // no hidden columns
+    TestBucketSpec{{"customer_id"}, 16});    // 16 buckets on customer_id
+```
+
+`TestBucketSpec::bucketColumns` lists the column names that compose the bucket
+key (must reference visible columns); `numBuckets` is the fixed bucket count.
 
 ### Hidden Columns
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,7 +17,9 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <utility>
 
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/ComplexVector.h"
@@ -87,15 +89,45 @@ TestTable::TestTable(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
-    folly::F14FastMap<std::string, velox::Variant> options)
+    folly::F14FastMap<std::string, velox::Variant> options,
+    std::optional<TestBucketSpec> bucketSpec)
     : Table(
           std::move(name),
           makeTestTableColumns(schema, hiddenColumns, options),
           options),
-      connector_(connector) {
+      connector_(connector),
+      bucketSpec_(std::move(bucketSpec)) {
   const auto& label = this->name().table;
-  exportedLayout_ =
-      std::make_unique<TestTableLayout>(label, this, connector_, allColumns());
+  if (bucketSpec_.has_value()) {
+    std::vector<const Column*> partitionColumns;
+    std::vector<velox::TypePtr> partitionKeyTypes;
+    std::vector<velox::column_index_t> bucketChannels;
+    for (const auto& columnName : bucketSpec_->bucketColumns) {
+      auto* column = findColumn(columnName);
+      VELOX_CHECK_NOT_NULL(
+          column, "Bucket column does not exist: {}", columnName);
+      partitionColumns.push_back(column);
+      partitionKeyTypes.push_back(column->type());
+      bucketChannels.push_back(schema->getChildIdx(columnName));
+    }
+
+    auto partitionType = std::make_unique<hive::HivePartitionType>(
+        bucketSpec_->numBuckets, std::move(partitionKeyTypes));
+    partitionFunction_ =
+        partitionType->makeSpec(bucketChannels, /*constants=*/{}, false)
+            ->create(bucketSpec_->numBuckets, /*localExchange=*/false);
+
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label,
+        this,
+        connector_,
+        allColumns(),
+        std::move(partitionColumns),
+        std::move(partitionType));
+  } else {
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        label, this, connector_, allColumns());
+  }
   layouts_.push_back(exportedLayout_.get());
   pool_ = velox::memory::memoryManager()->addLeafPool(label + "_table");
   columnTrackers_.resize(schema->size());
@@ -140,6 +172,62 @@ void TestTable::setStats(
   }
 }
 
+namespace {
+
+struct BucketedRows {
+  velox::RowVectorPtr rows;
+  int32_t bucketId;
+};
+
+std::vector<BucketedRows> splitByBucket(
+    const velox::RowVectorPtr& input,
+    velox::core::PartitionFunction& partitionFunction,
+    int32_t numBuckets,
+    velox::memory::MemoryPool* pool) {
+  std::vector<uint32_t> bucketIds;
+  if (auto single = partitionFunction.partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  VELOX_CHECK_EQ(bucketIds.size(), static_cast<size_t>(input->size()));
+
+  std::vector<std::vector<velox::vector_size_t>> indicesPerBucket(numBuckets);
+  for (velox::vector_size_t row = 0; row < input->size(); ++row) {
+    indicesPerBucket[bucketIds[row]].push_back(row);
+  }
+
+  std::vector<BucketedRows> result;
+  result.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    const auto& rows = indicesPerBucket[bucket];
+    if (rows.empty()) {
+      continue;
+    }
+    const auto rowCount = static_cast<velox::vector_size_t>(rows.size());
+    auto indices = velox::allocateIndices(rowCount, pool);
+    auto* indicesData = indices->asMutable<velox::vector_size_t>();
+    std::copy(rows.begin(), rows.end(), indicesData);
+    std::vector<velox::VectorPtr> wrappedChildren;
+    wrappedChildren.reserve(input->childrenSize());
+    for (auto& child : input->children()) {
+      wrappedChildren.push_back(
+          velox::BaseVector::wrapInDictionary(
+              /*nulls=*/nullptr, indices, rowCount, child));
+    }
+    result.push_back(
+        {std::make_shared<velox::RowVector>(
+             pool,
+             input->type(),
+             /*nulls=*/nullptr,
+             rowCount,
+             std::move(wrappedChildren)),
+         bucket});
+  }
+  return result;
+}
+
+} // namespace
+
 void TestTable::addData(
     const velox::RowVectorPtr& data,
     bool collectColumnStatistics) {
@@ -156,7 +244,16 @@ void TestTable::addData(
   VELOX_CHECK_GT(data->size(), 0, "Cannot append empty RowVector");
   auto copy = std::dynamic_pointer_cast<velox::RowVector>(
       velox::BaseVector::copy(*data, pool_.get()));
-  data_.push_back(copy);
+
+  if (partitionFunction_ != nullptr) {
+    for (auto& bucketed : splitByBucket(
+             copy, *partitionFunction_, bucketSpec_->numBuckets, pool_.get())) {
+      data_.push_back(std::move(bucketed.rows));
+      dataBucketIds_.push_back(bucketed.bucketId);
+    }
+  } else {
+    data_.push_back(copy);
+  }
   dataRows_ += data->size();
 
   if (!collectColumnStatistics) {
@@ -244,34 +341,85 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
 folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     uint32_t maxSplitCount) {
   SplitBatch batch;
-  auto end =
-      std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);
-  for (auto i = nextIndex_; i < end; ++i) {
+  const auto end = std::min(
+      nextOffset_ + static_cast<size_t>(maxSplitCount), dataIndices_.size());
+  for (auto i = nextOffset_; i < end; ++i) {
     batch.splits.push_back(
-        std::make_shared<TestConnectorSplit>(connectorId_, i));
+        std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]));
   }
-  nextIndex_ = end;
-  batch.noMoreSplits = (nextIndex_ >= splitCount_);
+  nextOffset_ = end;
+  batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
   co_return batch;
 }
+
+namespace {
+
+const TestTable& findTestTableForHandle(
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  auto testHandle =
+      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
+  VELOX_CHECK(testHandle, "Expected TestTableHandle");
+  auto table = ConnectorMetadata::metadata(testHandle->connectorId())
+                   ->findTable(testHandle->schemaTableName());
+  VELOX_CHECK(table, "Table does not exist: {}", testHandle->name());
+  return dynamic_cast<const TestTable&>(*table);
+}
+
+} // namespace
 
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& /*session*/,
-    const velox::connector::ConnectorTableHandlePtr&) {
-  co_return std::vector<PartitionHandlePtr>{
-      std::make_shared<PartitionHandle>()};
+    const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  const auto& testTable = findTestTableForHandle(tableHandle);
+  if (!testTable.bucketSpec().has_value()) {
+    co_return std::vector<PartitionHandlePtr>{
+        std::make_shared<PartitionHandle>()};
+  }
+  const auto numBuckets = testTable.bucketSpec()->numBuckets;
+  std::vector<PartitionHandlePtr> partitions;
+  partitions.reserve(numBuckets);
+  for (int32_t bucket = 0; bucket < numBuckets; ++bucket) {
+    partitions.push_back(
+        std::make_shared<hive::HivePartitionHandle>(
+            folly::F14FastMap<std::string, std::optional<std::string>>{},
+            bucket));
+  }
+  co_return partitions;
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&) {
-  auto maybeTableHandle =
-      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
-  VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");
+    const std::vector<PartitionHandlePtr>& partitions) {
+  const auto& testTable = findTestTableForHandle(tableHandle);
+
+  std::vector<size_t> dataIndices;
+  if (testTable.bucketSpec().has_value()) {
+    folly::F14FastSet<int32_t> selectedBuckets;
+    for (const auto& partition : partitions) {
+      auto hivePartition =
+          std::dynamic_pointer_cast<const hive::HivePartitionHandle>(partition);
+      VELOX_CHECK(
+          hivePartition && hivePartition->tableBucketNumber.has_value(),
+          "Bucketed scans require HivePartitionHandle with tableBucketNumber");
+      selectedBuckets.insert(hivePartition->tableBucketNumber.value());
+    }
+    const auto& bucketIds = testTable.dataBucketIds();
+    for (size_t i = 0; i < bucketIds.size(); ++i) {
+      if (selectedBuckets.contains(bucketIds[i])) {
+        dataIndices.push_back(i);
+      }
+    }
+  } else {
+    const auto numEntries = testTable.data().size();
+    dataIndices.reserve(numEntries);
+    for (size_t i = 0; i < numEntries; ++i) {
+      dataIndices.push_back(i);
+    }
+  }
   return std::make_shared<TestSplitSource>(
-      tableHandle->connectorId(), maybeTableHandle->size());
+      tableHandle->connectorId(), std::move(dataIndices));
 }
 
 std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(
@@ -434,14 +582,16 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
   schemas_.insert(tableName.schema);
   auto table = std::make_shared<TestTable>(
       tableName,
       schema,
       hiddenColumns,
       connector_,
-      folly::F14FastMap<std::string, velox::Variant>{});
+      folly::F14FastMap<std::string, velox::Variant>{},
+      std::move(bucketSpec));
   auto [it, ok] = tables_.emplace(std::move(tableName), std::move(table));
   VELOX_CHECK(ok, "Table already exists: {}", it->first.toString());
   return it->second;
@@ -695,8 +845,10 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
 std::shared_ptr<TestTable> TestConnector::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
-    const velox::RowTypePtr& hiddenColumns) {
-  return metadata_->addTable(std::move(tableName), schema, hiddenColumns);
+    const velox::RowTypePtr& hiddenColumns,
+    std::optional<TestBucketSpec> bucketSpec) {
+  return metadata_->addTable(
+      std::move(tableName), schema, hiddenColumns, std::move(bucketSpec));
 }
 
 bool TestConnector::dropTableIfExists(const SchemaTableName& name) {

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -431,6 +431,19 @@ std::shared_ptr<Table> TestConnectorMetadata::findTableInternal(
   return it->second;
 }
 
+int32_t TestTableLayout::splitBucket(
+    const velox::connector::ConnectorSplit& split) const {
+  const auto& testTable = static_cast<const TestTable&>(table());
+  VELOX_CHECK(
+      testTable.bucketSpec().has_value(),
+      "Bucketed scheduling requires a bucketed table");
+  const auto& testSplit = dynamic_cast<const TestConnectorSplit&>(split);
+  const auto& dataBucketIds = testTable.dataBucketIds();
+  VELOX_CHECK_LT(
+      testSplit.index(), dataBucketIds.size(), "Split index out of range");
+  return dataBucketIds[testSplit.index()];
+}
+
 TablePtr TestConnectorMetadata::findTable(const SchemaTableName& tableName) {
   return findTableInternal(tableName);
 }

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -22,10 +22,18 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::axiom::connector {
 
 class TestConnector;
+
+/// Hash-bucketing spec for a TestTable. Routes appended rows into buckets
+/// using the Hive partition function over 'bucketColumns'.
+struct TestBucketSpec {
+  std::vector<std::string> bucketColumns;
+  int32_t numBuckets;
+};
 
 /// The Table and Connector objects to which this layout correspond
 /// are specified explicitly at init time.
@@ -46,6 +54,29 @@ class TestTableLayout : public TableLayout {
             /*sortOrder=*/{},
             /*lookupKeys=*/{},
             /*supportsScan=*/true) {}
+
+  TestTableLayout(
+      const std::string& label,
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::vector<const Column*> partitionColumns,
+      std::unique_ptr<PartitionType> partitionType)
+      : TableLayout(
+            label,
+            table,
+            connector,
+            std::move(columns),
+            std::move(partitionColumns),
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            /*lookupKeys=*/{},
+            /*supportsScan=*/true),
+        partitionType_(std::move(partitionType)) {}
+
+  const PartitionType* partitionType() const override {
+    return partitionType_.get();
+  }
 
   /// Records discrete values to use in 'discretePredicateColumns' and
   /// 'discretePredicates' APIs. If called repeatedly, overwrites previous
@@ -78,6 +109,7 @@ class TestTableLayout : public TableLayout {
  private:
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
+  std::unique_ptr<PartitionType> partitionType_;
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -92,7 +124,8 @@ class TestTable : public Table {
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
-      folly::F14FastMap<std::string, velox::Variant> options);
+      folly::F14FastMap<std::string, velox::Variant> options,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -106,11 +139,21 @@ class TestTable : public Table {
     return data_;
   }
 
+  /// Bucket id of the i-th entry in 'data'. Empty for unbucketed tables.
+  const std::vector<int32_t>& dataBucketIds() const {
+    return dataBucketIds_;
+  }
+
+  const std::optional<TestBucketSpec>& bucketSpec() const {
+    return bucketSpec_;
+  }
+
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
   /// memory pool. When 'collectColumnStatistics' is true, computes per-column
   /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
-  /// Cannot be combined with setStats on the same table.
+  /// Cannot be combined with setStats on the same table. For bucketed tables,
+  /// each non-empty bucket of the input becomes one entry in 'data'.
   void addData(
       const velox::RowVectorPtr& data,
       bool collectColumnStatistics = true);
@@ -150,31 +193,35 @@ class TestTable : public Table {
   std::unique_ptr<TestTableLayout> exportedLayout_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<velox::RowVectorPtr> data_;
+  std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
   std::vector<ColumnTracker> columnTrackers_;
+
+  std::optional<TestBucketSpec> bucketSpec_;
+  std::unique_ptr<velox::core::PartitionFunction> partitionFunction_;
 };
 
-/// SplitSource generated via the TestSplitManager embedded in the
-/// TestConnector. Generates one TestConnectorSplit for each RowVector
-/// in the table's data_ vector.
+/// Emits one TestConnectorSplit per index in 'dataIndices'. Each index points
+/// into the table's data_ vector.
 class TestSplitSource : public SplitSource {
  public:
-  TestSplitSource(const std::string& connectorId, size_t splitCount)
-      : connectorId_(connectorId), splitCount_(splitCount) {}
+  TestSplitSource(
+      const std::string& connectorId,
+      std::vector<size_t> dataIndices)
+      : connectorId_(connectorId), dataIndices_(std::move(dataIndices)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;
-  const size_t splitCount_;
-  size_t nextIndex_{0};
+  const std::vector<size_t> dataIndices_;
+  size_t nextOffset_{0};
 };
 
-/// SplitManager embedded in the TestConnector. Returns one
-/// default-initialized PartitionHandle upon call to co_listPartitions.
-/// Generates a TestSplitSource that produces one TestConnectorSplit
-/// per RowVector in the table's data_ vector.
+/// Unbucketed: one PartitionHandle covering the whole table.
+/// Bucketed: one HivePartitionHandle per bucket; getSplitSource emits splits
+/// only for the requested buckets' entries.
 class TestSplitManager : public ConnectorSplitManager {
  public:
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
@@ -436,13 +483,13 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return splitManager_.get();
   }
 
-  /// Creates and returns a TestTable with the specified name and schema in the
-  /// in-memory map maintained in the connector metadata. Throws if the table
-  /// already exists.
+  /// Registers a TestTable in the connector metadata. Throws if the name is
+  /// already taken. When 'bucketSpec' is set, appended rows are hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns,
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Appends data to the table with the specified name.
   void appendData(
@@ -654,19 +701,25 @@ class TestConnector : public velox::connector::Connector {
       velox::connector::ConnectorQueryCtx* connectorQueryCtx,
       velox::connector::CommitStrategy commitStrategy) override;
 
-  /// Adds a TestTable with the specified name and schema. Throws if a table
-  /// with the same name already exists.
+  /// Registers a TestTable. Throws if the name is already taken. When
+  /// 'bucketSpec' is set, the table is hash-bucketed.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({}));
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
 
   /// Convenience overload that uses kDefaultSchema as the schema.
   std::shared_ptr<TestTable> addTable(
       const std::string& name,
       const velox::RowTypePtr& schema,
-      const velox::RowTypePtr& hiddenColumns = velox::ROW({})) {
-    return addTable({std::string(kDefaultSchema), name}, schema, hiddenColumns);
+      const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt) {
+    return addTable(
+        {std::string(kDefaultSchema), name},
+        schema,
+        hiddenColumns,
+        std::move(bucketSpec));
   }
 
   /// Appends data to the table with the specified name.

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -78,6 +78,9 @@ class TestTableLayout : public TableLayout {
     return partitionType_.get();
   }
 
+  int32_t splitBucket(
+      const velox::connector::ConnectorSplit& split) const override;
+
   /// Records discrete values to use in 'discretePredicateColumns' and
   /// 'discretePredicates' APIs. If called repeatedly, overwrites previous
   /// values.
@@ -218,6 +221,8 @@ class TestSplitSource : public SplitSource {
   const std::vector<size_t> dataIndices_;
   size_t nextOffset_{0};
 };
+
+class TestConnectorMetadata;
 
 /// Unbucketed: one PartitionHandle covering the whole table.
 /// Bucketed: one HivePartitionHandle per bucket; getSplitSource emits splits

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -17,12 +17,15 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
 #include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <numeric>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -545,6 +548,153 @@ TEST_F(TestConnectorTest, addDataAndSetStatsMutualExclusion) {
     VELOX_ASSERT_THROW(
         table->setStats(100, {{"a", {.numDistinct = 50}}}),
         "Cannot use both setStats and addData on table");
+  }
+}
+
+namespace {
+
+std::vector<uint32_t> referenceBucketIds(
+    const velox::RowVectorPtr& input,
+    const std::vector<velox::column_index_t>& channels,
+    int32_t numBuckets) {
+  velox::connector::hive::HivePartitionFunctionSpec spec(
+      numBuckets, channels, /*constValues=*/{});
+  std::vector<uint32_t> bucketIds;
+  if (auto single = spec.create(numBuckets, /*localExchange=*/false)
+                        ->partition(*input, bucketIds);
+      single.has_value()) {
+    bucketIds.assign(input->size(), single.value());
+  }
+  return bucketIds;
+}
+
+velox::connector::ConnectorTableHandlePtr makeScanHandle(
+    const TableLayout& layout,
+    const std::vector<std::string>& columnNames) {
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  std::vector<velox::connector::ColumnHandlePtr> columns;
+  columns.reserve(columnNames.size());
+  for (const auto& name : columnNames) {
+    columns.push_back(layout.createColumnHandle(nullptr, name));
+  }
+  std::vector<core::TypedExprPtr> empty;
+  return layout.createTableHandle(
+      nullptr, std::move(columns), *evaluator, empty, empty);
+}
+
+} // namespace
+
+CO_TEST_F(TestConnectorTest, bucketedTable) {
+  constexpr int32_t kNumBuckets = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "bucketed", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  std::vector<int64_t> keys(32);
+  std::iota(keys.begin(), keys.end(), 0);
+  auto input = makeRowVector({makeFlatVector<int64_t>(keys)});
+  connector_->appendData("bucketed", input);
+
+  const auto expected = referenceBucketIds(input, {0}, kNumBuckets);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto* splitManager = metadata_->splitManager();
+  auto partitions =
+      co_await splitManager->co_listPartitions(nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+
+  constexpr int32_t kSelectedBucket = 2;
+  auto source = splitManager->getSplitSource(
+      nullptr, tableHandle, {partitions[kSelectedBucket]});
+  while (true) {
+    auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
+    for (const auto& split : batch.splits) {
+      auto testSplit =
+          std::dynamic_pointer_cast<const TestConnectorSplit>(split);
+      CO_ASSERT_NE(testSplit, nullptr);
+      EXPECT_EQ(table->dataBucketIds()[testSplit->index()], kSelectedBucket);
+    }
+    if (batch.noMoreSplits) {
+      break;
+    }
+  }
+}
+
+TEST_F(TestConnectorTest, bucketedTableNonExistentBucketColumn) {
+  VELOX_ASSERT_THROW(
+      connector_->addTable(
+          "bad_bucket_col",
+          ROW({"a"}, {BIGINT()}),
+          velox::ROW({}),
+          TestBucketSpec{{"missing"}, 4}),
+      "Bucket column does not exist: missing");
+}
+
+CO_TEST_F(TestConnectorTest, bucketedTableNumBucketsExceedsNumRows) {
+  constexpr int32_t kNumBuckets = 16;
+  constexpr int32_t kNumRows = 4;
+  auto schema = ROW({"key"}, {BIGINT()});
+  auto table = connector_->addTable(
+      "sparse", schema, velox::ROW({}), TestBucketSpec{{"key"}, kNumBuckets});
+
+  auto input = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
+  connector_->appendData("sparse", input);
+
+  EXPECT_LE(table->data().size(), kNumRows);
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+  for (const auto& vector : table->data()) {
+    EXPECT_GT(vector->size(), 0);
+  }
+
+  auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
+  auto partitions = co_await metadata_->splitManager()->co_listPartitions(
+      nullptr, tableHandle);
+  EXPECT_EQ(partitions.size(), kNumBuckets);
+}
+
+TEST_F(TestConnectorTest, bucketedTableMultiColumnKeys) {
+  constexpr int32_t kNumBuckets = 8;
+  constexpr int32_t kNumRows = 64;
+  auto schema = ROW({"k1", "k2", "v"}, {BIGINT(), VARCHAR(), DOUBLE()});
+  auto table = connector_->addTable(
+      "multi_key",
+      schema,
+      velox::ROW({}),
+      TestBucketSpec{{"k1", "k2"}, kNumBuckets});
+
+  auto& layout = *table->layouts()[0];
+  EXPECT_NE(layout.partitionType(), nullptr);
+  EXPECT_EQ(layout.partitionColumns().size(), 2);
+
+  std::vector<int64_t> k1Values(kNumRows);
+  std::iota(k1Values.begin(), k1Values.end(), 0);
+  std::vector<std::string> k2Values;
+  k2Values.reserve(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    k2Values.push_back(fmt::format("s{}", i));
+  }
+  std::vector<double> vValues(kNumRows, 3.14);
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(k1Values),
+       makeFlatVector<std::string>(k2Values),
+       makeFlatVector<double>(vValues)});
+  connector_->appendData("multi_key", input);
+
+  EXPECT_EQ(table->data().size(), table->dataBucketIds().size());
+
+  const auto expected = referenceBucketIds(input, {0, 1}, kNumBuckets);
+  for (size_t i = 0; i < table->data().size(); ++i) {
+    const auto firstKey =
+        table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+    EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
   }
 }
 

--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -259,6 +259,28 @@ MarkDistinctResult addMarkDistinctNodes(
 
 } // namespace
 
+std::vector<uint32_t> joinKeyPartition(
+    const RelationOpPtr& op,
+    const ExprVector& keys) {
+  const auto& partitionKeys = op->distribution().partitionKeys();
+  std::vector<uint32_t> positions;
+  positions.reserve(partitionKeys.size());
+  for (const auto& partitionKey : partitionKeys) {
+    bool found = false;
+    for (uint32_t j = 0; j < keys.size(); ++j) {
+      if (keys[j]->sameOrEqual(*partitionKey)) {
+        positions.push_back(j);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return {};
+    }
+  }
+  return positions;
+}
+
 std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     const RelationOpPtr& plan,
     ExprVector desiredKeys) {
@@ -508,10 +530,12 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
 AggregationPlanner::AggregationPlanner(
     bool isSingleWorker,
     bool isSingleDriver,
-    bool alwaysPlanPartialAggregation)
+    bool alwaysPlanPartialAggregation,
+    bool enableBucketedExecution)
     : isSingleWorker_{isSingleWorker},
       isSingleDriver_{isSingleDriver},
-      alwaysPlanPartialAggregation_{alwaysPlanPartialAggregation} {}
+      alwaysPlanPartialAggregation_{alwaysPlanPartialAggregation},
+      enableBucketedExecution_{enableBucketedExecution} {}
 
 RelationOpPtr AggregationPlanner::planSingle(
     DerivedTableCP dt,
@@ -539,6 +563,12 @@ void AggregationPlanner::plan(
     PlanState& state) const {
   VELOX_CHECK_NOT_NULL(dt->aggregation);
   const auto* aggPlan = dt->aggregation;
+
+  const bool isBucketedAggregation = enableBucketedExecution_ &&
+      !alwaysPlanPartialAggregation_ && !isSingleWorker_ &&
+      !aggPlan->groupingKeys().empty() &&
+      plan->distribution().partitionType() != nullptr &&
+      !joinKeyPartition(plan, aggPlan->groupingKeys()).empty();
 
   PrecomputeProjection precompute(plan, dt, /*projectAllInputs=*/false);
   auto groupingKeys =
@@ -571,6 +601,20 @@ void AggregationPlanner::plan(
       std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
         return !agg->orderKeys().empty();
       });
+
+  if (isBucketedAggregation && !hasDistinct && !hasOrderBy) {
+    auto* singleAgg = make<Aggregation>(
+        plan,
+        std::move(groupingKeys),
+        /*preGroupedKeys=*/ExprVector{},
+        std::move(aggregates),
+        velox::core::AggregationNode::Step::kSingle,
+        aggPlan->columns());
+    state.addCost(*singleAgg);
+    plan = singleAgg;
+    return;
+  }
+
   if (hasDistinct) {
     auto distinctArgs = getCommonDistinctArgs(aggregates);
     if (distinctArgs.has_value()) {

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -33,13 +33,21 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     const RelationOpPtr& plan,
     ExprVector desiredKeys);
 
+/// Returns the positions in 'keys' of expressions that match 'op's partition
+/// keys, in partition-key order. Returns an empty vector if any partition key
+/// is missing from 'keys'.
+std::vector<uint32_t> joinKeyPartition(
+    const RelationOpPtr& op,
+    const ExprVector& keys);
+
 /// Plans aggregation operators for a derived table.
 class AggregationPlanner {
  public:
   AggregationPlanner(
       bool isSingleWorker,
       bool isSingleDriver,
-      bool alwaysPlanPartialAggregation);
+      bool alwaysPlanPartialAggregation,
+      bool enableBucketedExecution);
 
   /// Plans the aggregation for a derived table in the main optimization path.
   /// Chooses between single-step and split (partial + final) plans based on
@@ -107,6 +115,7 @@ class AggregationPlanner {
   bool isSingleWorker_;
   bool isSingleDriver_;
   bool alwaysPlanPartialAggregation_;
+  bool enableBucketedExecution_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -304,6 +304,7 @@ const auto& columnStatFieldNames() {
   };
   return kNames;
 }
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(ColumnStatField, columnStatFieldNames);
@@ -379,21 +380,20 @@ velox::ContinueFuture FinishWrite::abort() && noexcept {
   return metadata_->abortWrite(session_, handle_);
 }
 
-namespace {
-// Formats the header line for a fragment in toString/toSummaryString.
-std::string formatFragmentHeader(
-    int32_t index,
-    const ExecutableFragment& fragment) {
+std::string ExecutableFragment::toHeader(int32_t index) const {
+  std::string bucketedSuffix;
+  if (!splitToWorkerFns.empty()) {
+    bucketedSuffix =
+        fmt::format(" bucketed(scans={})", splitToWorkerFns.size());
+  }
   return fmt::format(
-      "Fragment {}: {} {}{}:",
+      "Fragment {}: {} {}{}{}:",
       index,
-      fragment.taskPrefix,
-      FragmentTypeName::toName(fragment.type),
-      fragment.width.has_value()
-          ? fmt::format(" numWorkers={}", fragment.width.value())
-          : "");
+      taskPrefix,
+      FragmentTypeName::toName(type),
+      width.has_value() ? fmt::format(" numWorkers={}", width.value()) : "",
+      bucketedSuffix);
 }
-} // namespace
 
 std::string MultiFragmentPlan::toString(
     bool detailed,
@@ -420,7 +420,7 @@ std::string MultiFragmentPlan::toString(
   std::stringstream out;
   for (auto i = 0; i < fragments_.size(); ++i) {
     const auto& fragment = fragments_[i];
-    out << formatFragmentHeader(i, fragment) << std::endl;
+    out << fragment.toHeader(i) << std::endl;
 
     out << fragment.fragment.planNode->toString(
                detailed,
@@ -452,7 +452,7 @@ std::string MultiFragmentPlan::toSummaryString(
   std::stringstream out;
   for (auto i = 0; i < fragments_.size(); ++i) {
     const auto& fragment = fragments_[i];
-    out << formatFragmentHeader(i, fragment) << std::endl;
+    out << fragment.toHeader(i) << std::endl;
     out << fragment.fragment.planNode->toSummaryString(options) << std::endl;
     if (!fragment.inputStages.empty()) {
       out << "Inputs: ";

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include "axiom/common/Enums.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/core/PlanFragment.h"
@@ -151,6 +152,16 @@ struct ExecutableFragment {
   /// Source fragments and Exchange node ids for remote shuffles producing input
   /// for 'this'.
   std::vector<InputStage> inputStages;
+
+  /// Per-scan closures mapping a split to a worker index in [0, width). The
+  /// runner consults this map when distributing splits; scans absent from
+  /// the map fall back to round-robin.
+  folly::F14FastMap<
+      velox::core::PlanNodeId,
+      connector::PartitionType::SplitToWorkerFn>
+      splitToWorkerFns;
+
+  std::string toHeader(int32_t index) const;
 };
 
 /// Describes a distributed plan handed to a Runner for parallel/distributed

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -57,7 +57,8 @@ Optimization::Optimization(
       aggregationPlanner_{
           isSingleWorker_,
           isSingleDriver_,
-          options_.alwaysPlanPartialAggregation},
+          options_.alwaysPlanPartialAggregation,
+          options_.enableBucketedExecution},
       toGraph_{schema, evaluator, options_, runtimeStats},
       toVelox_{session_, runnerOptions_, options_},
       runtimeStats_{std::move(runtimeStats)} {
@@ -877,23 +878,6 @@ RelationOpPtr repartitionForIndex(
   return repartition;
 }
 
-// Returns the positions in 'keys' for the expressions that determine the
-// partition. empty if the partition is not decided by 'keys'
-std::vector<uint32_t> joinKeyPartition(
-    const RelationOpPtr& op,
-    const ExprVector& keys) {
-  const auto& partitionKeys = op->distribution().partitionKeys();
-  std::vector<uint32_t> positions;
-  for (unsigned i = 0; i < partitionKeys.size(); ++i) {
-    auto nthKey = position(keys, *partitionKeys[i]);
-    if (nthKey == kNotFound) {
-      return {};
-    }
-    positions.push_back(nthKey);
-  }
-  return positions;
-}
-
 PlanObjectSet availableColumns(PlanObjectCP object) {
   PlanObjectSet set;
   if (object->is(PlanType::kTableNode)) {
@@ -1042,7 +1026,9 @@ RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
 
   // Copartitioning is possible if PartitionTypes are compatible and the table
   // has no fewer partitions than the plan.
-  bool shuffle = !copartition || copartition != planPartitionType;
+  bool shuffle =
+      !queryCtx()->optimization()->options().enableBucketedExecution ||
+      !copartition || copartition != planPartitionType;
   if (!shuffle) {
     // Check that the partition keys of the plan are assigned pairwise to the
     // partition columns of the layout.

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -77,6 +77,13 @@ std::vector<ConfigProperty> OptimizerOptions::properties() const {
           "Enable reducing semi joins.",
       },
       {
+          std::string(kEnableBucketedExecution),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(defaults.enableBucketedExecution),
+          "Skip shuffles for copartition-compatible bucketed scans; "
+          "requires runner support for per-bucket split routing.",
+      },
+      {
           std::string(kParallelProjectWidth),
           ConfigPropertyType::kInteger,
           std::to_string(defaults.parallelProjectWidth),
@@ -128,6 +135,7 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kSyntacticJoinOrder, options.syntacticJoinOrder);
   setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
   setBool(kEnableReducingExistences, options.enableReducingExistences);
+  setBool(kEnableBucketedExecution, options.enableBucketedExecution);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -43,6 +43,8 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "always_plan_partial_aggregation";
   static constexpr std::string_view kEnableReducingExistences =
       "enable_reducing_existences";
+  static constexpr std::string_view kEnableBucketedExecution =
+      "enable_bucketed_execution";
   static constexpr std::string_view kParallelProjectWidth =
       "parallel_project_width";
   static constexpr std::string_view kTraceFlags = "trace_flags";
@@ -93,6 +95,12 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.
   bool alwaysPlanPartialAggregation{false};
+
+  /// Skip shuffles and use single-step aggregation when scans are bucketed
+  /// on the join/grouping keys. Affected fragments carry per-scan routing
+  /// closures in ExecutableFragment::splitToWorkerFns; the runner uses these
+  /// to send each split to a fixed worker. Requires runner support.
+  bool enableBucketedExecution{false};
 
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -471,6 +471,8 @@ PlanP PlanSet::best(
   float matchCost = -1;
 
   const bool checkDistribution = !isSingleWorker() && distribution.has_value();
+  const bool bucketedEnabled =
+      queryCtx()->optimization()->options().enableBucketedExecution;
 
   for (const auto& plan : plans) {
     const float cost = plan->cost.cost;
@@ -483,9 +485,14 @@ PlanP PlanSet::best(
     };
 
     update(best, bestCost);
-    if (checkDistribution &&
-        plan->op->distribution().isSamePartition(distribution.value())) {
-      update(match, matchCost);
+    if (checkDistribution) {
+      const auto& dist = plan->op->distribution();
+      const bool matches = bucketedEnabled
+          ? dist.isCopartitionedWith(distribution.value())
+          : dist.isSamePartition(distribution.value());
+      if (matches) {
+        update(match, matchCost);
+      }
     }
   }
 

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -216,8 +216,18 @@ Distribution TableScan::outputDistribution(
     orderTypes.resize(numPrefix);
     replace(orderKeys, schemaColumns, columns.data());
   }
+
+  // Without bucketed execution the runner round-robins splits, so claiming a
+  // partitioned distribution would let later passes skip needed shuffles.
+  const auto* partitionType = distribution.partitionType();
+  if (!queryCtx()->optimization()->options().enableBucketedExecution &&
+      partitionType != nullptr) {
+    partitionType = nullptr;
+    partitionKeys.clear();
+  }
+
   return Distribution(
-      distribution.partitionType(),
+      partitionType,
       std::move(partitionKeys),
       std::move(orderKeys),
       std::move(orderTypes),

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -350,6 +350,32 @@ bool Distribution::isSamePartition(const DesiredDistribution& other) const {
   return true;
 }
 
+bool Distribution::isCopartitionedWith(const DesiredDistribution& other) const {
+  auto* myPartType = partitionType();
+  if (myPartType != other.partitionType) {
+    if (myPartType == nullptr || other.partitionType == nullptr ||
+        myPartType->copartition(*other.partitionType) == nullptr) {
+      return false;
+    }
+  }
+
+  if (partitionKeys().size() != other.partitionKeys.size()) {
+    return false;
+  }
+
+  if (partitionKeys().empty()) {
+    return false;
+  }
+
+  for (auto i = 0; i < partitionKeys().size(); ++i) {
+    if (!partitionKeys()[i]->sameOrEqual(*other.partitionKeys[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool Distribution::isSamePartition(const Distribution& other) const {
   if (kind() != other.kind() || partitionType() != other.partitionType()) {
     return false;

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -212,13 +212,18 @@ struct Distribution {
   }
 
   /// True if 'this' and 'other' have the same number/type of keys and same
-  /// distribution type. Data is copartitioned if both sides have a 1:1
-  /// equality on all partitioning key columns.
+  /// distribution type via strict pointer equality on PartitionType.
   bool isSamePartition(const Distribution& other) const;
 
-  /// Return if 'this' and 'other' have the same number/type of partitioning
-  /// keys and use same partitioning function.
+  /// True if 'this' has the same number/type of partitioning keys and uses
+  /// the same partitioning function (strict pointer equality on
+  /// PartitionType).
   bool isSamePartition(const DesiredDistribution& other) const;
+
+  /// Looser variant of isSamePartition: same partition keys and
+  /// PartitionTypes for which copartition() returns non-null. Returns false
+  /// when both sides have empty partitionKeys.
+  bool isCopartitionedWith(const DesiredDistribution& other) const;
 
   /// True if 'other' has the same ordering columns and order type.
   bool isSameOrder(const Distribution& other) const;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -323,6 +323,7 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   prediction_.clear();
   nodeHistory_.clear();
+  scanIdToBaseTable_.clear();
 
   if (options_.numWorkers > 1 && !options_.remoteOutput) {
     plan = addGather(plan);
@@ -356,6 +357,10 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   for (const auto& stage : stages) {
     velox::core::PlanConsistencyChecker::check(stage.fragment.planNode);
+  }
+
+  if (optimizerOptions_.enableBucketedExecution) {
+    routeBucketedSplits(stages);
   }
 
   if (options.remoteOutput) {
@@ -1226,9 +1231,14 @@ velox::core::PlanNodePtr ToVelox::makeScan(
         connectorSession, column->name(), std::move(subfields));
   }
 
+  auto scanId = nextId();
   velox::core::PlanNodePtr result =
       std::make_shared<velox::core::TableScanNode>(
-          nextId(), outputType, tableHandle, assignments);
+          scanId, outputType, tableHandle, assignments);
+
+  if (optimizerOptions_.enableBucketedExecution) {
+    scanIdToBaseTable_.emplace(scanId, scan.baseTable);
+  }
 
   if (filter != nullptr) {
     result =
@@ -2091,6 +2101,76 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
 
 extern std::string veloxToString(const velox::core::PlanNode* plan) {
   return plan->toString(true, true);
+}
+
+namespace {
+void collectTableScans(
+    const velox::core::PlanNode* node,
+    std::vector<const velox::core::TableScanNode*>& result) {
+  if (auto* scan = dynamic_cast<const velox::core::TableScanNode*>(node)) {
+    result.push_back(scan);
+    return;
+  }
+  for (const auto& child : node->sources()) {
+    collectTableScans(child.get(), result);
+  }
+}
+} // namespace
+
+void ToVelox::routeBucketedSplits(std::vector<ExecutableFragment>& stages) {
+  for (auto& stage : stages) {
+    std::vector<const velox::core::TableScanNode*> scans;
+    collectTableScans(stage.fragment.planNode.get(), scans);
+
+    std::vector<
+        std::pair<velox::core::PlanNodeId, const connector::TableLayout*>>
+        bucketedScans;
+    for (const auto* scan : scans) {
+      auto it = scanIdToBaseTable_.find(scan->id());
+      if (it == scanIdToBaseTable_.end()) {
+        continue;
+      }
+      const auto* layout =
+          it->second->schemaTable->connectorTable->layouts().at(0);
+      if (layout->partitionType() == nullptr) {
+        continue;
+      }
+      bucketedScans.emplace_back(scan->id(), layout);
+    }
+
+    if (bucketedScans.empty()) {
+      continue;
+    }
+
+    // copartition() can be non-transitive across larger pairs (for Hive,
+    // copartition(8, 12) is nullptr but copartition(4, 8) and
+    // copartition(4, 12) are 4). Reduce starting from the smallest so the
+    // chain converges on the divisor compatible with the rest.
+    std::sort(
+        bucketedScans.begin(),
+        bucketedScans.end(),
+        [](const auto& lhs, const auto& rhs) {
+          return lhs.second->partitionType()->numPartitions() <
+              rhs.second->partitionType()->numPartitions();
+        });
+
+    const auto* common = bucketedScans.front().second->partitionType();
+    for (size_t i = 1; i < bucketedScans.size(); ++i) {
+      common = common->copartition(*bucketedScans[i].second->partitionType());
+      VELOX_CHECK_NOT_NULL(
+          common, "Bucketed scans in a fragment must be co-partitionable");
+    }
+
+    const int32_t numWorkers = stage.width.value_or(
+        stage.type == FragmentType::kSource ? options_.numWorkers : 1);
+    stage.splitToWorkerFns.reserve(bucketedScans.size());
+    for (const auto& [scanId, layout] : bucketedScans) {
+      stage.splitToWorkerFns.emplace(
+          scanId,
+          layout->partitionType()->makeSplitToWorkerFn(
+              *layout, *common, numWorkers));
+    }
+  }
 }
 
 extern std::string planString(const MultiFragmentPlan* plan) {

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -361,6 +361,10 @@ class ToVelox {
 
   folly::F14FastMap<int32_t, LeafTableData> leafData_;
 
+  // Maps PlanNodeId of each emitted TableScanNode to its optimizer BaseTable
+  // so routeBucketedSplits can recover the connector layout per scan.
+  folly::F14FastMap<velox::core::PlanNodeId, BaseTableCP> scanIdToBaseTable_;
+
   // Serial number for plan nodes in executable plan.
   int32_t nodeCounter_{0};
 
@@ -376,6 +380,11 @@ class ToVelox {
   // when numWorkers > 1, consumed by toVeloxPlan to add a
   // TableWriteMerge(kFinal) after the gather exchange.
   std::optional<velox::core::ColumnStatsSpec> finalMergeSpec_;
+
+  // Stamps splitToWorkerFns on each fragment that contains bucketed leaf
+  // scans. The routing function is supplied by the PartitionType produced
+  // by chaining copartition() across the fragment's bucketed scans.
+  void routeBucketedSplits(std::vector<ExecutableFragment>& stages);
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/BucketedExecutionTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionTest.cpp
@@ -1,0 +1,499 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+void assertBucketedPlan(
+    const MultiFragmentPlan& plan,
+    int32_t fragmentIndex = 0) {
+  ASSERT_LT(fragmentIndex, plan.fragments().size());
+  ASSERT_FALSE(plan.fragments()[fragmentIndex].splitToWorkerFns.empty());
+}
+
+void assertNotBucketed(
+    const MultiFragmentPlan& plan,
+    int32_t fragmentIndex = 0) {
+  ASSERT_LT(fragmentIndex, plan.fragments().size());
+  ASSERT_TRUE(plan.fragments()[fragmentIndex].splitToWorkerFns.empty());
+}
+
+void assertAllNotBucketed(const MultiFragmentPlan& plan) {
+  for (const auto& fragment : plan.fragments()) {
+    ASSERT_TRUE(fragment.splitToWorkerFns.empty());
+  }
+}
+
+void assertFragmentBucketingCounts(
+    const MultiFragmentPlan& plan,
+    int32_t expectedBucketed,
+    int32_t expectedNotBucketed) {
+  int32_t bucketed = 0;
+  int32_t notBucketed = 0;
+  for (const auto& fragment : plan.fragments()) {
+    (fragment.splitToWorkerFns.empty() ? notBucketed : bucketed) += 1;
+  }
+  EXPECT_EQ(bucketed, expectedBucketed);
+  EXPECT_EQ(notBucketed, expectedNotBucketed);
+}
+
+class BucketedExecutionTest : public test::QueryTestBase {
+ protected:
+  lp::PlanBuilder::Context makeContext() const {
+    return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
+  }
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    optimizerOptions_.enableBucketedExecution = true;
+  }
+
+  void addBucketedTable(
+      const std::string& name,
+      const std::vector<std::string>& bucketColumns,
+      int32_t numBuckets,
+      const RowTypePtr& schema =
+          ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      int64_t numRows = 1'000'000) {
+    testConnector_->addTable(
+        name,
+        schema,
+        velox::ROW({}),
+        connector::TestBucketSpec{bucketColumns, numBuckets});
+    std::unordered_map<std::string, connector::ColumnStatistics> stats;
+    for (const auto& column : schema->names()) {
+      stats[column] = {.numDistinct = numRows / 10};
+    }
+    testConnector_->setStats(name, numRows, stats);
+  }
+
+  PlanAndStats planDistributed(const lp::LogicalPlanNodePtr& logicalPlan) {
+    return planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+  }
+};
+
+TEST_F(BucketedExecutionTest, join) {
+  addBucketedTable("j_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "j_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoin(matchScan("j_orders").build(), core::JoinType::kInner)
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders RIGHT JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoin(matchScan("j_orders").build(), core::JoinType::kLeft)
+            .project()
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders FULL OUTER JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoin(matchScan("j_orders").build(), core::JoinType::kFull)
+            .gather()
+            .build());
+  }
+
+  // LEFT currently emits a multi-fragment plan with a redundant repartition
+  // (rewritten to RIGHT but the bucket-routed side flows through an
+  // exchange). Bucket routing is in effect and results are correct.
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM j_orders LEFT JOIN j_customers "
+        "ON j_orders.customer_id = j_customers.id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan, /*fragmentIndex=*/1);
+  }
+
+  testConnector_->addTable(
+      "j_unbucketed", ROW({"id", "label"}, {BIGINT(), VARCHAR()}));
+  testConnector_->setStats(
+      "j_unbucketed", 50'000, {{"id", {.numDistinct = 50'000}}});
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM j_orders JOIN j_unbucketed "
+      "ON j_orders.customer_id = j_unbucketed.id",
+      kTestConnectorId));
+  assertFragmentBucketingCounts(
+      *plan.plan, /*expectedBucketed=*/1, /*expectedNotBucketed=*/2);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("j_orders")
+          .hashJoin(
+              matchScan("j_unbucketed").shuffle().build(),
+              core::JoinType::kInner)
+          .gather()
+          .build());
+}
+
+TEST_F(BucketedExecutionTest, semijoin) {
+  addBucketedTable("sj_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "sj_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM sj_orders WHERE customer_id IN "
+        "(SELECT id FROM sj_customers)",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("sj_orders")
+            .hashJoin(
+                matchScan("sj_customers").build(),
+                core::JoinType::kLeftSemiFilter)
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM sj_orders WHERE customer_id NOT IN "
+        "(SELECT id FROM sj_customers)",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+  }
+}
+
+TEST_F(BucketedExecutionTest, aggregation) {
+  testConnector_->addTable(
+      "a_orders",
+      ROW({"customer_id", "order_date", "amount"},
+          {BIGINT(), BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 128});
+  testConnector_->setStats(
+      "a_orders",
+      1'000'000,
+      {{"customer_id", {.numDistinct = 100'000}},
+       {"order_date", {.numDistinct = 365}},
+       {"amount", {.numDistinct = 500'000}}});
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id"}, {"sum(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .localPartition({"customer_id"})
+            .singleAggregation({"customer_id"}, {"sum(amount)"})
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id", "order_date"}, {"sum(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .localPartition({"customer_id", "order_date"})
+            .singleAggregation({"customer_id", "order_date"}, {"sum(amount)"})
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate(
+                {"customer_id"},
+                {"sum(amount)", "count(*)", "min(amount)", "max(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"customer_id"}, {"count(distinct amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) AS total FROM a_orders "
+        "GROUP BY customer_id HAVING sum(amount) > 1000",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext(), /*enableCoercions=*/true)
+            .tableScan("a_orders")
+            .aggregate(
+                {"customer_id"}, {"array_agg(amount ORDER BY order_date)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // Non-bucket grouping key falls through to partial+final.
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("a_orders")
+            .aggregate({"order_date"}, {"sum(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+    for (size_t i = 1; i < plan.plan->fragments().size(); ++i) {
+      assertNotBucketed(*plan.plan, /*fragmentIndex=*/static_cast<int32_t>(i));
+    }
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .partialAggregation()
+            .shuffle({"order_date"})
+            .localPartition({"order_date"})
+            .finalAggregation()
+            .gather()
+            .build());
+  }
+}
+
+TEST_F(BucketedExecutionTest, select) {
+  {
+    addBucketedTable("s_one", {"customer_id"}, 1);
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_one")
+            .aggregate({"customer_id"}, {"sum(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_one")
+            .localPartition({"customer_id"})
+            .singleAggregation({"customer_id"}, {"sum(amount)"})
+            .gather()
+            .build());
+  }
+
+  // gcd(128, 64) = 64.
+  {
+    addBucketedTable("s_down_a", {"customer_id"}, 128);
+    addBucketedTable(
+        "s_down_b",
+        {"customer_id"},
+        64,
+        ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+        500'000);
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM s_down_a JOIN s_down_b "
+        "ON s_down_a.customer_id = s_down_b.customer_id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_down_a")
+            .hashJoin(matchScan("s_down_b").build(), core::JoinType::kInner)
+            .gather()
+            .project()
+            .build());
+  }
+
+  // gcd(16, 9) = 1; copartition rejects.
+  {
+    addBucketedTable("s_incompat_a", {"customer_id"}, 16);
+    addBucketedTable(
+        "s_incompat_b",
+        {"id"},
+        9,
+        ROW({"id", "name"}, {BIGINT(), VARCHAR()}),
+        100'000);
+    auto plan = planDistributed(parseSelect(
+        "SELECT * FROM s_incompat_a JOIN s_incompat_b "
+        "ON s_incompat_a.customer_id = s_incompat_b.id",
+        kTestConnectorId));
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+  }
+
+  testConnector_->addTable(
+      "s_composite",
+      ROW({"region", "customer_id", "amount"}, {BIGINT(), BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"region", "customer_id"}, 128});
+  testConnector_->setStats(
+      "s_composite",
+      1'000'000,
+      {{"region", {.numDistinct = 10}},
+       {"customer_id", {.numDistinct = 100'000}},
+       {"amount", {.numDistinct = 500'000}}});
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_composite")
+            .aggregate({"region", "customer_id"}, {"sum(amount)"})
+            .build());
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_composite")
+            .localPartition({"region", "customer_id"})
+            .singleAggregation({"region", "customer_id"}, {"sum(amount)"})
+            .gather()
+            .build());
+  }
+
+  // Strict subset of bucket keys.
+  {
+    auto plan = planDistributed(
+        lp::PlanBuilder(makeContext())
+            .tableScan("s_composite")
+            .aggregate({"region"}, {"sum(amount)"})
+            .build());
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+  }
+}
+
+TEST_F(BucketedExecutionTest, unionall) {
+  // gcd(128, 4) = 4.
+  addBucketedTable("u_a", {"customer_id"}, 128);
+  addBucketedTable(
+      "u_b",
+      {"customer_id"},
+      4,
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) FROM ("
+        "  SELECT customer_id, amount FROM u_a"
+        "  UNION ALL"
+        "  SELECT customer_id, amount FROM u_b"
+        ") GROUP BY customer_id",
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // 3-way mixed bucket counts (4, 8, 12), gcd=4. Must accept regardless of
+  // insertion order — copartition() between any two is non-transitive.
+  addBucketedTable("u3_a", {"customer_id"}, 4);
+  addBucketedTable(
+      "u3_b",
+      {"customer_id"},
+      8,
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  addBucketedTable(
+      "u3_c",
+      {"customer_id"},
+      12,
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  for (const auto& [first, second, third] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"u3_a", "u3_b", "u3_c"},
+           {"u3_b", "u3_a", "u3_c"},
+           {"u3_c", "u3_b", "u3_a"}}) {
+    SCOPED_TRACE(fmt::format("{} {} {}", first, second, third));
+    auto plan = planDistributed(parseSelect(
+        fmt::format(
+            "SELECT customer_id, sum(amount) FROM ("
+            "  SELECT customer_id, amount FROM {}"
+            "  UNION ALL SELECT customer_id, amount FROM {}"
+            "  UNION ALL SELECT customer_id, amount FROM {}"
+            ") GROUP BY customer_id",
+            first,
+            second,
+            third),
+        kTestConnectorId));
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // Different bucket keys (same type) — must not co-fragment.
+  addBucketedTable("u_diff_cust", {"customer_id"}, 16);
+  addBucketedTable(
+      "u_diff_acct",
+      {"account_id"},
+      16,
+      ROW({"account_id", "amount"}, {BIGINT(), DOUBLE()}),
+      500'000);
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT customer_id, sum(amount) FROM ("
+        "  SELECT customer_id, amount FROM u_diff_cust"
+        "  UNION ALL"
+        "  SELECT account_id AS customer_id, amount FROM u_diff_acct"
+        ") GROUP BY customer_id",
+        kTestConnectorId));
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+  }
+}
+
+TEST_F(BucketedExecutionTest, gating) {
+  addBucketedTable("g_orders", {"customer_id"}, 128);
+
+  auto plan = lp::PlanBuilder(makeContext())
+                  .tableScan("g_orders")
+                  .aggregate({"customer_id"}, {"sum(amount)"})
+                  .build();
+
+  assertBucketedPlan(*planDistributed(plan).plan);
+
+  optimizerOptions_.enableBucketedExecution = false;
+  assertAllNotBucketed(*planDistributed(plan).plan);
+
+  optimizerOptions_.enableBucketedExecution = true;
+  optimizerOptions_.alwaysPlanPartialAggregation = true;
+  auto out = planDistributed(plan);
+  assertBucketedPlan(*out.plan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      out.plan,
+      matchScan("g_orders")
+          .partialAggregation()
+          .localPartition({"customer_id"})
+          .finalAggregation()
+          .gather()
+          .build());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -127,6 +127,8 @@ add_executable(
   SyntacticJoinOrderTest.cpp
   FeatureGen.cpp
   Genies.cpp
+  BucketedExecutionTest.cpp
+  HiveBucketedExecutionTest.cpp
   TestConnectorQueryTest.cpp
   TpchConnectorQueryTest.cpp
   UnnestTest.cpp

--- a/axiom/optimizer/tests/HiveBucketedExecutionTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionTest.cpp
@@ -1,6 +1,9 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
+#include <re2/re2.h>
+#include "axiom/connectors/hive/HiveConnectorMetadata.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 
@@ -47,13 +50,52 @@ class HiveBucketedExecutionTest : public test::HiveQueriesTestBase {
   void createBucketedTable(const std::string& name, const std::string& sql) {
     tablesToDrop_.push_back(name);
     runCtas(sql);
+    verifyBucketed(name, parseBucketCount(sql));
   }
 
-  PlanAndStats planQuery(std::string_view sql) {
-    return planVelox(
-        parseSelect(sql),
-        {.numWorkers = 4, .numDrivers = 4},
+  void verifyBucketed(const std::string& name, int32_t expectedBuckets) {
+    auto table = hiveMetadata().findTable({kDefaultSchema, name});
+    ASSERT_NE(table, nullptr);
+    ASSERT_FALSE(table->layouts().empty());
+    const auto* layout =
+        table->layouts().at(0)->as<connector::hive::HiveTableLayout>();
+    ASSERT_NE(layout, nullptr);
+    const auto* partitionType = layout->partitionType();
+    ASSERT_NE(partitionType, nullptr);
+    EXPECT_EQ(partitionType->numPartitions(), expectedBuckets);
+  }
+
+  static int32_t parseBucketCount(const std::string& sql) {
+    static const re2::RE2 kPattern(R"(bucket_count\s*=\s*(\d+))");
+    int32_t count;
+    VELOX_CHECK(re2::RE2::PartialMatch(sql, kPattern, &count));
+    return count;
+  }
+
+  void assertBucketedExecution(const lp::LogicalPlanNodePtr& logicalPlan) {
+    auto savedFlag = optimizerOptions_.enableBucketedExecution;
+    auto restoreFlag = folly::makeGuard([this, savedFlag]() {
+      optimizerOptions_.enableBucketedExecution = savedFlag;
+    });
+
+    optimizerOptions_.enableBucketedExecution = false;
+    auto referencePlan = planVelox(
+        logicalPlan,
+        MultiFragmentPlan::Options::singleNode(),
         optimizerOptions_);
+    auto reference = runFragmentedPlan(referencePlan).results;
+    ASSERT_GT(reference.size(), 0);
+
+    optimizerOptions_.enableBucketedExecution = true;
+    checkSame(logicalPlan, reference);
+  }
+
+  void checkBucketedQuery(std::string_view sql) {
+    auto logicalPlan = parseSelect(sql);
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    assertBucketedPlan(*plan.plan);
+    assertBucketedExecution(logicalPlan);
   }
 
   std::vector<std::string> tablesToDrop_;
@@ -73,9 +115,11 @@ TEST_F(HiveBucketedExecutionTest, join) {
       "cast(c_nationkey as varchar) as label FROM customer");
 
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT * FROM j_left JOIN j_right "
         "ON j_left.c_nationkey = j_right.c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
@@ -84,35 +128,31 @@ TEST_F(HiveBucketedExecutionTest, join) {
             .gather()
             .project()
             .build());
+    assertBucketedExecution(logicalPlan);
   }
 
-  {
-    auto plan = planQuery(
-        "SELECT * FROM j_left RIGHT JOIN j_right "
-        "ON j_left.c_nationkey = j_right.c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
+  checkBucketedQuery(
+      "SELECT * FROM j_left RIGHT JOIN j_right "
+      "ON j_left.c_nationkey = j_right.c_nationkey");
+  checkBucketedQuery(
+      "SELECT * FROM j_left FULL OUTER JOIN j_right "
+      "ON j_left.c_nationkey = j_right.c_nationkey");
 
+  // LEFT currently emits a sub-optimal multi-fragment shape with a redundant
+  // repartition. Results are correct, but the bucketed fragment isn't at
+  // index 0 — assert metadata via fragment search instead of the helper.
   {
-    auto plan = planQuery(
-        "SELECT * FROM j_left FULL OUTER JOIN j_right "
-        "ON j_left.c_nationkey = j_right.c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
-
-  // LEFT currently emits a sub-optimal multi-fragment shape.
-  {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT * FROM j_left LEFT JOIN j_right "
         "ON j_left.c_nationkey = j_right.c_nationkey");
-    bool foundBucketed = false;
-    for (const auto& fragment : plan.plan->fragments()) {
-      if (!fragment.splitToWorkerFns.empty()) {
-        foundBucketed = true;
-        break;
-      }
-    }
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+    bool foundBucketed = std::any_of(
+        plan.plan->fragments().begin(),
+        plan.plan->fragments().end(),
+        [](const auto& f) { return !f.splitToWorkerFns.empty(); });
     EXPECT_TRUE(foundBucketed);
+    assertBucketedExecution(logicalPlan);
   }
 
   tablesToDrop_.emplace_back("j_unbucketed");
@@ -120,9 +160,11 @@ TEST_F(HiveBucketedExecutionTest, join) {
       "CREATE TABLE j_unbucketed AS "
       "SELECT DISTINCT c_nationkey, "
       "cast(c_nationkey as varchar) as label FROM customer");
-  auto plan = planQuery(
+  auto logicalPlan = parseSelect(
       "SELECT * FROM j_left JOIN j_unbucketed "
       "ON j_left.c_nationkey = j_unbucketed.c_nationkey");
+  auto plan = planVelox(
+      logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
   bool foundBucketed = false;
   bool foundNotBucketed = false;
   for (const auto& fragment : plan.plan->fragments()) {
@@ -131,6 +173,7 @@ TEST_F(HiveBucketedExecutionTest, join) {
   }
   EXPECT_TRUE(foundBucketed);
   EXPECT_TRUE(foundNotBucketed);
+  assertBucketedExecution(logicalPlan);
 }
 
 TEST_F(HiveBucketedExecutionTest, semijoin) {
@@ -146,9 +189,11 @@ TEST_F(HiveBucketedExecutionTest, semijoin) {
       "AS SELECT DISTINCT c_nationkey FROM customer WHERE c_nationkey < 5");
 
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_custkey, c_nationkey FROM sj_left "
         "WHERE c_nationkey IN (SELECT c_nationkey FROM sj_right)");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
@@ -158,14 +203,12 @@ TEST_F(HiveBucketedExecutionTest, semijoin) {
                 core::JoinType::kLeftSemiFilter)
             .gather()
             .build());
+    assertBucketedExecution(logicalPlan);
   }
 
-  {
-    auto plan = planQuery(
-        "SELECT c_custkey, c_nationkey FROM sj_left "
-        "WHERE c_nationkey NOT IN (SELECT c_nationkey FROM sj_right)");
-    assertBucketedPlan(*plan.plan);
-  }
+  checkBucketedQuery(
+      "SELECT c_custkey, c_nationkey FROM sj_left "
+      "WHERE c_nationkey NOT IN (SELECT c_nationkey FROM sj_right)");
 }
 
 TEST_F(HiveBucketedExecutionTest, aggregation) {
@@ -176,8 +219,10 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
       "AS SELECT * FROM customer");
 
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_nationkey, count(*) FROM a_customers GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
@@ -186,64 +231,48 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
             .singleAggregation({"c_nationkey"}, {"count(*)"})
             .gather()
             .build());
+    assertBucketedExecution(logicalPlan);
   }
 
-  {
-    auto plan = planQuery(
-        "SELECT c_nationkey, c_mktsegment, count(*) FROM a_customers "
-        "GROUP BY c_nationkey, c_mktsegment");
-    assertBucketedPlan(*plan.plan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchHiveScan("a_customers")
-            .localPartition({"c_nationkey", "c_mktsegment"})
-            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
-            .gather()
-            .build());
-  }
+  checkBucketedQuery(
+      "SELECT c_nationkey, c_mktsegment, count(*) FROM a_customers "
+      "GROUP BY c_nationkey, c_mktsegment");
+  checkBucketedQuery(
+      "SELECT c_nationkey, count(*), min(c_acctbal), max(c_acctbal) "
+      "FROM a_customers GROUP BY c_nationkey");
+  checkBucketedQuery(
+      "SELECT c_nationkey, count(DISTINCT c_mktsegment) FROM a_customers "
+      "GROUP BY c_nationkey");
+  checkBucketedQuery(
+      "SELECT c_nationkey, count(*) AS cnt FROM a_customers "
+      "GROUP BY c_nationkey HAVING count(*) > 100");
 
+  // Non-bucket grouping key falls through to partial+final.
   {
-    auto plan = planQuery(
-        "SELECT c_nationkey, count(*), min(c_acctbal), max(c_acctbal) "
-        "FROM a_customers GROUP BY c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
-
-  {
-    auto plan = planQuery(
-        "SELECT c_nationkey, count(DISTINCT c_mktsegment) FROM a_customers "
-        "GROUP BY c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
-
-  {
-    auto plan = planQuery(
-        "SELECT c_nationkey, count(*) AS cnt FROM a_customers "
-        "GROUP BY c_nationkey HAVING count(*) > 100");
-    assertBucketedPlan(*plan.plan);
-  }
-
-  // Non-bucket grouping key forces partial+final.
-  {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_mktsegment, count(*) FROM a_customers GROUP BY c_mktsegment");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     ASSERT_GT(plan.plan->fragments().size(), 1);
     for (size_t i = 1; i < plan.plan->fragments().size(); ++i) {
       assertNotBucketed(*plan.plan, /*fragmentIndex=*/static_cast<int32_t>(i));
     }
+    assertBucketedExecution(logicalPlan);
   }
 }
 
 TEST_F(HiveBucketedExecutionTest, select) {
+  createBucketedTable(
+      "s_one",
+      "CREATE TABLE s_one "
+      "WITH (bucket_count = 1, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT * FROM customer");
   {
-    createBucketedTable(
-        "s_one",
-        "CREATE TABLE s_one "
-        "WITH (bucket_count = 1, bucketed_by = ARRAY['c_nationkey']) "
-        "AS SELECT * FROM customer");
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_nationkey, count(*) FROM s_one GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
@@ -252,26 +281,24 @@ TEST_F(HiveBucketedExecutionTest, select) {
             .singleAggregation({"c_nationkey"}, {"count(*)"})
             .gather()
             .build());
+    assertBucketedExecution(logicalPlan);
   }
 
   // gcd(16, 8) = 8.
-  {
-    createBucketedTable(
-        "s_match",
-        "CREATE TABLE s_match "
-        "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
-        "AS SELECT c_custkey, c_nationkey FROM customer");
-    createBucketedTable(
-        "s_down",
-        "CREATE TABLE s_down "
-        "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
-        "AS SELECT DISTINCT c_nationkey, "
-        "cast(c_nationkey as varchar) as label FROM customer");
-    auto plan = planQuery(
-        "SELECT * FROM s_match JOIN s_down "
-        "ON s_match.c_nationkey = s_down.c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
+  createBucketedTable(
+      "s_match",
+      "CREATE TABLE s_match "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "s_down",
+      "CREATE TABLE s_down "
+      "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+  checkBucketedQuery(
+      "SELECT * FROM s_match JOIN s_down "
+      "ON s_match.c_nationkey = s_down.c_nationkey");
 
   createBucketedTable(
       "s_composite",
@@ -279,9 +306,11 @@ TEST_F(HiveBucketedExecutionTest, select) {
       "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey', 'c_mktsegment']) "
       "AS SELECT * FROM customer");
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_nationkey, c_mktsegment, count(*) FROM s_composite "
         "GROUP BY c_nationkey, c_mktsegment");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     assertBucketedPlan(*plan.plan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
@@ -290,14 +319,18 @@ TEST_F(HiveBucketedExecutionTest, select) {
             .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
             .gather()
             .build());
+    assertBucketedExecution(logicalPlan);
   }
 
   // Strict subset of bucket keys.
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_nationkey, count(*) FROM s_composite "
         "GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     ASSERT_GT(plan.plan->fragments().size(), 1);
+    assertBucketedExecution(logicalPlan);
   }
 }
 
@@ -314,18 +347,14 @@ TEST_F(HiveBucketedExecutionTest, unionall) {
       "AS SELECT c_nationkey, c_custkey FROM customer");
 
   // gcd(16, 4) = 4.
-  {
-    auto plan = planQuery(
-        "SELECT c_nationkey, count(*) FROM ("
-        "  SELECT c_nationkey, c_custkey FROM u_a"
-        "  UNION ALL"
-        "  SELECT c_nationkey, c_custkey FROM u_b"
-        ") GROUP BY c_nationkey");
-    assertBucketedPlan(*plan.plan);
-  }
+  checkBucketedQuery(
+      "SELECT c_nationkey, count(*) FROM ("
+      "  SELECT c_nationkey, c_custkey FROM u_a"
+      "  UNION ALL"
+      "  SELECT c_nationkey, c_custkey FROM u_b"
+      ") GROUP BY c_nationkey");
 
-  // Bucketed on different keys (same type) — must split into separate
-  // fragments.
+  // Different bucket keys (same type) — must not co-fragment.
   createBucketedTable(
       "u_diff_a",
       "CREATE TABLE u_diff_a "
@@ -338,13 +367,16 @@ TEST_F(HiveBucketedExecutionTest, unionall) {
       "AS SELECT c_nationkey, c_custkey FROM customer");
 
   {
-    auto plan = planQuery(
+    auto logicalPlan = parseSelect(
         "SELECT c_nationkey, count(*) FROM ("
         "  SELECT c_nationkey FROM u_diff_a"
         "  UNION ALL"
         "  SELECT c_custkey AS c_nationkey FROM u_diff_b"
         ") GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
     ASSERT_GT(plan.plan->fragments().size(), 1);
+    assertBucketedExecution(logicalPlan);
   }
 }
 

--- a/axiom/optimizer/tests/HiveBucketedExecutionTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionTest.cpp
@@ -1,0 +1,352 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+void assertBucketedPlan(
+    const MultiFragmentPlan& plan,
+    int32_t fragmentIndex = 0) {
+  ASSERT_LT(fragmentIndex, plan.fragments().size());
+  ASSERT_FALSE(plan.fragments()[fragmentIndex].splitToWorkerFns.empty());
+}
+
+void assertNotBucketed(
+    const MultiFragmentPlan& plan,
+    int32_t fragmentIndex = 0) {
+  ASSERT_LT(fragmentIndex, plan.fragments().size());
+  ASSERT_TRUE(plan.fragments()[fragmentIndex].splitToWorkerFns.empty());
+}
+
+class HiveBucketedExecutionTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_CUSTOMER});
+  }
+
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+    optimizerOptions_.enableBucketedExecution = true;
+  }
+
+  void TearDown() override {
+    for (const auto& name : tablesToDrop_) {
+      hiveMetadata().dropTableIfExists({kDefaultSchema, name});
+    }
+    tablesToDrop_.clear();
+    HiveQueriesTestBase::TearDown();
+  }
+
+  void createBucketedTable(const std::string& name, const std::string& sql) {
+    tablesToDrop_.push_back(name);
+    runCtas(sql);
+  }
+
+  PlanAndStats planQuery(std::string_view sql) {
+    return planVelox(
+        parseSelect(sql),
+        {.numWorkers = 4, .numDrivers = 4},
+        optimizerOptions_);
+  }
+
+  std::vector<std::string> tablesToDrop_;
+};
+
+TEST_F(HiveBucketedExecutionTest, join) {
+  createBucketedTable(
+      "j_left",
+      "CREATE TABLE j_left "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "j_right",
+      "CREATE TABLE j_right "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+
+  {
+    auto plan = planQuery(
+        "SELECT * FROM j_left JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("j_left")
+            .hashJoin(matchHiveScan("j_right").build(), core::JoinType::kInner)
+            .gather()
+            .project()
+            .build());
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT * FROM j_left RIGHT JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT * FROM j_left FULL OUTER JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // LEFT currently emits a sub-optimal multi-fragment shape.
+  {
+    auto plan = planQuery(
+        "SELECT * FROM j_left LEFT JOIN j_right "
+        "ON j_left.c_nationkey = j_right.c_nationkey");
+    bool foundBucketed = false;
+    for (const auto& fragment : plan.plan->fragments()) {
+      if (!fragment.splitToWorkerFns.empty()) {
+        foundBucketed = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(foundBucketed);
+  }
+
+  tablesToDrop_.emplace_back("j_unbucketed");
+  runCtas(
+      "CREATE TABLE j_unbucketed AS "
+      "SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+  auto plan = planQuery(
+      "SELECT * FROM j_left JOIN j_unbucketed "
+      "ON j_left.c_nationkey = j_unbucketed.c_nationkey");
+  bool foundBucketed = false;
+  bool foundNotBucketed = false;
+  for (const auto& fragment : plan.plan->fragments()) {
+    (fragment.splitToWorkerFns.empty() ? foundNotBucketed : foundBucketed) =
+        true;
+  }
+  EXPECT_TRUE(foundBucketed);
+  EXPECT_TRUE(foundNotBucketed);
+}
+
+TEST_F(HiveBucketedExecutionTest, semijoin) {
+  createBucketedTable(
+      "sj_left",
+      "CREATE TABLE sj_left "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "sj_right",
+      "CREATE TABLE sj_right "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey FROM customer WHERE c_nationkey < 5");
+
+  {
+    auto plan = planQuery(
+        "SELECT c_custkey, c_nationkey FROM sj_left "
+        "WHERE c_nationkey IN (SELECT c_nationkey FROM sj_right)");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("sj_left")
+            .hashJoin(
+                matchHiveScan("sj_right").project().build(),
+                core::JoinType::kLeftSemiFilter)
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT c_custkey, c_nationkey FROM sj_left "
+        "WHERE c_nationkey NOT IN (SELECT c_nationkey FROM sj_right)");
+    assertBucketedPlan(*plan.plan);
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, aggregation) {
+  createBucketedTable(
+      "a_customers",
+      "CREATE TABLE a_customers "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT * FROM customer");
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) FROM a_customers GROUP BY c_nationkey");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("a_customers")
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, c_mktsegment, count(*) FROM a_customers "
+        "GROUP BY c_nationkey, c_mktsegment");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("a_customers")
+            .localPartition({"c_nationkey", "c_mktsegment"})
+            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
+            .gather()
+            .build());
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*), min(c_acctbal), max(c_acctbal) "
+        "FROM a_customers GROUP BY c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(DISTINCT c_mktsegment) FROM a_customers "
+        "GROUP BY c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) AS cnt FROM a_customers "
+        "GROUP BY c_nationkey HAVING count(*) > 100");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // Non-bucket grouping key forces partial+final.
+  {
+    auto plan = planQuery(
+        "SELECT c_mktsegment, count(*) FROM a_customers GROUP BY c_mktsegment");
+    assertBucketedPlan(*plan.plan);
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+    for (size_t i = 1; i < plan.plan->fragments().size(); ++i) {
+      assertNotBucketed(*plan.plan, /*fragmentIndex=*/static_cast<int32_t>(i));
+    }
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, select) {
+  {
+    createBucketedTable(
+        "s_one",
+        "CREATE TABLE s_one "
+        "WITH (bucket_count = 1, bucketed_by = ARRAY['c_nationkey']) "
+        "AS SELECT * FROM customer");
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) FROM s_one GROUP BY c_nationkey");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("s_one")
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .gather()
+            .build());
+  }
+
+  // gcd(16, 8) = 8.
+  {
+    createBucketedTable(
+        "s_match",
+        "CREATE TABLE s_match "
+        "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+        "AS SELECT c_custkey, c_nationkey FROM customer");
+    createBucketedTable(
+        "s_down",
+        "CREATE TABLE s_down "
+        "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+        "AS SELECT DISTINCT c_nationkey, "
+        "cast(c_nationkey as varchar) as label FROM customer");
+    auto plan = planQuery(
+        "SELECT * FROM s_match JOIN s_down "
+        "ON s_match.c_nationkey = s_down.c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  createBucketedTable(
+      "s_composite",
+      "CREATE TABLE s_composite "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey', 'c_mktsegment']) "
+      "AS SELECT * FROM customer");
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, c_mktsegment, count(*) FROM s_composite "
+        "GROUP BY c_nationkey, c_mktsegment");
+    assertBucketedPlan(*plan.plan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("s_composite")
+            .localPartition({"c_nationkey", "c_mktsegment"})
+            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
+            .gather()
+            .build());
+  }
+
+  // Strict subset of bucket keys.
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) FROM s_composite "
+        "GROUP BY c_nationkey");
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+  }
+}
+
+TEST_F(HiveBucketedExecutionTest, unionall) {
+  createBucketedTable(
+      "u_a",
+      "CREATE TABLE u_a "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+  createBucketedTable(
+      "u_b",
+      "CREATE TABLE u_b "
+      "WITH (bucket_count = 4, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+
+  // gcd(16, 4) = 4.
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) FROM ("
+        "  SELECT c_nationkey, c_custkey FROM u_a"
+        "  UNION ALL"
+        "  SELECT c_nationkey, c_custkey FROM u_b"
+        ") GROUP BY c_nationkey");
+    assertBucketedPlan(*plan.plan);
+  }
+
+  // Bucketed on different keys (same type) — must split into separate
+  // fragments.
+  createBucketedTable(
+      "u_diff_a",
+      "CREATE TABLE u_diff_a "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+  createBucketedTable(
+      "u_diff_b",
+      "CREATE TABLE u_diff_b "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_custkey']) "
+      "AS SELECT c_nationkey, c_custkey FROM customer");
+
+  {
+    auto plan = planQuery(
+        "SELECT c_nationkey, count(*) FROM ("
+        "  SELECT c_nationkey FROM u_diff_a"
+        "  UNION ALL"
+        "  SELECT c_custkey AS c_nationkey FROM u_diff_b"
+        ") GROUP BY c_nationkey");
+    ASSERT_GT(plan.plan->fragments().size(), 1);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -741,6 +741,8 @@ TEST_F(WriteTest, ctasBucketedSql) {
     }
   };
 
+  optimizerOptions_.enableBucketedExecution = true;
+
   runCtas(
       "CREATE TABLE test WITH (bucket_count = 8, bucketed_by = ARRAY['key']) AS "
       "SELECT rand() as key, l_orderkey, l_partkey, l_linenumber FROM lineitem",

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -116,9 +116,9 @@ std::optional<velox::common::SpillDiskOptions> makeSpillDiskOptions(
   return options;
 }
 
-// Streams splits from the source and distributes them round-robin across tasks.
 folly::coro::Task<void> co_generateAndDistributeSplits(
     std::shared_ptr<connector::SplitSource> source,
+    const connector::PartitionType::SplitToWorkerFn* splitToWorkerFn,
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
     std::function<void(std::exception_ptr)> onError,
@@ -133,8 +133,19 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     for (;;) {
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
-        tasks[taskIdx]->addSplit(scanId, velox::exec::Split(std::move(split)));
-        taskIdx = (taskIdx + 1) % tasks.size();
+        size_t targetTask;
+        if (splitToWorkerFn != nullptr) {
+          targetTask = static_cast<size_t>((*splitToWorkerFn)(*split));
+          VELOX_CHECK_LT(
+              targetTask,
+              tasks.size(),
+              "SplitToWorkerFn returned out-of-range worker index");
+        } else {
+          targetTask = taskIdx;
+          taskIdx = (taskIdx + 1) % tasks.size();
+        }
+        tasks[targetTask]->addSplit(
+            scanId, velox::exec::Split(std::move(split)));
         ++splitCount;
       }
       if (batch.noMoreSplits) {
@@ -478,7 +489,6 @@ void LocalRunner::makeStages(
           makeSpillDiskOptions(baseSpillDirectory_, taskId),
           onError);
       stages_.back().push_back(task);
-
       task->start(plan_->options().numDrivers);
     }
   }
@@ -496,11 +506,20 @@ void LocalRunner::makeStages(
 
       for (const auto& scan : scans) {
         auto source = splitSourceForScan(/*session=*/nullptr, *scan);
+        // nullptr selects round-robin distribution; non-null routes via the
+        // function's bucket → worker mapping.
+        const auto* splitToWorkerFn =
+            folly::get_ptr(fragment.splitToWorkerFns, scan->id());
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),
                 co_generateAndDistributeSplits(
-                    source, scan->id(), stage, onError, runtimeStats_)));
+                    source,
+                    splitToWorkerFn,
+                    scan->id(),
+                    stage,
+                    onError,
+                    runtimeStats_)));
       }
 
       for (const auto& input : fragment.inputStages) {


### PR DESCRIPTION
Summary:

Routes scan splits by the optimizer-supplied closure when bucketed execution is enabled. Runner contract: `fragment.splitToWorkerFns` maps each bucketed scan id to a `SplitToWorkerFn` closure; `LocalRunner` calls `(*fn)(*split)` to obtain a worker index in `[0, tasks.size())` and dispatches to that task. Otherwise round-robin.

The closure itself encapsulates the bucket math and N-divides-M downscaling (GCD across co-bucketed scans in the fragment), so the runner does no bucket-aware lookup.

Reviewed By: arhimondr

Differential Revision: D101852054


