### PR TITLE
refactor: Add ExprOptions parameter to ExpressionPlanner::toExpr (#1436)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -511,7 +511,9 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
   return veloxType;
 }
 
-lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
+lp::ExprApi ExpressionPlanner::toExpr(
+    const ExpressionPtr& node,
+    ExprOptions options) {
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());
@@ -577,7 +579,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         }
         return lp::Col(field, lp::Col(qualifier));
       }
-      return lp::Col(field, toExpr(dereference->base()));
+      return lp::Col(field, toExpr(dereference->base(), options));
     }
 
     case NodeType::kSubqueryExpression: {
@@ -615,23 +617,23 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* comparison = node->as<ComparisonExpression>();
       return lp::Call(
           toFunctionName(comparison->op()),
-          toExpr(comparison->left()),
-          toExpr(comparison->right()));
+          toExpr(comparison->left(), options),
+          toExpr(comparison->right(), options));
     }
 
     case NodeType::kNotExpression: {
       auto* negation = node->as<NotExpression>();
-      return lp::Call("not", toExpr(negation->value()));
+      return lp::Call("not", toExpr(negation->value(), options));
     }
 
     case NodeType::kLikePredicate: {
       auto* like = node->as<LikePredicate>();
 
       std::vector<lp::ExprApi> inputs;
-      inputs.emplace_back(toExpr(like->value()));
-      inputs.emplace_back(toExpr(like->pattern()));
+      inputs.emplace_back(toExpr(like->value(), options));
+      inputs.emplace_back(toExpr(like->pattern(), options));
       if (like->escape()) {
-        inputs.emplace_back(toExpr(like->escape()));
+        inputs.emplace_back(toExpr(like->escape(), options));
       }
 
       return lp::Call("like", std::move(inputs));
@@ -639,8 +641,8 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kLogicalBinaryExpression: {
       auto* logical = node->as<LogicalBinaryExpression>();
-      auto left = toExpr(logical->left());
-      auto right = toExpr(logical->right());
+      auto left = toExpr(logical->left(), options);
+      auto right = toExpr(logical->right(), options);
 
       switch (logical->op()) {
         case LogicalBinaryExpression::Operator::kAnd:
@@ -654,34 +656,34 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     case NodeType::kArithmeticUnaryExpression: {
       auto* unary = node->as<ArithmeticUnaryExpression>();
       if (unary->sign() == ArithmeticUnaryExpression::Sign::kMinus) {
-        return lp::Call("negate", toExpr(unary->value()));
+        return lp::Call("negate", toExpr(unary->value(), options));
       }
 
-      return toExpr(unary->value());
+      return toExpr(unary->value(), options);
     }
 
     case NodeType::kArithmeticBinaryExpression: {
       auto* binary = node->as<ArithmeticBinaryExpression>();
       return lp::Call(
           toFunctionName(binary->op()),
-          toExpr(binary->left()),
-          toExpr(binary->right()));
+          toExpr(binary->left(), options),
+          toExpr(binary->right(), options));
     }
 
     case NodeType::kBetweenPredicate: {
       auto* between = node->as<BetweenPredicate>();
       return lp::Call(
           "between",
-          toExpr(between->value()),
-          toExpr(between->min()),
-          toExpr(between->max()));
+          toExpr(between->value(), options),
+          toExpr(between->min(), options),
+          toExpr(between->max(), options));
     }
 
     case NodeType::kInPredicate: {
       auto* inPredicate = node->as<InPredicate>();
       const auto& valueList = inPredicate->valueList();
 
-      const auto value = toExpr(inPredicate->value());
+      const auto value = toExpr(inPredicate->value(), options);
 
       if (valueList->is(NodeType::kInListExpression)) {
         auto inList = valueList->as<InListExpression>();
@@ -691,14 +693,14 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
         inputs.emplace_back(value);
         for (const auto& expr : inList->values()) {
-          inputs.emplace_back(toExpr(expr));
+          inputs.emplace_back(toExpr(expr, options));
         }
 
         return lp::Call("in", inputs);
       }
 
       if (valueList->is(NodeType::kSubqueryExpression)) {
-        return lp::Call("in", value, toExpr(valueList));
+        return lp::Call("in", value, toExpr(valueList, options));
       }
 
       AXIOM_PRESTO_SEMANTIC_FAIL(
@@ -710,7 +712,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kExistsPredicate: {
       auto* exists = node->as<ExistsPredicate>();
-      return lp::Exists(toExpr(exists->subquery()));
+      return lp::Exists(toExpr(exists->subquery(), options));
     }
 
     case NodeType::kCast: {
@@ -718,9 +720,9 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       const auto type = resolveType(cast->toType());
 
       if (cast->isSafe()) {
-        return lp::TryCast(type, toExpr(cast->expression()));
+        return lp::TryCast(type, toExpr(cast->expression(), options));
       } else {
-        return lp::Cast(type, toExpr(cast->expression()));
+        return lp::Cast(type, toExpr(cast->expression(), options));
       }
     }
 
@@ -728,25 +730,26 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* atTimeZone = node->as<AtTimeZone>();
       return lp::Call(
           "at_timezone",
-          toExpr(atTimeZone->value()),
-          toExpr(atTimeZone->timeZone()));
+          toExpr(atTimeZone->value(), options),
+          toExpr(atTimeZone->timeZone(), options));
     }
 
     case NodeType::kSimpleCaseExpression: {
       auto* simpleCase = node->as<SimpleCaseExpression>();
 
-      const auto operand = toExpr(simpleCase->operand());
+      const auto operand = toExpr(simpleCase->operand(), options);
 
       std::vector<lp::ExprApi> inputs;
       inputs.reserve(1 + simpleCase->whenClauses().size());
 
       for (const auto& clause : simpleCase->whenClauses()) {
-        inputs.emplace_back(lp::Call("eq", operand, toExpr(clause->operand())));
-        inputs.emplace_back(toExpr(clause->result()));
+        inputs.emplace_back(
+            lp::Call("eq", operand, toExpr(clause->operand(), options)));
+        inputs.emplace_back(toExpr(clause->result(), options));
       }
 
       if (simpleCase->defaultValue()) {
-        inputs.emplace_back(toExpr(simpleCase->defaultValue()));
+        inputs.emplace_back(toExpr(simpleCase->defaultValue(), options));
       }
 
       return lp::Call("switch", inputs);
@@ -763,12 +766,12 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         if (clause->operand()->is(NodeType::kNullLiteral)) {
           continue;
         }
-        inputs.emplace_back(toExpr(clause->operand()));
-        inputs.emplace_back(toExpr(clause->result()));
+        inputs.emplace_back(toExpr(clause->operand(), options));
+        inputs.emplace_back(toExpr(clause->result(), options));
       }
 
       if (searchedCase->defaultValue()) {
-        inputs.emplace_back(toExpr(searchedCase->defaultValue()));
+        inputs.emplace_back(toExpr(searchedCase->defaultValue(), options));
       }
 
       // All WHEN clauses were dropped (all had NULL conditions).
@@ -786,7 +789,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kExtract: {
       auto* extract = node->as<Extract>();
-      auto expr = toExpr(extract->expression());
+      auto expr = toExpr(extract->expression(), options);
 
       switch (extract->field()) {
         case Extract::Field::kYear:
@@ -930,7 +933,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* array = node->as<ArrayConstructor>();
       std::vector<lp::ExprApi> values;
       for (const auto& value : array->values()) {
-        values.emplace_back(toExpr(value));
+        values.emplace_back(toExpr(value, options));
       }
 
       return lp::Call("array_constructor", values);
@@ -940,7 +943,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       auto* row = node->as<Row>();
       std::vector<lp::ExprApi> items;
       for (const auto& item : row->items()) {
-        items.emplace_back(toExpr(item));
+        items.emplace_back(toExpr(item, options));
       }
 
       return lp::Call("row_constructor", items);
@@ -951,7 +954,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       std::vector<core::ExprPtr> childExprs;
       childExprs.reserve(row->items().size());
       for (const auto& item : row->items()) {
-        childExprs.push_back(toExpr(item).expr());
+        childExprs.push_back(toExpr(item, options).expr());
       }
       return lp::ExprApi{std::make_shared<core::ConcatExpr>(
           row->fieldNames(), std::move(childExprs))};
@@ -962,7 +965,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
       std::vector<lp::ExprApi> args;
       for (const auto& arg : call->arguments()) {
-        args.push_back(toExpr(arg));
+        args.push_back(toExpr(arg, options));
       }
 
       const auto& funcName = call->name()->suffix();
@@ -979,13 +982,13 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
       }
 
       if (call->isDistinct() || call->filter() || call->orderBy()) {
-        return toAggregateCallExpr(call, funcName, args);
+        return toAggregateCallExpr(call, funcName, args, options);
       }
 
       auto callExpr = lp::Call(funcName, args);
 
       if (call->window() != nullptr) {
-        auto windowSpec = convertWindow(call->window());
+        auto windowSpec = convertWindow(call->window(), options);
         if (call->ignoreNulls()) {
           windowSpec.ignoreNulls();
         }
@@ -1011,23 +1014,26 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
         lambdaParamScope_.resize(scopeBegin);
       };
 
-      return lp::Lambda(names, toExpr(lambda->body()));
+      return lp::Lambda(names, toExpr(lambda->body(), options));
     }
 
     case NodeType::kSubscriptExpression: {
       auto* subscript = node->as<SubscriptExpression>();
       return lp::Call(
-          "subscript", toExpr(subscript->base()), toExpr(subscript->index()));
+          "subscript",
+          toExpr(subscript->base(), options),
+          toExpr(subscript->index(), options));
     }
 
     case NodeType::kIsNullPredicate: {
       auto* isNull = node->as<IsNullPredicate>();
-      return lp::Call("is_null", toExpr(isNull->value()));
+      return lp::Call("is_null", toExpr(isNull->value(), options));
     }
 
     case NodeType::kIsNotNullPredicate: {
       auto* isNull = node->as<IsNotNullPredicate>();
-      return lp::Call("not", lp::Call("is_null", toExpr(isNull->value())));
+      return lp::Call(
+          "not", lp::Call("is_null", toExpr(isNull->value(), options)));
     }
 
     case NodeType::kCurrentTime: {
@@ -1052,6 +1058,18 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
           return lp::Call("localtimestamp");
       }
       VELOX_UNREACHABLE();
