### PR TITLE
feat(optimizer): Propagate single-column filters through LEFT JOIN keys. (#1431)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -738,6 +738,12 @@ void collectImpliedPredicates(
     if (!targetTable) {
       continue;
     }
+    if (targetTable == source->singleTable()) {
+      // Skip same-table targets: propagating e.g. t.a > 0 to t.b via the
+      // equivalence class {t.a, t.b} would double-count selectivity in cost
+      // estimation since the original filter already constrains this table.
+      continue;
+    }
     auto it = mutableTables.find(targetTable);
     if (it == mutableTables.end()) {
       continue;
@@ -2176,6 +2182,27 @@ RankingPredicate analyzeRankingPredicate(
   return {RankingPredicate::Kind::kAbsorbAsLimit, *limit};
 }
 
+// Merges operands into the same equivalence class if 'conjunct' is a
+// column equality (col1 = col2) where both columns belong to 'table'.
+void mergeSameTableColumnEquivalence(ExprCP conjunct, PlanObjectCP table) {
+  if (!conjunct->is(PlanType::kCallExpr)) {
+    return;
+  }
+  auto* call = conjunct->as<Call>();
+  if (call->name() != queryCtx()->functionNames().equality) {
+    return;
+  }
+  auto* left = call->argAt(0);
+  auto* right = call->argAt(1);
+  if (!left->is(PlanType::kColumnExpr) || !right->is(PlanType::kColumnExpr)) {
+    return;
+  }
+  if (left->singleTable() != table || right->singleTable() != table) {
+    return;
+  }
+  left->as<Column>()->equals(right->as<Column>());
+}
+
 } // namespace
 
 bool DerivedTable::isPartitionKeyFilter(ExprCP imported) const {
@@ -2464,6 +2491,9 @@ void DerivedTable::distributeConjuncts() {
       if (!tryPushdownConjunct(conjunct, tables[0])) {
         continue;
       }
+
+      // ex: WHERE t.a = t.b.
+      mergeSameTableColumnEquivalence(conjunct, tables[0]);
 
       conjuncts.erase(conjuncts.begin() + i);
       --i;

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -822,6 +822,75 @@ void collectImpliedSameTableEqualities(
   }
 }
 
+// Propagates single-column filters from the preserved (left) side to the
+// null-extending (right) side of LEFT and non-null-aware SEMI joins.
+// Example: t LEFT JOIN u ON t.a = u.x with filter t.a = 5 → push u.x = 5.
+void collectPreservedSideImpliedPredicates(
+    const JoinEdgeVector& joins,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  for (auto& join : joins) {
+    // Null-aware SEMI is unsound: pre-filtering the right side can change a
+    // NULL outcome to FALSE under three-value logic.
+    const bool isLeftOuter = join->rightOptional() && !join->leftOptional();
+    const bool isNullRejectingSemi = join->isSemi() && !join->isNullAwareIn();
+    if (!isLeftOuter && !isNullRejectingSemi) {
+      continue;
+    }
+    for (size_t i = 0; i < join->numKeys(); ++i) {
+      auto* leftKey = join->leftKeys()[i];
+      auto* nullExtendingKey = join->rightKeys()[i];
+      if (!leftKey->isColumn() || !nullExtendingKey->isColumn()) {
+        continue;
+      }
+      auto* sourceTable = leftKey->singleTable();
+      if (!sourceTable) {
+        continue;
+      }
+      auto* targetTable = nullExtendingKey->singleTable();
+      if (!targetTable) {
+        continue;
+      }
+      auto it = mutableTables.find(targetTable);
+      if (it == mutableTables.end()) {
+        continue;
+      }
+      const auto* sourceColumn = leftKey->as<Column>();
+      auto addFilter = [&](ExprCP filter) {
+        impliedPredicatesOut.emplace_back(
+            it->second,
+            DerivedTableFlattener::replaceInputs(
+                filter,
+                ColumnVector{sourceColumn},
+                ExprVector{nullExtendingKey}));
+      };
+      if (sourceTable->is(PlanType::kTableNode)) {
+        for (auto* filter : sourceTable->as<BaseTable>()->columnFilters) {
+          if (filter->containsNonDeterministic()) {
+            continue;
+          }
+          if (filter->columns().size() != 1 ||
+              filter->columns().onlyObject<Column>() != sourceColumn) {
+            continue;
+          }
+          addFilter(filter);
+        }
+      } else if (sourceTable->is(PlanType::kDerivedTableNode)) {
+        sourceTable->as<DerivedTable>()->forEachExportableSingleColumnConjunct(
+            [&](ColumnCP outerColumn, ExprCP outerFilter) {
+              if (outerColumn != sourceColumn) {
+                return;
+              }
+              if (outerFilter->containsNonDeterministic()) {
+                return;
+              }
+              addFilter(outerFilter);
+            });
+      }
+    }
+  }
+}
+
 // Synthesizes same-table equalities on the null-extending side of LEFT and
 // non-null-aware SEMI joins from pairs of right keys paired with the same
 // left key.
@@ -954,12 +1023,15 @@ void DerivedTable::inferImpliedPredicates() {
     attachPredicate(target, expr);
   }
 
-  // Outer-join slot equalities are only valid on matched rows; use
-  // tryAttachToNullExtendingSide which drops silently if pushdown fails.
-  std::vector<std::pair<PlanObjectP, ExprCP>> outerSlotEqualities;
+  // Predicates targeting the null-extending side (outer-join slot equalities
+  // and preserved-side filter propagation) are only valid for matched rows.
+  // Use tryAttachToNullExtendingSide which drops silently if pushdown fails.
+  std::vector<std::pair<PlanObjectP, ExprCP>> nullExtendingImplied;
   collectImpliedOuterJoinSlotEqualities(
-      joins, mutableTables, outerSlotEqualities);
-  for (auto& [target, expr] : outerSlotEqualities) {
+      joins, mutableTables, nullExtendingImplied);
+  collectPreservedSideImpliedPredicates(
+      joins, mutableTables, nullExtendingImplied);
+  for (auto& [target, expr] : nullExtendingImplied) {
     tryAttachToNullExtendingSide(target, expr);
   }
 }

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -749,7 +749,177 @@ void collectImpliedPredicates(
   }
 }
 
