### PR TITLE
feat(parser): Lift outer-scope aggregate in scalar subquery (#1448)

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -371,7 +371,8 @@ SELECT (SELECT t.a WHERE t.a = 1) FROM t
 ----
 SELECT (SELECT t.b + 100 WHERE t.a > 1) FROM t
 ----
--- error: Correlated aggregate in a no-FROM subquery body is not supported yet
+-- Pure-outer aggregate: max(t.a) binds to the outer scope. Returns
+-- one row with max(t.a) over all t.
 SELECT (SELECT max(t.a)) FROM t
 ----
 -- No-FROM subquery body with a cardinality-neutral aggregate. count(*)
@@ -425,9 +426,37 @@ SELECT EXISTS (SELECT max(u.a + t.b) FROM u WHERE u.a = t.a) FROM t
 -- referencing outer.
 SELECT (SELECT min_by(u.a, t.b) FROM u WHERE u.a > 0) FROM t
 ----
--- Aggregate whose only argument references an outer column.
--- error: Correlated subquery with an aggregate whose arguments reference only outer columns is not supported yet
+-- The following pure-outer-aggregate queries use `-- duckdb:`
+-- overrides because DuckDB's subquery form does not implement the
+-- outer-scope lift consistently with its own explicit-aggregation
+-- form. See https://github.com/duckdb/duckdb/issues/23063.
+--
+-- Pure-outer aggregate with an empty body. count over zero rows = 0.
+-- duckdb: SELECT count(t.a) FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.a > 999)
 SELECT (SELECT count(t.a) FROM u WHERE u.a > 999) FROM t
