### PR TITLE
fix: Improve failure_message_template grouping in Scuba (#1341)

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -141,7 +141,9 @@ class ParserHelper {
           errorListener_.firstError(),
           errorListener_.line(),
           errorListener_.column(),
-          errorListener_.token());
+          errorListener_.token(),
+          PrestoSqlErrorKind::kSyntax,
+          errorListener_.firstError());
     }
 
     return ctx->statement();

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1591,5 +1591,28 @@ TEST_F(PrestoParserTest, friendlySqlFromFirst) {
       "FROM-first syntax requires Friendly SQL mode");
 }
 
+TEST_F(PrestoParserTest, syntaxErrorHasMessageTemplate) {
+  try {
+    parseSql("SELECT * FROM WHERE");
+    ADD_FAILURE() << "Expected PrestoSqlError";
+  } catch (const PrestoSqlError& e) {
+    EXPECT_EQ(e.kind(), PrestoSqlErrorKind::kSyntax);
+    EXPECT_FALSE(std::string_view(e.messageTemplate()).empty())
+        << "ANTLR syntax errors must have a messageTemplate for Scuba grouping";
+  }
+}
+
+TEST_F(PrestoParserTest, semanticErrorHasMessageTemplate) {
+  try {
+    parseSql("SELECT * FROM nonexistent_table_xyz");
+    ADD_FAILURE() << "Expected PrestoSqlError";
+  } catch (const PrestoSqlError& e) {
+    EXPECT_EQ(e.kind(), PrestoSqlErrorKind::kSemantic);
+    EXPECT_FALSE(std::string_view(e.messageTemplate()).empty())
+        << "Semantic errors must have a messageTemplate for Scuba grouping";
+    EXPECT_EQ(std::string(e.messageTemplate()), "Table not found: {}");
+  }
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/10

Fixes four sources of ungroupable `failure_message_template` entries in Scuba on Axiom clusters by ensuring every error path through `AxelQueryContext::handleError` produces a deterministic template string.

**1. Metastore Thrift exceptions (~1,400 queries/3d):**
`PRISM_METASTORE_CATCH` previously logged and re-threw raw Thrift exceptions. These hit the generic `std::exception` fallback where `what()` became the template.

Fix: pass through `VeloxException` unchanged, convert other `std::exception` to `VELOX_FAIL` with template `"{} failed: {}"`.

**2. Memory allocation errors:**
`VELOX_MEM_ALLOC_ERROR` pre-formats the message and passes it to `_VELOX_THROW` with `"{}"` as the format template, making `messageTemplate()` return `"{}"` — useless for grouping.

Fix: add a `VeloxException` branch in `handleError` that detects `"{}"` templates and falls back to the Velox error code (e.g. `MEM_ALLOC_ERROR`). Uses the `canonicalizeFailure` pipeline for proper Presto error code mapping (e.g. `GENERIC_INSUFFICIENT_RESOURCES`), and `createWithTemplate` to preserve the template for Scuba.

**3. DPAS permission errors:**
`DpasPermissionsClient` threw `std::runtime_error` with the full error message (including unique trace IDs, table names, user identities), producing a unique template per query.

Fix: convert the three throw sites to `VELOX_USER_FAIL` with proper format templates: `"DPAS permission check failed: {}"`, `"DPAS did not issue a result token: {}"`, `"Invalid input to DPAS permission service: {}"`.

**4. Thrift RPC transport errors:**
`TServiceRouterException` and other `apache::thrift::TException` subclasses (connection refused, timeouts) fell through to the generic fallback.

Fix: add a `TException` branch in `handleError` with static template `"Thrift RPC failed: {}"`.

Also addresses DARTS review feedback: error tests now verify message content via `HasSubstr` assertions instead of only checking the exception type.

Reviewed By: natashasehgal

Differential Revision: D101895583


