### PR TITLE
fix(optimizer): Improve distributed UNION ALL planning (#1330)

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -119,6 +119,17 @@ struct DerivedTable : public PlanObject {
   /// is empty. The children hold the per-leg expressions.
   // TODO: Rename setOp -> unionOp. Only UNION and UNION ALL use this
   // structure. INTERSECT and EXCEPT are translated to joins.
+  //
+  // TODO: Drop UNION (DISTINCT) from this representation entirely — it is
+  // conceptually UNION ALL followed by Aggregation(grouping = all output
+  // columns, no aggregates) and should be lowered that way in
+  // makeQueryGraph. This eliminates the special UNION DISTINCT path in
+  // makeUnionPlan (inline makeDistinct + somePartition force-shuffle), which
+  // exists today only because the inline single-step Aggregation isn't
+  // routed through aggregationPlanner_ and so doesn't get partial+final
+  // splits or distribution-aware planning. After lowering, UNION DISTINCT
+  // plans identically to "UNION ALL ... GROUP BY all_cols" and the
+  // hint-vs-requirement rule for desired distribution applies uniformly.
   ///
   /// A UNION ALL produces a single result set — each leg contributes rows
   /// to the same output columns. The output schema is defined once on the

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -575,7 +575,8 @@ void checkProducerConsumerLinkage(
           "Expected PartitionedOutputNode at root of producer fragment: {}",
           producer.taskPrefix);
 
-      if (partitionedOutput->isBroadcast()) {
+      if (partitionedOutput->isBroadcast() ||
+          partitionedOutput->isArbitrary()) {
         continue;
       }
 

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -236,3 +236,5 @@ class MultiFragmentPlan {
 using MultiFragmentPlanPtr = std::shared_ptr<const MultiFragmentPlan>;
 
 } // namespace facebook::axiom::optimizer
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::FragmentType);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3193,7 +3193,27 @@ PlanP Optimization::makeUnionPlan(
     return unionPlan(inputStates, result, distinct);
   }
 
-  if (!distribution.has_value()) {
+  // Treat the parent's desired distribution as a hint, not a requirement.
+  // UNION ALL has finer-grained knowledge than the parent: the parent can
+  // only add a single shuffle above the union (which would re-shuffle
+  // naturally-matching inputs unnecessarily); UNION ALL can shuffle only
+  // the inputs that need it. So if at least one input already produces the
+  // desired distribution natively, honor the request and shuffle only the
+  // inputs that don't. Otherwise drop the request — the parent's blanket
+  // shuffle is no worse than per-input shuffles in that case.
+  //
+  // Wrinkle: this assumes the parent commits to the desired distribution it
+  // requested. A parent that later switches strategy (e.g., a hash join that
+  // requests hash(K) for the build, then chooses to broadcast it instead)
+  // leaves the per-input shuffles in place even though they're now wasted.
+  // Such mis-specification is the parent's bug to fix, not UNION ALL's.
+  std::optional<DesiredDistribution> effectiveDistribution = distribution;
+  if (!isDistinct && effectiveDistribution.has_value() &&
+      std::ranges::all_of(inputNeedsShuffle, std::identity{})) {
+    effectiveDistribution.reset();
+  }
+
+  if (!effectiveDistribution.has_value()) {
     if (isDistinct) {
       // Pick some partitioning key and shuffle on that and make distinct.
       Distribution someDistribution = somePartition(inputs);
@@ -3211,10 +3231,61 @@ PlanP Optimization::makeUnionPlan(
         inputs[i] = make<Repartition>(
             inputs[i],
             Distribution{
-                distribution->partitionType, distribution->partitionKeys},
+                effectiveDistribution->partitionType,
+                effectiveDistribution->partitionKeys},
             inputs[i]->columns());
         inputStates[i].addCost(*inputs[i]);
       }
+    }
+  }
+
+  // For plain UNION ALL with multiple inputs, kSingle (gather-distributed)
+  // inputs cannot co-locate with parallel inputs in the consumer fragment —
+  // they would be multiplied across the parallel tasks. Group all kSingle
+  // inputs into one sub-union and wrap in arbitrary so they feed the parallel
+  // consumer fragment via a single exchange. Compatible parallel inputs
+  // (kSource and kFixed N) co-locate without wrapping.
+  if (!isDistinct && !effectiveDistribution.has_value() && inputs.size() > 1) {
+    RelationOpPtrVector singleInputs;
+    bool hasParallel = false;
+    for (const auto& input : inputs) {
+      if (input->distribution().isGather()) {
+        singleInputs.push_back(input);
+      } else {
+        hasParallel = true;
+      }
+    }
+
+    if (hasParallel && !singleInputs.empty()) {
+      RelationOpPtr singleSubUnion = singleInputs.size() == 1
+          ? singleInputs[0]
+          : make<UnionAll>(singleInputs);
+      auto* wrapped = make<Repartition>(
+          singleSubUnion, Distribution::arbitrary(), singleSubUnion->columns());
+
+      // Rebuild inputs: keep parallel inputs in place, replace the first
+      // kSingle input with the wrapped sub-union, drop the rest. inputStates
+      // is not 1:1 with inputs (unionPlan only sums costs across states),
+      // so we add the wrap's cost to one of the kSingle states and leave
+      // the state vector size unchanged.
+      RelationOpPtrVector newInputs;
+      newInputs.reserve(inputs.size());
+      bool wrapEmitted = false;
+      size_t firstSingleIndex = 0;
+      for (size_t i = 0; i < inputs.size(); ++i) {
+        if (!inputs[i]->distribution().isGather()) {
+          newInputs.emplace_back(inputs[i]);
+          continue;
+        }
+        if (wrapEmitted) {
+          continue;
+        }
+        wrapEmitted = true;
+        firstSingleIndex = i;
+        newInputs.emplace_back(wrapped);
+      }
+      inputs = std::move(newInputs);
+      inputStates[firstSingleIndex].addCost(*wrapped);
     }
   }
 

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -10,6 +10,7 @@ See also:
 - [Existence Pushdown](docs/ExistencePushdown.md) - Pushing semi-joins into subquery aggregations to reduce data before GROUP BY
 - [Testing](docs/Testing.md) - PlanMatcher for plan shape, SqlTest for correctness, test coverage guidelines
 - [DerivedTable Layers](docs/DerivedTableLayers.md) - Layered column ownership model and dependency rules
+- [UNION ALL Planning](docs/UnionAllPlanning.md) - Per-leg-class fragment placement model for UNION ALL in distributed plans
 - [Debugging Tips](docs/DebuggingTips.md) - Using the CLI, generating TPC-H data, speeding up test runs, adding debug logging
 
 The optimizer's input is Logical Plan. This is a tree of relational plan nodes defined using a hierarchy of logical_plan::LogicalPlanNode and logical_plan::Expr classes. Operations represented by the Logical Plan are fully typed and resolved. All names have been bound to schema objects and each operation has defined input and output types.

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1722,8 +1722,30 @@ void Limit::accept(
   visitor.visit(*this, context);
 }
 
+namespace {
+
+// Returns the first input's distribution if every input has the same
+// distribution per Distribution::isSamePartition. Otherwise returns an empty
+// Distribution.
+Distribution commonInputDistribution(const RelationOpPtrVector& inputs) {
+  VELOX_CHECK_GE(inputs.size(), 2, "UnionAll requires at least 2 inputs");
+  const auto& first = inputs[0]->distribution();
+  for (size_t i = 1; i < inputs.size(); ++i) {
+    if (!first.isSamePartition(inputs[i]->distribution())) {
+      return Distribution{};
+    }
+  }
+  return first;
+}
+
+} // namespace
+
 UnionAll::UnionAll(RelationOpPtrVector inputsVector)
-    : RelationOp{RelType::kUnionAll, nullptr, Distribution{}, inputsVector[0]->columns()},
+    : RelationOp{
+          RelType::kUnionAll,
+          /*input=*/nullptr,
+          commonInputDistribution(inputsVector),
+          inputsVector[0]->columns()},
       inputs{std::move(inputsVector)} {
   cost_.inputCardinality = 0;
   for (auto& input : inputs) {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -315,6 +315,107 @@ velox::core::PlanNodePtr ToVelox::addOutputRenames(
       std::move(source));
 }
 
+namespace {
+
+// Merges fragment-type contributions per the compatibility rules in
+// docs/UnionAllPlanning.md. nullopt means "no constraint".
+std::optional<FragmentType> mergeFragmentTypes(
+    std::optional<FragmentType> lhs,
+    std::optional<FragmentType> rhs) {
+  if (!lhs.has_value()) {
+    return rhs;
+  }
+  if (!rhs.has_value()) {
+    return lhs;
+  }
+  if (*lhs == *rhs) {
+    return lhs;
+  }
+  if ((*lhs == FragmentType::kSource && *rhs == FragmentType::kFixed) ||
+      (*lhs == FragmentType::kFixed && *rhs == FragmentType::kSource)) {
+    return FragmentType::kFixed;
+  }
+  VELOX_FAIL(
+      "Incompatible fragment-type contributions in same fragment: {} + {}",
+      *lhs,
+      *rhs);
+}
+
+std::optional<FragmentType> fragmentTypeContribution(const RelationOp& op) {
+  // Repartition is a fragment boundary — its contribution is the
+  // consumer-side type derived from its distribution kind.
+  if (op.relType() == RelType::kRepartition) {
+    switch (op.distribution().kind()) {
+      case Distribution::Kind::kPartitioned:
+        return FragmentType::kFixed;
+      case Distribution::Kind::kGather:
+        return FragmentType::kSingle;
+      case Distribution::Kind::kBroadcast:
+      case Distribution::Kind::kArbitrary:
+      case Distribution::Kind::kUnspecified:
+        return std::nullopt;
+    }
+  }
+
+  // For every other op, gather output means the op lives in a kSingle
+  // fragment: either the op itself emits gather (OrderBy, Limit) and
+  // synthesizes an implicit gather sub-fragment boundary, or it inherits
+  // gather from a single-partition input below.
+  if (op.distribution().isGather()) {
+    return FragmentType::kSingle;
+  }
+
+  switch (op.relType()) {
+    case RelType::kTableScan:
+      return FragmentType::kSource;
+    case RelType::kValues:
+      return FragmentType::kSingle;
+    case RelType::kUnionAll: {
+      std::optional<FragmentType> result;
+      for (const auto& input : op.as<UnionAll>()->inputs) {
+        result = mergeFragmentTypes(result, fragmentTypeContribution(*input));
+      }
+      return result;
+    }
+    case RelType::kJoin: {
+      const auto& join = *op.as<Join>();
+      return mergeFragmentTypes(
+          fragmentTypeContribution(*join.input()),
+          fragmentTypeContribution(*join.right));
+    }
+    case RelType::kRepartition:
+      VELOX_UNREACHABLE();
+    default:
+      return op.input() ? fragmentTypeContribution(*op.input()) : std::nullopt;
+  }
+}
+
+// Sets `fragment.type` (and `width` for kFixed) from the contents rooted at
+// `op`. The fragment type is derived by walking the RelationOp sub-tree down
+// to (but not including) any inner Repartition or leaf, merging contributions
+// per the compatibility rules in docs/UnionAllPlanning.md.
+//
+// For numWorkers == 1, all parallelism collapses to a single task; kSource,
+// kFixed N=1, and kSingle become equivalent. The compatibility rules (which
+// guard against multiplication of kSingle data across parallel tasks) don't
+// apply, so we skip the walk and use kSingle directly.
+void decideFragmentType(
+    const RelationOp& op,
+    const MultiFragmentPlan::Options& options,
+    ExecutableFragment& fragment) {
+  if (options.numWorkers == 1) {
+    fragment.type = FragmentType::kSingle;
+    return;
+  }
+
+  fragment.type = fragmentTypeContribution(op).value_or(FragmentType::kSource);
+  if (fragment.type == FragmentType::kFixed) {
+    fragment.width = options.numWorkers;
+  }
+}
+
+} // namespace
+
 PlanAndStats ToVelox::toVeloxPlan(
     RelationOpPtr plan,
     const MultiFragmentPlan::Options& options,
@@ -328,7 +429,18 @@ PlanAndStats ToVelox::toVeloxPlan(
     plan = addGather(plan);
   }
 
+  // The final (root) fragment is not capped by a Repartition. With
+  // remoteOutput, the root produces wire output; its type is whatever its
+  // contents demand. Otherwise the final fragment runs a single local
+  // consumer. Decide before recursing so operators inside (e.g. makeWrite)
+  // see the correct type.
   ExecutableFragment top = newFragment();
+  if (options.remoteOutput) {
+    decideFragmentType(*plan, options, top);
+  } else {
+    top.type = FragmentType::kSingle;
+  }
+
   std::vector<ExecutableFragment> stages;
   top.fragment.planNode = makeFragment(plan, top, stages);
   stages.push_back(std::move(top));
@@ -866,6 +978,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   }
 
   auto source = newFragment();
+  decideFragmentType(*op.input(), options_, source);
   auto input = makeFragment(op.input(), source, stages);
 
   velox::core::PlanNodePtr node;
@@ -885,7 +998,6 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   auto merge = std::make_shared<velox::core::MergeExchangeNode>(
       nextId(), node->outputType(), keys, sortOrder, exchangeSerdeKind_);
 
-  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(merge->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -905,6 +1017,7 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
   }
 
   auto source = newFragment();
+  decideFragmentType(*op.input(), options_, source);
   auto input = makeFragment(op.input(), source, stages);
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
@@ -915,7 +1028,6 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
 
   auto limitNode = addFinalLimit(nextId(), op.offset, op.limit, exchange);
 
-  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(exchange->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -946,6 +1058,7 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
   }
 
   auto source = newFragment();
+  decideFragmentType(*op.input(), options_, source);
   auto input = makeFragment(op.input(), source, stages);
 
   auto node = addPartialLimit(nextId(), 0, op.offset + op.limit, input);
@@ -963,7 +1076,6 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
 
   auto finalLimitNode = addFinalLimit(nextId(), op.offset, op.limit, exchange);
 
-  fragment.type = FragmentType::kSingle;
   fragment.inputStages.emplace_back(exchange->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
@@ -1442,9 +1554,6 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       (op.step == velox::core::AggregationNode::Step::kFinal ||
        op.step == velox::core::AggregationNode::Step::kSingle)) {
     input = addLocalPartition(nextId(), input, keys);
-    if (keys.empty()) {
-      fragment.type = FragmentType::kSingle;
-    }
   }
 
   auto preGroupedKeys = toFieldRefs(op.preGroupedKeys);
@@ -1616,7 +1725,10 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages,
     std::shared_ptr<velox::core::ExchangeNode>& exchange) {
+  // The producer fragment's type is determined by what's inside it. The
+  // Repartition's distribution describes the wire output and is independent.
   auto source = newFragment();
+  decideFragmentType(*repartition.input(), options_, source);
   auto sourcePlan = makeFragment(repartition.input(), source, stages);
 
   // TODO Figure out a cleaner solution to setting 'columns' for TableWrite.
@@ -1628,13 +1740,16 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
 
   const auto keys = toTypedExprs(distribution.partitionKeys());
 
-  if (distribution.isBroadcast()) {
+  if (distribution.isArbitrary()) {
+    VELOX_CHECK_EQ(0, keys.size());
+    source.fragment.planNode = velox::core::PartitionedOutputNode::arbitrary(
+        nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+  } else if (distribution.isBroadcast()) {
     VELOX_CHECK_EQ(0, keys.size());
     source.fragment.planNode = velox::core::PartitionedOutputNode::broadcast(
         nextId(), 1, outputType, exchangeSerdeKind_, sourcePlan);
   } else if (distribution.isGather()) {
     VELOX_CHECK_EQ(0, keys.size());
-    fragment.type = FragmentType::kSingle;
     source.fragment.planNode = velox::core::PartitionedOutputNode::single(
         nextId(), outputType, exchangeSerdeKind_, sourcePlan);
   } else {
@@ -1668,34 +1783,27 @@ velox::core::PlanNodePtr ToVelox::makeUnionAll(
     const UnionAll& unionAll,
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
-  // If no inputs have a repartition, this is a local exchange. If
-  // some have repartition and more than one have no repartition,
-  // this is a local exchange with a remote exchange as input. All the
-  // inputs with repartition go to one remote exchange.
-  std::vector<velox::core::PlanNodePtr> localSources;
-  std::shared_ptr<velox::core::ExchangeNode> exchange;
+  // Each Repartition input becomes its own remote Exchange (one producer
+  // per Exchange). Local inputs are added directly. All sources are then
+  // merged with a LocalPartition.
+  std::vector<velox::core::PlanNodePtr> sources;
+  sources.reserve(unionAll.inputs.size());
   for (const auto& input : unionAll.inputs) {
     if (input->relType() == RelType::kRepartition) {
+      std::shared_ptr<velox::core::ExchangeNode> exchange;
       makeRepartition(*input->as<Repartition>(), fragment, stages, exchange);
+      sources.push_back(exchange);
     } else {
-      localSources.push_back(makeFragment(input, fragment, stages));
+      sources.push_back(makeFragment(input, fragment, stages));
     }
-  }
-
-  if (localSources.empty()) {
-    return exchange;
-  }
-
-  if (exchange) {
-    localSources.push_back(exchange);
   }
 
   // LocalPartitionNode requires all sources to have the same output type
   // (including column names). Add a rename project to sources whose column
   // names differ from the first source.
-  const auto& targetType = localSources[0]->outputType();
-  for (auto i = 1; i < localSources.size(); ++i) {
-    auto& source = localSources[i];
+  const auto& targetType = sources[0]->outputType();
+  for (auto i = 1; i < sources.size(); ++i) {
+    auto& source = sources[i];
     const auto& sourceType = source->outputType();
     if (*targetType != *sourceType) {
       VELOX_CHECK(targetType->equivalent(*sourceType));
@@ -1712,13 +1820,12 @@ velox::core::PlanNodePtr ToVelox::makeUnionAll(
       velox::core::LocalPartitionNode::Type::kRepartition,
       /* scaleWriter */ false,
       std::make_shared<velox::exec::RoundRobinPartitionFunctionSpec>(),
-      localSources);
+      sources);
 }
 
 velox::core::PlanNodePtr ToVelox::makeValues(
     const Values& values,
     ExecutableFragment& fragment) {
-  fragment.type = FragmentType::kSingle;
   const auto& newColumns = values.columns();
   const auto newType = makeOutputType(newColumns);
   VELOX_DCHECK_EQ(newColumns.size(), newType->size());

--- a/axiom/optimizer/docs/UnionAllPlanning.md
+++ b/axiom/optimizer/docs/UnionAllPlanning.md
@@ -1,0 +1,567 @@
+# UNION ALL Fragment Planning
+
+## Goal
+
+Pick the cheapest fragment layout for a UNION ALL that:
+1. Produces correct results (all rows reach the consumer).
+2. Minimizes data movement (don't reshuffle what's already in the
+   right shape).
+
+## Planning context: bottom-up plans + top-down requirements
+
+Planning is bottom-up. By the time the optimizer plans UNION ALL, each
+leg has already been planned and the following are known:
+- The leg's output distribution (gather, hash(K), arbitrary, etc.).
+- The leg's intrinsic fragment characteristics — what kind of fragment
+  its root would naturally live in (connector-driven kSource, single-task
+  kSingle, hash-exchange-consuming kFixed N).
+- The leg's estimated cardinality.
+
+Requirements come top-down. The parent (the operator consuming UNION
+ALL's output) may pass a desired output distribution — e.g., GROUP BY
+on K wants hash(K) input.
+
+UNION ALL planning reconciles these by choosing:
+1. **Which legs are co-located** (live in the same fragment as the
+   UNION ALL operator). The choice is a tree decision: a leg with no
+   `Repartition` between it and the UNION ALL operator is co-located.
+2. **What kind of `Repartition`** to insert above each non-co-located
+   leg — `arbitrary`, `gather`, or `hash(K)`. (Broadcast is never an
+   option — it replicates each row to every consumer task, which would
+   multiply UNION ALL counts.)
+
+The parent's desired output distribution is treated as a hint: it is
+honored per-leg only when at least one leg already produces it
+natively; otherwise the parent inserts its own `Repartition` above the
+union. UNION ALL planning does not insert a `Repartition` above the
+union itself.
+
+The fragment type of the UNION ALL operator's host fragment is *not* an
+input to planning — it's a *consequence* of the co-location choice.
+- All co-located legs are scans → kSource fragment.
+- Any co-located leg is a hash-exchange consumer → kFixed N fragment
+  (kSource scans, if also co-located, adapt to the fixed width).
+- All co-located legs are single-task → kSingle fragment.
+
+Some combinations cannot co-locate — for example, a kSingle leg with
+any parallel leg, or two kFixed legs with different widths. The
+compatibility rules below define which combinations are allowed;
+planning must wrap any incompatible leg in a `Repartition` so the
+remaining co-located legs share a single fragment type.
+
+## The fragment-compatibility invariant
+
+Every fragment has a single **type**. A fragment is replicated across
+its tasks — every task runs the same plan, processing a different
+chunk of the input data. So legs co-located in the consumer fragment
+must agree on fragment type.
+
+Fragment types:
+
+- **kSource** — task count decided by the runtime, scaled by split
+  count. Multiple scans can share one kSource fragment; each task
+  receives splits from all of those scans. The optimizer may suggest
+  a target width as a cardinality-based hint, but the runtime is not
+  bound by it.
+- **kFixed N** — exactly N tasks, set in the plan. The width must
+  match the `numPartitions` of every hash exchange feeding this
+  fragment.
+- **kSingle** — exactly 1 task. Forced by a gather exchange or by an
+  inherently single-task operator (Values, global aggregation,
+  EnforceSingleRow).
+- **kCoordinator** — exactly 1 task, on the coordinator node.
+
+Compatibility rules for co-locating legs in one fragment:
+- **All kSource legs** → consumer fragment is kSource. Splits from all
+  scans get served to the runtime-decided task set.
+- **kSource + kFixed N** → consumer fragment is kFixed N. The scan
+  commits to N parallelism (loses runtime flexibility — if splits are
+  sparse, some of the N tasks may be idle) but its splits serve the
+  same N tasks that consume the hash exchange. Co-location works; a
+  cost-driven optimizer might wrap the scan in arbitrary anyway when
+  its expected parallelism is much smaller than N (future refinement,
+  not correctness).
+- **All kFixed legs with the same width N** → kFixed N. Each leg's
+  hash exchange feeds the same N tasks; each task gets partition i
+  from each leg.
+- **All kSingle legs** → kSingle.
+- **kSingle + any parallel leg** → CANNOT co-locate (correctness
+  violation: the single-row leg would be multiplied across the parallel
+  tasks). The kSingle leg must be wrapped in `Repartition(arbitrary)`.
+- **kFixed N1 + kFixed N2** with N1 ≠ N2 → cannot co-locate (a fragment
+  has one width). One leg must be wrapped. Not produced by the optimizer
+  today — every parallel leg ends up at `numWorkers`; covered here for
+  completeness.
+
+Note: An `arbitrary` exchange consumer can adopt any width, so it never
+constrains the consumer fragment type — it conforms to whatever the
+consumer already is. Same for the producer side: an arbitrary
+PartitionedOutput sends to whatever consumer count is requested at
+runtime.
+
+## Fragment type vs. output distribution — they're independent
+
+Two separate questions for the UNION ALL fragment (the one containing the
+local merge of all legs):
+
+1. **What's the fragment's type?** Driven by what's inside. If the fragment
+   contains scans → kSource. If it only contains hash-exchange consumers
+   → kFixed. If only a single-task source → kSingle.
+2. **What's the fragment's output distribution?** Driven by what the
+   parent needs. A `PartitionedOutput[HASH K]` at the root produces
+   hash(K) output for the GROUP BY consumer fragment, regardless of
+   whether the UNION ALL fragment itself is kSource or kFixed.
+
+A kSource UNION ALL fragment can absolutely produce hash(K) output for a
+downstream GROUP BY — the fragment runs connector-driven, locally merges its
+legs, and shuffles via a hash PartitionedOutput at the end.
+
+In code, a producer fragment's type is derived from its contents at lowering
+time by walking the RelationOp sub-tree down to (but not including) any
+inner Repartition or leaf, merging contributions per the compatibility rules
+above. The Repartition that caps the fragment carries the wire output via
+its `distribution()`; the two are independent.
+
+## Reference examples
+
+Each example states the SQL, leg facts, parent requirement, and the
+optimal plan shape per the design.
+
+Convention:
+- `t_big`, `t_small` — large/small tables.
+- `numWorkers = 4` for all examples unless stated.
+
+### Coverage matrices
+
+Examples are grouped into sections by what they exercise:
+- **A** — Parent imposes no distribution requirement (e.g., UNION ALL
+  feeds a filter, a project, or another UNION ALL).
+- **B** — Parent requires hash(K) (e.g., GROUP BY, hash join).
+- **C** — Parent requires gather/single (e.g., final query result,
+  ORDER BY at top).
+- **D** — UNION ALL as a hash join build (broadcast or shuffled).
+
+Within each section, examples are numbered (A1, A2, …, B1, B2, …).
+
+Coverage organized by leg fragment-type combination (rows) and
+parent's distribution requirement (columns).
+
+| Leg combination                | None | hash(K) | gather (single) |
+|--------------------------------|------|---------|-----------------|
+| All kSource                    | A1   | B1      | C1              |
+| All kFixed N (same width)      | A2   | B2      | C3              |
+| All kSingle                    | A3   | B3      | C2              |
+| kSource + kSingle              | A4   | B4      | C4              |
+| kFixed N + kSingle             | A5   | B5      | C5              |
+| kSource + kFixed N             | A6   | B6      | C6              |
+| kSource + kFixed + kSingle     | A7   | B7      | C7              |
+
+For section B, each example is the canonical case where any kFixed leg
+already produces the parent's required key. Three orthogonal variants
+apply on top:
+- **Wrong key:** kFixed leg produces hash(K') ≠ parent's hash(K) — add
+  `Repartition(hash K)` on top of that leg.
+- **Mixed match:** some kFixed legs match parent's K, others don't —
+  apply the per-leg decision independently.
+- **Join instead of GROUP BY:** same plan shape, parent fragment is a
+  hash join instead of FINAL aggregation.
+
+These variants don't change the leg-combination structure, so each
+gets one note in the "B variations" section rather than separate
+examples.
+
+### A. Parent imposes no distribution requirement
+
+**General principle (derived from A1–A7):**
+
+1. **If any parallel leg exists, group all kSingle legs into one
+   kSingle sub-fragment and wrap that sub-fragment in
+   `Repartition(arbitrary)`.** One arbitrary exchange total, regardless
+   of how many kSingle legs there are. Correctness — prevents row
+   multiplication.
+2. **Co-locate all remaining legs** (the wrapped-kSingle sub-union
+   plus all parallel kSource and kFixed N legs). The resulting union
+   fragment's type is:
+   - `kFixed N` if any co-located leg is kFixed N (kSource scans adapt
+     to the fixed width).
+   - `kSource` if all co-located legs are kSource.
+   - `kSingle` if no parallel legs exist (everything is kSingle, no
+     wrapping needed).
+3. **No remote exchanges are added** beyond:
+   - One arbitrary exchange for the kSingle sub-union (if any).
+   - The pre-existing exchanges intrinsic to each leg (e.g., a
+     DISTINCT's PARTIAL→FINAL hash exchange).
+
+The principle reduces to a per-leg classifier (kSingle vs. parallel)
+plus "co-locate everything compatible". No "main leg" heuristic, no
+cardinality-driven choices.
+
+#### A1. All kSource — two scans
+```sql
+SELECT * FROM t_big UNION ALL SELECT * FROM t_small
+```
+Legs: kSource + kSource.
+**Optimal:** Both scans co-located in one kSource UNION ALL fragment
+with a LocalPartition. No remote exchanges added.
+
+#### A2. All kFixed N — two parallel-hash-partitioned legs
+```sql
+(SELECT DISTINCT a FROM t1) UNION ALL (SELECT DISTINCT b FROM t2)
+```
+Legs: both kFixed N. Each is hash-partitioned for its own reason
+(DISTINCT needs hash for dedup); the keys may or may not be the same.
+**Optimal:** Both legs co-located in one kFixed N fragment with both
+incoming hash exchanges and a LocalPartition. Each leg's FINAL agg
+consumes only its own incoming hash exchange — they don't interfere
+even if hashed on different keys. No new exchanges added (the two
+PARTIAL→FINAL hash exchanges are intrinsic to each DISTINCT, pre-date
+union planning).
+
+#### A3. All kSingle — single-task legs
+```sql
+VALUES (1) UNION ALL SELECT COUNT(*) FROM t_a UNION ALL VALUES (2)
+```
+Legs: all kSingle.
+**Optimal:** All legs co-located in one kSingle fragment with a
+LocalPartition. No exchanges added.
+
+#### A4. kSource + kSingle — scan + Values
+```sql
+SELECT * FROM t_big UNION ALL VALUES (1, 'x')
+```
+Legs: kSource + kSingle.
+**Optimal:** kSingle group (just Values here) wrapped in arbitrary
+to feed the kSource union fragment. **1 new arbitrary exchange.**
+
+#### A5. kFixed N + kSingle — DISTINCT + Values
+```sql
+SELECT DISTINCT a FROM t_big UNION ALL VALUES (1)
+```
+Legs: kFixed N + kSingle.
+**Optimal:** kSingle group wrapped in arbitrary to feed the kFixed N
+union fragment that hosts the DISTINCT's FINAL agg. **1 new arbitrary
+exchange** (plus DISTINCT's pre-existing PARTIAL→FINAL hash).
+
+#### A6. kSource + kFixed N — scan + DISTINCT
+```sql
+SELECT a FROM t_huge UNION ALL SELECT DISTINCT a FROM t_other
+```
+Legs: kSource + kFixed N.
+**Optimal:** Co-locate both in one kFixed N fragment per the
+compatibility rules (scan adapts to fixed width, DISTINCT's hash
+exchange feeds the same N tasks). LocalPartition merges. No new
+exchanges added (DISTINCT's pre-existing hash exchange is the only
+remote one).
+
+#### A7. kSource + kFixed + kSingle — all three types
+```sql
+SELECT a FROM t_big
+UNION ALL SELECT DISTINCT a FROM t_other
+UNION ALL VALUES (1)
+```
+Legs: kSource + kFixed N + kSingle.
+**Optimal:** kSingle group wrapped in arbitrary. Scan + DISTINCT
+co-located in kFixed N union fragment per A6. **1 new arbitrary
+exchange** (plus DISTINCT's pre-existing hash).
+
+
+### B. Parent requires hash(K) on union output
+
+**General principle (derived from B1–B7):**
+
+1. **Apply section A's layout to all legs.**
+2. **Substitute hash(K) for arbitrary** in any wrapping A would
+   introduce. A wraps kSingle legs in arbitrary when parallel legs
+   exist; in B, hash(K) is used instead, since hash output is the
+   target anyway and the arbitrary intermediate is unnecessary. The
+   wrapped kSingle group becomes
+   a kFixed N producer of hash(K) that feeds the union fragment via a
+   hash exchange. The union fragment is kFixed N either way (since at
+   least one parallel leg exists or the wrap produces one).
+3. **Add a hash(K) shuffle above the union output if it isn't already
+   hash(K).** The output is hash(K) iff every leg arrived at the union
+   as hash(K) on the same K — true when all legs were already
+   conforming (B2) or all were wrapped in step 2 (B5: DISTINCT already
+   hash(K) + kSingle wrapped in hash(K)). Otherwise (any unwrapped
+   non-hash leg co-located in the union — typically a kSource scan), a
+   shuffle above the union is required.
+
+**Examples through the principle:**
+
+| Example | Step 2 (wrap kSingles in hash) | Step 3 (shuffle above union) | New hash exchanges |
+|---------|------|-------|-----|
+| B1 (all scans)              | n/a  | Yes  | 1   |
+| B2 (all kFixed already)     | n/a  | No   | 0 (just existing DISTINCT shuffles) |
+| B3 (all kSingle, no parallel) | n/a (no wrapping needed) | Yes (single → hash output) | 1 |
+| B4 (scan + kSingle)         | Yes (kSingle → hash) | Yes (scan rows still need shuffling) | 2 |
+| B5 (kFixed already + kSingle) | Yes (kSingle → hash) | No (all data arrives as hash(K)) | 1 |
+| B6 (scan + kFixed already)  | n/a  | Yes (scan rows still need shuffling) | 1 |
+| B7 (scan + kFixed already + kSingle) | Yes (kSingle → hash) | Yes (scan rows still need shuffling) | 2 |
+
+The cleanest cases (0 or 1 new shuffle) are B2 (everyone already
+hash(K)), B5 (kSingle wrap is the only non-conforming thing). The
+expensive cases (2 new shuffles) are when both a kSource scan and a
+kSingle are present.
+
+#### B1. All kSource — GROUP BY over two scans
+```sql
+SELECT k, COUNT(*) FROM (
+    SELECT k FROM t_big UNION ALL SELECT k FROM t_small
+) GROUP BY k
+```
+Legs: kSource + kSource. Neither produces hash(k).
+**Optimal:** Apply A → both scans co-located in kSource fragment. Add
+hash(k) shuffle above the union → output to a kFixed N consumer
+fragment running the parent. **1 new hash exchange.**
+
+#### B2. All kFixed N — GROUP BY over two already-hash(k) legs
+```sql
+SELECT k, COUNT(*) FROM (
+    (SELECT DISTINCT k FROM t1) UNION ALL (SELECT DISTINCT k FROM t2)
+) GROUP BY k
+```
+Legs: both kFixed N, both hash(k).
+**Optimal:** Apply A → both co-located in kFixed N fragment via their
+incoming hash exchanges. Output is already hash(k) (worker `i` has
+partition `i` from each leg). No shuffle above the union; the parent
+runs in the same fragment. **0 new exchanges** (DISTINCT's hashes are
+pre-existing).
+
+#### B3. All kSingle — GROUP BY over single-row legs
+```sql
+SELECT k, COUNT(*) FROM (
+    VALUES (1), (2) UNION ALL SELECT COUNT(*) AS k FROM t_a
+) GROUP BY k
+```
+Legs: all kSingle.
+**Optimal:** Apply A → all co-located in kSingle. Add hash(k) shuffle
+above the union → output to kFixed N consumer. **1 new hash exchange.**
+
+#### B4. kSource + kSingle — GROUP BY over scan + single-row
+```sql
+SELECT k, COUNT(*) FROM (
+    SELECT k FROM t_big UNION ALL VALUES (1)
+) GROUP BY k
+```
+Legs: kSource + kSingle.
+**Optimal:** Apply A with hash substitution → kSingle wrapped in
+hash(k); scan stays in the kFixed N union fragment receiving the
+kSingle's hash exchange. Union output isn't hash(k) (scan rows mixed
+in), so add a hash(k) shuffle above. **2 new hash exchanges.**
+
+#### B5. kFixed N + kSingle — GROUP BY over DISTINCT + single-row
+```sql
+SELECT k, COUNT(*) FROM (
+    SELECT DISTINCT k FROM t_big UNION ALL VALUES (1)
+) GROUP BY k
+```
+Legs: kFixed N (hash k) + kSingle.
+**Optimal:** Apply A with hash substitution → kSingle wrapped in
+hash(k); DISTINCT keeps its hash(k) as-is. Both feed the kFixed N
+union fragment as hash exchanges; output is already hash(k). No
+shuffle above. **1 new hash exchange** (the kSingle wrap).
+
+#### B6. kSource + kFixed N — GROUP BY over scan + already-hash(k) leg
+```sql
+SELECT k, COUNT(*) FROM (
+    SELECT k FROM t_big
+    UNION ALL
+    SELECT DISTINCT k FROM t2
+) GROUP BY k
+```
+Legs: kSource + kFixed N (hash(k)).
+**Optimal:** Apply A → scan + DISTINCT co-located in kFixed N. Output
+mixes scan rows (not hash) with DISTINCT rows (hash) → not hash(k).
+Add hash(k) shuffle above. **1 new hash exchange.**
+
+#### B7. kSource + kFixed + kSingle — GROUP BY over all three types
+```sql
+SELECT k, COUNT(*) FROM (
+    SELECT k FROM t_big
+    UNION ALL SELECT DISTINCT k FROM t_other
+    UNION ALL VALUES (1)
+) GROUP BY k
+```
+Legs: kSource + kFixed N + kSingle.
+**Optimal:** Apply A with hash substitution → kSingle wrapped in
+hash(k); scan + DISTINCT co-located in kFixed N. Union output mixes
+scan rows in, so add hash(k) shuffle above. **2 new hash exchanges.**
+
+#### B variations
+
+- **Different parent key (B1-style legs, parent wants hash(k1) instead
+  of hash(k))**: existing leg partitioning is useless; each leg gets
+  `Repartition(hash k1)`. Same shape as the corresponding base B
+  example but with extra shuffles where leg-output partitioning was
+  wasted.
+- **Join instead of GROUP BY (B1-style legs, parent is a hash join
+  probe on K)**: same plan shape as the corresponding base B example —
+  the consumer fragment is the kFixed N join fragment, otherwise
+  identical.
+
+### C. Parent requires gather (single)
+
+**General principle (derived from C1–C7):**
+
+C's parent is kSingle, which is *compatible* with kSingle legs (no
+multiplication problem when a kSingle leg sits in a kSingle host).
+That changes A's wrapping logic for C: kSingle legs don't need
+isolation; they belong in the kSingle final fragment directly.
+
+1. **Parallel legs (kSource, kFixed N):** co-locate them per A's
+   compatibility rules into one parallel sub-union fragment (kSource
+   if all scans, kFixed N if any kFixed N or mixed). Add a gather
+   exchange above this sub-union to feed the kSingle final fragment.
+2. **kSingle legs:** co-locate directly in the kSingle final
+   fragment — no wrapping, no exchange. They become local sources to
+   the LocalPartition that merges the union.
+3. **The FINAL operation** (ORDER BY / LIMIT / global agg) runs in
+   the kSingle final fragment, alongside the LocalPartition that
+   merges the gathered parallel data with the co-located kSingle legs.
+
+**Examples through the principle:**
+
+| Example | Parallel sub-union | kSingle legs co-located in final | New exchanges |
+|---------|--------------------|----------------------------------|---------------|
+| C1 (all scans)              | kSource (2 scans)            | —    | 1 gather |
+| C2 (all kSingle)            | —                            | all  | 0 |
+| C3 (all kFixed)             | kFixed N (2 DISTINCTs)       | —    | 1 gather |
+| C4 (scan + kSingle)         | kSource (scan)               | yes  | 1 gather |
+| C5 (kFixed + kSingle)       | kFixed N (DISTINCT)          | yes  | 1 gather |
+| C6 (scan + kFixed)          | kFixed N (scan + DISTINCT)   | —    | 1 gather |
+| C7 (all three)              | kFixed N (scan + DISTINCT)   | yes  | 1 gather |
+
+Uniform: 1 new gather for any case with a parallel leg, 0 if all
+legs are kSingle. C is genuinely the simplest of the three sections.
+
+#### C1. All kSource — scans feeding ORDER BY
+```sql
+SELECT * FROM (
+    SELECT a FROM t_big UNION ALL SELECT a FROM t_small
+) ORDER BY a
+```
+Legs: kSource + kSource.
+**Optimal:** Both scans co-located in kSource fragment per A1. Add a
+gather above the union → kSingle final fragment hosts the ORDER BY.
+**1 new gather exchange.**
+
+#### C2. All kSingle — single-task legs feeding ORDER BY
+```sql
+SELECT * FROM (
+    VALUES (1), (2) UNION ALL VALUES (3), (4)
+) ORDER BY 1
+```
+Legs: all kSingle.
+**Optimal:** All legs co-located in one kSingle fragment per A3. ORDER
+BY runs in the same fragment. **No new exchanges.**
+
+#### C3. All kFixed N — DISTINCTs feeding ORDER BY
+```sql
+SELECT * FROM (
+    (SELECT DISTINCT a FROM t1) UNION ALL (SELECT DISTINCT a FROM t2)
+) ORDER BY a
+```
+Legs: both kFixed N.
+**Optimal:** Both DISTINCTs co-located in kFixed N fragment per A2.
+Add a gather above the union → kSingle final fragment hosts the
+ORDER BY. **1 new gather exchange** (plus the two DISTINCTs'
+pre-existing hash exchanges).
+
+#### C4. kSource + kSingle — scan + Values feeding ORDER BY
+```sql
+SELECT * FROM (
+    SELECT a FROM t_big UNION ALL VALUES (1)
+) ORDER BY a
+```
+Legs: kSource + kSingle.
+**Optimal:** Scan in its own kSource fragment, gather above to kSingle
+final fragment. Values co-located in the kSingle final fragment as a
+local source. LocalPartition in the final fragment merges gathered
+scan data with Values; ORDER BY runs there. **1 new gather exchange.**
+
+#### C5. kFixed N + kSingle — DISTINCT + Values feeding ORDER BY
+```sql
+SELECT * FROM (
+    SELECT DISTINCT a FROM t_big UNION ALL VALUES (1)
+) ORDER BY a
+```
+DISTINCT in its own kFixed N fragment, gather above to kSingle final.
+Values co-located in the kSingle final. **1 new gather exchange**
+(plus DISTINCT's pre-existing hash).
+
+#### C6. kSource + kFixed N — scan + DISTINCT feeding ORDER BY
+```sql
+SELECT * FROM (
+    SELECT a FROM t_huge UNION ALL SELECT DISTINCT a FROM t_other
+) ORDER BY a
+```
+Scan + DISTINCT co-located in one kFixed N fragment per A6. Gather
+above to kSingle final hosting the ORDER BY. **1 new gather exchange.**
+
+#### C7. kSource + kFixed + kSingle — all three feeding ORDER BY
+```sql
+SELECT * FROM (
+    SELECT a FROM t_big
+    UNION ALL SELECT DISTINCT a FROM t_other
+    UNION ALL VALUES (1)
+) ORDER BY a
+```
+Scan + DISTINCT co-located in kFixed N (parallel sub-union). Gather
+above to kSingle final. Values co-located in the kSingle final. **1
+new gather exchange.**
+
+### D. UNION ALL as a hash join build
+
+These cases reduce to A or B depending on the join strategy. They are
+documented separately as concrete examples for join contexts.
+
+#### D1. UNION ALL as build of a broadcast hash join — A-class
+```sql
+SELECT * FROM t JOIN (SELECT a FROM t1 UNION ALL SELECT a FROM t2) u
+       ON t.a = u.a
+-- where the union output is small enough to broadcast
+```
+Broadcast means a `PartitionedOutput[BROADCAST]` is added above the
+union output, replicating it to all probe tasks. UNION ALL itself sees
+no distribution requirement — the broadcast is a transformation the
+parent applies above the union, regardless of what shape the union
+output is. Plan shape follows A.
+
+#### D2. UNION ALL as build of a shuffled hash join — B-class
+```sql
+SELECT * FROM t JOIN (SELECT a FROM t1 UNION ALL SELECT a FROM t2) u
+       ON t.a = u.a
+```
+Both probe (`t`) and build (the union) get hash-partitioned on `a` for
+the shuffled join. From UNION ALL's perspective, the parent (join
+build) requires hash(a) — same as B-class queries. Plan shape follows
+B1.
+
+## Known gaps
+
+The model above describes the implemented design. The known gaps below
+all share one root cause: planners that sit above UNION ALL don't
+communicate their distribution intent down to UNION ALL planning, and
+UNION ALL planning doesn't recognize the union's output distribution
+upward. Hash joins are an exception — they propagate the desired hash
+distribution to the build via `forBuild`, which UNION ALL planning
+honors. Plans below are correct but include unnecessary shuffles.
+
+- **Aggregations and windows above UNION ALL.** Aggregation and window
+  planning don't recognize that a UNION ALL output is already
+  hash-partitioned on the grouping/partition keys, so an aggregation
+  or window above the union adds a redundant local hash partition.
+  Affects the case described by section B.
+- **UNION DISTINCT.** Currently implemented as an inline single-step
+  Aggregation on top of UNION ALL with a force-shuffle on every leg.
+  The semantically equivalent UNION ALL + GROUP BY hits the same
+  aggregation gap above. Once aggregation planning propagates
+  distribution awareness, UNION DISTINCT can be lowered to UNION ALL +
+  GROUP BY and both forms will produce identical plans.
+- **ORDER BY / LIMIT / global aggregation above UNION ALL.** These
+  planners don't propagate the gather preference to UNION ALL
+  planning. UNION ALL falls back to A's rule and wraps kSingle legs in
+  `Repartition(arbitrary)` into the parallel sub-union, instead of
+  C's optimal layout (kSingle legs as local sources in the kSingle
+  final fragment). Affects mixed-leg cases C4, C5, C7 — one extra
+  arbitrary exchange per kSingle leg.

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(
   Genies.cpp
   TestConnectorQueryTest.cpp
   TpchConnectorQueryTest.cpp
+  UnionAllTest.cpp
   UnnestTest.cpp
   ValuesTest.cpp
   WriteTest.cpp

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -873,6 +873,7 @@ enum class ShuffleType {
   kPartitioned, // Partitioned shuffle (hash/range partitioning)
   kBroadcast, // Broadcast (isBroadcast() == true)
   kGather, // Gather to single partition (numPartitions() == 1)
+  kArbitrary, // Arbitrary (round-robin, isArbitrary() == true)
 };
 
 // Marks a shuffle boundary between fragments in a distributed plan.
@@ -998,6 +999,10 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
         break;
       case ShuffleType::kOrdered:
         // Already verified above with MergeExchange check.
+        break;
+      case ShuffleType::kArbitrary:
+        EXPECT_TRUE(partitionedOutput->isArbitrary());
+        AXIOM_TEST_RETURN_IF_FAILURE
         break;
     }
   }
@@ -1821,6 +1826,13 @@ PlanMatcherBuilder& PlanMatcherBuilder::broadcast() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
       matcher_, ShuffleType::kBroadcast);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::arbitrary() {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
+      matcher_, ShuffleType::kArbitrary);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -352,6 +352,10 @@ class PlanMatcherBuilder {
   /// Verifies that PartitionedOutputNode::isBroadcast() is true.
   PlanMatcherBuilder& broadcast();
 
+  /// Matches an arbitrary (round-robin) shuffle boundary in a distributed plan.
+  /// Verifies that PartitionedOutputNode::isArbitrary() is true.
+  PlanMatcherBuilder& arbitrary();
+
   /// Matches a gather shuffle boundary in a distributed plan.
   /// Verifies that PartitionedOutputNode::numPartitions() == 1.
   PlanMatcherBuilder& gather();

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -704,19 +704,26 @@ TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
 
   // Filter is pushed into the HiveScan as a subfield filter on x.
   // The Values child's constant filter (2 > 0) is folded and eliminated.
-  auto buildMatcher = [&] {
-    return core::PlanMatcherBuilder()
-        .hiveScan("t", test::gt("x", int64_t{0}))
-        .project()
-        .localPartition(matchValues().project().build());
-  };
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("t", test::gt("x", int64_t{0}))
+                       .project()
+                       .localPartition(matchValues().project().build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
 
-  auto plan = toSingleNodePlan(logicalPlan);
-  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
-
-  auto distributedPlan = planVelox(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+  {
+    // Values is isolated behind an arbitrary exchange.
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .hiveScan("t", test::gt("x", int64_t{0}))
+            .project()
+            .localPartition(matchValues().project().arbitrary().build())
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
 }
 
 // Same as above but with a non-trivial expression referenced twice
@@ -736,23 +743,32 @@ TEST_F(SetTest, filterOnDuplicateExpressionInUnionAll) {
 
   // Filter 'a > 0' becomes remaining filters 'x + 1 > 0' and 'x + 2 > 0'
   // on the respective scan branches.
-  auto buildMatcher = [&] {
-    return core::PlanMatcherBuilder()
-        .hiveScan("t", {}, "x + 1 > 0")
-        .project()
-        .localPartition(
-            core::PlanMatcherBuilder()
-                .hiveScan("t", {}, "x + 2 > 0")
-                .project()
-                .build());
-  };
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("t", {}, "x + 1 > 0")
+                       .project()
+                       .localPartition(
+                           core::PlanMatcherBuilder()
+                               .hiveScan("t", {}, "x + 2 > 0")
+                               .project()
+                               .build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
 
-  auto plan = toSingleNodePlan(logicalPlan);
-  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
-
-  auto distributedPlan = planVelox(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("t", {}, "x + 1 > 0")
+                       .project()
+                       .localPartition(
+                           core::PlanMatcherBuilder()
+                               .hiveScan("t", {}, "x + 2 > 0")
+                               .project()
+                               .build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
 }
 
 // Verifies that filtering a UNION ALL on a column not included in the outer
@@ -769,22 +785,30 @@ TEST_F(SetTest, filterColumnPruningInUnionAll) {
 
   auto logicalPlan = parseSelect(sql);
 
-  auto buildMatcher = [&] {
-    return core::PlanMatcherBuilder()
-        .hiveScan("t", test::gt("x", int64_t{0}))
-        .localPartition(
-            core::PlanMatcherBuilder()
-                .hiveScan("t", test::gt("x", int64_t{0}))
-                .project()
-                .build());
-  };
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("t", test::gt("x", int64_t{0}))
+                       .localPartition(
+                           core::PlanMatcherBuilder()
+                               .hiveScan("t", test::gt("x", int64_t{0}))
+                               .project()
+                               .build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
 
-  auto plan = toSingleNodePlan(logicalPlan);
-  AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
-
-  auto distributedPlan = planVelox(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("t", test::gt("x", int64_t{0}))
+                       .localPartition(
+                           core::PlanMatcherBuilder()
+                               .hiveScan("t", test::gt("x", int64_t{0}))
+                               .project()
+                               .build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
 }
 
 // Constant-false filters on UNION ALL branches cause them to be replaced with
@@ -1092,25 +1116,6 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
             .project({"x[1]"})
             .localPartition(matchValues(ROW({})).project({"5 as y"}).build())
             .build());
-  }
-}
-
-TEST_F(SetTest, unionAllWithDistinctWidthMismatch) {
-  std::vector<std::string> widthConstrainingInputs = {
-      "SELECT 1",
-      "SELECT COUNT(*) as n_regionkey FROM nation",
-      "SELECT n_regionkey FROM (SELECT n_regionkey FROM nation LIMIT 3)",
-  };
-  for (const auto& input : widthConstrainingInputs) {
-    auto plan = parseSelect(
-        fmt::format(
-            "SELECT COUNT(*) FROM ("
-            "  SELECT DISTINCT n_regionkey FROM nation"
-            "  UNION ALL"
-            "  {}"
-            ")",
-            input));
-    VELOX_ASSERT_THROW(planVelox(plan), "Partition count mismatch");
   }
 }
 

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -130,6 +130,7 @@ int main(int argc, char** argv) {
   facebook::axiom::optimizer::test::registerQueryFile("coercion.sql");
   facebook::axiom::optimizer::test::registerQueryFile(
       "distinctAggregation.sql");
+  facebook::axiom::optimizer::test::registerQueryFile("unionAll.sql");
   facebook::axiom::optimizer::test::registerQueryFile("unionAllFlatten.sql");
 
   return RUN_ALL_TESTS();

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -1,0 +1,831 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+// Tests for UNION ALL fragment planning. Each test covers one
+// leg-combination case and verifies both single-node and distributed
+// plans. See axiom/optimizer/docs/UnionAllPlanning.md for the design.
+//
+// TODO: Verify fragment types (kSource, kFixed N, kSingle) on the
+// distributed plans. Today the matchers only check exchange topology
+// (count + kind via .arbitrary() / .gather() / .shuffle(keys)). Adding
+// per-fragment type/width assertions to AXIOM_ASSERT_DISTRIBUTED_PLAN
+// is a follow-up.
+//
+// TODO: Extend PlanMatcher to allow specifying symbol aliases in
+// tableScan like other methods (singleAggregation, project, etc.).
+// Then we can use the same column names in SQL across tables and
+// reference them via aliases in matchers, instead of giving each table
+// a distinct column name to avoid internal disambiguation renames.
+class UnionAllTest : public test::QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+
+    // t and u have different column names ('a' and 'b') to avoid the
+    // optimizer's internal column-disambiguation rename ('u.a' → 'a_0')
+    // that would appear when both tables share the same column name.
+    testConnector_->addTable("t", ROW("a", BIGINT()))
+        ->setStats(100'000, {{"a", {.numDistinct = 1'000}}});
+    testConnector_->addTable("u", ROW("b", BIGINT()))
+        ->setStats(10'000, {{"b", {.numDistinct = 1'000}}});
+  }
+};
+
+// Two scans (kSource + kSource) co-locate in one fragment with a
+// LocalPartition. No remote exchanges.
+TEST_F(UnionAllTest, twoScans) {
+  auto logicalPlan = parseSelect("FROM t UNION ALL FROM u", kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t").localPartition(matchScan("u").project().build()).build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Two DISTINCTs (kFixed N + kFixed N) co-locate in one kFixed N fragment
+// with both incoming hash exchanges.
+TEST_F(UnionAllTest, twoDistincts) {
+  auto logicalPlan = parseSelect(
+      "SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .singleAggregation({"a"}, {})
+            .localPartition(
+                matchScan("u").singleAggregation({"b"}, {}).project().build())
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(matchScan("u")
+                                           .distributedAggregation({"b"}, {})
+                                           .project()
+                                           .build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// All single-task legs (kSingle + kSingle) co-locate in one kSingle
+// fragment.
+TEST_F(UnionAllTest, twoValues) {
+  auto logicalPlan =
+      parseSelect("VALUES 1, 2 UNION ALL VALUES 3", kTestConnectorId);
+
+  {
+    auto matcher =
+        matchValues().localPartition(matchValues().project().build()).build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Scan + Values (kSource + kSingle) — Values wrapped in arbitrary, scan
+// hosts the union fragment as kSource.
+TEST_F(UnionAllTest, scanAndValues) {
+  auto logicalPlan = parseSelect("FROM t UNION ALL VALUES 1", kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t").localPartition(matchValues().project().build()).build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(matchValues().project().arbitrary().build())
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Scan + two Values (kSource + kSingle + kSingle) — both Values legs are
+// grouped into one kSingle sub-union and wrapped in a single arbitrary
+// exchange (one wrap regardless of how many kSingle inputs there are).
+TEST_F(UnionAllTest, scanAndTwoValues) {
+  auto logicalPlan = parseSelect(
+      "FROM t UNION ALL VALUES 1 UNION ALL VALUES 2", kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           {matchValues().project().build(),
+                            matchValues().project().build()})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .localPartition(matchValues().project().build())
+                               .arbitrary()
+                               .build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// DISTINCT + Values (kFixed N + kSingle) — DISTINCT hosts the union
+// fragment as kFixed N; Values wrapped in arbitrary.
+TEST_F(UnionAllTest, distinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT DISTINCT a FROM t UNION ALL VALUES 1", kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .singleAggregation({"a"}, {})
+                       .localPartition(matchValues().project().build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .distributedAggregation({"a"}, {})
+            .localPartition(matchValues().project().arbitrary().build())
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Scan + DISTINCT (kSource + kFixed N) — scan adapts to kFixed N; both
+// legs co-locate in one kFixed N fragment with the DISTINCT's hash exchange
+// feeding the same N tasks. No arbitrary wrap.
+TEST_F(UnionAllTest, scanAndDistinct) {
+  auto logicalPlan = parseSelect(
+      "SELECT DISTINCT a FROM t UNION ALL FROM u", kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .singleAggregation({"a"}, {})
+                       .localPartition(matchScan("u").project().build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(matchScan("u").project().build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Scan + DISTINCT + Values (kSource + kFixed N + kSingle) — scan + DISTINCT
+// co-locate in kFixed N fragment, kSingle Values wrapped in arbitrary into
+// the same fragment.
+TEST_F(UnionAllTest, scanAndDistinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "FROM t "
+      "UNION ALL SELECT DISTINCT b FROM u "
+      "UNION ALL VALUES 1",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
+                 matchValues().project().build()})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           {matchScan("u")
+                                .distributedAggregation({"b"}, {})
+                                .project()
+                                .build(),
+                            matchValues().project().arbitrary().build()})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// B-class: GROUP BY over UNION ALL. Parent requires hash(K) on union output.
+// Per the design (axiom/optimizer/docs/UnionAllPlanning.md), the principle is
+// "Apply A; substitute hash(K) for arbitrary in any wrapping; add hash(K)
+// shuffle above the union if its output isn't already hash(K)."
+// ---------------------------------------------------------------------------
+
+// GROUP BY over two scans. Both scans co-locate in one kSource fragment per
+// twoScans; the GROUP BY's hash(a) shuffle goes above the union, with the
+// FINAL agg in a separate kFixed N fragment.
+TEST_F(UnionAllTest, groupByOverTwoScans) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM (FROM t UNION ALL FROM u) GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .singleAggregation({"a"}, {"count(*)"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .distributedAggregation({"a"}, {"count(*)"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over two DISTINCTs (kFixed N + kFixed N). Both legs already
+// produce hash output on their respective keys.
+//
+// TODO: The design's optimal plan would have the GROUP BY's FINAL agg
+// run in the same kFixed N fragment as the union, with no extra hash
+// shuffle (worker `i` already has all rows with hash(K) % N == i from
+// both legs). Today the optimizer doesn't propagate column renames
+// through UnionAll's distribution, so it can't see that the union output
+// is hash(K). It adds an extra local hash partition above the union
+// before the FINAL agg.
+TEST_F(UnionAllTest, groupByOverTwoDistincts) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM ("
+      "  SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .singleAggregation({"a"}, {})
+            .localPartition(
+                matchScan("u").singleAggregation({"b"}, {}).project().build())
+            .singleAggregation({"a"}, {"count(*)"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(matchScan("u")
+                                           .distributedAggregation({"b"}, {})
+                                           .project()
+                                           .build())
+                       .localPartition({"a"})
+                       .singleAggregation({"a"}, {"count(*)"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over two single-task legs. Union stays kSingle; the GROUP BY runs
+// in the same kSingle fragment. The query alias 'AS x(k)' doesn't propagate
+// to the agg's grouping key (which uses internal name 'c0'); a Project on
+// top renames 'c0' to 'k'.
+TEST_F(UnionAllTest, groupByOverTwoValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT k, COUNT(*) FROM ("
+      "  VALUES 1, 2 UNION ALL VALUES 3"
+      ") AS x(k) GROUP BY k",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .singleAggregation({"c0"}, {"count(*)"})
+                       .project()
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    // Even though the union is kSingle, the GROUP BY adds a hash shuffle
+    // to a separate kFixed N fragment for the FINAL agg.
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .distributedSingleAggregation({"c0"}, {"count(*)"})
+                       .project()
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over scan + Values (kSource + kSingle). Same A4 layout (Values
+// wrapped in arbitrary, scan in kSource union); GROUP BY's hash shuffle
+// goes above the union.
+TEST_F(UnionAllTest, groupByOverScanAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM ("
+      "  FROM t UNION ALL VALUES 1"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchValues().project().build())
+                       .singleAggregation({"a"}, {"count(*)"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(matchValues().project().arbitrary().build())
+            .distributedAggregation({"a"}, {"count(*)"})
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over DISTINCT + Values (kFixed N + kSingle). DISTINCT hosts the
+// kFixed N union, Values wrapped in arbitrary. The union's output is then
+// hash-shuffled to a separate kFixed N fragment for the FINAL agg.
+//
+// TODO: The design's optimal plan would wrap kSingle Values in hash(K)
+// directly (not arbitrary), making the union's output hash(K), and the
+// FINAL agg would run in the same kFixed N fragment as the union. Today
+// the kSingle wrap uses arbitrary and the agg adds its own hash shuffle
+// above.
+TEST_F(UnionAllTest, groupByOverDistinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM ("
+      "  SELECT DISTINCT a FROM t UNION ALL VALUES 1"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .singleAggregation({"a"}, {})
+                       .localPartition(matchValues().project().build())
+                       .singleAggregation({"a"}, {"count(*)"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .distributedAggregation({"a"}, {})
+            .localPartition(matchValues().project().arbitrary().build())
+            .distributedSingleAggregation({"a"}, {"count(*)"})
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over scan + DISTINCT (kSource + kFixed N). Both legs co-locate
+// per A6 in kFixed N union (scan adapts to fixed width). GROUP BY's hash
+// shuffle goes above the union (scan rows aren't hash(K), so output is
+// mixed and a shuffle is needed).
+TEST_F(UnionAllTest, groupByOverScanAndDistinct) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM ("
+      "  FROM t UNION ALL SELECT DISTINCT b FROM u"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                matchScan("u").singleAggregation({"b"}, {}).project().build())
+            .singleAggregation({"a"}, {"count(*)"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u")
+                                           .distributedAggregation({"b"}, {})
+                                           .project()
+                                           .build())
+                       .distributedAggregation({"a"}, {"count(*)"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// GROUP BY over scan + DISTINCT + Values (kSource + kFixed N + kSingle).
+// scan + DISTINCT co-locate in kFixed N, Values wrapped in arbitrary. GROUP
+// BY's hash shuffle goes above the union.
+TEST_F(UnionAllTest, groupByOverScanAndDistinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, COUNT(*) FROM ("
+      "  FROM t "
+      "  UNION ALL SELECT DISTINCT b FROM u "
+      "  UNION ALL VALUES 1"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
+                 matchValues().project().build()})
+            .singleAggregation({"a"}, {"count(*)"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           {matchScan("u")
+                                .distributedAggregation({"b"}, {})
+                                .project()
+                                .build(),
+                            matchValues().project().arbitrary().build()})
+                       .distributedAggregation({"a"}, {"count(*)"})
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// C-class: UNION ALL feeding ORDER BY (no LIMIT). Parent requires single-row
+// output. Per the design (UnionAllPlanning.md C principle), parallel legs
+// co-locate per A and a gather feeds the kSingle final fragment that hosts
+// ORDER BY. kSingle legs would ideally co-locate in the final fragment
+// directly.
+//
+// In all distributed plans, OrderBy splits into PARTIAL (in the parallel
+// fragment) + LocalMerge + PartitionedOutput[SINGLE] + MergeExchange (in the
+// final kSingle fragment). The matcher uses orderBy().localMerge().
+// shuffleMerge().
+// ---------------------------------------------------------------------------
+
+// ORDER BY over two scans. Both scans co-locate in one kSource fragment
+// per A1; that fragment's OrderBy is split into PARTIAL+LocalMerge with a
+// merge exchange to the final kSingle fragment.
+TEST_F(UnionAllTest, orderByOverTwoScans) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM (FROM t UNION ALL FROM u) ORDER BY a", kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over two single-task legs. The union is kSingle; per the design
+// the ORDER BY should run in the same kSingle fragment with no remote
+// exchange.
+//
+// TODO: The optimizer always emits a separate kSingle final fragment, even
+// when the union is already kSingle. The OrderBy is split into PARTIAL +
+// LocalMerge + MergeExchange + (no extra OrderBy) — one unnecessary gather.
+TEST_F(UnionAllTest, orderByOverTwoValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM (VALUES 1 UNION ALL VALUES 2) ORDER BY 1",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .orderBy({"c0 ASC NULLS LAST"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .orderBy({"c0 ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over two DISTINCTs. Both DISTINCTs co-locate in kFixed N per A2;
+// the ORDER BY's PARTIAL runs there with a gather (merge exchange) to the
+// kSingle final fragment.
+TEST_F(UnionAllTest, orderByOverTwoDistincts) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM ("
+      "  SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u"
+      ") ORDER BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .singleAggregation({"a"}, {})
+            .localPartition(
+                matchScan("u").singleAggregation({"b"}, {}).project().build())
+            .orderBy({"a ASC NULLS LAST"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(matchScan("u")
+                                           .distributedAggregation({"b"}, {})
+                                           .project()
+                                           .build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over scan + Values. Per the design, the scan is in its own kSource
+// fragment with a gather above; Values co-locate in the kSingle final
+// fragment.
+//
+// TODO: The optimizer follows A's rule (wrap kSingle in arbitrary into the
+// parallel fragment) instead of C's rule (co-locate kSingle in final
+// kSingle fragment). Today: Values wrapped in arbitrary into the kSource
+// union fragment with the scan; gather above. Same gather count, but extra
+// arbitrary exchange that the design avoids.
+TEST_F(UnionAllTest, orderByOverScanAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM (FROM t UNION ALL VALUES 1) ORDER BY a", kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchValues().project().build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(matchValues().project().arbitrary().build())
+            .orderBy({"a ASC NULLS LAST"})
+            .localMerge()
+            .shuffleMerge()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over DISTINCT + Values. Same TODO as orderByOverScanAndValues:
+// Values wrapped in arbitrary into the kFixed N union fragment with the
+// DISTINCT, instead of co-located in the kSingle final.
+TEST_F(UnionAllTest, orderByOverDistinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM (SELECT DISTINCT a FROM t UNION ALL VALUES 1) ORDER BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchScan("t")
+                       .singleAggregation({"a"}, {})
+                       .localPartition(matchValues().project().build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .distributedAggregation({"a"}, {})
+            .localPartition(matchValues().project().arbitrary().build())
+            .orderBy({"a ASC NULLS LAST"})
+            .localMerge()
+            .shuffleMerge()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over scan + DISTINCT. Both legs co-locate in kFixed N per A6;
+// gather above to kSingle final.
+TEST_F(UnionAllTest, orderByOverScanAndDistinct) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM (FROM t UNION ALL SELECT DISTINCT b FROM u) ORDER BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                matchScan("u").singleAggregation({"b"}, {}).project().build())
+            .orderBy({"a ASC NULLS LAST"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u")
+                                           .distributedAggregation({"b"}, {})
+                                           .project()
+                                           .build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ORDER BY over scan + DISTINCT + Values. Scan + DISTINCT co-locate in
+// kFixed N per A6; Values wrapped in arbitrary; gather above.
+//
+// TODO: The optimizer follows A's rule (wrap kSingle in arbitrary into the
+// parallel fragment) instead of C's rule (Values co-located in the kSingle
+// final fragment). Same gather count, but extra arbitrary exchange that the
+// design avoids.
+TEST_F(UnionAllTest, orderByOverScanAndDistinctAndValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM ("
+      "  FROM t "
+      "  UNION ALL SELECT DISTINCT b FROM u "
+      "  UNION ALL VALUES 1) ORDER BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
+                 matchValues().project().build()})
+            .orderBy({"a ASC NULLS LAST"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           {matchScan("u")
+                                .distributedAggregation({"b"}, {})
+                                .project()
+                                .build(),
+                            matchValues().project().arbitrary().build()})
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// D-class: UNION ALL as a hash join build. D1 is broadcast (A-class union),
+// D2 is shuffled (B-class union).
+// ---------------------------------------------------------------------------
+
+// UNION ALL as build of a broadcast hash join. Build is small (small input
+// table v plus filtered u) so the optimizer chooses broadcast over shuffled
+// join. Distinct column names ('a', 'c', 'b') avoid the optimizer's
+// disambiguation rename so matchers reference SQL-level names directly.
+//
+// Per D1's design: the build's union legs co-locate per A1 in one kSource
+// fragment with a BROADCAST output above; the join's desired hash(c) is
+// dropped because no leg produces it natively (treated as a hint, not a
+// requirement, when no leg matches).
+TEST_F(UnionAllTest, broadcastJoinBuildOverUnion) {
+  testConnector_->addTable("v", ROW("c", BIGINT()))
+      ->setStats(10, {{"c", {.numDistinct = 10}}});
+
+  auto logicalPlan = parseSelect(
+      "FROM t JOIN ("
+      "  FROM v UNION ALL FROM u WHERE b < 0"
+      ") s ON t.a = s.c",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .hashJoin(matchScan("v")
+                          .localPartition(
+                              matchScan("u").filter("b < 0").project().build())
+                          .build())
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher =
+        matchScan("t")
+            .hashJoin(matchScan("v")
+                          .localPartition(
+                              matchScan("u").filter("b < 0").project().build())
+                          .broadcast()
+                          .build())
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// UNION ALL as build of a shuffled hash join. Both build legs (the union)
+// and probe get hash-partitioned on the join key. The union legs co-locate
+// in one kSource fragment with a single hash output (B1 pattern). Distinct
+// column names ('a', 'c', 'b') avoid the optimizer's disambiguation rename.
+TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
+  testConnector_->addTable("v", ROW("c", BIGINT()))
+      ->setStats(100'000, {{"c", {.numDistinct = 1'000}}});
+
+  auto logicalPlan = parseSelect(
+      "SELECT t.a FROM t JOIN (FROM v UNION ALL FROM u) s ON t.a = s.c",
+      kTestConnectorId);
+
+  {
+    auto matcher = matchScan("v")
+                       .localPartition(matchScan("u").project().build())
+                       .hashJoin(matchScan("t").build())
+                       .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("v")
+                       .localPartition(matchScan("u").project().build())
+                       .shuffle({"c"})
+                       .hashJoin(matchScan("t").shuffle({"a"}).build())
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -184,11 +184,3 @@ SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
 SELECT * FROM (VALUES (1, null, 'a')) t(x, y, z)
 INTERSECT
 SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
-----
--- ROW subfield access in UNION ALL with positional subscript.
--- duckdb: VALUES (1), (3)
-SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
-----
--- ROW subfield access in UNION ALL with named field.
--- duckdb: VALUES (1), (3)
-SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))

--- a/axiom/optimizer/tests/sql/unionAll.sql
+++ b/axiom/optimizer/tests/sql/unionAll.sql
@@ -1,0 +1,60 @@
+-- UNION ALL queries. Uses table t(a BIGINT, b BIGINT, c DOUBLE) with 15
+-- rows across 3 splits (a in {1,2,3}). See sql/set.sql for the full data.
+--
+-- ROW subfield access in UNION ALL with positional subscript.
+-- duckdb: VALUES (1), (3)
+SELECT x[1] FROM (SELECT ROW(1, 2) AS x UNION ALL SELECT ROW(3, 4))
+----
+-- ROW subfield access in UNION ALL with named field.
+-- duckdb: VALUES (1), (3)
+SELECT x.a FROM (SELECT ROW(1 AS a, 2 AS b) AS x UNION ALL SELECT ROW(3 AS a, 4 AS b))
+----
+-- UNION ALL mixing EXCEPT (multi-task) with Values (single-task).
+SELECT * FROM (SELECT a FROM t EXCEPT SELECT a FROM t WHERE a > 2) UNION ALL SELECT 42
+----
+-- UNION ALL mixing INTERSECT (multi-task, semi-join) with Values
+-- (single-task). INTERSECT goes through a different code path than EXCEPT
+-- (semi-join vs anti-join).
+SELECT * FROM (
+  SELECT a FROM t WHERE a <= 2
+  INTERSECT
+  SELECT a FROM t WHERE a = 1
+) UNION ALL SELECT 42
+----
+-- UNION ALL with a multi-task input (EXCEPT) and multiple single-task
+-- inputs. Exercises grouping of multiple kSingle legs into one wrap.
+SELECT * FROM (
+  SELECT a FROM t WHERE a <= 2
+  EXCEPT
+  SELECT a FROM t WHERE a = 1
+) UNION ALL SELECT 42 UNION ALL SELECT 99
+----
+-- UNION ALL mixing DISTINCT subquery with scan.
+SELECT * FROM (SELECT DISTINCT a FROM t) UNION ALL (SELECT a FROM t)
+----
+-- UNION ALL of DISTINCT (kFixed N) and Values (kSingle).
+SELECT a FROM (
+  SELECT DISTINCT a FROM t UNION ALL SELECT 42
+)
+----
+-- UNION ALL of DISTINCT (kFixed N) and global aggregation (kSingle).
+SELECT a FROM (
+  SELECT DISTINCT a FROM t UNION ALL SELECT COUNT(*) AS a FROM t
+)
+----
+-- UNION ALL of DISTINCT (kFixed N) and LIMIT (kSingle). LIMIT 3 without
+-- ORDER BY is non-deterministic, so verify row count only.
+-- 3 distinct + 3 from LIMIT = 6 rows total.
+-- count 6
+SELECT a FROM (
+  SELECT DISTINCT a FROM t
+  UNION ALL
+  SELECT a FROM (SELECT a FROM t LIMIT 3)
+)
+----
+-- ORDER BY over UNION ALL of scan + Values. Verifies the gather above the
+-- union and the merging exchange feeding ORDER BY.
+SELECT * FROM (
+  SELECT a FROM t
+  UNION ALL SELECT 42
+) ORDER BY 1

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -399,15 +399,18 @@ bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
 }
 
 namespace {
-bool isBroadcast(const velox::core::PlanFragment& fragment) {
-  if (auto partitionedOutputNode =
-          std::dynamic_pointer_cast<const velox::core::PartitionedOutputNode>(
-              fragment.planNode)) {
-    return partitionedOutputNode->kind() ==
-        velox::core::PartitionedOutputNode::Kind::kBroadcast;
+// Returns true if the producer needs updateOutputBuffers to be called with the
+// number of consumer tasks. Broadcast and arbitrary outputs need this because
+// the producer doesn't know the consumer count from the plan alone.
+bool needsOutputBufferUpdate(const velox::core::PlanFragment& fragment) {
+  auto partitionedOutputNode =
+      std::dynamic_pointer_cast<const velox::core::PartitionedOutputNode>(
+          fragment.planNode);
+  if (!partitionedOutputNode) {
+    return false;
   }
-
-  return false;
+  return partitionedOutputNode->isBroadcast() ||
+      partitionedOutputNode->isArbitrary();
 }
 
 void gatherScans(
@@ -454,7 +457,7 @@ void LocalRunner::makeStages(
        ++fragmentIndex) {
     const auto& fragment = fragments_[fragmentIndex];
     stageMap[fragment.taskPrefix] = {
-        stages_.size(), isBroadcast(fragment.fragment)};
+        stages_.size(), needsOutputBufferUpdate(fragment.fragment)};
     stages_.emplace_back();
 
     auto numTasks = fragment.width.value_or(
@@ -504,7 +507,7 @@ void LocalRunner::makeStages(
       }
 
       for (const auto& input : fragment.inputStages) {
-        const auto [sourceStage, broadcast] =
+        const auto [sourceStage, needsUpdate] =
             stageMap[input.producerTaskPrefix];
 
         std::vector<std::shared_ptr<velox::exec::RemoteConnectorSplit>>
@@ -512,7 +515,7 @@ void LocalRunner::makeStages(
         for (const auto& task : stages_[sourceStage]) {
           sourceSplits.push_back(remoteSplit(task->taskId()));
 
-          if (broadcast) {
+          if (needsUpdate) {
             task->updateOutputBuffers(static_cast<int>(stage.size()), true);
           }
         }


### PR DESCRIPTION
Summary:

**Problem.** In distributed execution, all UNION ALL legs land in
the consumer fragment by default, but legs may have incompatible
scheduling constraints — a kSingle leg (Values, global aggregation)
wants exactly 1 task, a hash-partitioned exchange leg wants exactly
N tasks, a scan leg wants the runtime-decided task count. When
incompatible legs mix in one fragment, the resulting plan is
invalid (the fragment can't satisfy both task-count constraints)
and fails with "Partition count mismatch."

The bug exposes a design gap: the optimizer has no coherent model
for how UNION ALL legs map to fragments, when to insert a
Repartition between a leg and the union, and how the parent's
desired distribution interacts with leg placement.

**Solution.** Establish a per-leg-class fragment placement model
for UNION ALL in the optimizer. Distribution decisions live in
the optimizer; ToVelox stays a mechanical translator.

- **Compatibility rules.** Co-locate parallel legs (kSource,
  kFixed N of matching width) in one fragment. Isolate kSingle
  legs (Values, global aggregation) behind an arbitrary exchange
  only when at least one parallel leg exists — otherwise they
  would be multiplied across parallel tasks.

- **Parent's desired distribution is a hint, not a requirement.**
  Honor it per-leg only when at least one leg already produces it
  natively; otherwise drop it and let the parent (broadcast or
  hash) handle alignment above the union.

See axiom/optimizer/docs/UnionAllPlanning.md for the per-case
design — fragment-compatibility rules, the per-class wrapping
principles, and reference plans for each leg combination (no
parent, GROUP BY parent, ORDER BY parent, hash-join-build parent).

New UnionAllTest.cpp covers all leg combinations (23 tests,
single-node and distributed plans verified). New unionAll.sql
covers UNION ALL queries at the SQL execution level.

**Notable runtime-visible changes.** Runtimes need to handle two new
shapes that this commit produces but the current optimizer doesn't:

- **kFixed fragments from UNION ALL.** When UNION ALL legs include a
  hash-exchange consumer (e.g., DISTINCT), the union fragment is now
  kFixed N (matching that exchange's numPartitions), where previously
  it was kSource.
- **Arbitrary exchanges.** kSingle legs (Values, global aggregation)
  are now wrapped in Repartition(arbitrary), producing
  PartitionedOutput with Kind::kArbitrary. The runtime must wire
  arbitrary producer/consumer pairs (any consumer task count,
  on-demand pull).

Open follow-ups (tracked as TODOs in code):

- **Aggregations and windows above UNION ALL get an extra hash
  shuffle.** Aggregation and window planning don't recognize that a
  UNION ALL output is already hash-partitioned on the
  grouping/partition keys, so they add a redundant local hash
  partition above the union. Threading the desired distribution
  through these planners will close this gap (UnionAllTest.cpp, B2
  and B5 tests).
- **ORDER BY / LIMIT / global aggregation above UNION ALL** don't
  propagate the gather preference to UNION ALL planning. UNION ALL
  falls back to A's rule and wraps kSingle legs in arbitrary into the
  parallel sub-union, instead of co-locating them in the kSingle
  final fragment. One extra arbitrary exchange per kSingle leg in
  mixed-leg cases (UnionAllTest.cpp, C2/C4/C5/C7 tests).
- **UNION DISTINCT** is semantically UNION ALL + GROUP BY on all
  output columns, but today it has a separate code path that bolts
  an inline single-step Aggregation on top of UnionAll inside
  makeUnionPlan and force-shuffles every leg on a synthesized key to
  make the dedup correct. The same query written as UNION ALL +
  DISTINCT goes through the standard aggregation planner. These
  should converge: lower UNION DISTINCT to UNION ALL + Aggregation
  in the DT representation so both forms produce the same plan
  (DerivedTable.h, next to setOp).
- Extend PlanMatcher::tableScan to support symbol aliases
  (UnionAllTest.cpp top-of-file).
- Add fragment-type assertions to AXIOM_ASSERT_DISTRIBUTED_PLAN
  (UnionAllTest.cpp top-of-file).

Reviewed By: natashasehgal

Differential Revision: D104224879


