### PR TITLE
feat(session): Add connector-scoped session properties (#1397)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -294,7 +294,8 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", user_, connector::ConnectorSession::ConnectorProperties{});
   auto table = metadata->createTable(
       session,
       statement.tableName(),
@@ -317,7 +318,8 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", user_, connector::ConnectorSession::ConnectorProperties{});
   auto table = metadata->createTable(
       session,
       statement.tableName(),
@@ -335,7 +337,8 @@ std::string SqlQueryRunner::dropTable(
 
   const auto& tableName = statement.tableName();
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   const bool dropped = metadata->dropTable(
       session,
       statement.tableName(),
@@ -354,7 +357,8 @@ std::string SqlQueryRunner::addColumn(
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   auto result = metadata->addColumn(
       session,
       statement.tableName(),
@@ -390,7 +394,8 @@ std::string SqlQueryRunner::createSchema(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   metadata->createSchema(
       session, statement.schemaName(), statement.ifNotExists(), properties);
   return fmt::format("Created schema: {}", statement.schemaName());
@@ -399,7 +404,8 @@ std::string SqlQueryRunner::createSchema(
 std::string SqlQueryRunner::dropSchema(
     const presto::DropSchemaStatement& statement) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   metadata->dropSchema(session, statement.schemaName(), statement.ifExists());
   return fmt::format("Dropped schema: {}", statement.schemaName());
 }
@@ -859,6 +865,24 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
       options.tokenProvider);
 }
 
+Session::ConnectorProperties SqlQueryRunner::collectConnectorProperties()
+    const {
+  Session::ConnectorProperties connectorProperties;
+  for (const auto& [connectorId, connector] :
+       velox::connector::ConnectorRegistry::global().snapshot()) {
+    if (connector->configProvider()) {
+      auto props = sessionConfig_->effectiveValues(connectorId);
+      if (!props.empty()) {
+        connectorProperties.emplace(
+            connectorId,
+            connector::ConnectorSession::ConnectorProperties(
+                props.begin(), props.end()));
+      }
+    }
+  }
+  return connectorProperties;
+}
+
 std::string SqlQueryRunner::runExplain(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     presto::ExplainStatement::Type type,
@@ -1095,7 +1119,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   velox::exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
-  auto session = std::make_shared<Session>(queryCtx->queryId());
+  auto session = std::make_shared<Session>(
+      queryCtx->queryId(), user_, collectConnectorProperties());
   auto history = std::make_unique<optimizer::VeloxHistory>();
   if (schemaResolver == nullptr) {
     schemaResolver = std::make_shared<connector::SchemaResolver>();

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include "axiom/common/ConfigRegistry.h"
 #include "axiom/common/QueryRuntimeStats.h"
+#include "axiom/common/Session.h"
 #include "axiom/common/SessionConfig.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
@@ -292,6 +293,10 @@ class SqlQueryRunner {
 
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
       const RunOptions& options);
+
+  // Collects planning-time connector session properties from the SessionConfig.
+  facebook::axiom::Session::ConnectorProperties collectConnectorProperties()
+      const;
 
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,

--- a/axiom/common/Session.h
+++ b/axiom/common/Session.h
@@ -15,7 +15,14 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <folly/container/F14Map.h>
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom {
@@ -23,26 +30,42 @@ namespace facebook::axiom {
 /// Read-only query-specific information.
 class Session final {
  public:
-  explicit Session(std::string queryId, std::string user = {})
-      : queryId_{std::move(queryId)}, user_{std::move(user)} {}
+  /// Session properties grouped by connector id; the inner map holds one
+  /// connector's properties keyed by name.
+  using ConnectorProperties = folly::F14FastMap<
+      std::string,
+      connector::ConnectorSession::ConnectorProperties,
+      folly::transparent<std::hash<std::string_view>>,
+      folly::transparent<std::equal_to<>>>;
+
+  Session(
+      std::string queryId,
+      std::optional<std::string> user,
+      ConnectorProperties connectorProperties)
+      : queryId_{std::move(queryId)},
+        user_{std::move(user)},
+        connectorProperties_{std::move(connectorProperties)} {}
 
   /// Returns the query identifier.
   const std::string& queryId() const {
     return queryId_;
   }
 
-  /// Returns the identity of the user who submitted the query.
-  const std::string& user() const {
+  /// Returns the user who submitted the query, or `std::nullopt` if
+  /// unavailable.
+  const std::optional<std::string>& user() const {
     return user_;
   }
 
-  /// Creates a connector-scoped session carrying the query ID and user.
+  /// Returns a connector-scoped session for `connectorId` carrying that
+  /// connector's properties, or an empty set if none.
   connector::ConnectorSessionPtr toConnectorSession(
       std::string_view connectorId) const;
 
  private:
   const std::string queryId_;
-  const std::string user_;
+  const std::optional<std::string> user_;
+  const ConnectorProperties connectorProperties_;
 };
 
 using SessionPtr = std::shared_ptr<Session>;

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_library(
+  axiom_connectors
+  ConnectorMetadata.cpp
+  ConnectorMetadataRegistry.cpp
+  ConnectorSession.cpp
+  SchemaResolver.cpp
+)
 
 target_link_libraries(
   axiom_connectors

--- a/axiom/connectors/ConnectorSession.cpp
+++ b/axiom/connectors/ConnectorSession.cpp
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-#include "axiom/common/Session.h"
+#include "axiom/connectors/ConnectorSession.h"
 
-namespace facebook::axiom {
+namespace facebook::axiom::connector {
 
-connector::ConnectorSessionPtr Session::toConnectorSession(
-    std::string_view connectorId) const {
-  auto it = connectorProperties_.find(connectorId);
-  if (it == connectorProperties_.end()) {
-    return std::make_shared<connector::ConnectorSession>(
-        queryId_, user_, connector::ConnectorSession::ConnectorProperties{});
+std::optional<std::string> ConnectorSession::property(
+    std::string_view name) const {
+  auto found = properties_.find(name);
+  if (found == properties_.end()) {
+    return std::nullopt;
   }
-  return std::make_shared<connector::ConnectorSession>(
-      queryId_, user_, it->second);
+  return found->second;
 }
 
-} // namespace facebook::axiom
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorSession.h
+++ b/axiom/connectors/ConnectorSession.h
@@ -15,32 +15,54 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
+
+#include <folly/container/F14Map.h>
 
 namespace facebook::axiom::connector {
 
 /// Read-only query-specific information passed to connectors.
 class ConnectorSession final {
  public:
-  explicit ConnectorSession(std::string queryId, std::string user = {})
-      : queryId_{std::move(queryId)}, user_{std::move(user)} {}
+  /// This connector's session properties keyed by name. Values are
+  /// connector-defined and not validated.
+  using ConnectorProperties = folly::F14FastMap<
+      std::string,
+      std::string,
+      folly::transparent<std::hash<std::string_view>>,
+      folly::transparent<std::equal_to<>>>;
+
+  ConnectorSession(
+      std::string queryId,
+      std::optional<std::string> user,
+      ConnectorProperties properties)
+      : queryId_{std::move(queryId)},
+        user_{std::move(user)},
+        properties_{std::move(properties)} {}
 
   /// Returns the query identifier.
   const std::string& queryId() const {
     return queryId_;
   }
 
-  /// Returns the identity of the user who submitted the query. Empty when
-  /// user context is unavailable.
-  const std::string& user() const {
+  /// Returns the user who submitted the query, or `std::nullopt` if
+  /// unavailable.
+  const std::optional<std::string>& user() const {
     return user_;
   }
 
+  /// Returns the value of property `name`, or `std::nullopt` if not set.
+  std::optional<std::string> property(std::string_view name) const;
+
  private:
   const std::string queryId_;
-  const std::string user_;
+  const std::optional<std::string> user_;
+  const ConnectorProperties properties_;
 };
 
 using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -126,7 +126,8 @@ class LocalHiveConnectorMetadataTest
       WriteKind kind,
       dwio::common::FileFormat format) {
     std::string outputPath = metadata_->tablePath(table->name());
-    auto session = std::make_shared<ConnectorSession>("q-test");
+    auto session = std::make_shared<ConnectorSession>(
+        "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
     auto handle =
         metadata_->beginWrite(session, table, kind, /*explain=*/false);
 
@@ -317,7 +318,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
       {HiveWriteOptions::kFileFormat, "parquet"},
       {HiveWriteOptions::kCompressionKind, "zstd"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "test"},
@@ -406,7 +408,8 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
       {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
       {HiveWriteOptions::kFileFormat, "parquet"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "add_col_test"},
@@ -524,7 +527,8 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumnExplain) {
   folly::F14FastMap<std::string, velox::Variant> options = {
       {HiveWriteOptions::kFileFormat, "parquet"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   metadata_->createTable(
       session,
       {kDefaultSchema, "explain_add_col_test"},
@@ -620,7 +624,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
        {"ts", VARCHAR()},
        {"ds", VARCHAR()}});
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "test_empty"},
@@ -655,7 +660,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
   auto tableType =
       ROW({{"key1", BIGINT()}, {"key2", BIGINT()}, {"ds", VARCHAR()}});
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto staged = metadata_->createTable(
       session,
       {kDefaultSchema, "test_insert"},
@@ -704,7 +710,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
 TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
   auto tableType =
       ROW({{"key1", BIGINT()}, {"key2", BIGINT()}, {"ds", VARCHAR()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
   std::string tablePath = metadata_->tablePath({kDefaultSchema, "test_abort"});
 
   auto table = metadata_->createTable(
@@ -748,7 +755,8 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExists) {
   auto tableType = ROW({{"col1", BIGINT()}, {"col2", VARCHAR()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   auto table = metadata_->createTable(
       session,
@@ -781,7 +789,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExists) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsNewTable) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   auto table = metadata_->createTable(
       session,
@@ -798,7 +807,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsNewTable) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   auto table = metadata_->createTable(
       session,
@@ -834,7 +844,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
 
 TEST_F(LocalHiveConnectorMetadataTest, dropTableIfExists) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   auto table = metadata_->createTable(
       session,
@@ -869,7 +880,8 @@ TEST_F(LocalHiveConnectorMetadataTest, dropTableIfExists) {
 
 TEST_F(LocalHiveConnectorMetadataTest, dropTableExplain) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = std::make_shared<ConnectorSession>(
+      "q-test", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   auto table = metadata_->createTable(
       session,

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -168,7 +168,8 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     auto table = metadata_->findTable(tableName);
     VELOX_CHECK_NOT_NULL(table);
 
-    auto session = std::make_shared<ConnectorSession>("test-query");
+    auto session = std::make_shared<ConnectorSession>(
+        "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
     velox::exec::SimpleExpressionEvaluator evaluator(
         queryCtx_.get(), pool_.get());
 
@@ -284,7 +285,8 @@ TEST_F(SystemConnectorMetadataTest, tableLayout) {
   EXPECT_EQ(layouts[0]->connectorId(), kSystemCatalog);
 
   // Verify column handle creation.
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = std::make_shared<ConnectorSession>(
+      "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto columnHandle = layouts[0]->createColumnHandle(session, "query_id");
   ASSERT_NE(columnHandle, nullptr);
   EXPECT_EQ(columnHandle->name(), "query_id");
@@ -297,7 +299,8 @@ TEST_F(SystemConnectorMetadataTest, tableHandle) {
   const auto& layouts = table->layouts();
   ASSERT_EQ(layouts.size(), 1);
 
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = std::make_shared<ConnectorSession>(
+      "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto columnHandle = layouts[0]->createColumnHandle(session, "query_id");
 
   velox::exec::SimpleExpressionEvaluator evaluator(
@@ -316,7 +319,8 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
   auto table = metadata_->findTable(kQueriesTable);
   ASSERT_NE(table, nullptr);
 
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = std::make_shared<ConnectorSession>(
+      "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
 
   velox::exec::SimpleExpressionEvaluator evaluator(
       queryCtx_.get(), pool_.get());
@@ -481,7 +485,8 @@ TEST_F(SystemConnectorMetadataTest, sessionPropertiesSchema) {
 }
 
 TEST_F(SystemConnectorMetadataTest, schemas) {
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = std::make_shared<ConnectorSession>(
+      "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
   EXPECT_THAT(
       metadata_->listSchemaNames(session),
       testing::UnorderedElementsAre(
@@ -492,7 +497,8 @@ TEST_F(SystemConnectorMetadataTest, schemas) {
 }
 
 TEST_F(SystemConnectorMetadataTest, listTableNames) {
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = std::make_shared<ConnectorSession>(
+      "test-query", std::nullopt, ConnectorSession::ConnectorProperties{});
   EXPECT_THAT(
       metadata_->listTableNames(session, std::string(kRuntimeSchema)),
       testing::ElementsAre(kQueriesTable.table));

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -660,13 +660,14 @@ velox::connector::ColumnHandlePtr TestTableLayout::createColumnHandle(
 }
 
 velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
-    const ConnectorSessionPtr& /*session*/,
+    const ConnectorSessionPtr& session,
     std::vector<velox::connector::ColumnHandlePtr> columnHandles,
     velox::core::ExpressionEvaluator& /* evaluator */,
     std::vector<velox::core::TypedExprPtr> filters,
     std::vector<velox::core::TypedExprPtr>& rejectedFilters,
     velox::RowTypePtr /* dataColumns */,
     std::optional<LookupKeys> /*lookupKeys*/) const {
+  observedSession_ = session;
   rejectedFilters = std::move(filters);
   return std::make_shared<TestTableHandle>(*this, std::move(columnHandles));
 }

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -154,10 +154,18 @@ class TestTableLayout : public TableLayout {
       velox::RowTypePtr dataColumns,
       std::optional<LookupKeys> lookupKeys) const override;
 
+  /// Returns the ConnectorSession seen by the most recent createTableHandle()
+  /// call, or nullptr if it has not been called.
+  const ConnectorSessionPtr& observedSession() const {
+    return observedSession_;
+  }
+
  private:
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
   std::shared_ptr<const PartitionType> partitionType_;
+
+  mutable ConnectorSessionPtr observedSession_;
 };
 
 /// RowVectors are appended using the addData() interface and the vector

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/common/Session.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 
 #include <folly/coro/GtestHelpers.h>
@@ -131,6 +132,41 @@ TEST_F(TestConnectorTest, columnHandle) {
   EXPECT_NE(testColumnHandle, nullptr);
   EXPECT_EQ(testColumnHandle->name(), "a");
   EXPECT_EQ(testColumnHandle->type()->kind(), TypeKind::INTEGER);
+}
+
+// Verifies a connector-scoped session property set on the engine Session
+// reaches a planning-time metadata callback via toConnectorSession().
+TEST_F(TestConnectorTest, sessionProperty) {
+  auto schema = ROW({"a"}, {INTEGER()});
+  auto table = connector_->addTable("table", schema);
+  auto& layout = *table->layouts()[0];
+
+  ConnectorSession::ConnectorProperties properties{
+      {"collect_column_statistics", "false"}};
+  Session session(
+      "q",
+      /*user=*/std::nullopt,
+      {{connector_->connectorId(), std::move(properties)}});
+
+  auto evaluator =
+      std::make_unique<exec::SimpleExpressionEvaluator>(nullptr, nullptr);
+  std::vector<velox::connector::ColumnHandlePtr> columns;
+  columns.push_back(layout.createColumnHandle(/*session=*/nullptr, "a"));
+  std::vector<core::TypedExprPtr> empty;
+  layout.createTableHandle(
+      session.toConnectorSession(connector_->connectorId()),
+      std::move(columns),
+      *evaluator,
+      empty,
+      empty);
+
+  const auto* testLayout = dynamic_cast<const TestTableLayout*>(&layout);
+  ASSERT_NE(testLayout, nullptr);
+  ASSERT_NE(testLayout->observedSession(), nullptr);
+  EXPECT_EQ(
+      testLayout->observedSession()->property("collect_column_statistics"),
+      std::optional<std::string>{"false"});
+  EXPECT_EQ(testLayout->observedSession()->property("missing"), std::nullopt);
 }
 
 CO_TEST_F(TestConnectorTest, splitManager) {

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -158,7 +158,8 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = std::make_shared<ConnectorSession>(
+      "test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto tables = metadata_->listTableNames(session, "tiny");
   EXPECT_THAT(
       tables,
@@ -174,7 +175,8 @@ TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = std::make_shared<ConnectorSession>(
+      "test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto tables = metadata_->listTableNames(session, "sf1");
   ASSERT_EQ(tables.size(), 8);
   for (const auto& table : tables) {
@@ -183,7 +185,8 @@ TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesInvalidSchema) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = std::make_shared<ConnectorSession>(
+      "test", std::nullopt, ConnectorSession::ConnectorProperties{});
   auto tables = metadata_->listTableNames(session, "invalid");
   EXPECT_THAT(tables, testing::IsEmpty());
 }

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -466,7 +466,8 @@ PlanAndStats Optimization::toVeloxPlan(
 
   VeloxHistory history;
 
-  auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+  auto session = std::make_shared<Session>(
+      veloxQueryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
   Optimization opt{
       session,

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -324,7 +324,10 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
           optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
     }
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test",
+        std::nullopt,
+        connector::ConnectorSession::ConnectorProperties{});
     auto table = metadata->createTable(
         session,
         statement.tableName(),
@@ -342,7 +345,10 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     const auto& tableName = statement.tableName();
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test",
+        std::nullopt,
+        connector::ConnectorSession::ConnectorProperties{});
     const bool dropped = metadata->dropTable(
         session, tableName, statement.ifExists(), /*explain=*/false);
 
@@ -588,7 +594,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     exec::SimpleExpressionEvaluator evaluator(
         queryCtx.get(), optimizerPool_.get());
 
-    auto session = std::make_shared<Session>(queryCtx->queryId());
+    auto session = std::make_shared<Session>(
+        queryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
     optimizer::OptimizerOptions optimizerOptions;
     optimizerOptions.traceFlags = FLAGS_optimizer_trace;

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -92,7 +92,8 @@ class DerivedTablePrinterTest : public ::testing::Test {
 
     auto schemaResolver = std::make_shared<connector::SchemaResolver>();
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(
+        veloxQueryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -161,7 +161,8 @@ void HiveQueriesTestBase::createEmptyTable(
     const folly::F14FastMap<std::string, velox::Variant>& options) {
   hiveMetadata().dropTableIfExists({kDefaultSchema, name});
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   auto table = hiveMetadata().createTable(
       session,
       {kDefaultSchema, name},
@@ -195,7 +196,8 @@ void HiveQueriesTestBase::createTableFromFiles(
         << "File does not exist: " << filePath;
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   hiveMetadata().createTable(
       session,
       {kDefaultSchema, tableName},
@@ -231,7 +233,8 @@ void HiveQueriesTestBase::runCtas(const std::string& sql) {
     options[key] = ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = std::make_shared<connector::ConnectorSession>(
+      "test", std::nullopt, connector::ConnectorSession::ConnectorProperties{});
   auto table = hiveMetadata().createTable(
       session,
       ctasStatement->tableName(),

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -63,7 +63,8 @@ class PrecomputeProjectionTest : public ::testing::Test {
 
     auto schemaResolver = std::make_shared<connector::SchemaResolver>();
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(
+        veloxQueryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -186,7 +186,8 @@ PlanCost QueryTestBase::optimizationCost(
   };
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
-  auto session = std::make_shared<Session>(queryCtx->queryId());
+  auto session = std::make_shared<Session>(
+      queryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
   connector::SchemaResolver schemaResolver;
   Optimization opt(
       session,
@@ -216,7 +217,8 @@ void QueryTestBase::verifyOptimization(
   exec::SimpleExpressionEvaluator evaluator(
       veloxQueryCtx.get(), optimizerPool_.get());
 
-  auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+  auto session = std::make_shared<Session>(
+      veloxQueryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
   connector::SchemaResolver schemaResolver;
   VeloxHistory history;
@@ -261,7 +263,8 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
-  auto session = std::make_shared<Session>(queryCtx->queryId());
+  auto session = std::make_shared<Session>(
+      queryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
   std::unique_ptr<std::ofstream> planPath;
   if (planFilePathPrefix.has_value()) {

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -144,7 +144,8 @@ class RelationOpPrinterTest : public ::testing::Test {
 
     auto schemaResolver = std::make_shared<connector::SchemaResolver>();
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(
+        veloxQueryCtx->queryId(), std::nullopt, Session::ConnectorProperties{});
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -122,7 +122,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool.get());
 
-  auto session = std::make_shared<Session>(queryId);
+  auto session = std::make_shared<Session>(
+      queryId, std::nullopt, Session::ConnectorProperties{});
   connector::SchemaResolver schemaResolver;
   VeloxHistory history;
 

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -73,7 +73,10 @@ class WriteTest : public test::HiveQueriesTestBase {
     auto& metadata = hiveMetadata();
     dropTableIfExists(name);
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test",
+        std::nullopt,
+        connector::ConnectorSession::ConnectorProperties{});
     auto table = metadata.createTable(
         session,
         {kDefaultSchema, name},
@@ -97,7 +100,10 @@ class WriteTest : public test::HiveQueriesTestBase {
       options[key] = ConstantExprEvaluator::evaluateConstantExpr(*value);
     }
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test",
+        std::nullopt,
+        connector::ConnectorSession::ConnectorProperties{});
     auto table = metadata.createTable(
         session,
         statement.tableName(),

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -80,7 +80,9 @@ facebook::axiom::connector::TablePtr createTable(
   auto tableSchema = velox::ROW(std::move(schemaNames), std::move(schemaTypes));
 
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "pyspark_session");
+      "pyspark_session",
+      std::nullopt,
+      facebook::axiom::connector::ConnectorSession::ConnectorProperties{});
   auto table = metadata->createTable(
       session,
       writeNode.tableName(),
@@ -129,8 +131,10 @@ facebook::axiom::optimizer::PlanAndStats optimize(
   auto queryCtx = velox::core::QueryCtx::create();
   velox::exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool);
 
-  auto session =
-      std::make_shared<facebook::axiom::Session>(queryCtx->queryId());
+  auto session = std::make_shared<facebook::axiom::Session>(
+      queryCtx->queryId(),
+      std::nullopt,
+      facebook::axiom::Session::ConnectorProperties{});
 
   facebook::axiom::optimizer::Optimization opt(
       session,

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2298,7 +2298,9 @@ SqlStatementPtr parseShowSchemas(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-schemas");
+      "show-schemas",
+      std::nullopt,
+      facebook::axiom::connector::ConnectorSession::ConnectorProperties{});
   auto schemaNames = metadata->listSchemaNames(session);
   std::sort(schemaNames.begin(), schemaNames.end());
 
@@ -2348,7 +2350,9 @@ SqlStatementPtr parseShowTables(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-tables");
+      "show-tables",
+      std::nullopt,
+      facebook::axiom::connector::ConnectorSession::ConnectorProperties{});
   VELOX_USER_CHECK(
       metadata->schemaExists(session, schema),
       "Schema does not exist: {}",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/95


Connector metadata runs at plan time and receives a `ConnectorSession`, but that session carried only `queryId` and `user`. On the execution path a `SET SESSION catalog.key = value` already reaches connectors through Velox; the planning path had no equivalent channel, so a connector could not read a per-query override while the optimizer was planning.

`axiom::Session` now groups session properties by connector id. `toConnectorSession(connectorId)` returns that connector's slice with a single `find` (no prefix parsing), exposed via `ConnectorSession::property(name)`. The Axiom CLI populates the map from `SET SESSION`, reusing the same `SessionConfig` source it already uses for the execution-path connector configs, so an override set in SQL reaches a connector's planning-time metadata end to end.

Differential Revision: D105868669


