### PR TITLE
fix(optimizer): Don't convert hyper-edge outer joins to inner (#1406)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -66,19 +66,31 @@ bool addEdge(EdgeSet& edges, PlanObjectCP left, PlanObjectCP right) {
 }
 
 void fillJoins(
-    PlanObjectCP column,
+    ColumnCP column,
     const Equivalence& equivalence,
     EdgeSet& edges,
     DerivedTableP dt) {
+  auto* columnTable = column->singleTable();
+  if (columnTable == nullptr) {
+    return;
+  }
   for (auto& other : equivalence.columns) {
+    auto* otherTable = other->singleTable();
+    if (otherTable == nullptr) {
+      continue;
+    }
     // A join equality requires columns from different tables. Two columns
     // in the same equivalence class can belong to the same table, e.g. after
     // UNNEST.
-    if (column->as<Expr>()->singleTable() == other->as<Expr>()->singleTable()) {
+    if (columnTable == otherTable) {
+      continue;
+    }
+    if (!dt->tableSet.contains(columnTable) &&
+        !dt->tableSet.contains(otherTable)) {
       continue;
     }
     if (addEdge(edges, column, other)) {
-      addJoinEquality(column->as<Column>(), other->as<Column>(), dt->joins);
+      addJoinEquality(column, other, dt->joins);
     }
   }
 }
@@ -619,9 +631,7 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
 
   finalizeJoins();
 
-#ifndef NDEBUG
   checkConsistency();
-#endif
   auto plan = queryCtx()->optimization()->makeInitialPlan(*this);
   updateConstraints(*plan);
 }
@@ -692,9 +702,9 @@ void DerivedTable::addImpliedJoins() {
               fillJoins(left, *rightEq, edges, this);
             }
           } else if (leftEq) {
-            fillJoins(rightKey, *leftEq, edges, this);
+            fillJoins(rightKey->as<Column>(), *leftEq, edges, this);
           } else if (rightEq) {
-            fillJoins(leftKey, *rightEq, edges, this);
+            fillJoins(leftKey->as<Column>(), *rightEq, edges, this);
           }
         }
       }

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2538,6 +2538,12 @@ void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
         continue;
       }
 
