### PR TITLE
fix(parser): Preserve user case of output column names (#1396)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1948,9 +1948,41 @@ PlanBuilder::OutputColumnName PlanBuilder::findOrAssignOutputNameAt(
   return OutputColumnName{columnAlias, columnName};
 }
 
-LogicalPlanNodePtr PlanBuilder::buildOutputNode() {
+namespace {
+
+// CHECKs that hidden columns (per 'mappings') appear after all visible
+// columns in 'inputType'. Callers that index into the input column vector
+// by visible-output position rely on this layout.
+void checkHiddenColumnsTrailing(
+    const velox::RowType& inputType,
+    const NameMappings& mappings) {
+  bool sawHidden = false;
+  for (uint32_t i = 0; i < inputType.size(); ++i) {
+    if (mappings.isHidden(inputType.nameOf(i))) {
+      sawHidden = true;
+    } else {
+      VELOX_CHECK(
+          !sawHidden,
+          "Hidden columns must follow all visible columns in input type");
+    }
+  }
+}
+
+} // namespace
+
+LogicalPlanNodePtr PlanBuilder::buildOutputNode(
+    const std::vector<std::optional<std::string>>& displayNames) {
   const auto& inputType = node_->outputType();
   const auto numColumns = inputType->size();
+
+  VELOX_USER_CHECK_LE(
+      displayNames.size(),
+      numColumns,
+      "displayNames has more entries than output columns");
+
+  // 'displayNames[i]' is indexed by input position; valid because hidden
+  // columns are trailing.
+  checkHiddenColumnsTrailing(*inputType, *outputMapping_);
 
   std::vector<OutputNode::Entry> entries;
   entries.reserve(numColumns);
@@ -1961,7 +1993,9 @@ LogicalPlanNodePtr PlanBuilder::buildOutputNode() {
       continue;
     }
     std::string name;
-    if (auto userName = outputMapping_->userName(id)) {
+    if (i < displayNames.size() && displayNames[i].has_value()) {
+      name = displayNames[i].value();
+    } else if (auto userName = outputMapping_->userName(id)) {
       name = *userName;
     } else {
       name = findOrAssignOutputNameAt(i).name;
@@ -2011,14 +2045,18 @@ LogicalPlanNodePtr PlanBuilder::buildRenameProject() {
   return node_;
 }
 
-LogicalPlanNodePtr PlanBuilder::build() {
+LogicalPlanNodePtr PlanBuilder::build(
+    const std::vector<std::optional<std::string>>& displayNames) {
   VELOX_USER_CHECK_NOT_NULL(node_);
   VELOX_CHECK_NOT_NULL(outputMapping_);
 
   if (allowAmbiguousOutputNames_ && !node_->is(NodeKind::kTableWrite)) {
-    return buildOutputNode();
+    return buildOutputNode(displayNames);
   }
 
+  VELOX_USER_CHECK(
+      displayNames.empty(),
+      "displayNames is only supported when the build produces an OutputNode");
   return buildRenameProject();
 }
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -754,11 +754,18 @@ class PlanBuilder {
   /// When allowAmbiguousOutputNames is true, creates an OutputNode at the root
   /// that supports duplicate and empty names. Otherwise, creates a ProjectNode
   /// for renaming (or returns the plan as-is if no renaming is needed).
-  LogicalPlanNodePtr build();
+  ///
+  /// 'displayNames[i]', when set, overrides the default name of the i-th
+  /// output column in the root OutputNode. 'std::nullopt' entries and entries
+  /// past the end of the vector fall back to the default naming. Only
+  /// permitted when build produces an OutputNode.
+  LogicalPlanNodePtr build(
+      const std::vector<std::optional<std::string>>& displayNames = {});
 
  private:
   // Builds an OutputNode that preserves duplicate and empty output names.
-  LogicalPlanNodePtr buildOutputNode();
+  LogicalPlanNodePtr buildOutputNode(
+      const std::vector<std::optional<std::string>>& displayNames);
 
   // Builds a ProjectNode to rename output columns to user-specified names.
   // Returns the plan as-is if no renaming is needed.

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(example)
 add_library(
   axiom_sql_presto_parser
   ColumnsExpansion.cpp
+  DisplayNames.cpp
   ExpressionPlanner.cpp
   GroupByPlanner.cpp
   SortProjection.cpp

--- a/axiom/sql/presto/DisplayNames.cpp
+++ b/axiom/sql/presto/DisplayNames.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/DisplayNames.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace axiom::sql::presto {
+
+// static
+std::optional<std::string> DisplayNames::displayName(
+    const SingleColumn& singleColumn) {
+  if (singleColumn.alias() != nullptr) {
+    return singleColumn.alias()->value();
+  }
+  if (singleColumn.expression()->is(NodeType::kIdentifier)) {
+    return singleColumn.expression()->as<Identifier>()->value();
+  }
+  if (singleColumn.expression()->is(NodeType::kDereferenceExpression)) {
+    // For chained dereferences (a.b.c), field() is the rightmost.
+    return singleColumn.expression()
+        ->as<DereferenceExpression>()
+        ->field()
+        ->value();
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> DisplayNames::displayName(
+    const std::optional<std::string>& alias,
+    const std::string& name) const {
+  if (auto it = accumulatedNames.find({alias, name});
+      it != accumulatedNames.end()) {
+    return it->second;
+  }
+  if (alias.has_value()) {
+    if (auto it = accumulatedNames.find({std::nullopt, name});
+        it != accumulatedNames.end()) {
+      return it->second;
+    }
+  }
+  return std::nullopt;
+}
+
+void DisplayNames::captureLastNames(const lp::PlanBuilder& builder) {
+  std::vector<std::optional<std::string>> names =
+      builder.outputNames(/*includeHiddenColumns=*/false);
+  lastNames.clear();
+  lastNames.reserve(names.size());
+  for (const auto& name : names) {
+    lastNames.push_back(
+        name.has_value() ? displayName(std::nullopt, *name) : std::nullopt);
+  }
+}
+
+void DisplayNames::captureLastNames(const std::vector<IdentifierPtr>& aliases) {
+  lastNames.clear();
+  lastNames.reserve(aliases.size());
+  for (const auto& id : aliases) {
+    lastNames.emplace_back(id->value());
+  }
+}
+
+void DisplayNames::captureLastNames(const std::vector<SelectItemPtr>& items) {
+  lastNames.clear();
+  lastNames.reserve(items.size());
+  for (const auto& item : items) {
+    lastNames.push_back(displayName(*item->as<SingleColumn>()));
+  }
+}
+
+void DisplayNames::accumulate(
+    const lp::PlanBuilder& builder,
+    const std::optional<std::string>& relationAlias) {
+  if (lastNames.empty()) {
+    return;
+  }
+
+  std::vector<std::optional<std::string>> names =
+      builder.outputNames(/*includeHiddenColumns=*/false);
+  VELOX_CHECK_EQ(names.size(), lastNames.size());
+  for (size_t i = 0; i < names.size(); ++i) {
+    const auto& name = names[i];
+    const auto& display = lastNames[i];
+    if (!display.has_value() || !name.has_value()) {
+      continue;
+    }
+
+    accumulatedNames[{relationAlias, *name}] = *display;
+    if (relationAlias.has_value()) {
+      // Also key by nullopt so unprefixed lookups find the same entry.
+      accumulatedNames[{std::nullopt, *name}] = *display;
+    }
+  }
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/DisplayNames.h
+++ b/axiom/sql/presto/DisplayNames.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/ast/AstNodesAll.h"
+
+namespace axiom::sql::presto {
+
+namespace lp = facebook::axiom::logical_plan;
+
+/// Tracks per-query display names as the AST is walked. Held by
+/// 'RelationPlanner' and updated at SELECT and relation boundaries.
+///
+/// Example walk-through for `SELECT * FROM (SELECT a AS Foo FROM t) AS sub`:
+///   1. Inner SELECT finishes; 'lastNames' is set to ["Foo"].
+///   2. 'accumulate(builder, "sub")' writes ["Foo"] into 'accumulatedNames'
+///      under both {"sub", "foo"} and {nullopt, "foo"}.
+///   3. Outer 'SELECT *' calls 'captureLastNames(builder)', which reads
+///      'accumulatedNames[{nullopt, "foo"}]' and sets 'lastNames' to ["Foo"].
+///   4. 'plan()' passes 'lastNames' to PlanBuilder so the OutputNode preserves
+///      the user-written case 'Foo'.
+struct DisplayNames {
+  /// Per-column display names of the most recently processed
+  /// SELECT/relation.
+  std::vector<std::optional<std::string>> lastNames;
+
+  /// User-written case captured at relation boundaries (subqueries, CTEs,
+  /// AliasedRelation) as they finish planning. Star and COLUMNS expansions
+  /// in an enclosing SELECT consult this to recover the original case.
+  ///
+  /// Keyed by {relation alias, canonical column name}: an alias-qualified
+  /// relation (e.g. 'AS t') stores each column twice — once under its alias
+  /// and once under std::nullopt — so both 't.col' and bare 'col' lookups
+  /// find the override. An unaliased source stores only under std::nullopt.
+  /// The canonical column name is the lowercase form (matches what
+  /// 'PlanBuilder::outputNames()' returns).
+  folly::F14FastMap<
+      std::pair<std::optional<std::string>, std::string>,
+      std::string>
+      accumulatedNames;
+
+  /// User-written display name for a SingleColumn SELECT item, or nullopt
+  /// if the expression has no obvious source name (e.g., an arithmetic
+  /// expression with no alias).
+  static std::optional<std::string> displayName(
+      const SingleColumn& singleColumn);
+
+  /// Returns the display-case override for a column, if any. Falls back to
+  /// the unaliased key so a prefix-less lookup can find an entry recorded
+  /// under an explicit alias.
+  std::optional<std::string> displayName(
+      const std::optional<std::string>& alias,
+      const std::string& name) const;
+
+  /// Captures 'lastNames' by looking up each of 'builder' columns in
+  /// 'accumulatedNames'. Used when a SELECT passes columns through
+  /// unchanged (bare 'SELECT *') and there are no SELECT-item-derived
+  /// names to use.
+  void captureLastNames(const lp::PlanBuilder& builder);
+
+  /// Captures 'lastNames' from a user-provided column-alias list (e.g. CTE
+  /// 'WITH t(a, b) AS ...' or AliasedRelation '... AS sub(a, b)').
+  void captureLastNames(const std::vector<IdentifierPtr>& aliases);
+
+  /// Captures 'lastNames' from SELECT items. All items must be SingleColumn
+  /// (the global-aggregate path enforces this).
+  void captureLastNames(const std::vector<SelectItemPtr>& items);
+
+  /// Captures 'lastNames' into 'accumulatedNames' as the display names of
+  /// 'builder' columns under 'relationAlias', so an enclosing SELECT's star
+  /// or COLUMNS expansion can recover them. Must not register new output
+  /// names on 'builder'.
+  void accumulate(
+      const lp::PlanBuilder& builder,
+      const std::optional<std::string>& relationAlias);
+};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -482,7 +482,9 @@ std::string canonicalizeName(const std::string& name) {
 }
 
 std::string canonicalizeIdentifier(const Identifier& identifier) {
-  // TODO: Figure out whether 'delimited' identifiers should be kept as is.
+  // Presto matches identifiers case-insensitively regardless of quoting.
+  // Quoting only affects which characters are permitted and which case is
+  // preserved in the output schema; it does NOT alter matching semantics.
   return canonicalizeName(identifier.value());
 }
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/sql/presto/PrestoParser.h"
 #include <folly/ScopeGuard.h>
+#include <folly/container/F14Map.h>
+#include <folly/hash/Hash.h>
 #include <cctype>
 #include <unordered_set>
 #include "axiom/common/CatalogSchemaTableName.h"
@@ -23,6 +25,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ColumnsExpansion.h"
+#include "axiom/sql/presto/DisplayNames.h"
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
@@ -266,7 +269,15 @@ class RelationPlanner : public AstVisitor {
   }
 
   lp::LogicalPlanNodePtr plan() {
-    return builder_->build();
+    return builder_->build(displayNames_.lastNames);
+  }
+
+  // Clears 'displayNames_.lastNames'; a TableWrite root has no OutputNode to
+  // receive them.
+  template <typename... Args>
+  void tableWrite(Args&&... args) {
+    displayNames_.lastNames.clear();
+    builder_->tableWrite(std::forward<Args>(args)...);
   }
 
   const ViewMap& views() const {
@@ -435,8 +446,10 @@ class RelationPlanner : public AstVisitor {
       // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
       // the underlying SELECT/VALUES output columns to a, b.
       if (const auto& columnAliases = withEntry->columnNames()) {
+        displayNames_.captureLastNames(*columnAliases);
         applyColumnAliases(*columnAliases, withEntry->location(), tableName);
       }
+      displayNames_.accumulate(*builder_, tableName);
     } else {
       const auto [connectorId, connectorTable] = toConnectorTable(
           *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
@@ -446,6 +459,9 @@ class RelationPlanner : public AstVisitor {
               connectorId);
 
       if (metadata->findTable(connectorTable) != nullptr) {
+        // Drop display names captured from a sibling FROM relation so
+        // this table's columns aren't tagged with them.
+        displayNames_.lastNames.clear();
         inputTables_.insert(
             facebook::axiom::CatalogSchemaTableName{
                 connectorId, connectorTable});
@@ -531,9 +547,12 @@ class RelationPlanner : public AstVisitor {
 
     const auto& columnAliases = aliasedRelation.columnNames();
     if (!columnAliases.empty()) {
+      // Column-alias list shadows any case captured from the inner SELECT.
+      displayNames_.captureLastNames(columnAliases);
       applyColumnAliases(columnAliases, aliasedRelation.location(), alias);
     }
 
+    displayNames_.accumulate(*builder_, alias);
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
     builder_->as(alias);
   }
@@ -543,6 +562,7 @@ class RelationPlanner : public AstVisitor {
 
     if (query->is(NodeType::kQuery)) {
       processQuery(query->as<Query>());
+      displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
       return;
     }
 
@@ -738,6 +758,9 @@ class RelationPlanner : public AstVisitor {
   // embedded as WindowCallExpr in the IExpr tree.
   std::optional<std::vector<lp::ExprApi>> buildSelectProjections(
       const std::vector<SelectItemPtr>& selectItems) {
+    // Previous SELECT's display names must not leak into this scope.
+    displayNames_.lastNames.clear();
+
     // SELECT * FROM ...
     const bool isSingleSelectStar = selectItems.size() == 1 &&
         selectItems.at(0)->is(NodeType::kAllColumns) &&
@@ -745,6 +768,7 @@ class RelationPlanner : public AstVisitor {
         selectItems.at(0)->as<AllColumns>()->excludeColumns().empty() &&
         selectItems.at(0)->as<AllColumns>()->replaceItems().empty();
     if (isSingleSelectStar) {
+      displayNames_.captureLastNames(*builder_);
       return std::nullopt;
     }
 
@@ -768,6 +792,23 @@ class RelationPlanner : public AstVisitor {
     };
 
     std::vector<lp::ExprApi> exprs;
+    // Parallel to 'exprs'. Star and COLUMNS(...) expansions emit nullopt
+    // unless the source relation captured a display-case override.
+    std::vector<std::optional<std::string>> displayNames;
+    const auto recordDisplayUpTo = [&]() {
+      while (displayNames.size() < exprs.size()) {
+        displayNames.emplace_back(std::nullopt);
+      }
+    };
+    // Appends per-column display-name overrides for star/regex expansions.
+    const auto recordDisplayForExpansion =
+        [&](const std::vector<lp::PlanBuilder::OutputColumnName>& columns,
+            const std::optional<std::string>& prefix) {
+          for (const auto& column : columns) {
+            displayNames.push_back(
+                displayNames_.displayName(prefix, column.name));
+          }
+        };
     for (const auto& item : selectItems) {
       if (item->is(NodeType::kAllColumns)) {
         auto* allColumns = item->as<AllColumns>();
@@ -785,6 +826,7 @@ class RelationPlanner : public AstVisitor {
             allColumns->excludeColumns(),
             allColumns->replaceItems(),
             exprs);
+        recordDisplayForExpansion(selectedColumns, prefix);
       } else if (item->is(NodeType::kSelectColumns)) {
         auto* selectColumns = item->as<SelectColumns>();
 
@@ -804,6 +846,7 @@ class RelationPlanner : public AstVisitor {
             selectColumns->excludeColumns(),
             selectColumns->replaceItems(),
             exprs);
+        recordDisplayForExpansion(selectedColumns, prefix);
       } else {
         VELOX_CHECK(item->is(NodeType::kSingleColumn));
         auto* singleColumn = item->as<SingleColumn>();
@@ -814,10 +857,11 @@ class RelationPlanner : public AstVisitor {
         if (singleColumn->alias() != nullptr) {
           alias = canonicalizeIdentifier(*singleColumn->alias());
         }
+        auto display = DisplayNames::displayName(*singleColumn);
 
         if (tryExpandColumnsInExpression(
                 expr, alias, exprs, singleColumn->expression()->location())) {
-          // COLUMNS('regex') was found and expanded.
+          recordDisplayUpTo();
         } else {
           // Normal SingleColumn handling.
           if (alias.has_value()) {
@@ -827,10 +871,12 @@ class RelationPlanner : public AstVisitor {
             expr = expr.as(*alias);
           }
           exprs.push_back(expr);
+          displayNames.push_back(std::move(display));
         }
       }
     }
 
+    displayNames_.lastNames = std::move(displayNames);
     return exprs;
   }
 
@@ -1058,6 +1104,35 @@ class RelationPlanner : public AstVisitor {
     return toExpr(expr);
   }
 
+  // Plans 'query' as a subquery in a fresh builder, reporting whether it
+  // referenced the outer scope.
+  ExpressionPlanner::SubqueryPlanResult planSubquery(Query* query) {
+    // Save and restore the outer builder and 'displayNames_.lastNames'.
+    // Correlated subqueries run on the same RelationPlanner and must not
+    // leak their planning into the outer scope.
+    auto builder = std::move(builder_);
+    auto savedDisplayNames = std::move(displayNames_.lastNames);
+    SCOPE_EXIT {
+      builder_ = std::move(builder);
+      displayNames_.lastNames = std::move(savedDisplayNames);
+    };
+
+    // Wrap the outer scope so that any invocation flips a local flag.
+    // A subquery that resolves a name against the outer scope is
+    // correlated; its planned output binds physical column names from
+    // this outer context and must not be cached for reuse under a
+    // different outer.
+    bool touchedOuterScope = false;
+    builder_ = newBuilder(
+        [&touchedOuterScope, outerScope = builder->scope()](
+            const std::optional<std::string>& alias, const std::string& name) {
+          touchedOuterScope = true;
+          return outerScope(alias, name);
+        });
+    processQuery(query);
+    return {builder_->planNode(), touchedOuterScope};
+  }
+
   void addOrderBy(const OrderByPtr& orderBy) {
     if (orderBy == nullptr) {
       return;
@@ -1114,9 +1189,16 @@ class RelationPlanner : public AstVisitor {
 
   void processQuery(Query* query) {
     auto savedWithQueries = withQueries_;
+    auto savedAccumulatedNames = displayNames_.accumulatedNames;
     SCOPE_EXIT {
       withQueries_ = std::move(savedWithQueries);
+      displayNames_.accumulatedNames = std::move(savedAccumulatedNames);
     };
+
+    // A new query scope starts fresh. Any 'lastNames' from a sibling
+    // relation (e.g., the left side of a JOIN) must not leak into this
+    // query's accumulate() at processTableSubquery.
+    displayNames_.lastNames.clear();
 
     if (const auto& with = query->with()) {
       AXIOM_PRESTO_SYNTAX_CHECK(
@@ -1161,6 +1243,10 @@ class RelationPlanner : public AstVisitor {
     // FROM t -> builder.tableScan(t)
     processFrom(node->from());
 
+    // Subqueries inside FROM may have set 'displayNames_.lastNames'. Discard
+    // them so only this scope's SELECT-item-derived names reach plan().
+    displayNames_.lastNames.clear();
+
     // WHERE a > 1 -> builder.filter("a > 1")
     addFilter(node->where());
 
@@ -1186,6 +1272,9 @@ class RelationPlanner : public AstVisitor {
     } else {
       if (GroupByPlanner{builder_, exprPlanner_}.tryPlanGlobalAgg(
               selectItems, node->having())) {
+        // GroupByPlanner does not go through buildSelectProjections, so
+        // stage display names from the SELECT items directly.
+        displayNames_.captureLastNames(selectItems);
         // Nothing else to do. For aggregation, ORDER BY can only reference
         // SELECT list (aggregates). DISTINCT will be a no-op since global
         // aggregations without a group by are 1 row output.
@@ -1266,6 +1355,8 @@ class RelationPlanner : public AstVisitor {
     left->accept(this);
 
     auto leftBuilder = builder_;
+    // SQL set-operation output names come from the left input.
+    auto leftDisplayNames = std::move(displayNames_.lastNames);
 
     builder_ = newBuilder(leftBuilder->scope());
     right->accept(this);
@@ -1273,6 +1364,7 @@ class RelationPlanner : public AstVisitor {
 
     builder_ = leftBuilder;
     builder_->setOperation(op, *rightBuilder);
+    displayNames_.lastNames = std::move(leftDisplayNames);
   }
 
   std::shared_ptr<lp::PlanBuilder> newBuilder(
@@ -1290,42 +1382,15 @@ class RelationPlanner : public AstVisitor {
       parseSql_;
   std::shared_ptr<lp::PlanBuilder> builder_;
   ExpressionPlanner exprPlanner_{
-      [this](Query* query) -> ExpressionPlanner::SubqueryPlanResult {
-        // Save and restore builder. Correlated subqueries run on the same
-        // RelationPlanner and must not overwrite the outer scope's state.
-        // userOutputNames_ lives inside the builder, so it is saved and
-        // restored automatically.
-        auto builder = std::move(builder_);
-        SCOPE_EXIT {
-          builder_ = std::move(builder);
-        };
-
-        // Wrap the outer scope so that any invocation flips a local flag.
-        // A subquery that resolves a name against the outer scope is
-        // correlated; its planned output binds physical column names from
-        // this outer context and must not be cached for reuse under a
-        // different outer.
-        bool touchedOuterScope = false;
-        builder_ =
-            newBuilder([&touchedOuterScope, outerScope = builder->scope()](
-                           const std::optional<std::string>& alias,
-                           const std::string& name) {
-              touchedOuterScope = true;
-              return outerScope(alias, name);
-            });
-        processQuery(query);
-        return {builder_->planNode(), touchedOuterScope};
-      },
-      [this](const ExpressionPtr& expr) -> lp::ExprApi {
-        return toSortingKey(expr);
-      },
-      [this](const std::string& qualifier, const std::string& name) -> bool {
+      [this](Query* query) { return planSubquery(query); },
+      [this](const ExpressionPtr& expr) { return toSortingKey(expr); },
+      [this](const std::string& qualifier, const std::string& name) {
         // Only canonicalize if the qualifier resolves as a table alias (not a
         // struct field dereference) and the unqualified name is unambiguous.
         return builder_->hasQualifiedColumn(qualifier, name) &&
             builder_->hasColumn(name);
       },
-      [this](const std::string& first, const std::string& second) -> bool {
+      [this](const std::string& first, const std::string& second) {
         return builder_->hasColumn(first) ||
             builder_->hasQualifiedColumn(first, second);
       }};
@@ -1333,6 +1398,8 @@ class RelationPlanner : public AstVisitor {
   ViewMap views_;
   std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables_;
   bool friendlySql_;
+
+  DisplayNames displayNames_;
 };
 
 } // namespace
@@ -1974,7 +2041,7 @@ SqlStatementPtr parseInsert(
   auto inputColumns = planner.builder().findOrAssignOutputNames();
   VELOX_CHECK_EQ(inputColumns.size(), columnNames.size());
 
-  planner.builder().tableWrite(
+  planner.tableWrite(
       connectorId,
       connectorTable.schema,
       connectorTable.table,
@@ -2044,7 +2111,7 @@ SqlStatementPtr parseCreateTableAsSelect(
       columnNames.emplace_back(name.value());
     }
 
-    planBuilder.tableWrite(
+    planner.tableWrite(
         connectorId,
         connectorTable.schema,
         connectorTable.table,
@@ -2064,7 +2131,7 @@ SqlStatementPtr parseCreateTableAsSelect(
       columnNames.emplace_back(column->value());
     }
 
-    planBuilder.tableWrite(
+    planner.tableWrite(
         connectorId,
         connectorTable.schema,
         connectorTable.table,

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -268,15 +268,15 @@ TEST_F(PrestoParserTest, unnest) {
 TEST_F(PrestoParserTest, qualifiedColumnAccess) {
   {
     connector_->addTable("t", ROW({"x"}, {INTEGER()}));
-    auto matcher = matchScan().project().output({"x"});
 
     // Qualified and unqualified column access.
-    testSelect("SELECT t.x FROM t", matcher);
-    testSelect("SELECT x FROM t", matcher);
+    testSelect("SELECT t.x FROM t", matchScan().project().output({"x"}));
+    testSelect("SELECT x FROM t", matchScan().project().output({"x"}));
 
-    // Case insensitive column and table alias.
-    testSelect("SELECT t.X FROM t", matcher);
-    testSelect("SELECT T.X FROM t", matcher);
+    // Case insensitive column and table alias; output preserves the
+    // user-written case.
+    testSelect("SELECT t.X FROM t", matchScan().project().output({"X"}));
+    testSelect("SELECT T.X FROM t", matchScan().project().output({"X"}));
   }
 
   // Table alias takes priority over struct column name. Table 'u' has a
@@ -446,16 +446,15 @@ TEST_F(PrestoParserTest, hiddenColumns) {
 }
 
 TEST_F(PrestoParserTest, mixedCaseColumnNames) {
-  {
-    auto matcher = matchScan().project().output({"n_name", "n_regionkey"});
-    testSelect("SELECT N_NAME, n_ReGiOnKeY FROM nation", matcher);
-  }
-  {
-    auto matcher = matchScan().project().output({"n_name"});
-    testSelect("SELECT nation.n_name FROM nation", matcher);
-    testSelect("SELECT NATION.n_name FROM nation", matcher);
-    testSelect("SELECT \"NATION\".n_name FROM nation", matcher);
-  }
+  // Output schema preserves the user-written case of column references.
+  testSelect(
+      "SELECT N_NAME, n_ReGiOnKeY FROM nation",
+      matchScan().project().output({"N_NAME", "n_ReGiOnKeY"}));
+
+  auto matcher = matchScan().project().output({"n_name"});
+  testSelect("SELECT nation.n_name FROM nation", matcher);
+  testSelect("SELECT NATION.n_name FROM nation", matcher);
+  testSelect("SELECT \"NATION\".n_name FROM nation", matcher);
 }
 
 TEST_F(PrestoParserTest, withBasic) {
@@ -1391,6 +1390,112 @@ TEST_F(PrestoParserTest, outputNames) {
   // Duplicate output column names are preserved as-is (not deduplicated to
   // x, x_0).
   test("SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b)", {"x", "x"});
+}
+
+// Explicit SELECT aliases preserve the user's original case in the output
+// schema, even though identifier matching is case-insensitive.
+TEST_F(PrestoParserTest, outputNamesPreserveAliasCase) {
+  auto outputNames = [&](const std::string& sql) {
+    SCOPED_TRACE(sql);
+    return parseSelect(sql)->outputType()->names();
+  };
+
+  EXPECT_THAT(
+      outputNames("SELECT 1 AS FooBar, 2 AS MyCol"),
+      testing::ElementsAre("FooBar", "MyCol"));
+
+  EXPECT_THAT(
+      outputNames(R"(SELECT 1 AS "FooBar", 2 AS "MyCol")"),
+      testing::ElementsAre("FooBar", "MyCol"));
+
+  // Two aliases with the same canonical form are kept as distinct output
+  // columns, each with its user-written case.
+  EXPECT_THAT(
+      outputNames(R"(SELECT 1 AS "ABC", 2 AS "abc")"),
+      testing::ElementsAre("ABC", "abc"));
+
+  EXPECT_THAT(outputNames("SELECT 1 AS foo"), testing::ElementsAre("foo"));
+
+  // Column reference: output name follows the reference's written case,
+  // not the source's.
+  EXPECT_THAT(
+      outputNames("SELECT FooBar FROM (SELECT 1 AS FooBar) s"),
+      testing::ElementsAre("FooBar"));
+
+  EXPECT_THAT(
+      outputNames("SELECT FOOBAR FROM (SELECT 1 AS FooBar) s"),
+      testing::ElementsAre("FOOBAR"));
+
+  EXPECT_THAT(
+      outputNames(R"(SELECT "FooBar" FROM (SELECT 1 AS FooBar) s)"),
+      testing::ElementsAre("FooBar"));
+
+  // Global aggregation over a multi-column subquery parses and yields a
+  // single output column.
+  EXPECT_NO_THROW(parseSelect("SELECT sum(z) FROM (SELECT 1 AS x, 2 AS z) s"));
+
+  // Global aggregation preserves the user-written alias case.
+  EXPECT_THAT(
+      outputNames("SELECT sum(z) AS Total FROM (SELECT 1 AS z) s"),
+      testing::ElementsAre("Total"));
+
+  // An IN/scalar subquery in WHERE does not affect the outer SELECT's
+  // output names.
+  EXPECT_THAT(
+      outputNames("SELECT 1 AS OuterCol WHERE 1 IN (SELECT 1 AS InnerCol)"),
+      testing::ElementsAre("OuterCol"));
+
+  // Set-operation output names come from the left input.
+  EXPECT_THAT(
+      outputNames("SELECT 1 AS FooBar UNION ALL SELECT 2 AS Bar"),
+      testing::ElementsAre("FooBar"));
+  EXPECT_THAT(
+      outputNames("SELECT 1 AS FooBar INTERSECT SELECT 2 AS Bar"),
+      testing::ElementsAre("FooBar"));
+  EXPECT_THAT(
+      outputNames("SELECT 1 AS FooBar EXCEPT SELECT 2 AS Bar"),
+      testing::ElementsAre("FooBar"));
+
+  // Qualified column reference: output name follows the rightmost field's
+  // written case.
+  EXPECT_THAT(
+      outputNames("SELECT s.FooBar FROM (SELECT 1 AS FooBar) s"),
+      testing::ElementsAre("FooBar"));
+
+  // Star expansion propagates the source relation's per-column case.
+  EXPECT_THAT(
+      outputNames("SELECT * FROM (SELECT 1 AS FooBar) s"),
+      testing::ElementsAre("FooBar"));
+
+  EXPECT_THAT(
+      outputNames("SELECT s.* FROM (SELECT 1 AS FooBar) s"),
+      testing::ElementsAre("FooBar"));
+
+  // CTE star expansion propagates the inner SELECT's case.
+  EXPECT_THAT(
+      outputNames("WITH cte AS (SELECT 1 AS FooBar) SELECT * FROM cte"),
+      testing::ElementsAre("FooBar"));
+  EXPECT_THAT(
+      outputNames("WITH cte AS (SELECT 1 AS FooBar) SELECT cte.* FROM cte"),
+      testing::ElementsAre("FooBar"));
+
+  // CTE with an explicit column-alias list uses the alias-list case.
+  EXPECT_THAT(
+      outputNames("WITH cte(Bar) AS (SELECT 1 AS FooBar) SELECT * FROM cte"),
+      testing::ElementsAre("Bar"));
+
+  // Aliased subquery with an explicit column-alias list uses the
+  // alias-list case.
+  EXPECT_THAT(
+      outputNames("SELECT * FROM (SELECT 1) s(Bar)"),
+      testing::ElementsAre("Bar"));
+
+  // Star over a set operation propagates the left side's case (set-op
+  // output columns come from the left).
+  EXPECT_THAT(
+      outputNames(
+          "SELECT * FROM ((SELECT 1 AS FooBar) UNION ALL (SELECT 2 AS Bar)) u"),
+      testing::ElementsAre("FooBar"));
 }
 
 TEST_F(PrestoParserTest, qualifiedStarInUnionAfterJoin) {


### PR DESCRIPTION
Summary:

Presto matches identifiers case-insensitively but preserves user-written case in the output schema. Axiom previously canonicalized to lower case everywhere, so `SELECT 1 AS FooBar` returned a column named `foobar` instead of `FooBar`. This made result schemas differ from Presto on otherwise-identical queries.

The parser carries a per-projection display name into the root `OutputNode`. `PlanBuilder::build()` takes an optional `displayNames` vector that, when set, overrides the default name of each output column. Matching, lookup, and intermediate plan nodes continue to use canonicalized (lower-case) names — only the final, user-visible names are affected. For star expansion across relation boundaries, a parser-local map from `{relation alias, canonical column name}` to user case carries the source's per-column case into the outer SELECT.

Base-table per-column case from connector metadata is still deferred.

Reviewed By: amitkdutta

Differential Revision: D105854244


