### PR TITLE
feat(optimizer): Add greedy fallback for large join enumeration (#1428)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -54,10 +54,6 @@ Optimization::Optimization(
       logicalPlan_(&logicalPlan),
       history_(history),
       veloxQueryCtx_(std::move(veloxQueryCtx)),
-      topState_{
-          *this,
-          nullptr,
-          optimizerSession_->options().syntacticJoinOrder},
       aggregationPlanner_{
           isSingleWorker_,
           isSingleDriver_,
@@ -407,7 +403,7 @@ std::shared_ptr<const connector::PartitionType> foldCopartition(
 // common, then replace each non-null value with entry.copartition(*common).
 // Null entries pass through unchanged. Used at every join/union site that
 // combines two PlanStates' current fragment maps.
-void mergeFragmentMaps(GroupedLeaves& consumer, GroupedLeaves&& producer) {
+void mergeFragmentMaps(GroupedLeaves& consumer, GroupedLeaves producer) {
   std::vector<std::shared_ptr<const connector::PartitionType>> nonNullValues;
   for (const auto& [_, partitionType] : consumer) {
     if (partitionType != nullptr) {
@@ -510,12 +506,12 @@ PlanP Optimization::bestPlan() {
   PlanObjectSet targetColumns;
   targetColumns.unionObjects(root_->columns);
 
-  topState_.dt = root_;
-  topState_.setTargetExprsForDt(targetColumns);
+  topState_.emplace(*this, root_, options().syntacticJoinOrder);
+  topState_->setTargetExprsForDt(targetColumns);
 
-  makeJoinsWithSyntacticFallback(topState_);
+  makeJoinsWithSyntacticFallback(*topState_);
 
-  auto* winner = topState_.plans.best();
+  auto* winner = topState_->plans.best();
   if (auto it = planGroupedLeaves_.find(winner);
       it != planGroupedLeaves_.end()) {
     // Move-out is safe: 'winner' is the single plan ToVelox will emit, no
@@ -939,7 +935,8 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   // Take the first hand joined tables and bundle them with reducing joins that
   // can go on the build side.
 
-  if (!state.syntacticJoinOrder() && !candidates.empty()) {
+  if (!state.syntacticJoinOrder() && !state.greedyJoinOrder() &&
+      !candidates.empty()) {
     std::vector<JoinCandidate> bushes;
     for (auto& candidate : candidates) {
       if (auto bush = reducingJoins(state, candidate)) {
@@ -3023,9 +3020,9 @@ RelationOpPtr Optimization::placeSingleRowDtsForJoinFilter(
   return plan;
 }
 
-void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
-  PlanStateSaver save(state);
-
+RelationOpPtr Optimization::planDtAsLeaf(
+    DerivedTableCP from,
+    PlanState& state) {
   state.place(from);
 
   auto dtColumns = PlanObjectSet::fromObjects(from->columns);
@@ -3035,20 +3032,34 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
   MemoKey key =
       MemoKey::create(from, std::move(dtColumns), PlanObjectSet::single(from));
 
-  bool ignore = false;
-  auto plan = makePlan(*state.dt, key, std::nullopt, 1, ignore);
+  auto plan = makePlan(*state.dt, key, std::nullopt, 1);
   state.cost = plan->cost;
   // Inherit the DT's per-leaf bucketed map so subsequent operators planned
-  // atop this DT see its scans as fragment leaves.
+  // atop this DT see its scans as fragment leaves. Copy: 'plan' may be the
+  // input to multiple parents, so each consumer needs its own starting map.
   auto it = planGroupedLeaves_.find(plan);
   if (it != planGroupedLeaves_.end()) {
-    mergeFragmentMaps(
-        state.mutableCurrentGroupedLeaves(), GroupedLeaves{it->second});
+    // @lint-ignore CLANGTIDY PULSE_UNNECESSARY_COPY
+    GroupedLeaves leaves = it->second;
+    mergeFragmentMaps(state.mutableCurrentGroupedLeaves(), std::move(leaves));
   }
+  return plan->op;
+}
+
+void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
+  PlanStateSaver save(state);
+
+  auto planOp = planDtAsLeaf(from, state);
 
   // Make plans based on the dt alone as first.
-  makeJoins(plan->op, state);
+  makeJoins(std::move(planOp), state);
 
+  importReducingJoinsAndPlan(from, state);
+}
+
+void Optimization::importReducingJoinsAndPlan(
+    DerivedTableCP from,
+    PlanState& state) {
   // Look for reducing joins to import inside the DT. Bushy joins are
   // only allowed when the primary table is a base table — when it is a
   // subquery DT, bushy tables would be placed inside the MemoKey alongside
@@ -3074,14 +3085,13 @@ void Optimization::placeDerivedTable(DerivedTableCP from, PlanState& state) {
       state.downstreamColumns(),
       std::move(reducingTables),
       std::move(result.existences));
-  plan = makePlan(
+  auto reducingPlan = makePlan(
       *state.dt,
       reducingKey,
       /*distribution=*/std::nullopt,
-      /*existsFanout=*/result.existenceReduction,
-      /*needsShuffle=*/ignore);
-  state.cost = plan->cost;
-  makeJoins(plan->op, state);
+      /*existsFanout=*/result.existenceReduction);
+  state.cost = reducingPlan->cost;
+  makeJoins(reducingPlan->op, state);
 }
 
 bool Optimization::placeConjuncts(
@@ -3245,7 +3255,85 @@ std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
 
   return indices;
 }
+
 } // namespace
+
+PlanP Optimization::finalizePlanWithSingleRowDts(
+    RelationOpPtr& plan,
+    PlanState& state) {
+  const auto downstream = state.downstreamColumns();
+  std::vector<DerivedTableCP> singleRowDtsToPlace;
+  state.dt->singleRowDts.forEach<DerivedTable>([&](DerivedTableCP subquery) {
+    if (!state.isPlaced(subquery)) {
+      if (!downstream.containsAny(subquery->columns)) {
+        state.place(subquery);
+      } else {
+        singleRowDtsToPlace.push_back(subquery);
+      }
+    }
+  });
+
+  for (const auto* singleRowDt : singleRowDtsToPlace) {
+    plan = placeSingleRowDt(plan, singleRowDt, state);
+  }
+
+  addPostprocess(state.dt, plan, state);
+  return state.plans.addPlan(plan, state);
+}
+
+void Optimization::greedyJoinChainDescend(
+    RelationOpPtr plan,
+    PlanState& state) {
+  VELOX_CHECK_NOT_NULL(plan);
+
+  // An unknown-cost partial plan cannot be ranked, so greedy cannot pick a
+  // meaningful chain. Bail so the syntactic fallback in
+  // makeJoinsWithSyntacticFallback re-enumerates this DT.
+  if (!state.cost.cost.has_value()) {
+    return;
+  }
+
+  if (placeConjuncts(plan, state, false)) {
+    return;
+  }
+
+  auto candidates = nextJoins(state);
+  if (candidates.empty()) {
+    if (placeConjuncts(plan, state, true)) {
+      return;
+    }
+    finalizePlanWithSingleRowDts(plan, state);
+    return;
+  }
+
+  std::vector<NextJoin> extensions;
+  extensions.reserve(candidates.size());
+  for (auto& candidate : candidates) {
+    addJoin(candidate, plan, state, extensions);
+  }
+  if (extensions.empty()) {
+    return;
+  }
+
+  auto cheaper = [](const NextJoin* best, const NextJoin& next) {
+    return best == nullptr || next.cost.cardinality < best->cost.cardinality ||
+        (next.cost.cardinality == best->cost.cardinality &&
+         next.cost.cost < best->cost.cost);
+  };
+  const NextJoin* bestEqui = nullptr;
+  const NextJoin* bestCross = nullptr;
+  for (const auto& next : extensions) {
+    const NextJoin*& best = next.isEquiJoin() ? bestEqui : bestCross;
+    if (cheaper(best, next)) {
+      best = &next;
+    }
+  }
+  const NextJoin* chosen = bestEqui != nullptr ? bestEqui : bestCross;
+  VELOX_CHECK_NOT_NULL(chosen);
+
+  state.restore(*chosen);
+  greedyJoinChainDescend(chosen->plan, state);
+}
 
 void Optimization::makeJoins(PlanState& state) {
   // Sanity check that there are no RIGHT joins.
@@ -3350,6 +3438,12 @@ void Optimization::makeJoinsWithSyntacticFallback(PlanState& state) {
 
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   VELOX_CHECK_NOT_NULL(plan);
+
+  if (state.greedyJoinOrder() && !state.syntacticJoinOrder()) {
+    greedyJoinChainDescend(plan, state);
+    return;
+  }
+
   auto dt = state.dt;
 
   // An unknown-cost partial plan cannot be ranked, so cost-based enumeration
@@ -3374,27 +3468,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
       return;
     }
 
-    // Go over single-row DTs that haven't been placed yet. If unused, just mark
-    // as "placed". Otherwise, place these. Look for any unused single-row DTs.
-    // Mark them as "placed".
-    const auto downstream = state.downstreamColumns();
-    std::vector<DerivedTableCP> singleRowDtsToPlace;
-    state.dt->singleRowDts.forEach<DerivedTable>([&](DerivedTableCP subquery) {
-      if (!state.isPlaced(subquery)) {
-        if (!downstream.containsAny(subquery->columns)) {
-          state.place(subquery);
-        } else {
-          singleRowDtsToPlace.push_back(subquery);
-        }
-      }
-    });
-
-    for (const auto* singleRowDt : singleRowDtsToPlace) {
-      plan = placeSingleRowDt(plan, singleRowDt, state);
-    }
-
-    addPostprocess(dt, plan, state);
-    auto kept = state.plans.addPlan(plan, state);
+    auto kept = finalizePlanWithSingleRowDts(plan, state);
     trace(
         kept ? OptimizerOptions::kRetained : OptimizerOptions::kExceededBest,
         dt->id(),
@@ -3456,6 +3530,15 @@ PlanP Optimization::makePlan(
     return makeUnionPlan(key, distribution);
   }
   return makeDtPlan(dt, key, distribution, existsFanout, needsShuffle);
+}
+
+PlanP Optimization::makePlan(
+    const DerivedTable& dt,
+    const MemoKey& key,
+    const std::optional<DesiredDistribution>& distribution,
+    float existsFanout) {
+  bool needsShuffle = false;
+  return makePlan(dt, key, distribution, existsFanout, needsShuffle);
 }
 
 PlanP Optimization::makeUnionPlan(

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -253,6 +253,17 @@ class Optimization {
   // rankable plan exists.
   void makeJoinsWithSyntacticFallback(PlanState& state);
 
+  // Descends one greedy chain from 'plan', registering the result in
+  // 'state.plans'.
+  void greedyJoinChainDescend(RelationOpPtr plan, PlanState& state);
+
+  // Places any unplaced single-row derived tables on top of 'plan', applies
+  // postprocess (order, group, aggregate), and registers the completed plan
+  // in 'state.plans'. 'plan' is updated in place to reflect any added
+  // operators. Returns the registered Plan, or nullptr if the cost exceeded
+  // the best-so-far cutoff and the candidate was discarded.
+  PlanP finalizePlanWithSingleRowDts(RelationOpPtr& plan, PlanState& state);
+
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.
   //
@@ -270,6 +281,13 @@ class Optimization {
       const std::optional<DesiredDistribution>& distribution,
       float existsFanout,
       bool& needsShuffle);
+
+  // Overload for callers that do not need the 'needsShuffle' output.
+  PlanP makePlan(
+      const DerivedTable& dt,
+      const MemoKey& key,
+      const std::optional<DesiredDistribution>& distribution,
+      float existsFanout);
 
   // Plans a set operation (UNION ALL, UNION). Plans each child independently
   // using importUnionChild, combines them with UnionAll, and optionally adds
@@ -318,6 +336,14 @@ class Optimization {
   // Places a derived table as first table in a plan. Imports possibly reducing
   // joins into the plan if can.
   void placeDerivedTable(DerivedTableCP from, PlanState& state);
+
+  // Places 'from' and plans its inner DT via memo. Returns the relational
+  // op for the caller to extend.
+  RelationOpPtr planDtAsLeaf(DerivedTableCP from, PlanState& state);
+
+  // Imports reducing joins from the surrounding scope into 'from' for a
+  // bushier shape and plans the result.
+  void importReducingJoinsAndPlan(DerivedTableCP from, PlanState& state);
 
   // Adds the items from 'dt.conjuncts' that are not placed in 'state'
   // and whose prerequisite columns are placed. If conjuncts can be
@@ -443,7 +469,7 @@ class Optimization {
 
   // The top level PlanState. Contains the set of top level interesting plans.
   // Must stay alive as long as the Plans and RelationOps are reeferenced.
-  PlanState topState_;
+  std::optional<PlanState> topState_;
 
   // Controls tracing.
   int32_t traceFlags_{0};

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -86,6 +86,14 @@ std::vector<ConfigProperty> buildProperties(
           "Number of threads for parallel projection. 1 disables.",
       },
       {
+          std::string(OptimizerOptions::kGreedyJoinThreshold),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kGreedyJoinThresholdDefault),
+          "Use a greedy join-order search instead of exhaustive enumeration "
+          "when a single query block contains at least this many joined "
+          "tables. Greedy is approximate but bounded in planning time.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -129,6 +137,10 @@ std::string OptimizerOptions::normalize(
     auto width = std::stoi(std::string(value));
     VELOX_USER_CHECK_GE(
         width, 1, "parallel_project_width must be >= 1: {}", value);
+  } else if (name == kGreedyJoinThreshold) {
+    auto threshold = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        threshold, 1, "greedy_join_threshold must be >= 1: {}", value);
   }
   return std::string(value);
 }
@@ -159,6 +171,7 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
   setBool(kEnableReducingExistences, options.enableReducingExistences);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
+  setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -47,11 +47,14 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "enable_reducing_existences";
   static constexpr std::string_view kParallelProjectWidth =
       "parallel_project_width";
+  static constexpr std::string_view kGreedyJoinThreshold =
+      "greedy_join_threshold";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
   // and properties().
   static constexpr int32_t kParallelProjectWidthDefault = 1;
+  static constexpr int32_t kGreedyJoinThresholdDefault = 5;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -108,6 +111,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// they are always placed after the other tables, regardless of where they
   /// appear in the query.
   bool syntacticJoinOrder{kSyntacticJoinOrderDefault};
+
+  /// Use a greedy join-order search instead of exhaustive enumeration when
+  /// a single query block contains at least this many joined tables.
+  int32_t greedyJoinThreshold{kGreedyJoinThresholdDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -28,6 +28,13 @@ bool isSingleWorker() {
   return queryCtx()->optimization()->runnerOptions().numWorkers == 1;
 }
 
+bool computeGreedyJoinOrder(
+    const OptimizerOptions& options,
+    DerivedTableCP dt) {
+  return !options.syntacticJoinOrder &&
+      static_cast<int32_t>(dt->tables.size()) >= options.greedyJoinThreshold;
+}
+
 } // namespace
 
 PlanState::PlanState(
@@ -36,13 +43,15 @@ PlanState::PlanState(
     bool syntacticJoinOrder)
     : optimization(optimization),
       dt(dt),
-      syntacticJoinOrder_{syntacticJoinOrder} {}
+      syntacticJoinOrder_{syntacticJoinOrder},
+      greedyJoinOrder_{computeGreedyJoinOrder(optimization.options(), dt)} {}
 
 PlanState::PlanState(Optimization& optimization, DerivedTableCP dt, PlanP plan)
     : optimization(optimization),
       dt(dt),
       cost(plan->cost),
-      syntacticJoinOrder_{optimization.options().syntacticJoinOrder} {
+      syntacticJoinOrder_{optimization.options().syntacticJoinOrder},
+      greedyJoinOrder_{computeGreedyJoinOrder(optimization.options(), dt)} {
   if (auto it = optimization.planGroupedLeaves().find(plan);
       it != optimization.planGroupedLeaves().end()) {
     // Copy: planGroupedLeaves_[plan] is reused if 'plan' is selected as input
@@ -700,6 +709,10 @@ bool NextJoin::isWorse(const NextJoin& other) const {
 
   // Unknown costs are incomparable, so neither variant is declared worse.
   return lessThan(add(other.cost.cost, shuffle), cost.cost);
+}
+
+bool NextJoin::isEquiJoin() const {
+  return candidate->join != nullptr && candidate->join->numKeys() > 0;
 }
 
 velox::core::JoinType reverseJoinType(velox::core::JoinType joinType) {

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -192,6 +192,10 @@ struct NextJoin {
   /// If true, only 'other' should be tried. Use to compare equivalent joins
   /// with different join method or partitioning.
   bool isWorse(const NextJoin& other) const;
+
+  /// Returns true if this candidate joins on equi-keys, i.e. is a genuine
+  /// equality join rather than a cross product.
+  bool isEquiJoin() const;
 };
 
 class Optimization;
@@ -342,6 +346,12 @@ struct PlanState {
     return currentGroupedLeaves_;
   }
 
+  /// True when this PlanState should plan with the greedy join-order
+  /// heuristic instead of branch-and-bound.
+  bool greedyJoinOrder() const {
+    return greedyJoinOrder_;
+  }
+
  private:
   PlanObjectSet computeDownstreamColumns(bool includeFilters) const;
 
@@ -373,6 +383,8 @@ struct PlanState {
   // operator. Updated as scans are placed (insert), as joins fold copartition
   // (per-leaf coarsening), and as Repartitions are inserted (snapshot+reset).
   GroupedLeaves currentGroupedLeaves_;
+
+  const bool greedyJoinOrder_;
 };
 
 /// A scoped guard that restores fields of PlanState on destruction.

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -752,5 +752,52 @@ TEST_F(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
   EXPECT_TRUE(foundBucketedScan);
 }
 
+TEST_F(BucketedExecutionTest, greedyBucketed) {
+  addBucketedTable("g_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "g_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM g_orders JOIN g_customers "
+      "ON g_orders.customer_id = g_customers.id",
+      kTestConnectorId));
+  expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
+TEST_F(BucketedExecutionTest, greedyBucketedWithDimensions) {
+  constexpr int kNumDims = 20;
+
+  std::vector<std::string> factColumns{"customer_id"};
+  std::vector<TypePtr> factTypes{BIGINT()};
+  for (int i = 0; i < kNumDims; ++i) {
+    factColumns.push_back(fmt::format("dim_key_{}", i));
+    factTypes.push_back(BIGINT());
+  }
+  auto factSchema = ROW(std::move(factColumns), std::move(factTypes));
+
+  addBucketedTable("g_fact_a", {"customer_id"}, 128, factSchema);
+  addBucketedTable("g_fact_b", {"customer_id"}, 128, factSchema);
+
+  for (int i = 0; i < kNumDims; ++i) {
+    addUnbucketedTable(
+        fmt::format("g_dim_{}", i),
+        ROW({"d_id", "d_val"}, {BIGINT(), VARCHAR()}),
+        100);
+  }
+
+  std::string sql =
+      "SELECT g_fact_a.customer_id FROM g_fact_a JOIN g_fact_b "
+      "ON g_fact_a.customer_id = g_fact_b.customer_id";
+  for (int i = 0; i < kNumDims; ++i) {
+    sql += fmt::format(
+        " JOIN g_dim_{0} ON g_fact_a.dim_key_{0} = g_dim_{0}.d_id", i);
+  }
+
+  auto plan = planDistributed(parseSelect(sql, kTestConnectorId));
+  expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1907,5 +1907,179 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
   }
 }
 
+TEST_F(JoinTest, greedyJoinOrder) {
+  testConnector_->addTable("t1", ROW({"id1", "data1"}, BIGINT()))
+      ->setStats(100, {{"id1", {.numDistinct = 100}}});
+  testConnector_->addTable("t2", ROW({"id2", "data2"}, BIGINT()))
+      ->setStats(200, {{"id2", {.numDistinct = 200}}});
+  testConnector_->addTable("t3", ROW({"id3", "data3"}, BIGINT()))
+      ->setStats(400, {{"id3", {.numDistinct = 400}}});
+  testConnector_->addTable("t4", ROW({"id4", "data4"}, BIGINT()))
+      ->setStats(800, {{"id4", {.numDistinct = 800}}});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t1")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t2"),
+                             "id1 = id2",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t3"),
+                             "id2 = id3",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("t4"),
+                             "id3 = id4",
+                             lp::JoinType::kInner)
+                         .build();
+
+  {
+    SCOPED_TRACE("greedy fires (threshold=4)");
+    optimizerOptions_.greedyJoinThreshold = 4;
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher = matchScan("t4")
+                       .hashJoin(matchScan("t1").build())
+                       .hashJoin(matchScan("t2").build())
+                       .hashJoin(matchScan("t3").build())
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  {
+    SCOPED_TRACE("branch-and-bound (threshold=100)");
+    optimizerOptions_.greedyJoinThreshold = 100;
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher =
+        matchScan("t4")
+            .hashJoin(matchScan("t3")
+                          .hashJoin(matchScan("t2")
+                                        .hashJoin(matchScan("t1").build())
+                                        .build())
+                          .build())
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+TEST_F(JoinTest, greedyDtStart) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}))
+      ->setStats(1000, {});
+  testConnector_->addTable("base1", ROW({"id1", "x1"}, {BIGINT(), BIGINT()}))
+      ->setStats(500, {});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("t")
+                         .aggregate({"a"}, {"sum(b) as s"})
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("base1"),
+                             "a = id1",
+                             lp::JoinType::kLeft)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("t")
+          .singleAggregation({"a"}, {"sum(b) as s"})
+          .hashJoin(matchScan("base1").build(), core::JoinType::kLeft)
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(JoinTest, greedySnowflakeLeftDeep) {
+  testConnector_->addTable("fact", ROW({"fact_a", "fact_b"}, BIGINT()))
+      ->setStats(
+          10'000'000,
+          {{"fact_a", {.numDistinct = 100}}, {"fact_b", {.numDistinct = 100}}});
+  testConnector_->addTable("dim_a", ROW({"da_key", "da_sub"}, BIGINT()))
+      ->setStats(
+          100,
+          {{"da_key", {.numDistinct = 100}}, {"da_sub", {.numDistinct = 100}}});
+  testConnector_->addTable("sub_a", ROW({"sa_key"}, BIGINT()))
+      ->setStats(10, {{"sa_key", {.numDistinct = 10}}});
+  testConnector_->addTable("dim_b", ROW({"db_key", "db_sub"}, BIGINT()))
+      ->setStats(
+          100,
+          {{"db_key", {.numDistinct = 100}}, {"db_sub", {.numDistinct = 100}}});
+  testConnector_->addTable("sub_b", ROW({"sb_key"}, BIGINT()))
+      ->setStats(10, {{"sb_key", {.numDistinct = 10}}});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("fact")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("dim_a"),
+                             "fact_a = da_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("sub_a"),
+                             "da_sub = sa_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("dim_b"),
+                             "fact_b = db_key",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("sub_b"),
+                             "db_sub = sb_key",
+                             lp::JoinType::kInner)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 5;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("fact")
+                     .hashJoin(matchScan("dim_a").build())
+                     .hashJoin(matchScan("sub_a").build())
+                     .hashJoin(matchScan("dim_b").build())
+                     .hashJoin(matchScan("sub_b").build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(JoinTest, greedyValuesStart) {
+  testConnector_->addTable("v_t1", ROW({"a", "b"}, BIGINT()))
+      ->setStats(1000, {{"a", {.numDistinct = 1000}}});
+  testConnector_->addTable("v_t2", ROW({"c", "d"}, BIGINT()))
+      ->setStats(2000, {{"c", {.numDistinct = 2000}}});
+  testConnector_->addTable("v_t3", ROW({"e", "f"}, BIGINT()))
+      ->setStats(4000, {{"e", {.numDistinct = 4000}}});
+
+  auto rowVector = makeRowVector({"v"}, {makeFlatVector<int64_t>({1, 2, 3})});
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .values({rowVector})
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t1"),
+                             "v = a",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t2"),
+                             "a = c",
+                             lp::JoinType::kInner)
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("v_t3"),
+                             "c = e",
+                             lp::JoinType::kInner)
+                         .build();
+
+  optimizerOptions_.greedyJoinThreshold = 2;
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("v_t3")
+                     .hashJoin(core::PlanMatcherBuilder{}.values().build())
+                     .hashJoin(matchScan("v_t1").build())
+                     .hashJoin(matchScan("v_t2").build())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <limits>
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
@@ -35,6 +36,14 @@ namespace lp = facebook::axiom::logical_plan;
 class TpchPlanTest : public test::QueryTestBase {
  protected:
   static constexpr double kScaleFactor = 1.0;
+
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    // Pin TPC-H golden plans to exhaustive branch-and-bound.
+    // TODO: Drop this override and have greedy match B&B at the default
+    // threshold for TPC-H queries with 5+ tables (Q2, Q5, Q7, Q8, Q9, Q21).
+    optimizerOptions_.greedyJoinThreshold = std::numeric_limits<int32_t>::max();
+  }
 
   void configureTestConnector() override {
     testConnector_->addTpchTables(kScaleFactor);

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -123,3 +123,38 @@ RIGHT JOIN (
          (SELECT b FROM t ORDER BY b LIMIT 1) AS b0
 ) AS u ON a.a = u.a0 AND a.b = u.b0
 WHERE a.b = 10
+----
+-- 8-way self-join hitting the greedy join-enumeration cutoff.
+SELECT count(*)
+FROM t t1
+JOIN t t2 ON t1.b = t2.b
+JOIN t t3 ON t2.b = t3.b
+JOIN t t4 ON t3.b = t4.b
+JOIN t t5 ON t4.b = t5.b
+JOIN t t6 ON t5.b = t6.b
+JOIN t t7 ON t6.b = t7.b
+JOIN t t8 ON t7.b = t8.b
+----
+-- 20-way self-join. Stress-tests greedy at multiples of the default cutoff;
+-- result count is validated end-to-end against DuckDB.
+SELECT count(*)
+FROM t t1
+JOIN t t2 ON t1.b = t2.b
+JOIN t t3 ON t2.b = t3.b
+JOIN t t4 ON t3.b = t4.b
+JOIN t t5 ON t4.b = t5.b
+JOIN t t6 ON t5.b = t6.b
+JOIN t t7 ON t6.b = t7.b
+JOIN t t8 ON t7.b = t8.b
+JOIN t t9 ON t8.b = t9.b
+JOIN t t10 ON t9.b = t10.b
+JOIN t t11 ON t10.b = t11.b
+JOIN t t12 ON t11.b = t12.b
+JOIN t t13 ON t12.b = t13.b
+JOIN t t14 ON t13.b = t14.b
+JOIN t t15 ON t14.b = t15.b
+JOIN t t16 ON t15.b = t16.b
+JOIN t t17 ON t16.b = t17.b
+JOIN t t18 ON t17.b = t18.b
+JOIN t t19 ON t18.b = t19.b
+JOIN t t20 ON t19.b = t20.b


### PR DESCRIPTION
Summary:

Adds `OptimizerOptions::greedyJoinThreshold` (default 5). When a `DerivedTable`'s `tables` count reaches the threshold, `PlanState::greedyJoinOrder()` becomes true and the join-enumeration loop in `Optimization::makeJoins(PlanState&)` routes each starting-table chain into `greedyJoinChainDescend` instead of the branch-and-bound search. A 19-table query that previously hung the optimizer now plans in sub-second.

Greedy iterates start tables (including DerivedTables via `planDtAsLeaf`) and at each step picks the cheapest candidate from `nextJoins`, preferring equi-join edges over cross products via `NextJoin::isEquiJoin()`. `greedyJoinOrder_` is a `const bool` on `PlanState`, computed once in the constructor from `options().greedyJoinThreshold` and `dt->tables.size()`. Nested `makePlan` calls construct a fresh `PlanState` over a `tmpDt`, so the threshold check is re-applied for each subgraph and the bound holds end-to-end.

Bucketed-execution metadata is seeded from greedy's scan placement so partitioned scans retain their bucketing. Greedy is `O(numTables^3)` and not guaranteed cost-optimal.

B&B optimize time vs N for a same-key linear chain (`t1 ⋈ t2 ON t1.a=t2.a ⋈ t3 ON t2.a=t3.a ⋈ ...`), opt-mode `axiom_sql` CLI, B&B forced via `optimizer.greedy_join_threshold = INT_MAX`. Every join shares one equivalence class, so all N! orderings have identical cost and `isOverBest()` cannot prune.

| N tables | B&B optimize time |
| --- | --- |
| 3 | 0.58 ms |
| 4 | 2.78 ms |
| 5 | 134 ms |
| 6 | hang (> 60 s) |

Knee falls between N=5 and N=6. Threshold = 5 catches it: at the threshold B&B still completes in ~134 ms, one step above it explodes (`6! = 720` orderings vs `5! = 120`, with deeper recursion compounding the cost).

At threshold = 5, TPC-H queries with 5+ tables (Q2, Q5, Q7, Q8, Q9, Q21) cross into greedy and produce different plan shapes than the golden ones in `TpchPlanTest`. `TpchPlanTest::SetUp` overrides `greedyJoinThreshold = INT_MAX` to pin the existing matchers to B&B; a TODO above the override marks the follow-up to either lift the matchers to greedy plans or improve the cost model so greedy matches B&B for these shapes.

Reviewed By: mbasmanova

Differential Revision: D106236177


