### PR TITLE
fix(parser): Resolve enum keys against canonical uppercase

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -481,7 +481,15 @@ std::optional<lp::ExprApi> tryResolveEnumLiteral(
   const auto& catalog = parts[0];
   facebook::axiom::SchemaTypeName schemaTypeName{
       parts[1], folly::join('.', parts.begin() + 2, parts.end() - 1)};
-  const auto& valueName = parts.back();
+  // Enum types store their keys uppercase (the canonical form), so uppercase
+  // the referenced key for a case-insensitive lookup. The type and namespace
+  // parts stay lowercased.
+  std::string valueName = parts.back();
+  std::transform(
+      valueName.begin(),
+      valueName.end(),
+      valueName.begin(),
+      [](unsigned char character) { return std::toupper(character); });
 
   auto type = findQualifiedType(catalog, schemaTypeName, typeCache);
   if (type == nullptr) {

--- a/axiom/sql/presto/tests/EnumLiteralTest.cpp
+++ b/axiom/sql/presto/tests/EnumLiteralTest.cpp
@@ -69,13 +69,15 @@ class EnumLiteralTest : public PrestoParserTestBase {
 
     enumMetadata_ = std::make_shared<CountingTestConnectorMetadata>(nullptr);
 
+    // Enum keys are stored uppercase, the canonical form produced by the type
+    // parser and connectors.
     statusType_ = BIGINT_ENUM(LongEnumParameter(
         "tc.myschema.status",
-        {{"active", 0}, {"inactive", 1}, {"pending", 2}}));
+        {{"ACTIVE", 0}, {"INACTIVE", 1}, {"PENDING", 2}}));
     enumMetadata_->addType({"myschema", "status"}, statusType_);
 
     colorType_ = VARCHAR_ENUM(VarcharEnumParameter(
-        "tc.myschema.color", {{"red", "red_value"}, {"blue", "blue_value"}}));
+        "tc.myschema.color", {{"RED", "red_value"}, {"BLUE", "blue_value"}}));
     enumMetadata_->addType({"myschema", "color"}, colorType_);
 
     facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
@@ -292,7 +294,7 @@ TEST_F(EnumLiteralTest, typeofEnumLiteral) {
 
 TEST_F(EnumLiteralTest, multiPartTypeName) {
   auto multiPartType =
-      BIGINT_ENUM(LongEnumParameter("tc.b.foo.bar", {{"val", 42}}));
+      BIGINT_ENUM(LongEnumParameter("tc.b.foo.bar", {{"VAL", 42}}));
   enumMetadata_->addType({"b", "foo.bar"}, multiPartType);
 
   // CAST path.


### PR DESCRIPTION
Summary:
Enum types store their keys in canonical uppercase. The Presto SQL parser lowercases every part of a dotted name (for case-insensitive catalog/column matching), so a referenced enum key — e.g. `cat.schema.Color.RED` — arrives lowercased and misses the uppercase-stored key.

Re-uppercase the key in `tryResolveEnumLiteral` before the (verbatim) value lookup, so resolution stays case-insensitive: `Color.red` and `Color.RED` both resolve. The lowercasing happens earlier in `extractQualifiedParts` and must stay there — it is shared with column resolution, and only the enum path knows the last part is a key rather than a struct field. So the key is uppercased here, where that is known.

The connector-side change that stores keys uppercase is in the parent diff D105644657; the two halves land together.

Reviewed By: mbasmanova

Differential Revision: D107457921


