### PR TITLE
fix: Dedup scalar subqueries shared between SELECT and GROUP BY (#1386)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -39,6 +39,49 @@ namespace lp = facebook::axiom::logical_plan;
 namespace facebook::axiom::optimizer {
 namespace {
 
+// Structural identity for 'subqueries_' map keys. 'plan' is the inner
+// LogicalPlanNode that determines the subquery's result column; nullptr if
+// 'expr' is not a subquery-bearing pattern. 'kind' distinguishes scalar
+// vs. EXISTS vs. IN — they produce different result columns over the same
+// plan (scalar value vs. boolean mark) and must not collapse. 'inLhs' is
+// non-null only for IN, where different left-hand sides produce different
+// mark columns.
+enum class SubqueryKind { kScalar, kExists, kIn };
+
+struct SubqueryKey {
+  SubqueryKind kind{SubqueryKind::kScalar};
+  const lp::LogicalPlanNode* plan{nullptr};
+  // For kIn only: the IN predicate's left-hand side. Different LHS values
+  // produce different mark columns over the same subquery and must not
+  // collapse.
+  const lp::Expr* lhs{nullptr};
+};
+
+SubqueryKey subqueryKeyOf(const lp::ExprPtr& expr) {
+  if (expr->isSubquery()) {
+    return {
+        SubqueryKind::kScalar,
+        expr->as<lp::SubqueryExpr>()->subquery().get(),
+        nullptr};
+  }
+  if (expr->isSpecialForm()) {
+    const auto* specialForm = expr->as<lp::SpecialFormExpr>();
+    const auto form = specialForm->form();
+    if (form == lp::SpecialForm::kExists) {
+      const auto* inner = specialForm->inputAt(0)->as<lp::SubqueryExpr>();
+      return {SubqueryKind::kExists, inner->subquery().get(), nullptr};
+    }
+    if (form == lp::SpecialForm::kIn && specialForm->inputAt(1)->isSubquery()) {
+      const auto* inner = specialForm->inputAt(1)->as<lp::SubqueryExpr>();
+      return {
+          SubqueryKind::kIn,
+          inner->subquery().get(),
+          specialForm->inputAt(0).get()};
+    }
+  }
+  return {};
+}
+
 Value toValue(const velox::TypePtr& type, float cardinality) {
   return clampCardinality(Value{toType(type), cardinality});
 }
@@ -89,6 +132,35 @@ velox::ExceptionContext makeExceptionContext(ToGraphContext* ctx) {
   return e;
 }
 } // namespace
+
+size_t SubqueryExprHash::operator()(const lp::ExprPtr& expr) const {
+  const auto key = subqueryKeyOf(expr);
+  // translateExpr() looks up subqueries_ with arbitrary expressions; for
+  // non-subquery keys, fall back to pointer hash so the lookup misses
+  // cleanly. Only emplace is restricted to subquery-bearing patterns.
+  if (key.plan == nullptr) {
+    return std::hash<const lp::Expr*>{}(expr.get());
+  }
+  return folly::hash::hash_combine(
+      static_cast<size_t>(key.kind),
+      std::hash<const lp::LogicalPlanNode*>{}(key.plan),
+      std::hash<const lp::Expr*>{}(key.lhs));
+}
+
+bool SubqueryExprEqual::operator()(
+    const lp::ExprPtr& lhs,
+    const lp::ExprPtr& rhs) const {
+  if (lhs.get() == rhs.get()) {
+    return true;
+  }
+  const auto lhsKey = subqueryKeyOf(lhs);
+  const auto rhsKey = subqueryKeyOf(rhs);
+  if (lhsKey.plan == nullptr || rhsKey.plan == nullptr) {
+    return false;
+  }
+  return lhsKey.kind == rhsKey.kind && lhsKey.plan == rhsKey.plan &&
+      lhsKey.lhs == rhsKey.lhs;
+}
 
 ToGraph::ToGraph(
     const connector::SchemaResolver& schema,
@@ -3061,6 +3133,12 @@ void ToGraph::processScalarSubqueries(
     const std::vector<lp::SubqueryExprPtr>& scalars,
     SubqueryChain& chain) {
   for (const auto& subquery : scalars) {
+    // Skip if a structurally-equal subquery was already planned (e.g. the
+    // same subquery appears in both SELECT and GROUP BY).
+    if (subqueries_.contains(subquery)) {
+      continue;
+    }
+
     maybeWrapForChainedSubquery(input, chain);
 
     auto savedLifted = applyContext_.saveAndClearLifted();

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -101,6 +101,19 @@ struct SubfieldProjections {
   folly::F14FastMap<PathCP, ExprCP> pathToExpr;
 };
 
+// Hash and equality for ToGraph::subqueries_. Dedups the three subquery-
+// bearing expression patterns by the identity that determines their result
+// column. Other expression kinds fall back to pointer identity.
+struct SubqueryExprHash {
+  size_t operator()(const logical_plan::ExprPtr& expr) const;
+};
+
+struct SubqueryExprEqual {
+  bool operator()(
+      const logical_plan::ExprPtr& lhs,
+      const logical_plan::ExprPtr& rhs) const;
+};
+
 class ToGraph {
  public:
   ToGraph(
@@ -884,7 +897,22 @@ class ToGraph {
 
   // Maps an expression that contains a subquery to a column or constant that
   // should be used instead. Populated in 'processSubqueries()'.
-  folly::F14FastMap<logical_plan::ExprPtr, ExprCP> subqueries_;
+  //
+  // Uses structural equality on the subquery-bearing patterns so that two
+  // textually-identical occurrences share one result column:
+  //   - SubqueryExpr: keyed by inner LogicalPlanNode*.
+  //   - SpecialFormExpr(kExists): same.
+  //   - SpecialFormExpr(kIn): keyed by (LHS ExprPtr, inner LogicalPlanNode*),
+  //     since different left-hand sides produce different mark columns.
+  // The parser's AST-equality dedup ensures two textually-equal subqueries
+  // share one LogicalPlanNode, so pointer equality on the inner plan is the
+  // right structural identity here.
+  folly::F14FastMap<
+      logical_plan::ExprPtr,
+      ExprCP,
+      SubqueryExprHash,
+      SubqueryExprEqual>
+      subqueries_;
 
   folly::
       F14FastMap<TypedVariant, ExprCP, TypedVariantHasher, TypedVariantComparer>

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -1058,20 +1058,20 @@ TEST_F(SetTest, unionDistinctWithUnnestMultipleReferences) {
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-  auto matchUnion = [&] {
-    return matchScan("t")
-        .unnest()
-        .project()
-        .localPartition(matchScan("t").project().build())
-        .distinct()
-        .singleAggregation({}, {"count(*)"});
-  };
-
-  // TODO: Deduplicate identical scalar subqueries.
-  auto matcher = matchValues()
-                     .nestedLoopJoin(matchUnion().build())
-                     .nestedLoopJoin(matchUnion().build())
-                     .build();
+  // The two SELECT items reference the same scalar subquery, which is
+  // planned once and joined once; the outer Project emits the join's
+  // single output column twice (one per SELECT item).
+  auto matcher =
+      matchValues()
+          .nestedLoopJoin(matchScan("t")
+                              .unnest()
+                              .project()
+                              .localPartition(matchScan("t").project().build())
+                              .distinct()
+                              .singleAggregation({}, {"count(*) as cnt"})
+                              .build())
+          .project({"cnt", "cnt"})
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -20,6 +20,16 @@ SELECT a, b FROM t WHERE a IN ((SELECT max(a) FROM t), 1)
 -- IN list with two scalar subqueries.
 SELECT a, b FROM t WHERE a IN ((SELECT max(a) FROM t), (SELECT min(a) FROM t))
 ----
+-- Same scalar subquery in both SELECT and GROUP BY must resolve as a single
+-- grouping key.
+SELECT COALESCE(t.a, (SELECT max(a) FROM u))
+FROM t
+GROUP BY COALESCE(t.a, (SELECT max(a) FROM u))
+----
+-- Scalar subquery and EXISTS over the same inner subquery must produce
+-- distinct columns (a scalar value vs a boolean).
+SELECT (SELECT max(a) FROM u), EXISTS (SELECT max(a) FROM u) FROM t
+----
 -- Case-insensitive CTE alias resolution.
 WITH a AS (SELECT * FROM (VALUES (1)) t(a)) SELECT A.a FROM A
 ----

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -580,7 +580,15 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       if (query->is(NodeType::kQuery)) {
         VELOX_CHECK_NOT_NULL(
             subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
-        return lp::Subquery(subqueryPlanner_(query->as<Query>()));
+        // Look up first; if not cached, plan and insert. Do not hold an
+        // iterator across subqueryPlanner_ because it may recursively plan
+        // a subquery that mutates the cache and invalidates iterators.
+        if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
+          return it->second;
+        }
+        auto expr = lp::Subquery(subqueryPlanner_(query->as<Query>()));
+        subqueryCache_.emplace(query, expr);
+        return expr;
       }
 
       AXIOM_PRESTO_SYNTAX_FAIL(

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
@@ -144,6 +145,26 @@ class ExpressionPlanner {
   // connector-based resolution for dotted names (e.g., "catalog.schema.Type").
   facebook::velox::TypePtr resolveType(const TypeSignaturePtr& type);
 
+  // Dedups subquery expressions across textually-identical scalar subquery
+  // occurrences (e.g. same subquery in SELECT and GROUP BY of the same
+  // query). Keyed by AST structural equality on the inner Query, so two
+  // distinct AST nodes with equal Query bodies share one ExprApi (and
+  // therefore one inner LogicalPlanNode). Downstream ToGraph dedups
+  // subqueries by inner-plan pointer, so sharing the plan collapses them
+  // to a single result column. Holding StatementPtr (not a raw pointer)
+  // keeps the cached AST alive for the cache's lifetime.
+  struct SubqueryAstHash {
+    size_t operator()(const StatementPtr& query) const {
+      return query->hash();
+    }
+  };
+
+  struct SubqueryAstEqual {
+    bool operator()(const StatementPtr& lhs, const StatementPtr& rhs) const {
+      return *lhs == *rhs;
+    }
+  };
+
   SubqueryPlanner subqueryPlanner_;
   SortingKeyResolver sortingKeyResolver_;
   ShouldDropQualifier shouldDropQualifier_;
@@ -152,6 +173,10 @@ class ExpressionPlanner {
   // Per-query cache for user-defined type lookups. Entries with nullptr values
   // represent negatively cached (not-found) types.
   folly::F14FastMap<std::string, facebook::velox::TypePtr> typeCache_;
+
+  folly::
+      F14FastMap<StatementPtr, lp::ExprApi, SubqueryAstHash, SubqueryAstEqual>
+          subqueryCache_;
 
   // Lateral column alias mappings. When non-null, Identifier nodes matching
   // a key are resolved to the corresponding expression, unless the name also

--- a/axiom/sql/presto/ast/AstExpressions.h
+++ b/axiom/sql/presto/ast/AstExpressions.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <vector>
 #include "axiom/sql/presto/ast/AstNode.h"
 
@@ -44,6 +45,17 @@ class Identifier : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<std::string>{}(value_), std::hash<bool>{}(delimited_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Identifier>();
+    return value_ == o.value_ && delimited_ == o.delimited_;
+  }
+
  private:
   std::string value_;
   bool delimited_;
@@ -72,6 +84,19 @@ class QualifiedName : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    size_t h = parts_.size();
+    for (const auto& part : parts_) {
+      h = folly::hash::hash_combine(h, std::hash<std::string>{}(part));
+    }
+    return h;
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return parts_ == other.as<QualifiedName>()->parts_;
+  }
+
  private:
   std::vector<std::string> parts_;
 };
@@ -98,6 +123,17 @@ class DereferenceExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(base_), Node::deepHash(field_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<DereferenceExpression>();
+    return Node::deepEqual(base_, o.base_) && Node::deepEqual(field_, o.field_);
+  }
+
  private:
   ExpressionPtr base_;
   std::shared_ptr<Identifier> field_;
@@ -115,6 +151,15 @@ class FieldReference : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<int>{}(fieldIndex_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return fieldIndex_ == other.as<FieldReference>()->fieldIndex_;
+  }
+
  private:
   int fieldIndex_;
 };
@@ -130,6 +175,15 @@ class SymbolReference : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<std::string>{}(name_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return name_ == other.as<SymbolReference>()->name_;
+  }
+
  private:
   std::string name_;
 };
@@ -144,6 +198,15 @@ class Parameter : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<int>{}(position_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return position_ == other.as<Parameter>()->position_;
+  }
 
  private:
   int position_;
@@ -178,6 +241,20 @@ class ArithmeticBinaryExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Operator>{}(operator_),
+        Node::deepHash(left_),
+        Node::deepHash(right_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<ArithmeticBinaryExpression>();
+    return operator_ == o.operator_ && Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_);
+  }
+
  private:
   Operator operator_;
   ExpressionPtr left_;
@@ -205,6 +282,17 @@ class ArithmeticUnaryExpression : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Sign>{}(sign_), Node::deepHash(value_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<ArithmeticUnaryExpression>();
+    return sign_ == o.sign_ && Node::deepEqual(value_, o.value_);
+  }
 
  private:
   Sign sign_;
@@ -248,6 +336,20 @@ class ComparisonExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Operator>{}(operator_),
+        Node::deepHash(left_),
+        Node::deepHash(right_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<ComparisonExpression>();
+    return operator_ == o.operator_ && Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_);
+  }
+
  private:
   Operator operator_;
   ExpressionPtr left_;
@@ -280,6 +382,18 @@ class BetweenPredicate : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(value_), Node::deepHash(min_), Node::deepHash(max_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<BetweenPredicate>();
+    return Node::deepEqual(value_, o.value_) && Node::deepEqual(min_, o.min_) &&
+        Node::deepEqual(max_, o.max_);
+  }
+
  private:
   ExpressionPtr value_;
   ExpressionPtr min_;
@@ -306,6 +420,18 @@ class InPredicate : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(value_), Node::deepHash(valueList_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<InPredicate>();
+    return Node::deepEqual(value_, o.value_) &&
+        Node::deepEqual(valueList_, o.valueList_);
+  }
+
  private:
   ExpressionPtr value_;
   ExpressionPtr valueList_;
@@ -324,6 +450,15 @@ class InListExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHashAll(values_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(values_, other.as<InListExpression>()->values_);
+  }
+
  private:
   std::vector<ExpressionPtr> values_;
 };
@@ -339,6 +474,15 @@ class IsNullPredicate : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHash(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(value_, other.as<IsNullPredicate>()->value_);
+  }
+
  private:
   ExpressionPtr value_;
 };
@@ -353,6 +497,15 @@ class IsNotNullPredicate : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(value_, other.as<IsNotNullPredicate>()->value_);
+  }
 
  private:
   ExpressionPtr value_;
@@ -384,6 +537,21 @@ class LikePredicate : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(value_),
+        Node::deepHash(pattern_),
+        Node::deepHash(escape_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<LikePredicate>();
+    return Node::deepEqual(value_, o.value_) &&
+        Node::deepEqual(pattern_, o.pattern_) &&
+        Node::deepEqual(escape_, o.escape_);
+  }
+
  private:
   ExpressionPtr value_;
   ExpressionPtr pattern_;
@@ -400,6 +568,15 @@ class ExistsPredicate : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(subquery_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(subquery_, other.as<ExistsPredicate>()->subquery_);
+  }
 
  private:
   ExpressionPtr subquery_;
@@ -439,6 +616,22 @@ class QuantifiedComparisonExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<ComparisonExpression::Operator>{}(operator_),
+        std::hash<Quantifier>{}(quantifier_),
+        Node::deepHash(value_),
+        Node::deepHash(subquery_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<QuantifiedComparisonExpression>();
+    return operator_ == o.operator_ && quantifier_ == o.quantifier_ &&
+        Node::deepEqual(value_, o.value_) &&
+        Node::deepEqual(subquery_, o.subquery_);
+  }
+
  private:
   ComparisonExpression::Operator operator_;
   Quantifier quantifier_;
@@ -475,6 +668,20 @@ class LogicalBinaryExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Operator>{}(operator_),
+        Node::deepHash(left_),
+        Node::deepHash(right_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<LogicalBinaryExpression>();
+    return operator_ == o.operator_ && Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_);
+  }
+
  private:
   Operator operator_;
   ExpressionPtr left_;
@@ -491,6 +698,15 @@ class NotExpression : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(value_, other.as<NotExpression>()->value_);
+  }
 
  private:
   ExpressionPtr value_;

--- a/axiom/sql/presto/ast/AstFunctions.h
+++ b/axiom/sql/presto/ast/AstFunctions.h
@@ -15,9 +15,12 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <optional>
 #include <vector>
+#include "axiom/sql/presto/ast/AstExpressions.h"
 #include "axiom/sql/presto/ast/AstNode.h"
+#include "axiom/sql/presto/ast/AstSupport.h"
 
 namespace axiom::sql::presto {
 
@@ -57,6 +60,21 @@ class IfExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(condition_),
+        Node::deepHash(trueValue_),
+        Node::deepHash(falseValue_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<IfExpression>();
+    return Node::deepEqual(condition_, o.condition_) &&
+        Node::deepEqual(trueValue_, o.trueValue_) &&
+        Node::deepEqual(falseValue_, o.falseValue_);
+  }
+
  private:
   ExpressionPtr condition_;
   ExpressionPtr trueValue_;
@@ -75,6 +93,16 @@ class CoalesceExpression : public Expression {
     return operands_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(operands_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(
+        operands_, other.as<CoalesceExpression>()->operands_);
+  }
 
  private:
   std::vector<ExpressionPtr> operands_;
@@ -99,6 +127,18 @@ class NullIfExpression : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(first_), Node::deepHash(second_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<NullIfExpression>();
+    return Node::deepEqual(first_, o.first_) &&
+        Node::deepEqual(second_, o.second_);
+  }
 
  private:
   ExpressionPtr first_;
@@ -125,6 +165,18 @@ class WhenClause : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(operand_), Node::deepHash(result_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<WhenClause>();
+    return Node::deepEqual(operand_, o.operand_) &&
+        Node::deepEqual(result_, o.result_);
+  }
+
  private:
   ExpressionPtr operand_;
   ExpressionPtr result_;
@@ -149,6 +201,18 @@ class SearchedCaseExpression : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHashAll(whenClauses_), Node::deepHash(defaultValue_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SearchedCaseExpression>();
+    return Node::deepEqualAll(whenClauses_, o.whenClauses_) &&
+        Node::deepEqual(defaultValue_, o.defaultValue_);
+  }
 
  private:
   std::vector<std::shared_ptr<WhenClause>> whenClauses_;
@@ -181,6 +245,21 @@ class SimpleCaseExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(operand_),
+        Node::deepHashAll(whenClauses_),
+        Node::deepHash(defaultValue_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SimpleCaseExpression>();
+    return Node::deepEqual(operand_, o.operand_) &&
+        Node::deepEqualAll(whenClauses_, o.whenClauses_) &&
+        Node::deepEqual(defaultValue_, o.defaultValue_);
+  }
+
  private:
   ExpressionPtr operand_;
   std::vector<std::shared_ptr<WhenClause>> whenClauses_;
@@ -199,6 +278,16 @@ class TryExpression : public Expression {
     return innerExpression_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(innerExpression_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(
+        innerExpression_, other.as<TryExpression>()->innerExpression_);
+  }
 
  private:
   ExpressionPtr innerExpression_;
@@ -263,6 +352,28 @@ class FunctionCall : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(name_),
+        Node::deepHash(window_),
+        Node::deepHash(filter_),
+        Node::deepHash(orderBy_),
+        std::hash<bool>{}(distinct_),
+        std::hash<bool>{}(ignoreNulls_),
+        Node::deepHashAll(arguments_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<FunctionCall>();
+    return Node::deepEqual(name_, o.name_) &&
+        Node::deepEqual(window_, o.window_) &&
+        Node::deepEqual(filter_, o.filter_) &&
+        Node::deepEqual(orderBy_, o.orderBy_) && distinct_ == o.distinct_ &&
+        ignoreNulls_ == o.ignoreNulls_ &&
+        Node::deepEqualAll(arguments_, o.arguments_);
+  }
+
  private:
   std::shared_ptr<QualifiedName> name_;
   std::shared_ptr<Window> window_;
@@ -298,6 +409,20 @@ class Cast : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(expression_),
+        Node::deepHash(toType_),
+        std::hash<bool>{}(safe_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Cast>();
+    return Node::deepEqual(expression_, o.expression_) &&
+        Node::deepEqual(toType_, o.toType_) && safe_ == o.safe_;
+  }
 
  private:
   ExpressionPtr expression_;
@@ -342,6 +467,17 @@ class Extract : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(expression_), std::hash<Field>{}(field_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Extract>();
+    return Node::deepEqual(expression_, o.expression_) && field_ == o.field_;
+  }
+
  private:
   ExpressionPtr expression_;
   Field field_;
@@ -369,6 +505,18 @@ class CurrentTime : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Function>{}(function_),
+        precision_.has_value() ? std::hash<int>{}(*precision_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<CurrentTime>();
+    return function_ == o.function_ && precision_ == o.precision_;
+  }
+
  private:
   Function function_;
   std::optional<int> precision_;
@@ -379,6 +527,15 @@ class CurrentUser : public Expression {
   explicit CurrentUser(NodeLocation location)
       : Expression(NodeType::kCurrentUser, location) {}
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return 0;
+  }
+
+ protected:
+  bool equals(const Node& /*other*/) const override {
+    return true;
+  }
 };
 
 class AtTimeZone : public Expression {
@@ -401,6 +558,18 @@ class AtTimeZone : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(value_), Node::deepHash(timeZone_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<AtTimeZone>();
+    return Node::deepEqual(value_, o.value_) &&
+        Node::deepEqual(timeZone_, o.timeZone_);
+  }
+
  private:
   ExpressionPtr value_;
   ExpressionPtr timeZone_;
@@ -418,6 +587,15 @@ class SubqueryExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHash(query_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(query_, other.as<SubqueryExpression>()->query_);
+  }
+
  private:
   StatementPtr query_;
 };
@@ -434,6 +612,15 @@ class ArrayConstructor : public Expression {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHashAll(values_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(values_, other.as<ArrayConstructor>()->values_);
+  }
+
  private:
   std::vector<ExpressionPtr> values_;
 };
@@ -447,6 +634,15 @@ class Row : public Expression {
     return items_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(items_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(items_, other.as<Row>()->items_);
+  }
 
  private:
   std::vector<ExpressionPtr> items_;
@@ -473,6 +669,21 @@ class NamedRow : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    size_t namesHash = fieldNames_.size();
+    for (const auto& name : fieldNames_) {
+      namesHash =
+          folly::hash::hash_combine(namesHash, std::hash<std::string>{}(name));
+    }
+    return folly::hash::hash_combine(Node::deepHashAll(items_), namesHash);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<NamedRow>();
+    return Node::deepEqualAll(items_, o.items_) && fieldNames_ == o.fieldNames_;
+  }
+
  private:
   std::vector<ExpressionPtr> items_;
   std::vector<std::string> fieldNames_;
@@ -498,6 +709,17 @@ class SubscriptExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(base_), Node::deepHash(index_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SubscriptExpression>();
+    return Node::deepEqual(base_, o.base_) && Node::deepEqual(index_, o.index_);
+  }
+
  private:
   ExpressionPtr base_;
   ExpressionPtr index_;
@@ -514,6 +736,15 @@ class LambdaArgumentDeclaration : public Node {
     return name_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(name_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(name_, other.as<LambdaArgumentDeclaration>()->name_);
+  }
 
  private:
   std::shared_ptr<Identifier> name_;
@@ -540,6 +771,18 @@ class LambdaExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHashAll(arguments_), Node::deepHash(body_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<LambdaExpression>();
+    return Node::deepEqualAll(arguments_, o.arguments_) &&
+        Node::deepEqual(body_, o.body_);
+  }
+
  private:
   std::vector<std::shared_ptr<LambdaArgumentDeclaration>> arguments_;
   ExpressionPtr body_;
@@ -565,6 +808,18 @@ class BindExpression : public Expression {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHashAll(values_), Node::deepHash(function_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<BindExpression>();
+    return Node::deepEqualAll(values_, o.values_) &&
+        Node::deepEqual(function_, o.function_);
+  }
+
  private:
   std::vector<ExpressionPtr> values_;
   ExpressionPtr function_;
@@ -582,6 +837,16 @@ class GroupingOperation : public Expression {
     return groupingColumns_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(groupingColumns_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(
+        groupingColumns_, other.as<GroupingOperation>()->groupingColumns_);
+  }
 
  private:
   std::vector<std::shared_ptr<QualifiedName>> groupingColumns_;
@@ -608,6 +873,17 @@ class TableVersionExpression : public Expression {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<TableVersionType>{}(type_), Node::deepHash(expression_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<TableVersionExpression>();
+    return type_ == o.type_ && Node::deepEqual(expression_, o.expression_);
+  }
 
  private:
   TableVersionType type_;

--- a/axiom/sql/presto/ast/AstLiterals.h
+++ b/axiom/sql/presto/ast/AstLiterals.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <optional>
 #include <string>
 #include "axiom/sql/presto/ast/AstNode.h"
@@ -43,6 +44,15 @@ class BooleanLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<bool>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<BooleanLiteral>()->value_;
+  }
+
  private:
   bool value_;
 };
@@ -57,6 +67,15 @@ class StringLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<StringLiteral>()->value_;
+  }
 
  private:
   std::string value_;
@@ -73,6 +92,15 @@ class BinaryLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<BinaryLiteral>()->value_;
+  }
+
  private:
   std::string value_;
 };
@@ -87,6 +115,15 @@ class CharLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<CharLiteral>()->value_;
+  }
 
  private:
   std::string value_;
@@ -103,6 +140,15 @@ class LongLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<int64_t>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<LongLiteral>()->value_;
+  }
+
  private:
   int64_t value_;
 };
