### PR TITLE
refactor: Elide rename Projects at internal DT exits (#1402)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -222,7 +222,10 @@ DerivedTableScopeUse classifyScope(ExprCP expr, DerivedTableP dt) {
 }
 } // namespace
 
-void ToGraph::addDtColumn(DerivedTableP dt, std::string_view name) {
+void ToGraph::addDtColumn(
+    DerivedTableP dt,
+    std::string_view name,
+    bool propagateAlias) {
   const auto* expr = translateColumn(name);
 
   const auto scope = classifyScope(expr, dt);
@@ -246,7 +249,13 @@ void ToGraph::addDtColumn(DerivedTableP dt, std::string_view name) {
     dtColumn = expr->as<Column>();
   } else {
     const auto* columnName = toName(name);
-    dtColumn = make<Column>(columnName, dt, expr->value(), columnName);
+    Name alias = columnName;
+    if (propagateAlias && expr->isColumn() &&
+        expr->as<Column>()->relation() != dt &&
+        expr->as<Column>()->alias() != nullptr) {
+      alias = expr->as<Column>()->alias();
+    }
+    dtColumn = make<Column>(columnName, dt, expr->value(), alias);
   }
 
   dt->exprs.push_back(expr);
@@ -520,10 +529,11 @@ lp::ValuesNodePtr tryFoldConstantDt(
 
 void ToGraph::setDtUsedOutput(
     DerivedTableP dt,
-    const lp::LogicalPlanNode& node) {
+    const lp::LogicalPlanNode& node,
+    bool propagateAlias) {
   const auto& type = *node.outputType();
   for (auto i : usedChannels(node)) {
-    addDtColumn(dt, type.nameOf(i));
+    addDtColumn(dt, type.nameOf(i), propagateAlias);
   }
   dt->outputColumns = dt->columns;
 }
@@ -4594,7 +4604,7 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
   const auto& planRoot = *result.planRoot;
   currentDt_ = newDt();
   makeQueryGraph(planRoot, kAllAllowedInDt, /*orderObservedAbove=*/true);
-  setDtUsedOutput(currentDt_, planRoot);
+  setDtUsedOutput(currentDt_, planRoot, /*propagateAlias=*/false);
 
   // TODO Try constant fold the dt.
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -597,7 +597,17 @@ class ToGraph {
   // 'applyContext_.lifted.projections' (via 'splitCorrelatedProjection' for the
   // mixed-reference variant), and 'dt' is not extended with the unsplit
   // form (which would violate DerivedTable::checkConsistency).
-  void addDtColumn(DerivedTableP dt, std::string_view name);
+  //
+  // When 'propagateAlias' is true and the expression is a Column from a
+  // different relation with a non-null alias, the new wrapper Column
+  // inherits that alias so its outputName() matches the source. Same-DT
+  // columns are not affected (their requested 'name' is preserved as the
+  // wrapper's alias). Pass false at the top-level DT to preserve the
+  // makeQueryGraph name-preservation contract.
+  void addDtColumn(
+      DerivedTableP dt,
+      std::string_view name,
+      bool propagateAlias = true);
 
   // Splits a subquery projection expression that references both 'dt's
   // own tables and tables from an enclosing scope. Local-only maximal
@@ -610,11 +620,12 @@ class ToGraph {
   ExprCP splitCorrelatedProjection(ExprCP expr, DerivedTableP dt);
 
   // Populates 'dt' with one column per ordinal in usedChannels(node),
-  // named via node.outputType().nameOf(ordinal). Establishes the
-  // makeQueryGraph name-preservation contract; ordering is unspecified.
+  // named via node.outputType().nameOf(ordinal); ordering is unspecified.
+  // See addDtColumn for 'propagateAlias'.
   void setDtUsedOutput(
       DerivedTableP dt,
-      const logical_plan::LogicalPlanNode& node);
+      const logical_plan::LogicalPlanNode& node,
+      bool propagateAlias = true);
 
   DerivedTableP newDt();
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -518,8 +518,6 @@ TEST_F(JoinTest, crossThenLeft) {
   auto matcher =
       matchValues()
           .aggregation()
-          // TODO Remove redundant projection.
-          .project()
           .hashJoin(
               matchScan("u").nestedLoopJoin(matchScan("t").build()).build(),
               velox::core::JoinType::kRight)
@@ -586,13 +584,7 @@ TEST_F(JoinTest, filterPushdownThroughCrossJoinUnnest) {
         "SELECT * FROM (VALUES row(row(1, 2))) as t(x), UNNEST(array[1,2,3]) WHERE x.field0 > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchValues()
-                       .filter()
-                       // TODO Combine 2 projects into one.
-                       .project()
-                       .project()
-                       .unnest()
-                       .build();
+    auto matcher = matchValues().filter().project().unnest().project().build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -462,7 +462,6 @@ TEST_F(SetTest, exceptAll) {
   auto matchBuild = [](auto filters) {
     return core::PlanMatcherBuilder()
         .hiveScan("nation", std::move(filters))
-        .project()
         .build();
   };
 
@@ -501,7 +500,6 @@ TEST_F(SetTest, exceptAll) {
   auto matchPartitionedBuild = [](auto filters) {
     return core::PlanMatcherBuilder()
         .hiveScan("nation", std::move(filters))
-        .project()
         .shuffle()
         .build();
   };
@@ -541,7 +539,7 @@ TEST_F(SetTest, intersectAll) {
       kTestConnectorId);
 
   auto matchBuild = [](const std::string& table) {
-    return matchScan(table).project().build();
+    return matchScan(table).build();
   };
   {
     // Single-driver: counting left semi filter joins, no aggregation.
@@ -569,7 +567,7 @@ TEST_F(SetTest, intersectAll) {
   }
 
   auto matchPartitionedBuild = [](const std::string& table) {
-    return matchScan(table).project().shuffle().build();
+    return matchScan(table).shuffle().build();
   };
 
   {

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1140,7 +1140,6 @@ TEST_F(UnnestTest, join) {
                        .values()
                        .project()
                        .unnest()
-                       .project()
                        .hashJoin(
                            core::PlanMatcherBuilder{}
                                .values()
@@ -1148,6 +1147,7 @@ TEST_F(UnnestTest, join) {
                                .unnest()
                                .project()
                                .build())
+                       .project()
                        .build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);


### PR DESCRIPTION
Summary:

Internal DerivedTable exits used to emit a Project that renamed an inner column's name to the DT's output name. Consider:

    WITH v AS (
      SELECT v0, count(*) AS v1 FROM (VALUES 1,2,3) AS x(v0) GROUP BY v0
    )
    SELECT count(*), sum(v1)
    FROM (VALUES 1, 4) AS u(x) LEFT JOIN v ON u.x = v.v0

The inner Aggregation produced channel `c0_0` (Values' name); the WITH-clause exposed it as `v0`, so a Project sat on top of v's Aggregation just to rename `c0_0` to `v0`. Before / after:

    Before:
      Aggregation[count := count(), sum := sum("v1")] -> count, sum
        HashJoin[RIGHT v0=c0] -> v1
          Project[(v0:INT, "c0_0"), (v1:BIGINT, "v1")] -> v0, v1
            Aggregation[SINGLE [c0_0] v1 := count()] -> c0_0, v1
              Values -> c0_0
          Values -> c0

    After:
      Aggregation[count := count(), sum := sum("v1")] -> count, sum
        HashJoin[RIGHT c0_0=c0] -> v1
          Aggregation[SINGLE [c0_0] v1 := count()] -> c0_0, v1
            Values -> c0_0
          Values -> c0

The Project did no computation - only renames - and is now gone. The HashJoin's equality changes from `v0=c0` to `c0_0=c0`; both reference the same underlying value.

When `addDtColumn` mints a wrapper Column for a pure cross-DT column reference, the wrapper now inherits the source Column's alias. Both the wrapper and the source then report the same `outputName()`, so the existing `Project::isRedundant` check in `RelationOp.cpp` elides the DT-exit Project at codegen.

The top-level DT keeps the prior behavior. Its output column names form the makeQueryGraph name-preservation contract that `ToVelox::addOutputRenames` relies on for OutputNode lookup. The opt-out is a single `propagateAlias=false` at the top-level `setDtUsedOutput` call.

Differential Revision: D106095262


