### PR TITLE
fix: NLJ orientation: small side as build, not probe (#1357)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -704,19 +704,12 @@ void DerivedTable::addImpliedJoins() {
   }
 }
 
-namespace {
-
-bool isSingleRowDt(PlanObjectCP object) {
-  if (object->is(PlanType::kDerivedTableNode)) {
-    auto dt = object->as<DerivedTable>();
-    // A global aggregation (no grouping keys) always returns exactly one row,
-    // but only if there's no HAVING clause that could filter it out.
-    return (
-        dt->aggregation && dt->aggregation->groupingKeys().empty() &&
-        dt->having.empty() && dt->limit != 0 && dt->offset == 0);
-  }
-  return false;
+bool DerivedTable::isSingleRow() const {
+  return aggregation && aggregation->groupingKeys().empty() && having.empty() &&
+      limit != 0 && offset == 0;
 }
+
+namespace {
 
 // @return a subset of 'tables' that contain single row tables from
 // non-correlated scalar subqueries.
@@ -743,7 +736,8 @@ PlanObjectSet findSingleRowDts(
 
   PlanObjectSet singleRowDts;
   tablesCopy.forEach([&](PlanObjectCP object) {
-    if (isSingleRowDt(object)) {
+    if (object->is(PlanType::kDerivedTableNode) &&
+        object->as<DerivedTable>()->isSingleRow()) {
       ++numSingle;
       singleRowDts.add(object);
     }

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -72,6 +72,11 @@ using WindowPlanCP = const WindowPlan*;
 struct DerivedTable : public PlanObject {
   DerivedTable() : PlanObject(PlanType::kDerivedTableNode) {}
 
+  /// True if this DT is guaranteed to produce exactly one row: a global
+  /// aggregation (no grouping keys) with no HAVING clause and a non-zero
+  /// limit.
+  bool isSingleRow() const;
+
   /// Estimated number of rows produced by this DerivedTable. Set during
   /// planning by initializePlans() or makeInitialPlan(). For non-union DTs,
   /// computed as resultCardinality() of the initial physical plan. For union
@@ -155,7 +160,12 @@ struct DerivedTable : public PlanObject {
     return isUnion() && aggregation == nullptr;
   }
 
-  /// Single row tables from non-correlated scalar subqueries.
+  /// Single-row DTs (see isSingleRow()) that have no join dependencies in
+  /// this DT — not referenced by any join's keys, sides, or filter.
+  /// These can be appended at the end of the plan via cross-join, or
+  /// skipped entirely if no downstream column needs them. Single-row DTs
+  /// referenced by a join — including by a non-inner join's filter — are
+  /// not in this set; they're placed at the join site that needs them.
   PlanObjectSet singleRowDts;
 
   /// Tables that are not to the right sides of non-commutative joins.

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2399,9 +2399,8 @@ void Optimization::crossJoin(
   if (!isSingleWorker_) {
     buildInput = make<Repartition>(
         buildInput, Distribution::broadcast(), buildInput->columns());
+    buildState.addCost(*buildInput);
   }
-
-  buildState.addCost(*buildInput);
 
   state.cost.cost += buildState.cost.cost;
 
@@ -2679,12 +2678,17 @@ RelationOpPtr Optimization::placeSingleRowDt(
   bool needsShuffle = false;
   auto rightPlan = makePlan(*state.dt, memoKey, std::nullopt, 1, needsShuffle);
 
+  PlanState rightState(state.optimization, state.dt, rightPlan);
+
   auto rightOp = rightPlan->op;
 
   if (!isSingleWorker_) {
     rightOp = make<Repartition>(
         rightOp, Distribution::broadcast(), rightOp->columns());
+    rightState.addCost(*rightOp);
   }
+
+  state.cost.cost += rightState.cost.cost;
 
   auto resultColumns = plan->columns();
   resultColumns.insert(

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -2683,6 +2683,12 @@ RelationOpPtr Optimization::placeSingleRowDt(
       resultColumns.end(),
       rightOp->columns().begin(),
       rightOp->columns().end());
+
+  // The cross join exposes the right side's columns to downstream
+  // operators; register them with PlanState so state.columns() reflects
+  // what is now available.
+  state.placeColumns(rightOp->columns());
+
   auto* join = Join::makeCrossJoin(
       std::move(plan),
       std::move(rightOp),

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1945,7 +1945,9 @@ void Optimization::joinByHash(
 
   PlanStateSaver save(state, candidate);
 
-  auto probeColumns = PlanObjectSet::fromObjects(plan->columns());
+  auto extendedPlan = placeSingleRowDtsForJoinFilter(plan, candidate, state);
+
+  auto probeColumns = PlanObjectSet::fromObjects(extendedPlan->columns());
 
   auto [probeFilterColumns, buildFilterColumns] = computeJoinFilterColumns(
       candidate.join->filter(),
@@ -2000,7 +2002,7 @@ void Optimization::joinByHash(
         buildColumns, build, downstreamColumns, buildFilterColumns);
 
     return precomputeJoinInputs(
-        plan,
+        extendedPlan,
         buildPlan->op,
         probe,
         build,
@@ -2177,6 +2179,8 @@ void Optimization::joinByHashRight(
 
   PlanStateSaver save(state, candidate);
 
+  auto extendedPlan = placeSingleRowDtsForJoinFilter(plan, candidate, state);
+
   PlanObjectSet probeTables;
   PlanObjectSet probeColumns;
   for (auto probeTable : candidate.tables) {
@@ -2184,7 +2188,7 @@ void Optimization::joinByHashRight(
     probeTables.add(probeTable);
   }
 
-  auto buildColumns = PlanObjectSet::fromObjects(plan->columns());
+  auto buildColumns = PlanObjectSet::fromObjects(extendedPlan->columns());
 
   auto [probeFilterColumns, buildFilterColumns] = computeJoinFilterColumns(
       candidate.join->filter(), probeColumns, buildColumns);
@@ -2217,7 +2221,7 @@ void Optimization::joinByHashRight(
 
     return precomputeJoinInputs(
         probePlan->op,
-        plan,
+        extendedPlan,
         probe,
         build,
         state.dt,
@@ -2357,8 +2361,12 @@ void Optimization::crossJoin(
 
   const auto downstreamColumns = state.downstreamColumns();
 
+  RelationOpPtr extendedPlan = candidate.join
+      ? placeSingleRowDtsForJoinFilter(plan, candidate, state)
+      : plan;
+
   auto buildColumns = availableColumns(table);
-  auto probeColumns = PlanObjectSet::fromObjects(plan->columns());
+  auto probeColumns = PlanObjectSet::fromObjects(extendedPlan->columns());
 
   // Columns from the filter that belong to each side.
   PlanObjectSet probeFilterColumns;
@@ -2412,7 +2420,7 @@ void Optimization::crossJoin(
           buildColumns, build, downstreamColumns, buildFilterColumns);
 
       return precomputeJoinInputs(
-          plan,
+          extendedPlan,
           buildInput,
           probe,
           build,
@@ -2513,12 +2521,12 @@ void Optimization::crossJoin(
   } else {
     // No join edge - simple cross join.
     PlanObjectSet resultColumns;
-    resultColumns.unionObjects(plan->columns());
+    resultColumns.unionObjects(extendedPlan->columns());
     resultColumns.unionObjects(buildInput->columns());
     resultColumns.intersect(downstreamColumns);
 
     RelationOp* join = Join::makeCrossJoin(
-        plan,
+        extendedPlan,
         buildInput,
         velox::core::JoinType::kInner,
         {},
@@ -2699,6 +2707,46 @@ RelationOpPtr Optimization::placeSingleRowDt(
   state.place(subquery);
   state.addCost(*join);
   return join;
+}
+
+RelationOpPtr Optimization::placeSingleRowDtsForJoinFilter(
+    RelationOpPtr plan,
+    const JoinCandidate& candidate,
+    PlanState& state) {
+  const auto& join = *candidate.join;
+  if (join.filter().empty()) {
+    return plan;
+  }
+
+  PlanObjectSet referencedTables;
+  for (auto* conjunct : join.filter()) {
+    referencedTables.unionSet(conjunct->allTables());
+  }
+  referencedTables.except(PlanObjectSet::fromObjects(candidate.tables));
+  referencedTables.erase(state.dt);
+
+  // Place any unplaced single-row DT via cross join into 'plan' so its
+  // column is in scope when the join evaluates. Tables that the join
+  // itself will place (candidate.tables) and the enclosing DT were
+  // already excluded above. Any other unplaced non-single-row table
+  // indicates a graph that violates the DT composition rules, in which
+  // case VELOX_FAIL surfaces it loudly.
+  referencedTables.forEach([&](PlanObjectCP table) {
+    if (state.isPlaced(table)) {
+      return;
+    }
+    if (table->is(PlanType::kDerivedTableNode)) {
+      auto* subquery = table->as<DerivedTable>();
+      if (subquery->isSingleRow()) {
+        plan = placeSingleRowDt(plan, subquery, state);
+        return;
+      }
+    }
+    VELOX_FAIL(
+        "Join filter references column from unplaced non-single-row table: {}",
+        cname(table));
+  });
+  return plan;
 }
 
 void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -278,6 +278,18 @@ class Optimization {
       DerivedTableCP subquery,
       PlanState& state);
 
+  // For a non-inner join whose filter references columns from non-correlated
+  // single-row subqueries that are not yet placed, cross-joins the required
+  // subqueries into 'plan' (the probe/preserved side) so the filter's
+  // columns are in scope when the join evaluates. Returns the extended
+  // plan. Tables that the join itself will place (candidate.tables) are
+  // skipped. Mirrors the pattern in placeConjuncts that pulls single-row
+  // DTs in for plain Filter conjuncts.
+  RelationOpPtr placeSingleRowDtsForJoinFilter(
+      RelationOpPtr plan,
+      const JoinCandidate& candidate,
+      PlanState& state);
+
   // Adds the join represented by 'candidate' on top of 'plan'. Tries index and
   // hash based methods and adds the index and hash based plans to 'result'. If
   // one of these is clearly superior, only adds the better one.

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -934,14 +934,20 @@ void Join::initCost(float fanout, float rlFanout, float filterSelectivity) {
 
   const float buildSize = right->resultCardinality();
   const auto numKeys = leftKeys.size();
-  const auto probeCost = Costs::hashTableCost(buildSize) +
-      // Multiply by min(fanout, 1) because most misses will not compare and
-      // if fanout > 1, there is still only one compare.
-      (Costs::kKeyCompareCost * numKeys * std::min<float>(1, cost_.fanout)) +
-      numKeys * Costs::kHashColumnCost;
-
   const auto rowBytes = byteSize(right->columns());
   const auto rowCost = Costs::hashRowCost(buildSize, rowBytes);
+
+  // For NLJ (kCross), there's no hash table to probe, so the
+  // hashTableCost term — which models per-left-row bucket lookup — must
+  // not be charged.
+  const float probeCost = method == JoinMethod::kCross
+      ? 0.0f
+      : Costs::hashTableCost(buildSize) +
+          // Multiply by min(fanout, 1) because most misses will not compare and
+          // if fanout > 1, there is still only one compare.
+          (Costs::kKeyCompareCost * numKeys *
+           std::min<float>(1, cost_.fanout)) +
+          numKeys * Costs::kHashColumnCost;
 
   cost_.unitCost = probeCost + cost_.fanout * rowCost;
 }

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1335,12 +1335,12 @@ TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
-  // TODO: Optimizer should place the single-row side of the NLJ on the
-  // build (right) side, not the probe (left) side.
   auto matcher =
-      matchScan("u")
-          .singleAggregation({}, {"count(*) as count"})
-          .nestedLoopJoin(matchScan("t").unnest({"a"}, {"b"}).build())
+      matchScan("t")
+          .unnest({"a"}, {"b"})
+          .nestedLoopJoin(matchScan("u")
+                              .singleAggregation({}, {"count(*) as count"})
+                              .build())
           .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1317,5 +1317,69 @@ TEST_F(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// A LEFT JOIN whose ON clause references a single-row subquery's column via
+// a non-equi predicate must place the subquery's cross-join on the
+// preserved side before the LEFT join.
+TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), ARRAY(INTEGER())}));
+  testConnector_->addTable("u", ROW("x", INTEGER()));
+  testConnector_->addTable("v", ROW("x", INTEGER()));
+
+  auto query =
+      "SELECT sub.a "
+      "FROM ( "
+      "  SELECT a, x + (SELECT count(*) FROM u) AS y "
+      "  FROM t CROSS JOIN UNNEST(b) AS _(x) "
+      ") sub "
+      "LEFT JOIN v ON sub.a = v.x AND sub.y IS NOT NULL";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+  // TODO: Optimizer should place the single-row side of the NLJ on the
+  // build (right) side, not the probe (left) side.
+  auto matcher =
+      matchScan("u")
+          .singleAggregation({}, {"count(*) as count"})
+          .nestedLoopJoin(matchScan("t").unnest({"a"}, {"b"}).build())
+          .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same shape as leftJoinFilterOnSingleRowSubquery but with a small preserved
+// (left) side and a large optional (right) side, so the cost-based hash-right
+// variant wins.
+TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), ARRAY(INTEGER())}))
+      ->setStats(1, {{"a", {.numDistinct = 1}}});
+  testConnector_->addTable("u", ROW("x", INTEGER()))
+      ->setStats(1, {{"x", {.numDistinct = 1}}});
+  testConnector_->addTable("v", ROW("x", INTEGER()))
+      ->setStats(100'000, {{"x", {.numDistinct = 100'000}}});
+
+  auto query =
+      "SELECT sub.a "
+      "FROM ( "
+      "  SELECT a, x + (SELECT count(*) FROM u) AS y "
+      "  FROM t CROSS JOIN UNNEST(b) AS _(x) "
+      ") sub "
+      "LEFT JOIN v ON sub.a = v.x AND sub.y IS NOT NULL";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher = matchScan("v")
+                     .hashJoin(
+                         matchScan("t")
+                             .unnest({"a"}, {"b"})
+                             .nestedLoopJoin(matchScan("u")
+                                                 .singleAggregation(
+                                                     {}, {"count(*) as count"})
+                                                 .build())
+                             .build(),
+                         core::JoinType::kRight)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1290,5 +1290,32 @@ TEST_F(UnnestTest, unnestWithJoinAndFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// A column added by a CROSS JOIN with a single-row aggregate subquery
+// must remain in scope when followed by an UNNEST and both the SELECT
+// list and a WHERE filter reference that column.
+TEST_F(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
+  testConnector_->addTable(
+      "t", ROW({"a", "ids"}, {INTEGER(), ARRAY(INTEGER())}));
+  testConnector_->addTable("u", ROW("x", INTEGER()));
+
+  auto query =
+      "SELECT n, c FROM t "
+      " CROSS JOIN (SELECT count(*) c FROM u) "
+      " CROSS JOIN UNNEST(ids) AS _(n) "
+      "WHERE a < c";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher =
+      matchScan("t")
+          .nestedLoopJoin(
+              matchScan("u").singleAggregation({}, {"count(*) as c"}).build())
+          .filter("c > a::BIGINT")
+          .unnest({"c"}, {"ids"})
+          .project({"n", "c"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

A LEFT JOIN whose ON-clause filter referenced a non-correlated single-row scalar subquery would plan with the small (1-row) side as the left of the inner NestedLoopJoin (forcing the optimizer to materialize the larger right side as the NLJ build). Velox materializes the right side and streams the left, so the small side belongs on the right. This change addresses cost-model bugs that together produced the wrong orientation.

Bug A — `placeSingleRowDt` dropped the right subtree's cost.

`Optimization::placeSingleRowDt` builds the right-side subtree via `makePlan` and calls `state.addCost(*join)` to account for the cross-join op, but never folded the right subtree's accumulated cost into `state.cost`. Plans that attached a single-row DT through this helper looked artificially cheap (by the entire right subtree's cost) compared to plans that started from the same DT and added it as a regular table via `Optimization::crossJoin`. Fix mirrors the intent of the `crossJoin` pattern by initializing a `PlanState` from `rightPlan` and folding its cost into `state.cost` — but only adds the new Repartition op's cost in the multi-worker branch (avoiding a separate double-count bug present in `Optimization::crossJoin` itself; flagging that as a follow-up).

Bug B — `Join::initCost` charged hash-table-probe cost for `kCross`.

`Join::initCost` includes a `Costs::hashTableCost(buildSize)` term in `unitCost`, modeling per-left-row hash bucket lookup. NestedLoopJoin (`JoinMethod::kCross`) has no hash table — there's no per-left-row bucket lookup to charge. The term gets multiplied by `inputCardinality` and biases the cost in favor of plans where the small side is left (probe), forcing the large side onto build. Fix: zero out the probe-cost terms (`hashTableCost`, `kKeyCompareCost`, `kHashColumnCost`) for `kCross`. The remaining `cost_.fanout * hashRowCost(...)` term stays — it scales symmetrically with `N*M` and is the dominant term in NLJ work. A more thorough cleanup would replace the NLJ cost path entirely with NLJ-specific formulas (per-pair iteration + build memory penalty); flagging as a follow-up.

Bug C — `Optimization::crossJoin` double-counted the build's top op.

`PlanState buildState(..., buildPlan)` initialized `buildState.cost` from `buildPlan->cost` (which already includes the top op's `totalCost`). Then `buildState.addCost(*buildInput)` was called unconditionally — and in single-worker mode `buildInput == buildPlan->op`, so the top op's `totalCost` was added a second time. Fix: only call `addCost(*buildInput)` inside the `!isSingleWorker_` branch, after Repartition wrapping creates a new op not yet accounted in `buildPlan->cost`.

The `UnnestTest.leftJoinFilterOnSingleRowSubquery` matcher is updated to expect the new (correct) orientation: `NestedLoopJoin(left=Unnest+t, right=Aggregation count)`.

Reviewed By: xiaoxmeng

Differential Revision: D105018108


