### PR TITLE
fix: Add missing 'name' field to QueryRuntimeStats::toDynamic() (#1332)

### DIFF
--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -106,6 +106,7 @@ folly::dynamic QueryRuntimeStats::toDynamic() const {
   folly::dynamic result = folly::dynamic::object();
   for (const auto& [name, metric] : metrics_) {
     folly::dynamic entry = folly::dynamic::object();
+    entry["name"] = name;
     entry["sum"] = metric.sum;
     entry["count"] = static_cast<int64_t>(metric.count);
     entry["min"] = metric.min;

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -82,12 +82,14 @@ TEST(QueryRuntimeStatsTest, toDynamic) {
 
   auto parseKey = std::string(QueryRuntimeStats::kParseWallNanos);
   ASSERT_TRUE(dynamic.count(parseKey));
+  EXPECT_EQ(dynamic[parseKey]["name"].asString(), parseKey);
   EXPECT_EQ(dynamic[parseKey]["sum"].asInt(), 1000);
   EXPECT_EQ(dynamic[parseKey]["count"].asInt(), 1);
   EXPECT_EQ(dynamic[parseKey]["unit"].asString(), "NANO");
 
   auto splitsKey = std::string(QueryRuntimeStats::kGetSplitsCount);
   ASSERT_TRUE(dynamic.count(splitsKey));
+  EXPECT_EQ(dynamic[splitsKey]["name"].asString(), splitsKey);
   EXPECT_EQ(dynamic[splitsKey]["sum"].asInt(), 42);
   EXPECT_EQ(dynamic[splitsKey]["unit"].asString(), "NONE");
 }


### PR DESCRIPTION
Summary:

The CLI's QueryRuntimeStats::toDynamic() was missing the 'name' field in metric entries. This caused failures when the serialized runtime stats were consumed by downstream systems expecting the 'name' field to be present in each metric.

Added entry['name'] = name to match the expected format and updated tests to verify the field is present.

Differential Revision: D104256468


