### PR TITLE
feat(optimizer): Make OptimizerOptions config-file aware

### DIFF
--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -16,6 +16,7 @@
 #include "axiom/optimizer/OptimizerOptions.h"
 
 #include <fmt/format.h>
+#include <glog/logging.h>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -24,72 +25,102 @@ namespace facebook::axiom::optimizer {
 using velox::config::ConfigProperty;
 using velox::config::ConfigPropertyType;
 
-std::vector<ConfigProperty> OptimizerOptions::properties() const {
-  // Defaults come from field initializers on a default-constructed instance.
-  OptimizerOptions defaults;
-  return {
+namespace {
+
+std::vector<ConfigProperty> buildProperties(
+    const std::unordered_map<std::string, std::string>& configOverrides) {
+  std::vector<ConfigProperty> props = {
       {
-          std::string(kSampleJoins),
+          std::string(OptimizerOptions::kSampleJoins),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.sampleJoins),
+          fmt::to_string(OptimizerOptions::kSampleJoinsDefault),
           "Sample joins to determine optimal join order.",
       },
       {
-          std::string(kSampleFilters),
+          std::string(OptimizerOptions::kSampleFilters),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.sampleFilters),
+          fmt::to_string(OptimizerOptions::kSampleFiltersDefault),
           "Sample filters to estimate scan selectivity.",
       },
       {
-          std::string(kUseFilteredTableStats),
+          std::string(OptimizerOptions::kUseFilteredTableStats),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.useFilteredTableStats),
+          fmt::to_string(OptimizerOptions::kUseFilteredTableStatsDefault),
           "Use connector-provided table statistics for cardinality estimation.",
       },
       {
-          std::string(kPushdownSubfields),
+          std::string(OptimizerOptions::kPushdownSubfields),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.pushdownSubfields),
+          fmt::to_string(OptimizerOptions::kPushdownSubfieldsDefault),
           "Extract accessed subfields of complex columns in table scan.",
       },
       {
-          std::string(kAllMapsAsStruct),
+          std::string(OptimizerOptions::kAllMapsAsStruct),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.allMapsAsStruct),
+          fmt::to_string(OptimizerOptions::kAllMapsAsStructDefault),
           "Project maps with known key subsets as structs.",
       },
       {
-          std::string(kSyntacticJoinOrder),
+          std::string(OptimizerOptions::kSyntacticJoinOrder),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.syntacticJoinOrder),
+          fmt::to_string(OptimizerOptions::kSyntacticJoinOrderDefault),
           "Disable cost-based join ordering; use query order.",
       },
       {
-          std::string(kAlwaysPlanPartialAggregation),
+          std::string(OptimizerOptions::kAlwaysPlanPartialAggregation),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.alwaysPlanPartialAggregation),
+          fmt::to_string(
+              OptimizerOptions::kAlwaysPlanPartialAggregationDefault),
           "Always split aggregation into partial + final.",
       },
       {
-          std::string(kEnableReducingExistences),
+          std::string(OptimizerOptions::kEnableReducingExistences),
           ConfigPropertyType::kBoolean,
-          fmt::to_string(defaults.enableReducingExistences),
+          fmt::to_string(OptimizerOptions::kEnableReducingExistencesDefault),
           "Enable reducing semi joins.",
       },
       {
-          std::string(kParallelProjectWidth),
+          std::string(OptimizerOptions::kParallelProjectWidth),
           ConfigPropertyType::kInteger,
-          std::to_string(defaults.parallelProjectWidth),
+          std::to_string(OptimizerOptions::kParallelProjectWidthDefault),
           "Number of threads for parallel projection. 1 disables.",
       },
       {
-          std::string(kTraceFlags),
+          std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
-          std::to_string(defaults.traceFlags),
+          std::to_string(OptimizerOptions::kTraceFlagsDefault),
           "Bit mask for optimizer trace output: 1=retained, 2=exceeded best, 4=sample, 8=preprocess.",
       },
   };
+
+  if (configOverrides.empty()) {
+    return props;
+  }
+
+  std::unordered_map<std::string, size_t> propIndex;
+  for (size_t i = 0; i < props.size(); ++i) {
+    propIndex[props[i].name] = i;
+  }
+  for (const auto& [key, value] : configOverrides) {
+    auto it = propIndex.find(key);
+    if (it != propIndex.end()) {
+      props[it->second].defaultValue = value;
+    } else {
+      LOG(WARNING) << "Unregistered session property in optimizer config: "
+                   << key;
+    }
+  }
+
+  return props;
 }
