### PR TITLE
fix(tests): Fix waitForCompletion not being called in runFragmentedPlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/09c4fb905f0e02b0f334b0e99ff9e8b0c8a5165b...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/505a21e7c5f8970e219bdac44fad3c9cc2313010...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -136,19 +136,20 @@ TestResult QueryTestBase::runVelox(const core::PlanNodePtr& plan) {
 
 TestResult QueryTestBase::runFragmentedPlan(
     optimizer::PlanAndStats& planAndStats) {
-  TestResult result;
-
-  SCOPE_EXIT {
-    waitForCompletion(result.runner);
-    queryCtx_.reset();
-  };
-
-  result.runner = std::make_shared<runner::LocalRunner>(
+  auto runner = std::make_shared<runner::LocalRunner>(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       getQueryCtx(),
       std::make_shared<runner::ConnectorSplitSourceFactory>(),
       optimizerPool_);
+
+  SCOPE_EXIT {
+    waitForCompletion(runner);
+    queryCtx_.reset();
+  };
+
+  TestResult result;
+  result.runner = runner;
   result.results = readCursor(result.runner);
   result.stats = result.runner->stats();
   history_->recordVeloxExecution(planAndStats, result.stats);


### PR DESCRIPTION
`SCOPE_EXIT` in `runFragmentedPlan` captured `result.runner` by reference, but `return result` moves `result`, leaving `result.runner` null before `SCOPE_EXIT` fires. This means `waitForCompletion` was called with a null runner and skipped via the `if (runner)` check. When tasks hadn't finished by the time `TearDown` destroyed the `SharedArbitrator`, the test failed with "Unexpected alive participants on destruction."

Whether the bug triggers depends on NRVO (Named Return Value Optimization). With NRVO, the compiler elides the move and `SCOPE_EXIT` sees a live runner. Without NRVO, the move happens first and `SCOPE_EXIT` sees null. Debug builds on CI may or may not apply NRVO, explaining the flakiness.

Fix: create the runner as a local variable before `SCOPE_EXIT`, then copy it into `TestResult`. The `SCOPE_EXIT` captures the local, which is never moved.

Testing:

Compiled `QueryTestBase.cpp` with `-fno-elide-constructors` to disable NRVO and force the move. Added a diagnostic log to `waitForCompletion` to detect null runners.

Without fix: 5x "BUG: waitForCompletion called with null runner" (one per `runFragmentedPlan` call in the test).

With fix: zero BUG messages, `waitForCompletion` always sees a live runner.

Full test suite (357 tests): same results before and after the fix (355 pass, 2 pre-existing CsvReadWriteTest failures).

Fixes #1257.