### PR TITLE
fix(optimizer): Trim rejected-filter columns at the scan source

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3190,6 +3190,147 @@ std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
 }
 } // namespace
 
+namespace {
+// True if 'candidate' joins on equi-keys (not a cross product).
+bool isRealEdgeCandidate(const NextJoin& candidate) {
+  return candidate.candidate->join != nullptr &&
+      candidate.candidate->join->numKeys() > 0;
+}
+} // namespace
+
+void Optimization::greedyJoinChainDescend(
+    RelationOpPtr plan,
+    PlanState& state) {
+  VELOX_CHECK_NOT_NULL(plan);
+
+  if (placeConjuncts(plan, state, false)) {
+    return;
+  }
+
+  auto candidates = nextJoins(state);
+  if (candidates.empty()) {
+    if (placeConjuncts(plan, state, true)) {
+      return;
+    }
+
+    const auto downstream = state.downstreamColumns();
+    std::vector<DerivedTableCP> singleRowDtsToPlace;
+    state.dt->singleRowDts.forEach<DerivedTable>([&](DerivedTableCP subquery) {
+      if (!state.isPlaced(subquery)) {
+        if (!downstream.containsAny(subquery->columns)) {
+          state.place(subquery);
+        } else {
+          singleRowDtsToPlace.push_back(subquery);
+        }
+      }
+    });
+
+    for (const auto* singleRowDt : singleRowDtsToPlace) {
+      plan = placeSingleRowDt(plan, singleRowDt, state);
+    }
+
+    addPostprocess(state.dt, plan, state);
+    state.plans.addPlan(plan, state);
+    return;
+  }
+
+  std::vector<NextJoin> nextJoins;
+  nextJoins.reserve(candidates.size());
+  for (auto& candidate : candidates) {
+    // Multi-table builds and existence imports retrigger expensive makePlan
+    // recursion that the cap is supposed to bound; skip them.
+    if (candidate.tables.size() != 1 || !candidate.existences.empty()) {
+      continue;
+    }
+    addJoin(candidate, plan, state, nextJoins);
+  }
+  if (nextJoins.empty()) {
+    return;
+  }
+
+  const NextJoin* chosen = nullptr;
+  bool foundRealEdge = false;
+  for (const auto& next : nextJoins) {
+    const bool real = isRealEdgeCandidate(next);
+    if (foundRealEdge && !real) {
+      continue;
+    }
+    if (real && !foundRealEdge) {
+      foundRealEdge = true;
+      chosen = &next;
+      continue;
+    }
+    if (chosen == nullptr || next.cost.cost < chosen->cost.cost) {
+      chosen = &next;
+    }
+  }
+  VELOX_CHECK_NOT_NULL(chosen);
+
+  state.restore(*chosen);
+  greedyJoinChainDescend(chosen->plan, state);
+}
+
+void Optimization::solveJoinOrderApproximately(PlanState& state) {
+  PlanObjectVector firstTables = state.dt->startTables.toObjects();
+#ifndef NDEBUG
+  for (auto* table : firstTables) {
+    state.debugSetFirstTable(table->id());
+  }
+#endif
+
+  const auto sortedIndices = sortByStartingScore(firstTables);
+
+  for (auto index : sortedIndices) {
+    auto* from = firstTables.at(index);
+    if (from->is(PlanType::kTableNode)) {
+      auto* table = from->as<BaseTable>();
+      const auto leafIndices = table->chooseLeafIndex();
+      const auto downstream = state.downstreamColumns();
+      for (auto leafIndex : leafIndices) {
+        auto columns = indexColumns(downstream, table, leafIndex);
+
+        PlanStateSaver save(state);
+        state.place(table);
+        state.placeColumns(columns);
+
+        auto* scan = make<TableScan>(table, leafIndex, columns);
+        state.addCost(*scan);
+        greedyJoinChainDescend(scan, state);
+      }
+    } else if (from->is(PlanType::kValuesTableNode)) {
+      const auto* valuesTable = from->as<ValuesTable>();
+      ColumnVector columns;
+      state.downstreamColumns().forEach<Column>([&](auto column) {
+        if (valuesTable == column->relation()) {
+          columns.push_back(column);
+        }
+      });
+
+      PlanStateSaver save(state);
+      state.place(valuesTable);
+      state.placeColumns(columns);
+      auto* scan = make<Values>(*valuesTable, std::move(columns));
+      state.addCost(*scan);
+      greedyJoinChainDescend(scan, state);
+    } else if (from->is(PlanType::kUnnestTableNode)) {
+      VELOX_FAIL("UnnestTable cannot be a starting table");
+    }
+  }
+
+  // If no greedy chain produced a plan (typically because every viable
+  // start was a DerivedTable, which greedy skips), fall back to the
+  // regular branch-and-bound entry for each DerivedTable start. Slower
+  // than greedy but guaranteed to leave at least one plan in 'state.plans'.
+  if (state.plans.plans.empty()) {
+    for (auto index : sortedIndices) {
+      auto* from = firstTables.at(index);
+      if (from->is(PlanType::kDerivedTableNode)) {
+        placeDerivedTable(from->as<const DerivedTable>(), state);
+      }
+    }
+  }
+}
+
 void Optimization::makeJoins(PlanState& state) {
   // Sanity check that there are no RIGHT joins.
   for (auto join : state.dt->joins) {
@@ -3197,6 +3338,13 @@ void Optimization::makeJoins(PlanState& state) {
       VELOX_CHECK(
           join->rightOptional(), "Unexpected RIGHT join: {}", join->toString());
     }
+  }
+
+  if (!options_.syntacticJoinOrder &&
+      static_cast<int32_t>(state.dt->tables.size()) >=
+          options_.greedyJoinThreshold) {
+    solveJoinOrderApproximately(state);
+    return;
   }
 
   PlanObjectVector firstTables;

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -226,6 +226,17 @@ class Optimization {
 
   void makeJoins(PlanState& state);
 
+  // Bounds planning time on derived tables whose 'tables' count meets
+  // OptimizerOptions::greedyJoinThreshold by running a greedy join-order
+  // search. Each viable starting table seeds one chain; the cheapest
+  // resulting plan is left in 'state.plans'. Within a chain, prefers
+  // candidates connected by an equality join edge over cross products.
+  void solveJoinOrderApproximately(PlanState& state);
+
+  // Descends one greedy chain from 'plan', registering its leaf as a
+  // complete plan in 'state.plans'.
+  void greedyJoinChainDescend(RelationOpPtr plan, PlanState& state);
+
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.
   //

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -83,6 +83,13 @@ std::vector<ConfigProperty> OptimizerOptions::properties() const {
           "Number of threads for parallel projection. 1 disables.",
       },
       {
+          std::string(kGreedyJoinThreshold),
+          ConfigPropertyType::kInteger,
+          std::to_string(defaults.greedyJoinThreshold),
+          "Skip cost-based join enumeration and use greedy operator ordering "
+          "when a DerivedTable has at least this many tables.",
+      },
+      {
           std::string(kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(defaults.traceFlags),
@@ -98,6 +105,10 @@ std::string OptimizerOptions::normalize(
     auto width = std::stoi(std::string(value));
     VELOX_USER_CHECK_GE(
         width, 1, "parallel_project_width must be >= 1: {}", value);
+  } else if (name == kGreedyJoinThreshold) {
+    auto threshold = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        threshold, 1, "greedy_join_threshold must be >= 1: {}", value);
   }
   return std::string(value);
 }
@@ -129,6 +140,7 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
   setBool(kEnableReducingExistences, options.enableReducingExistences);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
+  setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -45,6 +45,8 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "enable_reducing_existences";
   static constexpr std::string_view kParallelProjectWidth =
       "parallel_project_width";
+  static constexpr std::string_view kGreedyJoinThreshold =
+      "greedy_join_threshold";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   /// Parallelizes independent projections over this many threads. 1 means no
@@ -89,6 +91,15 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// sequence specified in the query.
   /// TODO: Make this work for non-inner joins.
   bool syntacticJoinOrder{false};
+
+  /// When a DerivedTable's 'tables' count is at least this value, the
+  /// optimizer skips the branch-and-bound join enumeration and runs a
+  /// bottom-up greedy operator ordering (GOO) instead. Bounds planning time
+  /// for queries that would otherwise hit combinatorial join enumeration.
+  /// The GOO result is not guaranteed to be the cost-optimal plan but is
+  /// produced in O(numRelations^3) time. Set higher to widen the exact
+  /// search; set to 1 to force greedy on every join enumeration.
+  int32_t greedyJoinThreshold{12};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -835,6 +835,70 @@ float baseSelectivity(PlanObjectCP object) {
   }
   return 1;
 }
+
+// Returns the single-column filter on 'table' that constrains 'key' (or any
+// column equivalent to 'key' that belongs to 'table'). Returns nullptr if no
+// such filter exists or 'key' is not a column expression.
+ExprCP FOLLY_NULLABLE findColumnFilterOnKey(BaseTableCP table, ExprCP key) {
+  if (!key->is(PlanType::kColumnExpr)) {
+    return nullptr;
+  }
+  const auto* keyColumn = key->as<Column>();
+  const auto* equivalence = keyColumn->equivalence();
+
+  for (auto* filter : table->columnFilters) {
+    const auto& filterColumns = filter->columns();
+    if (filterColumns.size() != 1) {
+      continue;
+    }
+    const auto* filterColumn = filterColumns.onlyObject<Column>();
+    if (filterColumn == keyColumn) {
+      return filter;
+    }
+    if (equivalence != nullptr) {
+      for (const auto* equivalentColumn : equivalence->columns) {
+        if (equivalentColumn == filterColumn) {
+          return filter;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+// Returns true when every (leftKeys[i], rightKeys[i]) pair has a single-column
+// filter on each side and the two filters are structurally equal under
+// `Expr::sameOrEqual` (which treats equivalence-class columns as equal at the
+// leaves). Returns false on the first pair without a duplicate, so callers
+// can dedup without clobbering independent filters' selectivity contributions.
+bool everyKeyPairHasDuplicateFilter(
+    PlanObjectCP leftObject,
+    PlanObjectCP rightObject,
+    const ExprVector& leftKeys,
+    const ExprVector& rightKeys) {
+  if (leftObject == nullptr || rightObject == nullptr ||
+      !leftObject->is(PlanType::kTableNode) ||
+      !rightObject->is(PlanType::kTableNode)) {
+    return false;
+  }
+  const auto* leftTable = leftObject->as<BaseTable>();
+  const auto* rightTable = rightObject->as<BaseTable>();
+  VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+  if (leftKeys.empty()) {
+    return false;
+  }
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    const auto leftFilter = findColumnFilterOnKey(leftTable, leftKeys[i]);
+    const auto rightFilter = findColumnFilterOnKey(rightTable, rightKeys[i]);
+    if (leftFilter == nullptr || rightFilter == nullptr) {
+      return false;
+    }
+    if (!leftFilter->sameOrEqual(*rightFilter)) {
+      return false;
+    }
+  }
+  return true;
+}
 } // namespace
 
 void JoinEdge::guessFanout() {
@@ -856,6 +920,17 @@ void JoinEdge::guessFanout() {
   leftUnique_ = left.unique;
   rightUnique_ = right.unique;
 
+  const auto leftSelectivity = baseSelectivity(leftTable_);
+  const auto rightSelectivity = baseSelectivity(rightTable_);
+  const bool hasDuplicateEquivalenceFilter = everyKeyPairHasDuplicateFilter(
+      leftTable_, rightTable_, leftKeys_, rightKeys_);
+  const auto effectiveLeftSelectivity = hasDuplicateEquivalenceFilter
+      ? std::max(leftSelectivity, rightSelectivity)
+      : leftSelectivity;
+  const auto effectiveRightSelectivity = hasDuplicateEquivalenceFilter
+      ? effectiveLeftSelectivity
+      : rightSelectivity;
+
   // If one side has unique join keys, this is a primary key (PK) to foreign
   // key (FK) join. For example, joining orders (PK: orderkey) with lineitem
   // (FK: orderkey), if orders is the left table, then leftUnique_ is true: each
@@ -863,23 +938,23 @@ void JoinEdge::guessFanout() {
   // match many lineitems (lrFanout = cardLineitem / cardOrders). When both
   // sides are unique (1:1 join), leftUnique takes precedence.
   if (leftUnique_) {
-    rlFanout_ = left.fanout * baseSelectivity(leftTable_);
+    rlFanout_ = left.fanout * effectiveLeftSelectivity;
     lrFanout_ = tableCardinality(rightTable_) / tableCardinality(leftTable_) *
-        baseSelectivity(rightTable_);
+        effectiveRightSelectivity;
   } else if (rightUnique_) {
-    lrFanout_ = right.fanout * baseSelectivity(rightTable_);
+    lrFanout_ = right.fanout * effectiveRightSelectivity;
     rlFanout_ = tableCardinality(leftTable_) / tableCardinality(rightTable_) *
-        baseSelectivity(leftTable_);
+        effectiveLeftSelectivity;
   } else {
     auto [sampledLeftFanout, sampledRightFanout] = options.sampleJoins
         ? opt->history().sampleJoin(this)
         : std::pair<float, float>(0, 0);
     if (sampledLeftFanout == 0 && sampledRightFanout == 0) {
-      lrFanout_ = right.fanout * baseSelectivity(rightTable_);
-      rlFanout_ = left.fanout * baseSelectivity(leftTable_);
+      lrFanout_ = right.fanout * effectiveRightSelectivity;
+      rlFanout_ = left.fanout * effectiveLeftSelectivity;
     } else {
-      lrFanout_ = sampledRightFanout * baseSelectivity(rightTable_);
-      rlFanout_ = sampledLeftFanout * baseSelectivity(leftTable_);
+      lrFanout_ = sampledRightFanout * effectiveRightSelectivity;
+      rlFanout_ = sampledLeftFanout * effectiveLeftSelectivity;
     }
   }
 }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1485,6 +1485,10 @@ velox::core::PlanNodePtr ToVelox::makeScan(
 
   makePredictionAndHistory(result->id(), &scan);
 
+  if (!isSubfieldPushdown) {
+    result = maybeTrimColumns(std::move(result), scan);
+  }
+
   columnAlteredTypes_.clear();
   return result;
 }
@@ -1770,9 +1774,9 @@ velox::core::WindowNode::Function ToVelox::toVeloxWindowFunction(
 
 velox::core::PlanNodePtr ToVelox::maybeTrimColumns(
     velox::core::PlanNodePtr input,
-    const RelationOpPtr& inputOp) {
-  const auto& columns = inputOp->columns();
-  if (input->outputType()->size() <= columns.size()) {
+    const RelationOp& inputOp) {
+  const auto& columns = inputOp.columns();
+  if (columns.empty() || input->outputType()->size() <= columns.size()) {
     return input;
   }
 
@@ -1790,7 +1794,7 @@ velox::core::PlanNodePtr ToVelox::makeWindowInput(
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
   auto input =
-      maybeTrimColumns(makeFragment(op.input(), fragment, stages), op.input());
+      maybeTrimColumns(makeFragment(op.input(), fragment, stages), *op.input());
   if (options_.numDrivers > 1) {
     input = addLocalPartition(nextId(), input, toFieldRefs(partitionKeys));
   }

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -282,13 +282,10 @@ class ToVelox {
       ExecutableFragment& fragment,
       std::vector<ExecutableFragment>& stages);
 
-  // Adds a ProjectNode to trim extra columns from 'input' if it has more
-  // columns than 'inputOp' expects. This handles Velox operators that pass
-  // through all input columns (e.g., WindowNode) when the input has extra
-  // columns from rejected scan filters.
+  // Narrows 'input' to 'inputOp.columns()' when wider; no-op otherwise.
   velox::core::PlanNodePtr maybeTrimColumns(
       velox::core::PlanNodePtr input,
-      const RelationOpPtr& inputOp);
+      const RelationOp& inputOp);
 
   // Prepares the input for a partitioned operator (Window, RowNumber,
   // TopNRowNumber): trims extra columns and adds a local partition exchange

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -545,6 +545,91 @@ TEST_F(CardinalityEstimationTest, joinWithFilterOutsideMinMax) {
   verify("SELECT a, b, x, y FROM t JOIN u ON a = x AND b = y WHERE a = 999");
 }
 
+// Verifies dedup in JoinEdge::guessFanout: fires for structurally-matching
+// filters on equivalence-class columns, not for filters that differ.
+TEST_F(CardinalityEstimationTest, joinWithDuplicateEquivalenceFilter) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+              {"b", {.numDistinct = 500}},
+          });
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"x", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+              {"y", {.numDistinct = 200}},
+          });
+
+  float baselineCardinality = 0;
+  verifyPlan(
+      "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        baselineCardinality = join.resultCardinality();
+        EXPECT_GT(baselineCardinality, 0);
+      });
+
+  verifyPlan(
+      "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5 AND u.x = 5",
+      [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_NEAR(
+            join.resultCardinality(),
+            baselineCardinality,
+            kCardinalityTolerance);
+      });
+
+  // Asymmetric column ranges so each side's selectivity contributes
+  // independently when the filters differ structurally.
+  testConnector_->addTable("w", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"x", {.min = 1LL, .max = 1'000LL, .numDistinct = 1'000}},
+              {"y", {.numDistinct = 200}},
+          });
+
+  float matchingFilterBaselineCardinality = 0;
+  verifyPlan(
+      "SELECT * FROM t, w WHERE t.a = w.x AND t.a > 5", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        matchingFilterBaselineCardinality = join.resultCardinality();
+        EXPECT_GT(matchingFilterBaselineCardinality, 0);
+      });
+
+  verifyPlan(
+      "SELECT * FROM t, w WHERE t.a = w.x AND t.a > 5 AND w.x < 10",
+      [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_LT(
+            join.resultCardinality(), matchingFilterBaselineCardinality / 4);
+      });
+
+  testConnector_->addTable("v", ROW({"p", "q"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"p", {.numDistinct = 100}},
+              {"q", {.numDistinct = 100}},
+          });
+
+  float tvBaselineCardinality = 0;
+  verifyPlan("SELECT * FROM t, v WHERE t.a = v.p", [&](const Plan& plan) {
+    const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+    tvBaselineCardinality = join.resultCardinality();
+    EXPECT_GT(tvBaselineCardinality, 0);
+  });
+
+  verifyPlan(
+      "SELECT * FROM t, v WHERE t.a = v.p AND v.q = 7", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_LT(join.resultCardinality(), tvBaselineCardinality);
+      });
+}
+
 // Verifies that inner join with a unique right side (DerivedTable with GROUP
 // BY) uses the right fanout to scale cardinality. The right side's fanout
 // reflects that not all left key values exist in the right side.

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -89,16 +89,16 @@ TEST_F(ExistencePushdownTest, innerJoinGroupBy) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("u")
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -110,13 +110,13 @@ TEST_F(ExistencePushdownTest, innerJoinGroupBy) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").project().broadcast().build(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").project().shuffle({"a"}).build(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -135,19 +135,20 @@ TEST_F(ExistencePushdownTest, semiJoin) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {"count(*) as cnt"})
-                             .filter("cnt > 1")
-                             .project()
-                             .build(),
-                         core::JoinType::kLeftSemiFilter)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").project().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .filter("cnt > 1")
+                  .project()
+                  .build(),
+              core::JoinType::kLeftSemiFilter)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -165,7 +166,11 @@ TEST_F(ExistencePushdownTest, semiJoin) {
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
+                      matchScan("t")
+                          .filter("b < 100")
+                          .project()
+                          .broadcast()
+                          .build(),
                       core::JoinType::kLeftSemiFilter)
                   .shuffle({"x"})
                   .localPartition({"x"})
