### PR TITLE
fix(optimizer): Return 0 from estimateFanout on zero-NDV join keys

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -694,6 +694,13 @@ float estimateFanout(
     return scanCardinality;
   }
 
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (keys[i]->value().cardinality == 0 ||
+        otherKeys[i]->value().cardinality == 0) {
+      return 0;
+    }
+  }
+
   auto fanout = scanCardinality /
       std::max(keys[0]->value().cardinality, otherKeys[0]->value().cardinality);
   for (size_t i = 1; i < keys.size(); ++i) {

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -494,6 +494,57 @@ TEST_F(CardinalityEstimationTest, innerJoin) {
   });
 }
 
+// Verifies join cardinality estimation when a join key is constrained by a
+// literal outside the connector-reported [min, max] range. The join should
+// produce an empty result (cardinality clamped to a minimum of 1).
+TEST_F(CardinalityEstimationTest, joinWithFilterOutsideMinMax) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {{"a",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}},
+           {"b",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}}});
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {{"x",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}},
+           {"y",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}}});
+
+  auto verify = [&](const std::string& sql) {
+    SCOPED_TRACE(sql);
+    verifyPlan(sql, [](const Plan& plan) {
+      const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+      EXPECT_NEAR(join.resultCardinality(), 1, kCardinalityTolerance);
+    });
+  };
+
+  // Both join keys constrained to a literal outside [1, 100].
+  verify(
+      "SELECT a, b, x, y FROM t JOIN u ON a = x "
+      "WHERE a = 999 AND x = 999");
+
+  // Only the left join key constrained outside [1, 100].
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x WHERE a = 999");
+
+  // Only the right join key constrained outside [1, 100].
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x WHERE x = 999");
+
+  // Multi-key join with only one key pair contradicted.
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x AND b = y WHERE a = 999");
+}
+
 // Verifies that inner join with a unique right side (DerivedTable with GROUP
 // BY) uses the right fanout to scale cardinality. The right side's fanout
 // reflects that not all left key values exist in the right side.


### PR DESCRIPTION
Summary:
`estimateFanout` divides `scanCardinality` by `max(NDV_left, NDV_right)`. When constraint analysis detects a contradictory predicate (e.g. a literal outside the column's `[min, max]` range from connector stats), it produces a constraint with `cardinality = 0`. That zero flows into both NDV operands, the divide returns `inf`, and the inf propagates through `JoinEdge::guessFanout` into `Join::initCost`. The next operator then trips `RelationOp::checkInputCardinality`'s `std::isfinite` check and the planner aborts with `INVALID_STATE`.

Short-circuit `estimateFanout` to return 0 when any join key has zero NDV on either side. A zero NDV from constraint analysis means no distinct values match: there are no rows on that key. Returning 0 propagates correctly through `adjustFanoutForJoinType` (per-join-type clamps preserve outer/semi/anti semantics) and the global `RelationOp::resultCardinality` floor at 1. This avoids the divide-by-zero crash without overestimating fanout to `scanCardinality` as a floor-at-1 fix would.

Reviewed By: kagamiori

Differential Revision: D103268671


