### PR TITLE
refactor(tests): Consolidate PlanMatcherBuilder::hashJoin overloads with HashJoinDetails (#1369)

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1378,7 +1378,9 @@ TEST_F(JoinTest, leftJoinNoEqualitiesMultipleTables) {
       matchScan("nation")
           .hashJoin(matchScan("region").build(), core::JoinType::kInner)
           .hashJoin(
-              matchScan("customer").build(), core::JoinType::kLeftSemiProject)
+              matchScan("customer").build(),
+              core::JoinType::kLeftSemiProject,
+              {.nullAware = false})
           .project()
           .nestedLoopJoin(matchScan("supplier").build(), core::JoinType::kLeft)
           .build();

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1898,29 +1898,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
 PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
     const std::shared_ptr<PlanMatcher>& rightMatcher,
     JoinType joinType,
-    bool nullAware) {
-  return hashJoin(
-      rightMatcher, joinType, HashJoinDetails{.nullAware = nullAware});
-}
-
-PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
-    const std::shared_ptr<PlanMatcher>& rightMatcher,
-    JoinType joinType,
     const HashJoinDetails& details) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<HashJoinMatcher>(
       matcher_, rightMatcher, joinType, details);
   return *this;
-}
-
-PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
-    const std::shared_ptr<PlanMatcher>& rightMatcher,
-    JoinType joinType,
-    const std::vector<std::string>& outputColumnNames) {
-  return hashJoin(
-      rightMatcher,
-      joinType,
-      HashJoinDetails{.outputColumnNames = outputColumnNames});
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -295,37 +295,14 @@ class PlanMatcherBuilder {
       const std::shared_ptr<PlanMatcher>& rightMatcher);
 
   /// Matches a HashJoin node with the specified right side matcher, join type,
-  /// and nullAware flag.
+  /// and optional details. Supports symbol rewriting from child matchers.
   /// @param rightMatcher Matcher for the right (build) side of the join.
-  /// @param joinType Type of join (e.g., kInner, kLeft, kRight).
-  /// @param nullAware When true, the join semantic is IN / NOT IN. When false,
-  /// the join semantic is EXISTS / NOT EXISTS. Applies only to semi project
-  /// and anti joins.
-  PlanMatcherBuilder& hashJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
-      JoinType joinType,
-      bool nullAware = false);
-
-  /// Matches a HashJoin node with the specified right side matcher, join type,
-  /// and details.
-  /// @param rightMatcher Matcher for the right side of the join.
   /// @param joinType Type of join.
   /// @param details Join details. See HashJoinDetails.
   PlanMatcherBuilder& hashJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher,
       JoinType joinType,
-      const HashJoinDetails& details);
-
-  /// Matches a HashJoin node with the specified right side matcher, join type,
-  /// and expected output column names. Column names are verified as a set —
-  /// order does not matter. Supports symbol rewriting from child matchers.
-  /// @param rightMatcher Matcher for the right (build) side of the join.
-  /// @param joinType Type of join (e.g., kInner, kLeft, kRight).
-  /// @param outputColumnNames Expected column names in the join output.
-  PlanMatcherBuilder& hashJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
-      JoinType joinType,
-      const std::vector<std::string>& outputColumnNames);
+      const HashJoinDetails& details = {});
 
   /// Matches a NestedLoopJoin node with the specified right side matcher and
   /// join type.

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -428,12 +428,14 @@ TEST_F(SetTest, except) {
                                // 1) % 3 = 1 to all branches of 'except'.
                                .hiveScan("nation", test::gte("n_nationkey", 17))
                                .build(),
-                           core::JoinType::kAnti)
+                           core::JoinType::kAnti,
+                           {.nullAware = false})
                        .hashJoin(
                            core::PlanMatcherBuilder()
                                .hiveScan("nation", test::lte("n_nationkey", 5))
                                .build(),
-                           core::JoinType::kAnti)
+                           core::JoinType::kAnti,
+                           {.nullAware = false})
                        .singleAggregation()
                        .project()
                        .build();
@@ -1028,7 +1030,10 @@ TEST_F(SetTest, exceptUnionAll) {
   // rename project to align column names through LocalPartition.
   auto matchExcept = [](const std::string& left, const std::string& right) {
     return matchScan(left)
-        .hashJoin(matchScan(right).build(), core::JoinType::kAnti)
+        .hashJoin(
+            matchScan(right).build(),
+            core::JoinType::kAnti,
+            {.nullAware = false})
         .singleAggregation()
         .project();
   };

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -114,7 +114,7 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
                                .hiveScan("region", test::gt("r_name", "ASIA"))
                                .build(),
                            velox::core::JoinType::kAnti,
-                           /*nullAware=*/true)
+                           {.nullAware = true})
                        .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -462,7 +462,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
                                .hiveScan("region", test::gt("r_name", "ASIA"))
                                .build(),
                            velox::core::JoinType::kLeftSemiProject,