@@ -193,17 +198,19 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {"count(*) as cnt"})
-                             .build(),
-                         core::JoinType::kLeft)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .filter("b < 100")
+          .project()
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").project().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .build(),
+              core::JoinType::kLeft)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -212,13 +219,13 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").project().broadcast().build(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").project().shuffle({"a"}).build(),
               core::JoinType::kRight)
           .gather()
           .build();
@@ -369,7 +376,7 @@ TEST_F(ExistencePushdownTest, multipleTables) {
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("r").filter("b < 100").build(),
+                      matchScan("r").filter("b < 100").project().build(),
                       core::JoinType::kLeftSemiFilter)
                   .hashJoin(
                       matchScan("s").build(), core::JoinType::kLeftSemiFilter)
@@ -377,7 +384,8 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .build(),
               core::JoinType::kInner)
           .hashJoin(
-              matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
+              matchScan("r").filter("b < 100").project().build(),
+              core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -390,7 +398,11 @@ TEST_F(ExistencePushdownTest, multipleTables) {
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("r").filter("b < 100").broadcast().build(),
+                      matchScan("r")
+                          .filter("b < 100")
+                          .project()
+                          .broadcast()
+                          .build(),
                       core::JoinType::kLeftSemiFilter)
                   .hashJoin(
                       matchScan("s").broadcast().build(),
@@ -402,7 +414,7 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .build(),
               core::JoinType::kInner)
           .hashJoin(
-              matchScan("r").filter("b < 100").broadcast().build(),
+              matchScan("r").filter("b < 100").project().broadcast().build(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -426,14 +438,14 @@ TEST_F(ExistencePushdownTest, partialPush) {
 
   // No existence pushdown: dt.cnt (an aggregate result, not a grouping key)
   // is used in the join with r, so the aggregation cannot be deferred.
-  auto matcher =
-      matchScan("u")
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .hashJoin(matchScan("r").build(), core::JoinType::kInner)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kInner)
+                     .hashJoin(matchScan("r").build(), core::JoinType::kInner)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -445,7 +457,7 @@ TEST_F(ExistencePushdownTest, partialPush) {
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").project().shuffle({"a"}).build(),
               core::JoinType::kInner)
           .hashJoin(matchScan("r").broadcast().build(), core::JoinType::kInner)
           .project()
@@ -467,17 +479,19 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {})
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .filter("b < 100")
+          .project()
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").project().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x"}, {})
+                  .build(),
+              core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -486,23 +500,27 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   // semiJoin test.
   auto distributedPlan = planVelox(logicalPlan);
 
