### PR TITLE
feat(optimizer): Infer implied predicates across join keys (#1308)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -704,6 +704,106 @@ void DerivedTable::addImpliedJoins() {
   }
 }
 
+namespace {
+
+// Appends (target table, cloned predicate) pairs for predicates implied by
+// 'filter' across its source column's equivalence class. 'mutableTables' maps
+// the const handle returned by Column::singleTable() to the non-const handle
+// accepted by tryPushdownConjunct.
+void collectImpliedPredicates(
+    ExprCP filter,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  if (filter->containsNonDeterministic()) {
+    return;
+  }
+  // Multi-column predicates need Cartesian-product enumeration over
+  // per-column equivalence classes gated to the same target — a
+  // different design from the per-column propagation here.
+  if (filter->columns().size() != 1) {
+    return;
+  }
+  auto* source = filter->columns().onlyObject<Column>();
+  auto* equivalence = source->equivalence();
+  if (!equivalence) {
+    return;
+  }
+
+  folly::F14FastSet<ColumnCP> visited{source};
+  for (auto* target : equivalence->columns) {
+    if (!visited.insert(target).second) {
+      continue;
+    }
+    auto* targetTable = target->singleTable();
+    if (!targetTable) {
+      continue;
+    }
+    auto it = mutableTables.find(targetTable);
+    if (it == mutableTables.end()) {
+      continue;
+    }
+    impliedPredicatesOut.emplace_back(
+        it->second,
+        DerivedTableFlattener::replaceInputs(
+            filter, ColumnVector{source}, ExprVector{target}));
+  }
+}
+
+} // namespace
+
+void DerivedTable::inferImpliedPredicates() {
+  folly::F14FastMap<PlanObjectCP, PlanObjectP> mutableTables;
+  tableSet.forEachMutable(
+      [&](PlanObjectP table) { mutableTables.emplace(table, table); });
+
+  std::vector<std::pair<PlanObjectP, ExprCP>> implied;
+  for (auto* table : tables) {
+    if (table->is(PlanType::kTableNode)) {
+      for (auto* filter : table->as<BaseTable>()->columnFilters) {
+        collectImpliedPredicates(filter, mutableTables, implied);
+      }
+    } else if (table->is(PlanType::kDerivedTableNode)) {
+      auto* innerDt = table->as<DerivedTable>();
+      for (auto* filter : innerDt->conjuncts) {
+        if (filter->columns().size() != 1) {
+          continue;
+        }
+        auto* innerColumn = filter->columns().onlyObject<Column>();
+        for (size_t i = 0;
+             i < innerDt->columns.size() && i < innerDt->exprs.size();
+             ++i) {
+          if (innerDt->exprs[i] != innerColumn) {
+            continue;
+          }
+          auto* outerColumn = innerDt->columns[i];
+          auto outerFilter = DerivedTableFlattener::replaceInputs(
+              filter, ColumnVector{innerColumn}, ExprVector{outerColumn});
+          collectImpliedPredicates(outerFilter, mutableTables, implied);
+        }
+      }
+    }
+  }
+
+  for (auto& [target, expr] : implied) {
+    if (target->is(PlanType::kTableNode)) {
+      const auto& existing = target->as<BaseTable>()->columnFilters;
+      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
+            return candidate->sameOrEqual(*expr);
+          })) {
+        continue;
+      }
+    } else if (target->is(PlanType::kDerivedTableNode)) {
+      const auto& existing = target->as<DerivedTable>()->conjuncts;
+      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
+            return candidate->sameOrEqual(*expr);
+          })) {
+        continue;
+      }
+    }
+    tryPushdownConjunct(expr, target);
+  }
+}
+
 bool DerivedTable::isSingleRow() const {
   return aggregation && aggregation->groupingKeys().empty() && having.empty() &&
       limit != 0 && offset == 0;
@@ -2056,7 +2156,6 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
 }
 
 void DerivedTable::distributeConjuncts() {
-  std::vector<DerivedTableP> changedDts;
   if (!having.empty()) {
     VELOX_CHECK_NOT_NULL(aggregation);
 
@@ -2129,7 +2228,7 @@ void DerivedTable::distributeConjuncts() {
                   // existence flags. Leave in place.
       }
 
-      if (!tryPushdownConjunct(conjunct, tables[0], changedDts)) {
+      if (!tryPushdownConjunct(conjunct, tables[0])) {
         continue;
       }
 
@@ -2167,6 +2266,8 @@ void DerivedTable::distributeConjuncts() {
       }
     }
   }
+
+  inferImpliedPredicates();
 }
 
 void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
