### PR TITLE
fix(optimizer): Fix imprecise floating-point calculation causing fanout check violation

### DIFF
--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -442,7 +442,10 @@ double expectedNumDistincts(double numRows, double numDistinct) {
     return numDistinct;
   }
 
-  return numDistinct * (1.0 - std::exp(exponent));
+  // Use -expm1(x) instead of (1 - exp(x)) to avoid catastrophic cancellation
+  // when exponent ≈ 0. The naive form can land a few ULPs above
+  // min(numRows, numDistinct), breaking downstream invariants.
+  return numDistinct * -std::expm1(exponent);
 }
 
 // Static methods for populating join constraints.

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
@@ -248,6 +249,61 @@ TEST_F(AggregationTest, orderBy) {
                 .shuffle()
                 .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+}
+
+// Verifies plan construction succeeds when partial-aggregation
+// `maxCardinality` greatly exceeds `inputBeforePartial`. Guards the
+// `expectedNumDistincts` invariant `result <= min(numRows, numDistinct)`.
+TEST_F(AggregationTest, fanoutPrecisionRegression) {
+  // Stats sized to push `maxCardinality` far above `inputBeforePartial`:
+  // the selective filter narrows `inputBeforePartial` to ~10 and scales each
+  // post-filter per-key NDV to ~10, so with 11 keys the saturating-product
+  // `maxGroups` reaches ~5e10.
+  constexpr int64_t kHugeStat = 100'000'000'000LL;
+  constexpr int kNumKeys = 11;
+
+  std::vector<std::string> keys;
+  keys.reserve(kNumKeys);
+  for (int i = 0; i < kNumKeys; ++i) {
+    keys.push_back(fmt::format("k{}", i));
+  }
+
+  std::unordered_map<std::string, connector::ColumnStatistics> colStats;
+  colStats[keys[0]] = {
+      .min = velox::Variant{int64_t{1}},
+      .max = velox::Variant{kHugeStat},
+      .numDistinct = kHugeStat};
+  for (int i = 1; i < kNumKeys; ++i) {
+    colStats[keys[i]] = {.numDistinct = kHugeStat};
+  }
+
+  testConnector_->addTable("t", ROW(folly::copy(keys), BIGINT()))
+      ->setStats(kHugeStat, colStats);
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .filter(fmt::format("{} > 99999999990", keys[0]))
+                         .aggregate(keys, {"count(1)"})
+                         .build();
+
+  OptimizerOptions options;
+  options.alwaysPlanPartialAggregation = true;
+  auto plan = planVelox(
+                  logicalPlan,
+                  MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},
+                  options)
+                  .plan;
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .tableScan()
+                     .filter(fmt::format("{} > 99999999990", keys[0]))
+                     .partialAggregation(keys, {"count(1)"})
+                     .shuffle()
+                     .localPartition()
+                     .finalAggregation()
+                     .shuffle()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
 }
 
 // Verifies that repartitionForAgg correctly determines when shuffle is needed


### PR DESCRIPTION
Summary:
expectedNumDistincts returns a value greater than numRows due to catastrophic cancellation in `1 - exp(x)`, which trips `VELOX_CHECK_LE(cost_.fanout, 1.0f)` in Aggregation::Aggregation cost computation.

Minimal repro:
```
SELECT k0, k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, count(*)
FROM t                              -- ~1e11 rows, each k_i has NDV ~1e11
WHERE k0 > 99999999990              -- post-filter cardinality ~10
GROUP BY k0, k1, k2, k3, k4, k5, k6, k7, k8, k9, k10
```

Root cause: Aggregation::setCostWithGroups computes expectedNumDistincts(inputBeforePartial, maxCardinality) and divides by inputBeforePartial to derive the partial-aggregation cost_.fanout. The function implements the coupon-collector formula `numDistinct * (1 - exp(-numRows/numDistinct))` using a naive subtraction. When numDistinct >> numRows (i.e., D >> N), exp(-N/D) ≈ 1 and 1.0 - exp(...) suffers catastrophic cancellation — losing ~10 of double's ~15 significant digits. Multiplying the lossy result by D amplifies that ~1 ULP of exp rounding into ~D * 2^-52 absolute error. numGroups lands a few ULPs above the mathematical upper bound min(N, D), the ratio numGroups / N exceeds 1.0 in double, and the float cast rounds up to 1.0000001f > 1.0f. Downstream consumers that trust the formula's result ≤ min(N, D) invariant all see corrupted values. (D >> N could happen when many grouping keys saturate maxCardinality from maxGroups() to the table-cardinality cap, while a selective filter shrinks inputBeforePartial to a small N.)

Fix: Replace `numDistinct * (1.0 - std::exp(exponent))` with `numDistinct * -std::expm1(exponent)` in expectedNumDistincts(). std::expm1 is the standard numerically-stable form for e^x − 1 near zero such that the result respects the mathematical bound result ≤ min(numRows, numDistinct).

Differential Revision: D106848912


