### PR TITLE
feat(logical_plan): Add Context::connectorMetadata via QueryCtx-scoped registry lookup (#1445)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -26,6 +26,36 @@ namespace facebook::axiom::logical_plan {
 
 using connector::ConnectorMetadataRegistry;
 
+PlanBuilder::Context::Context(
+    const std::optional<std::string>& defaultConnectorId,
+    const std::optional<std::string>& defaultSchema,
+    std::shared_ptr<velox::core::QueryCtx> queryCtxPtr,
+    ExprResolver::FunctionRewriteHook hook,
+    std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser,
+    const velox::TypeCoercer* coercer)
+    : defaultConnectorId{defaultConnectorId},
+      defaultSchema{defaultSchema},
+      sqlParser{std::move(sqlParser)},
+      planNodeIdGenerator{std::make_shared<velox::core::PlanNodeIdGenerator>()},
+      nameAllocator{std::make_shared<NameAllocator>()},
+      queryCtx{std::move(queryCtxPtr)},
+      hook{std::move(hook)},
+      pool{
+          queryCtx && queryCtx->pool()
+              ? queryCtx->pool()->addLeafChild("literals")
+              : nullptr},
+      coercer{coercer} {}
+
+std::shared_ptr<connector::ConnectorMetadata>
+PlanBuilder::Context::connectorMetadata(const std::string& connectorId) const {
+  auto metadata = queryCtx
+      ? ConnectorMetadataRegistry::tryGet(*queryCtx, connectorId)
+      : ConnectorMetadataRegistry::tryGet(connectorId);
+  VELOX_USER_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
 PlanBuilder& PlanBuilder::values(
     const velox::RowTypePtr& rowType,
     std::vector<velox::Variant> rows) {
@@ -210,11 +240,11 @@ PlanBuilder& PlanBuilder::values(
 PlanBuilder& PlanBuilder::tableScan(
     const std::string& tableName,
     bool includeHiddenColumns) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
   return tableScan(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       tableName,
       includeHiddenColumns);
 }
@@ -225,12 +255,8 @@ PlanBuilder& PlanBuilder::from(const std::vector<std::string>& tableNames) {
 
   tableScan(tableNames.front());
 
-  Context context{defaultConnectorId_, defaultSchema_};
-  context.planNodeIdGenerator = planNodeIdGenerator_;
-  context.nameAllocator = nameAllocator_;
-
   for (auto i = 1; i < tableNames.size(); ++i) {
-    crossJoin(PlanBuilder(context).tableScan(tableNames.at(i)));
+    crossJoin(PlanBuilder(context_).tableScan(tableNames.at(i)));
   }
 
   return *this;
@@ -244,7 +270,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = context_.connectorMetadata(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -305,19 +331,22 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& schemaName,
     const std::string& tableName,
     bool includeHiddenColumns) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
   return tableScan(
-      defaultConnectorId_.value(), schemaName, tableName, includeHiddenColumns);
+      context_.defaultConnectorId.value(),
+      schemaName,
+      tableName,
+      includeHiddenColumns);
 }
 
 PlanBuilder& PlanBuilder::tableScan(
     const std::string& tableName,
     const std::vector<std::string>& columnNames) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
   return tableScan(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       tableName,
       columnNames);
 }
@@ -326,9 +355,9 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& schemaName,
     const std::string& tableName,
     const std::vector<std::string>& columnNames) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
   return tableScan(
-      defaultConnectorId_.value(), schemaName, tableName, columnNames);
+      context_.defaultConnectorId.value(), schemaName, tableName, columnNames);
 }
 
 PlanBuilder& PlanBuilder::tableScan(
@@ -339,7 +368,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = context_.connectorMetadata(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -427,7 +456,7 @@ PlanBuilder& PlanBuilder::dropHiddenColumns() {
 PlanBuilder& PlanBuilder::filter(const std::string& predicate) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Filter node cannot be a leaf node");
 
-  auto untypedExpr = sqlParser_->parseExpr(predicate);
+  auto untypedExpr = context_.sqlParser->parseExpr(predicate);
   return filter(untypedExpr);
 }
 
@@ -443,7 +472,7 @@ std::vector<ExprApi> PlanBuilder::parse(const std::vector<std::string>& exprs) {
   std::vector<ExprApi> untypedExprs;
   untypedExprs.reserve(exprs.size());
   for (const auto& sql : exprs) {
-    untypedExprs.emplace_back(sqlParser_->parseScalarOrWindowExpr(sql));
+    untypedExprs.emplace_back(context_.sqlParser->parseScalarOrWindowExpr(sql));
   }
   return untypedExprs;
 }
@@ -744,7 +773,7 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(parse(groupingKeys), parsedAggregates);
 }
@@ -827,7 +856,7 @@ PlanBuilder& PlanBuilder::aggregate(
   }
 
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(exprGroupingSets, parsedAggregates, groupingSetIndexName);
 }
