### PR TITLE
fix(optimizer): Fix semi-join with more than one key of correlated IN (#1322)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3040,7 +3040,8 @@ ExprCP ToGraph::processCorrelatedInPredicate(
     ExprCP leftKey,
     PlanObjectCP leftTable) {
   // Correlated IN subquery: process correlation conditions and create
-  // semi-join with both correlation equalities and IN equality.
+  // semi-join with the IN equality as the sole null-aware join key and
+  // correlation equalities moved to the join filter.
   auto decorrelated =
       extractDecorrelatedJoin(functionNames_, correlatedConjuncts_, subqueryDt);
   if (leftTable) {
@@ -3056,6 +3057,24 @@ ExprCP ToGraph::processCorrelatedInPredicate(
     joinLeftTable = decorrelated.leftTables.onlyObject();
   }
 
+  // Only the IN equality should be a null-aware join key. Correlation
+  // equalities are standard WHERE clause predicates with different null
+  // semantics, so they belong in the filter. Correlation equalities that match
+  // the IN key are redundant and dropped.
+  auto inRightKey = subqueryDt->columns.front();
+  for (auto i = 0; i < decorrelated.leftKeys.size(); ++i) {
+    if (decorrelated.leftKeys[i] == leftKey &&
+        decorrelated.rightKeys[i] == inRightKey) {
+      continue;
+    }
+    decorrelated.filter.push_back(
+        make<Call>(
+            functionNames_.equality,
+            toValue(velox::BOOLEAN(), 2),
+            ExprVector{decorrelated.leftKeys[i], decorrelated.rightKeys[i]},
+            FunctionSet()));
+  }
+
   auto* edge = JoinEdge::makeExists(
       joinLeftTable,
       subqueryDt,
@@ -3064,13 +3083,8 @@ ExprCP ToGraph::processCorrelatedInPredicate(
       /*nullAwareIn=*/true);
   currentDt_->joins.push_back(edge);
 
-  // Add correlation equalities.
-  for (auto i = 0; i < decorrelated.leftKeys.size(); ++i) {
-    edge->addEquality(decorrelated.leftKeys[i], decorrelated.rightKeys[i]);
-  }
-
-  // Add IN equality.
-  edge->addEquality(leftKey, subqueryDt->columns.front());
+  // Add IN equality as the single join key.
+  edge->addEquality(leftKey, inRightKey);
 
   return markColumn;
 }

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -767,24 +767,20 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
       const std::shared_ptr<PlanMatcher>& left,
       const std::shared_ptr<PlanMatcher>& right,
       JoinType joinType,
-      bool nullAware)
+      const HashJoinDetails& details)
       : PlanMatcherImpl<HashJoinNode>({left, right}),
         joinType_{joinType},