@@ -118,6 +164,15 @@ class DoubleLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return std::hash<double>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<DoubleLiteral>()->value_;
+  }
+
  private:
   double value_;
 };
@@ -132,6 +187,15 @@ class DecimalLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<DecimalLiteral>()->value_;
+  }
 
  private:
   std::string value_;
@@ -157,6 +221,17 @@ class GenericLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(valueType_), std::hash<std::string>{}(value_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<GenericLiteral>();
+    return Node::deepEqual(valueType_, o.valueType_) && value_ == o.value_;
+  }
+
  private:
   TypeSignaturePtr valueType_;
   std::string value_;
@@ -167,6 +242,17 @@ class NullLiteral : public Literal {
   explicit NullLiteral(NodeLocation location)
       : Literal(NodeType::kNullLiteral, location) {}
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return 0;
+  }
+
+ protected:
+  /// All NullLiteral instances compare equal — the node has no semantic fields
+  /// beyond its type tag.
+  bool equals(const Node& /*other*/) const override {
+    return true;
+  }
 };
 
 class TimeLiteral : public Literal {
@@ -179,6 +265,15 @@ class TimeLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<TimeLiteral>()->value_;
+  }
 
  private:
   std::string value_;
@@ -194,6 +289,15 @@ class TimestampLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<TimestampLiteral>()->value_;
+  }
 
  private:
   std::string value_;
