### PR TITLE
fix(optimizer): Skip implied joins outside DT tableSet (#1427)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -66,19 +66,31 @@ bool addEdge(EdgeSet& edges, PlanObjectCP left, PlanObjectCP right) {
 }
 
 void fillJoins(
-    PlanObjectCP column,
+    ColumnCP column,
     const Equivalence& equivalence,
     EdgeSet& edges,
     DerivedTableP dt) {
+  auto* columnTable = column->singleTable();
+  if (columnTable == nullptr) {
+    return;
+  }
   for (auto& other : equivalence.columns) {
+    auto* otherTable = other->singleTable();
+    if (otherTable == nullptr) {
+      continue;
+    }
     // A join equality requires columns from different tables. Two columns
     // in the same equivalence class can belong to the same table, e.g. after
     // UNNEST.
-    if (column->as<Expr>()->singleTable() == other->as<Expr>()->singleTable()) {
+    if (columnTable == otherTable) {
+      continue;
+    }
+    if (!dt->tableSet.contains(columnTable) &&
+        !dt->tableSet.contains(otherTable)) {
       continue;
     }
     if (addEdge(edges, column, other)) {
-      addJoinEquality(column->as<Column>(), other->as<Column>(), dt->joins);
+      addJoinEquality(column, other, dt->joins);
     }
   }
 }
@@ -619,9 +631,7 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
 
   finalizeJoins();
 
-#ifndef NDEBUG
   checkConsistency();
-#endif
   auto plan = queryCtx()->optimization()->makeInitialPlan(*this);
   updateConstraints(*plan);
 }
@@ -692,9 +702,9 @@ void DerivedTable::addImpliedJoins() {
               fillJoins(left, *rightEq, edges, this);
             }
           } else if (leftEq) {
-            fillJoins(rightKey, *leftEq, edges, this);
+            fillJoins(rightKey->as<Column>(), *leftEq, edges, this);
           } else if (rightEq) {
-            fillJoins(leftKey, *rightEq, edges, this);
+            fillJoins(leftKey->as<Column>(), *rightEq, edges, this);
           }
         }
       }

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1274,6 +1274,46 @@ TEST_F(JoinTest, impliedJoins) {
   }
 }
 
+// Implied join edges from an equivalence class must not reference tables
+// outside a subset DT's tableSet.
+TEST_F(JoinTest, impliedJoinChain) {
+  testConnector_->addTable("t1", ROW({"id1", "data1"}, BIGINT()))
+      ->setStats(1'000'000, {{"id1", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("t2", ROW({"id2", "data2"}, BIGINT()))
+      ->setStats(100, {{"id2", {.numDistinct = 100}}});
+  testConnector_->addTable("t3", ROW({"id3", "data3"}, BIGINT()))
+      ->setStats(100, {{"id3", {.numDistinct = 100}}});
+  testConnector_->addTable("t4", ROW({"id4", "data4"}, BIGINT()))
+      ->setStats(100, {{"id4", {.numDistinct = 100}}});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t1")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t2"),
+                             "id1 = id2",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t3"),
+                             "id2 = id3",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t4"),
+                             "id3 = id4",
+                             lp::JoinType::kInner)
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t3")
+                     .hashJoin(matchScan("t1")
+                                   .hashJoin(matchScan("t2").build())
+                                   .hashJoin(matchScan("t4").build())
+                                   .build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 TEST_F(JoinTest, impliedFilters) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});


### PR DESCRIPTION
Summary:

`fillJoins` generated equivalence-class edges with neither side in `dt->tableSet`. On subset DTs — existence DTs built via reducing-join import from a super DT's equivalence classes — those edges violated the `checkConsistency` invariant that at least one side of every join lives in `tableSet`:

    Neither side of a join is in tableSet: edt30, <join t2 inner t5 on t2.id1 = t5.id4>

Gate `fillJoins` to require at least one side in `dt->tableSet` before recording the implied edge — drop the edge only when both endpoints belong to sibling DTs outside the current scope. This is weaker than `addImpliedSemiEdge`, which requires the candidate side specifically.

Also promote `checkConsistency` from `#ifndef NDEBUG` to a runtime check. The bug surfaced only in dev/fuzzer builds because the assertion was compiled out in `mode/opt`; production now throws the same explicit error if a future change reintroduces the invariant violation.

Reviewed By: max-hoffman

Differential Revision: D106563854


