### PR TITLE
fix: Handle dense_rank/rank when ORDER BY is fully pruned (#1370)

### DIFF
--- a/axiom/connectors/hive/LocalTableBuilder.cpp
+++ b/axiom/connectors/hive/LocalTableBuilder.cpp
@@ -281,10 +281,11 @@ void LocalTableBuilder::build(const std::string& tablePath) {
   folly::F14FastMap<std::string, ColumnStatistics> aggregatedStats;
 
   for (auto& info : files) {
-    velox::io::IoStatistics dataIoStats;
-    velox::io::IoStatistics metadataIoStats;
-    velox::dwio::common::ReaderOptions readerOptions{
-        pool_, &dataIoStats, &metadataIoStats};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    velox::dwio::common::ReaderOptions readerOptions{pool_};
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     readerOptions.setFileFormat(fileFormat_);
 
     if (fileFormat_ == velox::dwio::common::FileFormat::TEXT && tableType) {

--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -676,10 +676,11 @@ SpecialFormExpr::SpecialFormExpr(
           SpecialFormName::toName(form));
 
       for (const auto& input : inputs_) {
-        VELOX_USER_CHECK_EQ(
-            input->type()->kind(),
-            velox::TypeKind::BOOLEAN,
-            "All inputs to AND and OR must be boolean");
+        VELOX_USER_CHECK(
+            input->type()->kind() == velox::TypeKind::BOOLEAN ||
+                input->type()->kind() == velox::TypeKind::UNKNOWN,
+            "All inputs to AND and OR must be boolean, but got {}",
+            input->type()->toString());
       }
       break;
     case SpecialForm::kCast:

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -67,6 +67,25 @@ TEST_F(ExprTest, looksConstant) {
   testLooksConstant(Cast(DOUBLE(), Col("a")), false);
 }
 
+TEST_F(ExprTest, conjunctAcceptsUnknownInput) {
+  // Mirror Velox's ConjunctExpr::resolveType, which accepts BOOLEAN or UNKNOWN.
+  auto schema = ROW({"p", "a"}, {BOOLEAN(), BIGINT()});
+  auto resolve = [&](const ExprApi& expr) {
+    return ExprResolver(nullptr, nullptr)
+        .resolveScalarTypes(expr.expr(), inputResolver(schema));
+  };
+
+  auto nullLiteral = Lit(Variant::null(TypeKind::UNKNOWN), UNKNOWN());
+
+  EXPECT_EQ(*resolve(Col("p") && nullLiteral)->type(), *BOOLEAN());
+  EXPECT_EQ(*resolve(nullLiteral || Col("p"))->type(), *BOOLEAN());
+
+  // Non-boolean, non-unknown inputs remain rejected.
+  VELOX_ASSERT_THROW(
+      resolve(Col("p") && Col("a")),
+      "All inputs to AND and OR must be boolean");
+}
+
 TEST_F(ExprTest, aggregateExprDistinctOrderBy) {
   auto makeAggregate =
       [this](const ExprApi& expr, const std::vector<SortKey>& ordering = {}) {

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1925,56 +1925,81 @@ bool isRankingFunction(Name name, const FunctionNames& names) {
       name == names.denseRank;
 }
 
-// Extracts the ranking limit from a predicate of the form column <= N,
-// column < N, or column = 1, where 'windowColumn' is the output of
-// 'windowFunction' which must be a ranking function (row_number, rank, or
-// dense_rank). Returns std::nullopt if the predicate does not match.
-std::optional<int32_t> extractRankingLimit(
+// Result of analyzing a predicate against a ranking window function output.
+struct RankingPredicate {
+  enum class Kind {
+    // Predicate does not match a ranking upper-bound shape.
+    kNotRanking,
+    // Predicate is a ranking upper bound; absorb as TopN limit.
+    kAbsorbAsLimit,
+    // Predicate is a ranking upper bound on rank()/dense_rank() with no
+    // effective ORDER BY -- rank is always 1 and the predicate is
+    // tautological. Drop the predicate.
+    kTautological,
+  };
+
+  Kind kind{Kind::kNotRanking};
+  int32_t limit{0}; // Only valid for kAbsorbAsLimit.
+};
+
+// Analyzes a predicate of the form column <= N, column < N, or column = 1,
+// where 'windowColumn' is the output of 'windowFunction' which must be a
+// ranking function (row_number, rank, or dense_rank).
+RankingPredicate analyzeRankingPredicate(
     ExprCP expr,
     const FunctionNames& names,
     ColumnCP windowColumn,
     WindowFunctionCP windowFunction) {
   if (!expr->is(PlanType::kCallExpr)) {
-    return std::nullopt;
+    return {};
   }
 
   const auto* call = expr->as<Call>();
   const auto& args = call->args();
   if (args.size() != 2 || args[0] != windowColumn ||
       !args[1]->is(PlanType::kLiteralExpr)) {
-    return std::nullopt;
+    return {};
   }
 
   if (!isRankingFunction(windowFunction->name(), names)) {
-    return std::nullopt;
+    return {};
   }
 
   const auto& literal = args[1];
   const auto& literalType = literal->value().type;
   if (!literalType->isTinyint() && !literalType->isSmallint() &&
       !literalType->isInteger() && !literalType->isBigint()) {
-    return std::nullopt;
+    return {};
   }
 
   auto value = integerValue(&literal->as<Literal>()->literal());
   auto callName = call->name();
+  std::optional<int32_t> limit;
   // ranking_func() <= N → limit = N. Valid when N > 0.
   if (callName == names.lte && value > 0) {
-    return static_cast<int32_t>(value);
+    limit = static_cast<int32_t>(value);
+  } else if (callName == names.lt && value > 1) {
+    // ranking_func() < N → limit = N - 1. Valid when N > 1.
+    limit = static_cast<int32_t>(value - 1);
+  } else if (callName == names.equality && value == 1) {
+    // ranking_func() = 1 → limit = 1. TopNRowNumber returns rows 1..limit,
+    // so = N for N > 1 cannot be converted to a limit.
+    limit = 1;
   }
 
-  // ranking_func() < N → limit = N - 1. Valid when N > 1.
-  if (callName == names.lt && value > 1) {
-    return static_cast<int32_t>(value - 1);
+  if (!limit.has_value()) {
+    return {};
   }
 
-  // ranking_func() = 1 → limit = 1. TopNRowNumber returns rows 1..limit,
-  // so = N for N > 1 cannot be converted to a limit.
-  if (callName == names.equality && value == 1) {
-    return 1;
+  // For rank() / dense_rank(), if the effective ORDER BY is empty (all rows
+  // in a partition tie), the rank is always 1 and the upper-bound predicate
+  // matches every row. Drop it as tautological.
+  if (windowFunction->orderKeys().empty() &&
+      windowFunction->name() != names.rowNumber) {
+    return {RankingPredicate::Kind::kTautological, 0};
   }
 
-  return std::nullopt;
+  return {RankingPredicate::Kind::kAbsorbAsLimit, *limit};
 }
 
 } // namespace
@@ -2134,13 +2159,20 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
       if (windowPlan->functions().size() == 1 &&
           imported->columns().size() == 1 &&
           imported->columns().contains(windowPlan->columns()[0])) {
-        if (auto rankingLimit = extractRankingLimit(
-                imported,
-                queryCtx()->functionNames(),
-                windowPlan->columns()[0],
-                windowPlan->functions()[0])) {
-          windowPlan = windowPlan->withRankingLimit(*rankingLimit);
-          return true;
+        auto result = analyzeRankingPredicate(
+            imported,
+            queryCtx()->functionNames(),
+            windowPlan->columns()[0],
+            windowPlan->functions()[0]);
+        switch (result.kind) {
+          case RankingPredicate::Kind::kAbsorbAsLimit:
+            windowPlan = windowPlan->withRankingLimit(result.limit);
+            return true;
+          case RankingPredicate::Kind::kTautological:
+            // Predicate is true for every row; drop it.
+            return true;
+          case RankingPredicate::Kind::kNotRanking:
+            break;
         }
       }
       return false;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1144,11 +1144,12 @@ void Optimization::addPostprocess(
       VELOX_CHECK(found, "outputColumn not in columns: {}", column->toString());
     }
 
+    auto& projectInput = maybeDropProject(plan);
     plan = make<Project>(
-        maybeDropProject(plan),
+        projectInput,
         outputExprs,
         *dt->outputColumns,
-        Project::isRedundant(plan, outputExprs, *dt->outputColumns));
+        Project::isRedundant(projectInput, outputExprs, *dt->outputColumns));
   }
 
   if (!limitConsumedByWindow && !dt->hasOrderBy() &&

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1140,6 +1140,15 @@ ExprCP ToGraph::translateWindowExpr(const lp::WindowExpr& window) {
   frame.endType = lpFrame.endType;
   frame.endValue = lpFrame.endValue ? translateExpr(lpFrame.endValue) : nullptr;
 
+  // If ORDER BY was fully pruned (all keys overlapped with PARTITION BY),
+  // a frame end of CURRENT ROW (the default with ORDER BY) is meaningless --
+  // there is no ordering to define "current". Normalize to the no-ORDER-BY
+  // default of UNBOUNDED FOLLOWING (entire partition).
+  if (filteredOrderKeys.empty() && !orderKeys.empty() &&
+      frame.endType == lp::WindowExpr::BoundType::kCurrentRow) {
+    frame.endType = lp::WindowExpr::BoundType::kUnboundedFollowing;
+  }
+
   auto callName = toName(window.name());
   // Window functions are non-deterministic and have non-default null behavior.
   funcs = funcs | FunctionSet::kNonDeterministic |

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -799,5 +799,45 @@ TEST_F(RankingTest, partitionKeyFilterPartialMatch) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
+TEST_F(RankingTest, denseRankWithRedundantOrderBy) {
+  // dense_rank()/rank() OVER (PARTITION BY a, b ORDER BY a) -- the ORDER BY
+  // column is also in PARTITION BY, so within a partition all rows tie at
+  // rank 1. The 'rk = 1' predicate matches every row and is dropped; only
+  // the Window remains (no Filter, no TopNRowNumber).
+  constexpr auto sql =
+      "SELECT n_name FROM ("
+      "  SELECT n_name, dense_rank() "
+      "    OVER (PARTITION BY n_regionkey, n_name ORDER BY n_regionkey) AS rk "
+      "  FROM nation"
+      ") WHERE rk = 1";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher =
+      matchScan("nation")
+          .window({"dense_rank() OVER (PARTITION BY n_regionkey, n_name)"})
+          .project({"n_name"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(RankingTest, projectOnlyRankColumn) {
+  // SELECT projects only the ranking column. Verify the final Project
+  // narrows the TopNRowNumber output to a single column instead of leaking
+  // the partition/order keys.
+  constexpr auto sql =
+      "SELECT rn FROM ("
+      "  SELECT row_number() "
+      "    OVER (PARTITION BY n_regionkey ORDER BY n_name) AS rn "
+      "  FROM nation"
+      ") WHERE rn = 1";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({"n_regionkey"}, {"n_name"}, 1)
+                     .project({"rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1026,16 +1026,17 @@ TEST_F(SetTest, exceptUnionAll) {
       ")";
 
   // Each EXCEPT becomes anti-join + aggregation (distinct). The UNION ALL
-  // combines the two branches via LocalPartition. The second branch gets a
-  // rename project to align column names with the first branch.
+  // combines the two branches via LocalPartition. Both branches get a
+  // rename project to align column names through LocalPartition.
   auto matchExcept = [](const std::string& left, const std::string& right) {
     return matchScan(left)
         .hashJoin(matchScan(right).build(), core::JoinType::kAnti)
-        .singleAggregation();
+        .singleAggregation()
+        .project();
   };
 
   auto matcher = matchExcept("t", "u")
-                     .localPartition(matchExcept("u", "t").project().build())
+                     .localPartition(matchExcept("u", "t").build())
                      .singleAggregation()
                      .build();
 

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -73,11 +73,22 @@ SELECT a, sum(b) FROM t GROUP BY a ORDER BY row_number() OVER (ORDER BY a)
 -- Subquery with window function and outer filter.
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn = 1
 ----
+-- Outer SELECT projects only the ranking column.
+SELECT rn FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn = 1
+----
 -- Filter on ranking function output (rn <= N).
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn <= 1
 ----
 -- Filter on ranking function output (rn > N).
 SELECT a, b FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn > 1
+----
+-- dense_rank with ORDER BY column also in PARTITION BY + ranking filter. The
+-- ORDER BY is redundant (constant within partition), so dense_rank is always
+-- 1 and 'dr = 1' matches every row.
+SELECT a, b FROM (SELECT a, b, dense_rank() OVER (PARTITION BY a, b ORDER BY a) AS dr FROM t) WHERE dr = 1
+----
+-- Same as above but with rank().
+SELECT a, b FROM (SELECT a, b, rank() OVER (PARTITION BY a, b ORDER BY a) AS r FROM t) WHERE r = 1
 ----
 -- Window function combined with ORDER BY and LIMIT.
 -- ordered


### PR DESCRIPTION
Summary:

Planning failed with `Ranking filter limit not consumed by RowNumber or TopNRowNumber` for queries like:

```
SELECT a, b FROM (
  SELECT a, b, dense_rank() OVER (PARTITION BY a, b ORDER BY a) AS dr FROM t
) WHERE dr = 1
```

When the ORDER BY column appears in PARTITION BY, `ToGraph` prunes it as redundant. Within a partition every row ties at rank 1, so `WHERE dr = 1` is true for every row. Filter pushdown extracted a TopN limit, but `makeWindowOp` couldn't consume it: the TopNRowNumber branch requires non-empty `orderKeys`, and the RowNumber branch requires `kRowNumber`. Neither matched, and the `VELOX_CHECK` fired.

Three related issues, all on the same path:

1. **`ToGraph.cpp`** -- When ORDER BY is fully pruned, the frame still carries `CURRENT ROW` (the default for ORDER BY queries). That bound is meaningless without ordering. Normalize to `UNBOUNDED FOLLOWING` (the no-ORDER-BY default), so the resulting Window plan is well-formed.
2. **`DerivedTable.cpp`** -- Refactor `extractRankingLimit` into `analyzeRankingPredicate`, returning one of `kNotRanking`, `kAbsorbAsLimit`, `kTautological`. For rank/dense_rank with empty effective `orderKeys`, the upper-bound predicate is always true; classify as `kTautological` and drop the predicate.
3. **`Optimization.cpp`** -- Pre-existing bug. `Project::isRedundant` was checked against the original `plan` rather than `maybeDropProject(plan)` (the actual input that the new Project wraps). When the inner identity Project was dropped, the new Project was still flagged redundant despite its input now having more columns; `makeProject` later dropped it, leaking unprune'd columns to the top of the plan and tripping `addOutputRenames`. Surfaces with `SELECT <rank_col> FROM (... row_number ... AS rn) WHERE rn = 1`.

Reviewed By: xiaoxmeng

Differential Revision: D105369799
