### PR TITLE
feat: Add QueryRuntimeStats for pipeline metrics reporting

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -344,6 +344,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
           std::string(catalog),
           std::string(schema),
           std::nullopt}};
+  completionInfo.runtimeStats = std::make_shared<QueryRuntimeStats>();
 
   onStart(runOptions, completionInfo);
 
@@ -363,18 +364,25 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
       statement = parseSingle(sql, runOptions);
     }
     completionInfo.startInfo.queryType = statement->kind();
+    completionInfo.runtimeStats->recordTiming(
+        QueryRuntimeStats::kParseWallNanos,
+        std::chrono::microseconds(completionInfo.timing.parse));
 
     runOptions.tokenProvider = checkPermission(
         runOptions,
         completionInfo,
         statement->views(),
         statement->referencedTables());
+    completionInfo.runtimeStats->recordTiming(
+        QueryRuntimeStats::kPermissionCheckWallNanos,
+        std::chrono::microseconds(completionInfo.timing.checkPermission));
 
     auto result = runUnchecked(
         *statement,
         runOptions,
         completionInfo.timing,
-        completionInfo.planString);
+        completionInfo.planString,
+        completionInfo.runtimeStats);
 
     completionInfo.numOutputRows = countRows(result.results);
     finalize();
@@ -468,7 +476,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options,
     QueryTiming& timing,
-    std::string& planString) {
+    std::string& planString,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   if (sqlStatement.isExplain()) {
     const auto* explain = sqlStatement.as<presto::ExplainStatement>();
 
@@ -582,12 +591,14 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     auto schema = std::make_shared<connector::SchemaResolver>();
     schema->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
-    return runLogicalPlan(ctas->plan(), options, timing, planString, schema);
+    return runLogicalPlan(
+        ctas->plan(), options, timing, planString, schema, runtimeStats);
   }
 
   if (sqlStatement.isInsert()) {
     const auto* insert = sqlStatement.as<presto::InsertStatement>();
-    return runLogicalPlan(insert->plan(), options, timing, planString);
+    return runLogicalPlan(
+        insert->plan(), options, timing, planString, nullptr, runtimeStats);
   }
 
   if (sqlStatement.isDropTable()) {
@@ -654,7 +665,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
   const auto logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
 
-  return runLogicalPlan(logicalPlan, options, timing, planString);
+  return runLogicalPlan(
+      logicalPlan, options, timing, planString, nullptr, runtimeStats);
 }
 
 std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
@@ -861,7 +873,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
         checkDerivedTable,
     const std::function<bool(const optimizer::RelationOp&)>& checkBestPlan,
     std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
-    bool explain) {
+    bool explain,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
@@ -887,6 +900,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   auto optimizerOptions = optimizer::OptimizerOptions::from(optimizerProps);
   optimizerOptions.explain = explain;
 
+  uint64_t toGraphNanos{0};
+  auto toGraphStart = std::chrono::steady_clock::now();
   optimizer::Optimization optimization(
       session,
       *logicalPlan,
@@ -900,25 +915,55 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {
     return {};
   }
+  toGraphNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                     std::chrono::steady_clock::now() - toGraphStart)
+                     .count();
 
-  auto best = optimization.bestPlan();
+  uint64_t bestPlanNanos{0};
+  optimizer::PlanP best;
+  {
+    velox::NanosecondTimer timer(&bestPlanNanos);
+    best = optimization.bestPlan();
+  }
   if (checkBestPlan && !checkBestPlan(*best->op)) {
     return {};
   }
 
-  return optimization.toVeloxPlan(best->op);
+  uint64_t toVeloxNanos{0};
+  optimizer::PlanAndStats result;
+  {
+    velox::NanosecondTimer timer(&toVeloxNanos);
+    result = optimization.toVeloxPlan(best->op);
+  }
+
+  if (runtimeStats) {
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeToGraphWallNanos,
+        std::chrono::nanoseconds(toGraphNanos));
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeBestPlanWallNanos,
+        std::chrono::nanoseconds(bestPlanNanos));
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeToVeloxWallNanos,
+        std::chrono::nanoseconds(toVeloxNanos));
+  }
+
+  return result;
 }
 
 std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
     optimizer::PlanAndStats& planAndStats,
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
-    const RunOptions& /*options*/) {
+    const RunOptions& options,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   return std::make_shared<runner::LocalRunner>(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,
-      std::make_shared<runner::ConnectorSplitSourceFactory>(),
-      executorPool_);
+      std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats),
+      executorPool_,
+      /*baseSpillDirectory=*/"",
+      runtimeStats);
 }
 
 SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
