### PR TITLE
feat: Add per-phase CPU time metrics to QueryRuntimeStats (#1389)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -17,6 +17,7 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <cmath>
+#include "velox/common/process/ProcessBase.h"
 
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadata.h"
@@ -391,20 +392,33 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
 
   try {
     presto::SqlStatementPtr statement;
+    uint64_t parseCpuNanos;
     {
+      auto cpuStart = velox::process::threadCpuNanos();
       velox::MicrosecondTimer parseTimer(&completionInfo.timing.parse);
       statement = parseSingle(sql, runOptions);
+      parseCpuNanos = velox::process::threadCpuNanos() - cpuStart;
     }
     completionInfo.startInfo.queryType = statement->kind();
     completionInfo.runtimeStats->recordTiming(
         QueryRuntimeStats::kParseWallNanos,
         std::chrono::microseconds(completionInfo.timing.parse));
+    completionInfo.runtimeStats->recordTiming(
+        QueryRuntimeStats::kParseCpuNanos,
+        std::chrono::nanoseconds(parseCpuNanos));
 
-    runOptions.tokenProvider = checkPermission(
-        runOptions,
-        completionInfo,
-        statement->views(),
-        statement->referencedTables());
+    {
+      auto permissionCpuStart = velox::process::threadCpuNanos();
+      runOptions.tokenProvider = checkPermission(
+          runOptions,
+          completionInfo,
+          statement->views(),
+          statement->referencedTables());
+      completionInfo.runtimeStats->recordTiming(
+          QueryRuntimeStats::kPermissionCheckCpuNanos,
+          std::chrono::nanoseconds(
+              velox::process::threadCpuNanos() - permissionCpuStart));
+    }
     completionInfo.runtimeStats->recordTiming(
         QueryRuntimeStats::kPermissionCheckWallNanos,
         std::chrono::microseconds(completionInfo.timing.checkPermission));
@@ -971,6 +985,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   optimizerOptions.explain = explain;
 
   uint64_t toGraphNanos{0};
+  uint64_t toGraphCpuNanos{0};
+  auto toGraphCpuStart = velox::process::threadCpuNanos();
   auto toGraphStart = std::chrono::steady_clock::now();
   optimizer::Optimization optimization(
       session,
@@ -986,25 +1002,32 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {
     return {};
   }
+  toGraphCpuNanos = velox::process::threadCpuNanos() - toGraphCpuStart;
   toGraphNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
                      std::chrono::steady_clock::now() - toGraphStart)
                      .count();
 
   uint64_t bestPlanNanos{0};
+  uint64_t bestPlanCpuNanos{0};
   optimizer::PlanP best;
   {
+    auto cpuStart = velox::process::threadCpuNanos();
     velox::NanosecondTimer timer(&bestPlanNanos);
     best = optimization.bestPlan();
+    bestPlanCpuNanos = velox::process::threadCpuNanos() - cpuStart;
   }
   if (checkBestPlan && !checkBestPlan(*best->op)) {
     return {};
   }
 
   uint64_t toVeloxNanos{0};
+  uint64_t toVeloxCpuNanos{0};
   optimizer::PlanAndStats result;
   {
+    auto cpuStart = velox::process::threadCpuNanos();
     velox::NanosecondTimer timer(&toVeloxNanos);
     result = optimization.toVeloxPlan(best->op);
+    toVeloxCpuNanos = velox::process::threadCpuNanos() - cpuStart;
   }
 
   if (runtimeStats) {
@@ -1012,11 +1035,20 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
         QueryRuntimeStats::kOptimizeToGraphWallNanos,
         std::chrono::nanoseconds(toGraphNanos));
     runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeToGraphCpuNanos,
+        std::chrono::nanoseconds(toGraphCpuNanos));
+    runtimeStats->recordTiming(
         QueryRuntimeStats::kOptimizeBestPlanWallNanos,
         std::chrono::nanoseconds(bestPlanNanos));
     runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeBestPlanCpuNanos,
+        std::chrono::nanoseconds(bestPlanCpuNanos));
+    runtimeStats->recordTiming(
         QueryRuntimeStats::kOptimizeToVeloxWallNanos,
         std::chrono::nanoseconds(toVeloxNanos));
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeToVeloxCpuNanos,
+        std::chrono::nanoseconds(toVeloxCpuNanos));
   }
 
   return result;
@@ -1096,7 +1128,9 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
   SqlResult result;
 
   optimizer::PlanAndStats planAndStats;
