### PR TITLE
feat(connectors): Thread ConnectorMetadataRegistry through SchemaResolver (#1363)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -606,7 +606,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
       // EXPLAIN ANALYZE runs the query for real, so createTable must not
       // be in explain mode. Regular EXPLAIN must be side-effect-free.
       auto table = createTable(*ctas, /*explain=*/!explain->isAnalyze());
-      schemaResolver = std::make_shared<connector::SchemaResolver>();
+      schemaResolver = std::make_shared<connector::SchemaResolver>(
+          connector::ConnectorMetadataRegistry::global());
       schemaResolver->setTargetTable(
           ctas->connectorId(), ctas->tableName(), table);
     } else if (statement->isCreateTable()) {
@@ -721,7 +722,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const auto* ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
     auto table = createTable(*ctas);
 
-    auto schema = std::make_shared<connector::SchemaResolver>();
+    auto schema = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
     schema->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
     return runLogicalPlan(
@@ -1098,7 +1100,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   auto session = std::make_shared<Session>(queryCtx->queryId());
   auto history = std::make_unique<optimizer::VeloxHistory>();
   if (schemaResolver == nullptr) {
-    schemaResolver = std::make_shared<connector::SchemaResolver>();
+    schemaResolver = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
   }
 
   auto optimizerProps = sessionConfig_->effectiveValues(kOptimizerPrefix);

--- a/axiom/connectors/SchemaResolver.cpp
+++ b/axiom/connectors/SchemaResolver.cpp
@@ -16,9 +16,12 @@
 
 #include "axiom/connectors/SchemaResolver.h"
 
-#include "axiom/connectors/ConnectorMetadataRegistry.h"
-
 namespace facebook::axiom::connector {
+
+SchemaResolver::SchemaResolver(
+    const Registry& registry,
+    std::string defaultSchema)
+    : registry_{registry}, defaultSchema_{std::move(defaultSchema)} {}
 
 void SchemaResolver::setTargetTable(
     const std::string& connectorId,
@@ -39,7 +42,9 @@ TablePtr SchemaResolver::findTable(
     return targetTable_;
   }
 
-  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = registry_.find(connectorId);
+  VELOX_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
   return metadata->findTable(tableName);
 }
 

--- a/axiom/connectors/SchemaResolver.h
+++ b/axiom/connectors/SchemaResolver.h
@@ -17,16 +17,21 @@
 #pragma once
 
 #include <string>
-#include <utility>
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 
 namespace facebook::axiom::connector {
 
 class SchemaResolver {
  public:
-  explicit SchemaResolver(std::string defaultSchema = "")
-      : defaultSchema_{std::move(defaultSchema)} {}
+  using Registry = ConnectorMetadataRegistry::Registry;
+
+  /// Constructs a SchemaResolver scoped to the given registry, with an
+  /// optional default schema.
+  explicit SchemaResolver(
+      const Registry& registry,
+      std::string defaultSchema = "");
 
   virtual ~SchemaResolver() = default;
 
@@ -46,6 +51,10 @@ class SchemaResolver {
       const SchemaTableName& tableName) const;
 
  private:
+  // Reference member: SchemaResolver is intentionally non-assignable and
+  // non-movable. The referenced Registry must outlive this resolver. Callers
+  // typically construct one resolver per query.
+  const Registry& registry_;
   const std::string defaultSchema_;
 
   std::string targetConnectorId_;

--- a/axiom/connectors/tests/SchemaResolverTest.cpp
+++ b/axiom/connectors/tests/SchemaResolverTest.cpp
@@ -16,10 +16,10 @@
 
 #include <gtest/gtest.h>
 
-#include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/connectors/tests/TestConnector.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::velox;
 
@@ -32,7 +32,8 @@ class SchemaResolverTest : public ::testing::Test {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     baseCatalog_ = generateCatalog("base", "baseschema");
     otherCatalog_ = generateCatalog("other", "otherschema");
-    resolver_ = std::make_shared<SchemaResolver>(baseCatalog_.schema);
+    resolver_ = std::make_shared<SchemaResolver>(
+        ConnectorMetadataRegistry::global(), baseCatalog_.schema);
   }
 
   void TearDown() override {
@@ -68,7 +69,7 @@ class SchemaResolverTest : public ::testing::Test {
   std::shared_ptr<SchemaResolver> resolver_;
 };
 
-TEST_F(SchemaResolverTest, bareTable) {
+TEST_F(SchemaResolverTest, findTable) {
   auto metadata = ConnectorMetadataRegistry::get("base");
   metadata->createTable(
       nullptr,
@@ -80,12 +81,9 @@ TEST_F(SchemaResolverTest, bareTable) {
 
   auto table = resolver_->findTable("base", {"baseschema", "table"});
   ASSERT_NE(table, nullptr);
-
-  table = resolver_->findTable("other", {"otherschema", "table"});
-  ASSERT_EQ(table, nullptr);
 }
 
-TEST_F(SchemaResolverTest, tablePlusSchema) {
+TEST_F(SchemaResolverTest, findTableInNonDefaultSchema) {
   auto metadata = ConnectorMetadataRegistry::get("base");
   metadata->createSchema(nullptr, "newschema", /*ifNotExists=*/false, {});
   metadata->createTable(
@@ -98,37 +96,17 @@ TEST_F(SchemaResolverTest, tablePlusSchema) {
 
   auto table = resolver_->findTable("base", {"newschema", "table"});
   ASSERT_NE(table, nullptr);
+}
 
-  table = resolver_->findTable("other", {"newschema", "table"});
+TEST_F(SchemaResolverTest, tableNotFound) {
+  // No table is created; lookup against an existing catalog/schema must return
+  // nullptr.
+  auto table = resolver_->findTable("base", {"baseschema", "missing_table"});
   ASSERT_EQ(table, nullptr);
 }
 
-TEST_F(SchemaResolverTest, tablePlusSchemaPlusCatalog) {
-  auto otherMetadata = ConnectorMetadataRegistry::get("other");
-  otherMetadata->createTable(
-      /*session=*/nullptr,
-      {"otherschema", "other_table"},
-      ROW({}),
-      {},
-      /*ifNotExists=*/false,
-      /*explain=*/false);
-  auto table = resolver_->findTable("other", {"otherschema", "other_table"});
-  ASSERT_NE(table, nullptr);
-
-  auto baseMetadata = ConnectorMetadataRegistry::get("base");
-  baseMetadata->createTable(
-      nullptr,
-      {"baseschema", "base_table"},
-      ROW({}),
-      {},
-      /*ifNotExists=*/false,
-      /*explain=*/false);
-  table = resolver_->findTable("base", {"baseschema", "base_table"});
-  ASSERT_NE(table, nullptr);
-}
-
-TEST_F(SchemaResolverTest, catalogMismatch) {
-  // Table exists in "other" catalog but not in "base".
+TEST_F(SchemaResolverTest, wrongCatalog) {
+  // Table exists in "other" catalog but lookup is routed through "base".
   auto metadata = ConnectorMetadataRegistry::get("other");
   metadata->createTable(
       /*session=*/nullptr,
@@ -139,6 +117,60 @@ TEST_F(SchemaResolverTest, catalogMismatch) {
       /*explain=*/false);
   auto table = resolver_->findTable("base", {"otherschema", "table"});
   ASSERT_EQ(table, nullptr);
+}
+
+TEST_F(SchemaResolverTest, unregisteredConnectorThrows) {
+  VELOX_ASSERT_THROW(
+      resolver_->findTable("nonexistent", {"baseschema", "table"}),
+      "ConnectorMetadata not registered: nonexistent");
+}
+
+TEST_F(SchemaResolverTest, scopedRegistryLookup) {
+  // Create a scoped registry that is a child of the global registry.
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  // Register a new connector with a table in the scoped registry only.
+  auto scopedConnector = std::make_shared<connector::TestConnector>("scoped");
+  const auto& scopedMetadata = scopedConnector->metadata();
+  scopedMetadata->createSchema(
+      nullptr, "scopedschema", /*ifNotExists=*/false, {});
+  scopedMetadata->createTable(
+      nullptr,
+      {"scopedschema", "scoped_orders"},
+      ROW({}),
+      {},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+  scopedRegistry->insert("scoped", scopedMetadata);
+
+  auto resolver{SchemaResolver{*scopedRegistry, "scopedschema"}};
+  auto table = resolver.findTable("scoped", {"scopedschema", "scoped_orders"});
+  ASSERT_NE(table, nullptr);
+
+  // The scoped registration must not have leaked into the global registry.
+  ASSERT_EQ(ConnectorMetadataRegistry::tryGet("scoped"), nullptr);
+}
+
+TEST_F(SchemaResolverTest, scopedRegistryFallsBackToParent) {
+  // Create a scoped registry with no local entries that falls back to global.
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  // Register a table in the globally-registered "base" catalog.
+  auto metadata = ConnectorMetadataRegistry::get("base");
+  metadata->createTable(
+      nullptr,
+      {"baseschema", "parent_table"},
+      ROW({}),
+      {},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  // Resolver using scoped registry should still find the global table.
+  auto resolver{SchemaResolver{*scopedRegistry, "baseschema"}};
+  auto table = resolver.findTable("base", {"baseschema", "parent_table"});
+  ASSERT_NE(table, nullptr);
 }
 
 } // namespace

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iostream>
 #include <utility>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/AggregationPlanner.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
@@ -462,7 +463,8 @@ PlanAndStats Optimization::toVeloxPlan(
   auto veloxQueryCtx = velox::core::QueryCtx::create();
   velox::exec::SimpleExpressionEvaluator evaluator(veloxQueryCtx.get(), &pool);
 
-  auto schemaResolver = std::make_shared<connector::SchemaResolver>();
+  auto schemaResolver = std::make_shared<connector::SchemaResolver>(
+      connector::ConnectorMetadataRegistry::global());
 
   VeloxHistory history;
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -176,7 +176,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
       connector_ = registerTpchConnector();
     }
 
-    schema_ = std::make_shared<connector::SchemaResolver>();
+    schema_ = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
 
     prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
         connector_->connectorId(),
@@ -390,7 +391,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         schema_ = originalSchemaResolver;
       };
 
-      schema_ = std::make_shared<connector::SchemaResolver>();
+      schema_ = std::make_shared<connector::SchemaResolver>(
+          connector::ConnectorMetadataRegistry::global());
       schema_->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
       runSql(ctas->plan());

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -90,7 +90,8 @@ class DerivedTablePrinterTest : public ::testing::Test {
 
     VeloxHistory history;
 
-    auto schemaResolver = std::make_shared<connector::SchemaResolver>();
+    auto schemaResolver = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
 
     auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -241,7 +241,8 @@ void HiveQueriesTestBase::runCtas(const std::string& sql) {
       /*explain=*/false);
   VELOX_CHECK_NOT_NULL(table);
 
-  connector::SchemaResolver schemaResolver;
+  connector::SchemaResolver schemaResolver{
+      connector::ConnectorMetadataRegistry::global()};
   schemaResolver.setTargetTable(
       ctasStatement->connectorId(), ctasStatement->tableName(), table);
 

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/PrecomputeProjection.h"
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/VeloxHistory.h"
@@ -61,7 +62,8 @@ class PrecomputeProjectionTest : public ::testing::Test {
 
     VeloxHistory history;
 
-    auto schemaResolver = std::make_shared<connector::SchemaResolver>();
+    auto schemaResolver = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
 
     auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -187,7 +187,8 @@ PlanCost QueryTestBase::optimizationCost(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
   auto session = std::make_shared<Session>(queryCtx->queryId());
-  connector::SchemaResolver schemaResolver;
+  connector::SchemaResolver schemaResolver{
+      connector::ConnectorMetadataRegistry::global()};
   Optimization opt(
       session,
       *logicalPlan,
@@ -218,7 +219,8 @@ void QueryTestBase::verifyOptimization(
 
   auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 
-  connector::SchemaResolver schemaResolver;
+  connector::SchemaResolver schemaResolver{
+      connector::ConnectorMetadataRegistry::global()};
   VeloxHistory history;
 
   Optimization optimization(
@@ -239,7 +241,8 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
     const MultiFragmentPlan::Options& options,
     const std::optional<OptimizerOptions>& optimizerOptions,
     const std::optional<std::string>& planFilePathPrefix) {
-  connector::SchemaResolver schemaResolver;
+  connector::SchemaResolver schemaResolver{
+      connector::ConnectorMetadataRegistry::global()};
   return planVelox(
       plan, schemaResolver, options, optimizerOptions, planFilePathPrefix);
 }

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -142,7 +142,8 @@ class RelationOpPrinterTest : public ::testing::Test {
 
     VeloxHistory history;
 
-    auto schemaResolver = std::make_shared<connector::SchemaResolver>();
+    auto schemaResolver = std::make_shared<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
 
     auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
 

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -123,7 +123,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
       queryCtx.get(), optimizerPool.get());
 
   auto session = std::make_shared<Session>(queryId);
-  connector::SchemaResolver schemaResolver;
+  connector::SchemaResolver schemaResolver{
+      connector::ConnectorMetadataRegistry::global()};
   VeloxHistory history;
 
   MultiFragmentPlan::Options options;

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/ConstantExprEvaluator.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
@@ -128,7 +130,8 @@ class WriteTest : public test::HiveQueriesTestBase {
 
     auto table = createTable(*ctasStatement);
 
-    connector::SchemaResolver schemaResolver;
+    connector::SchemaResolver schemaResolver{
+        connector::ConnectorMetadataRegistry::global()};
     schemaResolver.setTargetTable(
         ctasStatement->connectorId(), ctasStatement->tableName(), table);
 

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -18,6 +18,7 @@
 
 #include <glog/logging.h>
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/Optimization.h"
@@ -108,7 +109,8 @@ facebook::axiom::optimizer::PlanAndStats optimize(
   // Fetch connector and set up schema resolver.
   auto connector = velox::connector::getConnector(connectorId);
   auto schemaResolver =
-      std::make_shared<facebook::axiom::connector::SchemaResolver>();
+      std::make_shared<facebook::axiom::connector::SchemaResolver>(
+          facebook::axiom::connector::ConnectorMetadataRegistry::global());
 
   // Check if this is a CREATE TABLE operation and set up schema resolver.
   if (auto* createTableNode = isCreateTableNode(logicalPlan)) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/48


Add a `const Registry&` member to `SchemaResolver` so that `findTable()` uses a scoped registry instead of the global `ConnectorMetadataRegistry::get()`. Change the constructor signature to `SchemaResolver(const Registry& registry, std::string defaultSchema = "")` which requires every caller to pass a registry explicitly. Update all callers to pass `ConnectorMetadataRegistry::global()` (the previous implicit behavior).

Restructure `SchemaResolverTest` so each test verifies one independent behavior:
 - `findTable` and `findTableInNonDefaultSchema` cover positive lookups.
 - `tableNotFound` and `wrongCatalog` cover the two distinct negative paths.
 - `unregisteredConnectorThrows` covers the explicit error on a missing connector (matches the prior `ConnectorMetadataRegistry::get()` behavior).
 - `scopedRegistryLookup` and `scopedRegistryFallsBackToParent` cover the new scoped-registry behavior.

Reviewed By: mbasmanova

Differential Revision: D104608354


