### PR TITLE
fix(connectors): Drop TestConnector ctor side effect on global registry (#1361)

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -171,6 +171,13 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(
   connector::TestConnectorFactory factory(connectorId.c_str());
   auto connector = factory.newConnector(connectorId);
   registerConnector(connector);
+
+  auto* testConnector =
+      dynamic_cast<connector::TestConnector*>(connector.get());
+  VELOX_CHECK_NOT_NULL(testConnector);
+  connector::ConnectorMetadataRegistry::global().insert(
+      connector->connectorId(), testConnector->metadata());
+
   return connector;
 }
 

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/cli/Console.h"
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/connectors/ConnectorRegistry.h"
 
@@ -37,6 +38,7 @@ class ConsoleTest : public ::testing::Test {
     // Restore FLAGS_query to avoid polluting other tests.
     FLAGS_query = "";
     for (const auto& id : connectorIds_) {
+      facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(id);
       facebook::velox::connector::ConnectorRegistry::global().erase(id);
     }
   }
@@ -54,6 +56,8 @@ class ConsoleTest : public ::testing::Test {
                   fmt::format("console_test{}", kCounter++));
           facebook::velox::connector::ConnectorRegistry::global().insert(
               testConnector->connectorId(), testConnector);
+          facebook::axiom::connector::ConnectorMetadataRegistry::global()
+              .insert(testConnector->connectorId(), testConnector->metadata());
 
           connectorIds_.emplace_back(testConnector->connectorId());
 

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include <thread>
 #include "axiom/cli/QueryIdGenerator.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -49,6 +50,7 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   void TearDown() override {
     runner_.reset();
     for (const auto& id : connectorIds_) {
+      facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(id);
       facebook::velox::connector::ConnectorRegistry::global().erase(id);
     }
   }
@@ -68,6 +70,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
               connectorId);
       facebook::velox::connector::ConnectorRegistry::global().insert(
           testConnector_->connectorId(), testConnector_);
