### PR TITLE
feat(optimizer): Penalize single-stage aggregation under grouping-key skew (#1425)

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1416,6 +1416,30 @@ float sortCost(size_t numKeys, float cardinality) {
   }
   return Costs::kKeyCompareCost * numKeys * std::log2(cardinality);
 }
+
+// Returns true if 'input' is hash-partitioned and every partition key is
+// also a grouping key. In that case rows for each distinct grouping-key
+// value land on a single partition, so aggregation parallelism is bounded
+// by the number of distinct grouping-key values.
+bool isPartitionedByGroupingKeys(
+    const RelationOp& input,
+    const ExprVector& groupingKeys) {
+  const auto& partitionKeys = input.distribution().partitionKeys();
+  if (partitionKeys.empty()) {
+    return false;
+  }
+  return std::all_of(
+      partitionKeys.begin(),
+      partitionKeys.end(),
+      [&groupingKeys](const auto& partitionKey) {
+        return std::any_of(
+            groupingKeys.begin(),
+            groupingKeys.end(),
+            [&partitionKey](ExprCP groupKey) {
+              return groupKey->sameOrEqual(*partitionKey);
+            });
+      });
+}
 } // namespace
 
 void Aggregation::setCostWithGroups(float inputBeforePartial) {
@@ -1444,6 +1468,18 @@ void Aggregation::setCostWithGroups(float inputBeforePartial) {
     cost_.unitCost =
         aggregationCost(numKeys, aggregates.size(), rowBytes, numGroups) +
         localExchangeCost;
+
+    // Apply skew penalty: when numGroups < parallelism, only numGroups workers
+    // do meaningful work, so effective wall-time scales as parallelism /
+    // numGroups.
+    if (step == velox::core::AggregationNode::Step::kSingle) {
+      const auto parallelism =
+          runnerOptions.numWorkers * runnerOptions.numDrivers;
+      if (numGroups >= 1.0f && numGroups < parallelism &&
+          isPartitionedByGroupingKeys(*input_, groupingKeys)) {
+        cost_.unitCost *= static_cast<float>(parallelism) / numGroups;
+      }
+    }
 
     // numGroups can be > inputCardinality since this is calculated against
     // the input before partial and inputCardinality is scaled down by partial

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -250,6 +250,40 @@ TEST_F(AggregationTest, orderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
 }
 
+// Verifies that GROUP BY on a column with very few distinct values relative to
+// the available parallelism uses the partial + final shape rather than a
+// single-stage aggregation. With one driver per distinct grouping-key value,
+// single-stage aggregation on the post-shuffle data is bottlenecked by skew,
+// so the cost model must penalize it accordingly.
+TEST_F(AggregationTest, lowCardinalityGroupByPrefersPartialFinal) {
+  testConnector_->addTable("t", ROW({"k", "v"}, BIGINT()))
+      ->setStats(
+          1,
+          {
+              {"k", {.numDistinct = 1}},
+              {"v", {.numDistinct = 1}},
+          });
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({"k"}, {"sum(v)"})
+                         .build();
+  auto plan = planVelox(logicalPlan);
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .partialAggregation({"k"}, {"sum(v)"})
+                     .shuffle()
+                     .localPartition()
+                     .finalAggregation()
+                     .shuffle()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
 // Verifies that repartitionForAgg correctly determines when shuffle is needed
 // based on the relationship between the current partition keys and the required
 // grouping keys.
@@ -278,16 +312,17 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
                            .build();
     auto plan = planVelox(logicalPlan);
 
-    // There should be only ONE shuffle (for the first
-    // aggregation). The second aggregation should NOT require a shuffle
-    // because partitionKeys [a, b] ⊆ groupingKeys [a, b, d].
+    // The second aggregation should NOT need a remote shuffle because
+    // partitionKeys [a, b] ⊆ groupingKeys [a, b, d]; only a local
+    // repartition by [a, b, d] is needed to align the local hash table.
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .distributedSingleAggregation({"a", "b"}, {})
+                       .distributedAggregation({"a", "b"}, {})
                        .project()
-                       // No shuffle here - partitionKeys ⊆ groupingKeys
+                       // No remote shuffle here - partitionKeys ⊆ groupingKeys.
+                       .partialAggregation({"a", "b", "d"}, {})
                        .localPartition()
-                       .singleAggregation({"a", "b", "d"}, {})
+                       .finalAggregation()
                        .shuffle()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
@@ -303,14 +338,13 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
                            .build();
     auto plan = planVelox(logicalPlan);
 
-    // There should be TWO shuffles. The second aggregation
-    // MUST be after a shuffle because partitionKeys [a, b, c] ⊄ groupingKeys
-    // [a, b].
+    // The second aggregation MUST be after a remote shuffle because
+    // partitionKeys [a, b, c] ⊄ groupingKeys [a, b].
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
-                       .distributedSingleAggregation({"a", "b", "c"}, {})
+                       .distributedAggregation({"a", "b", "c"}, {})
                        .project()
-                       .distributedSingleAggregation({"a", "b"}, {})
+                       .distributedAggregation({"a", "b"}, {})
                        .shuffle()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -256,9 +256,10 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
 
   auto distributedMatcher = matchScan("u")
                                 .filter("x < 10")
+                                .partialAggregation({"x"}, {"count(*) as cnt"})
                                 .shuffle({"x"})
                                 .localPartition({"x"})
-                                .singleAggregation({"x"}, {"count(*) as cnt"})
+                                .finalAggregation({"x"}, {"count(cnt) as cnt"})
                                 .hashJoin(
                                     matchScan("v")
                                         .filter("a < 10")
@@ -287,16 +288,14 @@ TEST_F(ExistencePushdownTest, chainJoin) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
+  // r + s wrapped into a chainDt, pushed as existence inside the aggregation.
   auto matcher =
       matchScan("u")
           .hashJoin(
               matchScan("r")
                   .filter("b < 100")
                   .hashJoin(
-                      matchScan("s")
-                          .aliases({"s_a"})
-                          .filter("s_a < 100")
-                          .build(),
+                      matchScan("s").filter("a_0 < 100").build(),
                       core::JoinType::kInner)
                   .project()
                   .build(),
@@ -305,7 +304,7 @@ TEST_F(ExistencePushdownTest, chainJoin) {
           .hashJoin(
               matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
           .hashJoin(
-              matchScan("s").aliases({"s_a"}).filter("s_a < 100").build(),
+              matchScan("s").filter("a_0 < 100").build(),
               core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -317,11 +316,7 @@ TEST_F(ExistencePushdownTest, chainJoin) {
       matchScan("r")
           .filter("b < 100")
           .hashJoin(
-              matchScan("s")
-                  .aliases({"s_a"})
-                  .filter("s_a < 100")
-                  .broadcast()
-                  .build(),
+              matchScan("s").filter("a_0 < 100").broadcast().build(),
               core::JoinType::kInner)
           .hashJoin(
               matchScan("u")
@@ -330,8 +325,7 @@ TEST_F(ExistencePushdownTest, chainJoin) {
                           .filter("b < 100")
                           .hashJoin(
                               matchScan("s")
-                                  .aliases({"s_a"})
-                                  .filter("s_a < 100")
+                                  .filter("a_0 < 100")
                                   .broadcast()
                                   .build(),
                               core::JoinType::kInner)
@@ -395,9 +389,10 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .hashJoin(
                       matchScan("s").broadcast().build(),
                       core::JoinType::kLeftSemiFilter)
+                  .partialAggregation({"x", "y"}, {})
                   .shuffle({"x", "y"})
                   .localPartition({"x", "y"})
-                  .singleAggregation({"x", "y"}, {})
+                  .finalAggregation()
                   .broadcast()
                   .build(),
               core::JoinType::kInner)

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -346,15 +346,18 @@ TEST_F(RelationOpPrinterTest, markDistinct) {
           testing::HasSubstr("FILTER (WHERE __m0)"),
           testing::HasSubstr("FILTER (WHERE __m1)"),
           testing::StartsWith("    Repartition"),
-          testing::StartsWith("      MarkDistinct"),
-          testing::StartsWith("        Repartition"),
-          testing::StartsWith("          MarkDistinct"),
-          testing::StartsWith("            Repartition"),
-          testing::StartsWith("              TableScan"),
-          testing::StartsWith("                table: \"default\".\"t\""),
+          testing::StartsWith("      Aggregation"),
+          testing::HasSubstr("FILTER (WHERE __m0)"),
+          testing::HasSubstr("FILTER (WHERE __m1)"),
+          testing::StartsWith("        MarkDistinct"),
+          testing::StartsWith("          Repartition"),
+          testing::StartsWith("            MarkDistinct"),
+          testing::StartsWith("              Repartition"),
+          testing::StartsWith("                TableScan"),
+          testing::StartsWith("                  table: \"default\".\"t\""),
           testing::Eq("")));
 
-  EXPECT_EQ("agg(\"default\".\"t\")", toDistributedOneline(*logicalPlan));
+  EXPECT_EQ("agg(agg(\"default\".\"t\"))", toDistributedOneline(*logicalPlan));
 }
 
 TEST_F(RelationOpPrinterTest, cost) {

--- a/axiom/optimizer/tests/RemoteOutputTest.cpp
+++ b/axiom/optimizer/tests/RemoteOutputTest.cpp
@@ -92,15 +92,16 @@ TEST_F(RemoteOutputTest, groupByAggregation) {
   auto logicalPlan =
       parseSelect("SELECT sum(b) FROM t GROUP BY a", kTestConnectorId);
 
-  // Multi-worker without remote output: shuffle by group-by key, then
-  // single aggregation. A gather stage collects results from multiple
-  // workers onto a single node.
+  // Multi-worker without remote output: partial + shuffle + final
+  // aggregation, with a gather stage collecting results from the workers
+  // onto a single node.
   auto plan = planVelox(
       logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = false});
   auto matcher = matchScan("t")
+                     .partialAggregation({"a"}, {"sum(b)"})
                      .shuffle({"a"})
                      .localPartition({"a"})
-                     .singleAggregation({"a"}, {"sum(b)"})
+                     .finalAggregation()
                      .project()
                      .gather()
                      .build();


### PR DESCRIPTION
Summary:

When an aggregation's input is already hash-partitioned by (a subset of) the
grouping keys and the number of distinct groups is smaller than the available
parallelism (`numWorkers * numDrivers`), only `numGroups` of the parallel
units do real work. A single-stage aggregation in this regime is bottlenecked
by skew, so its wall-time scales as `parallelism / numGroups`.

Changes:
- `RelationOp.cpp`: add an anonymous-namespace helper
  `isPartitionedByGroupingKeys(input, groupingKeys)` that returns true when
  every partition key of the input is also a grouping key (analog of
  Presto's `PartitioningUtils.isPartitionedOn` used in
  `AddExchanges.visitAggregation`). In `Aggregation::setCostWithGroups`,
  multiply `cost_.unitCost` by `parallelism / numGroups` for `kSingle`
  aggregations that satisfy the predicate and have `numGroups < parallelism`.
  The factor is 1.0 when `numGroups >= parallelism`, so balanced plans are
  unaffected. The penalty is intentionally not applied to
  `kFinal`/`kIntermediate`, which already follow a partial step that ran
  with full parallelism — penalizing them would defeat partial+final.

Differential Revision: D105616417