-                           true)
+                           {.nullAware = true})
                        .project()
                        .build();
 
@@ -486,7 +486,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
                                .hiveScan("region", test::gt("r_name", "ASIA"))
                                .build(),
                            velox::core::JoinType::kLeftSemiProject,
-                           true)
+                           {.nullAware = true})
                        .project()
                        .build();
 
@@ -575,7 +575,7 @@ TEST_F(SubqueryTest, correlatedIn) {
                        .hashJoin(
                            matchHiveScan("customer").build(),
                            core::JoinType::kRightSemiProject,
-                           /*nullAware=*/true)
+                           {.nullAware = true})
                        .filter()
                        .project()
                        .build();
@@ -608,7 +608,7 @@ TEST_F(SubqueryTest, correlatedIn) {
                         matchScan("t").build(), core::JoinType::kLeftSemiFilter)
                     .build(),
                 core::JoinType::kLeftSemiProject,
-                /*nullAware=*/true)
+                {.nullAware = true})
             .project()
             .build();
 
@@ -915,7 +915,7 @@ TEST_F(SubqueryTest, correlatedProject) {
             .hashJoin(
                 core::PlanMatcherBuilder().hiveScan("region", {}).build(),
                 velox::core::JoinType::kLeftSemiProject,
-                false)
+                {.nullAware = false})
             .project()
             .build();
 
@@ -938,7 +938,7 @@ TEST_F(SubqueryTest, correlatedProject) {
             .hashJoin(
                 core::PlanMatcherBuilder().hiveScan("region", {}).build(),
                 velox::core::JoinType::kLeftSemiProject,
-                true)
+                {.nullAware = true})
             .project()
             .build();
 
@@ -961,7 +961,7 @@ TEST_F(SubqueryTest, correlatedProject) {
             .hashJoin(
                 core::PlanMatcherBuilder().hiveScan("region", {}).build(),
                 velox::core::JoinType::kLeftSemiProject,
-                true)
+                {.nullAware = true})
             .project()
             .build();
 
@@ -1024,7 +1024,8 @@ TEST_F(SubqueryTest, correlatedNotExists) {
         matchHiveScan("nation")
             .hashJoin(
                 core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kAnti)
+                velox::core::JoinType::kAnti,
+                {.nullAware = false})
             .build();
 
     SCOPED_TRACE(query);
@@ -1067,7 +1068,7 @@ TEST_F(SubqueryTest, correlatedNotExists) {
             .hashJoin(
                 core::PlanMatcherBuilder().hiveScan("region", {}).build(),
                 velox::core::JoinType::kLeftSemiProject,
-                false)
+                {.nullAware = false})
             .project()
             .build();
 
@@ -1655,7 +1656,7 @@ TEST_F(SubqueryTest, correlatedExistsThenUncorrelatedIn) {
                      .hashJoin(
                          matchHiveScan("region").build(),
                          velox::core::JoinType::kRightSemiProject,
-                         /*nullAware=*/true)
+                         {.nullAware = true})
                      .nestedLoopJoin(
                          matchHiveScan("nation").build(),
                          velox::core::JoinType::kLeftSemiProject)
@@ -1800,7 +1801,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .hashJoin(
                 matchHiveScan("nation").build(),
                 velox::core::JoinType::kRightSemiProject,
-                /*nullAware=*/true)
+                {.nullAware = true})
             .filter()
             .hashJoin(
                 matchHiveScan("region").build(), velox::core::JoinType::kInner)
@@ -1841,7 +1842,8 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
         matchHiveScan("supplier")
             .hashJoin(
                 matchHiveScan("nation").build(),
-                velox::core::JoinType::kRightSemiProject)
+                velox::core::JoinType::kRightSemiProject,
+                {.nullAware = false})
             .filter()
             .hashJoin(
                 matchHiveScan("region").build(), velox::core::JoinType::kInner)
@@ -1964,7 +1966,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                                .hashJoin(
                                    matchHiveScan("region").build(),
                                    core::JoinType::kRightSemiProject,
-                                   /*nullAware=*/true)
+                                   {.nullAware = true})
                                .filter()
                                .project()
                                .build(),
