### PR TITLE
fix: Set presto.array_agg.ignore_nulls=true in SqlQueryRunner

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -185,6 +185,10 @@ void SqlQueryRunner::initialize(
       kExecutionPrefix,
       velox::core::QueryConfig::kAdjustTimestampToTimezone,
       "true");
+  sessionConfig_->set(
+      kExecutionPrefix,
+      velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+      "true");
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Add `presto.array_agg.ignore_nulls=true` as a default session property in `SqlQueryRunner::initialize()`. Without this, `array_agg` includes null inputs in the result array, producing incorrect results for queries that rely on null-skipping — e.g. `COALESCE(array_agg(if(cond, val, null)), ARRAY[])` returns `[null]` instead of `[]`.

```sql
SELECT array_agg(x) FROM (VALUES null) t(x)
-- Before: [null]
-- After:  NULL
```

Differential Revision: D103221465


