### PR TITLE
feat(optimizer): Use multi-mask MarkDistinct for DISTINCT aggregations with filters (#1426)

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -186,14 +186,6 @@ AggregateVector dropDistinctFromAggregates(const AggregateVector& aggregates) {
   return result;
 }
 
-// Returns true if no distinct aggregate has a filter.
-bool canMakeMarkDistinctPlan(const AggregateVector& aggregates) {
-  return !std::any_of(
-      aggregates.begin(), aggregates.end(), [](const auto* agg) {
-        return agg->isDistinct() && agg->condition() != nullptr;
-      });
-}
-
 // Result of adding MarkDistinct nodes to a plan.
 struct MarkDistinctResult {
   RelationOpPtr plan;
@@ -201,8 +193,20 @@ struct MarkDistinctResult {
   PlanCost cost;
 };
 
+// Per-key-set group of distinct aggregates sharing the same MarkDistinct node.
+// markers[0] is the no-mask marker, markers[i+1] is the per-mask marker for
+// masks[i].
+struct MarkDistinctGroup {
+  ExprVector markDistinctKeys;
+  ColumnVector markers;
+  ColumnVector masks;
+  // Maps filter condition to its marker column. nullptr means unfiltered.
+  folly::F14FastMap<ExprCP, ColumnCP> filterToMarker;
+};
+
 // Adds MarkDistinct nodes for each unique set of distinct arguments and
-// rewrites distinct aggregates to masked non-distinct aggregates.
+// rewrites distinct aggregates to masked non-distinct aggregates. Handles
+// both filtered and unfiltered distinct aggregates via multi-mask MarkDistinct.
 MarkDistinctResult addMarkDistinctNodes(
     RelationOpPtr plan,
     const ExprVector& groupingKeys,
@@ -210,52 +214,94 @@ MarkDistinctResult addMarkDistinctNodes(
     bool isSingleWorker,
     PlanState& state) {
   PlanCost totalCost;
-  folly::F14FastMap<PlanObjectSet, ColumnCP> markers;
-
-  AggregateVector newAggregates;
-  newAggregates.reserve(aggregates.size());
   auto groupingKeySet = PlanObjectSet::fromObjects(groupingKeys);
+  size_t markerCounter = 0;
+
+  auto makeMarker = [&]() {
+    auto markerName = fmt::format("__m{}", markerCounter++);
+    return make<Column>(
+        toName(markerName),
+        /*relation=*/nullptr,
+        Value{toType(velox::BOOLEAN()), 2});
+  };
+
+  // Phase 1: Collect — group distinct aggregates by key set, allocate markers,
+  // and remember which marker each aggregate will reference in Phase 3.
+  folly::F14VectorMap<PlanObjectSet, MarkDistinctGroup> groups;
+  folly::F14FastMap<const Aggregate*, ColumnCP> aggregateToMarker;
   for (const auto* aggregate : aggregates) {
     if (!aggregate->isDistinct()) {
-      newAggregates.push_back(aggregate);
       continue;
     }
-
     auto markDistinctKeys = unionColumnArgs(groupingKeys, aggregate->args());
-    auto markDistinctKeySet = PlanObjectSet::fromObjects(markDistinctKeys);
-    if (markDistinctKeySet == groupingKeySet) {
-      // All distinct args are literals or already in grouping keys.
-      // MarkDistinct would be redundant since the aggregation's GROUP BY
-      // already partitions by these keys. Keep the aggregate unchanged with
-      // DISTINCT.
-      newAggregates.push_back(aggregate);
+    auto keySet = PlanObjectSet::fromObjects(markDistinctKeys);
+    if (keySet == groupingKeySet) {
       continue;
     }
-    auto [it, inserted] = markers.try_emplace(markDistinctKeySet, nullptr);
-    if (inserted) {
-      auto markerName = fmt::format("__m{}", markers.size() - 1);
-      it->second = make<Column>(
-          toName(markerName),
-          /*relation=*/nullptr,
-          Value{toType(velox::BOOLEAN()), 2});
-
-      if (!isSingleWorker) {
-        auto [repartitioned, repartitionCost] =
-            maybeRepartition(plan, ExprVector(markDistinctKeys), state);
-        plan = repartitioned;
-        totalCost.add(repartitionCost);
-      }
-
-      auto markDistinct =
-          make<MarkDistinct>(plan, it->second, std::move(markDistinctKeys));
-      totalCost.add(*markDistinct);
-      plan = markDistinct;
+    auto [groupIt, isNewGroup] = groups.try_emplace(std::move(keySet));
+    auto& group = groupIt->second;
+    if (isNewGroup) {
+      group.markDistinctKeys = std::move(markDistinctKeys);
+      // Reserve the no-mask marker name first so it has the smallest counter
+      // value in the group; per-mask markers follow as filters are seen.
+      auto* noMaskMarker = makeMarker();
+      group.markers.push_back(noMaskMarker);
+      group.filterToMarker[nullptr] = noMaskMarker;
     }
 
-    newAggregates.push_back(aggregate->replaceDistinctWithMarker(it->second));
+    auto* filter = aggregate->condition();
+    auto [markerIt, markerInserted] =
+        group.filterToMarker.try_emplace(filter, nullptr);
+    if (markerInserted) {
+      auto* marker = makeMarker();
+      markerIt->second = marker;
+      group.markers.push_back(marker);
+      // Filter conditions are projected to Column refs upstream; this cast
+      // cannot return null.
+      auto* maskColumn = filter->as<Column>();
+      VELOX_CHECK_NOT_NULL(
+          maskColumn,
+          "MarkDistinct mask must be a Column after flattenAggregates; got {}",
+          filter->toString());
+      group.masks.push_back(maskColumn);
+    }
+    aggregateToMarker[aggregate] = markerIt->second;
   }
 
-  return {plan, std::move(newAggregates), totalCost};
+  // Phase 2: Build a MarkDistinct per key set. F14VectorMap iterates in LIFO;
+  // use rbegin/rend for insertion order.
+  for (auto it = groups.rbegin(); it != groups.rend(); ++it) {
+    auto& group = it->second;
+
+    if (!isSingleWorker) {
+      auto [repartitioned, repartitionCost] =
+          maybeRepartition(plan, ExprVector(group.markDistinctKeys), state);
+      plan = repartitioned;
+      totalCost.add(repartitionCost);
+    }
+
+    plan = make<MarkDistinct>(
+        plan,
+        std::move(group.markers),
+        std::move(group.markDistinctKeys),
+        std::move(group.masks));
+    totalCost.add(*plan);
+  }
+
+  // Phase 3: Rewrite distinct aggregates via the Phase-1 lookup.
+  AggregateVector newAggregates;
+  newAggregates.reserve(aggregates.size());
+  for (const auto* aggregate : aggregates) {
+    auto it = aggregateToMarker.find(aggregate);
+    if (it == aggregateToMarker.end()) {
+      newAggregates.push_back(aggregate);
+      continue;
+    }
+    newAggregates.push_back(
+        aggregate->replaceDistinctAndFilterByMarker(it->second));
+  }
+
+  return {std::move(plan), std::move(newAggregates), totalCost};
 }
 
 // Collects unique column references from aggregate functions (args, ORDER BY
@@ -608,7 +654,7 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
     bool hasOrderBy,
     PlanState& state) const {
   auto [markedPlan, newAggregates, markCost] = addMarkDistinctNodes(
-      plan, groupingKeys, aggregates, isSingleWorker_, state);
+      std::move(plan), groupingKeys, aggregates, isSingleWorker_, state);
 
   PlanCost totalCost;
   totalCost.add(markCost);
@@ -858,26 +904,8 @@ void AggregationPlanner::plan(
       return;
     }
 
-    if (canMakeMarkDistinctPlan(aggregates)) {
-      auto [result, cost] = makeDistinctToMarkDistinctPlan(
-          plan, groupingKeys, aggregates, aggPlan, hasOrderBy, state);
-      plan = std::move(result);
-      state.cost.add(cost);
-      return;
-    }
-
-    // When neither GroupBy nor MarkDistinct
-    // can apply (e.g. DISTINCT with FILTER), fall back to single-step distinct
-    // aggregation.
-    auto [result, cost] = makeSingleAggregationPlan(
-        plan,
-        groupingKeys,
-        aggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
-        {},
-        nullptr,
-        state);
+    auto [result, cost] = makeDistinctToMarkDistinctPlan(
+        plan, groupingKeys, aggregates, aggPlan, hasOrderBy, state);
     plan = std::move(result);
     state.cost.add(cost);
     return;

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -186,9 +186,10 @@ const Aggregate* Aggregate::dropDistinct() const {
       orderTypes_);
 }
 
-const Aggregate* Aggregate::replaceDistinctWithMarker(ExprCP marker) const {
+const Aggregate* Aggregate::replaceDistinctAndFilterByMarker(
+    ExprCP marker) const {
   VELOX_CHECK(isDistinct_);
-  VELOX_CHECK_NULL(condition_);
+  VELOX_CHECK_NOT_NULL(marker);
   return make<Aggregate>(
       name(),
       value_,

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1204,8 +1204,10 @@ class Aggregate : public Call {
   /// Returns a copy with isDistinct set to false.
   const Aggregate* dropDistinct() const;
 
-  /// Returns a copy with isDistinct set to false and condition set to 'marker'.
-  const Aggregate* replaceDistinctWithMarker(ExprCP marker) const;
+  /// Returns a copy with isDistinct cleared and condition replaced by 'marker'.
+  /// Any prior FILTER condition is dropped because the marker already encodes
+  /// which rows pass the filter.
+  const Aggregate* replaceDistinctAndFilterByMarker(ExprCP marker) const;
 
   std::string toString() const override;
 

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -2212,20 +2212,26 @@ void TopNRowNumber::accept(
 
 MarkDistinct::MarkDistinct(
     RelationOpPtr input,
-    ColumnCP marker,
-    ExprVector keys)
+    ColumnVector markers,
+    ExprVector keys,
+    ColumnVector masks)
     : RelationOp(
           RelType::kMarkDistinct,
           input,
           [&]() {
-            // Output columns = input columns + marker column.
             ColumnVector cols = input->columns();
-            cols.push_back(marker);
+            for (const auto* marker : markers) {
+              cols.push_back(marker);
+            }
             return cols;
           }()),
-      marker_(marker),
-      keys_(std::move(keys)) {
-  VELOX_CHECK_NOT_NULL(marker_);
+      markers_(std::move(markers)),
+      keys_(std::move(keys)),
+      masks_(std::move(masks)) {
+  VELOX_CHECK_EQ(
+      markers_.size(),
+      masks_.size() + 1,
+      "MarkDistinct must have one marker for the no-mask channel plus one per mask");
   VELOX_CHECK(!keys_.empty());
   auto* optimization = queryCtx()->optimization();
   const auto& runnerOptions = optimization->runnerOptions();
@@ -2238,7 +2244,9 @@ MarkDistinct::MarkDistinct(
       std::max<double>(1, maxGroups(keys_, input_->constraints()));
   const auto numGroups =
       expectedNumDistincts(cost_.inputCardinality, maxCardinality);
-  const auto rowBytes = byteSize(keys_) + Costs::kHashRowBytes;
+  const auto maskBitmapBytes = (masks_.size() + 7) / 8;
+  const auto rowBytes =
+      byteSize(keys_) + Costs::kHashRowBytes + maskBitmapBytes;
   cost_.totalBytes = numGroups * rowBytes;
 
   // Cost is similar to a hash aggregation for tracking distinct values. Each
@@ -2251,12 +2259,14 @@ MarkDistinct::MarkDistinct(
   }
   auto markDistinctCost = Costs::kHashColumnCost * keys_.size() +
       Costs::hashTableCost(numGroups) + Costs::kKeyCompareCost * keys_.size() +
-      Costs::hashRowCost(numGroups, rowBytes);
+      Costs::hashRowCost(numGroups, rowBytes) +
+      masks_.size() * Costs::kSimpleAggregateCost;
   cost_.unitCost = localExchangeCost + markDistinctCost;
 
-  // Set constraints_. Result cardinality is the same as input cardinality.
   constraints_ = input->constraints();
-  constraints_.emplace(marker->id(), marker_->value());
+  for (const auto* marker : markers_) {
+    constraints_.emplace(marker->id(), marker->value());
+  }
 }
 
 void MarkDistinct::accept(

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -956,21 +956,33 @@ struct TopNRowNumber : public RelationOp {
 
 using TopNRowNumberCP = const TopNRowNumber*;
 
-/// Marks unique rows based on distinct keys. Produces a boolean marker column
-/// that is true for the first row seen for each unique combination of distinct
-/// keys.
+/// Marks unique rows based on distinct keys. Produces masks.size() + 1
+/// boolean marker columns:
+///
+/// markers[0]: no-mask marker — true for the first occurrence of each distinct
+/// key combination, regardless of any mask.
+///
+/// markers[i+1]: per-mask marker — true for the first occurrence of each
+/// distinct key combination where masks[i] is true.
+///
+/// When masks is empty, only the no-mask marker is produced.
 struct MarkDistinct : public RelationOp {
-  /// @param input The input relation.
-  /// @param marker The output boolean column that marks distinct rows.
-  /// @param keys The columns that define distinctness.
-  MarkDistinct(RelationOpPtr input, ColumnCP marker, ExprVector keys);
+  MarkDistinct(
+      RelationOpPtr input,
+      ColumnVector markers,
+      ExprVector keys,
+      ColumnVector masks);
 
-  ColumnCP marker() const {
-    return marker_;
+  const ColumnVector& markers() const {
+    return markers_;
   }
 
   const ExprVector& keys() const {
     return keys_;
+  }
+
+  const ColumnVector& masks() const {
+    return masks_;
   }
 
   void accept(
@@ -978,8 +990,9 @@ struct MarkDistinct : public RelationOp {
       RelationOpVisitorContext& context) const override;
 
  private:
-  ColumnCP const marker_;
+  const ColumnVector markers_;
   const ExprVector keys_;
+  const ColumnVector masks_;
 };
 
 using MarkDistinctCP = const MarkDistinct*;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -2307,12 +2307,34 @@ velox::core::PlanNodePtr ToVelox::makeMarkDistinct(
     }
   }
 
+  std::vector<std::string> markerNames;
+  markerNames.reserve(op.markers().size());
+  for (const auto* marker : op.markers()) {
+    markerNames.push_back(marker->outputName());
+  }
+
+  if (op.masks().empty()) {
+    // Single-marker mode: one no-mask marker, no masks.
+    auto node = std::make_shared<velox::core::MarkDistinctNode>(
+        nextId(), markerNames[0], toFieldRefs(op.keys()), std::move(input));
+    makePredictionAndHistory(node->id(), &op);
+    return node;
+  }
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> masks;
+  masks.reserve(op.masks().size());
+  for (const auto* mask : op.masks()) {
+    masks.push_back(
+        std::make_shared<velox::core::FieldAccessTypedExpr>(
+            velox::BOOLEAN(), mask->outputName()));
+  }
+
   auto node = std::make_shared<velox::core::MarkDistinctNode>(
       nextId(),
-      op.marker()->outputName(),
+      std::move(markerNames),
       toFieldRefs(op.keys()),
+      std::move(masks),
       std::move(input));
-
   makePredictionAndHistory(node->id(), &op);
   return node;
 }

--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -345,8 +345,8 @@ TEST_F(DistinctAggregationTest, markDistinctDifferentArgSets) {
       plan.plan,
       matchScan("t")
           .project({"a", "b as p0", "d % 5 as p1"})
-          .distributedMarkDistinct({"a", "p0"}, "m0")
-          .distributedMarkDistinct({"a", "p1"}, "m1")
+          .distributedMarkDistinct({"a", "p0"}, {"m0"})
+          .distributedMarkDistinct({"a", "p1"}, {"m1"})
           .distributedAggregation(
               {"a"},
               {"count(p0) filter (where m0)", "sum(p1) filter (where m1)"})
@@ -377,8 +377,8 @@ TEST_F(DistinctAggregationTest, markDistinctGlobalWithMultipleSets) {
       plan.plan,
       matchScan("t")
           .project({"b as p0", "d % 5 as p1"})
-          .distributedMarkDistinct({"p0"}, "m0")
-          .distributedMarkDistinct({"p1"}, "m1")
+          .distributedMarkDistinct({"p0"}, {"m0"})
+          .distributedMarkDistinct({"p1"}, {"m1"})
           .partialAggregation(
               {}, {"count(p0) filter (where m0)", "sum(p1) filter (where m1)"})
           .shuffle()
@@ -411,8 +411,8 @@ TEST_F(DistinctAggregationTest, markDistinctMixedDistinctAndNonDistinct) {
       plan.plan,
       matchScan("t")
           .project({"a", "b as p0", "d % 5 as p1"})
-          .distributedMarkDistinct({"a", "p0"}, "m0")
-          .distributedMarkDistinct({"a", "p1"}, "m1")
+          .distributedMarkDistinct({"a", "p0"}, {"m0"})
+          .distributedMarkDistinct({"a", "p1"}, {"m1"})
           .distributedAggregation(
               {"a"},
               {"count(p0) filter (where m0)",
@@ -445,8 +445,8 @@ TEST_F(DistinctAggregationTest, markDistinctMultiArgAggregates) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       plan.plan,
       matchScan("t")
-          .distributedMarkDistinct({"a", "b", "c"}, "m0")
-          .distributedMarkDistinct({"a", "d"}, "m1")
+          .distributedMarkDistinct({"a", "b", "c"}, {"m0"})
+          .distributedMarkDistinct({"a", "d"}, {"m1"})
           .distributedAggregation(
               {"a"},
               {"covar_pop(b, c) filter (where m0)",
@@ -482,7 +482,7 @@ TEST_F(DistinctAggregationTest, markDistinctSharedMarkers) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"b", "c"}, "m0")
+            .distributedMarkDistinct({"b", "c"}, {"m0"})
             .distributedAggregation(
                 {"b"},
                 {"count(c) filter (where m0)",
@@ -511,7 +511,7 @@ TEST_F(DistinctAggregationTest, markDistinctSharedMarkers) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"b", "c"}, "m0")
+            .distributedMarkDistinct({"b", "c"}, {"m0"})
             .distributedSingleAggregation(
                 {"b"},
                 {"covar_pop(b, c) filter (where m0)", "count(DISTINCT b)"})
@@ -548,8 +548,8 @@ TEST_F(DistinctAggregationTest, markDistinctOrderBy) {
         plan.plan,
         matchScan("t")
             .project({"a", "b as p0", "d % 5 as p1"})
-            .distributedMarkDistinct({"a", "p0"}, "m0")
-            .distributedMarkDistinct({"a", "p1"}, "m1")
+            .distributedMarkDistinct({"a", "p0"}, {"m0"})
+            .distributedMarkDistinct({"a", "p1"}, {"m1"})
             .distributedSingleAggregation(
                 {"a"},
                 {"array_agg(p0 ORDER BY p0 ASC NULLS LAST) filter (where m0)",
@@ -584,8 +584,8 @@ TEST_F(DistinctAggregationTest, markDistinctOrderBy) {
         plan.plan,
         matchScan("t")
             .project({"b as p0", "d % 5 as p1"})
-            .distributedMarkDistinct({"p0"}, "m0")
-            .distributedMarkDistinct({"p1"}, "m1")
+            .distributedMarkDistinct({"p0"}, {"m0"})
+            .distributedMarkDistinct({"p1"}, {"m1"})
             .distributedSingleAggregation(
                 {},
                 {"array_agg(p0 ORDER BY p0 ASC NULLS LAST) filter (where m0)",
@@ -622,8 +622,8 @@ TEST_F(DistinctAggregationTest, markDistinctLiterals) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"a", "b"}, "m0")
-            .distributedMarkDistinct({"a", "d"}, "m1")
+            .distributedMarkDistinct({"a", "b"}, {"m0"})
+            .distributedMarkDistinct({"a", "d"}, {"m1"})
             .distributedAggregation(
                 {"a"},
                 {"count(b) filter (where m0)",
@@ -650,7 +650,7 @@ TEST_F(DistinctAggregationTest, markDistinctLiterals) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"a", "b"}, "m0")
+            .distributedMarkDistinct({"a", "b"}, {"m0"})
             .distributedSingleAggregation(
                 {"a"}, {"count(b) filter (where m0)", "max_by(DISTINCT a, 1)"})
             .shuffle()
@@ -675,7 +675,7 @@ TEST_F(DistinctAggregationTest, markDistinctLiterals) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"a", "b"}, "m0")
+            .distributedMarkDistinct({"a", "b"}, {"m0"})
             .distributedSingleAggregation(
                 {"a"}, {"count(b) filter (where m0)", "count(DISTINCT 1)"})
             .shuffle()
@@ -685,6 +685,38 @@ TEST_F(DistinctAggregationTest, markDistinctLiterals) {
         matchScan("t")
             .singleAggregation(
                 {"a"}, {"count(DISTINCT b)", "count(DISTINCT 1)"})
+            .build());
+  }
+
+  {
+    SCOPED_TRACE(
+        "all-literal DISTINCT with FILTER + column DISTINCT → one MarkDistinct only for column DISTINCT");
+    auto logicalPlan =
+        lp::PlanBuilder(makeContext())
+            .tableScan("t")
+            .aggregate(
+                {"a"},
+                {"count(DISTINCT b)", "count(DISTINCT 1) FILTER (WHERE d > 0)"})
+            .build();
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .project({"a", "b", "d > 0 as p0"})
+            .distributedMarkDistinct({"a", "b"}, {"m0"})
+            .distributedSingleAggregation(
+                {"a"},
+                {"count(b) filter (where m0)",
+                 "count(DISTINCT 1) filter (where p0)"})
+            .shuffle()
+            .build());
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchScan("t")
+            .project({"a", "b", "d > 0 as p0"})
+            .singleAggregation(
+                {"a"},
+                {"count(DISTINCT b)", "count(DISTINCT 1) filter (where p0)"})
             .build());
   }
 }
@@ -707,8 +739,8 @@ TEST_F(DistinctAggregationTest, multipleMarkDistinctWithNoShuffleInBetween) {
       matchScan("t")
           .shuffle()
           .localPartition({"a", "b"})
-          .markDistinct({"a", "b"}, "m0")
-          .markDistinct({"a", "b", "c"}, "m1")
+          .markDistinct({"a", "b"}, {"m0"})
+          .markDistinct({"a", "b", "c"}, {"m1"})
           .distributedAggregation(
               {"a"},
               {"count(b) filter (where m0)",
@@ -723,206 +755,299 @@ TEST_F(DistinctAggregationTest, multipleMarkDistinctWithNoShuffleInBetween) {
           .build());
 }
 
-TEST_F(DistinctAggregationTest, basicDistinctSingleFilter) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+TEST_F(DistinctAggregationTest, markDistinctFilterDifferentArgSets) {
+  testConnector_->addTable(
+      "t",
+      ROW({"a", "b", "c", "d", "e"},
+          {BIGINT(), DOUBLE(), BIGINT(), BOOLEAN(), BOOLEAN()}));
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };
 
   {
-    SCOPED_TRACE(
-        "Grouped: DISTINCT with FILTER falls back to basic single-step plan.");
-    auto logicalPlan =
-        lp::PlanBuilder(makeContext())
-            .tableScan("t")
-            .aggregate({"a"}, {"count(DISTINCT b) FILTER (WHERE c > 0)"})
-            .build();
-    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
-            .distributedSingleAggregation(
-                {"a"}, {"count(DISTINCT b) filter (where p0)"})
-            .shuffle()
-            .build());
-    AXIOM_ASSERT_PLAN(
-        toSingleNodePlan(logicalPlan),
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
-            .singleAggregation({"a"}, {"count(DISTINCT b) filter (where p0)"})
-            .build());
-  }
-
-  {
-    SCOPED_TRACE(
-        "Global: DISTINCT with FILTER falls back to basic single-step plan.");
-    auto logicalPlan =
-        lp::PlanBuilder(makeContext())
-            .tableScan("t")
-            .aggregate({}, {"count(DISTINCT b) FILTER (WHERE c > 0)"})
-            .build();
-    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("t")
-            .project({"c > 0 as p0", "b"})
-            .distributedSingleAggregation(
-                {}, {"count(DISTINCT b) filter (where p0)"})
-            .build());
-    AXIOM_ASSERT_PLAN(
-        toSingleNodePlan(logicalPlan),
-        matchScan("t")
-            .project({"c > 0 as p0", "b"})
-            .singleAggregation({}, {"count(DISTINCT b) filter (where p0)"})
-            .build());
-  }
-}
-
-TEST_F(DistinctAggregationTest, basicDistinctMultipleFilters) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
-  SCOPE_EXIT {
-    testConnector_->dropTableIfExists("t");
-  };
-
-  {
-    SCOPED_TRACE(
-        "Multiple DISTINCT aggregates with different filters fall back to basic plan.");
+    SCOPED_TRACE("same key set, different filters → one MarkDistinct");
     auto logicalPlan = lp::PlanBuilder(makeContext())
                            .tableScan("t")
                            .aggregate(
                                {"a"},
-                               {"count(DISTINCT b) FILTER (WHERE c > 0)",
-                                "sum(DISTINCT b) FILTER (WHERE c > 5)"})
+                               {"count(DISTINCT b) FILTER (WHERE d)",
+                                "count(DISTINCT b) FILTER (WHERE e)"})
                            .build();
     auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .project({"a", "c > 0 as p0", "b", "c > 5 as p1"})
-            .distributedSingleAggregation(
+            .distributedMarkDistinct({"a", "b"}, {"m0", "m1", "m2"})
+            .distributedAggregation(
                 {"a"},
-                {"count(DISTINCT b) filter (where p0)",
-                 "sum(DISTINCT b) filter (where p1)"})
+                {"count(b) filter (where m1)", "count(b) filter (where m2)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
         toSingleNodePlan(logicalPlan),
         matchScan("t")
-            .project({"a", "c > 0 as p0", "b", "c > 5 as p1"})
             .singleAggregation(
                 {"a"},
-                {"count(DISTINCT b) filter (where p0)",
-                 "sum(DISTINCT b) filter (where p1)"})
+                {"count(DISTINCT b) filter (where d)",
+                 "count(DISTINCT b) filter (where e)"})
+            .build());
+  }
+
+  {
+    SCOPED_TRACE("different key sets → separate MarkDistincts");
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("t")
+                           .aggregate(
+                               {"a"},
+                               {"count(DISTINCT b) FILTER (WHERE d)",
+                                "count(DISTINCT c) FILTER (WHERE e)"})
+                           .build();
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .distributedMarkDistinct({"a", "b"}, {"m0", "m1"})
+            .distributedMarkDistinct({"a", "c"}, {"m2", "m3"})
+            .distributedAggregation(
+                {"a"},
+                {"count(b) filter (where m1)", "count(c) filter (where m3)"})
+            .shuffle()
+            .build());
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchScan("t")
+            .singleAggregation(
+                {"a"},
+                {"count(DISTINCT b) filter (where d)",
+                 "count(DISTINCT c) filter (where e)"})
             .build());
   }
 }
 
-TEST_F(DistinctAggregationTest, basicDistinctMixedFilterAndNonDistinct) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+TEST_F(DistinctAggregationTest, markDistinctFilterGlobalAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BOOLEAN()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({}, {"count(DISTINCT a) FILTER (WHERE b)"})
+                         .build();
+  auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("t")
+          .distributedMarkDistinct({"a"}, {"m0", "m1"})
+          .partialAggregation({}, {"count(a) filter (where m1)"})
+          .shuffle()
+          .localGather()
+          .finalAggregation()
+          .build());
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchScan("t")
+          .singleAggregation({}, {"count(DISTINCT a) filter (where b)"})
+          .build());
+}
+
+TEST_F(DistinctAggregationTest, markDistinctFilterSharedMarkers) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), BOOLEAN()}));
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };
 
   {
-    SCOPED_TRACE(
-        "Mix of DISTINCT with filter and non-DISTINCT falls back to basic plan.");
-    auto logicalPlan =
-        lp::PlanBuilder(makeContext())
-            .tableScan("t")
-            .aggregate(
-                {"a"}, {"count(DISTINCT b) FILTER (WHERE c > 0)", "avg(b)"})
-            .build();
+    SCOPED_TRACE("same args + same filter → shared marker");
+    auto logicalPlan = lp::PlanBuilder(makeContext())
+                           .tableScan("t")
+                           .aggregate(
+                               {"a"},
+                               {"count(DISTINCT b) FILTER (WHERE c)",
+                                "sum(DISTINCT b) FILTER (WHERE c)"})
+                           .build();
     auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
-            .distributedSingleAggregation(
-                {"a"}, {"count(DISTINCT b) filter (where p0)", "avg(b)"})
+            .distributedMarkDistinct({"a", "b"}, {"m0", "m1"})
+            .distributedAggregation(
+                {"a"},
+                {"count(b) filter (where m1)", "sum(b) filter (where m1)"})
             .shuffle()
             .build());
     AXIOM_ASSERT_PLAN(
         toSingleNodePlan(logicalPlan),
         matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
             .singleAggregation(
-                {"a"}, {"count(DISTINCT b) filter (where p0)", "avg(b)"})
+                {"a"},
+                {"count(DISTINCT b) filter (where c)",
+                 "sum(DISTINCT b) filter (where c)"})
+            .build());
+  }
+
+  {
+    SCOPED_TRACE("filtered + unfiltered same args → use no-mask marker");
+    auto logicalPlan =
+        lp::PlanBuilder(makeContext())
+            .tableScan("t")
+            .aggregate(
+                {"a"},
+                {"count(DISTINCT b)", "count(DISTINCT b) FILTER (WHERE c)"})
+            .build();
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .distributedMarkDistinct({"a", "b"}, {"m0", "m1"})
+            .distributedAggregation(
+                {"a"},
+                {"count(b) filter (where m0)", "count(b) filter (where m1)"})
+            .shuffle()
+            .build());
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchScan("t")
+            .singleAggregation(
+                {"a"},
+                {"count(DISTINCT b)", "count(DISTINCT b) filter (where c)"})
             .build());
   }
 }
 
