### PR TITLE
refactor(connector): Add explain to ConnectorMetadata::dropTable (#1309)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -290,8 +290,11 @@ std::string SqlQueryRunner::dropTable(
   const auto& tableName = statement.tableName();
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
-  const bool dropped =
-      metadata->dropTable(session, statement.tableName(), statement.ifExists());
+  const bool dropped = metadata->dropTable(
+      session,
+      statement.tableName(),
+      statement.ifExists(),
+      /*explain=*/false);
 
   if (dropped) {
     return fmt::format("Dropped table: {}", tableName);

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -249,12 +249,15 @@ connector::TablePtr SqlQueryRunner::createTable(
   }
 
   auto session = std::make_shared<connector::ConnectorSession>("test", user_);
-  return metadata->createTable(
+  auto table = metadata->createTable(
       session,
       statement.tableName(),
       statement.tableSchema(),
       options,
+      statement.ifNotExists(),
       explain);
+  VELOX_CHECK(table != nullptr || statement.ifNotExists());
+  return table;
 }
 
 connector::TablePtr SqlQueryRunner::createTable(
@@ -269,12 +272,15 @@ connector::TablePtr SqlQueryRunner::createTable(
   }
 
   auto session = std::make_shared<connector::ConnectorSession>("test", user_);
-  return metadata->createTable(
+  auto table = metadata->createTable(
       session,
       statement.tableName(),
       statement.tableSchema(),
       options,
+      /*ifNotExists=*/false,
       explain);
+  VELOX_CHECK_NOT_NULL(table);
+  return table;
 }
 
 std::string SqlQueryRunner::dropTable(
@@ -477,14 +483,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
           ctas->connectorId(), ctas->tableName(), table);
     } else if (statement->isCreateTable()) {
       const auto* create = statement->as<presto::CreateTableStatement>();
-      if (!create->ifNotExists()) {
-        auto metadata = ConnectorMetadataRegistry::get(create->connectorId());
-        VELOX_USER_CHECK(
-            !metadata->findTable(create->tableName()),
-            "Table already exists: {}.{}",
-            create->connectorId(),
-            create->tableName());
-      }
+      createTable(*create, /*explain=*/true);
       return {
           .message = fmt::format(
               "CREATE TABLE {}{}.{}",
@@ -555,7 +554,14 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
   if (sqlStatement.isCreateTable()) {
     const auto* create = sqlStatement.as<presto::CreateTableStatement>();
-    createTable(*create);
+    auto table = createTable(*create);
+    if (!table) {
+      return {
+          .message = fmt::format(
+              "Table already exists: {}.{}",
+              create->connectorId(),
+              create->tableName())};
+    }
     return {.message = fmt::format("Created table: {}", create->tableName())};
   }
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -845,25 +845,27 @@ class ConnectorMetadata {
   /// ConnectorSession in a connector dependent manner, then call createTable
   /// to retrieve a Table object. Any transaction semantics are
   /// connector-dependent, and the ConnectorSession may be null for connectors
-  /// which do not require it. Throws an error if the table exists. finishWrite
-  /// should be called to commit the new table and any writes even if no data
-  /// is added. To create an empty table, call createTable, then
-  /// beginWrite/finishWrite with the generated table object. To create the
-  /// table with data, call createTable to generate a Table, call beginWrite
-  /// with the Table object, perform writes against the table using the
-  /// returned insert handle, then finishWrite to commit the changes. The table
-  /// is not available via the findTable interface until after finishWrite
-  /// completes.
+  /// which do not require it. finishWrite should be called to commit the new
+  /// table and any writes even if no data is added. To create an empty table,
+  /// call createTable, then beginWrite/finishWrite with the generated table
+  /// object. To create the table with data, call createTable to generate a
+  /// Table, call beginWrite with the Table object, perform writes against the
+  /// table using the returned insert handle, then finishWrite to commit the
+  /// changes. The table is not available via the findTable interface until
+  /// after finishWrite completes.
   ///
-  /// When 'explain' is true, the connector must interpret properties and
-  /// return a valid Table with correct layout metadata, but must not create
-  /// directories, write files, or register the table. No cleanup is needed
-  /// after an explain call.
+  /// When 'ifNotExists' is true and the table already exists, returns nullptr.
+  /// When 'ifNotExists' is false and the table already exists, raises an
+  /// error. When 'explain' is true, the connector must interpret properties
+  /// and return a valid Table with correct layout metadata, but must not
+  /// create directories, write files, or register the table. No cleanup is
+  /// needed after an explain call.
   virtual TablePtr createTable(
       const ConnectorSessionPtr& /*session*/,
       const SchemaTableName& /*tableName*/,
       const velox::RowTypePtr& /*rowType*/,
       const folly::F14FastMap<std::string, velox::Variant>& /*options*/,
+      bool /*ifNotExists*/,
       bool /*explain*/) {
     VELOX_UNSUPPORTED();
   }

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -932,10 +932,14 @@ class ConnectorMetadata {
   /// Drops a table with the specified name. If table doesn't exist and
   /// 'ifExists' is false, raises an error. Otherwise, returns true if table
   /// was dropped and false if table didn't exist.
+  ///
+  /// When 'explain' is true, the connector must perform the same existence
+  /// check (respecting 'ifExists') but must not drop the table.
   virtual bool dropTable(
       const ConnectorSessionPtr& /*session*/,
       const SchemaTableName& /*tableName*/,
-      bool /*ifExists*/) {
+      bool /*ifExists*/,
+      bool /*explain*/) {
     VELOX_UNSUPPORTED();
   }
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1490,15 +1490,24 @@ std::optional<std::string> LocalHiveConnectorMetadata::makeStagingDirectory(
 bool LocalHiveConnectorMetadata::dropTable(
     const ConnectorSessionPtr& /* session */,
     const SchemaTableName& tableName,
-    bool ifExists) {
+    bool ifExists,
+    bool explain) {
   ensureInitialized();
 
   std::lock_guard<std::mutex> l(mutex_);
-  if (!tables_.contains(tableName.table)) {
+  const bool exists = tables_.contains(tableName.table);
+  if (explain) {
+    if (!exists) {
+      VELOX_USER_CHECK(ifExists, "Table doesn't exist: {}", tableName);
+    }
+    return exists;
+  }
+
+  if (!exists) {
     if (ifExists) {
       return false;
     }
-    VELOX_USER_FAIL("Table does not exist: {}", tableName);
+    VELOX_USER_FAIL("Table doesn't exist: {}", tableName);
   }
 
   deleteDirectoryRecursive(tablePath(tableName));

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1308,6 +1308,7 @@ TablePtr LocalHiveConnectorMetadata::createTable(
     const SchemaTableName& tableName,
     const velox::RowTypePtr& rowType,
     const folly::F14FastMap<std::string, velox::Variant>& options,
+    bool ifNotExists,
     bool explain) {
   VELOX_USER_CHECK(
       schemaExists(nullptr, tableName.schema),
@@ -1318,6 +1319,15 @@ TablePtr LocalHiveConnectorMetadata::createTable(
   auto createTableOptions = parseCreateTableOptions(options, format_);
 
   if (explain) {
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      if (findTableLocked(tableName.table)) {
+        if (ifNotExists) {
+          return nullptr;
+        }
+        VELOX_USER_FAIL("Table already exists: {}", tableName.toString());
+      }
+    }
     return createLocalTable(
         tableName.table,
         rowType,
@@ -1328,7 +1338,10 @@ TablePtr LocalHiveConnectorMetadata::createTable(
 
   auto path = tablePath(tableName);
   if (dirExists(path)) {
-    VELOX_USER_FAIL("Table {} already exists", tableName.toString());
+    if (ifNotExists) {
+      return nullptr;
+    }
+    VELOX_USER_FAIL("Table already exists: {}", tableName.toString());
   } else {
     createDir(path);
   }
@@ -1338,10 +1351,13 @@ TablePtr LocalHiveConnectorMetadata::createTable(
   const std::string filePath = schemaPath(path);
 
   std::lock_guard<std::mutex> l(mutex_);
-  VELOX_USER_CHECK_NULL(
-      findTableLocked(tableName.table),
-      "table {} already exists",
-      tableName.toString());
+  if (findTableLocked(tableName.table)) {
+    deleteDirectoryRecursive(path);
+    if (ifNotExists) {
+      return nullptr;
+    }
+    VELOX_USER_FAIL("Table already exists: {}", tableName.toString());
+  }
   {
     std::ofstream outputFile(filePath);
     VELOX_CHECK(outputFile.is_open());

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -313,11 +313,12 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
   bool dropTable(
       const ConnectorSessionPtr& session,
       const SchemaTableName& tableName,
-      bool ifExists) override;
+      bool ifExists,
+      bool explain) override;
 
-  /// Shortcut for dropTable(session, tableName, true).
+  /// Shortcut for dropTable(session, tableName, true, false).
   bool dropTableIfExists(const SchemaTableName& tableName) {
-    return dropTable(nullptr, tableName, true);
+    return dropTable(nullptr, tableName, true, /*explain=*/false);
   }
 
   bool dropTableIfExists(std::string_view tableName) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -288,6 +288,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
       const SchemaTableName& tableName,
       const velox::RowTypePtr& rowType,
       const folly::F14FastMap<std::string, velox::Variant>& options,
+      bool ifNotExists,
       bool explain) override;
 
   RowsFuture finishWrite(

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -319,7 +319,12 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
 
   auto session = std::make_shared<ConnectorSession>("q-test");
   auto table = metadata_->createTable(
-      session, {kDefaultSchema, "test"}, tableType, options, /*explain=*/false);
+      session,
+      {kDefaultSchema, "test"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
 
   // Table should be findable immediately after createTable, before
   // beginWrite/finishWrite. This is the flow for plain CREATE TABLE (no data).
@@ -407,6 +412,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
       {kDefaultSchema, "test_empty"},
       tableType,
       /*options=*/{},
+      /*ifNotExists=*/false,
       /*explain=*/false);
 
   auto emptyData = makeRowVector(tableType, 0);
@@ -441,6 +447,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
       {kDefaultSchema, "test_insert"},
       tableType,
       /*options=*/{},
+      /*ifNotExists=*/false,
       /*explain=*/false);
   auto handle = metadata_->beginWrite(
       session, staged, WriteKind::kCreate, /*explain=*/false);
@@ -491,6 +498,7 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       SchemaTableName{kDefaultSchema, "test_abort"},
       tableType,
       /*options=*/{},
+      /*ifNotExists=*/false,
       /*explain=*/false);
   auto handle = metadata_->beginWrite(
       session, table, WriteKind::kCreate, /*explain=*/false);
@@ -502,8 +510,9 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
           SchemaTableName{kDefaultSchema, "test_abort"},
           tableType,
           /*options=*/{},
+          /*ifNotExists=*/false,
           /*explain=*/false),
-      "Table \"default\".\"test_abort\" already exists");
+      "Table already exists: \"default\".\"test_abort\"");
   metadata_->abortWrite(session, handle).get();
   EXPECT_FALSE(std::filesystem::exists(tablePath));
 
@@ -512,6 +521,7 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       SchemaTableName{kDefaultSchema, "test_abort"},
       tableType,
       /*options=*/{},
+      /*ifNotExists=*/false,
       /*explain=*/false);
   handle = metadata_->beginWrite(
       session, table, WriteKind::kCreate, /*explain=*/false);
@@ -520,6 +530,92 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
   EXPECT_TRUE(std::filesystem::exists(tablePath));
   auto created = metadata_->findTable({kDefaultSchema, "test_abort"});
   EXPECT_NE(created, nullptr);
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExists) {
+  auto tableType = ROW({{"col1", BIGINT()}, {"col2", VARCHAR()}});
+  auto session = std::make_shared<ConnectorSession>("q-test");
+
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_ine"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  ASSERT_NE(table, nullptr);
+
+  auto table2 = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_ine"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/true,
+      /*explain=*/false);
+  ASSERT_EQ(table2, nullptr);
+
+  VELOX_ASSERT_THROW(
+      metadata_->createTable(
+          session,
+          {kDefaultSchema, "test_ine"},
+          tableType,
+          /*options=*/{},
+          /*ifNotExists=*/false,
+          /*explain=*/false),
+      "Table already exists: \"default\".\"test_ine\"");
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsNewTable) {
+  auto tableType = ROW({{"col1", BIGINT()}});
+  auto session = std::make_shared<ConnectorSession>("q-test");
+
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_ine_new"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/true,
+      /*explain=*/false);
+  ASSERT_NE(table, nullptr);
+
+  auto found = metadata_->findTable({kDefaultSchema, "test_ine_new"});
+  ASSERT_NE(found, nullptr);
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
+  auto tableType = ROW({{"col1", BIGINT()}});
+  auto session = std::make_shared<ConnectorSession>("q-test");
+
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_ine_explain"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  ASSERT_NE(table, nullptr);
+
+  auto explained = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_ine_explain"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/true,
+      /*explain=*/true);
+  ASSERT_EQ(explained, nullptr);
+
+  VELOX_ASSERT_THROW(
+      metadata_->createTable(
+          session,
+          {kDefaultSchema, "test_ine_explain"},
+          tableType,
+          /*options=*/{},
+          /*ifNotExists=*/false,
+          /*explain=*/true),
+      "Table already exists: \"default\".\"test_ine_explain\"");
+
+  ASSERT_NE(
+      metadata_->findTable({kDefaultSchema, "test_ine_explain"}), nullptr);
 }
 
 } // namespace

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -618,6 +618,77 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
       metadata_->findTable({kDefaultSchema, "test_ine_explain"}), nullptr);
 }
 
+TEST_F(LocalHiveConnectorMetadataTest, dropTableIfExists) {
+  auto tableType = ROW({{"col1", BIGINT()}});
+  auto session = std::make_shared<ConnectorSession>("q-test");
+
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_drop"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  ASSERT_NE(table, nullptr);
+
+  ASSERT_TRUE(metadata_->dropTable(
+      session,
+      {kDefaultSchema, "test_drop"},
+      /*ifExists=*/false,
+      /*explain=*/false));
+  ASSERT_EQ(metadata_->findTable({kDefaultSchema, "test_drop"}), nullptr);
+
+  VELOX_ASSERT_THROW(
+      metadata_->dropTable(
+          session,
+          {kDefaultSchema, "test_drop"},
+          /*ifExists=*/false,
+          /*explain=*/false),
+      "Table doesn't exist: \"default\".\"test_drop\"");
+
+  ASSERT_FALSE(metadata_->dropTable(
+      session,
+      {kDefaultSchema, "test_drop"},
+      /*ifExists=*/true,
+      /*explain=*/false));
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, dropTableExplain) {
+  auto tableType = ROW({{"col1", BIGINT()}});
+  auto session = std::make_shared<ConnectorSession>("q-test");
+
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "test_drop_explain"},
+      tableType,
+      /*options=*/{},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  ASSERT_NE(table, nullptr);
+
+  ASSERT_TRUE(metadata_->dropTable(
+      session,
+      {kDefaultSchema, "test_drop_explain"},
+      /*ifExists=*/false,
+      /*explain=*/true));
+  ASSERT_NE(
+      metadata_->findTable({kDefaultSchema, "test_drop_explain"}), nullptr);
+
+  VELOX_ASSERT_THROW(
+      metadata_->dropTable(
+          session,
+          {kDefaultSchema, "test_drop_missing_explain"},
+          /*ifExists=*/false,
+          /*explain=*/true),
+      "Table doesn't exist: \"default\".\"test_drop_missing_explain\"");
+
+  ASSERT_FALSE(metadata_->dropTable(
+      session,
+      {kDefaultSchema, "test_drop_missing_explain"},
+      /*ifExists=*/true,
+      /*explain=*/true));
+}
+
 } // namespace
 } // namespace facebook::axiom::connector::hive
 

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -68,7 +68,12 @@ class SchemaResolverTest : public ::testing::Test {
 TEST_F(SchemaResolverTest, bareTable) {
   auto metadata = ConnectorMetadataRegistry::get("base");
   metadata->createTable(
-      nullptr, {"baseschema", "table"}, ROW({}), {}, /*explain=*/false);
+      nullptr,
+      {"baseschema", "table"},
+      ROW({}),
+      {},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"baseschema", "table"});
   ASSERT_NE(table, nullptr);
