### PR TITLE
docs(skills): Add write-commit-message skill (#1400)

### DIFF
--- a/.claude/skills/write-commit-message/SKILL.md
+++ b/.claude/skills/write-commit-message/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: write-commit-message
+description: Draft a commit message for an Axiom commit. Use when the user asks to write, draft, or compose a commit message for an Axiom change. Encodes the project's content rules so the draft is showable without a separate review pass.
+---
+
+# Write Commit Message
+
+Drafts a commit message that follows the rules in `.claude/CLAUDE.md` (sections "Commit Messages" and "Body length and shape"). The rules there are authoritative — this skill is the workflow for applying them.
+
+## Process
+
+1. **Read the rules** — Open `.claude/CLAUDE.md` and re-read the "Commit Messages" and "Body length and shape" sections. Do not draft from memory.
+
+2. **Gather facts from the diff itself** — Never draft from the conversation alone. The conversation has scaffolding; the diff is the truth.
+   - Read the existing commit message (if amending).
+   - Read the full diff, not just file names.
+   - List the files touched.
+   - If the change fixes a bug, identify the user-visible symptom (error string, wrong output, crash) from the diff or the conversation. If you cannot state the symptom concretely, ask the user before drafting.
+
+3. **Draft** — Match length to the change. Each paragraph is one long line (no hard wraps). The right shape depends on what the diff actually does:
+
+   - **Trivial** (typo fix, comment edit, one-line rename, dependency bump): title alone, or title + one sentence + one-line test plan. Padding a trivial change with three paragraphs is a fail.
+   - **Small** (a focused bug fix, a single-file refactor, a small new helper): title + one paragraph (what + why with a concrete anchor) + one-line test plan.
+   - **Standard** (most fixes and features): title + 2-4 short paragraphs as below.
+   - **Large**: if you find yourself wanting >4 body paragraphs, the change should probably be split — or the extra material belongs in separate documentation (design doc, issue, wiki page) that the summary links to, not inlined in the commit message.
+
+   **Title**: `[Axiom] type(scope): Description` — capital start, no trailing period, ≤67 chars. Type ∈ {feat, fix, refactor, test, docs}. Scope optional.
+
+   Body paragraphs (include only those that carry weight for this change):
+   - **What + why**: lead with user-visible behavior change. Include one concrete example query, error message, or before/after fact. A reader without internals knowledge should get the gist.
+   - **Mechanism**: the core idea as ONE concept — a new field, a swapped algorithm, an added check, a rewrite step. Skip when the title + "what + why" already conveys it.
+   - **Deferred**: name a deliberately-not-done case and how it surfaces (NYI message, follow-up issue). Skip if none.
+   - **Test plan**: high-level coverage. Name the test file(s) and what scenarios they cover. Don't write "tests pass" or "CI green" — CI reports that; restating it is noise. State what was *covered*, not that it succeeded. For pure refactors with no new tests, omit the Test Plan section entirely — "existing tests cover this" / "covered by CI" is implied by "pure refactor" and adds no information.
+
+   **Prose clarity** — write so a tired reader gets each sentence on first read.
+   - Prefer short sentences. If a sentence has two clauses joined by "so", "because", "but", "even though", "although", or a comma + participle, consider splitting it. Contrastive joiners ("but X", "even though Y") are especially risky when both halves introduce a fact the reader does not already have — pack two new facts into one sentence and the reader stalls. State each rule in its own sentence, then connect them.
+   - Avoid stacked abstractions like "left the outer scope advertising the column as X" or "the projection inherits the source's reverseLookup names". Replace with a concrete chain.
+   - Avoid compiler/optimizer jargon ("outer reference", "outer scope", "binding context", "name resolution scope") unless the rest of the paragraph already established it. If you must use it, define it inline with a tiny example.
+   - Prefer plain verbs (`used`, `dropped`, `kept`) over jargon verbs (`advertise`, `surface`, `propagate`, `materialize`) unless the jargon is the precise term.
+   - Avoid hyphenated compound-noun stacks ("user-written case", "lookup-based fallback", "context-aware resolver"). They require the reader to unpack a modifier chain before getting to the noun. Rewrite as a relative clause ("the case the user wrote") or a single concrete noun.
+   - Prefer the word with one obvious meaning in this context. "Case" can mean legal case, match case, or upper/lower case — use "capitalization" when you mean letter case. Similarly: "operator" vs "function", "key" vs "column", "type" vs "kind" — pick the one a SQL reader and a C++ reader both interpret the same way.
+   - Show a complete example query that demonstrates the failure, paired with the resulting error. Don't describe a query in prose ("a reference to X from an outer query") when you can show one (`SELECT x FROM (...)`); the example carries the meaning without the reader holding context across sentences.
+   - Break any long code, query, or error string out into a fenced block on its own line. "Long" means more than ~6 words or anything that wraps the surrounding paragraph awkwardly. This applies whether the long string is paired with another or stands alone — a single long error string embedded mid-sentence still overloads the reader. Patterns:
+
+     Lead with the error, then explain:
+
+     ```
+     Planning failed with:
+
+         Ranking filter limit not consumed by RowNumber or TopNRowNumber
+
+     This happened for ranking queries whose ORDER BY became empty after redundancy elimination.
+     ```
+
+     Query + result:
+
+     ```
+     For example:
+
+         SELECT x FROM (SELECT x_2024 AS x FROM src)
+
+     fails with `Cannot resolve column` — the inner subquery produces a column named `x_2024`, not `x`.
+     ```
+
+     Short fragments (a single column name, a flag, a 2-3-word error name) stay inline.
+   - When in doubt, read the paragraph aloud. If you pause mid-sentence to decode it, split or simplify it.
+
+4. **Self-check before showing** — Walk every item; do not skip any.
+   - [ ] Title matches `[Axiom] type(scope): Description`, capital, no period, ≤67 chars.
+   - [ ] Para 1 leads with behavior, not internal symbol names.
+   - [ ] Para 1 has a concrete anchor (example, error message, before/after).
+   - [ ] Mechanism is one concept, not a diff retrace with sibling-function names.
+   - [ ] No reasoning journey (alternatives considered, sibling reused, layered fixes).
+   - [ ] Code symbols in plain backticks; never `` \`escaped\` ``.
+   - [ ] Each paragraph is ONE long line. No hard wrap at 72/80 columns. Bullet lists in the test plan are the exception.
+   - [ ] No "tests pass" / "N tests pass" / "CI green".
+   - [ ] Every factual claim verified against the diff, not recalled.
+   - [ ] Reads in ~30 seconds.
+   - [ ] Length matches the change. Trivial changes are not padded to standard length; standard changes are not condensed to one line.
+   - [ ] Prose clarity: no sentence longer than ~30 words; no stacked abstractions ("X advertising Y", "scope of Z"). Each sentence is parseable on first read.
+
+   If any item fails, fix the draft before showing.
+
+5. **Show the draft** — Present the final draft. Mention any facts you could not verify and want the user to confirm.
+
+## Common failure modes to avoid
+
+These are the patterns drafts most often hit, and that this skill exists to prevent:
+
+- **Restating the diff as prose** — "Adds X. Modifies Y. Changes Z." That's what the diff shows. State the behavior change and the one concept behind it.
+- **Function-by-function walkthrough** — "In `foo()`, we now do A. In `bar()`, we adjust B." The reviewer reads the diff for that. Collapse into the single mechanism.
+- **Enumerating touched files, classes, or call sites** — "Adopt it in `Foo`, `Bar`, `Baz`, `Qux`, and `Quux`." or "Updated across N call sites." The diff is the source of truth for scope. Naming the touched symbols eats space without informing the reader. Exception: name a specific file only when its role in the change is not obvious from the title (e.g., the test file that needed expectation updates, or the one production file the rest of the diff supports).
+- **Long lists embedded in a sentence** — any comma-separated enumeration of more than ~3 items inside a sentence forces the reader to parse a list while tracking the surrounding clause. Examples: a list of test scenarios ("covers aliases, qualified refs, star expansion, CTE expansion, AliasedRelation, set operations, and global aggregation"), a list of SQL variants ("DATE+INTERVAL, TIMESTAMP+INTERVAL, BIGINT same-type, INTEGER→BIGINT coercion, DESC ordering, ..."). Fix by either (a) breaking the list out into its own bullet sub-list, or (b) summarizing as a category ("the main alias-resolution scenarios"). The bullet form scales with item count; the summary form is right when individual items don't carry weight.
+- **Missing big picture** — Diving into internal symbols in paragraph 1. Lead with user-visible behavior; descend into mechanism in paragraph 2.
+- **Reasoning scaffolding** — "We considered X but chose Y because Z." Belongs in design docs or PR threads, not the commit log.
+- **Hard-wrapped paragraphs** — Hard line breaks at ~70/80 columns render as ragged short lines wherever the message is reflowed.
+- **Pass-counting test plans** — "All 47 tests pass." CI says that. State *what was covered*, not that it succeeded.
+
+## When NOT to invoke
+
+- Pure typo fixes to an already-approved message.
+- The user provides the full message themselves and asks you to commit it verbatim.
+
+For all other Axiom commit-message work — drafting, revising, or rewriting — invoke this skill.

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -625,9 +625,18 @@ void PlanBuilder::resolveProjections(
       const auto& id = expr->as<InputReferenceExpr>()->name();
       if (seenColumnIds.emplace(id).second) {
         outputNames.push_back(id);
-        for (const auto& name : outputMapping_->reverseLookup(id)) {
-          nameTracker.add(name, outputNames.back());
+        if (alias.has_value()) {
+          // An explicit alias overrides any name the source exposed for
+          // this column.
+          nameTracker.add(alias.value(), outputNames.back());
+        } else {
+          for (const auto& name : outputMapping_->reverseLookup(id)) {
+            nameTracker.add(name, outputNames.back());
+          }
         }
+        // TODO: An explicit alias on an identity projection does not
+        // override the source's userName, so the pre-alias name may
+        // surface in the output schema.
         mappings.copyUserName(id, *outputMapping_);
       } else {
         outputNames.push_back(newName(id));

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1390,6 +1390,12 @@ TEST_F(PrestoParserTest, outputNames) {
   // Duplicate output column names are preserved as-is (not deduplicated to
   // x, x_0).
   test("SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b)", {"x", "x"});
+
+  // SELECT * over a subquery with duplicate output aliases preserves the
+  // duplicate aliases.
+  test(
+      "SELECT * FROM (SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b))",
+      {"x", "x"});
 }
 
 // Explicit SELECT aliases preserve the user's original case in the output
@@ -1496,6 +1502,19 @@ TEST_F(PrestoParserTest, outputNamesPreserveAliasCase) {
       outputNames(
           "SELECT * FROM ((SELECT 1 AS FooBar) UNION ALL (SELECT 2 AS Bar)) u"),
       testing::ElementsAre("FooBar"));
+}
+
+TEST_F(PrestoParserTest, renameToAliasMatchingInnerColumnName) {
+  // A SELECT-list rename must be honored even when the alias coincides
+  // with a column name appearing in an inner subquery.
+  EXPECT_THAT(
+      parseSelect(
+          "WITH src AS (SELECT 1 AS x_2024),"
+          "     renamed AS (SELECT x_2024 AS x FROM src) "
+          "SELECT x FROM renamed")
+          ->outputType()
+          ->names(),
+      testing::ElementsAre("x"));
 }
 
 TEST_F(PrestoParserTest, qualifiedStarInUnionAfterJoin) {


### PR DESCRIPTION
Summary:

Adds a `write-commit-message` skill that drafts Axiom commit messages following the rules in `coding-style.md`. The skill walks the agent through a structured process and includes a self-check, so drafts are showable without a separate review pass.

Lives in two parallel files per the existing `coding-style.md` ↔ OSS `CLAUDE.md` sync convention:
- `axiom/.llms/skills/write-commit-message/SKILL.md` — internal copy, with Meta-specific guidance.
- `axiom/public_tld/.claude/skills/write-commit-message/SKILL.md` — OSS-mirrored copy, sanitized of internal references.

Also updates `diff-review` to check commit message quality during review. If 2 or more self-check items fail, the reviewer posts a single summary comment asking the author to redo the message using the new skill and amend. This keeps reviewers from rewriting messages inline and gives the author a single, actionable pointer.

The skill was developed against nine existing Axiom commits — each draft that was rejected as hard to read produced a new rule, then we re-ran the skill from scratch and verified the rule caught the issue.

Differential Revision: D105956010


