### PR TITLE
feat: Add runtimeStats parameter to ConnectorSplitManager::getSplitSource (#1331)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -889,7 +889,7 @@ SqlQueryRunner::executeSelectOrInsert(
 
   auto queryCtx = newQuery(options);
   auto planAndStats = optimize(logicalPlan, queryCtx, options);
-  return makeLocalRunner(planAndStats, queryCtx, options);
+  return makeLocalRunner(planAndStats, queryCtx, options, noopRuntimeStats_);
 }
 
 namespace {
@@ -920,7 +920,8 @@ std::string SqlQueryRunner::runExplainAnalyze(
   auto planAndStats = optimize(
       logicalPlan, queryCtx, options, nullptr, nullptr, schemaResolver);
 
-  auto runner = makeLocalRunner(planAndStats, queryCtx, options);
+  auto runner =
+      makeLocalRunner(planAndStats, queryCtx, options, noopRuntimeStats_);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };
@@ -1025,7 +1026,7 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
     optimizer::PlanAndStats& planAndStats,
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
     const RunOptions& options,
-    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+    QueryRuntimeStats& runtimeStats) {
   return std::make_shared<runner::LocalRunner>(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
@@ -1115,7 +1116,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
 
   planString = planAndStats.toString();
 
-  auto runner = makeLocalRunner(planAndStats, queryCtx, options, runtimeStats);
+  auto runner = makeLocalRunner(
+      planAndStats,
+      queryCtx,
+      options,
+      runtimeStats ? *runtimeStats : noopRuntimeStats_);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -343,8 +343,7 @@ class SqlQueryRunner {
       facebook::axiom::optimizer::PlanAndStats& planAndStats,
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
       const RunOptions& options,
-      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
-          nullptr);
+      facebook::axiom::QueryRuntimeStats& runtimeStats);
 
   // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
   // and the serialized Velox plan into 'planString'.
@@ -405,6 +404,9 @@ class SqlQueryRunner {
   // Identity of the user running queries. Used as table owner in CREATE TABLE.
   std::string user_;
   std::atomic<int32_t> queryCounter_{0};
+
+  // Noop stats instance for code paths that don't track runtime metrics.
+  facebook::axiom::QueryRuntimeStats noopRuntimeStats_;
 };
 
 } // namespace axiom::sql

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -17,6 +17,7 @@
 
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
@@ -92,11 +93,15 @@ class ConnectorSplitManager {
   /// Returns a SplitSource that covers the contents of 'partitions'. The set of
   /// partitions is exposed separately so that the caller may process the
   /// partitions in a specific order or distribute them to specific nodes in a
-  /// cluster.
+  /// cluster. Connector implementations may use 'runtimeStats' to record
+  /// split enumeration metrics (e.g., file listing, Metastore RPCs).
+  // TODO: Instrument PrismSplitManager with runtimeStats for split enumeration
+  // timing.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions) = 0;
+      const std::vector<PartitionHandlePtr>& partitions,
+      QueryRuntimeStats& runtimeStats) = 0;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -319,7 +319,8 @@ FilteredTableStats estimateStatsFromPartitionStats(
 std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    QueryRuntimeStats& /*runtimeStats*/) {
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
   auto metadata = ConnectorMetadataRegistry::get(tableHandle->connectorId());

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -70,7 +70,8 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions) override;
+      const std::vector<PartitionHandlePtr>& partitions,
+      QueryRuntimeStats& runtimeStats) override;
 };
 
 // Write-time stats for a single partition (or the whole table if

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -146,7 +146,8 @@ SystemSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    QueryRuntimeStats& /*runtimeStats*/) {
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }
 

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -116,7 +116,8 @@ class SystemSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions) override;
+      const std::vector<PartitionHandlePtr>& partitions,
+      QueryRuntimeStats& runtimeStats) override;
 };
 
 /// Axiom ConnectorMetadata for the system connector.

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -331,8 +331,9 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
       splitManager->co_listPartitions(session, tableHandle));
   EXPECT_EQ(partitions.size(), 1);
 
+  QueryRuntimeStats noopStats;
   auto splitSource =
