### PR TITLE
refactor(optimizer): Add MultiFragmentPlan::checkConsistency

### DIFF
--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "axiom/optimizer/MultiFragmentPlan.h"
+#include "velox/core/PlanNode.h"
 #include "velox/core/TableWriteTraits.h"
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 
 namespace facebook::axiom::optimizer {
 
@@ -460,6 +464,166 @@ std::string MultiFragmentPlan::toSummaryString(
     }
   }
   return out.str();
+}
+
+namespace {
+
+// Checks that each fragment's type is consistent with its width and that width
+// does not exceed numWorkers.
+void checkFragmentTypes(
+    const std::vector<ExecutableFragment>& fragments,
+    int32_t numWorkers) {
+  for (const auto& fragment : fragments) {
+    const auto& width = fragment.width;
+    const auto& taskPrefix = fragment.taskPrefix;
+
+    switch (fragment.type) {
+      case FragmentType::kFixed:
+        VELOX_CHECK(
+            width.has_value(),
+            "kFixed fragment must have width set: {}",
+            taskPrefix);
+        break;
+      case FragmentType::kSingle:
+      case FragmentType::kCoordinator:
+        VELOX_CHECK(
+            !width.has_value(),
+            "{} fragment must not have width set: {}",
+            FragmentTypeName::toName(fragment.type),
+            taskPrefix);
+        break;
+      case FragmentType::kSource:
+        break;
+    }
+
+    if (width.has_value()) {
+      VELOX_CHECK_GT(
+          width.value(), 0, "Fragment width must be positive: {}", taskPrefix);
+      VELOX_CHECK_LE(
+          width.value(),
+          numWorkers,
+          "Fragment width exceeds numWorkers: {}",
+          taskPrefix);
+    }
+  }
+}
+
+// Checks producer-consumer linkage: task prefixes are non-empty and unique,
+// each InputStage references a valid ExchangeNode and an existing producer
+// whose root is a PartitionedOutputNode with matching partition count. Also
+// checks for self-links, that the last fragment is not a producer, that each
+// producer has a single consumer, and that every non-last fragment is
+// referenced.
+void checkProducerConsumerLinkage(
+    const std::vector<ExecutableFragment>& fragments) {
+  folly::F14FastMap<std::string, size_t> fragmentIndices;
+  for (size_t i = 0; i < fragments.size(); ++i) {
+    const auto& prefix = fragments[i].taskPrefix;
+    VELOX_CHECK(!prefix.empty(), "Fragment task prefix must not be empty");
+    auto [_, inserted] = fragmentIndices.emplace(prefix, i);
+    VELOX_CHECK(inserted, "Duplicate fragment task prefix: {}", prefix);
+  }
+
+  folly::F14FastSet<size_t> referencedProducers;
+
+  for (const auto& consumer : fragments) {
+    for (const auto& inputStage : consumer.inputStages) {
+      auto* consumerNode = velox::core::PlanNode::findNodeById(
+          consumer.fragment.planNode.get(), inputStage.consumerNodeId);
+      VELOX_CHECK_NOT_NULL(
+          consumerNode,
+          "Consumer node not found: {}, fragment: {}",
+          inputStage.consumerNodeId,
+          consumer.taskPrefix);
+      VELOX_CHECK_NOT_NULL(
+          dynamic_cast<const velox::core::ExchangeNode*>(consumerNode),
+          "Consumer node must be an ExchangeNode: {}, fragment: {}",
+          inputStage.consumerNodeId,
+          consumer.taskPrefix);
+
+      auto it = fragmentIndices.find(inputStage.producerTaskPrefix);
+      VELOX_CHECK(
+          it != fragmentIndices.end(),
+          "Producer fragment not found: {}, consumer: {}",
+          inputStage.producerTaskPrefix,
+          consumer.taskPrefix);
+
+      VELOX_CHECK_NE(
+          it->second,
+          fragments.size() - 1,
+          "Last fragment cannot be a producer: {}",
+          inputStage.producerTaskPrefix);
+
+      VELOX_CHECK_NE(
+          inputStage.producerTaskPrefix,
+          consumer.taskPrefix,
+          "Fragment cannot be its own producer: {}",
+          consumer.taskPrefix);
+
+      auto [_, isNew] = referencedProducers.insert(it->second);
+      VELOX_CHECK(
+          isNew,
+          "Producer fragment referenced by multiple consumers: {}",
+          inputStage.producerTaskPrefix);
+
+      const auto& producer = fragments[it->second];
+      const auto* partitionedOutput =
+          dynamic_cast<const velox::core::PartitionedOutputNode*>(
+              producer.fragment.planNode.get());
+      VELOX_CHECK_NOT_NULL(
+          partitionedOutput,
+          "Expected PartitionedOutputNode at root of producer fragment: {}",
+          producer.taskPrefix);
+
+      if (partitionedOutput->isBroadcast()) {
+        continue;
+      }
+
+      if (consumer.type == FragmentType::kSource) {
+        continue;
+      }
+
+      VELOX_CHECK_EQ(
+          partitionedOutput->numPartitions(),
+          consumer.width.value_or(1),
+          "Partition count mismatch between producer {} and consumer {}",
+          producer.taskPrefix,
+          consumer.taskPrefix);
+    }
+  }
+
+  for (size_t i = 0; i < fragments.size() - 1; ++i) {
+    VELOX_CHECK(
+        referencedProducers.contains(i),
+        "Non-last fragment must be referenced by exactly one consumer: {}",
+        fragments[i].taskPrefix);
+  }
+}
+
+// Checks that the last fragment has a type compatible with local result
+// consumption.
+void checkLastFragment(const ExecutableFragment& last, int32_t numWorkers) {
+  VELOX_CHECK(
+      last.type == FragmentType::kSingle ||
+          last.type == FragmentType::kCoordinator ||
+          (last.type == FragmentType::kSource && numWorkers == 1),
+      "Last fragment must be kSingle or kCoordinator "
+      "when remoteOutput is false (kSource allowed only with numWorkers == 1): {}",
+      last.taskPrefix);
+}
+
+} // namespace
+
+void MultiFragmentPlan::checkConsistency() const {
+  VELOX_CHECK(!fragments_.empty(), "Plan must have at least one fragment");
+
+  checkFragmentTypes(fragments_, options_.numWorkers);
+
+  checkProducerConsumerLinkage(fragments_);
+
+  if (!options_.remoteOutput) {
+    checkLastFragment(fragments_.back(), options_.numWorkers);
+  }
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -224,6 +224,10 @@ class MultiFragmentPlan {
   std::string toSummaryString(
       velox::core::PlanSummaryOptions options = {}) const;
 
+  /// Validates structural consistency of the plan. Checks fragment types,
+  /// widths, producer-consumer linkage, and partition count alignment.
+  void checkConsistency() const;
+
  private:
   const std::vector<ExecutableFragment> fragments_;
   const Options options_;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -180,44 +180,6 @@ RelationOpPtr addGather(const RelationOpPtr& op) {
   return gather;
 }
 
-void checkStageWidths(const std::vector<ExecutableFragment>& stages) {
-  folly::F14FastMap<std::string, size_t> stageIndex;
-  for (size_t i = 0; i < stages.size(); ++i) {
-    stageIndex[stages[i].taskPrefix] = i;
-  }
-  for (const auto& consumer : stages) {
-    for (const auto& inputStage : consumer.inputStages) {
-      auto stageIt = stageIndex.find(inputStage.producerTaskPrefix);
-      VELOX_CHECK(
-          stageIt != stageIndex.end(),
-          "Cannot find producer stage {}",
-          inputStage.producerTaskPrefix);
-      const auto& producer = stages[stageIt->second];
-      auto* partitionedOutput =
-          dynamic_cast<const velox::core::PartitionedOutputNode*>(
-              producer.fragment.planNode.get());
-      VELOX_CHECK_NOT_NULL(
-          partitionedOutput,
-          "Expected PartitionedOutputNode at the root of producer stage {}",
-          producer.taskPrefix);
-      // Broadcast sends data to all consumer partitions regardless of
-      // consumer width.
-      if (partitionedOutput->isBroadcast()) {
-        continue;
-      }
-      // Skip width check for kSource consumers (task count determined at
-      // runtime by splits).
-      if (consumer.type == FragmentType::kSource) {
-        continue;
-      }
-      VELOX_CHECK_EQ(
-          partitionedOutput->numPartitions(),
-          consumer.width.value_or(1),
-          "Partition count mismatch between producer and consumer stage");
-    }
-  }
-}
-
 } // namespace
 
 void ToVelox::filterUpdated(BaseTableCP table) {
@@ -395,7 +357,6 @@ PlanAndStats ToVelox::toVeloxPlan(
   for (const auto& stage : stages) {
     velox::core::PlanConsistencyChecker::check(stage.fragment.planNode);
   }
-  checkStageWidths(stages);
 
   if (options.remoteOutput) {
     rootPlanNode = velox::core::PartitionedOutputNode::single(
@@ -405,8 +366,12 @@ PlanAndStats ToVelox::toVeloxPlan(
   auto finishWrite = std::move(finishWrite_);
   VELOX_DCHECK(!finishWrite_);
 
+  auto multiFragmentPlan =
+      std::make_shared<MultiFragmentPlan>(std::move(stages), options);
+  multiFragmentPlan->checkConsistency();
+
   return PlanAndStats{
-      std::make_shared<MultiFragmentPlan>(std::move(stages), options),
+      std::move(multiFragmentPlan),
       std::move(nodeHistory_),
       std::move(prediction_),
       std::move(finishWrite)};

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -114,9 +114,11 @@ add_executable(
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp
   JoinTest.cpp
+  MultiFragmentPlanTest.cpp
   TpchDataGenerator.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp
+  RemoteOutputTest.cpp
   QueryGraphContextTest.cpp
   RelationOpPrinterTest.cpp
   SetTest.cpp
@@ -130,7 +132,6 @@ add_executable(
   UnnestTest.cpp
   ValuesTest.cpp
   WriteTest.cpp
-  RemoteOutputTest.cpp
 )
 
 add_test(

--- a/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
+++ b/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/VectorStream.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+using namespace velox::exec::test;
+
+class MultiFragmentPlanTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  PlanBuilder startValues() {
+    return PlanBuilder(idGenerator_)
+        .values({BaseVector::create<RowVector>(
+            ROW("a", BIGINT()), 1, pool_.get())});
+  }
+
+  core::PlanFragment values() {
+    return core::PlanFragment(startValues().planNode());
+  }
+
+  core::PlanFragment partitionedOutput(int32_t numPartitions) {
+    return core::PlanFragment(
+        startValues().partitionedOutput({"a"}, numPartitions).planNode());
+  }
+
+  core::PlanFragment broadcastOutput() {
+    return core::PlanFragment(
+        startValues().partitionedOutputBroadcast().planNode());
+  }
+
+  core::PlanFragment exchange() {
+    return core::PlanFragment(
+        PlanBuilder(idGenerator_)
+            .exchange(
+                ROW("a", BIGINT()),
+                VectorSerde::kindName(VectorSerde::Kind::kPresto))
+            .planNode());
+  }
+
+  // Creates a single-fragment plan with the given type.
+  MultiFragmentPlan makeSingleFragmentPlan(
+      FragmentType type,
+      std::optional<int32_t> width = std::nullopt,
+      const MultiFragmentPlan::Options& options = defaultOptions()) {
+    ExecutableFragment fragment;
+    fragment.taskPrefix = "stage0";
+    fragment.type = type;
+    fragment.width = width;
+    fragment.fragment = values();
+    return MultiFragmentPlan({std::move(fragment)}, options);
+  }
+
+  static MultiFragmentPlan::Options defaultOptions() {
+    return {
+        .queryId = "test",
+        .numWorkers = 10,
+    };
+  }
+
+  std::shared_ptr<core::PlanNodeIdGenerator> idGenerator_ =
+      std::make_shared<core::PlanNodeIdGenerator>();
+
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::memoryManager()->addLeafPool();
+};
+
+TEST_F(MultiFragmentPlanTest, validSingleFragment) {
+  auto plan = makeSingleFragmentPlan(
+      FragmentType::kSource,
+      std::nullopt,
+      MultiFragmentPlan::Options::singleNode());
+  EXPECT_NO_THROW(plan.checkConsistency());
+}
+
+TEST_F(MultiFragmentPlanTest, validDistributedPlan) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage0";
+  producer.type = FragmentType::kSource;
+  producer.fragment = partitionedOutput(4);
+
+  ExecutableFragment consumer;
+  consumer.taskPrefix = "stage1";
+  consumer.type = FragmentType::kFixed;
+  consumer.width = 4;
+  consumer.fragment = exchange();
+  consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
+
+  auto plan =
+      MultiFragmentPlan({std::move(producer), std::move(consumer)}, options);
+  EXPECT_NO_THROW(plan.checkConsistency());
+}
+
+TEST_F(MultiFragmentPlanTest, emptyFragments) {
+  VELOX_ASSERT_THROW(
+      MultiFragmentPlan({}, defaultOptions()).checkConsistency(),
+      "Plan must have at least one fragment");
+}
+
+TEST_F(MultiFragmentPlanTest, fixedWithoutWidth) {
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kFixed).checkConsistency(),
+      "kFixed fragment must have width set");
+}
+
+TEST_F(MultiFragmentPlanTest, singleWithWidth) {
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kSingle, 1).checkConsistency(),
+      "fragment must not have width set");
+}
+
+TEST_F(MultiFragmentPlanTest, coordinatorWithWidth) {
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kCoordinator, 1).checkConsistency(),
+      "fragment must not have width set");
+}
+
+TEST_F(MultiFragmentPlanTest, invalidWidth) {
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kFixed, 0).checkConsistency(),
+      "Fragment width must be positive");
+
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kFixed, 20).checkConsistency(),
+      "Fragment width exceeds numWorkers");
+}
+
+TEST_F(MultiFragmentPlanTest, sourceWithWidthHint) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+  auto plan = makeSingleFragmentPlan(FragmentType::kSource, 5, options);
+  EXPECT_NO_THROW(plan.checkConsistency());
+}
+
+TEST_F(MultiFragmentPlanTest, missingProducer) {
+  ExecutableFragment fragment;
+  fragment.taskPrefix = "stage0";
+  fragment.type = FragmentType::kSingle;
+  fragment.fragment = exchange();
+  fragment.inputStages.emplace_back(
+      fragment.fragment.planNode->id(), "nonexistent");
+
+  auto plan = MultiFragmentPlan({std::move(fragment)}, defaultOptions());
+  VELOX_ASSERT_THROW(
+      plan.checkConsistency(),
+      "Producer fragment not found: nonexistent, consumer: stage0");
+}
+
+TEST_F(MultiFragmentPlanTest, producerNotPartitionedOutput) {
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage0";
+  producer.type = FragmentType::kSource;
+  producer.fragment = values();
+
+  ExecutableFragment consumer;
+  consumer.taskPrefix = "stage1";
+  consumer.type = FragmentType::kSingle;
+  consumer.fragment = exchange();
+  consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
+
+  auto plan = MultiFragmentPlan(
+      {std::move(producer), std::move(consumer)}, defaultOptions());
+  VELOX_ASSERT_THROW(plan.checkConsistency(), "Expected PartitionedOutputNode");
+}
+
+TEST_F(MultiFragmentPlanTest, lastFragmentIsProducer) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage1";
+  producer.type = FragmentType::kFixed;
+  producer.width = 4;
+  producer.fragment = partitionedOutput(4);
+
+  ExecutableFragment consumer;
+  consumer.taskPrefix = "stage0";
+  consumer.type = FragmentType::kFixed;
+  consumer.width = 4;
+  consumer.fragment = exchange();
+  consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage1");
+
+  {
+    auto plan = MultiFragmentPlan({consumer, producer}, options);
+    VELOX_ASSERT_THROW(
+        plan.checkConsistency(), "Last fragment cannot be a producer");
+  }
+
+  {
+    auto plan = MultiFragmentPlan({producer, consumer}, options);
+    ASSERT_NO_THROW(plan.checkConsistency());
+  }
+}
+
+TEST_F(MultiFragmentPlanTest, partitionCountMismatch) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage0";
+  producer.type = FragmentType::kSource;
+  producer.fragment = partitionedOutput(4);
+
+  ExecutableFragment consumer;
+  consumer.taskPrefix = "stage1";
+  consumer.type = FragmentType::kFixed;
+  consumer.width = 8;
+  consumer.fragment = exchange();
+  consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
+
+  auto plan =
+      MultiFragmentPlan({std::move(producer), std::move(consumer)}, options);
+  VELOX_ASSERT_THROW(plan.checkConsistency(), "Partition count mismatch");
+}
+
+TEST_F(MultiFragmentPlanTest, broadcastSkipsWidthCheck) {
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage0";
+  producer.type = FragmentType::kSource;
+  producer.fragment = broadcastOutput();
+
+  ExecutableFragment consumer;
+  consumer.taskPrefix = "stage1";
+  consumer.type = FragmentType::kSingle;
+  consumer.fragment = exchange();
+  consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
+
+  auto plan = MultiFragmentPlan(
+      {std::move(producer), std::move(consumer)}, defaultOptions());
+  EXPECT_NO_THROW(plan.checkConsistency());
+}
+
+TEST_F(MultiFragmentPlanTest, lastFragmentType) {
+  auto options = defaultOptions();
+  options.remoteOutput = false;
+
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kFixed, 4, options)
+          .checkConsistency(),
+      "Last fragment must be kSingle or kCoordinator");
+
+  VELOX_ASSERT_THROW(
+      makeSingleFragmentPlan(FragmentType::kSource, std::nullopt, options)
+          .checkConsistency(),
+      "Last fragment must be kSingle or kCoordinator");
+
+  // kSource is allowed as last fragment with numWorkers == 1.
+  EXPECT_NO_THROW(makeSingleFragmentPlan(
+                      FragmentType::kSource,
+                      std::nullopt,
+                      MultiFragmentPlan::Options::singleNode())
+                      .checkConsistency());
+
+  // kFixed is allowed as last fragment with remoteOutput.
+  options.remoteOutput = true;
+  EXPECT_NO_THROW(makeSingleFragmentPlan(FragmentType::kFixed, 4, options)
+                      .checkConsistency());
+}
+
+TEST_F(MultiFragmentPlanTest, orphanFragment) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+
+  ExecutableFragment orphan;
+  orphan.taskPrefix = "stage0";
+  orphan.type = FragmentType::kSource;
+  orphan.fragment = partitionedOutput(4);
+
+  ExecutableFragment output;
+  output.taskPrefix = "stage1";
+  output.type = FragmentType::kFixed;
+  output.width = 4;
+  output.fragment = values();
+
+  auto plan =
+      MultiFragmentPlan({std::move(orphan), std::move(output)}, options);
+  VELOX_ASSERT_THROW(
+      plan.checkConsistency(),
+      "Non-last fragment must be referenced by exactly one consumer: stage0");
+}
+
+TEST_F(MultiFragmentPlanTest, producerReferencedByMultipleConsumers) {
+  auto options = defaultOptions();
+  options.remoteOutput = true;
+
+  ExecutableFragment producer;
+  producer.taskPrefix = "stage0";
+  producer.type = FragmentType::kSource;
+  producer.fragment = partitionedOutput(4);
+
+  ExecutableFragment consumerA;
+  consumerA.taskPrefix = "stage1";
+  consumerA.type = FragmentType::kFixed;
+  consumerA.width = 4;
+  consumerA.fragment = exchange();
+  consumerA.inputStages.emplace_back(
+      consumerA.fragment.planNode->id(), "stage0");
+
+  ExecutableFragment consumerB;
+  consumerB.taskPrefix = "stage2";
+  consumerB.type = FragmentType::kFixed;
+  consumerB.width = 4;
+  consumerB.fragment = exchange();
+  consumerB.inputStages.emplace_back(
+      consumerB.fragment.planNode->id(), "stage0");
+
+  auto plan = MultiFragmentPlan(
+      {std::move(producer), std::move(consumerA), std::move(consumerB)},
+      options);
+  VELOX_ASSERT_THROW(
+      plan.checkConsistency(),
+      "Producer fragment referenced by multiple consumers: stage0");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
Move plan validation from ToVelox's checkStageWidths into MultiFragmentPlan::checkConsistency() so any caller can validate a plan. Extend with additional structural checks:

- Plan must have at least one fragment.
- Fragment task prefixes must be non-empty and unique.
- kFixed fragments must have width set.
- kSingle/kCoordinator fragments must not have width set.
- Width must be positive and <= numWorkers.
- Each InputStage consumer node must be an ExchangeNode in the consumer fragment's plan tree.
- Each InputStage must reference an existing producer fragment.
- A fragment cannot be its own producer.
- The last fragment cannot be a producer.
- Each producer must have exactly one consumer.
- Every non-last fragment must be referenced by a consumer.
- Producer fragment roots must be PartitionedOutputNode.
- Hash-partitioned numPartitions must match consumer width.
- When remoteOutput is false, the last fragment must be kSingle or kCoordinator (kSource allowed only with numWorkers == 1).

Reviewed By: xiaoxmeng

Differential Revision: D103984150