@@ -838,7 +867,7 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(
       parse(groupingKeys),
@@ -973,7 +1002,7 @@ PlanBuilder& PlanBuilder::rollup(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return rollup(parse(groupingKeys), parsedAggregates, groupingSetIndexName);
 }
@@ -1009,7 +1038,7 @@ PlanBuilder& PlanBuilder::cube(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return cube(parse(groupingKeys), parsedAggregates, groupingSetIndexName);
 }
@@ -1164,7 +1193,7 @@ PlanBuilder& PlanBuilder::join(
     JoinType joinType) {
   std::optional<ExprApi> conditionExpr;
   if (!condition.empty()) {
-    conditionExpr = sqlParser_->parseExpr(condition);
+    conditionExpr = context_.sqlParser->parseExpr(condition);
   }
 
   return join(right, conditionExpr, joinType);
@@ -1453,7 +1482,7 @@ PlanBuilder& PlanBuilder::setOperation(
     SetOperation op,
     const PlanBuilder& other) {
   // Do not use std::move(*this) — that invalidates resolver_ members
-  // (e.g. planNodeIdGenerator_ becomes null), causing crashes when the
+  // (e.g. context_.planNodeIdGenerator becomes null), causing crashes when the
   // builder is used for expression resolution after the set operation.
   VELOX_CHECK_NOT_NULL(node_);
   VELOX_CHECK_NOT_NULL(other.node_);
@@ -1563,7 +1592,7 @@ PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {
   sortingFields.reserve(sortingKeys.size());
 
   for (const auto& key : sortingKeys) {
-    auto orderBy = sqlParser_->parseOrderByExpr(key);
+    auto orderBy = context_.sqlParser->parseOrderByExpr(key);
     auto expr = resolveScalarTypes(orderBy.expr);
 
     sortingFields.push_back(
@@ -1635,7 +1664,7 @@ PlanBuilder& PlanBuilder::tableWrite(
 
   if (kind == WriteKind::kInsert) {
     // Check input types.
-    auto metadata = ConnectorMetadataRegistry::get(connectorId);
+    auto metadata = context_.connectorMetadata(connectorId);
     auto table = metadata->findTable(schemaTableName);
     VELOX_USER_CHECK_NOT_NULL(
         table, "Table not found: {}", schemaTableName.toString());
@@ -1688,8 +1717,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     std::vector<std::string> columnNames,
     folly::F14FastMap<std::string, std::string> options) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Table write node cannot be a leaf node");
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
 
   auto outputColumns = findOrAssignOutputNames();
   std::vector<ExprApi> columnExprs;
@@ -1699,8 +1728,8 @@ PlanBuilder& PlanBuilder::tableWrite(
   }
 
   return tableWrite(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       std::move(tableName),
       kind,
       std::move(columnNames),
@@ -1837,7 +1866,7 @@ PlanBuilder& PlanBuilder::as(const std::string& alias) {
 }
 
 std::string PlanBuilder::newName(const std::string& hint) {
-  return nameAllocator_->newName(hint);
+  return context_.nameAllocator->newName(hint);
 }
 
 size_t PlanBuilder::numOutput() const {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/ExprResolver.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
@@ -129,8 +131,10 @@ class PlanBuilder {
     /// Context.
     std::shared_ptr<NameAllocator> nameAllocator;
 
-    /// Enables constant folding when set. Also provides a memory pool for
-    /// evaluating constant expressions.
+    /// Enables constant folding (including memory pool) when set.
+    /// Enables a per-query connector metadata registry override (looked up
+    /// under `ConnectorMetadataRegistry::kRegistryKey`); when unset, lookups
+    /// go directly against the global registry.
     std::shared_ptr<velox::core::QueryCtx> queryCtx;
 
     /// Rewrites function calls during expression resolution, e.g. maps
@@ -163,20 +167,21 @@ class PlanBuilder {
         std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser =
             std::make_shared<velox::parse::DuckSqlExpressionsParser>(
                 velox::parse::ParseOptions{.parseInListAsArray = false}),
-        const velox::TypeCoercer* coercer = nullptr)
-        : defaultConnectorId{defaultConnectorId},
-          defaultSchema{defaultSchema},
-          sqlParser{std::move(sqlParser)},
-          planNodeIdGenerator{
-              std::make_shared<velox::core::PlanNodeIdGenerator>()},
-          nameAllocator{std::make_shared<NameAllocator>()},
-          queryCtx{std::move(queryCtxPtr)},
-          hook{std::move(hook)},
-          pool{
-              queryCtx && queryCtx->pool()
-                  ? queryCtx->pool()->addLeafChild("literals")
-                  : nullptr},
-          coercer{coercer} {}
+        const velox::TypeCoercer* coercer = nullptr);
+
+    /// Resolves connector metadata for `connectorId`.
+    ///
+    /// If `queryCtx` is set and has a `ConnectorMetadataRegistry` registered
+    /// under `ConnectorMetadataRegistry::kRegistryKey`, the lookup is
+    /// dispatched to that scoped registry; whether it falls back to the global
+    /// registry depends on the scoped registry's parent chain. Otherwise (no
+    /// `queryCtx`, or no registry override under `kRegistryKey`), the lookup
+    /// goes directly against the global registry. This will not return a
+    /// nullptr: it will throw an exception instead.
+    ///
+    /// @throws VeloxUserException if the connector is not registered.
+    std::shared_ptr<connector::ConnectorMetadata> connectorMetadata(
+        const std::string& connectorId) const;
   };
 
   /// Resolves a column reference from an outer query scope. Used to support
@@ -209,12 +214,8 @@ class PlanBuilder {
       const Context& context,
       bool allowAmbiguousOutputNames = false,
       Scope outerScope = nullptr)
-      : defaultConnectorId_{context.defaultConnectorId},
-        defaultSchema_{context.defaultSchema},
-        planNodeIdGenerator_{context.planNodeIdGenerator},
-        nameAllocator_{context.nameAllocator},
+      : context_{context},
         outerScope_{std::move(outerScope)},
-        sqlParser_{context.sqlParser},
         allowAmbiguousOutputNames_{allowAmbiguousOutputNames},
         coercer_{context.coercer},
         identifierCanonicalizer_{context.identifierCanonicalizer},
@@ -224,8 +225,8 @@ class PlanBuilder {
             context.hook,
             context.pool,
             context.planNodeIdGenerator} {
-    VELOX_CHECK_NOT_NULL(planNodeIdGenerator_);
-    VELOX_CHECK_NOT_NULL(nameAllocator_);
+    VELOX_CHECK_NOT_NULL(context_.planNodeIdGenerator);
+    VELOX_CHECK_NOT_NULL(context_.nameAllocator);
   }
 
   /// Adds a leaf Values node producing literal rows. Must be the first node
@@ -608,11 +609,11 @@ class PlanBuilder {
       std::vector<std::string> columnNames,
       const std::initializer_list<std::string>& columnExprs,
       folly::F14FastMap<std::string, std::string> options = {}) {
-    VELOX_USER_CHECK(defaultConnectorId_.has_value());
-    VELOX_USER_CHECK(defaultSchema_.has_value());
+    VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+    VELOX_USER_CHECK(context_.defaultSchema.has_value());
     return tableWrite(
-        defaultConnectorId_.value(),
-        defaultSchema_.value(),
+        context_.defaultConnectorId.value(),
+        context_.defaultSchema.value(),
         std::move(tableName),
         kind,
         std::move(columnNames),
@@ -627,11 +628,11 @@ class PlanBuilder {
       std::vector<std::string> columnNames,
       const std::vector<std::string>& columnExprs,
       folly::F14FastMap<std::string, std::string> options = {}) {
-    VELOX_USER_CHECK(defaultConnectorId_.has_value());
-    VELOX_USER_CHECK(defaultSchema_.has_value());
+    VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+    VELOX_USER_CHECK(context_.defaultSchema.has_value());
     return tableWrite(
-        defaultConnectorId_.value(),
-        defaultSchema_.value(),
+        context_.defaultConnectorId.value(),
+        context_.defaultSchema.value(),
         std::move(tableName),
         kind,
         std::move(columnNames),
@@ -811,7 +812,7 @@ class PlanBuilder {
   void setOperationImpl(SetOperation op, std::vector<LogicalPlanNodePtr> nodes);
 
   std::string nextId() {
-    return planNodeIdGenerator_->next();
+    return context_.planNodeIdGenerator->next();
   }
 
   std::string newName(const std::string& hint);
@@ -845,25 +846,14 @@ class PlanBuilder {
       std::vector<AggregateExprPtr>& exprs,
       NameMappings& mappings);
 
-  // Connector ID used when table names omit the catalog prefix.
-  const std::optional<std::string> defaultConnectorId_;
-
-  // Schema used when table names omit the schema prefix.
-  const std::optional<std::string> defaultSchema_;
-
-  // Generates unique plan-node IDs (shared across builders via Context).
-  const std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator_;
-
-  // Allocates unique internal column names (shared across builders via
-  // Context).
-  const std::shared_ptr<NameAllocator> nameAllocator_;
+  // Shared state inherited from the constructor's Context. Sole source of
+  // truth for default connector/schema, ID/name generators, queryCtx, and the
+  // SQL expression parser.
+  const Context context_;
 
   // Resolves column references from the enclosing query for correlated
   // subqueries. Null for top-level queries.
   const Scope outerScope_;
-
-  // Parses SQL expression strings into Velox expression trees.
-  const std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser_;
 
   const bool allowAmbiguousOutputNames_;
 

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -16,9 +16,13 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
+#include "folly/ScopeGuard.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
@@ -734,6 +738,94 @@ TEST_F(PlanBuilderTest, valuesTypeCoercionErrors) {
           {{"CAST(null AS boolean)"}, {"CAST(null AS bigint)"}},
           /*enableCoercions=*/false),
       "All values should have equivalent types: BIGINT vs. ROW<x:BOOLEAN>");
+}
+
+// Builds a QueryCtx with the given scoped connector metadata registry attached
+// under ConnectorMetadataRegistry::kRegistryKey.
+std::shared_ptr<core::QueryCtx> queryCtxWithRegistry(
+    std::shared_ptr<connector::ConnectorMetadataRegistry::Registry> registry) {
+  auto queryCtx = core::QueryCtx::create();
+  queryCtx->setRegistry(
+      connector::ConnectorMetadataRegistry::kRegistryKey, std::move(registry));
+  return queryCtx;
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryTableScan) {
+  // Create an isolated scoped registry (no parent fallback).
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  auto testConnector =
+      std::make_shared<connector::TestConnector>("scoped_connector");
+  registry->insert(testConnector->connectorId(), testConnector->metadata());
+
+  testConnector->addTable(
+      "orders", ROW({"o_custkey", "o_totalprice"}, {BIGINT(), DOUBLE()}));
+
+  PlanBuilder::Context context{
+      std::string("scoped_connector"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  auto plan = PlanBuilder(context).tableScan("orders").build();
+  ASSERT_NE(plan, nullptr);
+  EXPECT_THAT(
+      plan->outputType()->names(),
+      testing::ElementsAre("o_custkey", "o_totalprice"));
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryFrom) {
+  // Verify that from() propagates the scoped registry to subsequent table
+  // scans for the second and later tables.
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  auto testConnector =
+      std::make_shared<connector::TestConnector>("scoped_from");
+  registry->insert(testConnector->connectorId(), testConnector->metadata());
+
+  testConnector->addTable("t1", ROW({"a", "b"}, {BIGINT(), VARCHAR()}));
+  testConnector->addTable("t2", ROW({"c", "d"}, {INTEGER(), DOUBLE()}));
+
+  PlanBuilder::Context context{
+      std::string("scoped_from"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  // from() builds cross joins across t1 and t2. The second table scan
+  // must also use the scoped registry.
+  auto plan = PlanBuilder(context).from({"t1", "t2"}).build();
+  ASSERT_NE(plan, nullptr);
+  EXPECT_THAT(
+      plan->outputType()->names(), testing::ElementsAre("a", "b", "c", "d"));
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryTableNotFound) {
+  // Register a table in the global registry only. A scoped registry without
+  // that table should fail to resolve it.
+  auto globalConnector =
+      std::make_shared<connector::TestConnector>("global_only");
+  connector::ConnectorMetadataRegistry::global().insert(
+      globalConnector->connectorId(), globalConnector->metadata());
+  SCOPE_EXIT {
+    connector::ConnectorMetadataRegistry::global().erase(
+        globalConnector->connectorId());
+  };
+  globalConnector->addTable("global_table", ROW({"x"}, {BIGINT()}));
+
+  // Create an isolated registry with no parent, so it cannot see the global.
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  PlanBuilder::Context context{
+      std::string("global_only"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  // The scoped registry does not contain "global_only", so lookup fails.
+  VELOX_ASSERT_THROW(
+      PlanBuilder(context).tableScan("global_table"),
+      "ConnectorMetadata not registered: global_only");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

PlanBuilder can now use a per-query connector metadata registry instead of always hitting the global singleton. When you pass a `core::QueryCtx` with a scoped `ConnectorMetadataRegistry` attached (via `QueryCtx::setRegistry` under `ConnectorMetadataRegistry::kRegistryKey`), PlanBuilder's new `Context::connectorMetadata(connectorId)` helper resolves against that scoped registry first. If no `queryCtx` is set, or the key isn't registered, it falls back to the global registry. This enables test isolation: unit tests can spin up a child registry with only the connectors they care about, preventing cross-test pollution when multiple tests register the same connector ID. The scoped registry propagates through `from()` so multi-table scans in `FROM t1, t2, t3` all see the same scoped state.

Differential Revision: D104608353


