### PR TITLE
feat: Add --etc_dir config to axiom_sql

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+#include <fmt/ranges.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
-#include <iostream>
+#include <set>
+#include <unordered_map>
+#include "axiom/cli/CatalogProperties.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
 
@@ -35,27 +38,75 @@ int main(int argc, char** argv) {
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;
   runner.initialize([&]() {
+    VELOX_USER_CHECK(
+        FLAGS_data_path.empty() || FLAGS_etc_dir.empty(),
+        "--data_path and --etc_dir are mutually exclusive. Use --data_path for "
+        "the local Hive shorthand or --etc_dir for catalog .properties files.");
+
     auto defaultConnector = connectors.registerTpchConnector();
-    auto defaultSchema = "tiny";
+    std::unordered_map<std::string, std::string> defaultSchemas = {
+        {
+            defaultConnector->connectorId(),
+            "tiny",
+        },
+    };
+    std::set<std::string> catalogIds = {defaultConnector->connectorId()};
 
     connectors.registerTestConnector();
+    catalogIds.insert(facebook::axiom::Connectors::kTestConnectorId);
+    defaultSchemas.emplace(
+        facebook::axiom::Connectors::kTestConnectorId, "default");
+
+    auto registerConnector =
+        [&](std::string id,
+            std::string_view name,
+            const std::unordered_map<std::string, std::string>& config) {
+          VELOX_USER_CHECK(
+              catalogIds.insert(id).second,
+              "Catalog is already registered: {}",
+              id);
+          connectors.registerConnector(name, config, id);
+          if (name == "tpch") {
+            defaultSchemas.emplace(id, "tiny");
+          } else if (name == "hive" || name == "test") {
+            defaultSchemas.emplace(id, "default");
+          }
+        };
 
     if (!FLAGS_data_path.empty()) {
-      defaultConnector = connectors.registerLocalHiveConnector(
-          FLAGS_data_path, FLAGS_data_format);
-      defaultSchema = "default";
+      connectors.registerLocalHiveConnector(FLAGS_data_path, FLAGS_data_format);
+      catalogIds.insert(facebook::axiom::Connectors::kLocalHiveConnectorId);
+      defaultSchemas.emplace(
+          facebook::axiom::Connectors::kLocalHiveConnectorId, "default");
     }
 
-    std::string connectorId =
-        FLAGS_catalog.empty() ? defaultConnector->connectorId() : FLAGS_catalog;
-
-    if (FLAGS_schema.empty() &&
-        connectorId != defaultConnector->connectorId()) {
-      std::cerr << "Schema must be specified for connector " << connectorId;
-      exit(1);
+    for (auto& catalogProperties :
+         axiom::sql::loadCatalogProperties(FLAGS_etc_dir)) {
+      registerConnector(
+          std::move(catalogProperties.catalogName),
+          catalogProperties.connectorName,
+          catalogProperties.connectorConfig);
     }
 
-    std::string schema = FLAGS_schema.empty() ? defaultSchema : FLAGS_schema;
+    std::string connectorId;
+    if (!FLAGS_catalog.empty()) {
+      connectorId = FLAGS_catalog;
+    } else if (!FLAGS_data_path.empty()) {
+      connectorId = facebook::axiom::Connectors::kLocalHiveConnectorId;
+    } else {
+      connectorId = defaultConnector->connectorId();
+    }
+
+    std::string schema = FLAGS_schema;
+    if (schema.empty()) {
+      auto defaultSchemaIterator = defaultSchemas.find(connectorId);
+      VELOX_USER_CHECK(
+          defaultSchemaIterator != defaultSchemas.end() &&
+              !defaultSchemaIterator->second.empty(),
+          "Schema must be specified for connector {}",
+          connectorId);
+      schema = defaultSchemaIterator->second;
+    }
 
     return std::make_pair(connectorId, schema);
   });

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(
   axiom_cli
+  CatalogProperties.cpp
   Connectors.cpp
   Console.cpp
   QueryIdGenerator.cpp

--- a/axiom/cli/CatalogProperties.cpp
+++ b/axiom/cli/CatalogProperties.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/CatalogProperties.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+
+#include <folly/String.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace axiom::sql {
+namespace {
+
+constexpr std::string_view kConnectorNameProperty = "connector.name";
+
+std::unordered_map<std::string, std::string> parsePropertiesFile(
+    const std::filesystem::path& filePath) {
+  std::ifstream input(filePath);
+  VELOX_USER_CHECK(
+      input, "Failed to open catalog config file: {}", filePath.string());
+
+  std::unordered_map<std::string, std::string> properties;
+  std::string line;
+  size_t lineNumber{0};
+  while (std::getline(input, line)) {
+    ++lineNumber;
+    auto trimmedLine = folly::trimWhitespace(line).str();
+    if (trimmedLine.empty() || trimmedLine.starts_with('#')) {
+      continue;
+    }
+
+    auto separatorPosition = trimmedLine.find_first_of('=');
+    VELOX_USER_CHECK(
+        separatorPosition != std::string::npos,
+        "Catalog config line must use key=value syntax: {}:{}",
+        filePath.string(),
+        lineNumber);
+
+    auto key =
+        folly::trimWhitespace(trimmedLine.substr(0, separatorPosition)).str();
+    auto value =
+        folly::trimWhitespace(trimmedLine.substr(separatorPosition + 1)).str();
+    VELOX_USER_CHECK(
+        !key.empty(),
+        "Catalog config key is empty: {}:{}",
+        filePath.string(),
+        lineNumber);
+    VELOX_USER_CHECK(
+        properties.emplace(key, value).second,
+        "Duplicate catalog config property {} in {}:{}",
+        key,
+        filePath.string(),
+        lineNumber);
+  }
+
+  return properties;
+}
+
+} // namespace
+
+std::vector<CatalogProperties> loadCatalogProperties(std::string_view etcDir) {
+  if (etcDir.empty()) {
+    return {};
+  }
+
+  const auto catalogDirectory = std::filesystem::path(etcDir);
+  VELOX_USER_CHECK(
+      std::filesystem::exists(catalogDirectory),
+      "Catalog config directory does not exist: {}",
+      catalogDirectory.string());
+  VELOX_USER_CHECK(
+      std::filesystem::is_directory(catalogDirectory),
+      "Catalog config path is not a directory: {}",
+      catalogDirectory.string());
+
+  std::vector<std::filesystem::path> catalogFiles;
+  for (const auto& entry :
+       std::filesystem::directory_iterator(catalogDirectory)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".properties") {
+      catalogFiles.push_back(entry.path());
+    }
+  }
+  std::sort(catalogFiles.begin(), catalogFiles.end());
+
+  std::vector<CatalogProperties> catalogs;
+  catalogs.reserve(catalogFiles.size());
+  for (const auto& filePath : catalogFiles) {
+    auto properties = parsePropertiesFile(filePath);
+    auto connectorNameIterator =
+        properties.find(std::string(kConnectorNameProperty));
+    VELOX_USER_CHECK(
+        connectorNameIterator != properties.end(),
+        "Catalog config is missing required property {}: {}",
+        kConnectorNameProperty,
+        filePath.string());
+
+    auto catalogName = filePath.stem().string();
+    VELOX_USER_CHECK(
+        !catalogName.empty(),
+        "Catalog config file name must not be empty: {}",
+        filePath.string());
+
+    auto connectorName = connectorNameIterator->second;
+    properties.erase(connectorNameIterator);
+    catalogs.push_back(
+        CatalogProperties{
+            .catalogName = std::move(catalogName),
+            .connectorName = std::move(connectorName),
+            .connectorConfig = std::move(properties),
+        });
+  }
+
+  return catalogs;
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/CatalogProperties.h
+++ b/axiom/cli/CatalogProperties.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace axiom::sql {
+
+/// Describes one connector catalog properties file.
+struct CatalogProperties {
+  /// Catalog name derived from the file name without the `.properties` suffix.
+  std::string catalogName;
+
+  /// Connector implementation name from the `connector.name` property.
+  std::string connectorName;
+
+  /// Connector-specific properties excluding `connector.name`.
+  std::unordered_map<std::string, std::string> connectorConfig;
+};
+
+/// Loads connector catalogs from `${etcDir}/*.properties`.
+std::vector<CatalogProperties> loadCatalogProperties(std::string_view etcDir);
+
+} // namespace axiom::sql

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -18,7 +18,6 @@
 
 #include <folly/system/HardwareConcurrency.h>
 #include "axiom/common/SessionConfig.h"
-#include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
@@ -26,6 +25,7 @@
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -148,11 +148,11 @@ Connectors::registerLocalHiveConnector(
       {connector::hive::HiveMetadataConfig::kLocalFileFormat, dataFormat},
   };
 
-  auto config =
+  auto configBase =
       std::make_shared<velox::config::ConfigBase>(std::move(connectorConfig));
 
   velox::connector::hive::HiveConnectorFactory factory;
-  auto connector = factory.newConnector(connectorId, config, ioExecutor());
+  auto connector = factory.newConnector(connectorId, configBase, ioExecutor());
   registerConnector(connector);
 
   auto hiveConnector =
@@ -164,6 +164,43 @@ Connectors::registerLocalHiveConnector(
           hiveConnector));
 
   return connector;
+}
+
+std::shared_ptr<velox::connector::Connector> Connectors::registerConnector(
+    std::string_view connectorName,
+    const std::unordered_map<std::string, std::string>& connectorConfig,
+    const std::string& connectorId) {
+  if (connectorName == "tpch") {
+    return registerTpchConnector(connectorId);
+  }
+
+  if (connectorName == "hive") {
+    auto dataPathIterator = connectorConfig.find(
+        connector::hive::HiveMetadataConfig::kLocalDataPath);
+    VELOX_USER_CHECK(
+        dataPathIterator != connectorConfig.end(),
+        "Hive catalog config is missing required property {}: {}",
+        connector::hive::HiveMetadataConfig::kLocalDataPath,
+        connectorId);
+
+    auto fileFormatIterator = connectorConfig.find(
+        connector::hive::HiveMetadataConfig::kLocalFileFormat);
+    const std::string fileFormat = fileFormatIterator == connectorConfig.end()
+        ? "parquet"
+        : fileFormatIterator->second;
+
+    return registerLocalHiveConnector(
+        dataPathIterator->second, fileFormat, connectorId);
+  }
+
+  if (connectorName == "test") {
+    return registerTestConnector(connectorId);
+  }
+
+  VELOX_USER_FAIL(
+      "Unsupported connector.name in catalog config: {} for {}",
+      connectorName,
+      connectorId);
 }
 
 std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -18,6 +18,8 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "axiom/connectors/system/SystemConnector.h"
@@ -71,6 +73,23 @@ class Connectors {
       const std::string& dataFormat,
       const std::string& connectorId = kLocalHiveConnectorId);
 
+  /// Registers a connector from configuration properties.
+  ///
+  /// Delegates to specific registration helpers for each supported connector
+  /// implementation. For example:
+  /// - `tpch` uses registerTpchConnector
+  /// - `hive` uses registerLocalHiveConnector
+  /// - `test` uses registerTestConnector
+  ///
+  /// The `connectorConfig` provides connector-specific properties; for Hive,
+  /// this typically includes hive_local_data_path and optionally
+  /// hive_local_file_format. The `connectorId` is the catalog name used to
+  /// reference this connector in queries.
+  std::shared_ptr<velox::connector::Connector> registerConnector(
+      std::string_view connectorName,
+      const std::unordered_map<std::string, std::string>& connectorConfig,
+      const std::string& connectorId);
+
   /// Registers an in-memory test connector under `connectorId`.
   std::shared_ptr<velox::connector::Connector> registerTestConnector(
       const std::string& connectorId = kTestConnectorId);
@@ -97,7 +116,7 @@ class Connectors {
       const std::shared_ptr<velox::connector::Connector>& connector);
 
   // Unregister these on destruction.
-  std::vector<std::string> connectorIds_{};
+  std::vector<std::string> connectorIds_;
 
  private:
   static std::shared_ptr<folly::IOThreadPoolExecutor> getSharedIoExecutor();

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -33,6 +33,10 @@ DEFINE_string(
     "",
     "Root path of data. Data layout must follow Hive-style partitioning. ");
 DEFINE_string(data_format, "parquet", "Data format: parquet or dwrf.");
+DEFINE_string(
+    etc_dir,
+    "",
+    "Path to a directory of connector .properties files. Mutually exclusive with `--data_path`.");
 DEFINE_uint64(
     split_target_bytes,
     16 << 20,

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -19,6 +19,7 @@
 
 DECLARE_string(data_path);
 DECLARE_string(data_format);
+DECLARE_string(etc_dir);
 DECLARE_bool(debug);
 
 namespace axiom::sql {

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -28,7 +28,8 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 | `--init` | | Path to a SQL file with semicolon-separated statements to execute on startup before entering interactive mode or running `--query`. |
 | `--catalog` | | Default catalog (connector). If not specified, defaults to `hive` when `--data_path` is set, `tpch` otherwise. |
 | `--schema` | | Default schema. If not specified, defaults to `tiny` for TPC-H and `default` for Hive and Test connectors. |
-| `--data_path` | | Hive specific: root path for Hive-style partitioned data. Registers local Hive connector. |
+| `--etc_dir` | | Path to a directory of catalog `.properties` files. Mutually exclusive with `--data_path`. External catalogs are not selected automatically; use `--catalog` or fully-qualified names in SQL. |
+| `--data_path` | | Hive specific: root path for Hive-style partitioned data. Registers local Hive connector. Mutually exclusive with `--etc_dir`. |
 | `--data_format` | `parquet` | Hive specific: data format, `parquet`, `dwrf`, or `text`. |
 | `--split_target_bytes` | `16MB` | Hive specific: approximate bytes per split. |
 | `--num_workers` | `4` | Number of in-process workers. |
@@ -58,14 +59,32 @@ $ ./axiom_sql --query "select count(*) from sf1.orders"
 1500000
 ```
 
-**[Hive](../connectors/hive/README.md)** (`hive.default`) — Registered when `--data_path` is set. Reads and writes
-Parquet, DWRF, or TEXT (including CSV) files in a local directory with Hive-style partitioning. Supports
-`CREATE TABLE`, `CREATE TABLE AS SELECT`, `INSERT`, and `DROP TABLE`. Becomes the
-default catalog when registered.
+**[Hive](../connectors/hive/README.md)** (`hive.default`) — Registered via `--data_path` or configured through `.properties` files.
+Reads and writes Parquet, DWRF, or TEXT (including CSV) files in a local directory with Hive-style partitioning. Supports
+`CREATE TABLE`, `CREATE TABLE AS SELECT`, `INSERT`, and `DROP TABLE`.
+
+Using `--data_path`:
 
 ```
 $ ./axiom_sql --data_path /path/to/data --data_format parquet
 ```
+
+Configuring through `--etc_dir`:
+
+```properties
+# etc/hive.properties
+connector.name=hive
+hive_local_data_path=/path/to/data
+hive_local_file_format=parquet
+```
+
+```bash
+$ ./axiom_sql --etc_dir etc/
+```
+
+When `--etc_dir` is used, catalogs are available by name, but the
+CLI does not auto-select one. Use `--catalog <name>` or a fully qualified
+catalog.schema name in SQL, for example `USE hive2.default;`.
 
 **[System](../connectors/system/README.md)** (`system`) — Always registered. Read-only. Provides metadata tables
 such as session properties (`system.metadata.session_properties`).
@@ -84,6 +103,29 @@ create table t as select * from unnest(array[1,2,3], array[10,20,30]) as t(a, b)
 ```
 $ ./axiom_sql --init start.sql
 SQL> select * from t;
+```
+
+## Catalog Configuration Files
+
+Configuration files (`.properties` files) define catalogs for use with `--etc_dir`.
+Each file name (without `.properties` extension) becomes the catalog name.
+
+**Format:**
+- One property per line in `key=value` format
+- Lines starting with `#` are comments and are ignored
+- Whitespace before and after keys and values is trimmed
+- All whitespace is preserved within keys and values
+
+**Required properties:**
+- `connector.name` — The connector type: `hive`, `tpch`, or `test`
+
+**Example:**
+
+```properties
+# Hive connector for local data
+connector.name=hive
+hive_local_data_path=/path/to/data
+hive_local_file_format=parquet
 ```
 
 ## Examples

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   axiom_cli_test
+  CatalogPropertiesTest.cpp
   SqlQueryRunnerTest.cpp
   StdinReaderTest.cpp
   ConsoleTest.cpp

--- a/axiom/cli/tests/CatalogPropertiesTest.cpp
+++ b/axiom/cli/tests/CatalogPropertiesTest.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/CatalogProperties.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <fmt/core.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+
+namespace axiom::sql {
+namespace {
+
+class CatalogPropertiesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    directory_ = facebook::velox::common::testutil::TempDirectoryPath::create();
+    propertiesDirectory_ = std::filesystem::path(directory_->getPath());
+    std::filesystem::create_directories(propertiesDirectory_);
+  }
+
+  std::filesystem::path writeCatalogFile(
+      const std::string& name,
+      const std::string& contents) {
+    auto filePath = propertiesDirectory_ / fmt::format("{}.properties", name);
+    std::ofstream output(filePath);
+    output << contents;
+    return filePath;
+  }
+
+  std::shared_ptr<facebook::velox::common::testutil::TempDirectoryPath>
+      directory_;
+  std::filesystem::path propertiesDirectory_;
+};
+
+TEST_F(CatalogPropertiesTest, load) {
+  writeCatalogFile(
+      "analytics",
+      R"(connector.name = hive
+hive_local_data_path = /tmp/hive
+hive_local_file_format = parquet
+)");
+  writeCatalogFile(
+      "sandbox",
+      R"(# comment
+connector.name=test
+)");
+  std::ofstream(propertiesDirectory_ / "ignored.txt")
+      << "connector.name=test\n";
+
+  auto catalogs = loadCatalogProperties(directory_->getPath());
+
+  EXPECT_EQ(catalogs.size(), 2);
+  EXPECT_EQ(catalogs[0].catalogName, "analytics");
+  EXPECT_EQ(catalogs[0].connectorName, "hive");
+  EXPECT_THAT(
+      catalogs[0].connectorConfig,
+      ::testing::UnorderedElementsAre(
+          ::testing::Pair("hive_local_data_path", "/tmp/hive"),
+          ::testing::Pair("hive_local_file_format", "parquet")));
+  EXPECT_EQ(catalogs[1].catalogName, "sandbox");
+  EXPECT_EQ(catalogs[1].connectorName, "test");
+  EXPECT_TRUE(catalogs[1].connectorConfig.empty());
+}
+
+TEST_F(CatalogPropertiesTest, rejectInvalid) {
+  writeCatalogFile("broken", "hive_local_data_path=/tmp/hive\n");
+  VELOX_ASSERT_THROW(
+      loadCatalogProperties(directory_->getPath()), "connector.name");
+}
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/connectors/hive/HiveMetadataConfig.h
+++ b/axiom/connectors/hive/HiveMetadataConfig.h
@@ -32,6 +32,8 @@ class HiveMetadataConfig {
   static constexpr const char* kLocalDataPath = "hive_local_data_path";
 
   /// The name of the file format to use for processing data at kLocalDataPath.
+  /// Supported values: "parquet", "dwrf", "text". Defaults to "parquet" if
+  /// not specified.
   static constexpr const char* kLocalFileFormat = "hive_local_file_format";
 
   std::string localDataPath() const;


### PR DESCRIPTION
Before this change, Axiom CLI only supported one configurable external catalog path: --data_path for a local Hive catalog. That means users could not declaratively define arbitrary connector catalogs, and the CLI was limited to the built-in TPCH/Test/System connectors plus the Hive shorthand.

This PR expands CLI catalog configuration to support any supported connector via [--etc_dir/*.properties] files. Users can now define connector catalogs in [.properties] files and register multiple catalogs at startup, **without adding new flags for every connector type**.

**Why this matters**
Makes catalog configuration scalable and declarative
Keeps --data_path as a convenient shorthand for a single local Hive catalog
Allows multiple catalogs to coexist and be selected explicitly via [--catalog] or `USE`
Removes the need to hardcode connector registration behavior into CLI flag handling

**Behavior changes**
--data_path and --etc_dir are mutually exclusive
--data_path still registers a local Hive catalog
--etc_dir loads connector catalog definitions from [.properties] files

Default catalog selection is simple:
use [--catalog] if provided
otherwise, use Hive only when --data_path is set
otherwise, default to TPCH
