### PR TITLE
fix(optimizer): Track right-side columns when placing single-row DT cross-join (#1355)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2683,6 +2683,12 @@ RelationOpPtr Optimization::placeSingleRowDt(
       resultColumns.end(),
       rightOp->columns().begin(),
       rightOp->columns().end());
+
+  // The cross join exposes the right side's columns to downstream
+  // operators; register them with PlanState so state.columns() reflects
+  // what is now available.
+  state.placeColumns(rightOp->columns());
+
   auto* join = Join::makeCrossJoin(
       std::move(plan),
       std::move(rightOp),

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1290,5 +1290,32 @@ TEST_F(UnnestTest, unnestWithJoinAndFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// A column added by a CROSS JOIN with a single-row aggregate subquery
+// must remain in scope when followed by an UNNEST and both the SELECT
+// list and a WHERE filter reference that column.
+TEST_F(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
+  testConnector_->addTable(
+      "t", ROW({"a", "ids"}, {INTEGER(), ARRAY(INTEGER())}));
+  testConnector_->addTable("u", ROW("x", INTEGER()));
+
+  auto query =
+      "SELECT n, c FROM t "
+      " CROSS JOIN (SELECT count(*) c FROM u) "
+      " CROSS JOIN UNNEST(ids) AS _(n) "
+      "WHERE a < c";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher =
+      matchScan("t")
+          .nestedLoopJoin(
+              matchScan("u").singleAggregation({}, {"count(*) as c"}).build())
+          .filter("c > a::BIGINT")
+          .unnest({"c"}, {"ids"})
+          .project({"n", "c"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

A query that cross-joins a table with a single-row aggregate subquery and then UNNESTs an array, with both the SELECT list and a WHERE filter referencing the cross-joined aggregate column, asserted at PlanConsistencyChecker with "Field not found". Minimal shape:

  SELECT n, c
  FROM t
  CROSS JOIN (SELECT count(*) c FROM u)
  CROSS JOIN UNNEST(ids) AS _(n)
  WHERE a < c;

Failed with `Field not found: c. Available fields are: n.` at Type.cpp:573 via PlanConsistencyChecker::check during ToVelox.

Root cause: Optimization::placeSingleRowDt cross-joins the current plan with a single-row derived table (e.g., a scalar/aggregate subquery), exposes both sides' columns as the join's output, and calls state.place(subquery) — but never updates state.columns_ to include the right side's columns. Every other join site that adds a new operator updates state.columns_ via placeColumns or replaceColumns; this site was the lone outlier.

The missing update was hidden for filter-only paths by placeConjuncts, which unions singleRowDts.columns into the available set when checking conjunct placement. Optimization::crossJoinUnnest filters its replicateColumns by state.columns().contains(column) without that union, so the cross-joined column got dropped from the unnest output and downstream Project referenced a column its input no longer carried.

Fix: call state.placeColumns(rightOp->columns()) in placeSingleRowDt before std::move(rightOp), restoring the invariant.

Reviewed By: xiaoxmeng, kagamiori

Differential Revision: D104976975


