### PR TITLE
fix(optimizer): Honor syntactic_join_order at every step

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -942,6 +942,32 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
         return left.fanout < right.fanout;
       });
 
+  // Keep only the candidate that matches the next unplaced table in
+  // dt->joinOrder.
+  if (options_.syntacticJoinOrder && candidates.size() > 1) {
+    auto nextIt = std::find_if(
+        state.dt->joinOrder.begin(),
+        state.dt->joinOrder.end(),
+        [&](int32_t id) { return !state.isPlaced(queryCtx()->objectAt(id)); });
+    VELOX_CHECK(
+        nextIt != state.dt->joinOrder.end(),
+        "syntactic_join_order: all tables already placed but candidates remain");
+    const int32_t nextId = *nextIt;
+    auto it = std::find_if(
+        candidates.begin(),
+        candidates.end(),
+        [&](const JoinCandidate& candidate) {
+          return candidate.tables[0]->id() == nextId;
+        });
+    VELOX_CHECK(
+        it != candidates.end(),
+        "syntactic_join_order: next-in-order table {} is not among current join candidates",
+        nextId);
+    JoinCandidate match = std::move(*it);
+    candidates.clear();
+    candidates.push_back(std::move(match));
+  }
+
   return candidates;
 }
 

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <chrono>
+#include <future>
+#include <thread>
+
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -289,6 +293,53 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
       checkSame(logicalPlan, referenceResults);
     }
   }
+}
+
+// 12-way inner-join chain. Without the per-step restriction that keeps
+// the optimizer on the SQL-written order, the recursion enumerates
+// candidates and strategies at every level and the optimization does
+// not finish within the timeout.
+TEST_F(SyntacticJoinOrderTest, manyJoinsBoundedByOrder) {
+  constexpr int32_t kNumTables = 12;
+
+  for (int32_t i = 0; i < kNumTables; ++i) {
+    const auto key = fmt::format("k{}", i);
+    const auto rowType = ROW({key, fmt::format("v{}", i)}, BIGINT());
+    testConnector_->addTable(fmt::format("t{}", i), rowType)
+        ->setStats(1'000, {{key, {.numDistinct = 1'000}}});
+  }
+
+  lp::PlanBuilder::Context context(kTestConnectorId, "default");
+  lp::PlanBuilder builder(context);
+  builder.tableScan("t0");
+  for (int32_t i = 1; i < kNumTables; ++i) {
+    builder.join(
+        lp::PlanBuilder(context).tableScan(fmt::format("t{}", i)),
+        fmt::format("k0 = k{}", i),
+        lp::JoinType::kInner);
+  }
+  auto logicalPlan = builder.aggregate({}, {"count(1)"}).build();
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  optimizerOptions_.sampleJoins = false;
+
+  std::packaged_task<void()> task([&]() {
+    auto plan = toSingleNodePlan(logicalPlan);
+    ASSERT_NE(plan, nullptr);
+  });
+  auto future = task.get_future();
+  std::thread worker(std::move(task));
+
+  constexpr std::chrono::seconds kTimeout{30};
+  const auto status = future.wait_for(kTimeout);
+  if (status != std::future_status::ready) {
+    worker.detach();
+    FAIL() << "Optimization timed out after " << kTimeout.count() << "s; "
+           << "syntactic_join_order failed to bound enumeration";
+    return;
+  }
+  worker.join();
+  future.get();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Setting `syntactic_join_order = true` did not actually follow the SQL-written order at every enumeration step. The optimizer restricted only the starting table; at each recursive step it still enumerated all unplaced neighbors as candidates. With 10+ tables joined on equality keys, transitive equivalence-class inference expands the join graph into a near-complete graph and the recursion goes combinatorial. A 12-table query took over six minutes to plan.

Restrict candidates in `nextJoins()` to the one whose table id matches the next unplaced entry in `dt->joinOrder`. The recursion now walks the SQL-written order linearly — same 12-table query plans in 8s.

Differential Revision: D106538353