@@ -973,8 +1018,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     const RunOptions& options,
     QueryTiming& timing,
     std::string& planString,
-    std::shared_ptr<facebook::axiom::connector::SchemaResolver>
-        schemaResolver) {
+    std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   auto queryCtx = newQuery(options);
 
   SqlResult result;
@@ -988,12 +1033,19 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         options,
         nullptr,
         nullptr,
-        std::move(schemaResolver));
+        std::move(schemaResolver),
+        /*explain=*/false,
+        runtimeStats);
+  }
+  if (runtimeStats) {
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeWallNanos,
+        std::chrono::microseconds(timing.optimize));
   }
 
   planString = planAndStats.toString();
 
-  auto runner = makeLocalRunner(planAndStats, queryCtx, options);
+  auto runner = makeLocalRunner(planAndStats, queryCtx, options, runtimeStats);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };
@@ -1001,6 +1053,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
   {
     velox::MicrosecondTimer timer(&timing.execute);
     result.results = fetchResults(*runner);
+  }
+  if (runtimeStats) {
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kExecuteWallNanos,
+        std::chrono::microseconds(timing.execute));
   }
 
   return result;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <functional>
 #include "axiom/common/ConfigRegistry.h"
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/common/SessionConfig.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
@@ -99,6 +100,10 @@ struct QueryCompletionInfo {
 
   /// Wall-clock time when the query finished, excluding onComplete.
   std::chrono::system_clock::time_point endTime;
+
+  /// Per-component runtime metrics (timing, counters) collected across the
+  /// query pipeline. Populated during execution and serialized by loggers.
+  std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats;
 };
 
 /// Invoked when a query starts, before parsing.
@@ -315,12 +320,16 @@ class SqlQueryRunner {
           checkBestPlan = nullptr,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
           schemaResolver = nullptr,
-      bool explain = false);
+      bool explain = false,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
+          nullptr);
 
   std::shared_ptr<facebook::axiom::runner::LocalRunner> makeLocalRunner(
       facebook::axiom::optimizer::PlanAndStats& planAndStats,
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
-      const RunOptions& options);
+      const RunOptions& options,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
+          nullptr);
 
   // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
   // and the serialized Velox plan into 'planString'.
@@ -328,7 +337,9 @@ class SqlQueryRunner {
       const presto::SqlStatement& statement,
       const RunOptions& options,
       QueryTiming& timing,
-      std::string& planString);
+      std::string& planString,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
+          nullptr);
 
   SqlResult showSession(
       const presto::ShowSessionStatement& statement,
@@ -344,7 +355,9 @@ class SqlQueryRunner {
       QueryTiming& timing,
       std::string& planString,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
-          schemaResolver = nullptr);
+          schemaResolver = nullptr,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
+          nullptr);
 
   // Wait maxWaitMicros microseconds for the LocalRunner to complete.  If
   // `maxWaitMicros <= 0` this will check if the LocalRunner is completed and

--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   axiom_common
   CatalogSchemaTableName.cpp
   ConfigRegistry.cpp
+  QueryRuntimeStats.cpp
   SchemaTableName.cpp
   Session.cpp
   SessionConfig.cpp

