### PR TITLE
fix(optimizer): F14 hash diagnostics for Mac OS release CI bug (#1421)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -124,6 +124,55 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-macos-${{ matrix.build_type }}
 
+      - name: F14 Diagnostic - Symbol and Library Analysis
+        if: matrix.build_type == 'release'
+        run: |
+          BIN=_build/$BUILD_TYPE/axiom/optimizer/tests/axiom_optimizer_tests
+          if [ ! -x "$BIN" ]; then
+            echo "Test binary not found at $BIN — listing candidates:"
+            find _build/$BUILD_TYPE -name "axiom_optimizer_tests*" -type f | head -5
+            exit 0
+          fi
+
+          echo "=== otool -L (dynamic library deps for libc++/folly/velox) ==="
+          otool -L "$BIN" | grep -iE "libc\+\+|libfolly|libvelox|libsystem" || true
+
+          echo ""
+          echo "=== nm: __hash_memory symbol presence (T=defined U=undefined-from-dylib) ==="
+          nm "$BIN" | grep -i hash_memory || echo "no __hash_memory symbol (fully inlined per TU)"
+
+          echo ""
+          echo "=== nm: __murmur2_or_cityhash symbol presence ==="
+          nm "$BIN" | grep -i "murmur2_or_cityhash" || echo "no cityhash symbol (fully inlined per TU)"
+
+          echo ""
+          echo "=== nm: std::hash<...Repartition...> instantiations (demangled) ==="
+          nm "$BIN" | xcrun c++filt 2>/dev/null | grep -E "std::__1::hash.*Repartition|std::hash.*Repartition" | head -20 || echo "no std::hash<Repartition*> symbol (fully inlined)"
+
+          echo ""
+          echo "=== nm: F14DiagSelfTest constructor symbols (one per TU) ==="
+          nm "$BIN" | xcrun c++filt 2>/dev/null | grep -E "F14DiagSelfTest" | head -10 || true
+
+          echo ""
+          echo "=== otool -tV: disassembly of commitGroupedLeavesForRepartition (INSERT site, includes inlined std::hash) ==="
+          ADDR_INSERT=$(nm "$BIN" | grep "commitGroupedLeavesForRepartition" | awk '{print $1}' | head -1)
+          if [ -n "$ADDR_INSERT" ]; then
+            echo "symbol at address: 0x$ADDR_INSERT"
+            otool -tV "$BIN" 2>&1 | awk '/commitGroupedLeavesForRepartition.*:$/{p=1; n=0} p && /^[0-9a-fA-F_].*:$/ && !/commitGroupedLeavesForRepartition/{p=0} p && (++n <= 400)'
+          else
+            echo "commitGroupedLeavesForRepartition symbol not found (may be inlined into all callers)"
+          fi
+
+          echo ""
+          echo "=== otool -tV: disassembly of ToVelox::makeRepartition (FIND site, includes inlined std::hash) ==="
+          ADDR_FIND=$(nm "$BIN" | xcrun c++filt 2>/dev/null | grep -E "ToVelox::makeRepartition" | awk '{print $1}' | head -1)
+          if [ -n "$ADDR_FIND" ]; then
+            echo "symbol matched (demangled). Searching disassembly:"
+            otool -tV "$BIN" 2>&1 | awk '/ToVelox.*makeRepartition.*:$/{p=1; n=0} p && /^[0-9a-fA-F_].*:$/ && !/makeRepartition/{p=0} p && (++n <= 400)'
+          else
+            echo "ToVelox::makeRepartition symbol not found"
+          fi
+
       - name: Run Tests
         run: |
           ctest --test-dir _build/$BUILD_TYPE -j $NJOBS --output-on-failure --no-tests=error

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -28,12 +28,27 @@
 #include "folly/coro/BlockingWait.h"
 #include "folly/coro/Collect.h"
 #include "folly/coro/Task.h"
+#include "folly/hash/Hash.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
 
 namespace lp = facebook::axiom::logical_plan;
 
 namespace facebook::axiom::optimizer {
+
+namespace {
+struct F14DiagSelfTest {
+  F14DiagSelfTest() {
+    const void* const kPtr =
+        reinterpret_cast<const void*>(0xCAFEBABE12345678ULL);
+    std::cerr << "F14DIAG SELFTEST file=Optimization.cpp"
+              << " ptr=" << kPtr << std::hex << " std_hash=0x"
+              << std::hash<const void*>{}(kPtr) << " folly_hash=0x"
+              << folly::hasher<const void*>{}(kPtr) << std::dec << std::endl;
+  }
+};
+[[maybe_unused]] static const F14DiagSelfTest kF14DiagSelfTest;
+} // namespace
 
 Optimization::Optimization(
     SessionPtr session,
@@ -357,6 +372,13 @@ void commitGroupedLeavesForRepartition(
       !dist.partitionKeys().empty()) {
     state.mutableCurrentGroupedLeaves().emplace(repartition, nullptr);
   }
+  std::cerr << "F14DIAG INSERT file=Optimization.cpp"
+            << " ptr=" << repartition << std::hex << " std_hash=0x"
+            << std::hash<const Repartition*>{}(repartition) << " folly_hash=0x"
+            << folly::hasher<const Repartition*>{}(repartition) << std::dec
+            << " map_size="
+            << state.optimization.repartitionGroupedLeaves().size()
+            << std::endl;
 }
 
 namespace {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -15,6 +15,8 @@
  */
 #include "axiom/optimizer/ToVelox.h"
 #include <folly/container/F14Set.h>
+#include <folly/hash/Hash.h>
+#include <iostream>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
@@ -31,6 +33,20 @@
 namespace lp = facebook::axiom::logical_plan;
 
 namespace facebook::axiom::optimizer {
+
+namespace {
+struct F14DiagSelfTest {
+  F14DiagSelfTest() {
+    const void* const kPtr =
+        reinterpret_cast<const void*>(0xCAFEBABE12345678ULL);
+    std::cerr << "F14DIAG SELFTEST file=ToVelox.cpp"
+              << " ptr=" << kPtr << std::hex << " std_hash=0x"
+              << std::hash<const void*>{}(kPtr) << " folly_hash=0x"
+              << folly::hasher<const void*>{}(kPtr) << std::dec << std::endl;
+  }
+};
+[[maybe_unused]] static const F14DiagSelfTest kF14DiagSelfTest;
+} // namespace
 
 std::string PlanAndStats::toString() const {
   return plan->toString(
@@ -1886,7 +1902,16 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
     sourceGroupedLeaves = &groupedLeaves_->root;
   } else {
     auto it = groupedLeaves_->perRepartition.find(&repartition);
-    if (it != groupedLeaves_->perRepartition.end()) {
+    const bool found = it != groupedLeaves_->perRepartition.end();
+    std::cerr << "F14DIAG FIND file=ToVelox.cpp"
+              << " ptr=" << &repartition << std::hex << " std_hash=0x"
+              << std::hash<const Repartition*>{}(&repartition)
+              << " folly_hash=0x"
+              << folly::hasher<const Repartition*>{}(&repartition) << std::dec
+              << " found=" << found
+              << " map_size=" << groupedLeaves_->perRepartition.size()
+              << std::endl;
+    if (found) {
       sourceGroupedLeaves = &it->second;
     }
   }


### PR DESCRIPTION
Summary:

Temporary instrumentation to root-cause why `BucketedExecutionPlanTest` and `HiveBucketedExecutionPlanTest` fail with F14 MISS-on-present-key on Mac OS release builds but pass on Linux release and Mac OS debug. NOT for merge.

Adds three diagnostics. (1) A static-init `F14DiagSelfTest` in each of `Optimization.cpp` and `ToVelox.cpp` that hashes a constant pointer `0xCAFEBABE12345678` via both `std::hash<const void*>` and `folly::hasher<const void*>` and prints the result. If the two TUs print different `std_hash` values for the same pointer, per-TU divergence of libc++'s inlined `std::hash<T*>` body is proven. (2) An `F14DIAG INSERT` line at `commitGroupedLeavesForRepartition` in `Optimization.cpp` and an `F14DIAG FIND` line at the `groupedLeaves_->perRepartition.find(&repartition)` call site in `ToVelox.cpp`, each printing the pointer, the `std::hash` result, the `folly::hasher` result, the map size, and (for FIND) whether the lookup succeeded. (3) A new `F14 Diagnostic - Symbol and Library Analysis` step in the macOS GitHub Actions workflow that runs after Build and uses `otool -L`, `nm`, and `otool -tV` on the `axiom_optimizer_tests` binary to surface `__hash_memory` symbol presence, `__murmur2_or_cityhash` symbol presence, `std::hash<...Repartition>` instantiation symbols, and disassembly of the insert and find sites — telling us at build-time whether libc++ inlined the hash body per TU or routed through a single shared symbol.

The four outcomes the Mac CI logs can distinguish: SELFTEST values differ between TUs → libc++ inlining divergence; INSERT and FIND hash the same pointer to different values → libc++ hash nondeterminism within one process; hashes match across INSERT/FIND but `found=0` → bug is in F14 itself (probe walker, overflow count, or chunk derivation); all hashes match and `found=1` → the failure is in a different code path entirely. The symbol-and-disassembly step distinguishes hypothesis 1 from the others directly.

Differential Revision: D106410420


