### PR TITLE
feat(cli): Register PrestoConfigProvider for SET/SHOW SESSION (#1401)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
 target_link_libraries(
   axiom_cli
   velox_connector_registry
+  velox_presto_query_config
   velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -45,6 +45,8 @@
 #include "velox/core/QueryConfigProvider.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/PrestoConfigProvider.h"
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
@@ -167,6 +169,10 @@ void SqlQueryRunner::initialize(
   configRegistry_->add(
       kExecutionPrefix,
       std::make_shared<facebook::velox::core::QueryConfigProvider>());
+  configRegistry_->add(
+      velox::functions::prestosql::PrestoQueryConfig::kPrefix,
+      std::make_shared<
+          facebook::velox::functions::prestosql::PrestoConfigProvider>());
 
   // Register config providers for connectors that support session properties.
   for (const auto& [connectorId, connector] :
@@ -188,8 +194,8 @@ void SqlQueryRunner::initialize(
       velox::core::QueryConfig::kAdjustTimestampToTimezone,
       "true");
   sessionConfig_->set(
-      kExecutionPrefix,
-      velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+      velox::functions::prestosql::PrestoQueryConfig::kPrefix,
+      velox::functions::prestosql::PrestoQueryConfig::kArrayAggIgnoreNulls,
       "true");
 }
 
@@ -761,10 +767,17 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
   const auto queryId =
       options.queryId.value_or(fmt::format("query_{}", ++queryCounter_));
 
-  // Build Velox QueryConfig from execution session properties.
+  // Build Velox QueryConfig from session properties.
   auto executionProps = sessionConfig_->effectiveValues(kExecutionPrefix);
   std::unordered_map<std::string, std::string> queryConfig(
       executionProps.begin(), executionProps.end());
+  // effectiveValues() strips the prefix; re-qualify (e.g. 'foo' ->
+  // 'presto.foo') so PrestoQueryConfig accessors find the value.
+  for (const auto& [name, value] : sessionConfig_->effectiveValues(
+           velox::functions::prestosql::PrestoQueryConfig::kPrefix)) {
+    queryConfig[velox::functions::prestosql::PrestoQueryConfig::qualify(name)] =
+        value;
+  }
   // Per-query value, not a session property.
   queryConfig[velox::core::QueryConfig::kSessionStartTime] = std::to_string(
       options.sessionStartTimeMs.value_or(velox::getCurrentTimeMs()));

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -279,6 +279,41 @@ execution.session_timezone*| UTC*|*| STRING*| * (glob)
 
 ```
 
+## Presto function-package session property: array_agg.ignore_nulls
+
+```scrut
+$ $CLI --query "SHOW SESSION LIKE '%presto%';
+> SELECT array_agg(x) AS a FROM unnest(array[1,2,null]) _(x);
+> SET SESSION presto.array_agg.ignore_nulls = 'false';
+> SHOW SESSION LIKE '%presto%';
+> SELECT array_agg(x) AS a FROM unnest(array[1,2,null]) _(x)" 2>/dev/null
+*-+-*-+-*-+-* (glob)
+Name*| Value*| Default*| Type*| Description (glob)
+*-+-*-+-*-+-* (glob)
+presto.array_agg.ignore_nulls*| true*| false*| BOOLEAN*| * (glob)
+(1 rows in 1 batches)
+
+------
+     a
+------
+[1, 2]
+(1 rows in 1 batches)
+
+Session 'presto.array_agg.ignore_nulls' set to 'false'
+*-+-*-+-*-+-* (glob)
+Name*| Value*| Default*| Type*| Description (glob)
+*-+-*-+-*-+-* (glob)
+presto.array_agg.ignore_nulls*| false*| false*| BOOLEAN*| * (glob)
+(1 rows in 1 batches)
+
+------------
+           a
+------------
+[1, 2, null]
+(1 rows in 1 batches)
+
+```
+
 ## Error message for non-existent table
 
 ```scrut


### PR DESCRIPTION
Summary:

`SET SESSION presto.X` and `SHOW SESSION LIKE '%presto%'` now work in the Axiom CLI. After `presto.array_agg.ignore_nulls` moved to `PrestoQueryConfig`, the session registry no longer knew about it — `SET` threw "Unknown session property". A session round-trip now looks like:

    > SHOW SESSION LIKE '%presto%';
    presto.array_agg.ignore_nulls | true | false | BOOLEAN | ...
    > SELECT array_agg(x) FROM unnest(array[1, 2, null]) _(x);
    [1, 2]
    > SET SESSION presto.array_agg.ignore_nulls = 'false';
    > SELECT array_agg(x) FROM unnest(array[1, 2, null]) _(x);
    [1, 2, null]

`SqlQueryRunner` registers `PrestoConfigProvider` under `presto`. At query construction, `effectiveValues("presto")` is re-qualified before insertion into `QueryConfig`.

`presto` is a top-level prefix (sibling to `optimizer` and `execution`), not nested under `execution.presto.X`. The Presto function package is cross-cutting: it registers planning resolvers via `optimizer::FunctionRegistry::registerPrestoFunctions()` and runtime knobs via `PrestoConfigProvider`. Nesting under a single layer would mislead about what is being configured (a package, not a layer). If we ever split configs by layer, `presto.execution.X` / `presto.optimizer.X` would be the more natural shape than the layer-first inverse.

Differential Revision: D106053759


