### PR TITLE
fix(optimizer): Drop ordering/uniqueness from UNION ALL output Distribution (#1348)

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1724,9 +1724,12 @@ void Limit::accept(
 
 namespace {
 
-// Returns the first input's distribution if every input has the same
-// distribution per Distribution::isSamePartition. Otherwise returns an empty
-// Distribution.
+// Returns a Distribution describing the partitioning shared by every input
+// when their partitions match per Distribution::isSamePartition; otherwise
+// returns an empty Distribution. Only partition-related fields (kind,
+// partition type, partition keys) are propagated — UNION ALL preserves how
+// rows map to partitions but does not preserve per-input ordering,
+// uniqueness, or clustering.
 Distribution commonInputDistribution(const RelationOpPtrVector& inputs) {
   VELOX_CHECK_GE(inputs.size(), 2, "UnionAll requires at least 2 inputs");
   const auto& first = inputs[0]->distribution();
@@ -1735,7 +1738,11 @@ Distribution commonInputDistribution(const RelationOpPtrVector& inputs) {
       return Distribution{};
     }
   }
-  return first;
+  return Distribution{
+      first.kind(),
+      first.partitionType(),
+      first.partitionKeys(),
+  };
 }
 
 } // namespace

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -583,10 +583,32 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
   AggregationMatcher(
       const std::shared_ptr<PlanMatcher>& matcher,
       AggregationNode::Step step,
-      const std::vector<std::string>& groupingKeys,
-      const std::vector<std::string>& aggregates)
+      std::optional<bool> expectPreGrouped)
       : PlanMatcherImpl<AggregationNode>({matcher}),
         step_{step},
+        expectPreGrouped_{expectPreGrouped} {}
+
+  AggregationMatcher(
+      const std::shared_ptr<PlanMatcher>& matcher,
+      AggregationNode::Step step,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates)
+      : AggregationMatcher(
+            matcher,
+            step,
+            groupingKeys,
+            aggregates,
+            /*expectPreGrouped=*/std::nullopt) {}
+
+  AggregationMatcher(
+      const std::shared_ptr<PlanMatcher>& matcher,
+      AggregationNode::Step step,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      std::optional<bool> expectPreGrouped)
+      : PlanMatcherImpl<AggregationNode>({matcher}),
+        step_{step},
+        expectPreGrouped_{expectPreGrouped},
         groupingKeys_{groupingKeys},
         aggregates_{aggregates} {
     VELOX_CHECK(!groupingKeys_.empty() || !aggregates_.empty());
@@ -600,6 +622,11 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
 
     if (step_.has_value()) {
       EXPECT_EQ(plan.step(), step_.value());
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    if (expectPreGrouped_.has_value()) {
+      EXPECT_EQ(plan.isPreGrouped(), expectPreGrouped_.value());
       AXIOM_TEST_RETURN_IF_FAILURE
     }
 
@@ -687,6 +714,7 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
 
  private:
   const std::optional<AggregationNode::Step> step_;
+  const std::optional<bool> expectPreGrouped_;
   const std::vector<std::string> groupingKeys_;
   const std::vector<std::string> aggregates_;
 };
@@ -725,36 +753,6 @@ class DistinctMatcher : public PlanMatcherImpl<AggregationNode> {
     }
 
     return MatchResult::success();
-  }
-};
-
-class StreamingAggregationMatcher : public AggregationMatcher {
- public:
-  explicit StreamingAggregationMatcher(
-      const std::shared_ptr<PlanMatcher>& matcher)
-      : AggregationMatcher(matcher, AggregationNode::Step::kSingle) {}
-
-  StreamingAggregationMatcher(
-      const std::shared_ptr<PlanMatcher>& matcher,
-      const std::vector<std::string>& groupingKeys,
-      const std::vector<std::string>& aggregates)
-      : AggregationMatcher(
-            matcher,
-            AggregationNode::Step::kSingle,
-            groupingKeys,
-            aggregates) {}
-
-  MatchResult matchDetails(
-      const AggregationNode& plan,
-      const std::unordered_map<std::string, std::string>& symbols)
-      const override {
-    SCOPED_TRACE(plan.toString(true, false));
-
-    EXPECT_TRUE(plan.isPreGrouped())
-        << "Expected streaming aggregation (pre-grouped input)";
-    AXIOM_TEST_RETURN_IF_FAILURE
-
-    return AggregationMatcher::matchDetails(plan, symbols);
   }
 };
 
@@ -1654,7 +1652,9 @@ PlanMatcherBuilder& PlanMatcherBuilder::aggregation() {
 PlanMatcherBuilder& PlanMatcherBuilder::singleAggregation() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<AggregationMatcher>(
-      matcher_, AggregationNode::Step::kSingle);
+      matcher_,
+      AggregationNode::Step::kSingle,
+      /*expectPreGrouped=*/false);
   return *this;
 }
 