+      facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+          testConnector_->connectorId(), testConnector_->metadata());
 
       connectorIds_.emplace_back(testConnector_->connectorId());
 

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -92,6 +92,8 @@ axiom_sql --init init.sql --query "SELECT sum(b) FROM t"
 ```cpp
 auto connector = std::make_shared<TestConnector>("test");
 velox::connector::registerConnector(connector);
+ConnectorMetadataRegistry::global().insert(
+    connector->connectorId(), connector->metadata());
 
 // Create a table with schema.
 auto table = connector->addTable(

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -36,6 +36,8 @@ class SchemaResolverTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    ConnectorMetadataRegistry::global().erase("base");
+    ConnectorMetadataRegistry::global().erase("other");
     velox::connector::unregisterConnector("base");
     velox::connector::unregisterConnector("other");
   }
@@ -51,8 +53,9 @@ class SchemaResolverTest : public ::testing::Test {
       const std::string& schema) {
     auto connector = std::make_shared<connector::TestConnector>(id);
     velox::connector::registerConnector(connector);
-    auto metadata = ConnectorMetadataRegistry::get(id);
-    metadata->createSchema(nullptr, schema, /*ifNotExists=*/false, {});
+    ConnectorMetadataRegistry::global().insert(id, connector->metadata());
+    connector->metadata()->createSchema(
+        nullptr, schema, /*ifNotExists=*/false, {});
     return Catalog{
         .id = id,
         .schema = schema,

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -20,7 +20,6 @@
 #include <folly/container/F14Set.h>
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
-#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/core/ITypedExpr.h"
 
 namespace facebook::axiom::connector {
@@ -632,11 +631,12 @@ class TestConnector : public velox::connector::Connector {
         rootPool_{std::move(rootPool)},
         metadata_{std::make_shared<TestConnectorMetadata>(this)} {
     registerSerDe();
-    ConnectorMetadataRegistry::global().insert(id, metadata_);
   }
 
-  ~TestConnector() override {
-    ConnectorMetadataRegistry::global().erase(connectorId());
+  /// Returns the metadata instance owned by this connector. Callers are
+  /// responsible for inserting it into a ConnectorMetadataRegistry.
+  const std::shared_ptr<TestConnectorMetadata>& metadata() const {
+    return metadata_;
   }
 
   /// Returns the parent pool to use for TestTable allocations, or nullptr

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -43,11 +43,14 @@ class TestConnectorTest : public ::testing::Test, public test::VectorTestBase {
   void SetUp() override {
     connector_ = std::make_shared<TestConnector>("test");
     velox::connector::registerConnector(connector_);
-    metadata_ = ConnectorMetadataRegistry::get(connector_->connectorId());
+    ConnectorMetadataRegistry::global().insert(
+        connector_->connectorId(), connector_->metadata());
+    metadata_ = connector_->metadata();
   }
 
   void TearDown() override {
     metadata_.reset();
+    ConnectorMetadataRegistry::global().erase(connector_->connectorId());
     velox::connector::unregisterConnector(connector_->connectorId());
   }
 
@@ -65,10 +68,14 @@ TEST_F(TestConnectorTest, connectorRegister) {
   EXPECT_EQ(connector->connectorId(), connectorId);
 
   registerConnector(connector);
+  EXPECT_EQ(ConnectorMetadataRegistry::tryGet(connectorId), nullptr);
 
+  ConnectorMetadataRegistry::global().insert(
+      connectorId, connector->metadata());
   EXPECT_EQ(velox::connector::getConnector(connectorId).get(), connector.get());
   EXPECT_NE(ConnectorMetadataRegistry::tryGet(connectorId), nullptr);
 
+  ConnectorMetadataRegistry::global().erase(connectorId);
   velox::connector::unregisterConnector(connectorId);
   VELOX_ASSERT_THROW(
       velox::connector::getConnector(connectorId),

--- a/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/Expr.h"
 #include "axiom/logical_plan/ExprApi.h"
@@ -53,9 +54,12 @@ class LogicalPlanNodeSerdeTest : public testing::Test {
     connector_->addTable(
         "output_table", ROW({"col_a", "col_b"}, {BIGINT(), VARCHAR()}));
     velox::connector::registerConnector(connector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, connector_->metadata());
   }
 
   void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
     connector_.reset();
     pool_.reset();

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/logical_plan/PlanPrinter.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -53,9 +54,12 @@ class PlanPrinterTest : public testing::Test {
              ARRAY(BIGINT()),
              MAP(INTEGER(), REAL())}));
     velox::connector::registerConnector(connector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, connector_->metadata());
   }
 
   void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
     connector_.reset();
   }

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
@@ -54,9 +55,12 @@ class DerivedTablePrinterTest : public ::testing::Test {
 
     connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
     velox::connector::registerConnector(connector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, connector_->metadata());
   }
 
   void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
   }
 

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <functional>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/QueryGraph.h"
@@ -540,8 +541,11 @@ TEST_F(FiltersTest, rangeCardinalityMaxMin) {
   auto testConnector =
       std::make_shared<connector::TestConnector>(kTestConnectorId);
   velox::connector::registerConnector(testConnector);
+  connector::ConnectorMetadataRegistry::global().insert(
+      kTestConnectorId, testConnector->metadata());
 
   SCOPE_EXIT {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
   };
 
@@ -1010,8 +1014,11 @@ TEST_F(FiltersTest, cardinalityBasedSelectivity) {
   auto testConnector =
       std::make_shared<connector::TestConnector>(kTestConnectorId);
   velox::connector::registerConnector(testConnector);
+  connector::ConnectorMetadataRegistry::global().insert(
+      kTestConnectorId, testConnector->metadata());
 
   SCOPE_EXIT {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
   };
 

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
@@ -396,7 +397,10 @@ TEST_F(PlanTest, inList) {
 TEST_F(PlanTest, multipleConnectors) {
   auto extraConnector = std::make_shared<connector::TestConnector>("extra");
   velox::connector::registerConnector(extraConnector);
+  connector::ConnectorMetadataRegistry::global().insert(
+      "extra", extraConnector->metadata());
   SCOPE_EXIT {
+    connector::ConnectorMetadataRegistry::global().erase("extra");
     velox::connector::unregisterConnector("extra");
   };
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
@@ -64,6 +65,8 @@ void QueryTestBase::SetUp() {
 
   testConnector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
   velox::connector::registerConnector(testConnector_);
+  connector::ConnectorMetadataRegistry::global().insert(
+      kTestConnectorId, testConnector_->metadata());
   testConnector_->addTpchTables();
 
   optimizerPool_ = rootPool_->addLeafChild("optimizer");
@@ -86,6 +89,7 @@ void QueryTestBase::TearDown() {
   }
   queryCtx_.reset();
   optimizerPool_.reset();
+  connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
   velox::connector::unregisterConnector(kTestConnectorId);
   testConnector_.reset();
   velox::exec::ExchangeSource::factories().clear();

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -16,6 +16,7 @@
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
@@ -51,9 +52,12 @@ class RelationOpPrinterTest : public ::testing::Test {
 
     connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
     velox::connector::registerConnector(connector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, connector_->metadata());
   }
 
   void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::unregisterConnector(kTestConnectorId);
   }
 

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <filesystem>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/tests/SqlFile.h"
 #include "axiom/optimizer/tests/SqlTestBase.h"
 #include "axiom/optimizer/tests/TestDataPath.h"
@@ -96,6 +97,8 @@ class SqlTest : public SqlTestBase {
         suiteRootPool_);
     velox::connector::ConnectorRegistry::global().insert(
         kTestConnectorId, suiteConnector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, suiteConnector_->metadata());
 
     suiteDuckDbRunner_ = std::make_unique<exec::test::DuckDbQueryRunner>();
 
@@ -117,6 +120,7 @@ class SqlTest : public SqlTestBase {
 
   static void TearDownTestCase() {
     suiteDuckDbRunner_.reset();
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
     suiteConnector_.reset();
     suiteOptimizerPool_.reset();

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/tests/SqlTestBase.h"
 #include "axiom/common/Session.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
@@ -59,6 +60,8 @@ void SqlTestBase::SetUp() {
     connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
     velox::connector::ConnectorRegistry::global().insert(
         kTestConnectorId, connector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, connector_->metadata());
   }
 
   optimizerPool_ = rootPool_->addLeafChild("optimizer");
@@ -68,6 +71,7 @@ void SqlTestBase::SetUp() {
 void SqlTestBase::TearDown() {
   optimizerPool_.reset();
   if (createsConnectorPerTest()) {
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
     velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
     connector_.reset();
   }

--- a/axiom/pyspark/CollagenMain.cpp
+++ b/axiom/pyspark/CollagenMain.cpp
@@ -141,6 +141,8 @@ void CollagenMain::registerTestConnector() {
       facebook::velox::ROW({"primary_rid"}, {facebook::velox::BIGINT()}));
 
   facebook::velox::connector::registerConnector(connector);
+  facebook::axiom::connector::ConnectorMetadata::registerMetadata(
+      catalog_, connector->metadata());
 }
 
 void CollagenMain::registerTpchConnector() {

--- a/axiom/pyspark/tests/SparkToAxiomLambdaTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomLambdaTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/Expr.h"
 #include "axiom/pyspark/SparkToAxiom.h"
@@ -42,16 +43,20 @@ class SparkToAxiomLambdaTest : public ::testing::Test {
     pool_ = velox::memory::MemoryManager::getInstance()->addLeafPool();
 
     // Set up test connector
-    auto connector =
-        std::make_shared<facebook::axiom::connector::TestConnector>(
-            "test_connector");
-    velox::connector::registerConnector(connector);
+    connector_ = std::make_shared<facebook::axiom::connector::TestConnector>(
+        "test_connector");
+    velox::connector::registerConnector(connector_);
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+        connector_->connectorId(), connector_->metadata());
   }
 
   void TearDown() override {
-    // Cleanup is handled by the connector destructor
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+        connector_->connectorId());
+    velox::connector::unregisterConnector(connector_->connectorId());
   }
 
+  std::shared_ptr<facebook::axiom::connector::TestConnector> connector_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 

--- a/axiom/pyspark/tests/SparkToAxiomSetOperationTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomSetOperationTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/pyspark/SparkToAxiom.h"
@@ -30,7 +31,8 @@ using namespace facebook;
 namespace axiom::collagen::test {
 namespace {
 
-void registerTestConnector(const std::string& connectorId) {
+std::shared_ptr<facebook::axiom::connector::TestConnector>
+registerTestConnector(const std::string& connectorId) {
   auto connector =
       std::make_shared<facebook::axiom::connector::TestConnector>(connectorId);
 
@@ -40,6 +42,9 @@ void registerTestConnector(const std::string& connectorId) {
       "feature_table", velox::ROW({"primary_rid"}, {velox::BIGINT()}));
 
   velox::connector::registerConnector(connector);
+  facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+      connectorId, connector->metadata());
+  return connector;
 }
 
 class SparkToAxiomSetOperationTest : public ::testing::Test {
@@ -52,13 +57,16 @@ class SparkToAxiomSetOperationTest : public ::testing::Test {
     pool_ = velox::memory::MemoryManager::getInstance()->addLeafPool();
 
     // Set up test connector
-    registerTestConnector("test_connector");
+    connector_ = registerTestConnector("test_connector");
   }
 
   void TearDown() override {
-    // Cleanup is handled by the connector destructor
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+        connector_->connectorId());
+    velox::connector::unregisterConnector(connector_->connectorId());
   }
 
+  std::shared_ptr<facebook::axiom::connector::TestConnector> connector_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 

--- a/axiom/pyspark/tests/SparkToAxiomUnnestTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomUnnestTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/Expr.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
@@ -51,11 +52,15 @@ class SparkToAxiomUnnestTest : public ::testing::Test {
             {velox::BIGINT(), velox::MAP(velox::VARCHAR(), velox::INTEGER())}));
     velox::connector::ConnectorRegistry::global().insert(
         connectorId_, connector);
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+        connectorId_, connector->metadata());
 
     pool_ = velox::memory::memoryManager()->addLeafPool();
   }
 
   void TearDown() override {
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+        connectorId_);
     velox::connector::ConnectorRegistry::global().erase(connectorId_);
   }
 

--- a/axiom/pyspark/tests/SparkToAxiomWithColumnsRenamedTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomWithColumnsRenamedTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/pyspark/SparkToAxiom.h"
@@ -39,6 +40,8 @@ void registerTestConnector(const std::string& connectorId) {
       "feature_table", velox::ROW({"primary_rid"}, {velox::BIGINT()}));
 
   velox::connector::registerConnector(connector);
+  facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+      connectorId, connector->metadata());
 }
 
 class SparkToAxiomWithColumnsRenamedTest : public ::testing::Test {
@@ -54,6 +57,8 @@ class SparkToAxiomWithColumnsRenamedTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+        connectorId_);
     velox::connector::unregisterConnector(connectorId_);
   }
 

--- a/axiom/pyspark/tests/SparkToAxiomWithColumnsTest.cpp
+++ b/axiom/pyspark/tests/SparkToAxiomWithColumnsTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/pyspark/SparkToAxiom.h"
@@ -39,6 +40,8 @@ void registerTestConnector(const std::string& connectorId) {
           {"viewer_rid", "feature_a"}, {velox::BIGINT(), velox::DOUBLE()}));
 
   velox::connector::registerConnector(connector);
+  facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+      connectorId, connector->metadata());
 }
 
 class SparkToAxiomWithColumnsTest : public ::testing::Test {
@@ -54,6 +57,8 @@ class SparkToAxiomWithColumnsTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+        connectorId_);
     velox::connector::unregisterConnector(connectorId_);
   }
 

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/ExprPrinter.h"
 #include "axiom/logical_plan/PlanPrinter.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -39,10 +40,14 @@ void PrestoParserTestBase::SetUp() {
   connector_ =
       std::make_shared<facebook::axiom::connector::TestConnector>(kConnectorId);
   facebook::velox::connector::registerConnector(connector_);
+  facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+      kConnectorId, connector_->metadata());
   connector_->addTpchTables();
 }
 
 void PrestoParserTestBase::TearDown() {
+  facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(
+      kConnectorId);
   facebook::velox::connector::unregisterConnector(kConnectorId);
   connector_.reset();
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/40


TestConnector's constructor inserted its own metadata into
ConnectorMetadataRegistry::global() and the destructor erased it. This was
unique to TestConnector (Hive, TPC-H, and System all require explicit
Registry::insert from the caller) and let buggy tests pass for the wrong
reason: code that thought it was registering a fresh TestConnectorMetadata
into a scoped registry would silently leak a duplicate into the global one.

Drop the side effect. Add a public TestConnector::metadata() accessor so
callers can hand the same metadata instance to whichever registry they want,
preserving the "one metadata per connector" invariant. Update every direct
caller (production register helpers, test fixtures, benchmarks) to
explicitly insert into ConnectorMetadataRegistry::global() after
construction and erase on teardown, mirroring the existing pattern in
axiom/cli/Connectors.cpp::registerTpchConnector and
axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp.

A handful of callers that already explicitly registered metadata used to
construct a *fresh* TestConnectorMetadata for the registry; they now use
connector_->metadata() instead, restoring the invariant that the metadata
the connector mutates is the same one resolved through the registry.

Reviewed By: mbasmanova

Differential Revision: D104827853


