### PR TITLE
fix(optimizer): Handle pure-outer correlation conjuncts in scalar / IN / EXISTS subqueries (#1383)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,6 +87,8 @@ for the complete guide. Key rules are summarized below.
 - Avoid redundant comments that repeat what the code already says. Comments should explain *why*, not *what*.
 - Use `// TODO: Description.` for future work. Do not include author's username.
 - Do not duplicate comments between `.h` and `.cpp`. Document the function in the header; the implementation should not repeat the same comment. Duplicated comments diverge over time.
+- Don't leave reasoning-scaffolding comments in committed code. Comments that capture the thought process — naming a sibling function, citing an example from a design discussion ("e.g. for COUNT-style aggregates"), framing the code defensively against an alternative path that was considered and rejected — are useful working notes while writing but rot quickly: they couple to other functions' internals and to ephemeral conversation context that a fresh reader doesn't share. Before committing, delete any comment that names another function and contrasts it ("X does Y; we do Z"), cites a specific operator/aggregate from discussion, describes a path you didn't take, or reads as a running narrative. Keep only comments that describe an invariant the code maintains or a non-obvious constraint a reader must know.
+- After trimming, re-read the function as a fresh reader and check the *other* failure mode: stripping every comment can leave branches whose intent is no longer visible. A silent `else` to a non-trivial `if/else-if` chain, a state mutation whose justification depends on a downstream call, a deliberate-looking "do nothing" — these usually need a one-line `// why` even after every scaffolding comment is gone. Brevity is not "zero comments"; it is "no comment that doesn't earn its line."
 
 ### Naming Conventions
 
@@ -152,6 +154,19 @@ Format: `[Project] type(scope): Description`
 - Types: `feat`, `fix`, `refactor`, `test`, `docs`
 - Scope is optional, use for subsystem clarity (e.g., `parser`, `optimizer`)
 - Description starts with a capital letter, no trailing period
+
+### Body length and shape
+
+A reviewer should be able to read the message in ~30 seconds and walk away knowing what behavior changed, why, and what is deliberately not done. Aim for the title plus 3-5 short paragraphs:
+
+1. **What changed and why** — one paragraph, with one example query or one before/after fact.
+2. **Mechanism** — one paragraph, the core idea (a new field, a rewrite step, a swapped algorithm). Not a function-by-function walkthrough; the diff is the source of truth.
+3. **Deferred / known limitations** — one short paragraph; name the case and how it surfaces (NYI message, commented-out test, follow-up task). Do not re-explain the design rationale for each deferral.
+4. **Test plan** — one paragraph. State the high-level coverage; the diff is the source of truth for the specific cases. Don't write "tests pass" — CI reports that. Only call out a buck command if it's a non-obvious target a reviewer should run locally.
+
+Avoid the reasoning journey: which sibling function got reused, which alternative paths were considered, which Layer-1 fix enabled which Layer-2 fix. That belongs in the design doc or PR thread, not the commit message. If a section keeps growing past a paragraph, it's usually a hint that the change should be split.
+
+References to issue trackers (GitHub issue numbers, internal task IDs) belong in dedicated metadata fields where your VCS / review tool supports them, not in the summary body. References that don't resolve for an external reader read as noise.
 
 ## Common Mistakes
 

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2024,6 +2024,25 @@ bool DerivedTable::isZeroRows() const {
       tables[0]->as<ValuesTable>()->cardinality() == 0;
 }
 
+bool DerivedTable::isSingleRowNoColumnsValues() const {
+  if (tables.size() != 1 || !tables[0]->is(PlanType::kValuesTableNode)) {
+    return false;
+  }
+  const auto* values = tables[0]->as<ValuesTable>();
+  return values->columns.empty() && values->cardinality() == 1;
+}
+
+bool DerivedTable::hasNoPostprocess() const {
+  // HAVING requires aggregation, so it is implied empty when aggregation
+  // is null.
+  return conjuncts.empty() && aggregation == nullptr && windowPlan == nullptr &&
+      !hasOrderBy() && !hasLimit() && !hasOffset();
+}
+
+bool DerivedTable::hasCardinalityNeutralPostprocess() const {
+  return conjuncts.empty() && having.empty() && !hasLimit() && !hasOffset();
+}
+
 void DerivedTable::clearState() {
   columns.clear();
   exprs.clear();

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -363,6 +363,10 @@ struct DerivedTable : public PlanObject {
     return limit >= 0;
   }
 
+  bool hasOffset() const {
+    return offset > 0;
+  }
+
   bool hasUnnestTable() const {
     return std::ranges::any_of(tables, [](PlanObjectCP table) {
       return table->is(PlanType::kUnnestTableNode);
@@ -376,6 +380,25 @@ struct DerivedTable : public PlanObject {
   /// Returns true if this DT is known to produce zero rows (e.g., an empty
   /// ValuesTable with no data).
   bool isZeroRows() const;
+
+  /// Returns true if 'tables' is exactly one ValuesTable that produces a
+  /// single row with no columns. Does not look at postprocessing.
+  bool isSingleRowNoColumnsValues() const;
+
+  /// Returns true if this DT has no postprocessing — no filter,
+  /// aggregation, having, window, order by, limit, or offset. See
+  /// 'Optimization::addPostprocess' for the corresponding planning step.
+  bool hasNoPostprocess() const;
+
+  /// Returns true if this DT's postprocessing has no filter, HAVING,
+  /// LIMIT, or OFFSET. Aggregation, window, or ORDER BY may still be
+  /// present.
+  ///
+  /// Caller contract: the result is cardinality-neutral only when the
+  /// input is a single row. Callers must guarantee single-row input
+  /// before relying on this method's claim — under multi-row input,
+  /// aggregation with GROUP BY reduces cardinality.
+  bool hasCardinalityNeutralPostprocess() const;
 
   /// Sets enforceSingleRow flag if this DT doesn't naturally guarantee
   /// single-row output. A global aggregation (no grouping keys) without

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3343,12 +3343,10 @@ ExprCP Optimization::combineLeftDeep(Name func, const ExprVector& exprs) {
     return left->id() < right->id();
   });
   ExprCP result = copy[0];
+  const bool specialForm = SpecialFormCallNames::isSpecialForm(func);
   for (auto i = 1; i < copy.size(); ++i) {
     result = toGraph_.deduppedCall(
-        func,
-        result->value(),
-        ExprVector{result, copy[i]},
-        result->functions() | copy[i]->functions());
+        func, result->value(), ExprVector{result, copy[i]}, specialForm);
   }
   return result;
 }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -269,6 +269,16 @@ class Call : public Expr {
       FunctionSet functions);
 
  public:
+  /// 'functions' should be the call's own function-property bits
+  /// (deterministic, default-null-behavior, aggregate kind, etc.)
+  /// OR-ed with each arg's 'functions()'. The Call ctor stores
+  /// 'functions' as-is and does not aggregate from args, so the caller
+  /// is responsible for OR-ing. 'functions' is queried by
+  /// 'containsFunction' to decide whether a subtree contains, e.g., a
+  /// non-deterministic call. Build the call's own bits with
+  /// 'functionBits(name, /*specialForm=*/false)' for regular function
+  /// calls and 'functionBits(name, /*specialForm=*/true)' for special
+  /// forms.
   Call(Name name, Value value, ExprVector args, FunctionSet functions)
       : Call(PlanType::kCallExpr, name, value, std::move(args), functions) {}
 
@@ -321,6 +331,11 @@ class Call : public Expr {
 
 using CallCP = const Call*;
 
+/// Canonical names for special-form calls. Each member is a stable
+/// 'Name' pointer that 'QueryGraphContext' pre-registers in its
+/// interning table, so 'toName("__and")' returns the same address as
+/// 'SpecialFormCallNames::kAnd'. Use these constants directly wherever
+/// a 'Name' is expected — no 'toName()' wrapper needed.
 struct SpecialFormCallNames {
   static const char* kAnd;
   static const char* kOr;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -20,6 +20,7 @@
 #include "axiom/logical_plan/ExprPrinter.h"
 #include "axiom/logical_plan/PlanPrinter.h"
 #include "axiom/optimizer/AggregationPlanner.h"
+#include "axiom/optimizer/DerivedTableFlattener.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
@@ -110,21 +111,131 @@ ToGraph::ToGraph(
   reversibleFunctions_[SpecialFormCallNames::kOr] = SpecialFormCallNames::kOr;
 }
 
-void ToGraph::addDtColumn(DerivedTableP dt, std::string_view name) {
-  const auto* inner = translateColumn(name);
+namespace {
+// Classifies which scope an expression references relative to a target
+// DerivedTable 'dt':
+//   - hasLocal: 'expr' touches a table that belongs to 'dt' (its tableSet,
+//     or 'dt' itself). These are the only references allowed by
+//     DerivedTable::checkConsistency.
+//   - hasCorrelation: 'expr' touches a table from an enclosing query
+//     scope. Only valid in subquery contexts where allowCorrelations_ was
+//     enabled around the subquery body's projection translation.
+struct DerivedTableScopeUse {
+  bool hasLocal{false};
+  bool hasCorrelation{false};
+};
 
-  ColumnCP outer = nullptr;
-  if (inner->isColumn() && inner->as<Column>()->relation() == dt &&
-      inner->as<Column>()->outputName() == name) {
-    outer = inner->as<Column>();
-  } else {
-    const auto* columnName = toName(name);
-    outer = make<Column>(columnName, dt, inner->value(), columnName);
+// True if 'table' belongs to a scope outside of 'dt' (neither 'dt'
+// itself nor a member of 'dt->tableSet').
+bool isOutsideDt(PlanObjectCP table, DerivedTableCP dt) {
+  return table != dt && !dt->tableSet.contains(table);
+}
+
+// True if 'tables' contains any object outside of 'dt'.
+bool anyOutsideDt(const PlanObjectSet& tables, DerivedTableCP dt) {
+  bool outside = false;
+  tables.forEach([&](PlanObjectCP table) {
+    if (isOutsideDt(table, dt)) {
+      outside = true;
+    }
+  });
+  return outside;
+}
+
+DerivedTableScopeUse classifyScope(ExprCP expr, DerivedTableP dt) {
+  DerivedTableScopeUse result;
+  expr->allTables().forEach([&](PlanObjectCP table) {
+    if (isOutsideDt(table, dt)) {
+      result.hasCorrelation = true;
+    } else {
+      result.hasLocal = true;
+    }
+  });
+  return result;
+}
+} // namespace
+
+void ToGraph::addDtColumn(DerivedTableP dt, std::string_view name) {
+  const auto* expr = translateColumn(name);
+
+  const auto scope = classifyScope(expr, dt);
+
+  if (scope.hasCorrelation) {
+    // Only reachable from a subquery scope: 'correlations_' must be set
+    // for translateColumn to have produced a non-local reference.
+    VELOX_DCHECK_NOT_NULL(
+        correlations_,
+        "Correlated reference outside a subquery scope: {}",
+        expr->toString());
+    ExprCP residual =
+        scope.hasLocal ? splitCorrelatedProjection(expr, dt) : expr;
+    applyContext_.lifted.projections.push_back(residual);
+    return;
   }
 
-  dt->exprs.push_back(inner);
-  dt->columns.push_back(outer);
-  renames_[name] = outer;
+  ColumnCP dtColumn = nullptr;
+  if (expr->isColumn() && expr->as<Column>()->relation() == dt &&
+      expr->as<Column>()->outputName() == name) {
+    dtColumn = expr->as<Column>();
+  } else {
+    const auto* columnName = toName(name);
+    dtColumn = make<Column>(columnName, dt, expr->value(), columnName);
+  }
+
+  dt->exprs.push_back(expr);
+  dt->columns.push_back(dtColumn);
+  renames_[name] = dtColumn;
+}
+
+ExprCP ToGraph::splitCorrelatedProjection(ExprCP expr, DerivedTableP dt) {
+  const auto scope = classifyScope(expr, dt);
+
+  // No local references: nothing to export to dt. Keep 'expr' inline in
+  // the residual. Covers pure constants and pure-correlation subtrees.
+  if (!scope.hasLocal) {
+    return expr;
+  }
+
+  if (!scope.hasCorrelation) {
+    // Maximal local-only subtree: export as a column on dt, reusing if
+    // it is already a Column on dt.
+    if (expr->is(PlanType::kColumnExpr) &&
+        expr->as<Column>()->relation() == dt) {
+      // Column may not yet be in dt->columns; register it so the outer
+      // scope can see it.
+      auto* column = expr->as<Column>();
+      if (std::find(dt->columns.begin(), dt->columns.end(), column) ==
+          dt->columns.end()) {
+        dt->exprs.push_back(expr);
+        dt->columns.push_back(column);
+      }
+      return expr;
+    }
+    auto* column = make<Column>(newCName("__cp"), dt, expr->value());
+    dt->exprs.push_back(expr);
+    dt->columns.push_back(column);
+    return column;
+  }
+
+  if (expr->is(PlanType::kCallExpr)) {
+    const auto* call = expr->as<Call>();
+    ExprVector newArgs;
+    newArgs.reserve(call->args().size());
+    for (auto* arg : call->args()) {
+      newArgs.push_back(splitCorrelatedProjection(arg, dt));
+    }
+    return deduppedCall(
+        call->name(),
+        call->value(),
+        std::move(newArgs),
+        SpecialFormCallNames::isSpecialForm(call->name()));
+  }
+
+  // Invariant: a mixed-scope expression at this point is a Call.
+  VELOX_UNREACHABLE(
+      "Mixed outer/inner subquery projection expression with unhandled "
+      "shape: {}",
+      expr->toString());
 }
 
 namespace {
@@ -862,7 +973,7 @@ ExprCP ToGraph::deduppedCall(
     Name name,
     Value value,
     ExprVector args,
-    FunctionSet flags) {
+    bool specialForm) {
   canonicalizeCall(name, args);
   ExprDedupKey key = {name, args, value.type};
 
@@ -870,11 +981,22 @@ ExprCP ToGraph::deduppedCall(
   if (it->second) {
     return it->second;
   }
+  FunctionSet flags = functionBits(name, specialForm);
+  for (auto* arg : args) {
+    flags = flags | arg->functions();
+  }
   auto* call = make<Call>(name, value, std::move(args), flags);
   if (emplaced && !call->containsNonDeterministic()) {
     it->second = call;
   }
   return call;
+}
+
+ExprCP ToGraph::makeEquality(ExprCP left, ExprCP right) {
+  return deduppedCall(
+      functionNames_.equality,
+      toValue(velox::BOOLEAN(), 2),
+      ExprVector{left, right});
 }
 
 namespace {
@@ -1036,7 +1158,6 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
       expr->isSpecialForm() ? expr->as<lp::SpecialFormExpr>() : nullptr;
 
   if (call || specialForm) {
-    FunctionSet funcs;
     const auto& inputs = expr->inputs();
     ExprVector args;
     args.reserve(inputs.size());
@@ -1046,9 +1167,6 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
       auto arg = translateExpr(input);
       args.emplace_back(arg);
       allConstant &= arg->is(PlanType::kLiteralExpr);
-      if (arg->is(PlanType::kCallExpr)) {
-        funcs = funcs | arg->as<Call>()->functions();
-      }
     }
 
     auto cardinality = estimateCallCardinality(args);
@@ -1061,11 +1179,10 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
       }
     }
 
-    auto callFuncs = functionBits(name, specialForm != nullptr);
-
     // Propagate null for default-null-behavior functions: if any argument is a
     // null literal, the result is null.
-    if (!callFuncs.contains(FunctionSet::kNonDefaultNullBehavior) &&
+    if (!functionBits(name, specialForm != nullptr)
+             .contains(FunctionSet::kNonDefaultNullBehavior) &&
         hasNullLiteral(args)) {
       return makeNullConstant(expr->type());
     }
@@ -1080,10 +1197,11 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
       }
     }
 
-    funcs = funcs | callFuncs;
-    auto* callExpr = deduppedCall(
-        name, Value(exprType, cardinality), std::move(args), funcs);
-    return callExpr;
+    return deduppedCall(
+        name,
+        Value(exprType, cardinality),
+        std::move(args),
+        specialForm != nullptr);
   }
 
   if (expr->isWindow()) {
@@ -1537,6 +1655,16 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   folly::F14FastMap<AggregateDedupKey, ColumnCP, AggregateDedupHasher>
       uniqueAggregates;
 
+  // Inside a subquery, allow aggregate arguments to resolve against
+  // outer-query columns.
+  const bool wasAllowCorrelations = allowCorrelations_;
+  if (correlations_ != nullptr) {
+    allowCorrelations_ = true;
+  }
+  SCOPE_EXIT {
+    allowCorrelations_ = wasAllowCorrelations;
+  };
+
   // The keys for intermediate are the same as for final.
   ColumnVector intermediateColumns = columns;
   for (auto channel : channels) {
@@ -1614,6 +1742,10 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
           std::move(orderKeys),
           std::move(orderTypes));
 
+      // Result columns are placed on 'currentDt_' here. The post-loop
+      // block below rewrites them to 'applyContext_.outerDt' if any
+      // aggregate in the plan references outer columns (the caller
+      // will then lift the whole plan there).
       auto* column =
           make<Column>(name, currentDt_, aggregateExpr->value(), name);
       columns.push_back(column);
@@ -1627,6 +1759,43 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       deduppedAggregates.push_back(aggregateExpr);
       it->second = column;
       newRenames[name] = column;
+    }
+  }
+
+  // If any aggregate in this plan references outer columns, the caller
+  // will lift the whole plan to 'applyContext_.outerDt' (see
+  // 'anyAggregateReferencesOuter' at the call site). Move all aggregate
+  // result columns there so the plan's output columns live on the
+  // attachment DT.
+  if (applyContext_.outerDt != nullptr &&
+      std::ranges::any_of(deduppedAggregates, [&](AggregateCP aggregate) {
+        return anyOutsideDt(aggregate->allTables(), currentDt_);
+      })) {
+    folly::F14FastMap<ColumnCP, ColumnCP> rewrite;
+    for (size_t i = numGroupingKeys; i < columns.size(); ++i) {
+      auto* column = columns[i];
+      auto* intermediate = intermediateColumns[i];
+      auto* newColumn = make<Column>(
+          column->name(),
+          applyContext_.outerDt,
+          column->value(),
+          column->alias());
+      auto* newIntermediate = make<Column>(
+          intermediate->name(),
+          applyContext_.outerDt,
+          intermediate->value(),
+          intermediate->alias());
+      rewrite[column] = newColumn;
+      columns[i] = newColumn;
+      intermediateColumns[i] = newIntermediate;
+    }
+    for (auto& [name, expr] : newRenames) {
+      if (expr->is(PlanType::kColumnExpr)) {
+        auto it = rewrite.find(expr->as<Column>());
+        if (it != rewrite.end()) {
+          expr = it->second;
+        }
+      }
     }
   }
 
@@ -1839,7 +2008,7 @@ lp::ExprPtr ToGraph::processLeftJoinSubqueries(
   makeQueryGraph(right, kAllAllowedInDt, /*orderObservedAbove=*/false);
   addFilter(right, combineConjuncts(std::move(subqueryConjuncts)));
 
-  if (!correlatedConjuncts_.empty()) {
+  if (!applyContext_.lifted.predicates.empty()) {
     VELOX_NYI(
         "Unsupported subqueries in the ON clause of a LEFT or RIGHT join");
   }
@@ -2040,7 +2209,8 @@ void ToGraph::wrapInDt(
 void ToGraph::finalizeDt(
     const lp::LogicalPlanNode& node,
     DerivedTableP outerDt) {
-  VELOX_CHECK_EQ(0, correlatedConjuncts_.size());
+  VELOX_CHECK_EQ(0, applyContext_.lifted.predicates.size());
+  VELOX_CHECK_EQ(0, applyContext_.lifted.projections.size());
 
   if (!outerDt) {
     outerDt = newDt();
@@ -2054,27 +2224,38 @@ void ToGraph::finalizeDt(
   currentDt_->addTable(dt);
 }
 
-void ToGraph::finalizeDtWithCorrelatedConjuncts(
+void ToGraph::finalizeDtPreservingCorrelations(
     const lp::LogicalPlanNode& node) {
-  if (correlatedConjuncts_.empty()) {
+  // Rewriting a deferred aggregate through a DT wrap is not supported.
+  VELOX_CHECK_NULL(
+      applyContext_.lifted.aggregation,
+      "Pending correlated aggregation during finalizeDtPreservingCorrelations is not supported yet");
+
+  if (applyContext_.lifted.predicates.empty() &&
+      applyContext_.lifted.projections.empty()) {
     finalizeDt(node);
     return;
   }
 
   // In correlated subqueries with nested aggregations (e.g., a correlated
   // scalar subquery over a source that has GROUP BY), the correlated filter
-  // between the two aggregations populates correlatedConjuncts_ before the
-  // outer aggregation triggers finalizeDt. After wrapping, rewrite the
-  // conjuncts so their inner column references point to the wrapped DT's
-  // output columns rather than deeply nested base-table columns.
+  // between the two aggregations populates applyContext_.lifted.predicates
+  // before the outer aggregation triggers finalizeDt. After wrapping, rewrite
+  // the conjuncts so their inner column references point to the wrapped DT's
+  // output columns rather than deeply nested base-table columns. The same
+  // treatment applies to applyContext_.lifted.projections — a correlated
+  // projection expression collected before the outer aggregation also
+  // references pre-wrap columns and must be re-exported through the wrap.
   auto* dt = currentDt_;
-  auto saved = std::move(correlatedConjuncts_);
-  correlatedConjuncts_.clear();
+  auto saved = applyContext_.saveAndClearLifted();
   finalizeDt(node);
-  correlatedConjuncts_ = std::move(saved);
+  applyContext_.lifted = std::move(saved);
 
-  for (auto& conjunct : correlatedConjuncts_) {
+  for (auto& conjunct : applyContext_.lifted.predicates) {
     conjunct = dt->exportExpr(conjunct);
+  }
+  for (auto& projection : applyContext_.lifted.projections) {
+    projection = dt->exportExpr(projection);
   }
 }
 
@@ -2342,12 +2523,25 @@ void ToGraph::addProjection(const lp::ProjectNode& project) {
   QGVector<WindowFunctionCP> windowFunctions;
   ColumnVector windowColumns;
 
+  // Inside a subquery body, allow projection expressions to resolve names
+  // against outer-query columns. The outer scope leaves allowCorrelations_
+  // off, so a no-op for top-level projections.
+  const bool wasAllowCorrelations = allowCorrelations_;
+  if (correlations_ != nullptr) {
+    allowCorrelations_ = true;
+  }
+  SCOPE_EXIT {
+    allowCorrelations_ = wasAllowCorrelations;
+  };
+
   for (auto i : channels) {
     if (exprs[i]->isInputReference()) {
       const auto& name = exprs[i]->as<lp::InputReferenceExpr>()->name();
       // A variable projected to itself adds no renames. Inputs contain this
-      // all the time.
-      if (name == names[i]) {
+      // all the time. The renames_ check excludes correlated input refs
+      // whose value comes from the outer scope's correlations_ rather than
+      // the subquery's own input.
+      if (name == names[i] && renames_.contains(name)) {
         continue;
       }
     }
@@ -2448,6 +2642,85 @@ void extractSubqueries(const lp::ExprPtr& expr, Subqueries& subqueries) {
 }
 } // namespace
 
+ToGraph::ApplyContext::Lifted ToGraph::ApplyContext::saveAndClearLifted() {
+  Lifted saved = std::move(lifted);
+  lifted = {};
+  return saved;
+}
+
+void ToGraph::carryForwardOuterCorrelationKeys(
+    ApplyContext::Lifted* outerLifted,
+    AggregateVector& aggregates,
+    ColumnVector& columns) {
+  if (outerLifted == nullptr || outerLifted->predicates.empty()) {
+    return;
+  }
+
+  ColumnVector sources;
+  for (const auto* conjunct : outerLifted->predicates) {
+    conjunct->columns().forEach<Column>([&](ColumnCP col) {
+      if (!isOutsideDt(col->relation(), currentDt_) &&
+          std::find(sources.begin(), sources.end(), col) == sources.end()) {
+        sources.push_back(col);
+      }
+    });
+  }
+  if (sources.empty()) {
+    return;
+  }
+
+  ExprVector targets;
+  targets.reserve(sources.size());
+  for (auto* source : sources) {
+    auto* aggOutput = appendArbitraryAggregate(source, aggregates, columns);
+    // The DT-output column is a separate alias so 'exprs' references the
+    // post-aggregation column (available after Layer 4 of
+    // checkConsistency) rather than the pre-aggregation 'source'.
+    auto* dtOutput =
+        make<Column>(newCName("__cf"), currentDt_, aggOutput->value());
+    currentDt_->exprs.push_back(aggOutput);
+    currentDt_->columns.push_back(dtOutput);
+    targets.push_back(dtOutput);
+  }
+
+  for (auto& conjunct : outerLifted->predicates) {
+    conjunct = DerivedTableFlattener::replaceInputs(conjunct, sources, targets);
+  }
+}
+
+void ToGraph::appendOuterAggregationCarryForwards(
+    const lp::LogicalPlanNode& input,
+    SubqueryChain& chain,
+    ApplyContext::Lifted* outerLifted,
+    AggregateVector& aggregates,
+    ColumnVector& columns) {
+  appendArbitraryAggregates(input, aggregates, columns);
+  for (const auto& priorKey : chain.carryForwards) {
+    auto& expression = subqueries_.at(priorKey);
+    expression = appendArbitraryAggregate(expression, aggregates, columns);
+  }
+  carryForwardOuterCorrelationKeys(outerLifted, aggregates, columns);
+}
+
+DerivedTableP ToGraph::translateSubqueryBody(
+    const logical_plan::LogicalPlanNode& node) {
+  VELOX_CHECK(applyContext_.lifted.empty());
+
+  // 'outerDt' is the only ApplyContext field saved here; the lifted
+  // accumulators are scoped at the call site via 'saveAndClearLifted'.
+  auto* savedOuterDt =
+      std::exchange(applyContext_.outerDt, std::exchange(currentDt_, newDt()));
+  SCOPE_EXIT {
+    applyContext_.outerDt = savedOuterDt;
+  };
+  makeQueryGraph(node, kAllAllowedInDt, /*orderObservedAbove=*/false);
+  auto* subqueryDt = currentDt_;
+
+  setDtUsedOutput(subqueryDt, node);
+  currentDt_ = applyContext_.outerDt;
+  return subqueryDt;
+}
+
 DerivedTableP ToGraph::translateSubquery(
     const logical_plan::LogicalPlanNode& node,
     bool finalize) {
@@ -2466,14 +2739,8 @@ DerivedTableP ToGraph::translateSubquery(
     correlations_ = savedCorrelations;
   };
 
-  VELOX_CHECK(correlatedConjuncts_.empty());
+  auto* subqueryDt = translateSubqueryBody(node);
 
-  auto* outerDt = std::exchange(currentDt_, newDt());
-  makeQueryGraph(node, kAllAllowedInDt, /*orderObservedAbove=*/false);
-  auto* subqueryDt = currentDt_;
-
-  setDtUsedOutput(subqueryDt, node);
-  currentDt_ = outerDt;
   if (finalize) {
     currentDt_->addTable(subqueryDt);
   }
@@ -2538,16 +2805,9 @@ DecorrelatedJoin extractDecorrelatedJoin(
   return result;
 }
 
-// Holds extracted correlation keys from correlatedConjuncts.
-// Used internally during scalar subquery processing.
-struct CorrelationKeys {
-  PlanObjectCP leftTable{nullptr};
-  ExprVector leftKeys;
-  ExprVector rightKeys;
-  ExprVector nonEquiConjuncts;
-};
+} // namespace
 
-CorrelationKeys extractCorrelationKeys(
+ToGraph::CorrelationKeys ToGraph::extractCorrelationKeys(
     const FunctionNames& funcs,
     const ExprVector& correlatedConjuncts,
     DerivedTableP subqueryDt) {
@@ -2559,7 +2819,8 @@ CorrelationKeys extractCorrelationKeys(
 
     ExprCP left = nullptr;
     ExprCP right = nullptr;
-    if (isJoinEquality(funcs, conjunct, tables[0], tables[1], left, right)) {
+    if (optimizer::isJoinEquality(
+            funcs, conjunct, tables[0], tables[1], left, right)) {
       if (tables[1] == subqueryDt || subqueryDt->tableSet.contains(tables[1])) {
         result.leftKeys.push_back(left);
         result.rightKeys.push_back(right);
@@ -2581,8 +2842,6 @@ CorrelationKeys extractCorrelationKeys(
 
   return result;
 }
-
-} // namespace
 
 ColumnCP ToGraph::appendArbitraryAggregate(
     ExprCP expr,
@@ -2622,8 +2881,25 @@ void ToGraph::appendArbitraryAggregates(
   }
 }
 
-AggregationPlanCP ToGraph::processCorrelatedAggregation(AggregationPlanCP agg) {
-  if (correlatedConjuncts_.empty()) {
+namespace {
+// True if any aggregate's body references columns outside 'innerDt'
+// (i.e., outer-query columns).
+bool anyAggregateReferencesOuter(
+    AggregationPlanCP agg,
+    DerivedTableCP innerDt) {
+  for (const auto* aggregate : agg->aggregates()) {
+    if (anyOutsideDt(aggregate->allTables(), innerDt)) {
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
+AggregationPlanCP ToGraph::processCorrelatedAggregation(
+    AggregationPlanCP agg,
+    ExprVector& liftedPredicates) {
+  if (liftedPredicates.empty()) {
     return agg;
   }
 
@@ -2641,7 +2917,7 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(AggregationPlanCP agg) {
 
   // Check if all conjuncts are equalities. If any are non-equi, we'll
   // handle decorrelation at the outer level using AssignUniqueId.
-  if (!areAllJoinEqualities(functionNames_, correlatedConjuncts_)) {
+  if (!areAllJoinEqualities(functionNames_, liftedPredicates)) {
     // Non-equi correlation: keep the aggregation as-is (global agg).
     // The decorrelation will be handled at the outer level using
     // AssignUniqueId + LEFT JOIN + outer aggregation.
@@ -2652,7 +2928,7 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(AggregationPlanCP agg) {
   ExprVector groupingKeys;
   ColumnVector columns;
   ExprVector leftKeys;
-  for (const auto* conjunct : correlatedConjuncts_) {
+  for (const auto* conjunct : liftedPredicates) {
     const auto tables = conjunct->allTables().toObjects();
     VELOX_CHECK_EQ(2, tables.size());
 
@@ -2679,18 +2955,14 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(AggregationPlanCP agg) {
     }
   }
 
-  correlatedConjuncts_.clear();
+  liftedPredicates.clear();
   for (auto i = 0; i < leftKeys.size(); ++i) {
     currentDt_->exprs.push_back(columns[i]);
     currentDt_->columns.push_back(
         make<Column>(newCName("__gk"), currentDt_, columns[i]->value()));
 
-    correlatedConjuncts_.push_back(
-        make<Call>(
-            functionNames_.equality,
-            toValue(velox::BOOLEAN(), 2),
-            ExprVector{leftKeys[i], currentDt_->columns.back()},
-            FunctionSet()));
+    liftedPredicates.push_back(
+        makeEquality(leftKeys[i], currentDt_->columns.back()));
   }
 
   auto intermediateColumns = columns;
@@ -2754,14 +3026,13 @@ void ToGraph::processScalarSubqueries(
   for (const auto& subquery : scalars) {
     maybeWrapForChainedSubquery(input, chain);
 
+    auto savedLifted = applyContext_.saveAndClearLifted();
+    SCOPE_EXIT {
+      applyContext_.lifted = std::move(savedLifted);
+    };
     auto subqueryDt = translateSubquery(*subquery->subquery());
-
-    ExprCP column;
-    if (correlatedConjuncts_.empty()) {
-      column = processUncorrelatedScalarSubquery(subqueryDt);
-    } else {
-      column = processCorrelatedScalarSubquery(input, subqueryDt, chain);
-    }
+    auto* column =
+        attachScalarSubqueryToOuter(input, subqueryDt, chain, &savedLifted);
     subqueries_.emplace(subquery, column);
 
     // Track every subquery's result so any later heavy-path subquery in
@@ -2772,6 +3043,23 @@ void ToGraph::processScalarSubqueries(
       chain.carryForwards.push_back(subquery);
     }
   }
+}
+
+ExprCP ToGraph::attachScalarSubqueryToOuter(
+    const lp::LogicalPlanNode& input,
+    DerivedTableP subqueryDt,
+    SubqueryChain& chain,
+    ApplyContext::Lifted* outerLifted) {
+  if (!applyContext_.lifted.projections.empty()) {
+    return processProjectionCorrelatedScalarSubquery(
+        input, subqueryDt, chain, outerLifted);
+  }
+  if (!applyContext_.lifted.predicates.empty() ||
+      applyContext_.lifted.aggregation != nullptr) {
+    return processCorrelatedScalarSubquery(
+        input, subqueryDt, chain, outerLifted);
+  }
+  return processUncorrelatedScalarSubquery(subqueryDt);
 }
 
 void ToGraph::maybeWrapForChainedSubquery(
@@ -2838,26 +3126,37 @@ Literal* tryMakeLiteralForEmptyInput(AggregateCP agg) {
 ExprCP ToGraph::processCorrelatedScalarSubquery(
     const lp::LogicalPlanNode& input,
     DerivedTableP subqueryDt,
-    SubqueryChain& chain) {
-  auto correlation =
-      extractCorrelationKeys(functionNames_, correlatedConjuncts_, subqueryDt);
+    SubqueryChain& chain,
+    ApplyContext::Lifted* outerLifted) {
+  auto correlation = extractCorrelationKeys(
+      functionNames_, applyContext_.lifted.predicates, subqueryDt);
+
+  if (applyContext_.lifted.aggregation != nullptr) {
+    return buildCorrelatedAggregation(
+        input, subqueryDt, chain, correlation, outerLifted);
+  }
+
+  auto makeRowNumberColumn = [&]() {
+    return makeColumn(
+        "__rownum",
+        toValue(velox::BIGINT(), std::numeric_limits<int64_t>::max()));
+  };
 
   const bool hasAggregation = subqueryDt->hasAggregation();
 
-  if (!correlation.nonEquiConjuncts.empty()) {
-    // For non-equi correlation, expect only 1 column (the aggregate result).
-    VELOX_CHECK_EQ(1, subqueryDt->columns.size());
-  } else if (hasAggregation) {
-    // For equi-only correlation with aggregation, expect grouping keys +
-    // aggregate result.
-    VELOX_CHECK_EQ(correlatedConjuncts_.size() + 1, subqueryDt->columns.size());
+  // The equi-with-aggregation branch promoted correlation keys to grouping
+  // keys, so the inner DT exposes those keys alongside the aggregate result.
+  // Every other branch produces at least one subquery-result column;
+  // additional columns may exist as intermediates from
+  // 'splitCorrelatedProjection' when the caller is the projection path.
+  if (correlation.nonEquiConjuncts.empty() && hasAggregation) {
+    VELOX_CHECK_EQ(
+        applyContext_.lifted.predicates.size() + 1, subqueryDt->columns.size());
   } else {
-    // For equi-only correlation without aggregation, expect only 1 column (the
-    // subquery result).
-    VELOX_CHECK_EQ(1, subqueryDt->columns.size());
+    VELOX_CHECK_GE(subqueryDt->columns.size(), 1);
   }
 
-  correlatedConjuncts_.clear();
+  applyContext_.lifted.predicates.clear();
 
   if (correlation.nonEquiConjuncts.empty() && hasAggregation) {
     // Equi-join only with aggregation: create LEFT join with correlation keys.
@@ -2878,21 +3177,14 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
       // Wrap with COALESCE for aggregates that return non-NULL for empty input.
       // LEFT JOIN returns NULL for outer rows with no matches, but count-like
       // aggregates should return 0 (or similar default) instead.
-      return make<Call>(
+      return deduppedSpecialForm(
           SpecialFormCallNames::kCoalesce,
           aggregateResult->value(),
-          ExprVector{aggregateResult, literal},
-          FunctionSet());
+          ExprVector{aggregateResult, literal});
     }
 
     return aggregateResult;
   }
-
-  auto makeRowNumberColumn = [&]() {
-    return makeColumn(
-        "__rownum",
-        toValue(velox::BIGINT(), std::numeric_limits<int64_t>::max()));
-  };
 
   if (!hasAggregation) {
     // Correlation without aggregation: use AssignUniqueId + LEFT JOIN +
@@ -2964,17 +3256,12 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
   currentDt_->joins.push_back(join);
 
   // Build the outer aggregation: this subquery's count(...) plus
-  // arbitrary(...) carry-forwards for outer columns and for prior
-  // chain-mate subquery results.
+  // carry-forwards.
   auto* aggResultColumn = makeColumn("__agg", exportedAgg->value());
   AggregateVector allAggregates{exportedAgg};
   ColumnVector allColumns{chain.rowNumberColumn, aggResultColumn};
-  appendArbitraryAggregates(input, allAggregates, allColumns);
-  for (const auto& priorKey : chain.carryForwards) {
-    auto& expression = subqueries_.at(priorKey);
-    expression =
-        appendArbitraryAggregate(expression, allAggregates, allColumns);
-  }
+  appendOuterAggregationCarryForwards(
+      input, chain, outerLifted, allAggregates, allColumns);
 
   // The caller wraps currentDt_ before each subsequent heavy-path subquery,
   // so the aggregation slot must be fresh here.
@@ -2985,6 +3272,221 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
   return aggResultColumn;
 }
 
+ExprCP ToGraph::buildCorrelatedAggregation(
+    const lp::LogicalPlanNode& input,
+    DerivedTableP subqueryDt,
+    SubqueryChain& chain,
+    const CorrelationKeys& correlation,
+    ApplyContext::Lifted* outerLifted) {
+  auto* correlatedAgg = applyContext_.lifted.aggregation;
+  applyContext_.lifted.aggregation = nullptr;
+  applyContext_.lifted.predicates.clear();
+
+  // The LEFT JOIN below emits an outer row with NULL inner columns when
+  // no inner row matches the correlation. An aggregate argument that
+  // references only outer columns is non-NULL on that synthetic row,
+  // so the outer aggregation incorrectly processes it (e.g.,
+  // 'count(t.a)' returns 1 instead of 0). Mixed inner+outer arguments
+  // are safe — the NULL inner makes the whole arg NULL, which
+  // aggregates skip. Reject the pure-outer case.
+  for (const auto* agg : correlatedAgg->aggregates()) {
+    DerivedTableScopeUse aggScope;
+    for (const auto* arg : agg->args()) {
+      auto argScope = classifyScope(arg, subqueryDt);
+      aggScope.hasLocal |= argScope.hasLocal;
+      aggScope.hasCorrelation |= argScope.hasCorrelation;
+    }
+    if (aggScope.hasCorrelation && !aggScope.hasLocal) {
+      VELOX_NYI(
+          "Correlated subquery with an aggregate whose arguments reference only outer columns is not supported yet");
+    }
+  }
+
+  // Outer table for AssignUniqueId: prefer the one identified from
+  // equi-conjuncts, otherwise any outer table referenced by the
+  // aggregate body.
+  PlanObjectCP leftTable = correlation.leftTable;
+  if (leftTable == nullptr) {
+    for (const auto* agg : correlatedAgg->aggregates()) {
+      agg->allTables().forEach([&](PlanObjectCP table) {
+        if (leftTable == nullptr && isOutsideDt(table, subqueryDt)) {
+          leftTable = table;
+        }
+      });
+    }
+    VELOX_CHECK_NOT_NULL(leftTable);
+  }
+
+  // Rewrite each aggregate's args/orderKeys/condition so inner-column
+  // references come through subqueryDt's output (exportExpr promotes
+  // them). Outer-column references pass through unchanged.
+  AggregateVector rewrittenAggregates;
+  for (const auto* agg : correlatedAgg->aggregates()) {
+    ExprVector exportedArgs;
+    for (const auto* arg : agg->args()) {
+      exportedArgs.push_back(subqueryDt->exportExpr(arg));
+    }
+    ExprVector exportedOrderKeys;
+    for (const auto* orderKey : agg->orderKeys()) {
+      exportedOrderKeys.push_back(subqueryDt->exportExpr(orderKey));
+    }
+    ExprCP exportedCondition = agg->condition() != nullptr
+        ? subqueryDt->exportExpr(agg->condition())
+        : nullptr;
+    rewrittenAggregates.push_back(
+        make<Aggregate>(
+            agg->name(),
+            agg->value(),
+            exportedArgs,
+            agg->functions(),
+            agg->isDistinct(),
+            exportedCondition,
+            agg->intermediateType(),
+            exportedOrderKeys,
+            agg->orderTypes()));
+  }
+
+  ExprVector exportedFilter;
+  for (auto* conjunct : correlation.nonEquiConjuncts) {
+    exportedFilter.push_back(subqueryDt->exportExpr(conjunct));
+  }
+
+  ColumnCP joinRowNumberColumn = nullptr;
+  if (chain.rowNumberColumn == nullptr) {
+    chain.rowNumberColumn = makeColumn(
+        "__rownum",
+        toValue(velox::BIGINT(), std::numeric_limits<int64_t>::max()));
+    joinRowNumberColumn = chain.rowNumberColumn;
+  }
+
+  auto* join = make<JoinEdge>(
+      leftTable,
+      subqueryDt,
+      JoinEdge::Spec{
+          .filter = exportedFilter,
+          .joinType = velox::core::JoinType::kLeft,
+          .rowNumberColumn = joinRowNumberColumn,
+      });
+  for (auto i = 0; i < correlation.leftKeys.size(); ++i) {
+    join->addEquality(
+        subqueryDt->exportExpr(correlation.leftKeys[i]),
+        subqueryDt->exportExpr(correlation.rightKeys[i]));
+  }
+  currentDt_->joins.push_back(join);
+
+  // Output columns are already owned by currentDt_; reuse them as the
+  // outer aggregation's outputs.
+  ColumnVector allColumns{chain.rowNumberColumn};
+  for (const auto* col : correlatedAgg->columns()) {
+    allColumns.push_back(col);
+  }
+  appendOuterAggregationCarryForwards(
+      input, chain, outerLifted, rewrittenAggregates, allColumns);
+
+  VELOX_CHECK_NULL(currentDt_->aggregation);
+  currentDt_->aggregation = make<AggregationPlan>(
+      ExprVector{chain.rowNumberColumn},
+      rewrittenAggregates,
+      allColumns,
+      allColumns);
+
+  return correlatedAgg->columns().back();
+}
+
+ExprCP ToGraph::processProjectionCorrelatedScalarSubquery(
+    const lp::LogicalPlanNode& input,
+    DerivedTableP subqueryDt,
+    SubqueryChain& chain,
+    ApplyContext::Lifted* outerLifted) {
+  // Scalar subqueries produce exactly one SELECT expression, so
+  // 'addDtColumn' pushes at most one residual into 'liftedProjections'
+  // for this scope.
+  VELOX_CHECK_EQ(1, applyContext_.lifted.projections.size());
+  auto* column = applyContext_.lifted.projections.front();
+  applyContext_.lifted.projections.clear();
+
+  if (subqueryDt->isSingleRowNoColumnsValues()) {
+    if (!applyContext_.lifted.predicates.empty()) {
+      // The body has no FROM, so the WHERE filters the single empty-tuple
+      // row. Per outer row the scalar subquery returns 'column' if all
+      // predicates pass, NULL otherwise. Rewrite as 'IF(AND(predicates),
+      // column)'.
+      ExprVector conjuncts = std::move(applyContext_.lifted.predicates);
+      applyContext_.lifted.predicates.clear();
+      ExprCP condition = conjuncts.size() == 1
+          ? conjuncts.front()
+          : deduppedSpecialForm(
+                SpecialFormCallNames::kAnd,
+                toValue(velox::BOOLEAN(), 2),
+                std::move(conjuncts));
+      column = deduppedSpecialForm(
+          SpecialFormCallNames::kIf,
+          column->value(),
+          ExprVector{condition, column});
+    }
+    if (applyContext_.lifted.aggregation != nullptr) {
+      VELOX_NYI(
+          "Correlated aggregate in a no-FROM subquery body is not supported yet");
+    }
+    if (subqueryDt->hasNoPostprocess()) {
+      // The residual references no columns of subqueryDt; the DT can be
+      // dropped and the residual evaluated in the outer scope alone.
+      currentDt_->removeLastTable(subqueryDt);
+    } else if (!subqueryDt->hasCardinalityNeutralPostprocess()) {
+      subqueryDt->ensureSingleRow();
+    }
+    // Cardinality-neutral postprocess (agg/window/order by) is left in
+    // place: the DT must stay in the graph so the residual can reference
+    // its produced columns.
+    return column;
+  }
+
+  if (!applyContext_.lifted.predicates.empty() ||
+      applyContext_.lifted.aggregation != nullptr) {
+    // The decorrelating join may wrap the agg-result column and may push
+    // outer columns through a new outer aggregation as arbitrary()
+    // carry-forwards. Propagate both rewrites into the residual: the
+    // original references would otherwise be invisible above the
+    // aggregation.
+    //
+    // The agg-result rewrite only applies when the inner DT has an
+    // aggregation; for non-aggregating bodies, 'subqueryDt->columns'
+    // holds intermediate exports from 'splitCorrelatedProjection'
+    // that should not be substituted for each other.
+    const bool hasAggResult =
+        subqueryDt->hasAggregation() && !subqueryDt->columns.empty();
+    ColumnCP originalAgg = hasAggResult ? subqueryDt->columns.back() : nullptr;
+    const auto renamesBefore = renames_;
+    auto* wrappedAgg =
+        processCorrelatedScalarSubquery(input, subqueryDt, chain, outerLifted);
+    ColumnVector sources;
+    ExprVector targets;
+    if (originalAgg != nullptr && wrappedAgg != originalAgg) {
+      sources.push_back(originalAgg);
+      targets.push_back(wrappedAgg);
+    }
+    for (const auto& [name, newExpr] : renames_) {
+      auto it = renamesBefore.find(name);
+      if (it != renamesBefore.end() && it->second != newExpr) {
+        // Carry-forwards always replace a Column with another Column /
+        // Expr.
+        VELOX_DCHECK(
+            it->second->isColumn(),
+            "Non-column renames source in correlated-projection substitution");
+        sources.push_back(it->second->as<Column>());
+        targets.push_back(newExpr);
+      }
+    }
+    if (!sources.empty()) {
+      column = DerivedTableFlattener::replaceInputs(column, sources, targets);
+    }
+    return column;
+  }
+
+  subqueryDt->ensureSingleRow();
+  return column;
+}
+
 void ToGraph::processInPredicates(
     const lp::LogicalPlanNode& input,
     const std::vector<lp::ExprPtr>& inPredicates,
@@ -2992,9 +3494,29 @@ void ToGraph::processInPredicates(
   for (const auto& predicate : inPredicates) {
     maybeWrapForChainedSubquery(input, chain);
 
+    auto savedLifted = applyContext_.saveAndClearLifted();
+    SCOPE_EXIT {
+      applyContext_.lifted = std::move(savedLifted);
+    };
     auto subqueryDt = translateSubquery(
         *predicate->inputAt(1)->as<lp::SubqueryExpr>()->subquery());
-    VELOX_CHECK_EQ(1, subqueryDt->columns.size());
+    if (applyContext_.lifted.aggregation != nullptr) {
+      VELOX_NYI(
+          "Outer-column reference in the aggregate body of an IN subquery is not supported yet");
+    }
+
+    // Right side of the IN comparison. When the subquery's SELECT
+    // references outer columns, the lifted residual replaces the
+    // inner-DT column; otherwise the inner DT exposes a single column.
+    ExprCP inRightKey;
+    if (!applyContext_.lifted.projections.empty()) {
+      VELOX_CHECK_EQ(1, applyContext_.lifted.projections.size());
+      inRightKey = applyContext_.lifted.projections.front();
+      applyContext_.lifted.projections.clear();
+    } else {
+      VELOX_CHECK_EQ(1, subqueryDt->columns.size());
+      inRightKey = subqueryDt->columns.front();
+    }
 
     // Add a join edge and replace 'expr' with 'mark' column in the join
     // output.
@@ -3002,18 +3524,26 @@ void ToGraph::processInPredicates(
 
     auto leftKey = translateExpr(predicate->inputAt(0));
     // May be nullptr when the left expression references multiple tables
-    // (e.g., ROW(t.a, u.b) IN (SELECT ...)). Both processUncorrelated and
-    // processCorrelated handle nullptr by creating a join edge without a
-    // specific left table; the optimizer resolves it from the equality keys.
+    // (e.g., ROW(t.a, u.b) IN (SELECT ...)). The downstream IN-subquery
+    // processors handle nullptr by creating a join edge without a specific
+    // left table; the optimizer resolves it from the equality keys.
     auto* leftTable = leftKey->singleTable();
 
+    const bool inRightHasOuter =
+        anyOutsideDt(inRightKey->allTables(), subqueryDt);
+
     ExprCP column;
-    if (correlatedConjuncts_.empty()) {
+    if (applyContext_.lifted.predicates.empty() && !inRightHasOuter) {
       column = processUncorrelatedInPredicate(
           subqueryDt, markColumn, leftKey, leftTable);
     } else {
       column = processCorrelatedInPredicate(
-          subqueryDt, markColumn, leftKey, leftTable);
+          subqueryDt,
+          markColumn,
+          leftKey,
+          leftTable,
+          inRightKey,
+          inRightHasOuter);
     }
     subqueries_.emplace(predicate, column);
 
@@ -3047,19 +3577,24 @@ ExprCP ToGraph::processCorrelatedInPredicate(
     DerivedTableP subqueryDt,
     ColumnCP markColumn,
     ExprCP leftKey,
-    PlanObjectCP leftTable) {
+    PlanObjectCP leftTable,
+    ExprCP inRightKey,
+    bool inRightHasOuter) {
   // Correlated IN subquery: process correlation conditions and create
   // semi-join with the IN equality as the sole null-aware join key and
-  // correlation equalities moved to the join filter.
-  auto decorrelated =
-      extractDecorrelatedJoin(functionNames_, correlatedConjuncts_, subqueryDt);
+  // correlation equalities moved to the join filter. If 'inRightKey'
+  // references outer columns (the subquery's SELECT had outer refs),
+  // the IN equality also goes into the filter — equi-keys must
+  // evaluate on a single join side.
+  auto decorrelated = extractDecorrelatedJoin(
+      functionNames_, applyContext_.lifted.predicates, subqueryDt);
   if (leftTable) {
     decorrelated.leftTables.add(leftTable);
   } else {
     // Multi-table left expression: add all referenced tables.
     decorrelated.leftTables.unionSet(leftKey->allTables());
   }
-  correlatedConjuncts_.clear();
+  applyContext_.lifted.predicates.clear();
 
   PlanObjectCP joinLeftTable = nullptr;
   if (decorrelated.leftTables.size() == 1) {
@@ -3070,18 +3605,17 @@ ExprCP ToGraph::processCorrelatedInPredicate(
   // equalities are standard WHERE clause predicates with different null
   // semantics, so they belong in the filter. Correlation equalities that match
   // the IN key are redundant and dropped.
-  auto inRightKey = subqueryDt->columns.front();
   for (auto i = 0; i < decorrelated.leftKeys.size(); ++i) {
-    if (decorrelated.leftKeys[i] == leftKey &&
+    if (!inRightHasOuter && decorrelated.leftKeys[i] == leftKey &&
         decorrelated.rightKeys[i] == inRightKey) {
       continue;
     }
     decorrelated.filter.push_back(
-        make<Call>(
-            functionNames_.equality,
-            toValue(velox::BOOLEAN(), 2),
-            ExprVector{decorrelated.leftKeys[i], decorrelated.rightKeys[i]},
-            FunctionSet()));
+        makeEquality(decorrelated.leftKeys[i], decorrelated.rightKeys[i]));
+  }
+
+  if (inRightHasOuter) {
+    decorrelated.filter.push_back(makeEquality(leftKey, inRightKey));
   }
 
   auto* edge = JoinEdge::makeExists(
@@ -3092,8 +3626,10 @@ ExprCP ToGraph::processCorrelatedInPredicate(
       /*nullAwareIn=*/true);
   currentDt_->joins.push_back(edge);
 
-  // Add IN equality as the single join key.
-  edge->addEquality(leftKey, inRightKey);
+  if (!inRightHasOuter) {
+    // Add IN equality as the single join key.
+    edge->addEquality(leftKey, inRightKey);
+  }
 
   return markColumn;
 }
@@ -3105,13 +3641,25 @@ void ToGraph::processExistsSubqueries(
   for (const auto& existsExpr : exists) {
     maybeWrapForChainedSubquery(input, chain);
 
+    auto savedLifted = applyContext_.saveAndClearLifted();
+    SCOPE_EXIT {
+      applyContext_.lifted = std::move(savedLifted);
+    };
     auto subqueryDt = translateSubquery(
         *existsExpr->inputAt(0)->as<lp::SubqueryExpr>()->subquery(),
         /*finalize=*/false);
+    if (!applyContext_.lifted.projections.empty()) {
+      VELOX_NYI(
+          "Outer-column reference in the SELECT of an EXISTS subquery is not supported yet");
+    }
+    if (applyContext_.lifted.aggregation != nullptr) {
+      VELOX_NYI(
+          "Outer-column reference in the aggregate body of an EXISTS subquery is not supported yet");
+    }
 
     // A subquery that produces zero rows (e.g., LIMIT 0) makes EXISTS false.
     if (subqueryDt->isZeroRows()) {
-      correlatedConjuncts_.clear();
+      applyContext_.lifted.predicates.clear();
       subqueries_.emplace(
           existsExpr,
           make<Literal>(
@@ -3127,16 +3675,14 @@ void ToGraph::processExistsSubqueries(
     // number of rows, so it can be ignored. Replace the EXISTS with the
     // conjunction of all conjuncts (correlated and uncorrelated), or TRUE if
     // there are none.
-    if (subqueryDt->tables.size() == 1 &&
-        subqueryDt->tables[0]->is(PlanType::kValuesTableNode) &&
-        subqueryDt->tables[0]->as<ValuesTable>()->columns.empty() &&
-        !subqueryDt->hasLimit() && !subqueryDt->hasAggregation()) {
+    if (subqueryDt->isSingleRowNoColumnsValues() && !subqueryDt->hasLimit() &&
+        !subqueryDt->hasOffset() && !subqueryDt->hasAggregation()) {
       ExprVector allConjuncts = std::move(subqueryDt->conjuncts);
       allConjuncts.insert(
           allConjuncts.end(),
-          correlatedConjuncts_.begin(),
-          correlatedConjuncts_.end());
-      correlatedConjuncts_.clear();
+          applyContext_.lifted.predicates.begin(),
+          applyContext_.lifted.predicates.end());
+      applyContext_.lifted.predicates.clear();
 
       ExprCP result;
       if (allConjuncts.empty()) {
@@ -3145,11 +3691,10 @@ void ToGraph::processExistsSubqueries(
       } else if (allConjuncts.size() == 1) {
         result = allConjuncts[0];
       } else {
-        result = deduppedCall(
-            toName(SpecialFormCallNames::kAnd),
+        result = deduppedSpecialForm(
+            SpecialFormCallNames::kAnd,
             toValue(velox::BOOLEAN(), 2),
-            std::move(allConjuncts),
-            FunctionSet());
+            std::move(allConjuncts));
       }
       subqueries_.emplace(existsExpr, result);
       if (!result->columns().empty()) {
@@ -3159,7 +3704,7 @@ void ToGraph::processExistsSubqueries(
     }
 
     ExprCP column;
-    if (correlatedConjuncts_.empty()) {
+    if (applyContext_.lifted.predicates.empty()) {
       column = processUncorrelatedExists(subqueryDt);
     } else {
       column = processCorrelatedExists(subqueryDt);
@@ -3216,12 +3761,12 @@ ExprCP ToGraph::processCorrelatedExists(DerivedTableP subqueryDt) {
   // Finalize the subqueryDt (add to currentDt_).
   currentDt_->addTable(subqueryDt);
 
-  auto decorrelated =
-      extractDecorrelatedJoin(functionNames_, correlatedConjuncts_, subqueryDt);
+  auto decorrelated = extractDecorrelatedJoin(
+      functionNames_, applyContext_.lifted.predicates, subqueryDt);
   if (decorrelated.leftKeys.empty()) {
     VELOX_CHECK_EQ(decorrelated.leftTables.size(), 1);
   }
-  correlatedConjuncts_.clear();
+  applyContext_.lifted.predicates.clear();
 
   const auto* markColumn = addMarkColumn();
 
@@ -3398,7 +3943,7 @@ void ToGraph::addFilter(
       if (conjunct->allTables().isSubset(tables)) {
         return false;
       }
-      correlatedConjuncts_.push_back(conjunct);
+      applyContext_.lifted.predicates.push_back(conjunct);
       return true;
     });
   }
@@ -3619,7 +4164,15 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
   auto translateUnionInput = [&](const lp::LogicalPlanNode& input) {
     renames_ = renames;
     currentDt_ = newDt();
+    auto savedLifted = applyContext_.saveAndClearLifted();
+    SCOPE_EXIT {
+      applyContext_.lifted = std::move(savedLifted);
+    };
     makeQueryGraph(input, kAllAllowedInDt, /*orderObservedAbove=*/false);
+    if (!applyContext_.lifted.empty()) {
+      VELOX_NYI(
+          "Correlated reference inside a UNION ALL branch is not supported yet");
+    }
     auto* newDt = std::exchange(currentDt_, setDt);
 
     const auto& type = input.outputType();
@@ -3870,11 +4423,19 @@ void ToGraph::makeQueryGraph(
           input, allowedInDt, /*orderObservedAbove=*/false, excludeOuterJoins);
       if (currentDt_->hasAggregation() || currentDt_->hasLimit() ||
           currentDt_->windowPlan) {
-        finalizeDtWithCorrelatedConjuncts(input);
+        finalizeDtPreservingCorrelations(input);
       }
 
       auto* agg = translateAggregation(*node.as<lp::AggregateNode>());
-      if (auto* result = processCorrelatedAggregation(agg)) {
+      if (anyAggregateReferencesOuter(agg, currentDt_)) {
+        // The aggregate body references outer columns. It cannot validate
+        // against the inner DT's tableSet; defer to be attached to the
+        // outer DT by processCorrelatedScalarSubquery.
+        VELOX_CHECK_NULL(applyContext_.lifted.aggregation);
+        applyContext_.lifted.aggregation = agg;
+      } else if (
+          auto* result = processCorrelatedAggregation(
+              agg, applyContext_.lifted.predicates)) {
         currentDt_->aggregation = result;
       }
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -999,6 +999,38 @@ ExprCP ToGraph::makeEquality(ExprCP left, ExprCP right) {
       ExprVector{left, right});
 }
 
+ExprCP ToGraph::makeAnd(ExprVector args) {
+  VELOX_CHECK(!args.empty());
+  if (args.size() == 1) {
+    return args.front();
+  }
+  return deduppedSpecialForm(
+      SpecialFormCallNames::kAnd,
+      toValue(velox::BOOLEAN(), 2),
+      std::move(args));
+}
+
+ExprCP ToGraph::wrapScalarInGuards(ExprVector guards, ExprCP expr) {
+  if (guards.empty()) {
+    return expr;
+  }
+  return deduppedSpecialForm(
+      SpecialFormCallNames::kIf,
+      expr->value(),
+      ExprVector{makeAnd(std::move(guards)), expr});
+}
+
+ExprCP ToGraph::wrapMarkInGuards(ExprVector guards, ExprCP expr) {
+  if (guards.empty()) {
+    return expr;
+  }
+  ExprVector args;
+  args.reserve(guards.size() + 1);
+  args.push_back(expr);
+  args.insert(args.end(), guards.begin(), guards.end());
+  return makeAnd(std::move(args));
+}
+
 namespace {
 
 bool isJoinEquality(
@@ -3050,16 +3082,25 @@ ExprCP ToGraph::attachScalarSubqueryToOuter(
     DerivedTableP subqueryDt,
     SubqueryChain& chain,
     ApplyContext::Lifted* outerLifted) {
+  ExprCP result;
   if (!applyContext_.lifted.projections.empty()) {
-    return processProjectionCorrelatedScalarSubquery(
+    result = processProjectionCorrelatedScalarSubquery(
         input, subqueryDt, chain, outerLifted);
-  }
-  if (!applyContext_.lifted.predicates.empty() ||
+  } else if (
+      !applyContext_.lifted.predicates.empty() ||
       applyContext_.lifted.aggregation != nullptr) {
-    return processCorrelatedScalarSubquery(
-        input, subqueryDt, chain, outerLifted);
+    result =
+        processCorrelatedScalarSubquery(input, subqueryDt, chain, outerLifted);
+  } else {
+    result = processUncorrelatedScalarSubquery(subqueryDt);
   }
-  return processUncorrelatedScalarSubquery(subqueryDt);
+
+  // Wrap with pure-outer guards (e.g., from constant-folded correlation
+  // conjuncts): the outer row sees NULL when the gating condition
+  // fails, else the inner result.
+  auto guards = std::move(applyContext_.lifted.outerGuards);
+  applyContext_.lifted.outerGuards.clear();
+  return wrapScalarInGuards(std::move(guards), result);
 }
 
 void ToGraph::maybeWrapForChainedSubquery(
@@ -3409,20 +3450,10 @@ ExprCP ToGraph::processProjectionCorrelatedScalarSubquery(
     if (!applyContext_.lifted.predicates.empty()) {
       // The body has no FROM, so the WHERE filters the single empty-tuple
       // row. Per outer row the scalar subquery returns 'column' if all
-      // predicates pass, NULL otherwise. Rewrite as 'IF(AND(predicates),
-      // column)'.
-      ExprVector conjuncts = std::move(applyContext_.lifted.predicates);
+      // predicates pass, NULL otherwise.
+      auto conjuncts = std::move(applyContext_.lifted.predicates);
       applyContext_.lifted.predicates.clear();
-      ExprCP condition = conjuncts.size() == 1
-          ? conjuncts.front()
-          : deduppedSpecialForm(
-                SpecialFormCallNames::kAnd,
-                toValue(velox::BOOLEAN(), 2),
-                std::move(conjuncts));
-      column = deduppedSpecialForm(
-          SpecialFormCallNames::kIf,
-          column->value(),
-          ExprVector{condition, column});
+      column = wrapScalarInGuards(std::move(conjuncts), column);
     }
     if (applyContext_.lifted.aggregation != nullptr) {
       VELOX_NYI(
@@ -3545,6 +3576,9 @@ void ToGraph::processInPredicates(
           inRightKey,
           inRightHasOuter);
     }
+    auto guards = std::move(applyContext_.lifted.outerGuards);
+    applyContext_.lifted.outerGuards.clear();
+    column = wrapMarkInGuards(std::move(guards), column);
     subqueries_.emplace(predicate, column);
 
     // Carry the mark column forward so any later heavy-path scalar in the
@@ -3657,6 +3691,9 @@ void ToGraph::processExistsSubqueries(
           "Outer-column reference in the aggregate body of an EXISTS subquery is not supported yet");
     }
 
+    auto outerGuards = std::move(applyContext_.lifted.outerGuards);
+    applyContext_.lifted.outerGuards.clear();
+
     // A subquery that produces zero rows (e.g., LIMIT 0) makes EXISTS false.
     if (subqueryDt->isZeroRows()) {
       applyContext_.lifted.predicates.clear();
@@ -3673,8 +3710,8 @@ void ToGraph::processExistsSubqueries(
     // produces one row. Since the ValuesTable has no columns, any
     // uncorrelated conjuncts must be constants. ORDER BY does not affect the
     // number of rows, so it can be ignored. Replace the EXISTS with the
-    // conjunction of all conjuncts (correlated and uncorrelated), or TRUE if
-    // there are none.
+    // conjunction of all conjuncts (correlated, uncorrelated, and outer
+    // guards), or TRUE if there are none.
     if (subqueryDt->isSingleRowNoColumnsValues() && !subqueryDt->hasLimit() &&
         !subqueryDt->hasOffset() && !subqueryDt->hasAggregation()) {
       ExprVector allConjuncts = std::move(subqueryDt->conjuncts);
@@ -3682,19 +3719,16 @@ void ToGraph::processExistsSubqueries(
           allConjuncts.end(),
           applyContext_.lifted.predicates.begin(),
           applyContext_.lifted.predicates.end());
+      allConjuncts.insert(
+          allConjuncts.end(), outerGuards.begin(), outerGuards.end());
       applyContext_.lifted.predicates.clear();
 
       ExprCP result;
       if (allConjuncts.empty()) {
         result = make<Literal>(
             toConstantValue(velox::BOOLEAN()), registerVariant(true));
-      } else if (allConjuncts.size() == 1) {
-        result = allConjuncts[0];
       } else {
-        result = deduppedSpecialForm(
-            SpecialFormCallNames::kAnd,
-            toValue(velox::BOOLEAN(), 2),
-            std::move(allConjuncts));
+        result = makeAnd(std::move(allConjuncts));
       }
       subqueries_.emplace(existsExpr, result);
       if (!result->columns().empty()) {
@@ -3709,6 +3743,7 @@ void ToGraph::processExistsSubqueries(
     } else {
       column = processCorrelatedExists(subqueryDt);
     }
+    column = wrapMarkInGuards(std::move(outerGuards), column);
     subqueries_.emplace(existsExpr, column);
 
     // Carry the EXISTS result forward so any later heavy-path scalar in the
@@ -3939,11 +3974,25 @@ void ToGraph::addFilter(
   {
     PlanObjectSet tables = currentDt_->tableSet;
     tables.add(currentDt_);
-    std::erase_if(flat, [&](const auto* conjunct) {
+    std::erase_if(flat, [&](ExprCP conjunct) {
       if (conjunct->allTables().isSubset(tables)) {
         return false;
       }
-      applyContext_.lifted.predicates.push_back(conjunct);
+      // A conjunct with no inner-DT references (e.g. after constant
+      // folding collapses one side of an equality) is a pure-outer
+      // guard, not a correlation key. Route it to 'outerGuards' so
+      // 'attachScalarSubqueryToOuter' wraps the scalar result in an IF.
+      bool hasInner = false;
+      conjunct->columns().template forEach<Column>([&](ColumnCP col) {
+        if (tables.contains(col->relation())) {
+          hasInner = true;
+        }
+      });
+      if (hasInner) {
+        applyContext_.lifted.predicates.push_back(conjunct);
+      } else {
+        applyContext_.lifted.outerGuards.push_back(conjunct);
+      }
       return true;
     });
   }

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -124,9 +124,26 @@ class ToGraph {
   }
 
   /// Creates or returns pre-existing function call with name+args. If
-  /// deterministic, a new ExprCP is remembered for reuse.
-  ExprCP
-  deduppedCall(Name name, Value value, ExprVector args, FunctionSet flags);
+  /// deterministic, a new ExprCP is remembered for reuse. 'functions'
+  /// on the resulting Call is computed as 'functionBits(name,
+  /// specialForm) | <each arg's functions()>'.
+  ExprCP deduppedCall(
+      Name name,
+      Value value,
+      ExprVector args,
+      bool specialForm = false);
+
+  /// Shorthand for 'deduppedCall(name, value, args, /*specialForm=*/
+  /// true)' — use at sites that construct a named special form (kIf,
+  /// kAnd, kCoalesce, ...).
+  ExprCP deduppedSpecialForm(Name name, Value value, ExprVector args) {
+    return deduppedCall(name, value, std::move(args), /*specialForm=*/true);
+  }
+
+  /// Shorthand for a boolean equality call 'left = right'. Uses
+  /// 'deduppedCall' so the resulting Call has the correct flags and is
+  /// deduplicated.
+  ExprCP makeEquality(ExprCP left, ExprCP right);
 
   /// True if 'expr' is of the form a = b where a depends on leftTable and b on
   /// rightTable or vice versa. If true, returns the side depending on
@@ -150,6 +167,98 @@ class ToGraph {
   }
 
  private:
+  // State for translating a (possibly correlated) subquery's body.
+  // Held as a single 'applyContext_' member on 'ToGraph'. Populated by
+  // producers during body translation; drained by the outer scope's
+  // 'process*Subqueries' code after 'translateSubquery' returns.
+  // 'outerDt' is save/restored by 'translateSubqueryBody' on body entry;
+  // 'lifted' is save/restored by call sites that invoke
+  // 'translateSubquery' while their own scope already has pending lifted
+  // state (nested subqueries inside a body that already lifted state of
+  // its own). All three lifted fields are asserted empty at
+  // 'translateSubqueryBody' entry.
+  struct ApplyContext {
+    // The DT one scope out: where this body's lifted (correlated)
+    // accumulators will eventually be drained into as join predicates /
+    // outer aggregation / projection substitutions.
+    DerivedTableP outerDt{nullptr};
+
+    // The three lifted accumulators for this scope's body. Bundled in
+    // one struct so a single value captures the full snapshot for
+    // save/restore across nested 'translateSubquery' calls.
+    struct Lifted {
+      // Filter conjuncts found in the subquery body that reference
+      // outer-scope columns. Drained by the outer scope's
+      // 'processCorrelatedScalarSubquery' (and friends) to become join
+      // keys or filter on the decorrelating LEFT JOIN.
+      ExprVector predicates;
+
+      // Residual projection expressions from the subquery's SELECT that
+      // reference outer-scope columns. Each entry combines pure-inner
+      // exported columns of the inner DT with outer-column references
+      // and is evaluated above the decorrelated join (typically by
+      // being substituted as the subquery's value in the outer
+      // expression).
+      ExprVector projections;
+
+      // An aggregation from the subquery body whose aggregate body
+      // references outer-scope columns. It is not attached to the inner
+      // DT (its body would fail the inner DT's tableSet check). Its
+      // output columns are created with relation set to 'outerDt' so
+      // the SELECT projection split classifies them as correlated.
+      // 'processCorrelatedScalarSubquery' attaches it to the outer DT
+      // above the decorrelating LEFT JOIN.
+      AggregationPlanCP aggregation{nullptr};
+
+      // True if all three accumulators are empty/null.
+      bool empty() const {
+        return predicates.empty() && projections.empty() &&
+            aggregation == nullptr;
+      }
+    };
+    Lifted lifted;
+
+    // Moves the lifted-state fields into a snapshot and clears them
+    // in place so the next nested 'translateSubquery' starts with a
+    // clean slate. Restore via `applyContext_.lifted = std::move(saved)`
+    // — that overwrites any current state, which is the desired
+    // behavior during exceptional unwind when the inner's state was
+    // not drained by its consumer.
+    Lifted saveAndClearLifted();
+  };
+
+  // For each column referenced by 'outerLifted->predicates' that
+  // lives in 'currentDt_'s tableSet, append an 'arbitrary()' aggregate
+  // over it to 'aggregates'/'columns', add the resulting post-aggregation
+  // column to 'currentDt_->columns', and rewrite the predicates in place
+  // to reference the post-aggregation column. No-op when 'outerLifted' is
+  // null or has empty predicates. Used by
+  // 'appendOuterAggregationCarryForwards' to thread the enclosing scope's
+  // correlation keys through an injected outer aggregation.
+  void carryForwardOuterCorrelationKeys(
+      ApplyContext::Lifted* outerLifted,
+      AggregateVector& aggregates,
+      ColumnVector& columns);
+
+  // Outer-side join keys, inner-side join keys, and remaining non-equi
+  // conjuncts extracted from a subquery's correlated WHERE conjuncts.
+  // 'leftTable' is the single outer table the conjuncts reference, or
+  // null when there are no correlated conjuncts.
+  struct CorrelationKeys {
+    PlanObjectCP leftTable{nullptr};
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+    ExprVector nonEquiConjuncts;
+  };
+
+  // Extracts equi join keys + non-equi conjuncts from
+  // 'correlatedConjuncts' into a CorrelationKeys, classifying each
+  // conjunct's tables against 'subqueryDt'.
+  static CorrelationKeys extractCorrelationKeys(
+      const FunctionNames& funcs,
+      const ExprVector& correlatedConjuncts,
+      DerivedTableP subqueryDt);
+
   // For comparisons, swaps the args to have a canonical form for
   // deduplication. E.g column op constant, and smaller plan object id
   // to the left.
@@ -160,10 +269,12 @@ class ToGraph {
   // be skipped (e.g., DISTINCT in EXISTS).
   //
   // Side effects for equi-correlated aggregations:
-  // - Clears correlatedConjuncts_ and repopulates it with new equality
+  // - Clears 'liftedPredicates' and repopulates it with new equality
   //   expressions that reference the new grouping key columns.
   // - Adds grouping key columns to currentDt_->exprs and currentDt_->columns.
-  AggregationPlanCP processCorrelatedAggregation(AggregationPlanCP agg);
+  AggregationPlanCP processCorrelatedAggregation(
+      AggregationPlanCP agg,
+      ExprVector& liftedPredicates);
 
   // Converts 'plan' to PlanObjects and records join edges into
   // 'currentDt_'. Wraps 'node' in a new Derived table f 'node' does not match
@@ -409,17 +520,35 @@ class ToGraph {
       DerivedTableP outerDt = nullptr);
 
   // Wraps currentDt_ via finalizeDt, preserving any pending
-  // correlatedConjuncts_. After wrapping, rewrites the conjuncts so their
-  // inner column references point to the wrapped DT's output columns.
-  void finalizeDtWithCorrelatedConjuncts(
+  // applyContext_.lifted.predicates and applyContext_.lifted.projections. After
+  // wrapping, rewrites their column references so they point to the wrapped
+  // DT's output columns.
+  void finalizeDtPreservingCorrelations(
       const logical_plan::LogicalPlanNode& node);
 
   // Creates a wrapper DerivedTable with a COUNT(*) aggregation over 'inputDt'.
   // Returns the count column. The wrapper DT is added to currentDt_.
   ColumnCP makeCountStarWrapper(DerivedTableP inputDt);
 
-  // Adds a column 'name' from current DerivedTable to 'dt'.
+  // Adds a column 'name' from current DerivedTable to 'dt'. The looked-up
+  // expression usually references only tables owned by 'dt'; that case
+  // appends to 'dt->exprs' / 'dt->columns' and updates 'renames_'. In
+  // subquery scope the expression may also reference outer-query tables
+  // via 'correlations_'; in that case it is routed to
+  // 'applyContext_.lifted.projections' (via 'splitCorrelatedProjection' for the
+  // mixed-reference variant), and 'dt' is not extended with the unsplit
+  // form (which would violate DerivedTable::checkConsistency).
   void addDtColumn(DerivedTableP dt, std::string_view name);
+
+  // Splits a subquery projection expression that references both 'dt's
+  // own tables and tables from an enclosing scope. Local-only maximal
+  // sub-trees are appended to 'dt->exprs' / 'dt->columns' as new columns;
+  // the returned residual replaces each such sub-tree with a reference to
+  // its new column, and still carries the original correlated references
+  // for evaluation above the decorrelated join. The walk does not descend
+  // into aggregate bodies, so an outer-column reference inside an
+  // aggregate cannot be split out and triggers a VELOX_NYI.
+  ExprCP splitCorrelatedProjection(ExprCP expr, DerivedTableP dt);
 
   void setDtUsedOutput(
       DerivedTableP dt,
@@ -467,6 +596,21 @@ class ToGraph {
     std::vector<logical_plan::ExprPtr> carryForwards;
   };
 
+  // Appends carry-forward aggregates needed by an injected outer
+  // aggregation: 'arbitrary()' over downstream-referenced outer columns
+  // ('appendArbitraryAggregates'); 'arbitrary()' over prior chain-mate
+  // subquery results (updating their 'subqueries_' entries); and the
+  // enclosing scope's correlation keys via
+  // 'carryForwardOuterCorrelationKeys'. Used by
+  // 'processCorrelatedScalarSubquery' and 'buildCorrelatedAggregation'
+  // to keep their post-join aggregation construction in lock-step.
+  void appendOuterAggregationCarryForwards(
+      const logical_plan::LogicalPlanNode& input,
+      SubqueryChain& chain,
+      ApplyContext::Lifted* outerLifted,
+      AggregateVector& aggregates,
+      ColumnVector& columns);
+
   // Process subqueries used in filter's predicate or projection expressions
   // and populate subqueries_ map. For each IN <subquery> expression, create a
   // separate DT for the subquery and add a semi-join edge. Replace the whole IN
@@ -512,6 +656,21 @@ class ToGraph {
       const logical_plan::LogicalPlanNode& input,
       SubqueryChain& chain);
 
+  // Attaches a scalar subquery's translated body ('subqueryDt') to the
+  // outer scope, picking the decorrelation shape from 'applyContext_':
+  // pure uncorrelated, correlated WHERE / outer-referencing aggregate, or
+  // correlated projection. Returns the expression to substitute for the
+  // subquery in the outer expression. Drains 'applyContext_'.
+  //
+  // 'outerLifted' holds the enclosing scope's pending lifted state saved
+  // before this call. See 'carryForwardOuterCorrelationKeys' for how it
+  // is used by the branches that inject an aggregation into 'currentDt_'.
+  ExprCP attachScalarSubqueryToOuter(
+      const logical_plan::LogicalPlanNode& input,
+      DerivedTableP subqueryDt,
+      SubqueryChain& chain,
+      ApplyContext::Lifted* outerLifted);
+
   // Processes an uncorrelated scalar subquery. Attempts constant folding,
   // otherwise ensures single row. Returns the expression to map to the
   // subquery.
@@ -523,11 +682,44 @@ class ToGraph {
   // between consecutive heavy-path subqueries in the caller's loop; the
   // heavy path reads it on entry and updates it on exit. The caller is
   // responsible for appending the produced expression to chain.carryForwards
-  // so subsequent wraps and aggregations preserve the result.
+  // so subsequent wraps and aggregations preserve the result. 'outerLifted'
+  // is the enclosing scope's pending lifted state; the non-equi-with-
+  // aggregation branch routes it through 'carryForwardOuterCorrelationKeys'.
   ExprCP processCorrelatedScalarSubquery(
       const logical_plan::LogicalPlanNode& input,
       DerivedTableP subqueryDt,
-      SubqueryChain& chain);
+      SubqueryChain& chain,
+      ApplyContext::Lifted* outerLifted);
+
+  // Builds the AssignUniqueId + LEFT JOIN + outer aggregation that
+  // decorrelates a scalar subquery whose aggregate body references outer
+  // columns. The aggregate is held in 'applyContext_.lifted.aggregation'
+  // (set by 'translateAggregation'). Drains 'applyContext_.lifted.aggregation'
+  // and 'applyContext_.lifted.predicates' on return. 'outerLifted' is the
+  // enclosing scope's pending lifted state, routed through
+  // 'carryForwardOuterCorrelationKeys' so its correlation keys are
+  // exposed on the synthesized aggregation.
+  ExprCP buildCorrelatedAggregation(
+      const logical_plan::LogicalPlanNode& input,
+      DerivedTableP subqueryDt,
+      SubqueryChain& chain,
+      const CorrelationKeys& correlation,
+      ApplyContext::Lifted* outerLifted);
+
+  // Processes a scalar subquery whose SELECT references outer-query
+  // columns. Returns the expression to substitute for the subquery: a
+  // residual that combines pure-inner exports of subqueryDt with
+  // outer-column references, evaluated above the decorrelated join.
+  // The inner DT is integrated into the join graph (or dropped) as
+  // appropriate for its shape. Must be called only when
+  // 'applyContext_.lifted.projections' is non-empty; drains it on return.
+  // 'outerLifted' is forwarded to 'processCorrelatedScalarSubquery' when
+  // this method delegates to the heavy path.
+  ExprCP processProjectionCorrelatedScalarSubquery(
+      const logical_plan::LogicalPlanNode& input,
+      DerivedTableP subqueryDt,
+      SubqueryChain& chain,
+      ApplyContext::Lifted* outerLifted);
 
   // Processes IN <subquery> predicates, creating semi-joins with mark columns.
   // Populates subqueries_ with mappings from IN predicates to mark columns.
@@ -547,13 +739,19 @@ class ToGraph {
       ExprCP leftKey,
       PlanObjectCP leftTable);
 
-  // Processes a correlated IN <subquery> predicate.
-  // Returns the mark column to map to the predicate.
+  // Processes a correlated IN <subquery> predicate. 'inRightKey' is the
+  // right side of the IN comparison: the inner DT's single output
+  // column when the subquery's SELECT has no outer refs, or the lifted
+  // residual otherwise. 'inRightHasOuter' selects equi-key vs filter
+  // placement for the IN equality. Returns the mark column to map to
+  // the predicate.
   ExprCP processCorrelatedInPredicate(
       DerivedTableP subqueryDt,
       ColumnCP markColumn,
       ExprCP leftKey,
-      PlanObjectCP leftTable);
+      PlanObjectCP leftTable,
+      ExprCP inRightKey,
+      bool inRightHasOuter);
 
   // Processes EXISTS subqueries, creating mark joins or cross joins.
   // Populates subqueries_ with mappings from EXISTS expressions to mark columns
@@ -575,7 +773,7 @@ class ToGraph {
 
   // Translates a subquery into a DerivedTable. Sets up correlations_ to allow
   // the subquery to reference columns from the outer query. After translation,
-  // correlatedConjuncts_ contains any correlated predicates found.
+  // applyContext_.lifted.predicates contains any correlated predicates found.
   //
   // @param node The logical plan node representing the subquery.
   // @param finalize If true (default), adds the subquery DT to currentDt_ and
@@ -586,6 +784,14 @@ class ToGraph {
   DerivedTableP translateSubquery(
       const logical_plan::LogicalPlanNode& node,
       bool finalize = true);
+
+  // Translates the body of a subquery. Asserts that 'applyContext_' has
+  // no leftover lifted accumulators on entry, swaps 'currentDt_' for a
+  // fresh inner DT (save/restoring 'applyContext_.outerDt'), recursively
+  // translates 'node' into it, then restores 'currentDt_' and returns
+  // the inner DT.
+  DerivedTableP translateSubqueryBody(
+      const logical_plan::LogicalPlanNode& node);
 
   // Appends `arbitrary` aggregates for all columns used from 'input'.
   // Used when decorrelating non-equi correlated subqueries. Since the
@@ -646,9 +852,12 @@ class ToGraph {
   // True if expression is allowed to reference symbols from the 'outer' query.
   bool allowCorrelations_{false};
 
-  // Filter conjuncts found in a subquery that reference symbols from the
-  // 'outer' query.
-  ExprVector correlatedConjuncts_;
+  // Correlated-subquery accumulators for the currently active subquery
+  // body translation. Populated by producers (correlated predicates,
+  // projections, aggregations) and drained by the outer scope's
+  // 'process*Subqueries' code after 'translateSubquery' returns. At top
+  // level (outside any subquery scope), this is empty.
+  ApplyContext applyContext_;
 
   // Maps an expression that contains a subquery to a column or constant that
   // should be used instead. Populated in 'processSubqueries()'.

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -145,6 +145,22 @@ class ToGraph {
   /// deduplicated.
   ExprCP makeEquality(ExprCP left, ExprCP right);
 
+  /// Combines 'args' with AND. Returns 'args.front()' when there's one,
+  /// builds 'AND(args...)' otherwise. 'args' must be non-empty.
+  ExprCP makeAnd(ExprVector args);
+
+  /// Wraps a scalar subquery's result in 'IF(AND(guards), expr, NULL)'.
+  /// Returns 'expr' unchanged when 'guards' is empty. Semantics: when
+  /// the gating condition fails, the scalar subquery returns NULL,
+  /// matching the empty-inner aggregate semantics.
+  ExprCP wrapScalarInGuards(ExprVector guards, ExprCP expr);
+
+  /// Wraps an IN or EXISTS mark column in 'AND(expr, guards...)'.
+  /// Returns 'expr' unchanged when 'guards' is empty. Semantics: when
+  /// the gating condition fails, the mark is false (the gate is part
+  /// of the inner WHERE; no inner row would match).
+  ExprCP wrapMarkInGuards(ExprVector guards, ExprCP expr);
+
   /// True if 'expr' is of the form a = b where a depends on leftTable and b on
   /// rightTable or vice versa. If true, returns the side depending on
   /// 'leftTable' in 'left' and the other in 'right'.
@@ -210,10 +226,17 @@ class ToGraph {
       // above the decorrelating LEFT JOIN.
       AggregationPlanCP aggregation{nullptr};
 
-      // True if all three accumulators are empty/null.
+      // Filter conjuncts that reference only outer-scope columns (e.g.,
+      // an equality whose inner side constant-folded away). These are
+      // not correlation keys; they gate whether the subquery's result
+      // is observed by the outer row. Every subquery consumer must
+      // drain this field.
+      ExprVector outerGuards;
+
+      // True if all accumulators are empty/null.
       bool empty() const {
         return predicates.empty() && projections.empty() &&
-            aggregation == nullptr;
+            outerGuards.empty() && aggregation == nullptr;
       }
     };
     Lifted lifted;

--- a/axiom/optimizer/docs/Subqueries.md
+++ b/axiom/optimizer/docs/Subqueries.md
@@ -251,10 +251,13 @@ into a filter (e.g., it appears inside an aggregation or below a LIMIT):
    to a join key.
 
    ```sql
-   -- Not supported: correlation inside COUNT
+   -- Not supported by basic decorrelation: correlation inside COUNT
    SELECT * FROM customers c
    WHERE (SELECT COUNT(o.order_id + c.customer_id) FROM orders o) > 10
    ```
+
+   Scalar subqueries with this shape are decorrelated by an alternative
+   path — see "Outer-column reference inside an aggregate" below.
 
 4. **Correlation with LIMIT**: When a correlated subquery uses LIMIT to
    restrict results per outer row, decorrelation is not straightforward because
@@ -724,10 +727,12 @@ hash join key, while the inequality `u.b > t.b` becomes the join filter. When
 a correlation has only non-equality conditions (no equalities), a nested-loop
 join is used instead.
 
-#### Correlated Scalar Subquery in Projection
+#### Correlated Scalar Subquery in Projection — Correlation in WHERE Only
 
-Correlated scalar subqueries in the SELECT list are decorrelated the same way
-as in filters. With aggregation, the correlation key becomes a GROUP BY key:
+When the **inner WHERE clause** references outer columns but the **inner
+SELECT** references only inner columns, decorrelation works the same way as
+for correlated subqueries in filters. With aggregation, the correlation key
+becomes a GROUP BY key:
 
 ```sql
 -- Original
@@ -761,6 +766,190 @@ EnforceDistinct(keys=[__rownum], error="Scalar sub-query has returned multiple r
        │    └─ Scan(t)
        └─ Scan(u)
 ```
+
+#### Correlated Scalar Subquery with Outer Columns in the Projection
+
+A scalar subquery's **own SELECT expression** can also reference outer-query
+columns, independently of any correlation in its WHERE clause:
+
+```sql
+-- 'u.x' is inner, 't.a' is outer; both appear in the inner SELECT.
+SELECT (SELECT t.a + u.x FROM u WHERE u.k = t.k)
+FROM t;
+```
+
+Naively translating the subquery body would store `t.a + u.x` as a projection
+expression owned by the subquery's `DerivedTable`, violating the invariant
+that a `DerivedTable`'s expressions reference only its own tables. The
+optimizer therefore **splits** each correlated projection expression into:
+
+1. A set of **inner-only sub-expressions**, exported as additional columns
+   of the inner `DerivedTable`.
+2. A **residual outer expression** that combines those exported columns with
+   outer-column references. The residual is recorded in
+   `applyContext_.lifted.projections` (sibling of
+   `applyContext_.lifted.predicates`) and evaluated above the decorrelated
+   join by substituting it into the outer SELECT's expression tree.
+
+##### Split algorithm
+
+Walking the projection expression top-down, at each node:
+
+| Node references          | Action                                                                                       |
+|--------------------------|----------------------------------------------------------------------------------------------|
+| Inner cols only          | Export the whole subtree as an inner DT column; replace with a reference to that column.     |
+| Outer cols only          | Keep in the residual expression. Stop descending.                                            |
+| Both outer and inner     | Keep the node in the residual; recurse into children.                                        |
+| Aggregate (any contents) | Treat as opaque. See "Outer-column reference inside an aggregate" below.                     |
+
+##### Trivial pass-through (no inner FROM)
+
+When the subquery body has no FROM clause, the inner DT has no tables and the
+split produces no inner-only exports. The residual is the outer expression
+itself:
+
+```sql
+-- Original
+SELECT (SELECT a) FROM t;
+
+-- Rewritten as
+SELECT a FROM t;
+```
+
+The subquery disappears entirely. `EnforceSingleRow` is trivially satisfied
+because the empty-tuple input has cardinality 1.
+
+##### Top-level outer/inner mix, no correlated WHERE
+
+```sql
+-- Original
+SELECT (SELECT t.a + u.x FROM u WHERE u.x = 1)
+FROM t;
+
+-- Split: inner export {u_x = u.x}; residual {t.a + u_x}.
+-- Rewritten plan
+Project[ t.a + sub.u_x ]
+  └─ CrossJoin
+       ├─ Scan(t)
+       └─ EnforceSingleRow
+            └─ Filter[ u.x = 1 ]
+                 └─ Scan(u)
+```
+
+##### Outer ref combined with an aggregate result
+
+```sql
+-- Original
+SELECT (SELECT max(u.x) + t.a FROM u WHERE u.k = t.k)
+FROM t;
+
+-- Split: inner export {max_x = max(u.x)}; residual {max_x + t.a}.
+-- Inner WHERE correlation 'u.k = t.k' goes through the existing
+-- applyContext_.lifted.predicates path; applyContext_.lifted.projections
+-- carries 'max_x + t.a'.
+-- Rewritten as
+SELECT subq.max_x + t.a
+FROM t
+LEFT JOIN (
+    SELECT u.k, max(u.x) AS max_x
+    FROM u
+    GROUP BY u.k
+) AS subq ON subq.k = t.k;
+```
+
+##### Correlated projection but no correlated WHERE
+
+```sql
+-- Original
+SELECT (SELECT t.a + max(u.x) FROM u)
+FROM t;
+
+-- Split: inner export {max_x = max(u.x)}; residual {t.a + max_x}.
+-- Rewritten plan
+Project[ t.a + sub.max_x ]
+  └─ CrossJoin
+       ├─ Scan(t)
+       └─ Aggregate[ max(u.x) AS max_x ]
+            └─ Scan(u)
+```
+
+Cross join + single-row guarantee from the inner global aggregation. The
+residual `t.a + sub.max_x` evaluates above the join.
+
+##### Outer-column reference inside an aggregate
+
+```sql
+-- Original: 't.a' is inside max(...).
+SELECT (SELECT max(u.x + t.a) FROM u WHERE u.k = t.k)
+FROM t;
+```
+
+An aggregate whose body references outer columns cannot live on the inner
+DT — its body would fail the inner DT's `tableSet` check, which requires
+every referenced table to be in the DT's own `tableSet`. The aggregation
+is captured during translation in `applyContext_.lifted.aggregation`
+(sibling of `applyContext_.lifted.predicates` and
+`applyContext_.lifted.projections`) and never attached to the inner DT.
+Its result column is created with relation set to the outer DT at
+`translateAggregation` time, so the SELECT-projection split classifies
+references to it as correlated. When the subquery is processed,
+`buildCorrelatedAggregation` builds the LEFT JOIN + outer aggregation on
+the outer DT directly, using AssignUniqueId on the outer table to group
+one row per outer row:
+
+```
+-- Rewritten plan
+Project[ subq.result ]
+  └─ Aggregate GROUP BY t.__rownum,
+                max(u.x + t.a) AS result,
+                arbitrary(...) outer-column carry-forwards
+       └─ LeftJoin (t.k = u.k)
+            ├─ AssignUniqueId(__rownum)
+            │    └─ Scan(t)
+            └─ Scan(u)
+```
+
+The same shape applies when the subquery has no correlated WHERE clause:
+the join becomes a cross join (no equality keys, no filter), and any outer
+table referenced by the aggregate body serves as the AssignUniqueId target.
+
+```sql
+-- No correlated WHERE; t.b reference inside max() still triggers deferral.
+SELECT (SELECT max(u.x + t.b) FROM u) FROM t;
+```
+
+**Future optimization.** Algebraic identities such as
+`max(x + c) = max(x) + c` (with `c` constant per outer row) can rewrite the
+inner aggregate body to remove the outer reference, converting this case to
+the cheaper "outer ref combined with an aggregate result" form. Not required
+for correctness.
+
+##### Implementation notes
+
+- All correlation accumulators are fields of the `ApplyContext` struct,
+  held as a single `applyContext_` member on `ToGraph`. The
+  `outerDt` field is save/restored on entry to a subquery scope; the
+  lifted accumulators are shared across the `translateSubquery` call
+  boundary (asserted empty at entry).
+- `allowCorrelations_` is extended to be enabled around projection and
+  aggregate translation inside subquery bodies, in addition to
+  `translateConjuncts`.
+- `applyContext_.lifted.projections` is drained at the same boundaries as
+  `applyContext_.lifted.predicates` (e.g., precondition of `finalizeDt`;
+  saved and restored by `finalizeDtPreservingCorrelations`).
+- `applyContext_.lifted.aggregation` holds the deferred AggregationPlan;
+  its result column's relation is set to `applyContext_.outerDt` at
+  `translateAggregation` time so split classification treats references
+  to it as correlated.
+- `applyContext_.outerDt` is captured on entry to every subquery scope
+  (the enclosing DT, saved/restored via SCOPE_EXIT). Used as the
+  relation for `applyContext_.lifted.aggregation`'s output columns.
+- `processCorrelatedScalarSubquery` dispatches: if
+  `applyContext_.lifted.aggregation` is set, `buildCorrelatedAggregation`
+  builds the AssignUniqueId + LEFT JOIN + outer aggregation; otherwise
+  the existing equi-aggregation / no-aggregation / non-equi paths run.
+  Residual expressions from `applyContext_.lifted.projections` are
+  substituted into the outer expression via `subqueries_`.
 
 ### IN Subqueries
 
@@ -1033,6 +1222,8 @@ directly.
 |---------------|----------|--------------|
 | Scalar (with agg) | Filter/Projection/GROUP BY | Left join + GROUP BY correlation key |
 | Scalar (without agg) | Filter/Projection/GROUP BY | AssignUniqueId + Left join + EnforceDistinct |
+| Scalar (correlated projection, no aggregate over outer cols) | Projection | Split + same join shape as above + residual Project on top |
+| Scalar (aggregate body references outer cols) | Any | AssignUniqueId + Left join + outer Aggregate grouped by `__rownum` |
 | IN | Filter | Semi-join with correlation keys |
 | IN | Projection | Mark semi-join with correlation keys |
 | NOT IN | Filter | Anti-join with correlation keys |
@@ -1084,9 +1275,54 @@ const folly::F14FastMap<std::string, ExprCP>* correlations_;
 // True if expression is allowed to reference symbols from the 'outer' query.
 bool allowCorrelations_{false};
 
-// Filter conjuncts found in a subquery that reference symbols from the
-// 'outer' query.
-ExprVector correlatedConjuncts_;
+// Per-scope state for a (possibly correlated) subquery body translation.
+// Populated by producers during body translation, drained by the outer
+// scope's 'process*Subqueries' code after 'translateSubquery' returns.
+// 'outerDt' is save/restored on body entry; 'lifted' is save/restored
+// at every nested 'translateSubquery' call site via
+// 'saveAndClearLifted' so nested scopes start with a clean slate. All
+// three lifted fields are asserted empty at 'translateSubqueryBody'
+// entry.
+struct ApplyContext {
+  // The enclosing DT when translating inside a subquery scope. Drives
+  // placement of columns produced inside the subquery body that
+  // conceptually belong to the outer scope (e.g. 'lifted.aggregation'
+  // output columns).
+  DerivedTableP outerDt{nullptr};
+
+  // The three lifted accumulators for this scope's body. Bundled so a
+  // single value captures the full snapshot for save/restore across
+  // nested 'translateSubquery' calls.
+  struct Lifted {
+    // Filter conjuncts found in a subquery that reference outer-scope
+    // columns.
+    ExprVector predicates;
+
+    // Residual outer-side expressions from a subquery's SELECT that
+    // reference outer-scope columns. The inner DT owns only pure-inner
+    // sub-trees, materialized as exported columns; each entry here
+    // combines those exported columns with outer-column references and
+    // is evaluated above the decorrelated join.
+    ExprVector projections;
+
+    // A subquery's aggregation whose body references outer columns. It
+    // is not attached to the inner DT (its body would fail the inner
+    // DT's tableSet check). Its output columns are created with
+    // relation set to 'outerDt' so the SELECT-projection split
+    // classifies them as correlated.
+    // 'processCorrelatedScalarSubquery' attaches it to the outer DT
+    // above the decorrelating LEFT JOIN.
+    AggregationPlanCP aggregation{nullptr};
+  };
+  Lifted lifted;
+
+  // Moves the lifted-state fields into a snapshot and clears them so
+  // the next nested 'translateSubquery' starts with a clean slate.
+  // Restore via `applyContext_.lifted = std::move(snapshot)`.
+  Lifted saveAndClearLifted();
+};
+
+ApplyContext applyContext_;
 
 // Maps an expression that contains a subquery to a column or constant that
 // should be used instead. Populated in 'processSubqueries()'.
@@ -1136,7 +1372,7 @@ struct DecorrelatedJoin {
 };
 ```
 
-The `extractDecorrelatedJoin()` helper processes `correlatedConjuncts_` and
+The `extractDecorrelatedJoin()` helper processes `applyContext_.lifted.predicates` and
 separates equality conditions (which become join keys) from non-equality
 conditions (which become join filters).
 
@@ -1291,6 +1527,12 @@ DerivedTableP ToGraph::translateSubquery(
    ```
    TODO: Support by pre-computing subquery conjuncts as projected boolean
    columns on the appropriate side.
+
+6. **Multi-column scalar subqueries**
+   ```sql
+   -- Not supported: scalar context expects exactly one output column
+   SELECT (SELECT t.a, max(u.x) FROM u WHERE u.k = t.k) FROM t;
+   ```
 
 ## Architectural Notes
 

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -310,6 +310,20 @@ SELECT (SELECT max(u.a + t.b) + t.c FROM u) FROM t
 -- an inner global aggregate.
 SELECT (SELECT t.a + max(u.a) FROM u) FROM t
 ----
+-- Correlated WHERE where the inner side of the equality is a constant
+-- projection. Constant folding collapses one side, leaving a pure-outer
+-- gating condition: per outer row, the scalar returns the aggregate
+-- when the condition holds, else NULL.
+SELECT (SELECT max(o.b) FROM (SELECT 1 AS a, 42 AS b) o WHERE o.a = t.a) FROM t
+----
+-- Same shape inside an IN subquery: gate fails ⇒ no inner row matches
+-- ⇒ IN returns false.
+SELECT t.a IN (SELECT o.a FROM (SELECT 1 AS a) o WHERE o.a = t.a) FROM t
+----
+-- Same shape inside an EXISTS subquery: gate fails ⇒ no inner row ⇒
+-- EXISTS returns false.
+SELECT EXISTS (SELECT 1 FROM (SELECT 1 AS a) o WHERE o.a = t.a) FROM t
+----
 -- Two-level nested correlated scalar subqueries: the innermost body
 -- correlates on the middle scope's u, and the middle body correlates on
 -- the top scope's t.

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -276,3 +276,124 @@ SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 -- Uncorrelated scalar subquery whose source needs runtime single-row
 -- enforcement. Returns one row per outer row.
 SELECT (SELECT u.a FROM u WHERE u.a = 1) FROM t
+----
+-- Scalar subquery whose SELECT references an outer column. The subquery
+-- has no FROM clause: result is just the outer column.
+SELECT (SELECT a) FROM t
+----
+-- As above, but the inner SELECT is an expression over the outer column.
+SELECT (SELECT a + 1) FROM t
+----
+-- Scalar subquery with FROM, no correlated WHERE, projection mixes outer
+-- and inner columns at top level.
+SELECT (SELECT t.a + u.a FROM u WHERE u.a = 1) FROM t
+----
+-- Correlated WHERE plus correlated projection: outer column added to an
+-- inner aggregate result.
+SELECT (SELECT max(u.a) + t.a FROM u WHERE u.a = t.a) FROM t
+----
+-- Outer column inside an aggregate body.
+SELECT (SELECT max(u.a + t.a) FROM u WHERE u.a = t.a) FROM t
+----
+-- Outer column inside an aggregate body AND wrapping the aggregate result.
+SELECT (SELECT max(u.a + t.a) + t.a FROM u WHERE u.a = t.a) FROM t
+----
+-- WHERE, aggregate body, and post-aggregate residual each reference a
+-- different outer column.
+SELECT (SELECT max(u.a + t.b) + t.c FROM u WHERE u.a = t.a) FROM t
+----
+-- Aggregate body and post-aggregate residual reference different outer
+-- columns; no correlated WHERE.
+SELECT (SELECT max(u.a + t.b) + t.c FROM u) FROM t
+----
+-- Correlated projection but no correlated WHERE: outer column added to
+-- an inner global aggregate.
+SELECT (SELECT t.a + max(u.a) FROM u) FROM t
+----
+-- Two-level nested correlated scalar subqueries: the innermost body
+-- correlates on the middle scope's u, and the middle body correlates on
+-- the top scope's t.
+SELECT (SELECT (SELECT max(v.a) FROM v WHERE v.a > u.a) FROM u WHERE u.a = t.a) FROM t
+----
+-- No-FROM subquery body with a correlated WHERE. Per outer row the
+-- WHERE filters whether the single empty-tuple row passes; the scalar
+-- subquery returns the SELECT expression or NULL.
+SELECT (SELECT t.a WHERE t.a = 1) FROM t
+----
+SELECT (SELECT t.b + 100 WHERE t.a > 1) FROM t
+----
+-- NYI: no-FROM subquery body with an aggregate whose body references an
+-- outer column.
+-- error: Correlated aggregate in a no-FROM subquery body is not supported yet
+SELECT (SELECT max(t.a)) FROM t
+----
+-- No-FROM subquery body with a cardinality-neutral aggregate. count(*)
+-- over the single empty-tuple row produces 1; per outer row the result
+-- is t.a + 1.
+SELECT (SELECT count(*) + t.a) FROM t
+----
+-- No-FROM subquery body with LIMIT 0 — the single row is cut to zero,
+-- so the scalar subquery returns NULL per outer row.
+SELECT (SELECT t.a LIMIT 0) FROM t
+----
+-- Correlated WHERE plus correlated projection over a count-style
+-- aggregate. count(*) over empty input is 0 (not NULL), so per-outer-row
+-- result is t.a when no matching u row exists.
+SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a) FROM t
+----
+-- Same shape with a correlation that no outer row matches (t.a values
+-- are 1..3, u.a values are 1..5, t.a + 100 is never in u).
+SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a + 100) FROM t
+----
+-- NYI: outer-column reference in a non-inner join's ON condition inside
+-- a correlated subquery.
+-- error: Cannot resolve column in join input
+SELECT (SELECT max(u.a) FROM u LEFT JOIN v ON v.a = t.a) FROM t
+----
+-- NYI: correlated subquery whose body is a UNION ALL of two branches
+-- that each reference an outer column.
+-- error: Correlated reference inside a UNION ALL branch is not supported yet
+SELECT (SELECT max(a) FROM (SELECT u.a FROM u WHERE u.a = t.a UNION ALL SELECT v.a FROM v WHERE v.a = t.a)) FROM t
+----
+-- Outer-column reference in the SELECT of an IN subquery: the
+-- comparison value combines an inner column with an outer column.
+SELECT t.a IN (SELECT u.a + t.b FROM u WHERE u.a > 0) FROM t
+----
+-- NYI: outer-column reference inside an aggregate body of an IN
+-- subquery. The aggregate is in HAVING (not SELECT), so the SELECT
+-- projection stays purely local and only the aggregate-body lift fires.
+-- error: Outer-column reference in the aggregate body of an IN subquery is not supported yet
+SELECT t.a IN (SELECT u.a FROM u GROUP BY u.a HAVING max(u.a + t.b) > 0) FROM t
+----
+-- EXISTS ignores the subquery's SELECT projection, so an outer-column
+-- reference there is harmless: row existence is decided by the
+-- correlated WHERE alone.
+SELECT EXISTS (SELECT u.a + t.b FROM u WHERE u.a = t.a) FROM t
+----
+-- A global aggregate over the (possibly empty) inner relation always
+-- produces exactly one row, so EXISTS over an aggregating body is true
+-- for every outer row regardless of correlation.
+SELECT EXISTS (SELECT max(u.a + t.b) FROM u WHERE u.a = t.a) FROM t
+----
+-- Multi-arg aggregate with one arg referencing inner and another
+-- referencing outer.
+SELECT (SELECT min_by(u.a, t.b) FROM u WHERE u.a > 0) FROM t
+----
+-- NYI: aggregate whose args reference only outer columns.
+-- error: aggregate whose arguments reference only outer columns is not supported yet
+SELECT (SELECT count(t.a) FROM u WHERE u.a > 999) FROM t
+----
+-- Multiple aggregates, each referencing an outer column.
+SELECT (SELECT max(u.a + t.b) + min(u.a + t.c) FROM u WHERE u.a > 0) FROM t
+----
+-- Multiple aggregates where one references outer and another does not
+-- (constant arg, no args, inner-only arg).
+SELECT (SELECT max(u.a + t.b) + count(1) FROM u WHERE u.a > 0) FROM t
+----
+SELECT (SELECT max(u.a + t.b) + count(*) FROM u WHERE u.a > 0) FROM t
+----
+SELECT (SELECT max(u.a + t.b) + sum(u.a) FROM u WHERE u.a > 0) FROM t
+----
+-- Scalar subquery whose SELECT references the same inner column more
+-- than once alongside an outer column.
+SELECT (SELECT u.a + t.a + u.a + 1 FROM u WHERE u.a = t.a) FROM t


### PR DESCRIPTION
Summary:

`SELECT (SELECT max(o.b) FROM (SELECT 1 AS a, 42 AS b) o WHERE o.a = t.a) FROM t` previously failed in `extractCorrelationKeys` with `INVALID_STATE (2 vs. 1) Expression: 2 == tables.size()`. The inner `o.a` is a constant projection, so constant folding turns `o.a = t.a` into `1 = t.a` — a one-table conjunct. The correlation extraction assumed every lifted conjunct has exactly two tables (one outer, one inner).

A one-table conjunct that references only outer columns is not a correlation key — it's a per-outer-row gate on whether the inner subquery's result is meaningful for that row.

Mechanism: `addFilter` now classifies each lifted conjunct: those with at least one inner-DT column reference go to `ApplyContext::Lifted::predicates` (existing correlation channel); pure-outer ones go to a new `ApplyContext::Lifted::outerGuards` field. The three subquery consumers drain `outerGuards` and wrap their result:
- Scalar: `IF(AND(guards), result, NULL)` — empty inner means scalar is NULL.
- IN: `AND(mark, guards)` — gate fails ⇒ no inner row matches ⇒ mark is false.
- EXISTS: `AND(mark, guards)` — same as IN.

Reviewed By: amitkdutta

Differential Revision: D105592874