--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/QueryRuntimeStats.h"
+
+namespace facebook::axiom {
+
+namespace {
+bool runtimeMetricEquals(
+    const velox::RuntimeMetric& lhs,
+    const velox::RuntimeMetric& rhs) {
+  return lhs.sum == rhs.sum && lhs.count == rhs.count && lhs.min == rhs.min &&
+      lhs.max == rhs.max && lhs.unit == rhs.unit;
+}
+
+std::string_view unitToString(velox::RuntimeCounter::Unit unit) {
+  switch (unit) {
+    case velox::RuntimeCounter::Unit::kNanos:
+      return "NANO";
+    case velox::RuntimeCounter::Unit::kBytes:
+      return "BYTE";
+    case velox::RuntimeCounter::Unit::kNone:
+      return "NONE";
+  }
+  return "NONE";
+}
+} // namespace
+
+void mergeRuntimeMetric(
+    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
+    const std::string& name,
+    const velox::RuntimeMetric& metric) {
+  auto [it, inserted] = map.try_emplace(name, metric);
+  if (inserted) {
+    return;
+  }
+  while (true) {
+    auto current = it->second;
+    auto updated = current;
+    updated.merge(metric);
+    auto result = map.assign_if(
+        name,
+        std::move(updated),
+        [&current](const velox::RuntimeMetric& existing) {
+          return runtimeMetricEquals(existing, current);
+        });
+    if (result.has_value()) {
+      return;
+    }
+    it = map.find(name);
+    if (it == map.cend()) {
+      std::tie(it, inserted) = map.try_emplace(name, metric);
+      if (inserted) {
+        return;
+      }
+    }
+  }
+}
+
+void QueryRuntimeStats::recordTiming(
+    std::string_view name,
+    std::chrono::nanoseconds duration) {
+  mergeRuntimeMetric(
+      metrics_,
+      std::string(name),
+      velox::RuntimeMetric(
+          duration.count(), velox::RuntimeCounter::Unit::kNanos));
+}
+
+void QueryRuntimeStats::recordCount(std::string_view name, int64_t value) {
+  mergeRuntimeMetric(
+      metrics_,
+      std::string(name),
+      velox::RuntimeMetric(value, velox::RuntimeCounter::Unit::kNone));
+}
+
+void QueryRuntimeStats::merge(
+    std::string_view name,
+    const velox::RuntimeMetric& metric) {
+  mergeRuntimeMetric(metrics_, std::string(name), metric);
+}
+
+std::unordered_map<std::string, velox::RuntimeMetric> QueryRuntimeStats::toMap()
+    const {
+  std::unordered_map<std::string, velox::RuntimeMetric> result;
+  for (const auto& [name, metric] : metrics_) {
+    result.emplace(name, metric);
+  }
+  return result;
+}
+
+folly::dynamic QueryRuntimeStats::toDynamic() const {
+  folly::dynamic result = folly::dynamic::object();
+  for (const auto& [name, metric] : metrics_) {
+    folly::dynamic entry = folly::dynamic::object();
+    entry["sum"] = metric.sum;
+    entry["count"] = static_cast<int64_t>(metric.count);
+    entry["min"] = metric.min;
+    entry["max"] = metric.max;
+    entry["unit"] = unitToString(metric.unit);
+    result[name] = std::move(entry);
+  }
+  return result;
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <folly/concurrency/ConcurrentHashMap.h>
+#include <folly/dynamic.h>
+
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::axiom {
+
+/// Accumulates runtime metrics from Axiom's query pipeline (parser, optimizer,
+/// split manager, runner). Each metric is a velox::RuntimeMetric with
+/// sum/count/min/max. Thread-safe — multiple pipeline stages may record
+/// concurrently.
+class QueryRuntimeStats {
+ public:
+  // Parser.
+  static constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
+
+  // Optimizer.
+  static constexpr std::string_view kOptimizeWallNanos{
+      "axiom-optimizeWallNanos"};
+  static constexpr std::string_view kOptimizeToGraphWallNanos{
+      "axiom-optimizeToGraphWallNanos"};
+  static constexpr std::string_view kOptimizeBestPlanWallNanos{
+      "axiom-optimizeBestPlanWallNanos"};
+  static constexpr std::string_view kOptimizeToVeloxWallNanos{
+      "axiom-optimizeToVeloxWallNanos"};
+
+  // Split manager.
+  static constexpr std::string_view kListPartitionsWallNanos{
+      "axiom-listPartitionsWallNanos"};
+  static constexpr std::string_view kListPartitionsCount{
+      "axiom-listPartitionsCount"};
+  static constexpr std::string_view kGetSplitsWallNanos{
+      "axiom-getSplitsWallNanos"};
+  static constexpr std::string_view kGetSplitsCount{"axiom-getSplitsCount"};
+
+  // Permission check.
+  static constexpr std::string_view kPermissionCheckWallNanos{
+      "axiom-permissionCheckWallNanos"};
+
+  // Execution.
+  static constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
+
+  /// Records a wall-clock duration under the given metric name.
+  void recordTiming(std::string_view name, std::chrono::nanoseconds duration);
+
+  /// Records a count (e.g., number of partitions or splits).
+  void recordCount(std::string_view name, int64_t value);
+
+  /// Merges a pre-aggregated metric into this recorder.
+  void merge(std::string_view name, const velox::RuntimeMetric& metric);
+
+  /// Returns a snapshot of all recorded metrics.
+  std::unordered_map<std::string, velox::RuntimeMetric> toMap() const;
+
+  /// Serializes all metrics to folly::dynamic for Scribe logging. Format:
+  /// {"metricName": {"sum": N, "count": N, "min": N, "max": N, "unit": "..."}}
+  folly::dynamic toDynamic() const;
+
+ private:
+  folly::ConcurrentHashMap<std::string, velox::RuntimeMetric> metrics_;
+};
+
+/// RAII timer that records a wall-clock duration into QueryRuntimeStats on
+/// destruction. Guarantees the metric is recorded even if the timed scope
+/// exits via exception.
+class ScopedRuntimeStatsTimer {
+ public:
+  ScopedRuntimeStatsTimer(QueryRuntimeStats& stats, std::string_view metricName)
+      : stats_(stats),
+        metricName_(metricName),
+        start_(std::chrono::steady_clock::now()) {}
+
+  ~ScopedRuntimeStatsTimer() {
+    stats_.recordTiming(metricName_, std::chrono::steady_clock::now() - start_);
+  }
+
+  ScopedRuntimeStatsTimer(const ScopedRuntimeStatsTimer&) = delete;
+  ScopedRuntimeStatsTimer& operator=(const ScopedRuntimeStatsTimer&) = delete;
+
+ private:
+  QueryRuntimeStats& stats_;
+  std::string_view metricName_;
+  std::chrono::steady_clock::time_point start_;
+};
+
+/// Merges 'metric' into 'map' under 'name' using CAS-based optimistic locking.
+/// Shared by QueryRuntimeStats and SchedulerStatsRecorder.
+void mergeRuntimeMetric(
+    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
+    const std::string& name,
+    const velox::RuntimeMetric& metric);
+
+} // namespace facebook::axiom

--- a/axiom/common/tests/CMakeLists.txt
+++ b/axiom/common/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_common_tests
   CatalogSchemaTableNameTest.cpp
+  QueryRuntimeStatsTest.cpp
   SchemaTableNameTest.cpp
   SessionConfigTest.cpp
 )

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/QueryRuntimeStats.h"
+
+#include <thread>
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+namespace facebook::axiom {
+namespace {
+
+TEST(QueryRuntimeStatsTest, recordTiming) {
+  QueryRuntimeStats stats;
+  stats.recordTiming(
+      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(100));
+  stats.recordTiming(
+      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(200));
+
+  auto map = stats.toMap();
+  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
+  auto& metric = map.at(std::string(QueryRuntimeStats::kParseWallNanos));
+  EXPECT_EQ(metric.sum, 300);
+  EXPECT_EQ(metric.count, 2);
+  EXPECT_EQ(metric.min, 100);
+  EXPECT_EQ(metric.max, 200);
+  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNanos);
+}
+
+TEST(QueryRuntimeStatsTest, recordCount) {
+  QueryRuntimeStats stats;
+  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 10);
+  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 5);
+
+  auto map = stats.toMap();
+  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kListPartitionsCount)), 1);
+  auto& metric = map.at(std::string(QueryRuntimeStats::kListPartitionsCount));
+  EXPECT_EQ(metric.sum, 15);
+  EXPECT_EQ(metric.count, 2);
+  EXPECT_EQ(metric.min, 5);
+  EXPECT_EQ(metric.max, 10);
+  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNone);
+}
+
+TEST(QueryRuntimeStatsTest, merge) {
+  QueryRuntimeStats stats;
+
+  velox::RuntimeMetric existing(500, velox::RuntimeCounter::Unit::kNanos);
+  existing.addValue(300);
+  stats.merge(QueryRuntimeStats::kOptimizeWallNanos, existing);
+
+  auto map = stats.toMap();
+  auto& metric = map.at(std::string(QueryRuntimeStats::kOptimizeWallNanos));
+  EXPECT_EQ(metric.sum, 800);
+  EXPECT_EQ(metric.count, 2);
+  EXPECT_EQ(metric.min, 300);
+  EXPECT_EQ(metric.max, 500);
+}
+
+TEST(QueryRuntimeStatsTest, toDynamic) {
+  QueryRuntimeStats stats;
+  stats.recordTiming(
+      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(1000));
+  stats.recordCount(QueryRuntimeStats::kGetSplitsCount, 42);
+
+  auto dynamic = stats.toDynamic();
+  ASSERT_TRUE(dynamic.isObject());
+
+  auto parseKey = std::string(QueryRuntimeStats::kParseWallNanos);
+  ASSERT_TRUE(dynamic.count(parseKey));
+  EXPECT_EQ(dynamic[parseKey]["sum"].asInt(), 1000);
+  EXPECT_EQ(dynamic[parseKey]["count"].asInt(), 1);
+  EXPECT_EQ(dynamic[parseKey]["unit"].asString(), "NANO");
+
+  auto splitsKey = std::string(QueryRuntimeStats::kGetSplitsCount);
+  ASSERT_TRUE(dynamic.count(splitsKey));
+  EXPECT_EQ(dynamic[splitsKey]["sum"].asInt(), 42);
+  EXPECT_EQ(dynamic[splitsKey]["unit"].asString(), "NONE");
+}
+
+TEST(QueryRuntimeStatsTest, emptyStats) {
+  QueryRuntimeStats stats;
+  EXPECT_TRUE(stats.toMap().empty());
+
+  auto dynamic = stats.toDynamic();
+  ASSERT_TRUE(dynamic.isObject());
+  EXPECT_TRUE(dynamic.empty());
+}
+
+TEST(QueryRuntimeStatsTest, concurrentRecording) {
+  QueryRuntimeStats stats;
+  constexpr int kThreads = 8;
+  constexpr int kIterations = 1000;
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&stats]() {
+      for (int j = 0; j < kIterations; ++j) {
+        stats.recordTiming(
+            QueryRuntimeStats::kExecuteWallNanos, std::chrono::nanoseconds(1));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  auto map = stats.toMap();
+  auto& metric = map.at(std::string(QueryRuntimeStats::kExecuteWallNanos));
+  EXPECT_EQ(metric.sum, kThreads * kIterations);
+  EXPECT_EQ(metric.count, kThreads * kIterations);
+}
+
+} // namespace
+} // namespace facebook::axiom

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(axiom_runner_local_runner LocalRunner.cpp Runner.cpp)
 
 target_link_libraries(
   axiom_runner_local_runner
+  axiom_common
   axiom_optimizer_multifragment_plan
   axiom_connectors
   velox_common_base

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -76,8 +76,17 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
   auto splitManager = metadata->splitManager();
 
+  auto listStart = std::chrono::steady_clock::now();
   auto partitions = folly::coro::blockingWait(
       splitManager->co_listPartitions(session, handle));
+  if (runtimeStats_) {
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kListPartitionsWallNanos,
+        std::chrono::steady_clock::now() - listStart);
+    runtimeStats_->recordCount(
+        QueryRuntimeStats::kListPartitionsCount, partitions.size());
+  }
+
   return splitManager->getSplitSource(session, handle, partitions);
 }
 