+----
+-- Pure-outer aggregate with a correlated body filter. Every outer
+-- row qualifies, so max returns 3.
+-- duckdb: SELECT max(t.a) FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.a = t.a)
+SELECT (SELECT max(t.a) FROM u WHERE u.a = t.a) FROM t
+----
+-- Single-row outer: per-row evaluation gives the same answer.
+SELECT (SELECT count(t.a) FROM u WHERE u.a > 0) FROM (VALUES (1)) AS t(a)
+----
+-- Pure-outer aggregate inside a HAVING predicate.
+-- duckdb: SELECT count(*) FROM t HAVING EXISTS(SELECT 1) AND (SELECT max(a) FROM t) > 0
+SELECT count(*) FROM t HAVING (SELECT max(t.a)) > 0
+----
+-- Pure-outer aggregate wrapped in arithmetic.
+SELECT (SELECT max(t.a) + 1 FROM u WHERE u.a > 0) FROM t
+----
+-- Multiple pure-outer aggregates in one subquery expression, sharing
+-- the body's FROM/WHERE as the EXISTS gate.
+SELECT (SELECT max(t.a) - min(t.a) FROM u WHERE u.a > 0) FROM t
+----
+-- Pure-outer aggregate inside an ORDER BY key is not yet supported.
+-- error: Cannot replace inputs on AggregateCallExpr with filter
+SELECT t.a FROM t ORDER BY (SELECT max(t.a))
 ----
 -- Multiple aggregates, each referencing an outer column.
 SELECT (SELECT max(u.a + t.b) + min(u.a + t.c) FROM u WHERE u.a > 0) FROM t

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -581,34 +581,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     }
 
     case NodeType::kSubqueryExpression: {
-      auto* subquery = node->as<SubqueryExpression>();
-      auto query = subquery->query();
-
-      if (query->is(NodeType::kQuery)) {
-        VELOX_CHECK_NOT_NULL(
-            subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
-        // Look up first; if not cached, plan and insert. Do not hold an
-        // iterator across subqueryPlanner_ because it may recursively plan
-        // a subquery that mutates the cache and invalidates iterators.
-        if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
-          return it->second;
-        }
-        auto result = subqueryPlanner_(query->as<Query>());
-        auto expr = lp::Subquery(result.plan);
-        // Correlated subqueries bake in physical column names from the outer
-        // scope they were planned in; caching would let a second outer
-        // context reuse a plan whose references point at the first context's
-        // (now stale) names.
-        if (!result.touchedOuterScope) {
-          subqueryCache_.emplace(query, expr);
-        }
-        return expr;
-      }
-
-      AXIOM_PRESTO_SYNTAX_FAIL(
-          query->location(),
-          std::string(NodeTypeName::toName(query->type())),
-          "Subquery type is not supported yet");
+      return planSubquery(node->as<SubqueryExpression>(), /*scalar=*/true);
     }
 
     case NodeType::kComparisonExpression: {
@@ -710,7 +683,8 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kExistsPredicate: {
       auto* exists = node->as<ExistsPredicate>();
-      return lp::Exists(toExpr(exists->subquery()));
+      return lp::Exists(planSubquery(
+          exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
     }
 
     case NodeType::kCast: {
@@ -1082,6 +1056,47 @@ core::WindowCallExpr::BoundType toWindowBoundType(FrameBound::Type type) {
 }
 
 } // namespace
+
+lp::ExprApi ExpressionPlanner::planSubquery(
+    const SubqueryExpression* subquery,
+    bool scalar) {
+  auto query = subquery->query();
+
+  if (!query->is(NodeType::kQuery)) {
+    AXIOM_PRESTO_SYNTAX_FAIL(
+        query->location(),
+        std::string(NodeTypeName::toName(query->type())),
+        "Subquery type is not supported yet");
+  }
+
+  VELOX_CHECK_NOT_NULL(
+      subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
+
+  // Look up first; if not cached, plan and insert. Do not hold an
+  // iterator across subqueryPlanner_ because it may recursively plan
+  // a subquery that mutates the cache and invalidates iterators.
+  if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
+    return it->second;
+  }
+  auto result = subqueryPlanner_(query->as<Query>());
+  if (scalar) {
+    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+        result.plan->outputType()->size(),
+        1,
+        query->location(),
+        "",
+        "Scalar subquery must return exactly one column");
+  }
+  auto expr = lp::Subquery(result.plan);
+  // Correlated subqueries bake in physical column names from the outer
+  // scope they were planned in; caching would let a second outer
+  // context reuse a plan whose references point at the first context's
+  // (now stale) names.
+  if (!result.touchedOuterScope) {
+    subqueryCache_.emplace(query, expr);
+  }
+  return expr;
+}
 
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     const FunctionCall* call,

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -26,6 +26,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -37,6 +38,167 @@ namespace axiom::sql::presto {
 using namespace facebook::velox;
 
 namespace {
+
+// Returns the set of relation aliases directly visible in a simple
+// FROM clause (a single Table or AliasedRelation). Returns nullopt
+// for shapes we don't analyze (joins, etc.). A null `from` (no FROM
+// clause) returns an empty set.
+std::optional<folly::F14FastSet<std::string>> simpleFromAliases(
+    const RelationPtr& from) {
+  folly::F14FastSet<std::string> aliases;
+  if (from == nullptr) {
+    return aliases;
+  }
+  if (from->is(NodeType::kTable)) {
+    const auto& parts = from->as<Table>()->name()->parts();
+    aliases.insert(canonicalizeName(parts.back()));
+    return aliases;
+  }
+  if (from->is(NodeType::kAliasedRelation)) {
+    aliases.insert(
+        canonicalizeIdentifier(*from->as<AliasedRelation>()->alias()));
+    return aliases;
+  }
+  return std::nullopt;
+}
+
+// Walks an aggregate's argument expression to classify column refs as
+// inner-scope (qualifier matches `innerAliases`, or unqualified when
+// `innerAliases` is non-empty) vs outer-scope (qualifier doesn't
+// match, or unqualified when there is no FROM).
+class AggregateArgScopeClassifier : public DefaultTraversalVisitor {
+ public:
+  explicit AggregateArgScopeClassifier(
+      const folly::F14FastSet<std::string>& innerAliases)
+      : innerAliases_(innerAliases) {}
+
+  bool anyInner() const {
+    return anyInner_;
+  }
+  bool anyOuter() const {
+    return anyOuter_;
+  }
+
+ protected:
+  void visitIdentifier(Identifier* /*node*/) override {
+    if (innerAliases_.empty()) {
+      anyOuter_ = true;
+    } else {
+      anyInner_ = true;
+    }
+  }
+
+  void visitDereferenceExpression(DereferenceExpression* node) override {
+    if (node->base()->is(NodeType::kIdentifier)) {
+      const auto qualifier =
+          canonicalizeIdentifier(*node->base()->as<Identifier>());
+      if (innerAliases_.count(qualifier) > 0) {
+        anyInner_ = true;
+      } else {
+        anyOuter_ = true;
+      }
+      return;
+    }
+    DefaultTraversalVisitor::visitDereferenceExpression(node);
+  }
+
+  void visitSubqueryExpression(SubqueryExpression* /*node*/) override {}
+
+ private:
+  const folly::F14FastSet<std::string>& innerAliases_;
+  bool anyInner_{false};
+  bool anyOuter_{false};
+};
+
+// Walks an expression looking for an aggregate FunctionCall whose
+// args reference at least one outer column and no inner-scope column.
+class OuterScopeAggregateScanner : public DefaultTraversalVisitor {
+ public:
+  explicit OuterScopeAggregateScanner(
+      const folly::F14FastSet<std::string>& innerAliases)
+      : innerAliases_(innerAliases) {}
+
+  bool foundAny() const {
+    return foundAny_;
+  }
+
+ protected:
+  void visitFunctionCall(FunctionCall* node) override {
+    const auto name = canonicalizeName(node->name()->suffix());
+    if (exec::getAggregateFunctionEntry(name) != nullptr &&
+        node->window() == nullptr && !node->isDistinct() &&
+        node->filter() == nullptr && node->orderBy() == nullptr &&
+        !node->ignoreNulls() && !node->arguments().empty()) {
+      AggregateArgScopeClassifier classifier(innerAliases_);
+      for (const auto& arg : node->arguments()) {
+        arg->accept(&classifier);
+      }
+      if (classifier.anyOuter() && !classifier.anyInner()) {
+        foundAny_ = true;
+        return;
+      }
+    }
+    DefaultTraversalVisitor::visitFunctionCall(node);
+  }
+
+  void visitSubqueryExpression(SubqueryExpression* /*node*/) override {}
+
+ private:
+  const folly::F14FastSet<std::string>& innerAliases_;
+  bool foundAny_{false};
+};
+
+// Walks `expr`. Sets `anyMatch` if any column reference's name is in
+// `names`; sets `anyOther` if any column reference's name is not.
+void classifyColumnRefs(
+    const lp::ExprPtr& expr,
+    const folly::F14FastSet<std::string>& names,
+    bool& anyMatch,
+    bool& anyOther) {
+  if (expr->kind() == lp::ExprKind::kInputReference) {
+    if (names.count(expr->as<lp::InputReferenceExpr>()->name()) > 0) {
+      anyMatch = true;
+    } else {
+      anyOther = true;
+    }
+    return;
+  }
+  for (const auto& input : expr->inputs()) {
+    classifyColumnRefs(input, names, anyMatch, anyOther);
+  }
+}
+
+// True if `plan` (or any descendant) is an AggregateNode containing an
+// aggregate call whose arguments reference at least one outer column
+// and no inner-source column.
+bool hasOuterScopeAggregate(const lp::LogicalPlanNodePtr& plan) {
+  if (plan->kind() == lp::NodeKind::kAggregate) {
+    const auto* aggregateNode = plan->as<lp::AggregateNode>();
+    const auto& source = aggregateNode->inputs().front();
+    folly::F14FastSet<std::string> innerColumns(
+        source->outputType()->names().begin(),
+        source->outputType()->names().end());
+    for (const auto& aggregateCall : aggregateNode->aggregates()) {
+      bool anyInner = false;
+      bool anyOuter = false;
+      for (const auto& argExpr : aggregateCall->inputs()) {
+        classifyColumnRefs(argExpr, innerColumns, anyInner, anyOuter);
+        if (anyInner) {
+          break;
+        }
+      }
+      if (anyOuter && !anyInner) {
+        return true;
+      }
+    }
+  }
+  for (const auto& input : plan->inputs()) {
+    if (hasOuterScopeAggregate(input)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 int32_t parseInt(const TypeSignaturePtr& type) {
   AXIOM_PRESTO_SEMANTIC_CHECK(
@@ -443,6 +605,35 @@ TypePtr tryResolveBuiltinType(const TypeSignaturePtr& type) {
 }
 
 } // namespace
+
+bool isOuterScopeAggregateLiftCandidate(Query* query) {
+  if (query == nullptr || query->with() != nullptr ||
+      query->orderBy() != nullptr || query->offset() != nullptr ||
+      query->limit().has_value() || query->queryBody() == nullptr ||
+      !query->queryBody()->is(NodeType::kQuerySpecification)) {
+    return false;
+  }
+  const auto* spec = query->queryBody()->as<QuerySpecification>();
+  if (spec->groupBy() != nullptr || spec->having() != nullptr ||
+      spec->orderBy() != nullptr || spec->offset() != nullptr ||
+      spec->limit().has_value() || spec->select() == nullptr ||
+      spec->select()->isDistinct() ||
+      spec->select()->selectItems().size() != 1) {
+    return false;
+  }
+  const auto& item = spec->select()->selectItems().front();
+  if (!item->is(NodeType::kSingleColumn) ||
+      item->as<SingleColumn>()->expression() == nullptr) {
+    return false;
+  }
+  auto innerAliases = simpleFromAliases(spec->from());
+  if (!innerAliases.has_value()) {
+    return false;
+  }
+  OuterScopeAggregateScanner scanner(*innerAliases);
+  item->as<SingleColumn>()->expression()->accept(&scanner);
+  return scanner.foundAny();
+}
 
 void ExpressionPlanner::findWindowExprs(
     const core::ExprPtr& expr,
@@ -934,10 +1125,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     case NodeType::kFunctionCall: {
       auto* call = node->as<FunctionCall>();
 
-      std::vector<lp::ExprApi> args;
-      for (const auto& arg : call->arguments()) {
-        args.push_back(toExpr(arg));
-      }
+      auto args = translateArgs(call->arguments());
 
       const auto& funcName = call->name()->suffix();
       const auto lowerFuncName = canonicalizeName(funcName);
@@ -1055,6 +1243,107 @@ core::WindowCallExpr::BoundType toWindowBoundType(FrameBound::Type type) {
   VELOX_UNREACHABLE();
 }
 
+// AST-shape matcher for a scalar subquery that may be a candidate
+// for the outer-scope aggregate lift. Match is necessary but not
+// sufficient — the caller must still verify at the LP level that each
+// aggregate's arguments reference only outer columns.
+struct LiftablePureOuterAggregate {
+  Query* query;
+  const QuerySpecification* spec;
+
+  // Accepts a body of the form
+  //   SELECT <expr> FROM <inner> [WHERE <pred>]
+  // with no other top-level clauses. <expr> may itself contain
+  // aggregate function calls; per-aggregate validity is verified at
+  // the LP level by the caller.
+  static std::optional<LiftablePureOuterAggregate> match(Query* query) {
+    if (!isOuterScopeAggregateLiftCandidate(query)) {
+      return std::nullopt;
+    }
+    return LiftablePureOuterAggregate{
+        query, query->queryBody()->as<QuerySpecification>()};
+  }
+
+  // Plans `SELECT 1 FROM <body.from> [WHERE body.where]` for use as
+  // the EXISTS gate's source. The planned body's pre-aggregate input
+  // can't be reused because in the no-FROM case it has zero output
+  // columns and `lp::Subquery` requires at least one.
+  //
+  //   Before: SELECT count(t.a) FROM u WHERE u.a > 999
+  //   After:  SELECT 1           FROM u WHERE u.a > 999
+  lp::LogicalPlanNodePtr planExistsBody(
+      const ExpressionPlanner::SubqueryPlanner& planner) const {
+    const auto& selectLocation = spec->select()->location();
+    auto liftedSelect = std::make_shared<Select>(
+        selectLocation,
+        /*distinct=*/false,
+        std::vector<SelectItemPtr>{std::make_shared<SingleColumn>(
+            selectLocation,
+            std::make_shared<LongLiteral>(selectLocation, 1),
+            /*alias=*/nullptr)});
+    auto liftedQuery = std::make_shared<Query>(
+        query->location(),
+        /*with=*/nullptr,
+        std::make_shared<QuerySpecification>(
+            spec->location(), liftedSelect, spec->from(), spec->where()));
+    return planner(liftedQuery.get()).plan;
+  }
+};
+
+std::vector<core::ExprPtr> toCoreExprs(const std::vector<lp::ExprApi>& args) {
+  std::vector<core::ExprPtr> result;
+  result.reserve(args.size());
+  for (const auto& arg : args) {
+    result.push_back(arg.expr());
+  }
+  return result;
+}
+
+// Replaces every aggregate-function `CallExpr` in `expr` with an
+// `AggregateCallExpr` that has `filter` injected. Returns nullptr if
+// the tree contains a pre-existing `AggregateCallExpr` or
+// `WindowCallExpr` whose options can't be composed with the injected
+// filter (DISTINCT, FILTER, ORDER BY, window). Caller must pass an
+// expression translated outside an aggregation context; aggregates
+// must appear as `CallExpr`, not as `AggregateCallExpr`.
+core::ExprPtr wrapAggregatesWithFilter(
+    const core::ExprPtr& expr,
+    const core::ExprPtr& filter) {
+  if (expr->is(core::IExpr::Kind::kAggregate) ||
+      expr->is(core::IExpr::Kind::kWindow)) {
+    return nullptr;
+  }
+  if (expr->is(core::IExpr::Kind::kCall)) {
+    const auto* call = expr->as<core::CallExpr>();
+    if (exec::getAggregateFunctionEntry(canonicalizeName(call->name())) !=
+        nullptr) {
+      return std::make_shared<core::AggregateCallExpr>(
+          call->name(),
+          call->inputs(),
+          /*distinct=*/false,
+          filter,
+          std::vector<core::SortKey>{});
+    }
+  }
+  std::vector<core::ExprPtr> newInputs;
+  newInputs.reserve(expr->inputs().size());
+  bool changed{false};
+  for (const auto& input : expr->inputs()) {
+    auto rewritten = wrapAggregatesWithFilter(input, filter);
+    if (rewritten == nullptr) {
+      return nullptr;
+    }
+    if (rewritten != input) {
+      changed = true;
+    }
+    newInputs.push_back(std::move(rewritten));
+  }
+  if (!changed) {
+    return expr;
+  }
+  return expr->replaceInputs(std::move(newInputs));
+}
+
 } // namespace
 
 lp::ExprApi ExpressionPlanner::planSubquery(
@@ -1079,14 +1368,36 @@ lp::ExprApi ExpressionPlanner::planSubquery(
     return it->second;
   }
   auto result = subqueryPlanner_(query->as<Query>());
+
   if (scalar) {
+    if (auto lifted = tryLiftPureOuterAggregate(query->as<Query>(), result)) {
+      return *lifted;
+    }
     AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
         result.plan->outputType()->size(),
         1,
         query->location(),
         "",
         "Scalar subquery must return exactly one column");
+    AXIOM_PRESTO_SEMANTIC_CHECK(
+        !hasOuterScopeAggregate(result.plan),
+        query->location(),
+        "",
+        "Outer-scope aggregate could not be lifted. Lift supports a "
+        "subquery whose body is `SELECT <expr> FROM <inner> [WHERE "
+        "<pred>]` where every aggregate in <expr> takes only outer-"
+        "column arguments and binds to the immediate parent scope.");
+  } else {
+    // Outer-scope aggregate inside an EXISTS body silently flips
+    // EXISTS to true (the aggregation produces one row even over an
+    // empty body), so the parser must reject.
+    AXIOM_PRESTO_SEMANTIC_CHECK(
+        !hasOuterScopeAggregate(result.plan),
+        query->location(),
+        "",
+        "Outer-scope aggregate in an EXISTS body is not supported.");
   }
+
   auto expr = lp::Subquery(result.plan);
   // Correlated subqueries bake in physical column names from the outer
   // scope they were planned in; caching would let a second outer
@@ -1096,6 +1407,85 @@ lp::ExprApi ExpressionPlanner::planSubquery(
     subqueryCache_.emplace(query, expr);
   }
   return expr;
+}
+
+std::optional<lp::ExprApi> ExpressionPlanner::tryLiftPureOuterAggregate(
+    Query* query,
+    const SubqueryPlanResult& bodyResult) {
+  const auto shape = LiftablePureOuterAggregate::match(query);
+  if (!shape.has_value()) {
+    return std::nullopt;
+  }
+
+  // The body's planned plan must contain a top-level AggregateNode,
+  // either as the root (bare aggregate) or as the immediate input of a
+  // ProjectNode (aggregate wrapped in an expression).
+  const lp::AggregateNode* aggregateNode = nullptr;
+  if (bodyResult.plan->kind() == lp::NodeKind::kAggregate) {
+    aggregateNode = bodyResult.plan->as<lp::AggregateNode>();
+  } else if (
+      bodyResult.plan->kind() == lp::NodeKind::kProject &&
+      !bodyResult.plan->inputs().empty() &&
+      bodyResult.plan->inputs().front()->kind() == lp::NodeKind::kAggregate) {
+    aggregateNode = bodyResult.plan->inputs().front()->as<lp::AggregateNode>();
+  }
+  if (aggregateNode == nullptr || !aggregateNode->groupingKeys().empty()) {
+    return std::nullopt;
+  }
+
+  // Every aggregate in the body must be a plain aggregate (no
+  // DISTINCT/FILTER/ORDER BY) whose arguments reference at least one
+  // outer column and no inner-source column.
+  const auto& innerSource = aggregateNode->inputs().front();
+  folly::F14FastSet<std::string> innerColumns(
+      innerSource->outputType()->names().begin(),
+      innerSource->outputType()->names().end());
+  for (const auto& aggregateCall : aggregateNode->aggregates()) {
+    if (aggregateCall->isDistinct() || aggregateCall->filter() != nullptr ||
+        !aggregateCall->ordering().empty() || aggregateCall->inputs().empty()) {
+      return std::nullopt;
+    }
+    bool anyInner = false;
+    bool anyOuter = false;
+    for (const auto& argExpr : aggregateCall->inputs()) {
+      classifyColumnRefs(argExpr, innerColumns, anyInner, anyOuter);
+      if (anyInner) {
+        break;
+      }
+    }
+    if (anyInner || !anyOuter) {
+      return std::nullopt;
+    }
+  }
+
+  auto existsCheck =
+      lp::Exists(lp::Subquery(shape->planExistsBody(subqueryPlanner_)));
+
+  // Translate the body's SELECT expression in the outer scope and
+  // inject the EXISTS filter on every aggregate function call within
+  // it.
+  const auto& selectExpr = shape->spec->select()
+                               ->selectItems()
+                               .front()
+                               ->as<SingleColumn>()
+                               ->expression();
+  auto translated = toExpr(selectExpr);
+  auto wrapped =
+      wrapAggregatesWithFilter(translated.expr(), existsCheck.expr());
+  if (wrapped == nullptr) {
+    return std::nullopt;
+  }
+  return lp::ExprApi(wrapped);
+}
+
+std::vector<lp::ExprApi> ExpressionPlanner::translateArgs(
+    const std::vector<ExpressionPtr>& arguments) {
+  std::vector<lp::ExprApi> args;
+  args.reserve(arguments.size());
+  for (const auto& arg : arguments) {
+    args.push_back(toExpr(arg));
+  }
+  return args;
 }
 
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
@@ -1120,16 +1510,10 @@ lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     }
   }
 
-  std::vector<core::ExprPtr> inputExprs;
-  inputExprs.reserve(args.size());
-  for (const auto& arg : args) {
-    inputExprs.push_back(arg.expr());
-  }
-
   return lp::ExprApi(
       std::make_shared<core::AggregateCallExpr>(
           funcName,
-          std::move(inputExprs),
+          toCoreExprs(args),
           call->isDistinct(),
           std::move(filterExpr),
           std::move(sortKeys)));

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -39,6 +39,14 @@ std::string canonicalizeIdentifier(const Identifier& identifier);
 /// Parses a TypeSignature AST node into a Velox type.
 facebook::velox::TypePtr parseType(const TypeSignaturePtr& type);
 
+/// Returns true if `query` is a scalar subquery whose aggregate(s)
+/// bind to an outer scope per SQL's innermost-binding rule, making
+/// the body a candidate for outer-scope-aggregate lift. AST-only and
+/// conservative — unqualified column refs in a body with a FROM
+/// clause are treated as inner-scope; complex FROM shapes (joins,
+/// subqueries) are rejected.
+bool isOuterScopeAggregateLiftCandidate(Query* query);
+
 /// Translates Presto SQL AST expression nodes into logical plan ExprApi
 /// objects. Handles all expression types (literals, comparisons, arithmetic,
 /// function calls, casts, subqueries, etc.).
@@ -149,6 +157,10 @@ class ExpressionPlanner {
   // Converts a Window AST node into a WindowSpec.
   lp::WindowSpec convertWindow(const std::shared_ptr<Window>& window);
 
+  // Translates each AST argument via `toExpr`.
+  std::vector<lp::ExprApi> translateArgs(
+      const std::vector<ExpressionPtr>& arguments);
+
   // Builds an AggregateCallExpr from a FunctionCall AST node that has
   // DISTINCT, FILTER, or ORDER BY.
   lp::ExprApi toAggregateCallExpr(
@@ -158,10 +170,32 @@ class ExpressionPlanner {
 
   // Plans `subquery` via `subqueryPlanner_` and wraps the resulting
   // plan as an `lp::Subquery` expression, caching by AST identity.
-  // When `scalar` is true, enforces the SQL rule that a subquery used
+  // When `scalar` is true, applies the outer-scope-aggregate lift
+  // (`tryLiftPureOuterAggregate`), rejects unhandled outer-scope-
+  // aggregate shapes, and enforces the SQL rule that a subquery used
   // as a scalar expression must return exactly one column. EXISTS
-  // (which only checks row presence) passes false.
+  // (which only checks row presence) passes false to skip those
+  // checks.
   lp::ExprApi planSubquery(const SubqueryExpression* subquery, bool scalar);
+
+  // SQL binds an aggregate to the innermost query block containing all
+  // its column references. A scalar subquery body whose aggregates all
+  // take outer-scope-only arguments is therefore an outer-scope
+  // aggregation. Detects that shape (AST shape + LP-level check that
+  // each aggregate's args reference no inner-source column) and
+  // rewrites the subquery so each aggregate becomes
+  //
+  //   agg(outer_args) FILTER (WHERE EXISTS(SELECT 1 FROM <body's FROM>
+  //                                        [WHERE <body's WHERE>]))
+  //
+  // with any surrounding expression (arithmetic, multiple aggregates
+  // in one SELECT item) preserved around the lifted aggregates.
+  // `bodyResult` must be the result of planning `query` via
+  // `subqueryPlanner_`. Returns std::nullopt when the shape doesn't
+  // match; the caller falls through to normal subquery planning.
+  std::optional<lp::ExprApi> tryLiftPureOuterAggregate(
+      Query* query,
+      const SubqueryPlanResult& bodyResult);
 
   // Resolves a type signature, trying built-in Velox types first, then
   // connector-based resolution for dotted names (e.g., "catalog.schema.Type").

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -156,6 +156,13 @@ class ExpressionPlanner {
       const std::string& funcName,
       const std::vector<lp::ExprApi>& args);
 
+  // Plans `subquery` via `subqueryPlanner_` and wraps the resulting
+  // plan as an `lp::Subquery` expression, caching by AST identity.
+  // When `scalar` is true, enforces the SQL rule that a subquery used
+  // as a scalar expression must return exactly one column. EXISTS
+  // (which only checks row presence) passes false.
+  lp::ExprApi planSubquery(const SubqueryExpression* subquery, bool scalar);
+
   // Resolves a type signature, trying built-in Velox types first, then
   // connector-based resolution for dotted names (e.g., "catalog.schema.Type").
   facebook::velox::TypePtr resolveType(const TypeSignaturePtr& type);

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -242,7 +242,13 @@ class ExprAnalyzer : public DefaultTraversalVisitor {
   }
 
   void visitSubqueryExpression(SubqueryExpression* node) override {
-    // Aggregate function calls within a subquery do not count.
+    // Outer-scope aggregates in scalar subqueries are lifted to this
+    // block; count them so the block becomes an aggregation.
+    const auto& query = node->query();
+    if (query != nullptr && query->is(NodeType::kQuery) &&
+        isOuterScopeAggregateLiftCandidate(query->as<Query>())) {
+      ++numAggregates_;
+    }
   }
 
  private:
@@ -397,26 +403,24 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     }
   }
 
-  bool hasAggregate = false;
+  // Count visible aggregates, including outer-scope aggregates in
+  // lift-candidate scalar subqueries. `ExprAnalyzer` rejects nested
+  // aggregates as a side effect of the walk.
+  bool hasAggregate{false};
   for (const auto& item : selectItems) {
     VELOX_CHECK(item->is(NodeType::kSingleColumn));
-    auto* singleColumn = item->as<SingleColumn>();
-
     ExprAnalyzer exprAnalyzer;
-    singleColumn->expression()->accept(&exprAnalyzer);
-
+    item->as<SingleColumn>()->expression()->accept(&exprAnalyzer);
     if (exprAnalyzer.hasAggregate()) {
       hasAggregate = true;
-      break;
     }
   }
-
   if (!hasAggregate) {
     return false;
   }
 
-  // Resolve SELECT items into ExprApi.
   std::vector<lp::ExprApi> selectExprs;
+  selectExprs.reserve(selectItems.size());
   for (const auto& item : selectItems) {
     auto* singleColumn = item->as<SingleColumn>();
     auto expr = exprPlanner_.toExpr(singleColumn->expression());

--- a/axiom/sql/presto/README.md
+++ b/axiom/sql/presto/README.md
@@ -460,6 +460,24 @@ within a `SELECT ... FROM nation` query:
 testNationExpr("n_regionkey + 1", "plus(n_regionkey, 1:INTEGER)");
 ```
 
+When asserting a parsed plan with `LogicalPlanMatcherBuilder` (e.g.
+`.aggregate({}, {"..."})`), the expected expression strings are parsed by
+DuckDB. Two wildcard call names are recognized to stand in for subtrees
+that don't need exact verification:
+
+- `any()` — matches any actual subtree.
+- `any_exists()` — matches any actual `EXISTS(subquery(...))` subtree.
+  Use this when the EXISTS body is a planned logical plan, which DuckDB
+  cannot re-parse from SQL.
+
+```cpp
+// Verify aggregate is lifted with the expected name and arg, ignoring
+// the EXISTS body's planned subquery.
+matchScan()
+    .aggregate({}, {"max(n_nationkey) FILTER (WHERE any_exists())"})
+    .output();
+```
+
 #### Running tests
 
 ```bash

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -44,6 +44,104 @@ TEST_F(AggregationParserTest, countStar) {
   }
 }
 
+TEST_F(AggregationParserTest, nestedAggregateRejected) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT sum(count(n_nationkey)) FROM nation"),
+      "Cannot nest aggregations inside aggregation: sum");
+}
+
+// A scalar subquery whose body aggregates over only outer columns is
+// lifted into the outer query.
+TEST_F(AggregationParserTest, pureOuterAggregateLift) {
+  // No-FROM body, fully unqualified outer reference.
+  testSelect(
+      "SELECT (SELECT max(n_nationkey)) FROM nation",
+      matchScan()
+          .aggregate({}, {"max(n_nationkey) FILTER (WHERE any_exists())"})
+          .output());
+
+  // Outer reference qualified with the outer alias, body has its own
+  // FROM with non-overlapping column names.
+  testSelect(
+      "SELECT (SELECT count(t.n_nationkey) "
+      "FROM (VALUES (1)) AS u(x) WHERE u.x > 0) "
+      "FROM nation t",
+      matchScan()
+          .aggregate({}, {"count(n_nationkey) FILTER (WHERE any_exists())"})
+          .output());
+
+  // Outer-scope aggregate inside arithmetic resolves to the outer
+  // scope.
+  testSelect(
+      "SELECT (SELECT max(t.n_nationkey) + 1 "
+      "FROM (VALUES (1)) AS u(x)) "
+      "FROM nation t",
+      matchScan()
+          .aggregate({}, {"max(n_nationkey) FILTER (WHERE any_exists())"})
+          .project()
+          .output());
+
+  // Multiple outer-scope aggregates in one subquery expression all
+  // resolve to the outer scope.
+  testSelect(
+      "SELECT (SELECT max(t.n_nationkey) - min(t.n_nationkey) "
+      "FROM (VALUES (1)) AS u(x)) "
+      "FROM nation t",
+      matchScan()
+          .aggregate(
+              {},
+              {"max(n_nationkey) FILTER (WHERE any_exists())",
+               "min(n_nationkey) FILTER (WHERE any_exists())"})
+          .project()
+          .output());
+
+  // Body WHERE composes with the lift: the EXISTS gate carries it.
+  testSelect(
+      "SELECT (SELECT max(t.n_nationkey) + 1 "
+      "FROM (VALUES (1)) AS u(x) WHERE u.x > 0) "
+      "FROM nation t",
+      matchScan()
+          .aggregate({}, {"max(n_nationkey) FILTER (WHERE any_exists())"})
+          .project()
+          .output());
+}
+
+// Aggregate references an inner-scope column, so lift does not fire
+// and the outer block stays a Project.
+TEST_F(AggregationParserTest, innerScopeAggregateNotLifted) {
+  // Qualified with the inner alias.
+  testSelect(
+      "SELECT (SELECT max(inner_n.n_nationkey) FROM nation inner_n) "
+      "FROM nation outer_n",
+      matchScan().project().output());
+
+  // Unqualified column present in both inner and outer FROM lists;
+  // innermost-wins binds to the inner scope.
+  testSelect(
+      "SELECT (SELECT count(n_nationkey) FROM nation WHERE n_nationkey > 0) "
+      "FROM nation",
+      matchScan().project().output());
+}
+
+// Outer-scope aggregate in shapes the lift does not handle is
+// rejected at the parser layer: mixing inner- and outer-scope
+// aggregates in one expression (ambiguous per spec), and two-level
+// outer-scope binding (aggregate would bind to a grandparent scope).
+TEST_F(AggregationParserTest, unsupportedOuterScopeAggregateRejected) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT (SELECT max(t.n_nationkey) + count(u.x) "
+          "FROM (VALUES (1)) AS u(x)) "
+          "FROM nation t"),
+      "Outer-scope aggregate could not be lifted.");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT (SELECT (SELECT max(t.n_nationkey)) FROM region) "
+          "FROM nation t"),
+      "Outer-scope aggregate could not be lifted.");
+}
+
 TEST_F(AggregationParserTest, aggregateCoercions) {
   auto matcher = matchScan().aggregate().output();
 

--- a/axiom/sql/presto/tests/ExprMatcher.cpp
+++ b/axiom/sql/presto/tests/ExprMatcher.cpp
@@ -41,6 +41,14 @@ bool isWildcard(const velox::core::ExprPtr& expr) {
   return call->name() == ExprMatcher::kWildcard && call->inputs().empty();
 }
 
+bool isExistsWildcard(const velox::core::ExprPtr& expr) {
+  if (!expr->is(velox::core::IExpr::Kind::kCall)) {
+    return false;
+  }
+  const auto* call = expr->as<velox::core::CallExpr>();
+  return call->name() == ExprMatcher::kExistsWildcard && call->inputs().empty();
+}
+
 // Forward declaration for mutual recursion.
 bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected);
 
@@ -400,6 +408,21 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
   VELOX_CHECK_NOT_NULL(expected);
 
   if (isWildcard(expected)) {
+    return true;
+  }
+
+  if (isExistsWildcard(expected)) {
+    if (actual->kind() != ExprKind::kSpecialForm) {
+      ADD_FAILURE() << "Expected EXISTS (any_exists() wildcard), got "
+                    << actual->kindName() << ".";
+      return false;
+    }
+    const auto form = actual->as<SpecialFormExpr>()->form();
+    if (form != SpecialForm::kExists) {
+      ADD_FAILURE() << "Expected EXISTS special form, got "
+                    << SpecialFormName::toName(form) << ".";
+      return false;
+    }
     return true;
   }
 

--- a/axiom/sql/presto/tests/ExprMatcher.h
+++ b/axiom/sql/presto/tests/ExprMatcher.h
@@ -31,6 +31,11 @@ class ExprMatcher {
   /// with this name and zero inputs matches any actual subtree.
   static constexpr std::string_view kWildcard = "any";
 
+  /// Matches any actual EXISTS subtree. DuckDB->Velox expression
+  /// conversion does not support subqueries, so the EXISTS body
+  /// cannot be spelled in expected strings.
+  static constexpr std::string_view kExistsWildcard = "any_exists";
+
   /// Returns true if the trees match. On mismatch, sets gtest failures
   /// with SCOPED_TRACE context showing the path through the tree.
   static bool match(

--- a/axiom/sql/presto/tests/ExprMatcherTest.cpp
+++ b/axiom/sql/presto/tests/ExprMatcherTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/Expr.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Type.h"
@@ -63,6 +64,22 @@ velox::core::ExprPtr wildcard() {
       std::string{ExprMatcher::kWildcard},
       std::vector<velox::core::ExprPtr>{},
       std::nullopt);
+}
+
+velox::core::ExprPtr existsWildcard() {
+  return std::make_shared<velox::core::CallExpr>(
+      std::string{ExprMatcher::kExistsWildcard},
+      std::vector<velox::core::ExprPtr>{},
+      std::nullopt);
+}
+
+ExprPtr exists() {
+  auto subqueryPlan = std::make_shared<ValuesNode>(
+      "values_0",
+      ROW({"x"}, {BIGINT()}),
+      ValuesNode::Variants{Variant::row({42LL})});
+  auto subquery = std::make_shared<SubqueryExpr>(subqueryPlan);
+  return specialForm(BOOLEAN(), SpecialForm::kExists, {subquery});
 }
 
 class ExprMatcherTest : public testing::Test {
@@ -330,6 +347,24 @@ TEST_F(ExprMatcherTest, wildcardInSubtree) {
           "plus",
           std::vector<velox::core::ExprPtr>{parseExpr("a"), wildcard()},
           std::nullopt));
+}
+
+TEST_F(ExprMatcherTest, existsWildcardMatchesExists) {
+  ExprMatcher::match(exists(), existsWildcard());
+}
+
+TEST_F(ExprMatcherTest, existsWildcardRejectsNonExists) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(field(BOOLEAN(), "a"), existsWildcard()),
+      "Expected EXISTS (any_exists() wildcard)");
+
+  auto coalesce = specialForm(
+      BIGINT(),
+      SpecialForm::kCoalesce,
+      {field(BIGINT(), "a"), field(BIGINT(), "b")});
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(coalesce, existsWildcard()),
+      "Expected EXISTS special form, got COALESCE.");
 }
 
 } // namespace

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -595,6 +595,20 @@ TEST_F(PrestoParserTest, joinUsing) {
   }
 }
 
