### PR TITLE
feat(optimizer): SubfieldTracker handles OutputNode natively for column pruning (#1316)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -64,12 +64,30 @@ Optimization::Optimization(
   queryCtx()->optimization() = this;
 
   const auto* planRoot = logicalPlan_;
+  std::vector<int32_t> outputOrdinals;
   if (logicalPlan_->is(logical_plan::NodeKind::kOutput)) {
-    outputNames_ = logicalPlan_->as<logical_plan::OutputNode>()->entries();
+    const auto& entries =
+        logicalPlan_->as<logical_plan::OutputNode>()->entries();
+    outputNames_ = entries;
     planRoot = logicalPlan_->onlyInput().get();
+    outputOrdinals.reserve(entries.size());
+    for (const auto& entry : entries) {
+      outputOrdinals.push_back(entry.index);
+    }
+
+    // Remap outputNames_ indices to sequential positions after pruning.
+    std::sort(
+        outputNames_.begin(),
+        outputNames_.end(),
+        [](const auto& left, const auto& right) {
+          return left.index < right.index;
+        });
+    for (auto i = 0; i < outputNames_.size(); ++i) {
+      outputNames_[i].index = i;
+    }
   }
 
-  root_ = toGraph_.makeQueryGraph(*planRoot);
+  root_ = toGraph_.makeQueryGraph(*planRoot, std::move(outputOrdinals));
   root_->initializePlans();
 }
 

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -665,6 +665,20 @@ void SubfieldTracker::markAllSubfields(
   }
 }
 
+void SubfieldTracker::markSelectedSubfields(
+    const lp::LogicalPlanNode& node,
+    const std::vector<int32_t>& ordinals,
+    const MarkFieldsAccessedContext& context) {
+  markControl(node, context);
+
+  LogicalContextSource source = {.planNode = &node};
+  std::vector<Step> steps;
+  for (auto i : ordinals) {
+    markFieldAccessed(source, i, steps, /*isControl=*/false, context);
+    VELOX_CHECK(steps.empty());
+  }
+}
+
 bool PlanSubfields::hasColumn(
     const logical_plan::LogicalPlanNode* node,
     int32_t ordinal) const {

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -75,9 +75,19 @@ class SubfieldTracker {
 
   /// Goes over the local plan and collects all accessed columns and subfields.
   /// Reports 'control' and 'payload' columns and subfields separately.
+  ///
+  /// @param outputOrdinals If non-empty, only these ordinals of the root node
+  /// are marked as payload-accessed, enabling pruning of columns that
+  /// OutputNode does not export. When empty, all root output columns are
+  /// marked.
   std::pair<PlanSubfields, PlanSubfields> markAll(
-      const logical_plan::LogicalPlanNode& node) && {
-    markAllSubfields(node, {});
+      const logical_plan::LogicalPlanNode& node,
+      std::vector<int32_t> outputOrdinals = {}) && {
+    if (outputOrdinals.empty()) {
+      markAllSubfields(node, {});
+    } else {
+      markSelectedSubfields(node, outputOrdinals, {});
+    }
     return {controlSubfields_, payloadSubfields_};
   }
 
@@ -136,6 +146,11 @@ class SubfieldTracker {
 
   void markAllSubfields(
       const logical_plan::LogicalPlanNode& node,
+      const MarkFieldsAccessedContext& context);
+
+  void markSelectedSubfields(
+      const logical_plan::LogicalPlanNode& node,
+      const std::vector<int32_t>& ordinals,
       const MarkFieldsAccessedContext& context);
 
   void markControl(

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3585,11 +3585,13 @@ NormalizedJoin normalizeLogicalJoin(const lp::JoinNode& join) {
 
 } // namespace
 
-DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
+DerivedTableP ToGraph::makeQueryGraph(
+    const lp::LogicalPlanNode& logicalPlan,
+    std::vector<int32_t> outputOrdinals) {
   std::tie(controlSubfields_, payloadSubfields_) =
       SubfieldTracker([&](const auto& expr) {
         return tryFoldConstant(expr);
-      }).markAll(logicalPlan);
+      }).markAll(logicalPlan, std::move(outputOrdinals));
   currentDt_ = newDt();
   makeQueryGraph(logicalPlan, kAllAllowedInDt);
   setDtUsedOutput(currentDt_, logicalPlan);

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -112,7 +112,8 @@ class ToGraph {
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
   /// DerivedTable.
   DerivedTableP makeQueryGraph(
-      const logical_plan::LogicalPlanNode& logicalPlan);
+      const logical_plan::LogicalPlanNode& logicalPlan,
+      std::vector<int32_t> outputOrdinals = {});
 
   Name newCName(std::string_view prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -317,6 +317,24 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   }
 }
 
+TEST_F(AggregationTest, outputNodePrunesUnexportedColumns) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+
+  auto ctx = makeContext();
+  auto scan = lp::PlanBuilder(ctx).tableScan("t").planNode();
+  auto logicalPlan = std::make_shared<lp::OutputNode>(
+      ctx.planNodeIdGenerator->next(),
+      scan,
+      std::vector<lp::OutputNode::Entry>{{0, "a"}, {2, "c"}});
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t", ROW({"a", "c"}, BIGINT())).build();
+
+  AXIOM_ASSERT_PLAN(plan, matcher);
+  VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW({"a", "c"}, BIGINT()));
+}
+
 // TODO: Add tests for maybeProject() cost tracking once Project::unitCost is
 // implemented (currently 0, see the TODO in Project::Project). The
 // optimizationCost() helper is available for verifying cost differences between


### PR DESCRIPTION
Summary:

SubfieldTracker now handles OutputNode at the plan root instead of requiring the caller to strip it first. When OutputNode is present, only the ordinals listed in its entries are marked as payload-accessed, enabling the optimizer to prune internal columns that OutputNode does not export (e.g. $grouping_set_id from GROUPING SETS).

Previously, the Optimization constructor stripped OutputNode before passing the plan to makeQueryGraph/SubfieldTracker. Now the full plan flows through SubfieldTracker first (which detects and handles OutputNode), then OutputNode is stripped in makeQueryGraph before building DerivedTables. The outputNames_ indices are remapped after pruning to match the surviving column positions.

This is a no-op refactoring today — OutputNode currently exports all columns 1:1. The pruning activates when GroupId (D94281152) introduces $grouping_set_id as an internal column that OutputNode omits.

Axel continues to work unchanged — it still strips OutputNode before calling the optimizer, so the new code path is never triggered. A follow-up Axel diff will stop stripping OutputNode to enable pruning in distributed execution.

Differential Revision: D103705097


