### PR TITLE
feat: Add user-defined enum type resolution to parser via ConnectorMetadata (#1351)

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   ConfigRegistry.cpp
   QueryRuntimeStats.cpp
   SchemaTableName.cpp
+  SchemaTypeName.cpp
   Session.cpp
   SessionConfig.cpp
 )

--- a/axiom/common/SchemaTypeName.cpp
+++ b/axiom/common/SchemaTypeName.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/SchemaTypeName.h"
+
+#include <fmt/core.h>
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom {
+
+std::string SchemaTypeName::toString() const {
+  return fmt::format("{}", *this);
+}
+
+} // namespace facebook::axiom
+
+size_t std::hash<facebook::axiom::SchemaTypeName>::operator()(
+    const facebook::axiom::SchemaTypeName& name) const {
+  auto hash = folly::hasher<std::string>{}(name.type);
+  hash = facebook::velox::bits::hashMix(
+      hash, folly::hasher<std::string>{}(name.schema));
+  return hash;
+}

--- a/axiom/common/SchemaTypeName.h
+++ b/axiom/common/SchemaTypeName.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include <fmt/format.h>
+#include <ostream>
+
+namespace facebook::axiom {
+
+/// Structured representation of a schema-qualified type name.
+/// Parallels SchemaTableName for user-defined types (e.g., enums).
+struct SchemaTypeName {
+  std::string schema;
+  std::string type;
+
+  /// Returns "schema"."type" for display/logging only.
+  std::string toString() const;
+
+  bool operator==(const SchemaTypeName&) const = default;
+};
+
+// Used by gtest to print values in assertion failures.
+inline std::ostream& operator<<(std::ostream& os, const SchemaTypeName& name) {
+  return os << name.toString();
+}
+
+} // namespace facebook::axiom
+
+template <>
+struct std::hash<facebook::axiom::SchemaTypeName> {
+  size_t operator()(const facebook::axiom::SchemaTypeName& name) const;
+};
+
+template <>
+struct fmt::formatter<facebook::axiom::SchemaTypeName>
+    : fmt::formatter<std::string_view> {
+  auto format(const facebook::axiom::SchemaTypeName& name, format_context& ctx)
+      const {
+    return fmt::format_to(ctx.out(), R"d("{}"."{}")d", name.schema, name.type);
+  }
+};

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -17,6 +17,7 @@
 
 #include "axiom/common/Enums.h"
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "folly/CppAttributes.h"
@@ -833,6 +834,15 @@ class ConnectorMetadata {
   ///
   /// @return nullptr if view doesn't exist.
   virtual ViewPtr findView(const SchemaTableName& /*tableName*/) {
+    return nullptr;
+  }
+
+  /// Finds a user-defined type by schema-qualified name. Connectors that serve
+  /// user-defined types (e.g., enums from an external type registry) override
+  /// this method.
+  ///
+  /// @return nullptr if the type is not found.
+  virtual velox::TypePtr findType(const SchemaTypeName& /*typeName*/) {
     return nullptr;
   }
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -293,6 +293,21 @@ TablePtr TestConnectorMetadata::findTable(const SchemaTableName& tableName) {
   return findTableInternal(tableName);
 }
 
+velox::TypePtr TestConnectorMetadata::findType(const SchemaTypeName& typeName) {
+  auto it = types_.find(typeName);
+  if (it != types_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+void TestConnectorMetadata::addType(
+    const SchemaTypeName& typeName,
+    velox::TypePtr type) {
+  auto [_, inserted] = types_.emplace(typeName, std::move(type));
+  VELOX_CHECK(inserted, "Type already registered: {}", typeName);
+}
+
 ViewPtr TestConnectorMetadata::findView(const SchemaTableName& tableName) {
   auto it = views_.find(tableName);
   if (it == views_.end()) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -500,6 +500,12 @@ class TestConnectorMetadata : public ConnectorMetadata {
     return dropTable(nullptr, tableName, true, /*explain=*/false);
   }
 
+  velox::TypePtr findType(const SchemaTypeName& typeName) override;
+
+  /// Registers a user-defined type for findType() resolution. Throws if a type
+  /// with the same name is already registered.
+  void addType(const SchemaTypeName& typeName, velox::TypePtr type);
+
   ViewPtr findView(const SchemaTableName& tableName) override;
 
   /// Register a view with the given name, output schema, and SQL text.
@@ -546,6 +552,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   folly::F14FastMap<SchemaTableName, ViewDefinition> views_;
 
   folly::F14FastSet<std::string> schemas_{"default"};
+  folly::F14FastMap<SchemaTypeName, velox::TypePtr> types_;
 };
 
 /// At DataSource creation time, the data contained in the corresponding Table

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -15,14 +15,21 @@
  */
 
 #include "axiom/sql/presto/ExpressionPlanner.h"
+
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
+
 #include <algorithm>
 #include <cctype>
+
+#include "axiom/common/SchemaTypeName.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/parse/Expressions.h"
 
 namespace axiom::sql::presto {
@@ -221,51 +228,137 @@ lp::ExprApi parseDecimal(std::string_view value, NodeLocation location) {
       LongDecimalType::kMaxPrecision);
 }
 
-} // namespace
-
-void ExpressionPlanner::findWindowExprs(
-    const core::ExprPtr& expr,
-    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
-    std::vector<const core::IExpr*>& traversalOrder) {
-  if (expr->is(core::IExpr::Kind::kWindow)) {
-    if (windowExprs.emplace(expr.get(), expr).second) {
-      traversalOrder.push_back(expr.get());
+// Flattens a nested DereferenceExpression chain into dot-separated parts.
+// Returns true if the entire chain consists of identifiers and dereferences.
+// Returns false and clears 'parts' if any node is a different expression type.
+bool extractQualifiedParts(
+    const ExpressionPtr& node,
+    std::vector<std::string>& parts) {
+  if (node->is(NodeType::kIdentifier)) {
+    auto* identifier = node->as<Identifier>();
+    parts.push_back(canonicalizeName(identifier->value()));
+    return true;
+  }
+  if (node->is(NodeType::kDereferenceExpression)) {
+    auto* deref = node->as<DereferenceExpression>();
+    if (!extractQualifiedParts(deref->base(), parts)) {
+      return false;
     }
-    return;
+    parts.push_back(canonicalizeName(deref->field()->value()));
+    return true;
   }
-  for (const auto& input : expr->inputs()) {
-    findWindowExprs(input, windowExprs, traversalOrder);
+  parts.clear();
+  return false;
+}
+
+// Resolves a user-defined type from ConnectorMetadata. Returns the TypePtr,
+// or nullptr if not found. Uses the per-query cache to avoid repeated lookups.
+TypePtr findQualifiedType(
+    const std::string& catalog,
+    const facebook::axiom::SchemaTypeName& typeName,
+    folly::F14FastMap<std::string, TypePtr>& typeCache) {
+  auto qualifiedName =
+      fmt::format("{}.{}.{}", catalog, typeName.schema, typeName.type);
+
+  auto it = typeCache.find(qualifiedName);
+  if (it != typeCache.end()) {
+    return it->second;
   }
-}
 
-void ExpressionPlanner::findNestedWindowExprs(
-    const std::vector<lp::ExprApi>& exprs,
-    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
-    std::vector<const core::IExpr*>& traversalOrder) {
-  for (const auto& expr : exprs) {
-    if (!expr.expr()->is(core::IExpr::Kind::kWindow)) {
-      findWindowExprs(expr.expr(), windowExprs, traversalOrder);
-    }
+  auto metadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::tryGet(catalog);
+  if (metadata == nullptr) {
+    typeCache.emplace(qualifiedName, nullptr);
+    return nullptr;
   }
+
+  auto type = metadata->findType(typeName);
+  typeCache.emplace(qualifiedName, type);
+  return type;
 }
 
-std::string canonicalizeName(const std::string& name) {
-  std::string canonicalName;
-  canonicalName.resize(name.size());
-  std::transform(
-      name.begin(), name.end(), canonicalName.begin(), [](unsigned char c) {
-        return std::tolower(c);
-      });
-
-  return canonicalName;
+// Tries to resolve a dotted base name (e.g., "CATALOG.SCHEMA.TYPE") as a
+// connector-provided user-defined type. Returns nullptr if the name has
+// fewer than two dots or the connector does not know the type.
+TypePtr tryConnectorBasedTypeResolution(
+    std::string_view baseName,
+    folly::F14FastMap<std::string, TypePtr>& typeCache) {
+  auto firstDot = baseName.find('.');
+  if (firstDot == std::string_view::npos) {
+    return nullptr;
+  }
+  auto secondDot = baseName.find('.', firstDot + 1);
+  if (secondDot == std::string_view::npos) {
+    return nullptr;
+  }
+  auto catalog = canonicalizeName(std::string{baseName.substr(0, firstDot)});
+  auto schema = canonicalizeName(
+      std::string{baseName.substr(firstDot + 1, secondDot - firstDot - 1)});
+  auto typeName = canonicalizeName(std::string{baseName.substr(secondDot + 1)});
+  if (catalog.empty() || schema.empty() || typeName.empty()) {
+    return nullptr;
+  }
+  return findQualifiedType(
+      catalog, {std::move(schema), std::move(typeName)}, typeCache);
 }
 
-std::string canonicalizeIdentifier(const Identifier& identifier) {
-  // TODO: Figure out whether 'delimited' identifiers should be kept as is.
-  return canonicalizeName(identifier.value());
+// Attempts to resolve a qualified name (e.g., "catalog.schema.status.active")
+// as an enum literal. Returns nullopt if the type is not found. Throws
+// PrestoSqlError if the type is found but the value is not a valid enum member,
+// or if the resolved type is not an enum type.
+std::optional<lp::ExprApi> tryResolveEnumLiteral(
+    const std::vector<std::string>& parts,
+    folly::F14FastMap<std::string, TypePtr>& typeCache,
+    NodeLocation location) {
+  if (parts.size() < 4) {
+    return std::nullopt;
+  }
+
+  const auto& catalog = parts[0];
+  auto schema = parts[1];
+  auto typeName = folly::join('.', parts.begin() + 2, parts.end() - 1);
+  const auto& valueName = parts.back();
+
+  auto type = findQualifiedType(
+      catalog,
+      facebook::axiom::SchemaTypeName{std::move(schema), std::move(typeName)},
+      typeCache);
+  if (type == nullptr) {
+    return std::nullopt;
+  }
+
+  if (isBigintEnumType(*type)) {
+    auto enumType = asBigintEnum(type);
+    auto value = enumType->valueAt(valueName);
+    AXIOM_PRESTO_SEMANTIC_CHECK(
+        value.has_value(),
+        location,
+        valueName,
+        "Enum value not found in type: {}",
+        enumType->enumName());
+    return lp::Lit(*value, type);
+  }
+
+  if (isVarcharEnumType(*type)) {
+    auto enumType = asVarcharEnum(type);
+    auto value = enumType->valueAt(valueName);
+    AXIOM_PRESTO_SEMANTIC_CHECK(
+        value.has_value(),
+        location,
+        valueName,
+        "Enum value not found in type: {}",
+        enumType->enumName());
+    return lp::Lit(std::move(*value), type);
+  }
+
+  AXIOM_PRESTO_SEMANTIC_FAIL(
+      location, valueName, "Type is not an enum type: {}", type->toString());
 }
 
-TypePtr parseType(const TypeSignaturePtr& type) {
+// Resolves a TypeSignature to a Velox built-in type. Returns nullptr for
+// unknown non-parametric types. Nested types (ARRAY, MAP, etc.) use parseType
+// (declared in the header) which throws on failure.
+TypePtr tryResolveBuiltinType(const TypeSignaturePtr& type) {
   auto baseName = type->baseName();
   std::transform(
       baseName.begin(), baseName.end(), baseName.begin(), [](char c) {
@@ -341,10 +434,73 @@ TypePtr parseType(const TypeSignaturePtr& type) {
     }
   }
 
-  auto veloxType = getType(baseName, parameters);
+  return getType(baseName, parameters);
+}
 
+} // namespace
+
+void ExpressionPlanner::findWindowExprs(
+    const core::ExprPtr& expr,
+    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
+    std::vector<const core::IExpr*>& traversalOrder) {
+  if (expr->is(core::IExpr::Kind::kWindow)) {
+    if (windowExprs.emplace(expr.get(), expr).second) {
+      traversalOrder.push_back(expr.get());
+    }
+    return;
+  }
+  for (const auto& input : expr->inputs()) {
+    findWindowExprs(input, windowExprs, traversalOrder);
+  }
+}
+
+void ExpressionPlanner::findNestedWindowExprs(
+    const std::vector<lp::ExprApi>& exprs,
+    std::unordered_map<const core::IExpr*, core::ExprPtr>& windowExprs,
+    std::vector<const core::IExpr*>& traversalOrder) {
+  for (const auto& expr : exprs) {
+    if (!expr.expr()->is(core::IExpr::Kind::kWindow)) {
+      findWindowExprs(expr.expr(), windowExprs, traversalOrder);
+    }
+  }
+}
+
+std::string canonicalizeName(const std::string& name) {
+  std::string canonicalName;
+  canonicalName.resize(name.size());
+  std::transform(
+      name.begin(), name.end(), canonicalName.begin(), [](unsigned char c) {
+        return std::tolower(c);
+      });
+
+  return canonicalName;
+}
+
+std::string canonicalizeIdentifier(const Identifier& identifier) {
+  // TODO: Figure out whether 'delimited' identifiers should be kept as is.
+  return canonicalizeName(identifier.value());
+}
+
+TypePtr parseType(const TypeSignaturePtr& type) {
+  auto veloxType = tryResolveBuiltinType(type);
   AXIOM_PRESTO_SEMANTIC_CHECK(
-      veloxType != nullptr, type->location(), baseName, "Cannot resolve type");
+      veloxType != nullptr,
+      type->location(),
+      type->baseName(),
+      "Cannot resolve type");
+  return veloxType;
+}
+
+TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
+  auto veloxType = tryResolveBuiltinType(type);
+  if (veloxType == nullptr) {
+    veloxType = tryConnectorBasedTypeResolution(type->baseName(), typeCache_);
+  }
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      veloxType != nullptr,
+      type->location(),
+      type->baseName(),
+      "Cannot resolve type");
   return veloxType;
 }
 
@@ -367,6 +523,25 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kDereferenceExpression: {
       auto* dereference = node->as<DereferenceExpression>();
+
+      // Try to resolve as an enum literal (e.g., catalog.schema.Type.VALUE).
+      // When columnResolver_ is nullptr (e.g., parseSqlExpression for CREATE
+      // TABLE property values), there is no column scope to compete with — a
+      // 4-part dotted name can only be an enum literal.
+      std::vector<std::string> parts;
+      if (extractQualifiedParts(node, parts) && parts.size() >= 4) {
+        bool isColumn =
+            columnResolver_ != nullptr && columnResolver_(parts[0], parts[1]);
+
+        if (!isColumn) {
+          auto resolved =
+              tryResolveEnumLiteral(parts, typeCache_, node->location());
+          if (resolved.has_value()) {
+            return *resolved;
+          }
+        }
+      }
+
       auto field = canonicalizeIdentifier(*dereference->field());
       // The base of a dereference is a scope qualifier (table alias or
       // struct-typed column), not a value-producing expression. Lateral
@@ -518,7 +693,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kCast: {
       auto* cast = node->as<Cast>();
-      const auto type = parseType(cast->toType());
+      const auto type = resolveType(cast->toType());
 
       if (cast->isSafe()) {
         return lp::TryCast(type, toExpr(cast->expression()));
@@ -697,7 +872,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kGenericLiteral: {
       auto literal = node->as<GenericLiteral>();
-      auto type = parseType(literal->valueType());
+      auto type = resolveType(literal->valueType());
       // JSON literals use json_parse, not CAST. CAST(VARCHAR AS JSON)
       // wraps the value as a JSON string, while json_parse interprets the
       // value as JSON.

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -18,6 +18,9 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+
+#include <folly/container/F14Map.h>
+
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
@@ -63,18 +66,27 @@ class ExpressionPlanner {
   using ShouldDropQualifier = std::function<
       bool(const std::string& qualifier, const std::string& name)>;
 
+  /// Checks if a dotted name prefix resolves to a column or table alias in the
+  /// current scope. Returns true if 'first' is a column name OR if 'first' is
+  /// a table alias qualifying 'second' as a column. Used for column-first enum
+  /// literal resolution. Can be nullptr when no column scope is available.
+  using ColumnResolver =
+      std::function<bool(const std::string& first, const std::string& second)>;
+
   ExpressionPlanner(
       SubqueryPlanner subqueryPlanner,
       SortingKeyResolver sortingKeyResolver,
-      ShouldDropQualifier shouldDropQualifier = nullptr)
+      ShouldDropQualifier shouldDropQualifier = nullptr,
+      ColumnResolver columnResolver = nullptr)
       : subqueryPlanner_(std::move(subqueryPlanner)),
         sortingKeyResolver_(std::move(sortingKeyResolver)),
-        shouldDropQualifier_(std::move(shouldDropQualifier)) {}
+        shouldDropQualifier_(std::move(shouldDropQualifier)),
+        columnResolver_(std::move(columnResolver)) {}
 
   /// Finds WindowCallExpr nodes nested inside non-window expressions.
   /// Skips top-level window projections (where the ExprApi itself is a
   /// WindowCallExpr). Populates 'windowExprs' with pointers to the found
-  /// WindowCallExpr nodes (raw pointer → shared pointer) and
+  /// WindowCallExpr nodes (raw pointer -> shared pointer) and
   /// 'traversalOrder' with raw pointers in left-to-right order for
   /// deterministic plan generation.
   static void findNestedWindowExprs(
@@ -128,9 +140,18 @@ class ExpressionPlanner {
       const std::string& funcName,
       const std::vector<lp::ExprApi>& args);
 
+  // Resolves a type signature, trying built-in Velox types first, then
+  // connector-based resolution for dotted names (e.g., "catalog.schema.Type").
+  facebook::velox::TypePtr resolveType(const TypeSignaturePtr& type);
+
   SubqueryPlanner subqueryPlanner_;
   SortingKeyResolver sortingKeyResolver_;
   ShouldDropQualifier shouldDropQualifier_;
+  ColumnResolver columnResolver_;
+
+  // Per-query cache for user-defined type lookups. Entries with nullptr values
+  // represent negatively cached (not-found) types.
+  folly::F14FastMap<std::string, facebook::velox::TypePtr> typeCache_;
 
   // Lateral column alias mappings. When non-null, Identifier nodes matching
   // a key are resolved to the corresponding expression, unless the name also

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1306,6 +1306,10 @@ class RelationPlanner : public AstVisitor {
         // struct field dereference) and the unqualified name is unambiguous.
         return builder_->hasQualifiedColumn(qualifier, name) &&
             builder_->hasColumn(name);
+      },
+      [this](const std::string& first, const std::string& second) -> bool {
+        return builder_->hasColumn(first) ||
+            builder_->hasQualifiedColumn(first, second);
       }};
   std::unordered_map<std::string, std::shared_ptr<WithQuery>> withQueries_;
   ViewMap views_;

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -12,23 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(
-  axiom_logical_plan_matcher
-  ExprMatcher.cpp
-  LogicalPlanMatcher.cpp
-)
+add_library(axiom_logical_plan_matcher ExprMatcher.cpp LogicalPlanMatcher.cpp)
 
-target_link_libraries(
-  axiom_logical_plan_matcher
-  axiom_logical_plan
-  GTest::gtest
-)
+target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest)
 
 add_executable(
   axiom_sql_presto_test
   AggregationParserTest.cpp
   ColumnFilteringTest.cpp
   DdlParserTest.cpp
+  EnumLiteralTest.cpp
   ExprMatcherTest.cpp
   ExpressionParserTest.cpp
   PrestoSqlErrorTest.cpp

--- a/axiom/sql/presto/tests/EnumLiteralTest.cpp
+++ b/axiom/sql/presto/tests/EnumLiteralTest.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include "axiom/common/SchemaTypeName.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+namespace {
+
+// Wraps TestConnectorMetadata to count findType calls.
+class CountingTestConnectorMetadata
+    : public facebook::axiom::connector::TestConnectorMetadata {
+ public:
+  using TestConnectorMetadata::TestConnectorMetadata;
+
+  facebook::velox::TypePtr findType(
+      const facebook::axiom::SchemaTypeName& typeName) override {
+    ++count_;
+    return TestConnectorMetadata::findType(typeName);
+  }
+
+  int count() const {
+    return count_;
+  }
+
+  void reset() {
+    count_ = 0;
+  }
+
+ private:
+  int count_{0};
+};
+
+class EnumLiteralTest : public PrestoParserTestBase {
+ protected:
+  static void SetUpTestCase() {
+    PrestoParserTestBase::SetUpTestCase();
+    facebook::velox::registerBigintEnumType();
+    facebook::velox::registerVarcharEnumType();
+  }
+
+  void SetUp() override {
+    PrestoParserTestBase::SetUp();
+
+    enumMetadata_ = std::make_shared<CountingTestConnectorMetadata>(nullptr);
+
+    statusType_ = BIGINT_ENUM(LongEnumParameter(
+        "tc.myschema.status",
+        {{"active", 0}, {"inactive", 1}, {"pending", 2}}));
+    enumMetadata_->addType({"myschema", "status"}, statusType_);
+
+    colorType_ = VARCHAR_ENUM(VarcharEnumParameter(
+        "tc.myschema.color", {{"red", "red_value"}, {"blue", "blue_value"}}));
+    enumMetadata_->addType({"myschema", "color"}, colorType_);
+
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+        "tc", enumMetadata_);
+  }
+
+  void TearDown() override {
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase("tc");
+    enumMetadata_.reset();
+    PrestoParserTestBase::TearDown();
+  }
+
+  std::shared_ptr<CountingTestConnectorMetadata> enumMetadata_;
+  TypePtr statusType_;
+  TypePtr colorType_;
+};
+
+TEST_F(EnumLiteralTest, bigintEnum) {
+  // Happy path: bigint enum literal resolves to typed constant.
+  testSelect(
+      "SELECT tc.myschema.Status.ACTIVE FROM nation",
+      matchScan().project({lp::Lit(int64_t{0}, statusType_)}).output());
+
+  // Case-insensitive resolution.
+  auto verify = [&](std::string_view sql, int64_t expected) {
+    SCOPED_TRACE(sql);
+    testSelect(
+        fmt::format("SELECT {} FROM nation", sql),
+        matchScan().project({lp::Lit(expected, statusType_)}).output());
+  };
+  verify("tc.myschema.status.active", 0);
+  verify("tc.myschema.STATUS.INACTIVE", 1);
+  verify("tc.myschema.Status.Pending", 2);
+
+  // Unknown value is an error.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect("SELECT tc.myschema.Status.UNKNOWN FROM nation"),
+      "Enum value not found in type: tc.myschema.status");
+
+  // Non-enum type referenced as enum literal produces explicit error.
+  enumMetadata_->addType({"myschema", "notstruct"}, ROW({{"x", INTEGER()}}));
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect("SELECT tc.myschema.notstruct.x FROM nation"),
+      "Type is not an enum type");
+}
+
+TEST_F(EnumLiteralTest, varcharEnum) {
+  testSelect(
+      "SELECT tc.myschema.Color.RED FROM nation",
+      matchScan().project({lp::Lit("red_value", colorType_)}).output());
+}
+
+TEST_F(EnumLiteralTest, castToEnumType) {
+  // CAST resolves dotted type names through connector.
+  testSelect(
+      "SELECT CAST(n_regionkey AS tc.myschema.Status) FROM nation",
+      matchScan()
+          .project({lp::Cast(statusType_, lp::Col("n_regionkey"))})
+          .output());
+
+  // Case-insensitive CAST.
+  testSelect(
+      "SELECT CAST(n_regionkey AS TC.MYSCHEMA.STATUS) FROM nation",
+      matchScan()
+          .project({lp::Cast(statusType_, lp::Col("n_regionkey"))})
+          .output());
+
+  // Unknown type in CAST.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT CAST(n_regionkey AS tc.myschema.NonExistent) FROM nation"),
+      "Cannot resolve type");
+
+  // Unknown schema in CAST.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT CAST(n_regionkey AS tc.unknown.SomeType) FROM nation"),
+      "Cannot resolve type");
+}
+
+TEST_F(EnumLiteralTest, unknownTypeAndCatalog) {
+  // Unknown type with known catalog falls through to column dereference.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.myschema.NonExistent.VALUE FROM nation"),
+      "Cannot resolve column: tc");
+
+  // Unknown catalog falls through to column dereference.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT other.myschema.Status.ACTIVE FROM nation"),
+      "Cannot resolve column: other");
+}
+
+TEST_F(EnumLiteralTest, columnFirstResolution) {
+  // Create a table with a struct column named "tc" whose subfield chain
+  // matches a registered enum. Column dereference must win over enum.
+  connector_->addTable(
+      "structtest",
+      ROW({"tc"}, {ROW("myschema", ROW("status", ROW("active", BIGINT())))}));
+
+  auto structDeref =
+      lp::Col("active", lp::Col("status", lp::Col("myschema", lp::Col("tc"))));
+
+  testSelect(
+      "SELECT tc.myschema.status.active FROM structtest",
+      matchScan().project({structDeref}).output());
+
+  // Verify findType was not called — enum resolution was skipped.
+  enumMetadata_->reset();
+  parseSelect("SELECT tc.myschema.status.active FROM structtest");
+  EXPECT_EQ(enumMetadata_->count(), 0);
+
+  // Table alias collision: "tc" is a table alias that matches the catalog name.
+  // The alias must win — enum resolution must not be attempted.
+  connector_->addTable(
+      "aliastest", ROW({"myschema"}, {ROW("status", ROW("active", BIGINT()))}));
+
+  testSelect(
+      "SELECT tc.myschema.status.active FROM aliastest AS tc",
+      matchScan()
+          .project({lp::Col("active", lp::Col("status", lp::Col("myschema")))})
+          .output());
+
+  enumMetadata_->reset();
+  parseSelect("SELECT tc.myschema.status.active FROM aliastest AS tc");
+  EXPECT_EQ(enumMetadata_->count(), 0);
+}
+
+TEST_F(EnumLiteralTest, structFieldDereference) {
+  // Two-part name: column dereference (< 4 parts, never enum).
+  connector_->addTable(
+      "structtable", ROW({"s"}, {ROW("nested", ROW("field", BIGINT()))}));
+
+  testSelect(
+      "SELECT s.nested FROM structtable",
+      matchScan().project({lp::Col("nested", lp::Col("s"))}).output());
+
+  // Three-part name: still a column dereference (< 4 parts).
+  testSelect(
+      "SELECT s.nested.field FROM structtable",
+      matchScan()
+          .project({lp::Col("field", lp::Col("nested", lp::Col("s")))})
+          .output());
+}
+
+TEST_F(EnumLiteralTest, enumLiteralInClauses) {
+  {
+    SCOPED_TRACE("WHERE");
+    testSelect(
+        "SELECT n_name FROM nation "
+        "WHERE CAST(n_regionkey AS tc.myschema.Status) = "
+        "tc.myschema.Status.ACTIVE",
+        matchScan().filter().project().output());
+  }
+  {
+    SCOPED_TRACE("GROUP BY");
+    testSelect(
+        "SELECT tc.myschema.Status.ACTIVE, count(*) FROM nation "
+        "GROUP BY tc.myschema.Status.ACTIVE",
+        matchScan().aggregate().output());
+  }
+  {
+    SCOPED_TRACE("ORDER BY");
+    testSelect(
+        "SELECT n_name FROM nation "
+        "ORDER BY tc.myschema.Status.ACTIVE",
+        matchScan().project().sort().project().output());
+  }
+  {
+    SCOPED_TRACE("CASE WHEN");
+    testSelect(
+        "SELECT CASE "
+        "WHEN CAST(n_regionkey AS tc.myschema.Status) = "
+        "tc.myschema.Status.ACTIVE "
+        "THEN 'yes' ELSE 'no' END FROM nation",
+        matchScan().project().output());
+  }
+  {
+    SCOPED_TRACE("JOIN condition");
+    testSelect(
+        "SELECT n.n_name FROM nation n "
+        "JOIN region r ON CAST(n.n_regionkey AS tc.myschema.Status) = "
+        "tc.myschema.Status.ACTIVE",
+        matchScan().join(matchScan().build()).project().output());
+  }
+}
+
+TEST_F(EnumLiteralTest, compareEnumLiterals) {
+  testSelect(
+      "SELECT tc.myschema.Status.ACTIVE = tc.myschema.Status.INACTIVE "
+      "FROM nation",
+      matchScan()
+          .project({lp::Call(
+              "eq",
+              lp::Lit(int64_t{0}, statusType_),
+              lp::Lit(int64_t{1}, statusType_))})
+          .output());
+}
+
+TEST_F(EnumLiteralTest, typeofEnumLiteral) {
+  testSelect(
+      "SELECT typeof(tc.myschema.Status.ACTIVE) FROM nation",
+      matchScan().project().output());
+}
+
+TEST_F(EnumLiteralTest, multiPartTypeName) {
+  auto multiPartType =
+      BIGINT_ENUM(LongEnumParameter("tc.b.foo.bar", {{"val", 42}}));
+  enumMetadata_->addType({"b", "foo.bar"}, multiPartType);
+
+  // CAST path.
+  testSelect(
+      "SELECT CAST(n_regionkey AS tc.b.foo.bar) FROM nation",
+      matchScan()
+          .project({lp::Cast(multiPartType, lp::Col("n_regionkey"))})
+          .output());
+
+  // Literal path.
+  testSelect(
+      "SELECT tc.b.foo.bar.VAL FROM nation",
+      matchScan().project({lp::Lit(int64_t{42}, multiPartType)}).output());
+}
+
+TEST_F(EnumLiteralTest, castAndLiteralShareCache) {
+  enumMetadata_->reset();
+
+  parseSelect(
+      "SELECT CAST(n_regionkey AS tc.myschema.Status), "
+      "tc.myschema.Status.ACTIVE FROM nation");
+
+  EXPECT_EQ(enumMetadata_->count(), 1);
+}
+
+TEST_F(EnumLiteralTest, edgeCaseDotNames) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect("SELECT CAST(n_regionkey AS .a.b) FROM nation"),
+      "extraneous input '.'");
+
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect("SELECT CAST(n_regionkey AS a.b.) FROM nation"),
+      "extraneous input '.'");
+
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect("SELECT CAST(n_regionkey AS a..b) FROM nation"),
+      "missing ')'");
+}
+
+TEST_F(EnumLiteralTest, enumLiteralInCreateTableProperty) {
+  testCreateTable(
+      "CREATE TABLE t (id INTEGER) "
+      "WITH (status = tc.myschema.Status.ACTIVE)",
+      "t",
+      ROW({"id"}, {INTEGER()}),
+      {{"status", "0"}});
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Adds user-defined enum type resolution to Axiom by extending ConnectorMetadata with a findType() virtual method and integrating it into the SQL parser. Enables queries like `CAST(x AS catalog.schema.Status)` and enum literal references like `catalog.schema.Status.ACTIVE`.

Key changes:

- `SchemaTypeName` — New struct in `axiom/common/` paralleling `SchemaTableName`. Gives a typed identity for schema-qualified type names, used by `findType()` and `addType()`.

- `ConnectorMetadata::findType(const SchemaTypeName&)` — New virtual method (default returns nullptr). Connectors that serve user-defined types override this. Follows the same pattern as `findTable(SchemaTableName)`.

- Enum literal resolution — When the parser encounters a 4+ part DereferenceExpression chain (e.g., `catalog.schema.Type.VALUE`), it checks column scope first (including table aliases), then resolves the type via ConnectorMetadata and looks up the value using `EnumTypeBase::valueAt()` (added in D104496173). Returns `lp::ExprApi` directly — no intermediate struct or double type-dispatch. Non-enum types produce an explicit error instead of falling through to column dereference.

- CAST support — `CAST(x AS catalog.schema.TypeName)` resolves dotted type names through `ExpressionPlanner::resolveType()`, which tries built-in Velox types first, then connector-based resolution.

- Per-query type cache — A private `folly::F14FastMap<std::string, TypePtr>` member of `ExpressionPlanner`. Both CAST and literal paths share the same cache, ensuring within-query consistency. No constructor parameter or external plumbing needed.

- TestConnectorMetadata — Extended with `findType()`/`addType()` using `SchemaTypeName`. `addType()` checks for duplicates via `VELOX_CHECK`.

Reviewed By: mbasmanova

Differential Revision: D103939745