-      splitManager->getSplitSource(session, tableHandle, partitions);
+      splitManager->getSplitSource(session, tableHandle, partitions, noopStats);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -272,7 +272,8 @@ TestSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>&) {
+    const std::vector<PartitionHandlePtr>&,
+    QueryRuntimeStats& /*runtimeStats*/) {
   auto maybeTableHandle =
       std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
   VELOX_CHECK(maybeTableHandle, "Expected TestTableHandle");

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -183,7 +183,8 @@ class TestSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions) override;
+      const std::vector<PartitionHandlePtr>& partitions,
+      QueryRuntimeStats& runtimeStats) override;
 };
 
 class TestColumnHandle : public velox::connector::ColumnHandle {

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -156,8 +156,9 @@ CO_TEST_F(TestConnectorTest, splitManager) {
 
   auto partitions =
       co_await splitManager->co_listPartitions(nullptr, tableHandle);
+  QueryRuntimeStats noopStats;
   auto splitSource =
-      splitManager->getSplitSource(nullptr, tableHandle, partitions);
+      splitManager->getSplitSource(nullptr, tableHandle, partitions, noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -86,7 +86,8 @@ TpchSplitManager::co_listPartitions(
 std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const connector::ConnectorSessionPtr& /*session*/,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
-    const std::vector<PartitionHandlePtr>& /*partitions*/) {
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    QueryRuntimeStats& /*runtimeStats*/) {
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
           tableHandle.get());

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -61,7 +61,8 @@ class TpchSplitManager : public ConnectorSplitManager {
   std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
-      const std::vector<PartitionHandlePtr>& partitions) override;
+      const std::vector<PartitionHandlePtr>& partitions,
+      QueryRuntimeStats& runtimeStats) override;
 };
 
 /// A TableLayout for TPCH tables. Implements sampling by generating TPCH data.

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -210,8 +210,9 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       /*session=*/nullptr, tableHandle);
   CO_ASSERT_EQ(partitions.size(), 1);
 
+  QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      /*session=*/nullptr, tableHandle, partitions);
+      /*session=*/nullptr, tableHandle, partitions, noopStats);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -154,10 +154,15 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
   auto& optimization = queryCtx()->optimization();
   auto plan = optimization->toVelox().toVeloxPlan(
       filter, MultiFragmentPlan::Options::singleNode());
+  static QueryRuntimeStats noopStats;
   return std::make_shared<runner::LocalRunner>(
       std::move(plan.plan),
       std::move(plan.finishWrite),
-      sampleQueryCtx(*optimization->veloxQueryCtx()));
+      sampleQueryCtx(*optimization->veloxQueryCtx()),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(noopStats),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      noopStats);
 }
 
 // Maps hash value to number of times it appears in a table.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -258,10 +258,15 @@ std::shared_ptr<velox::core::QueryCtx> constantQueryCtx(
 std::vector<velox::RowVectorPtr> runConstantPlan(
     PlanAndStats& veloxPlan,
     velox::memory::MemoryPool* pool) {
+  QueryRuntimeStats noopStats;
   auto runner = std::make_shared<runner::LocalRunner>(
       veloxPlan.plan,
       std::move(veloxPlan.finishWrite),
-      constantQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()));
+      constantQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(noopStats),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      noopStats);
 
   std::vector<velox::RowVectorPtr> results;
   while (auto rows = runner->next()) {

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -650,8 +650,10 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         planAndStats.plan,
         std::move(planAndStats.finishWrite),
         queryCtx,
-        std::make_shared<runner::ConnectorSplitSourceFactory>(),
-        optimizerPool_);
+        std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats_),
+        optimizerPool_,
+        /*baseSpillDirectory=*/"",
+        runtimeStats_);
   }
 
   /// Runs a query and returns the result as a single vector in *resultVector,
@@ -981,6 +983,7 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
   // Result from first run of flag value sweep.
   std::vector<RowVectorPtr> referenceResult_;
   std::set<std::string> modifiedFlags_;
