### PR TITLE
feat: Add connector for querying raw files (#1435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,17 @@ with Velox. These components are:
   - top-level “optimizer” directory
 - Query Runner capable of orchestrating multi-stage Velox execution.
   - top-level “runner” directory
-- Connector - an extention of Velox Connector APIs to provide functionality
+- Connector - an extension of Velox Connector APIs to provide functionality
   necessary for query parsing and planning.
   - top-level “connectors” directory
-  - [Hive](axiom/connectors/hive/README.md) — Local filesystem connector for Parquet, DWRF, and TEXT (including CSV) files.
-  - [TPC-H](axiom/connectors/tpch/README.md) — Read-only, in-memory TPC-H benchmark data.
-  - [System](axiom/connectors/system/README.md) — Read-only metadata tables for session properties and active queries.
-  - [Test](axiom/connectors/tests/README.md) — In-memory read-write connector for unit testing.
+
+  | Connector | Description |
+  |-----------|-------------|
+  | [Hive](axiom/connectors/hive/README.md) | Local filesystem connector for Parquet, DWRF, and TEXT (including CSV) files. |
+  | [TPC-H](axiom/connectors/tpch/README.md) | Read-only, in-memory TPC-H benchmark data. |
+  | [System](axiom/connectors/system/README.md) | Read-only metadata tables for session properties and active queries. |
+  | [Test](axiom/connectors/tests/README.md) | In-memory read-write connector for unit testing. |
+  | [File](axiom/connectors/file/README.md) | Read-only connector multi-utility for running sql on raw files |
 - [CLI](axiom/cli/README.md) - Interactive SQL command line for executing
   queries against in-memory TPC-H dataset and local Hive data.
   - top-level “cli” directory
@@ -317,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/505a21e7c5f8970e219bdac44fad3c9cc2313010...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/457bb8ffd7674d4b2396fc8486451f1acc7ccd2b...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -116,6 +116,7 @@ int main(int argc, char** argv) {
 
   // Register after initialize() so sessionConfig() is available.
   connectors.registerSystemConnector(runner.sessionConfig());
+  connectors.registerFileConnector();
 
   axiom::sql::Console console{runner};
   console.initialize();

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(
   axiom_graphviz_printers
   axiom_hive_connector_metadata
   axiom_tpch_connector_metadata
+  axiom_file_connector
+  axiom_file_handler_parquet
   axiom_system_connector
   axiom_test_connector
   axiom_sql_presto_parser

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -19,6 +19,9 @@
 #include <folly/system/HardwareConcurrency.h>
 #include "axiom/common/SessionConfig.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/file/FileConnector.h"
+#include "axiom/connectors/file/core/FileConnectorMetadata.h"
+#include "axiom/connectors/file/parquet/ParquetFileHandler.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/connectors/system/SystemConnector.h"
@@ -232,6 +235,18 @@ void Connectors::registerSystemConnector(
   connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),
       std::make_shared<connector::system::SystemConnectorMetadata>(
+          connector.get()));
+}
+
+void Connectors::registerFileConnector(const std::string& connectorId) {
+  connector::file::registerParquetHandler();
+
+  auto connector =
+      std::make_shared<connector::file::FileConnector>(connectorId);
+  registerConnector(connector);
+  connector::ConnectorMetadataRegistry::global().insert(
+      connector->connectorId(),
+      std::make_shared<connector::file::FileConnectorMetadata>(
           connector.get()));
 }
 

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -101,6 +101,9 @@ class Connectors {
       const SessionConfig& sessionConfig,
       const std::string& connectorId = kSystemConnectorId);
 
+  /// Registers the file connector for querying raw files via SQL.
+  void registerFileConnector(const std::string& connectorId = "file");
+
  protected:
   /// Initialize file formats and ioExecutor. Must be called before
   /// registering any connectors.

--- a/axiom/connectors/file/CMakeLists.txt
+++ b/axiom/connectors/file/CMakeLists.txt
@@ -12,28 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_subdirectory(core)
+add_subdirectory(parquet)
+
+# Core connector library (format-agnostic).
+add_library(axiom_file_connector FileConnector.cpp FileHandler.cpp)
 
 target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  velox_core
-  Folly::folly
+  axiom_file_connector
+  PUBLIC
+    axiom_file_connector_core
+    axiom_connectors
+    velox_connector
+    velox_memory
+    velox_common_base
+    Folly::folly
 )
-
-add_subdirectory(file)
-add_subdirectory(system)
-
-if(VELOX_ENABLE_HIVE_CONNECTOR)
-  add_subdirectory(hive)
-endif()
-
-if(VELOX_ENABLE_TPCH_CONNECTOR)
-  add_subdirectory(tpch)
-endif()
 
 if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)