@@ -2248,10 +2349,7 @@ void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
   }
 }
 
-bool DerivedTable::tryPushdownConjunct(
-    ExprCP conjunct,
-    PlanObjectP table,
-    std::vector<DerivedTableP>& changedDts) {
+bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
   if (table->is(PlanType::kValuesTableNode)) {
     return false; // ValuesTable does not have filter push-down.
   }
@@ -2268,14 +2366,6 @@ bool DerivedTable::tryPushdownConjunct(
     auto innerDt = table->as<DerivedTable>();
     if (!innerDt->addFilter(conjunct)) {
       return false;
-    }
-
-    if (innerDt->isUnion()) {
-      for (auto* child : innerDt->unionInputs) {
-        pushBackUnique(changedDts, child);
-      }
-    } else {
-      pushBackUnique(changedDts, innerDt);
     }
     return true;
   }

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -430,6 +430,13 @@ struct DerivedTable : public PlanObject {
   // Updates cardinality and column constraints from the plan.
   void updateConstraints(const RelationOp& plan);
 
+  // Synthesizes single-column predicates implied by inner-join
+  // column equivalences. For each single-column filter on a
+  // BaseTable or inner DerivedTable, clones it to other columns
+  // in the same equivalence class. Skips non-deterministic and
+  // multi-column filters; see implementation for rationale.
+  void inferImpliedPredicates();
+
   // Completes 'joins' with edges implied by column equivalences.
   void addImpliedJoins();
 
@@ -521,13 +528,8 @@ struct DerivedTable : public PlanObject {
   //
   // @param conjunct The filter expression to push down.
   // @param table The target table (BaseTable, DerivedTable, etc.).
-  // @param changedDts Output parameter collecting DerivedTables that were
-  // modified.
   // @return true if the conjunct was successfully pushed down, false otherwise.
-  bool tryPushdownConjunct(
-      ExprCP conjunct,
-      PlanObjectP table,
-      std::vector<DerivedTable*>& changedDts);
+  bool tryPushdownConjunct(ExprCP conjunct, PlanObjectP table);
 
   // Returns true if 'imported' depends only on columns that are partition keys
   // of every window function in windowPlan.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -694,6 +694,13 @@ float estimateFanout(
     return scanCardinality;
   }
 
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (keys[i]->value().cardinality == 0 ||
+        otherKeys[i]->value().cardinality == 0) {
+      return 0;
+    }
+  }
+
   auto fanout = scanCardinality /
       std::max(keys[0]->value().cardinality, otherKeys[0]->value().cardinality);
   for (size_t i = 1; i < keys.size(); ++i) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -153,9 +153,10 @@ class Column : public Expr {
     return alias_ != nullptr ? alias_ : toString();
   }
 
-  /// Asserts that 'this' and 'other' are joined on equality. This has a
-  /// transitive effect, so if a and b are previously asserted equal and c is
-  /// asserted equal to b, a and c are also equal.
+  /// Asserts that 'this' and 'other' are joined on equality under inner-join
+  /// semantics (NULLs do not match). The relation is transitive, so if a and
+  /// b are previously asserted equal and c is asserted equal to b, a and c
+  /// are also equal.
   void equals(ColumnCP other) const;
 
   std::string toString() const override;
@@ -185,8 +186,7 @@ class Column : public Expr {
   // Optional alias copied from the the logical plan.
   Name alias_;
 
-  // Equivalence class. Lists all columns directly or indirectly asserted equal
-  // to 'this'.
+  // Equivalence class. See Column::equals.
   mutable EquivalenceP equivalence_{nullptr};
 
   // If this is a column of a BaseTable, points to the corresponding

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -494,6 +494,57 @@ TEST_F(CardinalityEstimationTest, innerJoin) {
   });
 }
 