@@ -239,6 +343,21 @@ class IntervalLiteral : public Literal {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<std::string>{}(value_),
+        std::hash<Sign>{}(sign_),
+        std::hash<IntervalField>{}(startField_),
+        endField_.has_value() ? std::hash<IntervalField>{}(*endField_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<IntervalLiteral>();
+    return value_ == o.value_ && sign_ == o.sign_ &&
+        startField_ == o.startField_ && endField_ == o.endField_;
+  }
+
  private:
   std::string value_;
   Sign sign_;
@@ -256,6 +375,15 @@ class EnumLiteral : public Literal {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(value_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return value_ == other.as<EnumLiteral>()->value_;
+  }
 
  private:
   std::string value_;

--- a/axiom/sql/presto/ast/AstNode.h
+++ b/axiom/sql/presto/ast/AstNode.h
@@ -15,8 +15,11 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <memory>
+#include <vector>
 #include "axiom/common/Enums.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace axiom::sql::presto {
 
@@ -281,6 +284,74 @@ class Node {
     return dynamic_cast<const T*>(this);
   }
 
+  /// Deep structural hash matching equals().
+  virtual size_t hash() const = 0;
+
+  bool operator==(const Node& other) const {
+    return type_ == other.type_ && equals(other);
+  }
+
+  bool operator!=(const Node& other) const {
+    return !(*this == other);
+  }
+
+  /// Null-safe deep equality on two Node trees. Returns true if both
+  /// are null, false if exactly one is null, otherwise `*a == *b`.
+  /// 'T' must be Node or a subclass.
+  template <typename T>
+  static bool deepEqual(
+      const std::shared_ptr<T>& a,
+      const std::shared_ptr<T>& b) {
+    if (a == b) {
+      return true;
+    }
+    if (!a || !b) {
+      return false;
+    }
+    return *a == *b;
+  }
+
+  /// Null-safe deep hash. Returns 0 for null.
+  /// 'T' must be Node or a subclass.
+  template <typename T>
+  static size_t deepHash(const std::shared_ptr<T>& a) {
+    return a ? a->hash() : 0;
+  }
+
+  /// Deep element-wise equality for two vectors of Node pointers.
+  /// 'T' must be Node or a subclass.
+  template <typename T>
+  static bool deepEqualAll(
+      const std::vector<std::shared_ptr<T>>& a,
+      const std::vector<std::shared_ptr<T>>& b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+      if (!deepEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Combined hash for a vector of Node pointers, matching deepEqualAll.
+  template <typename T>
+  static size_t deepHashAll(const std::vector<std::shared_ptr<T>>& a) {
+    size_t h = a.size();
+    for (const auto& item : a) {
+      h = folly::hash::hash_combine(h, deepHash(item));
+    }
+    return h;
+  }
+
+ protected:
+  /// Deep structural equality on the AST. Ignores NodeLocation. Called by
+  /// operator== after the node types have been confirmed to match, so
+  /// overrides may assume 'other' has the same dynamic type as 'this' and
+  /// use 'other.as<Subclass>()' without a null check.
+  virtual bool equals(const Node& other) const = 0;
+
  private:
   const NodeType type_;
   const NodeLocation location_;
@@ -299,6 +370,15 @@ using ExpressionPtr = std::shared_ptr<Expression>;
 class Statement : public Node {
  public:
   Statement(NodeType type, NodeLocation location) : Node(type, location) {}
+
+  size_t hash() const override {
+    VELOX_NYI("Statement::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("Statement::equals not implemented");
+  }
 };
 
 using StatementPtr = std::shared_ptr<Statement>;

--- a/axiom/sql/presto/ast/AstRelations.h
+++ b/axiom/sql/presto/ast/AstRelations.h
@@ -15,11 +15,14 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+#include "axiom/sql/presto/ast/AstExpressions.h"
 #include "axiom/sql/presto/ast/AstNode.h"
+#include "axiom/sql/presto/ast/AstSupport.h"
 
 namespace axiom::sql::presto {
 
@@ -87,6 +90,24 @@ class Query : public Statement {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(with_),
+        Node::deepHash(queryBody_),
+        Node::deepHash(orderBy_),
+        Node::deepHash(offset_),
+        limit_.has_value() ? std::hash<std::string>{}(*limit_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Query>();
+    return Node::deepEqual(with_, o.with_) &&
+        Node::deepEqual(queryBody_, o.queryBody_) &&
+        Node::deepEqual(orderBy_, o.orderBy_) &&
+        Node::deepEqual(offset_, o.offset_) && limit_ == o.limit_;
+  }
+
  private:
   std::shared_ptr<With> with_;
   QueryBodyPtr queryBody_;
@@ -151,6 +172,29 @@ class QuerySpecification : public QueryBody {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(select_),
+        Node::deepHash(from_),
+        Node::deepHash(where_),
+        Node::deepHash(groupBy_),
+        Node::deepHash(having_),
+        Node::deepHash(orderBy_),
+        Node::deepHash(offset_),
+        limit_.has_value() ? std::hash<std::string>{}(*limit_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<QuerySpecification>();
+    return Node::deepEqual(select_, o.select_) &&
+        Node::deepEqual(from_, o.from_) && Node::deepEqual(where_, o.where_) &&
+        Node::deepEqual(groupBy_, o.groupBy_) &&
+        Node::deepEqual(having_, o.having_) &&
+        Node::deepEqual(orderBy_, o.orderBy_) &&
+        Node::deepEqual(offset_, o.offset_) && limit_ == o.limit_;
+  }
+
  private:
   std::shared_ptr<Select> select_;
   RelationPtr from_;
@@ -191,6 +235,18 @@ class SingleColumn : public SelectItem {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(expression_), Node::deepHash(alias_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SingleColumn>();
+    return Node::deepEqual(expression_, o.expression_) &&
+        Node::deepEqual(alias_, o.alias_);
+  }
+
  private:
   ExpressionPtr expression_;
   std::shared_ptr<Identifier> alias_;
@@ -202,6 +258,16 @@ struct ReplaceItem {
   ExpressionPtr expression;
   /// Column being replaced.
   std::shared_ptr<Identifier> column;
+
+  bool operator==(const ReplaceItem& other) const {
+    return Node::deepEqual(expression, other.expression) &&
+        Node::deepEqual(column, other.column);
+  }
+
+  size_t hash() const {
+    return folly::hash::hash_combine(
+        Node::deepHash(expression), Node::deepHash(column));
+  }
 };
 
 /// Represents SELECT * or t.* with optional EXCLUDE and REPLACE modifiers.
@@ -233,6 +299,25 @@ class AllColumns : public SelectItem {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    size_t replaceHash = replaceItems_.size();
+    for (const auto& item : replaceItems_) {
+      replaceHash = folly::hash::hash_combine(replaceHash, item.hash());
+    }
+    return folly::hash::hash_combine(
+        Node::deepHash(prefix_),
+        Node::deepHashAll(excludeColumns_),
+        replaceHash);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<AllColumns>();
+    return Node::deepEqual(prefix_, o.prefix_) &&
+        Node::deepEqualAll(excludeColumns_, o.excludeColumns_) &&
+        replaceItems_ == o.replaceItems_;
+  }
 
  private:
   std::shared_ptr<QualifiedName> prefix_;
@@ -277,6 +362,26 @@ class SelectColumns : public SelectItem {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    size_t replaceHash = replaceItems_.size();
+    for (const auto& item : replaceItems_) {
+      replaceHash = folly::hash::hash_combine(replaceHash, item.hash());
+    }
+    return folly::hash::hash_combine(
+        std::hash<std::string>{}(pattern_),
+        Node::deepHash(prefix_),
+        Node::deepHashAll(excludeColumns_),
+        replaceHash);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SelectColumns>();
+    return pattern_ == o.pattern_ && Node::deepEqual(prefix_, o.prefix_) &&
+        Node::deepEqualAll(excludeColumns_, o.excludeColumns_) &&
+        replaceItems_ == o.replaceItems_;
+  }
+
  private:
   std::string pattern_;
   std::shared_ptr<QualifiedName> prefix_;
@@ -304,6 +409,18 @@ class Select : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<bool>{}(distinct_), Node::deepHashAll(selectItems_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Select>();
+    return distinct_ == o.distinct_ &&
+        Node::deepEqualAll(selectItems_, o.selectItems_);
+  }
+
  private:
   bool distinct_;
   std::vector<SelectItemPtr> selectItems_;
@@ -327,6 +444,18 @@ class Table : public QueryBody {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(name_), Node::deepHash(version_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Table>();
+    return Node::deepEqual(name_, o.name_) &&
+        Node::deepEqual(version_, o.version_);
+  }
 
  private:
   std::shared_ptr<QualifiedName> name_;
@@ -358,6 +487,21 @@ class AliasedRelation : public Relation {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(relation_),
+        Node::deepHash(alias_),
+        Node::deepHashAll(columnNames_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<AliasedRelation>();
+    return Node::deepEqual(relation_, o.relation_) &&
+        Node::deepEqual(alias_, o.alias_) &&
+        Node::deepEqualAll(columnNames_, o.columnNames_);
+  }
 
  private:
   RelationPtr relation_;
@@ -393,6 +537,21 @@ class SampledRelation : public Relation {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(relation_),
+        std::hash<Type>{}(sampleType_),
+        Node::deepHash(samplePercentage_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SampledRelation>();
+    return Node::deepEqual(relation_, o.relation_) &&
+        sampleType_ == o.sampleType_ &&
+        Node::deepEqual(samplePercentage_, o.samplePercentage_);
+  }
+
  private:
   RelationPtr relation_;
   Type sampleType_;
@@ -409,6 +568,15 @@ class TableSubquery : public QueryBody {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHash(query_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(query_, other.as<TableSubquery>()->query_);
+  }
+
  private:
   StatementPtr query_;
 };
@@ -422,6 +590,15 @@ class Lateral : public Relation {
     return query_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHash(query_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(query_, other.as<Lateral>()->query_);
+  }
 
  private:
   RelationPtr query_;
@@ -447,6 +624,18 @@ class Unnest : public Relation {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHashAll(expressions_), std::hash<bool>{}(withOrdinality_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Unnest>();
+    return Node::deepEqualAll(expressions_, o.expressions_) &&
+        withOrdinality_ == o.withOrdinality_;
+  }
+
  private:
   std::vector<ExpressionPtr> expressions_;
   bool withOrdinality_;
@@ -461,6 +650,15 @@ class Values : public QueryBody {
     return rows_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(rows_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(rows_, other.as<Values>()->rows_);
+  }
 
  private:
   std::vector<ExpressionPtr> rows_;
@@ -485,6 +683,15 @@ class JoinOn : public JoinCriteria {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHash(expression_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqual(expression_, other.as<JoinOn>()->expression_);
+  }
+
  private:
   ExpressionPtr expression_;
 };
@@ -500,6 +707,15 @@ class JoinUsing : public JoinCriteria {
     return columns_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(columns_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(columns_, other.as<JoinUsing>()->columns_);
+  }
 
  private:
   std::vector<std::shared_ptr<Identifier>> columns_;
@@ -539,6 +755,22 @@ class Join : public Relation {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Type>{}(joinType_),
+        Node::deepHash(left_),
+        Node::deepHash(right_),
+        Node::deepHash(criteria_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Join>();
+    return joinType_ == o.joinType_ && Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_) &&
+        Node::deepEqual(criteria_, o.criteria_);
+  }
+
  private:
   Type joinType_;
   RelationPtr left_;
@@ -571,6 +803,20 @@ class NaturalJoin : public Relation {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Join::Type>{}(joinType_),
+        Node::deepHash(left_),
+        Node::deepHash(right_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<NaturalJoin>();
+    return joinType_ == o.joinType_ && Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_);
+  }
 
  private:
   Join::Type joinType_;
@@ -620,6 +866,20 @@ class Union : public SetOperation {
       : SetOperation(NodeType::kUnion, location, left, right, distinct) {}
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(left_),
+        Node::deepHash(right_),
+        std::hash<bool>{}(distinct_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Union>();
+    return Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_) && distinct_ == o.distinct_;
+  }
 };
 
 class Intersect : public SetOperation {
@@ -632,6 +892,20 @@ class Intersect : public SetOperation {
       : SetOperation(NodeType::kIntersect, location, left, right, distinct) {}
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(left_),
+        Node::deepHash(right_),
+        std::hash<bool>{}(distinct_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Intersect>();
+    return Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_) && distinct_ == o.distinct_;
+  }
 };
 
 class Except : public SetOperation {
@@ -644,6 +918,20 @@ class Except : public SetOperation {
       : SetOperation(NodeType::kExcept, location, left, right, distinct) {}
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(left_),
+        Node::deepHash(right_),
+        std::hash<bool>{}(distinct_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Except>();
+    return Node::deepEqual(left_, o.left_) &&
+        Node::deepEqual(right_, o.right_) && distinct_ == o.distinct_;
+  }
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/AstSupport.h
+++ b/axiom/sql/presto/ast/AstSupport.h
@@ -15,15 +15,16 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include <optional>
 #include <vector>
+#include "axiom/sql/presto/ast/AstExpressions.h"
 #include "axiom/sql/presto/ast/AstNode.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace axiom::sql::presto {
 
 // Forward declarations
-class Identifier;
-class QualifiedName;
 class OrderBy;
 
 // Support Classes
@@ -75,6 +76,22 @@ class TypeSignature : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<std::string>{}(baseName_),
+        Node::deepHashAll(parameters_),
+        rowFieldName_.has_value() ? std::hash<std::string>{}(*rowFieldName_)
+                                  : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<TypeSignature>();
+    return baseName_ == o.baseName_ &&
+        Node::deepEqualAll(parameters_, o.parameters_) &&
+        rowFieldName_ == o.rowFieldName_;
+  }
+
  private:
   const std::string baseName_;
   const std::vector<TypeSignaturePtr> parameters_;
@@ -101,6 +118,15 @@ class Property : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    VELOX_NYI("Property::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("Property::equals not implemented");
+  }
+
  private:
   std::shared_ptr<Identifier> name_;
   ExpressionPtr value_;
@@ -123,6 +149,17 @@ class CallArgument : public Node {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(name_), Node::deepHash(value_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<CallArgument>();
+    return Node::deepEqual(name_, o.name_) && Node::deepEqual(value_, o.value_);
+  }
 
  private:
   std::shared_ptr<Identifier> name_;
@@ -158,6 +195,20 @@ class FrameBound : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Type>{}(boundType_),
+        value_.has_value() ? Node::deepHash(*value_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<FrameBound>();
+    return boundType_ == o.boundType_ &&
+        value_.has_value() == o.value_.has_value() &&
+        (!value_.has_value() || Node::deepEqual(*value_, *o.value_));
+  }
+
  private:
   Type boundType_;
   std::optional<ExpressionPtr> value_;
@@ -191,6 +242,20 @@ class WindowFrame : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<Type>{}(frameType_),
+        Node::deepHash(start_),
+        Node::deepHash(end_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<WindowFrame>();
+    return frameType_ == o.frameType_ && Node::deepEqual(start_, o.start_) &&
+        Node::deepEqual(end_, o.end_);
+  }
+
  private:
   Type frameType_;
   std::shared_ptr<FrameBound> start_;
@@ -222,6 +287,21 @@ class Window : public Node {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHashAll(partitionBy_),
+        Node::deepHash(orderBy_),
+        Node::deepHash(frame_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<Window>();
+    return Node::deepEqualAll(partitionBy_, o.partitionBy_) &&
+        Node::deepEqual(orderBy_, o.orderBy_) &&
+        Node::deepEqual(frame_, o.frame_);
+  }
 
  private:
   std::vector<ExpressionPtr> partitionBy_;
@@ -267,6 +347,20 @@ class SortItem : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(sortKey_),
+        std::hash<Ordering>{}(ordering_),
+        std::hash<NullOrdering>{}(nullOrdering_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<SortItem>();
+    return Node::deepEqual(sortKey_, o.sortKey_) && ordering_ == o.ordering_ &&
+        nullOrdering_ == o.nullOrdering_;
+  }
+
  private:
   ExpressionPtr sortKey_;
   Ordering ordering_;
@@ -285,6 +379,15 @@ class OrderBy : public Node {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHashAll(sortItems_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(sortItems_, other.as<OrderBy>()->sortItems_);
+  }
+
  private:
   std::vector<std::shared_ptr<SortItem>> sortItems_;
 };
@@ -300,6 +403,15 @@ class Offset : public Node {
     return offset_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return std::hash<std::string>{}(offset_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return offset_ == other.as<Offset>()->offset_;
+  }
 
  private:
   std::string offset_;
@@ -329,6 +441,16 @@ class SimpleGroupBy : public GroupingElement {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHashAll(expressions_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(
+        expressions_, other.as<SimpleGroupBy>()->expressions_);
+  }
+
  private:
   std::vector<ExpressionPtr> expressions_;
 };
@@ -344,6 +466,28 @@ class GroupingSets : public GroupingElement {
     return sets_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    size_t h = sets_.size();
+    for (const auto& set : sets_) {
+      h = folly::hash::hash_combine(h, Node::deepHashAll(set));
+    }
+    return h;
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& otherSets = other.as<GroupingSets>()->sets_;
+    if (sets_.size() != otherSets.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < sets_.size(); ++i) {
+      if (!Node::deepEqualAll(sets_[i], otherSets[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 
  private:
   std::vector<std::vector<ExpressionPtr>> sets_;
@@ -361,6 +505,15 @@ class Cube : public GroupingElement {
   }
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return Node::deepHashAll(expressions_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(expressions_, other.as<Cube>()->expressions_);
+  }
+
  private:
   std::vector<ExpressionPtr> expressions_;
 };
@@ -377,6 +530,15 @@ class Rollup : public GroupingElement {
     return expressions_;
   }
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return Node::deepHashAll(expressions_);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    return Node::deepEqualAll(expressions_, other.as<Rollup>()->expressions_);
+  }
 
  private:
   std::vector<ExpressionPtr> expressions_;
@@ -400,6 +562,18 @@ class GroupBy : public Node {
   }
 
   void accept(AstVisitor* visitor) override;
+
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<bool>{}(distinct_), Node::deepHashAll(groupingElements_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<GroupBy>();
+    return distinct_ == o.distinct_ &&
+        Node::deepEqualAll(groupingElements_, o.groupingElements_);
+  }
 
  private:
   bool distinct_;
@@ -437,6 +611,27 @@ class WithQuery : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        Node::deepHash(name_),
+        Node::deepHash(query_),
+        columnNames_.has_value() ? Node::deepHashAll(*columnNames_) : 0);
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<WithQuery>();
+    if (!(Node::deepEqual(name_, o.name_) &&
+          Node::deepEqual(query_, o.query_))) {
+      return false;
+    }
+    if (columnNames_.has_value() != o.columnNames_.has_value()) {
+      return false;
+    }
+    return !columnNames_.has_value() ||
+        Node::deepEqualAll(*columnNames_, *o.columnNames_);
+  }
+
  private:
   std::shared_ptr<Identifier> name_;
   StatementPtr query_;
@@ -462,6 +657,18 @@ class With : public Node {
 
   void accept(AstVisitor* visitor) override;
 
+  size_t hash() const override {
+    return folly::hash::hash_combine(
+        std::hash<bool>{}(recursive_), Node::deepHashAll(queries_));
+  }
+
+ protected:
+  bool equals(const Node& other) const override {
+    const auto& o = *other.as<With>();
+    return recursive_ == o.recursive_ &&
+        Node::deepEqualAll(queries_, o.queries_);
+  }
+
  private:
   bool recursive_;
   std::vector<std::shared_ptr<WithQuery>> queries_;
@@ -472,6 +679,15 @@ class TableElement : public Node {
  public:
   explicit TableElement(NodeType type, NodeLocation location)
       : Node(type, location) {}
+
+  size_t hash() const override {
+    VELOX_NYI("TableElement::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("TableElement::equals not implemented");
+  }
 };
 
 using TableElementPtr = std::shared_ptr<TableElement>;
@@ -681,6 +897,15 @@ class TransactionMode : public Node {
  public:
   explicit TransactionMode(NodeType type, NodeLocation location)
       : Node(type, location) {}
+
+  size_t hash() const override {
+    VELOX_NYI("TransactionMode::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("TransactionMode::equals not implemented");
+  }
 };
 
 using TransactionModePtr = std::shared_ptr<TransactionMode>;
@@ -743,6 +968,15 @@ class RoutineBody : public Node {
  public:
   explicit RoutineBody(NodeType type, NodeLocation location)
       : Node(type, location) {}
+
+  size_t hash() const override {
+    VELOX_NYI("RoutineBody::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("RoutineBody::equals not implemented");
+  }
 };
 
 using RoutineBodyPtr = std::shared_ptr<RoutineBody>;
@@ -783,6 +1017,15 @@ class ExplainOption : public Node {
  public:
   explicit ExplainOption(NodeType type, NodeLocation location)
       : Node(type, location) {}
+
+  size_t hash() const override {
+    VELOX_NYI("ExplainOption::hash not implemented");
+  }
+
+ protected:
+  bool equals(const Node&) const override {
+    VELOX_NYI("ExplainOption::equals not implemented");
+  }
 };
 
 using ExplainOptionPtr = std::shared_ptr<ExplainOption>;

--- a/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
+++ b/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
@@ -1,0 +1,1892 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/sql/presto/ast/AstExpressions.h"
+#include "axiom/sql/presto/ast/AstFunctions.h"
+#include "axiom/sql/presto/ast/AstLiterals.h"
+#include "axiom/sql/presto/ast/AstRelations.h"
+#include "axiom/sql/presto/ast/AstSupport.h"
+
+namespace axiom::sql::presto {
+namespace {
+
+TEST(AstEqualityTest, longLiteralEqualsSelf) {
+  auto a = std::make_shared<LongLiteral>(NodeLocation{0, 0}, 42);
+  EXPECT_TRUE(*a == *a);
+  EXPECT_EQ(a->hash(), a->hash());
+}
+
+TEST(AstEqualityTest, longLiteralIgnoresNodeLocation) {
+  auto a = std::make_shared<LongLiteral>(NodeLocation{1, 1}, 42);
+  auto b = std::make_shared<LongLiteral>(NodeLocation{99, 99}, 42);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, deepEqualHandlesNullPtrs) {
+  NodePtr a, b;
+  EXPECT_TRUE(Node::deepEqual(a, b));
+}
+
+TEST(AstEqualityTest, deepEqualAllHandlesVector) {
+  std::vector<NodePtr> a, b;
+  a.push_back(std::make_shared<LongLiteral>(NodeLocation{0, 0}, 1));
+  b.push_back(std::make_shared<LongLiteral>(NodeLocation{0, 0}, 1));
+  EXPECT_TRUE(Node::deepEqualAll(a, b));
+}
+
+TEST(AstEqualityTest, deepEqualAllRejectsLengthMismatch) {
+  std::vector<NodePtr> a, b;
+  a.push_back(std::make_shared<LongLiteral>(NodeLocation{0, 0}, 1));
+  EXPECT_FALSE(Node::deepEqualAll(a, b));
+}
+
+TEST(AstEqualityTest, booleanLiteralEquals) {
+  auto a = std::make_shared<BooleanLiteral>(NodeLocation{0, 0}, true);
+  auto b = std::make_shared<BooleanLiteral>(NodeLocation{5, 5}, true);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, booleanLiteralNotEqual) {
+  auto a = std::make_shared<BooleanLiteral>(NodeLocation{0, 0}, true);
+  auto b = std::make_shared<BooleanLiteral>(NodeLocation{0, 0}, false);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, stringLiteralEquals) {
+  auto a = std::make_shared<StringLiteral>(NodeLocation{0, 0}, "hello");
+  auto b = std::make_shared<StringLiteral>(NodeLocation{5, 5}, "hello");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, stringLiteralNotEqual) {
+  auto a = std::make_shared<StringLiteral>(NodeLocation{0, 0}, "hello");
+  auto b = std::make_shared<StringLiteral>(NodeLocation{0, 0}, "world");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, binaryLiteralEquals) {
+  auto a = std::make_shared<BinaryLiteral>(NodeLocation{0, 0}, "deadbeef");
+  auto b = std::make_shared<BinaryLiteral>(NodeLocation{5, 5}, "deadbeef");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, binaryLiteralNotEqual) {
+  auto a = std::make_shared<BinaryLiteral>(NodeLocation{0, 0}, "deadbeef");
+  auto b = std::make_shared<BinaryLiteral>(NodeLocation{0, 0}, "cafebabe");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, charLiteralEquals) {
+  auto a = std::make_shared<CharLiteral>(NodeLocation{0, 0}, "abc");
+  auto b = std::make_shared<CharLiteral>(NodeLocation{5, 5}, "abc");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, charLiteralNotEqual) {
+  auto a = std::make_shared<CharLiteral>(NodeLocation{0, 0}, "abc");
+  auto b = std::make_shared<CharLiteral>(NodeLocation{0, 0}, "xyz");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, doubleLiteralEquals) {
+  auto a = std::make_shared<DoubleLiteral>(NodeLocation{0, 0}, 3.14);
+  auto b = std::make_shared<DoubleLiteral>(NodeLocation{5, 5}, 3.14);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, doubleLiteralNotEqual) {
+  auto a = std::make_shared<DoubleLiteral>(NodeLocation{0, 0}, 3.14);
+  auto b = std::make_shared<DoubleLiteral>(NodeLocation{0, 0}, 2.71);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, decimalLiteralEquals) {
+  auto a = std::make_shared<DecimalLiteral>(NodeLocation{0, 0}, "1.23");
+  auto b = std::make_shared<DecimalLiteral>(NodeLocation{5, 5}, "1.23");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, decimalLiteralNotEqual) {
+  auto a = std::make_shared<DecimalLiteral>(NodeLocation{0, 0}, "1.23");
+  auto b = std::make_shared<DecimalLiteral>(NodeLocation{0, 0}, "4.56");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, genericLiteralEquals) {
+  auto type1 = std::make_shared<TypeSignature>(NodeLocation{0, 0}, "varchar");
+  auto type2 = std::make_shared<TypeSignature>(NodeLocation{5, 5}, "varchar");
+  auto a = std::make_shared<GenericLiteral>(NodeLocation{0, 0}, type1, "value");
+  auto b = std::make_shared<GenericLiteral>(NodeLocation{5, 5}, type2, "value");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, genericLiteralNotEqualValue) {
+  auto type = std::make_shared<TypeSignature>(NodeLocation{0, 0}, "varchar");
+  auto a = std::make_shared<GenericLiteral>(NodeLocation{0, 0}, type, "value");
+  auto b = std::make_shared<GenericLiteral>(NodeLocation{0, 0}, type, "other");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, nullLiteralAlwaysEqual) {
+  auto a = std::make_shared<NullLiteral>(NodeLocation{0, 0});
+  auto b = std::make_shared<NullLiteral>(NodeLocation{5, 5});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, timeLiteralEquals) {
+  auto a = std::make_shared<TimeLiteral>(NodeLocation{0, 0}, "12:00:00");
+  auto b = std::make_shared<TimeLiteral>(NodeLocation{5, 5}, "12:00:00");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, timeLiteralNotEqual) {
+  auto a = std::make_shared<TimeLiteral>(NodeLocation{0, 0}, "12:00:00");
+  auto b = std::make_shared<TimeLiteral>(NodeLocation{0, 0}, "13:00:00");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, timestampLiteralEquals) {
+  auto a = std::make_shared<TimestampLiteral>(
+      NodeLocation{0, 0}, "2024-01-01 00:00:00");
+  auto b = std::make_shared<TimestampLiteral>(
+      NodeLocation{5, 5}, "2024-01-01 00:00:00");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, timestampLiteralNotEqual) {
+  auto a = std::make_shared<TimestampLiteral>(
+      NodeLocation{0, 0}, "2024-01-01 00:00:00");
+  auto b = std::make_shared<TimestampLiteral>(
+      NodeLocation{0, 0}, "2024-02-02 00:00:00");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, intervalLiteralEquals) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{5, 5},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, intervalLiteralEqualsWithEndField) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "1",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kYear,
+      IntervalLiteral::IntervalField::kMonth);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{5, 5},
+      "1",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kYear,
+      IntervalLiteral::IntervalField::kMonth);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, intervalLiteralNotEqualValue) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "7",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, intervalLiteralNotEqualSign) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kNegative,
+      IntervalLiteral::IntervalField::kDay);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, intervalLiteralNotEqualStartField) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kDay);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "5",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kHour);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, intervalLiteralNotEqualEndField) {
+  auto a = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "1",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kYear,
+      IntervalLiteral::IntervalField::kMonth);
+  auto b = std::make_shared<IntervalLiteral>(
+      NodeLocation{0, 0},
+      "1",
+      IntervalLiteral::Sign::kPositive,
+      IntervalLiteral::IntervalField::kYear);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, enumLiteralEquals) {
+  auto a = std::make_shared<EnumLiteral>(NodeLocation{0, 0}, "RED");
+  auto b = std::make_shared<EnumLiteral>(NodeLocation{5, 5}, "RED");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, enumLiteralNotEqual) {
+  auto a = std::make_shared<EnumLiteral>(NodeLocation{0, 0}, "RED");
+  auto b = std::make_shared<EnumLiteral>(NodeLocation{0, 0}, "BLUE");
+  EXPECT_FALSE(*a == *b);
+}
+
+namespace {
+NodeLocation loc(int line = 0, int col = 0) {
+  return NodeLocation{line, col};
+}
+
+std::shared_ptr<LongLiteral> longLit(int64_t v) {
+  return std::make_shared<LongLiteral>(loc(), v);
+}
+} // namespace
+
+TEST(AstEqualityTest, identifierEquals) {
+  auto a = std::make_shared<Identifier>(loc(0, 0), "foo", false);
+  auto b = std::make_shared<Identifier>(loc(5, 5), "foo", false);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, identifierNotEqualValue) {
+  auto a = std::make_shared<Identifier>(loc(), "foo", false);
+  auto b = std::make_shared<Identifier>(loc(), "bar", false);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, identifierNotEqualDelimited) {
+  auto a = std::make_shared<Identifier>(loc(), "foo", false);
+  auto b = std::make_shared<Identifier>(loc(), "foo", true);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, qualifiedNameEquals) {
+  auto a = std::make_shared<QualifiedName>(
+      loc(0, 0), std::vector<std::string>{"a", "b"});
+  auto b = std::make_shared<QualifiedName>(
+      loc(5, 5), std::vector<std::string>{"a", "b"});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, qualifiedNameNotEqual) {
+  auto a = std::make_shared<QualifiedName>(
+      loc(), std::vector<std::string>{"a", "b"});
+  auto b = std::make_shared<QualifiedName>(
+      loc(), std::vector<std::string>{"a", "c"});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, dereferenceExpressionEquals) {
+  auto base1 = std::make_shared<Identifier>(loc(), "t", false);
+  auto field1 = std::make_shared<Identifier>(loc(), "f", false);
+  auto base2 = std::make_shared<Identifier>(loc(5, 5), "t", false);
+  auto field2 = std::make_shared<Identifier>(loc(5, 5), "f", false);
+  auto a = std::make_shared<DereferenceExpression>(loc(), base1, field1);
+  auto b = std::make_shared<DereferenceExpression>(loc(5, 5), base2, field2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, dereferenceExpressionNotEqual) {
+  auto base = std::make_shared<Identifier>(loc(), "t", false);
+  auto field1 = std::make_shared<Identifier>(loc(), "f", false);
+  auto field2 = std::make_shared<Identifier>(loc(), "g", false);
+  auto a = std::make_shared<DereferenceExpression>(loc(), base, field1);
+  auto b = std::make_shared<DereferenceExpression>(loc(), base, field2);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, fieldReferenceEquals) {
+  auto a = std::make_shared<FieldReference>(loc(0, 0), 3);
+  auto b = std::make_shared<FieldReference>(loc(5, 5), 3);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, fieldReferenceNotEqual) {
+  auto a = std::make_shared<FieldReference>(loc(), 3);
+  auto b = std::make_shared<FieldReference>(loc(), 4);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, symbolReferenceEquals) {
+  auto a = std::make_shared<SymbolReference>(loc(0, 0), "x");
+  auto b = std::make_shared<SymbolReference>(loc(5, 5), "x");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, symbolReferenceNotEqual) {
+  auto a = std::make_shared<SymbolReference>(loc(), "x");
+  auto b = std::make_shared<SymbolReference>(loc(), "y");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, parameterEquals) {
+  auto a = std::make_shared<Parameter>(loc(0, 0), 2);
+  auto b = std::make_shared<Parameter>(loc(5, 5), 2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, parameterNotEqual) {
+  auto a = std::make_shared<Parameter>(loc(), 2);
+  auto b = std::make_shared<Parameter>(loc(), 3);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, arithmeticBinaryExpressionEquals) {
+  auto a = std::make_shared<ArithmeticBinaryExpression>(
+      loc(0, 0),
+      ArithmeticBinaryExpression::Operator::kAdd,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<ArithmeticBinaryExpression>(
+      loc(5, 5),
+      ArithmeticBinaryExpression::Operator::kAdd,
+      longLit(1),
+      longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, arithmeticBinaryExpressionNotEqualOperand) {
+  auto a = std::make_shared<ArithmeticBinaryExpression>(
+      loc(),
+      ArithmeticBinaryExpression::Operator::kAdd,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<ArithmeticBinaryExpression>(
+      loc(),
+      ArithmeticBinaryExpression::Operator::kAdd,
+      longLit(1),
+      longLit(3));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, arithmeticBinaryExpressionNotEqualOperator) {
+  // 1 + 2 vs 1 - 2.
+  auto a = std::make_shared<ArithmeticBinaryExpression>(
+      loc(),
+      ArithmeticBinaryExpression::Operator::kAdd,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<ArithmeticBinaryExpression>(
+      loc(),
+      ArithmeticBinaryExpression::Operator::kSubtract,
+      longLit(1),
+      longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, arithmeticUnaryExpressionEquals) {
+  auto a = std::make_shared<ArithmeticUnaryExpression>(
+      loc(0, 0), ArithmeticUnaryExpression::Sign::kMinus, longLit(1));
+  auto b = std::make_shared<ArithmeticUnaryExpression>(
+      loc(5, 5), ArithmeticUnaryExpression::Sign::kMinus, longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, arithmeticUnaryExpressionNotEqualSign) {
+  auto a = std::make_shared<ArithmeticUnaryExpression>(
+      loc(), ArithmeticUnaryExpression::Sign::kMinus, longLit(1));
+  auto b = std::make_shared<ArithmeticUnaryExpression>(
+      loc(), ArithmeticUnaryExpression::Sign::kPlus, longLit(1));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, comparisonExpressionEquals) {
+  auto a = std::make_shared<ComparisonExpression>(
+      loc(0, 0),
+      ComparisonExpression::Operator::kEqual,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<ComparisonExpression>(
+      loc(5, 5),
+      ComparisonExpression::Operator::kEqual,
+      longLit(1),
+      longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, comparisonExpressionNotEqualOperator) {
+  // a = b vs a < b.
+  auto a = std::make_shared<ComparisonExpression>(
+      loc(), ComparisonExpression::Operator::kEqual, longLit(1), longLit(2));
+  auto b = std::make_shared<ComparisonExpression>(
+      loc(), ComparisonExpression::Operator::kLessThan, longLit(1), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, betweenPredicateEquals) {
+  auto a = std::make_shared<BetweenPredicate>(
+      loc(0, 0), longLit(5), longLit(1), longLit(10));
+  auto b = std::make_shared<BetweenPredicate>(
+      loc(5, 5), longLit(5), longLit(1), longLit(10));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, betweenPredicateNotEqual) {
+  auto a = std::make_shared<BetweenPredicate>(
+      loc(), longLit(5), longLit(1), longLit(10));
+  auto b = std::make_shared<BetweenPredicate>(
+      loc(), longLit(5), longLit(2), longLit(10));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, inPredicateEquals) {
+  auto list1 = std::make_shared<InListExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto list2 = std::make_shared<InListExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto a = std::make_shared<InPredicate>(loc(0, 0), longLit(5), list1);
+  auto b = std::make_shared<InPredicate>(loc(5, 5), longLit(5), list2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, inPredicateNotEqual) {
+  auto list = std::make_shared<InListExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto a = std::make_shared<InPredicate>(loc(), longLit(5), list);
+  auto b = std::make_shared<InPredicate>(loc(), longLit(6), list);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, inListExpressionEquals) {
+  auto a = std::make_shared<InListExpression>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<InListExpression>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, inListExpressionNotEqual) {
+  auto a = std::make_shared<InListExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<InListExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(3)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, isNullPredicateEquals) {
+  auto a = std::make_shared<IsNullPredicate>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<IsNullPredicate>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, isNullPredicateNotEqual) {
+  auto a = std::make_shared<IsNullPredicate>(loc(), longLit(1));
+  auto b = std::make_shared<IsNullPredicate>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, isNotNullPredicateEquals) {
+  auto a = std::make_shared<IsNotNullPredicate>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<IsNotNullPredicate>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, isNotNullPredicateNotEqual) {
+  auto a = std::make_shared<IsNotNullPredicate>(loc(), longLit(1));
+  auto b = std::make_shared<IsNotNullPredicate>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, likePredicateEquals) {
+  auto pat = std::make_shared<StringLiteral>(loc(), "a%");
+  auto a = std::make_shared<LikePredicate>(loc(0, 0), longLit(1), pat);
+  auto b = std::make_shared<LikePredicate>(loc(5, 5), longLit(1), pat);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, likePredicateNotEqualPattern) {
+  auto pat1 = std::make_shared<StringLiteral>(loc(), "a%");
+  auto pat2 = std::make_shared<StringLiteral>(loc(), "b%");
+  auto a = std::make_shared<LikePredicate>(loc(), longLit(1), pat1);
+  auto b = std::make_shared<LikePredicate>(loc(), longLit(1), pat2);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, likePredicateNotEqualEscape) {
+  auto pat = std::make_shared<StringLiteral>(loc(), "a%");
+  auto esc = std::make_shared<StringLiteral>(loc(), "\\");
+  auto a = std::make_shared<LikePredicate>(loc(), longLit(1), pat, nullptr);
+  auto b = std::make_shared<LikePredicate>(loc(), longLit(1), pat, esc);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, existsPredicateEquals) {
+  auto a = std::make_shared<ExistsPredicate>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<ExistsPredicate>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, existsPredicateNotEqual) {
+  auto a = std::make_shared<ExistsPredicate>(loc(), longLit(1));
+  auto b = std::make_shared<ExistsPredicate>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, quantifiedComparisonExpressionEquals) {
+  auto a = std::make_shared<QuantifiedComparisonExpression>(
+      loc(0, 0),
+      ComparisonExpression::Operator::kEqual,
+      QuantifiedComparisonExpression::Quantifier::kAll,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<QuantifiedComparisonExpression>(
+      loc(5, 5),
+      ComparisonExpression::Operator::kEqual,
+      QuantifiedComparisonExpression::Quantifier::kAll,
+      longLit(1),
+      longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, quantifiedComparisonExpressionNotEqualQuantifier) {
+  auto a = std::make_shared<QuantifiedComparisonExpression>(
+      loc(),
+      ComparisonExpression::Operator::kEqual,
+      QuantifiedComparisonExpression::Quantifier::kAll,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<QuantifiedComparisonExpression>(
+      loc(),
+      ComparisonExpression::Operator::kEqual,
+      QuantifiedComparisonExpression::Quantifier::kAny,
+      longLit(1),
+      longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, logicalBinaryExpressionEquals) {
+  auto a = std::make_shared<LogicalBinaryExpression>(
+      loc(0, 0),
+      LogicalBinaryExpression::Operator::kAnd,
+      longLit(1),
+      longLit(2));
+  auto b = std::make_shared<LogicalBinaryExpression>(
+      loc(5, 5),
+      LogicalBinaryExpression::Operator::kAnd,
+      longLit(1),
+      longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, logicalBinaryExpressionNotEqualOperator) {
+  // a AND b vs a OR b.
+  auto a = std::make_shared<LogicalBinaryExpression>(
+      loc(), LogicalBinaryExpression::Operator::kAnd, longLit(1), longLit(2));
+  auto b = std::make_shared<LogicalBinaryExpression>(
+      loc(), LogicalBinaryExpression::Operator::kOr, longLit(1), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, notExpressionEquals) {
+  auto a = std::make_shared<NotExpression>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<NotExpression>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, notExpressionNotEqual) {
+  auto a = std::make_shared<NotExpression>(loc(), longLit(1));
+  auto b = std::make_shared<NotExpression>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, ifExpressionEquals) {
+  auto a = std::make_shared<IfExpression>(
+      loc(0, 0), longLit(1), longLit(2), longLit(3));
+  auto b = std::make_shared<IfExpression>(
+      loc(5, 5), longLit(1), longLit(2), longLit(3));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, ifExpressionNotEqual) {
+  auto a = std::make_shared<IfExpression>(loc(), longLit(1), longLit(2));
+  auto b = std::make_shared<IfExpression>(loc(), longLit(1), longLit(99));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, coalesceExpressionEquals) {
+  auto a = std::make_shared<CoalesceExpression>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<CoalesceExpression>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, coalesceExpressionNotEqual) {
+  auto a = std::make_shared<CoalesceExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<CoalesceExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1), longLit(3)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, nullIfExpressionEquals) {
+  auto a =
+      std::make_shared<NullIfExpression>(loc(0, 0), longLit(1), longLit(2));
+  auto b =
+      std::make_shared<NullIfExpression>(loc(5, 5), longLit(1), longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, nullIfExpressionNotEqual) {
+  auto a = std::make_shared<NullIfExpression>(loc(), longLit(1), longLit(2));
+  auto b = std::make_shared<NullIfExpression>(loc(), longLit(1), longLit(3));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, whenClauseEquals) {
+  auto a = std::make_shared<WhenClause>(loc(0, 0), longLit(1), longLit(2));
+  auto b = std::make_shared<WhenClause>(loc(5, 5), longLit(1), longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, whenClauseNotEqual) {
+  auto a = std::make_shared<WhenClause>(loc(), longLit(1), longLit(2));
+  auto b = std::make_shared<WhenClause>(loc(), longLit(1), longLit(3));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, searchedCaseExpressionEquals) {
+  auto when1 = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto when2 = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto a = std::make_shared<SearchedCaseExpression>(
+      loc(0, 0), std::vector<std::shared_ptr<WhenClause>>{when1}, longLit(99));
+  auto b = std::make_shared<SearchedCaseExpression>(
+      loc(5, 5), std::vector<std::shared_ptr<WhenClause>>{when2}, longLit(99));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, searchedCaseExpressionNotEqual) {
+  auto when = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto a = std::make_shared<SearchedCaseExpression>(
+      loc(), std::vector<std::shared_ptr<WhenClause>>{when}, longLit(99));
+  auto b = std::make_shared<SearchedCaseExpression>(
+      loc(), std::vector<std::shared_ptr<WhenClause>>{when}, longLit(100));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, simpleCaseExpressionEquals) {
+  auto when1 = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto when2 = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto a = std::make_shared<SimpleCaseExpression>(
+      loc(0, 0),
+      longLit(5),
+      std::vector<std::shared_ptr<WhenClause>>{when1},
+      longLit(99));
+  auto b = std::make_shared<SimpleCaseExpression>(
+      loc(5, 5),
+      longLit(5),
+      std::vector<std::shared_ptr<WhenClause>>{when2},
+      longLit(99));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, simpleCaseExpressionNotEqual) {
+  auto when = std::make_shared<WhenClause>(loc(), longLit(1), longLit(10));
+  auto a = std::make_shared<SimpleCaseExpression>(
+      loc(),
+      longLit(5),
+      std::vector<std::shared_ptr<WhenClause>>{when},
+      longLit(99));
+  auto b = std::make_shared<SimpleCaseExpression>(
+      loc(),
+      longLit(6),
+      std::vector<std::shared_ptr<WhenClause>>{when},
+      longLit(99));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, tryExpressionEquals) {
+  auto a = std::make_shared<TryExpression>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<TryExpression>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, tryExpressionNotEqual) {
+  auto a = std::make_shared<TryExpression>(loc(), longLit(1));
+  auto b = std::make_shared<TryExpression>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, functionCallEquals) {
+  auto name1 =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"f"});
+  auto name2 =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"f"});
+  auto a = std::make_shared<FunctionCall>(
+      loc(0, 0), name1, std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<FunctionCall>(
+      loc(5, 5), name2, std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, functionCallNotEqualName) {
+  auto fName =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"f"});
+  auto gName =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"g"});
+  auto a = std::make_shared<FunctionCall>(
+      loc(), fName, std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<FunctionCall>(
+      loc(), gName, std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, functionCallNotEqualDistinct) {
+  auto name =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"f"});
+  auto a = std::make_shared<FunctionCall>(
+      loc(),
+      name,
+      nullptr,
+      nullptr,
+      nullptr,
+      /*distinct=*/false,
+      /*ignoreNulls=*/false,
+      std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<FunctionCall>(
+      loc(),
+      name,
+      nullptr,
+      nullptr,
+      nullptr,
+      /*distinct=*/true,
+      /*ignoreNulls=*/false,
+      std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, castEquals) {
+  auto type1 = std::make_shared<TypeSignature>(loc(), "varchar");
+  auto type2 = std::make_shared<TypeSignature>(loc(5, 5), "varchar");
+  auto a = std::make_shared<Cast>(loc(0, 0), longLit(1), type1, false);
+  auto b = std::make_shared<Cast>(loc(5, 5), longLit(1), type2, false);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, castNotEqualSafe) {
+  auto type = std::make_shared<TypeSignature>(loc(), "varchar");
+  auto a = std::make_shared<Cast>(loc(), longLit(1), type, false);
+  auto b = std::make_shared<Cast>(loc(), longLit(1), type, true);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, extractEquals) {
+  auto a =
+      std::make_shared<Extract>(loc(0, 0), longLit(1), Extract::Field::kYear);
+  auto b =
+      std::make_shared<Extract>(loc(5, 5), longLit(1), Extract::Field::kYear);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, extractNotEqualField) {
+  auto a = std::make_shared<Extract>(loc(), longLit(1), Extract::Field::kYear);
+  auto b = std::make_shared<Extract>(loc(), longLit(1), Extract::Field::kMonth);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, currentTimeEquals) {
+  auto a = std::make_shared<CurrentTime>(
+      loc(0, 0), CurrentTime::Function::kTimestamp, 3);
+  auto b = std::make_shared<CurrentTime>(
+      loc(5, 5), CurrentTime::Function::kTimestamp, 3);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, currentTimeNotEqualFunction) {
+  auto a =
+      std::make_shared<CurrentTime>(loc(), CurrentTime::Function::kTimestamp);
+  auto b = std::make_shared<CurrentTime>(loc(), CurrentTime::Function::kDate);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, currentTimeNotEqualPrecision) {
+  auto a = std::make_shared<CurrentTime>(
+      loc(), CurrentTime::Function::kTimestamp, 3);
+  auto b = std::make_shared<CurrentTime>(
+      loc(), CurrentTime::Function::kTimestamp, 6);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, currentUserAlwaysEqual) {
+  auto a = std::make_shared<CurrentUser>(loc(0, 0));
+  auto b = std::make_shared<CurrentUser>(loc(5, 5));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, atTimeZoneEquals) {
+  auto tz1 = std::make_shared<StringLiteral>(loc(), "UTC");
+  auto tz2 = std::make_shared<StringLiteral>(loc(), "UTC");
+  auto a = std::make_shared<AtTimeZone>(loc(0, 0), longLit(1), tz1);
+  auto b = std::make_shared<AtTimeZone>(loc(5, 5), longLit(1), tz2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, atTimeZoneNotEqual) {
+  auto utc = std::make_shared<StringLiteral>(loc(), "UTC");
+  auto pst = std::make_shared<StringLiteral>(loc(), "PST");
+  auto a = std::make_shared<AtTimeZone>(loc(), longLit(1), utc);
+  auto b = std::make_shared<AtTimeZone>(loc(), longLit(1), pst);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, subqueryExpressionEqualsSharedInner) {
+  // Two distinct SubqueryExpression instances wrapping the same inner Query.
+  auto select = std::make_shared<Select>(
+      loc(), false, std::vector<std::shared_ptr<SelectItem>>{});
+  auto querySpec = std::make_shared<QuerySpecification>(loc(), select);
+  StatementPtr query = std::make_shared<Query>(loc(), nullptr, querySpec);
+  auto a = std::make_shared<SubqueryExpression>(loc(0, 0), query);
+  auto b = std::make_shared<SubqueryExpression>(loc(5, 5), query);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, subqueryExpressionEqualsDistinctInner) {
+  auto makeQuery = []() {
+    auto select = std::make_shared<Select>(
+        loc(), false, std::vector<std::shared_ptr<SelectItem>>{});
+    auto querySpec = std::make_shared<QuerySpecification>(loc(), select);
+    return std::static_pointer_cast<Statement>(
+        std::make_shared<Query>(loc(), nullptr, querySpec));
+  };
+  auto a = std::make_shared<SubqueryExpression>(loc(0, 0), makeQuery());
+  auto b = std::make_shared<SubqueryExpression>(loc(5, 5), makeQuery());
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, subqueryExpressionNotEqualNullVsNonNull) {
+  auto select = std::make_shared<Select>(
+      loc(), false, std::vector<std::shared_ptr<SelectItem>>{});
+  auto querySpec = std::make_shared<QuerySpecification>(loc(), select);
+  StatementPtr query = std::make_shared<Query>(loc(), nullptr, querySpec);
+  auto a = std::make_shared<SubqueryExpression>(loc(), query);
+  auto b = std::make_shared<SubqueryExpression>(loc(), nullptr);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, arrayConstructorEquals) {
+  auto a = std::make_shared<ArrayConstructor>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<ArrayConstructor>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, arrayConstructorNotEqual) {
+  auto a = std::make_shared<ArrayConstructor>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<ArrayConstructor>(
+      loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, rowEquals) {
+  auto a = std::make_shared<Row>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<Row>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, rowNotEqual) {
+  auto a = std::make_shared<Row>(loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<Row>(loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, namedRowEquals) {
+  auto a = std::make_shared<NamedRow>(
+      loc(0, 0),
+      std::vector<ExpressionPtr>{longLit(1)},
+      std::vector<std::string>{"f"});
+  auto b = std::make_shared<NamedRow>(
+      loc(5, 5),
+      std::vector<ExpressionPtr>{longLit(1)},
+      std::vector<std::string>{"f"});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, namedRowNotEqualFieldName) {
+  auto a = std::make_shared<NamedRow>(
+      loc(),
+      std::vector<ExpressionPtr>{longLit(1)},
+      std::vector<std::string>{"f"});
+  auto b = std::make_shared<NamedRow>(
+      loc(),
+      std::vector<ExpressionPtr>{longLit(1)},
+      std::vector<std::string>{"g"});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, subscriptExpressionEquals) {
+  auto a =
+      std::make_shared<SubscriptExpression>(loc(0, 0), longLit(1), longLit(2));
+  auto b =
+      std::make_shared<SubscriptExpression>(loc(5, 5), longLit(1), longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, subscriptExpressionNotEqual) {
+  auto a = std::make_shared<SubscriptExpression>(loc(), longLit(1), longLit(2));
+  auto b = std::make_shared<SubscriptExpression>(loc(), longLit(1), longLit(3));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, lambdaArgumentDeclarationEquals) {
+  auto id1 = std::make_shared<Identifier>(loc(), "x", false);
+  auto id2 = std::make_shared<Identifier>(loc(), "x", false);
+  auto a = std::make_shared<LambdaArgumentDeclaration>(loc(0, 0), id1);
+  auto b = std::make_shared<LambdaArgumentDeclaration>(loc(5, 5), id2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, lambdaArgumentDeclarationNotEqual) {
+  auto x = std::make_shared<Identifier>(loc(), "x", false);
+  auto y = std::make_shared<Identifier>(loc(), "y", false);
+  auto a = std::make_shared<LambdaArgumentDeclaration>(loc(), x);
+  auto b = std::make_shared<LambdaArgumentDeclaration>(loc(), y);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, lambdaExpressionEquals) {
+  auto id = std::make_shared<Identifier>(loc(), "x", false);
+  auto arg1 = std::make_shared<LambdaArgumentDeclaration>(loc(), id);
+  auto arg2 = std::make_shared<LambdaArgumentDeclaration>(loc(), id);
+  auto a = std::make_shared<LambdaExpression>(
+      loc(0, 0),
+      std::vector<std::shared_ptr<LambdaArgumentDeclaration>>{arg1},
+      longLit(1));
+  auto b = std::make_shared<LambdaExpression>(
+      loc(5, 5),
+      std::vector<std::shared_ptr<LambdaArgumentDeclaration>>{arg2},
+      longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, lambdaExpressionNotEqualBody) {
+  auto id = std::make_shared<Identifier>(loc(), "x", false);
+  auto arg = std::make_shared<LambdaArgumentDeclaration>(loc(), id);
+  auto a = std::make_shared<LambdaExpression>(
+      loc(),
+      std::vector<std::shared_ptr<LambdaArgumentDeclaration>>{arg},
+      longLit(1));
+  auto b = std::make_shared<LambdaExpression>(
+      loc(),
+      std::vector<std::shared_ptr<LambdaArgumentDeclaration>>{arg},
+      longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, bindExpressionEquals) {
+  auto a = std::make_shared<BindExpression>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1)}, longLit(2));
+  auto b = std::make_shared<BindExpression>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1)}, longLit(2));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, bindExpressionNotEqual) {
+  auto a = std::make_shared<BindExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)}, longLit(2));
+  auto b = std::make_shared<BindExpression>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)}, longLit(3));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, groupingOperationEquals) {
+  auto name1 =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
+  auto name2 =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
+  auto a = std::make_shared<GroupingOperation>(
+      loc(0, 0), std::vector<std::shared_ptr<QualifiedName>>{name1});
+  auto b = std::make_shared<GroupingOperation>(
+      loc(5, 5), std::vector<std::shared_ptr<QualifiedName>>{name2});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, groupingOperationNotEqual) {
+  auto na =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
+  auto nb =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"b"});
+  auto a = std::make_shared<GroupingOperation>(
+      loc(), std::vector<std::shared_ptr<QualifiedName>>{na});
+  auto b = std::make_shared<GroupingOperation>(
+      loc(), std::vector<std::shared_ptr<QualifiedName>>{nb});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, tableVersionExpressionEquals) {
+  auto a = std::make_shared<TableVersionExpression>(
+      loc(0, 0),
+      TableVersionExpression::TableVersionType::kVersion,
+      longLit(1));
+  auto b = std::make_shared<TableVersionExpression>(
+      loc(5, 5),
+      TableVersionExpression::TableVersionType::kVersion,
+      longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, tableVersionExpressionNotEqualType) {
+  auto a = std::make_shared<TableVersionExpression>(
+      loc(), TableVersionExpression::TableVersionType::kVersion, longLit(1));
+  auto b = std::make_shared<TableVersionExpression>(
+      loc(), TableVersionExpression::TableVersionType::kTimestamp, longLit(1));
+  EXPECT_FALSE(*a == *b);
+}
+
+namespace {
+std::shared_ptr<Select> emptySelect(bool distinct = false) {
+  return std::make_shared<Select>(
+      loc(), distinct, std::vector<std::shared_ptr<SelectItem>>{});
+}
+
+std::shared_ptr<QuerySpecification> makeQuerySpec(
+    const std::shared_ptr<Select>& select,
+    const RelationPtr& from = nullptr) {
+  return std::make_shared<QuerySpecification>(loc(), select, from);
+}
+
+std::shared_ptr<Table> makeTable(const std::string& name) {
+  auto qn =
+      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{name});
+  return std::make_shared<Table>(loc(), qn);
+}
+} // namespace
+
+TEST(AstEqualityTest, queryEquals) {
+  auto a =
+      std::make_shared<Query>(loc(0, 0), nullptr, makeQuerySpec(emptySelect()));
+  auto b =
+      std::make_shared<Query>(loc(5, 5), nullptr, makeQuerySpec(emptySelect()));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, queryNotEqualLimit) {
+  auto a = std::make_shared<Query>(
+      loc(),
+      nullptr,
+      makeQuerySpec(emptySelect()),
+      nullptr,
+      nullptr,
+      std::string{"10"});
+  auto b = std::make_shared<Query>(
+      loc(),
+      nullptr,
+      makeQuerySpec(emptySelect()),
+      nullptr,
+      nullptr,
+      std::string{"20"});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, querySpecificationEquals) {
+  auto a = makeQuerySpec(emptySelect(), makeTable("t"));
+  auto b = makeQuerySpec(emptySelect(), makeTable("t"));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, querySpecificationNotEqualFrom) {
+  auto a = makeQuerySpec(emptySelect(), makeTable("t1"));
+  auto b = makeQuerySpec(emptySelect(), makeTable("t2"));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, singleColumnEquals) {
+  auto a = std::make_shared<SingleColumn>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<SingleColumn>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, singleColumnNotEqualAlias) {
+  auto aliasX = std::make_shared<Identifier>(loc(), "x", false);
+  auto aliasY = std::make_shared<Identifier>(loc(), "y", false);
+  auto a = std::make_shared<SingleColumn>(loc(), longLit(1), aliasX);
+  auto b = std::make_shared<SingleColumn>(loc(), longLit(1), aliasY);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, allColumnsEquals) {
+  auto a = std::make_shared<AllColumns>(
+      loc(0, 0),
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  auto b = std::make_shared<AllColumns>(
+      loc(5, 5),
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, allColumnsNotEqualExclude) {
+  auto excludeA = std::make_shared<Identifier>(loc(), "a", false);
+  auto excludeB = std::make_shared<Identifier>(loc(), "b", false);
+  auto a = std::make_shared<AllColumns>(
+      loc(),
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{excludeA},
+      std::vector<ReplaceItem>{});
+  auto b = std::make_shared<AllColumns>(
+      loc(),
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{excludeB},
+      std::vector<ReplaceItem>{});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, selectColumnsEquals) {
+  auto a = std::make_shared<SelectColumns>(
+      loc(0, 0),
+      "a.*",
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  auto b = std::make_shared<SelectColumns>(
+      loc(5, 5),
+      "a.*",
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, selectColumnsNotEqualPattern) {
+  auto a = std::make_shared<SelectColumns>(
+      loc(),
+      "a.*",
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  auto b = std::make_shared<SelectColumns>(
+      loc(),
+      "b.*",
+      nullptr,
+      std::vector<std::shared_ptr<Identifier>>{},
+      std::vector<ReplaceItem>{});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, selectEquals) {
+  auto a = emptySelect();
+  auto b = emptySelect();
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, selectNotEqualDistinct) {
+  // SELECT a vs SELECT DISTINCT a — the distinct flag matters.
+  auto item1 = std::make_shared<SingleColumn>(loc(), longLit(1));
+  auto item2 = std::make_shared<SingleColumn>(loc(), longLit(1));
+  auto a = std::make_shared<Select>(
+      loc(), false, std::vector<std::shared_ptr<SelectItem>>{item1});
+  auto b = std::make_shared<Select>(
+      loc(), true, std::vector<std::shared_ptr<SelectItem>>{item2});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, tableEquals) {
+  auto a = makeTable("t");
+  auto b = makeTable("t");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, tableNotEqualName) {
+  auto a = makeTable("t1");
+  auto b = makeTable("t2");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, aliasedRelationEquals) {
+  auto aliasA = std::make_shared<Identifier>(loc(), "x", false);
+  auto aliasB = std::make_shared<Identifier>(loc(), "x", false);
+  auto a = std::make_shared<AliasedRelation>(loc(0, 0), makeTable("t"), aliasA);
+  auto b = std::make_shared<AliasedRelation>(loc(5, 5), makeTable("t"), aliasB);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, aliasedRelationNotEqualAlias) {
+  // t1 AS x vs t1 AS y — alias name participates in equality.
+  auto aliasX = std::make_shared<Identifier>(loc(), "x", false);
+  auto aliasY = std::make_shared<Identifier>(loc(), "y", false);
+  auto a = std::make_shared<AliasedRelation>(loc(), makeTable("t1"), aliasX);
+  auto b = std::make_shared<AliasedRelation>(loc(), makeTable("t1"), aliasY);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, sampledRelationEquals) {
+  auto a = std::make_shared<SampledRelation>(
+      loc(0, 0),
+      makeTable("t"),
+      SampledRelation::Type::kBernoulli,
+      longLit(10));
+  auto b = std::make_shared<SampledRelation>(
+      loc(5, 5),
+      makeTable("t"),
+      SampledRelation::Type::kBernoulli,
+      longLit(10));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, sampledRelationNotEqualType) {
+  auto a = std::make_shared<SampledRelation>(
+      loc(), makeTable("t"), SampledRelation::Type::kBernoulli, longLit(10));
+  auto b = std::make_shared<SampledRelation>(
+      loc(), makeTable("t"), SampledRelation::Type::kSystem, longLit(10));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, tableSubqueryEquals) {
+  auto makeQuery = []() {
+    return std::static_pointer_cast<Statement>(
+        std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect())));
+  };
+  auto a = std::make_shared<TableSubquery>(loc(0, 0), makeQuery());
+  auto b = std::make_shared<TableSubquery>(loc(5, 5), makeQuery());
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, tableSubqueryNotEqual) {
+  auto qa = std::static_pointer_cast<Statement>(std::make_shared<Query>(
+      loc(), nullptr, makeQuerySpec(emptySelect(), makeTable("t1"))));
+  auto qb = std::static_pointer_cast<Statement>(std::make_shared<Query>(
+      loc(), nullptr, makeQuerySpec(emptySelect(), makeTable("t2"))));
+  auto a = std::make_shared<TableSubquery>(loc(), qa);
+  auto b = std::make_shared<TableSubquery>(loc(), qb);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, lateralEquals) {
+  auto a = std::make_shared<Lateral>(loc(0, 0), makeTable("t"));
+  auto b = std::make_shared<Lateral>(loc(5, 5), makeTable("t"));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, lateralNotEqual) {
+  auto a = std::make_shared<Lateral>(loc(), makeTable("t1"));
+  auto b = std::make_shared<Lateral>(loc(), makeTable("t2"));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, unnestEquals) {
+  auto a = std::make_shared<Unnest>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1)}, false);
+  auto b = std::make_shared<Unnest>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1)}, false);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, unnestNotEqualOrdinality) {
+  // UNNEST(x) vs UNNEST(x) WITH ORDINALITY — the ordinality flag matters.
+  auto a = std::make_shared<Unnest>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)}, false);
+  auto b = std::make_shared<Unnest>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)}, true);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, valuesEquals) {
+  auto a = std::make_shared<Values>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  auto b = std::make_shared<Values>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1), longLit(2)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, valuesNotEqualRows) {
+  auto a =
+      std::make_shared<Values>(loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b =
+      std::make_shared<Values>(loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, joinOnEquals) {
+  auto a = std::make_shared<JoinOn>(loc(0, 0), longLit(1));
+  auto b = std::make_shared<JoinOn>(loc(5, 5), longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, joinOnNotEqual) {
+  auto a = std::make_shared<JoinOn>(loc(), longLit(1));
+  auto b = std::make_shared<JoinOn>(loc(), longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, joinUsingEquals) {
+  auto colA = std::make_shared<Identifier>(loc(), "a", false);
+  auto colB = std::make_shared<Identifier>(loc(), "a", false);
+  auto a = std::make_shared<JoinUsing>(
+      loc(0, 0), std::vector<std::shared_ptr<Identifier>>{colA});
+  auto b = std::make_shared<JoinUsing>(
+      loc(5, 5), std::vector<std::shared_ptr<Identifier>>{colB});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, joinUsingNotEqual) {
+  auto colA = std::make_shared<Identifier>(loc(), "a", false);
+  auto colB = std::make_shared<Identifier>(loc(), "b", false);
+  auto a = std::make_shared<JoinUsing>(
+      loc(), std::vector<std::shared_ptr<Identifier>>{colA});
+  auto b = std::make_shared<JoinUsing>(
+      loc(), std::vector<std::shared_ptr<Identifier>>{colB});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, joinCriteriaDifferentSubtypes) {
+  // JoinOn vs JoinUsing — different concrete JoinCriteria types are unequal
+  // via the base Node::operator== type_ check.
+  auto onCrit = std::make_shared<JoinOn>(loc(), longLit(1));
+  auto col = std::make_shared<Identifier>(loc(), "a", false);
+  auto usingCrit = std::make_shared<JoinUsing>(
+      loc(), std::vector<std::shared_ptr<Identifier>>{col});
+  EXPECT_FALSE(
+      static_cast<const Node&>(*onCrit) ==
+      static_cast<const Node&>(*usingCrit));
+}
+
+TEST(AstEqualityTest, joinEquals) {
+  auto critA = std::make_shared<JoinOn>(loc(), longLit(1));
+  auto critB = std::make_shared<JoinOn>(loc(), longLit(1));
+  auto a = std::make_shared<Join>(
+      loc(0, 0), Join::Type::kInner, makeTable("t1"), makeTable("t2"), critA);
+  auto b = std::make_shared<Join>(
+      loc(5, 5), Join::Type::kInner, makeTable("t1"), makeTable("t2"), critB);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, joinNotEqualType) {
+  // INNER JOIN vs LEFT JOIN — the join type matters.
+  auto crit = std::make_shared<JoinOn>(loc(), longLit(1));
+  auto a = std::make_shared<Join>(
+      loc(), Join::Type::kInner, makeTable("t1"), makeTable("t2"), crit);
+  auto b = std::make_shared<Join>(
+      loc(), Join::Type::kLeft, makeTable("t1"), makeTable("t2"), crit);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, naturalJoinEquals) {
+  auto a = std::make_shared<NaturalJoin>(
+      loc(0, 0), Join::Type::kInner, makeTable("t1"), makeTable("t2"));
+  auto b = std::make_shared<NaturalJoin>(
+      loc(5, 5), Join::Type::kInner, makeTable("t1"), makeTable("t2"));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, naturalJoinNotEqualType) {
+  auto a = std::make_shared<NaturalJoin>(
+      loc(), Join::Type::kInner, makeTable("t1"), makeTable("t2"));
+  auto b = std::make_shared<NaturalJoin>(
+      loc(), Join::Type::kLeft, makeTable("t1"), makeTable("t2"));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, unionEquals) {
+  auto a = std::make_shared<Union>(
+      loc(0, 0), makeTable("t1"), makeTable("t2"), true);
+  auto b = std::make_shared<Union>(
+      loc(5, 5), makeTable("t1"), makeTable("t2"), true);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, unionNotEqualDistinct) {
+  // UNION (distinct=true) vs UNION ALL (distinct=false).
+  auto a =
+      std::make_shared<Union>(loc(), makeTable("t1"), makeTable("t2"), true);
+  auto b =
+      std::make_shared<Union>(loc(), makeTable("t1"), makeTable("t2"), false);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, intersectEquals) {
+  auto a = std::make_shared<Intersect>(
+      loc(0, 0), makeTable("t1"), makeTable("t2"), true);
+  auto b = std::make_shared<Intersect>(
+      loc(5, 5), makeTable("t1"), makeTable("t2"), true);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, intersectNotEqualOperand) {
+  auto a = std::make_shared<Intersect>(
+      loc(), makeTable("t1"), makeTable("t2"), true);
+  auto b = std::make_shared<Intersect>(
+      loc(), makeTable("t1"), makeTable("t3"), true);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, exceptEquals) {
+  auto a = std::make_shared<Except>(
+      loc(0, 0), makeTable("t1"), makeTable("t2"), true);
+  auto b = std::make_shared<Except>(
+      loc(5, 5), makeTable("t1"), makeTable("t2"), true);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, exceptNotEqualDistinct) {
+  auto a =
+      std::make_shared<Except>(loc(), makeTable("t1"), makeTable("t2"), true);
+  auto b =
+      std::make_shared<Except>(loc(), makeTable("t1"), makeTable("t2"), false);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, typeSignatureEquals) {
+  auto a = std::make_shared<TypeSignature>(loc(0, 0), "varchar");
+  auto b = std::make_shared<TypeSignature>(loc(5, 5), "varchar");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, typeSignatureNotEqualBaseName) {
+  auto a = std::make_shared<TypeSignature>(loc(), "varchar");
+  auto b = std::make_shared<TypeSignature>(loc(), "bigint");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, typeSignatureWithParameters) {
+  auto k1 = std::make_shared<TypeSignature>(loc(), "K");
+  auto v1 = std::make_shared<TypeSignature>(loc(), "V");
+  auto k2 = std::make_shared<TypeSignature>(loc(), "K");
+  auto v2 = std::make_shared<TypeSignature>(loc(), "V");
+  auto a = std::make_shared<TypeSignature>(
+      loc(), "map", std::vector<TypeSignaturePtr>{k1, v1});
+  auto b = std::make_shared<TypeSignature>(
+      loc(), "map", std::vector<TypeSignaturePtr>{k2, v2});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, callArgumentEquals) {
+  auto name1 = std::make_shared<Identifier>(loc(), "x", false);
+  auto name2 = std::make_shared<Identifier>(loc(), "x", false);
+  auto a = std::make_shared<CallArgument>(loc(0, 0), name1, longLit(1));
+  auto b = std::make_shared<CallArgument>(loc(5, 5), name2, longLit(1));
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, callArgumentNotEqualValue) {
+  auto name = std::make_shared<Identifier>(loc(), "x", false);
+  auto a = std::make_shared<CallArgument>(loc(), name, longLit(1));
+  auto b = std::make_shared<CallArgument>(loc(), name, longLit(2));
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, frameBoundEquals) {
+  auto a = std::make_shared<FrameBound>(
+      loc(0, 0), FrameBound::Type::kUnboundedPreceding);
+  auto b = std::make_shared<FrameBound>(
+      loc(5, 5), FrameBound::Type::kUnboundedPreceding);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, frameBoundNotEqualType) {
+  auto a = std::make_shared<FrameBound>(
+      loc(), FrameBound::Type::kUnboundedPreceding);
+  auto b = std::make_shared<FrameBound>(loc(), FrameBound::Type::kCurrentRow);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, windowFrameEquals) {
+  auto start1 = std::make_shared<FrameBound>(
+      loc(), FrameBound::Type::kUnboundedPreceding);
+  auto start2 = std::make_shared<FrameBound>(
+      loc(), FrameBound::Type::kUnboundedPreceding);
+  auto a = std::make_shared<WindowFrame>(
+      loc(0, 0), WindowFrame::Type::kRows, start1);
+  auto b = std::make_shared<WindowFrame>(
+      loc(5, 5), WindowFrame::Type::kRows, start2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, windowFrameNotEqualType) {
+  auto start1 = std::make_shared<FrameBound>(
+      loc(), FrameBound::Type::kUnboundedPreceding);
+  auto start2 = std::make_shared<FrameBound>(
+      loc(), FrameBound::Type::kUnboundedPreceding);
+  auto a =
+      std::make_shared<WindowFrame>(loc(), WindowFrame::Type::kRows, start1);
+  auto b =
+      std::make_shared<WindowFrame>(loc(), WindowFrame::Type::kRange, start2);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, windowEquals) {
+  auto a = std::make_shared<Window>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<Window>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, windowNotEqualPartitionBy) {
+  auto a =
+      std::make_shared<Window>(loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b =
+      std::make_shared<Window>(loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, sortItemEquals) {
+  auto a = std::make_shared<SortItem>(
+      loc(0, 0),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto b = std::make_shared<SortItem>(
+      loc(5, 5),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, sortItemNotEqualOrdering) {
+  auto a = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto b = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kDescending,
+      SortItem::NullOrdering::kFirst);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, sortItemNotEqualNullOrdering) {
+  auto a = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto b = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kLast);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, orderByEquals) {
+  auto item1 = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto item2 = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto a = std::make_shared<OrderBy>(
+      loc(0, 0), std::vector<std::shared_ptr<SortItem>>{item1});
+  auto b = std::make_shared<OrderBy>(
+      loc(5, 5), std::vector<std::shared_ptr<SortItem>>{item2});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, orderByNotEqual) {
+  auto itemAsc = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kAscending,
+      SortItem::NullOrdering::kFirst);
+  auto itemDesc = std::make_shared<SortItem>(
+      loc(),
+      longLit(1),
+      SortItem::Ordering::kDescending,
+      SortItem::NullOrdering::kFirst);
+  auto a = std::make_shared<OrderBy>(
+      loc(), std::vector<std::shared_ptr<SortItem>>{itemAsc});
+  auto b = std::make_shared<OrderBy>(
+      loc(), std::vector<std::shared_ptr<SortItem>>{itemDesc});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, offsetEquals) {
+  auto a = std::make_shared<Offset>(loc(0, 0), "10");
+  auto b = std::make_shared<Offset>(loc(5, 5), "10");
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, offsetNotEqual) {
+  auto a = std::make_shared<Offset>(loc(), "10");
+  auto b = std::make_shared<Offset>(loc(), "20");
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, simpleGroupByEquals) {
+  auto a = std::make_shared<SimpleGroupBy>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<SimpleGroupBy>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, simpleGroupByNotEqual) {
+  auto a = std::make_shared<SimpleGroupBy>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<SimpleGroupBy>(
+      loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, groupingSetsEquals) {
+  auto a = std::make_shared<GroupingSets>(
+      loc(0, 0),
+      std::vector<std::vector<ExpressionPtr>>{{longLit(1)}, {longLit(2)}});
+  auto b = std::make_shared<GroupingSets>(
+      loc(5, 5),
+      std::vector<std::vector<ExpressionPtr>>{{longLit(1)}, {longLit(2)}});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, groupingSetsNotEqual) {
+  auto a = std::make_shared<GroupingSets>(
+      loc(), std::vector<std::vector<ExpressionPtr>>{{longLit(1)}});
+  auto b = std::make_shared<GroupingSets>(
+      loc(), std::vector<std::vector<ExpressionPtr>>{{longLit(2)}});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, cubeEquals) {
+  auto a =
+      std::make_shared<Cube>(loc(0, 0), std::vector<ExpressionPtr>{longLit(1)});
+  auto b =
+      std::make_shared<Cube>(loc(5, 5), std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, cubeNotEqual) {
+  auto a =
+      std::make_shared<Cube>(loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b =
+      std::make_shared<Cube>(loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, rollupEquals) {
+  auto a = std::make_shared<Rollup>(
+      loc(0, 0), std::vector<ExpressionPtr>{longLit(1)});
+  auto b = std::make_shared<Rollup>(
+      loc(5, 5), std::vector<ExpressionPtr>{longLit(1)});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, rollupNotEqual) {
+  auto a =
+      std::make_shared<Rollup>(loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto b =
+      std::make_shared<Rollup>(loc(), std::vector<ExpressionPtr>{longLit(2)});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, groupByEquals) {
+  auto elem1 = std::make_shared<SimpleGroupBy>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto elem2 = std::make_shared<SimpleGroupBy>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto a = std::make_shared<GroupBy>(
+      loc(0, 0), false, std::vector<GroupingElementPtr>{elem1});
+  auto b = std::make_shared<GroupBy>(
+      loc(5, 5), false, std::vector<GroupingElementPtr>{elem2});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, groupByNotEqualDistinct) {
+  auto elem = std::make_shared<SimpleGroupBy>(
+      loc(), std::vector<ExpressionPtr>{longLit(1)});
+  auto a = std::make_shared<GroupBy>(
+      loc(), false, std::vector<GroupingElementPtr>{elem});
+  auto b = std::make_shared<GroupBy>(
+      loc(), true, std::vector<GroupingElementPtr>{elem});
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, withQueryEquals) {
+  auto name1 = std::make_shared<Identifier>(loc(), "cte", false);
+  auto name2 = std::make_shared<Identifier>(loc(), "cte", false);
+  auto query1 =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto query2 =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto a = std::make_shared<WithQuery>(loc(0, 0), name1, query1);
+  auto b = std::make_shared<WithQuery>(loc(5, 5), name2, query2);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, withQueryNotEqualName) {
+  auto nameA = std::make_shared<Identifier>(loc(), "a", false);
+  auto nameB = std::make_shared<Identifier>(loc(), "b", false);
+  auto query =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto a = std::make_shared<WithQuery>(loc(), nameA, query);
+  auto b = std::make_shared<WithQuery>(loc(), nameB, query);
+  EXPECT_FALSE(*a == *b);
+}
+
+TEST(AstEqualityTest, withEquals) {
+  auto name1 = std::make_shared<Identifier>(loc(), "cte", false);
+  auto name2 = std::make_shared<Identifier>(loc(), "cte", false);
+  auto query1 =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto query2 =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto wq1 = std::make_shared<WithQuery>(loc(), name1, query1);
+  auto wq2 = std::make_shared<WithQuery>(loc(), name2, query2);
+  auto a = std::make_shared<With>(
+      loc(0, 0), false, std::vector<std::shared_ptr<WithQuery>>{wq1});
+  auto b = std::make_shared<With>(
+      loc(5, 5), false, std::vector<std::shared_ptr<WithQuery>>{wq2});
+  EXPECT_TRUE(*a == *b);
+  EXPECT_EQ(a->hash(), b->hash());
+}
+
+TEST(AstEqualityTest, withNotEqualRecursive) {
+  auto name = std::make_shared<Identifier>(loc(), "cte", false);
+  auto query =
+      std::make_shared<Query>(loc(), nullptr, makeQuerySpec(emptySelect()));
+  auto wq = std::make_shared<WithQuery>(loc(), name, query);
+  auto a = std::make_shared<With>(
+      loc(), false, std::vector<std::shared_ptr<WithQuery>>{wq});
+  auto b = std::make_shared<With>(
+      loc(), true, std::vector<std::shared_ptr<WithQuery>>{wq});
+  EXPECT_FALSE(*a == *b);
+}
+
+} // namespace
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/ast/tests/CMakeLists.txt
+++ b/axiom/sql/presto/ast/tests/CMakeLists.txt
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_sql_presto_ast AstBuilder.cpp AstNodesAll.cpp AstPrinter.cpp)
+add_executable(axiom_sql_presto_ast_equality_test AstEqualityTest.cpp)
+
+add_test(axiom_sql_presto_ast_equality_test axiom_sql_presto_ast_equality_test)
 
 target_link_libraries(
+  axiom_sql_presto_ast_equality_test
   axiom_sql_presto_ast
-  axiom_sql_presto_grammar
-  axiom_sql_presto_error
-  velox_exception
+  GTest::gtest
+  GTest::gtest_main
 )
-
-if(AXIOM_BUILD_TESTING)
-  add_subdirectory(tests)
-endif()

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -509,6 +509,20 @@ TEST_F(AggregationParserTest, groupingKeyExpr) {
   }
 }
 
+// A scalar subquery appearing in both the SELECT list and the GROUP BY clause
+// must plan successfully when the SELECT expression matches the grouping key.
+TEST_F(AggregationParserTest, scalarSubqueryRepeatedInSelectAndGroupBy) {
+  connector_->addTable("t", ROW("a", INTEGER()));
+  connector_->addTable("u", ROW("b", INTEGER()));
+
+  auto matcher = matchScan().aggregate().output();
+  testSelect(
+      "SELECT COALESCE(t.a, (SELECT b FROM u)) "
+      "FROM t "
+      "GROUP BY COALESCE(t.a, (SELECT b FROM u))",
+      matcher);
+}
+
 TEST_F(AggregationParserTest, having) {
   auto matcher = matchScan().aggregate().filter().project().output();
 


### PR DESCRIPTION
Summary:

When the same scalar subquery appeared in both SELECT and GROUP BY (e.g. `SELECT COALESCE(t.a, (SELECT b FROM u)) FROM t GROUP BY COALESCE(t.a, (SELECT b FROM u))`), planning failed with `Cannot resolve column: a not in [expr -> expr]`. `GroupByPlanner::rewritePostAggregateExprs` matches SELECT expressions to grouping keys via `core::ExprPtr` equality; each occurrence of the subquery was being planned independently, producing distinct `LogicalPlanNode` trees with different internal column names, so the comparison returned false.

The fix has two layers:

1. **Parser** — `ExpressionPlanner` caches subquery plans keyed by the inner `Query` AST node using structural equality. Two textually-identical subqueries now resolve to the same `LogicalPlanNode`.

2. **Optimizer** — `ToGraph::subqueries_` switches from pointer-keyed to structural equality on subquery-bearing expressions, keyed by `(kind, inner LogicalPlanNode*, IN-LHS)`. `ExprResolver` wraps each `core::SubqueryExpr` occurrence in a fresh `lp::SubqueryExpr`, so we key on the shared inner plan, which both `SubqueryExpr` instances point to. The `kind` discriminator (scalar / EXISTS / IN) keeps scalar and EXISTS over the same plan distinct — they produce different result columns (a scalar value vs a boolean mark). The IN-LHS field keeps `x IN (q)` and `y IN (q)` distinct, since different left-hand sides produce different mark columns.

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D105654803