+
+} // namespace
+
+OptimizerOptions::OptimizerOptions() : properties_(buildProperties({})) {}
+
+OptimizerOptions::OptimizerOptions(
+    std::unordered_map<std::string, std::string> configOverrides)
+    : properties_(buildProperties(configOverrides)) {}
 
 std::string OptimizerOptions::normalize(
     std::string_view name,
@@ -104,7 +135,6 @@ std::string OptimizerOptions::normalize(
 
 OptimizerOptions OptimizerOptions::from(
     const folly::F14FastMap<std::string, std::string>& properties) {
-  // Sets 'field' from the property map if present, otherwise keeps default.
   auto setBool = [&](std::string_view key, bool& field) {
     auto it = properties.find(key);
     if (it != properties.end()) {

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -18,6 +18,7 @@
 #include <folly/container/F14Map.h>
 #include <algorithm>
 #include <cstdint>
+#include <unordered_map>
 
 #include "axiom/common/SchemaTableName.h"
 #include "velox/common/config/ConfigProvider.h"
@@ -31,6 +32,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr uint32_t kSample = 4;
   static constexpr uint32_t kPreprocess = 8;
 
+  // Property name constants.
   static constexpr std::string_view kSampleJoins = "sample_joins";
   static constexpr std::string_view kSampleFilters = "sample_filters";
   static constexpr std::string_view kUseFilteredTableStats =
@@ -47,52 +49,66 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "parallel_project_width";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
+  // Default values — single source of truth for field initializers
+  // and properties().
+  static constexpr int32_t kParallelProjectWidthDefault = 1;
+  static constexpr bool kPushdownSubfieldsDefault = false;
+  static constexpr bool kAllMapsAsStructDefault = false;
+  static constexpr bool kSampleJoinsDefault = false;
+  static constexpr bool kSampleFiltersDefault = false;
+  static constexpr bool kUseFilteredTableStatsDefault = true;
+  static constexpr bool kEnableReducingExistencesDefault = true;
+  static constexpr uint32_t kTraceFlagsDefault = 0;
+  static constexpr bool kSyntacticJoinOrderDefault = false;
+  static constexpr bool kAlwaysPlanPartialAggregationDefault = false;
+
+  /// Constructs with code defaults only.
+  OptimizerOptions();
+
+  /// Constructs a config-file-aware provider. Config-file values override
+  /// code defaults in the output of `properties()`, enabling the three-layer
+  /// cascade: code default -> config file -> session override.
+  explicit OptimizerOptions(
+      std::unordered_map<std::string, std::string> configOverrides);
+
   /// Parallelizes independent projections over this many threads. 1 means no
   /// parallel projection.
-  int32_t parallelProjectWidth{1};
+  int32_t parallelProjectWidth{kParallelProjectWidthDefault};
 
   /// Produces skyline subfield sets of complex type columns as top level
   /// columns in table scan.
-  bool pushdownSubfields{false};
+  bool pushdownSubfields{kPushdownSubfieldsDefault};
 
   /// Makes all maps for which a known subset of keys is accessed to
   /// be projected out as structs.
-  bool allMapsAsStruct{false};
+  bool allMapsAsStruct{kAllMapsAsStructDefault};
 
   /// Map from table name to list of map columns to be read as structs unless
   /// the whole map is accessed as a map.
   folly::F14FastMap<std::string, std::vector<std::string>> mapAsStruct;
 
-  /// Enable join order sampling during optimization. If this flag is set, joins
-  /// are sampled to determine the optimal join order. If join sampling is
-  /// disabled, the optimizer will fall back on cardinality estimation.
-  bool sampleJoins{false};
+  /// Enable join order sampling during optimization.
+  bool sampleJoins{kSampleJoinsDefault};
 
-  /// Enable filter selectivity sampling during optimization. If this flag is
-  /// set, filters will be evaluated against a sample of source data to
-  /// determine the estimated cardinality of the scan. If filter sampling is
-  /// disabled, a default selectivity will be used.
-  bool sampleFilters{false};
+  /// Enable filter selectivity sampling during optimization.
+  bool sampleFilters{kSampleFiltersDefault};
 
-  /// Enable using connector-provided table statistics (co_estimateStats) for
-  /// cardinality estimation. When disabled, the optimizer falls back to
-  /// sampling or constraint-based estimation.
-  bool useFilteredTableStats{true};
+  /// Enable using connector-provided table statistics for cardinality
+  /// estimation.
+  bool useFilteredTableStats{kUseFilteredTableStatsDefault};
 
   /// Enable reducing semi joins.
-  bool enableReducingExistences{true};
+  bool enableReducingExistences{kEnableReducingExistencesDefault};
 
   /// Produce trace of plan candidates.
-  uint32_t traceFlags{0};
+  uint32_t traceFlags{kTraceFlagsDefault};
 
-  /// Disable cost-based join order selection. Perform the joins in the exact
-  /// sequence specified in the query.
-  /// TODO: Make this work for non-inner joins.
-  bool syntacticJoinOrder{false};
+  /// Disable cost-based join order selection.
+  bool syntacticJoinOrder{kSyntacticJoinOrderDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.
-  bool alwaysPlanPartialAggregation{false};
+  bool alwaysPlanPartialAggregation{kAlwaysPlanPartialAggregationDefault};
 
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.
@@ -104,8 +120,11 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static OptimizerOptions from(
       const folly::F14FastMap<std::string, std::string>& properties);
 
-  // ConfigProvider implementation.
-  std::vector<velox::config::ConfigProperty> properties() const override;
+  /// Returns metadata for all optimizer session properties. Defaults
+  /// reflect config-file overrides when provided at construction.
+  std::vector<velox::config::ConfigProperty> properties() const override {
+    return properties_;
+  }
   std::string normalize(std::string_view name, std::string_view value)
       const override;
 
@@ -124,6 +143,9 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
     return std::find(it->second.begin(), it->second.end(), column) !=
         it->second.end();
   }
+
+ private:
+  std::vector<velox::config::ConfigProperty> properties_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/OptimizerOptions.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer {
+
+namespace {
+
+// Finds a property's default value by name.
+std::string getDefault(
+    const std::vector<velox::config::ConfigProperty>& props,
+    std::string_view name) {
+  for (const auto& prop : props) {
+    if (prop.name == name) {
+      return prop.defaultValue.value_or("");
+    }
+  }
+  VELOX_UNREACHABLE("Property not found: {}", name);
+}
+
+} // namespace
+
+TEST(OptimizerOptionsTest, codeDefaults) {
+  OptimizerOptions options;
+  auto props = options.properties();
+
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSampleJoins), "false");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSyntacticJoinOrder), "false");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kParallelProjectWidth), "1");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kTraceFlags), "0");
+  EXPECT_EQ(
+      getDefault(props, OptimizerOptions::kUseFilteredTableStats), "true");
+}
+
+TEST(OptimizerOptionsTest, configOverrides) {
+  OptimizerOptions options(
+      {{std::string(OptimizerOptions::kSyntacticJoinOrder), "true"},
+       {std::string(OptimizerOptions::kParallelProjectWidth), "4"}});
+  auto props = options.properties();
+
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSyntacticJoinOrder), "true");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kParallelProjectWidth), "4");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSampleJoins), "false");
+}
+
+TEST(OptimizerOptionsTest, from) {
+  folly::F14FastMap<std::string, std::string> props = {
+      {std::string(OptimizerOptions::kSampleJoins), "true"},
+      {std::string(OptimizerOptions::kParallelProjectWidth), "8"},
+      {std::string(OptimizerOptions::kTraceFlags), "5"},
+  };
+  auto options = OptimizerOptions::from(props);
+
+  EXPECT_TRUE(options.sampleJoins);
+  EXPECT_EQ(options.parallelProjectWidth, 8);
+  EXPECT_EQ(options.traceFlags, 5);
+  EXPECT_FALSE(options.syntacticJoinOrder);
+  EXPECT_FALSE(options.sampleFilters);
+}
+
+TEST(OptimizerOptionsTest, normalizeRejectsInvalidWidth) {
+  OptimizerOptions options;
+  EXPECT_THROW(
+      options.normalize(OptimizerOptions::kParallelProjectWidth, "0"),
+      facebook::velox::VeloxUserError);
+}
+
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
Adds a constructor to `OptimizerOptions` that accepts config-file overrides, following the same pattern as Velox's `QueryConfigProvider`. When overrides are provided, `properties()` returns config-file values as defaults instead of code defaults, enabling the three-layer cascade: code default -> config file -> session override.

Introduces `static constexpr` default-value constants (e.g., `kSampleJoinsDefault`) as the single source of truth — both field initializers and `properties()` reference them. The property metadata vector is built once at construction and cached in `properties_`.

`OptimizerOptions` retains its existing role as both a data carrier and a `ConfigProvider`. A future diff will separate these concerns; this change is the minimal addition needed to wire optimizer session properties end-to-end in Axel.

Differential Revision: D106835768


