### PR TITLE
fix(logical_plan): Preserve SELECT alias colliding with id (#1399)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -625,9 +625,18 @@ void PlanBuilder::resolveProjections(
       const auto& id = expr->as<InputReferenceExpr>()->name();
       if (seenColumnIds.emplace(id).second) {
         outputNames.push_back(id);
-        for (const auto& name : outputMapping_->reverseLookup(id)) {
-          nameTracker.add(name, outputNames.back());
+        if (alias.has_value()) {
+          // An explicit alias overrides any name the source exposed for
+          // this column.
+          nameTracker.add(alias.value(), outputNames.back());
+        } else {
+          for (const auto& name : outputMapping_->reverseLookup(id)) {
+            nameTracker.add(name, outputNames.back());
+          }
         }
+        // TODO: An explicit alias on an identity projection does not
+        // override the source's userName, so the pre-alias name may
+        // surface in the output schema.
         mappings.copyUserName(id, *outputMapping_);
       } else {
         outputNames.push_back(newName(id));

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1390,6 +1390,12 @@ TEST_F(PrestoParserTest, outputNames) {
   // Duplicate output column names are preserved as-is (not deduplicated to
   // x, x_0).
   test("SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b)", {"x", "x"});
+
+  // SELECT * over a subquery with duplicate output aliases preserves the
+  // duplicate aliases.
+  test(
+      "SELECT * FROM (SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b))",
+      {"x", "x"});
 }
 
 // Explicit SELECT aliases preserve the user's original case in the output
@@ -1496,6 +1502,19 @@ TEST_F(PrestoParserTest, outputNamesPreserveAliasCase) {
       outputNames(
           "SELECT * FROM ((SELECT 1 AS FooBar) UNION ALL (SELECT 2 AS Bar)) u"),
       testing::ElementsAre("FooBar"));
+}
+
+TEST_F(PrestoParserTest, renameToAliasMatchingInnerColumnName) {
+  // A SELECT-list rename must be honored even when the alias coincides
+  // with a column name appearing in an inner subquery.
+  EXPECT_THAT(
+      parseSelect(
+          "WITH src AS (SELECT 1 AS x_2024),"
+          "     renamed AS (SELECT x_2024 AS x FROM src) "
+          "SELECT x FROM renamed")
+          ->outputType()
+          ->names(),
+      testing::ElementsAre("x"));
 }
 
 TEST_F(PrestoParserTest, qualifiedStarInUnionAfterJoin) {


### PR DESCRIPTION
Summary:

A SELECT-list rename was silently dropped when the alias happened to equal an internal column id, so downstream references to the alias failed with `Cannot resolve column`. For example, `SELECT x_2024 AS x FROM src` over a CTE producing `x_2024` left the outer scope advertising the column as `x_2024` instead of `x`, because `NameAllocator::newName` strips a trailing `_<digits>` suffix from id hints and the resulting id `x` was treated as proof that the projection was an identity.

In `PlanBuilder::resolveProjections`, when an identity projection carries an explicit alias, register that alias as the column's user-facing name instead of inheriting the source's `reverseLookup` names.

Differential Revision: D105947464