+    }
+
+    case NodeType::kGroupingOperation: {
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          !options.rejectGroupingOps,
+          node->location(),
+          std::nullopt,
+          "GROUPING() is not allowed in WHERE clause");
+      AXIOM_PRESTO_SYNTAX_FAIL(
+          node->location(),
+          std::nullopt,
+          "GROUPING() requires GROUP BY with GROUPING SETS, CUBE, or ROLLUP");
     }
 
     default:
@@ -1086,10 +1104,11 @@ core::WindowCallExpr::BoundType toWindowBoundType(FrameBound::Type type) {
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     const FunctionCall* call,
     const std::string& funcName,
-    const std::vector<lp::ExprApi>& args) {
+    const std::vector<lp::ExprApi>& args,
+    ExprOptions options) {
   core::ExprPtr filterExpr;
   if (call->filter() != nullptr) {
-    filterExpr = toExpr(call->filter()).expr();
+    filterExpr = toExpr(call->filter(), options).expr();
   }
 
   std::vector<core::SortKey> sortKeys;
@@ -1099,7 +1118,7 @@ lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
       VELOX_CHECK_NOT_NULL(
           sortingKeyResolver_,
           "Sorting key resolution requires a SortingKeyResolver");
-      auto keyExpr = sortingKeyResolver_(item->sortKey());
+      auto keyExpr = sortingKeyResolver_(item->sortKey(), options);
       sortKeys.push_back(
           {keyExpr.expr(), item->isAscending(), item->isNullsFirst()});
     }
