### PR TITLE
fix(optimizer): Skip Repartitions in UNION distinct when all inputs are gather-distributed (#1317)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3195,12 +3195,20 @@ PlanP Optimization::makeUnionPlan(
 
   if (!distribution.has_value()) {
     if (isDistinct) {
-      // Pick some partitioning key and shuffle on that and make distinct.
-      Distribution someDistribution = somePartition(inputs);
-      for (auto i = 0; i < inputs.size(); ++i) {
-        inputs[i] = make<Repartition>(
-            inputs[i], someDistribution, inputs[i]->columns());
-        inputStates[i].addCost(*inputs[i]);
+      // Skip Repartitions when all inputs have gather distribution (e.g.,
+      // Values, global aggregation, Limit). All data is already on a single
+      // node, so hash-partitioning for dedup is unnecessary.
+      const bool allGather =
+          std::all_of(inputs.begin(), inputs.end(), [](const auto& input) {
+            return input->distribution().isGather();
+          });
+      if (!allGather) {
+        Distribution someDistribution = somePartition(inputs);
+        for (auto i = 0; i < inputs.size(); ++i) {
+          inputs[i] = make<Repartition>(
+              inputs[i], someDistribution, inputs[i]->columns());
+          inputStates[i].addCost(*inputs[i]);
+        }
       }
     }
   } else {

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1095,6 +1095,51 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
   }
 }
 
+// UNION ALL where one leg is a constant and another contains a UNION (distinct)
+// over constants.
+TEST_F(SetTest, unionAllWithValuesOnlyUnionSubquery) {
+  auto logicalPlan = parseSelect(
+      "SELECT 'x'"
+      " UNION ALL"
+      " SELECT * FROM (SELECT 'a' UNION SELECT 'b')");
+
+  // Single-node plan: inner UNION is a round-robin LocalPartition (2 sources)
+  // followed by Aggregation for dedup.
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(
+      plan,
+      matchValues()
+          .project({"'x' as x"})
+          .localPartition(
+              matchValues()
+                  .project({"'a' as a"})
+                  .localPartition(matchValues().project({"'b'"}).build())
+                  .singleAggregation({"a"}, {})
+                  .project({"a"})
+                  .build())
+          .build());
+
+  // Distributed plan: All inputs of the inner UNION are Values
+  // (gather-distributed), so no remote exchanges before aggregation.
+  // TODO: the localPartition by 'a' added by ToVelox is redundant with
+  // localPartition of inner UNION. Remove the extra localPartition by 'a'.
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan,
+      matchValues()
+          .project({"'x' as x"})
+          .localPartition(
+              matchValues()
+                  .project({"'a' as a"})
+                  .localPartition(matchValues().project({"'b'"}).build())
+                  .localPartition({"a"})
+                  .singleAggregation({"a"}, {})
+                  .project({"a"})
+                  .build())
+          .gather()
+          .build());
+}
+
 TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
   std::vector<std::string> widthConstrainingInputs = {
       "SELECT 1",

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -192,3 +192,8 @@ SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
 -- ROW subfield access in UNION ALL with named field.
 -- duckdb: VALUES (1), (3)
 SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))
+----
+-- UNION ALL with nested UNION subquery over constants.
+SELECT 'x'
+UNION ALL
+SELECT * FROM (SELECT 'a' UNION SELECT 'b')


### PR DESCRIPTION
Summary:

In multi-worker mode, makeUnionPlan in Optimization.cpp
adds hash-partitioned Repartition nodes for UNION
DISTINCT to shuffle data for deduplication. When all
inputs are gather-distributed (e.g., Values nodes from
constant expressions), the consumer fragment has
width=1. The Repartition nodes produce hash-partitioned
exchanges with non-empty partitioning keys targeting
that single-partition consumer, which causes ToVelox to
throw "Non-empty partitioning keys require more than
one partition". This PR fixes it by not inserting Repartition
nodes when all inputs already have gather distribution,
since all data is on a single node and dedup can run
locally without exchanges.

Differential Revision: D103766267