+// A scalar subquery (subquery used as an expression) must return
+// exactly one column.
+TEST_F(PrestoParserTest, scalarSubqueryMultipleColumnsRejected) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT (SELECT n_nationkey, n_name FROM nation) FROM nation"),
+      "Scalar subquery must return exactly one column");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT (SELECT max(t.n_nationkey), min(t.n_nationkey) FROM (VALUES (1)) AS _(x)) "
+          "FROM nation t"),
+      "Scalar subquery must return exactly one column");
+}
+
 TEST_F(PrestoParserTest, joinOnSubquery) {
   auto matcher = matchScan()
                      .join(matchScan().build())

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -609,6 +609,16 @@ TEST_F(PrestoParserTest, scalarSubqueryMultipleColumnsRejected) {
       "Scalar subquery must return exactly one column");
 }
 
+// EXISTS over a body whose aggregate's args reference only outer
+// columns is rejected at parse time.
+TEST_F(PrestoParserTest, existsOuterScopeAggregateRejected) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT t.n_nationkey FROM nation t "
+          "WHERE EXISTS (SELECT max(t.n_nationkey) FROM (VALUES (1)) AS u(x) WHERE u.x > 999)"),
+      "Outer-scope aggregate in an EXISTS body is not supported.");
+}
+
 TEST_F(PrestoParserTest, joinOnSubquery) {
   auto matcher = matchScan()
                      .join(matchScan().build())


### PR DESCRIPTION
Summary:

SQL's innermost-binding rule says an aggregate whose arguments reference only outer-query columns binds to the outer scope, not to the subquery body. Previously the parser produced an LP that either surfaced wrong results or fell through to a cryptic optimizer error. For example:

    SELECT (SELECT count(t.a) FROM (VALUES (1)) AS u(x) WHERE u.x > 0)
    FROM (VALUES (1), (2)) AS t(a)

returns 2 per SQL (the outer aggregation folds two outer rows) — now matches that.

After planning each scalar subquery body, the parser detects the narrow shape

    SELECT agg(...) FROM <inner> [WHERE <pred>]

and rewrites it in the outer query block as

    agg(...) FILTER (WHERE EXISTS(SELECT 1 FROM <inner> [WHERE <pred>]))

An LP-level check confirms the aggregate's args reference at least one outer column and no inner-source column.

Shapes that lift in principle but aren't covered yet — wrapped (`max(t.a) + 1`), mixed inner/outer aggregates, two-level outer-scope binding — now fail at the parser layer with a clean semantic error instead of an obscure optimizer NYI or assertion failure.

EXISTS over a body with an outer-scope aggregate is also rejected. Previously such queries silently returned true for every outer row: the inner aggregation produces one row even over an empty body, so EXISTS sees that row and is true. For example, `EXISTS (SELECT max(t.a) FROM u WHERE u.x > 999)` returned true for every outer row instead of false. The lift itself is scalar-only; in EXISTS position the parser rejects with a separate, EXISTS-specific error.

Differential Revision: D107526384