@@ -2029,7 +2031,8 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            matchHiveScan("supplier")
                                .hashJoin(
                                    matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiProject)
+                                   core::JoinType::kRightSemiProject,
+                                   {.nullAware = false})
                                .filter()
                                .project()
                                .build(),
@@ -2184,7 +2187,7 @@ TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
     return matchHiveScan("nation").hashJoin(
         matchHiveScan("region").build(),
         core::JoinType::kLeftSemiProject,
-        /*nullAware=*/true);
+        {.nullAware = true});
   };
 
   // IN <subquery> inside an aggregate expression.
@@ -2230,12 +2233,12 @@ TEST_F(SubqueryTest, nestedInSubqueries) {
                      .hashJoin(
                          matchHiveScan("region").build(),
                          velox::core::JoinType::kLeftSemiProject,
-                         /*nullAware=*/true)
+                         {.nullAware = true})
                      .project()
                      .hashJoin(
                          matchValues().project().build(),
                          velox::core::JoinType::kLeftSemiProject,
-                         /*nullAware=*/true)
+                         {.nullAware = true})
                      .project()
                      .build();
 
@@ -2304,10 +2307,13 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
                      .hashJoin(
                          matchScan("v").build(),
                          core::JoinType::kLeftSemiProject,
-                         /*nullAware=*/true)
+                         {.nullAware = true})
                      .project()
                      .hashJoin(matchScan("t").build(), core::JoinType::kInner)
-                     .hashJoin(matchScan("v").build(), core::JoinType::kAnti)
+                     .hashJoin(
+                         matchScan("v").build(),
+                         core::JoinType::kAnti,
+                         {.nullAware = false})
                      .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -2340,7 +2346,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
                                .shuffle({"c"}, /*replicateNullsAndAny=*/true)
                                .build(),
                            velox::core::JoinType::kAnti,
-                           /*nullAware=*/true)
+                           {.nullAware = true})
                        .gather()
                        .build();
 
@@ -2362,7 +2368,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
                                .shuffle({"c"}, /*replicateNullsAndAny=*/true)
                                .build(),
                            velox::core::JoinType::kLeftSemiProject,
-                           /*nullAware=*/true)
+                           {.nullAware = true})
                        .project()
                        .gather()
                        .build();
@@ -2381,7 +2387,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
                        .hashJoin(
                            matchScan("u").shuffle({"c"}).build(),
                            velox::core::JoinType::kRightSemiProject,
-                           /*nullAware=*/true)
+                           {.nullAware = true})
                        .project()
                        .gather()
                        .build();

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -206,14 +206,16 @@ TEST_F(TpchPlanTest, q03) {
                   .hashJoin(
                       startMatcher("customer").build(),
                       core::JoinType::kInner,
-                      {"o_orderkey", "o_orderdate", "o_shippriority"})
+                      {.outputColumnNames =
+                           {{"o_orderkey", "o_orderdate", "o_shippriority"}}})
                   .build(),
               core::JoinType::kInner,
-              {"l_orderkey",
-               "l_extendedprice",
-               "l_discount",
-               "o_orderdate",
-               "o_shippriority"})
+              {.outputColumnNames =
+                   {{"l_orderkey",
+                     "l_extendedprice",
+                     "l_discount",
+                     "o_orderdate",
+                     "o_shippriority"}}})
           .project()
           .aggregation()
           .topN()
@@ -550,7 +552,7 @@ TEST_F(TpchPlanTest, q16) {
           .hashJoin(
               startMatcher("supplier").build(),
               core::JoinType::kAnti,
-              /*nullAware=*/true)
+              {.nullAware = true})
           .aggregation()
           .orderBy()
           .build();
@@ -752,7 +754,8 @@ TEST_F(TpchPlanTest, q22) {
                                  startMatcher("customer").aggregation().build())
                              .filter()
                              .build(),
-                         velox::core::JoinType::kRightSemiProject)
+                         velox::core::JoinType::kRightSemiProject,
+                         {.nullAware = false})
                      .filter()
                      .project()
                      .aggregation()


### PR DESCRIPTION
Summary:

Replace the `hashJoin(right, type, bool nullAware)` and `hashJoin(right, type, vector<string> outputColumnNames)` overloads with a single `hashJoin(right, type, HashJoinDetails = {})` overload. 

This reduces the hashJoin API surface from 4 overloads to 2 overloads.

Differential Revision: D105043545