+      // Hyper-edge outer joins (left keys span multiple tables) cannot be
+      // converted to inner joins.
+      if (join->leftTable() == nullptr) {
+        continue;
+      }
+
       auto rightJoinColumns = PlanObjectSet::fromObjects(join->rightColumns());
       auto leftJoinColumns = PlanObjectSet::fromObjects(join->leftColumns());
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -398,7 +398,7 @@ std::shared_ptr<const connector::PartitionType> foldCopartition(
 // common, then replace each non-null value with entry.copartition(*common).
 // Null entries pass through unchanged. Used at every join/union site that
 // combines two PlanStates' current fragment maps.
-void mergeFragmentMaps(GroupedLeaves& consumer, GroupedLeaves&& producer) {
+void mergeFragmentMaps(GroupedLeaves& consumer, GroupedLeaves producer) {
   std::vector<std::shared_ptr<const connector::PartitionType>> nonNullValues;
   for (const auto& [_, partitionType] : consumer) {
     if (partitionType != nullptr) {
@@ -928,7 +928,8 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   // Take the first hand joined tables and bundle them with reducing joins that
   // can go on the build side.
 
-  if (!options().syntacticJoinOrder && !candidates.empty()) {
+  if (!options().syntacticJoinOrder && !state.greedyJoinOrder() &&
+      !candidates.empty()) {
     std::vector<JoinCandidate> bushes;
     for (auto& candidate : candidates) {
       if (auto bush = reducingJoins(state, candidate)) {
@@ -3001,9 +3002,9 @@ RelationOpPtr Optimization::placeSingleRowDtsForJoinFilter(
   return plan;
 }
 
-void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
-  PlanStateSaver save(state);
-
+RelationOpPtr Optimization::planDtAsLeaf(
+    DerivedTableCP from,
+    PlanState& state) {
   state.place(from);
 
   auto dtColumns = PlanObjectSet::fromObjects(from->columns);
@@ -3013,20 +3014,35 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
   MemoKey key =
       MemoKey::create(from, std::move(dtColumns), PlanObjectSet::single(from));
 
-  bool ignore = false;
+  bool ignore{false};
   auto plan = makePlan(*state.dt, key, std::nullopt, 1, ignore);
   state.cost = plan->cost;
   // Inherit the DT's per-leaf bucketed map so subsequent operators planned
-  // atop this DT see its scans as fragment leaves.
+  // atop this DT see its scans as fragment leaves. Copy: 'plan' may be the
+  // input to multiple parents, so each consumer needs its own starting map.
   auto it = planGroupedLeaves_.find(plan);
   if (it != planGroupedLeaves_.end()) {
-    mergeFragmentMaps(
-        state.mutableCurrentGroupedLeaves(), GroupedLeaves{it->second});
+    // @lint-ignore CLANGTIDY PULSE_UNNECESSARY_COPY
+    GroupedLeaves leaves = it->second;
+    mergeFragmentMaps(state.mutableCurrentGroupedLeaves(), std::move(leaves));
   }
+  return plan->op;
+}
+
+void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
+  PlanStateSaver save(state);
+
+  auto planOp = planDtAsLeaf(from, state);
 
   // Make plans based on the dt alone as first.
-  makeJoins(plan->op, state);
+  makeJoins(std::move(planOp), state);
 
+  importReducingJoinsAndPlan(from, state);
+}
+
+void Optimization::importReducingJoinsAndPlan(
+    DerivedTableCP from,
+    PlanState& state) {
   // Look for reducing joins to import inside the DT. Bushy joins are
   // only allowed when the primary table is a base table — when it is a
   // subquery DT, bushy tables would be placed inside the MemoKey alongside
@@ -3052,14 +3068,15 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
       state.downstreamColumns(),
       std::move(reducingTables),
       std::move(result.existences));
-  plan = makePlan(
+  bool ignore{false};
+  auto reducingPlan = makePlan(
       *state.dt,
       reducingKey,
       /*distribution=*/std::nullopt,
       /*existsFanout=*/result.existenceReduction,
       /*needsShuffle=*/ignore);
-  state.cost = plan->cost;
-  makeJoins(plan->op, state);
+  state.cost = reducingPlan->cost;
+  makeJoins(reducingPlan->op, state);
 }
 
 bool Optimization::placeConjuncts(
@@ -3216,7 +3233,147 @@ std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
 
   return indices;
 }
+
+// Returns true if 'candidate' joins on equi-keys (not a cross product).
+bool isRealEdgeCandidate(const NextJoin& candidate) {
+  return candidate.candidate->join != nullptr &&
+      candidate.candidate->join->numKeys() > 0;
+}
 } // namespace
+
+void Optimization::greedyJoinChainDescend(
+    RelationOpPtr plan,
+    PlanState& state) {
+  VELOX_CHECK_NOT_NULL(plan);
+
+  if (placeConjuncts(plan, state, false)) {
+    return;
+  }
+
+  auto candidates = nextJoins(state);
+  if (candidates.empty()) {
+    if (placeConjuncts(plan, state, true)) {
+      return;
+    }
+
+    const auto downstream = state.downstreamColumns();
+    std::vector<DerivedTableCP> singleRowDtsToPlace;
+    state.dt->singleRowDts.forEach<DerivedTable>([&](DerivedTableCP subquery) {
+      if (!state.isPlaced(subquery)) {
+        if (!downstream.containsAny(subquery->columns)) {
+          state.place(subquery);
+        } else {
+          singleRowDtsToPlace.push_back(subquery);
+        }
+      }
+    });
+
+    for (const auto* singleRowDt : singleRowDtsToPlace) {
+      plan = placeSingleRowDt(plan, singleRowDt, state);
+    }
+
+    addPostprocess(state.dt, plan, state);
+    state.plans.addPlan(plan, state);
+    return;
+  }
+
+  std::vector<NextJoin> extensions;
+  extensions.reserve(candidates.size());
+  for (auto& candidate : candidates) {
+    addJoin(candidate, plan, state, extensions);
+  }
+  if (extensions.empty()) {
+    return;
+  }
+
+  auto cheapestOf = [&](bool wantReal) -> const NextJoin* {
+    const NextJoin* best = nullptr;
+    for (const auto& next : extensions) {
+      if (isRealEdgeCandidate(next) != wantReal) {
+        continue;
+      }
+      if (best == nullptr || next.cost.cardinality < best->cost.cardinality ||
+          (next.cost.cardinality == best->cost.cardinality &&
+           next.cost.cost < best->cost.cost)) {
+        best = &next;
+      }
+    }
+    return best;
+  };
+  const NextJoin* chosen = cheapestOf(/*wantReal=*/true);
+  if (chosen == nullptr) {
+    chosen = cheapestOf(/*wantReal=*/false);
+  }
+  VELOX_CHECK_NOT_NULL(chosen);
+
+  state.restore(*chosen);
+  greedyJoinChainDescend(chosen->plan, state);
+}
+
+void Optimization::solveJoinOrderApproximately(PlanState& state) {
+  state.setGreedyJoinOrder(true);
+  SCOPE_EXIT {
+    state.setGreedyJoinOrder(false);
+  };
+
+  PlanObjectVector firstTables = state.dt->startTables.toObjects();
+
+  const auto sortedIndices = sortByStartingScore(firstTables);
+
+  for (auto index : sortedIndices) {
+    auto* from = firstTables.at(index);
+#ifndef NDEBUG
+    state.debugSetFirstTable(from->id());
+#endif
+    if (from->is(PlanType::kTableNode)) {
+      auto* table = from->as<BaseTable>();
+      const auto leafIndices = table->chooseLeafIndex();
+      const auto downstream = state.downstreamColumns();
+      for (auto leafIndex : leafIndices) {
+        auto columns = indexColumns(downstream, table, leafIndex);
+
+        PlanStateSaver save(state);
+        state.place(table);
+        state.placeColumns(columns);
+
+        auto* scan = make<TableScan>(table, leafIndex, columns);
+        state.addCost(*scan);
+        if (auto partitionType = leafIndex->layout->partitionType()) {
+          state.mutableCurrentGroupedLeaves().emplace(
+              scan, std::move(partitionType));
+        }
+        greedyJoinChainDescend(scan, state);
+      }
+    } else if (from->is(PlanType::kValuesTableNode)) {
+      const auto* valuesTable = from->as<ValuesTable>();
+      ColumnVector columns;
+      state.downstreamColumns().forEach<Column>([&](auto column) {
+        if (valuesTable == column->relation()) {
+          columns.push_back(column);
+        }
+      });
+
+      PlanStateSaver save(state);
+      state.place(valuesTable);
+      state.placeColumns(columns);
+      auto* scan = make<Values>(*valuesTable, std::move(columns));
+      state.addCost(*scan);
+      greedyJoinChainDescend(scan, state);
+    } else if (from->is(PlanType::kDerivedTableNode)) {
+      PlanStateSaver save(state);
+      auto* dt = from->as<const DerivedTable>();
+      auto planOp = planDtAsLeaf(dt, state);
+      greedyJoinChainDescend(std::move(planOp), state);
+      importReducingJoinsAndPlan(dt, state);
+    } else if (from->is(PlanType::kUnnestTableNode)) {
+      VELOX_FAIL("UnnestTable cannot be a starting table");
+    }
+  }
+
+  VELOX_CHECK(
+      !state.plans.plans.empty(),
+      "solveJoinOrderApproximately produced no plan");
+}
 
 void Optimization::makeJoins(PlanState& state) {
   // Sanity check that there are no RIGHT joins.
@@ -3225,6 +3382,13 @@ void Optimization::makeJoins(PlanState& state) {
       VELOX_CHECK(
           join->rightOptional(), "Unexpected RIGHT join: {}", join->toString());
     }
+  }
+
+  if (!options().syntacticJoinOrder &&
+      static_cast<int32_t>(state.dt->tables.size()) >=
+          options().greedyJoinThreshold) {
+    solveJoinOrderApproximately(state);
+    return;
   }
 
   PlanObjectVector firstTables;
@@ -3296,6 +3460,12 @@ void Optimization::makeJoins(PlanState& state) {
 
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   VELOX_CHECK_NOT_NULL(plan);
+
+  if (state.greedyJoinOrder()) {
+    greedyJoinChainDescend(plan, state);
+    return;
+  }
+
   auto dt = state.dt;
 
   if (state.isOverBest()) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -245,6 +245,15 @@ class Optimization {
 
   void makeJoins(PlanState& state);
 
+  // Bounds planning time on large derived tables via greedy join-order
+  // search. Each (starting table, leaf index) pair seeds one chain; the
+  // cheapest resulting plan is left in 'state.plans'.
+  void solveJoinOrderApproximately(PlanState& state);
+
+  // Descends one greedy chain from 'plan', registering the result in
+  // 'state.plans'.
+  void greedyJoinChainDescend(RelationOpPtr plan, PlanState& state);
+
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.
   //
@@ -310,6 +319,14 @@ class Optimization {
   // Places a derived table as first table in a plan. Imports possibly reducing
   // joins into the plan if can.
   void placeDerivedTable(DerivedTableCP from, PlanState& state);
+
+  // Places 'from' and plans its inner DT via memo. Returns the relational
+  // op for the caller to extend.
+  RelationOpPtr planDtAsLeaf(DerivedTableCP from, PlanState& state);
+
+  // Imports reducing joins from the surrounding scope into 'from' for a
+  // bushier shape and plans the result.
+  void importReducingJoinsAndPlan(DerivedTableCP from, PlanState& state);
 
   // Adds the items from 'dt.conjuncts' that are not placed in 'state'
   // and whose prerequisite columns are placed. If conjuncts can be

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -86,6 +86,14 @@ std::vector<ConfigProperty> buildProperties(
           "Number of threads for parallel projection. 1 disables.",
       },
       {
+          std::string(OptimizerOptions::kGreedyJoinThreshold),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kGreedyJoinThresholdDefault),
+          "Use a greedy join-order search instead of exhaustive enumeration "
+          "when a single query block contains at least this many joined "
+          "tables. Greedy is approximate but bounded in planning time.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -129,6 +137,10 @@ std::string OptimizerOptions::normalize(
     auto width = std::stoi(std::string(value));
     VELOX_USER_CHECK_GE(
         width, 1, "parallel_project_width must be >= 1: {}", value);
+  } else if (name == kGreedyJoinThreshold) {
+    auto threshold = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        threshold, 1, "greedy_join_threshold must be >= 1: {}", value);
   }
   return std::string(value);
 }
@@ -159,6 +171,7 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
   setBool(kEnableReducingExistences, options.enableReducingExistences);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
+  setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -47,11 +47,14 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "enable_reducing_existences";
   static constexpr std::string_view kParallelProjectWidth =
       "parallel_project_width";
+  static constexpr std::string_view kGreedyJoinThreshold =
+      "greedy_join_threshold";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
   // and properties().
   static constexpr int32_t kParallelProjectWidthDefault = 1;
+  static constexpr int32_t kGreedyJoinThresholdDefault = 5;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -105,6 +108,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
 
   /// Disable cost-based join order selection.
   bool syntacticJoinOrder{kSyntacticJoinOrderDefault};
+
+  /// Use a greedy join-order search instead of exhaustive enumeration when
+  /// a single query block contains at least this many joined tables.
+  int32_t greedyJoinThreshold{kGreedyJoinThresholdDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -330,6 +330,17 @@ struct PlanState {
     return currentGroupedLeaves_;
   }
 
+  /// True while greedy join enumeration is driving this PlanState. Routes
+  /// nested makePlan / placeConjuncts re-entries back into the greedy path
+  /// so the planning-time bound holds end-to-end.
+  bool greedyJoinOrder() const {
+    return greedyJoinOrder_;
+  }
+
+  void setGreedyJoinOrder(bool value) {
+    greedyJoinOrder_ = value;
+  }
+
  private:
   PlanObjectSet computeDownstreamColumns(bool includeFilters) const;
 
@@ -358,6 +369,10 @@ struct PlanState {
   // operator. Updated as scans are placed (insert), as joins fold copartition
   // (per-leaf coarsening), and as Repartitions are inserted (snapshot+reset).
   GroupedLeaves currentGroupedLeaves_;
+
+  // See greedyJoinOrder(). Set by solveJoinOrderApproximately for the
+  // duration of its SCOPE_EXIT-bounded run.
+  bool greedyJoinOrder_{false};
 };
 
 /// A scoped guard that restores fields of PlanState on destruction.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -846,6 +846,67 @@ float baseSelectivity(PlanObjectCP object) {
   }
   return 1;
 }
+
+// Returns the single-column filter on 'table' that constrains 'key' (or any
+// column equivalent to 'key' that belongs to 'table'). Returns nullptr if no
+// such filter exists or 'key' is not a column expression.
+ExprCP FOLLY_NULLABLE findColumnFilterOnKey(BaseTableCP table, ExprCP key) {
+  if (!key->is(PlanType::kColumnExpr)) {
+    return nullptr;
+  }
+  const auto* keyColumn = key->as<Column>();
+  const auto* equivalence = keyColumn->equivalence();
+
+  for (auto* filter : table->columnFilters) {
+    const auto& filterColumns = filter->columns();
+    if (filterColumns.size() != 1) {
+      continue;
+    }
+    const auto* filterColumn = filterColumns.onlyObject<Column>();
+    if (filterColumn == keyColumn) {
+      return filter;
+    }
+    if (equivalence != nullptr) {
+      for (const auto* equivalentColumn : equivalence->columns) {
+        if (equivalentColumn == filterColumn) {
+          return filter;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+// Returns true when every (leftKeys[i], rightKeys[i]) pair has a single-column
+// filter on each side and the two filters are structurally equal under
+// `Expr::sameOrEqual` (which treats equivalence-class columns as equal at the
+// leaves). Returns false on the first pair without a duplicate.
+bool everyKeyPairHasDuplicateFilter(
+    PlanObjectCP leftObject,
+    PlanObjectCP rightObject,
+    const ExprVector& leftKeys,
+    const ExprVector& rightKeys) {
+  if (leftObject == nullptr || rightObject == nullptr ||
+      !leftObject->is(PlanType::kTableNode) ||
+      !rightObject->is(PlanType::kTableNode)) {
+    return false;
+  }
+  const auto* leftTable = leftObject->as<BaseTable>();
+  const auto* rightTable = rightObject->as<BaseTable>();
+  VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+  VELOX_DCHECK(!leftKeys.empty());
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    const auto leftFilter = findColumnFilterOnKey(leftTable, leftKeys[i]);
+    const auto rightFilter = findColumnFilterOnKey(rightTable, rightKeys[i]);
+    if (leftFilter == nullptr || rightFilter == nullptr) {
+      return false;
+    }
+    if (!leftFilter->sameOrEqual(*rightFilter)) {
+      return false;
+    }
+  }
+  return true;
+}
 } // namespace
 
 void JoinEdge::guessFanout() {
@@ -867,6 +928,17 @@ void JoinEdge::guessFanout() {
   leftUnique_ = left.unique;
   rightUnique_ = right.unique;
 
+  const auto leftSelectivity = baseSelectivity(leftTable_);
+  const auto rightSelectivity = baseSelectivity(rightTable_);
+  const bool hasDuplicateEquivalenceFilter = everyKeyPairHasDuplicateFilter(
+      leftTable_, rightTable_, leftKeys_, rightKeys_);
+  const auto effectiveLeftSelectivity = hasDuplicateEquivalenceFilter
+      ? std::max(leftSelectivity, rightSelectivity)
+      : leftSelectivity;
+  const auto effectiveRightSelectivity = hasDuplicateEquivalenceFilter
+      ? effectiveLeftSelectivity
+      : rightSelectivity;
+
   // If one side has unique join keys, this is a primary key (PK) to foreign
   // key (FK) join. For example, joining orders (PK: orderkey) with lineitem
   // (FK: orderkey), if orders is the left table, then leftUnique_ is true: each
@@ -874,23 +946,23 @@ void JoinEdge::guessFanout() {
   // match many lineitems (lrFanout = cardLineitem / cardOrders). When both
   // sides are unique (1:1 join), leftUnique takes precedence.
   if (leftUnique_) {
-    rlFanout_ = left.fanout * baseSelectivity(leftTable_);
+    rlFanout_ = left.fanout * effectiveLeftSelectivity;
     lrFanout_ = tableCardinality(rightTable_) / tableCardinality(leftTable_) *
-        baseSelectivity(rightTable_);
+        effectiveRightSelectivity;
   } else if (rightUnique_) {
-    lrFanout_ = right.fanout * baseSelectivity(rightTable_);
+    lrFanout_ = right.fanout * effectiveRightSelectivity;
     rlFanout_ = tableCardinality(leftTable_) / tableCardinality(rightTable_) *
-        baseSelectivity(leftTable_);
+        effectiveLeftSelectivity;
   } else {
     auto [sampledLeftFanout, sampledRightFanout] = options.sampleJoins
         ? opt->history().sampleJoin(this)
         : std::pair<float, float>(0, 0);
     if (sampledLeftFanout == 0 && sampledRightFanout == 0) {
-      lrFanout_ = right.fanout * baseSelectivity(rightTable_);
-      rlFanout_ = left.fanout * baseSelectivity(leftTable_);
+      lrFanout_ = right.fanout * effectiveRightSelectivity;
+      rlFanout_ = left.fanout * effectiveLeftSelectivity;
     } else {
-      lrFanout_ = sampledRightFanout * baseSelectivity(rightTable_);
-      rlFanout_ = sampledLeftFanout * baseSelectivity(leftTable_);
+      lrFanout_ = sampledRightFanout * effectiveRightSelectivity;
+      rlFanout_ = sampledLeftFanout * effectiveLeftSelectivity;
     }
   }
 }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -612,6 +612,11 @@ class JoinEdge {
   }
 
   static JoinEdge* makeInner(PlanObjectCP leftTable, PlanObjectCP rightTable) {
+    VELOX_CHECK_NOT_NULL(
+        leftTable,
+        "Inner join requires a left table; hyper-edge joins (leftTable=nullptr) "
+        "cannot be converted to inner.");
+    VELOX_CHECK_NOT_NULL(rightTable, "Inner join requires a right table.");
     VELOX_CHECK(
         !leftTable->is(PlanType::kUnnestTableNode) &&
             !rightTable->is(PlanType::kUnnestTableNode),

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -673,5 +673,52 @@ TEST_F(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
   EXPECT_TRUE(foundBucketedScan);
 }
 
+TEST_F(BucketedExecutionTest, greedyBucketed) {
+  addBucketedTable("g_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "g_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM g_orders JOIN g_customers "
+      "ON g_orders.customer_id = g_customers.id",
+      kTestConnectorId));
+  expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
+TEST_F(BucketedExecutionTest, greedyBucketedWithDimensions) {
+  constexpr int kNumDims = 8;
+
+  std::vector<std::string> factColumns{"customer_id"};
+  std::vector<TypePtr> factTypes{BIGINT()};
+  for (int i = 0; i < kNumDims; ++i) {
+    factColumns.push_back(fmt::format("dim_key_{}", i));
+    factTypes.push_back(BIGINT());
+  }
+  auto factSchema = ROW(std::move(factColumns), std::move(factTypes));
+
+  addBucketedTable("g_fact_a", {"customer_id"}, 128, factSchema);
+  addBucketedTable("g_fact_b", {"customer_id"}, 128, factSchema);
+
+  for (int i = 0; i < kNumDims; ++i) {
+    addUnbucketedTable(
+        fmt::format("g_dim_{}", i),
+        ROW({"d_id", "d_val"}, {BIGINT(), VARCHAR()}),
+        100);
+  }
+
+  std::string sql =
+      "SELECT g_fact_a.customer_id FROM g_fact_a JOIN g_fact_b "
+      "ON g_fact_a.customer_id = g_fact_b.customer_id";
+  for (int i = 0; i < kNumDims; ++i) {
+    sql += fmt::format(
+        " JOIN g_dim_{0} ON g_fact_a.dim_key_{0} = g_dim_{0}.d_id", i);
+  }
+
+  auto plan = planDistributed(parseSelect(sql, kTestConnectorId));
+  expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -545,6 +545,103 @@ TEST_F(CardinalityEstimationTest, joinWithFilterOutsideMinMax) {
   verify("SELECT a, b, x, y FROM t JOIN u ON a = x AND b = y WHERE a = 999");
 }
 
+// Join cardinality is unchanged when both sides carry the same single-column
+// filter on equivalence-class columns, but reduced when the per-side filters
+// differ.
+TEST_F(CardinalityEstimationTest, joinWithDuplicateEquivalenceFilter) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"a", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+              {"b", {.numDistinct = 500}},
+          });
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"x", {.min = 1LL, .max = 100LL, .numDistinct = 100}},
+              {"y", {.numDistinct = 200}},
+          });
+
+  float baselineCardinality = 0;
+  verifyPlan(
+      "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        baselineCardinality = join.resultCardinality();
+        EXPECT_GT(baselineCardinality, 0);
+      });
+
+  verifyPlan(
+      "SELECT * FROM t, u WHERE t.a = u.x AND t.a = 5 AND u.x = 5",
+      [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_NEAR(
+            join.resultCardinality(),
+            baselineCardinality,
+            kCardinalityTolerance);
+      });
+
+  // Asymmetric column ranges so each side's selectivity contributes
+  // independently when the filters differ structurally.
+  testConnector_->addTable("w", ROW({"x", "y"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"x", {.min = 1LL, .max = 1'000LL, .numDistinct = 1'000}},
+              {"y", {.numDistinct = 200}},
+          });
+
+  float matchingFilterBaselineCardinality = 0;
+  verifyPlan(
+      "SELECT * FROM t, w WHERE t.a = w.x AND t.a > 5", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        matchingFilterBaselineCardinality = join.resultCardinality();
+        EXPECT_GT(matchingFilterBaselineCardinality, 0);
+      });
+
+  verifyPlan(
+      "SELECT * FROM t, w WHERE t.a = w.x AND t.a > 5 AND w.x < 10",
+      [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_LT(
+            join.resultCardinality(), matchingFilterBaselineCardinality / 4);
+      });
+
+  testConnector_->addTable("v", ROW({"p", "q"}, BIGINT()))
+      ->setStats(
+          1'000,
+          {
+              {"p", {.numDistinct = 100}},
+              {"q", {.numDistinct = 100}},
+          });
+
+  float tvBaselineCardinality = 0;
+  verifyPlan("SELECT * FROM t, v WHERE t.a = v.p", [&](const Plan& plan) {
+    const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+    tvBaselineCardinality = join.resultCardinality();
+    EXPECT_GT(tvBaselineCardinality, 0);
+  });
+
+  verifyPlan(
+      "SELECT * FROM t, v WHERE t.a = v.p AND v.q = 7", [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_LT(join.resultCardinality(), tvBaselineCardinality);
+      });
+
+  verifyPlan(
+      "SELECT * FROM t, u "
+      "WHERE t.a = u.x AND t.a = 5 AND u.x = 5 AND t.b = 200",
+      [&](const Plan& plan) {
+        const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
+        EXPECT_NEAR(
+            join.resultCardinality(),
+            baselineCardinality,
+            kCardinalityTolerance);
+      });
+}
+
 // Verifies that inner join with a unique right side (DerivedTable with GROUP
 // BY) uses the right fanout to scale cardinality. The right side's fanout
 // reflects that not all left key values exist in the right side.

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1908,5 +1908,179 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
   }
 }
 
+TEST_F(JoinTest, greedyJoinOrder) {
+  testConnector_->addTable("t1", ROW({"id1", "data1"}, BIGINT()))
+      ->setStats(100, {});
+  testConnector_->addTable("t2", ROW({"id2", "data2"}, BIGINT()))
+      ->setStats(200, {});
+  testConnector_->addTable("t3", ROW({"id3", "data3"}, BIGINT()))
+      ->setStats(400, {});
+  testConnector_->addTable("t4", ROW({"id4", "data4"}, BIGINT()))
+      ->setStats(800, {});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t1")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t2"),
+                             "id1 = id2",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t3"),
+                             "id2 = id3",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t4"),
+                             "id3 = id4",
+                             lp::JoinType::kInner)
+                         .build();
+
+  {
+    SCOPED_TRACE("greedy fires (threshold=4)");
+    optimizerOptions_.greedyJoinThreshold = 4;
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = matchScan("t4")
+                       .hashJoin(matchScan("t1").build())
+                       .hashJoin(matchScan("t2").build())
+                       .hashJoin(matchScan("t3").build())
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  {
+    SCOPED_TRACE("branch-and-bound (threshold=100)");
+    optimizerOptions_.greedyJoinThreshold = 100;
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher =
+        matchScan("t4")
+            .hashJoin(matchScan("t3")
+                          .hashJoin(matchScan("t2")
+                                        .hashJoin(matchScan("t1").build())
+                                        .build())
+                          .build())
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+TEST_F(JoinTest, greedyDtStart) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}))
+      ->setStats(1000, {});
+  testConnector_->addTable("base1", ROW({"id1", "x1"}, {BIGINT(), BIGINT()}))
+      ->setStats(500, {});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t")
+                         .aggregate({"a"}, {"sum(b) as s"})
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("base1"),
+                             "a = id1",
+                             lp::JoinType::kLeft)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("t")
+          .singleAggregation({"a"}, {"sum(b) as s"})
+          .hashJoin(matchScan("base1").build(), core::JoinType::kLeft)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(JoinTest, greedyBushy) {
+  testConnector_->addTable("fact", ROW({"fact_a", "fact_b"}, BIGINT()))
+      ->setStats(
+          10'000'000,
+          {{"fact_a", {.numDistinct = 100}}, {"fact_b", {.numDistinct = 100}}});
+  testConnector_->addTable("dim_a", ROW({"da_key", "da_sub"}, BIGINT()))
+      ->setStats(
+          100,
+          {{"da_key", {.numDistinct = 100}}, {"da_sub", {.numDistinct = 100}}});
+  testConnector_->addTable("sub_a", ROW({"sa_key"}, BIGINT()))
+      ->setStats(10, {{"sa_key", {.numDistinct = 10}}});
+  testConnector_->addTable("dim_b", ROW({"db_key", "db_sub"}, BIGINT()))
+      ->setStats(
+          100,
+          {{"db_key", {.numDistinct = 100}}, {"db_sub", {.numDistinct = 100}}});
+  testConnector_->addTable("sub_b", ROW({"sb_key"}, BIGINT()))
+      ->setStats(10, {{"sb_key", {.numDistinct = 10}}});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("fact")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("dim_a"),
+                             "fact_a = da_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("sub_a"),
+                             "da_sub = sa_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("dim_b"),
+                             "fact_b = db_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("sub_b"),
+                             "db_sub = sb_key",
+                             lp::JoinType::kInner)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 5;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("fact")
+                     .hashJoin(matchScan("dim_a").build())
+                     .hashJoin(matchScan("sub_a").build())
+                     .hashJoin(matchScan("dim_b").build())
+                     .hashJoin(matchScan("sub_b").build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(JoinTest, greedyValuesStart) {
+  testConnector_->addTable("v_t1", ROW({"a", "b"}, BIGINT()))
+      ->setStats(1000, {{"a", {.numDistinct = 1000}}});
+  testConnector_->addTable("v_t2", ROW({"c", "d"}, BIGINT()))
+      ->setStats(2000, {{"c", {.numDistinct = 2000}}});
+  testConnector_->addTable("v_t3", ROW({"e", "f"}, BIGINT()))
+      ->setStats(4000, {{"e", {.numDistinct = 4000}}});
+
+  auto rowVector = makeRowVector({"v"}, {makeFlatVector<int64_t>({1, 2, 3})});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .values({rowVector})
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t1"),
+                             "v = a",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t2"),
+                             "a = c",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t3"),
+                             "c = e",
+                             lp::JoinType::kInner)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("v_t3")
+                     .hashJoin(core::PlanMatcherBuilder{}.values().build())
+                     .hashJoin(matchScan("v_t1").build())
+                     .hashJoin(matchScan("v_t2").build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1328,10 +1328,10 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1359,10 +1359,10 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IN (1, 2, 3)";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .filter("x IN (1, 2, 3)")
+    auto matcher = matchScan("t")
+                       .filter("a IN (1, 2, 3)")
                        .hashJoin(
-                           matchScan("t").filter("a IN (1, 2, 3)").build(),
+                           matchScan("u").filter("x IN (1, 2, 3)").build(),
                            core::JoinType::kInner)
                        .build();
 
@@ -1430,10 +1430,10 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1449,12 +1449,12 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("u")
-            .filter("x = 5")
-            .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+        matchScan("t")
+            .filter("a = 5")
             .hashJoin(
                 matchScan("v").filter("k = 5").build(), core::JoinType::kInner)
+            .hashJoin(
+                matchScan("u").filter("x = 5").build(), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1274,6 +1274,46 @@ TEST_F(JoinTest, impliedJoins) {
   }
 }
 
+// Implied join edges from an equivalence class must not reference tables
+// outside a subset DT's tableSet.
+TEST_F(JoinTest, impliedJoinChain) {
+  testConnector_->addTable("t1", ROW({"id1", "data1"}, BIGINT()))
+      ->setStats(1'000'000, {{"id1", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("t2", ROW({"id2", "data2"}, BIGINT()))
+      ->setStats(100, {{"id2", {.numDistinct = 100}}});
+  testConnector_->addTable("t3", ROW({"id3", "data3"}, BIGINT()))
+      ->setStats(100, {{"id3", {.numDistinct = 100}}});
+  testConnector_->addTable("t4", ROW({"id4", "data4"}, BIGINT()))
+      ->setStats(100, {{"id4", {.numDistinct = 100}}});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t1")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t2"),
+                             "id1 = id2",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t3"),
+                             "id2 = id3",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t4"),
+                             "id3 = id4",
+                             lp::JoinType::kInner)
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t3")
+                     .hashJoin(matchScan("t1")
+                                   .hashJoin(matchScan("t2").build())
+                                   .hashJoin(matchScan("t4").build())
+                                   .build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 TEST_F(JoinTest, impliedFilters) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -18,6 +18,8 @@
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/type/Type.h"
 
@@ -288,6 +290,14 @@ TEST_F(QueryGraphContextTest, pathOrdering) {
     EXPECT_FALSE(pathValues[i] < pathValues[i - 1])
         << "Sort result not ordered at index " << i;
   }
+}
+
+TEST_F(QueryGraphContextTest, joinEdgeMakeInnerRejectsNullTables) {
+  auto* table = make<BaseTable>();
+  VELOX_ASSERT_THROW(
+      JoinEdge::makeInner(nullptr, table), "Inner join requires a left table");
+  VELOX_ASSERT_THROW(
+      JoinEdge::makeInner(table, nullptr), "Inner join requires a right table");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
@@ -51,6 +52,9 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
 
   void SetUp() override {
     HiveQueriesTestBase::SetUp();
+
+    // Pin TPC-H golden plans to exhaustive branch-and-bound.
+    optimizerOptions_.greedyJoinThreshold = std::numeric_limits<int32_t>::max();
 
     referenceBuilder_ =
         std::make_unique<exec::test::TpchQueryBuilder>(localFileFormat_);

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -104,3 +104,38 @@ WHERE EXISTS (
   SELECT 1 FROM (VALUES (1, 1), (2, 3), (3, 3)) AS u(x, y)
   WHERE u.x = t.a AND u.y = t.a
 )
+----
+-- 8-way self-join hitting the greedy join-enumeration cutoff.
+SELECT count(*)
+FROM t t1
+JOIN t t2 ON t1.b = t2.b
+JOIN t t3 ON t2.b = t3.b
+JOIN t t4 ON t3.b = t4.b
+JOIN t t5 ON t4.b = t5.b
+JOIN t t6 ON t5.b = t6.b
+JOIN t t7 ON t6.b = t7.b
+JOIN t t8 ON t7.b = t8.b
+----
+-- 20-way self-join. Stress-tests greedy at multiples of the default cutoff;
+-- result count is validated end-to-end against DuckDB.
+SELECT count(*)
+FROM t t1
+JOIN t t2 ON t1.b = t2.b
+JOIN t t3 ON t2.b = t3.b
+JOIN t t4 ON t3.b = t4.b
+JOIN t t5 ON t4.b = t5.b
+JOIN t t6 ON t5.b = t6.b
+JOIN t t7 ON t6.b = t7.b
+JOIN t t8 ON t7.b = t8.b
+JOIN t t9 ON t8.b = t9.b
+JOIN t t10 ON t9.b = t10.b
+JOIN t t11 ON t10.b = t11.b
+JOIN t t12 ON t11.b = t12.b
+JOIN t t13 ON t12.b = t13.b
+JOIN t t14 ON t13.b = t14.b
+JOIN t t15 ON t14.b = t15.b
+JOIN t t16 ON t15.b = t16.b
+JOIN t t17 ON t16.b = t17.b
+JOIN t t18 ON t17.b = t18.b
+JOIN t t19 ON t18.b = t19.b
+JOIN t t20 ON t19.b = t20.b

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -139,3 +139,11 @@ JOIN t t17 ON t16.b = t17.b
 JOIN t t18 ON t17.b = t18.b
 JOIN t t19 ON t18.b = t19.b
 JOIN t t20 ON t19.b = t20.b
+----
+-- RIGHT JOIN whose inferred left keys span multiple tables (hyper-edge).
+-- error: Failed to place a table
+SELECT 1
+FROM t AS ref_4
+RIGHT JOIN (SELECT (SELECT c FROM t LIMIT 1) AS c0) AS subq_0
+  ON CAST(null AS double) > subq_0.c0
+WHERE ref_4.b = ref_4.b


### PR DESCRIPTION
Summary:

`tryConvertOuterJoins` fed hyper-edge outer joins (`leftKeys` spanning multiple tables, so `JoinEdge::leftTable() == nullptr`) into `JoinEdge::makeInner`, which dereferenced the left table and crashed.

`tryConvertOuterJoins` now skips hyper-edges. `JoinEdge::makeInner` gains `VELOX_CHECK_NOT_NULL` guards so any future caller fails fast with a clear message instead of segfaulting.

Differential Revision: D105851780


