### PR TITLE
fix(optimizer): Gather input to EnforceSingleRow (#1380)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1160,6 +1160,12 @@ void Optimization::addPostprocess(
   }
 
   if (dt->enforceSingleRow) {
+    // EnforceSingleRow requires gather input. Single-worker plans
+    // satisfy this by construction; no Repartition needed there.
+    if (!isSingleWorker_ && !plan->distribution().isGather()) {
+      plan = make<Repartition>(plan, Distribution::gather(), plan->columns());
+      state.addCost(*plan);
+    }
     auto enforceSingleRow = make<EnforceSingleRow>(plan);
     state.addCost(*enforceSingleRow);
     plan = enforceSingleRow;

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -1123,14 +1123,54 @@ TEST_F(SubqueryTest, enforceSingleRow) {
   }
 
   {
-    auto matcher =
-        matchHiveScan("region")
-            .nestedLoopJoin(
-                matchHiveScan("nation").enforceSingleRow().broadcast().build())
-            .filter()
-            .project()
-            .gather()
-            .build();
+    auto matcher = matchHiveScan("region")
+                       .nestedLoopJoin(matchHiveScan("nation")
+                                           .gather()
+                                           .enforceSingleRow()
+                                           .broadcast()
+                                           .build())
+                       .filter()
+                       .project()
+                       .gather()
+                       .build();
+
+    auto distributedPlan = planVelox(logicalPlan);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+  }
+}
+
+TEST_F(SubqueryTest, enforceSingleRowInProjection) {
+  auto query =
+      "SELECT (SELECT r_regionkey FROM region WHERE r_name = 'AFRICA') "
+      "FROM nation";
+  auto logicalPlan = parseSelect(query);
+
+  {
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("region", test::eq("r_name", "AFRICA"))
+                       .enforceSingleRow()
+                       .nestedLoopJoin(matchHiveScan("nation").build())
+                       .build();
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  {
+    // TODO: Plan has an extra fragment and an extra shuffle. A
+    // broadcast-then-EnforceSingleRow shape would collapse the gather
+    // + broadcast pair into a single broadcast with EnforceSingleRow
+    // running on each consumer.
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("region", test::eq("r_name", "AFRICA"))
+                       .gather()
+                       .enforceSingleRow()
+                       .nestedLoopJoin(
+                           core::PlanMatcherBuilder()
+                               .tableScan("nation")
+                               .broadcast()
+                               .build())
+                       .build();
 
     auto distributedPlan = planVelox(logicalPlan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -272,3 +272,7 @@ SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 ----
 -- Correlated NOT IN subquery with reversed operand order in correlation.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
+----
+-- Uncorrelated scalar subquery whose source needs runtime single-row
+-- enforcement. Returns one row per outer row.
+SELECT (SELECT u.a FROM u WHERE u.a = 1) FROM t


### PR DESCRIPTION
Summary:

In distributed plans, an EnforceSingleRow + cross-join pattern emitted (workers × drivers) × correct_rows. For example `SELECT (SELECT u.a FROM u WHERE u.a = 1) FROM t` over 15 t rows and 4 workers × 4 drivers returned 240 rows instead of 15.

EnforceSingleRow requires its input on a single task to validate the single-row contract. The planner now inserts a gather Repartition above any non-gather input to EnforceSingleRow (skipped in single-worker mode). Combined with the companion Velox change marking `EnforceSingleRowNode::requiresSingleThread()`, the resulting kSingle fragment runs as one task with one driver.

Differential Revision: D105507321
