### PR TITLE
build: Skip Velox status badge workflow in forks

### DIFF
--- a/.github/workflows/velox-status.yml
+++ b/.github/workflows/velox-status.yml
@@ -36,6 +36,7 @@ permissions:
   contents: read
 jobs:
   update-badge:
+    if: github.repository == 'facebookincubator/axiom'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Forks inherit the scheduled cron trigger and run the badge workflow daily. If a fork has the `GIST_TOKEN` secret, it overwrites the upstream gist with the fork's stale submodule pointer — causing the badge in the upstream README to show an outdated Velox commit.

Add `if: github.repository == 'facebookincubator/axiom'` so the workflow only runs in the upstream repo.