### PR TITLE
fix(optimizer): Recognize gather as self-co-partitioned in isSamePartition (#1333)

### DIFF
--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -354,7 +354,9 @@ bool Distribution::isSamePartition(const Distribution& other) const {
   if (kind() != other.kind() || partitionType() != other.partitionType()) {
     return false;
   }
-  if (isBroadcast()) {
+  if (isBroadcast() || isGather()) {
+    // Broadcast: every task gets all rows. Gather: one task gets all rows.
+    // Both are trivially co-partitioned with themselves.
     return true;
   }
   if (partitionKeys().size() != other.partitionKeys().size()) {

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -681,11 +681,10 @@ TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
   auto plan = toSingleNodePlan(logicalPlan);
   AXIOM_ASSERT_PLAN(plan, buildMatcher().build());
 
-  // TODO: The distributed plan has a redundant gather since there are no
-  // table scans. Check isSingleThreadedPipeline in ToVelox.
+  // All-gather UnionAll output stays gather; no extra gather Repartition
+  // needed.
   auto distributedPlan = planVelox(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      distributedPlan.plan, buildMatcher().gather().build());
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, buildMatcher().build());
 }
 
 // Same as above but with a table column referenced twice (SELECT x as a, x as

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -115,10 +115,10 @@ TEST_F(UnionAllTest, twoValues) {
   }
 
   {
-    auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
-                       .gather()
-                       .build();
+    // All-gather UnionAll output stays gather; no extra gather Repartition
+    // needed.
+    auto matcher =
+        matchValues().localPartition(matchValues().project().build()).build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -355,13 +355,16 @@ TEST_F(UnionAllTest, groupByOverTwoValues) {
   }
 
   {
-    // Even though the union is kSingle, the GROUP BY adds a hash shuffle
-    // to a separate kFixed N fragment for the FINAL agg.
+    // The union is kSingle (all-gather inputs); the GROUP BY's
+    // repartitionForAgg recognizes the gather distribution and skips the
+    // remote hash shuffle. Aggregation runs locally in the same fragment;
+    // an in-fragment LocalPartition[HASH] is added by ToVelox for
+    // multi-driver execution.
     auto matcher = matchValues()
                        .localPartition(matchValues().project().build())
-                       .distributedSingleAggregation({"c0"}, {"count(*)"})
+                       .localPartition({"c0"})
+                       .singleAggregation({"c0"}, {"count(*)"})
                        .project()
-                       .gather()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }


### PR DESCRIPTION
Summary:

`Distribution::isSamePartition` returned false for two gather distributions because of a too-strict empty-partitionKeys check. Two gather distributions are trivially co-partitioned: both place all rows on a single task. The check was correct for arbitrary/unspecified (no defined per-row routing), but wrong for gather.

The bug propagates through `UnionAll::commonInputDistribution`: a `UnionAll` over all-gather inputs (e.g., Values, global aggregation, Limit) ended up with empty distribution instead of gather. Downstream consumers (e.g., `repartitionForAgg`'s `isGather()` short-circuit) missed the chance to skip unnecessary work.

Fix: add `isGather()` to the same trivially-equal branch as `isBroadcast()` in `Distribution::isSamePartition`.

Visible plan improvements (no functional change beyond removing wasted work):
- `SELECT k, COUNT(*) FROM (SELECT 'a' AS k UNION ALL SELECT 'b') GROUP BY k`: previously added a remote hash shuffle; now recognizes the gathered input and runs locally.
- `VALUES 1, 2 UNION ALL VALUES 3` distributed: previously wrapped in a redundant gather Repartition; now stays in one kSingle fragment.
- `SELECT b FROM (SELECT 'x' as a, 'x' as b UNION ALL SELECT 'y', 'z') WHERE a <> ''`: removes the redundant gather flagged by an existing TODO.

Differential Revision: D104323936