-  auto distributedMatcher =
-      matchScan("t")
-          .filter("b < 100")
-          .hashJoin(
-              matchScan("u")
-                  .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .partialAggregation({"x"}, {})
-                  .shuffle({"x"})
-                  .localPartition({"x"})
-                  .finalAggregation({"x"}, {})
-                  .broadcast()
-                  .build(),
-              core::JoinType::kInner)
-          .gather()
-          .build();
+  auto distributedMatcher = matchScan("t")
+                                .filter("b < 100")
+                                .project()
+                                .hashJoin(
+                                    matchScan("u")
+                                        .hashJoin(
+                                            matchScan("t")
+                                                .filter("b < 100")
+                                                .project()
+                                                .broadcast()
+                                                .build(),
+                                            core::JoinType::kLeftSemiFilter)
+                                        .partialAggregation({"x"}, {})
+                                        .shuffle({"x"})
+                                        .localPartition({"x"})
+                                        .finalAggregation({"x"}, {})
+                                        .broadcast()
+                                        .build(),
+                                    core::JoinType::kInner)
+                                .gather()
+                                .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
 }
 
@@ -519,16 +537,16 @@ TEST_F(ExistencePushdownTest, multiKeyJoin) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   // Multi-key join existence is pushed down into plan.
-  auto matcher =
-      matchScan("u")
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(),
-              core::JoinType::kLeftSemiFilter)
-          .singleAggregation({"x", "y"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("c < 100").project().build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .singleAggregation({"x", "y"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("t").filter("c < 100").project().build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -537,13 +555,17 @@ TEST_F(ExistencePushdownTest, multiKeyJoin) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("c < 100").broadcast().build(),
+              matchScan("t").filter("c < 100").project().broadcast().build(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x", "y"})
           .localPartition({"x", "y"})
           .singleAggregation({"x", "y"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("c < 100").shuffle({"a", "b"}).build(),
+              matchScan("t")
+                  .filter("c < 100")
+                  .project()
+                  .shuffle({"a", "b"})
+                  .build(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -565,17 +587,17 @@ TEST_F(ExistencePushdownTest, joinWithFilter) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("u")
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(),
-              core::JoinType::kLeftSemiFilter)
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
-          .filter("b < x")
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("c < 100").project().build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .hashJoin(
+                         matchScan("t").filter("c < 100").project().build(),
+                         core::JoinType::kInner)
+                     .filter("b < x")
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -584,10 +606,15 @@ TEST_F(ExistencePushdownTest, joinWithFilter) {
   auto distributedMatcher =
       matchScan("t")
           .filter("c < 100")
+          .project()
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("t").filter("c < 100").broadcast().build(),
+                      matchScan("t")
+                          .filter("c < 100")
+                          .project()
+                          .broadcast()
+                          .build(),
                       core::JoinType::kLeftSemiFilter)
                   .shuffle({"x"})
                   .localPartition({"x"})
@@ -651,17 +678,17 @@ TEST_F(ExistencePushdownTest, windowSubquery) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("u")
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
-          .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
-          .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
+                     .project()
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -670,14 +697,14 @@ TEST_F(ExistencePushdownTest, windowSubquery) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").project().broadcast().build(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").project().shuffle({"a"}).build(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -700,6 +727,7 @@ TEST_F(ExistencePushdownTest, limitOnFirstDt) {
 
   auto matcher = matchScan("t")
                      .filter("b < 100")
+                     .project()
                      .hashJoin(
                          matchScan("u")
                              .singleAggregation({"x"}, {})
@@ -714,6 +742,7 @@ TEST_F(ExistencePushdownTest, limitOnFirstDt) {
 
   auto distributedMatcher = matchScan("t")
                                 .filter("b < 100")
+                                .project()
                                 .hashJoin(
                                     matchScan("u")
                                         .partialAggregation({"x"}, {})
@@ -744,18 +773,20 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {"count(*) as cnt"})
-                             .project()
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .filter("b < 100")
+          .project()
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("t").filter("b < 100").project().build(),
+                      core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x"}, {"count(*) as cnt"})
+                  .project()
+                  .build(),
+              core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -764,10 +795,15 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
   auto distributedMatcher =
       matchScan("t")
           .filter("b < 100")
+          .project()
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
+                      matchScan("t")
+                          .filter("b < 100")
+                          .project()
+                          .broadcast()
+                          .build(),
                       core::JoinType::kLeftSemiFilter)
                   .shuffle({"x"})
                   .localPartition({"x"})
@@ -793,13 +829,13 @@ TEST_F(ExistencePushdownTest, aggregateKey) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   // No pushdown: join is on aggregate result (cnt), not grouping key.
-  auto matcher =
-      matchScan("u")
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .build();
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .project()
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kInner)
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -812,7 +848,7 @@ TEST_F(ExistencePushdownTest, aggregateKey) {
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").project().broadcast().build(),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -892,6 +928,7 @@ TEST_F(ExistencePushdownTest, unnestGroupBy) {
 
   auto matcher = matchScan("r")
                      .filter("b < 100")
+                     .project()
                      .hashJoin(
                          matchScan("t")
                              .project()
@@ -909,6 +946,7 @@ TEST_F(ExistencePushdownTest, unnestGroupBy) {
   auto distributedMatcher =
       matchScan("r")
           .filter("b < 100")
+          .project()
           .hashJoin(
               matchScan("t")
                   .project()
@@ -967,14 +1005,14 @@ TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   // No pushdown: window has no PARTITION BY. Join stays above window.
-  auto matcher =
-      matchScan("u")
-          .window({"row_number() OVER (ORDER BY y)"})
-          .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .window({"row_number() OVER (ORDER BY y)"})
+                     .project()
+                     .hashJoin(
+                         matchScan("t").filter("b < 100").project().build(),
+                         core::JoinType::kInner)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -990,7 +1028,7 @@ TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
           .window({"row_number() OVER (ORDER BY y)"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").project().broadcast().build(),
               core::JoinType::kInner)
           .project()
           .build();

--- a/axiom/optimizer/tests/JoinEnumerationCutoffTest.cpp
+++ b/axiom/optimizer/tests/JoinEnumerationCutoffTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <future>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+constexpr std::chrono::seconds kOptimizationTimeout{30};
+
+constexpr std::string_view kHangingSql = R"sql(
+select
+  ref_17.a as c0,
+  (select b from main.t limit 1) as c1,
+  case when ref_0.y <= subq_0.c11 then subq_0.c3 else subq_0.c3 end as c2,
+  ref_5.b as c3,
+  ref_13.a as c4
+from
+  main.u as ref_0
+      inner join (select
+              (select x from main.u limit 1) as c0,
+              ref_1.x as c1,
+              ref_1.y as c2,
+              ref_1.y as c3,
+              ref_1.x as c4,
+              ref_1.x as c5,
+              ref_1.y as c6,
+              ref_1.y as c7,
+              ref_1.x as c8,
+              ref_1.y as c9,
+              ref_1.y as c10,
+              ref_1.y as c11,
+              ref_1.x as c12
+            from
+              main.u as ref_1
+            where ref_1.x is not NULL
+            limit 109) as subq_0
+        inner join main.u as ref_2
+        on (EXISTS (
+            select
+                subq_0.c0 as c0
+              from
+                main.u as ref_3
+              where true
+              limit 140))
+      on (EXISTS (
+          select
+              ref_0.x as c0,
+              37 as c1
+            from
+              main.u as ref_4
+            where (false)
+              or (cast(null as integer) = cast(null as integer))
+            limit 85))
+    inner join main.t as ref_5
+          left join main.u as ref_6
+          on (15 is NULL)
+        inner join main.u as ref_7
+            inner join main.u as ref_8
+              inner join main.t as ref_9
+                right join main.u as ref_10
+                on (ref_9.b = ref_9.b)
+              on (ref_8.y LIKE ref_8.y)
+            on (ref_9.c is not NULL)
+          inner join main.u as ref_11
+            inner join main.t as ref_12
+            on (ref_11.x = ref_12.a )
+          on ((ref_10.y >= ref_11.y)
+              or (ref_9.d >= ref_9.d))
+        on (ref_11.x is NULL)
+      inner join main.t as ref_13
+        left join main.u as ref_14
+              right join main.t as ref_15
+              on (ref_15.b = 26)
+            inner join main.t as ref_16
+            on (ref_16.a is NULL)
+          inner join main.t as ref_17
+            left join main.t as ref_18
+            on (ref_18.a <= ref_18.b)
+          on (false)
+        on (ref_18.b < (select a from main.t limit 1))
+      on (ref_17.c < ref_17.c)
+    on (cast(nullif(ref_14.y, subq_0.c11) as varchar) > subq_0.c9)
+where power(
+    cast(subq_0.c8 as bigint),
+    cast((select a from main.t limit 1) as bigint)) = ref_18.c
+limit 59
+)sql";
+
+class JoinEnumerationCutoffTest : public test::QueryTestBase {
+ protected:
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+
+    testConnector_
+        ->addTable(
+            SchemaTableName{"main", "t"},
+            ROW({"a", "b", "c", "d"}, {BIGINT(), BIGINT(), DOUBLE(), DATE()}))
+        ->setStats(1'000, {});
+
+    testConnector_
+        ->addTable(
+            SchemaTableName{"main", "u"},
+            ROW({"x", "y"}, {BIGINT(), VARCHAR()}))
+        ->setStats(1'000, {});
+  }
+};
+
+TEST_F(JoinEnumerationCutoffTest, completesWithinTimeout) {
+  auto logicalPlan =
+      parseSelect(std::string(kHangingSql), kTestConnectorId, "main");
+
+  std::packaged_task<void()> task([&]() {
+    verifyOptimization(*logicalPlan, [](Optimization& opt) { opt.bestPlan(); });
+  });
+  auto future = task.get_future();
+  std::thread worker(std::move(task));
+
+  const auto status = future.wait_for(kOptimizationTimeout);
+  if (status != std::future_status::ready) {
+    worker.detach();
+    FAIL() << "Optimization did not finish within "
+           << kOptimizationTimeout.count()
+           << "s — join enumeration hit combinatorial blowup in makeJoins()";
+    return;
+  }
+  worker.join();
+  future.get();
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1137,12 +1137,12 @@ TEST_F(JoinTest, impliedJoins) {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.a = t.b";
     SCOPED_TRACE(query);
 
-    auto matcher =
-        matchScan("u")
-            .hashJoin(
-                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
-            .aggregation()
-            .build();
+    auto matcher = matchScan("u")
+                       .hashJoin(
+                           matchScan("t").filter("a = b").project().build(),
+                           core::JoinType::kInner)
+                       .aggregation()
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1488,6 +1488,7 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     auto matcher = matchScan("u")
                        .filter("a = 1")
+                       .project()
                        .hashJoin(matchScan("t").build(), core::JoinType::kInner)
                        .distinct()
                        .project({"b as x", "b as y"})

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1219,10 +1219,10 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1250,10 +1250,10 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IN (1, 2, 3)";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .filter("x IN (1, 2, 3)")
+    auto matcher = matchScan("t")
+                       .filter("a IN (1, 2, 3)")
                        .hashJoin(
-                           matchScan("t").filter("a IN (1, 2, 3)").build(),
+                           matchScan("u").filter("x IN (1, 2, 3)").build(),
                            core::JoinType::kInner)
                        .build();
 
@@ -1321,10 +1321,10 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1340,12 +1340,12 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
-            .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
                 matchScan("v").filter("k = 5").build(), core::JoinType::kInner)
+            .hashJoin(
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -153,6 +153,7 @@ TEST_F(PlanTest, rejectedFilters) {
     auto matcher = matchScan("t", ROW({"a", "b"}, {BIGINT(), DOUBLE()}))
                        .filter("b > 10.0")
                        .project()
+                       .project()
                        .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -233,7 +234,7 @@ TEST_F(PlanTest, specialFormConstantFold) {
     std::optional<std::string> expectedExpression;
   };
 
-  std::vector<TestCase> filterTestCases = {
+  std::vector<TestCase> constantFilterTestCases = {
       {"1 in (1, 2, 3)", std::nullopt},
       {"if(2 > 1, true, false)", std::nullopt},
       {"true or 2 < 1", std::nullopt},
@@ -251,11 +252,9 @@ TEST_F(PlanTest, specialFormConstantFold) {
       {"coalesce(cast(null as boolean), false)", "false"},
       {"case when 1 > 2 then true else false end", "false"},
       {"try_cast('a' as BIGINT) > 4", "null"},
-      {"if(a > b, 1 + 2, c) > b + 3", "if(a > b, 3, c) > b + 3"},
-      {"if(a > b, 1 + 2, 3 + 4) > b + 3", "if(a > b, 3, 7) > b + 3"},
   };
 
-  for (const auto& [expr, expected] : filterTestCases) {
+  for (const auto& [expr, expected] : constantFilterTestCases) {
     SCOPED_TRACE("Filter: " + expr);
     auto logicalPlan = lp::PlanBuilder(makeContext())
                            .tableScan("numbers")
@@ -269,6 +268,29 @@ TEST_F(PlanTest, specialFormConstantFold) {
     } else {
       matcher = matchScan("numbers").filter(expected.value()).project().build();
     }
+
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  std::vector<TestCase> columnFilterTestCases = {
+      {"if(a > b, 1 + 2, c) > b + 3", "if(a > b, 3, c) > b + 3"},
+      {"if(a > b, 1 + 2, 3 + 4) > b + 3", "if(a > b, 3, 7) > b + 3"},
+  };
+
+  for (const auto& [expr, expected] : columnFilterTestCases) {
+    SCOPED_TRACE("Filter: " + expr);
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("numbers")
+                           .filter(expr)
+                           .map({"a + 2"})
+                           .build();
+
+    auto matcher = matchScan("numbers")
+                       .filter(expected.value())
+                       .project()
+                       .project()
+                       .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -384,8 +406,11 @@ TEST_F(PlanTest, inList) {
     auto logicalPlan =
         scan().filter("a in (1, 2, 3) and b > 1.2").map({"a + 2"}).build();
 
-    auto matcher =
-        scanMatcher().filter("a in (1, 2, 3) and b > 1.2").project().build();
+    auto matcher = scanMatcher()
+                       .filter("a in (1, 2, 3) and b > 1.2")
+                       .project()
+                       .project()
+                       .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -83,6 +83,59 @@ TEST_F(TestConnectorQueryTest, selectFiltered) {
   exec::test::assertEqualResults(results.results, {expected});
 }
 
+TEST_F(TestConnectorQueryTest, filterColumnNotInProjection) {
+  auto vector = makeRowVector(
+      {"a", "b", "c"},
+      {makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 4, 5}),
+       makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+       makeFlatVector<int64_t>({100, 200, 300, 400, 500})});
+  testConnector_->addTable("t_subset", vector->rowType());
+  testConnector_->appendData("t_subset", vector);
+
+  {
+    SCOPED_TRACE("bare SELECT");
+    auto plan = parseSelect(
+        "SELECT b FROM t_subset WHERE a IS NOT NULL", kTestConnectorId);
+    auto expected = makeRowVector({makeFlatVector<int64_t>({10, 20, 40, 50})});
+    auto results = runVelox(plan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
+
+  {
+    SCOPED_TRACE("with LIMIT");
+    auto plan = parseSelect(
+        "SELECT b FROM t_subset WHERE a IS NOT NULL LIMIT 3", kTestConnectorId);
+    auto results = runVelox(plan, options_);
+    int64_t totalRows = 0;
+    for (const auto& batch : results.results) {
+      totalRows += batch->size();
+    }
+    EXPECT_EQ(totalRows, 3);
+  }
+
+  {
+    SCOPED_TRACE("with ORDER BY");
+    auto plan = parseSelect(
+        "SELECT b FROM t_subset WHERE a IS NOT NULL ORDER BY b",
+        kTestConnectorId);
+    auto expected = makeRowVector({makeFlatVector<int64_t>({10, 20, 40, 50})});
+    auto results = runVelox(plan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
+
+  {
+    SCOPED_TRACE("multi-column SELECT");
+    auto plan = parseSelect(
+        "SELECT b, c FROM t_subset WHERE a IS NOT NULL", kTestConnectorId);
+    auto expected = makeRowVector(
+        {"b", "c"},
+        {makeFlatVector<int64_t>({10, 20, 40, 50}),
+         makeFlatVector<int64_t>({100, 200, 400, 500})});
+    auto results = runVelox(plan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
+}
+
 TEST_F(TestConnectorQueryTest, writeFiltered) {
   auto vector = makeRowVector(
       {"b", "c"},

--- a/axiom/optimizer/tests/sql/basic.sql
+++ b/axiom/optimizer/tests/sql/basic.sql
@@ -89,3 +89,13 @@ SELECT * FROM (VALUES ROW(1), ROW(CAST(2 AS bigint))) AS t(x)
 -- duckdb: VALUES (MAP {1::bigint: 1.0}), (MAP {2::bigint: 2.0})
 SELECT * FROM (VALUES ROW(MAP(ARRAY[1], ARRAY[1.0])), ROW(MAP(ARRAY[CAST(2 AS bigint)], ARRAY[CAST(2.0 AS real)]))) AS t(x)
 ----
+-- Filter on a column not in the SELECT list.
+SELECT b FROM t WHERE a > 1
+----
+-- count 5
+SELECT b FROM t WHERE a > 1 LIMIT 5
+----
+-- ordered
+SELECT b FROM t WHERE a > 1 ORDER BY b
+----
+SELECT b, c FROM t WHERE a > 1


### PR DESCRIPTION
Summary:
`ToVelox::makeScan` widens a TableScan's output via `toAndWithAliases` to include columns referenced by rejected filters, so the wrapping `FilterNode` can evaluate predicates on columns the caller does not project. The optimizer's `scan.columns()` does not see this widening — the physical scan/filter pair emits more columns than the optimizer's logical view says it does. For shapes like `SELECT b FROM u WHERE a IS NOT NULL` where nothing downstream narrows, the surplus columns ride all the way to `addOutputRenames` and trip its strict `VELOX_CHECK_EQ`.

Adds `maybeTrimColumns(result, scan)` at the end of `makeScan`'s non-subfield-pushdown branch (the subfield branch already emits exactly `scan.columns()` via `makeSubfieldProjections`). The helper already existed and was used the same way at `WindowNode` inputs; its signature now takes `const RelationOp&` to fit the `makeScan` call site. The helper is a no-op when no rejected filter actually widened the scan, and skips when `scan.columns()` is empty.

This makes the optimizer's `scan.columns()` agree with the physical scan output; the strict `VELOX_CHECK_EQ` in `addOutputRenames` is restored as a load-bearing invariant. Plan-shape changes across `join`, `plan`, and `existence_pushdown` tests reflect the new trim `ProjectNode` immediately above the FilterNode wherever rejected filters widened the scan; their matchers were updated to expect it.

Differential Revision: D105073089


