### PR TITLE
misc: Plumb query metadata through SqlQueryRunner callbacks (#1310)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -332,12 +332,18 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     const RunOptions& options) {
   auto runOptions = options;
   runOptions.queryId = options.queryId.value_or(queryIdGenerator_());
+  const auto& catalog =
+      runOptions.defaultConnectorId.value_or(defaultConnectorId_);
+  const auto& schema = runOptions.defaultSchema.value_or(defaultSchema_);
 
   QueryCompletionInfo completionInfo{
       .startInfo = {
           *runOptions.queryId,
           std::string(sql),
-          std::chrono::system_clock::now()}};
+          std::chrono::system_clock::now(),
+          std::string(catalog),
+          std::string(schema),
+          std::nullopt}};
 
   onStart(runOptions, completionInfo);
 
@@ -356,6 +362,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
       velox::MicrosecondTimer parseTimer(&completionInfo.timing.parse);
       statement = parseSingle(sql, runOptions);
     }
+    completionInfo.startInfo.queryType = statement->kind();
 
     runOptions.tokenProvider = checkPermission(
         runOptions,

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -49,6 +49,16 @@ struct QueryStartInfo {
 
   /// Wall-clock time when the query was created.
   std::chrono::system_clock::time_point createTime;
+
+  /// Holds the session catalog in effect when the query started.
+  std::string catalog;
+
+  /// Holds the session schema in effect when the query started.
+  std::string schema;
+
+  /// Statement kind resolved during parsing. Remains empty in the start
+  /// callback because parsing happens after onStart fires.
+  std::optional<presto::SqlStatementKind> queryType;
 };
 
 /// Holds error details when a query fails.
@@ -147,7 +157,7 @@ class SqlQueryRunner {
     bool debugMode{false};
 
     /// Called before parsing. Receives query metadata (query ID, SQL text,
-    /// creation time).
+    /// creation time, and session catalog/schema).
     QueryStartCallback onStart;
 
     /// Called after execution completes (success or failure). Carries

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -901,6 +901,30 @@ TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletion) {
   EXPECT_EQ(startQueryId, completionQueryId);
 }
 
+TEST_F(SqlQueryRunnerTest, callbacksReceiveQueryMetadata) {
+  QueryStartInfo capturedStart;
+  QueryCompletionInfo capturedCompletion;
+
+  runner_->run(
+      "SELECT 1",
+      {.onStart = [&](const QueryStartInfo& info) { capturedStart = info; },
+       .onComplete =
+           [&](const QueryCompletionInfo& info) {
+             capturedCompletion = info;
+           }});
+
+  EXPECT_EQ(capturedStart.catalog, runner_->defaultConnectorId());
+  EXPECT_EQ(capturedStart.schema, runner_->defaultSchema());
+  EXPECT_FALSE(capturedStart.queryType.has_value());
+  EXPECT_EQ(
+      capturedCompletion.startInfo.catalog, runner_->defaultConnectorId());
+  EXPECT_EQ(capturedCompletion.startInfo.schema, runner_->defaultSchema());
+  ASSERT_TRUE(capturedCompletion.startInfo.queryType.has_value());
+  EXPECT_EQ(
+      *capturedCompletion.startInfo.queryType,
+      presto::SqlStatementKind::kSelect);
+}
+
 TEST_F(SqlQueryRunnerTest, completionCallbackOnError) {
   QueryCompletionInfo captured;
 


### PR DESCRIPTION
Summary:

axiom: Extend `QueryStartInfo` to carry per-query `catalog`, `schema`, and `SqlStatementKind` so callback consumers can use resolved metadata without adding fb-specific string conversion in OSS Axiom.

Reviewed By: natashasehgal

Differential Revision: D103335152


