### PR TITLE
fix: Window function inputs not updated when LEFT join demoted to INNER (#1358)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1069,15 +1069,32 @@ void DerivedTable::replaceJoinOutputs(
     }
   }
 
-  // Post-aggregation fields (exprs, orderKeys) reference aggregation output
-  // columns, not the join output columns being replaced. When a grouping key
-  // is a simple Column, translateAggregation reuses that Column object as the
-  // aggregation output — so the same object appears in both 'source' (join
-  // output) and aggregation->columns(). Replacing it in post-aggregation
-  // fields would substitute the aggregation output reference with the raw
-  // pre-aggregation expression, which is invalid above the aggregation
-  // boundary.
+  // Post-aggregation fields (window functions, exprs, orderKeys) reference
+  // aggregation output columns, not the join output columns being replaced.
+  // When a grouping key is a simple Column, translateAggregation reuses that
+  // Column object as the aggregation output — so the same object appears in
+  // both 'source' (join output) and aggregation->columns(). Replacing it in
+  // post-aggregation fields would substitute the aggregation output reference
+  // with the raw pre-aggregation expression, which is invalid above the
+  // aggregation boundary.
   if (!aggregation) {
+    if (windowPlan) {
+      WindowFunctionVector newFunctions;
+      newFunctions.reserve(windowPlan->functions().size());
+      bool anyChange{false};
+      for (const auto* func : windowPlan->functions()) {
+        const auto* newFunc =
+            DerivedTableFlattener::replaceInputs(func, source, target);
+        anyChange |= newFunc != func;
+        newFunctions.push_back(newFunc->as<WindowFunction>());
+      }
+      if (anyChange) {
+        windowPlan = make<WindowPlan>(
+            std::move(newFunctions),
+            windowPlan->columns(),
+            windowPlan->rankingLimit());
+      }
+    }
     for (auto& expr : exprs) {
       expr = DerivedTableFlattener::replaceInputs(expr, source, target);
     }

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -665,5 +665,25 @@ TEST_F(WindowTest, dependentWindowFunctions) {
   }
 }
 
+// Window ORDER BY references a column from the right side of a LEFT JOIN
+// whose WHERE further filters the right side.
+TEST_F(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
+  testConnector_->addTable("t", ROW("x", BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+
+  auto plan = toSingleNodePlan(
+      "SELECT ROW_NUMBER() OVER (ORDER BY u.y) AS rn "
+      "FROM t "
+      "LEFT JOIN u ON u.x = t.x "
+      "WHERE t.x = u.x");
+
+  auto matcher = matchScan("u")
+                     .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+                     .window({"row_number() OVER (ORDER BY y)"})
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

A query with a window function whose partition keys, order keys, args, or frame bounds reference the right (null-supplying) side of a `LEFT JOIN`, plus a `WHERE` predicate that rejects NULLs from that side, would fail planning with `window order key references column not available at this layer: dt1, dt1.<col>` (or, in `mode/opt` builds where `checkConsistency` is compiled out, `Field not found: dt1.<col>` from `PlanConsistencyChecker` during `ToVelox`).

Minimal repro:

```
SELECT ROW_NUMBER() OVER (ORDER BY u.y) AS rn
FROM t LEFT JOIN u ON u.x = t.x
WHERE t.x = u.x
```

`ToGraph::addJoinColumns` creates wrapper output columns owned by the enclosing DT for each used column on the null-supplying side of a non-inner join (e.g., `dt1.y` wraps `u.y`). Downstream expressions reference these wrapper columns. When `WHERE` rejects NULLs from that side, `DerivedTable::addFilter`'s null-rejecting path demotes the join to INNER via `toInnerJoin` and then calls `replaceJoinOutputs(rightColumns(), rightExprs())` to substitute the wrapper columns with their underlying source expressions in downstream usages.

`replaceJoinOutputs` previously updated `conjuncts`, `aggregation`, `exprs`, and `orderKeys` — but not `windowPlan`. So any window function that referenced a wrapper column kept the dangling reference after demotion, and the consistency check (or, in opt builds, the eventual ToVelox lookup) flagged the column as unavailable.

Fix: extend `replaceJoinOutputs` to rebuild `windowPlan` when the column-replacement changes any window function. Uses the existing `DerivedTableFlattener::replaceInputs` `kWindowExpr` branch which already rewrites partition keys, order keys, args, and frame bounds. Gated on `!aggregation` for the same reason `exprs`/`orderKeys` are gated: when aggregation exists, window inputs reference aggregation outputs (not join outputs).

Differential Revision: D105042971


