### PR TITLE
fix: Apply CTE column-alias list in PrestoParser (#1373)

### DIFF
--- a/axiom/connectors/hive/LocalTableBuilder.cpp
+++ b/axiom/connectors/hive/LocalTableBuilder.cpp
@@ -281,10 +281,11 @@ void LocalTableBuilder::build(const std::string& tablePath) {
   folly::F14FastMap<std::string, ColumnStatistics> aggregatedStats;
 
   for (auto& info : files) {
-    velox::io::IoStatistics dataIoStats;
-    velox::io::IoStatistics metadataIoStats;
-    velox::dwio::common::ReaderOptions readerOptions{
-        pool_, &dataIoStats, &metadataIoStats};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    velox::dwio::common::ReaderOptions readerOptions{pool_};
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     readerOptions.setFileFormat(fileFormat_);
 
     if (fileFormat_ == velox::dwio::common::FileFormat::TEXT && tableType) {

--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -676,10 +676,11 @@ SpecialFormExpr::SpecialFormExpr(
           SpecialFormName::toName(form));
 
       for (const auto& input : inputs_) {
-        VELOX_USER_CHECK_EQ(
-            input->type()->kind(),
-            velox::TypeKind::BOOLEAN,
-            "All inputs to AND and OR must be boolean");
+        VELOX_USER_CHECK(
+            input->type()->kind() == velox::TypeKind::BOOLEAN ||
+                input->type()->kind() == velox::TypeKind::UNKNOWN,
+            "All inputs to AND and OR must be boolean, but got {}",
+            input->type()->toString());
       }
       break;
     case SpecialForm::kCast:

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -273,7 +273,9 @@ PlanBuilder& PlanBuilder::tableScan(
 
     originalNames.push_back(name);
     outputNames.push_back(newName(name));
-    outputMapping_->add(name, outputNames.back());
+    outputMapping_->add(
+        identifierCanonicalizer_ ? identifierCanonicalizer_(name) : name,
+        outputNames.back());
   };
 
   for (auto i = 0; i < schema->size(); ++i) {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -147,6 +147,14 @@ class PlanBuilder {
     /// override this with their dialect's coercer.
     const velox::TypeCoercer* coercer{nullptr};
 
+    /// Optional transform applied to user-facing column names introduced by
+    /// 'tableScan' before they are stored in the name lookup map. SQL
+    /// dialects with case-insensitive identifiers set this to a lowercasing
+    /// function so that case-insensitive references in the query body
+    /// resolve against connector-supplied column names. Defaults to
+    /// identity, leaving names as-is.
+    std::function<std::string(const std::string&)> identifierCanonicalizer;
+
     explicit Context(
         const std::optional<std::string>& defaultConnectorId = std::nullopt,
         const std::optional<std::string>& defaultSchema = std::nullopt,
@@ -209,6 +217,7 @@ class PlanBuilder {
         sqlParser_{context.sqlParser},
         allowAmbiguousOutputNames_{allowAmbiguousOutputNames},
         coercer_{context.coercer},
+        identifierCanonicalizer_{context.identifierCanonicalizer},
         resolver_{
             context.queryCtx,
             context.coercer,
@@ -856,6 +865,10 @@ class PlanBuilder {
   // in practice it's a static singleton (TypeCoercer::defaults() or a
   // dialect's coercer).
   const velox::TypeCoercer* coercer_;
+
+  // Optional transform applied to user-facing column names. See
+  // Context::identifierCanonicalizer.
+  std::function<std::string(const std::string&)> identifierCanonicalizer_;
 
   // Root of the plan tree built so far. Null before the first leaf node
   // (values or tableScan) is added.

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -67,6 +67,25 @@ TEST_F(ExprTest, looksConstant) {
   testLooksConstant(Cast(DOUBLE(), Col("a")), false);
 }
 
+TEST_F(ExprTest, conjunctAcceptsUnknownInput) {
+  // Mirror Velox's ConjunctExpr::resolveType, which accepts BOOLEAN or UNKNOWN.
+  auto schema = ROW({"p", "a"}, {BOOLEAN(), BIGINT()});
+  auto resolve = [&](const ExprApi& expr) {
+    return ExprResolver(nullptr, nullptr)
+        .resolveScalarTypes(expr.expr(), inputResolver(schema));
+  };
+
+  auto nullLiteral = Lit(Variant::null(TypeKind::UNKNOWN), UNKNOWN());
+
+  EXPECT_EQ(*resolve(Col("p") && nullLiteral)->type(), *BOOLEAN());
+  EXPECT_EQ(*resolve(nullLiteral || Col("p"))->type(), *BOOLEAN());
+
+  // Non-boolean, non-unknown inputs remain rejected.
+  VELOX_ASSERT_THROW(
+      resolve(Col("p") && Col("a")),
+      "All inputs to AND and OR must be boolean");
+}
+
 TEST_F(ExprTest, aggregateExprDistinctOrderBy) {
   auto makeAggregate =
       [this](const ExprApi& expr, const std::vector<SortKey>& ordering = {}) {

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1925,56 +1925,81 @@ bool isRankingFunction(Name name, const FunctionNames& names) {
       name == names.denseRank;
 }
 
-// Extracts the ranking limit from a predicate of the form column <= N,
-// column < N, or column = 1, where 'windowColumn' is the output of
-// 'windowFunction' which must be a ranking function (row_number, rank, or
-// dense_rank). Returns std::nullopt if the predicate does not match.
-std::optional<int32_t> extractRankingLimit(
+// Result of analyzing a predicate against a ranking window function output.
+struct RankingPredicate {
+  enum class Kind {
+    // Predicate does not match a ranking upper-bound shape.
+    kNotRanking,
+    // Predicate is a ranking upper bound; absorb as TopN limit.
+    kAbsorbAsLimit,
+    // Predicate is a ranking upper bound on rank()/dense_rank() with no
+    // effective ORDER BY -- rank is always 1 and the predicate is
+    // tautological. Drop the predicate.
+    kTautological,
+  };
+
+  Kind kind{Kind::kNotRanking};
+  int32_t limit{0}; // Only valid for kAbsorbAsLimit.
+};
+
+// Analyzes a predicate of the form column <= N, column < N, or column = 1,
+// where 'windowColumn' is the output of 'windowFunction' which must be a
+// ranking function (row_number, rank, or dense_rank).
+RankingPredicate analyzeRankingPredicate(
     ExprCP expr,
     const FunctionNames& names,
     ColumnCP windowColumn,
     WindowFunctionCP windowFunction) {
   if (!expr->is(PlanType::kCallExpr)) {
-    return std::nullopt;
+    return {};
   }
 
   const auto* call = expr->as<Call>();
   const auto& args = call->args();
   if (args.size() != 2 || args[0] != windowColumn ||
       !args[1]->is(PlanType::kLiteralExpr)) {
-    return std::nullopt;
+    return {};
   }
 
   if (!isRankingFunction(windowFunction->name(), names)) {
-    return std::nullopt;
+    return {};
   }
 
   const auto& literal = args[1];
   const auto& literalType = literal->value().type;
   if (!literalType->isTinyint() && !literalType->isSmallint() &&
       !literalType->isInteger() && !literalType->isBigint()) {
-    return std::nullopt;
+    return {};
   }
 
   auto value = integerValue(&literal->as<Literal>()->literal());
   auto callName = call->name();
+  std::optional<int32_t> limit;
   // ranking_func() <= N → limit = N. Valid when N > 0.
   if (callName == names.lte && value > 0) {
-    return static_cast<int32_t>(value);
+    limit = static_cast<int32_t>(value);
+  } else if (callName == names.lt && value > 1) {
+    // ranking_func() < N → limit = N - 1. Valid when N > 1.
+    limit = static_cast<int32_t>(value - 1);
+  } else if (callName == names.equality && value == 1) {
+    // ranking_func() = 1 → limit = 1. TopNRowNumber returns rows 1..limit,
+    // so = N for N > 1 cannot be converted to a limit.
+    limit = 1;
   }
 
-  // ranking_func() < N → limit = N - 1. Valid when N > 1.
-  if (callName == names.lt && value > 1) {
-    return static_cast<int32_t>(value - 1);
+  if (!limit.has_value()) {
+    return {};
   }
 
-  // ranking_func() = 1 → limit = 1. TopNRowNumber returns rows 1..limit,
-  // so = N for N > 1 cannot be converted to a limit.
-  if (callName == names.equality && value == 1) {
-    return 1;
+  // For rank() / dense_rank(), if the effective ORDER BY is empty (all rows
+  // in a partition tie), the rank is always 1 and the upper-bound predicate
+  // matches every row. Drop it as tautological.
+  if (windowFunction->orderKeys().empty() &&
+      windowFunction->name() != names.rowNumber) {
+    return {RankingPredicate::Kind::kTautological, 0};
   }
 
-  return std::nullopt;
+  return {RankingPredicate::Kind::kAbsorbAsLimit, *limit};
 }
 
 } // namespace
@@ -2134,13 +2159,20 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
       if (windowPlan->functions().size() == 1 &&
           imported->columns().size() == 1 &&
           imported->columns().contains(windowPlan->columns()[0])) {
-        if (auto rankingLimit = extractRankingLimit(
-                imported,
-                queryCtx()->functionNames(),
-                windowPlan->columns()[0],
-                windowPlan->functions()[0])) {
-          windowPlan = windowPlan->withRankingLimit(*rankingLimit);
-          return true;
+        auto result = analyzeRankingPredicate(
+            imported,
+            queryCtx()->functionNames(),
+            windowPlan->columns()[0],
+            windowPlan->functions()[0]);
+        switch (result.kind) {
+          case RankingPredicate::Kind::kAbsorbAsLimit:
+            windowPlan = windowPlan->withRankingLimit(result.limit);
+            return true;
+          case RankingPredicate::Kind::kTautological:
+            // Predicate is true for every row; drop it.
+            return true;
+          case RankingPredicate::Kind::kNotRanking:
+            break;
         }
       }
       return false;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1144,11 +1144,12 @@ void Optimization::addPostprocess(
       VELOX_CHECK(found, "outputColumn not in columns: {}", column->toString());
     }
 
+    auto& projectInput = maybeDropProject(plan);
     plan = make<Project>(
-        maybeDropProject(plan),
+        projectInput,
         outputExprs,
         *dt->outputColumns,
-        Project::isRedundant(plan, outputExprs, *dt->outputColumns));
+        Project::isRedundant(projectInput, outputExprs, *dt->outputColumns));
   }
 
   if (!limitConsumedByWindow && !dt->hasOrderBy() &&

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1140,6 +1140,15 @@ ExprCP ToGraph::translateWindowExpr(const lp::WindowExpr& window) {
   frame.endType = lpFrame.endType;
   frame.endValue = lpFrame.endValue ? translateExpr(lpFrame.endValue) : nullptr;
 
+  // If ORDER BY was fully pruned (all keys overlapped with PARTITION BY),
+  // a frame end of CURRENT ROW (the default with ORDER BY) is meaningless --
+  // there is no ordering to define "current". Normalize to the no-ORDER-BY
+  // default of UNBOUNDED FOLLOWING (entire partition).
+  if (filteredOrderKeys.empty() && !orderKeys.empty() &&
+      frame.endType == lp::WindowExpr::BoundType::kCurrentRow) {
+    frame.endType = lp::WindowExpr::BoundType::kUnboundedFollowing;
+  }
+
   auto callName = toName(window.name());
   // Window functions are non-deterministic and have non-default null behavior.
   funcs = funcs | FunctionSet::kNonDeterministic |

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -799,5 +799,45 @@ TEST_F(RankingTest, partitionKeyFilterPartialMatch) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
+TEST_F(RankingTest, denseRankWithRedundantOrderBy) {
+  // dense_rank()/rank() OVER (PARTITION BY a, b ORDER BY a) -- the ORDER BY
+  // column is also in PARTITION BY, so within a partition all rows tie at
+  // rank 1. The 'rk = 1' predicate matches every row and is dropped; only
+  // the Window remains (no Filter, no TopNRowNumber).
+  constexpr auto sql =
+      "SELECT n_name FROM ("
+      "  SELECT n_name, dense_rank() "
+      "    OVER (PARTITION BY n_regionkey, n_name ORDER BY n_regionkey) AS rk "
+      "  FROM nation"
+      ") WHERE rk = 1";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher =
+      matchScan("nation")
+          .window({"dense_rank() OVER (PARTITION BY n_regionkey, n_name)"})
+          .project({"n_name"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(RankingTest, projectOnlyRankColumn) {
+  // SELECT projects only the ranking column. Verify the final Project
+  // narrows the TopNRowNumber output to a single column instead of leaking
+  // the partition/order keys.
+  constexpr auto sql =
+      "SELECT rn FROM ("
+      "  SELECT row_number() "
+      "    OVER (PARTITION BY n_regionkey ORDER BY n_name) AS rn "
+      "  FROM nation"
+      ") WHERE rn = 1";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({"n_regionkey"}, {"n_name"}, 1)
+                     .project({"rn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1026,16 +1026,17 @@ TEST_F(SetTest, exceptUnionAll) {
       ")";
 
   // Each EXCEPT becomes anti-join + aggregation (distinct). The UNION ALL
-  // combines the two branches via LocalPartition. The second branch gets a
-  // rename project to align column names with the first branch.
+  // combines the two branches via LocalPartition. Both branches get a
+  // rename project to align column names through LocalPartition.
   auto matchExcept = [](const std::string& left, const std::string& right) {
     return matchScan(left)
         .hashJoin(matchScan(right).build(), core::JoinType::kAnti)
-        .singleAggregation();
+        .singleAggregation()
+        .project();
   };
 
   auto matcher = matchExcept("t", "u")
-                     .localPartition(matchExcept("u", "t").project().build())
+                     .localPartition(matchExcept("u", "t").build())
                      .singleAggregation()
                      .build();
 

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -73,11 +73,22 @@ SELECT a, sum(b) FROM t GROUP BY a ORDER BY row_number() OVER (ORDER BY a)
 -- Subquery with window function and outer filter.
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn = 1
 ----
+-- Outer SELECT projects only the ranking column.
+SELECT rn FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn = 1
+----
 -- Filter on ranking function output (rn <= N).
 SELECT * FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn <= 1
 ----
 -- Filter on ranking function output (rn > N).
 SELECT a, b FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) WHERE rn > 1
+----
+-- dense_rank with ORDER BY column also in PARTITION BY + ranking filter. The
+-- ORDER BY is redundant (constant within partition), so dense_rank is always
+-- 1 and 'dr = 1' matches every row.
+SELECT a, b FROM (SELECT a, b, dense_rank() OVER (PARTITION BY a, b ORDER BY a) AS dr FROM t) WHERE dr = 1
+----
+-- Same as above but with rank().
+SELECT a, b FROM (SELECT a, b, rank() OVER (PARTITION BY a, b ORDER BY a) AS r FROM t) WHERE r = 1
 ----
 -- Window function combined with ORDER BY and LIMIT.
 -- ordered

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -789,7 +789,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       std::vector<std::string> names;
       names.reserve(lambda->arguments().size());
       for (const auto& arg : lambda->arguments()) {
-        names.emplace_back(arg->name()->value());
+        names.emplace_back(canonicalizeName(arg->name()->value()));
       }
 
       return lp::Lambda(names, toExpr(lambda->body()));

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -245,17 +245,25 @@ class RelationPlanner : public AstVisitor {
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql,
       bool friendlySql = true)
-      : context_{
-          defaultConnectorId,
-          defaultSchema,
-          /*queryCtxPtr=*/nullptr,
-          /*hook=*/nullptr,
-          std::make_shared<lp::ThrowingSqlExpressionsParser>(),
-          &::facebook::velox::functions::prestosql::typeCoercer()},
+      : context_{makePrestoContext(defaultConnectorId, defaultSchema)},
         defaultSchema_{defaultSchema},
         parseSql_{parseSql},
         builder_(newBuilder()),
         friendlySql_{friendlySql} {}
+
+  static lp::PlanBuilder::Context makePrestoContext(
+      const std::string& defaultConnectorId,
+      const std::string& defaultSchema) {
+    lp::PlanBuilder::Context ctx{
+        defaultConnectorId,
+        defaultSchema,
+        /*queryCtxPtr=*/nullptr,
+        /*hook=*/nullptr,
+        std::make_shared<lp::ThrowingSqlExpressionsParser>(),
+        &::facebook::velox::functions::prestosql::typeCoercer()};
+    ctx.identifierCanonicalizer = &canonicalizeName;
+    return ctx;
+  }
 
   lp::LogicalPlanNodePtr plan() {
     return builder_->build();

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -431,6 +431,12 @@ class RelationPlanner : public AstVisitor {
       };
       // TODO: Change WithQuery to store Query and not Statement.
       processQuery(dynamic_cast<Query*>(withEntry->query().get()));
+
+      // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
+      // the underlying SELECT/VALUES output columns to a, b.
+      if (const auto& columnAliases = withEntry->columnNames()) {
+        applyColumnAliases(*columnAliases, withEntry->location(), tableName);
+      }
     } else {
       const auto [connectorId, connectorTable] = toConnectorTable(
           *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
@@ -494,6 +500,30 @@ class RelationPlanner : public AstVisitor {
     builder_->sample(percentage.expr(), sampleMethod);
   }
 
+  // Renames the current builder output columns to match a user-supplied
+  // column-alias list (from 'WITH cte(c1, c2) AS (...)' or
+  // '(SELECT ...) AS r(c1, c2)'). Adds a Project node.
+  void applyColumnAliases(
+      const std::vector<std::shared_ptr<Identifier>>& columnAliases,
+      const NodeLocation& location,
+      const std::string& token) {
+    const auto outputNames = builder_->findOrAssignOutputNames();
+    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+        columnAliases.size(),
+        outputNames.size(),
+        location,
+        token,
+        "Column alias list size does not match the number of output columns");
+
+    std::vector<lp::ExprApi> renames;
+    renames.reserve(outputNames.size());
+    for (auto i = 0; i < outputNames.size(); ++i) {
+      auto name = canonicalizeIdentifier(*columnAliases.at(i));
+      renames.push_back(outputNames[i].toCol().as(name));
+    }
+    builder_->project(renames);
+  }
+
   void processAliasedRelation(const AliasedRelation& aliasedRelation) {
     processFrom(aliasedRelation.relation());
 
@@ -501,27 +531,7 @@ class RelationPlanner : public AstVisitor {
 
     const auto& columnAliases = aliasedRelation.columnNames();
     if (!columnAliases.empty()) {
-      const size_t numOutput = builder_->numOutput();
-      AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
-          columnAliases.size(),
-          numOutput,
-          aliasedRelation.location(),
-          alias,
-          "Column alias list size does not match the number of columns available for '{}'",
-          alias);
-
-      // Add projection to rename columns. Column aliases override output
-      // names from the inner subquery.
-      std::vector<lp::ExprApi> renames;
-      renames.reserve(numOutput);
-
-      for (auto i = 0; i < numOutput; ++i) {
-        auto name = canonicalizeIdentifier(*columnAliases.at(i));
-        auto outputColumn = builder_->findOrAssignOutputNameAt(i);
-        renames.push_back(outputColumn.toCol().as(name));
-      }
-
-      builder_->project(renames);
+      applyColumnAliases(columnAliases, aliasedRelation.location(), alias);
     }
 
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1034,5 +1034,18 @@ TEST_F(ExpressionParserTest, bigintToRealCoercion) {
   EXPECT_EQ(*REAL(), *parseExpr("real '1' / bigint '2'")->type());
 }
 
+// SQL identifiers are case-insensitive: a column declared with mixed case
+// in the table schema must resolve when referenced with any case.
+TEST_F(ExpressionParserTest, mixedCaseColumnName) {
+  connector_->addTable("mixedCase", ROW({"orderingId"}, {BIGINT()}));
+
+  ASSERT_NO_THROW(testSelect(
+      "SELECT orderingId FROM mixedCase", matchScan().project().output()));
+  ASSERT_NO_THROW(testSelect(
+      "SELECT orderingid FROM mixedCase", matchScan().project().output()));
+  ASSERT_NO_THROW(testSelect(
+      "SELECT ORDERINGID FROM mixedCase", matchScan().project().output()));
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1023,6 +1023,10 @@ TEST_F(ExpressionParserTest, lambda) {
   // array_sort w/ comparator.
   ASSERT_NO_THROW(parseExpr(
       "array_sort(array[3, 1, 2], (x, y) -> IF(x < y, -1, IF(x > y, 1, 0)))"));
+
+  // Mixed-case lambda parameter names.
+  ASSERT_NO_THROW(
+      parseExpr("reduce(array[1,2,3], 0, (x, fooBar) -> x + fooBar, s -> s)"));
 }
 
 // Presto allows BIGINT -> REAL coercion: real / bigint returns REAL.

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -465,6 +465,18 @@ TEST_F(PrestoParserTest, withMultipleCtes) {
       matchScan().project().output({"n_nationkey", "n_name"}));
 }
 
+TEST_F(PrestoParserTest, withColumnAliases) {
+  auto matcher =
+      lp::test::LogicalPlanMatcherBuilder().values().project().project().output(
+          {"a", "b"});
+  testSelect("WITH t(a, b) AS (VALUES (1, 'x')) SELECT a, b FROM t", matcher);
+
+  // Mismatched alias-list size is rejected.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("WITH t(a, b) AS (VALUES (1)) SELECT * FROM t"),
+      "Column alias list size does not match the number of output columns");
+}
+
 TEST_F(PrestoParserTest, withReferencedMultipleTimes) {
   // Same CTE referenced twice in a JOIN.
   auto matcher = matchScan()


### PR DESCRIPTION
Summary:

`WITH t(a, b) AS (VALUES (1, 'x')) SELECT a, b FROM t` failed with `Cannot resolve column: a not in [t.c0, t.c1, c0, c1]`. The `WITH cte(col1, col2) AS (...)` syntax renames the underlying SELECT/VALUES output columns, but `PrestoParser` processed the CTE body via `processQuery` and never consulted `WithQuery::columnNames()`. Column references to the aliased names failed to resolve because the mapping still held the original names from the inner query.

Mirror the existing `AliasedRelation` path (`(SELECT ...) AS r(col1, col2)`): after processing the CTE body, if `WithQuery::columnNames()` is set, insert a `Project` that renames each output column to the user-supplied alias.

Reviewed By: xiaoxmeng

Differential Revision: D105380486
