### PR TITLE
fix(optimizer): Dedup Call exprs produced by replaceInputs. (#1429)

### DIFF
--- a/axiom/optimizer/DerivedTableFlattener.cpp
+++ b/axiom/optimizer/DerivedTableFlattener.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "axiom/optimizer/DerivedTableFlattener.h"
+#include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/QueryGraph.h"
 
 namespace facebook::axiom::optimizer {
@@ -26,14 +27,6 @@ void unionChildFunctions(FunctionSet& functions, const ExprVector& children) {
       functions = functions | child->as<Call>()->functions();
     }
   }
-}
-
-// Returns the function flags for a scalar Call with new children.
-FunctionSet computeCallFunctions(CallCP call, const ExprVector& newChildren) {
-  FunctionSet functions = functionBits(
-      call->name(), SpecialFormCallNames::isSpecialForm(call->name()));
-  unionChildFunctions(functions, newChildren);
-  return functions;
 }
 
 // Returns the function flags for an Aggregate with new children.
@@ -111,12 +104,11 @@ ExprCP replaceInputs(ExprCP expr, const ExprMapping& mapping) {
       }
 
       const auto* call = expr->as<Call>();
-      auto functions = computeCallFunctions(call, newChildren);
-      return make<Call>(
+      return queryCtx()->optimization()->deduppedCall(
           call->name(),
           call->value(),
           std::move(newChildren),
-          std::move(functions));
+          /*specialForm=*/SpecialFormCallNames::isSpecialForm(call->name()));
     }
     case PlanType::kFieldExpr: {
       auto* field = expr->as<Field>();

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -133,6 +133,20 @@ class Optimization {
     return toGraph_.isJoinEquality(expr, leftTable, rightTable, left, right);
   }
 
+  /// Interns a Call so equivalent calls share pointer identity.
+  ExprCP deduppedCall(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      bool specialForm = false) {
+    return toGraph_.deduppedCall(name, value, std::move(args), specialForm);
+  }
+
+  /// Creates a deduped equality expression with correct boolean cardinality.
+  ExprCP makeEquality(ExprCP left, ExprCP right) {
+    return toGraph_.makeEquality(left, right);
+  }
+
   const SessionPtr& session() const {
     return session_;
   }

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -737,12 +737,12 @@ TEST_F(SetTest, nondeterministicFilterAboveUnion) {
 
     auto buildMatcher = [&] {
       return core::PlanMatcherBuilder()
-          .hiveScan("nation", {}, "cast(n_nationkey as double) > rand()")
+          .hiveScan("nation", {}, "rand() < cast(n_nationkey as double)")
           .project()
           .localPartition(
               core::PlanMatcherBuilder()
                   .hiveScan(
-                      "region", {}, "cast(r_regionkey as double) > rand()")
+                      "region", {}, "rand() < cast(r_regionkey as double)")
                   .project()
                   .build());
     };


### PR DESCRIPTION
Summary:

DerivedTableFlattener::replaceInputs constructed fresh Calls via make<Call>, bypassing dedup. Downstream pointer-based dedup (e.g., BaseTable::addFilter multi-column branch) missed translated copies. Routes the Call branch through ToGraph::deduppedCall so the result shares pointer identity with any equivalent dedupped Call. Adds Optimization::toGraph() accessor.

Side effect: deduppedCall runs canonicalizeCall, which swaps args and flips name for reversible binary ops (e.g., gt(x, y) -> lt(y, x)). SetTest.nondeterministicFilterAboveUnion matcher strings updated for the new canonical form.

Reviewed By: mbasmanova

Differential Revision: D106459543