@@ -1663,7 +1663,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::singleAggregation(
     const std::vector<std::string>& aggregates) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<AggregationMatcher>(
-      matcher_, AggregationNode::Step::kSingle, groupingKeys, aggregates);
+      matcher_,
+      AggregationNode::Step::kSingle,
+      groupingKeys,
+      aggregates,
+      /*expectPreGrouped=*/false);
   return *this;
 }
 
@@ -1701,7 +1705,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::finalAggregation(
 
 PlanMatcherBuilder& PlanMatcherBuilder::streamingAggregation() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<StreamingAggregationMatcher>(matcher_);
+  matcher_ = std::make_shared<AggregationMatcher>(
+      matcher_,
+      AggregationNode::Step::kSingle,
+      /*expectPreGrouped=*/true);
   return *this;
 }
 
@@ -1709,8 +1716,12 @@ PlanMatcherBuilder& PlanMatcherBuilder::streamingAggregation(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<StreamingAggregationMatcher>(
-      matcher_, groupingKeys, aggregates);
+  matcher_ = std::make_shared<AggregationMatcher>(
+      matcher_,
+      AggregationNode::Step::kSingle,
+      groupingKeys,
+      aggregates,
+      /*expectPreGrouped=*/true);
   return *this;
 }
 

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -830,5 +830,60 @@ TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Distribution-metadata propagation through UNION ALL. UNION ALL preserves
+// only how rows map to partitions (kind, partition type, partition keys);
+// per-input ordering, uniqueness, and clustering do not survive because
+// rows from different legs interleave arbitrarily.
+// ---------------------------------------------------------------------------
+
+// GROUP BY on a key that each leg of the UNION ALL is independently sorted
+// on. The aggregation must be hash-based, not streaming: even though each
+// leg is sorted on the grouping key, the UNION ALL output is not, so
+// streaming aggregation would emit one group per leg per key.
+//
+// TODO: The per-leg OrderBy nodes are dead work — the hash aggregation
+// above the union doesn't need sorted input, and SQL does not require
+// subquery ORDER BY (without LIMIT) to be observed by the outer query.
+// When the optimizer learns to drop these, this matcher will need to
+// drop the .orderBy({...}) nodes.
+TEST_F(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
+  auto logicalPlan = parseSelect(
+      "SELECT a, count(*) FROM ("
+      "  (SELECT a FROM t ORDER BY a)"
+      "  UNION ALL"
+      "  (SELECT b FROM u ORDER BY b)"
+      ") GROUP BY a",
+      kTestConnectorId);
+
+  {
+    auto matcher =
+        matchScan("t")
+            .orderBy({"a"})
+            .localPartition(matchScan("u").orderBy({"b"}).project().build())
+            .singleAggregation({"a"}, {"count(*)"})
+            .build();
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  }
+
+  {
+    auto matcher = matchScan("t")
+                       .orderBy({"a"})
+                       .localMerge()
+                       .shuffleMerge()
+                       .localPartition(matchScan("u")
+                                           .orderBy({"b"})
+                                           .localMerge()
+                                           .shuffleMerge()
+                                           .project()
+                                           .build())
+                       .partialAggregation({"a"}, {"count(*)"})
+                       .localPartition({"a"})
+                       .finalAggregation()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/unionAll.sql
+++ b/axiom/optimizer/tests/sql/unionAll.sql
@@ -60,3 +60,11 @@ SELECT * FROM (
   SELECT a FROM t
   UNION ALL SELECT 42
 ) ORDER BY 1
+----
+-- GROUP BY over UNION ALL where both legs are independently sorted on the
+-- grouping key.
+SELECT a, count(*) c FROM (
+  (SELECT a FROM t ORDER BY a)
+  UNION ALL
+  (SELECT a FROM t ORDER BY a)
+) GROUP BY a


### PR DESCRIPTION
Summary:

commonInputDistribution() in RelationOp.cpp returned the entire
Distribution of the first input when all inputs share a partition,
which propagated 'orderKeys', 'orderTypes', 'numKeysUnique', and
'clusterKeys' downstream. UNION ALL preserves only how rows map to
partitions (kind / partition type / partition keys) — it does not
preserve per-input ordering, key uniqueness, or clustering, since
rows from different inputs are arbitrarily interleaved.

Constructs a fresh Distribution that keeps only the partition fields
(kind, partitionType, partitionKeys). Downstream operators no longer
incorrectly assume the union's output is sorted, unique, or
clustered.

Reviewed By: xiaoxmeng, kagamiori

Differential Revision: D104749461


