### PR TITLE
perf(optimizer): Prune stale renames_ entries at DT boundaries (#1388)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2331,6 +2331,20 @@ void ToGraph::finalizeDt(
 
   currentDt_ = outerDt;
   currentDt_->addTable(dt);
+
+  // Prune 'renames_' entries that point inside the just-wrapped 'dt'.
+  // 'setDtUsedOutput' above re-mapped renames for every name in
+  // 'usedChannels(node)' to 'dt'-owned columns; remaining entries still
+  // reference 'dt's inner tables, which are unreachable by name from the
+  // new outer scope. Keeping them wastes lookup time and inflates later
+  // walks that visit 'renames_' to rewrite expressions through a wrap.
+  for (auto it = renames_.begin(); it != renames_.end();) {
+    if (it->second->allTables().hasIntersection(dt->tableSet)) {
+      it = renames_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 void ToGraph::finalizeDtPreservingCorrelations(


### PR DESCRIPTION
Summary:

`renames_` accumulates name→Expr bindings from every scan column, project alias, aggregation result, and subquery output column across the whole query. When `finalizeDt` wraps `currentDt_` under a new outer DT, the wrapped DT's inner tables become unaddressable by name from the new outer scope. `setDtUsedOutput` (called from `finalizeDt`) re-maps the names in `usedChannels(node)` to the wrapper's columns, but entries for names not used downstream remain pointing at now-inner tables. They aren't reachable via `translateColumn` lookups from the new outer scope (no caller can name them), but they still bloat `renames_` and inflate the per-entry walks done by `wrapForSubqueryCorrelation` (which loops `renames_` and rewrites any entry referencing tables inside the wrapped DT).

Prune those stale entries at the end of `finalizeDt`: erase any entry whose value references a table in the just-wrapped `dt->tableSet`. Entries re-mapped by `setDtUsedOutput` reference the wrapping `dt` directly (not its inner tables), so they survive. Correlation references to outer-of-outer tables also survive (they don't intersect `dt->tableSet`).

Reviewed By: xiaoxmeng

Differential Revision: D105695342