-TEST_F(DistinctAggregationTest, basicDistinctFilterWithOrderBy) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+TEST_F(DistinctAggregationTest, markDistinctFilterOrderBy) {
+  testConnector_->addTable(
+      "t", ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), BOOLEAN()}));
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };
 
-  {
-    SCOPED_TRACE(
-        "DISTINCT with FILTER and ORDER BY falls back to basic single-step plan.");
-    auto logicalPlan =
-        lp::PlanBuilder(makeContext())
-            .tableScan("t")
-            .aggregate(
-                {"a"},
-                {"array_agg(DISTINCT b ORDER BY b) FILTER (WHERE c > 0)"})
-            .build();
-    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
-            .distributedSingleAggregation(
-                {"a"},
-                {"array_agg(DISTINCT b ORDER BY b ASC NULLS LAST) filter (where p0)"})
-            .shuffle()
-            .build());
-    AXIOM_ASSERT_PLAN(
-        toSingleNodePlan(logicalPlan),
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b"})
-            .singleAggregation(
-                {"a"}, {"array_agg(DISTINCT b ORDER BY b) filter (where p0)"})
-            .build());
-  }
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate(
+              {"a"}, {"array_agg(DISTINCT b ORDER BY b) FILTER (WHERE c)"})
+          .build();
+  auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("t")
+          .distributedMarkDistinct({"a", "b"}, {"m0", "m1"})
+          .distributedSingleAggregation(
+              {"a"},
+              {"array_agg(b ORDER BY b ASC NULLS LAST) filter (where m1)"})
+          .shuffle()
+          .build());
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchScan("t")
+          .singleAggregation(
+              {"a"}, {"array_agg(DISTINCT b ORDER BY b) filter (where c)"})
+          .build());
 }
 
