### PR TITLE
fix(optimizer): IN subqueries with constant LHS or shared CTE (#1418)

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -385,6 +385,14 @@ struct DerivedTable : public PlanObject {
   /// single row with no columns. Does not look at postprocessing.
   bool isSingleRowNoColumnsValues() const;
 
+  /// True when this DT consists of a projection over an optional WHERE,
+  /// with no FROM (the only source is the synthetic single-row no-cols
+  /// values), no aggregation, no window, no ORDER BY, and no LIMIT/OFFSET.
+  bool isProjectFilterOnly() const {
+    return isSingleRowNoColumnsValues() && !hasAggregation() && !hasWindow() &&
+        !hasOrderBy() && !hasLimit() && !hasOffset();
+  }
+
   /// Returns true if this DT has no postprocessing — no filter,
   /// aggregation, having, window, order by, limit, or offset. See
   /// 'Optimization::addPostprocess' for the corresponding planning step.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3909,6 +3909,26 @@ void ToGraph::processInPredicates(
     const bool isCorrelated =
         !applyContext_.lifted.predicates.empty() || inRightHasOuter;
 
+    // Fold `<const> IN (SELECT <proj> WHERE <cond>)` over a no-FROM
+    // subquery into `<cond> AND <const> = <proj>`. A SEMI cannot
+    // represent this case: leftKey has no table to anchor its left side.
+    if (!isCorrelated && leftKey->allTables().empty() &&
+        subqueryDt->isProjectFilterOnly() && subqueryDt->exprs.size() == 1) {
+      ExprCP projection = subqueryDt->exprs.front();
+      ExprVector parts = std::move(subqueryDt->conjuncts);
+      parts.push_back(makeEquality(leftKey, projection));
+      ExprVector guards = std::move(applyContext_.lifted.outerGuards);
+      applyContext_.lifted.outerGuards.clear();
+      currentDt_->removeLastTable(subqueryDt);
+      ExprCP result =
+          wrapMarkInGuards(std::move(guards), makeAnd(std::move(parts)));
+      subqueries_.emplace(predicate, result);
+      if (!result->columns().empty()) {
+        chain.carryForwards.push_back(predicate);
+      }
+      continue;
+    }
+
     // Velox HashJoin cannot represent a multi-key null-aware join, so the
     // SEMI's left side must be a single table. If correlation reaches more
     // than one outer table (via leftKey, inRightKey, or correlation
@@ -4605,8 +4625,13 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
     renames_ = renames;
     currentDt_ = newDt();
     auto savedLifted = applyContext_.saveAndClearLifted();
+    // Cached subquery columns are bound to the branch's DT; scope per
+    // branch so sibling branches re-translate against their own DT.
+    auto savedSubqueries = std::move(subqueries_);
+    subqueries_.clear();
     SCOPE_EXIT {
       applyContext_.lifted = std::move(savedLifted);
+      subqueries_ = std::move(savedSubqueries);
     };
     makeQueryGraph(input, kAllAllowedInDt, /*orderObservedAbove=*/false);
     if (!applyContext_.lifted.empty()) {

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -508,3 +508,21 @@ FROM (VALUES (1)) AS t(a)
 LEFT JOIN (VALUES (1, 'x')) AS u(k, b) ON t.a = u.k
 INNER JOIN (VALUES (1)) AS v(c)
   ON u.b IN (SELECT 'x' FROM (VALUES (1)) AS w(d) WHERE d = v.c)
+----
+-- Shared CTE with a nested-IN filter, referenced from both UNION legs,
+-- second leg wrapping it in GROUP BY.
+WITH s AS (
+    SELECT x FROM (VALUES (1)) t(x) WHERE x IN (SELECT 1 WHERE 1 IN (SELECT 1))
+)
+SELECT x FROM s
+UNION ALL
+SELECT x FROM (SELECT x, sum(x) AS sx FROM s GROUP BY x) WHERE sx > 0
+----
+-- Same shape with a single reference inside a GROUP BY.
+WITH s AS (
+    SELECT x FROM (VALUES (1)) t(x) WHERE x IN (SELECT 1 WHERE 1 IN (SELECT 1))
+)
+SELECT x FROM (SELECT x, sum(x) AS sx FROM s GROUP BY x) WHERE sx > 0
+----
+-- IN with a constant left-hand side over a no-FROM subquery.
+SELECT 1 WHERE 1 IN (SELECT 1)


### PR DESCRIPTION
Summary:

Two planning failures on `IN` subqueries.

    SELECT 1 WHERE 1 IN (SELECT 1)

failed with `Failed to place a table` because the SEMI built for the IN had no left-side table to anchor to. Fold `<const> IN (SELECT <proj> WHERE <cond>)` over a no-FROM subquery body into `<cond> AND <const> = <proj>` instead, mirroring the existing EXISTS fast path.

    WITH s AS (
        SELECT x FROM (VALUES (1)) t(x)
        WHERE x IN (SELECT 1 WHERE 1 IN (SELECT 1))
    )
    SELECT x FROM s
    UNION ALL
    SELECT x FROM (SELECT x, sum(x) AS sx FROM s GROUP BY x) WHERE sx > 0

failed with `agg->groupingKeys().empty()`. The cached SEMI mark column from the first leg's translation leaked into the second leg, where its owning DT was out of scope; the conjunct then routed through `applyContext_.lifted.predicates` into the aggregation handler. Scope `subqueries_` per UNION-ALL branch, matching `wrapInDt`.

Differential Revision: D106335341


