### PR TITLE
fix(optimizer): Default join and filter sampling off

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1170,19 +1170,19 @@ TEST_F(SqlQueryRunnerTest, timingFieldsOnParseError) {
 
 TEST_F(SqlQueryRunnerTest, sessionProperties) {
   // Default value.
-  assertSessionProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "false", "false");
 
   // SET changes the value.
-  auto result = run("SET SESSION optimizer.sample_joins = false");
+  auto result = run("SET SESSION optimizer.sample_joins = true");
   ASSERT_TRUE(result.message.has_value());
-  EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' set to 'false'");
-  assertSessionProperty("optimizer.sample_joins", "false", "true");
+  EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' set to 'true'");
+  assertSessionProperty("optimizer.sample_joins", "true", "false");
 
   // RESET restores the default.
   result = run("RESET SESSION optimizer.sample_joins");
   ASSERT_TRUE(result.message.has_value());
   EXPECT_EQ(*result.message, "Session 'optimizer.sample_joins' reset");
-  assertSessionProperty("optimizer.sample_joins", "true", "true");
+  assertSessionProperty("optimizer.sample_joins", "false", "false");
 
   // Invalid value.
   VELOX_ASSERT_THROW(

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -66,13 +66,13 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Enable join order sampling during optimization. If this flag is set, joins
   /// are sampled to determine the optimal join order. If join sampling is
   /// disabled, the optimizer will fall back on cardinality estimation.
-  bool sampleJoins{true};
+  bool sampleJoins{false};
 
   /// Enable filter selectivity sampling during optimization. If this flag is
   /// set, filters will be evaluated against a sample of source data to
   /// determine the estimated cardinality of the scan. If filter sampling is
   /// disabled, a default selectivity will be used.
-  bool sampleFilters{true};
+  bool sampleFilters{false};
 
   /// Enable using connector-provided table statistics (co_estimateStats) for
   /// cardinality estimation. When disabled, the optimizer falls back to


### PR DESCRIPTION
Summary: Join-order and filter-selectivity sampling are still experimental and not ready to be enabled by default.

Differential Revision: D106296035