+  uint64_t optimizeCpuNanos{0};
   {
+    auto cpuStart = velox::process::threadCpuNanos();
     velox::MicrosecondTimer timer(&timing.optimize);
     planAndStats = optimize(
         logicalPlan,
@@ -1107,11 +1141,15 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         std::move(schemaResolver),
         /*explain=*/false,
         runtimeStats);
+    optimizeCpuNanos = velox::process::threadCpuNanos() - cpuStart;
   }
   if (runtimeStats) {
     runtimeStats->recordTiming(
         QueryRuntimeStats::kOptimizeWallNanos,
         std::chrono::microseconds(timing.optimize));
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kOptimizeCpuNanos,
+        std::chrono::nanoseconds(optimizeCpuNanos));
   }
 
   planString = planAndStats.toString();
@@ -1125,14 +1163,20 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     waitForCompletion(runner, options.timeoutMicros);
   };
 
+  uint64_t executeCpuNanos{0};
   {
+    auto cpuStart = velox::process::threadCpuNanos();
     velox::MicrosecondTimer timer(&timing.execute);
     result.results = fetchResults(*runner);
+    executeCpuNanos = velox::process::threadCpuNanos() - cpuStart;
   }
   if (runtimeStats) {
     runtimeStats->recordTiming(
         QueryRuntimeStats::kExecuteWallNanos,
         std::chrono::microseconds(timing.execute));
+    runtimeStats->recordTiming(
+        QueryRuntimeStats::kExecuteCpuNanos,
+        std::chrono::nanoseconds(executeCpuNanos));
   }
 
   return result;

--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -117,4 +117,13 @@ folly::dynamic QueryRuntimeStats::toDynamic() const {
   return result;
 }
 