-TEST_F(DistinctAggregationTest, basicDistinctMixedFilterAndNoFilter) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+TEST_F(DistinctAggregationTest, markDistinctFilterMixedDistinctAndNonDistinct) {
+  testConnector_->addTable(
+      "t",
+      ROW({"a", "b", "c", "d", "e"},
+          {BIGINT(), DOUBLE(), BIGINT(), BOOLEAN(), BOOLEAN()}));
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };
 
-  {
-    SCOPED_TRACE(
-        "DISTINCT with filter + DISTINCT without filter on different columns falls back to basic plan.");
-    auto logicalPlan =
-        lp::PlanBuilder(makeContext())
-            .tableScan("t")
-            .aggregate(
-                {"a"},
-                {"count(DISTINCT b) FILTER (WHERE c > 0)", "sum(DISTINCT c)"})
-            .build();
-    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b", "c"})
-            .distributedSingleAggregation(
-                {"a"},
-                {"count(DISTINCT b) filter (where p0)", "sum(DISTINCT c)"})
-            .shuffle()
-            .build());
-    AXIOM_ASSERT_PLAN(
-        toSingleNodePlan(logicalPlan),
-        matchScan("t")
-            .project({"a", "c > 0 as p0", "b", "c"})
-            .singleAggregation(
-                {"a"},
-                {"count(DISTINCT b) filter (where p0)", "sum(DISTINCT c)"})
-            .build());
-  }
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate(
+              {"a"},
+              {"sum(b) FILTER (WHERE e)", "count(DISTINCT c) FILTER (WHERE d)"})
+          .build();
+  auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("t")
+          .distributedMarkDistinct({"a", "c"}, {"m0", "m1"})
+          .distributedAggregation(
+              {"a"}, {"sum(b) filter (where e)", "count(c) filter (where m1)"})
+          .shuffle()
+          .build());
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchScan("t")
+          .singleAggregation(
+              {"a"},
+              {"sum(b) filter (where e)", "count(DISTINCT c) filter (where d)"})
+          .build());
+}
+
+TEST_F(DistinctAggregationTest, markDistinctFilterRedundantKeys) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BOOLEAN()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  // Distinct args equal grouping keys: aggregation's GROUP BY already
+  // partitions on those columns, so DISTINCT is kept on the aggregate and no
+  // MarkDistinct is added.
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate({"a"}, {"count(DISTINCT a) FILTER (WHERE b)"})
+          .build();
+  auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("t")
+          .distributedSingleAggregation(
+              {"a"}, {"count(DISTINCT a) filter (where b)"})
+          .shuffle()
+          .build());
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchScan("t")
+          .singleAggregation({"a"}, {"count(DISTINCT a) filter (where b)"})
+          .build());
+}
+
+TEST_F(DistinctAggregationTest, markDistinctFilterExpressionCondition) {
+  testConnector_->addTable(
+      "t",
+      ROW({"a", "b", "c", "d"}, {BIGINT(), DOUBLE(), DOUBLE(), BOOLEAN()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  // Two filters on the same distinct key set: one boolean column, one
+  // expression. Verifies expression filters are materialized into a Project
+  // before MarkDistinct and that both kinds fold into one MarkDistinct.
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate(
+                             {"a"},
+                             {"count(DISTINCT b) FILTER (WHERE d)",
+                              "count(DISTINCT b) FILTER (WHERE c > 0.0)"})
+                         .build();
+  auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("t")
+          .project({"a", "d", "b", "c > 0.0"})
+          .distributedMarkDistinct({"a", "b"}, {"m0", "m1", "m2"})
+          .distributedAggregation(
+              {"a"},
+              {"count(b) filter (where m1)", "count(b) filter (where m2)"})
+          .shuffle()
+          .build());
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchScan("t")
+          .project({"a", "d", "b", "c > 0.0 as p0"})
+          .singleAggregation(
+              {"a"},
+              {"count(DISTINCT b) filter (where d)",
+               "count(DISTINCT b) filter (where p0)"})
+          .build());
 }
 
 TEST_F(
@@ -946,7 +1071,7 @@ TEST_F(
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"b"}, "m0")
+            .distributedMarkDistinct({"b"}, {"m0"})
             .distributedSingleAggregation(
                 {}, {"count(b) filter (where m0)", "count(DISTINCT 1)"})
             .build());