@@ -112,17 +121,21 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     std::shared_ptr<connector::SplitSource> source,
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
-    std::function<void(std::exception_ptr)> onError) {
+    std::function<void(std::exception_ptr)> onError,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   std::exception_ptr ex;
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
 
+    auto getSplitsStart = std::chrono::steady_clock::now();
+    int64_t splitCount = 0;
     size_t taskIdx = 0;
     for (;;) {
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
         tasks[taskIdx]->addSplit(scanId, velox::exec::Split(std::move(split)));
         taskIdx = (taskIdx + 1) % tasks.size();
+        ++splitCount;
       }
       if (batch.noMoreSplits) {
         break;
@@ -130,6 +143,13 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     }
     for (auto& task : tasks) {
       task->noMoreSplits(scanId);
+    }
+
+    if (runtimeStats) {
+      runtimeStats->recordTiming(
+          QueryRuntimeStats::kGetSplitsWallNanos,
+          std::chrono::steady_clock::now() - getSplitsStart);
+      runtimeStats->recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
     }
   } catch (...) {
     ex = std::current_exception();
@@ -194,12 +214,14 @@ LocalRunner::LocalRunner(
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
-    std::string baseSpillDirectory)
+    std::string baseSpillDirectory,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats)
     : plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
-      baseSpillDirectory_{std::move(baseSpillDirectory)} {
+      baseSpillDirectory_{std::move(baseSpillDirectory)},
+      runtimeStats_{std::move(runtimeStats)} {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
   if (!baseSpillDirectory_.empty()) {
@@ -478,7 +500,7 @@ void LocalRunner::makeStages(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),
                 co_generateAndDistributeSplits(
-                    source, scan->id(), stage, onError)));
+                    source, scan->id(), stage, onError, runtimeStats_)));
       }
 
       for (const auto& input : fragment.inputStages) {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -18,6 +18,7 @@
 
 #include <folly/coro/AsyncScope.h>
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
@@ -64,9 +65,16 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
 /// Generic SplitSourceFactory that delegates the work to ConnectorSplitManager.
 class ConnectorSplitSourceFactory : public SplitSourceFactory {
  public:
+  ConnectorSplitSourceFactory(
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr)
+      : runtimeStats_(std::move(runtimeStats)) {}
+
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) override;
+
+ protected:
+  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
 };
 
 /// Runner for in-process execution of a distributed plan.
