### PR TITLE
fix(parser): Reject scalar subquery with multiple columns (#1449)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -581,34 +581,7 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
     }
 
     case NodeType::kSubqueryExpression: {
-      auto* subquery = node->as<SubqueryExpression>();
-      auto query = subquery->query();
-
-      if (query->is(NodeType::kQuery)) {
-        VELOX_CHECK_NOT_NULL(
-            subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
-        // Look up first; if not cached, plan and insert. Do not hold an
-        // iterator across subqueryPlanner_ because it may recursively plan
-        // a subquery that mutates the cache and invalidates iterators.
-        if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
-          return it->second;
-        }
-        auto result = subqueryPlanner_(query->as<Query>());
-        auto expr = lp::Subquery(result.plan);
-        // Correlated subqueries bake in physical column names from the outer
-        // scope they were planned in; caching would let a second outer
-        // context reuse a plan whose references point at the first context's
-        // (now stale) names.
-        if (!result.touchedOuterScope) {
-          subqueryCache_.emplace(query, expr);
-        }
-        return expr;
-      }
-
-      AXIOM_PRESTO_SYNTAX_FAIL(
-          query->location(),
-          std::string(NodeTypeName::toName(query->type())),
-          "Subquery type is not supported yet");
+      return planSubquery(node->as<SubqueryExpression>(), /*scalar=*/true);
     }
 
     case NodeType::kComparisonExpression: {
@@ -710,7 +683,8 @@ lp::ExprApi ExpressionPlanner::toExpr(const ExpressionPtr& node) {
 
     case NodeType::kExistsPredicate: {
       auto* exists = node->as<ExistsPredicate>();
-      return lp::Exists(toExpr(exists->subquery()));
+      return lp::Exists(planSubquery(
+          exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
     }
 
     case NodeType::kCast: {
@@ -1082,6 +1056,47 @@ core::WindowCallExpr::BoundType toWindowBoundType(FrameBound::Type type) {
 }
 
 } // namespace
+
+lp::ExprApi ExpressionPlanner::planSubquery(
+    const SubqueryExpression* subquery,
+    bool scalar) {
+  auto query = subquery->query();
+
+  if (!query->is(NodeType::kQuery)) {
+    AXIOM_PRESTO_SYNTAX_FAIL(
+        query->location(),
+        std::string(NodeTypeName::toName(query->type())),
+        "Subquery type is not supported yet");
+  }
+
+  VELOX_CHECK_NOT_NULL(
+      subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
+
+  // Look up first; if not cached, plan and insert. Do not hold an
+  // iterator across subqueryPlanner_ because it may recursively plan
+  // a subquery that mutates the cache and invalidates iterators.
+  if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
+    return it->second;
+  }
+  auto result = subqueryPlanner_(query->as<Query>());
+  if (scalar) {
+    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+        result.plan->outputType()->size(),
+        1,
+        query->location(),
+        "",
+        "Scalar subquery must return exactly one column");
+  }
+  auto expr = lp::Subquery(result.plan);
+  // Correlated subqueries bake in physical column names from the outer
+  // scope they were planned in; caching would let a second outer
+  // context reuse a plan whose references point at the first context's
+  // (now stale) names.
+  if (!result.touchedOuterScope) {
+    subqueryCache_.emplace(query, expr);
+  }
+  return expr;
+}
 
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     const FunctionCall* call,

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -156,6 +156,13 @@ class ExpressionPlanner {
       const std::string& funcName,
       const std::vector<lp::ExprApi>& args);
 
+  // Plans `subquery` via `subqueryPlanner_` and wraps the resulting
+  // plan as an `lp::Subquery` expression, caching by AST identity.
+  // When `scalar` is true, enforces the SQL rule that a subquery used
+  // as a scalar expression must return exactly one column. EXISTS
+  // (which only checks row presence) passes false.
+  lp::ExprApi planSubquery(const SubqueryExpression* subquery, bool scalar);
+
   // Resolves a type signature, trying built-in Velox types first, then
   // connector-based resolution for dotted names (e.g., "catalog.schema.Type").
   facebook::velox::TypePtr resolveType(const TypeSignaturePtr& type);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -595,6 +595,20 @@ TEST_F(PrestoParserTest, joinUsing) {
   }
 }
 
+// A scalar subquery (subquery used as an expression) must return
+// exactly one column.
+TEST_F(PrestoParserTest, scalarSubqueryMultipleColumnsRejected) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT (SELECT n_nationkey, n_name FROM nation) FROM nation"),
+      "Scalar subquery must return exactly one column");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT (SELECT max(t.n_nationkey), min(t.n_nationkey) FROM (VALUES (1)) AS _(x)) "
+          "FROM nation t"),
+      "Scalar subquery must return exactly one column");
+}
+
 TEST_F(PrestoParserTest, joinOnSubquery) {
   auto matcher = matchScan()
                      .join(matchScan().build())


### PR DESCRIPTION
Summary:

A subquery used as a scalar expression must return exactly one column. Previously the parser produced a malformed LP and the optimizer failed with a cryptic internal assertion. For example:

    SELECT (SELECT max(t.a), min(t.a) FROM (VALUES (1)) AS u(x))
    FROM (VALUES (10), (20)) AS t(a)

now fails at the parser with:

    Semantic error at 0:8: Scalar subquery must return exactly one column: 2 vs 1

instead of `VELOX_CHECK_EQ(1, 2)` in `processProjectionCorrelatedScalarSubquery`.

Extracts the cache + plan + wrap logic from the `kSubqueryExpression` AST case into a `planSubquery(subquery, scalar)` helper. The scalar-position path passes `scalar=true` and checks the body's output column count against 1. EXISTS (which only checks row presence) passes `scalar=false` and reuses the same caching path. IN keeps the scalar path — its body must also be single-column.

Differential Revision: D107525843


