### PR TITLE
fix(optimizer): Keep joinOrder in sync with tables in clearState and removeTables (#1335)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -168,26 +168,26 @@ float compositeNdv(PlanObjectCP table, const ExprVector& keys) {
 
 } // namespace
 
-void DerivedTable::checkSetOpConsistency() const {
+void DerivedTable::checkUnionConsistency() const {
   VELOX_CHECK(
-      setOp.value() == logical_plan::SetOperation::kUnion ||
-          setOp.value() == logical_plan::SetOperation::kUnionAll,
-      "setOp must be union or unionAll: {}, {}",
-      cname,
-      logical_plan::SetOperationName::toName(setOp.value()));
-  VELOX_CHECK_EQ(
-      tables.size(), 0, "tables must be empty for set operation: {}", cname);
-  VELOX_CHECK(
-      exprs.empty(), "exprs must be empty for set operation: {}", cname);
+      isUnion(), "checkUnionConsistency called on non-union DT: {}", cname);
+  VELOX_CHECK_EQ(tables.size(), 0, "tables must be empty for union: {}", cname);
+  VELOX_CHECK(exprs.empty(), "exprs must be empty for union: {}", cname);
   VELOX_CHECK_GE(
-      children.size(),
+      unionInputs.size(),
       2,
-      "set operation must have at least 2 children: {}",
+      "set operation must have at least 2 unionInputs: {}",
       cname);
 
-  // Union DT cannot have post-processing.
-  VELOX_CHECK_NULL(
-      aggregation, "Union DT must not have aggregation: {}", cname);
+  // The only aggregation allowed is UNION DISTINCT's dedup: GROUP BY all
+  // output columns, no aggregates.
+  if (aggregation != nullptr) {
+    VELOX_CHECK(
+        aggregation->aggregates().empty(),
+        "Union DT aggregation must have no aggregates (only grouping keys "
+        "for UNION DISTINCT dedup): {}",
+        cname);
+  }
   VELOX_CHECK_NULL(windowPlan, "Union DT must not have windowPlan: {}", cname);
   VELOX_CHECK(having.empty(), "Union DT must not have having: {}", cname);
   VELOX_CHECK(conjuncts.empty(), "Union DT must not have conjuncts: {}", cname);
@@ -213,7 +213,7 @@ void DerivedTable::checkSetOpConsistency() const {
   // Each child's columns must contain the parent's columns (shared Column
   // objects) and have 1:1 exprs. Exprs must reference only the child's own
   // tables or the child itself.
-  for (const auto* child : children) {
+  for (const auto* child : unionInputs) {
     VELOX_CHECK_GE(
         child->columns.size(),
         columns.size(),
@@ -252,8 +252,8 @@ void DerivedTable::checkSetOpConsistency() const {
 void DerivedTable::checkConsistency() const {
   VELOX_CHECK_NOT_NULL(cname);
 
-  if (setOp.has_value()) {
-    checkSetOpConsistency();
+  if (isUnion()) {
+    checkUnionConsistency();
     return;
   }
 
@@ -317,9 +317,9 @@ void DerivedTable::checkConsistency() const {
   }
 
   VELOX_CHECK_EQ(
-      children.size(),
+      unionInputs.size(),
       0,
-      "children must be empty for non-set-operation: {}",
+      "unionInputs must be empty for non-set-operation: {}",
       cname);
   VELOX_CHECK_GT(
       tables.size(),
@@ -574,7 +574,7 @@ void DerivedTable::initializePlans() {
 void DerivedTable::distributeAllConjuncts() {
   distributeConjuncts();
 
-  if (!setOp.has_value()) {
+  if (!isUnion()) {
     for (auto* table : tables) {
       if (table->is(PlanType::kDerivedTableNode)) {
         const_cast<PlanObject*>(table)
@@ -583,16 +583,16 @@ void DerivedTable::distributeAllConjuncts() {
       }
     }
   } else {
-    for (auto* child : children) {
+    for (auto* child : unionInputs) {
       child->distributeAllConjuncts();
     }
   }
 }
 
 void DerivedTable::finalizeJoinsAndMakePlans() {
-  if (!setOp.has_value()) {
+  if (!isUnion()) {
     VELOX_CHECK(!tables.empty());
-    VELOX_CHECK(children.empty());
+    VELOX_CHECK(unionInputs.empty());
 
     for (auto* table : tables) {
       if (table->is(PlanType::kDerivedTableNode)) {
@@ -603,16 +603,16 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
     }
   } else {
     VELOX_CHECK(tables.empty());
-    VELOX_CHECK(!children.empty());
+    VELOX_CHECK(!unionInputs.empty());
 
-    for (auto* child : children) {
+    for (auto* child : unionInputs) {
       child->finalizeJoinsAndMakePlans();
     }
 
-    // Set initial cardinality as the sum of children's cardinalities so that
+    // Set initial cardinality as the sum of unionInputs's cardinalities so that
     // makeInitialPlan can use it when estimating groups for makeDistinct.
     cardinality = 0;
-    for (const auto* child : children) {
+    for (const auto* child : unionInputs) {
       cardinality += child->cardinality;
     }
   }
@@ -964,7 +964,7 @@ void DerivedTable::import(
   VELOX_DCHECK(joins.empty());
   VELOX_DCHECK(!superTables.empty());
   VELOX_DCHECK(superTables.contains(primaryTable));
-  VELOX_DCHECK(!super.setOp.has_value(), "Cannot import from a union DT");
+  VELOX_DCHECK(!super.isUnion(), "Cannot import from a union DT");
 
   copySubset(super, superTables);
 
@@ -1489,11 +1489,11 @@ findJoin(DerivedTableP dt, std::vector<PlanObjectP>& tables, bool create) {
   return nullptr;
 }
 
-// Check if a non-UNION DT has a limit or one of the children of a UNION DT
+// Check if a non-UNION DT has a limit or one of the unionInputs of a UNION DT
 // has a limit.
 bool dtHasLimit(const DerivedTable& dt) {
-  if (dt.setOp.has_value()) {
-    for (const auto& child : dt.children) {
+  if (dt.isUnion()) {
+    for (const auto& child : dt.unionInputs) {
       if (child->is(PlanType::kDerivedTableNode) &&
           child->as<DerivedTable>()->hasLimit()) {
         return true;
@@ -1895,8 +1895,7 @@ void DerivedTable::clearState() {
   having.clear();
   aggregation = nullptr;
   windowPlan = nullptr;
-  children.clear();
-  setOp = std::nullopt;
+  unionInputs.clear();
   orderKeys.clear();
   orderTypes.clear();
   limit = -1;
@@ -1944,7 +1943,7 @@ DerivedTable* DerivedTable::wrapChildWithFilter(
   auto* wrapper = make<DerivedTable>();
   wrapper->cname = queryCtx()->optimization()->newCName("wdt");
 
-  // In a set operation, all children share Column objects whose relation_
+  // In a set operation, all unionInputs share Column objects whose relation_
   // points to the parent set DT. Create new intermediate columns with relation_
   // = child so that the wrapper's importExpr translates the conjunct into
   // child-column space. Without this, the conjunct would reference the set DT
@@ -1976,26 +1975,24 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
     return false;
   }
 
-  if (setOp.has_value()) {
-    for (auto i = 0; i < children.size(); ++i) {
-      if (!children[i]->addFilter(conjunct)) {
+  if (isUnion()) {
+    for (auto i = 0; i < unionInputs.size(); ++i) {
+      if (!unionInputs[i]->addFilter(conjunct)) {
         // The child cannot accept the filter (e.g. it has a window or limit).
         // Wrap the child in a new DT that holds the filter above it.
-        children[i] = wrapChildWithFilter(children[i], conjunct);
+        unionInputs[i] = wrapChildWithFilter(unionInputs[i], conjunct);
       }
     }
 
-    if (setOp.value() == logical_plan::SetOperation::kUnionAll) {
-      // Drop children that became zero-rows after filter pushdown.
+    if (isUnionAll()) {
       std::erase_if(
-          children, [](const auto* child) { return child->isZeroRows(); });
+          unionInputs, [](const auto* child) { return child->isZeroRows(); });
 
-      if (children.size() == 1) {
-        auto* only = children[0];
-        children.clear();
-        setOp = std::nullopt;
+      if (unionInputs.size() == 1) {
+        auto* only = unionInputs[0];
+        unionInputs.clear();
         flattenDt(only);
-      } else if (children.empty()) {
+      } else if (unionInputs.empty()) {
         makeEmpty();
       }
     }
@@ -2088,14 +2085,13 @@ void DerivedTable::distributeConjuncts() {
   expandConjuncts(conjuncts);
 
   // A nondeterminstic filter can be pushed down past a cardinality
-  // neutral border. This is either a single leaf table or a union all
-  // of dts.
+  // neutral border. This is either a single leaf table or a pure UNION
+  // ALL of dts (no dedup aggregation — pushing below dedup would let each
+  // duplicate row evaluate the predicate independently).
   const bool allowNondeterministic = tables.size() == 1 &&
       (tables[0]->is(PlanType::kTableNode) ||
        (tables[0]->is(PlanType::kDerivedTableNode) &&
-        tables[0]->as<DerivedTable>()->setOp.has_value() &&
-        tables[0]->as<DerivedTable>()->setOp.value() ==
-            logical_plan::SetOperation::kUnionAll));
+        tables[0]->as<DerivedTable>()->isUnionAll()));
 
   tryConvertOuterJoins(allowNondeterministic);
 
@@ -2258,8 +2254,8 @@ bool DerivedTable::tryPushdownConjunct(
       return false;
     }
 
-    if (innerDt->setOp.has_value()) {
-      for (auto* child : innerDt->children) {
+    if (innerDt->isUnion()) {
+      for (auto* child : innerDt->unionInputs) {
         pushBackUnique(changedDts, child);
       }
     } else {

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1220,11 +1220,15 @@ ExprCP DerivedTable::importExpr(ExprCP expr) const {
 void DerivedTable::removeTables(
     PlanObjectCP table,
     const std::vector<PlanObjectCP>& chain) {
-  eraseFirst(tables, table);
-  tableSet.erase(table);
+  auto removeOne = [&](PlanObjectCP t) {
+    eraseFirst(tables, t);
+    tableSet.erase(t);
+    eraseFirst(joinOrder, t->id());
+  };
+
+  removeOne(table);
   for (auto& chainTable : chain) {
-    eraseFirst(tables, chainTable);
-    tableSet.erase(chainTable);
+    removeOne(chainTable);
   }
 }
 
@@ -1890,6 +1894,7 @@ void DerivedTable::clearState() {
   outputColumns.reset();
   tables.clear();
   tableSet = PlanObjectSet{};
+  joinOrder.clear();
   joins.clear();
   conjuncts.clear();
   having.clear();

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -85,8 +85,8 @@ struct DerivedTable : public PlanObject {
   /// HAVING, ORDER BY, etc.
   ColumnVector columns;
 
-  /// Exprs projected out. 1:1 to 'columns' or empty if 'this' represents a set
-  /// operation (setOp is set).
+  /// Exprs projected out. 1:1 to 'columns' or empty if 'this' is a UNION
+  /// ALL (isUnion is true).
   ExprVector exprs;
 
   /// Ordered list of columns this DT produces as output. Subset of 'columns'.
@@ -114,48 +114,46 @@ struct DerivedTable : public PlanObject {
   /// 'tableSet' are not considered.
   PlanObjectSet tableSet;
 
-  /// Set if this is a union or unionAll. If set, 'children' has at least 2
-  /// operands. When setOp is set, 'tables' and 'joins' are empty and 'exprs'
-  /// is empty. The children hold the per-leg expressions.
-  // TODO: Rename setOp -> unionOp. Only UNION and UNION ALL use this
-  // structure. INTERSECT and EXCEPT are translated to joins.
-  //
-  // TODO: Drop UNION (DISTINCT) from this representation entirely — it is
-  // conceptually UNION ALL followed by Aggregation(grouping = all output
-  // columns, no aggregates) and should be lowered that way in
-  // makeQueryGraph. This eliminates the special UNION DISTINCT path in
-  // makeUnionPlan (inline makeDistinct + somePartition force-shuffle), which
-  // exists today only because the inline single-step Aggregation isn't
-  // routed through aggregationPlanner_ and so doesn't get partial+final
-  // splits or distribution-aware planning. After lowering, UNION DISTINCT
-  // plans identically to "UNION ALL ... GROUP BY all_cols" and the
-  // hint-vs-requirement rule for desired distribution applies uniformly.
+  /// Per-leg DTs of a UNION ALL. Has at least 2 entries for a union DT and
+  /// is empty for a non-union DT. When non-empty, 'tables', 'joins', and
+  /// 'exprs' are empty; the per-leg DTs hold the per-leg expressions.
+  /// ToGraph translates INTERSECT and EXCEPT to joins, and lowers UNION
+  /// DISTINCT to UNION ALL + GROUP BY all columns (the dedup lives on this
+  /// DT's `aggregation`).
   ///
   /// A UNION ALL produces a single result set — each leg contributes rows
   /// to the same output columns. The output schema is defined once on the
-  /// parent, and all children feed into it. No child "owns" the output
-  /// columns; the parent does. Each child's 'exprs' describes how that
-  /// child populates the shared output columns.
+  /// parent, and all legs feed into it. No leg "owns" the output columns;
+  /// the parent does. Each leg's 'exprs' describes how that leg populates
+  /// the shared output columns.
   ///
   /// Column structure:
   ///
   ///   setDt (parent):
   ///     columns = [col_a, col_b, ...]  (relation_ == setDt)
-  ///     exprs = {}                     (empty — setOp DTs have no exprs)
+  ///     exprs = {}                     (empty — union DTs have no exprs)
   ///     outputColumns = columns
   ///
-  ///   child DTs:
+  ///   leg DTs:
   ///     columns contains setDt->columns (shared Column objects from parent,
-  ///             plus possibly the child's own columns from makeQueryGraph)
-  ///     exprs = [expr_a, expr_b, ...]  (1:1 with columns, reference child's
-  ///                                     internal tables or child's own
+  ///             plus possibly the leg's own columns from makeQueryGraph)
+  ///     exprs = [expr_a, expr_b, ...]  (1:1 with columns, reference the
+  ///                                     leg's internal tables or its own
   ///                                     aggregation/window output columns)
   ///     outputColumns = setDt->columns
-  std::optional<logical_plan::SetOperation> setOp;
+  QGVector<DerivedTable*> unionInputs;
 
-  /// Operands if 'this' is a union or unionAll. Has at least 2 entries when
-  /// 'setOp' is set.
-  QGVector<DerivedTable*> children;
+  /// True if this DT is a UNION or UNION ALL.
+  bool isUnion() const {
+    return !unionInputs.empty();
+  }
+
+  /// True if this DT is a UNION ALL without a dedup aggregation. UNION
+  /// DISTINCT is lowered in ToGraph to UNION ALL + an aggregation grouping
+  /// on all output columns; isUnionAll() returns false in that case.
+  bool isUnionAll() const {
+    return isUnion() && aggregation == nullptr;
+  }
 
   /// Single row tables from non-correlated scalar subqueries.
   PlanObjectSet singleRowDts;
@@ -422,7 +420,7 @@ struct DerivedTable : public PlanObject {
   void finalizeJoinsAndMakePlans();
 
   // Asserts invariants specific to union / unionAll DerivedTables.
-  void checkSetOpConsistency() const;
+  void checkUnionConsistency() const;
 
   // Updates cardinality and column constraints from the plan.
   void updateConstraints(const RelationOp& plan);

--- a/axiom/optimizer/DerivedTableDotPrinter.cpp
+++ b/axiom/optimizer/DerivedTableDotPrinter.cpp
@@ -249,7 +249,7 @@ void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
     out << " dt" << dt.id() << "_" << cname(table) << ";";
   }
 
-  for (auto* table : dt.children) {
+  for (auto* table : dt.unionInputs) {
     out << " dt" << dt.id() << "_" << cname(table) << ";";
   }
   out << "}\n\n";
@@ -269,7 +269,7 @@ void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
         << "\"];\n";
   }
 
-  for (auto* table : dt.children) {
+  for (auto* table : dt.unionInputs) {
     out << "    dt" << dt.id() << "_" << cname(table) << " [label=\""
         << cname(table) << "\", ";
     // Rounded square for derived tables.
@@ -286,9 +286,10 @@ void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
         << cname(dt.tables[dt.tables.size() / 2]) << " [style=invis];\n\n";
   }
 
-  if (!dt.children.empty()) {
+  if (!dt.unionInputs.empty()) {
     out << "    dt" << dt.id() << "_header -> dt" << dt.id() << "_"
-        << cname(dt.children[dt.children.size() / 2]) << " [style=invis];\n\n";
+        << cname(dt.unionInputs[dt.unionInputs.size() / 2])
+        << " [style=invis];\n\n";
   }
 
   int joinNum = 1;
@@ -339,13 +340,13 @@ void printDerivedTableCluster(
          "CELLPADDING=\"4\">\n";
   out << "        <TR><TD BGCOLOR=\"" << kPalette.header << "\" WIDTH=\""
       << headerWidth << "\"><B>" << escapeHtml(dt.cname);
-  if (dt.setOp.has_value()) {
-    out << " " << logical_plan::SetOperationName::toName(dt.setOp.value());
+  if (dt.isUnion()) {
+    out << " UNION ALL";
   }
   out << "</B></TD></TR>\n";
 
   // Output columns.
-  if (dt.setOp.has_value()) {
+  if (dt.isUnion()) {
     for (auto* col : dt.columns) {
       printRow(out, escapeHtml(col->name()));
     }
@@ -500,12 +501,12 @@ void printDerivedTableWithChildren(
     printAllTables(table, out);
   }
 
-  for (const auto* child : dt.children) {
+  for (const auto* child : dt.unionInputs) {
     printAllTables(child, out);
   }
 
   auto children = dt.tables;
-  for (const auto* child : dt.children) {
+  for (const auto* child : dt.unionInputs) {
     children.push_back(child);
   }
 

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -185,13 +185,13 @@ std::string visitDerivedTable(const DerivedTable& dt) {
   std::stringstream out;
   out << headerLine(dt.cname, dt.cardinality, dt.columns);
 
-  if (dt.setOp.has_value()) {
+  if (dt.isUnion()) {
     VELOX_CHECK_EQ(0, dt.exprs.size());
   } else {
     VELOX_CHECK_EQ(dt.columns.size(), dt.exprs.size());
   }
 
-  if (!dt.setOp.has_value()) {
+  if (!dt.isUnion()) {
     out << "  output:" << std::endl;
     for (auto i = 0; i < dt.columns.size(); ++i) {
       out << "    " << dt.columns.at(i)->name()
@@ -299,11 +299,10 @@ std::string visitDerivedTable(const DerivedTable& dt) {
     }
   }
 
-  if (dt.setOp.has_value()) {
-    out << "  " << logical_plan::SetOperationName::toName(dt.setOp.value())
-        << ": ";
+  if (dt.isUnion()) {
+    out << "  UNION ALL: ";
     int32_t i = 0;
-    for (const auto* child : dt.children) {
+    for (const auto* child : dt.unionInputs) {
       if (i > 0) {
         out << ", ";
       }
@@ -312,7 +311,7 @@ std::string visitDerivedTable(const DerivedTable& dt) {
     }
     out << std::endl;
 
-    for (const auto* child : dt.children) {
+    for (const auto* child : dt.unionInputs) {
       out << std::endl;
       out << visitDerivedTable(*child);
     }

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -110,7 +110,7 @@ void collectBaseTables(
       collectBaseTables(table->as<DerivedTable>(), baseTables);
     }
   }
-  for (auto* child : dt->children) {
+  for (auto* child : dt->unionInputs) {
     collectBaseTables(child, baseTables);
   }
 }

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -84,8 +84,8 @@ void Optimization::estimateLeafSelectivity(BaseTable& baseTable) {
 
 namespace {
 void collectBaseTables(DerivedTable* dt, std::vector<BaseTable*>& baseTables) {
-  if (dt->setOp.has_value()) {
-    for (auto* child : dt->children) {
+  if (dt->isUnion()) {
+    for (auto* child : dt->unionInputs) {
       collectBaseTables(child, baseTables);
     }
   } else {
@@ -2845,55 +2845,8 @@ ColumnVector indexColumns(
   return result;
 }
 
-RelationOpPtr makeDistinct(const RelationOpPtr& input) {
-  ExprVector groupingKeys;
-  for (const auto& column : input->columns()) {
-    groupingKeys.push_back(column);
-  }
-
-  return make<Aggregation>(
-      input,
-      groupingKeys,
-      /*preGroupedKeys*/ ExprVector{},
-      AggregateVector{},
-      velox::core::AggregationNode::Step::kSingle,
-      input->columns());
-}
-
-Distribution somePartition(const RelationOpPtrVector& inputs) {
-  float card = 1;
-
-  // A simple type and many values is a good partitioning key.
-  auto score = [&](ColumnCP column) {
-    const auto& value = column->value();
-    const auto card = value.cardinality;
-    return value.type->kind() >= velox::TypeKind::ARRAY ? card / 10000 : card;
-  };
-
-  const auto& firstInput = inputs[0];
-  auto inputColumns = firstInput->columns();
-  std::ranges::sort(inputColumns, [&](ColumnCP left, ColumnCP right) {
-    return score(left) > score(right);
-  });
-
-  ExprVector columns;
-  for (const auto* column : inputColumns) {
-    card *= column->value().cardinality;
-    columns.push_back(column);
-    if (card > 100'000) {
-      break;
-    }
-  }
-
-  return {/*partitionType=*/nullptr, std::move(columns)};
-}
-
-// Adds the costs in the input states to the first state and if 'distinct' is
-// not null adds the cost of that to the first state.
-PlanP unionPlan(
-    std::vector<PlanState>& states,
-    const RelationOpPtr& result,
-    Aggregation* distinct) {
+// Adds the costs in the input states to the first state.
+PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
   auto& firstState = states[0];
 
   for (auto i = 1; i < states.size(); ++i) {
@@ -2901,9 +2854,6 @@ PlanP unionPlan(
 
     firstState.cost.cost += otherCost.cost;
     firstState.cost.cardinality += otherCost.cardinality;
-  }
-  if (distinct) {
-    firstState.addCost(*distinct);
   }
   return make<Plan>(result, states[0]);
 }
@@ -3079,10 +3029,10 @@ RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   PlanState state(*this, &dt);
   RelationOpPtr result;
 
-  if (dt.setOp.has_value()) {
+  if (dt.isUnion()) {
     // Union: assemble from already-planned children.
     RelationOpPtrVector childOps;
-    for (auto* childDt : dt.children) {
+    for (auto* childDt : dt.unionInputs) {
       auto* plans = memo_.find(childDt->memoKey());
       VELOX_CHECK(
           plans != nullptr, "Expecting to find a plan for union branch");
@@ -3090,8 +3040,8 @@ RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
     }
 
     result = make<UnionAll>(std::move(childOps));
-    if (dt.setOp.value() == logical_plan::SetOperation::kUnion) {
-      result = makeDistinct(result);
+    if (dt.aggregation) {
+      addAggregation(&dt, result, state);
     }
 
     state.plans.addPlan(result, state);
@@ -3114,7 +3064,7 @@ PlanP Optimization::makePlan(
     bool& needsShuffle) {
   needsShuffle = false;
   if (key.firstTable->is(PlanType::kDerivedTableNode) &&
-      key.firstTable->as<DerivedTable>()->setOp.has_value()) {
+      key.firstTable->as<DerivedTable>()->isUnion()) {
     return makeUnionPlan(key, distribution);
   }
   return makeDtPlan(dt, key, distribution, existsFanout, needsShuffle);
@@ -3130,18 +3080,18 @@ PlanP Optimization::makeUnionPlan(
   std::vector<PlanState> inputStates;
   std::vector<bool> inputNeedsShuffle;
 
-  // For UNION DISTINCT, the deduplication (GROUP BY) requires all the UNION's
-  // output columns. Ensure the needed columns include at least these, even if
-  // the consumer doesn't reference them (e.g., COUNT(*) needs no specific
-  // columns). Without this, pruneOutputColumns can prune children
+  // When the union has an aggregation (e.g., UNION DISTINCT lowered to
+  // UNION ALL + GROUP BY all columns), the dedup requires all the UNION's
+  // output columns. Ensure the needed columns include at least these, even
+  // if the consumer doesn't reference them (e.g., COUNT(*) needs no
+  // specific columns). Without this, pruneOutputColumns can prune children
   // inconsistently, causing UnionAll::initConstraints to crash.
-  const bool isDistinct = *setDt->setOp == lp::SetOperation::kUnion;
   PlanObjectSet childColumns{key.columns};
-  if (isDistinct) {
+  if (setDt->aggregation) {
     childColumns.unionObjects(setDt->columns);
   }
 
-  for (auto* inputDt : setDt->children) {
+  for (auto* inputDt : setDt->unionInputs) {
     // Only include the child DT in the input tables. Extra tables from
     // the parent key (e.g., reducing bushy join tables) reference joins
     // against the UNION ALL DT which don't exist for individual children.
@@ -3150,7 +3100,7 @@ PlanP Optimization::makeUnionPlan(
 
     PlanP inputPlan;
     bool inputShuffle = false;
-    if (inputDt->setOp.has_value()) {
+    if (inputDt->isUnion()) {
       // Nested union (e.g., UNION ALL of UNION ALL).
       // TODO: Flatten nested unions in ToGraph.
       inputPlan = makeUnionPlan(inputKey, distribution);
@@ -3183,14 +3133,16 @@ PlanP Optimization::makeUnionPlan(
     inputNeedsShuffle.push_back(inputShuffle);
   }
 
-  if (isSingleWorker_) {
-    RelationOpPtr result = make<UnionAll>(inputs);
-    Aggregation* distinct = nullptr;
-    if (isDistinct) {
-      result = makeDistinct(result);
-      distinct = result->as<Aggregation>();
+  auto finishUnionPlan = [&](RelationOpPtrVector finalInputs) {
+    RelationOpPtr result = make<UnionAll>(std::move(finalInputs));
+    if (setDt->aggregation) {
+      addAggregation(setDt, result, inputStates[0]);
     }
-    return unionPlan(inputStates, result, distinct);
+    return unionPlan(inputStates, result);
+  };
+
+  if (isSingleWorker_) {
+    return finishUnionPlan(std::move(inputs));
   }
 
   // Treat the parent's desired distribution as a hint, not a requirement.
@@ -3208,24 +3160,14 @@ PlanP Optimization::makeUnionPlan(
   // leaves the per-input shuffles in place even though they're now wasted.
   // Such mis-specification is the parent's bug to fix, not UNION ALL's.
   std::optional<DesiredDistribution> effectiveDistribution = distribution;
-  if (!isDistinct && effectiveDistribution.has_value() &&
+  if (effectiveDistribution.has_value() &&
       std::ranges::all_of(inputNeedsShuffle, std::identity{})) {
     effectiveDistribution.reset();
   }
 
-  if (!effectiveDistribution.has_value()) {
-    if (isDistinct) {
-      // Pick some partitioning key and shuffle on that and make distinct.
-      Distribution someDistribution = somePartition(inputs);
-      for (auto i = 0; i < inputs.size(); ++i) {
-        inputs[i] = make<Repartition>(
-            inputs[i], someDistribution, inputs[i]->columns());
-        inputStates[i].addCost(*inputs[i]);
-      }
-    }
-  } else {
-    // Some need a shuffle. Add the shuffles, add an optional distinct and
-    // return with no shuffle needed.
+  if (effectiveDistribution.has_value()) {
+    // Some inputs need a shuffle to reach the parent's desired distribution;
+    // wrap those.
     for (auto i = 0; i < inputs.size(); ++i) {
       if (inputNeedsShuffle[i]) {
         inputs[i] = make<Repartition>(
@@ -3237,15 +3179,13 @@ PlanP Optimization::makeUnionPlan(
         inputStates[i].addCost(*inputs[i]);
       }
     }
-  }
-
-  // For plain UNION ALL with multiple inputs, kSingle (gather-distributed)
-  // inputs cannot co-locate with parallel inputs in the consumer fragment —
-  // they would be multiplied across the parallel tasks. Group all kSingle
-  // inputs into one sub-union and wrap in arbitrary so they feed the parallel
-  // consumer fragment via a single exchange. Compatible parallel inputs
-  // (kSource and kFixed N) co-locate without wrapping.
-  if (!isDistinct && !effectiveDistribution.has_value() && inputs.size() > 1) {
+  } else {
+    // No parent distribution requirement. kSingle (gather-distributed)
+    // inputs cannot co-locate with parallel inputs in the consumer fragment
+    // — they would be multiplied across the parallel tasks. Group all
+    // kSingle inputs into one sub-union and wrap in arbitrary so they feed
+    // the parallel consumer fragment via a single exchange. Compatible
+    // parallel inputs (kSource and kFixed N) co-locate without wrapping.
     RelationOpPtrVector singleInputs;
     bool hasParallel = false;
     for (const auto& input : inputs) {
@@ -3289,13 +3229,7 @@ PlanP Optimization::makeUnionPlan(
     }
   }
 
-  RelationOpPtr result = make<UnionAll>(inputs);
-  Aggregation* distinct = nullptr;
-  if (isDistinct) {
-    result = makeDistinct(result);
-    distinct = result->as<Aggregation>();
-  }
-  return unionPlan(inputStates, result, distinct);
+  return finishUnionPlan(std::move(inputs));
 }
 
 PlanP Optimization::makeDtPlan(

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3471,20 +3471,19 @@ void translateSetOperationInput(
 
 void ToGraph::translateUnion(const lp::SetNode& set) {
   auto* setDt = currentDt_;
-  setDt->setOp = set.operation();
+  const auto parentOperation = set.operation();
 
   auto shouldFlatten = [&](const lp::LogicalPlanNode& input) {
     if (input.kind() != lp::NodeKind::kSet) {
       return false;
     }
-    const auto inputSetOp = input.as<lp::SetNode>()->operation();
-    const auto parentSetOp = setDt->setOp;
-    if (inputSetOp == parentSetOp) {
+    const auto inputOperation = input.as<lp::SetNode>()->operation();
+    if (inputOperation == parentOperation) {
       // Same set operation can be flattened.
       return true;
     }
-    if (inputSetOp == lp::SetOperation::kUnionAll &&
-        parentSetOp == lp::SetOperation::kUnion) {
+    if (inputOperation == lp::SetOperation::kUnionAll &&
+        parentOperation == lp::SetOperation::kUnion) {
       // UNION ALL can be flattened into UNION.
       return true;
     }
@@ -3529,14 +3528,31 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
       newDt->columns = setDt->columns;
     }
 
-    setDt->children.push_back(newDt);
+    setDt->unionInputs.push_back(newDt);
   };
 
   translateSetOperationInput(set, shouldFlatten, translateUnionInput);
 
   setDt->outputColumns = setDt->columns;
-  for (auto* child : setDt->children) {
+  for (auto* child : setDt->unionInputs) {
     child->outputColumns = setDt->columns;
+  }
+
+  // Lower UNION DISTINCT to UNION ALL + GROUP BY (group on every output
+  // column, no aggregates). The flattening above used the original
+  // operation, so nested UNION DISTINCTs collapsed to one setDt with
+  // children flattened as needed; only the outer dedup remains.
+  if (parentOperation == lp::SetOperation::kUnion) {
+    ExprVector groupingKeys;
+    groupingKeys.reserve(setDt->columns.size());
+    for (auto* column : setDt->columns) {
+      groupingKeys.push_back(column);
+    }
+    setDt->aggregation = make<AggregationPlan>(
+        std::move(groupingKeys),
+        AggregateVector{},
+        setDt->columns,
+        setDt->columns);
   }
 
   renames_ = std::move(renames);

--- a/axiom/optimizer/docs/Testing.md
+++ b/axiom/optimizer/docs/Testing.md
@@ -53,6 +53,28 @@ auto detailed = PlanMatcherBuilder()
 
 Node-only matching (no arguments) should be reserved for local development and debugging. Checked-in tests should verify the details relevant to the optimization being tested.
 
+#### Test comments
+
+Test comments should describe **what behavior the test verifies**, not the history that led to writing it or how the optimizer happens to implement it today.
+
+```cpp
+// ❌ Avoid — historical / implementation detail.
+// Regression: outer filter pushed into a UNION DISTINCT leg that becomes
+// zero-rows previously failed in checkConsistency with "Size mismatch
+// between joinOrder and tables" (clearState reset tables but not
+// joinOrder, leaving stale entries when the leg DT was reused).
+TEST_F(SetTest, ...) { ... }
+
+// ✅ Prefer — describe the behavior under test.
+// UNION DISTINCT with an outer filter that pushes into the legs and
+// reduces one to zero rows: dedup still applies to the surviving leg.
+TEST_F(SetTest, ...) { ... }
+```
+
+The bug story rots: original failure modes change, internal class names get renamed, line numbers shift. The behavior the test verifies stays stable — that's what future readers (and you, six months later) need to understand the test.
+
+The bug story belongs in the commit message and the diff/PR description, where readers know to look for historical context. Don't duplicate it into the test code.
+
 #### Alias propagation
 
 The optimizer generates internal column names (e.g., `dt3.__p12`) that are implementation details subject to change without notice. PlanMatcher handles this via **alias capture and propagation**: you assign test-defined aliases in aggregations and projects, then reference them in subsequent matchers. The test fully controls these names, making them independent of optimizer internals. The framework rewrites your aliases to actual column names during matching.

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -33,10 +33,12 @@ class SetTest : public test::HiveQueriesTestBase {
  protected:
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
-    createTpchTables(
-        {velox::tpch::Table::TBL_NATION,
-         velox::tpch::Table::TBL_PART,
-         velox::tpch::Table::TBL_PARTSUPP});
+    createTpchTables({
+        velox::tpch::Table::TBL_REGION,
+        velox::tpch::Table::TBL_NATION,
+        velox::tpch::Table::TBL_PART,
+        velox::tpch::Table::TBL_PARTSUPP,
+    });
   }
 };
 
@@ -685,6 +687,97 @@ TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
   // needed.
   auto distributedPlan = planVelox(logicalPlan);
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, buildMatcher().build());
+}
+
+// UNION DISTINCT over all-gather inputs (e.g., constant Values) plans as a
+// single fragment with no remote shuffles. The dedup runs locally because
+// all data is already on a single task.
+TEST_F(SetTest, unionDistinctOverGatherInputs) {
+  auto logicalPlan = parseSelect("SELECT 1 AS k UNION SELECT 2");
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchValues()
+          .project()
+          .localPartition(matchValues().project().build())
+          .singleAggregation({"k"}, {})
+          .build());
+
+  // TODO: The inner localPartition({"k"}) is a redundant hash repartition
+  // immediately after the round-robin local merge from UnionAll. ToVelox's
+  // makeAggregation adds it for multi-driver hash co-location even though
+  // the round-robin just spread the data. Folding the two would let
+  // makeAggregation skip this step.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planVelox(logicalPlan).plan,
+      matchValues()
+          .project()
+          .localPartition(matchValues().project().build())
+          .localPartition({"k"})
+          .singleAggregation({"k"}, {})
+          .build());
+}
+
+// A nondeterministic filter pushes below UNION ALL (no dedup → safe) but
+// must stay above UNION DISTINCT's dedup — pushing it into the legs would
+// let each duplicate row evaluate the predicate independently before dedup,
+// changing query semantics.
+//
+// The filter references a column (`k > rand()` rather than
+// `rand() < 0.5`) so that distributeConjuncts considers it for pushdown
+// (the pushdown path requires the conjunct to reference a single table).
+TEST_F(SetTest, nondeterministicFilterAboveUnion) {
+  // UNION ALL: filter pushes into both scan legs (no dedup → safe). The
+  // pushed predicate becomes a TableScan column filter; an extra Filter
+  // node above the union no longer exists.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT k FROM (SELECT n_nationkey AS k FROM nation "
+        "UNION ALL SELECT r_regionkey AS k FROM region) WHERE k > rand()");
+
+    auto buildMatcher = [&] {
+      return core::PlanMatcherBuilder()
+          .hiveScan("nation", {}, "cast(n_nationkey as double) > rand()")
+          .project()
+          .localPartition(
+              core::PlanMatcherBuilder()
+                  .hiveScan(
+                      "region", {}, "cast(r_regionkey as double) > rand()")
+                  .project()
+                  .build());
+    };
+
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), buildMatcher().build());
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        planVelox(logicalPlan).plan, buildMatcher().gather().build());
+  }
+
+  // UNION DISTINCT: filter stays above the aggregation (dedup), not pushed
+  // into the scan legs.
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT k FROM (SELECT n_nationkey AS k FROM nation "
+        "UNION SELECT r_regionkey AS k FROM region) WHERE k > rand()");
+
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchHiveScan("nation")
+            .project()
+            .localPartition(matchHiveScan("region").project().build())
+            .singleAggregation({"k"}, {})
+            .filter("cast(k as double) > rand()")
+            .build());
+
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        planVelox(logicalPlan).plan,
+        matchHiveScan("nation")
+            .project()
+            .localPartition(matchHiveScan("region").project().build())
+            .distributedAggregation({"k"}, {})
+            .filter("cast(k as double) > rand()")
+            .gather()
+            .build());
+  }
 }
 
 // Same as above but with a table column referenced twice (SELECT x as a, x as

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -184,3 +184,7 @@ SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
 SELECT * FROM (VALUES (1, null, 'a')) t(x, y, z)
 INTERSECT
 SELECT * FROM (VALUES (1, null, 'b')) t(x, y, z)
+----
+-- UNION DISTINCT with an outer filter that pushes into the legs and
+-- reduces the constant leg to zero rows; dedup still applies.
+SELECT k FROM (SELECT 1 AS k UNION SELECT a AS k FROM t) WHERE k > 1


### PR DESCRIPTION
Summary:

`DerivedTable::clearState` cleared every member except `joinOrder`, leaving stale entries when the DT was reused after clearing. `DerivedTable::removeTables` similarly removed from `tables` and `tableSet` but not from `joinOrder`.

The leftover `joinOrder` entries triggered `checkConsistency`'s `joinOrder.size() == tables.size()` check on subsequent use — visible in queries that hit `clearState` between `addTable` calls (e.g., a UNION DISTINCT leg with a constant Values input followed by an outer filter that pushes through). The check failed with "Size mismatch between joinOrder and tables".

Fix: clear and erase `joinOrder` in lockstep with `tables` in both functions.

Differential Revision: D104400197


