### PR TITLE
feat(cli): Add --print_timing and --repeat for perf measurement

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -18,10 +18,12 @@
 #include <folly/container/F14Map.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
+#include <iostream>
 #include <set>
 #include "axiom/cli/CatalogProperties.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
+#include "velox/common/base/Exceptions.h"
 
 DEFINE_string(
     catalog,
@@ -116,7 +118,14 @@ int main(int argc, char** argv) {
 
   axiom::sql::Console console{runner};
   console.initialize();
-  console.run();
+  // Invalid CLI flags throw VeloxUserError; surface them as a clean
+  // 'Error: ...' line and a non-zero exit.
+  try {
+    console.run();
+  } catch (const facebook::velox::VeloxUserError& e) {
+    std::cerr << "Error: " << e.message() << std::endl;
+    return 1;
+  }
 
   return 0;
 }

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <optional>
 #include <set>
 #include "axiom/cli/ResultPrinter.h"
@@ -58,6 +59,20 @@ DEFINE_string(
     "Path to a SQL file to execute on startup before entering interactive mode or running --query");
 
 DEFINE_bool(debug, false, "Enable debug mode");
+
+DEFINE_bool(
+    print_timing,
+    false,
+    "Print per-statement timing (parse / optimize / execute). Always on in "
+    "interactive mode.");
+
+DEFINE_int32(
+    repeat,
+    1,
+    "Run the --query input this many times back-to-back. Useful for perf "
+    "measurements, re-running flaky queries, or queries with "
+    "non-deterministic results. The input must be a single statement. "
+    "Does not apply to --init. Stops on the first error.");
 
 using namespace facebook::velox;
 
@@ -102,27 +117,107 @@ void Console::initialize() {
 }
 
 void Console::run() {
+  gflags::CommandLineFlagInfo repeatInfo;
+  gflags::GetCommandLineFlagInfo("repeat", &repeatInfo);
+
+  VELOX_USER_CHECK_GE(FLAGS_repeat, 1, "--repeat must be at least 1");
+
   if (!FLAGS_init.empty()) {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
     VELOX_USER_CHECK(success, "Cannot open init file: {}", FLAGS_init);
-    runNoThrow(sql, false);
+    runMultiple(sql, FLAGS_print_timing);
   }
 
+  const bool interactive = isatty(STDIN_FILENO);
+
+  // Pick the user-SQL source: --query first, then piped stdin.
+  std::string userSql;
   if (!FLAGS_query.empty()) {
-    runNoThrow(FLAGS_query, false);
-  } else {
-    const bool interactive = isatty(STDIN_FILENO);
-    if (interactive) {
-      std::cout << "Axiom SQL. Type statement and end with ;.\n"
-                   "Type .help for available commands."
-                << std::endl;
+    userSql = FLAGS_query;
+  } else if (!interactive) {
+    userSql.assign(std::istreambuf_iterator<char>(std::cin), {});
+  }
+
+  if (!userSql.empty()) {
+    if (repeatInfo.is_default) {
+      runMultiple(userSql, FLAGS_print_timing);
+    } else {
+      // Explicit --repeat: treat the input as a single statement.
+      runRepeat(userSql, FLAGS_repeat, FLAGS_print_timing);
     }
-    readCommands("SQL> ", interactive);
+    return;
+  }
+
+  // No user SQL: enter interactive REPL.
+  VELOX_USER_CHECK(
+      repeatInfo.is_default, "--repeat is not supported in interactive mode");
+  if (interactive) {
+    std::cout << "Axiom SQL. Type statement and end with ;.\n"
+                 "Type .help for available commands."
+              << std::endl;
+  }
+  readCommands("SQL> ", interactive || FLAGS_print_timing);
+}
+
+namespace {
+std::string formatTiming(
+    const QueryTiming& timing,
+    const cli::Timing& cpuTiming) {
+  return fmt::format(
+      "Parsing: {} | Optimizing: {} | Executing: {} | Total: {}",
+      facebook::velox::succinctMicros(timing.parse),
+      facebook::velox::succinctMicros(timing.optimize),
+      facebook::velox::succinctMicros(timing.execute),
+      cpuTiming.toString());
+}
+} // namespace
+
+bool Console::runOnce(std::string_view sql, bool printTiming) {
+  QueryCompletionInfo completionInfo;
+
+  SqlQueryRunner::RunOptions options{
+      .numWorkers = FLAGS_num_workers,
+      .numDrivers = FLAGS_num_drivers,
+      .splitTargetBytes = FLAGS_split_target_bytes,
+      .debugMode = FLAGS_debug,
+      .onComplete =
+          [&](const QueryCompletionInfo& info) { completionInfo = info; },
+  };
+
+  cli::Timing cpuTiming;
+  try {
+    auto result = cli::time<SqlQueryRunner::SqlResult>(
+        [&]() { return runner_.run(sql, options); }, cpuTiming);
+
+    if (result.message.has_value()) {
+      std::cout << result.message.value() << std::endl;
+    } else {
+      if (FLAGS_debug && !result.results.empty()) {
+        std::cout << result.results.front()->rowType()->toString() << std::endl;
+      }
+      cli::printResults(result.results, FLAGS_max_rows);
+    }
+
+    if (printTiming) {
+      std::cout << "Query ID: " << completionInfo.startInfo.queryId << " | "
+                << formatTiming(completionInfo.timing, cpuTiming) << std::endl;
+    }
+    return true;
+  } catch (const std::exception&) {
+    // run() threw after firing the completion callback, so telemetry was
+    // captured.
+    std::cerr << "Query failed: " << completionInfo.errorInfo->message
+              << std::endl;
+    if (printTiming) {
+      std::cerr << "Query ID: " << completionInfo.startInfo.queryId << " | "
+                << formatTiming(completionInfo.timing, cpuTiming) << std::endl;
+    }
+    return false;
   }
 }
 
-void Console::runNoThrow(std::string_view sql, bool isInteractive) {
+void Console::runMultiple(std::string_view sql, bool printTiming) {
   // Parse and execute statements one at a time so that DDL statements
   // (e.g. CREATE TABLE) take effect before subsequent statements (e.g.
   // INSERT) are parsed.
@@ -130,65 +225,21 @@ void Console::runNoThrow(std::string_view sql, bool isInteractive) {
     if (sqlText.empty()) {
       continue;
     }
-
-    // The completion callback captures telemetry for error reporting.
-    QueryCompletionInfo completionInfo;
-
-    SqlQueryRunner::RunOptions options{
-        .numWorkers = FLAGS_num_workers,
-        .numDrivers = FLAGS_num_drivers,
-        .splitTargetBytes = FLAGS_split_target_bytes,
-        .debugMode = FLAGS_debug,
-        .onComplete =
-            [&](const QueryCompletionInfo& info) { completionInfo = info; },
-    };
-
-    auto formatTiming = [](const QueryTiming& timing,
-                           const cli::Timing& cpuTiming) {
-      return fmt::format(
-          "Parsing: {} | Optimizing: {} | Executing: {} | Total: {}",
-          facebook::velox::succinctMicros(timing.parse),
-          facebook::velox::succinctMicros(timing.optimize),
-          facebook::velox::succinctMicros(timing.execute),
-          cpuTiming.toString());
-    };
-
-    cli::Timing cpuTiming;
-    try {
-      auto result = cli::time<SqlQueryRunner::SqlResult>(
-          [&]() { return runner_.run(sqlText, options); }, cpuTiming);
-
-      if (result.message.has_value()) {
-        std::cout << result.message.value() << std::endl;
-      } else {
-        if (FLAGS_debug && !result.results.empty()) {
-          std::cout << result.results.front()->rowType()->toString()
-                    << std::endl;
-        }
-        cli::printResults(result.results, FLAGS_max_rows);
-      }
-
-      if (isInteractive) {
-        std::cout << "Query ID: " << completionInfo.startInfo.queryId << " | "
-                  << formatTiming(completionInfo.timing, cpuTiming)
-                  << std::endl;
-      }
-    } catch (const std::exception&) {
-      // run() threw after firing the completion callback, so telemetry
-      // was captured.
-      std::cerr << "Query failed: " << completionInfo.errorInfo->message
-                << std::endl;
-      if (isInteractive) {
-        std::cerr << "Query ID: " << completionInfo.startInfo.queryId << " | "
-                  << formatTiming(completionInfo.timing, cpuTiming)
-                  << std::endl;
-      }
+    if (!runOnce(sqlText, printTiming)) {
       return;
     }
   }
 }
 
-void Console::readCommands(const std::string& prompt, bool interactive) {
+void Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
+  for (int i = 0; i < repeat; ++i) {
+    if (!runOnce(sql, printTiming)) {
+      return;
+    }
+  }
+}
+
+void Console::readCommands(const std::string& prompt, bool printTiming) {
   linenoiseSetMultiLine(1);
   linenoiseHistorySetMaxLen(1024);
 
@@ -204,7 +255,7 @@ void Console::readCommands(const std::string& prompt, bool interactive) {
     std::string command = cli::readCommand(prompt, atEnd);
     if (atEnd) {
       if (!command.empty()) {
-        runNoThrow(command, interactive);
+        runMultiple(command, printTiming);
       }
       break;
     }
@@ -254,7 +305,7 @@ void Console::readCommands(const std::string& prompt, bool interactive) {
         std::cerr << "Cannot open file: " << filePath << std::endl;
         continue;
       }
-      runNoThrow(sql, interactive);
+      runMultiple(sql, printTiming);
       continue;
     }
 
@@ -332,7 +383,7 @@ void Console::readCommands(const std::string& prompt, bool interactive) {
       continue;
     }
 
-    runNoThrow(command, interactive);
+    runMultiple(command, printTiming);
   }
 }
 } // namespace axiom::sql

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -33,16 +33,30 @@ class Console {
   /// Initializes the CLI with usage message and logging settings.
   void initialize();
 
-  /// Runs the CLI, either executing a single query if passed in
-  /// or entering interactive mode to read commands from stdin.
+  /// Runs the CLI. Executes `--query` if set, otherwise reads piped
+  /// stdin if non-interactive, otherwise enters the interactive REPL.
+  /// Honors `--repeat` for `--query` and piped-stdin paths.
+  ///
+  /// Throws VeloxUserError on invalid CLI flags. Query failures during
+  /// execution are caught internally and printed to stderr; they do
+  /// not throw.
   void run();
 
  private:
-  // Executes SQL, catching any exceptions.
-  void runNoThrow(std::string_view sql, bool isInteractive);
+  // Runs a single SQL statement and prints results/timing. Returns true on
+  // success, false if the query threw.
+  bool runOnce(std::string_view sql, bool printTiming);
+
+  // Splits 'sql' into individual statements and runs each one in sequence.
+  // Stops on the first failure.
+  void runMultiple(std::string_view sql, bool printTiming);
+
+  // Runs 'sql' (a single SQL statement) 'repeat' times back-to-back.
+  // Stops on the first failure.
+  void runRepeat(std::string_view sql, int repeat, bool printTiming);
 
   // Reads and executes commands from standard input in interactive mode.
-  void readCommands(const std::string& prompt, bool interactive);
+  void readCommands(const std::string& prompt, bool printTiming);
 
   SqlQueryRunner& runner_;
 };

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -172,7 +172,9 @@ runtime statistics.
 
 ## Timing Output
 
-In interactive mode, each statement prints timing after execution:
+In interactive mode, each statement prints timing after execution. In
+non-interactive mode (piped stdin or `--query`), pass `--print_timing`
+to enable the same output:
 
 ```
 Parsing: 10.58ms / 8.76ms user / 1.83ms system (100%)
@@ -187,6 +189,26 @@ Optimizing: 3.27ms | Executing: 5.27ms | Total: 19.26ms / 16.36ms user / 4.65ms 
 | Total | Wall-clock time for the entire query lifecycle. |
 
 Each field shows wall time, user CPU, system CPU, and CPU utilization %.
+
+### Repeating a query
+
+Pass `--repeat N` together with `--query` (or piped stdin) to run the
+input N times back-to-back. Useful for perf measurements, re-running
+flaky queries, or queries with non-deterministic results. The input
+must be a single statement; multi-statement input is rejected. Stops
+on the first error. Not supported in interactive mode.
+
+## Exit Status
+
+| Condition | Exit code |
+|-----------|-----------|
+| Invalid CLI flags (e.g. `--repeat 0`, `--repeat` in interactive mode) | 1 |
+| All statements completed | 0 |
+| One or more statements failed at parse / optimize / execute | 0 |
+
+Query failures print `Query failed: ...` to stderr but do not change
+the exit code. Wrap the CLI in shell tooling if you need to detect
+query failure (e.g. grep for `Query failed:` in stderr).
 
 ## Query History
 

--- a/axiom/cli/tests/CliRepeatTest.md
+++ b/axiom/cli/tests/CliRepeatTest.md
@@ -1,0 +1,57 @@
+# Smoke tests for --print_timing and --repeat flags
+
+## --print_timing emits a timing line in non-TTY mode
+
+```scrut
+$ $CLI --query "SELECT 1" --print_timing 2>/dev/null | grep -oE '^Query ID: \S+ \| Parsing:'
+Query ID: * | Parsing: (glob)
+```
+
+## --repeat with --query runs the query multiple times
+
+```scrut
+$ $CLI --query "SELECT 1" --repeat 3 --print_timing 2>/dev/null | grep -oE '^Query ID: \S+ \| Parsing:'
+Query ID: * | Parsing: (glob)
+Query ID: * | Parsing: (glob)
+Query ID: * | Parsing: (glob)
+```
+
+## --repeat with stdin runs the piped SQL multiple times
+
+```scrut
+$ echo "SELECT 1" | $CLI --query '' --repeat 3 --print_timing 2>/dev/null | grep -oE '^Query ID: \S+ \| Parsing:'
+Query ID: * | Parsing: (glob)
+Query ID: * | Parsing: (glob)
+Query ID: * | Parsing: (glob)
+```
+
+## --repeat stops on the first failure
+
+```scrut
+$ $CLI --query "SELECT * FROM nonexistent_table" --repeat 3 --print_timing 2>&1 >/dev/null | grep -oE '^Query ID: \S+ \| Parsing:'
+Query ID: * | Parsing: (glob)
+```
+
+## --repeat without --print_timing runs the query N times silently
+
+```scrut
+$ $CLI --query "SELECT 1 as a" --repeat 3 2>/dev/null | grep 'rows in 1 batches'
+(1 rows in 1 batches)
+(1 rows in 1 batches)
+(1 rows in 1 batches)
+```
+
+## --repeat with multi-statement input fails (CLI exits 0; error to stderr)
+
+```scrut
+$ $CLI --query "SELECT 1; SELECT 2" --repeat 2 2>&1 >/dev/null | grep -oE 'Expected a single statement.*'
+Expected a single statement. If you want to run multiple statements, use parseMultiple().
+```
+
+## --repeat must be at least 1 (CLI exits 1)
+
+```scrut
+$ $CLI --query "SELECT 1" --repeat 0 2>&1 1>/dev/null
+Error: (0 vs. 1) --repeat must be at least 1
+[1]
+```

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -321,6 +321,13 @@ $ $CLI --query "SELECT * FROM nonexistent_table" 2>&1 >/dev/null | grep 'Query f
 Query failed: * (glob)
 ```
 
+## Query failure does not change the CLI exit code
+
+```scrut
+$ $CLI --query "SELECT * FROM nonexistent_table" 2>/dev/null
+[0]
+```
+
 ## Cleanly log dictionary wrapped result vectors (window functions produce encoded vectors)
 
 ```scrut


### PR DESCRIPTION
Summary:
A common perf-measurement workflow runs a single SQL file through the CLI several times back-to-back, captures the per-run parse/optimize/execute timing, drops the first run as warmup, and aggregates the rest. Today neither piece works in non-interactive mode: timing is only printed in the REPL, and looping at the shell level launches a fresh CLI process each time — process startup, connector init, and ANTLR/JIT warmup dominate, so per-run timings are not comparable. Adds `--print_timing` to force the timing line in non-interactive runs, and `--repeat N` to run the input query N times inside one CLI invocation (default 1).

`--repeat` is honored when the SQL comes from `--query` or piped stdin and rejected in interactive mode. The input is treated as a single statement; multi-statement input is rejected by the parser. Stops on the first failure. `--init` is never repeated.

Invalid CLI flags now exit 1 with a clean `Error: ...` line; query failures still exit 0 (documented in `README.md`).

Differential Revision: D106233823