+ScopedCpuWallStatsTimer::~ScopedCpuWallStatsTimer() {
+  if (std::this_thread::get_id() == startThreadId_) {
+    auto cpuElapsed = velox::process::threadCpuNanos() - cpuStart_;
+    stats_.recordTiming(cpuMetricName_, std::chrono::nanoseconds(cpuElapsed));
+  }
+  auto wallElapsed = std::chrono::steady_clock::now() - wallStart_;
+  stats_.recordTiming(wallMetricName_, wallElapsed);
+}
+
 } // namespace facebook::axiom

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -19,12 +19,14 @@
 #include <chrono>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <folly/dynamic.h>
 
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/process/ProcessBase.h"
 
 namespace facebook::axiom {
 
@@ -36,38 +38,57 @@ class QueryRuntimeStats {
  public:
   // Parser.
   static constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
+  static constexpr std::string_view kParseCpuNanos{"axiom-parseCpuNanos"};
 
   // Optimizer.
   static constexpr std::string_view kOptimizeWallNanos{
       "axiom-optimizeWallNanos"};
+  static constexpr std::string_view kOptimizeCpuNanos{"axiom-optimizeCpuNanos"};
   static constexpr std::string_view kOptimizeToGraphWallNanos{
       "axiom-optimizeToGraphWallNanos"};
+  static constexpr std::string_view kOptimizeToGraphCpuNanos{
+      "axiom-optimizeToGraphCpuNanos"};
   static constexpr std::string_view kOptimizeBestPlanWallNanos{
       "axiom-optimizeBestPlanWallNanos"};
+  static constexpr std::string_view kOptimizeBestPlanCpuNanos{
+      "axiom-optimizeBestPlanCpuNanos"};
   static constexpr std::string_view kOptimizeToVeloxWallNanos{
       "axiom-optimizeToVeloxWallNanos"};
+  static constexpr std::string_view kOptimizeToVeloxCpuNanos{
+      "axiom-optimizeToVeloxCpuNanos"};
 
   // Split manager.
   static constexpr std::string_view kListPartitionsWallNanos{
       "axiom-listPartitionsWallNanos"};
+  static constexpr std::string_view kListPartitionsCpuNanos{
+      "axiom-listPartitionsCpuNanos"};
   static constexpr std::string_view kListPartitionsCount{
       "axiom-listPartitionsCount"};
   static constexpr std::string_view kGetSplitsWallNanos{
       "axiom-getSplitsWallNanos"};
+  static constexpr std::string_view kGetSplitsCpuNanos{
+      "axiom-getSplitsCpuNanos"};
   static constexpr std::string_view kGetSplitsCount{"axiom-getSplitsCount"};
 
   // Permission check.
   static constexpr std::string_view kPermissionCheckWallNanos{
       "axiom-permissionCheckWallNanos"};
+  static constexpr std::string_view kPermissionCheckCpuNanos{
+      "axiom-permissionCheckCpuNanos"};
 
   // Connector.
   static constexpr std::string_view kFindTableWallNanos{
       "axiom-findTableWallNanos"};
+  static constexpr std::string_view kFindTableCpuNanos{
+      "axiom-findTableCpuNanos"};
   static constexpr std::string_view kEstimateStatsWallNanos{
       "axiom-estimateStatsWallNanos"};
+  static constexpr std::string_view kEstimateStatsCpuNanos{
+      "axiom-estimateStatsCpuNanos"};
 
   // Execution.
   static constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
+  static constexpr std::string_view kExecuteCpuNanos{"axiom-executeCpuNanos"};
 
   /// Records a wall-clock duration under the given metric name.
   void recordTiming(std::string_view name, std::chrono::nanoseconds duration);
@@ -111,6 +132,55 @@ class ScopedRuntimeStatsTimer {
   std::string_view metricName_;
   std::chrono::steady_clock::time_point start_;
 };
+
+/// RAII timer that records both wall-clock and thread CPU durations into
+/// QueryRuntimeStats on destruction. CPU time is only recorded if the
+/// destructor runs on the same thread as the constructor — coroutine
+/// suspension may resume on a different thread, making per-thread CPU
+/// measurement invalid. Wall time is always recorded.
+class ScopedCpuWallStatsTimer {
+ public:
+  ScopedCpuWallStatsTimer(
+      QueryRuntimeStats& stats,
+      std::string_view wallMetricName,
+      std::string_view cpuMetricName)
+      : stats_(stats),
+        wallMetricName_(wallMetricName),
+        cpuMetricName_(cpuMetricName),
+        wallStart_(std::chrono::steady_clock::now()),
+        cpuStart_(velox::process::threadCpuNanos()),
+        startThreadId_(std::this_thread::get_id()) {}
+
+  ~ScopedCpuWallStatsTimer();
+
+  ScopedCpuWallStatsTimer(const ScopedCpuWallStatsTimer&) = delete;
+  ScopedCpuWallStatsTimer& operator=(const ScopedCpuWallStatsTimer&) = delete;
+  ScopedCpuWallStatsTimer(ScopedCpuWallStatsTimer&&) = delete;
+  ScopedCpuWallStatsTimer& operator=(ScopedCpuWallStatsTimer&&) = delete;
+
+ private:
+  QueryRuntimeStats& stats_;
+  std::string_view wallMetricName_;
+  std::string_view cpuMetricName_;
+  std::chrono::steady_clock::time_point wallStart_;
+  uint64_t cpuStart_;
+  std::thread::id startThreadId_;
+};
+
+/// Records thread CPU time elapsed since 'cpuStart' if still on the same
+/// thread ('startThreadId'). Skips recording when the thread switched (e.g.
+/// after co_await) to avoid invalid per-thread CPU measurements.
+inline void recordCpuIfSameThread(
+    QueryRuntimeStats& stats,
+    std::string_view metricName,
+    uint64_t cpuStart,
+    std::thread::id startThreadId) {
+  if (std::this_thread::get_id() == startThreadId) {
+    stats.recordTiming(
+        metricName,
+        std::chrono::nanoseconds(velox::process::threadCpuNanos() - cpuStart));
+  }
+}
 
 /// Merges 'metric' into 'map' under 'name' using CAS-based optimistic locking.
 /// Shared by QueryRuntimeStats and SchedulerStatsRecorder.

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -18,6 +18,7 @@
 
 #include <thread>
 
+#include <folly/BenchmarkUtil.h>
 #include <folly/json.h>
 #include <gtest/gtest.h>
 
@@ -127,6 +128,42 @@ TEST(QueryRuntimeStatsTest, concurrentRecording) {
   auto& metric = map.at(std::string(QueryRuntimeStats::kExecuteWallNanos));
   EXPECT_EQ(metric.sum, kThreads * kIterations);
   EXPECT_EQ(metric.count, kThreads * kIterations);
+}
+
+TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
+  QueryRuntimeStats stats;
+  {
+    ScopedCpuWallStatsTimer timer(
+        stats,
+        QueryRuntimeStats::kParseWallNanos,
+        QueryRuntimeStats::kParseCpuNanos);
+    int64_t sum = 0;
+    for (int64_t i = 0; i < 1'000'000; ++i) {
+      sum += i;
+    }
+    folly::doNotOptimizeAway(sum);
+  }
+  auto map = stats.toMap();
+  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
+  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseCpuNanos)), 1);
+
+  auto wallNanos = map.at(std::string(QueryRuntimeStats::kParseWallNanos)).sum;
+  auto cpuNanos = map.at(std::string(QueryRuntimeStats::kParseCpuNanos)).sum;
+  EXPECT_GT(wallNanos, 0);
+  EXPECT_GT(cpuNanos, 0);
+  EXPECT_LE(cpuNanos, wallNanos);
+}
+
+TEST(QueryRuntimeStatsTest, cpuMetricNaming) {
+  QueryRuntimeStats stats;
+  stats.recordTiming(
+      QueryRuntimeStats::kFindTableCpuNanos, std::chrono::nanoseconds(5000));
+
+  auto dynamic = stats.toDynamic();
+  auto key = std::string(QueryRuntimeStats::kFindTableCpuNanos);
+  ASSERT_TRUE(dynamic.count(key));
+  EXPECT_EQ(dynamic[key]["unit"].asString(), "NANO");
+  EXPECT_EQ(dynamic[key]["sum"].asInt(), 5000);
 }
 
 } // namespace

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -163,11 +163,18 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
   // query context executor if available, otherwise run inline.
   auto collectTask = folly::coro::collectAllRange(std::move(tasks));
   auto* executor = veloxQueryCtx_->executor();
