### PR TITLE
feat(parser): Add SHOW TABLES support (#1353)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -110,6 +110,17 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         makeRowVector({"Schema"}, {makeFlatVector(expected)}));
   }
 
+  void assertTables(
+      const std::vector<std::string>& expected,
+      const std::string& query = "SHOW TABLES") {
+    auto result = run(query);
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(
+        result.results[0],
+        makeRowVector({"Table"}, {makeFlatVector(expected)}));
+  }
+
   void assertSessionProperty(
       std::string_view name,
       std::string_view expectedValue,
@@ -796,6 +807,18 @@ TEST_F(SqlQueryRunnerTest, showSchemasWithLike) {
       result.results[0],
       makeRowVector(
           {"Schema"}, {makeFlatVector<std::string>({kDefaultSchema, "dev"})}));
+}
+
+TEST_F(SqlQueryRunnerTest, showTables) {
+  run("CREATE TABLE alpha AS SELECT 1 AS x");
+  run("CREATE TABLE beta AS SELECT 2 AS y");
+  SCOPE_EXIT {
+    run("DROP TABLE IF EXISTS alpha");
+    run("DROP TABLE IF EXISTS beta");
+  };
+
+  assertTables({"alpha", "beta"});
+  assertTables({"alpha"}, "SHOW TABLES LIKE 'a%'");
 }
 
 TEST_F(SqlQueryRunnerTest, showCreateTable) {

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -987,6 +987,13 @@ class ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const std::string& schemaName) = 0;
 
+  /// Returns table names in the given schema. Connectors with unbounded
+  /// table sets (e.g., dynamic resolution) return empty. Results are not
+  /// guaranteed to be in any particular order.
+  virtual std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) = 0;
+
   /// Creates a schema with the given name and properties. If 'ifNotExists' is
   /// true, succeeds silently when the schema already exists. Otherwise, raises
   /// a user error if the schema already exists.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1174,6 +1174,22 @@ TablePtr LocalHiveConnectorMetadata::findTable(
   return findTableLocked(tableName.table);
 }
 
+std::vector<std::string> LocalHiveConnectorMetadata::listTableNames(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  if (schemaName != kDefaultSchema) {
+    return {};
+  }
+  ensureInitialized();
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::string> result;
+  result.reserve(tables_.size());
+  for (const auto& [name, _] : tables_) {
+    result.push_back(name);
+  }
+  return result;
+}
+
 std::shared_ptr<LocalTable> LocalHiveConnectorMetadata::findTableLocked(
     std::string_view name) const {
   auto it = tables_.find(name);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -240,6 +240,10 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
     return schemaName == kDefaultSchema;
   }
 
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
   ConnectorSplitManager* splitManager() override {
     ensureInitialized();
     return &splitManager_;

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -180,4 +180,19 @@ TablePtr SystemConnectorMetadata::findTable(const SchemaTableName& tableName) {
   return nullptr;
 }
 
+std::vector<std::string> SystemConnectorMetadata::listTableNames(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  if (schemaName == kRuntimeSchema) {
+    return {std::string(kQueriesTable.table)};
+  }
+  if (schemaName == kMetadataSchema) {
+    return {
+        std::string(kSessionPropertiesTable.table),
+        std::string(kFunctionsTable.table),
+    };
+  }
+  return {};
+}
+
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -143,6 +143,10 @@ class SystemConnectorMetadata : public ConnectorMetadata {
     return schemaName == kRuntimeSchema || schemaName == kMetadataSchema;
   }
 
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
   ConnectorSplitManager* splitManager() override {
     return splitManager_.get();
   }

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -490,6 +490,19 @@ TEST_F(SystemConnectorMetadataTest, schemas) {
   EXPECT_FALSE(metadata_->schemaExists(session, "information_schema"));
 }
 
+TEST_F(SystemConnectorMetadataTest, listTableNames) {
+  auto session = std::make_shared<ConnectorSession>("test-query");
+  EXPECT_THAT(
+      metadata_->listTableNames(session, std::string(kRuntimeSchema)),
+      testing::ElementsAre(kQueriesTable.table));
+  EXPECT_THAT(
+      metadata_->listTableNames(session, std::string(kMetadataSchema)),
+      testing::UnorderedElementsAre(
+          kSessionPropertiesTable.table, kFunctionsTable.table));
+  EXPECT_THAT(
+      metadata_->listTableNames(session, "unknown"), testing::IsEmpty());
+}
+
 TEST_F(SystemConnectorMetadataTest, sessionPropertiesAllColumns) {
   sessionProvider_->addProperty(
       {"a", "x", "boolean", "true", "false", "First."});

--- a/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
+++ b/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
@@ -58,6 +58,12 @@ class StubConnectorMetadata : public ConnectorMetadata {
     return false;
   }
 
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return {};
+  }
+
  private:
   std::string label_;
 };

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -325,6 +325,19 @@ bool TestConnectorMetadata::schemaExists(
   return schemas_.contains(schemaName);
 }
 
