### PR TITLE
test: Suppress TSAN warnings from unsafe executor stats collection

### DIFF
--- a/axiom/common/TrackedExecutor.cpp
+++ b/axiom/common/TrackedExecutor.cpp
@@ -16,10 +16,20 @@
 
 #include "axiom/common/TrackedExecutor.h"
 
+#include <folly/synchronization/SanitizeThread.h>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "velox/common/time/CpuWallTimer.h"
 
 namespace facebook::axiom {
+
+TrackedExecutor::Metrics::Metrics() {
+  folly::annotate_benign_race_sized(
+      this,
+      sizeof(*this),
+      "axiom::TrackedExecutor::Metrics is deliberately not thread safe",
+      __FILE__,
+      __LINE__);
+}
 
 TrackedExecutor::Func TrackedExecutor::wrapFunc(Func func) {
   auto enqueueTime = std::chrono::steady_clock::now();

--- a/axiom/common/TrackedExecutor.h
+++ b/axiom/common/TrackedExecutor.h
@@ -81,7 +81,11 @@ class TrackedExecutor final : public folly::Executor {
 
   struct Metrics {
     // Not thread safe. Prefer potential inaccuracy over synchronization
-    // overhead.
+    // overhead. Construction annotates the whole struct as benignly racy so
+    // ThreadSanitizer does not flag concurrent updates from the wrapped tasks
+    // or reads from reportTo().
+    Metrics();
+
     velox::RuntimeMetric waitTime_{velox::RuntimeCounter::Unit::kNanos};
     velox::RuntimeMetric executionWallTime_{
         velox::RuntimeCounter::Unit::kNanos};


### PR DESCRIPTION
Summary:
- `TrackedExecutor::Metrics` aggregates wait/wall/cpu timings into three non-atomic `velox::RuntimeMetric` counters. The struct is deliberately not thread safe — the existing comment notes it prefers potential inaccuracy over synchronization overhead.
- Concurrent writes from wrapped-task lambdas and a read from `reportTo()` triggered TSan warnings on tests like `LoadPartitionOperationTest.execute_doublePartitioned_loadsDataSuccessfully`.
- `Metrics()` now calls `folly::annotate_benign_race_sized(this, sizeof(*this), ...)` so TSan ignores all accesses to the three metric fields.
- Per-function `__attribute__((__no_sanitize__("thread")))` would not suffice: the actual reads/writes happen inside `velox::RuntimeMetric::addValue` and inside `folly::ConcurrentHashMap`'s memcpy path, none of which is lexically inside the annotated `TrackedExecutor` functions.

Differential Revision: D106142332