@@ -81,7 +86,12 @@ TEST_F(SchemaResolverTest, tablePlusSchema) {
   auto metadata = ConnectorMetadataRegistry::get("base");
   metadata->createSchema(nullptr, "newschema", /*ifNotExists=*/false, {});
   metadata->createTable(
-      nullptr, {"newschema", "table"}, ROW({}), {}, /*explain=*/false);
+      nullptr,
+      {"newschema", "table"},
+      ROW({}),
+      {},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
 
   auto table = resolver_->findTable("base", {"newschema", "table"});
   ASSERT_NE(table, nullptr);
@@ -97,13 +107,19 @@ TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
       {"otherschema", "other_table"},
       ROW({}),
       {},
+      /*ifNotExists=*/false,
       /*explain=*/false);
   auto table = resolver_->findTable("other", {"otherschema", "other_table"});
   ASSERT_NE(table, nullptr);
 
   auto baseMetadata = ConnectorMetadataRegistry::get("base");
   baseMetadata->createTable(
-      nullptr, {"baseschema", "base_table"}, ROW({}), {}, /*explain=*/false);
+      nullptr,
+      {"baseschema", "base_table"},
+      ROW({}),
+      {},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
   table = resolver_->findTable("base", {"baseschema", "base_table"});
   ASSERT_NE(table, nullptr);
 }