+std::vector<std::string> TestConnectorMetadata::listTableNames(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  std::vector<std::string> result;
+  result.reserve(tables_.size());
+  for (const auto& [name, _] : tables_) {
+    if (name.schema == schemaName) {
+      result.push_back(name.table);
+    }
+  }
+  return result;
+}
+
 void TestConnectorMetadata::createSchema(
     const ConnectorSessionPtr& /*session*/,
     const std::string& schemaName,

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -518,6 +518,10 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const std::string& schemaName) override;
 
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
   void createSchema(
       const ConnectorSessionPtr& session,
       const std::string& schemaName,

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -229,6 +229,21 @@ bool TpchConnectorMetadata::schemaExists(
   return isValidTpchSchema(schemaName);
 }
 
+std::vector<std::string> TpchConnectorMetadata::listTableNames(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  if (!isValidTpchSchema(schemaName)) {
+    return {};
+  }
+
+  std::vector<std::string> result;
+  result.reserve(std::size(velox::tpch::tables));
+  for (auto tpchTable : velox::tpch::tables) {
+    result.emplace_back(velox::tpch::toTableName(tpchTable));
+  }
+  return result;
+}
+
 ViewPtr TpchConnectorMetadata::findView(const SchemaTableName& tableName) {
   if (!tableName.schema.empty() && !isValidTpchSchema(tableName.schema)) {
     return nullptr;

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -183,6 +183,10 @@ class TpchConnectorMetadata : public ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const std::string& schemaName) override;
 
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
   ViewPtr findView(const SchemaTableName& tableName) override;
 
   void createView(

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 #include <folly/coro/GtestHelpers.h>
 #include <folly/init/Init.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/connectors/tpch/TpchConnector.h"
@@ -154,6 +155,37 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
   EXPECT_EQ(tpchTableHandle->getTable(), tpchLayout->getTpchTable());
   EXPECT_DOUBLE_EQ(
       tpchTableHandle->getScaleFactor(), tpchLayout->getScaleFactor());
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
+  auto session = std::make_shared<ConnectorSession>("test");
+  auto tables = metadata_->listTableNames(session, "tiny");
+  EXPECT_THAT(
+      tables,
+      testing::ElementsAre(
+          "part",
+          "supplier",
+          "partsupp",
+          "customer",
+          "orders",
+          "lineitem",
+          "nation",
+          "region"));
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
+  auto session = std::make_shared<ConnectorSession>("test");
+  auto tables = metadata_->listTableNames(session, "sf1");
+  ASSERT_EQ(tables.size(), 8);
+  for (const auto& table : tables) {
+    EXPECT_EQ(table.find('.'), std::string::npos) << table;
+  }
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesInvalidSchema) {
+  auto session = std::make_shared<ConnectorSession>("test");
+  auto tables = metadata_->listTableNames(session, "invalid");
+  EXPECT_THAT(tables, testing::IsEmpty());
 }
 
 CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2194,11 +2194,66 @@ SqlStatementPtr parseShowSchemas(
   lp::PlanBuilder builder(ctx);
   builder.values(ROW({"Schema"}, VARCHAR()), std::move(data));
 
-  if (showSchemas.getLikePattern().has_value()) {
+  if (showSchemas.likePattern().has_value()) {
     builder.filter(makeLikeExpr(
-        "Schema",
-        showSchemas.getLikePattern().value(),
-        showSchemas.getEscape()));
+        "Schema", showSchemas.likePattern().value(), showSchemas.escape()));
+  }
+
+  return std::make_shared<SelectStatement>(
+      builder.build(), ViewMap{}, ReferencedTables{});
+}
+
+SqlStatementPtr parseShowTables(
+    const ShowTables& showTables,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  static constexpr std::string_view kTableColumnName = "Table";
+
+  std::string connectorId = defaultConnectorId;
+  std::string schema = defaultSchema;
+
+  if (showTables.schemaName()) {
+    const auto& parts = showTables.schemaName()->parts();
+    VELOX_USER_CHECK_LE(
+        parts.size(),
+        2,
+        "Invalid schema reference: {}",
+        showTables.schemaName()->fullyQualifiedName());
+    if (parts.size() == 1) {
+      schema = parts[0];
+    } else if (parts.size() == 2) {
+      connectorId = parts[0];
+      schema = parts[1];
+    }
+  }
+
+  auto metadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+  auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
+      "show-tables");
+  VELOX_USER_CHECK(
+      metadata->schemaExists(session, schema),
+      "Schema does not exist: {}",
+      schema);
+  auto tableNames = metadata->listTableNames(session, schema);
+  std::sort(tableNames.begin(), tableNames.end());
+
+  std::vector<Variant> data;
+  data.reserve(tableNames.size());
+  for (const auto& tableName : tableNames) {
+    data.emplace_back(Variant::row({tableName}));
+  }
+
+  lp::PlanBuilder::Context ctx(connectorId);
+  lp::PlanBuilder builder(ctx);
+  builder.values(
+      ROW({std::string(kTableColumnName)}, VARCHAR()), std::move(data));
+
+  if (showTables.likePattern().has_value()) {
+    builder.filter(makeLikeExpr(
+        std::string(kTableColumnName),
+        showTables.likePattern().value(),
+        showTables.escape()));
   }
 
   return std::make_shared<SelectStatement>(
@@ -2273,6 +2328,11 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kShowSchemas)) {
     return parseShowSchemas(*query->as<ShowSchemas>(), defaultConnectorId);
+  }
+
+  if (query->is(NodeType::kShowTables)) {
+    return parseShowTables(
+        *query->as<ShowTables>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kShowCatalogs)) {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1010,7 +1010,26 @@ std::any AstBuilder::visitShowCreateFunction(
 
 std::any AstBuilder::visitShowTables(PrestoSqlParser::ShowTablesContext* ctx) {
   trace("visitShowTables");
-  return visitChildren("visitShowTables", ctx);
+
+  std::shared_ptr<QualifiedName> schemaName;
+  if (ctx->qualifiedName() != nullptr) {
+    schemaName = getQualifiedName(ctx->qualifiedName());
+  }
+
+  std::optional<std::string> likePattern;
+  std::optional<std::string> escape;
+  if (ctx->LIKE() != nullptr) {
+    likePattern = visitExpression(ctx->pattern)->as<StringLiteral>()->value();
+  }
+  if (ctx->ESCAPE() != nullptr) {
+    escape = visitExpression(ctx->escape)->as<StringLiteral>()->value();
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<ShowTables>(
+      getLocation(ctx),
+      std::move(schemaName),
+      std::move(likePattern),
+      std::move(escape)));
 }
 
 std::any AstBuilder::visitShowSchemas(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -803,6 +803,10 @@ void ShowSchemas::accept(AstVisitor* visitor) {
   visitor->visitShowSchemas(this);
 }
 
+void ShowTables::accept(AstVisitor* visitor) {
+  visitor->visitShowTables(this);
+}
+
 void ShowCreateTable::accept(AstVisitor* visitor) {
   visitor->visitShowCreateTable(this);
 }

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -892,11 +892,11 @@ class ShowSchemas : public Statement {
     return catalog_;
   }
 
-  const std::optional<std::string>& getLikePattern() const {
+  const std::optional<std::string>& likePattern() const {
     return likePattern_;
   }
 
-  const std::optional<std::string>& getEscape() const {
+  const std::optional<std::string>& escape() const {
     return escape_;
   }
 
@@ -904,6 +904,41 @@ class ShowSchemas : public Statement {
 
  private:
   std::optional<std::string> catalog_;
+  std::optional<std::string> likePattern_;
+  std::optional<std::string> escape_;
+};
+
+/// SHOW TABLES with optional schema qualifier and LIKE filter. The qualifier
+/// is a QualifiedName that can be `schema` or `catalog.schema`. LIKE applies
+/// to the table name only.
+class ShowTables : public Statement {
+ public:
+  ShowTables(
+      NodeLocation location,
+      std::shared_ptr<QualifiedName> schemaName,
+      std::optional<std::string> likePattern,
+      std::optional<std::string> escape)
+      : Statement(NodeType::kShowTables, location),
+        schemaName_(std::move(schemaName)),
+        likePattern_(std::move(likePattern)),
+        escape_(std::move(escape)) {}
+
+  const std::shared_ptr<QualifiedName>& schemaName() const {
+    return schemaName_;
+  }
+
+  const std::optional<std::string>& likePattern() const {
+    return likePattern_;
+  }
+
+  const std::optional<std::string>& escape() const {
+    return escape_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> schemaName_;
   std::optional<std::string> likePattern_;
   std::optional<std::string> escape_;
 };

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -587,6 +587,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowTables(ShowTables* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowCreateTable(ShowCreateTable* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1068,6 +1068,8 @@ TEST_F(PrestoParserTest, explainShow) {
   auto matcher = matchValues();
   testExplain("EXPLAIN SHOW CATALOGS", matcher);
 
+  testExplain("EXPLAIN SHOW TABLES", matcher);
+
   testExplain("EXPLAIN SHOW COLUMNS FROM nation", matcher);
 
   testExplain("EXPLAIN SHOW FUNCTIONS", matcher);
@@ -1115,6 +1117,23 @@ TEST_F(PrestoParserTest, showCatalogs) {
     auto matcher = matchValues().filter();
     testSelect("SHOW CATALOGS LIKE 'tpch'", matcher);
   }
+}
+
+TEST_F(PrestoParserTest, showTables) {
+  testSelect("SHOW TABLES", matchValues());
+  testSelect("SHOW TABLES FROM default", matchValues());
+  testSelect("SHOW TABLES LIKE 'line%'", matchValues().filter());
+  testSelect("SHOW TABLES FROM default LIKE 'nation'", matchValues().filter());
+
+  VELOX_ASSERT_THROW(
+      parseSelect("SHOW TABLES FROM a.b.c"), "Invalid schema reference");
+
+  VELOX_ASSERT_THROW(
+      parseSelect("SHOW TABLES FROM unknown_catalog.tiny"), "not registered");
+
+  VELOX_ASSERT_THROW(
+      parseSelect("SHOW TABLES FROM nonexistent_schema"),
+      "Schema does not exist");
 }
 
 TEST_F(PrestoParserTest, describe) {


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/36

Add SHOW TABLES support following the SHOW SCHEMAS pattern.

Behavior:
- SHOW TABLES returns a single column "Table" containing table names only — no schema or catalog prefix. LIKE applies to the table name only.
- Results are sorted alphabetically by the parser for deterministic output, matching SHOW SCHEMAS and Presto Java behavior. The listTableNames() API does not guarantee ordering.
- listTableNames() is pure virtual — every connector must explicitly decide. Connectors with unbounded or dynamically resolved table sets (e.g., metastore-backed catalogs) return an empty list.
- Connectors with finite, locally loaded tables (TPC-H, test, local hive, system, impulse) return their full table list.

Error handling (matches Presto Java):
- SHOW TABLES FROM <unknown_schema> fails with "Schema does not exist" (validated via schemaExists before listing).
- SHOW TABLES FROM <unknown_catalog>.<schema> fails with "ConnectorMetadata not registered".
- SHOW TABLES FROM a.b.c (3+ part qualifier) fails with "Invalid schema reference".
- SHOW TABLES LIKE <pattern> ESCAPE <invalid> fails with "Escape string must be a single character" (empty or multi-char escape).

Supported forms:
- SHOW TABLES — tables in the current schema
- SHOW TABLES FROM <schema> — tables in a specific schema
- SHOW TABLES FROM <catalog>.<schema> — tables in a specific catalog and schema
- SHOW TABLES LIKE <pattern> — filter by LIKE pattern
- SHOW TABLES FROM <schema> LIKE <pattern> — combined

Reviewed By: mbasmanova

Differential Revision: D104926294


