### PR TITLE
fix: Failure on range filter over UNION ALL with NULL literal column

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1820,7 +1820,33 @@ void UnionAll::initConstraints() {
         : 0;
     bool anyUnknownTrueFraction = combined.trueFraction == Value::kUnknown;
 
-    // Combine constraints from remaining inputs.
+    // Derive min and max across all legs. All-NULL legs contribute no
+    // bound. A leg with unknown bound wipes the combined bound — no later
+    // leg can recover it.
+    auto deriveBound = [&](VariantCP Value::* bound,
+                           const auto& compare) -> VariantCP {
+      VariantCP result = nullptr;
+      for (size_t j = 0; j < inputs.size(); ++j) {
+        const Value& inputValue = inputConstraint(j);
+        if (inputValue.nullFraction == 1.0) {
+          continue;
+        }
+        VariantCP candidate = inputValue.*bound;
+        if (candidate == nullptr) {
+          return nullptr;
+        }
+        if (result == nullptr || compare(*candidate, *result)) {
+          result = candidate;
+        }
+      }
+      return result;
+    };
+    combined.min = deriveBound(
+        &Value::min, [](const auto& a, const auto& b) { return a < b; });
+    combined.max = deriveBound(
+        &Value::max, [](const auto& a, const auto& b) { return b < a; });
+
+    // Combine remaining fields from inputs beyond the first.
     for (size_t j = 1; j < inputs.size(); ++j) {
       const Value& inputValue = inputConstraint(j);
       float inputRows = inputs[j]->resultCardinality();
@@ -1835,23 +1861,6 @@ void UnionAll::initConstraints() {
         weightedTrueFraction += inputValue.trueFraction * inputRows;
       }
       combined.nullable = combined.nullable || inputValue.nullable;
-
-      // Combine min/max (use nullptr if any is unknown).
-      if (combined.min != nullptr && inputValue.min != nullptr) {
-        if (*inputValue.min < *combined.min) {
-          combined.min = inputValue.min;
-        }
-      } else {
-        combined.min = nullptr;
-      }
-
-      if (combined.max != nullptr && inputValue.max != nullptr) {
-        if (*combined.max < *inputValue.max) {
-          combined.max = inputValue.max;
-        }
-      } else {
-        combined.max = nullptr;
-      }
     }
 
     combined.nullFraction =

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -68,6 +68,9 @@ struct Value {
 
   /// Minimum and maximum values. Applies to orderable types (integers, floats,
   /// dates, timestamps). Not set for booleans, strings, or complex types.
+  /// nullptr means no bound known. Otherwise points to a Variant with an
+  /// actual value — never a null-valued Variant, since NULL is not a value
+  /// that bounds a range.
   VariantCP min{nullptr};
   VariantCP max{nullptr};
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -942,11 +942,15 @@ ExprCP ToGraph::makeConstant(const lp::ConstantExpr& constant) {
   }
 
   Value value(temp.type, 1);
-  // For scalar types, set min and max to the literal value
-  if (temp.type->isPrimitiveType()) {
-    // Scalar/primitive type - set min and max to the variant
-    value.min = temp.value.get();
-    value.max = temp.value.get();
+  if (temp.value->isNull()) {
+    value.nullFraction = 1.0;
+  } else {
+    value.nullFraction = 0.0;
+    value.nullable = false;
+    if (temp.type->isPrimitiveType()) {
+      value.min = temp.value.get();
+      value.max = temp.value.get();
+    }
   }
 
   auto* literal = make<Literal>(value, temp.value.get());

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -1263,6 +1263,33 @@ TEST_F(CardinalityEstimationTest, unionAll) {
       });
 }
 
+// UNION ALL with one leg projecting a NULL literal column. The literal's
+// Value must contribute no min/max bound (NULL is not a value).
+TEST_F(CardinalityEstimationTest, unionAllWithNullLiteral) {
+  testConnector_->addTable("t", ROW({"a"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {{"a",
+            {.nullPct = 10, .min = 1LL, .max = 500LL, .numDistinct = 100}}});
+
+  verifyPlan(
+      "SELECT a FROM t UNION ALL SELECT NULL FROM t", [](const Plan& plan) {
+        const auto& op = *plan.op;
+        ASSERT_EQ(op.columns().size(), 1);
+        EXPECT_NEAR(op.resultCardinality(), 2'000, kCardinalityTolerance);
+
+        auto a = findConstraint(op, 0);
+        ASSERT_TRUE(a.has_value());
+        // (1000 * 0.1 + 1000 * 1.0) / 2000 = 0.55.
+        EXPECT_NEAR(a->nullFraction, 0.55, kTolerance);
+        // Either leg can produce NULLs.
+        EXPECT_TRUE(a->nullable);
+        // NULL-literal leg contributes only NULLs and so does not affect
+        // the range. Bounds come from the t.a leg alone.
+        AXIOM_ASSERT_RANGE(*a, 1, 500);
+      });
+}
+
 // Verifies that UNION produces deduplicated cardinality.
 TEST_F(CardinalityEstimationTest, unionDistinct) {
   testConnector_->addTable("t", ROW({"a"}, BIGINT()))


### PR DESCRIPTION
Summary:
A query that range-filters a column whose value flows through a `UNION ALL` where one leg projects a NULL literal would fail planning with `missing Variant value` from `Variant::throwCheckPtrError`. The failure fires whenever the optimizer cannot push the predicate below the union — e.g., a window function or non-equi join sits in between.

Minimal repro:

```
SELECT u.x FROM u JOIN (SELECT t FROM e UNION ALL SELECT NULL) ON u.x > t
```

Root cause: two interacting bugs in `Value` derivation.

1. `ToGraph::makeConstant` constructed a NULL literal's `Value` with `min` and `max` pointing to a NULL-valued `Variant` (kind set, storage null), and `nullFraction` left at the default 0. The first violates the contract that `Value::min/max` is either `nullptr` (no bound) or a `Variant` with an actual value. The second misrepresents that the column is 100% NULL.

2. `UnionAll::initConstraints` combined min/max by checking `inputValue.min != nullptr` but did not also check `!inputValue.min->isNull()`. With (1), the union output inherited the NULL-valued Variant pointer from the literal leg. Even with (1) fixed and the literal leg producing `min == nullptr`, the existing wipe-on-unknown logic was over-conservative: a leg with `nullFraction == 1.0` contributes no bound (NULL is not a value that bounds a range), so it should be skipped — not treated as "unknown" that wipes the combined bound.

Downstream, `rangeSelectivityImpl` dereferenced the bad `min` pointer via `value<KIND>()` → failure.

Fix:

- `ToGraph::makeConstant`: NULL literals leave `min`/`max` as `nullptr` and set `nullFraction = 1.0`. Non-NULL literals also explicitly set `nullFraction = 0.0` and `nullable = false`.
- `UnionAll::initConstraints`: skip all-NULL legs (they contribute no bound) and treat unknown bounds correctly.
- `Schema.h`: documented on `Value::min/max` that `nullptr` means no bound known and a non-`nullptr` pointer always references a `Variant` with an actual value.

Differential Revision: D105121943


