### PR TITLE
feat(optimizer): Schedule system scans on coordinator (#1364)

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -131,7 +131,9 @@ int main(int argc, char** argv) {
   });
 
   // Register after initialize() so sessionConfig() is available.
-  connectors.registerSystemConnector(runner.sessionConfig());
+  auto systemConnector =
+      connectors.registerSystemConnector(runner.sessionConfig());
+  runner.setSystemConnectorId(systemConnector->connectorId());
   connectors.registerFileConnector();
 
   axiom::sql::Console console{runner};

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -226,7 +226,8 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(
   return connector;
 }
 
-void Connectors::registerSystemConnector(
+std::shared_ptr<velox::connector::Connector>
+Connectors::registerSystemConnector(
     const SessionConfig& sessionConfig,
     const std::string& connectorId) {
   sessionPropertiesProvider_ =
@@ -241,6 +242,7 @@ void Connectors::registerSystemConnector(
       connector->connectorId(),
       std::make_shared<connector::system::SystemConnectorMetadata>(
           connector.get()));
+  return connector;
 }
 
 void Connectors::registerFileConnector(const std::string& connectorId) {

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -101,7 +101,7 @@ class Connectors {
 
   /// Registers the system connector for the runtime.queries and
   /// metadata.session_properties tables.
-  void registerSystemConnector(
+  std::shared_ptr<velox::connector::Connector> registerSystemConnector(
       const SessionConfig& sessionConfig,
       const std::string& connectorId = kSystemConnectorId);
 

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1253,6 +1253,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   auto connectorProperties = collectConnectorProperties(*sessionConfig_);
   auto optimizerOptions = optimizer::OptimizerOptions::from(
       sessionConfig_->effectiveValues(kOptimizerPrefix));
+  optimizerOptions.systemConnectorId = systemConnectorId_;
   optimizerOptions.explain = explain;
   auto optimizerSession = std::make_shared<optimizer::OptimizerSession>(
       queryCtx->queryId(),

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -363,6 +363,11 @@ class SqlQueryRunner {
     return defaultSchema_;
   }
 
+  /// Sets the connector ID whose scans must run on the coordinator.
+  void setSystemConnectorId(std::string connectorId) {
+    systemConnectorId_ = std::move(connectorId);
+  }
+
  private:
   // Checks permissions for the query via the configured PermissionCheck
   // callback. Returns a TokenProvider for authenticated file system access.
@@ -490,6 +495,8 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;
   std::string defaultSchema_;
+  // Connector whose table scans must run on the coordinator.
+  std::string systemConnectorId_;
   const std::string user_;
   std::atomic<int32_t> queryCounter_{0};
   const bool useOptimizerV2_{false};

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -18,6 +18,7 @@
 #include <folly/container/F14Map.h>
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 
 #include "axiom/common/SchemaTableName.h"
@@ -145,6 +146,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.
   bool explain{false};
+
+  /// Connector ID whose table scans must run on the coordinator. Empty means
+  /// no connector requires coordinator placement.
+  std::string systemConnectorId;
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "sample_joins").

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -115,6 +115,17 @@ std::optional<float> orderPrefixDistance(
   return selection;
 }
 
+bool isCoordinatorOnlyScan(BaseTableCP baseTable) {
+  auto* optimization = queryCtx()->optimization();
+  if (optimization == nullptr) {
+    return false;
+  }
+
+  const auto& systemConnectorId = optimization->options().systemConnectorId;
+  return !systemConnectorId.empty() &&
+      baseTable->schemaTable->connectorId() == systemConnectorId;
+}
+
 } // namespace
 
 TableScan::TableScan(
@@ -206,6 +217,10 @@ Distribution TableScan::outputDistribution(
     const BaseTable* baseTable,
     ColumnGroupCP index,
     const ColumnVector& columns) {
+  if (isCoordinatorOnlyScan(baseTable)) {
+    return Distribution::gather();
+  }
+
   // Re-express the index's distribution over the scan's output columns. At scan
   // time no equivalence classes exist, so rename matches schema columns to
   // output columns by identity.

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -408,6 +408,39 @@ std::optional<FragmentType> fragmentTypeContribution(const RelationOp& op) {
   }
 }
 
+// Returns true if a system-connector scan is reachable within the fragment
+// rooted at 'op', i.e. without crossing a Repartition boundary into a producer
+// fragment. The system connector's data exists only on the coordinator.
+bool containsSystemScan(
+    const RelationOp& op,
+    std::string_view systemConnectorId) {
+  if (systemConnectorId.empty() || op.relType() == RelType::kRepartition) {
+    return false;
+  }
+  if (op.relType() == RelType::kTableScan) {
+    return op.as<TableScan>()->baseTable->schemaTable->connectorId() ==
+        systemConnectorId;
+  }
+  // Multi-input operators must recurse into every input. A new multi-input
+  // RelType added here must be handled explicitly, or its right-hand inputs
+  // would be skipped and a system scan under them missed.
+  if (op.relType() == RelType::kUnionAll) {
+    for (const auto& input : op.as<UnionAll>()->inputs) {
+      if (containsSystemScan(*input, systemConnectorId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (op.relType() == RelType::kJoin) {
+    const auto& join = *op.as<Join>();
+    return containsSystemScan(*join.input(), systemConnectorId) ||
+        containsSystemScan(*join.right, systemConnectorId);
+  }
+  return op.input() != nullptr &&
+      containsSystemScan(*op.input(), systemConnectorId);
+}
+
 // Sets `fragment.type` (and `width` for kFixed) from the contents rooted at
 // `op`. The fragment type is derived by walking the RelationOp sub-tree down
 // to (but not including) any inner Repartition or leaf, merging contributions
@@ -420,7 +453,10 @@ std::optional<FragmentType> fragmentTypeContribution(const RelationOp& op) {
 void decideFragmentType(
     const RelationOp& op,
     const MultiFragmentPlan::Options& options,
+    std::string_view systemConnectorId,
     ExecutableFragment& fragment) {
+  // Single-node mode: the one node is the coordinator, so kSingle is already
+  // coordinator-equivalent and the system-scan distinction does not apply.
   if (options.numWorkers == 1) {
     fragment.type = FragmentType::kSingle;
     return;
@@ -429,6 +465,16 @@ void decideFragmentType(
   fragment.type = fragmentTypeContribution(op).value_or(FragmentType::kSource);
   if (fragment.type == FragmentType::kFixed) {
     fragment.width = options.numWorkers;
+  }
+
+  // A system-connector scan exists only on the coordinator; its gather
+  // distribution already made this fragment single-task, so pin it there.
+  if (containsSystemScan(op, systemConnectorId)) {
+    VELOX_CHECK_EQ(
+        fragment.type,
+        FragmentType::kSingle,
+        "System scan must not share a fragment with a parallel source");
+    fragment.type = FragmentType::kCoordinator;
   }
 }
 
@@ -544,10 +590,13 @@ PlanAndStats ToVelox::toVeloxPlan(
   // consumer. Decide before recursing so operators inside (e.g. makeWrite)
   // see the correct type.
   ExecutableFragment top = newFragment();
-  if (options.remoteOutput) {
-    decideFragmentType(*plan, options, top);
-  } else {
-    top.type = FragmentType::kSingle;
+  decideFragmentType(
+      *plan, options, optimizerSession_->options().systemConnectorId, top);
+  if (!options.remoteOutput) {
+    if (top.type != FragmentType::kCoordinator) {
+      top.type = FragmentType::kSingle;
+      top.width.reset();
+    }
   }
 
   std::vector<ExecutableFragment> stages;
@@ -564,10 +613,10 @@ PlanAndStats ToVelox::toVeloxPlan(
   // For the root fragment when no addGather was inserted, apply the
   // optimizer's root groupedLeaves directly to top.groupedNodes so the
   // runtime/connector pair sees the root's bucketed-leaf routing.
-  // Skip when top.type is kSingle: a single-task root has no groupId
-  // routing (local consumer) and applyGroupedLeaves would otherwise
-  // overwrite the type with kFixed and trip checkLastFragment.
-  if (gatherRepartition_ == nullptr && top.type != FragmentType::kSingle) {
+  // Skip single-task roots: they have no groupId routing, and
+  // applyGroupedLeaves would otherwise overwrite the type with kFixed.
+  if (gatherRepartition_ == nullptr && top.type != FragmentType::kSingle &&
+      top.type != FragmentType::kCoordinator) {
     applyGroupedLeaves(top, groupedLeaves_->root);
   }
 
@@ -1068,7 +1117,9 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   auto sortOrder = toSortOrders(op.distribution().orderTypes());
   auto keys = toFieldRefs(op.distribution().orderKeys());
 
-  if (isSingle_) {
+  // A gather input (e.g. a system scan or a global aggregation) is already
+  // single-task, so sort it inline rather than across a merge exchange.
+  if (isSingle_ || op.input()->distribution().isGather()) {
     auto input = makeFragment(op.input(), fragment, stages);
 
     if (options_.numDrivers == 1) {
@@ -1106,7 +1157,11 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   }
 
   auto source = newFragment();
-  decideFragmentType(*op.input(), options_, source);
+  decideFragmentType(
+      *op.input(),
+      options_,
+      optimizerSession_->options().systemConnectorId,
+      source);
   auto input = makeFragment(op.input(), source, stages);
 
   // At one driver the per-worker sort yields a single sorted run, so emit a
@@ -1151,13 +1206,17 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
     const Limit& op,
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
-  if (isSingle_) {
+  if (isSingle_ || op.input()->distribution().isGather()) {
     auto input = makeFragment(op.input(), fragment, stages);
     return addFinalLimit(nextId(), op.offset, op.limit, input);
   }
 
   auto source = newFragment();
-  decideFragmentType(*op.input(), options_, source);
+  decideFragmentType(
+      *op.input(),
+      options_,
+      optimizerSession_->options().systemConnectorId,
+      source);
   auto input = makeFragment(op.input(), source, stages);
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
@@ -1201,7 +1260,11 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
   }
 
   auto source = newFragment();
-  decideFragmentType(*op.input(), options_, source);
+  decideFragmentType(
+      *op.input(),
+      options_,
+      optimizerSession_->options().systemConnectorId,
+      source);
   auto input = makeFragment(op.input(), source, stages);
 
   auto node = addPartialLimit(nextId(), 0, op.offset + op.limit, input);
@@ -1897,7 +1960,11 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   // The producer fragment's type is determined by what's inside it. The
   // Repartition's distribution describes the wire output and is independent.
   auto source = newFragment();
-  decideFragmentType(*repartition.input(), options_, source);
+  decideFragmentType(
+      *repartition.input(),
+      options_,
+      optimizerSession_->options().systemConnectorId,
+      source);
 
   // Save the outer consumer's groupedLeaves (used to size our PartitionedOutput
   // below) and set the inner recursion's consumer context to source's

--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -6,9 +6,8 @@ This document describes how Axiom's optimizer plans distributed execution: how p
 
 The optimizer's role is to decide where exchanges go, what partitioning each exchange uses, and how many tasks each fragment should run with. The runtime takes the resulting `MultiFragmentPlan` and: creates tasks, enumerates and distributes splits to them, and wires producer/consumer exchanges between them.
 
-**Implementation status.** Sections 1 and 2 describe the fragment and exchange model that is in place today, with two exceptions called out where they appear:
+**Implementation status.** Sections 1 and 2 describe the fragment and exchange model that is in place today, including `kCoordinator` fragments and SystemConnector isolation. Grouped execution is the one exception:
 
-- **`kCoordinator` fragments and SystemConnector isolation** are not yet implemented. Section 1 (UNION ALL with single-task inputs) and Section 2 (`FragmentType::kCoordinator`) describe the intended behavior.
 - **Grouped execution** (Section 3) — including the `PartitionType` API, `groupedNodes` / `groupedExecution` fields on `ExecutableFragment`, `GroupedSplitSource`, and split-level `groupId` tagging — is a design proposal, not yet implemented.
 
 ### 1. Fragment Structure and Scheduling Constraints

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ target_link_libraries(
 add_executable(
   axiom_optimizer_tests
   AggregationTest.cpp
+  CoordinatorSchedulingTest.cpp
   DistinctAggregationTest.cpp
   OutputNodeTest.cpp
   CardinalityEstimationTest.cpp
@@ -162,7 +163,9 @@ target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   axiom_optimizer_tests_query_test_base
   axiom_runner_tests_utils
+  axiom_connectors
   axiom_test_connector
+  velox_connector_registry
   velox_dwio_text_reader_register
   velox_dwio_text_writer_register
   GTest::gmock

--- a/axiom/optimizer/tests/CoordinatorSchedulingTest.cpp
+++ b/axiom/optimizer/tests/CoordinatorSchedulingTest.cpp
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/connectors/ConnectorRegistry.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+class CoordinatorSchedulingTest : public test::QueryTestBase {
+ protected:
+  static constexpr const char* kSystemConnectorIdForTest = "coordinator_system";
+  static constexpr const char* kMetadataConnectorIdForTest =
+      "coordinator_metadata";
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    optimizerOptions_.systemConnectorId = kSystemConnectorIdForTest;
+
+    testConnector_->addTable("t", ROW("a", BIGINT()))
+        ->setStats(100'000, {{"a", {.numDistinct = 1'000}}});
+
+    systemConnector_ = registerConnector(kSystemConnectorIdForTest);
+    systemConnector_->addTable("s", ROW("c", BIGINT()))
+        ->setStats(1'000, {{"c", {.numDistinct = 100}}});
+
+    metadataConnector_ = registerConnector(kMetadataConnectorIdForTest);
+    metadataConnector_->addTable("m", ROW("d", BIGINT()))
+        ->setStats(1'000, {{"d", {.numDistinct = 100}}});
+  }
+
+  void TearDown() override {
+    if (metadataConnector_) {
+      unregisterConnector(kMetadataConnectorIdForTest);
+      metadataConnector_.reset();
+    }
+    if (systemConnector_) {
+      unregisterConnector(kSystemConnectorIdForTest);
+      systemConnector_.reset();
+    }
+    QueryTestBase::TearDown();
+  }
+
+  // Registers a TestConnector in both global registries before exposing it to
+  // the caller, so a throw mid-registration cannot leave a half-registered id.
+  static std::shared_ptr<connector::TestConnector> registerConnector(
+      const std::string& connectorId) {
+    auto connector = std::make_shared<connector::TestConnector>(connectorId);
+    velox::connector::ConnectorRegistry::global().insert(
+        connectorId, connector);
+    connector::ConnectorMetadataRegistry::global().insert(
+        connectorId, connector->metadata());
+    return connector;
+  }
+
+  static void unregisterConnector(const std::string& connectorId) {
+    connector::ConnectorMetadataRegistry::global().erase(connectorId);
+    velox::connector::ConnectorRegistry::global().erase(connectorId);
+  }
+
+  static MultiFragmentPlan::Options distributed() {
+    return {.numWorkers = 4, .numDrivers = 4};
+  }
+
+  std::shared_ptr<connector::TestConnector> systemConnector_;
+  std::shared_ptr<connector::TestConnector> metadataConnector_;
+};
+
+// A standalone system scan is one kCoordinator fragment.
+TEST_F(CoordinatorSchedulingTest, systemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect("FROM coordinator_system.default.s", kTestConnectorId),
+      distributed());
+
+  auto matcher =
+      matchScan("s").fragmentType(FragmentType::kCoordinator).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// A filter and projection over a system scan stay in one kCoordinator fragment.
+TEST_F(
+    CoordinatorSchedulingTest,
+    filterProjectOverSystemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c + 1 FROM coordinator_system.default.s WHERE c < 50",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .filter("c < 50")
+                     .project()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// ORDER BY over a system scan sorts inline in the kCoordinator fragment with no
+// remote merge exchange.
+TEST_F(
+    CoordinatorSchedulingTest,
+    orderByOverSystemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c FROM coordinator_system.default.s ORDER BY c",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .orderBy()
+                     .localMerge()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// LIMIT over an already-gathered system scan runs inline (partial + local
+// gather + final) in the kCoordinator fragment, with no remote gather.
+TEST_F(CoordinatorSchedulingTest, limitOverSystemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c FROM coordinator_system.default.s LIMIT 10",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .localLimit(0, 10)
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// ORDER BY ... LIMIT over a system scan keeps the sort and limit together in
+// one kCoordinator fragment (TopN + local merge + final limit), no remote
+// merge exchange.
+TEST_F(
+    CoordinatorSchedulingTest,
+    orderByLimitOverSystemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c FROM coordinator_system.default.s ORDER BY c LIMIT 10",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .topN()
+                     .localMerge()
+                     .limit()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// A cardinality-reducing aggregation over a system scan stays with the scan in
+// one kCoordinator fragment (partial + local gather + final).
+TEST_F(
+    CoordinatorSchedulingTest,
+    aggregationOverSystemScanUsesCoordinatorFragment) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT count(*) FROM coordinator_system.default.s",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .partialAggregation()
+                     .localGather()
+                     .finalAggregation()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// UNION ALL of a system scan with single-task Values co-locates both legs in
+// one kCoordinator fragment; the Values leg runs on the coordinator.
+TEST_F(CoordinatorSchedulingTest, unionOfSystemScanAndValues) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c AS a FROM coordinator_system.default.s UNION ALL VALUES 1",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .project()
+                     .localPartition(matchValues().project().build())
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// UNION ALL of two system scans co-locates both in one kCoordinator fragment.
+TEST_F(CoordinatorSchedulingTest, unionOfTwoSystemScans) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c FROM coordinator_system.default.s "
+          "UNION ALL SELECT c FROM coordinator_system.default.s",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .localPartition(matchScan("s").project().build())
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// UNION ALL of a system scan with a parallel scan isolates the system scan in
+// its own kCoordinator fragment behind an arbitrary exchange; the parallel scan
+// keeps full parallelism in a kSource fragment feeding a kSingle root.
+TEST_F(CoordinatorSchedulingTest, unionOfSystemScanAndScan) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT c AS a FROM coordinator_system.default.s UNION ALL FROM t",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .project()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .arbitrary()
+                     .localPartition(matchScan("t").project().build())
+                     .fragmentType(FragmentType::kSource)
+                     .gather()
+                     .fragmentType(FragmentType::kSingle)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// The system connector id is configurable, not hardcoded: a scan of the
+// separately-configured metadata connector is a kCoordinator fragment.
+TEST_F(CoordinatorSchedulingTest, systemConnectorIdIsConfigurable) {
+  auto options = optimizerOptions_;
+  options.systemConnectorId = kMetadataConnectorIdForTest;
+
+  auto plan = planVelox(
+      parseSelect("FROM coordinator_metadata.default.m", kTestConnectorId),
+      distributed(),
+      options);
+
+  auto matcher =
+      matchScan("m").fragmentType(FragmentType::kCoordinator).build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// With no system connector configured, a scan of the same table is an ordinary
+// parallel kSource fragment gathered into a kSingle root.
+TEST_F(CoordinatorSchedulingTest, systemCatalogIsNotHardcoded) {
+  auto options = optimizerOptions_;
+  options.systemConnectorId.clear();
+
+  auto plan = planVelox(
+      parseSelect("FROM coordinator_system.default.s", kTestConnectorId),
+      distributed(),
+      options);
+
+  auto matcher = matchScan("s")
+                     .fragmentType(FragmentType::kSource)
+                     .gather()
+                     .fragmentType(FragmentType::kSingle)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// Join of a parallel scan with a system scan: the system scan is the broadcast
+// build in its own kCoordinator fragment; the probe keeps full parallelism in a
+// kSource fragment gathered into a kSingle root.
+TEST_F(CoordinatorSchedulingTest, systemScanJoinWithScan) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT a FROM t JOIN coordinator_system.default.s ON a = c",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("s")
+                                   .fragmentType(FragmentType::kCoordinator)
+                                   .broadcast()
+                                   .build())
+                     .fragmentType(FragmentType::kSource)
+                     .gather()
+                     .fragmentType(FragmentType::kSingle)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// System scan on the probe side (syntactic join order): the join runs in the
+// kCoordinator root fragment with the system scan; the parallel build is
+// broadcast from its own kSource fragment.
+TEST_F(CoordinatorSchedulingTest, systemScanProbeJoinWithScan) {
+  auto options = optimizerOptions_;
+  options.syntacticJoinOrder = true;
+
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT a FROM coordinator_system.default.s JOIN t ON c = a",
+          kTestConnectorId),
+      distributed(),
+      options);
+
+  auto matcher = matchScan("s")
+                     .hashJoin(matchScan("t")
+                                   .fragmentType(FragmentType::kSource)
+                                   .broadcast()
+                                   .build())
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// Join of a system scan with single-task Values co-locates in one kCoordinator
+// fragment.
+TEST_F(CoordinatorSchedulingTest, joinOfSystemScanAndValues) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT s.c FROM coordinator_system.default.s AS s "
+          "JOIN (VALUES 1) AS v(x) ON s.c = v.x",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .hashJoin(matchValues().project().build())
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// A self-join of a system scan keeps both scans in one kCoordinator fragment.
+TEST_F(CoordinatorSchedulingTest, joinOfTwoSystemScans) {
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT s1.c FROM coordinator_system.default.s AS s1 "
+          "JOIN coordinator_system.default.s AS s2 ON s1.c = s2.c",
+          kTestConnectorId),
+      distributed());
+
+  auto matcher = matchScan("s")
+                     .hashJoin(matchScan("s").build())
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -547,13 +547,8 @@ TEST_F(UnionAllTest, orderByOverTwoScans) {
   }
 }
 
-// ORDER BY over two single-task legs. The union is kSingle; per the design
-// the ORDER BY should run in the same kSingle fragment with no remote
-// exchange.
-//
-// TODO: The optimizer always emits a separate kSingle final fragment, even
-// when the union is already kSingle. The OrderBy is split into PARTIAL +
-// LocalMerge + MergeExchange + (no extra OrderBy) — one unnecessary gather.
+// ORDER BY over two single-task legs. The union is kSingle, so the ORDER BY
+// runs in the same kSingle fragment with no remote exchange.
 TEST_F(UnionAllTest, orderByOverTwoValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (VALUES 1 UNION ALL VALUES 2) ORDER BY 1",
@@ -572,7 +567,6 @@ TEST_F(UnionAllTest, orderByOverTwoValues) {
                        .localPartition(matchValues().project().build())
                        .orderBy({"c0 ASC NULLS LAST"})
                        .localMerge()
-                       .shuffleMerge()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -459,7 +459,9 @@ TEST_F(WindowTest, nonRedundantOrderByWithDifferentKeys) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
-  // No partition keys — gather, then Window + TopN + merge + limit + project.
+  // No partition keys — a single gather; the Window, TopN and final LIMIT then
+  // run inline on that one task, so the outer ORDER BY ... LIMIT needs no
+  // second (merge) exchange.
   auto distributedPlan = toDistributedPlan(sql);
   auto distributedMatcher =
       matchScan("nation")
@@ -468,7 +470,6 @@ TEST_F(WindowTest, nonRedundantOrderByWithDifferentKeys) {
           .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
           .topN(10)
           .localMerge()
-          .shuffleMerge()
           .finalLimit(0, 10)
           .project()
           .build();
@@ -527,8 +528,9 @@ TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
-  // No partition keys — gather, then two Windows + TopN + merge + limit +
-  // project.
+  // No partition keys — a single gather; both Windows, the TopN and the final
+  // LIMIT then run inline on that one task, so the outer ORDER BY ... LIMIT
+  // needs no second (merge) exchange.
   auto distributedPlan = toDistributedPlan(sql);
   auto distributedMatcher =
       matchScan("nation")
@@ -540,7 +542,6 @@ TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
           .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"})
           .topN(10)
           .localMerge()
-          .shuffleMerge()
           .finalLimit(0, 10)
           .project()
           .build();

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -562,6 +562,42 @@ TEST_P(WriteTest, insertBucketedSql) {
   }
 }
 
+// A write over a coordinator-only scan keeps the write and scan in a single
+// coordinator fragment, with no parallel source fragment.
+TEST_P(WriteTest, insertFromCoordinatorScan) {
+  if (useV2_) {
+    GTEST_SKIP() << "Coordinator placement of system scans is v1-only.";
+  }
+  SCOPE_EXIT {
+    dropTableIfExists("test");
+  };
+
+  createTable("test", ROW({"a"}, {BIGINT()}), {});
+
+  auto options = optimizerOptions_;
+  options.systemConnectorId = exec::test::kHiveConnectorId;
+
+  auto plan = planVelox(
+      parseInsert(
+          "INSERT INTO test "
+          "SELECT n_nationkey FROM nation WHERE n_nationkey < 3"),
+      {
+          .numWorkers = 4,
+          .numDrivers = 4,
+      },
+      options);
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .tableWrite()
+                     .localGather()
+                     .tableWriteMerge()
+                     .fragmentType(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  verifyPlanSerde(*plan.plan, pool());
+}
+
 TEST_P(WriteTest, ctasSql) {
   {
     SCOPE_EXIT {


### PR DESCRIPTION
Summary:

Design: https://www.internalfb.com/phabricator/paste/view/P2399293723#system-connector-coordin

System-connector tables expose process-local state (active queries, session properties, function metadata) that exists only on the coordinator, so a scan of one must run as a single task on the coordinator rather than as an ordinary parallel worker scan.

Thread the registered system connector id into `OptimizerOptions` (set by the runner from the connector registry, matched by id rather than a literal) and return a gather distribution for such scans, which lets the existing single-task machinery isolate them. Type a fragment `FragmentType::kCoordinator` by leaf-detection: walk the fragment, stopping at `Repartition` boundaries, and pin it to the coordinator when it contains a system scan. An assert enforces that a system scan never shares a fragment with a parallel source. `ORDER BY` and `OFFSET` over an already-gathered input now run inline instead of across a redundant merge exchange.

Cardinality-increasing work above the scan (`UNNEST`, exploding joins) still runs on the coordinator; moving it to workers via an interior coordinator-exit exchange is a follow-up.

Differential Revision: D104445782