--- a/axiom/connectors/file/FileConnector.cpp
+++ b/axiom/connectors/file/FileConnector.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/file/FileConnector.h"
+
+#include "axiom/connectors/file/FileHandler.h"
+#include "axiom/connectors/file/core/FileTable.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector::file {
+
+std::unique_ptr<velox::connector::DataSource> FileConnector::createDataSource(
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
+  auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
+  VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
+
+  auto& fileHandler = handler(fileHandle->schemaTableName().schema);
+  return fileHandler.create(
+      fileHandle->filePath(),
+      fileHandle->suffix().empty()
+          ? std::nullopt
+          : std::optional<std::string>(fileHandle->suffix()),
+      outputType,
+      fileHandle->fullSchema(),
+      columnHandles,
+      connectorQueryCtx->memoryPool());
+}
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/FileConnector.h
+++ b/axiom/connectors/file/FileConnector.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom::connector::file {
+
+/// Read-only Velox connector for querying raw files.
+/// See README.md for architecture and usage details.
+class FileConnector : public velox::connector::Connector {
+ public:
+  explicit FileConnector(const std::string& id) : Connector(id) {}
+
+  /// Creates a DataSource by dispatching to the file-type-specific
+  /// handler identified by the table handle's schema name.
+  std::unique_ptr<velox::connector::DataSource> createDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::connector::ConnectorQueryCtx* connectorQueryCtx) override;
+
+  std::unique_ptr<velox::connector::DataSink> createDataSink(
+      velox::RowTypePtr,
+      velox::connector::ConnectorInsertTableHandlePtr,
+      velox::connector::ConnectorQueryCtx*,
+      velox::connector::CommitStrategy) override {
+    VELOX_UNSUPPORTED("FileConnector does not support writes");
+  }
+};
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/FileHandler.cpp
+++ b/axiom/connectors/file/FileHandler.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/file/FileHandler.h"
+
+#include <map>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector::file {
+
+namespace {
+
+std::map<std::string, FileHandler*>& handlerRegistry() {
+  static std::map<std::string, FileHandler*> registry;
+  return registry;
+}
+
+} // namespace
+
+void registerHandler(const std::string& schemaName, FileHandler& handler) {
+  auto [it, inserted] = handlerRegistry().emplace(schemaName, &handler);
+  VELOX_CHECK(
+      inserted, "FileHandler already registered for schema: {}", schemaName);
+}
+
+FileHandler& handler(const std::string& schemaName) {
+  auto& registry = handlerRegistry();
+  auto it = registry.find(schemaName);
+  VELOX_USER_CHECK(
+      it != registry.end(), "Unsupported file format: {}", schemaName);
+  return *it->second;
+}
+
+std::vector<std::string> schemas() {
+  auto& registry = handlerRegistry();
+  std::vector<std::string> names;
+  names.reserve(registry.size());
+  for (const auto& [name, handler] : registry) {
+    names.push_back(name);
+  }
+  return names;
+}
+
+bool hasHandler(const std::string& schemaName) {
+  return handlerRegistry().contains(schemaName);
+}
+
+void FileHandler::addMetadataTable(
+    std::string suffix,
+    velox::RowTypePtr schema,
+    MetadataSourceFactory factory) {
+  metadataTables_.emplace(
+      std::move(suffix), MetadataTable{std::move(schema), std::move(factory)});
+}
+
+const velox::RowTypePtr& FileHandler::metadataSchema(
+    const std::string& suffix) const {
+  auto it = metadataTables_.find(suffix);
+  VELOX_USER_CHECK(
+      it != metadataTables_.end(), "Unsupported metadata table: {}", suffix);
+  return it->second.schema;
+}
+
+std::unique_ptr<velox::connector::DataSource> FileHandler::create(
+    const std::string& /*filePath*/,
+    std::optional<std::string> suffix,
+    const velox::RowTypePtr& outputType,
+    const velox::RowTypePtr& fullSchema,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    velox::memory::MemoryPool* pool) const {
+  if (!suffix.has_value()) {
+    return createDataSource(outputType, fullSchema, columnHandles, pool);
+  }
+  auto it = metadataTables_.find(*suffix);
+  VELOX_USER_CHECK(
+      it != metadataTables_.end(), "Unsupported metadata table: {}", *suffix);
+  return it->second.factory(outputType, columnHandles, pool);
+}
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/FileHandler.h
+++ b/axiom/connectors/file/FileHandler.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom::connector::file {
+
+/// Factory function that creates a metadata DataSource.
+using MetadataSourceFactory =
+    std::function<std::unique_ptr<velox::connector::DataSource>(
+        const velox::RowTypePtr& outputType,
+        const velox::connector::ColumnHandleMap& columnHandles,
+        velox::memory::MemoryPool* pool)>;
+
+/// Abstracts format-specific file operations. Each file type provides
+/// a concrete implementation and registers itself under a schema name.
+///
+/// Subclasses implement resolve() and createDataSource() for
+/// format-specific logic, and register metadata tables with factory
+/// lambdas via addMetadataTable() in their constructor.
+class FileHandler {
+ public:
+  virtual ~FileHandler() = default;
+
+  /// Reads the data schema from the file header.
+  virtual velox::RowTypePtr resolve(
+      const std::string& filePath,
+      velox::memory::MemoryPool* pool) const = 0;
+
+  /// Returns the fixed schema for a metadata table by $-suffix.
+  const velox::RowTypePtr& metadataSchema(const std::string& suffix) const;
+
+  /// Creates a DataSource for reading from a file. Dispatches to
+  /// createDataSource() for row data or the registered factory for
+  /// metadata tables.
+  std::unique_ptr<velox::connector::DataSource> create(
+      const std::string& filePath,
+      std::optional<std::string> suffix,
+      const velox::RowTypePtr& outputType,
+      const velox::RowTypePtr& fullSchema,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool) const;
+
+ protected:
+  /// Registers a metadata table with its schema and factory.
+  void addMetadataTable(
+      std::string suffix,
+      velox::RowTypePtr schema,
+      MetadataSourceFactory factory);
+
+  /// Creates a streaming DataSource for reading row data.
+  virtual std::unique_ptr<velox::connector::DataSource> createDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::RowTypePtr& fullSchema,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool) const = 0;
+
+ private:
+  struct MetadataTable {
+    velox::RowTypePtr schema;
+    MetadataSourceFactory factory;
+  };
+  std::map<std::string, MetadataTable> metadataTables_;
+};
+
+/// Registers a handler under a schema name. Fails if already registered.
+/// All registration must happen during single-threaded startup (before
+/// query execution begins). Use std::call_once in the registration
+/// function to guarantee idempotency.
+void registerHandler(const std::string& schemaName, FileHandler& handler);
+
+/// Returns the handler for the given schema name. Fails if not found.
+FileHandler& handler(const std::string& schemaName);
+
+/// Returns the schema names of all registered handlers.
+std::vector<std::string> schemas();
+
+/// Returns true if a handler is registered for the given schema name.
+bool hasHandler(const std::string& schemaName);
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/README.md
+++ b/axiom/connectors/file/README.md
@@ -1,0 +1,186 @@
+# File Connector
+
+## Overview
+
+The file connector provides read-only access to individual files on disk. Point
+a query at a file path and no catalog, no metastore, no table registration is needed. It is a multi-utility feature for doing deterministic data analytics on top of the raw file directly.
+SQL is only one front-end; the connector is queryable through any Axiom
+front-end (e.g. the dataframe API).
+
+The connector is **file-type/format-agnostic by design**. The core layer handles
+table-name parsing, split management, and column handles without any knowledge
+of how bytes on disk are structured. All format-specific logic is isolated
+behind the **`FileHandler`** interface: each handler teaches the connector how
+to read one file type — how to extract the schema, how to stream row data, and
+what synthetic metadata tables to expose. (see
+[Adding a New File Handler](#adding-a-new-file-handler)).
+
+## Capabilities
+
+**Reads:**
+- Scan row data from a supported file via its absolute file path.
+- Auto-detect schema from the file header.
+- Column projection — only the requested columns are decoded.
+- Streaming reads — row data is returned one batch at a time, not buffered in
+  memory.
+- Synthetic metadata tables via `$`-suffix naming (see
+  [Appendix: Handler Reference](#appendix-handler-reference)).
+
+## Usage
+
+The file connector is registered under catalog `file`. The schema name selects
+the file-format handler (e.g. `parquet`). Table names are absolute file paths,
+quoted in SQL. See the [CLI README](../../cli/README.md) for how to launch
+`axiom_sql`.
+
+### Reading row data
+
+```sql
+-- Read all rows from a Parquet file.
+SELECT * FROM file."parquet"."/data/file.parquet" LIMIT 10;
+
+-- Project specific columns.
+SELECT id, name
+FROM file."parquet"."/data/file.parquet"
+WHERE name = 'alpha';
+```
+
+### Inspecting file metadata
+
+Append a `$`-suffix to the file path to query a synthetic metadata table. No
+data rows are read — the connector extracts metadata from the file header and
+internal structure.
+
+```sql
+-- Inspect per-column-chunk encodings, compression, and statistics.
+SELECT name, encodings, compression, min, max, null_count
+FROM file."parquet"."/data/file.parquet$column_chunks";
+```
+
+Which metadata tables are available depends on the file handler. See
+[Appendix: Handler Reference](#appendix-handler-reference) for the tables each
+handler exposes.
+
+## Table Name Format
+
+A table name is a file path with an optional metadata-table suffix:
+
+```
+<file-path>[$<suffix>]
+```
+
+- A plain path (no `$` suffix) maps to the **data table** — row data from the
+  file.
+- A path ending with a recognized `$`-suffix maps to the corresponding
+  **metadata table** (e.g. `$row_groups`, `$column_chunks`).
+- An unrecognized `$`-suffix produces an error from the handler.
+
+`FileTable::parseName()` splits on the last `$`, but treats it as a suffix
+separator only when the text after it contains no path separator.
+
+A `$` inside a directory name (e.g. `/data/$data2/file.example`) is therefore part of the path, not a suffix, and resolves to the data table.
+
+## Adding a New File Handler
+
+To add support for a new file format (e.g. ORC):
+
+1. Create a subdirectory `<name_file_type>/` with a header and implementation. Subclass
+   `FileHandler` and implement `resolve()` (read the file header and return the
+   schema) and `createDataSource()` (return a `DataSource` that streams row
+   data). Register metadata tables in the constructor via `addMetadataTable()`.
+
+2. Define data source classes in the handler's `.cpp` file. Use
+   `StreamingDataSource` as the base for row data and `MetadataDataSource` as
+   the base for metadata tables.
+
+3. Add an idempotent registration function (e.g. `registerFileTypeHandler()`) that
+   creates a static handler instance and calls
+   `registerHandler("filetype", handler)`.
+
+4. Create a separate CMake library target for the handler with its
+   format-specific dependencies.
+
+5. Write tests: add an end-to-end test in `tests/` that queries the format
+   through the runner, and unit tests in `core/tests/` if adding new core types.
+
+---
+
+## Appendix: Handler Reference
+
+### Parquet Handler
+
+`parquet/ParquetFileHandler.h` provides read support for Parquet files and
+exposes two synthetic metadata tables: `$row_groups` and `$column_chunks`.
+
+#### Parquet $row_groups
+
+Lists one row per row group with size and row-count statistics.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `row_group_id` | BIGINT | Zero-based row group index within the file. |
+| `num_rows` | BIGINT | Number of rows in the row group. |
+| `total_byte_size` | BIGINT | Total uncompressed byte size of all column data in the row group. |
+| `total_compressed_size` | BIGINT | Total compressed byte size of all column data in the row group. |
+
+```sql
+SELECT row_group_id, num_rows, total_byte_size, total_compressed_size
+FROM file."parquet"."/data/file.parquet$row_groups";
+```
+
+Example output:
+
+```
+ row_group_id | num_rows | total_byte_size | total_compressed_size
+--------------+----------+-----------------+-----------------------
+            0 |       25 |            2987 |                  1627
+```
+
+#### Parquet $column_chunks
+
+Lists one row per (row group, column chunk) with its page encodings,
+compression codec, byte sizes, value count, and column-chunk statistics.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `row_group_id` | BIGINT | Zero-based row group index. |
+| `column_id` | BIGINT | Zero-based column index within the row group. |
+| `name` | VARCHAR | Column name from the file schema. |
+| `compression` | VARCHAR | Compression codec (e.g. `none`, `zstd`, `snappy`, `gzip`). |
+| `encodings` | VARCHAR | Comma-separated Parquet page encodings (e.g. `RLE,PLAIN`, `RLE_DICTIONARY`). |
+| `compressed_size` | BIGINT | Total compressed byte size of the column chunk. |
+| `uncompressed_size` | BIGINT | Total uncompressed byte size of the column chunk. |
+| `num_values` | BIGINT | Number of values (including nulls) in the column chunk. |
+| `min` | VARCHAR | Minimum value from the column-chunk statistics, formatted as text. NULL when the file carries no statistics for the column. |
+| `max` | VARCHAR | Maximum value from the column-chunk statistics, formatted as text. NULL when the file carries no statistics for the column. |
+| `null_count` | BIGINT | Number of null values in the column chunk. NULL when the file carries no statistics. |
+
+Parquet column-chunk statistics can also carry a distinct-value count, but it is
+not exposed today: the Velox Parquet reader does not surface it and most writers
+leave it unset.
+
+```sql
+-- Inspect encodings and compression for every column chunk.
+SELECT row_group_id, name, encodings, compression
+FROM file."parquet"."/data/file.parquet$column_chunks";
+
+-- Find columns with high compression ratios.
+SELECT name, compression,
+       uncompressed_size / NULLIF(compressed_size, 0) AS ratio
+FROM file."parquet"."/data/file.parquet$column_chunks"
+WHERE compressed_size > 0
+ORDER BY ratio DESC;
+
+-- Inspect per-column value ranges.
+SELECT name, min, max, null_count
+FROM file."parquet"."/data/file.parquet$column_chunks";
+```
+
+Example output:
+
+```
+ row_group_id | column_id | name | compression | encodings          | compressed_size | uncompressed_size | num_values | min   | max  | null_count
+--------------+-----------+------+-------------+--------------------+-----------------+-------------------+------------+-------+------+-----------
+            0 |         0 | id   | zstd        | RLE,PLAIN          |             187 |               305 |         25 | 1     | 25   |          0
+            0 |         1 | name | zstd        | RLE,RLE_DICTIONARY |             279 |               360 |         25 | alpha | zeta |          0
+```

--- a/axiom/connectors/file/core/CMakeLists.txt
+++ b/axiom/connectors/file/core/CMakeLists.txt
@@ -12,28 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_library(axiom_file_connector_core FileConnectorMetadata.cpp FileTable.cpp)
 
 target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  velox_core
-  Folly::folly
+  axiom_file_connector_core
+  PUBLIC axiom_connectors velox_connector velox_memory velox_common_base Folly::folly
 )
-
-add_subdirectory(file)
-add_subdirectory(system)
-
-if(VELOX_ENABLE_HIVE_CONNECTOR)
-  add_subdirectory(hive)
-endif()
-
-if(VELOX_ENABLE_TPCH_CONNECTOR)
-  add_subdirectory(tpch)
-endif()
 
 if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/file/core/FileConnectorMetadata.h"
+
+#include "axiom/connectors/file/FileHandler.h"
+#include "axiom/connectors/file/core/FileTable.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector::file {
+
+folly::coro::Task<SplitBatch> FileSplitSource::co_getSplits(
+    uint32_t /*maxSplitCount*/) {
+  SplitBatch batch;
+  if (!done_) {
+    batch.splits.emplace_back(
+        std::make_shared<FileSplit>(connectorId_, filePath_));
+    done_ = true;
+  }
+  batch.noMoreSplits = true;
+  co_return batch;
+}
+
+TablePtr FileConnectorMetadata::findTable(const SchemaTableName& tableName) {
+  auto& fileHandler = handler(tableName.schema);
+  auto [filePath, suffix] = FileTable::parseName(tableName.table);
+
+  auto schema = suffix.empty() ? fileHandler.resolve(filePath, pool_.get())
+                               : fileHandler.metadataSchema(suffix);
+
+  return std::make_shared<FileTable>(
+      tableName, schema, connector_, filePath, suffix);
+}
+
+std::vector<std::string> FileConnectorMetadata::listSchemaNames(
+    const ConnectorSessionPtr& /*session*/) {
+  return schemas();
+}
+
+bool FileConnectorMetadata::schemaExists(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  return hasHandler(schemaName);
+}
+
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+FileConnectorMetadata::SplitManager::co_listPartitions(
+    const ConnectorSessionPtr& /*session*/,
+    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<PartitionHandle>()};
+}
+
+std::shared_ptr<SplitSource>
+FileConnectorMetadata::SplitManager::getSplitSource(
+    const ConnectorSessionPtr& /*session*/,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
+    QueryRuntimeStats& /*runtimeStats*/) {
+  auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
+  VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
+  return std::make_shared<FileSplitSource>(
+      tableHandle->connectorId(), fileHandle->filePath());
+}
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/FileConnectorMetadata.h
+++ b/axiom/connectors/file/core/FileConnectorMetadata.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/file/core/FileTable.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::axiom::connector::file {
+
+/// Emits exactly one FileSplit per file.
+class FileSplitSource : public SplitSource {
+ public:
+  FileSplitSource(const std::string& connectorId, std::string filePath)
+      : connectorId_(connectorId), filePath_(std::move(filePath)) {}
+
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
+
+ private:
+  const std::string connectorId_;
+  const std::string filePath_;
+  bool done_{false};
+};
+
+/// Resolves file paths as table names.
+class FileConnectorMetadata : public ConnectorMetadata {
+ public:
+  explicit FileConnectorMetadata(velox::connector::Connector* connector)
+      : connector_(connector),
+        pool_(velox::memory::memoryManager()->addLeafPool("file_metadata")) {}
+
+  /// Resolves a table from a schema name (format) and file path.
+  TablePtr findTable(const SchemaTableName& tableName) override;
+
+  /// Returns all registered file format names.
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& session) override;
+
+  /// Returns true if a handler exists for the given format name.
+  bool schemaExists(
+      const ConnectorSessionPtr& session,
+      const std::string& schemaName) override;
+
+  /// Returns an empty list; tables are file paths, not enumerable.
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return {};
+  }
+
+  ConnectorSplitManager* splitManager() override {
+    return &splitManager_;
+  }
+
+ private:
+  /// Manages split generation for file connector queries.
+  class SplitManager : public ConnectorSplitManager {
+   public:
+    folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
+        const ConnectorSessionPtr& session,
+        const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
+
+    std::shared_ptr<SplitSource> getSplitSource(
+        const ConnectorSessionPtr& session,
+        const velox::connector::ConnectorTableHandlePtr& tableHandle,
+        const std::vector<PartitionHandlePtr>& partitions,
+        const std::shared_ptr<PartitionType>& partitionType,
+        QueryRuntimeStats& runtimeStats) override;
+  };
+
+  velox::connector::Connector* connector_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  SplitManager splitManager_;
+};
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/FileDataSources.h
+++ b/axiom/connectors/file/core/FileDataSources.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/file/core/FileTable.h"
+
+namespace facebook::axiom::connector::file {
+
+/// Common base for all file connector data sources. Handles split
+/// management and DataSource boilerplate methods.
+class FileDataSource : public velox::connector::DataSource {
+ public:
+  FileDataSource(
+      const velox::RowTypePtr& outputType,
+      velox::memory::MemoryPool* pool)
+      : outputType_(outputType), pool_(pool) {}
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override {
+    split_ = std::dynamic_pointer_cast<FileSplit>(split);
+    VELOX_CHECK(split_, "Expected FileSplit");
+  }
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {}
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ protected:
+  // Verifies that every output column has a matching entry in 'columnHandles'.
+  // Shared by the row-data and metadata data sources so the check lives in one
+  // place.
+  static void validateOutputColumns(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles) {
+    for (const auto& name : outputType->names()) {
+      VELOX_CHECK(
+          columnHandles.contains(name),
+          "No handle for output column: {}",
+          name);
+    }
+  }
+
+  const velox::RowTypePtr outputType_;
+  velox::memory::MemoryPool* pool_;
+  std::shared_ptr<FileSplit> split_;
+  uint64_t completedRows_{0};
+};
+
+/// Base for streaming data sources that read row data one batch at a
+/// time. Subclasses implement onSplit() to initialize the reader and
+/// readBatch() to return the next batch.
+class StreamingDataSource : public FileDataSource {
+ public:
+  using FileDataSource::FileDataSource;
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override {
+    FileDataSource::addSplit(std::move(split));
+    onSplit(split_->filePath);
+  }
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& /*future*/) override {
+    auto result = readBatch(size);
+    if (result.has_value() && *result) {
+      completedRows_ += (*result)->size();
+    }
+    return result;
+  }
+
+ protected:
+  virtual void onSplit(const std::string& filePath) = 0;
+  virtual std::optional<velox::RowVectorPtr> readBatch(uint64_t size) = 0;
+};
+
+/// Base for metadata data sources that produce a single batch. Handles
+/// column projection from the full metadata schema to the requested
+/// output columns. Subclasses implement build() to produce a full
+/// RowVector with all columns.
+class MetadataDataSource : public FileDataSource {
+ public:
+  MetadataDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::RowTypePtr& fullSchema,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool)
+      : FileDataSource(outputType, pool), fullSchema_(fullSchema) {
+    validateOutputColumns(outputType_, columnHandles);
+    for (const auto& name : outputType_->names()) {
+      auto handle = columnHandles.find(name)->second;
+      auto index = fullSchema->getChildIdxIfExists(handle->name());
+      VELOX_CHECK(index.has_value(), "Column not found: {}", handle->name());
+    }
+  }
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t /*size*/,
+      velox::ContinueFuture& /*future*/) override {
+    VELOX_CHECK(split_, "No split added");
+    if (!needData_) {
+      return nullptr;
+    }
+    needData_ = false;
+    auto full = build();
+    if (!full || full->size() == 0) {
+      return velox::RowVector::createEmpty(outputType_, pool_);
+    }
+    auto result = project(full);
+    completedRows_ += result->size();
+    return result;
+  }
+
+ protected:
+  virtual velox::RowVectorPtr build() = 0;
+
+ private:
+  velox::RowVectorPtr project(const velox::RowVectorPtr& full) {
+    if (outputType_->equivalent(*fullSchema_)) {
+      return full;
+    }
+    std::vector<velox::VectorPtr> children;
+    children.reserve(outputType_->size());
+    for (const auto& name : outputType_->names()) {
+      auto index = fullSchema_->getChildIdx(name);
+      children.push_back(full->childAt(index));
+    }
+    return std::make_shared<velox::RowVector>(
+        pool_, outputType_, nullptr, full->size(), std::move(children));
+  }
+
+  const velox::RowTypePtr fullSchema_;
+  bool needData_{true};
+};
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/FileTable.cpp
+++ b/axiom/connectors/file/core/FileTable.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/file/core/FileTable.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector::file {
+
+using namespace facebook::velox;
+
+std::pair<std::string, std::string> FileTable::parseName(
+    const std::string& tableName) {
+  auto pos = tableName.rfind('$');
+  if (pos != std::string::npos && pos > 0) {
+    auto suffix = tableName.substr(pos + 1);
+    if (suffix.find('/') == std::string::npos) {
+      return {tableName.substr(0, pos), std::move(suffix)};
+    }
+  }
+  return {tableName, ""};
+}
+
+FileTableLayout::FileTableLayout(
+    Table* table,
+    velox::connector::Connector* connector,
+    std::vector<const Column*> columns,
+    std::string filePath,
+    std::string suffix)
+    : TableLayout(
+          table->name().schema,
+          table,
+          connector,
+          std::move(columns),
+          /*partitionColumns=*/{},
+          /*orderColumns=*/{},
+          /*sortOrder=*/{},
+          /*lookupKeys=*/{},
+          /*supportsScan=*/true),
+      filePath_(std::move(filePath)),
+      suffix_(std::move(suffix)) {}
+
+velox::connector::ColumnHandlePtr FileTableLayout::createColumnHandle(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& columnName,
+    std::vector<velox::common::Subfield> /*subfields*/,
+    std::optional<TypePtr> /*castToType*/,
+    SubfieldMapping /*subfieldMapping*/) const {
+  auto column = findColumn(columnName);
+  VELOX_CHECK_NOT_NULL(column, "Column not found: {}", columnName);
+  return std::make_shared<FileColumnHandle>(columnName);
+}
+
+velox::connector::ConnectorTableHandlePtr FileTableLayout::createTableHandle(
+    const ConnectorSessionPtr& /*session*/,
+    std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+    core::ExpressionEvaluator& /*evaluator*/,
+    std::vector<core::TypedExprPtr> filters,
+    std::vector<core::TypedExprPtr>& rejectedFilters,
+    RowTypePtr /*dataColumns*/,
+    std::optional<LookupKeys> /*lookupKeys*/) const {
+  rejectedFilters = std::move(filters);
+  return std::make_shared<FileTableHandle>(
+      connectorId(),
+      table().name(),
+      filePath_,
+      suffix_,
+      table().type(),
+      std::move(columnHandles));
+}
+
+FileTable::FileTable(
+    const SchemaTableName& tableName,
+    const RowTypePtr& schema,
+    velox::connector::Connector* connector,
+    std::string filePath,
+    std::string suffix)
+    : Table(tableName, makeColumns(schema)) {
+  layout_ = std::make_unique<FileTableLayout>(
+      this, connector, allColumns(), std::move(filePath), std::move(suffix));
+  layouts_.push_back(layout_.get());
+}
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/FileTable.h
+++ b/axiom/connectors/file/core/FileTable.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom::connector::file {
+
+/// Carries the file path for a single file read.
+struct FileSplit : public velox::connector::ConnectorSplit {
+  FileSplit(const std::string& connectorId, std::string filePath)
+      : ConnectorSplit(connectorId), filePath(std::move(filePath)) {}
+
+  const std::string filePath;
+};
+
+/// Column handle that wraps a single column name for projection.
+class FileColumnHandle : public velox::connector::ColumnHandle {
+ public:
+  explicit FileColumnHandle(const std::string& name) : name_(name) {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+ private:
+  const std::string name_;
+};
+
+/// Carries the resolved file path, metadata suffix, full schema, and
+/// column handles for a file connector query.
+class FileTableHandle : public velox::connector::ConnectorTableHandle {
+ public:
+  FileTableHandle(
+      const std::string& connectorId,
+      SchemaTableName schemaTableName,
+      std::string filePath,
+      std::string suffix,
+      velox::RowTypePtr fullSchema,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles)
+      : ConnectorTableHandle(connectorId),
+        schemaTableName_(std::move(schemaTableName)),
+        filePath_(std::move(filePath)),
+        suffix_(std::move(suffix)),
+        fullSchema_(std::move(fullSchema)),
+        qualifiedName_(
+            fmt::format(
+                "{}.{}",
+                schemaTableName_.schema,
+                schemaTableName_.table)),
+        columnHandles_(std::move(columnHandles)) {}
+
+  const std::string& name() const override {
+    return qualifiedName_;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  const SchemaTableName& schemaTableName() const {
+    return schemaTableName_;
+  }
+
+  const std::string& filePath() const {
+    return filePath_;
+  }
+
+  /// Metadata table suffix (e.g. "encodings"). Empty for data tables.
+  const std::string& suffix() const {
+    return suffix_;
+  }
+
+  /// Full table schema resolved during planning.
+  const velox::RowTypePtr& fullSchema() const {
+    return fullSchema_;
+  }
+
+  const std::vector<velox::connector::ColumnHandlePtr>& columnHandles() const {
+    return columnHandles_;
+  }
+
+ private:
+  const SchemaTableName schemaTableName_;
+  const std::string filePath_;
+  const std::string suffix_;
+  const velox::RowTypePtr fullSchema_;
+  const std::string qualifiedName_;
+  const std::vector<velox::connector::ColumnHandlePtr> columnHandles_;
+};
+
+/// Defines the physical layout for a file connector table.
+class FileTableLayout : public TableLayout {
+ public:
+  FileTableLayout(
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::string filePath,
+      std::string suffix);
+
+  bool supportsSampling() const override {
+    return false;
+  }
+
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields,
+      std::optional<velox::TypePtr> castToType,
+      SubfieldMapping subfieldMapping) const override;
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
+
+ private:
+  std::string filePath_;
+  std::string suffix_;
+};
+
+/// Represents a table backed by a file on disk.
+class FileTable : public Table {
+ public:
+  FileTable(
+      const SchemaTableName& tableName,
+      const velox::RowTypePtr& schema,
+      velox::connector::Connector* connector,
+      std::string filePath,
+      std::string suffix);
+
+  /// Splits a table name into a file path and a metadata suffix. A '$' is
+  /// treated as the suffix separator only when it is not at the start of the
+  /// name and the part after it contains no path separator, so a '$' inside a
+  /// directory name (e.g. "/data/$backup/file.parquet") stays part of the path
+  /// and yields an empty suffix. A plain path returns an empty suffix (data
+  /// table); "/path/file.parquet$column_chunks" returns suffix "column_chunks".
+  static std::pair<std::string, std::string> parseName(
+      const std::string& tableName);
+
+  const std::vector<const TableLayout*>& layouts() const override {
+    return layouts_;
+  }
+
+  uint64_t numRows() const override {
+    return 0;
+  }
+
+ private:
+  std::vector<const TableLayout*> layouts_;
+  std::unique_ptr<FileTableLayout> layout_;
+};
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/tests/CMakeLists.txt
+++ b/axiom/connectors/file/core/tests/CMakeLists.txt
@@ -12,29 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
-
-target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  velox_core
-  Folly::folly
+add_executable(
+  axiom_file_connector_core_test
+  FileConnectorMetadataTest.cpp
+  FileHandlerTest.cpp
+  FileTableTest.cpp
 )
 
-add_subdirectory(file)
-add_subdirectory(system)
+add_test(axiom_file_connector_core_test axiom_file_connector_core_test)
 
-if(VELOX_ENABLE_HIVE_CONNECTOR)
-  add_subdirectory(hive)
-endif()
-
-if(VELOX_ENABLE_TPCH_CONNECTOR)
-  add_subdirectory(tpch)
-endif()
-
-if(AXIOM_BUILD_TESTING)
-  add_subdirectory(tests)
-endif()
+target_link_libraries(
+  axiom_file_connector_core_test
+  axiom_file_connector
+  axiom_file_connector_core
+  axiom_file_handler_parquet
+  velox_dwio_parquet_writer
+  velox_vector_test_lib
+  velox_exec_test_lib
+  GTest::gtest
+  GTest::gtest_main
+)

--- a/axiom/connectors/file/core/tests/FileConnectorMetadataTest.cpp
+++ b/axiom/connectors/file/core/tests/FileConnectorMetadataTest.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/file/FileConnector.h"
+#include "axiom/connectors/file/core/FileConnectorMetadata.h"
+#include "axiom/connectors/file/parquet/ParquetFileHandler.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/ConnectorRegistry.h"
+
+namespace facebook::axiom::connector::file {
+namespace {
+
+using namespace facebook::velox;
+
+constexpr const char* kConnectorId = "file";
+
+class FileConnectorMetadataApiTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    registerParquetHandler();
+  }
+
+  void SetUp() override {
+    connector_ = std::make_shared<FileConnector>(kConnectorId);
+    velox::connector::ConnectorRegistry::global().insert(
+        kConnectorId, connector_);
+  }
+
+  void TearDown() override {
+    velox::connector::ConnectorRegistry::global().erase(kConnectorId);
+  }
+
+  std::shared_ptr<FileConnector> connector_;
+};
+
+TEST_F(FileConnectorMetadataApiTest, listSchemaNames) {
+  FileConnectorMetadata metadata(connector_.get());
+  auto names = metadata.listSchemaNames(nullptr);
+  EXPECT_FALSE(names.empty());
+  EXPECT_TRUE(std::find(names.begin(), names.end(), "parquet") != names.end());
+}
+
+TEST_F(FileConnectorMetadataApiTest, schemaExistsForRegistered) {
+  FileConnectorMetadata metadata(connector_.get());
+  EXPECT_TRUE(metadata.schemaExists(nullptr, "parquet"));
+}
+
+TEST_F(FileConnectorMetadataApiTest, schemaDoesNotExistForUnknown) {
+  FileConnectorMetadata metadata(connector_.get());
+  EXPECT_FALSE(metadata.schemaExists(nullptr, "orc"));
+}
+
+TEST_F(FileConnectorMetadataApiTest, listTableNamesReturnsEmpty) {
+  FileConnectorMetadata metadata(connector_.get());
+  EXPECT_TRUE(metadata.listTableNames(nullptr, "parquet").empty());
+}
+
+TEST_F(FileConnectorMetadataApiTest, splitManagerNotNull) {
+  FileConnectorMetadata metadata(connector_.get());
+  EXPECT_NE(metadata.splitManager(), nullptr);
+}
+
+TEST_F(FileConnectorMetadataApiTest, createDataSinkThrows) {
+  VELOX_ASSERT_THROW(
+      connector_->createDataSink(nullptr, nullptr, nullptr, {}),
+      "FileConnector does not support writes");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/tests/FileHandlerTest.cpp
+++ b/axiom/connectors/file/core/tests/FileHandlerTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/file/FileHandler.h"
+#include "axiom/connectors/file/parquet/ParquetFileHandler.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::connector::file {
+namespace {
+
+using namespace facebook::velox;
+
+class FileHandlerRegistryTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    registerParquetHandler();
+  }
+};
+
+TEST_F(FileHandlerRegistryTest, unknownHandlerFails) {
+  VELOX_ASSERT_THROW(handler("orc"), "Unsupported file format: orc");
+}
+
+TEST_F(FileHandlerRegistryTest, schemasReturnsRegisteredNames) {
+  auto names = schemas();
+  EXPECT_FALSE(names.empty());
+  EXPECT_TRUE(std::find(names.begin(), names.end(), "parquet") != names.end());
+}
+
+TEST_F(FileHandlerRegistryTest, hasHandlerForRegistered) {
+  EXPECT_TRUE(hasHandler("parquet"));
+}
+
+TEST_F(FileHandlerRegistryTest, hasHandlerFalseForUnknown) {
+  EXPECT_FALSE(hasHandler("orc"));
+  EXPECT_FALSE(hasHandler("default"));
+}
+
+TEST_F(FileHandlerRegistryTest, duplicateRegistrationFails) {
+  auto& existing = handler("parquet");
+  VELOX_ASSERT_THROW(
+      registerHandler("parquet", existing),
+      "FileHandler already registered for schema: parquet");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/tests/FileTableTest.cpp
+++ b/axiom/connectors/file/core/tests/FileTableTest.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/file/FileConnector.h"
+#include "axiom/connectors/file/core/FileConnectorMetadata.h"
+#include "axiom/connectors/file/parquet/ParquetFileHandler.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::axiom::connector::file {
+namespace {
+
+using namespace facebook::velox;
+
+constexpr const char* kConnectorId = "file";
+
+class FileTableTest : public ::testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    velox::filesystems::registerLocalFileSystem();
+    dwio::common::LocalFileSink::registerFactory();
+    registerParquetHandler();
+  }
+
+  void SetUp() override {
+    connector_ = std::make_shared<FileConnector>(kConnectorId);
+    velox::connector::ConnectorRegistry::global().insert(
+        kConnectorId, connector_);
+
+    tempFile_ = exec::test::TempFilePath::create();
+    parquetPath_ = tempFile_->getPath() + ".parquet";
+
+    auto ids = makeFlatVector<int64_t>({1, 2, 3});
+    auto names = makeFlatVector<StringView>({"a", "b", "c"});
+    auto rowVector = makeRowVector({"id", "name"}, {ids, names});
+    auto schema = asRowType(rowVector->type());
+
+    parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    auto sink = dwio::common::FileSink::create(
+        fmt::format("file:{}", parquetPath_), {.pool = rootPool_.get()});
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), writerOptions, rootPool_, schema);
+    writer->write(rowVector);
+    writer->close();
+  }
+
+  void TearDown() override {
+    velox::connector::ConnectorRegistry::global().erase(kConnectorId);
+    std::remove(parquetPath_.c_str());
+  }
+
+  std::shared_ptr<FileConnector> connector_;
+  std::shared_ptr<exec::test::TempFilePath> tempFile_;
+  std::string parquetPath_;
+};
+
+TEST_F(FileTableTest, numRowsReturnsZero) {
+  FileConnectorMetadata metadata(connector_.get());
+  auto table = metadata.findTable({"parquet", parquetPath_});
+  EXPECT_EQ(table->numRows(), 0);
+}
+
+TEST_F(FileTableTest, hasOneLayout) {
+  FileConnectorMetadata metadata(connector_.get());
+  auto table = metadata.findTable({"parquet", parquetPath_});
+  EXPECT_EQ(table->layouts().size(), 1);
+}
+
+TEST_F(FileTableTest, columnMapMatchesSchema) {
+  FileConnectorMetadata metadata(connector_.get());
+  auto table = metadata.findTable({"parquet", parquetPath_});
+
+  const auto& columns = table->columnMap();
+  EXPECT_EQ(columns.size(), 2);
+  EXPECT_TRUE(columns.contains("id"));
+  EXPECT_TRUE(columns.contains("name"));
+}
+
+TEST_F(FileTableTest, metadataTableColumnMap) {
+  FileConnectorMetadata metadata(connector_.get());
+  auto table = metadata.findTable({"parquet", parquetPath_ + "$column_chunks"});
+
+  const auto& columns = table->columnMap();
+  EXPECT_TRUE(columns.contains("row_group_id"));
+  EXPECT_TRUE(columns.contains("column_id"));
+  EXPECT_TRUE(columns.contains("name"));
+  EXPECT_TRUE(columns.contains("compression"));
+  EXPECT_TRUE(columns.contains("encodings"));
+  EXPECT_TRUE(columns.contains("compressed_size"));
+  EXPECT_TRUE(columns.contains("uncompressed_size"));
+  EXPECT_TRUE(columns.contains("num_values"));
+  EXPECT_TRUE(columns.contains("min"));
+  EXPECT_TRUE(columns.contains("max"));
+  EXPECT_TRUE(columns.contains("null_count"));
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/parquet/CMakeLists.txt
+++ b/axiom/connectors/file/parquet/CMakeLists.txt
@@ -12,29 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_library(axiom_file_handler_parquet ParquetFileHandler.cpp)
 
 target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  velox_core
-  Folly::folly
+  axiom_file_handler_parquet
+  PUBLIC
+    axiom_file_connector_core
+    velox_connector
+    velox_dwio_parquet_reader
+    velox_dwio_common
+    velox_file
 )
-
-add_subdirectory(file)
-add_subdirectory(system)
-
-if(VELOX_ENABLE_HIVE_CONNECTOR)
-  add_subdirectory(hive)
-endif()
-
-if(VELOX_ENABLE_TPCH_CONNECTOR)
-  add_subdirectory(tpch)
-endif()
-
-if(AXIOM_BUILD_TESTING)
-  add_subdirectory(tests)
-endif()

--- a/axiom/connectors/file/parquet/ParquetFileHandler.cpp
+++ b/axiom/connectors/file/parquet/ParquetFileHandler.cpp
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/file/parquet/ParquetFileHandler.h"
+
+#include <folly/synchronization/CallOnce.h>
+
+#include "axiom/connectors/file/core/FileDataSources.h"
+#include "velox/common/compression/Compression.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/parquet/reader/Metadata.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::axiom::connector::file {
+
+using namespace facebook::velox;
+
+namespace {
+
+constexpr const char* kColumnChunks = "column_chunks";
+constexpr const char* kRowGroups = "row_groups";
+
+const RowTypePtr& rowGroupsSchema() {
+  static auto kSchema = ROW({
+      {"row_group_id", BIGINT()},
+      {"num_rows", BIGINT()},
+      {"total_byte_size", BIGINT()},
+      {"total_compressed_size", BIGINT()},
+  });
+  return kSchema;
+}
+
+const RowTypePtr& columnChunksSchema() {
+  static auto kSchema = ROW({
+      {"row_group_id", BIGINT()},
+      {"column_id", BIGINT()},
+      {"name", VARCHAR()},
+      {"compression", VARCHAR()},
+      {"encodings", VARCHAR()},
+      {"compressed_size", BIGINT()},
+      {"uncompressed_size", BIGINT()},
+      {"num_values", BIGINT()},
+      {"min", VARCHAR()},
+      {"max", VARCHAR()},
+      {"null_count", BIGINT()},
+  });
+  return kSchema;
+}
+
+std::unique_ptr<parquet::ParquetReader> openFile(
+    const std::string& filePath,
+    memory::MemoryPool* pool) {
+  dwio::common::ReaderOptions readerOptions(pool);
+  auto fileSystem = filesystems::getFileSystem(filePath, /*config=*/nullptr);
+  auto readFile = fileSystem->openFileForRead(filePath);
+  auto input =
+      std::make_unique<dwio::common::BufferedInput>(std::move(readFile), *pool);
+  return std::make_unique<parquet::ParquetReader>(
+      std::move(input), readerOptions);
+}
+
+class ParquetDataSource : public StreamingDataSource {
+ public:
+  ParquetDataSource(
+      const RowTypePtr& outputType,
+      const RowTypePtr& /*fullSchema*/,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      memory::MemoryPool* pool)
+      : StreamingDataSource(outputType, pool) {
+    validateOutputColumns(outputType_, columnHandles);
+    projectedColumns_ = outputType_->names();
+  }
+
+ protected:
+  void onSplit(const std::string& filePath) override {
+    reader_ = openFile(filePath, pool_);
+    dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.select(
+        std::make_shared<dwio::common::ColumnSelector>(
+            reader_->rowType(), projectedColumns_));
+    auto scanSpec = std::make_shared<velox::common::ScanSpec>("");
+    scanSpec->addAllChildFields(*outputType_);
+    rowReaderOptions.setScanSpec(std::move(scanSpec));
+    rowReader_ = reader_->createRowReader(rowReaderOptions);
+    output_ = BaseVector::create(outputType_, 1, pool_);
+  }
+
+  std::optional<RowVectorPtr> readBatch(uint64_t size) override {
+    if (!rowReader_) {
+      return nullptr;
+    }
+    auto rowsRead = rowReader_->next(size, output_);
+    if (rowsRead == 0) {
+      return nullptr;
+    }
+    auto rowVector = std::dynamic_pointer_cast<RowVector>(output_);
+    for (auto i = 0; i < rowVector->childrenSize(); ++i) {
+      BaseVector::flattenVector(rowVector->childAt(i));
+    }
+    return rowVector;
+  }
+
+ private:
+  std::vector<std::string> projectedColumns_;
+  std::unique_ptr<parquet::ParquetReader> reader_;
+  std::unique_ptr<dwio::common::RowReader> rowReader_;
+  VectorPtr output_;
+};
+
+class RowGroupsDataSource : public MetadataDataSource {
+ public:
+  RowGroupsDataSource(
+      const RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      memory::MemoryPool* pool)
+      : MetadataDataSource(outputType, rowGroupsSchema(), columnHandles, pool) {
+  }
+
+ protected:
+  RowVectorPtr build() override {
+    auto reader = openFile(split_->filePath, pool_);
+    auto fileMetadata = reader->fileMetaData();
+    auto numRowGroups = static_cast<vector_size_t>(fileMetadata.numRowGroups());
+
+    auto rowGroupIds =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRowGroups, pool_);
+    auto numRows =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRowGroups, pool_);
+    auto totalByteSize =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRowGroups, pool_);
+    auto totalCompressedSize =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRowGroups, pool_);
+
+    for (vector_size_t i = 0; i < numRowGroups; ++i) {
+      auto rowGroup = fileMetadata.rowGroup(i);
+      rowGroupIds->set(i, static_cast<int64_t>(i));
+      numRows->set(i, rowGroup.numRows());
+      totalByteSize->set(i, rowGroup.totalByteSize());
+      totalCompressedSize->set(i, rowGroup.totalCompressedSize());
+    }
+
+    return std::make_shared<RowVector>(
+        pool_,
+        rowGroupsSchema(),
+        nullptr,
+        numRowGroups,
+        std::vector<VectorPtr>{
+            rowGroupIds, numRows, totalByteSize, totalCompressedSize});
+  }
+};
+
+// Joins a column chunk's page encodings into a comma-separated string of
+// Parquet encoding names (e.g. "RLE,PLAIN").
+std::string encodingsToString(
+    const std::vector<parquet::thrift::Encoding>& encodings) {
+  std::string result;
+  for (auto encoding : encodings) {
+    std::string_view name;
+    if (!result.empty()) {
+      result += ',';
+    }
+    if (apache::thrift::TEnumTraits<parquet::thrift::Encoding>::findName(
+            encoding, &name)) {
+      result.append(name);
+    } else {
+      result += std::to_string(static_cast<int32_t>(encoding));
+    }
+  }
+  return result;
+}
+
+// Column-chunk statistics formatted for display. Empty optionals mean the
+// chunk carries no statistics for that field.
+struct ColumnChunkStats {
+  std::optional<std::string> min;
+  std::optional<std::string> max;
+  std::optional<int64_t> nullCount;
+};
+
+// Reads min/max/null_count from a column chunk's Parquet statistics, formatting
+// numeric min/max as decimal strings. Returns empty optionals when the chunk
+// has no statistics or 'type' has no comparable min/max representation.
+ColumnChunkStats readColumnChunkStats(
+    parquet::ColumnChunkMetaDataPtr& chunk,
+    const TypePtr& type,
+    int64_t numRows) {
+  ColumnChunkStats stats;
+  if (!chunk.hasStatistics()) {
+    return stats;
+  }
+  stats.nullCount = chunk.getColumnMetadataStatsNullCount();
+  if (type == nullptr) {
+    return stats;
+  }
+
+  auto columnStats = chunk.getColumnStatistics(type, numRows);
+  if (auto* intStats = dynamic_cast<dwio::common::IntegerColumnStatistics*>(
+          columnStats.get())) {
+    if (intStats->getMinimum().has_value()) {
+      stats.min = std::to_string(intStats->getMinimum().value());
+    }
+    if (intStats->getMaximum().has_value()) {
+      stats.max = std::to_string(intStats->getMaximum().value());
+    }
+  } else if (
+      auto* doubleStats = dynamic_cast<dwio::common::DoubleColumnStatistics*>(
+          columnStats.get())) {
+    if (doubleStats->getMinimum().has_value()) {
+      stats.min = std::to_string(doubleStats->getMinimum().value());
+    }
+    if (doubleStats->getMaximum().has_value()) {
+      stats.max = std::to_string(doubleStats->getMaximum().value());
+    }
+  } else if (
+      auto* stringStats = dynamic_cast<dwio::common::StringColumnStatistics*>(
+          columnStats.get())) {
+    stats.min = stringStats->getMinimum();
+    stats.max = stringStats->getMaximum();
+  }
+  return stats;
+}
+
+class ColumnChunksDataSource : public MetadataDataSource {
+ public:
+  ColumnChunksDataSource(
+      const RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      memory::MemoryPool* pool)
+      : MetadataDataSource(
+            outputType,
+            columnChunksSchema(),
+            columnHandles,
+            pool) {}
+
+ protected:
+  RowVectorPtr build() override {
+    auto reader = openFile(split_->filePath, pool_);
+    auto fileMetadata = reader->fileMetaData();
+    const auto& schema = reader->rowType();
+
+    vector_size_t totalRows = 0;
+    for (int rg = 0; rg < fileMetadata.numRowGroups(); ++rg) {
+      totalRows += fileMetadata.rowGroup(rg).numColumns();
+    }
+
+    auto rowGroupIds =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+    auto columnIds =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+    auto names =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
+    auto compressions =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
+    auto encodings =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
+    auto compressedSizes =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+    auto uncompressedSizes =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+    auto numValues =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+    auto mins =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
+    auto maxes =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
+    auto nullCounts =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
+
+    vector_size_t row = 0;
+    for (int rg = 0; rg < fileMetadata.numRowGroups(); ++rg) {
+      auto rowGroup = fileMetadata.rowGroup(rg);
+      for (int col = 0; col < rowGroup.numColumns(); ++col) {
+        auto chunk = rowGroup.columnChunk(col);
+        auto columnName = col < static_cast<int>(schema->size())
+            ? std::string(schema->nameOf(col))
+            : fmt::format("column_{}", col);
+        auto compression = common::compressionKindToString(chunk.compression());
+        auto encoding = encodingsToString(chunk.encodings());
+
+        auto columnType = col < static_cast<int>(schema->size())
+            ? schema->childAt(col)
+            : nullptr;
+        auto stats =
+            readColumnChunkStats(chunk, columnType, rowGroup.numRows());
+
+        rowGroupIds->set(row, static_cast<int64_t>(rg));
+        columnIds->set(row, static_cast<int64_t>(col));
+        names->set(row, StringView(columnName));
+        compressions->set(row, StringView(compression));
+        encodings->set(row, StringView(encoding));
+        compressedSizes->set(row, chunk.totalCompressedSize());
+        uncompressedSizes->set(row, chunk.totalUncompressedSize());
+        numValues->set(row, chunk.numValues());
+        setOptionalString(*mins, row, stats.min);
+        setOptionalString(*maxes, row, stats.max);
+        setOptionalInt(*nullCounts, row, stats.nullCount);
+        ++row;
+      }
+    }
+
+    return std::make_shared<RowVector>(
+        pool_,
+        columnChunksSchema(),
+        nullptr,
+        row,
+        std::vector<VectorPtr>{
+            rowGroupIds,
+            columnIds,
+            names,
+            compressions,
+            encodings,
+            compressedSizes,
+            uncompressedSizes,
+            numValues,
+            mins,
+            maxes,
+            nullCounts});
+  }
+
+ private:
+  static void setOptionalString(
+      FlatVector<StringView>& vector,
+      vector_size_t row,
+      const std::optional<std::string>& value) {
+    if (value.has_value()) {
+      vector.set(row, StringView(value.value()));
+    } else {
+      vector.setNull(row, true);
+    }
+  }
+
+  static void setOptionalInt(
+      FlatVector<int64_t>& vector,
+      vector_size_t row,
+      std::optional<int64_t> value) {
+    if (value.has_value()) {
+      vector.set(row, value.value());
+    } else {
+      vector.setNull(row, true);
+    }
+  }
+};
+
+} // namespace
+
+ParquetFileHandler::ParquetFileHandler() {
+  addMetadataTable(
+      kRowGroups,
+      rowGroupsSchema(),
+      [](const auto& outputType, const auto& columnHandles, auto* pool) {
+        return std::make_unique<RowGroupsDataSource>(
+            outputType, columnHandles, pool);
+      });
+  addMetadataTable(
+      kColumnChunks,
+      columnChunksSchema(),
+      [](const auto& outputType, const auto& columnHandles, auto* pool) {
+        return std::make_unique<ColumnChunksDataSource>(
+            outputType, columnHandles, pool);
+      });
+}
+
+void registerParquetHandler() {
+  static folly::once_flag once;
+  folly::call_once(once, [] {
+    static ParquetFileHandler handler;
+    registerHandler("parquet", handler);
+  });
+}
+
+velox::RowTypePtr ParquetFileHandler::resolve(
+    const std::string& filePath,
+    velox::memory::MemoryPool* pool) const {
+  velox::dwio::common::ReaderOptions readerOptions(pool);
+  auto fileSystem =
+      velox::filesystems::getFileSystem(filePath, /*config=*/nullptr);
+  auto readFile = fileSystem->openFileForRead(filePath);
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::move(readFile), *pool);
+  auto reader = std::make_unique<velox::parquet::ParquetReader>(
+      std::move(input), readerOptions);
+  return reader->rowType();
+}
+
+std::unique_ptr<velox::connector::DataSource>
+ParquetFileHandler::createDataSource(
+    const velox::RowTypePtr& outputType,
+    const velox::RowTypePtr& fullSchema,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    velox::memory::MemoryPool* pool) const {
+  return std::make_unique<ParquetDataSource>(
+      outputType, fullSchema, columnHandles, pool);
+}
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/parquet/ParquetFileHandler.h
+++ b/axiom/connectors/file/parquet/ParquetFileHandler.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/file/FileHandler.h"
+
+namespace facebook::axiom::connector::file {
+
+/// FileHandler implementation for Parquet files. Reads schemas via
+/// ParquetReader and exposes $row_groups and $column_chunks metadata tables.
+class ParquetFileHandler : public FileHandler {
+ public:
+  ParquetFileHandler();
+
+  velox::RowTypePtr resolve(
+      const std::string& filePath,
+      velox::memory::MemoryPool* pool) const override;
+
+ protected:
+  std::unique_ptr<velox::connector::DataSource> createDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::RowTypePtr& fullSchema,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool) const override;
+};
+
+/// Registers the Parquet handler under the "parquet" schema name.
+/// Safe to call multiple times; only the first call has an effect.
+void registerParquetHandler();
+
+} // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/tests/CMakeLists.txt
+++ b/axiom/connectors/file/tests/CMakeLists.txt
@@ -12,29 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_executable(axiom_file_connector_test FileConnectorTest.cpp)
+
+add_test(NAME axiom_file_connector_test COMMAND axiom_file_connector_test)
 
 target_link_libraries(
-  axiom_connectors
-  axiom_common
-  velox_common_base
-  velox_memory
-  velox_connector
-  velox_core
-  Folly::folly
+  axiom_file_connector_test
+  axiom_cli
+  velox_dwio_parquet_writer
+  velox_vector_test_lib
+  velox_exec_test_lib
+  GTest::gtest
+  GTest::gmock
 )
