### PR TITLE
feat(config): Support config-file overrides in ConfigRegistry

### DIFF
--- a/axiom/common/ConfigRegistry.cpp
+++ b/axiom/common/ConfigRegistry.cpp
@@ -24,7 +24,8 @@ using velox::config::ConfigProvider;
 
 void ConfigRegistry::add(
     std::string_view prefix,
-    std::shared_ptr<ConfigProvider> provider) {
+    std::shared_ptr<ConfigProvider> provider,
+    const std::unordered_map<std::string, std::string>& configFileOverrides) {
   const auto key = std::string(prefix);
   VELOX_USER_CHECK(
       providers_.find(key) == providers_.end(),
@@ -34,6 +35,11 @@ void ConfigRegistry::add(
   folly::F14FastMap<std::string, ConfigProperty> propertyMap;
   for (auto& prop : provider->properties()) {
     auto name = prop.name;
+    // Override code default with config-file value if available.
+    auto fileIt = configFileOverrides.find(name);
+    if (fileIt != configFileOverrides.end()) {
+      prop.defaultValue = fileIt->second;
+    }
     VELOX_CHECK(
         propertyMap.emplace(name, std::move(prop)).second,
         "Duplicate config property: {}.{}",

--- a/axiom/common/ConfigRegistry.h
+++ b/axiom/common/ConfigRegistry.h
@@ -33,9 +33,16 @@ class ConfigRegistry {
   /// to the provider's property list are not reflected. Throws if the
   /// prefix is already registered. Not thread-safe — call only during
   /// single-threaded startup before sharing the registry.
+  ///
+  /// If 'configFileOverrides' is provided, its values override the code
+  /// defaults in ConfigProperty::defaultValue for matching property names.
+  /// This enables a three-layer config cascade: code default → config file
+  /// → session override.
   void add(
       std::string_view prefix,
-      std::shared_ptr<velox::config::ConfigProvider> provider);
+      std::shared_ptr<velox::config::ConfigProvider> provider,
+      const std::unordered_map<std::string, std::string>& configFileOverrides =
+          {});
 
   /// Result of resolving a prefix-qualified property name.
   struct Resolution {

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -169,4 +169,53 @@ TEST_F(SessionConfigTest, duplicatePrefix) {
       "Config prefix already registered");
 }
 
+TEST(ConfigRegistryTest, configFileDefaults) {
+  auto registry = std::make_shared<ConfigRegistry>();
+  registry->add(
+      "test",
+      std::make_shared<TestConfigProvider>(),
+      {{"flag_a", "false"}, {"count", "99"}});
+
+  // Verify overridden defaults via resolve().
+  auto flagResolution = registry->resolve("test.flag_a");
+  EXPECT_EQ(flagResolution.property.defaultValue, "false");
+
+  auto countResolution = registry->resolve("test.count");
+  EXPECT_EQ(countResolution.property.defaultValue, "99");
+
+  // Properties not in the config file retain their code defaults.
+  auto ratioResolution = registry->resolve("test.ratio");
+  EXPECT_EQ(ratioResolution.property.defaultValue, "0.5");
+
+  // SessionConfig sees the config-file defaults.
+  SessionConfig config(registry);
+  EXPECT_EQ(config.effectiveValue("test.flag_a"), "false");
+  EXPECT_EQ(config.effectiveValue("test.count"), "99");
+  EXPECT_EQ(config.effectiveValue("test.ratio"), "0.5");
+
+  // Session override still wins over config-file default.
+  config.set("test.flag_a", "true");
+  EXPECT_EQ(config.effectiveValue("test.flag_a"), "true");
+
+  // Reset returns to config-file default, not code default.
+  config.reset("test.flag_a");
+  EXPECT_EQ(config.effectiveValue("test.flag_a"), "false");
+
+  // effectiveValues returns config-file defaults for unset properties.
+  auto props = config.effectiveValues("test");
+  EXPECT_EQ(props["flag_a"], "false");
+  EXPECT_EQ(props["count"], "99");
+  EXPECT_EQ(props["ratio"], "0.5");
+
+  // all() shows config-file default as the default value.
+  auto entries = config.all();
+  for (const auto& entry : entries) {
+    if (entry.property.name == "flag_a") {
+      EXPECT_EQ(entry.property.defaultValue, "false");
+      EXPECT_EQ(entry.currentValue, "false");
+      EXPECT_FALSE(entry.isOverridden);
+    }
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
Add support for overriding code defaults with config-file values in ConfigRegistry::add(). This enables a three-layer configuration cascade: code default → config file → session override.

Previously, ConfigProvider only knew about code-defined defaults (e.g., spill_enabled=false from QueryConfig.h). When an application loaded different defaults from a config file (e.g., spill-enabled=true from config.properties), ConfigRegistry had no way to reflect that. This caused SessionConfig::effectiveValues() to return code defaults instead of deployment defaults, which could shadow config-file values.

The fix adds an optional configFileOverrides parameter to ConfigRegistry::add(). When provided, matching property names have their ConfigProperty::defaultValue updated in the registry's snapshot.

Differential Revision: D103955913