@@ -78,6 +86,7 @@ class LocalRunner : public Runner,
   /// @param baseSpillDirectory Base directory for spill files. If non-empty,
   /// each task gets a unique subdirectory under this path. Empty disables
   /// spilling at the task level.
+  /// @param runtimeStats Optional recorder for split enumeration metrics.
   LocalRunner(
       optimizer::MultiFragmentPlanPtr plan,
       optimizer::FinishWrite finishWrite,
@@ -85,7 +94,8 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr,
-      std::string baseSpillDirectory = "");
+      std::string baseSpillDirectory = "",
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
 
   ~LocalRunner() override;
 
@@ -176,6 +186,7 @@ class LocalRunner : public Runner,
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
+  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
   folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
   bool splitScopeJoined_{false};
 };


### PR DESCRIPTION
Summary:
Axiom's query pipeline had no runtime metrics reporting — the `runtimeStats` field in `CliQueryLogger` was hardcoded to `"{}"`. This adds `QueryRuntimeStats`, a thread-safe metrics collector using `velox::RuntimeMetric` (sum/count/min/max per metric), and wires it across the Axiom CLI pipeline.

Eleven metrics cover the full pipeline: parse time, optimizer sub-phases (toGraph, bestPlan, toVelox), split manager timing (listPartitions, getSplits) with partition/split counts, permission check time, and execution time.

The class lives in `axiom/common/` so both Axiom and Axel can use it. A shared `mergeRuntimeMetric()` free function extracts the CAS-based optimistic merge loop that was duplicated between `QueryRuntimeStats` and `SchedulerStatsRecorder`.

`CliQueryLogger` now serializes the collected metrics into the `runtimeStats` Scuba field via `toDynamic()`, replacing the hardcoded empty object.

Planned follow-ups: connector-level `findTable` timing (Schema→Metastore) and `co_estimateStats` timing during optimization.

Reviewed By: arhimondr

Differential Revision: D103452410