@@ -1121,14 +1140,15 @@ lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
 }
 
 lp::WindowSpec ExpressionPlanner::convertWindow(
-    const std::shared_ptr<Window>& window) {
+    const std::shared_ptr<Window>& window,
+    ExprOptions options) {
   lp::WindowSpec spec;
 
   if (!window->partitionBy().empty()) {
     std::vector<lp::ExprApi> partitionKeys;
     partitionKeys.reserve(window->partitionBy().size());
     for (const auto& key : window->partitionBy()) {
-      partitionKeys.push_back(toExpr(key));
+      partitionKeys.push_back(toExpr(key, options));
     }
     spec.partitionBy(std::move(partitionKeys));
   }
@@ -1139,7 +1159,9 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
     orderByKeys.reserve(sortItems.size());
     for (const auto& item : sortItems) {
       orderByKeys.emplace_back(
-          toExpr(item->sortKey()), item->isAscending(), item->isNullsFirst());
+          toExpr(item->sortKey(), options),
+          item->isAscending(),
+          item->isNullsFirst());
     }
     spec.orderBy(orderByKeys);
   }
@@ -1150,7 +1172,7 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
     auto startType = toWindowBoundType(frame->start()->boundType());
     std::optional<lp::ExprApi> startValue;
     if (frame->start()->value().has_value()) {
-      startValue = toExpr(frame->start()->value().value());
+      startValue = toExpr(frame->start()->value().value(), options);
     }
 
     auto endType = frame->end() != nullptr
