### PR TITLE
refactor: Remove SplitOptions (#1312)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -912,18 +912,12 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
 std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
     optimizer::PlanAndStats& planAndStats,
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
-    const RunOptions& options) {
-  connector::SplitOptions splitOptions{
-      .targetSplitCount =
-          static_cast<int32_t>(options.numWorkers * options.numDrivers * 2),
-      .fileBytesPerSplit = options.splitTargetBytes,
-  };
-
+    const RunOptions& /*options*/) {
   return std::make_shared<runner::LocalRunner>(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,
-      std::make_shared<runner::ConnectorSplitSourceFactory>(splitOptions),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(),
       executorPool_);
 }
 

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -49,19 +49,6 @@ class SplitSource {
   virtual void cancel() {}
 };
 
-/// Options for split generation.
-struct SplitOptions {
-  /// Make no more than one split per file.
-  bool wholeFile{false};
-
-  /// If non-0, gives a minimum number of splits to generate, e.g. at least one
-  /// for each driver of each worker.
-  int32_t targetSplitCount{0};
-
-  /// Target size of split.
-  uint64_t fileBytesPerSplit{128ULL << 20U};
-};
-
 /// Describes a single partition of a TableLayout. A TableLayout has at least
 /// one partition, even if it has no partitioning columns.
 class PartitionHandle {
@@ -88,8 +75,7 @@ class ConnectorSplitManager {
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions,
-      SplitOptions = {}) = 0;
+      const std::vector<PartitionHandlePtr>& partitions) = 0;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -319,8 +319,7 @@ FilteredTableStats estimateStatsFromPartitionStats(
 std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/,
-    SplitOptions options) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
   auto metadata = ConnectorMetadataRegistry::get(tableHandle->connectorId());
@@ -344,7 +343,6 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
       std::move(selectedFiles),
       layout->fileFormat(),
       layout->connector()->connectorId(),
-      options,
       layout->serdeParameters());
 }
 
@@ -364,17 +362,7 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
   while (batch.splits.size() < limit && fileIdx_ < files_.size()) {
     const auto& filePath = files_[fileIdx_]->path;
     const auto fileSize = fs::file_size(filePath);
-    int64_t splitsPerFile =
-        ceil2<uint64_t>(fileSize, options_.fileBytesPerSplit);
-    if (options_.targetSplitCount) {
-      auto numFiles = files_.size();
-      if (splitsPerFile * numFiles < options_.targetSplitCount) {
-        auto perFile = ceil2<uint64_t>(options_.targetSplitCount, numFiles);
-        int64_t bytesInSplit = ceil2<uint64_t>(fileSize, perFile);
-        splitsPerFile = ceil2<uint64_t>(
-            fileSize, std::max<uint64_t>(bytesInSplit, 32 << 20));
-      }
-    }
+    int64_t splitsPerFile = ceil2<uint64_t>(fileSize, kFileBytesPerSplit);
     const int64_t splitSize = ceil2<uint64_t>(fileSize, splitsPerFile);
     while (splitWithinFile_ < splitsPerFile && batch.splits.size() < limit) {
       auto builder = velox::connector::hive::HiveConnectorSplitBuilder(filePath)

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -37,10 +37,8 @@ class LocalHiveSplitSource : public SplitSource {
       std::vector<const FileInfo*> files,
       velox::dwio::common::FileFormat format,
       const std::string& connectorId,
-      SplitOptions options,
       std::unordered_map<std::string, std::string> serdeParameters = {})
-      : options_(options),
-        format_(format),
+      : format_(format),
         connectorId_(connectorId),
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)) {}
@@ -50,7 +48,9 @@ class LocalHiveSplitSource : public SplitSource {
       int32_t /*bucket*/) override;
 
  private:
-  const SplitOptions options_;
+  // Target number of bytes per split when partitioning files.
+  static constexpr uint64_t kFileBytesPerSplit{128ULL << 20U};
+
   const velox::dwio::common::FileFormat format_;
   const std::string connectorId_;
   std::vector<const FileInfo*> files_;
@@ -72,8 +72,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions,
-      SplitOptions options = {}) override;
+      const std::vector<PartitionHandlePtr>& partitions) override;
 };
 
 // Write-time stats for a single partition (or the whole table if

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -147,8 +147,7 @@ SystemSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/,
-    SplitOptions /*options*/) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/) {
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }
 

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -118,8 +118,7 @@ class SystemSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions,
-      SplitOptions options = {}) override;
+      const std::vector<PartitionHandlePtr>& partitions) override;
 };
 
 /// Axiom ConnectorMetadata for the system connector.

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -267,8 +267,7 @@ TestSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&,
-    SplitOptions) {
+    const std::vector<PartitionHandlePtr>&) {
   auto maybeTableHandle =
       std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
   VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -186,8 +186,7 @@ class TestSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions,
-      SplitOptions options = {}) override;
+      const std::vector<PartitionHandlePtr>& partitions) override;
 };
 
 class TestColumnHandle : public velox::connector::ColumnHandle {

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -150,7 +150,7 @@ CO_TEST_F(TestConnectorTest, splitManager) {
   auto partitions =
       co_await splitManager->co_listPartitions(nullptr, tableHandle);
   auto splitSource =
-      splitManager->getSplitSource(nullptr, tableHandle, partitions, {});
+      splitManager->getSplitSource(nullptr, tableHandle, partitions);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -86,8 +86,7 @@ TpchSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const connector::ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/,
-    SplitOptions options) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/) {
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
           tableHandle.get());
