### PR TITLE
fix(parser): Skip lateral alias substitution for dereference qualifiers

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -362,15 +362,23 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     case NodeType::kDereferenceExpression: {
       auto* dereference = node->as<DereferenceExpression>();
       auto field = canonicalizeIdentifier(*dereference->field());
-      // Strip table qualifier when safe (not a struct field, name is
-      // unambiguous).
-      if (shouldDropQualifier_ &&
-          dereference->base()->is(NodeType::kIdentifier)) {
+      // The base of a dereference is a scope qualifier (table alias or
+      // struct-typed column), not a value-producing expression. Lateral
+      // column alias substitution must not apply to it; bypass toExpr to
+      // build the qualifier directly when the base is a bare identifier.
+      //
+      // TODO: extend the resolver so lateral aliases are a third fallback
+      // scope after table.column and struct dereference. Requires moving
+      // lateral substitution from here into PlanBuilder::resolveInputName.
+      if (dereference->base()->is(NodeType::kIdentifier)) {
         auto qualifier =
             canonicalizeIdentifier(*dereference->base()->as<Identifier>());
-        if (shouldDropQualifier_(qualifier, field)) {
+        // Strip table qualifier when safe (not a struct field, name is
+        // unambiguous).
+        if (shouldDropQualifier_ && shouldDropQualifier_(qualifier, field)) {
           return lp::Col(field);
         }
+        return lp::Col(field, lp::Col(qualifier));
       }
       return lp::Col(field, toExpr(dereference->base()));
     }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1348,6 +1348,23 @@ TEST_F(PrestoParserTest, qualifiedStarWithAmbiguousColumnAfterJoin) {
           .output({"n_nationkey", "n_name", "n_regionkey", "n_comment"}));
 }
 
+// A SELECT projection alias that collides with a table alias must not be
+// substituted for the table alias when used as a dereference qualifier
+// later in the same SELECT. The qualifier in a dereference is a scope
+// reference, not a value, so lateral column alias substitution must not
+// apply to it. The JOIN with same-named columns keeps the qualifier from
+// being dropped before reaching the resolution path under test.
+TEST_F(PrestoParserTest, lateralAliasCollidingWithTableAlias) {
+  testSelect(
+      "SELECT a.x + 1 AS a, a.x + 2 "
+      "FROM (VALUES (1)) t(x) JOIN (VALUES (1)) a(x) ON t.x = a.x",
+      matchValues()
+          .project()
+          .join(matchValues().project().build(), {"t_x", "a_x"})
+          .project({"a_x + 1", "a_x + 2"})
+          .output());
+}
+
 // FETCH FIRST n ROWS ONLY is equivalent to LIMIT n. Each LIMIT query below is
 // paired with a FETCH FIRST query to verify they produce the same plan.
 TEST_F(PrestoParserTest, limit) {


### PR DESCRIPTION
Summary:
A SELECT projection alias whose name collides with a table alias caused an assertion failure in ExprResolver when the table alias was used as a qualifier later in the same SELECT. For example:

  SELECT a.x + 1 AS a, count(*) FILTER (WHERE a.x > 0)
  FROM (VALUES (1)) t(x)
  JOIN (VALUES (1)) a(x) ON t.x = a.x
  GROUP BY 1

failed with `(INTEGER vs. ROW) Expected a struct, but got INTEGER` at ExprResolver.cpp:758.

Root cause: ExpressionPlanner::toExpr handles lateral column aliases (Friendly SQL extension `SELECT i+1 AS j, j+2 AS k`) by substituting bare Identifier nodes that match a previously-defined SELECT alias. The skip-if-column guard uses output column names but not table aliases. When `a.x` is parsed as a Dereference whose base is the Identifier `a`, the recursive `toExpr` on the base substitutes `a` with the alias's expression (an INTEGER), and the dereference then tries to access `.x` on that INTEGER and asserts.

The base of a dereference is a scope qualifier (table alias or struct-typed column), not a value-producing expression. Lateral alias substitution should not apply to it. This change bypasses the recursive toExpr for the bare-identifier base case and constructs the qualifier directly via lp::Col, so the resolver receives the original qualified reference and resolves it against the table/struct scopes.

Adds a TODO documenting the principled follow-up: move lateral substitution from translation time into the resolver so lateral aliases become a third fallback scope after table.column and struct dereference, allowing struct-typed lateral aliases to be field-accessed by name.

Differential Revision: D104916896