@@ -116,6 +132,7 @@ TEST_F(SchemaResolverTest, catalogMismatch) {
       {"otherschema", "table"},
       ROW({}),
       {},
+      /*ifNotExists=*/false,
       /*explain=*/false);
   auto table = resolver_->findTable("base", {"otherschema", "table"});
   ASSERT_EQ(table, nullptr);

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -437,6 +437,7 @@ std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns) {
+  schemas_.insert(tableName.schema);
   auto table = std::make_shared<TestTable>(
       tableName,
       schema,
@@ -453,17 +454,26 @@ TablePtr TestConnectorMetadata::createTable(
     const SchemaTableName& tableName,
     const velox::RowTypePtr& rowType,
     const folly::F14FastMap<std::string, velox::Variant>& options,
+    bool ifNotExists,
     bool explain) {
+  VELOX_USER_CHECK(
+      schemas_.contains(tableName.schema),
+      "Schema does not exist: {}",
+      tableName.schema);
+
+  if (tables_.contains(tableName)) {
+    if (ifNotExists) {
+      return nullptr;
+    }
+    VELOX_USER_FAIL("Table already exists: {}", tableName.toString());
+  }
+
   for (const auto& [key, value] : options) {
     VELOX_USER_CHECK(
         key == kHidden || key == kExplainIo,
         "TestConnector does not support CREATE TABLE property: {}",
         key);
   }
-  VELOX_USER_CHECK(
-      schemas_.contains(tableName.schema),
-      "Schema does not exist: {}",
-      tableName.schema);
 
   // Parse optional 'hidden' property to add hidden VARCHAR columns.
   // Hidden columns are not part of the schema — they are created implicitly.
@@ -491,7 +501,7 @@ TablePtr TestConnectorMetadata::createTable(
     return table;
   }
   auto [it, ok] = tables_.emplace(tableName, std::move(table));
-  VELOX_CHECK(ok, "Table already exists: {}", tableName.toString());
+  VELOX_CHECK(ok);
   return it->second;
 }
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -538,7 +538,17 @@ RowsFuture TestConnectorMetadata::finishWrite(
 bool TestConnectorMetadata::dropTable(
     const ConnectorSessionPtr& /* session */,
     const SchemaTableName& tableName,
-    bool ifExists) {
+    bool ifExists,
+    bool explain) {
+  if (explain) {
+    const bool exists = tables_.contains(tableName);
+    if (!exists) {
+      VELOX_USER_CHECK(
+          ifExists, "Table doesn't exist: {}", tableName.toString());
+    }
+    return exists;
+  }
+
   const bool dropped = tables_.erase(tableName) == 1;
   if (!ifExists) {
     VELOX_USER_CHECK(dropped, "Table doesn't exist: {}", tableName.toString());

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -487,11 +487,12 @@ class TestConnectorMetadata : public ConnectorMetadata {
   bool dropTable(
       const ConnectorSessionPtr& session,
       const SchemaTableName& tableName,
-      bool ifExists) override;
+      bool ifExists,
+      bool explain) override;
 
-  /// Shortcut for dropTable(session, tableName, true).
+  /// Shortcut for dropTable(session, tableName, true, false).
   bool dropTableIfExists(const SchemaTableName& tableName) {
-    return dropTable(nullptr, tableName, true);
+    return dropTable(nullptr, tableName, true, /*explain=*/false);
   }
 
   ViewPtr findView(const SchemaTableName& tableName) override;

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -468,6 +468,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaTableName& tableName,
       const velox::RowTypePtr& rowType,
       const folly::F14FastMap<std::string, velox::Variant>& options,
+      bool ifNotExists,
       bool explain) override;
 
   ConnectorWriteHandlePtr beginWrite(

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -325,12 +325,15 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     }
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
-    return metadata->createTable(
+    auto table = metadata->createTable(
         session,
         statement.tableName(),
         statement.tableSchema(),
         options,
+        /*ifNotExists=*/false,
         /*explain=*/false);
+    VELOX_CHECK_NOT_NULL(table);
+    return table;
   }
 
   void dropTable(const ::axiom::sql::presto::DropTableStatement& statement) {

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -343,8 +343,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     const auto& tableName = statement.tableName();
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
-    const bool dropped =
-        metadata->dropTable(session, tableName, statement.ifExists());
+    const bool dropped = metadata->dropTable(
+        session, tableName, statement.ifExists(), /*explain=*/false);
 
     if (dropped) {
       std::cout << "Dropped table: " << tableName.toString() << std::endl;

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -163,7 +163,13 @@ void HiveQueriesTestBase::createEmptyTable(
 
   auto session = std::make_shared<connector::ConnectorSession>("test");
   auto table = hiveMetadata().createTable(
-      session, {kDefaultSchema, name}, tableType, options, /*explain=*/false);
+      session,
+      {kDefaultSchema, name},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  VELOX_CHECK_NOT_NULL(table);
   auto handle = hiveMetadata().beginWrite(
       session, table, connector::WriteKind::kCreate, /*explain=*/false);
   hiveMetadata().finishWrite(session, handle, {}, nullptr, {}).get();
@@ -195,6 +201,7 @@ void HiveQueriesTestBase::createTableFromFiles(
       {kDefaultSchema, tableName},
       tableType,
       options,
+      /*ifNotExists=*/false,
       /*explain=*/false);
 
   auto tablePath = hiveMetadata().tablePath({kDefaultSchema, tableName});
@@ -230,7 +237,9 @@ void HiveQueriesTestBase::runCtas(const std::string& sql) {
       ctasStatement->tableName(),
       ctasStatement->tableSchema(),
       options,
+      /*ifNotExists=*/false,
       /*explain=*/false);
+  VELOX_CHECK_NOT_NULL(table);
 
   connector::SchemaResolver schemaResolver;
   schemaResolver.setTargetTable(

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -53,7 +53,13 @@ class WriteTest : public test::HiveQueriesTestBase {
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
     auto table = metadata.createTable(
-        session, {kDefaultSchema, name}, tableType, options, /*explain=*/false);
+        session,
+        {kDefaultSchema, name},
+        tableType,
+        options,
+        /*ifNotExists=*/false,
+        /*explain=*/false);
+    VELOX_CHECK_NOT_NULL(table);
     auto handle = metadata.beginWrite(
         session, table, connector::WriteKind::kCreate, /*explain=*/false);
     metadata.finishWrite(session, handle, {}, nullptr, {}).get();
@@ -70,12 +76,15 @@ class WriteTest : public test::HiveQueriesTestBase {
     }
 
     auto session = std::make_shared<connector::ConnectorSession>("test");
-    return metadata.createTable(
+    auto table = metadata.createTable(
         session,
         statement.tableName(),
         statement.tableSchema(),
         options,
+        /*ifNotExists=*/false,
         /*explain=*/false);
+    VELOX_CHECK_NOT_NULL(table);
+    return table;
   }
 
   void runCtas(

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -81,8 +81,15 @@ facebook::axiom::connector::TablePtr createTable(
 
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
       "pyspark_session");
-  return metadata->createTable(
-      session, writeNode.tableName(), tableSchema, options, /*explain=*/false);
+  auto table = metadata->createTable(
+      session,
+      writeNode.tableName(),
+      tableSchema,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  VELOX_CHECK_NOT_NULL(table);
+  return table;
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Adds an `explain` parameter to `ConnectorMetadata::dropTable()`. When `explain=true`, the connector performs the same existence check (respecting `ifExists`) as a real drop but does not mutate state. This lets `EXPLAIN DROP TABLE` route through the connector for validation.

Removes the now-redundant `validateDropTableExists` helpers — existence validation lives next to the rest of the drop logic.

Updates all overrides and callers to pass the new parameter.

Reviewed By: arhimondr, mbasmanova

Differential Revision: D101877374


