### PR TITLE
fix(parser): Default DECIMAL without parameters to DECIMAL(38, 0)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -277,7 +277,12 @@ TypePtr parseType(const TypeSignaturePtr& type) {
   }
 
   std::vector<TypeParameter> parameters;
-  if (!type->parameters().empty()) {
+  if (baseName == "DECIMAL" && type->parameters().empty()) {
+    // DECIMAL without explicit precision/scale defaults to DECIMAL(38, 0),
+    // matching Presto's behavior.
+    parameters.emplace_back(static_cast<int32_t>(38));
+    parameters.emplace_back(static_cast<int32_t>(0));
+  } else if (!type->parameters().empty()) {
     const auto numParams = type->parameters().size();
     parameters.reserve(numParams);
 

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -26,21 +26,32 @@ namespace lp = facebook::axiom::logical_plan;
 namespace {
 namespace core = facebook::velox::core;
 
-// Indexes the SELECT-list projections by expression and by alias for
-// matching ORDER BY sort keys. An alias whose ordinal is 0 is ambiguous
-// (defined by more than one projection) and may only be used unambiguously.
+// Indexes the SELECT-list projections by expression and by output name for
+// matching ORDER BY sort keys. A name whose ordinal is 0 is ambiguous —
+// two or more projections share the name but produce different expressions
+// — and using it as a sort key fails. Two projections that share a name
+// but produce equal expressions (e.g. `SELECT t.a, t.a`) do not collide.
 struct ProjectionIndex {
   core::ExprMap<size_t> byExpr;
   folly::F14FastMap<std::string, size_t> byAlias;
 
   explicit ProjectionIndex(const std::vector<lp::ExprApi>& projections) {
+    core::IExprEqual exprEqual;
     for (size_t i = 0; i < projections.size(); ++i) {
       byExpr.emplace(projections[i].expr(), i + 1);
       if (projections[i].alias().has_value()) {
         auto [iter, inserted] =
             byAlias.emplace(projections[i].alias().value(), i + 1);
-        if (!inserted) {
-          iter->second = 0;
+        if (!inserted && iter->second != 0) {
+          // Two projections share the same output name. This is only
+          // ambiguous if they project different expressions; if both
+          // resolve to the same expression (e.g. `SELECT t.a, t.a`),
+          // either ordinal works for ORDER BY.
+          if (!exprEqual(
+                  projections[iter->second - 1].expr(),
+                  projections[i].expr())) {
+            iter->second = 0;
+          }
         }
       }
     }

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -104,6 +104,10 @@ TEST_F(ExpressionParserTest, types) {
   test("null as timestamp", TIMESTAMP());
   test("null as decimal(3, 2)", DECIMAL(3, 2));
   test("null as decimal(33, 10)", DECIMAL(33, 10));
+  // DECIMAL without parameters defaults to DECIMAL(38, 0), matching Presto.
+  test("null as decimal", DECIMAL(38, 0));
+  test("12 as decimal", DECIMAL(38, 0));
+  test("12.45 as decimal", DECIMAL(38, 0));
 
   facebook::velox::registerTDigestType();
   facebook::velox::registerQDigestType();

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -161,10 +161,7 @@ TEST_F(SortParserTest, nonSelectedColumn) {
     projections.insert(
         projections.end(), extraColumns.begin(), extraColumns.end());
 
-    auto builder = lp::test::LogicalPlanMatcherBuilder()
-                       .tableScan()
-                       .project(projections)
-                       .sort(sortKeys);
+    auto builder = matchScan().project(projections).sort(sortKeys);
 
     if (!extraColumns.empty()) {
       builder.project({"b", "a", "product", "x"});
@@ -194,8 +191,7 @@ TEST_F(SortParserTest, ambiguousAlias) {
 
   testSelect(
       "SELECT a as b, b FROM t ORDER BY c",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a as first_b", "b as second_b", "c"})
           .sort({"c"})
           .project({"first_b", "second_b"})
@@ -203,27 +199,45 @@ TEST_F(SortParserTest, ambiguousAlias) {
 
   testSelect(
       "SELECT a as b, b FROM t ORDER BY 1",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a as first_b", "b as second_b"})
           .sort({"first_b"})
           .output({"b", "b"}));
 
   testSelect(
       "SELECT a as b, b FROM t ORDER BY 2",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a as first_b", "b as second_b"})
           .sort({"second_b"})
           .output({"b", "b"}));
 
   testSelect(
       "SELECT a as b FROM t ORDER BY b",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
-          .project({"a as b"})
-          .sort({"b"})
-          .output({"b"}));
+      matchScan().project({"a as b"}).sort({"b"}).output({"b"}));
+
+  // SELECT entries that share an output name but project the same
+  // expression are not ambiguous: ORDER BY on the shared name resolves to
+  // the common expression. Works with a bare column, with a qualified
+  // column, with an expression, and with duplicates mixed with unique
+  // columns.
+  testSelect(
+      "SELECT a, a FROM t ORDER BY a",
+      matchScan().project({"a", "a as a_0"}).sort({"a"}).output({"a", "a"}));
+
+  testSelect(
+      "SELECT t.a, t.a FROM t ORDER BY t.a",
+      matchScan().project({"a", "a as a_0"}).sort({"a"}).output({"a", "a"}));
+
+  testSelect(
+      "SELECT a + 1, a + 1 FROM t ORDER BY a + 1",
+      matchScan().project().sort().output());
+
+  testSelect(
+      "SELECT a, b, a FROM t ORDER BY a",
+      matchScan()
+          .project({"a", "b", "a as a_0"})
+          .sort({"a"})
+          .output({"a", "b", "a"}));
 }
 
 TEST_F(SortParserTest, star) {
@@ -231,8 +245,7 @@ TEST_F(SortParserTest, star) {
 
   testSelect(
       "SELECT * FROM t ORDER BY 1, 3, e, f, a + c",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .sort({"a", "c", "e", "f", "a + c"})
           .output({"a", "b", "c", "d", "e", "f"}));
 }
@@ -244,8 +257,7 @@ TEST_F(SortParserTest, starWithHiddenColumn) {
   lp::LogicalPlanNodePtr outputNode;
   testSelect(
       "SELECT * FROM t ORDER BY \"$path\"",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .sort({"\"$path\""})
           .project([&](const auto& node) { outputNode = node; })
           .output({"a", "b"}));
@@ -260,9 +272,8 @@ TEST_F(SortParserTest, joinedTable) {
       "FROM nation, region "
       "WHERE n_regionkey = r_regionkey "
       "ORDER BY r_name",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
-          .join(lp::test::LogicalPlanMatcherBuilder().tableScan().build())
+      matchScan()
+          .join(matchScan().build())
           .filter()
           .project({"n_name", "r_name"})
           .sort({"r_name"})
@@ -272,12 +283,8 @@ TEST_F(SortParserTest, joinedTable) {
 
 TEST_F(SortParserTest, distinct) {
   connector_->addTable("t", ROW({"a", "b"}, INTEGER()));
-  auto matcher = lp::test::LogicalPlanMatcherBuilder()
-                     .tableScan()
-                     .project({"a"})
-                     .aggregate({"a"}, {})
-                     .sort({"a"})
-                     .output({"a"});
+  auto matcher =
+      matchScan().project({"a"}).aggregate({"a"}, {}).sort({"a"}).output({"a"});
 
   testSelect("SELECT DISTINCT a FROM t ORDER BY a", matcher);
   testSelect("SELECT DISTINCT a FROM t ORDER BY 1", matcher);
@@ -392,8 +399,7 @@ TEST_F(SortParserTest, differentExpressions) {
 
   testSelect(
       "SELECT a + b AS ab_sum FROM t ORDER BY a + c",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a + b as ab_sum", "a + c as ac_sum"})
           .sort({"ac_sum"})
           .project({"ab_sum"})
@@ -406,8 +412,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
 
   testSelect(
       "SELECT a * 2 AS b FROM t ORDER BY b * -1",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a * 2 as b", "a * 2 * -1 as sortFun"})
           .sort({"sortFun"})
           .project({"b"})
@@ -415,16 +420,11 @@ TEST_F(SortParserTest, outputAliasInExpression) {
 
   testSelect(
       "SELECT a * 2 AS b FROM t ORDER BY b",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
-          .project({"a * 2 as b"})
-          .sort({"b"})
-          .output({"b"}));
+      matchScan().project({"a * 2 as b"}).sort({"b"}).output({"b"}));
 
   testSelect(
       "SELECT a * -2 AS a FROM t ORDER BY a * -1",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a * -2 as selectFun", "a * -2 * -1 as sortFun"})
           .sort({"sortFun"})
           .project({"selectFun"})
@@ -432,8 +432,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
 
   testSelect(
       "SELECT a AS b, a * -2 AS c FROM t ORDER BY b + c",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"a as b", "a * -2 as c", "a + a * -2 as sortFun"})
           .sort({"sortFun"})
           .project({"b", "c"})
@@ -441,8 +440,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
 
   testSelect(
       "SELECT 1 AS x FROM t ORDER BY x + 1",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"1 as x", "1 + 1 as sortFun"})
           .sort({"sortFun"})
           .project({"x"})
@@ -454,8 +452,7 @@ TEST_F(SortParserTest, outputAliasInExpression) {
 
   testSelect(
       "SELECT 1 AS a, a FROM t2 ORDER BY b + 1",
-      lp::test::LogicalPlanMatcherBuilder()
-          .tableScan()
+      matchScan()
           .project({"1 as alias", "a as col", "b + 1 as sortFun"})
           .sort({"sortFun"})
           .project({"alias", "col"})


### PR DESCRIPTION
Summary: Match Presto: `CAST(x AS DECIMAL)` defaults to `DECIMAL(38, 0)` instead of failing the parametric-type arity check.

Differential Revision: D105438374