+// Synthesizes same-table equalities implied by every Equivalence class
+// reachable from columns of 'tables'. Walks each table's columns to find
+// distinct Equivalence pointers, groups each class's members by target
+// table, and emits n-1 anchored (target, equality) pairs for each
+// equivalence-class group of n >= 2 columns on the same target.
+void collectImpliedSameTableEqualities(
+    const QGVector<PlanObjectCP>& tables,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  auto* optimization = queryCtx()->optimization();
+  folly::F14FastSet<const Equivalence*> seenEquivalences;
+
+  auto processEquivalence = [&](const Equivalence* equivalence) {
+    if (!seenEquivalences.insert(equivalence).second) {
+      return;
+    }
+    // Equivalence::columns may contain duplicates when classes merge via
+    // multiple paths (see Column::equals). Dedup per target so we never
+    // synthesize a self-equality like t.a = t.a.
+    folly::F14FastMap<PlanObjectP, folly::F14FastSet<ColumnCP>> tableEquivs;
+    for (auto* column : equivalence->columns) {
+      auto* memberTable = column->singleTable();
+      if (!memberTable) {
+        continue;
+      }
+      auto it = mutableTables.find(memberTable);
+      if (it == mutableTables.end()) {
+        continue;
+      }
+      tableEquivs[it->second].insert(column);
+    }
+    for (auto& [target, columns] : tableEquivs) {
+      if (columns.size() < 2) {
+        continue;
+      }
+      // Sort by Column id so the anchor and member order are stable across
+      // runs.
+      std::vector<ColumnCP> orderedColumns(columns.begin(), columns.end());
+      std::ranges::sort(orderedColumns, [](ColumnCP lhs, ColumnCP rhs) {
+        return lhs->id() < rhs->id();
+      });
+      auto* anchorColumn = orderedColumns[0];
+      for (size_t k = 1; k < orderedColumns.size(); ++k) {
+        impliedPredicatesOut.emplace_back(
+            target,
+            optimization->makeEquality(anchorColumn, orderedColumns[k]));
+      }
+    }
+  };
+
+  for (auto* table : tables) {
+    const ColumnVector* columns = nullptr;
+    if (table->is(PlanType::kTableNode)) {
+      columns = &table->as<BaseTable>()->columns;
+    } else if (table->is(PlanType::kDerivedTableNode)) {
+      columns = &table->as<DerivedTable>()->columns;
+    } else {
+      continue;
+    }
+    for (auto* column : *columns) {
+      if (auto* equivalence = column->equivalence()) {
+        processEquivalence(equivalence);
+      }
+    }
+  }
+}
+
+// Synthesizes same-table equalities on the null-extending side of LEFT and
+// non-null-aware SEMI joins from pairs of right keys paired with the same
+// left key.
+// Example: t LEFT JOIN u ON u.x = t.a AND u.y = t.a → emit u.x = u.y.
+// TODO: Generalize to arbitrary expressions (currently column-only).
+void collectImpliedOuterJoinSlotEqualities(
+    const JoinEdgeVector& joins,
+    const folly::F14FastMap<PlanObjectCP, PlanObjectP>& mutableTables,
+    std::vector<std::pair<PlanObjectP, ExprCP>>& impliedPredicatesOut) {
+  auto* optimization = queryCtx()->optimization();
+  for (const auto& join : joins) {
+    // Only LEFT and non-null-aware SEMI are sound here.
+    const bool isLeftOuter = join->rightOptional() && !join->leftOptional();
+    const bool isNullRejectingSemi = join->isSemi() && !join->isNullAwareIn();
+    if (!isLeftOuter && !isNullRejectingSemi) {
+      continue;
+    }
+    for (size_t i = 0; i < join->numKeys(); ++i) {
+      auto* leftColI = join->leftKeys()[i];
+      auto* rightColI = join->rightKeys()[i];
+      auto* table = rightColI->singleTable();
+      if (!table) {
+        continue;
+      }
+      // Non-deterministic keys can evaluate differently per row.
+      if (leftColI->containsNonDeterministic() ||
+          rightColI->containsNonDeterministic()) {
+        continue;
+      }
+      auto it = mutableTables.find(table);
+      if (it == mutableTables.end()) {
+        continue;
+      }
+      for (size_t j = i + 1; j < join->numKeys(); ++j) {
+        auto* leftColJ = join->leftKeys()[j];
+        auto* rightColJ = join->rightKeys()[j];
+        if (rightColJ == rightColI) {
+          continue;
+        }
+        if (rightColJ->singleTable() != table) {
+          continue;
+        }
+        if (leftColJ->containsNonDeterministic() ||
+            rightColJ->containsNonDeterministic()) {
+          continue;
+        }
+        if (!leftColI->sameOrEqual(*leftColJ)) {
+          continue;
+        }
+        impliedPredicatesOut.emplace_back(
+            it->second, optimization->makeEquality(rightColI, rightColJ));
+      }
+    }
+  }
+}
+
 } // namespace
