### PR TITLE
fix(parser): Preserve qualifier when it names a lambda parameter (#1376)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/ExpressionPlanner.h"
+#include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <algorithm>
 #include <cctype>
@@ -373,9 +374,18 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       if (dereference->base()->is(NodeType::kIdentifier)) {
         auto qualifier =
             canonicalizeIdentifier(*dereference->base()->as<Identifier>());
+        // A lambda parameter shadows any outer alias of the same name, so
+        // the qualifier must be preserved for ExprResolver to dereference it
+        // as a struct field of the parameter. Search innermost-first to
+        // match SQL lexical scoping.
+        const bool isLambdaParam = std::find(
+                                       lambdaParamScope_.rbegin(),
+                                       lambdaParamScope_.rend(),
+                                       qualifier) != lambdaParamScope_.rend();
         // Strip table qualifier when safe (not a struct field, name is
         // unambiguous).
-        if (shouldDropQualifier_ && shouldDropQualifier_(qualifier, field)) {
+        if (!isLambdaParam && shouldDropQualifier_ &&
+            shouldDropQualifier_(qualifier, field)) {
           return lp::Col(field);
         }
         return lp::Col(field, lp::Col(qualifier));
@@ -791,6 +801,13 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       for (const auto& arg : lambda->arguments()) {
         names.emplace_back(canonicalizeName(arg->name()->value()));
       }
+
+      const auto scopeBegin = lambdaParamScope_.size();
+      lambdaParamScope_.insert(
+          lambdaParamScope_.end(), names.begin(), names.end());
+      SCOPE_EXIT {
+        lambdaParamScope_.resize(scopeBegin);
+      };
 
       return lp::Lambda(names, toExpr(lambda->body()));
     }

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -138,6 +138,14 @@ class ExpressionPlanner {
   const std::unordered_map<std::string, facebook::velox::core::ExprPtr>*
       aliasExprs_{nullptr};
   const std::unordered_set<std::string>* columnNames_{nullptr};
+
+  // Lambda parameters currently in scope. Entries are appended on entering a
+  // lambda body and dropped on exit, so the vector grows from outermost
+  // (front) to innermost (back); lookups search back-to-front to match SQL
+  // lexical scoping. Used to prevent 'shouldDropQualifier_' from stripping
+  // the qualifier of 'x.field' when 'x' names a lambda parameter rather than
+  // an outer table alias.
+  std::vector<std::string> lambdaParamScope_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1029,6 +1029,19 @@ TEST_F(ExpressionParserTest, lambda) {
       parseExpr("reduce(array[1,2,3], 0, (x, fooBar) -> x + fooBar, s -> s)"));
 }
 
+// A lambda parameter named like an outer table alias shadows the alias
+// inside the lambda body: 'x.a' resolves to the field 'a' of the lambda
+// parameter 'x' (a ROW), not to the outer table's column 'a'.
+TEST_F(ExpressionParserTest, lambdaParameterShadowsTableAlias) {
+  connector_->addTable(
+      "t",
+      ROW({"a", "b"}, {ARRAY(BIGINT()), ARRAY(ROW("a", ARRAY(BIGINT())))}));
+
+  testSelect(
+      "SELECT FILTER(x.b, x -> x.a IS NOT NULL) FROM t x GROUP BY x.b",
+      matchScan().aggregate().project().output());
+}
+
 // Presto allows BIGINT -> REAL coercion: real / bigint returns REAL.
 TEST_F(ExpressionParserTest, bigintToRealCoercion) {
   EXPECT_EQ(*REAL(), *parseExpr("real '1' / bigint '2'")->type());


### PR DESCRIPTION
Summary:

`ExpressionPlanner::toExpr` strips the qualifier from `x.a` whenever `shouldDropQualifier_(qualifier, field)` returns true (qualifier is a table alias and `field` is unambiguous). The check looks only at the outer schema and has no awareness of lambda parameter scope, so it stripped the qualifier inside `x -> x.a` when an outer table aliased `x` also had a column `a`. The lambda body's `x.a` then resolved against the outer scope instead of the lambda parameter:

- Without GROUP BY: silently resolved to the outer column `a` (semantic bug, types matched by coincidence).
- With GROUP BY removing `a` from scope: visible `Cannot resolve column: a` error in `ExprResolver`.

Track in-scope lambda parameter names in a stack on `ExpressionPlanner` (push on entering a `LambdaExpression` body, pop on exit). In the `DereferenceExpression` case, when the base is a bare identifier, skip the qualifier-drop optimization if the qualifier matches an in-scope lambda parameter. The qualifier is preserved as `Col(field, Col(qualifier))`, and `ExprResolver` falls through to its existing struct-dereference path: resolve `qualifier` as a value (the lambda parameter, a ROW), then dereference `field` as a ROW field.

Reviewed By: xiaoxmeng

Differential Revision: D105396267


