### PR TITLE
fix(cli): Report optimize/execute time for EXPLAIN (#1411)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -60,6 +60,44 @@ using connector::ConnectorMetadataRegistry;
 
 namespace {
 
+// Times a phase: writes wall-clock micros to 'wallMicros', and if
+// 'runtimeStats' is non-null, also records wall and CPU durations under the
+// given keys.
+class PhaseTimer {
+ public:
+  PhaseTimer(
+      uint64_t& wallMicros,
+      QueryRuntimeStats* runtimeStats,
+      std::string_view wallKey,
+      std::string_view cpuKey)
+      : runtimeStats_(runtimeStats),
+        wallKey_(wallKey),
+        cpuKey_(cpuKey),
+        wallMicros_(wallMicros),
+        cpuStartNanos_(velox::process::threadCpuNanos()),
+        timer_(std::in_place, &wallMicros) {}
+
+  ~PhaseTimer() {
+    // Destroy the wall timer first so wallMicros_ is finalized before we
+    // read it below.
+    timer_.reset();
+    if (runtimeStats_ != nullptr) {
+      const auto cpuNanos = velox::process::threadCpuNanos() - cpuStartNanos_;
+      runtimeStats_->recordTiming(
+          wallKey_, std::chrono::microseconds(wallMicros_));
+      runtimeStats_->recordTiming(cpuKey_, std::chrono::nanoseconds(cpuNanos));
+    }
+  }
+
+ private:
+  QueryRuntimeStats* const runtimeStats_;
+  const std::string_view wallKey_;
+  const std::string_view cpuKey_;
+  uint64_t& wallMicros_;
+  const uint64_t cpuStartNanos_;
+  std::optional<velox::MicrosecondTimer> timer_;
+};
+
 // Wraps a Velox connector's ConfigProvider pointer into an owned
 // ConfigProvider for use with ConfigRegistry. The underlying connector
 // must outlive this wrapper.
@@ -626,23 +664,33 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
       }
 
       std::string text;
-      optimize(
-          logicalPlan,
-          newQuery(options),
-          options,
-          [&](const auto& dt) {
-            text = optimizer::explainIo(&dt, outputTable);
-            return false; // Stop optimization.
-          },
-          nullptr,
-          schemaResolver,
-          /*explain=*/true);
+      auto queryCtx = newQuery(options);
+      {
+        PhaseTimer phaseTimer(
+            timing.optimize,
+            runtimeStats.get(),
+            QueryRuntimeStats::kOptimizeWallNanos,
+            QueryRuntimeStats::kOptimizeCpuNanos);
+        optimize(
+            logicalPlan,
+            queryCtx,
+            options,
+            [&](const auto& dt) {
+              text = optimizer::explainIo(&dt, outputTable);
+              return false; // Stop optimization.
+            },
+            nullptr,
+            schemaResolver,
+            /*explain=*/true,
+            runtimeStats);
+      }
       return {.message = std::move(text)};
     }
 
     if (explain->isAnalyze()) {
       return {
-          .message = runExplainAnalyze(logicalPlan, options, schemaResolver)};
+          .message = runExplainAnalyze(
+              logicalPlan, options, timing, runtimeStats, schemaResolver)};
     } else {
       return {
           .message = runExplain(
@@ -650,6 +698,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
               explain->type(),
               explain->format(),
               options,
+              timing,
+              runtimeStats,
               schemaResolver)};
     }
   }