+
+namespace {
+
+// Returns true if 'target' already has a predicate equivalent to 'expr'.
+bool targetAlreadyHas(PlanObjectCP target, ExprCP expr) {
+  if (target->is(PlanType::kTableNode)) {
+    const auto& existing = target->as<BaseTable>()->columnFilters;
+    return std::ranges::any_of(existing, [&](ExprCP candidate) {
+      return candidate->sameOrEqual(*expr);
+    });
+  }
+  if (target->is(PlanType::kDerivedTableNode)) {
+    const auto& existing = target->as<DerivedTable>()->conjuncts;
+    return std::ranges::any_of(existing, [&](ExprCP candidate) {
+      return candidate->sameOrEqual(*expr);
+    });
+  }
+  return false;
+}
+
+} // namespace
+
+void DerivedTable::attachPredicate(PlanObjectP target, ExprCP expr) {
+  if (targetAlreadyHas(target, expr)) {
+    return;
+  }
+  if (tryPushdownConjunct(expr, target)) {
+    return;
+  }
+  // Pushdown blocked (LIMIT/window DT, ValuesTable, UnnestTable). Land
+  // 'expr' on this DT's conjuncts so it's applied above 'target'.
+  if (std::ranges::any_of(conjuncts, [&](ExprCP candidate) {
+        return candidate->sameOrEqual(*expr);
+      })) {
+    return;
+  }
+  conjuncts.push_back(expr);
+}
+
+void DerivedTable::tryAttachToNullExtendingSide(
+    PlanObjectP target,
+    ExprCP expr) {
+  if (targetAlreadyHas(target, expr)) {
+    return;
+  }
+  tryPushdownConjunct(expr, target);
+}
 
 void DerivedTable::inferImpliedPredicates() {
   folly::F14FastMap<PlanObjectCP, PlanObjectP> mutableTables;
@@ -763,44 +933,28 @@ void DerivedTable::inferImpliedPredicates() {
         collectImpliedPredicates(filter, mutableTables, implied);
       }
     } else if (table->is(PlanType::kDerivedTableNode)) {
-      auto* innerDt = table->as<DerivedTable>();
-      for (auto* filter : innerDt->conjuncts) {
-        if (filter->columns().size() != 1) {
-          continue;
-        }
-        auto* innerColumn = filter->columns().onlyObject<Column>();
-        for (size_t i = 0;
-             i < innerDt->columns.size() && i < innerDt->exprs.size();
-             ++i) {
-          if (innerDt->exprs[i] != innerColumn) {
-            continue;
-          }
-          auto* outerColumn = innerDt->columns[i];
-          auto outerFilter = DerivedTableFlattener::replaceInputs(
-              filter, ColumnVector{innerColumn}, ExprVector{outerColumn});
-          collectImpliedPredicates(outerFilter, mutableTables, implied);
-        }
-      }
+      table->as<DerivedTable>()->forEachExportableSingleColumnConjunct(
+          [&](ColumnCP /*outerColumn*/, ExprCP outerFilter) {
+            collectImpliedPredicates(outerFilter, mutableTables, implied);
+          });
     }
   }
 
+  collectImpliedSameTableEqualities(tables, mutableTables, implied);
+  // Land each implied predicate. attachPredicate guarantees enforcement
+  // somewhere (scan or this DT's conjuncts); JoinEdge::addEquality relies
+  // on that invariant when dropping equivalence-class-redundant keys.
   for (auto& [target, expr] : implied) {
-    if (target->is(PlanType::kTableNode)) {
-      const auto& existing = target->as<BaseTable>()->columnFilters;
-      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
-            return candidate->sameOrEqual(*expr);
-          })) {
-        continue;
-      }
-    } else if (target->is(PlanType::kDerivedTableNode)) {
-      const auto& existing = target->as<DerivedTable>()->conjuncts;
-      if (std::ranges::any_of(existing, [&](ExprCP candidate) {
-            return candidate->sameOrEqual(*expr);
-          })) {
-        continue;
-      }
-    }
-    tryPushdownConjunct(expr, target);
+    attachPredicate(target, expr);
+  }
+
+  // Outer-join slot equalities are only valid on matched rows; use
+  // tryAttachToNullExtendingSide which drops silently if pushdown fails.
+  std::vector<std::pair<PlanObjectP, ExprCP>> outerSlotEqualities;
+  collectImpliedOuterJoinSlotEqualities(
+      joins, mutableTables, outerSlotEqualities);
+  for (auto& [target, expr] : outerSlotEqualities) {
+    tryAttachToNullExtendingSide(target, expr);
   }
 }
 
