### PR TITLE
fix(optimizer): Drop nullptr padding in repartitionForWrite constants (#1304)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1846,15 +1846,14 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
     const auto& partitionColumns = layout->partitionColumns();
     if (!partitionColumns.empty()) {
       std::vector<velox::column_index_t> channels;
-      std::vector<velox::VectorPtr> constants;
+      channels.reserve(partitionColumns.size());
       for (auto i = 0; i < partitionColumns.size(); ++i) {
         channels.push_back(
             input->outputType()->getChildIdx(partitionColumns[i]->name()));
-        constants.push_back(nullptr);
       }
 
       auto spec = layout->partitionType()->makeSpec(
-          channels, constants, /*isLocal=*/true);
+          channels, /*constants=*/{}, /*isLocal=*/true);
       auto inputs = std::vector<velox::core::PlanNodePtr>{input};
       input = std::make_shared<velox::core::LocalPartitionNode>(
           nextId(),

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -25,6 +25,23 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
+// Asserts that each fragment in 'plan' round-trips through serialize and
+// deserialize and produces an equivalent plan tree.
+void verifyPlanSerde(
+    const MultiFragmentPlan& plan,
+    velox::memory::MemoryPool* pool) {
+  for (const auto& fragment : plan.fragments()) {
+    SCOPED_TRACE(fragment.taskPrefix);
+    auto serialized = fragment.fragment.planNode->serialize();
+    auto deserialized =
+        velox::ISerializable::deserialize<velox::core::PlanNode>(
+            serialized, pool);
+    ASSERT_EQ(
+        fragment.fragment.planNode->toString(true, true),
+        deserialized->toString(true, true));
+  }
+}
+
 class WriteTest : public test::HiveQueriesTestBase {
  protected:
   const std::string kDefaultSchema{
@@ -32,6 +49,11 @@ class WriteTest : public test::HiveQueriesTestBase {
 
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
+    velox::Type::registerSerDe();
+    velox::common::Filter::registerSerDe();
+    velox::core::ITypedExpr::registerSerDe();
+    velox::core::PlanNode::registerSerDe();
+    velox::connector::hive::HiveConnector::registerSerDe();
     createTpchTables(
         {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_LINEITEM});
   }
@@ -117,6 +139,8 @@ class WriteTest : public test::HiveQueriesTestBase {
         return;
       }
     }
+
+    verifyPlanSerde(*plan.plan, pool());
 
     auto result = runFragmentedPlan(plan);
 


### PR DESCRIPTION
Summary:

`repartitionForWrite` padded the `constants` argument to `PartitionType::makeSpec` with a `nullptr` per partition column. This violates the `HivePartitionFunctionSpec` contract — `constValues` only carries entries for `kConstantChannel` slots — and crashes `HivePartitionFunctionSpec::serialize()` whenever a bucketed write plan is serialized.

Drops the nullptr padding. Partition columns are never `kConstantChannel`, so `constants` stays empty.

Reviewed By: kagamiori

Differential Revision: D102892689