+// Verifies join cardinality estimation when a join key is constrained by a
+// literal outside the connector-reported [min, max] range. The join should
+// produce an empty result (cardinality clamped to a minimum of 1).
+TEST_F(CardinalityEstimationTest, joinWithFilterOutsideMinMax) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {{"a",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}},
+           {"b",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}}});
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {{"x",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}},
+           {"y",
+            {.min = velox::Variant::create<int64_t>(1),
+             .max = velox::Variant::create<int64_t>(100),
+             .numDistinct = 100}}});
+
+  auto verify = [&](const std::string& sql) {
+    SCOPED_TRACE(sql);
+    verifyPlan(sql, [](const Plan& plan) {
+      const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+      EXPECT_NEAR(join.resultCardinality(), 1, kCardinalityTolerance);
+    });
+  };
+
+  // Both join keys constrained to a literal outside [1, 100].
+  verify(
+      "SELECT a, b, x, y FROM t JOIN u ON a = x "
+      "WHERE a = 999 AND x = 999");
+
+  // Only the left join key constrained outside [1, 100].
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x WHERE a = 999");
+
+  // Only the right join key constrained outside [1, 100].
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x WHERE x = 999");
+
+  // Multi-key join with only one key pair contradicted.
+  verify("SELECT a, b, x, y FROM t JOIN u ON a = x AND b = y WHERE a = 999");
+}
+
 // Verifies that inner join with a unique right side (DerivedTable with GROUP
 // BY) uses the right fanout to scale cardinality. The right side's fanout
 // reflects that not all left key values exist in the right side.

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -239,6 +239,7 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   auto matcher = matchScan("u")
+                     .filter("x < 10")
                      .singleAggregation({"x"}, {"count(*) as cnt"})
                      .hashJoin(
                          matchScan("v")
@@ -254,6 +255,7 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher = matchScan("u")
+                                .filter("x < 10")
                                 .shuffle({"x"})
                                 .localPartition({"x"})
                                 .singleAggregation({"x"}, {"count(*) as cnt"})
@@ -285,20 +287,26 @@ TEST_F(ExistencePushdownTest, chainJoin) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  // r + s wrapped into a chainDt, pushed as existence inside the aggregation.
   auto matcher =
       matchScan("u")
           .hashJoin(
               matchScan("r")
                   .filter("b < 100")
-                  .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+                  .hashJoin(
+                      matchScan("s")
+                          .aliases({"s_a"})
+                          .filter("s_a < 100")
+                          .build(),
+                      core::JoinType::kInner)
                   .project()
                   .build(),
               core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
               matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
-          .hashJoin(matchScan("s").build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("s").aliases({"s_a"}).filter("s_a < 100").build(),
+              core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
@@ -308,14 +316,24 @@ TEST_F(ExistencePushdownTest, chainJoin) {
   auto distributedMatcher =
       matchScan("r")
           .filter("b < 100")
-          .hashJoin(matchScan("s").broadcast().build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("s")
+                  .aliases({"s_a"})
+                  .filter("s_a < 100")
+                  .broadcast()
+                  .build(),
+              core::JoinType::kInner)
           .hashJoin(
               matchScan("u")
                   .hashJoin(
                       matchScan("r")
                           .filter("b < 100")
                           .hashJoin(
-                              matchScan("s").broadcast().build(),
+                              matchScan("s")
+                                  .aliases({"s_a"})
+                                  .filter("s_a < 100")
+                                  .broadcast()
+                                  .build(),
                               core::JoinType::kInner)
                           .project()
                           .broadcast()

--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -165,6 +165,32 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+
+  // Filter on a join key propagates to the other side via the equivalence.
+  {
+    lp::PlanBuilder::Context ctx(exec::test::kHiveConnectorId, kDefaultSchema);
+    auto logicalPlan =
+        lp::PlanBuilder(ctx)
+            .from({"nation", "region"})
+            .filter("n_regionkey = r_regionkey AND n_regionkey = 1")
+            .aggregate({}, {"count(*)"})
+            .build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .hiveScan("nation", test::eq("n_regionkey", (int64_t)1))
+            .hashJoin(
+                core::PlanMatcherBuilder()
+                    .hiveScan("region", test::eq("r_regionkey", (int64_t)1))
+                    .build(),
+                velox::core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
 }
 
 // Duplicate literals in an IN list should be deduplicated.

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1213,6 +1213,154 @@ TEST_F(JoinTest, impliedJoins) {
   }
 }
 
+TEST_F(JoinTest, impliedFilters) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+  testConnector_->addTable("v", ROW({"k", "m"}, BIGINT()))
+      ->setStats(100, {{"k", {.numDistinct = 100}}});
+
+  // Equality propagates from t.a to u.x via the join equivalence.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .filter("x = 5")
+            .hashJoin(
+                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Range propagates similarly.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a > 100";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .filter("a > 100")
+                       .hashJoin(
+                           matchScan("u").filter("x > 100").build(),
+                           core::JoinType::kInner)
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // IN propagates across the equivalence.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IN (1, 2, 3)";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("u")
+                       .filter("x IN (1, 2, 3)")
+                       .hashJoin(
+                           matchScan("t").filter("a IN (1, 2, 3)").build(),
+                           core::JoinType::kInner)
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // IS NULL propagates across the equivalence. Sound under inner-join
+  // semantics: t.a = u.x already rejects NULL on both sides, so adding
+  // u.x IS NULL on u (and the original t.a IS NULL on t) does not change the
+  // result, but lets the storage layer prune NULL rows before the join.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IS NULL";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .filter("a IS NULL")
+                       .hashJoin(
+                           matchScan("u").filter("x IS NULL").build(),
+                           core::JoinType::kInner)
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // IS NOT NULL likewise propagates.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IS NOT NULL";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .filter("a IS NOT NULL")
+                       .hashJoin(
+                           matchScan("u").filter("x IS NOT NULL").build(),
+                           core::JoinType::kInner)
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Non-deterministic predicates do not propagate.
+  {
+    auto query =
+        "SELECT * FROM t, u "
+        "WHERE t.a = u.x AND t.a = cast(random() * 100 as bigint)";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .filter("a = cast(random() * 100.0 as bigint)")
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Predicates already present on a sibling column should not be re-pushed.
+  // Both t.a = 5 and u.x = 5 exist before inference; inference sees that
+  // u.x = 5 is already on u (sameOrEqual finds it) and skips the redundant
+  // push, and likewise for the reverse direction.
+  {
+    auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5 AND u.x = 5";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .filter("x = 5")
+            .hashJoin(
+                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Three-table chain: t.a = u.x AND u.x = v.k puts t.a, u.x, v.k in one
+  // equivalence class. A filter on t.a propagates to both u.x and v.k.
+  {
+    auto query =
+        "SELECT * FROM t, u, v "
+        "WHERE t.a = u.x AND u.x = v.k AND t.a = 5";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .filter("x = 5")
+            .hashJoin(
+                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+            .hashJoin(
+                matchScan("v").filter("k = 5").build(), core::JoinType::kInner)
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
 // LEFT JOIN with no equalities when the DT has 3+ tables. The comma join
 // between nation and region is inlined into the same DT. The EXISTS semi-join
 // adds a 3rd table. The subsequent LEFT JOIN ON clause uses contains() which

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -97,7 +97,19 @@ class PlanMatcherImpl : public PlanMatcher {
       newSymbols.erase(alias);
     }
 
-    return matchDetails(*specificNode, newSymbols);
+    auto result = matchDetails(*specificNode, newSymbols);
+    if (!result.match || aliases_.empty()) {
+      return result;
+    }
+    const auto& names = plan->outputType()->names();
+    VELOX_USER_CHECK_LE(aliases_.size(), names.size());
+    auto resultSymbols = result.symbols;
+    for (size_t i = 0; i < aliases_.size(); ++i) {
+      if (aliases_[i].has_value()) {
+        resultSymbols[*aliases_[i]] = names[i];
+      }
+    }
+    return MatchResult::success(std::move(resultSymbols));
   }
 
   int32_t shuffleBoundaryCount() const override {
@@ -1997,6 +2009,22 @@ PlanMatcherBuilder& PlanMatcherBuilder::assignUniqueId(
     const std::string& alias) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<AssignUniqueIdMatcher>(matcher_, alias);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::aliases(
+    const std::vector<std::optional<std::string>>& aliases) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  std::unordered_set<std::string> seen;
+  for (const auto& alias : aliases) {
+    if (alias.has_value()) {
+      VELOX_USER_CHECK(
+          seen.insert(*alias).second,
+          "Duplicate alias in PlanMatcherBuilder::aliases(): {}",
+          *alias);
+    }
+  }
+  matcher_->setAliases(aliases);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -121,6 +121,17 @@ class PlanMatcher {
   virtual int32_t shuffleBoundaryCount() const {
     return 0;
   }
+
+  /// Binds aliases to the matched node's output columns by position. See
+  /// PlanMatcherBuilder::aliases() for usage. nullopt entries are skipped.
+  void setAliases(std::vector<std::optional<std::string>> aliases) {
+    aliases_ = std::move(aliases);
+  }
+
+ protected:
+  // Aliases bound to the matched node's output columns by position.
+  // Applied on successful match by PlanMatcherImpl::match().
+  std::vector<std::optional<std::string>> aliases_;
 };
 
 /// Match details for a HashJoin node beyond join type. Each field is
@@ -452,6 +463,17 @@ class PlanMatcherBuilder {
   /// as a symbol alias for use in parent matchers via symbol rewriting.
   /// @param alias The alias to use for the unique ID column.
   PlanMatcherBuilder& assignUniqueId(const std::string& alias);
+
+  /// Binds aliases to the previous matcher's output columns by position so
+  /// downstream matchers can reference them by stable names regardless of
+  /// optimizer-generated internal names. For each i where aliases[i] is set,
+  /// maps the alias to the i-th output column name. nullopt entries are
+  /// skipped. Fails at match time if aliases.size() exceeds the matched
+  /// node's output column count.
+  /// @param aliases The aliases to register, indexed by output column
+  /// position. Use std::nullopt to skip a column.
+  PlanMatcherBuilder& aliases(
+      const std::vector<std::optional<std::string>>& aliases);
 
   /// Matches an EnforceDistinct node, which validates that input has unique
   /// values for the specified key columns. Throws if duplicates are found.


### PR DESCRIPTION
Summary:

Example: `SELECT * FROM t JOIN u ON t.a = u.x WHERE t.a = 5`. Without this change, `t.a = 5` is pushed down only to `t`; `u` is scanned in full and rows are discarded at the join. With this change, the equality `t.a = u.x` puts `t.a` and `u.x` in the same equivalence class, so we synthesize `u.x = 5` and push it to `u` — letting the storage layer prune rows on **both** sides before the join.

Adds `DerivedTable::inferImpliedPredicates`, called at the end of `distributeConjuncts`. For each single-column filter on a `BaseTable` or inner `DerivedTable` (sourced from `BaseTable::columnFilters` or `DerivedTable::conjuncts`), clones the filter to every other column in the source column's equivalence class on other tables in the same DT, via `tryPushdownConjunct`. Dedups against the target's existing filters using `Expr::sameOrEqual`.

**Fundamental guards (correctness — must always hold):**
- Skips non-deterministic filters: cloning `random()` across the equivalence would re-evaluate on each side and produce different values.
- Equivalence classes are inner-join only (asserted at construction by `Column::equals`; `QueryGraph.h` spells out the contract). Propagation to the null-extending side of an outer join would discard rows that should survive as NULL-extended.

**Scope guard (could be lifted later):**
- Single-column predicates only. Multi-column predicates require Cartesian-product enumeration over per-column equivalence-class members gated to a single target — a separate design from the per-column propagation here, deferred.

Reviewed By: mbasmanova

Differential Revision: D103322604