@@ -814,6 +864,8 @@ std::string SqlQueryRunner::runExplain(
     presto::ExplainStatement::Type type,
     presto::ExplainStatement::Format format,
     const RunOptions& options,
+    QueryTiming& timing,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats,
     std::shared_ptr<connector::SchemaResolver> schemaResolver) {
   const bool explain = schemaResolver != nullptr;
 
@@ -840,57 +892,86 @@ std::string SqlQueryRunner::runExplain(
 
     case presto::ExplainStatement::Type::kGraph: {
       std::string text;
-      optimize(
-          logicalPlan,
-          newQuery(options),
-          options,
-          [&](const auto& dt) {
-            if (format == presto::ExplainStatement::Format::kGraphviz) {
-              std::ostringstream out;
-              graphviz::DerivedTableDotPrinter::print(dt, out);
-              text = out.str();
-            } else {
-              text = optimizer::DerivedTablePrinter::toText(dt);
-            }
-            return false; // Stop optimization.
-          },
-          nullptr,
-          schemaResolver,
-          explain);
+      auto queryCtx = newQuery(options);
+      {
+        PhaseTimer phaseTimer(
+            timing.optimize,
+            runtimeStats.get(),
+            QueryRuntimeStats::kOptimizeWallNanos,
+            QueryRuntimeStats::kOptimizeCpuNanos);
+        optimize(
+            logicalPlan,
+            queryCtx,
+            options,
+            [&](const auto& dt) {
+              if (format == presto::ExplainStatement::Format::kGraphviz) {
+                std::ostringstream out;
+                graphviz::DerivedTableDotPrinter::print(dt, out);
+                text = out.str();
+              } else {
+                text = optimizer::DerivedTablePrinter::toText(dt);
+              }
+              return false; // Stop optimization.
+            },
+            nullptr,
+            schemaResolver,
+            explain,
+            runtimeStats);
+      }
       return text;
     }
 
     case presto::ExplainStatement::Type::kOptimized: {
       std::string text;
-      optimize(
-          logicalPlan,
-          newQuery(options),
-          options,
-          nullptr,
-          [&](const auto& plan) {
-            text = optimizer::RelationOpPrinter::toText(
-                plan,
-                {
-                    .includeCost = true,
-                    .includeConstraints = options.debugMode,
-                });
-            return false; // Stop optimization.
-          },
-          schemaResolver,
-          explain);
+      auto queryCtx = newQuery(options);
+      {
+        PhaseTimer phaseTimer(
+            timing.optimize,
+            runtimeStats.get(),
+            QueryRuntimeStats::kOptimizeWallNanos,
+            QueryRuntimeStats::kOptimizeCpuNanos);
+        optimize(
+            logicalPlan,
+            queryCtx,
+            options,
+            nullptr,
+            [&](const auto& plan) {
+              text = optimizer::RelationOpPrinter::toText(
+                  plan,
+                  {
+                      .includeCost = true,
+                      .includeConstraints = options.debugMode,
+                  });
+              return false; // Stop optimization.
+            },
+            schemaResolver,
+            explain,
+            runtimeStats);
+      }
       return text;
     }
 
-    case presto::ExplainStatement::Type::kExecutable:
-      return optimize(
-                 logicalPlan,
-                 newQuery(options),
-                 options,
-                 nullptr,
-                 nullptr,
-                 schemaResolver,
-                 explain)
-          .toString();
+    case presto::ExplainStatement::Type::kExecutable: {
+      optimizer::PlanAndStats planAndStats;
+      auto queryCtx = newQuery(options);
+      {
+        PhaseTimer phaseTimer(
+            timing.optimize,
+            runtimeStats.get(),
+            QueryRuntimeStats::kOptimizeWallNanos,
+            QueryRuntimeStats::kOptimizeCpuNanos);
+        planAndStats = optimize(
+            logicalPlan,
+            queryCtx,
+            options,
+            nullptr,
+            nullptr,
+            schemaResolver,
+            explain,
+            runtimeStats);
+      }
+      return planAndStats.toString();
+    }
 
     case presto::ExplainStatement::Type::kIo:
       // Handled in run() before calling runExplain().
@@ -942,18 +1023,45 @@ std::string printPlanWithStats(
 std::string SqlQueryRunner::runExplainAnalyze(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
+    QueryTiming& timing,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats,
     std::shared_ptr<connector::SchemaResolver> schemaResolver) {
   auto queryCtx = newQuery(options);
-  auto planAndStats = optimize(
-      logicalPlan, queryCtx, options, nullptr, nullptr, schemaResolver);
+  optimizer::PlanAndStats planAndStats;
+  {
+    PhaseTimer phaseTimer(
+        timing.optimize,
+        runtimeStats.get(),
+        QueryRuntimeStats::kOptimizeWallNanos,
+        QueryRuntimeStats::kOptimizeCpuNanos);
+    planAndStats = optimize(
+        logicalPlan,
+        queryCtx,
+        options,
+        nullptr,
+        nullptr,
+        schemaResolver,
+        /*explain=*/false,
+        runtimeStats);
+  }
 
-  auto runner =
-      makeLocalRunner(planAndStats, queryCtx, options, noopRuntimeStats_);
+  auto runner = makeLocalRunner(
+      planAndStats,
+      queryCtx,
+      options,
+      runtimeStats ? *runtimeStats : noopRuntimeStats_);
   SCOPE_EXIT {
     waitForCompletion(runner, options.timeoutMicros);
   };
 
-  auto results = fetchResults(*runner);
+  {
+    PhaseTimer phaseTimer(
+        timing.execute,
+        runtimeStats.get(),
+        QueryRuntimeStats::kExecuteWallNanos,
+        QueryRuntimeStats::kExecuteCpuNanos);
+    auto results = fetchResults(*runner);
+  }
 
   std::stringstream out;
   out << printPlanWithStats(
@@ -1141,10 +1249,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
   SqlResult result;
 
   optimizer::PlanAndStats planAndStats;
-  uint64_t optimizeCpuNanos{0};
   {
-    auto cpuStart = velox::process::threadCpuNanos();
-    velox::MicrosecondTimer timer(&timing.optimize);
+    PhaseTimer phaseTimer(
+        timing.optimize,
+        runtimeStats.get(),
+        QueryRuntimeStats::kOptimizeWallNanos,
+        QueryRuntimeStats::kOptimizeCpuNanos);
     planAndStats = optimize(
         logicalPlan,
         queryCtx,
@@ -1154,15 +1264,6 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         std::move(schemaResolver),
         /*explain=*/false,
         runtimeStats);
-    optimizeCpuNanos = velox::process::threadCpuNanos() - cpuStart;
-  }
-  if (runtimeStats) {
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeWallNanos,
-        std::chrono::microseconds(timing.optimize));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeCpuNanos,
-        std::chrono::nanoseconds(optimizeCpuNanos));
   }
 
   planString = planAndStats.toString();
@@ -1176,20 +1277,13 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     waitForCompletion(runner, options.timeoutMicros);
   };
 
-  uint64_t executeCpuNanos{0};
   {
-    auto cpuStart = velox::process::threadCpuNanos();
-    velox::MicrosecondTimer timer(&timing.execute);
-    result.results = fetchResults(*runner);
-    executeCpuNanos = velox::process::threadCpuNanos() - cpuStart;
-  }
-  if (runtimeStats) {
-    runtimeStats->recordTiming(
+    PhaseTimer phaseTimer(
+        timing.execute,
+        runtimeStats.get(),
         QueryRuntimeStats::kExecuteWallNanos,
-        std::chrono::microseconds(timing.execute));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kExecuteCpuNanos,
-        std::chrono::nanoseconds(executeCpuNanos));
+        QueryRuntimeStats::kExecuteCpuNanos);
+    result.results = fetchResults(*runner);
   }
 
   return result;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -298,12 +298,16 @@ class SqlQueryRunner {
       presto::ExplainStatement::Type type,
       presto::ExplainStatement::Format format,
       const RunOptions& options,
+      QueryTiming& timing,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
           schemaResolver = nullptr);
 
   std::string runExplainAnalyze(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options,
+      QueryTiming& timing,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
           schemaResolver = nullptr);
 

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -209,6 +209,32 @@ TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
       std::exception);
 }
 
