### PR TITLE
fix(optimizer): UNNEST on window function output causes self-join

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1339,7 +1339,7 @@ void ToGraph::addUnnest(const lp::UnnestNode& unnest) {
 
   auto* unnestDt = currentDt_;
   const bool needsSeparateUnnest = unnestDt->hasAggregation() ||
-      unnestDt->hasOrderBy() || unnestDt->hasLimit();
+      unnestDt->hasOrderBy() || unnestDt->hasLimit() || unnestDt->hasWindow();
   if (needsSeparateUnnest) {
     finalizeDt(*unnest.onlyInput());
   }

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1381,5 +1381,26 @@ TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+TEST_F(UnnestTest, crossJoinUnnestOnWindowFunctionOutput) {
+  testConnector_->addTable("t", ROW({"a"}, {INTEGER()}));
+
+  auto query =
+      "SELECT x "
+      "FROM ("
+      "  SELECT count(*) OVER () n "
+      "  FROM t"
+      ") CROSS JOIN UNNEST(sequence(1, n)) AS _(x)";
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .window({"count(*) OVER () as n"})
+                     .project({"sequence(1, n) as seq"})
+                     .unnest({}, {"seq"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
A query that applies CROSS JOIN UNNEST on a window function output incorrectly causes a join with itself.

Minimal repro:

```
SELECT *
FROM (
  SELECT row_number() OVER () n
  FROM (VALUES 1) v (a)
) CROSS JOIN UNNEST(array[n]) t (x)
```

Root cause:
Window function output columns are created with relation() = currentDt_ (the DerivedTable being built), because their values are collective computations over sets of rows that cannot be attributed to any child table in tableSet. When addUnnest resolves the UNNEST expression, singleTable() traces through to this column and returns currentDt_ as the leftTable for the join edge. The DT then becomes both the container of the join (via joins.push_back) and an endpoint of the join — a self-referential cycle that violates the invariant that join endpoints must be children in tableSet.

addUnnest already handles this for aggregation (hasAggregation()) and other operations (hasOrderBy(), hasLimit()) by calling finalizeDt to wrap the current DT into a child before creating the UNNEST join edge. But window functions were missing from this check.

Fix: add hasWindow() to the needsSeparateUnnest condition in ToGraph::addUnnest.

Differential Revision: D105200404


