### PR TITLE
fix(parser): Handle aggregate alias collisions with GROUP BY keys (#1392)

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -77,3 +77,7 @@ SELECT reduce_agg(a, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2 + b) FROM t GROUP B
 -- DISTINCT applied on top of a GROUP BY, ordered by the grouping key.
 -- ordered
 SELECT DISTINCT a, COUNT(*) AS cnt FROM t GROUP BY a ORDER BY a
+----
+-- Aggregate alias collides with a GROUP BY key name.
+-- duckdb: SELECT max(b) FROM t GROUP BY b
+SELECT MAX(b) AS b FROM t GROUP BY b

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -551,11 +551,45 @@ void GroupByPlanner::collectAggregates(
   }
 }
 
+namespace {
+
+// Returns the unqualified output names that 'projections' would install in
+// a mapping: explicit aliases, or input column names for identity
+// projections of root columns. Computed projections without an alias have
+// no predictable output name and are omitted.
+folly::F14FastSet<std::string> outputNamesOf(
+    const std::vector<lp::ExprApi>& projections) {
+  folly::F14FastSet<std::string> names;
+  for (const auto& projection : projections) {
+    if (projection.name().has_value()) {
+      names.insert(projection.name().value());
+    } else if (const auto* field = dynamic_cast<const core::FieldAccessExpr*>(
+                   projection.expr().get());
+               field != nullptr && field->isRootColumn()) {
+      names.insert(field->name());
+    }
+  }
+  return names;
+}
+
+} // namespace
+
 void GroupByPlanner::addAggregate(bool useGroupingSets) {
+  const auto groupingKeyNames = outputNamesOf(groupingKeys_);
+
+  // SQL lets an aggregate's SELECT alias shadow a grouping-key name with
+  // the same text. PlanBuilder rejects this collision when binding the
+  // aggregate, so strip the colliding alias here; the subsequent project
+  // step reapplies the alias on top of the aggregate, realizing the shadow.
   std::vector<lp::ExprApi> aggregateExprs;
   aggregateExprs.reserve(aggregates_.size());
   for (const auto& agg : aggregates_) {
-    aggregateExprs.push_back(agg);
+    if (agg.name().has_value() &&
+        groupingKeyNames.contains(agg.name().value())) {
+      aggregateExprs.emplace_back(agg.expr());
+    } else {
+      aggregateExprs.push_back(agg);
+    }
   }
 
   if (useGroupingSets) {

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -85,6 +85,14 @@ TEST_F(AggregationParserTest, simpleGroupBy) {
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT 1 GROUP BY 0"),
       "GROUP BY position is not in select list: 0");
+
+  // Aggregate alias may shadow a GROUP BY key name.
+  testSelect(
+      "SELECT MAX(n_nationkey) AS n_nationkey FROM nation GROUP BY n_nationkey",
+      matchScan()
+          .aggregate({"n_nationkey"}, {"max(n_nationkey) AS m"})
+          .project({"m AS n_nationkey"})
+          .output());
 }
 
 // GROUP BY ordinals with SELECT * and other expanding items.


### PR DESCRIPTION
Summary:

`SELECT MAX(b) AS b FROM t GROUP BY b` and similar queries (where an aggregate's SELECT alias matches a grouping-key name) failed with `Duplicate name: b` in `NameMappings::add` inside `PlanBuilder::aggregate`. The grouping key installs `b` in the aggregate node's output mapping; the aggregate's explicit alias then tries to install `b` again and hits the duplicate-name check.

Fix in `GroupByPlanner::addAggregate`: strip SELECT aliases from the aggregates before calling `builder_->aggregate`. The aggregate produces only internal names with no risk of colliding with grouping keys; user-visible aliases are reapplied by the subsequent project step, so a SELECT alias naturally shadows a grouping-key name per SQL semantics.

Side effect: aliased aggregates now always have a rename-only Project on top, even when the names don't collide. The optimizer does not currently fold rename-only Projects into the parent; that's a separate improvement, intentionally visible in the updated `PlanMatcher` and TPC-H tests as a marker.

Reviewed By: amitkdutta

Differential Revision: D105783173


