### PR TITLE
feat(connector): Expose affinity ID in connector splits (#1374)

### DIFF
--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -25,9 +25,13 @@ namespace facebook::axiom::connector {
 
 class PartitionType;
 
-/// Wraps a Velox ConnectorSplit with an optional group ID for bucketed
-/// execution routing. Splits with the same groupId are routed to the same
-/// task. When unset, the runtime is free to assign the split to any task.
+/// Wraps a Velox ConnectorSplit with optional placement metadata. groupId is a
+/// hard within-query routing constraint for grouped execution: splits with the
+/// same groupId are routed to the same task. affinityId is a soft cross-query
+/// affinity hint: schedulers prefer to route splits with the same affinityId
+/// to the same task, but may choose another task for load balancing. When both
+/// are present, grouped-execution routing through groupId takes precedence
+/// over affinityId.
 struct Split {
   /// The underlying Velox connector split.
   std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
@@ -35,6 +39,13 @@ struct Split {
   /// Group ID for bucketed routing; splits sharing a groupId are routed to
   /// the same task. Absent means any task may handle this split.
   std::optional<int32_t> groupId{std::nullopt};
+
+  /// Stable connector-generated affinity ID for split affinity. Connectors
+  /// that support split affinity must generate the same ID for repeated reads
+  /// of the same physical split input. Different physical splits may share an
+  /// affinityId; such collisions only cause them to share a preferred task. If
+  /// unset, no affinityId-based placement hint is available for this split.
+  std::optional<int64_t> affinityId{std::nullopt};
 };
 
 /// A batch of splits returned by SplitSource::co_getSplits.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -390,7 +390,8 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
             "Bucketed scan requires bucketNumber on every file");
         groupId = info->bucketNumber.value() % partitionType_->numPartitions();
       }
-      batch.splits.push_back(Split{builder.build(), groupId});
+      batch.splits.push_back(
+          Split{.connectorSplit = builder.build(), .groupId = groupId});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -128,7 +128,8 @@ folly::coro::Task<SplitBatch> SystemSplitSource::co_getSplits(
     uint32_t /*maxSplitCount*/) {
   SplitBatch batch;
   if (!done_) {
-    batch.splits.push_back(Split{std::make_shared<SystemSplit>(connectorId_)});
+    batch.splits.push_back(
+        Split{.connectorSplit = std::make_shared<SystemSplit>(connectorId_)});
     done_ = true;
   }
   batch.noMoreSplits = true;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -405,7 +405,8 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
       VELOX_CHECK_LT(i, dataBucketIds_.size());
       groupId = dataBucketIds_[i] % partitionType_->numPartitions();
     }
-    batch.splits.push_back(Split{std::move(split), groupId});
+    batch.splits.push_back(
+        Split{.connectorSplit = std::move(split), .groupId = groupId});
   }
   nextOffset_ = end;
   batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -116,8 +116,10 @@ folly::coro::Task<SplitBatch> TpchSplitSource::co_getSplits(
       std::min(nextSplitIdx_ + static_cast<int64_t>(maxSplitCount), numSplits_);
   for (auto i = nextSplitIdx_; i < end; ++i) {
     batch.splits.push_back(
-        Split{std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
-            connectorId_, numSplits_, i)});
+        Split{
+            .connectorSplit =
+                std::make_shared<velox::connector::tpch::TpchConnectorSplit>(
+                    connectorId_, numSplits_, i)});
   }
   nextSplitIdx_ = end;
   batch.noMoreSplits = (nextSplitIdx_ >= numSplits_);

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -43,7 +43,8 @@ class SimpleSplitSource : public connector::SplitSource {
     auto end = std::min(
         nextIndex_ + static_cast<size_t>(maxSplitCount), splits_.size());
     for (auto i = nextIndex_; i < end; ++i) {
-      batch.splits.push_back(connector::Split{std::move(splits_[i])});
+      batch.splits.push_back(
+          connector::Split{.connectorSplit = std::move(splits_.at(i))});
     }
     nextIndex_ = end;
     batch.noMoreSplits = (nextIndex_ >= splits_.size());


### PR DESCRIPTION
Summary:

Axiom already carries `Split::groupId` for grouped execution. `groupId` is a hard within-query routing constraint: splits with the same `groupId` must be routed to the same task. A scheduler may additionally use groupId for cross-query affinity. But groupId only exists for grouped execution.

This change adds `Split::affinityId` for  non-grouped scans that want soft cross-query affinity. Connectors that can derive a stable value for the same physical split input may populate it, and connectors that cannot leave it unset. The scheduler may prefer routing splits with the same `affinityId` on the same task. 

The Axiom split shape remains a simple aggregate: `connectorSplit`, optional `groupId`, and optional `affinityId`. When both `groupId` and `affinityId` are present, grouped-execution placement through `groupId` takes precedence. `affinityId` generation is left to connector implementation

Reviewed By: mbasmanova

Differential Revision: D105350177