@@ -969,7 +1094,7 @@ TEST_F(
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchScan("t")
-            .distributedMarkDistinct({"a", "b"}, "m0")
+            .distributedMarkDistinct({"a", "b"}, {"m0"})
             .distributedSingleAggregation(
                 {"a"}, {"count(b) filter (where m0)", "count(DISTINCT 1)"})
             .shuffle()

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1596,10 +1596,10 @@ class MarkDistinctMatcher : public PlanMatcherImpl<MarkDistinctNode> {
   MarkDistinctMatcher(
       const std::shared_ptr<PlanMatcher>& matcher,
       const std::vector<std::string>& distinctKeys,
-      std::optional<std::string> markerAlias)
+      const std::vector<std::string>& markerAliases)
       : PlanMatcherImpl<MarkDistinctNode>({matcher}),
         distinctKeys_{distinctKeys},
-        markerAlias_{std::move(markerAlias)} {
+        markerAliases_{markerAliases} {
     VELOX_CHECK(!distinctKeys_.empty());
   }
 
@@ -1620,16 +1620,22 @@ class MarkDistinctMatcher : public PlanMatcherImpl<MarkDistinctNode> {
     }
     AXIOM_TEST_RETURN_IF_FAILURE
 
+    const auto& markers = plan.markerNames();
+    EXPECT_EQ(markerAliases_.size(), markers.size())
+        << "Test expects " << markerAliases_.size() << " marker(s) but the "
+        << "MarkDistinct node produced " << markers.size();
+    AXIOM_TEST_RETURN_IF_FAILURE
+
     std::unordered_map<std::string, std::string> newSymbols = symbols;
-    if (markerAlias_.has_value()) {
-      newSymbols[*markerAlias_] = plan.markerName();
+    for (size_t i = 0; i < markerAliases_.size(); ++i) {
+      newSymbols[markerAliases_[i]] = markers[i];
     }
     return MatchResult::success(std::move(newSymbols));
   }
 
  private:
   const std::vector<std::string> distinctKeys_;
-  const std::optional<std::string> markerAlias_;
+  const std::vector<std::string> markerAliases_;
 };
 
 // Matches a GroupIdNode and verifies grouping sets, aggregation inputs, and
@@ -2216,8 +2222,8 @@ PlanMatcherBuilder& PlanMatcherBuilder::topNRowNumber(
 
 PlanMatcherBuilder& PlanMatcherBuilder::distributedMarkDistinct(
     const std::vector<std::string>& keys,
-    const std::string& markerAlias) {
-  return shuffle().localPartition(keys).markDistinct(keys, markerAlias);
+    const std::vector<std::string>& markerAliases) {
+  return shuffle().localPartition(keys).markDistinct(keys, markerAliases);
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::distributedAggregation(
@@ -2251,10 +2257,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::markDistinct() {
 
 PlanMatcherBuilder& PlanMatcherBuilder::markDistinct(
     const std::vector<std::string>& distinctKeys,
-    std::optional<std::string> markerAlias) {
+    const std::vector<std::string>& markerAliases) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<MarkDistinctMatcher>(
-      matcher_, distinctKeys, std::move(markerAlias));
+      matcher_, distinctKeys, markerAliases);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -496,10 +496,10 @@ class PlanMatcherBuilder {
       int32_t limit);
 
   /// Matches the distributed mark-distinct pattern:
-  /// shuffle → localPartition(keys) → markDistinct(keys, markerAlias).
+  /// shuffle → localPartition(keys) → markDistinct(keys, markerAliases).
   PlanMatcherBuilder& distributedMarkDistinct(
       const std::vector<std::string>& keys,
-      const std::string& markerAlias);
+      const std::vector<std::string>& markerAliases);
 
   /// Matches the distributed (split) aggregation pattern:
   /// partialAggregation(groupingKeys, aggregates) → shuffle →
@@ -520,15 +520,19 @@ class PlanMatcherBuilder {
   /// Matches any MarkDistinct node regardless of distinct keys.
   PlanMatcherBuilder& markDistinct();
 
-  /// Matches a MarkDistinct node with the specified distinct keys.
+  /// Matches a MarkDistinct node with the specified distinct keys and
+  /// registers symbol aliases for every marker column it produces. A
+  /// MarkDistinct node emits 1 + masks().size() marker columns: a no-mask
+  /// marker at index 0 and one per-mask marker at index i+1 for masks()[i].
   /// @param distinctKeys List of expected distinct keys. Supports symbol
-  /// rewriting from child matchers.
-  /// @param markerAlias If provided, registers a symbol mapping from this
-  /// alias to the marker column name, so downstream matchers can reference the
-  /// marker by alias.
+  ///   rewriting from child matchers.
+  /// @param markerAliases Aliases for every marker column, in position order.
+  ///   Must have exactly one entry per marker the node produces. Pass the
+  ///   no-argument `markDistinct()` overload to match without verifying
+  ///   marker count.
   PlanMatcherBuilder& markDistinct(
       const std::vector<std::string>& distinctKeys,
-      std::optional<std::string> markerAlias = std::nullopt);
+      const std::vector<std::string>& markerAliases);
 
   /// Matches a GroupId node with the specified grouping sets, aggregation
   /// inputs, and group ID column alias. Each grouping set is a list of output

--- a/axiom/optimizer/tests/sql/distinctAggregation.sql
+++ b/axiom/optimizer/tests/sql/distinctAggregation.sql
@@ -81,24 +81,35 @@ SELECT a, covar_pop(DISTINCT c, 1.0), covar_samp(DISTINCT c, 2.0) FROM t GROUP B
 -- DISTINCT: literal in args alongside different DISTINCT column sets.
 SELECT a, count(DISTINCT c), covar_pop(DISTINCT CAST(b AS DOUBLE), 1.0) FROM t GROUP BY a
 ----
--- DISTINCT with FILTER: grouped aggregation.
-SELECT a, count(DISTINCT b) FILTER (WHERE c > 0) FROM t GROUP BY a
+-- DISTINCT+FILTER: same key set, different filters.
+SELECT a, count(DISTINCT b) FILTER (WHERE c > 5), count(DISTINCT b) FILTER (WHERE c < 10) FROM t GROUP BY a
 ----
--- DISTINCT with FILTER: global aggregation.
+-- DISTINCT+FILTER: different distinct key sets, different filters.
+SELECT a, count(DISTINCT b) FILTER (WHERE c > 5), sum(DISTINCT c) FILTER (WHERE b > 50) FROM t GROUP BY a
+----
+-- DISTINCT+FILTER: global aggregation.
 SELECT count(DISTINCT b) FILTER (WHERE c > 0) FROM t
 ----
--- DISTINCT with FILTER: multiple DISTINCT aggregates with different filters.
-SELECT a, count(DISTINCT b) FILTER (WHERE c > 5.0), sum(DISTINCT c) FILTER (WHERE c > 10.0) FROM t GROUP BY a
+-- DISTINCT+FILTER: same args and same filter, different agg functions.
+SELECT a, count(DISTINCT b) FILTER (WHERE c > 5), sum(DISTINCT b) FILTER (WHERE c > 5) FROM t GROUP BY a
 ----
--- DISTINCT with FILTER: mix of DISTINCT-with-filter and non-DISTINCT.
-SELECT a, count(DISTINCT b) FILTER (WHERE c > 0), avg(c) FROM t GROUP BY a
+-- DISTINCT+FILTER: filtered and unfiltered on the same args.
+SELECT a, count(DISTINCT b), count(DISTINCT b) FILTER (WHERE c > 5) FROM t GROUP BY a
 ----
--- DISTINCT with FILTER and ORDER BY.
--- error: Aggregations over sorted unique values are not supported yet
+-- DISTINCT+FILTER+ORDER BY.
 SELECT a, array_agg(DISTINCT b ORDER BY b) FILTER (WHERE c > 0) FROM t GROUP BY a
+----
+-- DISTINCT+FILTER: non-distinct FILTER alongside distinct FILTER.
+SELECT a, sum(b) FILTER (WHERE c > 5), count(DISTINCT b) FILTER (WHERE c < 10) FROM t GROUP BY a
 ----
 -- DISTINCT with FILTER + DISTINCT without filter on different columns.
 SELECT a, count(DISTINCT b) FILTER (WHERE c > 0), sum(DISTINCT c) FROM t GROUP BY a
+----
+-- DISTINCT+FILTER: distinct args equal grouping keys.
+SELECT a, count(DISTINCT a) FILTER (WHERE c > 5) FROM t GROUP BY a
+----
+-- DISTINCT+FILTER: all-literal DISTINCT with FILTER alongside column-args DISTINCT.
+SELECT a, count(DISTINCT b), count(DISTINCT 1) FILTER (WHERE c > 5) FROM t GROUP BY a
 ----
 -- DISTINCT: combination of distinct on literal args and on grouping keys.
 SELECT a, count(DISTINCT 1), count(DISTINCT a), count(DISTINCT b) FROM t GROUP BY a


### PR DESCRIPTION
Summary:

Previously, Axiom optimizer handles aggregation over DISTINCT inputs via makeDistinctToMarkDistinctPlan, only if those aggregations have no filter. And DISTINCT aggregations with filters fall back to the basic single-step aggregation plan. Now that https://github.com/facebookincubator/velox/pull/17565 has extended the Velox MarkDistinct operator to allow input masks, this PR integrates the multi-mask MarkDistinct into the optimizer so that DISTINCT … FILTER (…) aggregations can be handled via MarkDistinct. For example:
```
SELECT a, count(DISTINCT b) FILTER (WHERE c0),
          count(DISTINCT b) FILTER (WHERE c1)
FROM t GROUP BY a
```
is now planned as:
```
Scan(t)
  → MarkDistinct(keys=[a, b], masks=[c0, c1], markers=[m0, m1, m2])
  → Aggregation(group=[a],
                aggs=[count(b) FILTER (WHERE m1),
                      count(b) FILTER (WHERE m2)])
```

After this change, queries eligible for Distinct-to-GroupBy transformation are still handled by makeDistinctToGroupByPlan (pre-existing behavior). The rest queries are handled by makeDistinctToMarkDistinctPlan.

Reviewed By: mbasmanova

Differential Revision: D106564747


