### PR TITLE
refactor: Make sure SplitSource is always closed before destruction

### DIFF
--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -30,18 +30,44 @@ struct SplitBatch {
 };
 
 /// Enumerates splits. The table and partitions to cover are given to
-/// ConnectorSplitManager.
+/// ConnectorSplitManager. Callers must invoke co_close() when done consuming
+/// splits, before the SplitSource is destroyed. co_close() releases background
+/// resources and waits for any in-flight work to complete.
 class SplitSource {
  public:
-  virtual ~SplitSource() = default;
+  SplitSource() = default;
+  SplitSource(const SplitSource&) = delete;
+  SplitSource& operator=(const SplitSource&) = delete;
+  SplitSource(SplitSource&&) = delete;
+  SplitSource& operator=(SplitSource&&) = delete;
+
+  virtual ~SplitSource() {
+    VELOX_CHECK(
+        closed_, "co_close() must be called before destroying SplitSource");
+  }
 
   /// Returns up to 'maxSplitCount' splits, or fewer if the source is
   /// exhausted. Sets SplitBatch::noMoreSplits when no further splits remain.
   virtual folly::coro::Task<SplitBatch> co_getSplits(
       uint32_t maxSplitCount) = 0;
 
-  /// Cancel the split source and interrupt all background activity.
-  virtual void cancel() {}
+  /// Close the split source and interrupt all background activity.
+  /// Must be called exactly once before the SplitSource is destroyed.
+  folly::coro::Task<void> co_close() noexcept {
+    if (closed_) {
+      co_return;
+    }
+    co_await co_closeImpl();
+    closed_ = true;
+  }
+
+ protected:
+  virtual folly::coro::Task<void> co_closeImpl() noexcept {
+    co_return;
+  }
+
+ private:
+  bool closed_{false};
 };
 
 /// Describes a single partition of a TableLayout. A TableLayout has at least

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -345,6 +345,7 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
       break;
     }
   }
+  folly::coro::blockingWait(splitSource->co_close());
   ASSERT_EQ(splits.size(), 1);
   ASSERT_NE(splits[0], nullptr);
 }

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -163,6 +163,7 @@ CO_TEST_F(TestConnectorTest, splitManager) {
       break;
     }
   }
+  co_await splitSource->co_close();
   EXPECT_EQ(splits.size(), kNumSplits);
   for (size_t i = 0; i < kNumSplits; ++i) {
     auto split = std::dynamic_pointer_cast<TestConnectorSplit>(splits[i]);

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -191,6 +191,7 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       break;
     }
   }
+  co_await splitSource->co_close();
   EXPECT_FALSE(splits.empty());
 }
 } // namespace

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -113,6 +113,7 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
     std::function<void(std::exception_ptr)> onError) {
+  std::exception_ptr ex;
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
 
@@ -131,8 +132,12 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       task->noMoreSplits(scanId);
     }
   } catch (...) {
-    onError(std::current_exception());
-    throw;
+    ex = std::current_exception();
+  }
+  co_await source->co_close();
+  if (ex) {
+    onError(ex);
+    std::rethrow_exception(ex);
   }
 }
 


### PR DESCRIPTION
Summary:
Make close a coroutine to allow async operations (like canceling background
activity)

Differential Revision: D103427001