+  axiom::QueryRuntimeStats runtimeStats_;
 };
 
 // Reads multi-line command from 'in' until encounters ';' followed by zero or

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -144,8 +144,10 @@ TestResult QueryTestBase::runFragmentedPlan(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       getQueryCtx(),
-      std::make_shared<runner::ConnectorSplitSourceFactory>(),
-      optimizerPool_);
+      std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats_),
+      optimizerPool_,
+      /*baseSpillDirectory=*/"",
+      runtimeStats_);
 
   SCOPE_EXIT {
     waitForCompletion(runner);

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -269,6 +269,7 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
   // A QueryCtx created for each compiled query.
   std::shared_ptr<velox::core::QueryCtx> queryCtx_;
   std::unique_ptr<optimizer::VeloxHistory> history_;
+  QueryRuntimeStats runtimeStats_;
 
   inline static int32_t gQueryCounter{0};
   inline static std::unique_ptr<VeloxHistory> gSuiteHistory;

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -144,12 +144,15 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   auto best = optimization.bestPlan();
   auto planAndStats = optimization.toVeloxPlan(best->op);
 
+  static QueryRuntimeStats noopStats;
   return std::make_shared<runner::LocalRunner>(
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,
-      std::make_shared<runner::ConnectorSplitSourceFactory>(),
-      optimizerPool);
+      std::make_shared<runner::ConnectorSplitSourceFactory>(noopStats),
+      optimizerPool,
+      /*baseSpillDirectory=*/"",
+      noopStats);
 }
 
 void SqlTestBase::runSetupStatement(

--- a/axiom/optimizer/tests/SqlTestBase.h
+++ b/axiom/optimizer/tests/SqlTestBase.h
@@ -19,6 +19,7 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <functional>
 #include <optional>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 
@@ -174,6 +175,7 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
 
   std::shared_ptr<velox::memory::MemoryPool> optimizerPool_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+  QueryRuntimeStats runtimeStats_;
 };
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -80,6 +80,7 @@ class LocalRunner : public Runner {
  private:
   std::shared_ptr<::facebook::velox::memory::MemoryPool> aggregatePool_;
   std::shared_ptr<::facebook::velox::memory::MemoryPool> leafPool_;
+  ::facebook::axiom::QueryRuntimeStats runtimeStats_;
 };
 
 std::vector<velox::RowVectorPtr> LocalRunner::execute(
@@ -94,10 +95,17 @@ std::vector<velox::RowVectorPtr> LocalRunner::execute(
       aggregatePool_);
 
   auto splitSourceFactory =
-      std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>();
+      std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>(
+          runtimeStats_);
 
   auto runner = std::make_shared<facebook::axiom::runner::LocalRunner>(
-      plan_, std::move(finishWrite_), queryCtx, splitSourceFactory, leafPool_);
+      plan_,
+      std::move(finishWrite_),
+      queryCtx,
+      splitSourceFactory,
+      leafPool_,
+      /*baseSpillDirectory=*/"",
+      runtimeStats_);
   try {
     while (auto rows = runner->next()) {
       results.push_back(rows);

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -79,15 +79,14 @@ ConnectorSplitSourceFactory::splitSourceForScan(
   auto listStart = std::chrono::steady_clock::now();
   auto partitions = folly::coro::blockingWait(
       splitManager->co_listPartitions(session, handle));
-  if (runtimeStats_) {
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kListPartitionsWallNanos,
-        std::chrono::steady_clock::now() - listStart);
-    runtimeStats_->recordCount(
-        QueryRuntimeStats::kListPartitionsCount, partitions.size());
-  }
+  runtimeStats_.recordTiming(
+      QueryRuntimeStats::kListPartitionsWallNanos,
+      std::chrono::steady_clock::now() - listStart);
+  runtimeStats_.recordCount(
+      QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
-  return splitManager->getSplitSource(session, handle, partitions);
+  return splitManager->getSplitSource(
+      session, handle, partitions, runtimeStats_);
 }
 
 namespace {
@@ -122,7 +121,7 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
     std::function<void(std::exception_ptr)> onError,
-    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+    QueryRuntimeStats& runtimeStats) {
   std::exception_ptr ex;
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
@@ -145,12 +144,10 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       task->noMoreSplits(scanId);
     }
 
-    if (runtimeStats) {
-      runtimeStats->recordTiming(
-          QueryRuntimeStats::kGetSplitsWallNanos,
-          std::chrono::steady_clock::now() - getSplitsStart);
-      runtimeStats->recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
-    }
+    runtimeStats.recordTiming(
+        QueryRuntimeStats::kGetSplitsWallNanos,
+        std::chrono::steady_clock::now() - getSplitsStart);
+    runtimeStats.recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
   } catch (...) {
     ex = std::current_exception();
   }
@@ -215,13 +212,13 @@ LocalRunner::LocalRunner(
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
     std::string baseSpillDirectory,
-    std::shared_ptr<QueryRuntimeStats> runtimeStats)
+    QueryRuntimeStats& runtimeStats)
     : plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
       baseSpillDirectory_{std::move(baseSpillDirectory)},
