### PR TITLE
feat(optimizer): SubfieldTracker handles OutputNode natively for column pruning (#1340)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -63,13 +63,19 @@ Optimization::Optimization(
       runtimeStats_{std::move(runtimeStats)} {
   queryCtx()->optimization() = this;
 
-  const auto* planRoot = logicalPlan_;
   if (logicalPlan_->is(logical_plan::NodeKind::kOutput)) {
-    outputNames_ = logicalPlan_->as<logical_plan::OutputNode>()->entries();
-    planRoot = logicalPlan_->onlyInput().get();
+    // Resolve entries to source names so addOutputRenames can look up by
+    // name; pruning may invalidate the original ordinals.
+    const auto& output = *logicalPlan_->as<logical_plan::OutputNode>();
+    const auto& inputType = *output.onlyInput()->outputType();
+    outputColumnMappings_.reserve(output.entries().size());
+    for (const auto& entry : output.entries()) {
+      outputColumnMappings_.push_back(
+          {inputType.nameOf(entry.index), entry.name});
+    }
   }
 
-  root_ = toGraph_.makeQueryGraph(*planRoot);
+  root_ = toGraph_.makeQueryGraph(*logicalPlan_);
   root_->initializePlans();
 }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -63,7 +63,8 @@ class Optimization {
   /// given, these can be used to record history data about the execution of
   /// each relevant node for costing future queries.
   PlanAndStats toVeloxPlan(RelationOpPtr plan) {
-    return toVelox_.toVeloxPlan(std::move(plan), runnerOptions_, outputNames_);
+    return toVelox_.toVeloxPlan(
+        std::move(plan), runnerOptions_, outputColumnMappings_);
   }
 
   ToVelox& toVelox() {
@@ -359,8 +360,8 @@ class Optimization {
   // Top level plan to optimize.
   const logical_plan::LogicalPlanNode* const logicalPlan_;
 
-  // User-facing output column names from the root OutputNode.
-  std::vector<logical_plan::OutputNode::Entry> outputNames_;
+  // Resolved root OutputNode entries; empty when there is no OutputNode.
+  std::vector<OutputColumnNameMapping> outputColumnMappings_;
 
   // Source of historical cost/cardinality information.
   History& history_;

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -64,6 +64,14 @@ SubfieldTracker::SubfieldTracker(
   }
 }
 
+SubfieldTracker::MarkAllResult SubfieldTracker::markAll(
+    const lp::LogicalPlanNode& node) && {
+  markAllSubfields(node, {});
+  const auto* planRoot =
+      node.is(lp::NodeKind::kOutput) ? node.onlyInput().get() : &node;
+  return {std::move(controlSubfields_), std::move(payloadSubfields_), planRoot};
+}
+
 namespace {
 
 PathCP stepsToPath(std::span<const Step> steps) {
@@ -655,6 +663,26 @@ void SubfieldTracker::markControl(
 void SubfieldTracker::markAllSubfields(
     const lp::LogicalPlanNode& node,
     const MarkFieldsAccessedContext& context) {
+  // Mark only the source ordinals OutputNode exports on its input,
+  // enabling pruning of columns the OutputNode does not list.
+  if (node.is(lp::NodeKind::kOutput)) {
+    const auto& output = *node.as<lp::OutputNode>();
+    const auto& input = *output.onlyInput();
+    markControl(input, context);
+
+    LogicalContextSource source = {.planNode = &input};
+    std::vector<Step> steps;
+    for (const auto& entry : output.entries()) {
+      markFieldAccessed(
+          source, entry.index, steps, /*isControl=*/false, context);
+      VELOX_CHECK(
+          steps.empty(),
+          "OutputNode entry at ordinal {} must be a top-level column",
+          entry.index);
+    }
+    return;
+  }
+
   markControl(node, context);
 
   LogicalContextSource source = {.planNode = &node};

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -73,13 +73,26 @@ class SubfieldTracker {
       std::function<logical_plan::ConstantExprPtr(const logical_plan::ExprPtr&)>
           tryFoldConstant);
 
+  /// Subfield results plus the effective plan root after stripping any
+  /// root OutputNode.
+  struct MarkAllResult {
+    /// Columns and subfields used as join keys, group-by keys, etc.
+    PlanSubfields controlSubfields;
+    /// Columns and subfields used as payload (projected, aggregated, etc.).
+    PlanSubfields payloadSubfields;
+    /// The effective plan root after stripping OutputNode. If the root is an
+    /// OutputNode, this points to its only input; otherwise it is the original
+    /// root. Callers should use this as the plan root for subsequent
+    /// processing.
+    const logical_plan::LogicalPlanNode* planRoot{nullptr};
+  };
+
   /// Goes over the local plan and collects all accessed columns and subfields.
   /// Reports 'control' and 'payload' columns and subfields separately.
-  std::pair<PlanSubfields, PlanSubfields> markAll(
-      const logical_plan::LogicalPlanNode& node) && {
-    markAllSubfields(node, {});
-    return {controlSubfields_, payloadSubfields_};
-  }
+  /// When the root is an OutputNode, only the source ordinals listed in its
+  /// entries are marked as payload-accessed on its input, enabling pruning
+  /// of columns the OutputNode does not export.
+  MarkAllResult markAll(const logical_plan::LogicalPlanNode& node) &&;
 
   /// If 'step' applied to result of the function of 'metadata'
   /// corresponds to an argument, returns the ordinal of the argument.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4560,13 +4560,15 @@ NormalizedJoin normalizeLogicalJoin(const lp::JoinNode& join) {
 } // namespace
 
 DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
-  std::tie(controlSubfields_, payloadSubfields_) =
-      SubfieldTracker([&](const auto& expr) {
-        return tryFoldConstant(expr);
-      }).markAll(logicalPlan);
+  auto result = SubfieldTracker([&](const auto& expr) {
+                  return tryFoldConstant(expr);
+                }).markAll(logicalPlan);
+  controlSubfields_ = std::move(result.controlSubfields);
+  payloadSubfields_ = std::move(result.payloadSubfields);
+  const auto& planRoot = *result.planRoot;
   currentDt_ = newDt();
-  makeQueryGraph(logicalPlan, kAllAllowedInDt, /*orderObservedAbove=*/true);
-  setDtUsedOutput(currentDt_, logicalPlan);
+  makeQueryGraph(planRoot, kAllAllowedInDt, /*orderObservedAbove=*/true);
+  setDtUsedOutput(currentDt_, planRoot);
 
   // TODO Try constant fold the dt.
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -123,7 +123,9 @@ class ToGraph {
       std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
 
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
-  /// DerivedTable.
+  /// DerivedTable. Strips a root OutputNode after SubfieldTracker prunes
+  /// columns it does not export. Surviving columns keep their original
+  /// names; positions are not stable — downstream must look up by name.
   DerivedTableP makeQueryGraph(
       const logical_plan::LogicalPlanNode& logicalPlan);
 
@@ -607,6 +609,9 @@ class ToGraph {
   // aggregate cannot be split out and triggers a VELOX_NYI.
   ExprCP splitCorrelatedProjection(ExprCP expr, DerivedTableP dt);
 
+  // Populates 'dt' with one column per ordinal in usedChannels(node),
+  // named via node.outputType().nameOf(ordinal). Establishes the
+  // makeQueryGraph name-preservation contract; ordering is unspecified.
   void setDtUsedOutput(
       DerivedTableP dt,
       const logical_plan::LogicalPlanNode& node);

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -245,47 +245,52 @@ void ToVelox::filterUpdated(BaseTableCP table) {
 
 velox::core::PlanNodePtr ToVelox::addOutputRenames(
     velox::core::PlanNodePtr input,
-    const std::vector<logical_plan::OutputNode::Entry>& outputNames) {
-  VELOX_CHECK_EQ(outputNames.size(), input->outputType()->size());
-
-  // If the input is a ProjectNode that only does renames/reorders (all
-  // expressions are FieldAccessTypedExpr on input columns), look through it
-  // to compose the renames and avoid stacking two rename-only projects.
+    const std::vector<OutputColumnNameMapping>& outputNames) {
+  // Look through an identity Project on top of input to avoid stacking
+  // two rename-only projects.
   auto* project = dynamic_cast<const velox::core::ProjectNode*>(input.get());
   const std::vector<velox::core::TypedExprPtr>* innerProjections = nullptr;
   if (isIdentityProject(input.get())) {
     innerProjections = &project->projections();
   }
 
-  // Resolve the effective source: the project's input if we can look
-  // through, otherwise the input itself.
-  auto source = innerProjections ? project->sources()[0] : std::move(input);
-  const auto& sourceType = source->outputType();
+  auto composeFrom = innerProjections ? project->sources()[0] : input;
+  const auto& lookupType = input->outputType();
+  const auto& composeType = composeFrom->outputType();
 
-  // Check if the composed result is a no-op: each output column maps to the
-  // same-named source column at the same index.
-  if (sourceType->size() == outputNames.size()) {
-    bool needRename = false;
+  // Check if the composed rename is a no-op: each output column resolves
+  // to the same-named source column at the same position in composeFrom.
+  if (composeType->size() == outputNames.size()) {
+    bool isNoOp = true;
     for (size_t i = 0; i < outputNames.size(); ++i) {
-      auto index = outputNames[i].index;
-      const auto& sourceName = [&]() -> const std::string& {
-        if (innerProjections) {
-          return static_cast<const velox::core::FieldAccessTypedExpr*>(
-                     (*innerProjections)[index].get())
-              ->name();
-        }
-        return sourceType->nameOf(index);
-      }();
-
-      if (outputNames[i].name != sourceName ||
-          sourceName != sourceType->nameOf(i)) {
-        needRename = true;
+      const auto lookupIndex =
+          lookupType->getChildIdxIfExists(outputNames[i].sourceName);
+      if (!lookupIndex.has_value()) {
+        isNoOp = false;
+        break;
+      }
+      // Resolve through the identity project to the source column in
+      // composeFrom.
+      std::string_view sourceName;
+      size_t sourceIndex;
+      if (innerProjections) {
+        const auto& name =
+            static_cast<const velox::core::FieldAccessTypedExpr*>(
+                (*innerProjections)[*lookupIndex].get())
+                ->name();
+        sourceName = name;
+        sourceIndex = composeType->getChildIdx(name);
+      } else {
+        sourceName = lookupType->nameOf(*lookupIndex);
+        sourceIndex = *lookupIndex;
+      }
+      if (outputNames[i].outputName != sourceName || sourceIndex != i) {
+        isNoOp = false;
         break;
       }
     }
-
-    if (!needRename) {
-      return source;
+    if (isNoOp) {
+      return composeFrom;
     }
   }
 
@@ -294,25 +299,33 @@ velox::core::PlanNodePtr ToVelox::addOutputRenames(
 
   std::vector<velox::core::TypedExprPtr> projections;
   projections.reserve(outputNames.size());
-  for (const auto& entry : outputNames) {
-    names.push_back(entry.name);
+
+  // Duplicate outputName values are permitted; OutputNode allows the same
+  // source column to appear under multiple output names.
+  for (const auto& column : outputNames) {
+    const auto lookupIndex = lookupType->getChildIdxIfExists(column.sourceName);
+    VELOX_CHECK(
+        lookupIndex.has_value(),
+        "OutputNode source column '{}' not found in optimized plan output [{}]. "
+        "This violates the makeQueryGraph name-preservation contract.",
+        column.sourceName,
+        lookupType->toString());
+    names.push_back(column.outputName);
     if (innerProjections) {
-      projections.push_back((*innerProjections)[entry.index]);
+      projections.push_back((*innerProjections)[*lookupIndex]);
     } else {
       projections.push_back(
           std::make_shared<velox::core::FieldAccessTypedExpr>(
-              sourceType->childAt(entry.index),
-              sourceType->nameOf(entry.index)));
+              composeType->childAt(*lookupIndex), column.sourceName));
     }
   }
 
   auto id = innerProjections ? project->id() : nextId();
-
   return std::make_shared<velox::core::ProjectNode>(
       std::move(id),
       std::move(names),
       std::move(projections),
-      std::move(source));
+      std::move(composeFrom));
 }
 
 namespace {
@@ -419,7 +432,7 @@ void decideFragmentType(
 PlanAndStats ToVelox::toVeloxPlan(
     RelationOpPtr plan,
     const MultiFragmentPlan::Options& options,
-    const std::vector<logical_plan::OutputNode::Entry>& outputNames) {
+    const std::vector<OutputColumnNameMapping>& outputNames) {
   options_ = options;
 
   prediction_.clear();
@@ -1530,9 +1543,9 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
           type, toTypedExprs(aggregate->args()), aggregate->name());
 
       aggregates.push_back({
-          .call = call,
-          .rawInputTypes = rawInputTypes,
-          .mask = mask,
+          .call = std::move(call),
+          .rawInputTypes = std::move(rawInputTypes),
+          .mask = std::move(mask),
           .sortingKeys = toFieldRefs(aggregate->orderKeys()),
           .sortingOrders = toSortOrders(aggregate->orderTypes()),
           .distinct = aggregate->isDistinct(),
@@ -1549,7 +1562,8 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
       }
       auto call = std::make_shared<velox::core::CallTypedExpr>(
           type, std::move(inputs), aggregate->name());
-      aggregates.push_back({.call = call, .rawInputTypes = rawInputTypes});
+      aggregates.push_back(
+          {.call = std::move(call), .rawInputTypes = std::move(rawInputTypes)});
     }
   }
 

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -34,6 +34,16 @@ using NodeHistoryMap = folly::F14FastMap<velox::core::PlanNodeId, std::string>;
 using NodePredictionMap =
     folly::F14FastMap<velox::core::PlanNodeId, NodePrediction>;
 
+/// Maps a source column name to its user-requested output name for the
+/// final projection in toVeloxPlan. Resolved eagerly because column
+/// pruning invalidates the original ordinals.
+struct OutputColumnNameMapping {
+  /// Column name in the plan below OutputNode.
+  std::string sourceName;
+  /// Output column name from OutputNode entry.
+  std::string outputName;
+};
+
 /// Plan and specification for recording execution history amd planning ttime
 /// predictions.
 struct PlanAndStats {
@@ -56,11 +66,12 @@ class ToVelox {
 
   /// Converts physical plan (a tree of RelationOp) to an executable
   /// multi-fragment Velox plan. If outputNames is non-empty, adds a
-  /// final projection to rename or reorder output columns.
+  /// final projection that selects the named source columns from the
+  /// optimized plan's outputType and renames them per outputName.
   PlanAndStats toVeloxPlan(
       RelationOpPtr plan,
       const MultiFragmentPlan::Options& options,
-      const std::vector<logical_plan::OutputNode::Entry>& outputNames = {});
+      const std::vector<OutputColumnNameMapping>& outputNames = {});
 
   /// Per-leaf-table data produced by filterUpdated().
   struct LeafTableData {
@@ -101,12 +112,12 @@ class ToVelox {
   }
 
  private:
-  // Adds a Velox ProjectNode that renames or reorders output columns per the
-  // given OutputNode entries. Returns the input unchanged if all names and
-  // positions already match.
+  // Adds a Velox ProjectNode that selects 'outputNames' from 'input' by
+  // source name and renames them per outputName. Returns 'input' unchanged
+  // when all names and positions already match.
   velox::core::PlanNodePtr addOutputRenames(
       velox::core::PlanNodePtr input,
-      const std::vector<logical_plan::OutputNode::Entry>& outputNames);
+      const std::vector<OutputColumnNameMapping>& outputNames);
 
   velox::core::FieldAccessTypedExprPtr toFieldRef(ExprCP expr);
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ add_executable(
   axiom_optimizer_tests
   AggregationTest.cpp
   DistinctAggregationTest.cpp
+  OutputNodeTest.cpp
   CardinalityEstimationTest.cpp
   CsvReadWriteTest.cpp
   DerivedTablePrinterTest.cpp

--- a/axiom/optimizer/tests/OutputNodeTest.cpp
+++ b/axiom/optimizer/tests/OutputNodeTest.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class OutputNodeTest : public test::QueryTestBase {
+ protected:
+  lp::PlanBuilder::Context makeContext() const {
+    return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
+  }
+};
+
+// Verifies the optimizer honors OutputNode entry shapes documented in
+// OutputNode::Entry — drop, reorder, duplicate, identity.
+TEST_F(OutputNodeTest, entries) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+
+  auto makePlan = [&](const std::vector<lp::OutputNode::Entry>& entries)
+      -> velox::core::PlanNodePtr {
+    auto ctx = makeContext();
+    auto scan = lp::PlanBuilder(ctx).tableScan("t").planNode();
+    auto logicalPlan = std::make_shared<lp::OutputNode>(
+        ctx.planNodeIdGenerator->next(), scan, entries);
+    return toSingleNodePlan(logicalPlan);
+  };
+
+  // Drop: column b is pruned. Scan reads only {a, c}.
+  {
+    auto plan = makePlan({{0, "a"}, {2, "c"}});
+    VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW({"a", "c"}, BIGINT()));
+    auto matcher = matchScan("t", ROW({"a", "c"}, BIGINT())).build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Reorder: scan reads {a, c}, Project reorders to {c, a}.
+  {
+    auto plan = makePlan({{2, "c"}, {0, "a"}});
+    VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW({"c", "a"}, BIGINT()));
+    auto matcher =
+        matchScan("t", ROW({"a", "c"}, BIGINT())).project({"c", "a"}).build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Duplicate: source column a is referenced twice. Scan reads only {a}.
+  {
+    auto plan = makePlan({{0, "x"}, {0, "y"}});
+    VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW({"x", "y"}, BIGINT()));
+    auto matcher = matchScan("t", ROW({"a"}, BIGINT()))
+                       .project({"a AS x", "a AS y"})
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Identity: all columns, same order. No ProjectNode added.
+  {
+    auto plan = makePlan({{0, "a"}, {1, "b"}, {2, "c"}});
+    VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW({"a", "b", "c"}, BIGINT()));
+    auto matcher = matchScan("t", ROW({"a", "b", "c"}, BIGINT())).build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

SubfieldTracker special-cases an OutputNode at the plan root: only
the source ordinals listed in its entries are marked as payload-
accessed on the input, enabling pruning of columns the OutputNode
does not export. The OutputNode is stripped before DerivedTable
construction.

OutputNode entries are resolved to source column names once in
Optimization; ToVelox::addOutputRenames looks up source columns by
name in the optimized plan's outputType. This handles reorder,
drop, and duplicate output columns — all permitted by the OutputNode
contract (LogicalPlanNode.h:918) — without depending on the
optimizer's internal column ordering.

Documents the makeQueryGraph name-preservation contract: surviving
columns retain their LogicalPlan names; positions are unspecified.

Differential Revision: D104432434


