### PR TITLE
fix(parser): Build AST node for GROUPING(...) expression

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -2538,7 +2538,14 @@ std::any AstBuilder::visitSearchedCase(
 std::any AstBuilder::visitGroupingOperation(
     PrestoSqlParser::GroupingOperationContext* ctx) {
   trace("visitGroupingOperation");
-  return visitChildren("visitGroupingOperation", ctx);
+  std::vector<std::shared_ptr<QualifiedName>> columns;
+  columns.reserve(ctx->qualifiedName().size());
+  for (auto* qualifiedNameCtx : ctx->qualifiedName()) {
+    columns.push_back(getQualifiedName(qualifiedNameCtx));
+  }
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<GroupingOperation>(
+          getLocation(ctx), std::move(columns)));
 }
 
 std::any AstBuilder::visitBasicStringLiteral(

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -207,6 +207,21 @@ TEST_F(AggregationParserTest, groupingSets) {
           testing::ElementsAre(0, 1), testing::ElementsAre(0)));
 }
 
+TEST_F(AggregationParserTest, groupingFunction) {
+  // GROUPING(col) is rejected with a clear unsupported-expression error.
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSql(
+          "SELECT GROUPING(n_regionkey), count(1) FROM nation "
+          "GROUP BY GROUPING SETS ((n_regionkey), ())"),
+      "Unsupported expression type: GroupingOperation");
+
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSql(
+          "SELECT GROUPING(n_regionkey, n_name), count(1) FROM nation "
+          "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())"),
+      "Unsupported expression type: GroupingOperation");
+}
+
 TEST_F(AggregationParserTest, rollup) {
   lp::AggregateNodePtr agg;
   auto matcher =


### PR DESCRIPTION
Summary:
Any query using `GROUPING(col)` failed in the parser with an internal runtime error:

    visitChildren called with more than one child: 4 (visitGroupingOperation)

`AstBuilder::visitGroupingOperation` was a stub. It now builds a `GroupingOperation` AST node. End-to-end planning is still unimplemented and fails with `Unsupported expression type: GroupingOperation`.

Differential Revision: D106331077


