### PR TITLE
feat: Add findTable connector timing to QueryRuntimeStats

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -910,7 +910,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
       queryCtx,
       evaluator,
       optimizerOptions,
-      opts);
+      opts,
+      runtimeStats);
 
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {
     return {};

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -60,6 +60,12 @@ class QueryRuntimeStats {
   static constexpr std::string_view kPermissionCheckWallNanos{
       "axiom-permissionCheckWallNanos"};
 
+  // Connector.
+  static constexpr std::string_view kFindTableWallNanos{
+      "axiom-findTableWallNanos"};
+  static constexpr std::string_view kEstimateStatsWallNanos{
+      "axiom-estimateStatsWallNanos"};
+
   // Execution.
   static constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -43,7 +43,8 @@ Optimization::Optimization(
     std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
     velox::core::ExpressionEvaluator& evaluator,
     OptimizerOptions options,
-    MultiFragmentPlan::Options runnerOptions)
+    MultiFragmentPlan::Options runnerOptions,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats)
     : session_{std::move(session)},
       options_(std::move(options)),
       runnerOptions_(std::move(runnerOptions)),
@@ -57,8 +58,9 @@ Optimization::Optimization(
           isSingleWorker_,
           isSingleDriver_,
           options_.alwaysPlanPartialAggregation},
-      toGraph_{schema, evaluator, options_},
-      toVelox_{session_, runnerOptions_, options_} {
+      toGraph_{schema, evaluator, options_, runtimeStats},
+      toVelox_{session_, runnerOptions_, options_},
+      runtimeStats_{std::move(runtimeStats)} {
   queryCtx()->optimization() = this;
 
   const auto* planRoot = logicalPlan_;
@@ -161,9 +163,15 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
   // query context executor if available, otherwise run inline.
   auto collectTask = folly::coro::collectAllRange(std::move(tasks));
   auto* executor = veloxQueryCtx_->executor();
+  auto estimateStart = std::chrono::steady_clock::now();
   auto results = executor ? folly::coro::blockingWait(co_withExecutor(
                                 executor, std::move(collectTask)))
                           : folly::coro::blockingWait(std::move(collectTask));
+  if (runtimeStats_) {
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kEstimateStatsWallNanos,
+        std::chrono::steady_clock::now() - estimateStart);
+  }
 
   // Apply results.
   for (auto& [baseTable, taskIndex, columnIndices] : tableTasks) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/common/Session.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/AggregationPlanner.h"
@@ -42,7 +43,8 @@ class Optimization {
       std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
       velox::core::ExpressionEvaluator& evaluator,
       OptimizerOptions options = {},
-      MultiFragmentPlan::Options runnerOptions = {});
+      MultiFragmentPlan::Options runnerOptions = {},
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
 
   /// Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
@@ -381,6 +383,8 @@ class Optimization {
   // duplicate processing when the same BaseTable appears in multiple DTs
   // (e.g., via existence pushdown).
   folly::F14FastSet<int32_t> estimatedBaseTables_;
+
+  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -130,7 +130,13 @@ SchemaTableCP Schema::findTable(
 
   VELOX_CHECK_NOT_NULL(source_);
 
+  auto findStart = std::chrono::steady_clock::now();
   auto connectorTable = source_->findTable(std::string(connectorId), tableName);
+  if (runtimeStats_) {
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kFindTableWallNanos,
+        std::chrono::steady_clock::now() - findStart);
+  }
   if (!connectorTable) {
     return nullptr;
   }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/PlanObject.h"
 
@@ -404,7 +405,10 @@ struct SchemaTable {
 class Schema {
  public:
   /// Constructs a Schema for producing executable plans, backed by 'source'.
-  explicit Schema(const connector::SchemaResolver& source) : source_{&source} {}
+  explicit Schema(
+      const connector::SchemaResolver& source,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr)
+      : source_{&source}, runtimeStats_{std::move(runtimeStats)} {}
 
   /// Returns the table with 'name' or nullptr if not found, using
   /// the connector specified by connectorId to perform table lookups.
@@ -426,6 +430,7 @@ class Schema {
   using ConnectorMap = folly::F14FastMap<std::string_view, TableMap>;
 
   const connector::SchemaResolver* source_;
+  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
   mutable ConnectorMap connectorTables_;
 };
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -92,8 +92,9 @@ velox::ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
 ToGraph::ToGraph(
     const connector::SchemaResolver& schema,
     velox::core::ExpressionEvaluator& evaluator,
-    const OptimizerOptions& options)
-    : schema_{schema},
+    const OptimizerOptions& options,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats)
+    : schema_{schema, std::move(runtimeStats)},
       evaluator_{evaluator},
       options_{options},
       functionNames_{queryCtx()->functionNames()} {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/PathSet.h"
@@ -105,7 +106,8 @@ class ToGraph {
   ToGraph(
       const connector::SchemaResolver& schemaResolver,
       velox::core::ExpressionEvaluator& evaluator,
-      const OptimizerOptions& options);
+      const OptimizerOptions& options,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
 
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
   /// DerivedTable.


### PR DESCRIPTION
Summary:
Adds `axiom-findTableWallNanos` metric to track wall-clock time spent in connector metadata resolution (Metastore RPCs). Threads `runtimeStats` from `Optimization` → `ToGraph` → `Schema::findTable()`, where the `source_->findTable()` call is timed. Since `runtimeStats` is already on `Optimization` (from the parent diff), this works in both CLI and Axel paths automatically.

The metric accumulates across multiple tables in a query — a 3-table JOIN records 3 separate timings merged into one sum/count/min/max metric.

Reviewed By: arhimondr

Differential Revision: D103795953