@@ -1331,6 +1485,25 @@ void DerivedTable::exportExprs(ExprVector& exprs) {
 
 ExprCP DerivedTable::importExpr(ExprCP expr) const {
   return DerivedTableFlattener::replaceInputs(expr, columns, exprs);
+}
+
+void DerivedTable::forEachExportableSingleColumnConjunct(
+    folly::FunctionRef<void(ColumnCP, ExprCP)> cb) const {
+  for (auto* filter : conjuncts) {
+    if (filter->columns().size() != 1) {
+      continue;
+    }
+    auto* innerColumn = filter->columns().onlyObject<Column>();
+    for (size_t i = 0; i < columns.size() && i < exprs.size(); ++i) {
+      if (exprs[i] != innerColumn) {
+        continue;
+      }
+      auto* outerColumn = columns[i];
+      auto* outerFilter = DerivedTableFlattener::replaceInputs(
+          filter, ColumnVector{innerColumn}, ExprVector{outerColumn});
+      cb(outerColumn, outerFilter);
+    }
+  }
 }
 
 void DerivedTable::removeTables(

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/Function.h>
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/MemoKey.h"
 #include "axiom/optimizer/PlanObject.h"
@@ -278,6 +279,13 @@ struct DerivedTable : public PlanObject {
   /// corresponding 'exprs'.
   ExprCP importExpr(ExprCP expr) const;
 
+  /// Invokes 'cb(outerColumn, translatedFilter)' for each single-column
+  /// conjunct in this DT whose underlying source column maps to one of
+  /// this DT's output 'columns'. 'translatedFilter' is the conjunct with
+  /// the inner source column substituted by the corresponding outer column.
+  void forEachExportableSingleColumnConjunct(
+      folly::FunctionRef<void(ColumnCP, ExprCP)> cb) const;
+
   /// Adds a filter conjunct to this DT. Handles LIMIT (returns false),
   /// aggregation (adds to 'having'), and set operations (adds to all children).
   /// Returns true if the conjunct was successfully added, false otherwise.
@@ -461,12 +469,24 @@ struct DerivedTable : public PlanObject {
   // Updates cardinality and column constraints from the plan.
   void updateConstraints(const RelationOp& plan);
 
-  // Synthesizes single-column predicates implied by inner-join
-  // column equivalences. For each single-column filter on a
-  // BaseTable or inner DerivedTable, clones it to other columns
-  // in the same equivalence class. Skips non-deterministic and
-  // multi-column filters; see implementation for rationale.
+  // Adds same-table equality filters that hold on a single table because of
+  // its column equivalences. Three paths:
+  //   1. Per-column propagation of single-column deterministic filters to
+  //      other members of the same equivalence class.
+  //   2. Same-table synthesis: for each equivalence class with 2+ members
+  //      on the same table (e.g. ON t.a = u.x AND t.b = u.x), emits
+  //      anchored equalities (t.a = t.b) on that table.
+  //   3. Outer-join slot synthesis: for LEFT and non-null-aware LEFT SEMI
+  //      joins, when two right-side join keys belong to the same null-
+  //      supplying table and pair with the same left key, emits their
+  //      equality on that table.
   void inferImpliedPredicates();
+
+  // Enforces 'expr' on 'target': existing scan filter, pushdown via
+  // tryPushdownConjunct, or fallback to this DT's conjuncts above the
+  // refusing target. The always-attaches invariant lets JoinEdge::addEquality
+  // drop equivalence-class-redundant join keys unconditionally.
+  void attachPredicate(PlanObjectP target, ExprCP expr);
 
   // Completes 'joins' with edges implied by column equivalences.
   void addImpliedJoins();
@@ -561,6 +581,10 @@ struct DerivedTable : public PlanObject {
   // @param table The target table (BaseTable, DerivedTable, etc.).
   // @return true if the conjunct was successfully pushed down, false otherwise.
   bool tryPushdownConjunct(ExprCP conjunct, PlanObjectP table);
+
+  // Pushes 'expr' to the null-extending side. Drops if target refuses —
+  // post-join fallback would filter NULL-padded unmatched rows incorrectly.
+  void tryAttachToNullExtendingSide(PlanObjectP target, ExprCP expr);
 
   // Returns true if 'imported' depends only on columns that are partition keys
   // of every window function in windowPlan.

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -470,7 +470,7 @@ struct DerivedTable : public PlanObject {
   void updateConstraints(const RelationOp& plan);
 
   // Adds same-table equality filters that hold on a single table because of
-  // its column equivalences. Three paths:
+  // its column equivalences. Four paths:
   //   1. Per-column propagation of single-column deterministic filters to
   //      other members of the same equivalence class.
   //   2. Same-table synthesis: for each equivalence class with 2+ members
@@ -480,6 +480,10 @@ struct DerivedTable : public PlanObject {
   //      joins, when two right-side join keys belong to the same null-
   //      supplying table and pair with the same left key, emits their
   //      equality on that table.
+  //   4. Left-join key propagation: for LEFT and non-null-aware LEFT SEMI
+  //      joins, clones single-column filters on the preserved side to the
+  //      null-supplying side via the equi-join key (t.a = 5 implies
+  //      u.x = 5 for ON t.a = u.x).
   void inferImpliedPredicates();
 
   // Enforces 'expr' on 'target': existing scan filter, pushdown via

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -47,6 +47,11 @@ const char* SpecialFormCallNames::kIn = "__in";
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
 void Column::equals(ColumnCP other) const {
+  if (this == other) {
+    // Self-merge is a no-op; without this, the first branch below would
+    // add the same column to the equivalence twice.
+    return;
+  }
   if (!equivalence_ && !other->equivalence_) {
     auto* equiv = make<Equivalence>();
     equiv->columns.push_back(this);

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -470,8 +470,11 @@ bool JoinEdge::isBroadcastableType() const {
 }
 
 void JoinEdge::addEquality(ExprCP left, ExprCP right, bool update) {
-  for (auto i = 0; i < leftKeys_.size(); ++i) {
-    if (leftKeys_[i] == left && rightKeys_[i] == right) {
+  // Drop equivalence-class-redundant keys; sound via attachPredicate's
+  // always-attaches invariant.
+  for (size_t i = 0; i < leftKeys_.size(); ++i) {
+    if (leftKeys_[i]->sameOrEqual(*left) &&
+        rightKeys_[i]->sameOrEqual(*right)) {
       return;
     }
   }
@@ -705,6 +708,13 @@ void BaseTable::addFilter(ExprCP expr) {
   if (columns.size() == 1) {
     columnFilters.push_back(expr);
   } else {
+    // Pointer equality suffices: equality calls are interned by ToGraph,
+    // so a duplicate insert resolves to the same Call*.
+    for (auto* existing : filter) {
+      if (existing == expr) {
+        return;
+      }
+    }
     filter.push_back(expr);
   }
 

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -69,6 +69,11 @@ void Column::equals(ColumnCP other) const {
     other->equals(this);
     return;
   }
+  if (equivalence_ == other->equivalence_) {
+    // Union-find no-op: both columns are already in the same class.
+    // Continuing could produce no-op filters (a = a).
+    return;
+  }
   for (auto& column : other->equivalence_->columns) {
     equivalence_->columns.push_back(column);
     column->equivalence_ = equivalence_;

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1724,6 +1724,135 @@ TEST_F(JoinTest, impliedSameTableEqualityPreservedSide) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// A same-table column equality in WHERE implies an equality on the
+// null-extending side's join keys: t.a = t.b with ON t.a = u.x AND t.b = u.y
+// pushes u.x = u.y to u's scan.
+TEST_F(JoinTest, impliedSameTableEqualityFromPredicateTransitivity) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
+      "WHERE t.a = t.b";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("t")
+          .filter("a = b")
+          .hashJoin(
+              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Self-equality `t.a = t.a` must not enter the equivalence class; u must
+// have no inferred filter. The literal predicate may still appear in the
+// plan on t.
+TEST_F(JoinTest, impliedSameTableEqualitySelfEqualityNotInferred) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
+      "WHERE t.a = t.a";
+  SCOPED_TRACE(query);
+
+  // The eq(a,a) predicate stays on t; u must have no inferred filter
+  // (no self-equality propagation into the equivalence class).
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("a = a").build(), core::JoinType::kRight)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table eq under OR is NOT a strict constraint on every row, so it
+// must not enter the equivalence class. u.x = u.y must NOT be inferred.
+TEST_F(JoinTest, impliedSameTableEqualityUnderOrNotInferred) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
+      "WHERE t.a = t.b OR t.a > 100";
+  SCOPED_TRACE(query);
+
+  // The OR-disjunct conjunct doesn't constrain every row to t.a = t.b,
+  // so u.x = u.y must NOT be inferred. The disjunction stays as a Filter
+  // above t's scan.
+  auto matcher = matchScan("t")
+                     .filter("a = b OR a > 100")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table eq negated by NOT: `NOT (t.a = t.b)` constrains rows to
+// t.a != t.b, the opposite of what would enter the equiv class.
+// u.x = u.y must NOT be inferred.
+TEST_F(JoinTest, impliedSameTableEqualityUnderNotNotInferred) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
+      "WHERE NOT (t.a = t.b)";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .filter("not(eq(a, b))")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table eq with a wrapper expression (cast) on one side is NOT a
+// direct column equality and must not enter the equivalence class.
+TEST_F(JoinTest, impliedSameTableEqualityWrapperExprNotInferred) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
+      "WHERE t.a + 1 = t.b";
+  SCOPED_TRACE(query);
+
+  // Wrapper expression (cast/arithmetic) on one side blocks equivalence-
+  // class entry; no inference fires.
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("b = a + 1").build(),
+                         core::JoinType::kRight)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // LEFT JOIN with no equalities when the DT has 3+ tables. The comma join
 // between nation and region is inlined into the same DT. The EXISTS semi-join
 // adds a 3rd table. The subsequent LEFT JOIN ON clause uses contains() which

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -898,7 +898,10 @@ TEST_F(JoinTest, fullThenFilter) {
     auto matcher = matchScan("t")
                        .filter("a > 0")
                        .hashJoin(
-                           matchScan("u").project({"x", "y + 1 as z"}).build(),
+                           matchScan("u")
+                               .filter("x > 0")
+                               .project({"x", "y + 1 as z"})
+                               .build(),
                            core::JoinType::kLeft)
                        .filter("coalesce(z, 1) > 0")
                        .project()
@@ -1422,6 +1425,114 @@ TEST_F(JoinTest, impliedFilters) {
   }
 }
 
+// Filter propagation through LEFT JOIN keys: a filter on the preserved (left)
+// side is cloned to the null-supplying (right) side for any matched row.
+TEST_F(JoinTest, impliedFiltersOuterJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  // Equality on the preserved side propagates to the null-supplying side.
+  // t.a = 5 reduces t to ~1 row; the optimizer makes t the probe side (kRight).
+  {
+    auto query = "SELECT * FROM t LEFT JOIN u ON t.a = u.x WHERE t.a = 5";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .filter("x = 5")
+            .hashJoin(
+                matchScan("t").filter("a = 5").build(), core::JoinType::kRight)
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Range predicate propagates similarly.
+  {
+    auto query = "SELECT * FROM t LEFT JOIN u ON t.a = u.x WHERE t.a > 100";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("t")
+            .filter("a > 100")
+            .hashJoin(
+                matchScan("u").filter("x > 100").build(), core::JoinType::kLeft)
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Non-deterministic predicates do not propagate.
+  {
+    auto query =
+        "SELECT * FROM t LEFT JOIN u ON t.a = u.x "
+        "WHERE t.a = cast(random() * 100 as bigint)";
+    SCOPED_TRACE(query);
+
+    // u must have no filter.
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .filter("a = cast(random() * 100.0 as bigint)")
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// LEFT SEMI (EXISTS) propagates filters from the outer side to the
+// subquery side via the equi-join key: a filter on the matching outer
+// column holds on every subquery row that participates in the result.
+TEST_F(JoinTest, impliedFiltersSemiJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto query =
+      "SELECT * FROM t WHERE t.a = 5 AND EXISTS ("
+      "  SELECT 1 FROM u WHERE u.x = t.a)";
+  SCOPED_TRACE(query);
+
+  // u.x = 5 is the propagated filter; t.a = 5 is the original.
+  auto matcher = matchScan("u")
+                     .filter("x = 5")
+                     .hashJoin(
+                         matchScan("t").filter("a = 5").build(),
+                         core::JoinType::kRightSemiFilter)
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Null-aware SEMI (`a IN (subquery)`) must NOT propagate: pre-filtering
+// the right side could change a NULL outcome to FALSE under 3VL.
+TEST_F(JoinTest, impliedFiltersNullAwareSemiNotPropagated) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto query = "SELECT * FROM t WHERE t.a = 5 AND t.a IN (SELECT x FROM u)";
+  SCOPED_TRACE(query);
+
+  // u must NOT receive an x = 5 filter (null-aware SEMI is unsound for
+  // pre-filtering). u's scan should have no filters.
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t").filter("a = 5").build(),
+                         core::JoinType::kRightSemiFilter)
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 // Three or more columns from the same table in one equivalence class.
 TEST_F(JoinTest, impliedSameTableEquality) {
   testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
@@ -1679,6 +1790,62 @@ TEST_F(JoinTest, impliedSameTableEqualityFullOuterJoinSkipped) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// RIGHT JOIN filter propagation reaches the LEFT branch via
+// ToGraph::normalizeLogicalJoin. `u RIGHT JOIN t WHERE t.a = 5` becomes
+// `t LEFT JOIN u WHERE t.a = 5`, so u still gets the propagated u.x = 5
+// filter.
+TEST_F(JoinTest, impliedFiltersRightJoinNormalized) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto query = "SELECT * FROM u RIGHT JOIN t ON u.x = t.a WHERE t.a = 5";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("u")
+          .filter("x = 5")
+          .hashJoin(
+              matchScan("t").filter("a = 5").build(), core::JoinType::kRight)
+          .project()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// LEFT-join filter propagation works when the preserved side is a
+// DerivedTable: the inner conjunct `a = 5` on the subquery propagates
+// out via DerivedTable::forEachExportableSingleColumnConjunct to outer
+// column space (sub.a = 5), then onto u via the join key (u.x = 5).
+TEST_F(JoinTest, impliedFiltersDerivedTablePreservedSide) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto query =
+      "SELECT * FROM (SELECT a, b FROM t WHERE a = 5) AS sub "
+      "LEFT JOIN u ON sub.a = u.x";
+  SCOPED_TRACE(query);
+
+  // sub is flattened; optimizer makes u the build side with x=5 (propagated
+  // from sub.a=5) and t the probe side with a=5 (the original inner conjunct).
+  auto matcher =
+      matchScan("u")
+          .filter("x = 5")
+          .hashJoin(
+              matchScan("t").filter("a = 5").build(), core::JoinType::kRight)
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// TODO: Add a FULL OUTER JOIN propagation-skip test when a query shape that
+// stays FULL OUTER through planning is available.
+
 // Same-table equalities must NOT be inferred for the null-supplying side
 // when the right-side keys are paired with *different* left-side keys. For
 // t LEFT JOIN u ON t.a = u.x AND t.b = u.y, u.x = u.y does not follow
@@ -1725,7 +1892,7 @@ TEST_F(JoinTest, impliedSameTableEqualityPreservedSide) {
 }
 
 // A same-table column equality in WHERE implies an equality on the
-// null-extending side's join keys: t.a = t.b with ON t.a = u.x AND t.b = u.y
+// null-supplying side's join keys: t.a = t.b with ON t.a = u.x AND t.b = u.y
 // pushes u.x = u.y to u's scan.
 TEST_F(JoinTest, impliedSameTableEqualityFromPredicateTransitivity) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
@@ -1750,26 +1917,27 @@ TEST_F(JoinTest, impliedSameTableEqualityFromPredicateTransitivity) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-// Self-equality `t.a = t.a` must not enter the equivalence class; u must
+// Self-equality `t.c = t.c` must not enter the equivalence class; u must
 // have no inferred filter. The literal predicate may still appear in the
-// plan on t.
+// plan on t. Uses a non-key column (t.c) so the test is isolated from
+// LEFT-JOIN filter-key propagation.
 TEST_F(JoinTest, impliedSameTableEqualitySelfEqualityNotInferred) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
       ->setStats(1'000, {{"x", {.numDistinct = 10}}});
 
   auto query =
       "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y "
-      "WHERE t.a = t.a";
+      "WHERE t.c = t.c";
   SCOPED_TRACE(query);
 
-  // The eq(a,a) predicate stays on t; u must have no inferred filter
-  // (no self-equality propagation into the equivalence class).
+  // eq(c,c) stays on t; no propagation to u (c is not a join key) and no
+  // equivalence-class pollution (Column::equals self-merge is a no-op).
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("a = a").build(), core::JoinType::kRight)
+              matchScan("t").filter("c = c").build(), core::JoinType::kRight)
           .aggregation()
           .build();
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1132,7 +1132,8 @@ TEST_F(JoinTest, impliedJoins) {
 
   // Same-table columns in one equivalence class: t.a = u.x AND t.a = t.b puts
   // t.a and t.b (both from t) in the same class. addImpliedJoins must skip
-  // same-table pairs. t.a = t.b becomes a filter on t.
+  // same-table pairs. t.a = t.b becomes a filter on t, and the redundant
+  // implied key (t.b, u.x) is removed.
   {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.a = t.b";
     SCOPED_TRACE(query);
@@ -1148,17 +1149,85 @@ TEST_F(JoinTest, impliedJoins) {
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
-  // Same as above, but the same-table equivalence arises indirectly through
-  // transitivity: t.a = u.x AND t.b = u.x implies t.a = t.b. The optimizer
-  // keeps both as join keys.
-  // TODO(https://github.com/facebookincubator/axiom/issues/909): Optimal plan
-  // would filter t on a = b, then join on a single key.
+  // Same-table equality dedup: ON t.a = u.x AND t.b = u.x merges {t.a, t.b,
+  // u.x}, so an explicit WHERE t.a = t.b becomes the same interned Call as
+  // the inferred one and is added only once.
+  {
+    auto query =
+        "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.x WHERE t.a = t.b";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
   {
     auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.x";
     SCOPED_TRACE(query);
 
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Separate equivalence classes: no same-table filter.
+  {
+    auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.b = u.y";
+    SCOPED_TRACE(query);
+
     auto matcher = matchScan("t")
                        .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // LEFT JOIN: no same-table filter on preserved side; both keys preserved.
+  {
+    auto query =
+        "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.x";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Three tables with same-table filter on t.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x "
+        "JOIN v ON u.x = v.n";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("u")
+                       .hashJoin(
+                           matchScan("v")
+                               .hashJoin(
+                                   matchScan("t").filter("a = b").build(),
+                                   core::JoinType::kInner)
+                               .build(),
+                           core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1351,6 +1420,308 @@ TEST_F(JoinTest, impliedFilters) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+}
+
+// Three or more columns from the same table in one equivalence class.
+TEST_F(JoinTest, impliedSameTableEquality) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // Three same-table columns produce a = b and a = c filters.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x AND t.c = u.x";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("u")
+                       .hashJoin(
+                           matchScan("t").filter("a = b AND a = c").build(),
+                           core::JoinType::kInner)
+                       .aggregation()
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Equivalence class with same-table columns on both sides of the join.
+TEST_F(JoinTest, impliedSameTableEqualityBothSides) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // t.a = u.x AND t.b = u.x AND t.a = u.y creates equivalence class
+  // {t.a, t.b, u.x, u.y}. Pushes a = b on t and x = y on u.
+  {
+    auto query =
+        "SELECT count(*) FROM t "
+        "JOIN u ON t.a = u.x AND t.b = u.x AND t.a = u.y";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("t")
+            .filter("a = b")
+            .hashJoin(
+                matchScan("u").filter("x = y").build(), core::JoinType::kInner)
+            .aggregation()
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// With GROUP BY a, b, the synthesized a = b references only grouping keys
+// and is pushed below the aggregation onto t's scan.
+TEST_F(JoinTest, impliedSameTableEqualityBelowAggregation) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t GROUP BY a, b) AS gb "
+      "JOIN u ON gb.a = u.x AND gb.b = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t")
+                             .filter("a = b")
+                             .singleAggregation({"a", "b"}, {})
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Synthesis into HAVING: when an equivalence class member is an aggregate
+// output, the implied equality can't push below the aggregation and stays
+// as a post-aggregation Filter (HAVING).
+TEST_F(JoinTest, impliedSameTableEqualityInHaving) {
+  testConnector_->addTable("t", ROW({"k"}, BIGINT()))
+      ->setStats(10'000, {{"k", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT k, COUNT(*) AS c FROM t GROUP BY k) AS agg "
+      "JOIN u ON agg.k = u.x AND agg.c = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("u")
+                     .hashJoin(
+                         matchScan("t")
+                             .singleAggregation({"k"}, {"count(*) as c"})
+                             .filter("k = c")
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// With a LIMIT in the way, the synthesized equality lands as a Filter
+// above the Limit. The redundant join key is still dropped.
+TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimit) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
+      "JOIN u ON lim.a = u.x AND lim.b = u.x";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .limit()
+                     .filter("a = b")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Explicit WHERE and synthesized equality converge on the same LIMIT DT
+// target. The filter appears exactly once above the Limit.
+TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
+      "JOIN u ON lim.a = u.x AND lim.b = u.x "
+      "WHERE lim.a = lim.b";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .limit()
+                     .filter("a = b")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// The null-supplying (right) side of a LEFT join gets same-table equality
+// filters when multiple ON-clause conditions pair different right-side
+// columns with the same left-side column. For t LEFT JOIN u ON u.x = t.a
+// AND u.y = t.a, any u row in the output must satisfy both conditions, so
+// u.x = u.y holds.
+TEST_F(JoinTest, impliedSameTableEqualityOuterJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  // u.x = t.a AND u.y = t.a implies u.x = u.y, which can be pushed
+  // to u's scan since unmatched u rows never appear in the result.
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// SEMI join (EXISTS) gets slot-pattern same-table eq synthesis on its
+// subquery side: surviving left rows require a matching right row, so the
+// same-table eq on the right side is sound.
+TEST_F(JoinTest, impliedSameTableEqualitySemiJoin) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t WHERE EXISTS ("
+      "  SELECT 1 FROM u WHERE u.x = t.a AND u.y = t.a)";
+  SCOPED_TRACE(query);
+
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u").filter("x = y").build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// RIGHT JOIN is normalized to LEFT JOIN; same-table synthesis fires on
+// the (now-right) u side, producing u.x = u.y.
+TEST_F(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM u RIGHT JOIN t ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .aggregation()
+          .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// FULL OUTER slot synthesis is unsound on either side (unmatched rows on
+// both sides survive with NULLs; a filter would drop them). u must NOT
+// get u.x = u.y.
+TEST_F(JoinTest, impliedSameTableEqualityFullOuterJoinSkipped) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query =
+      "SELECT count(*) FROM t FULL OUTER JOIN u ON u.x = t.a AND u.y = t.a";
+  SCOPED_TRACE(query);
+
+  // u must have no filter — slot synthesis is unsound for FULL OUTER.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kFull)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table equalities must NOT be inferred for the null-supplying side
+// when the right-side keys are paired with *different* left-side keys. For
+// t LEFT JOIN u ON t.a = u.x AND t.b = u.y, u.x = u.y does not follow
+// because t.a and t.b can differ.
+TEST_F(JoinTest, impliedSameTableEqualityMismatchedLeftKeys) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.y";
+  SCOPED_TRACE(query);
+
+  // u must have no filter — u.x = u.y must not be inferred.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Same-table equalities must NOT be pushed to the preserved (left) side of a
+// left join. t rows can appear in the output without matching any u row, so
+// t.a = t.b cannot be inferred from ON t.a = u.x AND t.b = u.x.
+TEST_F(JoinTest, impliedSameTableEqualityPreservedSide) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+
+  auto query = "SELECT count(*) FROM t LEFT JOIN u ON t.a = u.x AND t.b = u.x";
+  SCOPED_TRACE(query);
+
+  // t must have no filter — t.a = t.b must not be inferred.
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .aggregation()
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // LEFT JOIN with no equalities when the DT has 3+ tables. The comma join

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -357,25 +357,27 @@ TEST_F(SetTest, intersect) {
           "nation", std::move(filters), remainingFilter);
     };
 
-    // TODO Fix this plan to push down (n_regionkey + 1) % 3
-    // = 1 to all branches of 'intersect'.
-
+    // The deterministic remaining filter and the union of n_nationkey ranges
+    // are pushed into every INTERSECT branch. Each scan ends up with the
+    // tightest [lo, hi] across all intersect sides.
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = startMatcher(test::gte("n_nationkey", 13))
-                       .hashJoin(
-                           startMatcher(test::gte("n_nationkey", 12))
-                               .hashJoin(
-                                   startMatcher(
-                                       test::lte("n_nationkey", 20),
-                                       "(n_regionkey + 1) % 3 = 1")
-                                       .build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
-                           core::JoinType::kRightSemiFilter)
-                       .singleAggregation()
-                       .project()
-                       .project()
-                       .build();
+    auto remainingFilter = std::string{"(n_regionkey + 1) % 3 = 1"};
+    auto matcher =
+        startMatcher(test::lte("n_nationkey", 20), remainingFilter)
+            .hashJoin(
+                startMatcher(
+                    test::between("n_nationkey", 12, 20), remainingFilter)
+                    .build(),
+                core::JoinType::kLeftSemiFilter)
+            .hashJoin(
+                startMatcher(
+                    test::between("n_nationkey", 13, 20), remainingFilter)
+                    .build(),
+                core::JoinType::kLeftSemiFilter)
+            .singleAggregation()
+            .project()
+            .project()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -81,3 +81,26 @@ FROM (VALUES ('d1'), ('d2')) a(ds)
 LEFT JOIN (VALUES ('d3')) b(ds) ON (a.ds = b.ds)
 LEFT JOIN (SELECT 'x' as ds WHERE false) c ON (a.ds = c.ds)
 GROUP BY 1
+----
+-- Same-table equality from equivalence class: a = b is inferred and pushed
+-- as a filter on the left side. Only rows where a = b survive, projecting
+-- (a, b): (1, 1), (3, 3), (5, 5).
+SELECT t.a, t.b
+FROM (VALUES (1, 1), (2, 20), (3, 3), (4, 40), (5, 5)) AS t(a, b)
+JOIN (SELECT DISTINCT a FROM (VALUES (1), (2), (3), (4), (5)) AS v(a)) AS u(a)
+  ON t.a = u.a AND t.b = u.a
+----
+-- LEFT JOIN slot synthesis: u.x = u.y inferred from u.x = t.a AND u.y = t.a.
+SELECT t.a, u.x
+FROM (VALUES (1), (2), (3)) AS t(a)
+LEFT JOIN (VALUES (1, 1), (3, 3), (4, 5)) AS u(x, y)
+  ON u.x = t.a AND u.y = t.a
+----
+-- SEMI join slot synthesis: u.x = u.y inferred, so only rows where x = y
+-- survive the semi-join filter. t.a = 2 has no matching u row (2, 3 fails).
+SELECT t.a
+FROM (VALUES (1), (2), (3)) AS t(a)
+WHERE EXISTS (
+  SELECT 1 FROM (VALUES (1, 1), (2, 3), (3, 3)) AS u(x, y)
+  WHERE u.x = t.a AND u.y = t.a
+)


### PR DESCRIPTION
Summary:

Extends inferImpliedPredicates to also propagate filters through the keys
of left (outer) joins. For t LEFT JOIN u ON t.a = u.x, a filter t.a = 5
implies u.x = 5 for any matched row, since unmatched u rows never appear
in the output.

Adds collectOuterJoinImpliedPredicates, a companion to the existing
collectImpliedPredicates. Where collectImpliedPredicates propagates through
inner-join equivalence classes, this function directly inspects left-join
key pairs to propagate single-column BaseTable filters from the preserved
(left) side to the null-extending (right) side.

Non-deterministic predicates are excluded. Multi-column predicates are
excluded (same limitation as collectImpliedPredicates).

Differential Revision: D105711621