+TEST_F(SqlQueryRunnerTest, explainPopulatesOptimizeTiming) {
+  auto runWithTiming = [&](std::string_view sql) {
+    QueryTiming timing;
+    SqlQueryRunner::RunOptions options{
+        .onComplete = [&](const QueryCompletionInfo& info) {
+          timing = info.timing;
+        }};
+    runner_->run(sql, options);
+    return timing;
+  };
+
+  // EXPLAIN (TYPE LOGICAL) does not populate optimize timing.
+  EXPECT_EQ(0, runWithTiming("EXPLAIN (TYPE LOGICAL) SELECT 1").optimize);
+
+  // All other EXPLAIN variants populate optimize timing.
+  EXPECT_GT(runWithTiming("EXPLAIN (TYPE GRAPH) SELECT 1").optimize, 0);
+  EXPECT_GT(runWithTiming("EXPLAIN (TYPE OPTIMIZED) SELECT 1").optimize, 0);
+  EXPECT_GT(runWithTiming("EXPLAIN SELECT 1").optimize, 0);
+  EXPECT_GT(runWithTiming("EXPLAIN (TYPE IO) SELECT 1").optimize, 0);
+
+  // EXPLAIN ANALYZE populates both optimize and execute timing.
+  auto analyzeTiming = runWithTiming("EXPLAIN ANALYZE SELECT 1");
+  EXPECT_GT(analyzeTiming.optimize, 0);
+  EXPECT_GT(analyzeTiming.execute, 0);
+}
+
 TEST_F(SqlQueryRunnerTest, explainCtas) {
   {
     auto result = run("EXPLAIN (TYPE LOGICAL) CREATE TABLE t AS SELECT 1 AS x");

--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -30,12 +30,14 @@ std::string NameMappings::QualifiedName::toString() const {
 void NameMappings::add(const QualifiedName& name, const std::string& id) {
   bool ok = mappings_.emplace(name, id).second;
   VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
+  reverseIndex_[id].push_back(name);
 }
 
 void NameMappings::add(const std::string& name, const std::string& id) {
-  bool ok =
-      mappings_.emplace(QualifiedName{.alias = {}, .name = name}, id).second;
+  QualifiedName qualified{.alias = {}, .name = name};
+  bool ok = mappings_.emplace(qualified, id).second;
   VELOX_CHECK(ok, "Duplicate name: {}", name);
+  reverseIndex_[id].push_back(std::move(qualified));
 }
 
 void NameMappings::markHidden(const std::string& id) {
@@ -89,19 +91,16 @@ std::optional<std::string> NameMappings::lookup(
 
 std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
     const std::string& id) const {
-  std::vector<QualifiedName> names;
-  for (const auto& [key, value] : mappings_) {
-    if (value == id) {
-      names.push_back(key);
-    }
+  auto it = reverseIndex_.find(id);
+  if (it == reverseIndex_.end()) {
+    return {};
   }
-
+  const auto& names = it->second;
   VELOX_CHECK_LE(names.size(), 2);
   if (names.size() == 2) {
     VELOX_CHECK_EQ(names[0].name, names[1].name);
     VELOX_CHECK_NE(names[0].alias.has_value(), names[1].alias.has_value());
   }
-
   return names;
 }
 
@@ -116,9 +115,17 @@ void NameMappings::setAlias(const std::string& alias) {
     }
   }
 
+  // Every surviving entry gets the new alias.
   for (auto& [name, id] : names) {
-    mappings_.emplace(
-        QualifiedName{.alias = alias, .name = std::move(name)}, std::move(id));
+    QualifiedName qualified{.alias = alias, .name = std::move(name)};
+    mappings_.emplace(std::move(qualified), std::move(id));
+  }
+
+  // Rebuild from mappings_ so both surviving unqualified entries and the
+  // newly-added qualified entries appear in reverseIndex_.
+  reverseIndex_.clear();
+  for (const auto& [name, id] : mappings_) {
+    reverseIndex_[id].push_back(name);
   }
 }
 
@@ -133,9 +140,18 @@ void NameMappings::merge(const NameMappings& other) {
   }
 
   for (const auto& [name, id] : other.mappings_) {
-    if (mappings_.contains(name)) {
+    if (auto existing = mappings_.find(name); existing != mappings_.end()) {
       VELOX_CHECK(!name.alias.has_value());
-      mappings_.erase(name);
+      const auto& existingId = existing->second;
+      if (auto entry = reverseIndex_.find(existingId);
+          entry != reverseIndex_.end()) {
+        auto& names = entry->second;
+        std::erase(names, name);
+        if (names.empty()) {
+          reverseIndex_.erase(entry);
+        }
+      }
+      mappings_.erase(existing);
     } else if (
         !name.alias.has_value() && leftQualifiedNames.contains(name.name)) {
       // Don't add an unqualified name from the right side if the left side
@@ -144,6 +160,7 @@ void NameMappings::merge(const NameMappings& other) {
       // removed by an earlier merge.
     } else {
       mappings_.emplace(name, id);
+      reverseIndex_[id].push_back(name);
     }
   }
 

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -109,6 +109,7 @@ class NameMappings {
 
   void reset() {
     mappings_.clear();
+    reverseIndex_.clear();
     userNames_.clear();
   }
 
@@ -120,6 +121,10 @@ class NameMappings {
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.
   folly::F14FastMap<QualifiedName, std::string, QualifiedNameHasher> mappings_;
+
+  // Inverse of mappings_: each ID maps to the QualifiedName(s) that resolve
+  // to it (at most 2: with and without alias). Kept in sync with mappings_.
+  folly::F14FastMap<std::string, std::vector<QualifiedName>> reverseIndex_;
 
   // IDs of hidden columns.
   folly::F14FastSet<std::string> hiddenIds_;

--- a/axiom/sql/presto/ast/UpperCaseInputStream.h
+++ b/axiom/sql/presto/ast/UpperCaseInputStream.h
@@ -22,25 +22,26 @@
 
 namespace axiom::sql::presto {
 /**
- * This class is a thin wrapper around ANTLRInputStream to allow streams to be
- * case-insensitive by always forcing the stream to be upper case. This is done
- * by wrapping the look-ahead and checking if the value returned != 0. For now,
- * we uppercase all; however, we may need to reconsider EOF or use sophisicated
- * unicode when supported.
+ * ANTLRInputStream wrapper that case-folds ASCII letters so the lexer
+ * matches keywords case-insensitively. Presto's keyword and unquoted-
+ * identifier grammar is ASCII-only; non-ASCII codepoints pass through
+ * unchanged.
  */
 class UpperCaseInputStream final : public antlr4::ANTLRInputStream {
  public:
   explicit UpperCaseInputStream(std::string_view input)
       : antlr4::ANTLRInputStream(input) {}
-  // Force the casing to be upper case
+
   size_t LA(ssize_t i) override {
     size_t c = antlr4::ANTLRInputStream::LA(i);
-    if (c == 0) {
-      return c;
+    if (c - 'a' < kNumAsciiLowerLetters) {
+      return c - ('a' - 'A');
     }
-
-    return toupper(c);
+    return c;
   }
+
+ private:
+  static constexpr size_t kNumAsciiLowerLetters = 'z' - 'a' + 1;
 };
 
 } // namespace axiom::sql::presto


### PR DESCRIPTION
Summary:

`--print_timing` reported `Optimizing: 0us` for `EXPLAIN` and `Executing: 0us` for `EXPLAIN ANALYZE`, even though both phases ran. Only `EXPLAIN (TYPE LOGICAL)` truly skips optimization; everything else was just being measured wrong.

The EXPLAIN code paths in `SqlQueryRunner` never received the `QueryTiming` and `QueryRuntimeStats` that `runUnchecked` already had in hand. Now they do, via a small `PhaseTimer` helper that replaces an existing inline pattern in `runLogicalPlan` and is reused at each EXPLAIN site.

Differential Revision: D106242787
