### PR TITLE
feat(connectors): Let bucketed fragment width reach numWorkers (#1441)

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -27,6 +27,18 @@
 
 namespace facebook::axiom::connector::hive {
 
+HivePartitionType::HivePartitionType(
+    int32_t numBuckets,
+    int32_t numPartitions,
+    std::vector<velox::TypePtr> partitionKeyTypes)
+    : numBuckets_(numBuckets),
+      numPartitions_(numPartitions),
+      partitionKeyTypes_(std::move(partitionKeyTypes)) {
+  VELOX_CHECK_GT(numBuckets_, 0);
+  VELOX_CHECK_GT(numPartitions_, 0);
+  VELOX_CHECK_LE(numPartitions_, numBuckets_);
+}
+
 std::shared_ptr<PartitionType> HivePartitionType::copartition(
     const PartitionType& other) const {
   const auto* otherPartitionType = other.as<HivePartitionType>();
@@ -43,12 +55,12 @@ std::shared_ptr<PartitionType> HivePartitionType::copartition(
       return nullptr;
     }
   }
-  const int32_t otherNumPartitions = otherPartitionType->numPartitions_;
-  if (otherNumPartitions % numPartitions_ == 0) {
-    return std::make_shared<HivePartitionType>(numPartitions_, thisTypes);
+  const int32_t otherNumBuckets = otherPartitionType->numBuckets_;
+  if (otherNumBuckets % numBuckets_ == 0) {
+    return std::make_shared<HivePartitionType>(numBuckets_, thisTypes);
   }
-  if (numPartitions_ % otherNumPartitions == 0) {
-    return std::make_shared<HivePartitionType>(otherNumPartitions, otherTypes);
+  if (numBuckets_ % otherNumBuckets == 0) {
+    return std::make_shared<HivePartitionType>(otherNumBuckets, otherTypes);
   }
   return nullptr;
 }
@@ -56,24 +68,31 @@ std::shared_ptr<PartitionType> HivePartitionType::copartition(
 std::shared_ptr<PartitionType> HivePartitionType::scaleDown(
     int32_t maxPartitions) const {
   VELOX_CHECK_GT(maxPartitions, 0);
-  int32_t numResultPartitions = std::min(numPartitions_, maxPartitions);
-  while (numResultPartitions > 1 && numPartitions_ % numResultPartitions != 0) {
-    --numResultPartitions;
-  }
   return std::make_shared<HivePartitionType>(
-      numResultPartitions, partitionKeyTypes_);
+      numBuckets_, std::min(numBuckets_, maxPartitions), partitionKeyTypes_);
 }
 
 velox::core::PartitionFunctionSpecPtr HivePartitionType::makeSpec(
     const std::vector<velox::column_index_t>& channels,
     const std::vector<velox::VectorPtr>& constants,
     bool /*isLocal*/) const {
+  std::vector<int> bucketToPartition;
+  if (numPartitions_ != numBuckets_) {
+    bucketToPartition.reserve(numBuckets_);
+    for (int32_t bucket = 0; bucket < numBuckets_; ++bucket) {
+      bucketToPartition.push_back(bucket % numPartitions_);
+    }
+  }
   return std::make_shared<velox::connector::hive::HivePartitionFunctionSpec>(
-      numPartitions_, channels, constants);
+      numBuckets_, std::move(bucketToPartition), channels, constants);
 }
 
 std::string HivePartitionType::toString() const {
-  return fmt::format("{} Hive buckets", numPartitions_);
+  if (numPartitions_ == numBuckets_) {
+    return fmt::format("{} Hive buckets", numBuckets_);
+  }
+  return fmt::format(
+      "{} Hive buckets -> {} partitions", numBuckets_, numPartitions_);
 }
 
 namespace {

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -41,22 +41,35 @@ struct HivePartitionHandle : public PartitionHandle {
   const std::optional<int32_t> tableBucketNumber;
 };
 
-/// For Hive, 'partition' means 'bucket'.
+/// For Hive, 'partition' means 'bucket'. Carries the native bucket count
+/// and a (possibly smaller) partition count produced by scaleDown.
 class HivePartitionType : public connector::PartitionType {
  public:
+  /// Constructs an unscaled HivePartitionType. The partition count equals
+  /// 'numBuckets'.
   HivePartitionType(
-      int32_t numPartitions,
+      int32_t numBuckets,
       std::vector<velox::TypePtr> partitionKeyTypes)
-      : numPartitions_(numPartitions),
-        partitionKeyTypes_(std::move(partitionKeyTypes)) {
-    VELOX_CHECK_GT(numPartitions_, 0);
-  }
+      : HivePartitionType(
+            numBuckets,
+            numBuckets,
+            std::move(partitionKeyTypes)) {}
+
+  /// Constructs a scaled HivePartitionType where the partition count
+  /// ('numPartitions') is less than or equal to the table's native bucket
+  /// count ('numBuckets').
+  HivePartitionType(
+      int32_t numBuckets,
+      int32_t numPartitions,
+      std::vector<velox::TypePtr> partitionKeyTypes);
 
   std::shared_ptr<PartitionType> copartition(
       const PartitionType& any) const override;
 
-  /// Returns the largest divisor of numPartitions() that is <=
-  /// maxPartitions.
+  /// Returns a HivePartitionType whose partition count is
+  /// min(numBuckets, maxPartitions). The native bucket count is preserved;
+  /// the partition count drives fragment width, and makeSpec maps native
+  /// buckets onto partitions via modulo.
   std::shared_ptr<PartitionType> scaleDown(
       int32_t maxPartitions) const override;
 
@@ -69,9 +82,15 @@ class HivePartitionType : public connector::PartitionType {
     return numPartitions_;
   }
 
+  /// Native bucket count of the underlying Hive table layout.
+  int32_t numBuckets() const {
+    return numBuckets_;
+  }
+
   std::string toString() const override;
 
  private:
+  const int32_t numBuckets_;
   const int32_t numPartitions_;
   const std::vector<velox::TypePtr> partitionKeyTypes_;
 };

--- a/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
+++ b/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
@@ -42,12 +42,12 @@ TEST(HivePartitionTypeTest, scaleDownIdentityWhenWithinLimit) {
   EXPECT_EQ(scaled->numPartitions(), 8);
 }
 
-TEST(HivePartitionTypeTest, scaleDownPicksLargestDivisor) {
+TEST(HivePartitionTypeTest, scaleDownClampsToMax) {
   const auto partitionType = makePartitionType(256);
 
   auto scaled = partitionType.scaleDown(100);
   ASSERT_NE(scaled, nullptr);
-  EXPECT_EQ(scaled->numPartitions(), 64);
+  EXPECT_EQ(scaled->numPartitions(), 100);
 
   scaled = partitionType.scaleDown(64);
   ASSERT_NE(scaled, nullptr);
@@ -55,7 +55,7 @@ TEST(HivePartitionTypeTest, scaleDownPicksLargestDivisor) {
 
   scaled = partitionType.scaleDown(63);
   ASSERT_NE(scaled, nullptr);
-  EXPECT_EQ(scaled->numPartitions(), 32);
+  EXPECT_EQ(scaled->numPartitions(), 63);
 }
 
 TEST(HivePartitionTypeTest, scaleDownToOne) {
@@ -71,7 +71,7 @@ TEST(HivePartitionTypeTest, scaleDownPrimePartitionCount) {
 
   auto scaled = partitionType.scaleDown(6);
   ASSERT_NE(scaled, nullptr);
-  EXPECT_EQ(scaled->numPartitions(), 1);
+  EXPECT_EQ(scaled->numPartitions(), 6);
 
   scaled = partitionType.scaleDown(7);
   ASSERT_NE(scaled, nullptr);
@@ -89,7 +89,7 @@ TEST(HivePartitionTypeTest, scaleDownRejectsNonPositiveMax) {
   VELOX_ASSERT_THROW(partitionType.scaleDown(-1), "");
 }
 
-TEST(HivePartitionTypeTest, ctorRejectsNonPositiveNumPartitions) {
+TEST(HivePartitionTypeTest, ctorRejectsNonPositiveNumBuckets) {
   VELOX_ASSERT_THROW(HivePartitionType(0, std::vector<TypePtr>{BIGINT()}), "");
   VELOX_ASSERT_THROW(HivePartitionType(-1, std::vector<TypePtr>{BIGINT()}), "");
 }

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -373,6 +373,71 @@ TEST_F(HiveBucketedExecutionTest, select) {
   }
 }
 
+TEST_F(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
+  createBucketedTable(
+      "wc_customers",
+      "CREATE TABLE wc_customers "
+      "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT * FROM customer");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT c_nationkey, count(*) FROM wc_customers "
+        "GROUP BY c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 5, .numDrivers = 4}, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("wc_customers")
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .bucketed()
+            .fragmentWidth(5)
+            .gather()
+            .build());
+    assertBucketedExecution(logicalPlan);
+  }
+
+  createBucketedTable(
+      "wc_left",
+      "CREATE TABLE wc_left "
+      "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  tablesToDrop_.emplace_back("wc_unbucketed");
+  runCtas(
+      "CREATE TABLE wc_unbucketed AS "
+      "SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey as varchar) as label FROM customer");
+
+  {
+    auto logicalPlan = parseSelect(
+        "SELECT * FROM wc_left JOIN wc_unbucketed "
+        "ON wc_left.c_nationkey = wc_unbucketed.c_nationkey");
+    auto plan = planVelox(
+        logicalPlan, {.numWorkers = 5, .numDrivers = 4}, optimizerOptions_);
+    int32_t bucketedScans = 0;
+    int32_t hashExchanges = 0;
+    int32_t bucketedFragmentWidth = 0;
+    for (const auto& fragment : plan.plan->fragments()) {
+      if (!fragment.groupedNodes.empty()) {
+        ASSERT_TRUE(fragment.width.has_value());
+        bucketedFragmentWidth = *fragment.width;
+        for (const auto& [_, partitionType] : fragment.groupedNodes) {
+          if (partitionType == nullptr) {
+            ++hashExchanges;
+          } else {
+            ++bucketedScans;
+          }
+        }
+      }
+    }
+    EXPECT_EQ(bucketedScans, 1);
+    EXPECT_EQ(hashExchanges, 1);
+    EXPECT_EQ(bucketedFragmentWidth, 5);
+    assertBucketedExecution(logicalPlan);
+  }
+}
+
 TEST_F(HiveBucketedExecutionTest, unionall) {
   // Different bucket keys (same type) — must not co-fragment.
   createBucketedTable(


### PR DESCRIPTION
Summary:

Before: `HivePartitionType::scaleDown(numWorkers)` walked down to the largest divisor of `numBuckets` <= `numWorkers`, so 200 workers on a 256-bucket table left 72 workers idle (`width = 128`). After: `width = numWorkers`, with bucket `b` landing on task `b % numWorkers` on both the scan and exchange sides.

`HivePartitionType` carries the native bucket count alongside the partition count. `scaleDown` clamps the partition count to `min(numBuckets, maxPartitions)`. `makeSpec` builds a `bucketToPartition` lookup of length `numBuckets` with values in `[0, numPartitions)` and passes it to the existing `velox::connector::hive::HivePartitionFunctionSpec` constructor that already accepts this — same mechanism as Presto-Java's `BucketPartitionFunction`, no Velox change. The Hive, Prism, and Test split sources each tag their splits' `groupId` with `bucket % numPartitions()` inline.

`TestPartitionType::scaleDown` continues to walk to a divisor because `TestConnector` uses `HashPartitionFunctionSpec`, which has no `bucketToPartition` overload.

Reviewed By: arhimondr

Differential Revision: D107160687


