### PR TITLE
fix: Convert ANTLR codepoint indices to byte offsets in splitStatements (#1375)

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1364,6 +1364,34 @@ std::vector<SqlStatementPtr> PrestoParser::parseMultiple(
   return results;
 }
 
+// Returns the byte offset in 'utf8' that corresponds to the given UTF-32
+// codepoint index. ANTLR's getStartIndex/getStopIndex return codepoint
+// offsets, but std::string_view::substr operates on bytes, so they must be
+// converted before slicing.
+size_t codepointToByteOffset(std::string_view utf8, size_t codepointIndex) {
+  size_t byteOffset = 0;
+  size_t cp = 0;
+  while (cp < codepointIndex && byteOffset < utf8.size()) {
+    auto c = static_cast<unsigned char>(utf8[byteOffset]);
+    size_t step;
+    if (c < 0x80) {
+      step = 1;
+    } else if ((c & 0xe0) == 0xc0) {
+      step = 2;
+    } else if ((c & 0xf0) == 0xe0) {
+      step = 3;
+    } else if ((c & 0xf8) == 0xf0) {
+      step = 4;
+    } else {
+      VELOX_USER_FAIL(
+          "Invalid UTF-8 start byte at offset {}: {:#x}", byteOffset, c);
+    }
+    byteOffset += step;
+    ++cp;
+  }
+  return byteOffset;
+}
+
 std::vector<std::string_view> PrestoParser::splitStatements(
     std::string_view sql) {
   std::vector<std::string_view> statements;
@@ -1386,10 +1414,12 @@ std::vector<std::string_view> PrestoParser::splitStatements(
     if (token->getText() == ";") {
       // Find the last token before the semicolon (on default channel)
       if (i > statementStart) {
-        size_t startIndex = tokenStream.get(statementStart)->getStartIndex();
-        size_t endIndex = tokenStream.get(i - 1)->getStopIndex();
+        size_t startIndex = codepointToByteOffset(
+            sql, tokenStream.get(statementStart)->getStartIndex());
+        size_t endIndex = codepointToByteOffset(
+            sql, tokenStream.get(i - 1)->getStopIndex() + 1);
 
-        auto stmt = sql.substr(startIndex, endIndex - startIndex + 1);
+        auto stmt = sql.substr(startIndex, endIndex - startIndex);
 
         while (!stmt.empty() && std::isspace(stmt.front())) {
           stmt.remove_prefix(1);
@@ -1416,10 +1446,12 @@ std::vector<std::string_view> PrestoParser::splitStatements(
     }
 
     if (lastTokenIdx >= statementStart) {
-      size_t startIndex = tokenStream.get(statementStart)->getStartIndex();
-      size_t endIndex = tokenStream.get(lastTokenIdx)->getStopIndex();
+      size_t startIndex = codepointToByteOffset(
+          sql, tokenStream.get(statementStart)->getStartIndex());
+      size_t endIndex = codepointToByteOffset(
+          sql, tokenStream.get(lastTokenIdx)->getStopIndex() + 1);
 
-      auto stmt = sql.substr(startIndex, endIndex - startIndex + 1);
+      auto stmt = sql.substr(startIndex, endIndex - startIndex);
 
       while (!stmt.empty() && std::isspace(stmt.front())) {
         stmt.remove_prefix(1);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -70,6 +70,54 @@ TEST_F(PrestoParserTest, parseMultipleWithComments) {
   ASSERT_TRUE(statements[1]->isSelect());
 }
 
+TEST_F(PrestoParserTest, parseMultipleWithMultiByteUtf8Char) {
+  // Multi-byte UTF-8 characters anywhere in the input must not cause the
+  // lexer to lose subsequent tokens. ANTLR token positions are codepoint
+  // indices, but splitStatements slices the original UTF-8 string and so
+  // must convert codepoint offsets to byte offsets.
+  auto parser = makeParser();
+
+  // 2-byte UTF-8 (U+00F1) in a leading comment.
+  {
+    auto statements = parser.parseMultiple("-- ñ\nSELECT 1");
+    ASSERT_EQ(1, statements.size());
+    ASSERT_TRUE(statements[0]->isSelect());
+  }
+
+  // 2-byte UTF-8 in a string literal.
+  {
+    auto statements = parser.parseMultiple("SELECT 'ñ'; SELECT 1");
+    ASSERT_EQ(2, statements.size());
+    ASSERT_TRUE(statements[0]->isSelect());
+    ASSERT_TRUE(statements[1]->isSelect());
+  }
+
+  // 3-byte UTF-8 (U+20AC '€') in a comment between statements.
+  {
+    auto statements = parser.parseMultiple("SELECT 1; -- €\nSELECT 2");
+    ASSERT_EQ(2, statements.size());
+    ASSERT_TRUE(statements[0]->isSelect());
+    ASSERT_TRUE(statements[1]->isSelect());
+  }
+
+  // Multiple multi-byte chars to exercise cumulative offset shift.
+  {
+    auto statements =
+        parser.parseMultiple("-- ñ ñ ñ\nSELECT 'ä' AS x; SELECT 'ö' AS y");
+    ASSERT_EQ(2, statements.size());
+    ASSERT_TRUE(statements[0]->isSelect());
+    ASSERT_TRUE(statements[1]->isSelect());
+  }
+
+  // 4-byte UTF-8 (U+1F389 '🎉') in a comment between statements.
+  {
+    auto statements = parser.parseMultiple("SELECT 1; -- 🎉\nSELECT 2");
+    ASSERT_EQ(2, statements.size());
+    ASSERT_TRUE(statements[0]->isSelect());
+    ASSERT_TRUE(statements[1]->isSelect());
+  }
+}
+
 TEST_F(PrestoParserTest, parseMultipleWithBlockComments) {
   auto parser = makeParser();
 


### PR DESCRIPTION
Summary:

`PrestoParser::splitStatements` sliced the original UTF-8 SQL with `sql.substr(startIndex, length)` where `startIndex` and `length` came from ANTLR's `Token::getStartIndex()` / `getStopIndex()`. Those return **UTF-32 codepoint** offsets, but `string_view::substr` operates on **bytes**. Any non-ASCII character earlier in the input shifted byte offsets, so the sliced statement was truncated by one byte per extra-byte UTF-8 character.

Symptoms varied:
- Single statement with a multi-byte char (e.g. `-- ñ\nSELECT 1`): the trailing `1` was dropped, producing a syntax error.
- Multi-row VALUES with non-ASCII content (e.g. `'Lorelie Cañete'`): later identifier references in the query got truncated, producing `Cannot resolve column: <truncated>` errors.

Add `codepointToByteOffset(utf8, codepointIndex)` that walks the UTF-8 string, classifies each leading byte (1/2/3/4-byte sequence) and advances the codepoint counter. `VELOX_USER_FAIL` on invalid UTF-8 lead bytes -- silently advancing would mask future bugs. Apply the conversion at both `substr` call sites in `splitStatements` (mid-statement `;` boundary and final-statement path).

Reviewed By: amitkdutta

Differential Revision: D105386373