+  auto estimateCpuStart = velox::process::threadCpuNanos();
+  auto estimateThreadId = std::this_thread::get_id();
   auto estimateStart = std::chrono::steady_clock::now();
   auto results = executor ? folly::coro::blockingWait(co_withExecutor(
                                 executor, std::move(collectTask)))
                           : folly::coro::blockingWait(std::move(collectTask));
   if (runtimeStats_) {
+    recordCpuIfSameThread(
+        *runtimeStats_,
+        QueryRuntimeStats::kEstimateStatsCpuNanos,
+        estimateCpuStart,
+        estimateThreadId);
     runtimeStats_->recordTiming(
         QueryRuntimeStats::kEstimateStatsWallNanos,
         std::chrono::steady_clock::now() - estimateStart);

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -15,10 +15,12 @@
  */
 
 #include "axiom/optimizer/Schema.h"
+
 #include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/PlanUtils.h"
+#include "velox/common/process/ProcessBase.h"
 
 #include <numbers>
 
@@ -146,9 +148,14 @@ SchemaTableCP Schema::findTable(
 
   VELOX_CHECK_NOT_NULL(source_);
 
+  auto findCpuStart = velox::process::threadCpuNanos();
   auto findStart = std::chrono::steady_clock::now();
   auto connectorTable = source_->findTable(std::string(connectorId), tableName);
   if (runtimeStats_) {
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kFindTableCpuNanos,
+        std::chrono::nanoseconds(
+            velox::process::threadCpuNanos() - findCpuStart));
     runtimeStats_->recordTiming(
         QueryRuntimeStats::kFindTableWallNanos,
         std::chrono::steady_clock::now() - findStart);

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -76,9 +76,16 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
   auto splitManager = metadata->splitManager();
 
+  auto listCpuStart = velox::process::threadCpuNanos();
+  auto listThreadId = std::this_thread::get_id();
   auto listStart = std::chrono::steady_clock::now();
   auto partitions = folly::coro::blockingWait(
       splitManager->co_listPartitions(session, handle));
+  recordCpuIfSameThread(
+      runtimeStats_,
+      QueryRuntimeStats::kListPartitionsCpuNanos,
+      listCpuStart,
+      listThreadId);
   runtimeStats_.recordTiming(
       QueryRuntimeStats::kListPartitionsWallNanos,
       std::chrono::steady_clock::now() - listStart);
@@ -126,6 +133,8 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
 
+    auto getSplitsCpuStart = velox::process::threadCpuNanos();
+    auto getSplitsThreadId = std::this_thread::get_id();
     auto getSplitsStart = std::chrono::steady_clock::now();
     int64_t splitCount = 0;
     size_t taskIdx = 0;
@@ -144,6 +153,11 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       task->noMoreSplits(scanId);
     }
 
+    recordCpuIfSameThread(
+        runtimeStats,
+        QueryRuntimeStats::kGetSplitsCpuNanos,
+        getSplitsCpuStart,
+        getSplitsThreadId);
     runtimeStats.recordTiming(
         QueryRuntimeStats::kGetSplitsWallNanos,
         std::chrono::steady_clock::now() - getSplitsStart);


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/59

Adds thread CPU time measurement alongside existing wall-clock metrics for all query pipeline phases (parse, optimize, findTable, estimateStats, listPartitions, getSplits, permissionCheck, execute). This enables diagnosing latency spikes by distinguishing on-CPU work from I/O wait (e.g. metastore RPC). RPC time can be derived as `wallTime - cpuTime`.

Adds `ScopedCpuWallStatsTimer` RAII class that records both wall and CPU time in a single scope using `velox::process::threadCpuNanos()`.

New metrics flow through the existing pipeline (Presto UI, Scuba, ODS, CLI) with no downstream changes — the `*CpuNanos` naming convention is auto-detected by AxelQueryLogger.

Reviewed By: arhimondr

Differential Revision: D105709800


