### PR TITLE
docs(optimizer): Document RelationOp::distribution

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -252,6 +252,15 @@ void RelationOp::checkInputCardinality() const {
   }
 }
 
+void RelationOp::checkDistribution() const {
+  if (distribution_.isBroadcast()) {
+    VELOX_CHECK_EQ(
+        relType_,
+        RelType::kRepartition,
+        "Broadcast distribution is only valid on Repartition");
+  }
+}
+
 std::string RelationOp::toString() const {
   return RelationOpPrinter::toText(*this);
 }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -130,6 +130,12 @@ enum class RelType {
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
 
+} // namespace facebook::axiom::optimizer
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::RelType);
+
+namespace facebook::axiom::optimizer {
+
 /// Physical relational operator. This is the common base class of all
 /// elements of plan candidates. The immutable Exprs, Columns and
 /// BaseTables in the query graph are referenced from
@@ -155,6 +161,7 @@ class RelationOp {
         columns_(std::move(columns)),
         input_(std::move(input)) {
     checkInputCardinality();
+    checkDistribution();
   }
 
   /// Convenience constructor for operators that project all input columns as
@@ -207,6 +214,14 @@ class RelationOp {
     return RelTypeName::toName(relType_);
   }
 
+  /// Distribution of the data produced by this operator. For all operators
+  /// except Repartition, this describes how the data is laid out across tasks —
+  /// hash-partitioned on K, gathered to one task, or unpartitioned. For
+  /// Repartition, it describes the exchange between the Repartition's producer
+  /// fragment and its consumer fragment: hash-partitioned, gather, arbitrary,
+  /// or broadcast (every consumer task receives a full copy). Broadcast is only
+  /// valid on a Repartition; no other operator type can have broadcast
+  /// distribution.
   const Distribution& distribution() const {
     return distribution_;
   }
@@ -304,6 +319,8 @@ class RelationOp {
  private:
   void checkInputCardinality() const;
 
+  void checkDistribution() const;
+
   // thread local reference count. PlanObjects are freed when the
   // QueryGraphContext arena is freed, candidate plans are freed when no longer
   // referenced.
@@ -393,8 +410,9 @@ struct Values : RelationOp {
   const ValuesTable& valuesTable;
 };
 
-/// Represents a repartition, i.e. query fragment boundary. The distribution of
-/// the output is '_distribution'.
+/// Represents a repartition, i.e., a query fragment boundary. The
+/// `distribution()` describes the kind of exchange (broadcast, arbitrary,
+/// gather, or hash-partitioned) and its output partitioning.
 class Repartition : public RelationOp {
  public:
   Repartition(

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -373,8 +373,11 @@ bool Distribution::isSameOrder(const Distribution& other) const {
 Distribution Distribution::rename(
     const ExprVector& exprs,
     const ColumnVector& names) const {
+  // Broadcast describes the kind of exchange a Repartition emits and is not
+  // inherited by downstream operators (rename produces a Distribution for a
+  // non-Repartition consumer).
   if (isBroadcast()) {
-    return *this;
+    return Distribution{};
   }
 
   // Partitioning survives projection if all partitioning columns are projected

--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -67,8 +67,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupBy) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"b"}, {})
-            .splitAggregation({}, {"count(b)", "covar_pop(b, b)"})
+            .distributedAggregation({"b"}, {})
+            .distributedAggregation({}, {"count(b)", "covar_pop(b, b)"})
             .build());
     AXIOM_ASSERT_PLAN(
         toSingleNodePlan(logicalPlan),
@@ -88,8 +88,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupBy) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a", "b"}, {})
-            .splitAggregation({"a"}, {"count(b)"})
+            .distributedAggregation({"a", "b"}, {})
+            .distributedAggregation({"a"}, {"count(b)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -108,8 +108,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupBy) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a", "b"}, {})
-            .splitAggregation({"a"}, {"count(b)", "covar_pop(b, b)"})
+            .distributedAggregation({"a", "b"}, {})
+            .distributedAggregation({"a"}, {"count(b)", "covar_pop(b, b)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -141,8 +141,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithExpressionInputs) {
         plan.plan,
         matchScan("t")
             .project({"a + 1 as p0", "b + c as p1"})
-            .splitAggregation({"p0", "p1"}, {})
-            .splitAggregation({"p0"}, {"count(p1)", "sum(p1)"})
+            .distributedAggregation({"p0", "p1"}, {})
+            .distributedAggregation({"p0"}, {"count(p1)", "sum(p1)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -168,8 +168,9 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithExpressionInputs) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a", "b", "c"}, {})
-            .splitAggregation({"a"}, {"covar_pop(b, c)", "covar_samp(c, b)"})
+            .distributedAggregation({"a", "b", "c"}, {})
+            .distributedAggregation(
+                {"a"}, {"covar_pop(b, c)", "covar_samp(c, b)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -191,8 +192,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithExpressionInputs) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"b", "c"}, {})
-            .splitAggregation({"b"}, {"covar_pop(b, c)"})
+            .distributedAggregation({"b", "c"}, {})
+            .distributedAggregation({"b"}, {"covar_pop(b, c)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -224,7 +225,7 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithOrderBy) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"c", "a", "b"}, {})
+            .distributedAggregation({"c", "a", "b"}, {})
             .distributedSingleAggregation(
                 {"c"}, {"max_by(a, b ORDER BY a)", "min_by(a, b ORDER BY b)"})
             .shuffle()
@@ -252,7 +253,7 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithOrderBy) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a", "b"}, {})
+            .distributedAggregation({"a", "b"}, {})
             .distributedSingleAggregation(
                 {"a"}, {"max_by(b, 1 ORDER BY b)", "min_by(b, 2 ORDER BY b)"})
             .shuffle()
@@ -287,8 +288,8 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithLiterals) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a", "b"}, {})
-            .splitAggregation({"a"}, {"max_by(b, 1)", "min_by(b, 2)"})
+            .distributedAggregation({"a", "b"}, {})
+            .distributedAggregation({"a"}, {"max_by(b, 1)", "min_by(b, 2)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
@@ -313,7 +314,7 @@ TEST_F(DistinctAggregationTest, singleDistinctToGroupByWithLiterals) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .splitAggregation({"a"}, {})
+            .distributedAggregation({"a"}, {})
             .partialAggregation({"a"}, {"count(1)", "count(2)"})
             .localPartition({"a"})
             .finalAggregation()
@@ -347,7 +348,7 @@ TEST_F(DistinctAggregationTest, markDistinctDifferentArgSets) {
           .project({"a", "b as p0", "d % 5 as p1"})
           .distributedMarkDistinct({"a", "p0"}, "m0")
           .distributedMarkDistinct({"a", "p1"}, "m1")
-          .splitAggregation(
+          .distributedAggregation(
               {"a"},
               {"count(p0) filter (where m0)", "sum(p1) filter (where m1)"})
           .shuffle()
@@ -413,7 +414,7 @@ TEST_F(DistinctAggregationTest, markDistinctMixedDistinctAndNonDistinct) {
           .project({"a", "b as p0", "d % 5 as p1"})
           .distributedMarkDistinct({"a", "p0"}, "m0")
           .distributedMarkDistinct({"a", "p1"}, "m1")
-          .splitAggregation(
+          .distributedAggregation(
               {"a"},
               {"count(p0) filter (where m0)",
                "sum(p1) filter (where m1)",
@@ -447,7 +448,7 @@ TEST_F(DistinctAggregationTest, markDistinctMultiArgAggregates) {
       matchScan("t")
           .distributedMarkDistinct({"a", "b", "c"}, "m0")
           .distributedMarkDistinct({"a", "d"}, "m1")
-          .splitAggregation(
+          .distributedAggregation(
               {"a"},
               {"covar_pop(b, c) filter (where m0)",
                "count(d) filter (where m1)"})
@@ -483,7 +484,7 @@ TEST_F(DistinctAggregationTest, markDistinctSharedMarkers) {
         plan.plan,
         matchScan("t")
             .distributedMarkDistinct({"b", "c"}, "m0")
-            .splitAggregation(
+            .distributedAggregation(
                 {"b"},
                 {"count(c) filter (where m0)",
                  "covar_pop(b, c) filter (where m0)",
@@ -624,7 +625,7 @@ TEST_F(DistinctAggregationTest, markDistinctLiterals) {
         matchScan("t")
             .distributedMarkDistinct({"a", "b"}, "m0")
             .distributedMarkDistinct({"a", "d"}, "m1")
-            .splitAggregation(
+            .distributedAggregation(
                 {"a"},
                 {"count(b) filter (where m0)",
                  "max_by(d, 1) filter (where m1)"})
@@ -709,7 +710,7 @@ TEST_F(DistinctAggregationTest, multipleMarkDistinctWithNoShuffleInBetween) {
           .localPartition({"a", "b"})
           .markDistinct({"a", "b"}, "m0")
           .markDistinct({"a", "b", "c"}, "m1")
-          .splitAggregation(
+          .distributedAggregation(
               {"a"},
               {"count(b) filter (where m0)",
                "covar_pop(b, c) filter (where m1)"})

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1002,7 +1002,24 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
     }
   }
 
-  // Verify partition keys if specified.
+  // Verify replicateNullsAndAny if specified.
+  if (replicateNullsAndAny_.has_value()) {
+    EXPECT_EQ(
+        partitionedOutput->isReplicateNullsAndAny(),
+        replicateNullsAndAny_.value());
+    AXIOM_TEST_RETURN_IF_FAILURE
+  }
+
+  // Match the producer first so its symbols are available for the partition
+  // key lookup below (keys reference producer-fragment column names).
+  DistributedMatchContext producerContext{
+      context->fragments, producerFragment, context->taskPrefixToFragmentIndex};
+  auto producerResult = producerMatcher_->match(
+      partitionedOutput->sources()[0], symbols, &producerContext);
+  if (!producerResult.match) {
+    return MatchResult::failure();
+  }
+
   if (!keys_.empty()) {
     const auto& actualKeys = partitionedOutput->keys();
     EXPECT_EQ(actualKeys.size(), keys_.size())
@@ -1011,14 +1028,12 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
     AXIOM_TEST_RETURN_IF_FAILURE
 
     for (size_t i = 0; i < keys_.size(); ++i) {
-      // Apply symbol rewriting to expected key name.
       auto expectedKey = keys_[i];
-      auto it = symbols.find(expectedKey);
-      if (it != symbols.end()) {
+      auto it = producerResult.symbols.find(expectedKey);
+      if (it != producerResult.symbols.end()) {
         expectedKey = it->second;
       }
 
-      // Extract name from FieldAccessTypedExpr.
       auto fieldAccess =
           std::dynamic_pointer_cast<const FieldAccessTypedExpr>(actualKeys[i]);
       EXPECT_TRUE(fieldAccess != nullptr)
@@ -1031,23 +1046,7 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
     AXIOM_TEST_RETURN_IF_FAILURE
   }
 
-  // Verify replicateNullsAndAny if specified.
-  if (replicateNullsAndAny_.has_value()) {
-    EXPECT_EQ(
-        partitionedOutput->isReplicateNullsAndAny(),
-        replicateNullsAndAny_.value())
-        << "replicateNullsAndAny mismatch: expected "
-        << replicateNullsAndAny_.value() << ", got "
-        << partitionedOutput->isReplicateNullsAndAny();
-    AXIOM_TEST_RETURN_IF_FAILURE
-  }
-
-  // Update context for producer fragment matching.
-  DistributedMatchContext producerContext{
-      context->fragments, producerFragment, context->taskPrefixToFragmentIndex};
-
-  return producerMatcher_->match(
-      partitionedOutput->sources()[0], symbols, &producerContext);
+  return producerResult;
 }
 
 class PartitionedOutputMatcher : public PlanMatcherImpl<PartitionedOutputNode> {
@@ -1988,14 +1987,14 @@ PlanMatcherBuilder& PlanMatcherBuilder::distributedMarkDistinct(
   return shuffle().localPartition(keys).markDistinct(keys, markerAlias);
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::splitAggregation(
+PlanMatcherBuilder& PlanMatcherBuilder::distributedAggregation(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
-  partialAggregation(groupingKeys, aggregates).shuffle();
+  partialAggregation(groupingKeys, aggregates);
   if (groupingKeys.empty()) {
-    localGather();
+    gather().localGather();
   } else {
-    localPartition(groupingKeys);
+    shuffle(groupingKeys).localPartition(groupingKeys);
   }
   return finalAggregation();
 }
@@ -2003,11 +2002,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::splitAggregation(
 PlanMatcherBuilder& PlanMatcherBuilder::distributedSingleAggregation(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
-  shuffle();
   if (groupingKeys.empty()) {
-    localGather();
+    gather().localGather();
   } else {
-    localPartition(groupingKeys);
+    shuffle(groupingKeys).localPartition(groupingKeys);
   }
   return singleAggregation(groupingKeys, aggregates);
 }

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -465,11 +465,11 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& keys,
       const std::string& markerAlias);
 
-  /// Matches the split aggregation pattern:
+  /// Matches the distributed (split) aggregation pattern:
   /// partialAggregation(groupingKeys, aggregates) → shuffle →
   /// localPartition(groupingKeys) → finalAggregation.
   /// For empty groupingKeys, uses localGather instead of localPartition.
-  PlanMatcherBuilder& splitAggregation(
+  PlanMatcherBuilder& distributedAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 


### PR DESCRIPTION
Summary:
Document the semantics of `RelationOp::distribution()`:

- For all operators except Repartition, this describes how the output
  data is laid out across tasks (hash-partitioned on K, gathered to
  one task, or unpartitioned).
- For Repartition, it describes the exchange between the producer
  fragment and the consumer fragment (hash-partitioned, gather,
  arbitrary, or broadcast).

Broadcast distribution is only valid on Repartition. Add a runtime
check (`checkDistribution`) in the basic RelationOp constructor that
enforces this invariant.

Also tighten the Repartition class doc to match.

Differential Revision: D104231625


