### PR TITLE
misc: Throw on SHOW TABLES for dynamic catalogs (#1447)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -1008,9 +1008,13 @@ class ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const std::string& schemaName) = 0;
 
-  /// Returns table names in the given schema. Connectors with unbounded
-  /// table sets (e.g., dynamic resolution) return empty. Results are not
-  /// guaranteed to be in any particular order.
+  /// Returns whether this connector supports listing table names.
+  virtual bool listTableNamesSupported() const {
+    return true;
+  }
+
+  /// Returns table names in the given schema. Results are not guaranteed to be
+  /// in any particular order.
   virtual std::vector<std::string> listTableNames(
       const ConnectorSessionPtr& session,
       const std::string& schemaName) = 0;

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2353,6 +2353,10 @@ SqlStatementPtr parseShowTables(
       metadata->schemaExists(session, schema),
       "Schema does not exist: {}",
       schema);
+  VELOX_USER_CHECK(
+      metadata->listTableNamesSupported(),
+      "SHOW TABLES is not supported for catalog '{}'",
+      connectorId);
   auto tableNames = metadata->listTableNames(session, schema);
   std::sort(tableNames.begin(), tableNames.end());
 


### PR DESCRIPTION
Summary:

Make dynamic connectors report that table-name listing is unsupported, and have the `SHOW TABLES` planner fail with a catalog-specific user error instead of returning an empty result. `ConnectorMetadata::listTableNamesSupported()` now captures whether a connector can enumerate tables, while Prism, XDB, and Configerator override it to false because their table sets are dynamically resolved or not safely enumerable.

Reviewed By: mbasmanova

Differential Revision: D107467219


