### PR TITLE
fix(build): Add missing CMake link dependencies

### DIFF
--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
 
 target_link_libraries(
   axiom_logical_plan
+  axiom_common
   velox_type
   velox_serialization
   velox_common_base

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -62,5 +62,6 @@ target_link_libraries(
   axiom_connectors
   axiom_logical_plan
   axiom_optimizer_multifragment_plan
+  axiom_runner_local_runner
   velox_connector
 )

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(axiom_optimizer_tests_query_test_base QueryTestBase.cpp)
 target_link_libraries(
   axiom_optimizer_tests_query_test_base
   axiom_optimizer
+  axiom_sql_presto_parser
   axiom_test_connector
   velox_tpch_gen
   axiom_hive_connector_metadata


### PR DESCRIPTION
Summary:
Fix missing CMake link dependencies in Axiom that were discovered
while building Axel OSS on macOS. These deps are resolved
transitively by Buck in fbcode but must be explicit in CMake.

1. logical_plan/CMakeLists.txt: Add axiom_common dependency to
   axiom_logical_plan. The logical plan module uses types from
   axiom/common/ but didn't declare the link dependency.

2. optimizer/CMakeLists.txt: Add axiom_runner_local_runner dependency
   to axiom_optimizer. The optimizer uses the local runner for plan
   execution.

3. optimizer/tests/CMakeLists.txt: Add axiom_sql_presto_parser
   dependency to axiom_optimizer_tests_query_test_base. Test utilities
   need the SQL parser for query construction.

Differential Revision: D104679285