@@ -97,8 +96,7 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
   return std::make_shared<TpchSplitSource>(
       tpchTableHandle->getTable(),
       tpchTableHandle->getScaleFactor(),
-      tpchTableHandle->connectorId(),
-      options);
+      tpchTableHandle->connectorId());
 }
 
 folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
@@ -108,7 +106,7 @@ folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
     auto rowType = velox::tpch::getTableSchema(table_);
     size_t rowSize = rowType->children().size() * 10;
     const auto totalRows = velox::tpch::getRowCount(table_, scaleFactor_);
-    const auto rowsPerSplit = options_.fileBytesPerSplit / rowSize;
+    const auto rowsPerSplit = kFileBytesPerSplit / rowSize;
     numSplits_ = (totalRows + rowsPerSplit - 1) / rowsPerSplit;
   }
 

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -27,27 +27,29 @@ class TpchConnectorMetadata;
 
 class TpchSplitSource : public SplitSource {
  public:
+  /// Constructs a TpchSplitSource with the specified number of splits.
   TpchSplitSource(
       velox::tpch::Table table,
       double scaleFactor,
       const std::string& connectorId,
-      SplitOptions options)
-      : options_(options),
-        table_(table),
+      int64_t numSplits = -1)
+      : table_(table),
         scaleFactor_(scaleFactor),
-        connectorId_(connectorId) {}
+        connectorId_(connectorId),
+        numSplits_(numSplits) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(
       uint32_t maxSplitCount,
       int32_t /*bucket*/) override;
 
  private:
-  const SplitOptions options_;
+  static constexpr uint64_t kFileBytesPerSplit{128ULL << 20U};
+
   const velox::tpch::Table table_;
   const double scaleFactor_;
   const std::string connectorId_;
   int64_t nextSplitIdx_{0};
-  int64_t numSplits_{-1};
+  int64_t numSplits_;
 };
 
 class TpchSplitManager : public ConnectorSplitManager {
@@ -61,8 +63,7 @@ class TpchSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions,
-      SplitOptions options = {}) override;
+      const std::vector<PartitionHandlePtr>& partitions) override;
 };
 
 /// A TableLayout for TPCH tables. Implements sampling by generating TPCH data.

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -646,17 +646,11 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
   std::shared_ptr<runner::LocalRunner> makeRunner(
       optimizer::PlanAndStats& planAndStats,
       const std::shared_ptr<core::QueryCtx>& queryCtx) {
-    connector::SplitOptions splitOptions{
-        .targetSplitCount =
-            static_cast<int32_t>(FLAGS_num_workers * FLAGS_num_drivers * 2),
-        .fileBytesPerSplit = static_cast<uint64_t>(FLAGS_split_target_bytes),
-    };
-
     return std::make_shared<runner::LocalRunner>(
         planAndStats.plan,
         std::move(planAndStats.finishWrite),
         queryCtx,
-        std::make_shared<runner::ConnectorSplitSourceFactory>(splitOptions),
+        std::make_shared<runner::ConnectorSplitSourceFactory>(),
         optimizerPool_);
   }
 

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -93,14 +93,8 @@ std::vector<velox::RowVectorPtr> LocalRunner::execute(
       velox::cache::AsyncDataCache::getInstance(),
       aggregatePool_);
 
-  // Todo: pass executor to queryCtx
-  facebook::axiom::connector::SplitOptions splitOptions{
-      .targetSplitCount = FLAGS_num_workers * FLAGS_num_drivers * 2,
-      .fileBytesPerSplit = static_cast<uint64_t>(FLAGS_split_target_bytes)};
-
   auto splitSourceFactory =
-      std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>(
-          splitOptions);
+      std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>();
 
   auto runner = std::make_shared<facebook::axiom::runner::LocalRunner>(
       plan_, std::move(finishWrite_), queryCtx, splitSourceFactory, leafPool_);

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -79,7 +79,7 @@ ConnectorSplitSourceFactory::splitSourceForScan(
 
   auto partitions = folly::coro::blockingWait(
       splitManager->co_listPartitions(session, handle));
-  return splitManager->getSplitSource(session, handle, partitions, options_);
+  return splitManager->getSplitSource(session, handle, partitions);
 }
 
 namespace {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -64,15 +64,9 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
 /// Generic SplitSourceFactory that delegates the work to ConnectorSplitManager.
 class ConnectorSplitSourceFactory : public SplitSourceFactory {
  public:
-  ConnectorSplitSourceFactory(connector::SplitOptions options = {})
-      : options_(std::move(options)) {}
-
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) override;
-
- protected:
-  const connector::SplitOptions options_;
 };
 
 /// Runner for in-process execution of a distributed plan.


### PR DESCRIPTION
Summary:

The engine should not be providing requirements on the split size. This should
be responsibility of a connector.

Reviewed By: amitkdutta

Differential Revision: D103427000


