### PR TITLE
fix(optimizer): Stop tracking cardinality as a subfield step

### DIFF
--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -65,15 +65,6 @@ bool FunctionRegistry::registerSubscript(std::string_view name) {
   return true;
 }
 
-bool FunctionRegistry::registerCardinality(std::string_view name) {
-  VELOX_USER_CHECK(!name.empty());
-  if (cardinality_.has_value() && cardinality_.value() != name) {
-    return false;
-  }
-  cardinality_ = name;
-  return true;
-}
-
 bool FunctionRegistry::registerArbitrary(std::string_view name) {
   VELOX_USER_CHECK(!name.empty());
   if (arbitrary_.has_value() && arbitrary_.value() != name) {
@@ -380,7 +371,6 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerNegation(fullName("not"));
   registry->registerElementAt(fullName("element_at"));
   registry->registerSubscript(fullName("subscript"));
-  registry->registerCardinality(fullName("cardinality"));
   registry->registerArbitrary(fullName("arbitrary"));
   registry->registerCount(fullName("count"));
   registry->registerLessThan(fullName("lt"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -257,10 +257,6 @@ class FunctionRegistry {
     return subscript_;
   }
 
-  const std::optional<std::string>& cardinality() const {
-    return cardinality_;
-  }
-
   const std::string& specialForm(logical_plan::SpecialForm specialForm) {
     auto it = specialForms_.find(specialForm);
     VELOX_USER_CHECK(it != specialForms_.end());
@@ -301,12 +297,6 @@ class FunctionRegistry {
   /// @return true if successfully registered, false if a different 'subfield'
   /// function is already registered.
   bool registerSubscript(std::string_view name);
-
-  /// Registers function 'name' that has semantics of Presto's 'cardinality',
-  /// i.e. returns the number of entries in an array or map.
-  /// @return true if successfully registered, false if a different
-  /// 'cardinality' function is already registered.
-  bool registerCardinality(std::string_view name);
 
   /// Registers function 'name' that has semantics of Presto's 'arbitrary'
   /// aggregate function, i.e. returns an arbitrary value from the group.
@@ -503,7 +493,6 @@ class FunctionRegistry {
   std::string negation_{"not"};
   std::optional<std::string> elementAt_;
   std::optional<std::string> subscript_;
-  std::optional<std::string> cardinality_;
   std::optional<std::string> lessThan_;
   std::optional<std::string> lessThanOrEqual_;
   std::optional<std::string> greaterThan_;

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -29,7 +29,6 @@ const auto& stepKindNames() {
       {StepKind::kField, "FIELD"},
       {StepKind::kSubscript, "SUBSCRIPT"},
       {StepKind::kElementAt, "ELEMENT_AT"},
-      {StepKind::kCardinality, "CARDINALITY"},
   };
   return kNames;
 }
@@ -234,9 +233,6 @@ std::string Path::toString() const {
   std::stringstream out;
   for (auto& step : steps_) {
     switch (step.kind) {
-      case StepKind::kCardinality:
-        out << ".cardinality";
-        break;
       case StepKind::kField:
         if (step.field) {
           out << "." << step.field;
@@ -351,10 +347,6 @@ void QueryGraphContext::populateFunctionNames() {
 
   if (auto subscript = registry->subscript()) {
     functionNames_.subscript = this->toName(subscript.value());
-  }
-
-  if (auto cardinality = registry->cardinality()) {
-    functionNames_.cardinality = this->toName(cardinality.value());
   }
 
   if (auto arbitrary = registry->arbitrary()) {

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -175,7 +175,6 @@ enum class StepKind : uint8_t {
   kField,
   kSubscript,
   kElementAt,
-  kCardinality,
 };
 
 AXIOM_DECLARE_ENUM_NAME(StepKind);
@@ -242,12 +241,6 @@ class Path {
   Path* subscript(int64_t id) {
     VELOX_CHECK(mutable_);
     steps_.push_back(Step{.kind = StepKind::kSubscript, .id = id});
-    return this;
-  }
-
-  Path* cardinality() {
-    VELOX_CHECK(mutable_);
-    steps_.push_back(Step{.kind = StepKind::kCardinality});
     return this;
   }
 
@@ -321,7 +314,6 @@ struct FunctionNames {
   Name negation{nullptr};
   Name elementAt{nullptr};
   Name subscript{nullptr};
-  Name cardinality{nullptr};
   Name lt{nullptr};
   Name lte{nullptr};
   Name gt{nullptr};

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -58,10 +58,6 @@ SubfieldTracker::SubfieldTracker(
   if (auto subscript = registry->subscript()) {
     subscript_ = toName(subscript.value());
   }
-
-  if (auto cardinality = registry->cardinality()) {
-    cardinality_ = toName(cardinality.value());
-  }
 }
 
 SubfieldTracker::MarkAllResult SubfieldTracker::markAll(
@@ -391,13 +387,6 @@ void SubfieldTracker::markSubfields(
 
   if (expr->isCall()) {
     auto name = toName(expr->as<lp::CallExpr>()->name());
-    if (name == cardinality_) {
-      steps.push_back({.kind = StepKind::kCardinality});
-      markSubfields(expr->inputAt(0), steps, isControl, context);
-      steps.pop_back();
-      return;
-    }
-
     if (name == subscript_ || name == elementAt_) {
       const auto stepKind =
           (name == elementAt_) ? StepKind::kElementAt : StepKind::kSubscript;

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -166,7 +166,6 @@ class SubfieldTracker {
 
   Name elementAt_{nullptr};
   Name subscript_{nullptr};
-  Name cardinality_{nullptr};
 
   PlanSubfields controlSubfields_;
   PlanSubfields payloadSubfields_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -692,11 +692,6 @@ bool ToGraph::isSubfield(
       }
       return false;
     }
-    if (name == functionNames_.cardinality) {
-      step.kind = StepKind::kCardinality;
-      input = expr->inputAt(0);
-      return true;
-    }
   }
   return false;
 }
@@ -1024,13 +1019,6 @@ ExprCP ToGraph::makeGetter(const Step& step, ExprCP base) {
           baseFuncs());
     }
 
-    case StepKind::kCardinality: {
-      return make<Call>(
-          functionNames_.cardinality,
-          toConstantValue(velox::BIGINT()),
-          ExprVector{base},
-          baseFuncs());
-    }
     default:
       VELOX_NYI();
   }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -153,8 +153,6 @@ std::vector<velox::common::Subfield> columnSubfields(
               std::make_unique<velox::common::Subfield::LongSubscript>(
                   step.id));
           break;
-        case StepKind::kCardinality:
-          VELOX_UNSUPPORTED();
       }
       first = false;
     }

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -128,18 +128,10 @@ TEST_F(QueryGraphContextTest, toType) {
   // Identical child types with different names get equal pointers.
   EXPECT_EQ(dedupRow1->childAt(0).get(), dedupDifferentNames->childAt(0).get());
 
-  auto* path = make<Path>()
-                   ->subscript("field")
-                   ->subscript(123)
-                   ->field("f1")
-                   ->cardinality();
+  auto* path = make<Path>()->subscript("field")->subscript(123)->field("f1");
   auto interned = queryCtx()->toPath(path);
   EXPECT_EQ(interned, path);
-  auto* path2 = make<Path>()
-                    ->subscript("field")
-                    ->subscript(123)
-                    ->field("f1")
-                    ->cardinality();
+  auto* path2 = make<Path>()->subscript("field")->subscript(123)->field("f1");
   auto interned2 = queryCtx()->toPath(path2);
   EXPECT_EQ(interned2, interned);
 }
@@ -202,9 +194,9 @@ TEST_F(QueryGraphContextTest, stepOrdering) {
   {
     Step a{.kind = StepKind::kField, .field = toName("a")};
     Step b{.kind = StepKind::kSubscript, .field = toName("b")};
-    Step c{.kind = StepKind::kCardinality};
+    Step c{.kind = StepKind::kElementAt, .field = toName("c")};
 
-    // kField < kSubscript < kElementAt < kCardinality (enum order).
+    // kField < kSubscript < kElementAt (enum order).
     // Verify ordering and asymmetry: if A < B then B > A.
     EXPECT_LT(a, b);
     EXPECT_GT(b, a);

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -720,6 +720,32 @@ TEST_P(SubfieldTest, maps) {
   }
 }
 
+TEST_P(SubfieldTest, cardinality) {
+  createFeaturesTable();
+
+  // cardinality(m) requires the whole map.
+  {
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("features")
+                           .project({"cardinality(float_features) as n"})
+                           .build();
+    auto plan = extractPlanNode(planVelox(logicalPlan));
+    verifyRequiredSubfields(plan, {{"float_features", {}}});
+  }
+
+  // cardinality(m) and m[k] on the same column: the whole map is required.
+  {
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("features")
+                           .project(
+                               {"cardinality(float_features) as n",
+                                "float_features[10100::int] as v"})
+                           .build();
+    auto plan = extractPlanNode(planVelox(logicalPlan));
+    verifyRequiredSubfields(plan, {{"float_features", {}}});
+  }
+}
+
 TEST_P(SubfieldTest, parallelExpr) {
   FeatureOptions opts;
   const auto vectors = createFeaturesTable(opts);


### PR DESCRIPTION
Summary:
`cardinality(<map_or_array_col>)` failed during planning:

    SELECT cardinality(m) FROM t

failed with `VELOX_UNSUPPORTED` in `ToVelox::columnSubfields`. Velox does not support cardinality pushdown.

Treat `cardinality(col)` as a regular function call so `col` is marked as fully needed. Removes the now-dead enum value, its handlers, and the `FunctionRegistry::registerCardinality`/`cardinality()` accessors.

Differential Revision: D106371380


