### PR TITLE
fix(optimizer): Correctness bugs and failures in correlated subqueries (#1443)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -29,10 +29,7 @@
 #include "axiom/runner/LocalRunner.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
-#include "velox/expression/ConstantExpr.h"
-#include "velox/expression/Expr.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/FunctionRegistry.h"
 
 namespace lp = facebook::axiom::logical_plan;
 
@@ -88,6 +85,12 @@ Value toValue(const velox::TypePtr& type, float cardinality) {
 
 Value toConstantValue(const velox::TypePtr& type) {
   return toValue(type, 1);
+}
+
+// Canonical Literal for a BOOLEAN constant.
+Literal* makeBoolLiteral(bool value) {
+  return make<Literal>(
+      toConstantValue(velox::BOOLEAN()), registerVariant(value));
 }
 
 OrderType toOrderType(lp::SortOrder sort) {
@@ -2473,8 +2476,14 @@ void pruneUnreachableRenames(
 void ToGraph::finalizeDt(
     const lp::LogicalPlanNode& node,
     DerivedTableP outerDt) {
-  VELOX_CHECK_EQ(0, applyContext_.lifted.predicates.size());
-  VELOX_CHECK_EQ(0, applyContext_.lifted.projections.size());
+  VELOX_USER_CHECK_EQ(
+      0,
+      applyContext_.lifted.predicates.size(),
+      "Nested correlation across subquery boundaries is not supported yet");
+  VELOX_USER_CHECK_EQ(
+      0,
+      applyContext_.lifted.projections.size(),
+      "Nested correlation across subquery boundaries is not supported yet");
 
   if (!outerDt) {
     outerDt = newDt();
@@ -3165,13 +3174,10 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(
     return agg;
   }
 
-  // For EXISTS subqueries with DISTINCT (aggregation with no aggregate
-  // functions), the DISTINCT can be dropped since EXISTS only checks row
-  // existence. Skip adding grouping keys from correlation and just keep
-  // the correlation conjuncts for later processing.
+  // DISTINCT (aggregation with no aggregate functions) does not change
+  // the membership set seen by EXISTS or IN, so drop it and let the
+  // correlation conjuncts flow up.
   if (agg->aggregates().empty()) {
-    // This is a DISTINCT (aggregation with only grouping keys, no
-    // aggregates). For EXISTS, we can skip it entirely.
     return nullptr;
   }
 
@@ -3512,6 +3518,10 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
     DerivedTableP subqueryDt,
     SubqueryChain& chain,
     ApplyContext::Lifted* outerLifted) {
+  VELOX_USER_CHECK(
+      !subqueryDt->hasLimit(),
+      "LIMIT in a correlated scalar subquery is not supported yet");
+
   // Non-equi correlation conjuncts land in the decorrelating LEFT JOIN's
   // filter. A filter reference to a sibling of the join's left side is
   // unplaceable. Wrap when there is at least one non-equi conjunct AND the
@@ -3889,6 +3899,13 @@ void ToGraph::processInPredicates(
       VELOX_NYI(
           "Outer-column reference in the aggregate body of an IN subquery is not supported yet");
     }
+    // The correlation rewrite for a global aggregate promotes the
+    // correlation column to a grouping key, leaving the inner subquery
+    // with one extra output column the IN consumer cannot place. Catch
+    // it before it surfaces as an internal arity check.
+    VELOX_USER_CHECK(
+        subqueryDt->aggregation == nullptr || subqueryDt->columns.size() == 1,
+        "IN over a correlated aggregation is not supported yet");
 
     // Right side of the IN comparison. When the subquery's SELECT
     // references outer columns, the lifted residual replaces the
@@ -4019,6 +4036,14 @@ ExprCP ToGraph::processCorrelatedInPredicate(
     PlanObjectCP leftTable,
     ExprCP inRightKey,
     bool inRightHasOuter) {
+  VELOX_USER_CHECK(
+      !subqueryDt->hasLimit(),
+      "LIMIT in a correlated IN subquery is not supported yet");
+  VELOX_USER_CHECK(
+      subqueryDt->aggregation == nullptr ||
+          !subqueryDt->aggregation->groupingKeys().empty(),
+      "IN over a correlated global aggregate is not supported yet");
+
   // Correlated IN subquery: process correlation conditions and create
   // semi-join with the IN equality as the sole null-aware join key and
   // correlation equalities moved to the join filter. If 'inRightKey'
@@ -4081,6 +4106,7 @@ void ToGraph::processExistsSubqueries(
     maybeWrapForChainedSubquery(input, chain);
 
     auto savedLifted = applyContext_.saveAndClearLifted();
+    applyContext_.lifted.isExists = true;
     SCOPE_EXIT {
       applyContext_.lifted = std::move(savedLifted);
     };
@@ -4102,10 +4128,25 @@ void ToGraph::processExistsSubqueries(
     // A subquery that produces zero rows (e.g., LIMIT 0) makes EXISTS false.
     if (subqueryDt->isZeroRows()) {
       applyContext_.lifted.predicates.clear();
-      subqueries_.emplace(
-          existsExpr,
-          make<Literal>(
-              toConstantValue(velox::BOOLEAN()), registerVariant(false)));
+      subqueries_.emplace(existsExpr, makeBoolLiteral(false));
+      continue;
+    }
+
+    // LIMIT N >= 1 is redundant for EXISTS: `EXISTS (... LIMIT N OFFSET M)`
+    // matches `EXISTS (... OFFSET M)`.
+    if (subqueryDt->hasLimit() && subqueryDt->limit >= 1) {
+      subqueryDt->limit = -1;
+    }
+
+    // EXISTS over a single-row body is TRUE.
+    if (subqueryDt->isSingleRow()) {
+      applyContext_.lifted.predicates.clear();
+      ExprCP result =
+          wrapMarkInGuards(std::move(outerGuards), makeBoolLiteral(true));
+      subqueries_.emplace(existsExpr, result);
+      if (!result->columns().empty()) {
+        chain.carryForwards.push_back(existsExpr);
+      }
       continue;
     }
 
@@ -4128,13 +4169,9 @@ void ToGraph::processExistsSubqueries(
           allConjuncts.end(), outerGuards.begin(), outerGuards.end());
       applyContext_.lifted.predicates.clear();
 
-      ExprCP result;
-      if (allConjuncts.empty()) {
-        result = make<Literal>(
-            toConstantValue(velox::BOOLEAN()), registerVariant(true));
-      } else {
-        result = makeAnd(std::move(allConjuncts));
-      }
+      ExprCP result = allConjuncts.empty()
+          ? static_cast<ExprCP>(makeBoolLiteral(true))
+          : makeAnd(std::move(allConjuncts));
       subqueries_.emplace(existsExpr, result);
       if (!result->columns().empty()) {
         chain.carryForwards.push_back(existsExpr);
@@ -4197,6 +4234,11 @@ ExprCP ToGraph::processUncorrelatedExists(DerivedTableP subqueryDt) {
 }
 
 ExprCP ToGraph::processCorrelatedExists(DerivedTableP subqueryDt) {
+  VELOX_USER_CHECK(
+      subqueryDt->aggregation == nullptr ||
+          !subqueryDt->aggregation->groupingKeys().empty(),
+      "EXISTS over a global aggregate with HAVING or OFFSET is not supported yet");
+
   // Correlated EXISTS: create mark join.
   // Finalize the subqueryDt (add to currentDt_).
   currentDt_->addTable(subqueryDt);
@@ -4901,6 +4943,27 @@ void ToGraph::makeQueryGraph(
         // outer DT by processCorrelatedScalarSubquery.
         VELOX_CHECK_NULL(applyContext_.lifted.aggregation);
         applyContext_.lifted.aggregation = agg;
+      } else if (applyContext_.lifted.isExists && agg->groupingKeys().empty()) {
+        // Keep the aggregation untransformed so the EXISTS consumer can
+        // detect a single-row body.
+        currentDt_->aggregation = agg;
+      } else if (!agg->groupingKeys().empty() && !agg->aggregates().empty()) {
+        // Grouped aggregate with correlation. Inner-side columns
+        // referenced by a lifted predicate must be in `groupingKeys` so
+        // they survive to the outer as join keys.
+        PlanObjectSet groupingKeyColumns;
+        groupingKeyColumns.unionColumns(agg->groupingKeys());
+        for (ExprCP predicate : applyContext_.lifted.predicates) {
+          predicate->columns().forEach([&](PlanObjectCP column) {
+            if (isOutsideDt(column->as<Column>()->relation(), currentDt_)) {
+              return;
+            }
+            VELOX_USER_CHECK(
+                groupingKeyColumns.contains(column),
+                "Correlation predicate references a column not in GROUP BY is not supported yet");
+          });
+        }
+        currentDt_->aggregation = agg;
       } else if (
           auto* result = processCorrelatedAggregation(
               agg, applyContext_.lifted.predicates)) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -218,6 +218,12 @@ class ToGraph {
     // one struct so a single value captures the full snapshot for
     // save/restore across nested 'translateSubquery' calls.
     struct Lifted {
+      // True while translating the body of an EXISTS subquery.
+      // Suppresses correlation rewrites that would lose the body's
+      // single-row property. Lives in 'Lifted' so 'saveAndClearLifted'
+      // resets it for any nested scalar/IN subquery whose body should
+      // not inherit EXISTS semantics.
+      bool isExists{false};
       // Filter conjuncts found in the subquery body that reference
       // outer-scope columns. Drained by the outer scope's
       // 'processCorrelatedScalarSubquery' (and friends) to become join
@@ -248,7 +254,9 @@ class ToGraph {
       // drain this field.
       ExprVector outerGuards;
 
-      // True if all accumulators are empty/null.
+      // True if all accumulators are empty/null. Does not consult
+      // 'isExists', which is a context-mode flag piggybacking on
+      // 'Lifted' for save/restore — not an accumulator.
       bool empty() const {
         return predicates.empty() && projections.empty() &&
             outerGuards.empty() && aggregation == nullptr;

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -79,12 +79,9 @@ SELECT a FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL
 -- HAVING + ORDER BY with grouping sets.
 SELECT a AS foo FROM t GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL ORDER BY a DESC
 ----
--- TODO: Support DISTINCT aggregation with grouping sets.
--- error: DISTINCT aggregation with grouping sets
+-- error: DISTINCT aggregation with grouping sets is not supported yet
 SELECT b, count(DISTINCT a) AS c FROM t GROUP BY ROLLUP(b)
 ----
--- TODO: Support ORDER BY in aggregates with global grouping sets. kSingle
--- emits spurious default rows from empty driver partitions for the global set.
 -- error: ORDER BY in aggregate functions is not supported with global grouping sets
 SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)
 ----

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -296,6 +296,18 @@ SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 -- Correlated NOT IN subquery with reversed operand order in correlation.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 ----
+-- NOT IN excludes rows where the left key is NULL.
+SELECT a FROM (VALUES (1), (CAST(NULL AS INTEGER)), (5)) AS l(a)
+WHERE a NOT IN (SELECT b FROM (VALUES (1), (3)) AS r(b))
+----
+-- Uncorrelated `WHERE NOT EXISTS` over an empty subquery returns every
+-- outer row.
+SELECT a FROM t WHERE NOT EXISTS (SELECT 1 FROM v WHERE false)
+----
+-- Uncorrelated `WHERE EXISTS` over a non-empty subquery returns every
+-- outer row.
+SELECT a FROM t WHERE EXISTS (SELECT 1 FROM v)
+----
 -- Uncorrelated scalar subquery whose source needs runtime single-row
 -- enforcement. Returns one row per outer row.
 SELECT (SELECT u.a FROM u WHERE u.a = 1) FROM t
@@ -359,8 +371,6 @@ SELECT (SELECT t.a WHERE t.a = 1) FROM t
 ----
 SELECT (SELECT t.b + 100 WHERE t.a > 1) FROM t
 ----
--- NYI: no-FROM subquery body with an aggregate whose body references an
--- outer column.
 -- error: Correlated aggregate in a no-FROM subquery body is not supported yet
 SELECT (SELECT max(t.a)) FROM t
 ----
@@ -382,13 +392,13 @@ SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a) FROM t
 -- are 1..3, u.a values are 1..5, t.a + 100 is never in u).
 SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a + 100) FROM t
 ----
--- NYI: outer-column reference in a non-inner join's ON condition inside
--- a correlated subquery.
+-- Outer-column reference in a non-INNER join's ON condition inside a
+-- correlated subquery.
 -- error: Cannot resolve column in join input
 SELECT (SELECT max(u.a) FROM u LEFT JOIN v ON v.a = t.a) FROM t
 ----
--- NYI: correlated subquery whose body is a UNION ALL of two branches
--- that each reference an outer column.
+-- Correlated subquery whose body is a UNION ALL of two branches that each
+-- reference an outer column.
 -- error: Correlated reference inside a UNION ALL branch is not supported yet
 SELECT (SELECT max(a) FROM (SELECT u.a FROM u WHERE u.a = t.a UNION ALL SELECT v.a FROM v WHERE v.a = t.a)) FROM t
 ----
@@ -396,9 +406,8 @@ SELECT (SELECT max(a) FROM (SELECT u.a FROM u WHERE u.a = t.a UNION ALL SELECT v
 -- comparison value combines an inner column with an outer column.
 SELECT t.a IN (SELECT u.a + t.b FROM u WHERE u.a > 0) FROM t
 ----
--- NYI: outer-column reference inside an aggregate body of an IN
--- subquery. The aggregate is in HAVING (not SELECT), so the SELECT
--- projection stays purely local and only the aggregate-body lift fires.
+-- Outer-column reference inside an aggregate body of an IN subquery
+-- (HAVING max(u.a + t.b) > 0).
 -- error: Outer-column reference in the aggregate body of an IN subquery is not supported yet
 SELECT t.a IN (SELECT u.a FROM u GROUP BY u.a HAVING max(u.a + t.b) > 0) FROM t
 ----
@@ -416,8 +425,8 @@ SELECT EXISTS (SELECT max(u.a + t.b) FROM u WHERE u.a = t.a) FROM t
 -- referencing outer.
 SELECT (SELECT min_by(u.a, t.b) FROM u WHERE u.a > 0) FROM t
 ----
--- NYI: aggregate whose args reference only outer columns.
--- error: aggregate whose arguments reference only outer columns is not supported yet
+-- Aggregate whose only argument references an outer column.
+-- error: Correlated subquery with an aggregate whose arguments reference only outer columns is not supported yet
 SELECT (SELECT count(t.a) FROM u WHERE u.a > 999) FROM t
 ----
 -- Multiple aggregates, each referencing an outer column.
@@ -535,3 +544,183 @@ SELECT a, array_agg(b ORDER BY b + (SELECT 0)) AS vals FROM t GROUP BY a
 ----
 -- Non-order-sensitive aggregate with ORDER BY containing a subquery.
 SELECT sum(a ORDER BY a + (SELECT 1)) AS total FROM t
+----
+-- Correlated scalar subquery whose body returns more than one row per
+-- outer row (multiple t.b for each t.a) must fail at runtime.
+-- error: Scalar sub-query has returned multiple rows
+SELECT (SELECT t2.b FROM t t2 WHERE t2.a = t.a) FROM t
+----
+-- Uncorrelated scalar subquery whose body returns more than one row
+-- must fail at runtime.
+-- error: Expected single row of input. Received 5 rows.
+SELECT (SELECT a FROM u) FROM t
+----
+-- Correlated EXISTS over a scalar-aggregate body. EXISTS is true iff
+-- the per-outer aggregate produces a row — for count(*) without
+-- HAVING, that's iff u has any matching row.
+SELECT t.a FROM t WHERE EXISTS (
+  SELECT count(*) FROM u WHERE u.a = t.a
+)
+----
+-- Correlated EXISTS over an aggregate body with HAVING. No `u.a` value
+-- has more than one row, so HAVING is never satisfied and the result
+-- is empty.
+-- count 0
+-- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+SELECT t.a FROM t WHERE EXISTS (
+  SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 1
+)
+----
+-- Correlated EXISTS over an aggregate body with HAVING that is
+-- satisfied for outers whose key appears in u.
+-- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+SELECT t.a FROM t WHERE EXISTS (
+  SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) >= 1
+)
+----
+-- Correlated IN over a grouping aggregate body where the IN right-
+-- hand side is one of the grouping keys.
+SELECT t.a FROM t WHERE t.a IN (
+  SELECT u.a FROM u WHERE u.a >= t.a GROUP BY u.a
+)
+----
+-- Correlated NOT EXISTS over an aggregate body with HAVING. Outers
+-- with no surviving group are kept.
+-- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+SELECT t.a FROM t WHERE NOT EXISTS (
+  SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 5
+)
+----
+-- IN whose subquery body is a scalar aggregate, so the IN right-hand
+-- side column is the aggregate result itself (not a grouping key).
+-- error: IN over a correlated global aggregate is not supported yet
+SELECT t.a FROM t WHERE t.a IN (
+  SELECT max(u.a) FROM u WHERE u.a <= t.a
+)
+----
+-- Correlated scalar subquery whose body is a UNION ALL of two
+-- branches, each filtering by an outer column.
+-- error: Correlated reference inside a UNION ALL branch is not supported yet
+SELECT t.a, (
+  SELECT count(*) FROM (
+    SELECT u.a FROM u WHERE u.a > t.a
+    UNION ALL
+    SELECT v.a FROM v WHERE v.a > t.a
+  )
+) FROM t
+----
+-- Correlated scalar subquery whose body has a Limit between the
+-- Aggregate and the correlated Filter.
+SELECT t.a, (
+  SELECT max(x) FROM (
+    SELECT u.a AS x FROM u WHERE u.a > t.a LIMIT 10
+  )
+) FROM t
+----
+-- Uncorrelated scalar subquery inside the UNNEST array constructor.
+-- error: Unexpected expression: Subquery
+SELECT v.x
+FROM (VALUES (ARRAY[10, 20, 30])) s(arr)
+CROSS JOIN UNNEST(ARRAY[(SELECT max(a) FROM u), arr[1]]) AS v(x)
+----
+-- Correlated scalar subquery inside the UNNEST array constructor;
+-- correlates to the input row above the UNNEST. DuckDB rejects nested
+-- lateral joins, so the expected result is hardcoded.
+-- duckdb: VALUES (1, 1), (2, 2)
+-- error: Unexpected expression: Subquery
+SELECT s.k, v.x
+FROM (VALUES (1), (2)) s(k)
+CROSS JOIN UNNEST(ARRAY[(SELECT max(a) FROM u WHERE u.a = s.k)]) AS v(x)
+----
+-- Correlated scalar subquery with LIMIT 1 body. The no-match outer
+-- must survive with NULL.
+-- error: LIMIT in a correlated scalar subquery is not supported yet
+SELECT u.a, (SELECT t.b FROM t WHERE t.a = u.a + 1 LIMIT 1) FROM u
+----
+-- Correlated EXISTS with LIMIT 1 body.
+SELECT u.a FROM u WHERE EXISTS (SELECT 1 FROM t WHERE t.a > u.a LIMIT 1)
+----
+-- Correlated NOT EXISTS with LIMIT 1 body.
+SELECT u.a FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t.a > u.a LIMIT 1)
+----
+-- A correlated scalar whose body is a Join of two correlated
+-- single-row subqueries returns one row per outer.
+-- error: Nested correlation across subquery boundaries is not supported yet
+SELECT u.a,
+       (SELECT l.b + r.b
+        FROM (SELECT max(b) AS b FROM t WHERE t.a = u.a) l,
+             (SELECT max(b) AS b FROM t WHERE t.a = u.a + 1) r)
+FROM u
+----
+-- Correlated scalar whose body joins a correlated single-row subquery
+-- with an uncorrelated single-row subquery. Outers with no matching
+-- left row must surface a single NULL row, not |right| NULL-extended
+-- rows.
+-- error: Nested correlation across subquery boundaries is not supported yet
+SELECT u.a,
+       (SELECT l.b + r.b
+        FROM (SELECT max(b) AS b FROM t WHERE t.a = u.a + 10) l,
+             (SELECT max(b) AS b FROM t) r)
+FROM u
+----
+-- Correlated EXISTS over a Join with single-side correlation.
+-- error: Nested correlation across subquery boundaries is not supported yet
+SELECT u.a
+FROM u
+WHERE EXISTS (
+  SELECT 1
+  FROM (SELECT t.a FROM t WHERE t.a = u.a + 1) l,
+       (SELECT t.a FROM t) r)
+----
+-- Correlated IN whose body has a multi-conjunct Filter mixing a
+-- correlation predicate with an uncorrelated predicate. Both
+-- conjuncts must survive pull-through into the semi-join condition.
+SELECT u.a IN (SELECT t.a FROM t WHERE t.a = u.a AND t.b > 0) FROM u
+----
+-- Correlated EXISTS whose body has a multi-conjunct Filter mixing a
+-- correlation predicate with an uncorrelated predicate. Both
+-- conjuncts must survive pull-through into the semi-join condition.
+SELECT u.a FROM u
+WHERE EXISTS (SELECT 1 FROM t WHERE t.a = u.a AND t.b > 0)
+----
+-- Correlated scalar `count(*)` body with a HAVING predicate over the
+-- aggregate result.
+SELECT (SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 0) FROM t
+----
+-- Correlated IN whose right-hand side is the result of a scalar
+-- `count(*)` over a correlated body. For outers with no matching u
+-- rows, `count(*)` returns 0 — so `t.a IN (...)` matches when t.a = 0.
+-- error: IN over a correlated aggregation is not supported yet
+SELECT t.a IN (SELECT count(*) FROM u WHERE u.a = t.a) FROM t
+----
+-- Correlated IN whose right-hand side is the aggregate result of a
+-- grouping aggregate (not a grouping key).
+SELECT t.a IN (
+  SELECT count(*) FROM u WHERE u.a = t.a GROUP BY u.a
+) FROM t
+----
+-- Correlated grouped aggregate whose correlation predicate references
+-- an inner column outside the GROUP BY clause: t.b is consumed by the
+-- aggregate (grouped by t.a only) and cannot become a join key at the
+-- outer level.
+-- error: Correlation predicate references a column not in GROUP BY is not supported yet
+SELECT u.a IN (
+  SELECT count(*) FROM t WHERE t.b = u.a GROUP BY t.a
+) FROM u
+----
+-- Correlated IN whose body is a scalar aggregate with HAVING.
+-- error: IN over a correlated aggregation is not supported yet
+SELECT t.a IN (
+  SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 0
+) FROM t
+----
+-- Correlated NOT IN whose body is a scalar aggregate that can return
+-- NULL (max over empty body). NULL on the right-hand side propagates
+-- NULL through NOT IN per SQL three-valued logic.
+-- error: IN over a correlated global aggregate is not supported yet
+SELECT t.a NOT IN (SELECT max(u.a) FROM u WHERE u.a > t.a) FROM t
+----
+-- EXISTS over a correlated `count(*)` body where the WHERE
+-- eliminates every body row. Scalar aggregates always emit one
+-- row, so EXISTS sees it → TRUE for every outer.
+SELECT EXISTS (SELECT count(*) FROM u WHERE u.a = t.a + 100) FROM t


### PR DESCRIPTION
Summary:

Fixes correctness bugs and failures in translation of correlated subqueries. (Discovered while working on Optimizer v2.)

EXISTS over a global aggregate.

    SELECT EXISTS (SELECT count(*) FROM u WHERE u.a = t.a + 100) FROM t

returned FALSE for every outer row. A global aggregate always emits one row, so EXISTS is TRUE. Skip the correlation rewrite for an EXISTS body and short-circuit to TRUE when the body is single-row.

IN over a grouped aggregate.

    SELECT t.a IN (SELECT count(*) FROM u WHERE u.a = t.a GROUP BY u.a) FROM t

failed in `processCorrelatedAggregation` (precondition: input must be global). Skip the rewrite when the input is already grouped; correlation predicates flow up as join keys.

EXISTS / NOT EXISTS over a body with LIMIT.

    SELECT u.a FROM u WHERE EXISTS (SELECT 1 FROM t WHERE t.a > u.a LIMIT 1)

returned no rows. The planner lifted the LIMIT above the correlation and picked one t row globally. LIMIT N >= 1 is redundant for EXISTS — drop it.

Scalar / IN over a body with LIMIT. The same LIMIT-lifting bug also returned wrong results for scalar and IN consumers, but LIMIT is meaningful there. Fail loudly with NYI instead.

Reviewed By: xiaoxmeng

Differential Revision: D107381854


