### PR TITLE
fix(optimizer): Dedup pre-grouped keys to satisfy size invariant (#1365)

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -66,14 +66,12 @@ AggregateVector flattenAggregates(
   return flatAggregates;
 }
 
-// Computes the pre-grouped keys for streaming aggregation based on input's
-// orderKeys and clusterKeys. For orderKeys, returns the longest prefix that
-// is also a grouping key (order guarantees break at the first non-grouping
-// key). For clusterKeys, returns any subset that are grouping keys (clustering
-// only requires contiguous values, not ordering). Returns whichever set is
-// larger to maximize streaming benefit.
+} // namespace
+
+namespace detail {
+
 ExprVector computePreGroupedKeys(
-    const RelationOp& input,
+    const Distribution& distribution,
     const ExprVector& groupingKeys) {
   if (groupingKeys.empty()) {
     return {};
@@ -88,28 +86,43 @@ ExprVector computePreGroupedKeys(
     return false;
   };
 
+  // Distinct ExprCP pointers can refer to the same logical column after a
+  // rename or project; pointer identity is not enough.
+  auto alreadyAdded = [](ExprCP key, const ExprVector& result) {
+    for (const auto& existing : result) {
+      if (existing->sameOrEqual(*key)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   // Check orderKeys - find the longest prefix that is in groupingKeys.
   // For ordered data, we can only use a prefix because the order guarantee
   // breaks once we hit a key not in groupingKeys.
   ExprVector fromOrderKeys;
-  const auto& orderKeys = input.distribution().orderKeys();
-  for (const auto& key : orderKeys) {
-    if (isGroupingKey(key)) {
-      fromOrderKeys.push_back(key);
-    } else {
+  for (const auto& key : distribution.orderKeys()) {
+    if (!isGroupingKey(key)) {
       break; // Must be a prefix for ordered data.
     }
+    if (alreadyAdded(key, fromOrderKeys)) {
+      continue;
+    }
+    fromOrderKeys.push_back(key);
   }
 
   // Check clusterKeys - any subset of groupingKeys works.
   // Clustering doesn't require prefix matching since rows with the same
   // cluster key values are contiguous regardless of other columns.
   ExprVector fromClusterKeys;
-  const auto& clusterKeys = input.distribution().clusterKeys();
-  for (const auto& key : clusterKeys) {
-    if (isGroupingKey(key)) {
-      fromClusterKeys.push_back(key);
+  for (const auto& key : distribution.clusterKeys()) {
+    if (!isGroupingKey(key)) {
+      continue;
     }
+    if (alreadyAdded(key, fromClusterKeys)) {
+      continue;
+    }
+    fromClusterKeys.push_back(key);
   }
 
   // Return the larger subset for maximum streaming benefit.
@@ -118,6 +131,10 @@ ExprVector computePreGroupedKeys(
   return fromOrderKeys.size() >= fromClusterKeys.size() ? fromOrderKeys
                                                         : fromClusterKeys;
 }
+
+} // namespace detail
+
+namespace {
 
 // Returns the union of column expressions from groupingKeys and args,
 // skipping literals. Throws on unexpected expression types other than column
@@ -548,7 +565,8 @@ void AggregationPlanner::plan(
   plan = std::move(precompute).maybeProject();
   state.place(aggPlan);
 
-  auto preGroupedKeys = computePreGroupedKeys(*plan, groupingKeys);
+  auto preGroupedKeys =
+      detail::computePreGroupedKeys(plan->distribution(), groupingKeys);
   if ((isSingleWorker_ && isSingleDriver_) || !preGroupedKeys.empty()) {
     auto* singleAgg = make<Aggregation>(
         plan,

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -33,6 +33,20 @@ std::pair<RelationOpPtr, PlanCost> maybeRepartition(
     const RelationOpPtr& plan,
     ExprVector desiredKeys);
 
+namespace detail {
+// Computes the pre-grouped keys for streaming aggregation based on
+// 'distribution'. For orderKeys, returns the longest prefix that is also a
+// grouping key (order guarantees break at the first non-grouping key). For
+// clusterKeys, returns any subset that are grouping keys (clustering only
+// requires contiguous values, not ordering). Returns whichever set is larger
+// to maximize streaming benefit. Semantic duplicates (different `ExprCP`
+// pointers that `sameOrEqual`) are dropped to keep the result no larger than
+// `groupingKeys` — exposed for unit testing.
+ExprVector computePreGroupedKeys(
+    const Distribution& distribution,
+    const ExprVector& groupingKeys);
+} // namespace detail
+
 /// Plans aggregation operators for a derived table.
 class AggregationPlanner {
  public:

--- a/axiom/optimizer/tests/AggregationPlannerTest.cpp
+++ b/axiom/optimizer/tests/AggregationPlannerTest.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/AggregationPlanner.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/VeloxHistory.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+
+namespace lp = facebook::axiom::logical_plan;
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+class AggregationPlannerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+  }
+
+  void SetUp() override {
+    rootPool_ = memory::memoryManager()->addRootPool("root");
+    optimizerPool_ = rootPool_->addLeafChild("optimizer");
+  }
+
+  void runTest(
+      const lp::LogicalPlanNodePtr& plan,
+      const std::function<void(DerivedTableCP derivedTable)>& testRoutine) {
+    auto allocator =
+        std::make_unique<HashStringAllocator>(optimizerPool_.get());
+    auto context = std::make_unique<QueryGraphContext>(*allocator);
+    queryCtx() = context.get();
+    SCOPE_EXIT {
+      queryCtx() = nullptr;
+    };
+
+    auto veloxQueryCtx = core::QueryCtx::create();
+    exec::SimpleExpressionEvaluator evaluator(
+        veloxQueryCtx.get(), optimizerPool_.get());
+
+    VeloxHistory history;
+    auto schemaResolver = std::make_shared<connector::SchemaResolver>();
+    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+
+    Optimization opt{
+        session,
+        *plan,
+        *schemaResolver,
+        history,
+        veloxQueryCtx,
+        evaluator,
+        {},
+        {.numWorkers = 1, .numDrivers = 1}};
+
+    testRoutine(opt.rootDt());
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> optimizerPool_;
+};
+
+// Two `ExprCP` entries that refer to the same logical column (different
+// pointers, made equivalent via `Column::equals`) collapse to a single
+// pre-grouped key. Verified for both `orderKeys` and `clusterKeys` since each
+// has its own dedup loop.
+TEST_F(AggregationPlannerTest, dedupSemanticDuplicates) {
+  auto logicalPlan = lp::PlanBuilder{}
+                         .values(ROW({"k"}, INTEGER()), {variant::row({1})})
+                         .aggregate({"k"}, {"sum(k)"})
+                         .build();
+
+  runTest(logicalPlan, [&](DerivedTableCP derivedTable) {
+    auto* groupingKey = derivedTable->aggregation->groupingKeys()[0];
+    auto* duplicateKey =
+        make<Column>(toName("k"), derivedTable, Value(toType(INTEGER()), 1));
+    groupingKey->as<Column>()->equals(duplicateKey);
+
+    Distribution viaOrderKeys(
+        Distribution::Kind::kPartitioned,
+        /*partitionType=*/nullptr,
+        /*partitionKeys=*/{},
+        /*orderKeys=*/{groupingKey, duplicateKey},
+        /*orderTypes=*/
+        {OrderType::kAscNullsLast, OrderType::kAscNullsLast});
+    EXPECT_THAT(
+        detail::computePreGroupedKeys(viaOrderKeys, {groupingKey}),
+        ::testing::ElementsAre(groupingKey));
+
+    Distribution viaClusterKeys(
+        Distribution::Kind::kPartitioned,
+        /*partitionType=*/nullptr,
+        /*partitionKeys=*/{},
+        /*orderKeys=*/{},
+        /*orderTypes=*/{},
+        /*numKeysUnique=*/0,
+        /*clusterKeys=*/{groupingKey, duplicateKey});
+    EXPECT_THAT(
+        detail::computePreGroupedKeys(viaClusterKeys, {groupingKey}),
+        ::testing::ElementsAre(groupingKey));
+  });
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -226,3 +226,23 @@ target_link_libraries(
   GTest::gtest_main
   pthread
 )
+
+add_executable(axiom_aggregation_planner_test AggregationPlannerTest.cpp)
+
+add_test(
+  NAME axiom_aggregation_planner_test
+  COMMAND axiom_aggregation_planner_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+  axiom_aggregation_planner_test
+  axiom_logical_plan_builder
+  axiom_optimizer
+  velox_aggregates
+  velox_expression
+  velox_functions_prestosql
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main
+)


### PR DESCRIPTION
Summary:

`AggregationPlanner::computePreGroupedKeys` walks `orderKeys` and `clusterKeys` and pushes each entry matching any grouping key via `sameOrEqual`. When one logical column appears under different `ExprCP` pointers — e.g. after a rename or a Project producing multiple references to the same source column — both refs get pushed, violating `VELOX_DCHECK_LE(preGroupedKeys.size(), groupingKeys.size())` at `RelationOp.cpp:1302`. The downstream name-based check in `PlanNode.cpp` would also reject this.

Dedup within each result vector via `sameOrEqual`. The `orderKeys` path keeps its longest-prefix semantics — `sorted-on-(a, a, b)` is equivalent to `sorted-on-(a, b)`, so skipping duplicates doesn't break the prefix invariant.

Moved `computePreGroupedKeys` to `axiom::optimizer::detail::` and changed the signature to take `const Distribution&` so it can be unit-tested directly against constructed inputs.

Differential Revision: D104950196