-      runtimeStats_{std::move(runtimeStats)} {
+      runtimeStats_(runtimeStats) {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
   if (!baseSpillDirectory_.empty()) {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -65,16 +65,15 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
 /// Generic SplitSourceFactory that delegates the work to ConnectorSplitManager.
 class ConnectorSplitSourceFactory : public SplitSourceFactory {
  public:
-  ConnectorSplitSourceFactory(
-      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr)
-      : runtimeStats_(std::move(runtimeStats)) {}
+  explicit ConnectorSplitSourceFactory(QueryRuntimeStats& runtimeStats)
+      : runtimeStats_(runtimeStats) {}
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan) override;
 
  protected:
-  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
+  QueryRuntimeStats& runtimeStats_;
 };
 
 /// Runner for in-process execution of a distributed plan.
@@ -91,11 +90,10 @@ class LocalRunner : public Runner,
       optimizer::MultiFragmentPlanPtr plan,
       optimizer::FinishWrite finishWrite,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
-      std::shared_ptr<SplitSourceFactory> splitSourceFactory =
-          std::make_shared<ConnectorSplitSourceFactory>(),
-      std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr,
-      std::string baseSpillDirectory = "",
-      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
+      std::shared_ptr<SplitSourceFactory> splitSourceFactory,
+      std::shared_ptr<velox::memory::MemoryPool> outputPool,
+      std::string baseSpillDirectory,
+      QueryRuntimeStats& runtimeStats);
 
   ~LocalRunner() override;
 
@@ -186,7 +184,7 @@ class LocalRunner : public Runner,
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
-  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
+  QueryRuntimeStats& runtimeStats_;
   folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
   bool splitScopeJoined_{false};
 };

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -138,7 +138,13 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     const auto queryId = plan->options().queryId;
 
     return std::make_shared<LocalRunner>(
-        std::move(plan), optimizer::FinishWrite{}, makeQueryCtx(queryId));
+        std::move(plan),
+        optimizer::FinishWrite{},
+        makeQueryCtx(queryId),
+        std::make_shared<ConnectorSplitSourceFactory>(runtimeStats_),
+        /*outputPool=*/nullptr,
+        /*baseSpillDirectory=*/"",
+        runtimeStats_);
   }
 
   // Fetches all remaining data from the runner.
@@ -155,6 +161,7 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
       std::make_shared<velox::core::PlanNodeIdGenerator>()};
 
   int32_t queryCounter_{0};
+  QueryRuntimeStats runtimeStats_;
 
   velox::RowTypePtr rowType_;
 };
@@ -270,9 +277,10 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
       std::move(join),
       optimizer::FinishWrite{},
       std::move(queryCtx),
-      std::make_shared<ConnectorSplitSourceFactory>(),
+      std::make_shared<ConnectorSplitSourceFactory>(runtimeStats_),
       /*outputPool=*/nullptr,
-      spillDir->getPath());
+      spillDir->getPath(),
+      runtimeStats_);
 
   auto results = readCursor(localRunner);
   EXPECT_EQ(1, results.size());

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -398,7 +398,10 @@ PrestoQueryReplayRunner::run(
       std::move(multiFragmentPlan),
       optimizer::FinishWrite{},
       makeQueryCtx(queryId, queryRootPool),
-      std::make_shared<runner::SimpleSplitSourceFactory>(nodeSplitMap));
+      std::make_shared<runner::SimpleSplitSourceFactory>(nodeSplitMap),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      runtimeStats_);
 
   std::vector<velox::RowVectorPtr> result;
   try {

--- a/axiom/runner/tests/PrestoQueryReplayRunner.h
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/QueryCtx.h"
@@ -90,6 +91,7 @@ class PrestoQueryReplayRunner {
   const std::unordered_map<std::string, std::string> config_;
   const std::unordered_map<std::string, std::string> hiveConfig_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  QueryRuntimeStats runtimeStats_;
 };
 
 } // namespace facebook::axiom::runner


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/54


Adds `runtimeStats` parameter (default `nullptr`) to `ConnectorSplitManager::getSplitSource()` so connector implementations can record split enumeration metrics (e.g., Metastore call timing, file listing latency, split count).

The parameter is optional because most callers don't need metrics today — only the Axel distributed scheduler (child diff D104153202) passes a non-null `runtimeStats`. Making it `= nullptr` avoids changing every existing call site while allowing connectors to opt in to instrumentation incrementally.

All connector implementations updated to accept the new parameter:
- **OSS:** LocalHive, System, Tpch, Test
- **Internal:** Prism, Configerator, Impulse, Xdb, Astra

No connector uses `runtimeStats` internally yet — this is plumbing for follow-up Prism split enumeration metrics. Also wires `runtimeStats` through `LocalRunner::getSplitSource` for the single-node execution path.

Reviewed By: arhimondr

Differential Revision: D103904683