-        nullAware_{nullAware} {}
-
-  HashJoinMatcher(
-      const std::shared_ptr<PlanMatcher>& left,
-      const std::shared_ptr<PlanMatcher>& right,
-      JoinType joinType,
-      const std::vector<std::string>& outputColumnNames)
-      : PlanMatcherImpl<HashJoinNode>({left, right}),
-        joinType_{joinType},
-        outputColumnNames_(
-            {outputColumnNames.begin(), outputColumnNames.end()}) {
-    VELOX_USER_CHECK_EQ(
-        outputColumnNames_->size(),
-        outputColumnNames.size(),
-        "Duplicate column names in outputColumnNames");
+        nullAware_{details.nullAware},
+        leftKeys_{details.leftKeys},
+        rightKeys_{details.rightKeys},
+        filter_{details.filter},
+        outputColumnNames_{details.outputColumnNames} {
+    if (leftKeys_.has_value() && rightKeys_.has_value()) {
+      VELOX_CHECK_EQ(
+          leftKeys_->size(),
+          rightKeys_->size(),
+          "leftKeys and rightKeys must have the same size");
+    }
   }
 
   MatchResult matchDetails(
@@ -805,6 +801,47 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
 
     AXIOM_TEST_RETURN_IF_FAILURE
 
+    if (leftKeys_.has_value()) {
+      EXPECT_EQ(plan.leftKeys().size(), leftKeys_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < leftKeys_->size(); ++i) {
+        auto it = symbols.find((*leftKeys_)[i]);
+        auto expected = it != symbols.end() ? it->second : (*leftKeys_)[i];
+        EXPECT_EQ(plan.leftKeys()[i]->name(), expected);
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    if (rightKeys_.has_value()) {
+      EXPECT_EQ(plan.rightKeys().size(), rightKeys_->size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+
+      for (auto i = 0; i < rightKeys_->size(); ++i) {
+        auto it = symbols.find((*rightKeys_)[i]);
+        auto expected = it != symbols.end() ? it->second : (*rightKeys_)[i];
+        EXPECT_EQ(plan.rightKeys()[i]->name(), expected);
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    if (filter_.has_value()) {
+      if (filter_->empty()) {
+        EXPECT_EQ(plan.filter(), nullptr);
+      } else {
+        EXPECT_NE(plan.filter(), nullptr);
+        AXIOM_TEST_RETURN_IF_FAILURE
+
+        auto expected =
+            parse::DuckSqlExpressionsParser().parseExpr(filter_.value());
+        if (!symbols.empty()) {
+          expected = rewriteInputNames(expected, symbols);
+        }
+        ExprMatcher::match(plan.filter(), expected->dropAlias());
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
     if (outputColumnNames_.has_value()) {
       const auto& outputType = plan.outputType();
 
@@ -812,7 +849,13 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
       std::set<std::string> expectedColumns;
       for (const auto& name : *outputColumnNames_) {
         auto it = symbols.find(name);
-        expectedColumns.insert(it != symbols.end() ? it->second : name);
+        const auto& resolved = it != symbols.end() ? it->second : name;
+        VELOX_USER_CHECK_EQ(
+            expectedColumns.count(resolved),
+            0,
+            "Duplicate output column name: {}",
+            resolved);
+        expectedColumns.insert(resolved);
       }
 
       std::set<std::string> actualColumns;
@@ -831,7 +874,10 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
  private:
   const std::optional<JoinType> joinType_;
   const std::optional<bool> nullAware_;
-  const std::optional<std::set<std::string>> outputColumnNames_;
+  const std::optional<std::vector<std::string>> leftKeys_;
+  const std::optional<std::vector<std::string>> rightKeys_;
+  const std::optional<std::string> filter_;
+  const std::optional<std::vector<std::string>> outputColumnNames_;
 };
 
 class NestedLoopJoinMatcher : public PlanMatcherImpl<NestedLoopJoinNode> {
@@ -1736,9 +1782,17 @@ PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
     const std::shared_ptr<PlanMatcher>& rightMatcher,
     JoinType joinType,
     bool nullAware) {
+  return hashJoin(
+      rightMatcher, joinType, HashJoinDetails{.nullAware = nullAware});
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
+    const std::shared_ptr<PlanMatcher>& rightMatcher,
+    JoinType joinType,
+    const HashJoinDetails& details) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<HashJoinMatcher>(
-      matcher_, rightMatcher, joinType, nullAware);
+      matcher_, rightMatcher, joinType, details);
   return *this;
 }
 
@@ -1746,10 +1800,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
     const std::shared_ptr<PlanMatcher>& rightMatcher,
     JoinType joinType,
     const std::vector<std::string>& outputColumnNames) {
-  VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<HashJoinMatcher>(
-      matcher_, rightMatcher, joinType, outputColumnNames);
-  return *this;
+  return hashJoin(
+      rightMatcher,
+      joinType,
+      HashJoinDetails{.outputColumnNames = outputColumnNames});
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -123,6 +123,29 @@ class PlanMatcher {
   }
 };
 
+/// Match details for a HashJoin node beyond join type. Each field is
+/// optional: leave as nullopt to skip the check, set a value to assert it.
+struct HashJoinDetails {
+  /// When set, asserts plan.isNullAware() matches.
+  std::optional<bool> nullAware;
+
+  /// When set, asserts left-side join keys (must have same size as
+  /// rightKeys when both are set).
+  std::optional<std::vector<std::string>> leftKeys;
+
+  /// When set, asserts right-side join keys (must have same size as
+  /// leftKeys when both are set).
+  std::optional<std::vector<std::string>> rightKeys;
+
+  /// When set, asserts the join filter expression (e.g., "a = b AND c > 0").
+  /// Empty string asserts no filter.
+  std::optional<std::string> filter;
+
+  /// When set, asserts output column names (order-insensitive, duplicates
+  /// rejected).
+  std::optional<std::vector<std::string>> outputColumnNames;
+};
+
 class PlanMatcherBuilder {
  public:
   /// Matches any TableScan node regardless of table name or output type.
@@ -271,6 +294,16 @@ class PlanMatcherBuilder {
       const std::shared_ptr<PlanMatcher>& rightMatcher,
       JoinType joinType,
       bool nullAware = false);
+
+  /// Matches a HashJoin node with the specified right side matcher, join type,
+  /// and details.
+  /// @param rightMatcher Matcher for the right side of the join.
+  /// @param joinType Type of join.
+  /// @param details Join details. See HashJoinDetails.
+  PlanMatcherBuilder& hashJoin(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      JoinType joinType,
+      const HashJoinDetails& details);
 
   /// Matches a HashJoin node with the specified right side matcher, join type,
   /// and expected output column names. Column names are verified as a set —

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -617,6 +617,108 @@ TEST_F(SubqueryTest, correlatedIn) {
   }
 }
 
+// Correlated IN subquery where the correlation predicate is an equality
+// on different columns than the IN equality.
+TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()));
+
+  // Single correlation equality.
+  {
+    auto query =
+        "SELECT t.a IN ("
+        "  SELECT u.x FROM u "
+        "  WHERE u.y = t.b"
+        ") FROM t";
+
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").build(),
+                           core::JoinType::kLeftSemiProject,
+                           {.nullAware = true,
+                            .leftKeys = std::vector<std::string>{"a"},
+                            .rightKeys = std::vector<std::string>{"x"},
+                            .filter = "b = y"})
+                       .project()
+                       .build();
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Two correlation equalities.
+  {
+    auto query =
+        "SELECT t.a IN ("
+        "  SELECT u.x FROM u "
+        "  WHERE u.y = t.b AND u.z = t.c"
+        ") FROM t";
+
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").build(),
+                           core::JoinType::kLeftSemiProject,
+                           {.nullAware = true,
+                            .leftKeys = std::vector<std::string>{"a"},
+                            .rightKeys = std::vector<std::string>{"x"},
+                            .filter = "b = y AND c = z"})
+                       .project()
+                       .build();
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Correlated IN subquery with both equality and non-equality correlation
+// predicates.
+TEST_F(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()));
+
+  auto query =
+      "SELECT t.a IN ("
+      "  SELECT u.x FROM u "
+      "  WHERE u.y = t.b AND u.z < t.c"
+      ") FROM t";
+
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u").build(),
+                         core::JoinType::kLeftSemiProject,
+                         {.nullAware = true,
+                          .leftKeys = std::vector<std::string>{"a"},
+                          .rightKeys = std::vector<std::string>{"x"},
+                          .filter = "c > z AND b = y"})
+                     .project()
+                     .build();
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Correlated IN subquery where the correlation equality duplicates the IN key.
+TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+
+  auto query =
+      "SELECT t.a IN ("
+      "  SELECT u.x FROM u "
+      "  WHERE u.x = t.a"
+      ") FROM t";
+
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u").build(),
+                         core::JoinType::kLeftSemiProject,
+                         {.nullAware = true,
+                          .leftKeys = std::vector<std::string>{"a"},
+                          .rightKeys = std::vector<std::string>{"x"},
+                          .filter = ""})
+                     .project()
+                     .build();
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // IN subquery where the left-side expression references multiple tables.
 TEST_F(SubqueryTest, multiTableInSubquery) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -242,3 +242,33 @@ SELECT
     END AS r,
     (SELECT count(*) FROM u WHERE u.a < t.c) AS z
 FROM t
+----
+-- Correlated IN subquery with single correlation equality.
+SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- Correlated NOT IN subquery with single correlation equality.
+SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- Correlated IN subquery with multiple correlation equalities.
+SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c = t.c) FROM t
+----
+-- Correlated NOT IN subquery with multiple correlation equalities.
+SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c = t.c) FROM t
+----
+-- Correlated IN subquery with mixed equality and non-equality correlation.
+SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
+----
+-- Correlated NOT IN subquery with mixed equality and non-equality correlation.
+SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
+----
+-- Correlated IN subquery where correlation equality is redundant with IN key.
+SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.a = t.a) FROM t
+----
+-- Correlated NOT IN subquery where correlation equality is redundant with IN key.
+SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.a = t.a) FROM t
+----
+-- Correlated IN subquery with reversed operand order in correlation.
+SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
+----
+-- Correlated NOT IN subquery with reversed operand order in correlation.
+SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t


### PR DESCRIPTION
Summary:

For a correlated IN subquery like `SELECT t.a IN (SELECT u.x FROM u 
WHERE u.y = t.b) FROM t`, 
the optimizer extracts two equalities: the IN equality (`t.a = u.x`) and the 
correlation equality (`u.y = t.b`). Previously, both were added as equi-join 
keys on a null-aware semi-project join, producing a multi-key null-aware 
join that Velox rejects with "Null-aware joins allow only one join key".

This fix keeps only the IN equality as the join key and moves correlation 
equalities into the join filter. This is the semantically correct 
decomposition: the IN equality uses null-aware semantics (NULL 
produces NULL) while correlation equalities are standard WHERE 
predicates (NULL produces false).

This PR also adds a new API PlanMatcherBuilder::hashJoin that allows specifying the join keys and join filter.

Reviewed By: mbasmanova

Differential Revision: D103965663


