### PR TITLE
fix: Accept UNKNOWN inputs to AND / OR special form (#1368)

### DIFF
--- a/axiom/connectors/hive/LocalTableBuilder.cpp
+++ b/axiom/connectors/hive/LocalTableBuilder.cpp
@@ -281,10 +281,11 @@ void LocalTableBuilder::build(const std::string& tablePath) {
   folly::F14FastMap<std::string, ColumnStatistics> aggregatedStats;
 
   for (auto& info : files) {
-    velox::io::IoStatistics dataIoStats;
-    velox::io::IoStatistics metadataIoStats;
-    velox::dwio::common::ReaderOptions readerOptions{
-        pool_, &dataIoStats, &metadataIoStats};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    velox::dwio::common::ReaderOptions readerOptions{pool_};
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     readerOptions.setFileFormat(fileFormat_);
 
     if (fileFormat_ == velox::dwio::common::FileFormat::TEXT && tableType) {

--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -676,10 +676,11 @@ SpecialFormExpr::SpecialFormExpr(
           SpecialFormName::toName(form));
 
       for (const auto& input : inputs_) {
-        VELOX_USER_CHECK_EQ(
-            input->type()->kind(),
-            velox::TypeKind::BOOLEAN,
-            "All inputs to AND and OR must be boolean");
+        VELOX_USER_CHECK(
+            input->type()->kind() == velox::TypeKind::BOOLEAN ||
+                input->type()->kind() == velox::TypeKind::UNKNOWN,
+            "All inputs to AND and OR must be boolean, but got {}",
+            input->type()->toString());
       }
       break;
     case SpecialForm::kCast:

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -67,6 +67,25 @@ TEST_F(ExprTest, looksConstant) {
   testLooksConstant(Cast(DOUBLE(), Col("a")), false);
 }
 
+TEST_F(ExprTest, conjunctAcceptsUnknownInput) {
+  // Mirror Velox's ConjunctExpr::resolveType, which accepts BOOLEAN or UNKNOWN.
+  auto schema = ROW({"p", "a"}, {BOOLEAN(), BIGINT()});
+  auto resolve = [&](const ExprApi& expr) {
+    return ExprResolver(nullptr, nullptr)
+        .resolveScalarTypes(expr.expr(), inputResolver(schema));
+  };
+
+  auto nullLiteral = Lit(Variant::null(TypeKind::UNKNOWN), UNKNOWN());
+
+  EXPECT_EQ(*resolve(Col("p") && nullLiteral)->type(), *BOOLEAN());
+  EXPECT_EQ(*resolve(nullLiteral || Col("p"))->type(), *BOOLEAN());
+
+  // Non-boolean, non-unknown inputs remain rejected.
+  VELOX_ASSERT_THROW(
+      resolve(Col("p") && Col("a")),
+      "All inputs to AND and OR must be boolean");
+}
+
 TEST_F(ExprTest, aggregateExprDistinctOrderBy) {
   auto makeAggregate =
       [this](const ExprApi& expr, const std::vector<SortKey>& ordering = {}) {


### PR DESCRIPTION
Summary:

Axiom's `SpecialFormExpr` constructor rejected any input to `kAnd` / `kOr` whose type was not exactly `BOOLEAN`. This is stricter than Velox's `ConjunctExpr::resolveType`, which accepts both `BOOLEAN` and `UNKNOWN`. The mismatch caused planning failures on Presto-style expressions where a bare `NULL` literal flows into a logical operator, e.g.:

```
WHERE x = 1 OR NULL
```

The `NULL` literal has `UNKNOWN` type and is not coerced before reaching `SpecialFormExpr`'s constructor, so Axiom fails with "All inputs to AND and OR must be boolean" while Velox would happily evaluate it.

Relax the check to mirror Velox's contract: accept `BOOLEAN` or `UNKNOWN`. Also include the offending type in the error message for the still-rejected cases.

Repro: query ID `20260508_152034_31143_kq8fv` against the `bi` catalog, replayed via `replay_presto`.

Reviewed By: amitkdutta

Differential Revision: D105354870
