### PR TITLE
fix(optimizer): Propagate distribution through UnionAll

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3200,12 +3200,20 @@ PlanP Optimization::makeUnionPlan(
 
   if (!distribution.has_value()) {
     if (isDistinct) {
-      // Pick some partitioning key and shuffle on that and make distinct.
-      Distribution someDistribution = somePartition(inputs);
-      for (auto i = 0; i < inputs.size(); ++i) {
-        inputs[i] = make<Repartition>(
-            inputs[i], someDistribution, inputs[i]->columns());
-        inputStates[i].addCost(*inputs[i]);
+      // Skip Repartitions when all inputs have gather distribution (e.g.,
+      // Values, global aggregation, Limit). All data is already on a single
+      // node, so hash-partitioning for dedup is unnecessary.
+      const bool allGather =
+          std::all_of(inputs.begin(), inputs.end(), [](const auto& input) {
+            return input->distribution().isGather();
+          });
+      if (!allGather) {
+        Distribution someDistribution = somePartition(inputs);
+        for (auto i = 0; i < inputs.size(); ++i) {
+          inputs[i] = make<Repartition>(
+              inputs[i], someDistribution, inputs[i]->columns());
+          inputStates[i].addCost(*inputs[i]);
+        }
       }
     }
   } else {

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1699,8 +1699,31 @@ void Limit::accept(
   visitor.visit(*this, context);
 }
 
+namespace {
+// Propagates distribution through UnionAll: if all inputs share the same gather
+// or hash-partition distribution, the UnionAll preserves it.
+Distribution unionAllDistribution(const RelationOpPtrVector& inputs) {
+  if (std::all_of(inputs.begin(), inputs.end(), [](const auto& input) {
+        return input->distribution().isGather();
+      })) {
+    return Distribution::gather();
+  }
+
+  const auto& first = inputs[0]->distribution();
+  if (!first.isBroadcast() && !first.isGather() &&
+      std::all_of(inputs.begin() + 1, inputs.end(), [&](const auto& input) {
+        return !input->distribution().isBroadcast() &&
+            input->distribution().isSamePartition(first);
+      })) {
+    return Distribution{first.distributionType(), first.partitionKeys()};
+  }
+
+  return Distribution{};
+}
+} // namespace
+
 UnionAll::UnionAll(RelationOpPtrVector inputsVector)
-    : RelationOp{RelType::kUnionAll, nullptr, Distribution{}, inputsVector[0]->columns()},
+    : RelationOp{RelType::kUnionAll, nullptr, unionAllDistribution(inputsVector), inputsVector[0]->columns()},
       inputs{std::move(inputsVector)} {
   cost_.inputCardinality = 0;
   for (auto& input : inputs) {

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1095,6 +1095,53 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
   }
 }
 
+// UNION ALL where one leg is a constant and another contains a UNION (distinct)
+// over constants. The inner UNION skips Repartitions since all inputs are
+// Values — dedup runs locally without exchanges.
+TEST_F(SetTest, unionAllWithValuesOnlyUnionSubquery) {
+  auto logicalPlan = parseSelect(
+      "SELECT 'x'"
+      " UNION ALL"
+      " SELECT * FROM (SELECT 'a' UNION SELECT 'b') c");
+
+  // Single-node plan: inner UNION is a round-robin LocalPartition (2 sources)
+  // followed by Aggregation for dedup. No hash LocalPartition.
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(
+      plan,
+      matchValues()
+          .project()
+          .localPartition(
+              matchValues()
+                  .project()
+                  .localPartition(matchValues().project().build())
+                  .aggregation()
+                  .project()
+                  .build())
+          .build());
+
+  // Distributed plan: same structure with a gather at the root. No remote
+  // exchanges for the inner UNION because all inputs are Values (width=1).
+  // Without this fix, planVelox would throw "Non-empty partitioning keys
+  // require more than one partition" because the inner UNION's Repartitions
+  // target a width=1 consumer.
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan,
+      matchValues()
+          .project()
+          .localPartition(
+              matchValues()
+                  .project()
+                  .localPartition(matchValues().project().build())
+                  .localPartition()
+                  .aggregation()
+                  .project()
+                  .build())
+          .gather()
+          .build());
+}
+
 TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
   std::vector<std::string> widthConstrainingInputs = {
       "SELECT 1",

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -681,11 +681,11 @@ TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
   auto plan = toSingleNodePlan(logicalPlan);
   AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
 
-  // TODO: The distributed plan has a redundant gather since there are no
-  // table scans. Check isSingleThreadedPipeline in ToVelox.
+  // Distributed plan: all Values inputs have gather distribution, so the
+  // UnionAll also has gather distribution. No remote exchanges, single
+  // fragment, same as the single-node plan.
   auto distributedPlan = planVelox(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, buildMatcher().build());
 }
 
 // Same as above but with a table column referenced twice (SELECT x as a, x as
@@ -1120,11 +1120,10 @@ TEST_F(SetTest, unionAllWithValuesOnlyUnionSubquery) {
                   .build())
           .build());
 
-  // Distributed plan: same structure with a gather at the root. No remote
-  // exchanges for the inner UNION because all inputs are Values (width=1).
-  // Without this fix, planVelox would throw "Non-empty partitioning keys
-  // require more than one partition" because the inner UNION's Repartitions
-  // target a width=1 consumer.
+  // Distributed plan: all Values inputs have gather distribution, so the
+  // UnionAll also has gather distribution. No remote exchanges, single
+  // fragment, same structure as the single-node plan plus the inner hash
+  // LocalPartition before dedup.
   auto distributedPlan = planVelox(logicalPlan);
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       distributedPlan.plan,
@@ -1138,7 +1137,6 @@ TEST_F(SetTest, unionAllWithValuesOnlyUnionSubquery) {
                   .aggregation()
                   .project()
                   .build())
-          .gather()
           .build());
 }
 
