### PR TITLE
feat(optimizer): Drop dead sorts in ToGraph; fix Presto Sort placement for DISTINCT + GROUP BY (#1349)

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -349,11 +349,6 @@ struct DerivedTable : public PlanObject {
     return !orderKeys.empty();
   }
 
-  void dropOrderBy() {
-    orderKeys.clear();
-    orderTypes.clear();
-  }
-
   bool hasLimit() const {
     return limit >= 0;
   }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1823,7 +1823,7 @@ lp::ExprPtr ToGraph::processLeftJoinSubqueries(
   VELOX_CHECK(!subqueryConjuncts.empty());
 
   auto* outerDt = std::exchange(currentDt_, newDt());
-  makeQueryGraph(right, kAllAllowedInDt);
+  makeQueryGraph(right, kAllAllowedInDt, /*orderObservedAbove=*/false);
   addFilter(right, combineConjuncts(std::move(subqueryConjuncts)));
 
   if (!correlatedConjuncts_.empty()) {
@@ -2016,9 +2016,11 @@ DerivedTableP ToGraph::newDt() {
   return dt;
 }
 
-void ToGraph::wrapInDt(const lp::LogicalPlanNode& node) {
+void ToGraph::wrapInDt(
+    const lp::LogicalPlanNode& node,
+    bool orderObservedAbove) {
   auto* outerDt = std::exchange(currentDt_, newDt());
-  makeQueryGraph(node, kAllAllowedInDt);
+  makeQueryGraph(node, kAllAllowedInDt, orderObservedAbove);
   finalizeDt(node, outerDt);
 }
 
@@ -2454,7 +2456,7 @@ DerivedTableP ToGraph::translateSubquery(
   VELOX_CHECK(correlatedConjuncts_.empty());
 
   auto* outerDt = std::exchange(currentDt_, newDt());
-  makeQueryGraph(node, kAllAllowedInDt);
+  makeQueryGraph(node, kAllAllowedInDt, /*orderObservedAbove=*/false);
   auto* subqueryDt = currentDt_;
 
   setDtUsedOutput(subqueryDt, node);
@@ -3215,7 +3217,8 @@ ExprCP ToGraph::processCorrelatedExists(DerivedTableP subqueryDt) {
 
 void ToGraph::applySampling(
     const lp::SampleNode& sample,
-    uint64_t allowedInDt) {
+    uint64_t allowedInDt,
+    bool orderObservedAbove) {
   auto constantPercentageExpr = tryFoldConstant(sample.percentage());
   VELOX_USER_CHECK_NOT_NULL(
       constantPercentageExpr,
@@ -3236,7 +3239,7 @@ void ToGraph::applySampling(
   VELOX_USER_CHECK_LE(percentage, 100, "Sampling percentage must be <= 100");
 
   if (percentage == 100) {
-    makeQueryGraph(*sample.onlyInput(), allowedInDt);
+    makeQueryGraph(*sample.onlyInput(), allowedInDt, orderObservedAbove);
     return;
   }
 
@@ -3259,7 +3262,7 @@ void ToGraph::applySampling(
 
       const auto& input = *sample.onlyInput();
       auto* outerDt = std::exchange(currentDt_, newDt());
-      makeQueryGraph(input, kAllAllowedInDt);
+      makeQueryGraph(input, kAllAllowedInDt, orderObservedAbove);
       addFilter(input, predicate);
       finalizeDt(sample, outerDt);
       break;
@@ -3484,7 +3487,7 @@ bool hasNondeterministic(const lp::ExprPtr& expr) {
 void ToGraph::translateSetJoin(const lp::SetNode& set) {
   auto* setDt = currentDt_;
   for (auto& input : set.inputs()) {
-    wrapInDt(*input);
+    wrapInDt(*input, /*orderObservedAbove=*/false);
   }
 
   const bool exists = set.operation() == lp::SetOperation::kIntersect ||
@@ -3589,7 +3592,7 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
   auto translateUnionInput = [&](const lp::LogicalPlanNode& input) {
     renames_ = renames;
     currentDt_ = newDt();
-    makeQueryGraph(input, kAllAllowedInDt);
+    makeQueryGraph(input, kAllAllowedInDt, /*orderObservedAbove=*/false);
     auto* newDt = std::exchange(currentDt_, setDt);
 
     const auto& type = input.outputType();
@@ -3684,7 +3687,7 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
         return tryFoldConstant(expr);
       }).markAll(logicalPlan);
   currentDt_ = newDt();
-  makeQueryGraph(logicalPlan, kAllAllowedInDt);
+  makeQueryGraph(logicalPlan, kAllAllowedInDt, /*orderObservedAbove=*/true);
   setDtUsedOutput(currentDt_, logicalPlan);
 
   // TODO Try constant fold the dt.
@@ -3695,19 +3698,26 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
 void ToGraph::makeFilterQueryGraph(
     const lp::FilterNode& filter,
     uint64_t allowedInDt,
+    bool orderObservedAbove,
     bool excludeOuterJoins,
     bool excludeWindows) {
   const auto& input = *filter.onlyInput();
 
   if (hasNondeterministic(filter.predicate())) {
     auto* outerDt = std::exchange(currentDt_, newDt());
-    makeQueryGraph(input, kAllAllowedInDt, excludeOuterJoins);
+    makeQueryGraph(
+        input, kAllAllowedInDt, orderObservedAbove, excludeOuterJoins);
     addFilter(input, filter.predicate());
     finalizeDt(filter, outerDt);
     return;
   }
 
-  makeQueryGraph(input, allowedInDt, excludeOuterJoins, excludeWindows);
+  makeQueryGraph(
+      input,
+      allowedInDt,
+      orderObservedAbove,
+      excludeOuterJoins,
+      excludeWindows);
 
   // If the current DT has any window function outputs, finalize the DT
   // so that filters are evaluated in the outer DT after the window.
@@ -3731,6 +3741,7 @@ void ToGraph::makeFilterQueryGraph(
 void ToGraph::makeProjectQueryGraph(
     const lp::ProjectNode& project,
     uint64_t allowedInDt,
+    bool orderObservedAbove,
     bool excludeOuterJoins,
     bool excludeWindows) {
   // Window functions cannot appear below a join — filtering rows before
@@ -3739,7 +3750,7 @@ void ToGraph::makeProjectQueryGraph(
   const bool hasWindow =
       std::ranges::any_of(project.expressions(), optimizer::hasWindow);
   if (hasWindow && excludeWindows) {
-    wrapInDt(project);
+    wrapInDt(project, /*orderObservedAbove=*/false);
     return;
   }
 
@@ -3752,30 +3763,20 @@ void ToGraph::makeProjectQueryGraph(
   // "correlated" conjunct. Wrap the project upfront to isolate its tables.
   if (excludeOuterJoins && !currentDt_->tables.empty() &&
       std::ranges::any_of(project.expressions(), optimizer::hasSubquery)) {
-    wrapInDt(project);
+    wrapInDt(project, /*orderObservedAbove=*/false);
     return;
   }
 
   makeQueryGraph(
-      *project.onlyInput(), allowedInDt, excludeOuterJoins, excludeWindows);
-
-  // Check if this project contains window expressions and apply DT
-  // boundary rules.
-  bool windowHasPartitionOrOrderKeys = false;
-  for (const auto& expr : project.expressions()) {
-    if (expr->isWindow()) {
-      const auto* window = expr->as<lp::WindowExpr>();
-      if (!window->partitionKeys().empty() || !window->ordering().empty()) {
-        windowHasPartitionOrOrderKeys = true;
-      }
-    }
-  }
+      *project.onlyInput(),
+      allowedInDt,
+      hasWindow ? false : orderObservedAbove,
+      excludeOuterJoins,
+      excludeWindows);
 
   if (hasWindow) {
     if (currentDt_->hasLimit() || windowReferencesWindow(project)) {
       finalizeDt(*project.onlyInput());
-    } else if (currentDt_->hasOrderBy() && windowHasPartitionOrOrderKeys) {
-      currentDt_->dropOrderBy();
     }
   }
 
@@ -3793,16 +3794,17 @@ void ToGraph::makeProjectQueryGraph(
 void ToGraph::makeQueryGraph(
     const lp::LogicalPlanNode& node,
     uint64_t allowedInDt,
+    bool orderObservedAbove,
     bool excludeOuterJoins,
     bool excludeWindows) {
   if (!contains(allowedInDt, node.kind())) {
-    wrapInDt(node);
+    wrapInDt(node, orderObservedAbove);
     return;
   }
 
   if (excludeOuterJoins && node.is(lp::NodeKind::kJoin) &&
       node.as<lp::JoinNode>()->joinType() != lp::JoinType::kInner) {
-    wrapInDt(node);
+    wrapInDt(node, /*orderObservedAbove=*/false);
     return;
   }
 
@@ -3816,12 +3818,14 @@ void ToGraph::makeQueryGraph(
       makeBaseTable(*node.as<lp::TableScanNode>());
       break;
     case lp::NodeKind::kSample:
-      applySampling(*node.as<lp::SampleNode>(), allowedInDt);
+      applySampling(
+          *node.as<lp::SampleNode>(), allowedInDt, orderObservedAbove);
       break;
     case lp::NodeKind::kFilter:
       makeFilterQueryGraph(
           *node.as<lp::FilterNode>(),
           allowedInDt,
+          orderObservedAbove,
           excludeOuterJoins,
           excludeWindows);
       break;
@@ -3829,17 +3833,17 @@ void ToGraph::makeQueryGraph(
       makeProjectQueryGraph(
           *node.as<lp::ProjectNode>(),
           allowedInDt,
+          orderObservedAbove,
           excludeOuterJoins,
           excludeWindows);
       break;
     case lp::NodeKind::kAggregate: {
       const auto& input = *node.onlyInput();
-      makeQueryGraph(input, allowedInDt, excludeOuterJoins);
+      makeQueryGraph(
+          input, allowedInDt, /*orderObservedAbove=*/false, excludeOuterJoins);
       if (currentDt_->hasAggregation() || currentDt_->hasLimit() ||
           currentDt_->windowPlan) {
         finalizeDtWithCorrelatedConjuncts(input);
-      } else if (currentDt_->hasOrderBy()) {
-        currentDt_->dropOrderBy();
       }
 
       auto* agg = translateAggregation(*node.as<lp::AggregateNode>());
@@ -3869,6 +3873,7 @@ void ToGraph::makeQueryGraph(
       makeQueryGraph(
           *left,
           allowedInDt,
+          /*orderObservedAbove=*/false,
           /*excludeOuterJoins=*/true,
           /*excludeWindows=*/true);
 
@@ -3886,6 +3891,7 @@ void ToGraph::makeQueryGraph(
         makeQueryGraph(
             *right,
             allowedInDt,
+            /*orderObservedAbove=*/false,
             /*excludeOuterJoins=*/true,
             /*excludeWindows=*/true);
       }
@@ -3894,11 +3900,13 @@ void ToGraph::makeQueryGraph(
     } break;
     case lp::NodeKind::kSort: {
       const auto& input = *node.onlyInput();
-      makeQueryGraph(input, allowedInDt);
-      if (currentDt_->hasLimit()) {
-        finalizeDt(input);
+      makeQueryGraph(input, allowedInDt, /*orderObservedAbove=*/false);
+      if (orderObservedAbove) {
+        if (currentDt_->hasLimit()) {
+          finalizeDt(input);
+        }
+        addOrderBy(*node.as<lp::SortNode>());
       }
-      addOrderBy(*node.as<lp::SortNode>());
     } break;
     case lp::NodeKind::kLimit: {
       const auto& limit = *node.as<lp::LimitNode>();
@@ -3906,7 +3914,8 @@ void ToGraph::makeQueryGraph(
         makeEmptyValuesTable(limit);
         break;
       }
-      makeQueryGraph(*node.onlyInput(), allowedInDt);
+      makeQueryGraph(
+          *node.onlyInput(), allowedInDt, /*orderObservedAbove=*/true);
       addLimit(limit);
       // After combining limits, if the result is 0 rows, replace with empty
       // values. This handles cases like OFFSET >= inner LIMIT.
@@ -3929,12 +3938,15 @@ void ToGraph::makeQueryGraph(
     } break;
     case lp::NodeKind::kUnnest: {
       makeQueryGraph(
-          *node.onlyInput(), allowedInDt, /*excludeOuterJoins=*/true);
+          *node.onlyInput(),
+          allowedInDt,
+          orderObservedAbove,
+          /*excludeOuterJoins=*/true);
       addUnnest(*node.as<lp::UnnestNode>());
     } break;
     case lp::NodeKind::kTableWrite: {
       VELOX_DCHECK_EQ(allowedInDt, kAllAllowedInDt);
-      wrapInDt(*node.onlyInput());
+      wrapInDt(*node.onlyInput(), /*orderObservedAbove=*/false);
       addWrite(*node.as<lp::TableWriteNode>());
     } break;
     default:

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -168,9 +168,14 @@ class ToGraph {
   // Converts 'plan' to PlanObjects and records join edges into
   // 'currentDt_'. Wraps 'node' in a new Derived table f 'node' does not match
   // allowedInDt or 'node' is an outer join and 'excludeOuterJoins' is true.
+  //
+  // 'orderObservedAbove' is true when some consumer above this node would
+  // observe an order produced here. A Sort encountered with this bit false
+  // is skipped — its order is dead.
   void makeQueryGraph(
       const logical_plan::LogicalPlanNode& node,
       uint64_t allowedInDt,
+      bool orderObservedAbove,
       bool excludeOuterJoins = false,
       bool excludeWindows = false);
 
@@ -179,6 +184,7 @@ class ToGraph {
   void makeFilterQueryGraph(
       const logical_plan::FilterNode& filter,
       uint64_t allowedInDt,
+      bool orderObservedAbove,
       bool excludeOuterJoins,
       bool excludeWindows);
 
@@ -187,6 +193,7 @@ class ToGraph {
   void makeProjectQueryGraph(
       const logical_plan::ProjectNode& project,
       uint64_t allowedInDt,
+      bool orderObservedAbove,
       bool excludeOuterJoins,
       bool excludeWindows);
 
@@ -329,7 +336,8 @@ class ToGraph {
 
   void applySampling(
       const logical_plan::SampleNode& sample,
-      uint64_t allowedInDt);
+      uint64_t allowedInDt,
+      bool orderObservedAbove);
 
   bool isSubfield(
       const logical_plan::ExprPtr& expr,
@@ -386,7 +394,12 @@ class ToGraph {
   // DerivedTable. Done for joins to the right of non-inner joins,
   // group bys as non-top operators, whenever descendents of 'node'
   // are not freely reorderable with its parents' descendents.
-  void wrapInDt(const logical_plan::LogicalPlanNode& node);
+  // Wraps 'node' in a fresh inner DT and attaches it to the current outer
+  // DT. 'orderObservedAbove' is forwarded to the inner traversal — set per
+  // the caller's consumer semantics.
+  void wrapInDt(
+      const logical_plan::LogicalPlanNode& node,
+      bool orderObservedAbove);
 
   // Finalizes 'currentDt_' by setting its output columns based on 'node',
   // then nests it inside 'outerDt' (or a new DT if 'outerDt' is nullptr).

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -720,42 +720,45 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
       "WHERE t.b < 100",
       kTestConnectorId);
 
+  // The subquery's ORDER BY is dropped by the dead-sort optimization (the
+  // outer join discards order), which unblocks existence pushdown.
+
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  // No pushdown: ORDER BY blocks it.
-  //
-  // TODO: ORDER BY inside a FROM-clause subquery without LIMIT is semantically
-  // meaningless — the parent join discards the order. Eliminating it early
-  // (e.g., via dropOrderBy() in ToGraph) would unblock existence pushdown here
-  // and simplify the distributed plan (removing shuffleMerge). The check is in
-  // DerivedTable::validatePushdown (DerivedTable.cpp), which rejects subqueries
-  // with hasOrderBy().
-  auto matcher =
-      matchScan("u")
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .orderBy({"cnt"})
-          .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .build();
+  auto matcher = matchScan("t")
+                     .filter("b < 100")
+                     .hashJoin(
+                         matchScan("u")
+                             .hashJoin(
+                                 matchScan("t").filter("b < 100").build(),
+                                 core::JoinType::kLeftSemiFilter)
+                             .singleAggregation({"x"}, {"count(*) as cnt"})
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("u")
-          .shuffle({"x"})
-          .localPartition({"x"})
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .orderBy({"cnt"})
-          .localMerge()
-          .shuffleMerge()
-          .project()
+      matchScan("t")
+          .filter("b < 100")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").broadcast().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .shuffle({"x"})
+                  .localPartition({"x"})
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .project()
+                  .broadcast()
+                  .build(),
               core::JoinType::kInner)
+          .gather()
           .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
 }

--- a/axiom/optimizer/tests/HiveQueriesTest.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTest.cpp
@@ -257,18 +257,13 @@ TEST_F(HiveQueriesTest, joinWithLimitBothSides) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    // TODO: We don't need orderBy before the join.
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan("nation")
-                       .limit()
-                       .orderBy()
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .tableScan("region")
-                               .limit()
-                               .orderBy()
-                               .build())
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan("nation")
+            .limit()
+            .hashJoin(
+                core::PlanMatcherBuilder().tableScan("region").limit().build())
+            .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -840,13 +840,9 @@ TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
 // GROUP BY on a key that each leg of the UNION ALL is independently sorted
 // on. The aggregation must be hash-based, not streaming: even though each
 // leg is sorted on the grouping key, the UNION ALL output is not, so
-// streaming aggregation would emit one group per leg per key.
-//
-// TODO: The per-leg OrderBy nodes are dead work — the hash aggregation
-// above the union doesn't need sorted input, and SQL does not require
-// subquery ORDER BY (without LIMIT) to be observed by the outer query.
-// When the optimizer learns to drop these, this matcher will need to
-// drop the .orderBy({...}) nodes.
+// streaming aggregation would emit one group per leg per key. The per-leg
+// ORDER BYs are dropped by the dead-sort optimization (their order is
+// unobservable past the order-destroying UNION ALL).
 TEST_F(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
   auto logicalPlan = parseSelect(
       "SELECT a, count(*) FROM ("
@@ -857,29 +853,18 @@ TEST_F(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
       kTestConnectorId);
 
   {
-    auto matcher =
-        matchScan("t")
-            .orderBy({"a"})
-            .localPartition(matchScan("u").orderBy({"b"}).project().build())
-            .singleAggregation({"a"}, {"count(*)"})
-            .build();
+    auto matcher = matchScan("t")
+                       .localPartition(matchScan("u").project().build())
+                       .singleAggregation({"a"}, {"count(*)"})
+                       .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
     auto matcher = matchScan("t")
-                       .orderBy({"a"})
-                       .localMerge()
-                       .shuffleMerge()
-                       .localPartition(matchScan("u")
-                                           .orderBy({"b"})
-                                           .localMerge()
-                                           .shuffleMerge()
-                                           .project()
-                                           .build())
-                       .partialAggregation({"a"}, {"count(*)"})
-                       .localPartition({"a"})
-                       .finalAggregation()
+                       .localPartition(matchScan("u").project().build())
+                       .distributedAggregation({"a"}, {"count(*)"})
+                       .gather()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -963,11 +963,7 @@ class RelationPlanner : public AstVisitor {
         numSelectItems);
   }
 
-  // Adds project, distinct, and sort nodes. Uses
-  // SortProjection::widenProjections to resolve ORDER BY expressions against
-  // SELECT-list expressions by expression identity, then validates that no
-  // widening occurred since DISTINCT requires ORDER BY to reference only
-  // SELECT-list columns.
+  // Adds project, distinct, and sort nodes for a no-GROUP-BY SELECT DISTINCT.
   void addDistinctAndOrderBy(
       const std::vector<SelectItemPtr>& selectItems,
       const OrderByPtr& orderBy) {
@@ -979,33 +975,41 @@ class RelationPlanner : public AstVisitor {
       return;
     }
     extractNestedWindows(projections.value());
+    builder_->project(projections.value());
+    addDistinctAndOrderByOnProjection(projections.value(), orderBy);
+  }
+
+  // Adds DISTINCT and (optional) ORDER BY assuming the SELECT list has
+  // already been projected. 'projectedExprs' are the SELECT-list expressions
+  // currently produced by the builder. Validates that every ORDER BY key
+  // matches a SELECT-list expression (SELECT DISTINCT semantics).
+  void addDistinctAndOrderByOnProjection(
+      const std::vector<lp::ExprApi>& projectedExprs,
+      const OrderByPtr& orderBy) {
     if (orderBy == nullptr) {
-      builder_->project(projections.value());
       builder_->distinct();
       return;
     }
 
-    const size_t numSelectItems = projections->size();
-    auto expansion = buildSortKeyExprs(orderBy, projections.value());
+    auto expansion = buildSortKeyExprs(orderBy, projectedExprs);
+    auto ordinals = SortProjection::resolveSortKeys(
+        expansion.sortKeyExprs,
+        expansion.preResolved,
+        projectedExprs,
+        [&](size_t /*index*/) {
+          AXIOM_PRESTO_SEMANTIC_FAIL(
+              orderBy->location(),
+              "ORDER BY",
+              "For SELECT DISTINCT, ORDER BY expressions must be output expressions");
+        });
 
-    auto ordinals = SortProjection::widenProjections(
-        expansion.sortKeyExprs, expansion.preResolved, projections.value());
-
-    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
-        projections->size(),
-        numSelectItems,
-        orderBy->location(),
-        "ORDER BY",
-        "For SELECT DISTINCT, ORDER BY expressions must be output expressions");
-
-    builder_->project(projections.value());
     builder_->distinct();
     SortProjection::sortAndTrim(
         *builder_,
         ordinals,
         expansion.ascending,
         expansion.nullsFirst,
-        numSelectItems);
+        projectedExprs.size());
   }
 
   lp::ExprApi toSortingKey(const ExpressionPtr& expr) {
@@ -1137,15 +1141,18 @@ class RelationPlanner : public AstVisitor {
     if (auto groupBy = node->groupBy()) {
       auto selectExprs = expandSelectExprs(selectItems);
 
+      // When DISTINCT is also present, skip ORDER BY in the GROUP BY
+      // planner so the Sort lands ABOVE the DISTINCT aggregate.
+      const OrderByPtr noOrderBy;
       GroupByPlanner{builder_, exprPlanner_}.plan(
           groupBy->groupingElements(),
           groupBy->isDistinct(),
           selectExprs,
           node->having(),
-          orderBy);
+          distinct ? noOrderBy : orderBy);
 
       if (distinct) {
-        builder_->distinct();
+        addDistinctAndOrderByOnProjection(selectExprs, orderBy);
       }
     } else {
       if (GroupByPlanner{builder_, exprPlanner_}.tryPlanGlobalAgg(

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -26,6 +26,27 @@ namespace lp = facebook::axiom::logical_plan;
 namespace {
 namespace core = facebook::velox::core;
 
+// Indexes the SELECT-list projections by expression and by alias for
+// matching ORDER BY sort keys. An alias whose ordinal is 0 is ambiguous
+// (defined by more than one projection) and may only be used unambiguously.
+struct ProjectionIndex {
+  core::ExprMap<size_t> byExpr;
+  folly::F14FastMap<std::string, size_t> byAlias;
+
+  explicit ProjectionIndex(const std::vector<lp::ExprApi>& projections) {
+    for (size_t i = 0; i < projections.size(); ++i) {
+      byExpr.emplace(projections[i].expr(), i + 1);
+      if (projections[i].alias().has_value()) {
+        auto [iter, inserted] =
+            byAlias.emplace(projections[i].alias().value(), i + 1);
+        if (!inserted) {
+          iter->second = 0;
+        }
+      }
+    }
+  }
+};
+
 // Recursively replaces root FieldAccessExpr nodes that match an output alias
 // with the alias's underlying expression. Throws if the alias is ambiguous.
 core::ExprPtr replaceAliases(
@@ -62,6 +83,30 @@ core::ExprPtr replaceAliases(
 
   return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
 }
+
+// Looks up a single sort key in 'index'. Returns the matching 1-based
+// ordinal, or 0 if not present (caller decides whether to widen or fail).
+// 'preResolvedOrdinal' short-circuits the lookup when the sort key was
+// already resolved (e.g., from a positional ORDER BY ordinal).
+size_t lookupSortKey(
+    const lp::ExprApi& sortKey,
+    size_t preResolvedOrdinal,
+    const std::vector<lp::ExprApi>& projections,
+    const ProjectionIndex& index) {
+  if (preResolvedOrdinal != 0) {
+    return preResolvedOrdinal;
+  }
+  if (sortKey.alias().has_value()) {
+    auto it = index.byAlias.find(sortKey.alias().value());
+    if (it != index.byAlias.end()) {
+      VELOX_USER_CHECK_NE(it->second, 0, "Column is ambiguous: {}", it->first);
+      return it->second;
+    }
+  }
+  auto resolved = replaceAliases(sortKey.expr(), index.byAlias, projections);
+  auto it = index.byExpr.find(resolved);
+  return it != index.byExpr.end() ? it->second : 0;
+}
 } // namespace
 
 std::vector<size_t> SortProjection::widenProjections(
@@ -72,58 +117,52 @@ std::vector<size_t> SortProjection::widenProjections(
       preResolvedOrdinals.size(),
       sortKeyExprs.size(),
       "Must be the same size as sortKeyExprs.");
+
+  ProjectionIndex index{projections};
   std::vector<size_t> ordinals;
   ordinals.reserve(sortKeyExprs.size());
 
-  facebook::velox::core::ExprMap<size_t> projectionMap;
-  folly::F14FastMap<std::string, size_t> aliasMap;
-  // Iterate through projections matching ordinals to projections and aliases.
-  for (size_t i = 0; i < projections.size(); ++i) {
-    projectionMap.emplace(projections[i].expr(), i + 1);
-    if (projections[i].alias().has_value()) {
-      auto [alias, inserted] =
-          aliasMap.emplace(projections[i].alias().value(), i + 1);
-      // We throw for ambiguous aliases only if they are referenced by a
-      // sorting key. Let's mark it as ambiguous here for now denoted by the
-      // '0' ordinal and throw later when we process the sorting keys.
-      if (!inserted) {
-        alias->second = 0;
-      }
+  for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
+    auto ordinal = lookupSortKey(
+        sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
+    if (ordinal != 0) {
+      ordinals.push_back(ordinal);
+      continue;
     }
+    // Sort key not present in the SELECT list; widen the projection.
+    auto resolved =
+        replaceAliases(sortKeyExprs[i].expr(), index.byAlias, projections);
+    ordinal = projections.size() + 1;
+    index.byExpr.emplace(resolved, ordinal);
+    projections.emplace_back(std::move(resolved), sortKeyExprs[i].alias());
+    ordinals.push_back(ordinal);
   }
 
-  // Iterate through sort keys matching them to ordinals.
+  return ordinals;
+}
+
+std::vector<size_t> SortProjection::resolveSortKeys(
+    const std::vector<lp::ExprApi>& sortKeyExprs,
+    const std::vector<size_t>& preResolvedOrdinals,
+    const std::vector<lp::ExprApi>& projections,
+    const std::function<void(size_t)>& onUnresolved) {
+  VELOX_CHECK_EQ(
+      preResolvedOrdinals.size(),
+      sortKeyExprs.size(),
+      "Must be the same size as sortKeyExprs.");
+
+  ProjectionIndex index{projections};
+  std::vector<size_t> ordinals;
+  ordinals.reserve(sortKeyExprs.size());
+
   for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
-    // Use pre-resolved ordinal if available.
-    if (preResolvedOrdinals[i] != 0) {
-      ordinals.push_back(preResolvedOrdinals[i]);
-    } else {
-      // Match alias if one is used.
-      const auto aliasMapValue = sortKeyExprs[i].alias().has_value()
-          ? aliasMap.find(sortKeyExprs[i].alias().value())
-          : aliasMap.end();
-      if (aliasMapValue != aliasMap.end()) {
-        auto ordinal = aliasMapValue->second;
-        VELOX_USER_CHECK_NE(
-            ordinal, 0, "Column is ambiguous: {}", aliasMapValue->first);
-        ordinals.push_back(ordinal);
-      }
-      // Match expression directly if no alias is used, expanding out
-      // projections list if sorts keys don't match our SELECT list.
-      else {
-        auto resolved =
-            replaceAliases(sortKeyExprs[i].expr(), aliasMap, projections);
-        auto [projectionIt, inserted] =
-            projectionMap.emplace(resolved, projections.size() + 1);
-        if (inserted) {
-          ordinals.push_back(projections.size() + 1);
-          lp::ExprApi newProjection(resolved, sortKeyExprs[i].alias());
-          projections.push_back(std::move(newProjection));
-        } else {
-          ordinals.push_back(projectionIt->second);
-        }
-      }
+    auto ordinal = lookupSortKey(
+        sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
+    if (ordinal == 0) {
+      onUnresolved(i);
+      VELOX_FAIL("onUnresolved callback must throw");
     }
+    ordinals.push_back(ordinal);
   }
 
   return ordinals;

--- a/axiom/sql/presto/SortProjection.h
+++ b/axiom/sql/presto/SortProjection.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <functional>
+
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ast/AstSupport.h"
@@ -42,6 +44,18 @@ class SortProjection {
       const std::vector<facebook::axiom::logical_plan::ExprApi>& sortKeyExprs,
       const std::vector<size_t>& preResolvedOrdinals,
       std::vector<facebook::axiom::logical_plan::ExprApi>& projections);
+
+  /// Resolves sort keys against `projections` without widening. Returns
+  /// 1-based ordinals for every key. Invokes `onUnresolved` with the index
+  /// of the first sort key not present in `projections`; the callback is
+  /// expected to throw (e.g., a Presto semantic error). Use this when
+  /// every ORDER BY key must match a SELECT-list expression (e.g., SELECT
+  /// DISTINCT).
+  static std::vector<size_t> resolveSortKeys(
+      const std::vector<facebook::axiom::logical_plan::ExprApi>& sortKeyExprs,
+      const std::vector<size_t>& preResolvedOrdinals,
+      const std::vector<facebook::axiom::logical_plan::ExprApi>& projections,
+      const std::function<void(size_t index)>& onUnresolved);
 
   /// Adds a SortNode using sort keys resolved by ordinals, then drops any extra
   /// columns that were added for sorting.

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -312,6 +312,39 @@ TEST_F(SortParserTest, distinct) {
       "Cannot resolve column: a not in [expr -> expr]");
 }
 
+// SELECT DISTINCT combined with GROUP BY and ORDER BY. The Sort node must
+// land ABOVE the DISTINCT aggregate, and ORDER BY may reference only
+// SELECT-list columns.
+TEST_F(SortParserTest, distinctWithGroupBy) {
+  connector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // ORDER BY a SELECT-list column.
+  {
+    auto matcher = matchScan("t")
+                       .aggregate({"a"}, {"count(1)"})
+                       .aggregate({"a", "count"}, {})
+                       .sort({"a"})
+                       .output({"a", "count"});
+
+    testSelect(
+        "SELECT DISTINCT a, COUNT(1) FROM t GROUP BY a ORDER BY a", matcher);
+    testSelect(
+        "SELECT DISTINCT a, COUNT(1) FROM t GROUP BY a ORDER BY 1", matcher);
+  }
+
+  // ORDER BY a column that is in GROUP BY but not in the SELECT list — must
+  // fail because SELECT DISTINCT requires ORDER BY to reference SELECT-list
+  // columns only.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT DISTINCT a FROM t GROUP BY a, b ORDER BY b"),
+      "ORDER BY expressions must be output expressions");
+
+  // ORDER BY ordinal beyond the SELECT list.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT DISTINCT a FROM t GROUP BY a, b ORDER BY 2"),
+      "ORDER BY position is not in the select list: 2");
+}
+
 TEST_F(SortParserTest, distinctOrderByOriginalName) {
   connector_->addTable("t", ROW({"a", "b"}, INTEGER()));
 


### PR DESCRIPTION
Summary:

Adds a dead-sort elimination pass to ToGraph: a top-down liveness analysis that skips emitting `dt->orderKeys` for Sort nodes whose output order is not observed by any consumer. Threads a single `orderObservedAbove` bit through the LogicalPlan traversal:

- LIMIT, OFFSET, root output: observe order.
- Filter, Project, Sample (Bernoulli, 100%), Unnest, structural wraps: preserve order (pass through).
- Aggregate, Join, UnionAll, INTERSECT/EXCEPT, set-join inputs, TableWrite, non-inner-join wraps: destroy order.
- Sort itself overrides any order produced below (children get false).

The bit subsumes existing ad hoc code in the Aggregate and window-Project paths that explicitly cleared inherited `orderKeys`. `DerivedTable::dropOrderBy()` is removed (no remaining callers).

Also fixes PrestoParser to place the Sort node ABOVE the DISTINCT aggregate when both GROUP BY and DISTINCT are present. SQL evaluates `FROM → GROUP BY → SELECT/DISTINCT → ORDER BY`, so ORDER BY operates on the post-DISTINCT result. Pre-fix, the parser positioned the Sort BETWEEN the two aggregates; the dead-sort opt correctly identified it as unobservable past the DISTINCT (which destroys order) and dropped it, silently producing unordered output for `SELECT DISTINCT ... GROUP BY ... ORDER BY`. Refactors the existing no-GROUP-BY DISTINCT validation into shared `SortProjection::resolveSortKeys`; both DISTINCT paths now call it. Validates that ORDER BY references only SELECT-list columns (matching existing no-GROUP-BY semantics).

Test plan changes follow from the new behavior:
- `UnionAllTest.groupByOverUnionAllWithOrderedLegs`: matcher drops per-leg `.orderBy()` (sorts now elided pre-execution).
- `HiveQueriesTest.joinWithLimitBothSides`: matcher drops `.orderBy()` per existing TODO that this fix resolves.
- `ExistencePushdownTest.orderByOnFirstDt`: dead-sort drop unblocks existence pushdown; new matchers reflect the pushed-down plan.
- `SortParserTest.distinctWithGroupBy` (new): regression test for the parser fix, including the SELECT-list-only validation for DISTINCT + GROUP BY + ORDER BY.

Differential Revision: D104781825


