### PR TITLE
perf(parser): Inline ASCII case-fold in UpperCaseInputStream (#1410)

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -30,12 +30,14 @@ std::string NameMappings::QualifiedName::toString() const {
 void NameMappings::add(const QualifiedName& name, const std::string& id) {
   bool ok = mappings_.emplace(name, id).second;
   VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
+  reverseIndex_[id].push_back(name);
 }
 
 void NameMappings::add(const std::string& name, const std::string& id) {
-  bool ok =
-      mappings_.emplace(QualifiedName{.alias = {}, .name = name}, id).second;
+  QualifiedName qualified{.alias = {}, .name = name};
+  bool ok = mappings_.emplace(qualified, id).second;
   VELOX_CHECK(ok, "Duplicate name: {}", name);
+  reverseIndex_[id].push_back(std::move(qualified));
 }
 
 void NameMappings::markHidden(const std::string& id) {
@@ -89,19 +91,16 @@ std::optional<std::string> NameMappings::lookup(
 
 std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
     const std::string& id) const {
-  std::vector<QualifiedName> names;
-  for (const auto& [key, value] : mappings_) {
-    if (value == id) {
-      names.push_back(key);
-    }
+  auto it = reverseIndex_.find(id);
+  if (it == reverseIndex_.end()) {
+    return {};
   }
-
+  const auto& names = it->second;
   VELOX_CHECK_LE(names.size(), 2);
   if (names.size() == 2) {
     VELOX_CHECK_EQ(names[0].name, names[1].name);
     VELOX_CHECK_NE(names[0].alias.has_value(), names[1].alias.has_value());
   }
-
   return names;
 }
 
@@ -116,9 +115,17 @@ void NameMappings::setAlias(const std::string& alias) {
     }
   }
 
+  // Every surviving entry gets the new alias.
   for (auto& [name, id] : names) {
-    mappings_.emplace(
-        QualifiedName{.alias = alias, .name = std::move(name)}, std::move(id));
+    QualifiedName qualified{.alias = alias, .name = std::move(name)};
+    mappings_.emplace(std::move(qualified), std::move(id));
+  }
+
+  // Rebuild from mappings_ so both surviving unqualified entries and the
+  // newly-added qualified entries appear in reverseIndex_.
+  reverseIndex_.clear();
+  for (const auto& [name, id] : mappings_) {
+    reverseIndex_[id].push_back(name);
   }
 }
 
@@ -133,9 +140,18 @@ void NameMappings::merge(const NameMappings& other) {
   }
 
   for (const auto& [name, id] : other.mappings_) {
-    if (mappings_.contains(name)) {
+    if (auto existing = mappings_.find(name); existing != mappings_.end()) {
       VELOX_CHECK(!name.alias.has_value());
-      mappings_.erase(name);
+      const auto& existingId = existing->second;
+      if (auto entry = reverseIndex_.find(existingId);
+          entry != reverseIndex_.end()) {
+        auto& names = entry->second;
+        std::erase(names, name);
+        if (names.empty()) {
+          reverseIndex_.erase(entry);
+        }
+      }
+      mappings_.erase(existing);
     } else if (
         !name.alias.has_value() && leftQualifiedNames.contains(name.name)) {
       // Don't add an unqualified name from the right side if the left side
@@ -144,6 +160,7 @@ void NameMappings::merge(const NameMappings& other) {
       // removed by an earlier merge.
     } else {
       mappings_.emplace(name, id);
+      reverseIndex_[id].push_back(name);
     }
   }
 

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -109,6 +109,7 @@ class NameMappings {
 
   void reset() {
     mappings_.clear();
+    reverseIndex_.clear();
     userNames_.clear();
   }
 
@@ -120,6 +121,10 @@ class NameMappings {
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.
   folly::F14FastMap<QualifiedName, std::string, QualifiedNameHasher> mappings_;
+
+  // Inverse of mappings_: each ID maps to the QualifiedName(s) that resolve
+  // to it (at most 2: with and without alias). Kept in sync with mappings_.
+  folly::F14FastMap<std::string, std::vector<QualifiedName>> reverseIndex_;
 
   // IDs of hidden columns.
   folly::F14FastSet<std::string> hiddenIds_;

--- a/axiom/sql/presto/ast/UpperCaseInputStream.h
+++ b/axiom/sql/presto/ast/UpperCaseInputStream.h
@@ -22,25 +22,26 @@
 
 namespace axiom::sql::presto {
 /**
- * This class is a thin wrapper around ANTLRInputStream to allow streams to be
- * case-insensitive by always forcing the stream to be upper case. This is done
- * by wrapping the look-ahead and checking if the value returned != 0. For now,
- * we uppercase all; however, we may need to reconsider EOF or use sophisicated
- * unicode when supported.
+ * ANTLRInputStream wrapper that case-folds ASCII letters so the lexer
+ * matches keywords case-insensitively. Presto's keyword and unquoted-
+ * identifier grammar is ASCII-only; non-ASCII codepoints pass through
+ * unchanged.
  */
 class UpperCaseInputStream final : public antlr4::ANTLRInputStream {
  public:
   explicit UpperCaseInputStream(std::string_view input)
       : antlr4::ANTLRInputStream(input) {}
-  // Force the casing to be upper case
+
   size_t LA(ssize_t i) override {
     size_t c = antlr4::ANTLRInputStream::LA(i);
-    if (c == 0) {
-      return c;
+    if (c - 'a' < kNumAsciiLowerLetters) {
+      return c - ('a' - 'A');
     }
-
-    return toupper(c);
+    return c;
   }
+
+ private:
+  static constexpr size_t kNumAsciiLowerLetters = 'z' - 'a' + 1;
 };
 
 } // namespace axiom::sql::presto


### PR DESCRIPTION
Summary:

`UpperCaseInputStream::LA` is called by the ANTLR lexer on every codepoint of the input. The previous implementation forwarded to libc `toupper`, which is a non-inlined function call plus an indirect lookup in `__toupper_l(c, _NL_CURRENT_LOCALE)` even when `c` is in the ASCII range. Replace with an inline ASCII fold: Presto's keyword and unquoted-identifier grammar is ASCII-only, so non-ASCII codepoints can pass through unchanged.

Measured on a 90-query prod batch through `axiom/cli:cli` (opt build, 5 measured runs per query after one warmup):

    parse_sum  before  692ms
               after   663ms  (-4.2%)
    optimize/execute: unchanged
    no regressions in the working set

Differential Revision: D106242004