@@ -1159,6 +1157,58 @@ TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
             input));
     VELOX_ASSERT_THROW(planVelox(plan), "Partition count mismatch");
   }
+}
+
+// Both inner GROUP BYs shuffle on n_regionkey, so both legs have
+// hash(n_regionkey) distribution. unionAllDistribution propagates it, so the
+// outer GROUP BY needs no additional shuffle.
+TEST_F(SetTest, unionAllPreservesMatchingHashDistribution) {
+  auto logicalPlan = parseSelect(
+      "SELECT n_regionkey, SUM(cnt) FROM ("
+      "  SELECT n_regionkey, COUNT(n_name) as cnt"
+      "    FROM nation GROUP BY n_regionkey"
+      "  UNION ALL"
+      "  SELECT n_regionkey, COUNT(n_nationkey) as cnt"
+      "    FROM nation GROUP BY n_regionkey"
+      ") t GROUP BY n_regionkey");
+
+  auto distributedPlan = planVelox(logicalPlan);
+
+  // The second leg's columns are disambiguated (n_regionkey_2) because both
+  // legs scan the same table.
+  auto innerLeg = [](const std::string& key) {
+    return core::PlanMatcherBuilder()
+        .tableScan("nation")
+        .partialAggregation()
+        .shuffle({key})
+        .localPartition({key})
+        .finalAggregation();
+  };
+
+  // Outer GROUP BY: localPartition → aggregation with NO shuffle.
+  // Without hash propagation, the optimizer would add a redundant shuffle here.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan,
+      innerLeg("n_regionkey")
+          .localPartition(innerLeg("n_regionkey_2").project().build())
+          .localPartition({"n_regionkey"})
+          .aggregation()
+          .gather()
+          .build());
+}
+
+// All inputs are gather distribution. unionAllDistribution propagates
+// gather, so the distributed plan needs no root gather exchange.
+TEST_F(SetTest, unionAllPreservesMatchingGatherDistribution) {
+  auto logicalPlan = parseSelect("SELECT 1 UNION ALL SELECT 2");
+
+  auto distributedPlan = planVelox(logicalPlan);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      distributedPlan.plan,
+      matchValues()
+          .project()
+          .localPartition({matchValues().project().build()})
+          .build());
 }
 
 } // namespace

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -200,3 +200,14 @@ SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 
 SELECT 'x'
 UNION ALL
 SELECT * FROM (SELECT 'a' UNION SELECT 'b') c
+----
+-- UNION ALL of two GROUP BYs on the same key. UNION ALL preserves the distribution so the outer
+-- GROUP BY needs no additional shuffle.
+SELECT a, SUM(cnt) FROM (
+  SELECT a, COUNT(b) as cnt FROM t GROUP BY a
+  UNION ALL
+  SELECT a, COUNT(c) as cnt FROM t GROUP BY a
+) sub GROUP BY a
+----
+-- UNION ALL of two gather distributions. No shuffle required.
+SELECT 1 UNION ALL SELECT 2

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -192,3 +192,11 @@ SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
 -- ROW subfield access in UNION ALL with named field.
 -- duckdb: VALUES (1), (3)
 SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))
+----
+-- UNION ALL with nested UNION subquery over constants.
+-- Regression test: UNION over Values skips Repartitions, avoiding a crash
+-- when the consumer fragment has width=1.
+-- duckdb: VALUES ('x'), ('a'), ('b')
+SELECT 'x'
+UNION ALL
+SELECT * FROM (SELECT 'a' UNION SELECT 'b') c


### PR DESCRIPTION
Summary:
UnionAll always reported Distribution{} regardless of its inputs, discarding distribution 
metadata. This caused two inefficiencies:
1. a redundant gather exchange at the root for all-Values UNION ALLs that are already on 
a single node,
2. redundant shuffles when a UNION ALL of identically-partitioned inputs feeds into a 
consumer that needs the same partitioning.

This fix adds unionAllDistribution() in UnionAll constructor which propagates the common 
distribution: gather when all inputs are gather, matching hash partition when all inputs 
share the same hash partition, Distribution{} otherwise.

Differential Revision: D103790718