-
-add_subdirectory(file)
-add_subdirectory(system)
-
-if(VELOX_ENABLE_HIVE_CONNECTOR)
-  add_subdirectory(hive)
-endif()
-
-if(VELOX_ENABLE_TPCH_CONNECTOR)
-  add_subdirectory(tpch)
-endif()
-
-if(AXIOM_BUILD_TESTING)
-  add_subdirectory(tests)
-endif()

--- a/axiom/connectors/file/tests/FileConnectorTest.cpp
+++ b/axiom/connectors/file/tests/FileConnectorTest.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/cli/Connectors.h"
+#include "axiom/cli/SqlQueryRunner.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::axiom::connector::file {
+namespace {
+
+using namespace facebook::velox;
+
+constexpr const char* kConnectorId = "file";
+
+// Drives the file connector through the full SQL stack
+class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    velox::filesystems::registerLocalFileSystem();
+  }
+
+  void SetUp() override {
+    connectors_ = std::make_unique<Connectors>();
+    runner_ = std::make_unique<::axiom::sql::SqlQueryRunner>("test_user");
+    runner_->initialize([this]() {
+      connectors_->registerFileConnector(kConnectorId);
+      return std::make_pair(std::string(kConnectorId), std::string("parquet"));
+    });
+
+    tempFile_ = exec::test::TempFilePath::create();
+    parquetPath_ = tempFile_->getPath() + ".parquet";
+    writeTestParquetFile(parquetPath_);
+  }
+
+  void TearDown() override {
+    runner_.reset();
+    // Connectors' destructor unregisters the connector and its metadata.
+    connectors_.reset();
+    std::remove(parquetPath_.c_str());
+  }
+
+  void writeTestParquetFile(const std::string& path) {
+    auto rowVector = makeRowVector(
+        {"id", "name"},
+        {makeFlatVector<int64_t>({1, 2, 3}),
+         makeFlatVector<StringView>({"alpha", "beta", "gamma"})});
+    auto schema = asRowType(rowVector->type());
+
+    parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    auto sink = dwio::common::FileSink::create(
+        fmt::format("file:{}", path), {.pool = rootPool_.get()});
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), writerOptions, rootPool_, schema);
+    writer->write(rowVector);
+    writer->close();
+  }
+
+  // Runs a SELECT and returns its single result vector.
+  RowVectorPtr query(const std::string& sql) {
+    auto result = runner_->run(sql, {});
+    VELOX_CHECK(
+        !result.message.has_value(), "Query produced no result: {}", sql);
+    VELOX_CHECK_EQ(result.results.size(), 1);
+    return result.results[0];
+  }
+
+  // SQL reference for the data table.
+  std::string table() const {
+    return fmt::format("file.\"parquet\".\"{}\"", parquetPath_);
+  }
+
+  // SQL reference for a $-suffix metadata table.
+  std::string metadataTable(const std::string& suffix) const {
+    return fmt::format("file.\"parquet\".\"{}${}\"", parquetPath_, suffix);
+  }
+
+  std::unique_ptr<Connectors> connectors_;
+  std::unique_ptr<::axiom::sql::SqlQueryRunner> runner_;
+  std::shared_ptr<exec::test::TempFilePath> tempFile_;
+  std::string parquetPath_;
+};
+
+TEST_F(FileConnectorTest, fullScan) {
+  test::assertEqualVectors(
+      query(fmt::format("SELECT * FROM {} ORDER BY id", table())),
+      makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<StringView>({"alpha", "beta", "gamma"})}));
+}
+
+TEST_F(FileConnectorTest, projection) {
+  test::assertEqualVectors(
+      query(fmt::format("SELECT name FROM {} ORDER BY name", table())),
+      makeRowVector(
+          {"name"}, {makeFlatVector<StringView>({"alpha", "beta", "gamma"})}));
+}
+
+TEST_F(FileConnectorTest, rowGroupsMetadata) {
+  // The test file is written as a single row group holding all three rows.
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT row_group_id, num_rows FROM {}",
+              metadataTable("row_groups"))),
+      makeRowVector(
+          {"row_group_id", "num_rows"},
+          {makeFlatVector<int64_t>({0}), makeFlatVector<int64_t>({3})}));
+}
+
+TEST_F(FileConnectorTest, columnChunksMetadata) {
+  // One row per column chunk: the two columns of the single row group.
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT column_id, name, num_values FROM {} ORDER BY column_id",
+              metadataTable("column_chunks"))),
+      makeRowVector(
+          {"column_id", "name", "num_values"},
+          {makeFlatVector<int64_t>({0, 1}),
+           makeFlatVector<StringView>({"id", "name"}),
+           makeFlatVector<int64_t>({3, 3})}));
+}
+
+TEST_F(FileConnectorTest, columnChunksStatistics) {
+  // Column statistics come from the Parquet column-chunk metadata. The test
+  // data has no nulls, so null_count is zero for both columns.
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT min, max, null_count FROM {} ORDER BY column_id",
+              metadataTable("column_chunks"))),
+      makeRowVector(
+          {"min", "max", "null_count"},
+          {makeFlatVector<StringView>({"1", "alpha"}),
+           makeFlatVector<StringView>({"3", "gamma"}),
+           makeFlatVector<int64_t>({0, 0})}));
+}
+
+TEST_F(FileConnectorTest, unsupportedMetadataTableFails) {
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format("SELECT * FROM {}", metadataTable("stripes")), {}),
+      "Unsupported metadata table: stripes");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::file
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Adds the file connector — a read-only connector that lets users query raw files (e.g. Parquet as initially supported).

The connector uses a pluggable FileHandler interface so new file formats can be added without modifying the core.

For now, by default Parquet handler shipped in this diff. Later, it can be easily extended to other file type/file formats. Metadata tables are accessed via a $-suffix on the table name

The schema name in the SQL query selects the handler; Example:
```
  SELECT
    name,
    ROUND(SUM(uncompressed_size) / SUM(compressed_size), 2) AS ratio
  FROM file."parquet"."/data/file.parquet$column_chunks"
  GROUP BY name
  HAVING ratio < 2  -- Less than 2x compression
  ORDER BY ratio;
````

```
 SELECT name, encodings, compression, min, max, null_count
  FROM file.\"parquet\".\"$TEST_FILE\$column_chunks\"
  ORDER BY name
```

```
  SELECT
    name,
    ROUND(SUM(uncompressed_size) / NULLIF(SUM(compressed_size), 0), 2) AS ratio
  FROM file.\"parquet\".\"$TEST_FILE\$column_chunks\"
  GROUP BY name
  ORDER BY ratio DESC
```
More details are on this doc:
https://docs.google.com/document/d/19Ism5Tc8FQbmtYBy3TLL5oWNwwh-Iw48YsXkp2usywA/edit?tab=t.0

Differential Revision: D106889121
