### PR TITLE
refactor: Remove bucket parameter from the SplitSource interface (#1313)

### DIFF
--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -25,8 +25,7 @@ namespace facebook::axiom::connector {
 struct SplitBatch {
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
 
-  /// True when there are no more splits to return (for the requested bucket,
-  /// or globally if no bucket was specified).
+  /// True when there are no more splits to return.
   bool noMoreSplits{false};
 };
 
@@ -34,16 +33,12 @@ struct SplitBatch {
 /// ConnectorSplitManager.
 class SplitSource {
  public:
-  static constexpr int32_t kNoBucket = -1;
-
   virtual ~SplitSource() = default;
 
   /// Returns up to 'maxSplitCount' splits, or fewer if the source is
   /// exhausted. Sets SplitBatch::noMoreSplits when no further splits remain.
-  /// If 'bucket' is specified, returns only splits for that bucket.
   virtual folly::coro::Task<SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t bucket = kNoBucket) = 0;
+      uint32_t maxSplitCount) = 0;
 
   /// Cancel the split source and interrupt all background activity.
   virtual void cancel() {}

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -355,8 +355,7 @@ T ceil2(T x, T y) {
 } // namespace
 
 folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
-    uint32_t maxSplitCount,
-    int32_t /*bucket*/) {
+    uint32_t maxSplitCount) {
   SplitBatch batch;
   const size_t limit = maxSplitCount;
   while (batch.splits.size() < limit && fileIdx_ < files_.size()) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -43,9 +43,7 @@ class LocalHiveSplitSource : public SplitSource {
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)) {}
 
-  folly::coro::Task<SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t /*bucket*/) override;
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   // Target number of bytes per split when partitioning files.

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -125,8 +125,7 @@ SystemTable::SystemTable(
 // =====================
 
 folly::coro::Task<SplitBatch> SystemSplitSource::co_getSplits(
-    uint32_t /*maxSplitCount*/,
-    int32_t /*bucket*/) {
+    uint32_t /*maxSplitCount*/) {
   SplitBatch batch;
   if (!done_) {
     batch.splits.push_back(std::make_shared<SystemSplit>(connectorId_));

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -99,9 +99,7 @@ class SystemSplitSource : public SplitSource {
   explicit SystemSplitSource(const std::string& connectorId)
       : connectorId_(connectorId) {}
 
-  folly::coro::Task<SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t /*bucket*/) override;
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -242,8 +242,7 @@ std::unique_ptr<ColumnStatistics> TestTable::ColumnTracker::toColumnStatistics(
 }
 
 folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
-    uint32_t maxSplitCount,
-    int32_t /*bucket*/) {
+    uint32_t maxSplitCount) {
   SplitBatch batch;
   auto end =
       std::min(nextIndex_ + static_cast<size_t>(maxSplitCount), splitCount_);

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -163,9 +163,7 @@ class TestSplitSource : public SplitSource {
   TestSplitSource(const std::string& connectorId, size_t splitCount)
       : connectorId_(connectorId), splitCount_(splitCount) {}
 
-  folly::coro::Task<SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t /*bucket*/) override;
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -100,8 +100,7 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
 }
 
 folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
-    uint32_t maxSplitCount,
-    int32_t /*bucket*/) {
+    uint32_t maxSplitCount) {
   if (numSplits_ < 0) {
     auto rowType = velox::tpch::getTableSchema(table_);
     size_t rowSize = rowType->children().size() * 10;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -38,9 +38,7 @@ class TpchSplitSource : public SplitSource {
         connectorId_(connectorId),
         numSplits_(numSplits) {}
 
-  folly::coro::Task<SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t /*bucket*/) override;
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   static constexpr uint64_t kFileBytesPerSplit{128ULL << 20U};

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -38,8 +38,7 @@ class SimpleSplitSource : public connector::SplitSource {
       : splits_(std::move(splits)) {}
 
   folly::coro::Task<connector::SplitBatch> co_getSplits(
-      uint32_t maxSplitCount,
-      int32_t /*bucket*/) override {
+      uint32_t maxSplitCount) override {
     connector::SplitBatch batch;
     auto end = std::min(
         nextIndex_ + static_cast<size_t>(maxSplitCount), splits_.size());


### PR DESCRIPTION
Summary:

Not needed now. In the future we may decide to implement per-bucket split
buffering in the engine.

Reviewed By: amitkdutta

Differential Revision: D103426997