@@ -1158,7 +1180,7 @@ lp::WindowSpec ExpressionPlanner::convertWindow(
         : core::WindowCallExpr::BoundType::kCurrentRow;
     std::optional<lp::ExprApi> endValue;
     if (frame->end() != nullptr && frame->end()->value().has_value()) {
-      endValue = toExpr(frame->end()->value().value());
+      endValue = toExpr(frame->end()->value().value(), options);
     }
 
     // For RANGE n PRECEDING / n FOLLOWING the execution engine compares the

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -39,6 +39,12 @@ std::string canonicalizeIdentifier(const Identifier& identifier);
 /// Parses a TypeSignature AST node into a Velox type.
 facebook::velox::TypePtr parseType(const TypeSignaturePtr& type);
 
+/// Options for context-specific validation during expression translation.
+struct ExprOptions {
+  /// When true, rejects GROUPING() calls with a semantic error.
+  bool rejectGroupingOps = false;
+};
+
 /// Translates Presto SQL AST expression nodes into logical plan ExprApi
 /// objects. Handles all expression types (literals, comparisons, arithmetic,
 /// function calls, casts, subqueries, etc.).
@@ -74,8 +80,8 @@ class ExpressionPlanner {
   /// functions). Required when the expression may contain aggregate function
   /// calls with ORDER BY clauses. Can be nullptr if aggregates with ORDER BY
   /// are not expected.
-  using SortingKeyResolver =
-      std::function<lp::ExprApi(const ExpressionPtr& expr)>;
+  using SortingKeyResolver = std::function<
+      lp::ExprApi(const ExpressionPtr& expr, ExprOptions options)>;
 
   /// Returns true if the table qualifier should be dropped from a column
   /// reference (e.g. t.col -> col).
@@ -115,7 +121,7 @@ class ExpressionPlanner {
   /// Translates an AST expression into an ExprApi. Aggregate options
   /// (DISTINCT, FILTER, ORDER BY) are embedded in the returned ExprApi via
   /// AggregateCallExpr. Window functions are embedded via WindowCallExpr.
-  lp::ExprApi toExpr(const ExpressionPtr& node);
+  lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {});
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.
   /// When set, Identifier nodes matching an alias key are resolved to the
@@ -147,14 +153,17 @@ class ExpressionPlanner {
       std::vector<const facebook::velox::core::IExpr*>& traversalOrder);
 
   // Converts a Window AST node into a WindowSpec.
-  lp::WindowSpec convertWindow(const std::shared_ptr<Window>& window);
+  lp::WindowSpec convertWindow(
+      const std::shared_ptr<Window>& window,
+      ExprOptions options);
 
   // Builds an AggregateCallExpr from a FunctionCall AST node that has
   // DISTINCT, FILTER, or ORDER BY.
   lp::ExprApi toAggregateCallExpr(
       const FunctionCall* call,
       const std::string& funcName,
-      const std::vector<lp::ExprApi>& args);
+      const std::vector<lp::ExprApi>& args,
+      ExprOptions options);
 
   // Resolves a type signature, trying built-in Velox types first, then
   // connector-based resolution for dotted names (e.g., "catalog.schema.Type").

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -293,17 +293,17 @@ class RelationPlanner : public AstVisitor {
     return *builder_;
   }
 
-  lp::ExprApi toExpr(const ExpressionPtr& node) {
-    return exprPlanner_.toExpr(node);
+  lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {}) {
+    return exprPlanner_.toExpr(node, options);
   }
 
  private:
-  void addFilter(const ExpressionPtr& filter) {
+  void addFilter(const ExpressionPtr& filter, ExprOptions options) {
     if (filter == nullptr) {
       return;
     }
 
-    auto expr = toExpr(filter);
+    auto expr = toExpr(filter, options);
     auto expanded =
         ColumnsExpansion::expand(expr, *builder_, filter->location());
     if (expanded.empty()) {
@@ -1089,7 +1089,7 @@ class RelationPlanner : public AstVisitor {
         projectedExprs.size());
   }
 
-  lp::ExprApi toSortingKey(const ExpressionPtr& expr) {
+  lp::ExprApi toSortingKey(const ExpressionPtr& expr, ExprOptions options) {
     if (expr->is(NodeType::kLongLiteral)) {
       const auto n = expr->as<LongLiteral>()->value();
       AXIOM_PRESTO_SEMANTIC_CHECK_GE(
@@ -1109,7 +1109,7 @@ class RelationPlanner : public AstVisitor {
       return column.toCol();
     }
 
-    return toExpr(expr);
+    return toExpr(expr, options);
   }
 
   // Plans 'query' as a subquery in a fresh builder, reporting whether it
@@ -1150,7 +1150,7 @@ class RelationPlanner : public AstVisitor {
 
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
-      auto expr = toSortingKey(item->sortKey());
+      auto expr = toSortingKey(item->sortKey(), {});
 
       // Expand COLUMNS() calls to multiple sort keys with the same
       // ordering direction.
@@ -1255,7 +1255,7 @@ class RelationPlanner : public AstVisitor {
     displayNames_.lastNames.clear();
 
     // WHERE a > 1 -> builder.filter("a > 1")
-    addFilter(node->where());
+    addFilter(node->where(), {.rejectGroupingOps = true});
 
     const auto& selectItems = node->select()->selectItems();
     const bool distinct = node->select()->isDistinct();
@@ -1390,7 +1390,9 @@ class RelationPlanner : public AstVisitor {
   std::shared_ptr<lp::PlanBuilder> builder_;
   ExpressionPlanner exprPlanner_{
       [this](Query* query) { return planSubquery(query); },
-      [this](const ExpressionPtr& expr) { return toSortingKey(expr); },
+      [this](const ExpressionPtr& expr, ExprOptions options) {
+        return toSortingKey(expr, options);
+      },
       [this](const std::string& qualifier, const std::string& name) {
         // Only canonicalize if the qualifier resolves as a table alias (not a
         // struct field dereference) and the unqualified name is unambiguous.

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -208,18 +208,18 @@ TEST_F(AggregationParserTest, groupingSets) {
 }
 
 TEST_F(AggregationParserTest, groupingFunction) {
-  // GROUPING(col) is rejected with a clear unsupported-expression error.
+  // GROUPING() is not yet implemented and is rejected with a clear error.
   AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
       parseSql(
           "SELECT GROUPING(n_regionkey), count(1) FROM nation "
           "GROUP BY GROUPING SETS ((n_regionkey), ())"),
-      "Unsupported expression type: GroupingOperation");
+      "GROUPING() requires GROUP BY");
 
   AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
       parseSql(
           "SELECT GROUPING(n_regionkey, n_name), count(1) FROM nation "
           "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())"),
-      "Unsupported expression type: GroupingOperation");
+      "GROUPING() requires GROUP BY");
 }
 
 TEST_F(AggregationParserTest, rollup) {

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 #include <limits>
+#include "axiom/sql/presto/ExpressionPlanner.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
@@ -1062,6 +1064,25 @@ TEST_F(ExpressionParserTest, mixedCaseColumnName) {
       "SELECT orderingid FROM mixedCase", matchScan().project().output()));
   ASSERT_NO_THROW(testSelect(
       "SELECT ORDERINGID FROM mixedCase", matchScan().project().output()));
+}
+
+TEST_F(ExpressionParserTest, exprOptionsRejectGroupingOps) {
+  auto groupingNode = std::make_shared<GroupingOperation>(
+      NodeLocation{1, 0},
+      std::vector<std::shared_ptr<QualifiedName>>{
+          std::make_shared<QualifiedName>(
+              NodeLocation{1, 0}, std::vector<std::string>{"col"})});
+
+  ExpressionPlanner planner{nullptr, nullptr};
+
+  // Flag OFF — falls through to syntax error.
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      planner.toExpr(groupingNode, {}), "GROUPING() requires GROUP BY");
+
+  // Flag ON — semantic rejection.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      planner.toExpr(groupingNode, {.rejectGroupingOps = true}),
+      "not allowed in WHERE");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Add an `ExprOptions` parameter to `ExpressionPlanner::toExpr` so callers can pass context-specific validation flags without mutable state on the planner.

Before: Rejecting expressions in certain contexts (e.g., GROUPING() in WHERE) required setting a boolean field on ExpressionPlanner and remembering to reset it — a sticky toggle that leaked across nested calls and wasn't exception-safe.

After: Callers pass `{.rejectGroupingOps = true}`for example, as a scoped parameter. The flag flows through recursive `toExpr` calls naturally and disappears when the call returns. No field, no toggle, no cleanup.

`ExprOptions` is a struct so future context flags (e.g., rejecting window functions) extend the struct without changing the `toExpr` signature or existing call sites.

No behavior change — the struct defaults to `{}` and no caller passes non-default options yet. The child diff (D94242997) uses this parameter for GROUPING() validation.

Differential Revision: D106882657


