### PR TITLE
fix(optimizer): Dedup constants by stored bytes via ConstantCache (#1432)

### DIFF
--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -198,6 +198,28 @@ $ $CLI --query "SELECT INTERVAL '1' DAY AS d, INTERVAL '13' MONTH AS m" 2>/dev/n
 1 00:00:00.000 | 1-1
 ```
 
+## AT TIME ZONE constant fold preserves the target timezone
+
+```scrut
+$ $CLI --query "SELECT TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/Los_Angeles' AS ts" 2>/dev/null
+-------------------------------------------
+                                         ts
+-------------------------------------------
+2026-05-07 03:00:00.000 America/Los_Angeles
+(1 rows in 1 batches)
+
+```
+
+```scrut
+$ $CLI --query "SELECT date_format(TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/Los_Angeles', '%H') AS la, date_format(TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/New_York', '%H') AS ny" 2>/dev/null
+---+---
+la | ny
+---+---
+03 | 06
+(1 rows in 1 batches)
+
+```
+
 ## IPADDRESS displays a formatted IP address
 
 ```scrut

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   axiom_optimizer
   AggregationPlanner.cpp
   BitSet.cpp
+  ConstantCache.cpp
   ConstantExprEvaluator.cpp
   Cost.cpp
   DerivedTable.cpp

--- a/axiom/optimizer/ConstantCache.cpp
+++ b/axiom/optimizer/ConstantCache.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/ConstantCache.h"
+
+#include <folly/hash/Hash.h>
+#include <functional>
+#include <typeindex>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/type/FloatingPointUtil.h"
+
+namespace facebook::axiom::optimizer {
+
+namespace {
+
+template <velox::TypeKind Kind>
+uint64_t hashScalar(const velox::Variant& value) {
+  using NativeType = typename velox::TypeTraits<Kind>::NativeType;
+  if constexpr (std::is_floating_point_v<NativeType>) {
+    return velox::util::floating_point::NaNAwareHash<NativeType>{}(
+        value.value<Kind>());
+  } else {
+    return folly::Hash{}(value.value<Kind>());
+  }
+}
+
+template <velox::TypeKind Kind>
+bool equalScalar(const velox::Variant& lhs, const velox::Variant& rhs) {
+  using NativeType = typename velox::TypeTraits<Kind>::NativeType;
+  if constexpr (std::is_floating_point_v<NativeType>) {
+    return velox::util::floating_point::NaNAwareEquals<NativeType>{}(
+        lhs.value<Kind>(), rhs.value<Kind>());
+  } else {
+    return lhs.value<Kind>() == rhs.value<Kind>();
+  }
+}
+
+// Hashes `value` from its stored bytes, recursing into ARRAY / ROW / MAP
+// containers. Bypasses any custom comparator the Variant's type may carry
+// (Variant::hash() routes through that comparator).
+uint64_t structuralHash(const velox::Variant& value) {
+  if (value.isNull()) {
+    return velox::bits::kNullHash;
+  }
+  const auto kind = value.kind();
+  if (kind == velox::TypeKind::ARRAY) {
+    const auto& children = value.value<velox::TypeKind::ARRAY>();
+    uint64_t hash = velox::bits::kNullHash;
+    for (size_t i = 0; i < children.size(); ++i) {
+      hash = velox::bits::hashMix(hash, structuralHash(children[i]));
+    }
+    return hash;
+  }
+  if (kind == velox::TypeKind::ROW) {
+    const auto& children = value.value<velox::TypeKind::ROW>();
+    uint64_t hash = velox::bits::kNullHash;
+    for (size_t i = 0; i < children.size(); ++i) {
+      hash = velox::bits::hashMix(hash, structuralHash(children[i]));
+    }
+    return hash;
+  }
+  if (kind == velox::TypeKind::MAP) {
+    const auto& entries = value.value<velox::TypeKind::MAP>();
+    uint64_t hash = velox::bits::kNullHash;
+    for (const auto& [key, mapped] : entries) {
+      const auto entryHash =
+          velox::bits::hashMix(structuralHash(key), structuralHash(mapped));
+      hash = velox::bits::commutativeHashMix(hash, entryHash);
+    }
+    return hash;
+  }
+  if (kind == velox::TypeKind::OPAQUE) {
+    const auto& capsule = value.value<velox::TypeKind::OPAQUE>();
+    return velox::bits::hashMix(
+        std::hash<std::type_index>{}(capsule.type->typeIndex()),
+        folly::Hash{}(reinterpret_cast<uintptr_t>(capsule.obj.get())));
+  }
+  if (kind == velox::TypeKind::UNKNOWN) {
+    return velox::bits::kNullHash;
+  }
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(hashScalar, kind, value);
+}
+
+// Returns true iff `lhs` and `rhs` hold the same stored bytes, recursing
+// into ARRAY / ROW / MAP. Bypasses any custom comparator the Variant's
+// type may carry (Variant::operator== routes through that comparator).
+bool structuralEquals(const velox::Variant& lhs, const velox::Variant& rhs) {
+  if (lhs.kind() != rhs.kind()) {
+    return false;
+  }
+  if (lhs.isNull() || rhs.isNull()) {
+    return lhs.isNull() && rhs.isNull();
+  }
+  const auto kind = lhs.kind();
+  if (kind == velox::TypeKind::ARRAY) {
+    const auto& lhsElements = lhs.value<velox::TypeKind::ARRAY>();
+    const auto& rhsElements = rhs.value<velox::TypeKind::ARRAY>();
+    if (lhsElements.size() != rhsElements.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < lhsElements.size(); ++i) {
+      if (!structuralEquals(lhsElements[i], rhsElements[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (kind == velox::TypeKind::ROW) {
+    const auto& lhsFields = lhs.value<velox::TypeKind::ROW>();
+    const auto& rhsFields = rhs.value<velox::TypeKind::ROW>();
+    if (lhsFields.size() != rhsFields.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < lhsFields.size(); ++i) {
+      if (!structuralEquals(lhsFields[i], rhsFields[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (kind == velox::TypeKind::MAP) {
+    const auto& lhsEntries = lhs.value<velox::TypeKind::MAP>();
+    const auto& rhsEntries = rhs.value<velox::TypeKind::MAP>();
+    if (lhsEntries.size() != rhsEntries.size()) {
+      return false;
+    }
+    auto lhsIt = lhsEntries.begin();
+    auto rhsIt = rhsEntries.begin();
+    while (lhsIt != lhsEntries.end()) {
+      if (!structuralEquals(lhsIt->first, rhsIt->first) ||
+          !structuralEquals(lhsIt->second, rhsIt->second)) {
+        return false;
+      }
+      ++lhsIt;
+      ++rhsIt;
+    }
+    return true;
+  }
+  if (kind == velox::TypeKind::OPAQUE) {
+    const auto& lhsCapsule = lhs.value<velox::TypeKind::OPAQUE>();
+    const auto& rhsCapsule = rhs.value<velox::TypeKind::OPAQUE>();
+    return lhsCapsule.type->typeIndex() == rhsCapsule.type->typeIndex() &&
+        lhsCapsule.obj == rhsCapsule.obj;
+  }
+  if (kind == velox::TypeKind::UNKNOWN) {
+    return true;
+  }
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(equalScalar, kind, lhs, rhs);
+}
+
+} // namespace
+
+size_t ConstantCache::KeyHash::operator()(const Key& key) const {
+  return velox::bits::hashMix(
+      std::hash<const velox::Type*>()(key.type), structuralHash(*key.value));
+}
+
+bool ConstantCache::KeyEqual::operator()(const Key& lhs, const Key& rhs) const {
+  return lhs.type == rhs.type && structuralEquals(*lhs.value, *rhs.value);
+}
+
+ExprCP ConstantCache::get(const logical_plan::ConstantExpr& constant) {
+  Key key{toType(constant.type()), constant.value()};
+  auto it = entries_.find(key);
+  if (it != entries_.end()) {
+    return it->second;
+  }
+
+  Value value(key.type, 1);
+  if (key.value->isNull()) {
+    value.nullFraction = 1.0;
+  } else {
+    value.nullFraction = 0.0;
+    value.nullable = false;
+    if (key.type->isPrimitiveType()) {
+      value.min = key.value.get();
+      value.max = key.value.get();
+    }
+  }
+
+  auto* literal = make<Literal>(value, key.value.get());
+  entries_[std::move(key)] = literal;
+  return literal;
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ConstantCache.h
+++ b/axiom/optimizer/ConstantCache.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <memory>
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::axiom::optimizer {
+
+/// Interns Literal nodes by (Type, Variant stored bytes), bypassing any
+/// custom comparator the type provides.
+class ConstantCache {
+ public:
+  /// Returns the interned Literal for `constant`, creating one on first
+  /// sight. Two ConstantExprs whose stored bytes match (after recursing
+  /// into ARRAY / ROW / MAP) collapse to the same Literal; otherwise the
+  /// returned pointers are distinct.
+  ExprCP get(const logical_plan::ConstantExpr& constant);
+
+ private:
+  struct Key {
+    const velox::Type* type;
+    std::shared_ptr<const velox::Variant> value;
+  };
+
+  struct KeyHash {
+    size_t operator()(const Key& key) const;
+  };
+
+  struct KeyEqual {
+    bool operator()(const Key& lhs, const Key& rhs) const;
+  };
+
+  folly::F14FastMap<Key, ExprCP, KeyHash, KeyEqual> entries_;
+};
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1217,28 +1217,7 @@ bool ToGraph::isJoinEquality(
 }
 
 ExprCP ToGraph::makeConstant(const lp::ConstantExpr& constant) {
-  TypedVariant temp{toType(constant.type()), constant.value()};
-  auto it = constantDedup_.find(temp);
-  if (it != constantDedup_.end()) {
-    return it->second;
-  }
-
-  Value value(temp.type, 1);
-  if (temp.value->isNull()) {
-    value.nullFraction = 1.0;
-  } else {
-    value.nullFraction = 0.0;
-    value.nullable = false;
-    if (temp.type->isPrimitiveType()) {
-      value.min = temp.value.get();
-      value.max = temp.value.get();
-    }
-  }
-
-  auto* literal = make<Literal>(value, temp.value.get());
-
-  constantDedup_[std::move(temp)] = literal;
-  return literal;
+  return constantCache_.get(constant);
 }
 
 ExprCP ToGraph::makeNullConstant(const velox::TypePtr& type) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/common/QueryRuntimeStats.h"
+#include "axiom/optimizer/ConstantCache.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/PathSet.h"
@@ -51,26 +52,6 @@ struct ExprDedupHasher {
 
 using FunctionDedupMap =
     folly::F14FastMap<ExprDedupKey, ExprCP, ExprDedupHasher>;
-
-struct TypedVariant {
-  /// Canonical Type pointer returned by QueryGraphContext::toType.
-  const velox::Type* type;
-  std::shared_ptr<const velox::Variant> value;
-};
-
-struct TypedVariantHasher {
-  size_t operator()(const TypedVariant& value) const {
-    return velox::bits::hashMix(
-        std::hash<const velox::Type*>()(value.type), value.value->hash());
-  }
-};
-
-struct TypedVariantComparer {
-  bool operator()(const TypedVariant& left, const TypedVariant& right) const {
-    // Types have been deduped, hence, we compare pointers.
-    return left.type == right.type && *left.value == *right.value;
-  }
-};
 
 /// Represents a path over an Expr of complex type. Used as a key
 /// for a map from unique step to the dedupped Expr that is the getter.
@@ -977,9 +958,7 @@ class ToGraph {
       SubqueryExprEqual>
       subqueries_;
 
-  folly::
-      F14FastMap<TypedVariant, ExprCP, TypedVariantHasher, TypedVariantComparer>
-          constantDedup_;
+  ConstantCache constantCache_;
 
   // Dedup map from name + ExprVector to corresponding CallExpr.
   FunctionDedupMap functionDedup_;

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(
 add_executable(
   axiom_optimizer_tests
   AggregationTest.cpp
+  ConstantCacheTest.cpp
   DistinctAggregationTest.cpp
   OutputNodeTest.cpp
   CardinalityEstimationTest.cpp
@@ -158,6 +159,7 @@ target_link_libraries(
   axiom_test_connector
   velox_dwio_text_reader_register
   velox_dwio_text_writer_register
+  velox_presto_types
   GTest::gmock
   glog::glog
   GTest::gtest

--- a/axiom/optimizer/tests/ConstantCacheTest.cpp
+++ b/axiom/optimizer/tests/ConstantCacheTest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/ConstantCache.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Variant.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class ConstantCacheTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+    allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
+    ctx_ = std::make_unique<QueryGraphContext>(*allocator_);
+    queryCtx() = ctx_.get();
+  }
+
+  void TearDown() override {
+    queryCtx() = nullptr;
+    ctx_.reset();
+    allocator_.reset();
+    pool_.reset();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::HashStringAllocator> allocator_;
+  std::unique_ptr<QueryGraphContext> ctx_;
+};
+
+// Two TIMESTAMP WITH TIME ZONE values that share an instant but carry
+// different timezone IDs intern to distinct Literals: downstream
+// formatting and extraction operations depend on the tz_id, so collapsing
+// them would yield wrong results.
+TEST_F(ConstantCacheTest, getDistinguishesTimestampWithTimeZone) {
+  constexpr int64_t kMillis = 1'778'148'000'000;
+  const int16_t utcId = tz::getTimeZoneID("UTC");
+  const int16_t laId = tz::getTimeZoneID("America/Los_Angeles");
+  ASSERT_NE(utcId, laId);
+
+  lp::ConstantExpr utc{
+      TIMESTAMP_WITH_TIME_ZONE(),
+      std::make_shared<Variant>(
+          Variant::typeWithCustomComparison<TypeKind::BIGINT>(
+              pack(kMillis, utcId), TIMESTAMP_WITH_TIME_ZONE()))};
+  lp::ConstantExpr la{
+      TIMESTAMP_WITH_TIME_ZONE(),
+      std::make_shared<Variant>(
+          Variant::typeWithCustomComparison<TypeKind::BIGINT>(
+              pack(kMillis, laId), TIMESTAMP_WITH_TIME_ZONE()))};
+
+  ConstantCache cache;
+  EXPECT_NE(cache.get(utc), cache.get(la));
+}
+
+TEST_F(ConstantCacheTest, getInternsEqualScalars) {
+  lp::ConstantExpr first{BIGINT(), std::make_shared<Variant>(int64_t{42})};
+  lp::ConstantExpr second{BIGINT(), std::make_shared<Variant>(int64_t{42})};
+
+  ConstantCache cache;
+  EXPECT_EQ(cache.get(first), cache.get(second));
+}
+
+TEST_F(ConstantCacheTest, getDistinguishesArraysByElement) {
+  const auto type = ARRAY(BIGINT());
+  lp::ConstantExpr a{
+      type,
+      std::make_shared<Variant>(Variant::array(
+          {Variant(int64_t{1}), Variant(int64_t{2}), Variant(int64_t{3})}))};
+  lp::ConstantExpr b{
+      type,
+      std::make_shared<Variant>(Variant::array(
+          {Variant(int64_t{1}), Variant(int64_t{2}), Variant(int64_t{4})}))};
+
+  ConstantCache cache;
+  EXPECT_NE(cache.get(a), cache.get(b));
+}
+
+TEST_F(ConstantCacheTest, getDistinguishesRowsByField) {
+  const auto type = ROW({"x", "y"}, {BIGINT(), VARCHAR()});
+  lp::ConstantExpr a{
+      type,
+      std::make_shared<Variant>(
+          Variant::row({Variant(int64_t{7}), Variant(std::string{"hello"})}))};
+  lp::ConstantExpr b{
+      type,
+      std::make_shared<Variant>(
+          Variant::row({Variant(int64_t{7}), Variant(std::string{"world"})}))};
+
+  ConstantCache cache;
+  EXPECT_NE(cache.get(a), cache.get(b));
+}
+
+TEST_F(ConstantCacheTest, getDistinguishesMapsByValue) {
+  const auto type = MAP(BIGINT(), VARCHAR());
+  std::map<Variant, Variant> entriesA{
+      {Variant(int64_t{1}), Variant(std::string{"one"})},
+      {Variant(int64_t{2}), Variant(std::string{"two"})}};
+  std::map<Variant, Variant> entriesB{
+      {Variant(int64_t{1}), Variant(std::string{"one"})},
+      {Variant(int64_t{2}), Variant(std::string{"TWO"})}};
+
+  lp::ConstantExpr a{
+      type, std::make_shared<Variant>(Variant::map(std::move(entriesA)))};
+  lp::ConstantExpr b{
+      type, std::make_shared<Variant>(Variant::map(std::move(entriesB)))};
+
+  ConstantCache cache;
+  EXPECT_NE(cache.get(a), cache.get(b));
+}
+
+TEST_F(ConstantCacheTest, getDistinguishesNullFromNonNull) {
+  lp::ConstantExpr nullExpr{
+      BIGINT(), std::make_shared<Variant>(TypeKind::BIGINT)};
+  lp::ConstantExpr nonNull{BIGINT(), std::make_shared<Variant>(int64_t{0})};
+
+  ConstantCache cache;
+  EXPECT_NE(cache.get(nullExpr), cache.get(nonNull));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -23,7 +23,9 @@
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/utils/DfFunctions.h"
 #include "velox/exec/tests/utils/TpchQueryBuilder.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -313,6 +315,35 @@ TEST_F(PlanTest, specialFormConstantFold) {
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+}
+
+// Two AT TIME ZONE folds that share an instant but request different
+// timezones must produce distinct packed constants.
+TEST_F(PlanTest, atTimeZoneConstantFoldPreservesTzId) {
+  testConnector_->addTable("numbers", ROW({"a"}, BIGINT()));
+
+  constexpr int64_t kMillis = 1'778'148'000'000; // 2026-05-07 10:00:00 UTC.
+  const auto laId = tz::getTimeZoneID("America/Los_Angeles");
+  const auto nyId = tz::getTimeZoneID("America/New_York");
+  ASSERT_NE(laId, nyId);
+
+  const auto laPacked = std::to_string(pack(kMillis, laId));
+  const auto nyPacked = std::to_string(pack(kMillis, nyId));
+
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("numbers")
+          .project(
+              {"at_timezone(cast('2026-05-07 10:00:00 UTC' as timestamp with time zone), 'America/Los_Angeles')",
+               "at_timezone(cast('2026-05-07 10:00:00 UTC' as timestamp with time zone), 'America/New_York')",
+               "a"})
+          .build();
+
+  auto matcher =
+      matchScan("numbers").project({laPacked, nyPacked, "a"}).build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // Verifies that func(..., null, ...) is folded to null for

--- a/axiom/optimizer/tests/sql/coercion.sql
+++ b/axiom/optimizer/tests/sql/coercion.sql
@@ -17,3 +17,30 @@ SELECT CAST(c AS DECIMAL(4,1)) = CAST(b AS DOUBLE) FROM t
 SELECT CAST(c AS DECIMAL(4,1)) / CAST(b AS DOUBLE) FROM t
 ----
 SELECT SIN(CAST(c AS DECIMAL(4,1))) FROM t
+----
+-- count 1
+SELECT 1 WHERE date_format(
+    parse_datetime('2026-05-07+10:00UTC', 'yyyy-MM-dd+HH:mmz')
+        AT TIME ZONE 'America/Los_Angeles',
+    '%Y-%m-%d %H:%i') = '2026-05-07 03:00'
+----
+-- Two AT TIME ZONE folds over the same instant must produce distinct
+-- formatted strings for distinct target timezones.
+-- count 1
+SELECT
+    date_format(
+        TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/Los_Angeles',
+        '%H') AS la,
+    date_format(
+        TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/New_York',
+        '%H') AS ny
+FROM (VALUES (1)) AS t(x)
+WHERE date_format(
+        TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/Los_Angeles',
+        '%H') = '03'
+  AND date_format(
+        TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/New_York',
+        '%H') = '06'
+----
+-- count 1
+SELECT 1 WHERE hour(TIMESTAMP '2026-05-07 10:00:00 UTC' AT TIME ZONE 'America/Los_Angeles') = 3


### PR DESCRIPTION
Summary:

`Optimization`'s constant cache keyed on `Variant::operator==`, which routes through the type's custom comparator. For `TIMESTAMP WITH TIME ZONE` the comparator ignores the `tz_id`, so two literals that share an instant but format differently collapsed onto one cache entry and downstream operations saw the wrong `tz_id`.

Wraps the cache in a new `ConstantCache` class that keys on the `Variant`'s stored bytes (recursing for `ARRAY` / `ROW` / `MAP`); `ToGraph::makeConstant` now delegates to it. `tryCreateConstantInList` is untouched — `IN` is itself a semantic check.

Differential Revision: D106596012


