### PR TITLE
fix: Explicit error for unresolved enum types with known catalog (#1384)

### DIFF
--- a/axiom/common/SchemaTypeName.h
+++ b/axiom/common/SchemaTypeName.h
@@ -51,6 +51,6 @@ struct fmt::formatter<facebook::axiom::SchemaTypeName>
     : fmt::formatter<std::string_view> {
   auto format(const facebook::axiom::SchemaTypeName& name, format_context& ctx)
       const {
-    return fmt::format_to(ctx.out(), R"d("{}"."{}")d", name.schema, name.type);
+    return fmt::format_to(ctx.out(), "{}.{}", name.schema, name.type);
   }
 };

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -303,9 +303,10 @@ TypePtr tryConnectorBasedTypeResolution(
 }
 
 // Attempts to resolve a qualified name (e.g., "catalog.schema.status.active")
-// as an enum literal. Returns nullopt if the type is not found. Throws
-// PrestoSqlError if the type is found but the value is not a valid enum member,
-// or if the resolved type is not an enum type.
+// as an enum literal. Returns nullopt if the catalog is not registered. Throws
+// PrestoSqlError if the catalog is registered but the type is not found, if the
+// value is not a valid enum member, or if the resolved type is not an enum
+// type.
 std::optional<lp::ExprApi> tryResolveEnumLiteral(
     const std::vector<std::string>& parts,
     folly::F14FastMap<std::string, TypePtr>& typeCache,
@@ -315,15 +316,19 @@ std::optional<lp::ExprApi> tryResolveEnumLiteral(
   }
 
   const auto& catalog = parts[0];
-  auto schema = parts[1];
-  auto typeName = folly::join('.', parts.begin() + 2, parts.end() - 1);
+  facebook::axiom::SchemaTypeName schemaTypeName{
+      parts[1], folly::join('.', parts.begin() + 2, parts.end() - 1)};
   const auto& valueName = parts.back();
 
-  auto type = findQualifiedType(
-      catalog,
-      facebook::axiom::SchemaTypeName{std::move(schema), std::move(typeName)},
-      typeCache);
+  auto type = findQualifiedType(catalog, schemaTypeName, typeCache);
   if (type == nullptr) {
+    if (facebook::axiom::connector::ConnectorMetadataRegistry::tryGet(
+            catalog) != nullptr) {
+      AXIOM_PRESTO_SEMANTIC_FAIL(
+          location,
+          fmt::format("{}.{}", catalog, schemaTypeName),
+          "Type not found");
+    }
     return std::nullopt;
   }
 

--- a/axiom/sql/presto/tests/EnumLiteralTest.cpp
+++ b/axiom/sql/presto/tests/EnumLiteralTest.cpp
@@ -157,10 +157,20 @@ TEST_F(EnumLiteralTest, castToEnumType) {
 }
 
 TEST_F(EnumLiteralTest, unknownTypeAndCatalog) {
-  // Unknown type with known catalog falls through to column dereference.
-  VELOX_ASSERT_THROW(
+  // Unknown type with known catalog produces explicit error.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSelect("SELECT tc.myschema.NonExistent.VALUE FROM nation"),
-      "Cannot resolve column: tc");
+      "near 'tc.myschema.nonexistent': Type not found");
+
+  // Case-insensitive: token is lowercased.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect("SELECT tc.MYSCHEMA.NONEXISTENT.VALUE FROM nation"),
+      "near 'tc.myschema.nonexistent': Type not found");
+
+  // Multi-part type name with known catalog.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect("SELECT tc.myschema.foo.bar.VALUE FROM nation"),
+      "near 'tc.myschema.foo.bar': Type not found");
 
   // Unknown catalog falls through to column dereference.
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
Summary:

When enum literal resolution fails for a known catalog (registered in ConnectorMetadataRegistry), throws an explicit "Type not found" error instead of falling through to column dereference, which produced a confusing "Cannot resolve column" error.

- `ExpressionPlanner.cpp` — After `findQualifiedType` returns nullptr, checks if the catalog is registered. If so, throws `AXIOM_PRESTO_SEMANTIC_FAIL("Type not found: catalog.schema.type")`.

- `EnumLiteralTest.cpp` — Updated `unknownTypeAndCatalog` test to expect the new error via `AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR`.

Reviewed By: mbasmanova

Differential Revision: D103939746


