### PR TITLE
fix: Process subqueries in aggregate ORDER BY expressions (#1403)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1777,10 +1777,19 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
   const auto numGroupingKeys = agg.groupingKeys().size();
   const auto channels = usedChannels(agg);
+
+  // Looked up twice per aggregate: subquery processing and translation.
+  std::vector<velox::exec::AggregateFunctionMetadata> aggMetadata;
+  aggMetadata.reserve(agg.aggregates().size());
+  for (const auto& aggregate : agg.aggregates()) {
+    aggMetadata.push_back(
+        velox::exec::getAggregateFunctionMetadata(aggregate->name()));
+  }
+
   {
     bool mayFinalize = true;
-    // Single chain spans all grouping-key and aggregate-input/filter
-    // expressions so heavy-path correlated scalar subqueries across them
+    // Single chain spans all grouping-key, aggregate-input, filter, and
+    // ordering expressions so correlated scalar subqueries across them
     // share the wrap-and-export state.
     SubqueryChain chain;
     for (const auto& key : agg.groupingKeys()) {
@@ -1800,6 +1809,11 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       }
       if (aggregate->filter()) {
         processSubqueries(input, aggregate->filter(), mayFinalize, chain);
+      }
+      if (aggMetadata[channel - numGroupingKeys].orderSensitive) {
+        for (const auto& field : aggregate->ordering()) {
+          processSubqueries(input, field.expression, mayFinalize, chain);
+        }
       }
     }
   }
@@ -1907,8 +1921,7 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
     auto aggName = toName(aggregate->name());
 
-    const auto& metadata =
-        velox::exec::getAggregateFunctionMetadata(aggregate->name());
+    const auto& metadata = aggMetadata[channel - numGroupingKeys];
 
     if (metadata.ignoreDuplicates) {
       funcs = funcs | FunctionSet::kIgnoreDuplicatesAggregate;

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -526,3 +526,12 @@ SELECT x FROM (SELECT x, sum(x) AS sx FROM s GROUP BY x) WHERE sx > 0
 ----
 -- IN with a constant left-hand side over a no-FROM subquery.
 SELECT 1 WHERE 1 IN (SELECT 1)
+----
+-- Scalar subquery in aggregate ORDER BY expression.
+SELECT array_agg(a ORDER BY a + (SELECT 1)) AS vals FROM t
+----
+-- Scalar subquery in aggregate ORDER BY with GROUP BY.
+SELECT a, array_agg(b ORDER BY b + (SELECT 0)) AS vals FROM t GROUP BY a
+----
+-- Non-order-sensitive aggregate with ORDER BY containing a subquery.
+SELECT sum(a ORDER BY a + (SELECT 1)) AS total FROM t


### PR DESCRIPTION
Summary:

`processSubqueries` in `translateAggregation` processes subquery expressions in aggregate inputs and filters but skips ordering expressions. A query like `array_agg(a ORDER BY a + (SELECT 1))` fails with a `VELOX_CHECK` in `translateExpr` because the `(SELECT 1)` subquery was never wrapped and exported during the subquery processing pass.

Add the missing `processSubqueries` call for `aggregate->ordering()`, matching the existing pattern for inputs and filter. The call shares the same `SubqueryChain` so correlated subqueries across inputs, ordering, and filter share wrap-and-export state.

Reviewed By: mbasmanova

Differential Revision: D99000025


