### PR TITLE
fix(parser): Skip subquery cache for correlated subqueries

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -55,6 +55,19 @@ WITH u AS (
 )
 SELECT (SELECT count(*) FROM u WHERE a > v.a) FROM (SELECT 1 AS a) v
 ----
+-- A CTE that contains a correlated scalar subquery, referenced multiple
+-- times from outer scalar subqueries. Each outer reference reparses the
+-- CTE body with freshly uniquified column names; the inner correlated
+-- reference must resolve to each expansion's own outer column, not stay
+-- bound to the first expansion's name.
+WITH u AS (
+  SELECT (SELECT count(*) FROM (VALUES (1)) t(a) WHERE a > u.k) AS c
+  FROM (VALUES (1)) u(k)
+)
+SELECT
+  (SELECT count(*) FROM u WHERE c > 0),
+  (SELECT count(*) FROM u WHERE c = 0)
+----
 -- 3 levels with cross-level references and name shadowing.
 -- Level 0 (v): x=20, y=30. Level 1 (u): x=10 (shadows v.x), a=5.
 -- Level 2 references u.a (level 1), v.y (level 0), u.x (level 1 shadow).

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -591,8 +591,15 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
           return it->second;
         }
-        auto expr = lp::Subquery(subqueryPlanner_(query->as<Query>()));
-        subqueryCache_.emplace(query, expr);
+        auto result = subqueryPlanner_(query->as<Query>());
+        auto expr = lp::Subquery(result.plan);
+        // Correlated subqueries bake in physical column names from the outer
+        // scope they were planned in; caching would let a second outer
+        // context reuse a plan whose references point at the first context's
+        // (now stale) names.
+        if (!result.touchedOuterScope) {
+          subqueryCache_.emplace(query, expr);
+        }
         return expr;
       }
 

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -49,11 +49,26 @@ facebook::velox::TypePtr parseType(const TypeSignaturePtr& type);
 /// provided to handle subqueries and ordinal sort keys in aggregates.
 class ExpressionPlanner {
  public:
+  /// Carries a planned subquery's logical plan together with a flag marking
+  /// whether the subquery is correlated. Correlated subqueries must not be
+  /// cached because their planned output binds physical column names from a
+  /// specific outer scope; reusing the plan under a different outer scope
+  /// would leave dangling input references.
+  struct SubqueryPlanResult {
+    /// Built logical plan for the subquery.
+    lp::LogicalPlanNodePtr plan;
+
+    /// True if planning resolved at least one column reference against the
+    /// outer scope (the subquery is correlated).
+    bool touchedOuterScope{false};
+  };
+
   /// Callback to plan a subquery. Takes the Query AST node, returns the built
-  /// logical plan. Required when the expression may contain subquery
-  /// expressions (e.g. IN (SELECT ...), scalar subqueries). Can be nullptr
-  /// if subqueries are not expected.
-  using SubqueryPlanner = std::function<lp::LogicalPlanNodePtr(Query* query)>;
+  /// logical plan and a flag indicating whether the subquery is correlated.
+  /// Required when the expression may contain subquery expressions (e.g. IN
+  /// (SELECT ...), scalar subqueries). Can be nullptr if subqueries are not
+  /// expected.
+  using SubqueryPlanner = std::function<SubqueryPlanResult(Query* query)>;
 
   /// Callback to resolve ordinal sort keys (e.g. ORDER BY 1 inside aggregate
   /// functions). Required when the expression may contain aggregate function

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1284,7 +1284,7 @@ class RelationPlanner : public AstVisitor {
       parseSql_;
   std::shared_ptr<lp::PlanBuilder> builder_;
   ExpressionPlanner exprPlanner_{
-      [this](Query* query) -> lp::LogicalPlanNodePtr {
+      [this](Query* query) -> ExpressionPlanner::SubqueryPlanResult {
         // Save and restore builder. Correlated subqueries run on the same
         // RelationPlanner and must not overwrite the outer scope's state.
         // userOutputNames_ lives inside the builder, so it is saved and
@@ -1294,9 +1294,21 @@ class RelationPlanner : public AstVisitor {
           builder_ = std::move(builder);
         };
 
-        builder_ = newBuilder(builder->scope());
+        // Wrap the outer scope so that any invocation flips a local flag.
+        // A subquery that resolves a name against the outer scope is
+        // correlated; its planned output binds physical column names from
+        // this outer context and must not be cached for reuse under a
+        // different outer.
+        bool touchedOuterScope = false;
+        builder_ =
+            newBuilder([&touchedOuterScope, outerScope = builder->scope()](
+                           const std::optional<std::string>& alias,
+                           const std::string& name) {
+              touchedOuterScope = true;
+              return outerScope(alias, name);
+            });
         processQuery(query);
-        return builder_->planNode();
+        return {builder_->planNode(), touchedOuterScope};
       },
       [this](const ExpressionPtr& expr) -> lp::ExprApi {
         return toSortingKey(expr);


### PR DESCRIPTION
Summary:
`ExpressionPlanner::subqueryCache_` is unsafe for correlated subqueries: the cached `lp::Subquery` binds physical column names resolved against the outer scope at planning time, so a second cache hit from a different outer scope returns a plan with dangling `InputReferenceExpr` nodes and surfaces as `Field not found <name>` in `SubfieldTracker::markSubfields`. Trigger: a CTE containing a correlated scalar subquery, referenced twice from outer scalar subqueries that each filter on the CTE's computed column — outer column names get uniquified per expansion (`k` vs `k_3`) but the cached inner plan still references `k`.

Wrap the outer `Scope` handed to each subquery's `PlanBuilder` so any invocation flips a `touchedOuterScope` flag. The flag rides back through `SubqueryPlanner` and gates `subqueryCache_.emplace`: uncorrelated subqueries are still cached and deduped; correlated ones are replanned per outer scope.

Known limitation: a correlated subquery repeated in SELECT and GROUP BY no longer dedups. The grouping-key match this cache was originally added to fix can resurface in correlated form and needs a separate higher-layer fix.

Differential Revision: D105768045


