### PR TITLE
fix(parser): Recurse into field access when finding nested aggregates (#1377)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/ExpressionPlanner.h"
+#include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <algorithm>
 #include <cctype>
@@ -373,9 +374,18 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       if (dereference->base()->is(NodeType::kIdentifier)) {
         auto qualifier =
             canonicalizeIdentifier(*dereference->base()->as<Identifier>());
+        // A lambda parameter shadows any outer alias of the same name, so
+        // the qualifier must be preserved for ExprResolver to dereference it
+        // as a struct field of the parameter. Search innermost-first to
+        // match SQL lexical scoping.
+        const bool isLambdaParam = std::find(
+                                       lambdaParamScope_.rbegin(),
+                                       lambdaParamScope_.rend(),
+                                       qualifier) != lambdaParamScope_.rend();
         // Strip table qualifier when safe (not a struct field, name is
         // unambiguous).
-        if (shouldDropQualifier_ && shouldDropQualifier_(qualifier, field)) {
+        if (!isLambdaParam && shouldDropQualifier_ &&
+            shouldDropQualifier_(qualifier, field)) {
           return lp::Col(field);
         }
         return lp::Col(field, lp::Col(qualifier));
@@ -791,6 +801,13 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       for (const auto& arg : lambda->arguments()) {
         names.emplace_back(canonicalizeName(arg->name()->value()));
       }
+
+      const auto scopeBegin = lambdaParamScope_.size();
+      lambdaParamScope_.insert(
+          lambdaParamScope_.end(), names.begin(), names.end());
+      SCOPE_EXIT {
+        lambdaParamScope_.resize(scopeBegin);
+      };
 
       return lp::Lambda(names, toExpr(lambda->body()));
     }

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -138,6 +138,14 @@ class ExpressionPlanner {
   const std::unordered_map<std::string, facebook::velox::core::ExprPtr>*
       aliasExprs_{nullptr};
   const std::unordered_set<std::string>* columnNames_{nullptr};
+
+  // Lambda parameters currently in scope. Entries are appended on entering a
+  // lambda body and dropped on exit, so the vector grows from outermost
+  // (front) to innermost (back); lookups search back-to-front to match SQL
+  // lexical scoping. Used to prevent 'shouldDropQualifier_' from stripping
+  // the qualifier of 'x.field' when 'x' names a lambda parameter rather than
+  // an outer table alias.
+  std::vector<std::string> lambdaParamScope_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -143,6 +143,11 @@ void findAggregates(
     case core::IExpr::Kind::kInput:
       return;
     case core::IExpr::Kind::kFieldAccess:
+      // Field access can wrap any expression (e.g. 'max(x).y'), so recurse
+      // into children to find aggregates nested under a dereference.
+      for (const auto& input : expr->inputs()) {
+        findAggregates(input, aggregates, aggregateSet);
+      }
       return;
     case core::IExpr::Kind::kAggregate: {
       if (aggregateSet.emplace(expr).second) {

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -69,6 +69,15 @@ TEST_F(AggregationParserTest, simpleGroupBy) {
       parseSql("SELECT n_name AS x FROM nation GROUP BY x"),
       "Cannot resolve column: x");
 
+  // Field access on an aggregate result: 'max(x).y' projects the field 'y'
+  // of the per-group max ROW.
+  {
+    connector_->addTable("t", ROW({"k", "x"}, {BIGINT(), ROW("y", BIGINT())}));
+    testSelect(
+        "SELECT MAX(x).y FROM t GROUP BY k",
+        matchScan().aggregate().project().output());
+  }
+
   // GROUP BY ordinal out of range.
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT 1 GROUP BY 1, 2"),

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1029,6 +1029,19 @@ TEST_F(ExpressionParserTest, lambda) {
       parseExpr("reduce(array[1,2,3], 0, (x, fooBar) -> x + fooBar, s -> s)"));
 }
 
+// A lambda parameter named like an outer table alias shadows the alias
+// inside the lambda body: 'x.a' resolves to the field 'a' of the lambda
+// parameter 'x' (a ROW), not to the outer table's column 'a'.
+TEST_F(ExpressionParserTest, lambdaParameterShadowsTableAlias) {
+  connector_->addTable(
+      "t",
+      ROW({"a", "b"}, {ARRAY(BIGINT()), ARRAY(ROW("a", ARRAY(BIGINT())))}));
+
+  testSelect(
+      "SELECT FILTER(x.b, x -> x.a IS NOT NULL) FROM t x GROUP BY x.b",
+      matchScan().aggregate().project().output());
+}
+
 // Presto allows BIGINT -> REAL coercion: real / bigint returns REAL.
 TEST_F(ExpressionParserTest, bigintToRealCoercion) {
   EXPECT_EQ(*REAL(), *parseExpr("real '1' / bigint '2'")->type());


### PR DESCRIPTION
Summary:

`GroupByPlanner::findAggregates` returned immediately on a `kFieldAccess` IExpr without recursing into its children. Field-access nodes wrap arbitrary expressions (e.g., `MAX(x).y` is `Dereference(MAX(x), "y")`), so an aggregate nested under a dereference was never discovered. The aggregate then never made it into `aggregateReplacements`, and the post-aggregation rewrite (`replaceInputs`) left the original `MAX(x)` IExpr in the projection. The downstream resolver tried to look up `x` against the post-GROUP-BY scope, which only contains grouping keys and aggregate outputs, and threw `Cannot resolve column: x`.

Recurse into the children of `kFieldAccess` in `findAggregates` so dereferences over aggregate calls — including the chained `MAX_BY(...).answers.satisfaction` shape used in production — are correctly extracted and substituted by their post-aggregation column references.

Reviewed By: xiaoxmeng

Differential Revision: D105405431


