### PR TITLE
fix(logical_plan): JOIN ON resolves outer-scope column references (#1444)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1176,17 +1176,29 @@ ExprPtr resolveJoinInputName(
     const std::optional<std::string>& alias,
     const std::string& name,
     const NameMappings& mapping,
-    const velox::RowTypePtr& inputRowType) {
+    const velox::RowTypePtr& inputRowType,
+    const PlanBuilder::Scope& outerScope) {
   if (alias.has_value()) {
     if (auto id = mapping.lookup(alias.value(), name)) {
       return makeInputRef(inputRowType->findChild(id.value()), id.value());
     }
 
+    // The ON condition may reference outer-scope columns when the JOIN
+    // sits inside a correlated subquery.
+    if (outerScope) {
+      return outerScope(alias, name);
+    }
     return nullptr;
   }
 
   if (auto id = mapping.lookup(name)) {
     return makeInputRef(inputRowType->findChild(id.value()), id.value());
+  }
+
+  if (outerScope) {
+    if (auto expr = outerScope(alias, name)) {
+      return expr;
+    }
   }
 
   VELOX_USER_FAIL(
@@ -1215,7 +1227,7 @@ PlanBuilder& PlanBuilder::join(
     expr = resolver_.resolveScalarTypes(
         condition->expr(), [&](const auto& alias, const auto& name) {
           return resolveJoinInputName(
-              alias, name, *outputMapping_, inputRowType);
+              alias, name, *outputMapping_, inputRowType, outerScope_);
         });
   }
 

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -53,11 +53,11 @@ class PlanBuilderTest : public testing::Test {
 };
 
 TEST_F(PlanBuilderTest, anonymousOutputNames) {
-  auto builder = PlanBuilder()
-                     .values(
-                         ROW({"a"}, {BIGINT()}),
-                         std::vector<Variant>{Variant::row({123LL})})
-                     .project({"a + 1", "a + 2 as b"});
+  auto builder =
+      PlanBuilder()
+          .values(
+              ROW({"a"}, BIGINT()), std::vector<Variant>{Variant::row({123LL})})
+          .project({"a + 1", "a + 2 as b"});
 
   using Name = PlanBuilder::OutputColumnName;
 

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -394,7 +394,7 @@ SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a + 100) FROM t
 ----
 -- Outer-column reference in a non-INNER join's ON condition inside a
 -- correlated subquery.
--- error: Cannot resolve column in join input
+-- error: Cannot resolve column name: a
 SELECT (SELECT max(u.a) FROM u LEFT JOIN v ON v.a = t.a) FROM t
 ----
 -- Correlated subquery whose body is a UNION ALL of two branches that each

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -765,6 +765,18 @@ TEST_F(PrestoParserTest, exists) {
   }
 }
 
+// JOIN ON in a correlated subquery body resolves outer-scope columns
+// the same way WHERE does.
+TEST_F(PrestoParserTest, correlatedSubqueryWithOuterReferenceInJoinOn) {
+  auto matcher = matchScan("region").project().output();
+  testSelect(
+      "SELECT ("
+      " SELECT max(s.s_nationkey) "
+      " FROM supplier s LEFT JOIN nation n ON n.n_nationkey = r.r_regionkey"
+      ") FROM region r",
+      matcher);
+}
+
 TEST_F(PrestoParserTest, structDereferenceInCorrelatedSubquery) {
   connector_->addTable(
       "t",


### PR DESCRIPTION
Summary:

A correlated subquery whose body contains a JOIN with an outer-column reference in the ON condition,

    SELECT (SELECT max(u.a) FROM u LEFT JOIN v ON v.a = t.a) FROM t

failed with `Cannot resolve column in join input: t`. WHERE chains to outer scope for correlated subqueries; JOIN ON didn't.

Fall through to `outerScope_` when neither join side has the column.

The optimizer's downstream decorrelation does not yet handle outer-refs in non-INNER JOIN ON (LATERAL semantics); such queries now reach the optimizer and fail there instead.

Reviewed By: xiaoxmeng

Differential Revision: D107388117


