### PR TITLE
refactor(optimizer): Introduce Distribution::Kind enum

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -293,7 +293,7 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
 
   if (shuffle) {
     Distribution distribution{
-        plan->distribution().distributionType(), std::move(desiredKeys)};
+        plan->distribution().partitionType(), std::move(desiredKeys)};
     auto* repartition =
         make<Repartition>(plan, std::move(distribution), plan->columns());
     cost.add(*repartition);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -808,8 +808,8 @@ bool isIndexColocated(
 
   // True if 'input' is partitioned so that each partitioning key is joined to
   // the corresponding partition key in 'info'.
-  if (input->distribution().distributionType() !=
-      distribution.distributionType()) {
+  if (input->distribution().kind() != distribution.kind() ||
+      input->distribution().partitionType() != distribution.partitionType()) {
     return false;
   }
 
@@ -871,7 +871,7 @@ RelationOpPtr repartitionForIndex(
 
   auto* repartition = make<Repartition>(
       plan,
-      Distribution{distribution.distributionType(), std::move(keyExprs)},
+      Distribution{distribution.partitionType(), std::move(keyExprs)},
       plan->columns());
   state.addCost(*repartition);
   return repartition;
@@ -946,14 +946,13 @@ void alignJoinSides(
 
   auto part = joinKeyPartition(input, keys);
   if (part.empty()) {
-    Distribution distribution{
-        DistributionType{},
-        keys,
-        /*orderKeys=*/{},
-        /*orderTypes=*/{},
-        /*numKeysUnique=*/0,
-        /*clusterKeys=*/{},
-        replicateNullsAndAny};
+    Distribution distribution{/*partitionType=*/nullptr,
+                              keys,
+                              /*orderKeys=*/{},
+                              /*orderTypes=*/{},
+                              /*numKeysUnique=*/0,
+                              /*clusterKeys=*/{},
+                              replicateNullsAndAny};
     auto* repartition =
         make<Repartition>(input, std::move(distribution), input->columns());
     state.addCost(*repartition);
@@ -972,7 +971,7 @@ void alignJoinSides(
   }
 
   Distribution distribution{
-      input->distribution().distributionType(), std::move(distColumns)};
+      input->distribution().partitionType(), std::move(distColumns)};
   auto* repartition = make<Repartition>(
       otherInput, std::move(distribution), otherInput->columns());
   otherState.addCost(*repartition);
@@ -1042,8 +1041,7 @@ RelationOpPtr repartitionForWrite(const RelationOpPtr& plan, PlanState& state) {
     keyValues.emplace_back(write->columnExprs().at(index));
   }
 
-  const auto* planPartitionType =
-      plan->distribution().distributionType().partitionType();
+  const auto* planPartitionType = plan->distribution().partitionType();
 
   auto copartition =
       copartitionType(planPartitionType, layout->partitionType());
@@ -1992,9 +1990,7 @@ void Optimization::joinByHash(
     for (auto i : partKeys) {
       buildPartKeys.push_back(build.keys[i]);
     }
-    forBuild = {
-        plan->distribution().distributionType().partitionType(),
-        std::move(buildPartKeys)};
+    forBuild = {plan->distribution().partitionType(), std::move(buildPartKeys)};
   }
 
   bool needsShuffle = false;
@@ -2063,7 +2059,7 @@ void Optimization::joinByHash(
           }
         }
         Distribution distribution{
-            plan->distribution().distributionType(),
+            plan->distribution().partitionType(),
             copartition,
             /*orderKeys=*/{},
             /*orderTypes=*/{},
@@ -2898,7 +2894,7 @@ Distribution somePartition(const RelationOpPtrVector& inputs) {
     }
   }
 
-  return {DistributionType{}, std::move(columns)};
+  return {/*partitionType=*/nullptr, std::move(columns)};
 }
 
 // Adds the costs in the input states to the first state and if 'distinct' is
@@ -3224,8 +3220,7 @@ PlanP Optimization::makeUnionPlan(
         inputs[i] = make<Repartition>(
             inputs[i],
             Distribution{
-                DistributionType(distribution->partitionType),
-                distribution->partitionKeys},
+                distribution->partitionType, distribution->partitionKeys},
             inputs[i]->columns());
         inputStates[i].addCost(*inputs[i]);
       }

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -217,7 +217,7 @@ Distribution TableScan::outputDistribution(
     replace(orderKeys, schemaColumns, columns.data());
   }
   return Distribution(
-      distribution.distributionType(),
+      distribution.partitionType(),
       std::move(partitionKeys),
       std::move(orderKeys),
       std::move(orderTypes),
@@ -253,11 +253,29 @@ void RelationOp::checkInputCardinality() const {
 }
 
 void RelationOp::checkDistribution() const {
-  if (distribution_.isBroadcast()) {
-    VELOX_CHECK_EQ(
-        relType_,
-        RelType::kRepartition,
-        "Broadcast distribution is only valid on Repartition");
+  const auto kind = distribution_.kind();
+  if (relType_ == RelType::kRepartition) {
+    // A Repartition must specify what kind of exchange it emits.
+    VELOX_CHECK_NE(
+        kind,
+        Distribution::Kind::kUnspecified,
+        "Repartition requires a specific distribution kind");
+  } else {
+    // Broadcast and arbitrary describe consumer-side exchange semantics; they
+    // only exist on a Repartition. Distribution::rename drops them when
+    // producing a Distribution for a non-Repartition consumer.
+    VELOX_CHECK(
+        kind != Distribution::Kind::kBroadcast &&
+            kind != Distribution::Kind::kArbitrary,
+        "Distribution kind {} is only valid on Repartition, got {}",
+        kind,
+        relTypeName());
+    // replicateNullsAndAny describes a hash exchange's NULL handling and is
+    // only meaningful on a Repartition.
+    VELOX_CHECK(
+        !distribution_.isReplicateNullsAndAny(),
+        "replicateNullsAndAny is only valid on Repartition, got {}",
+        relTypeName());
   }
 }
 
@@ -1890,7 +1908,8 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
           RelType::kAssignUniqueId,
           input,
           Distribution(
-              input->distribution().distributionType(),
+              input->distribution().kind(),
+              input->distribution().partitionType(),
               input->distribution().partitionKeys(),
               input->distribution().orderKeys(),
               input->distribution().orderTypes(),

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -252,6 +252,15 @@ void RelationOp::checkInputCardinality() const {
   }
 }
 
+void RelationOp::checkDistribution() const {
+  if (distribution_.isBroadcast()) {
+    VELOX_CHECK_EQ(
+        relType_,
+        RelType::kRepartition,
+        "Broadcast distribution is only valid on Repartition");
+  }
+}
+
 std::string RelationOp::toString() const {
   return RelationOpPrinter::toText(*this);
 }

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -130,6 +130,12 @@ enum class RelType {
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
 
+} // namespace facebook::axiom::optimizer
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::RelType);
+
+namespace facebook::axiom::optimizer {
+
 /// Physical relational operator. This is the common base class of all
 /// elements of plan candidates. The immutable Exprs, Columns and
 /// BaseTables in the query graph are referenced from
@@ -155,6 +161,7 @@ class RelationOp {
         columns_(std::move(columns)),
         input_(std::move(input)) {
     checkInputCardinality();
+    checkDistribution();
   }
 
   /// Convenience constructor for operators that project all input columns as
@@ -207,6 +214,14 @@ class RelationOp {
     return RelTypeName::toName(relType_);
   }
 
+  /// Distribution of the data produced by this operator. For all operators
+  /// except Repartition, this describes how the data is laid out across tasks —
+  /// hash-partitioned on K, gathered to one task, or unpartitioned. For
+  /// Repartition, it describes the exchange between the Repartition's producer
+  /// fragment and its consumer fragment: hash-partitioned, gather, arbitrary,
+  /// or broadcast (every consumer task receives a full copy). Broadcast is only
+  /// valid on a Repartition; no other operator type can have broadcast
+  /// distribution.
   const Distribution& distribution() const {
     return distribution_;
   }
@@ -304,6 +319,8 @@ class RelationOp {
  private:
   void checkInputCardinality() const;
 
+  void checkDistribution() const;
+
   // thread local reference count. PlanObjects are freed when the
   // QueryGraphContext arena is freed, candidate plans are freed when no longer
   // referenced.
@@ -393,8 +410,9 @@ struct Values : RelationOp {
   const ValuesTable& valuesTable;
 };
 
-/// Represents a repartition, i.e. query fragment boundary. The distribution of
-/// the output is '_distribution'.
+/// Represents a repartition, i.e., a query fragment boundary. The
+/// `distribution()` describes the kind of exchange (broadcast, arbitrary,
+/// gather, or hash-partitioned) and its output partitioning.
 class Repartition : public RelationOp {
  public:
   Repartition(

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -215,13 +215,14 @@ class RelationOp {
   }
 
   /// Distribution of the data produced by this operator. For all operators
-  /// except Repartition, this describes how the data is laid out across tasks —
-  /// hash-partitioned on K, gathered to one task, or unpartitioned. For
+  /// except Repartition, this describes how the data is laid out across tasks
+  /// — partitioned on K, gathered to one task, or unpartitioned. For
   /// Repartition, it describes the exchange between the Repartition's producer
-  /// fragment and its consumer fragment: hash-partitioned, gather, arbitrary,
-  /// or broadcast (every consumer task receives a full copy). Broadcast is only
-  /// valid on a Repartition; no other operator type can have broadcast
-  /// distribution.
+  /// fragment and its consumer fragment: partitioned, gather, arbitrary, or
+  /// broadcast (every consumer task receives a full copy). Broadcast and
+  /// arbitrary are produced only by a Repartition, but operators downstream of
+  /// a Repartition inherit that distribution since they operate on the
+  /// post-exchange data shape.
   const Distribution& distribution() const {
     return distribution_;
   }

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -373,8 +373,11 @@ bool Distribution::isSameOrder(const Distribution& other) const {
 Distribution Distribution::rename(
     const ExprVector& exprs,
     const ColumnVector& names) const {
+  // Broadcast describes the kind of exchange a Repartition emits and is not
+  // inherited by downstream operators (rename produces a Distribution for a
+  // non-Repartition consumer).
   if (isBroadcast()) {
-    return *this;
+    return Distribution{};
   }
 
   // Partitioning survives projection if all partitioning columns are projected

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -25,6 +25,22 @@
 namespace facebook::axiom::optimizer {
 
 namespace {
+const auto& distributionKindNames() {
+  static const folly::F14FastMap<Distribution::Kind, std::string_view> kNames =
+      {
+          {Distribution::Kind::kUnspecified, "UNSPECIFIED"},
+          {Distribution::Kind::kPartitioned, "PARTITIONED"},
+          {Distribution::Kind::kGather, "GATHER"},
+          {Distribution::Kind::kBroadcast, "BROADCAST"},
+          {Distribution::Kind::kArbitrary, "ARBITRARY"},
+      };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Distribution, Kind, distributionKindNames);
+
+namespace {
 const auto& orderTypeNames() {
   static const folly::F14FastMap<OrderType, std::string_view> kNames = {
       {OrderType::kAscNullsFirst, "ASC NULLS FIRST"},
@@ -204,7 +220,7 @@ SchemaTableCP Schema::findTable(
     VELOX_CHECK_EQ(orderKeys.size(), orderTypes.size());
 
     Distribution distribution(
-        DistributionType(layout->partitionType()),
+        layout->partitionType(),
         std::move(partition),
         std::move(orderKeys),
         std::move(orderTypes));
@@ -317,7 +333,7 @@ ColumnCP IndexInfo::schemaColumn(ColumnCP keyValue) const {
 }
 
 bool Distribution::isSamePartition(const DesiredDistribution& other) const {
-  if (distributionType().partitionType() != other.partitionType) {
+  if (partitionType() != other.partitionType) {
     return false;
   }
 
@@ -335,10 +351,10 @@ bool Distribution::isSamePartition(const DesiredDistribution& other) const {
 }
 
 bool Distribution::isSamePartition(const Distribution& other) const {
-  if (distributionType() != other.distributionType()) {
+  if (kind() != other.kind() || partitionType() != other.partitionType()) {
     return false;
   }
-  if (isBroadcast() || other.isBroadcast()) {
+  if (isBroadcast()) {
     return true;
   }
   if (partitionKeys().size() != other.partitionKeys().size()) {
@@ -373,10 +389,10 @@ bool Distribution::isSameOrder(const Distribution& other) const {
 Distribution Distribution::rename(
     const ExprVector& exprs,
     const ColumnVector& names) const {
-  // Broadcast describes the kind of exchange a Repartition emits and is not
-  // inherited by downstream operators (rename produces a Distribution for a
-  // non-Repartition consumer).
-  if (isBroadcast()) {
+  // Broadcast and arbitrary describe the kind of exchange a Repartition emits
+  // and are not inherited by downstream operators (rename produces a
+  // Distribution for a non-Repartition consumer).
+  if (isBroadcast() || isArbitrary()) {
     return Distribution{};
   }
 
@@ -407,14 +423,17 @@ Distribution Distribution::rename(
     }
   }
 
+  // rename() produces a Distribution for a non-Repartition consumer (Project),
+  // so replicateNullsAndAny does not apply.
   return Distribution(
-      distributionType_,
+      kind_,
+      partitionType_,
       std::move(partitionKeys),
       std::move(orderKeys),
       std::move(orderTypes),
       numKeysUnique_,
       std::move(clusterKeys),
-      replicateNullsAndAny_);
+      /*replicateNullsAndAny=*/false);
 }
 
 namespace {
@@ -443,8 +462,8 @@ std::string Distribution::toString() const {
   if (!partitionKeys().empty()) {
     out << "P ";
     exprsToString(partitionKeys(), out);
-    if (distributionType().partitionType() != nullptr) {
-      out << " " << distributionType().partitionType()->toString();
+    if (partitionType() != nullptr) {
+      out << " " << partitionType()->toString();
     } else {
       out << " Velox hash";
     }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -116,86 +116,100 @@ struct DesiredDistribution {
   ExprVector partitionKeys;
 };
 
-/// Distribution of data. Describes a possible partition function that assigns a
-/// row of data to a partition based on some combination of partition keys. For
-/// a join to be copartitioned, both sides must have compatible partition
-/// functions and the join keys must include the partition keys.
-class DistributionType {
- public:
-  DistributionType(bool isGather = false)
-      : isGather_{isGather}, partitionType_{nullptr} {}
-
-  DistributionType(const connector::PartitionType* partitionType)
-      : isGather_{false}, partitionType_{partitionType} {}
-
-  bool operator==(const DistributionType& other) const = default;
-
-  static DistributionType gather() {
-    static const DistributionType kGather(true);
-    return kGather;
-  }
-
-  bool isGather() const {
-    return isGather_;
-  }
-
-  const connector::PartitionType* partitionType() const {
-    return partitionType_;
-  }
-
- private:
-  bool isGather_;
-
-  /// Partition function. nullptr is not partitioned.
-  const connector::PartitionType* partitionType_;
-};
-
-/// Describes output of relational operator. If this is partitioned on
-/// some keys, distributionType gives the partition function and
-/// 'partition' gives the input for the partition function.
+/// Describes output of relational operator. For most operators this reflects
+/// how the data is laid out across tasks. For Repartition, it describes the
+/// kind of exchange the Repartition emits. See RelationOp::distribution() for
+/// the full semantics.
 struct Distribution {
-  // TODO Distribution(/*broadcast=*/false) is used to specify *any*
-  // distribution. Provide a better way.
-  explicit Distribution(bool broadcast = false)
-      : numKeysUnique_{0}, isBroadcast_{broadcast} {}
+  /// Kind of distribution. Represents both the data layout for non-Repartition
+  /// operators and the exchange kind for Repartition.
+  enum class Kind {
+    /// No specific distribution is guaranteed. Not valid on Repartition.
+    kUnspecified,
+    /// Partitioned on `partitionKeys` using `partitionType` (connector-
+    /// specific) or standard Velox hash when `partitionType` is nullptr.
+    kPartitioned,
+    /// All rows on one task / one partition.
+    kGather,
+    /// Broadcast (every consumer task receives a full copy). Only valid on
+    /// Repartition.
+    kBroadcast,
+    /// Arbitrary / round-robin (any consumer task count, on-demand pull).
+    /// Only valid on Repartition.
+    kArbitrary,
+  };
+
+  AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Kind);
+
+  Distribution() = default;
 
   Distribution(
-      DistributionType distributionType,
+      Kind kind,
+      const connector::PartitionType* partitionType,
       ExprVector partitionKeys,
       ExprVector orderKeys = {},
       OrderTypeVector orderTypes = {},
       int32_t numKeysUnique = 0,
       ExprVector clusterKeys = {},
       bool replicateNullsAndAny = false)
-      : distributionType_{distributionType},
+      : kind_{kind},
+        partitionType_{partitionType},
         partitionKeys_{std::move(partitionKeys)},
         orderKeys_{std::move(orderKeys)},
         orderTypes_{std::move(orderTypes)},
         numKeysUnique_{numKeysUnique},
-        isBroadcast_{false},
         replicateNullsAndAny_{replicateNullsAndAny},
         clusterKeys_{std::move(clusterKeys)} {
     VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
-    if (isGather()) {
+    if (kind_ == Kind::kGather) {
       VELOX_CHECK_EQ(partitionKeys_.size(), 0);
     }
   }
 
+  /// Convenience constructor for hash partitioning.
+  Distribution(
+      const connector::PartitionType* partitionType,
+      ExprVector partitionKeys,
+      ExprVector orderKeys = {},
+      OrderTypeVector orderTypes = {},
+      int32_t numKeysUnique = 0,
+      ExprVector clusterKeys = {},
+      bool replicateNullsAndAny = false)
+      : Distribution{
+            Kind::kPartitioned,
+            partitionType,
+            std::move(partitionKeys),
+            std::move(orderKeys),
+            std::move(orderTypes),
+            numKeysUnique,
+            std::move(clusterKeys),
+            replicateNullsAndAny} {}
+
   /// Returns a Distribution for use in a broadcast shuffle.
   static Distribution broadcast() {
-    return Distribution{/*broadcast=*/true};
+    return {Kind::kBroadcast, /*partitionType=*/nullptr, /*partitionKeys=*/{}};
   }
 
-  /// Returns a distribution for an end of query gather from last stage
-  /// fragments. Specifying order will create a merging exchange when the
-  /// Distribution occurs in a Repartition.
-  static Distribution gather(
-      ExprVector orderKeys = {},
-      OrderTypeVector orderTypes = {}) {
-    static const DistributionType kGather(/*isGather=*/true);
+  /// Returns a Distribution for use in an arbitrary (round-robin) shuffle.
+  static Distribution arbitrary() {
+    return {Kind::kArbitrary, /*partitionType=*/nullptr, /*partitionKeys=*/{}};
+  }
+
+  /// Returns a distribution that gathers all rows to a single task. Used
+  /// wherever an operator requires a single task (e.g., final query gather,
+  /// LIMIT or ORDER BY in a subquery, global aggregation).
+  static Distribution gather() {
+    return {Kind::kGather, /*partitionType=*/nullptr, /*partitionKeys=*/{}};
+  }
+
+  /// Returns a distribution for an ordered gather. Creates a merging exchange
+  /// when the Distribution occurs in a Repartition.
+  static Distribution gather(ExprVector orderKeys, OrderTypeVector orderTypes) {
+    VELOX_CHECK_EQ(orderKeys.size(), orderTypes.size());
     return {
-        kGather,
-        {},
+        Kind::kGather,
+        /*partitionType=*/nullptr,
+        /*partitionKeys=*/{},
         std::move(orderKeys),
         std::move(orderTypes),
     };
@@ -213,16 +227,26 @@ struct Distribution {
   /// True if 'other' has the same ordering columns and order type.
   bool isSameOrder(const Distribution& other) const;
 
+  Kind kind() const {
+    return kind_;
+  }
+
   bool isGather() const {
-    return distributionType_.isGather();
+    return kind_ == Kind::kGather;
   }
 
   bool isBroadcast() const {
-    return isBroadcast_;
+    return kind_ == Kind::kBroadcast;
   }
 
-  const DistributionType& distributionType() const {
-    return distributionType_;
+  bool isArbitrary() const {
+    return kind_ == Kind::kArbitrary;
+  }
+
+  /// Connector-specific partitioning function, or nullptr if standard Velox
+  /// hash partitioning (or no partitioning).
+  const connector::PartitionType* partitionType() const {
+    return partitionType_;
   }
 
   const ExprVector& partitionKeys() const {
@@ -254,36 +278,39 @@ struct Distribution {
   std::string toString() const;
 
  private:
-  DistributionType distributionType_;
+  Kind kind_{Kind::kUnspecified};
 
-  /// Partitioning columns. The values of these columns determine which of
-  /// partition contains any given row. Should be used together with
-  /// DistributionType::partitionType.
+  // Connector-specific partition function. nullptr means standard Velox hash
+  // (when kind_ is kPartitioned) or no partitioning otherwise.
+  const connector::PartitionType* partitionType_{nullptr};
+
+  // Partitioning columns. The values of these columns determine which
+  // partition contains any given row. Used with `partitionType_` when
+  // `kind_ == kPartitioned`.
   ExprVector partitionKeys_;
 
-  /// Ordering columns. Each partition is ordered by these. Specifies that
-  /// streaming group by or merge join are possible.
+  // Ordering columns. Each partition is ordered by these. Specifies that
+  // streaming group by or merge join are possible.
   ExprVector orderKeys_;
 
-  /// Corresponds 1:1 to 'order'. The size of this gives the number of leading
-  /// columns of 'order' on which the data is sorted.
+  // Corresponds 1:1 to 'order'. The size of this gives the number of leading
+  // columns of 'order' on which the data is sorted.
   OrderTypeVector orderTypes_;
 
-  /// Number of leading elements of 'order' such that these uniquely identify a
-  /// row. 0 if there is no uniqueness. This can be non-0 also if data is not
-  /// sorted. This indicates a uniqueness for joining.
-  int32_t numKeysUnique_;
+  // Number of leading elements of 'order' such that these uniquely identify a
+  // row. 0 if there is no uniqueness. This can be non-0 also if data is not
+  // sorted. This indicates a uniqueness for joining.
+  int32_t numKeysUnique_{0};
 
-  bool isBroadcast_;
-
-  /// When true, rows with NULLs in partition keys are replicated to all
-  /// partitions and one arbitrary non-null row is also replicated. Required
-  /// for correct distributed execution of null-aware anti joins (NOT IN).
+  // When true, rows with NULLs in partition keys are replicated to all
+  // partitions and one arbitrary non-null row is also replicated. Required
+  // for correct distributed execution of null-aware anti joins (NOT IN). Only
+  // meaningful when this Distribution is used on a Repartition.
   bool replicateNullsAndAny_{false};
 
-  /// Clustering columns. Rows with the same values in these columns are
-  /// contiguous but not necessarily ordered. Enables streaming group by
-  /// when clustering keys are a subset of grouping keys.
+  // Clustering columns. Rows with the same values in these columns are
+  // contiguous but not necessarily ordered. Enables streaming group by
+  // when clustering keys are a subset of grouping keys.
   ExprVector clusterKeys_;
 };
 
@@ -435,3 +462,5 @@ class Schema {
 };
 
 } // namespace facebook::axiom::optimizer
+
+AXIOM_EMBEDDED_ENUM_FORMATTER(facebook::axiom::optimizer::Distribution, Kind);

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -993,8 +993,7 @@ velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
             ->name()));
   }
 
-  if (const auto* partitionType =
-          distribution.distributionType().partitionType()) {
+  if (const auto* partitionType = distribution.partitionType()) {
     return partitionType->makeSpec(
         keyIndices, /*constants=*/{}, /*isLocal=*/false);
   }


### PR DESCRIPTION
Summary:
Replace the `DistributionType` wrapper class and the loose
`isBroadcast_` / `distributionType_.isGather_` flags on `Distribution`
with a single `Distribution::Kind` enum:

  enum class Kind {
    kUnspecified,  // No specific distribution is guaranteed.
    kPartitioned,  // Partitioned on partitionKeys via partitionType.
    kGather,       // All rows on one task.
    kBroadcast,    // Every consumer task receives a full copy.
                   // Only valid on Repartition.
    kArbitrary,    // Round-robin / on-demand pull.
                   // Only valid on Repartition.
  };

The connector::PartitionType pointer that DistributionType used to
carry is now a direct member of Distribution. DistributionType is
deleted.

Other cleanups:
- Strengthen RelationOp::checkDistribution: a Repartition must
  specify a kind (not kUnspecified); replicateNullsAndAny is only
  valid on a Repartition.
- Distribution::rename (called from Project) now drops
  replicateNullsAndAny since the renamed Distribution sits on a
  non-Repartition consumer.

Differential Revision: D104238345


