### PR TITLE
fix(optimizer): Export or erase unreachable subqueries_ entries after finalizeDt's wrap

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2468,6 +2468,27 @@ void pruneUnreachableRenames(
   }
 }
 
+// Repairs cached subquery results whose value lives inside 'dt' after
+// the wrap. Aggregating wraps drop the entry, non-aggregating wraps re-export
+// via exportExpr to keep dedup alive across the wrap.
+void repairCachedSubqueries(
+    folly::F14FastMap<lp::ExprPtr, ExprCP, SubqueryExprHash, SubqueryExprEqual>&
+        subqueries,
+    DerivedTableP dt) {
+  for (auto it = subqueries.begin(); it != subqueries.end();) {
+    if (it->second->hasAnyTableIn(dt->tableSet)) {
+      if (dt->hasAggregation()) {
+        it = subqueries.erase(it);
+      } else {
+        it->second = dt->exportExpr(it->second);
+        ++it;
+      }
+    } else {
+      ++it;
+    }
+  }
+}
+
 } // namespace
 
 void ToGraph::finalizeDt(
@@ -2488,6 +2509,7 @@ void ToGraph::finalizeDt(
   currentDt_->addTable(dt);
 
   pruneUnreachableRenames(renames_, dt);
+  repairCachedSubqueries(subqueries_, dt);
 }
 
 void ToGraph::finalizeDtPreservingCorrelations(

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -2217,6 +2217,59 @@ TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
   }
 }
 
+TEST_F(SubqueryTest, commonScalarSubquery) {
+  // MAX((SELECT 1)) and a bare (SELECT 1) in the same SELECT. Verifies
+  // each occurrence becomes its own subplan (no dedup across the
+  // aggregating wrap).
+  {
+    auto query = "SELECT MAX((SELECT 1)), (SELECT 1)";
+    SCOPED_TRACE(query);
+
+    auto plan = toSingleNodePlan(query);
+
+    auto aggregateBranch = matchValues()
+                               .project()
+                               .nestedLoopJoin(matchValues().build())
+                               .singleAggregation()
+                               .build();
+
+    auto matcher = matchValues()
+                       .project()
+                       .nestedLoopJoin(aggregateBranch)
+                       .project()
+                       .build();
+
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Shared (SELECT max(s_suppkey) FROM supplier) used in WHERE and
+  // SELECT alongside an IN subquery whose semi-join wraps the current
+  // DT. Verifies a single supplier scan reused by both the filter and
+  // the projection.
+  {
+    auto query =
+        "SELECT n.n_nationkey, (SELECT max(s_suppkey) FROM supplier) "
+        "FROM nation n "
+        "WHERE n.n_regionkey IN (SELECT r_regionkey FROM region) "
+        "  AND n.n_nationkey > (SELECT max(s_suppkey) FROM supplier)";
+    SCOPED_TRACE(query);
+
+    auto plan = toSingleNodePlan(query);
+    auto matcher = matchHiveScan("nation")
+                       .nestedLoopJoin(
+                           matchHiveScan("supplier")
+                               .singleAggregation({}, {"max(s_suppkey) as max"})
+                               .build())
+                       .filter("gt(n_nationkey, max)")
+                       .hashJoin(
+                           matchHiveScan("region").build(),
+                           core::JoinType::kLeftSemiFilter)
+                       .build();
+
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
 TEST_F(SubqueryTest, nestedInSubqueries) {
   // IN subquery on a column derived from another IN subquery. The inner IN
   // produces a mark column used to compute 'flag'. The outer IN uses 'flag'

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -535,3 +535,12 @@ SELECT a, array_agg(b ORDER BY b + (SELECT 0)) AS vals FROM t GROUP BY a
 ----
 -- Non-order-sensitive aggregate with ORDER BY containing a subquery.
 SELECT sum(a ORDER BY a + (SELECT 1)) AS total FROM t
+----
+-- Common scalar subquery in aggregation and non-aggregation.
+SELECT MAX((SELECT 1)), (SELECT 1)
+----
+-- Common scalar subquery in WHERE and SELECT, interleaved by a correlated IN subquery.
+SELECT t.a, (SELECT max(a) FROM u)
+FROM t
+WHERE t.b IN (SELECT a FROM v)
+  AND t.a < (SELECT max(a) FROM u)


### PR DESCRIPTION
Summary:
Two references to the same scalar subquery in the same SELECT block crash during translation when anything between the references forces a finalizeDt wrap of the in-progress DT .

Minimal repro:
```
SELECT 1, 1 UNION ALL SELECT MAX((SELECT 1)), (SELECT 1)
```

Root cause: ToGraph::finalizeDt wraps currentDt_ into outerDt, entries in the subqueries_ cache may still pointed at columns inside the now-wrapped dt and were unreachable from outerDt. When the next translateExpr in the outer scope looked up the subquery in subqueries_ and substituted the stale Column into an outer expression, that expression ended up referencing a Column whose owning DT was not in the operator's tableSet, tripping DerivedTable::checkConsistency.

wrapForSubqueryCorrelation already rewrites subqueries_ through its wrap via exportExpr; the finalizeDt path had no equivalent step.

Fix: add repairCachedSubqueries(subqueries_, dt) to finalizeDt, called right after pruneUnreachableRenames. Non-aggregating wraps re-export the cached column via dt->exportExpr so dedup survives. Aggregating wraps drop the entry instead, because the wrap's projection is constrained to the aggregation's outputs only. Dropping forces the next lookup to re-translate the subquery as a fresh subplan against outerDt.

Why not use arbitrary() to carry forward the subquery result through aggregation: The aggregation can come with a WHERE clause that filter out all rows. When the input is empty, aggregation returns NULL — but a bare uncorrelated scalar subquery must return its own value regardless of input cardinality.

E.g., `SELECT MAX((SELECT 42)), (SELECT 42) FROM t WHERE FALSE` should yield `(NULL, 42)`, but arbitrary() carry-forward yields `(NULL, NULL)`.

Differential Revision: D106742717


