### PR TITLE
feat(pyspark): Translate Spark explode and posexplode generators (#1311)

### DIFF
--- a/axiom/pyspark/SparkToAxiom.cpp
+++ b/axiom/pyspark/SparkToAxiom.cpp
@@ -36,6 +36,75 @@ using namespace facebook;
 namespace axiom::collagen {
 namespace {
 
+bool isGeneratorFunction(const std::string& functionName) {
+  return functionName == "explode" || functionName == "posexplode" ||
+      functionName == "explode_outer" || functionName == "posexplode_outer";
+}
+
+bool isOuterGenerator(const std::string& functionName) {
+  return functionName == "explode_outer" || functionName == "posexplode_outer";
+}
+
+/// Extracts the generator function name from an expression (direct or aliased).
+/// Returns empty string if no generator is found.
+std::string findGeneratorFunction(
+    const spark::connect::Expression& expression) {
+  if (expression.has_unresolved_function() &&
+      isGeneratorFunction(expression.unresolved_function().function_name())) {
+    return expression.unresolved_function().function_name();
+  }
+  if (expression.has_alias() &&
+      expression.alias().expr().has_unresolved_function() &&
+      isGeneratorFunction(
+          expression.alias().expr().unresolved_function().function_name())) {
+    return expression.alias().expr().unresolved_function().function_name();
+  }
+  return "";
+}
+
+struct UnnestColumnNames {
+  std::vector<std::vector<std::string>> unnestedNames;
+  std::optional<std::string> ordinalityName;
+};
+
+// Picks the unnested column names from explode/posexplode aliases, falling
+// back to "col" (array) or ("key", "value") (map) defaults. For posexplode
+// the first alias names the ordinality column and subsequent aliases name
+// the unnested columns.
+UnnestColumnNames resolveUnnestColumnNames(
+    const std::string& generatorName,
+    const velox::TypePtr& unnestExprType,
+    const std::vector<std::string>& aliasNames) {
+  UnnestColumnNames result;
+  const bool isPosExplode = generatorName == "posexplode";
+  const size_t aliasOffset = isPosExplode ? 1 : 0;
+  if (isPosExplode) {
+    if (aliasNames.empty()) {
+      result.ordinalityName = "pos";
+    } else {
+      result.ordinalityName = aliasNames[0];
+    }
+  }
+
+  const auto aliasAt = [&](size_t index, std::string_view fallback) {
+    return index < aliasNames.size() ? aliasNames[index]
+                                     : std::string{fallback};
+  };
+
+  if (unnestExprType->isArray()) {
+    result.unnestedNames.push_back({aliasAt(aliasOffset, "col")});
+  } else if (unnestExprType->isMap()) {
+    result.unnestedNames.push_back(
+        {aliasAt(aliasOffset, "key"), aliasAt(aliasOffset + 1, "value")});
+  } else {
+    COLLAGEN_NYI(
+        "{} on type {} is not supported",
+        generatorName,
+        unnestExprType->toString());
+  }
+  return result;
+}
+
 // Tries to resolve a function signature. Returns the return type if the
 // signature was found, or throws a descriptive error message.
 velox::TypePtr resolveFunction(
@@ -170,6 +239,13 @@ void SparkToAxiom::visit(
 void SparkToAxiom::visit(
     const spark::connect::Project& project,
     SparkPlanVisitorContext& context) {
+  for (const auto& expression : project.expressions()) {
+    if (!findGeneratorFunction(expression).empty()) {
+      visitProjectWithGenerator(project, context);
+      return;
+    }
+  }
+
   // Note that we first visit the project input subtree, before visiting the
   // expressions themselves. This ensures that by the time we visit the
   // expressions, we are ready to bind attributes to the output of the current
@@ -201,6 +277,160 @@ void SparkToAxiom::visit(
   auto planNode = std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
       nextId(), std::move(planNode_), std::move(exprNames), std::move(exprs));
   setPlanNode(planNode, context.planId);
+}
+
+void SparkToAxiom::visitProjectWithGenerator(
+    const spark::connect::Project& project,
+    SparkPlanVisitorContext& context) {
+  SparkPlanVisitor::visit(project.input(), context);
+
+  LOG(INFO) << "Creating unnest node from generator in project ["
+            << context.planId << "]";
+
+  const spark::connect::Expression* generatorExpr = nullptr;
+  std::string generatorName;
+  std::vector<std::string> aliasNames;
+  int generatorCount = 0;
+
+  std::vector<const spark::connect::Expression*> nonGeneratorExprs;
+
+  for (const auto& expression : project.expressions()) {
+    auto genFunc = findGeneratorFunction(expression);
+    if (!genFunc.empty()) {
+      ++generatorCount;
+      if (generatorExpr == nullptr) {
+        generatorExpr = &expression;
+        generatorName = genFunc;
+
+        if (expression.has_alias()) {
+          for (const auto& name : expression.alias().name()) {
+            aliasNames.push_back(name);
+          }
+        }
+      }
+    } else {
+      nonGeneratorExprs.push_back(&expression);
+    }
+  }
+
+  COLLAGEN_CHECK(
+      generatorExpr != nullptr,
+      "Expected generator expression in project but none found");
+
+  // Spark rejects multiple generators in a single SELECT.
+  COLLAGEN_CHECK(
+      generatorCount == 1,
+      "Only one generator allowed per select clause but found {}. "
+      "Use separate select() calls for multiple explode operations.",
+      generatorCount);
+
+  COLLAGEN_CHECK(
+      !isOuterGenerator(generatorName),
+      "{} is not supported yet. UnnestNode uses inner semantics "
+      "(rows with empty arrays/maps are dropped). Use explode/posexplode instead.",
+      generatorName);
+
+  const spark::connect::Expression::UnresolvedFunction* genFuncPtr;
+  if (generatorExpr->has_alias()) {
+    genFuncPtr = &generatorExpr->alias().expr().unresolved_function();
+  } else {
+    genFuncPtr = &generatorExpr->unresolved_function();
+  }
+
+  COLLAGEN_CHECK(
+      genFuncPtr->arguments().size() >= 1,
+      "{} requires at least 1 argument",
+      generatorName);
+
+  visit(genFuncPtr->arguments(0), context);
+  auto unnestExpr = std::move(expr_);
+
+  auto names =
+      resolveUnnestColumnNames(generatorName, unnestExpr->type(), aliasNames);
+
+  auto unnestNode = std::make_shared<facebook::axiom::logical_plan::UnnestNode>(
+      nextId(),
+      std::move(planNode_),
+      std::vector<ExprPtr>{unnestExpr},
+      std::move(names.unnestedNames),
+      std::move(names.ordinalityName));
+
+  // Always wrap with a ProjectNode. UnnestNode's output type also includes the
+  // pre-unnest input columns, but Spark's select(explode(...)) emits only the
+  // unnested columns (plus any explicitly selected pass-throughs). The
+  // wrapper also converts posexplode's 1-based ordinality to Spark's 0-based
+  // position via (pos - 1).
+  const bool isPosExplode = generatorName == "posexplode";
+  setPlanNode(
+      buildProjectAroundUnnest(
+          std::move(unnestNode), nonGeneratorExprs, isPosExplode, context),
+      context.planId);
+}
+
+SparkToAxiom::LogicalPlanNodePtr SparkToAxiom::buildProjectAroundUnnest(
+    std::shared_ptr<facebook::axiom::logical_plan::UnnestNode> unnestNode,
+    const std::vector<const spark::connect::Expression*>& nonGeneratorExprs,
+    bool isPosExplode,
+    SparkPlanVisitorContext& context) {
+  // Make the unnest node visible to nested visit() calls so non-generator
+  // expressions (typically simple field references) can be resolved against
+  // its output schema.
+  planNode_ = unnestNode;
+
+  std::vector<ExprPtr> projExprs;
+  std::vector<std::string> projNames;
+
+  for (const auto* expr : nonGeneratorExprs) {
+    visit(*expr, context);
+    auto name = std::move(exprName_);
+    if (name.empty()) {
+      name = expr_->type()->toString();
+      folly::toLowerAscii(name);
+    }
+    projNames.emplace_back(std::move(name));
+    projExprs.emplace_back(std::move(expr_));
+  }
+
+  // UnnestNode emits all input columns followed by unnested columns, with the
+  // ordinality column last when present.
+  const auto& unnestOutputType = unnestNode->outputType();
+  const auto numOutputCols = static_cast<uint32_t>(unnestOutputType->size());
+  const auto numInputCols =
+      static_cast<uint32_t>(unnestNode->onlyInput()->outputType()->size());
+  const uint32_t ordinalityIdx =
+      isPosExplode ? numOutputCols - 1 : numOutputCols;
+
+  for (uint32_t i = numInputCols; i < numOutputCols; ++i) {
+    auto colType = unnestOutputType->childAt(i);
+    std::string colName{unnestOutputType->nameOf(i)};
+    if (i == ordinalityIdx) {
+      // Convert Velox's 1-based ordinality to Spark's 0-based position by
+      // subtracting 1.
+      auto posRef =
+          std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+              colType, colName);
+      auto oneConst =
+          std::make_shared<facebook::axiom::logical_plan::ConstantExpr>(
+              velox::BIGINT(),
+              std::make_shared<velox::variant>(velox::variant(int64_t{1})));
+      projExprs.emplace_back(
+          std::make_shared<facebook::axiom::logical_plan::CallExpr>(
+              colType,
+              "minus",
+              std::vector<ExprPtr>{std::move(posRef), std::move(oneConst)}));
+    } else {
+      projExprs.emplace_back(
+          std::make_shared<facebook::axiom::logical_plan::InputReferenceExpr>(
+              colType, colName));
+    }
+    projNames.emplace_back(std::move(colName));
+  }
+
+  return std::make_shared<facebook::axiom::logical_plan::ProjectNode>(
+      nextId(),
+      std::move(unnestNode),
+      std::move(projNames),
+      std::move(projExprs));
 }
 
 void SparkToAxiom::visit(

--- a/axiom/pyspark/SparkToAxiom.h
+++ b/axiom/pyspark/SparkToAxiom.h
@@ -210,6 +210,40 @@ class SparkToAxiom : public SparkPlanVisitor {
       SparkPlanVisitorContext& context,
       std::vector<ExprPtr>& params,
       std::vector<facebook::velox::TypePtr>& paramTypes);
+
+  /// Translates a Spark Connect Project containing a generator function
+  /// (explode, posexplode) into the equivalent Axiom logical plan.
+  ///
+  /// A generator like posexplode(arr) does not fit the ProjectNode shape
+  /// because it emits multiple rows per input row. The translation produces
+  /// two nodes:
+  ///   1. UnnestNode  - flattens the generator's array or map argument,
+  ///      emitting one row per element, optionally with a 1-based
+  ///      ordinality column.
+  ///   2. ProjectNode (wrapping) - drops input columns that are not in the
+  ///      SELECT list (Spark's select(explode(...)) keeps only the unnested
+  ///      columns), converts posexplode's 1-based ordinality to Spark's
+  ///      0-based position via (pos - 1), and applies user-supplied aliases.
+  ///
+  /// Spark allows at most one generator per SELECT clause and this is
+  /// enforced with COLLAGEN_CHECK. The _outer variants are not yet
+  /// supported and raise COLLAGEN_NYI until Axiom's UnnestNode exposes
+  /// outer-unnest semantics.
+  void visitProjectWithGenerator(
+      const spark::connect::Project& project,
+      SparkPlanVisitorContext& context);
+
+  /// Builds the wrapping ProjectNode for visitProjectWithGenerator. Selects
+  /// only the columns that should appear in the Project's output: any
+  /// pass-through columns from 'nonGeneratorExprs' followed by the unnested
+  /// columns (and the converted 0-based position for posexplode). Also sets
+  /// planNode_ to 'unnestNode' so non-generator expressions can be resolved
+  /// against its output schema.
+  LogicalPlanNodePtr buildProjectAroundUnnest(
+      std::shared_ptr<facebook::axiom::logical_plan::UnnestNode> unnestNode,
+      const std::vector<const spark::connect::Expression*>& nonGeneratorExprs,
+      bool isPosExplode,
+      SparkPlanVisitorContext& context);
 };
 
 } // namespace axiom::collagen

--- a/axiom/pyspark/tests/CMakeLists.txt
+++ b/axiom/pyspark/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   collagen_spark_velox_converter_test
   SparkToAxiomLambdaTest.cpp
   SparkToAxiomSetOperationTest.cpp
+  SparkToAxiomUnnestTest.cpp
   SparkToAxiomWithColumnsRenamedTest.cpp
   SparkToAxiomWithColumnsTest.cpp
   SparkVeloxConverterTest.cpp

--- a/axiom/pyspark/tests/SparkToAxiomUnnestTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomUnnestTest.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/pyspark/SparkToAxiom.h"
+#include "axiom/pyspark/third-party/protos/relations.grpc.pb.h" // @manual=fbcode//axiom/pyspark/third-party/protos:collagen_proto-cpp
+#include "velox/common/memory/Memory.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+
+namespace axiom::collagen::test {
+namespace {
+
+class SparkToAxiomUnnestTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+    velox::memory::MemoryManager::testingSetInstance({});
+
+    connectorId_ = "test-connector-unnest";
+    auto connector =
+        std::make_shared<facebook::axiom::connector::TestConnector>(
+            connectorId_);
+    connector->addTable(
+        "test_table_with_array",
+        velox::ROW(
+            {"id", "arr"}, {velox::BIGINT(), velox::ARRAY(velox::INTEGER())}));
+    connector->addTable(
+        "test_table_with_map",
+        velox::ROW(
+            {"id", "m"},
+            {velox::BIGINT(), velox::MAP(velox::VARCHAR(), velox::INTEGER())}));
+    velox::connector::ConnectorRegistry::global().insert(
+        connectorId_, connector);
+
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  void TearDown() override {
+    velox::connector::ConnectorRegistry::global().erase(connectorId_);
+  }
+
+  // Builds a Project relation wrapping a table scan with the given generator
+  // expressions. Each entry in generators is {function_name, column_name,
+  // alias_names}. Non-generator expressions are added via nonGenColumns.
+  spark::connect::Relation buildProjectWithExplode(
+      const std::string& tableName,
+      const std::string& genFuncName,
+      const std::string& genColumn,
+      const std::vector<std::string>& aliasNames,
+      const std::vector<std::string>& nonGenColumns = {}) {
+    spark::connect::Relation relation;
+    relation.mutable_common()->set_plan_id(1);
+
+    auto* project = relation.mutable_project();
+
+    auto* input = project->mutable_input();
+    input->mutable_common()->set_plan_id(2);
+    input->mutable_read()->mutable_named_table()->set_unparsed_identifier(
+        tableName);
+
+    for (const auto& col : nonGenColumns) {
+      project->add_expressions()
+          ->mutable_unresolved_attribute()
+          ->set_unparsed_identifier(col);
+    }
+
+    auto* genExpr = project->add_expressions();
+    if (!aliasNames.empty()) {
+      auto* alias = genExpr->mutable_alias();
+      for (const auto& name : aliasNames) {
+        alias->add_name(name);
+      }
+      auto* func = alias->mutable_expr()->mutable_unresolved_function();
+      func->set_function_name(genFuncName);
+      func->add_arguments()
+          ->mutable_unresolved_attribute()
+          ->set_unparsed_identifier(genColumn);
+    } else {
+      auto* func = genExpr->mutable_unresolved_function();
+      func->set_function_name(genFuncName);
+      func->add_arguments()
+          ->mutable_unresolved_attribute()
+          ->set_unparsed_identifier(genColumn);
+    }
+
+    return relation;
+  }
+
+  std::string connectorId_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(SparkToAxiomUnnestTest, explodeCreatesUnnestNode) {
+  auto relation = buildProjectWithExplode(
+      "test_table_with_array", "explode", "arr", {"elem"}, {"id"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto& planNode = converter.planNode();
+  ASSERT_NE(planNode, nullptr);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          planNode.get());
+  ASSERT_NE(projectNode, nullptr);
+
+  ASSERT_EQ(projectNode->inputs().size(), 1);
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  ASSERT_EQ(unnestNode->unnestExpressions().size(), 1);
+  EXPECT_TRUE(unnestNode->unnestExpressions()[0]->type()->isArray());
+
+  ASSERT_EQ(unnestNode->unnestedNames().size(), 1);
+  ASSERT_EQ(unnestNode->unnestedNames()[0].size(), 1);
+  EXPECT_EQ(unnestNode->unnestedNames()[0][0], "elem");
+
+  const auto& outputType = projectNode->outputType();
+  bool hasId = false;
+  bool hasElem = false;
+  for (uint32_t i = 0; i < outputType->size(); ++i) {
+    if (outputType->nameOf(i) == "id") {
+      hasId = true;
+    }
+    if (outputType->nameOf(i) == "elem") {
+      hasElem = true;
+    }
+  }
+  EXPECT_TRUE(hasId);
+  EXPECT_TRUE(hasElem);
+}
+
+TEST_F(SparkToAxiomUnnestTest, explodeWithoutAlias) {
+  auto relation =
+      buildProjectWithExplode("test_table_with_array", "explode", "arr", {});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  // Bare explode is always wrapped with a ProjectNode so the input columns
+  // (id, arr) don't leak into the output schema. Spark's
+  // `df.select(explode("arr"))` emits only the unnested column.
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr);
+
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  ASSERT_EQ(unnestNode->unnestedNames().size(), 1);
+  EXPECT_EQ(unnestNode->unnestedNames()[0][0], "col");
+
+  const auto& outputType = projectNode->outputType();
+  ASSERT_EQ(outputType->size(), 1);
+  EXPECT_EQ(outputType->nameOf(0), "col");
+}
+
+TEST_F(SparkToAxiomUnnestTest, explodeOuterThrowsNYI) {
+  auto relation = buildProjectWithExplode(
+      "test_table_with_array", "explode_outer", "arr", {"elem"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  EXPECT_THROW(converter.visit(relation, context), std::exception);
+}
+
+TEST_F(SparkToAxiomUnnestTest, posexplodeOuterThrowsNYI) {
+  auto relation = buildProjectWithExplode(
+      "test_table_with_array", "posexplode_outer", "arr", {"elem"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  EXPECT_THROW(converter.visit(relation, context), std::exception);
+}
+
+TEST_F(SparkToAxiomUnnestTest, multipleGeneratorsRejected) {
+  // Build a project with two explode calls — Spark rejects this too.
+  spark::connect::Relation relation;
+  relation.mutable_common()->set_plan_id(1);
+
+  auto* project = relation.mutable_project();
+  auto* input = project->mutable_input();
+  input->mutable_common()->set_plan_id(2);
+  input->mutable_read()->mutable_named_table()->set_unparsed_identifier(
+      "test_table_with_array");
+
+  auto* gen1 = project->add_expressions()->mutable_unresolved_function();
+  gen1->set_function_name("explode");
+  gen1->add_arguments()
+      ->mutable_unresolved_attribute()
+      ->set_unparsed_identifier("arr");
+
+  auto* gen2 = project->add_expressions()->mutable_unresolved_function();
+  gen2->set_function_name("explode");
+  gen2->add_arguments()
+      ->mutable_unresolved_attribute()
+      ->set_unparsed_identifier("arr");
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  EXPECT_THROW(converter.visit(relation, context), std::exception);
+}
+
+TEST_F(SparkToAxiomUnnestTest, mapExplodeWithMultiNameAlias) {
+  auto relation = buildProjectWithExplode(
+      "test_table_with_map", "explode", "m", {"k", "v"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr);
+
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  ASSERT_EQ(unnestNode->unnestedNames().size(), 1);
+  ASSERT_EQ(unnestNode->unnestedNames()[0].size(), 2);
+  EXPECT_EQ(unnestNode->unnestedNames()[0][0], "k");
+  EXPECT_EQ(unnestNode->unnestedNames()[0][1], "v");
+
+  // Wrapper drops the input columns (id, m); only the aliased key/value
+  // make it to the output schema.
+  const auto& outputType = projectNode->outputType();
+  ASSERT_EQ(outputType->size(), 2);
+  EXPECT_EQ(outputType->nameOf(0), "k");
+  EXPECT_EQ(outputType->nameOf(1), "v");
+}
+
+TEST_F(SparkToAxiomUnnestTest, mapExplodeDefaultNames) {
+  auto relation =
+      buildProjectWithExplode("test_table_with_map", "explode", "m", {});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr);
+
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  ASSERT_EQ(unnestNode->unnestedNames().size(), 1);
+  ASSERT_EQ(unnestNode->unnestedNames()[0].size(), 2);
+  EXPECT_EQ(unnestNode->unnestedNames()[0][0], "key");
+  EXPECT_EQ(unnestNode->unnestedNames()[0][1], "value");
+
+  const auto& outputType = projectNode->outputType();
+  ASSERT_EQ(outputType->size(), 2);
+  EXPECT_EQ(outputType->nameOf(0), "key");
+  EXPECT_EQ(outputType->nameOf(1), "value");
+}
+
+// Regression test for a DARTS finding: Spark's df.select(explode("arr")) emits
+// only the unnested column, but UnnestNode's natural output type also includes
+// the pre-unnest input columns. The wrapping ProjectNode must drop them.
+TEST_F(SparkToAxiomUnnestTest, bareExplodeArrayWithAliasDropsInputColumns) {
+  auto relation =
+      buildProjectWithExplode("test_table_with_array", "explode", "arr", {"e"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr);
+
+  const auto& outputType = projectNode->outputType();
+  ASSERT_EQ(outputType->size(), 1)
+      << "select(explode(arr).alias(e)) must emit only the unnested column, "
+         "not the pre-unnest input columns";
+  EXPECT_EQ(outputType->nameOf(0), "e");
+}
+
+// posexplode is always wrapped with a ProjectNode that subtracts 1 from the
+// ordinality column to convert Velox's 1-based indexing to Spark's 0-based.
+TEST_F(SparkToAxiomUnnestTest, posexplodeWrapsWithMinusOne) {
+  auto relation =
+      buildProjectWithExplode("test_table_with_array", "posexplode", "arr", {});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr)
+      << "posexplode must always wrap with ProjectNode for pos-1 conversion";
+
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  // UnnestNode keeps default names: element="col", ordinality="pos".
+  ASSERT_EQ(unnestNode->unnestedNames()[0][0], "col");
+  ASSERT_TRUE(unnestNode->ordinalityName().has_value());
+  EXPECT_EQ(unnestNode->ordinalityName().value(), "pos");
+
+  // The ProjectNode replaces the pos column with `pos - 1`. Find that column
+  // in the projections and verify it's a CallExpr for "minus".
+  const auto& outputType = projectNode->outputType();
+  const auto& projections = projectNode->expressions();
+  bool foundPosMinusOne = false;
+  for (uint32_t i = 0; i < outputType->size(); ++i) {
+    if (outputType->nameOf(i) == "pos") {
+      const auto* callExpr =
+          dynamic_cast<const facebook::axiom::logical_plan::CallExpr*>(
+              projections[i].get());
+      ASSERT_NE(callExpr, nullptr) << "pos column must be a CallExpr (pos - 1)";
+      EXPECT_EQ(callExpr->name(), "minus");
+      foundPosMinusOne = true;
+    }
+  }
+  EXPECT_TRUE(foundPosMinusOne);
+}
+
+// Spark posexplode alias order is (pos, element). The first alias names the
+// position column; the second names the element column.
+TEST_F(SparkToAxiomUnnestTest, posexplodeAliasOrderingIsPosThenElement) {
+  auto relation = buildProjectWithExplode(
+      "test_table_with_array", "posexplode", "arr", {"my_pos", "my_elem"});
+
+  SparkToAxiom converter(connectorId_, "default", pool_.get());
+  SparkPlanVisitorContext context;
+  converter.visit(relation, context);
+
+  const auto* projectNode =
+      dynamic_cast<const facebook::axiom::logical_plan::ProjectNode*>(
+          converter.planNode().get());
+  ASSERT_NE(projectNode, nullptr);
+
+  const auto* unnestNode =
+      dynamic_cast<const facebook::axiom::logical_plan::UnnestNode*>(
+          projectNode->inputs()[0].get());
+  ASSERT_NE(unnestNode, nullptr);
+
+  ASSERT_TRUE(unnestNode->ordinalityName().has_value());
+  EXPECT_EQ(unnestNode->ordinalityName().value(), "my_pos");
+  ASSERT_EQ(unnestNode->unnestedNames()[0][0], "my_elem");
+
+  // Output schema must contain both aliased names.
+  const auto& outputType = projectNode->outputType();
+  bool hasMyPos = false;
+  bool hasMyElem = false;
+  for (uint32_t i = 0; i < outputType->size(); ++i) {
+    if (outputType->nameOf(i) == "my_pos") {
+      hasMyPos = true;
+    }
+    if (outputType->nameOf(i) == "my_elem") {
+      hasMyElem = true;
+    }
+  }
+  EXPECT_TRUE(hasMyPos);
+  EXPECT_TRUE(hasMyElem);
+}
+
+} // namespace
+} // namespace axiom::collagen::test


### PR DESCRIPTION
Summary:

Adds Spark Connect translation for the explode and posexplode generator
functions over arrays and maps. Honors alias preservation, with
posexplode emitting a 0-based position column to match Spark semantics.

The explode_outer and posexplode_outer variants are not yet supported
and throw a clear NYI error rather than silently returning incorrect
results.

Multiple generators in a single Project are rejected, matching Spark's
"Only one generator allowed per select clause" behavior.

Differential Revision: D100885457


