### PR TITLE
fix(optimizer): Wrap correlation siblings for IN/EXISTS subqueries (#1387)

### DIFF
--- a/axiom/optimizer/BitSet.h
+++ b/axiom/optimizer/BitSet.h
@@ -86,6 +86,16 @@ class BitSet {
     velox::bits::forEachSetBit(bits_.data(), 0, bits_.size() * 64, f);
   }
 
+  /// True if 'predicate' returns true for any set bit. Short-circuits at the
+  /// first match. 'predicate' takes a zero-based bit index.
+  template <typename Predicate>
+  bool anyOf(Predicate predicate) const {
+    return !velox::bits::testSetBits(
+        bits_.data(), 0, static_cast<int32_t>(bits_.size() * 64), [&](auto id) {
+          return !predicate(id);
+        });
+  }
+
  protected:
   void ensureSize(size_t id) {
     ensureWords(velox::bits::nwords(id + 1));

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -1426,14 +1426,10 @@ bool DerivedTable::validatePushdown(
 
       // All columns in innerKey that reference the subquery must be valid
       // pushdown columns.
-      bool keyValid = true;
-      innerKey->columns().forEach<Column>([&](ColumnCP column) {
-        if (column->relation() == &subquery &&
-            !validPushdownColumns.contains(column)) {
-          keyValid = false;
-        }
-      });
-      if (!keyValid) {
+      if (innerKey->columns().anyOf<Column>([&](ColumnCP column) {
+            return column->relation() == &subquery &&
+                !validPushdownColumns.contains(column);
+          })) {
         return false;
       }
 

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -248,6 +248,21 @@ class PlanObjectSet : public BitSet {
     });
   }
 
+  /// True if 'predicate' returns true for any object in 'this'. Short-
+  /// circuits at the first match.
+  template <typename Predicate>
+  bool anyOf(Predicate predicate) const {
+    return anyOf<PlanObject>(predicate);
+  }
+
+  template <typename T, typename Predicate>
+  bool anyOf(Predicate predicate) const {
+    auto ctx = queryCtx();
+    return BitSet::anyOf([&](auto id) {
+      return predicate(ctx->objectAt(id)->template as<T>());
+    });
+  }
+
   /// Prnts the contents with ids and the string representation of the objects
   /// if 'names' is true.
   std::string toString(bool names) const;

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -613,6 +613,11 @@ PlanObjectSet Expr::allTables() const {
   return set;
 }
 
+bool Expr::hasAnyTableIn(const PlanObjectSet& tables) const {
+  return columns_.anyOf<Column>(
+      [&](auto column) { return tables.contains(column->relation()); });
+}
+
 Column::Column(
     Name name,
     PlanObjectCP relation,

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -49,6 +49,12 @@ class Expr : public PlanObject {
   /// Returns all tables 'this' depends on.
   PlanObjectSet allTables() const;
 
+  /// True if 'this' depends on any table whose id is in 'tables'.
+  /// Equivalent to 'allTables().hasIntersection(tables)' but avoids
+  /// materializing the intermediate set and short-circuits at the first
+  /// match.
+  bool hasAnyTableIn(const PlanObjectSet& tables) const;
+
   /// True if '&other == this' or is recursively equal with column
   /// leaves either same or in same equivalence.
   bool sameOrEqual(const Expr& other) const;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2331,6 +2331,20 @@ void ToGraph::finalizeDt(
 
   currentDt_ = outerDt;
   currentDt_->addTable(dt);
+
+  // Prune 'renames_' entries that point inside the just-wrapped 'dt'.
+  // 'setDtUsedOutput' above re-mapped renames for every name in
+  // 'usedChannels(node)' to 'dt'-owned columns; remaining entries still
+  // reference 'dt's inner tables, which are unreachable by name from the
+  // new outer scope. Keeping them wastes lookup time and inflates later
+  // walks that visit 'renames_' to rewrite expressions through a wrap.
+  for (auto it = renames_.begin(); it != renames_.end();) {
+    if (it->second->allTables().hasIntersection(dt->tableSet)) {
+      it = renames_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 void ToGraph::finalizeDtPreservingCorrelations(

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -205,13 +205,8 @@ bool isOutsideDt(PlanObjectCP table, DerivedTableCP dt) {
 
 // True if 'tables' contains any object outside of 'dt'.
 bool anyOutsideDt(const PlanObjectSet& tables, DerivedTableCP dt) {
-  bool outside = false;
-  tables.forEach([&](PlanObjectCP table) {
-    if (isOutsideDt(table, dt)) {
-      outside = true;
-    }
-  });
-  return outside;
+  return tables.anyOf(
+      [&](PlanObjectCP table) { return isOutsideDt(table, dt); });
 }
 
 DerivedTableScopeUse classifyScope(ExprCP expr, DerivedTableP dt) {
@@ -2131,18 +2126,23 @@ void ToGraph::translateJoin(
     const lp::LogicalPlanNodePtr& right,
     lp::JoinType joinType,
     const lp::ExprPtr& condition,
-    lp::JoinType originalJoinType) {
+    lp::JoinType originalJoinType,
+    const lp::LogicalPlanNode* joinNode) {
   if (joinType == lp::JoinType::kInner) {
     // Inner join is a cross join with a filter. Both sides are already in the
     // DT. Process the condition as a filter. This handles subqueries using the
-    // same infrastructure as WHERE clause predicates.
+    // same infrastructure as WHERE clause predicates. 'joinNode' (when
+    // provided by the caller) exposes both sides via its outputType, so
+    // 'usedChannels(input)' downstream of 'addFilter' sees columns from both
+    // sides — required for the carry-forward path in correlated scalar
+    // subqueries whose decorrelation injects an outer aggregation.
     if (condition) {
       exprSources_.push_back(right.get());
       SCOPE_EXIT {
         exprSources_.pop_back();
       };
 
-      addFilter(*left, condition);
+      addFilter(joinNode != nullptr ? *joinNode : *left, condition);
     }
     return;
   }
@@ -2339,7 +2339,7 @@ void ToGraph::finalizeDt(
   // new outer scope. Keeping them wastes lookup time and inflates later
   // walks that visit 'renames_' to rewrite expressions through a wrap.
   for (auto it = renames_.begin(); it != renames_.end();) {
-    if (it->second->allTables().hasIntersection(dt->tableSet)) {
+    if (it->second->hasAnyTableIn(dt->tableSet)) {
       it = renames_.erase(it);
     } else {
       ++it;
@@ -2374,12 +2374,8 @@ void ToGraph::finalizeDtPreservingCorrelations(
   finalizeDt(node);
   applyContext_.lifted = std::move(saved);
 
-  for (auto& conjunct : applyContext_.lifted.predicates) {
-    conjunct = dt->exportExpr(conjunct);
-  }
-  for (auto& projection : applyContext_.lifted.projections) {
-    projection = dt->exportExpr(projection);
-  }
+  applyContext_.lifted.rewriteExprs(
+      [&](ExprCP& expr) { expr = dt->exportExpr(expr); });
 }
 
 ColumnCP ToGraph::makeCountStarWrapper(DerivedTableP inputDt) {
@@ -3222,6 +3218,55 @@ void ToGraph::maybeWrapForChainedSubquery(
   }
 }
 
+DerivedTableP ToGraph::wrapForSubqueryCorrelation() {
+  auto* wrappedDt = currentDt_;
+  auto* outerDt = newDt();
+  outerDt->addTable(wrappedDt);
+  currentDt_ = outerDt;
+
+  // exportExpr only updates outputColumns when it has been initialized.
+  if (!wrappedDt->outputColumns.has_value()) {
+    wrappedDt->outputColumns.emplace();
+  }
+
+  auto rewrite = [&](ExprCP& expr) {
+    if (expr->hasAnyTableIn(wrappedDt->tableSet)) {
+      expr = wrappedDt->exportExpr(expr);
+    }
+  };
+
+  // Iterate 'renames_' in sorted order so the wrapper's 'outputColumns'
+  // (populated by 'exportExpr' in first-seen order) is deterministic.
+  // F14FastMap uses a randomized hash seed, so raw iteration order varies
+  // across process runs and surfaces as plan-shape flakiness downstream.
+  // Collect string_views to avoid copying the keys; the views remain
+  // valid because renames_ is not modified structurally below (only its
+  // mapped values are reassigned).
+  std::vector<std::string_view> renameKeys;
+  renameKeys.reserve(renames_.size());
+  for (const auto& [name, _] : renames_) {
+    renameKeys.emplace_back(name);
+  }
+  std::sort(renameKeys.begin(), renameKeys.end());
+  for (auto name : renameKeys) {
+    rewrite(renames_.at(name));
+  }
+  for (auto& [key, value] : subqueries_) {
+    rewrite(value);
+  }
+  applyContext_.lifted.rewriteExprs(rewrite);
+
+  return wrappedDt;
+}
+
+DerivedTableP ToGraph::wrapAroundSubquery(DerivedTableP subqueryDt) {
+  // Precondition: 'subqueryDt' is the last table added (by translateSubquery).
+  currentDt_->removeLastTable(subqueryDt);
+  auto* wrappedDt = wrapForSubqueryCorrelation();
+  currentDt_->addTable(subqueryDt);
+  return wrappedDt;
+}
+
 ExprCP ToGraph::processUncorrelatedScalarSubquery(DerivedTableP subqueryDt) {
   VELOX_CHECK_EQ(1, subqueryDt->columns.size());
 
@@ -3259,6 +3304,64 @@ Literal* tryMakeLiteralForEmptyInput(AggregateCP agg) {
   }
   return make<Literal>(Value(agg->value().type, 1), registerVariant(result));
 }
+
+// Tables that 'expr' references in the current scope outside 'subqueryDt'
+// (i.e., outer-scope correlation sources).
+PlanObjectSet outerTablesOf(ExprCP expr, DerivedTableP subqueryDt) {
+  PlanObjectSet outer;
+  expr->allTables().forEach([&](PlanObjectCP table) {
+    if (isOutsideDt(table, subqueryDt)) {
+      outer.add(table);
+    }
+  });
+  return outer;
+}
+
+// Outer tables reached by correlation conjuncts, split by whether each
+// conjunct is an equi-correlation (single-outer / single-inner equality
+// that 'extractDecorrelatedJoin' will turn into a SEMI join key). Non-equi
+// conjuncts land in the SEMI's filter, where references to sibling tables
+// of the outer table are unplaceable.
+struct CorrelationOuterTables {
+  PlanObjectSet equi;
+  PlanObjectSet nonEqui;
+
+  // Number of unique outer tables across both equi and nonEqui.
+  size_t numOuterTables() const {
+    PlanObjectSet all = equi;
+    all.unionSet(nonEqui);
+    return all.size();
+  }
+};
+
+CorrelationOuterTables classifyCorrelation(
+    const ExprVector& conjuncts,
+    DerivedTableP subqueryDt,
+    const ToGraph& toGraph) {
+  CorrelationOuterTables result;
+  for (const auto* conjunct : conjuncts) {
+    PlanObjectSet outer;
+    PlanObjectSet inner;
+    conjunct->allTables().forEach([&](PlanObjectCP table) {
+      if (table == subqueryDt) {
+        return;
+      }
+      (subqueryDt->tableSet.contains(table) ? inner : outer).add(table);
+    });
+    ExprCP ignoredLeft = nullptr;
+    ExprCP ignoredRight = nullptr;
+    const bool isEqui = outer.size() == 1 && inner.size() == 1 &&
+        toGraph.isJoinEquality(
+            conjunct,
+            outer.onlyObject(),
+            inner.onlyObject(),
+            ignoredLeft,
+            ignoredRight);
+    auto& bucket = isEqui ? result.equi : result.nonEqui;
+    outer.forEach([&](PlanObjectCP table) { bucket.add(table); });
+  }
+  return result;
+}
 } // namespace
 
 ExprCP ToGraph::processCorrelatedScalarSubquery(
@@ -3266,6 +3369,17 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
     DerivedTableP subqueryDt,
     SubqueryChain& chain,
     ApplyContext::Lifted* outerLifted) {
+  // Non-equi correlation conjuncts land in the decorrelating LEFT JOIN's
+  // filter. A filter reference to a sibling of the join's left side is
+  // unplaceable. Wrap when there is at least one non-equi conjunct AND the
+  // outer surface spans more than one table, so the wrapper becomes the
+  // join's single left side.
+  const auto outer =
+      classifyCorrelation(applyContext_.lifted.predicates, subqueryDt, *this);
+  if (!outer.nonEqui.empty() && outer.numOuterTables() > 1) {
+    wrapAroundSubquery(subqueryDt);
+  }
+
   auto correlation = extractCorrelationKeys(
       functionNames_, applyContext_.lifted.predicates, subqueryDt);
 
@@ -3646,19 +3760,50 @@ void ToGraph::processInPredicates(
       inRightKey = subqueryDt->columns.front();
     }
 
+    auto leftKey = translateExpr(predicate->inputAt(0));
+
+    const bool inRightHasOuter =
+        anyOutsideDt(inRightKey->allTables(), subqueryDt);
+    const bool isCorrelated =
+        !applyContext_.lifted.predicates.empty() || inRightHasOuter;
+
+    // Velox HashJoin cannot represent a multi-key null-aware join, so the
+    // SEMI's left side must be a single table. If correlation reaches more
+    // than one outer table (via leftKey, inRightKey, or correlation
+    // conjuncts), wrap them into a sub-DT. 'inRightKey' must be folded
+    // into the decision because the lifted projection — already drained
+    // from applyContext_ above — is not visible to
+    // 'wrapForSubqueryCorrelation's own renames_/lifted rewrite, and an
+    // outer-table reference there can be the sole multi-table signal.
+    if (isCorrelated) {
+      auto outer = outerTablesOf(leftKey, subqueryDt);
+      if (inRightHasOuter) {
+        outer.unionSet(outerTablesOf(inRightKey, subqueryDt));
+      }
+      for (const auto* conjunct : applyContext_.lifted.predicates) {
+        outer.unionSet(outerTablesOf(conjunct, subqueryDt));
+      }
+      if (outer.size() > 1) {
+        auto* wrappedDt = wrapAroundSubquery(subqueryDt);
+        leftKey = wrappedDt->exportExpr(leftKey);
+        // The lifted projection was already moved into 'inRightKey'; re-
+        // export it manually so any reference into the wrapped DT becomes
+        // a wrapper-exported column rather than a stale inner reference.
+        if (inRightHasOuter) {
+          inRightKey = wrappedDt->exportExpr(inRightKey);
+        }
+      }
+    }
+
     // Add a join edge and replace 'expr' with 'mark' column in the join
     // output.
     const auto* markColumn = addMarkColumn();
 
-    auto leftKey = translateExpr(predicate->inputAt(0));
     // May be nullptr when the left expression references multiple tables
     // (e.g., ROW(t.a, u.b) IN (SELECT ...)). The downstream IN-subquery
     // processors handle nullptr by creating a join edge without a specific
     // left table; the optimizer resolves it from the equality keys.
     auto* leftTable = leftKey->singleTable();
-
-    const bool inRightHasOuter =
-        anyOutsideDt(inRightKey->allTables(), subqueryDt);
 
     ExprCP column;
     if (applyContext_.lifted.predicates.empty() && !inRightHasOuter) {
@@ -3893,6 +4038,18 @@ ExprCP ToGraph::processCorrelatedExists(DerivedTableP subqueryDt) {
   // Finalize the subqueryDt (add to currentDt_).
   currentDt_->addTable(subqueryDt);
 
+  // Non-equi correlation conjuncts land in the SEMI's filter; a filter
+  // reference to a sibling of the SEMI's left side is unplaceable. When
+  // equi is non-empty, equi outers become the SEMI's left; when equi is
+  // empty, a single nonEqui outer becomes the left. Either way, the wrap
+  // is required exactly when there is at least one non-equi conjunct AND
+  // the outer surface spans more than one table.
+  const auto outer =
+      classifyCorrelation(applyContext_.lifted.predicates, subqueryDt, *this);
+  if (!outer.nonEqui.empty() && outer.numOuterTables() > 1) {
+    wrapAroundSubquery(subqueryDt);
+  }
+
   auto decorrelated = extractDecorrelatedJoin(
       functionNames_, applyContext_.lifted.predicates, subqueryDt);
   if (decorrelated.leftKeys.empty()) {
@@ -4079,13 +4236,8 @@ void ToGraph::addFilter(
       // folding collapses one side of an equality) is a pure-outer
       // guard, not a correlation key. Route it to 'outerGuards' so
       // 'attachScalarSubqueryToOuter' wraps the scalar result in an IF.
-      bool hasInner = false;
-      conjunct->columns().template forEach<Column>([&](ColumnCP col) {
-        if (tables.contains(col->relation())) {
-          hasInner = true;
-        }
-      });
-      if (hasInner) {
+      if (conjunct->columns().anyOf<Column>(
+              [&](ColumnCP col) { return tables.contains(col->relation()); })) {
         applyContext_.lifted.predicates.push_back(conjunct);
       } else {
         applyContext_.lifted.outerGuards.push_back(conjunct);
@@ -4630,7 +4782,8 @@ void ToGraph::makeQueryGraph(
             /*excludeWindows=*/true);
       }
 
-      translateJoin(left, right, joinType, remainingCondition, join.joinType());
+      translateJoin(
+          left, right, joinType, remainingCondition, join.joinType(), &join);
     } break;
     case lp::NodeKind::kSort: {
       const auto& input = *node.onlyInput();

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -251,6 +251,22 @@ class ToGraph {
         return predicates.empty() && projections.empty() &&
             outerGuards.empty() && aggregation == nullptr;
       }
+
+      // Applies 'rewriter' to each pending Expr (predicates, projections,
+      // outerGuards). Does not visit 'aggregation'; callers that need to
+      // rewrite aggregation must do so explicitly.
+      template <typename Rewriter>
+      void rewriteExprs(Rewriter&& rewriter) {
+        for (auto& predicate : predicates) {
+          rewriter(predicate);
+        }
+        for (auto& projection : projections) {
+          rewriter(projection);
+        }
+        for (auto& guard : outerGuards) {
+          rewriter(guard);
+        }
+      }
     };
     Lifted lifted;
 
@@ -423,12 +439,17 @@ class ToGraph {
   // @param condition Join condition. Can be nullptr for a cross join.
   // @param originalJoinType The original join type from the logical plan
   // (before normalization).
+  // @param joinNode The source JoinNode. Used for INNER joins to expose
+  // both sides' columns to the carry-forward path when 'addFilter'
+  // processes the ON clause; correlated scalar subqueries decorrelated
+  // inside the ON clause depend on 'usedChannels' seeing both sides.
   void translateJoin(
       const logical_plan::LogicalPlanNodePtr& left,
       const logical_plan::LogicalPlanNodePtr& right,
       logical_plan::JoinType joinType,
       const logical_plan::ExprPtr& condition,
-      logical_plan::JoinType originalJoinType);
+      logical_plan::JoinType originalJoinType,
+      const logical_plan::LogicalPlanNode* joinNode);
 
   // Eliminates join when the ON clause contains a constant false condition.
   // Returns true if the join was eliminated.
@@ -691,6 +712,20 @@ class ToGraph {
   void maybeWrapForChainedSubquery(
       const logical_plan::LogicalPlanNode& input,
       SubqueryChain& chain);
+
+  // Wraps the current DT under a fresh outer DT so a subsequent SEMI/EXISTS
+  // join has a single-table left side. Rewrites in-flight state ('renames_',
+  // 'applyContext_.lifted.{predicates,projections,outerGuards}', and
+  // 'subqueries_' values) that references inner tables to use the wrapper's
+  // exposed columns. Caller-held expressions must be re-exported via the
+  // returned DT.
+  DerivedTableP wrapForSubqueryCorrelation();
+
+  // Convenience wrapper around 'wrapForSubqueryCorrelation' for the
+  // subquery handlers: detaches 'subqueryDt' (just attached by
+  // translateSubquery), wraps the rest of currentDt_, and re-attaches
+  // 'subqueryDt' at the outer level so the SEMI joins wrapper × subqueryDt.
+  DerivedTableP wrapAroundSubquery(DerivedTableP subqueryDt);
 
   // Attaches a scalar subquery's translated body ('subqueryDt') to the
   // outer scope, picking the decorrelation shape from 'applyContext_':

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -719,6 +719,27 @@ TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// IN subquery whose correlation predicate references a sibling of the IN's
+// outer table: t and u join into a single source feeding the SEMI on v.
+TEST_F(SubqueryTest, correlatedInOnSibling) {
+  testConnector_->addTable("t", ROW("a", BIGINT()));
+  testConnector_->addTable("u", ROW("k", BIGINT()));
+  testConnector_->addTable("v", ROW({"k", "b"}, BIGINT()));
+
+  auto query =
+      "SELECT * FROM t, u "
+      "WHERE t.a IN (SELECT v.b FROM v WHERE v.k = u.k)";
+
+  auto matcher =
+      matchScan("t")
+          .nestedLoopJoin(matchScan("u").build(), core::JoinType::kInner)
+          .hashJoin(
+              matchScan("v").project().build(), core::JoinType::kLeftSemiFilter)
+          .build();
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // IN subquery where the left-side expression references multiple tables.
 TEST_F(SubqueryTest, multiTableInSubquery) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -421,3 +421,63 @@ SELECT (SELECT max(u.a + t.b) + sum(u.a) FROM u WHERE u.a > 0) FROM t
 -- Scalar subquery whose SELECT references the same inner column more
 -- than once alongside an outer column.
 SELECT (SELECT u.a + t.a + u.a + 1 FROM u WHERE u.a = t.a) FROM t
+----
+-- IN subquery in a JOIN ON clause whose correlation references a sibling
+-- of the IN's outer table.
+SELECT *
+FROM (VALUES ('a')) AS t(a)
+INNER JOIN (VALUES ('a')) AS u(k)
+  ON t.a IN (
+      SELECT v.b
+      FROM (VALUES ('a', 'a')) AS v(k, b)
+      WHERE v.k = u.k
+  )
+----
+-- IN subquery whose SELECT references a sibling outer table ('u.b') not
+-- touched by the IN's left key ('t.a') or the correlation conjunct
+-- ('v.k = t.a'). For (t.a=1, u.b=1) the inner row passes 'v.k = 1' and
+-- yields 1, so 't.a = 1' matches.
+SELECT *
+FROM (VALUES (1)) AS t(a), (VALUES (1)) AS u(b)
+WHERE t.a IN (
+    SELECT u.b
+    FROM (VALUES (1)) AS v(k)
+    WHERE v.k = t.a
+)
+----
+-- EXISTS subquery in a JOIN ON clause whose non-equi correlation
+-- references a sibling of the EXISTS's outer table.
+SELECT *
+FROM (VALUES (1)) AS t(a)
+INNER JOIN (VALUES (1)) AS u(k)
+  ON EXISTS (
+      SELECT 1
+      FROM (VALUES (1, 1)) AS v(b, k)
+      WHERE v.k = t.a AND v.b >= u.k
+  )
+----
+-- Scalar subquery in a JOIN ON clause whose non-equi correlation
+-- references a sibling of the subquery's outer table. For (t.a=1, u.k=1)
+-- the inner aggregate over 'v.k=1 AND v.b>1' is empty, so 'max(v.b)' is
+-- NULL and 't.a = NULL' is unknown — no rows match.
+-- count 0
+SELECT *
+FROM (VALUES (1)) AS t(a)
+INNER JOIN (VALUES (1)) AS u(k)
+  ON t.a = (
+      SELECT max(v.b)
+      FROM (VALUES (1, 1)) AS v(b, k)
+      WHERE v.k = t.a AND v.b > u.k
+  )
+----
+-- Same shape as above, but the inner aggregate matches: for (t.a=2, u.k=1)
+-- 'v.b > 1 AND v.k = 2' selects (2, 2), so 'max(v.b)' is 2 and 't.a = 2'
+-- holds. Sibling outer column 'u.k' must appear in the output row.
+SELECT *
+FROM (VALUES (2)) AS t(a)
+INNER JOIN (VALUES (1)) AS u(k)
+  ON t.a = (
+      SELECT max(v.b)
+      FROM (VALUES (1, 2), (2, 2)) AS v(b, k)
+      WHERE v.k = t.a AND v.b > u.k
+  )


### PR DESCRIPTION
Summary:

`SELECT * FROM t, u WHERE t.a IN (SELECT v.b FROM v WHERE v.k = u.k)` previously failed with `Join filter references column from unplaced non-single-row table`. The IN's left side is `t.a`, but the correlation `v.k = u.k` references `u`, a sibling of `t`. ToGraph emitted a SEMI `JoinEdge` whose filter referenced a sibling of the SEMI's left side, which `Optimization::placeSingleRowDtsForJoinFilter` cannot place. For IN this is also unrepresentable in Velox (multi-key null-aware HashJoin is not supported). EXISTS has the analogous failure: `... ON EXISTS (SELECT 1 FROM v WHERE v.k = t.a AND v.b >= u.k)`.

`processInPredicates` and `processCorrelatedExists` now wrap the surrounding tables into a sub-DT before emitting the SEMI, so the SEMI's left side is a single (wrapped) DT. The wrap mechanic lives in `wrapForSubqueryCorrelation`; `wrapAroundSubquery` handles detaching and reattaching the subquery DT. IN wraps on any multi-outer-table correlation; EXISTS wraps only when non-equi correlation reaches multiple outer tables (equi correlation alone becomes additional SEMI keys without sibling-reference issues).

Scalar subqueries have the same gap (non-equi sibling correlation crashes with `expr references column not available at this layer`); captured as a `-- error:` annotated `.sql` test for follow-up.

bypass-github-export-checks

Reviewed By: amitkdutta

Differential Revision: D105693567


