### PR TITLE
feat(logical_plan): Support scoped connector registries

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -26,6 +26,36 @@ namespace facebook::axiom::logical_plan {
 
 using connector::ConnectorMetadataRegistry;
 
+PlanBuilder::Context::Context(
+    const std::optional<std::string>& defaultConnectorId,
+    const std::optional<std::string>& defaultSchema,
+    std::shared_ptr<velox::core::QueryCtx> queryCtxPtr,
+    ExprResolver::FunctionRewriteHook hook,
+    std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser,
+    const velox::TypeCoercer* coercer)
+    : defaultConnectorId{defaultConnectorId},
+      defaultSchema{defaultSchema},
+      sqlParser{std::move(sqlParser)},
+      planNodeIdGenerator{std::make_shared<velox::core::PlanNodeIdGenerator>()},
+      nameAllocator{std::make_shared<NameAllocator>()},
+      queryCtx{std::move(queryCtxPtr)},
+      hook{std::move(hook)},
+      pool{
+          queryCtx && queryCtx->pool()
+              ? queryCtx->pool()->addLeafChild("literals")
+              : nullptr},
+      coercer{coercer} {}
+
+std::shared_ptr<connector::ConnectorMetadata>
+PlanBuilder::Context::connectorMetadata(const std::string& connectorId) const {
+  auto metadata = queryCtx
+      ? ConnectorMetadataRegistry::tryGet(*queryCtx, connectorId)
+      : ConnectorMetadataRegistry::tryGet(connectorId);
+  VELOX_USER_CHECK_NOT_NULL(
+      metadata, "ConnectorMetadata not registered: {}", connectorId);
+  return metadata;
+}
+
 PlanBuilder& PlanBuilder::values(
     const velox::RowTypePtr& rowType,
     std::vector<velox::Variant> rows) {
@@ -210,11 +240,11 @@ PlanBuilder& PlanBuilder::values(
 PlanBuilder& PlanBuilder::tableScan(
     const std::string& tableName,
     bool includeHiddenColumns) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
   return tableScan(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       tableName,
       includeHiddenColumns);
 }
@@ -225,12 +255,8 @@ PlanBuilder& PlanBuilder::from(const std::vector<std::string>& tableNames) {
 
   tableScan(tableNames.front());
 
-  Context context{defaultConnectorId_, defaultSchema_};
-  context.planNodeIdGenerator = planNodeIdGenerator_;
-  context.nameAllocator = nameAllocator_;
-
   for (auto i = 1; i < tableNames.size(); ++i) {
-    crossJoin(PlanBuilder(context).tableScan(tableNames.at(i)));
+    crossJoin(PlanBuilder(context_).tableScan(tableNames.at(i)));
   }
 
   return *this;
@@ -244,7 +270,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = context_.connectorMetadata(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -305,19 +331,22 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& schemaName,
     const std::string& tableName,
     bool includeHiddenColumns) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
   return tableScan(
-      defaultConnectorId_.value(), schemaName, tableName, includeHiddenColumns);
+      context_.defaultConnectorId.value(),
+      schemaName,
+      tableName,
+      includeHiddenColumns);
 }
 
 PlanBuilder& PlanBuilder::tableScan(
     const std::string& tableName,
     const std::vector<std::string>& columnNames) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
   return tableScan(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       tableName,
       columnNames);
 }
@@ -326,9 +355,9 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& schemaName,
     const std::string& tableName,
     const std::vector<std::string>& columnNames) {
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
   return tableScan(
-      defaultConnectorId_.value(), schemaName, tableName, columnNames);
+      context_.defaultConnectorId.value(), schemaName, tableName, columnNames);
 }
 
 PlanBuilder& PlanBuilder::tableScan(
@@ -339,7 +368,7 @@ PlanBuilder& PlanBuilder::tableScan(
   VELOX_USER_CHECK_NULL(node_, "Table scan node must be the leaf node");
 
   SchemaTableName schemaTableName{schemaName, tableName};
-  auto metadata = ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = context_.connectorMetadata(connectorId);
   auto table = metadata->findTable(schemaTableName);
   VELOX_USER_CHECK_NOT_NULL(
       table, "Table not found: {}", schemaTableName.toString());
@@ -427,7 +456,7 @@ PlanBuilder& PlanBuilder::dropHiddenColumns() {
 PlanBuilder& PlanBuilder::filter(const std::string& predicate) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Filter node cannot be a leaf node");
 
-  auto untypedExpr = sqlParser_->parseExpr(predicate);
+  auto untypedExpr = context_.sqlParser->parseExpr(predicate);
   return filter(untypedExpr);
 }
 
@@ -443,7 +472,7 @@ std::vector<ExprApi> PlanBuilder::parse(const std::vector<std::string>& exprs) {
   std::vector<ExprApi> untypedExprs;
   untypedExprs.reserve(exprs.size());
   for (const auto& sql : exprs) {
-    untypedExprs.emplace_back(sqlParser_->parseScalarOrWindowExpr(sql));
+    untypedExprs.emplace_back(context_.sqlParser->parseScalarOrWindowExpr(sql));
   }
   return untypedExprs;
 }
@@ -744,7 +773,7 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(parse(groupingKeys), parsedAggregates);
 }
@@ -827,7 +856,7 @@ PlanBuilder& PlanBuilder::aggregate(
   }
 
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(exprGroupingSets, parsedAggregates, groupingSetIndexName);
 }
@@ -838,7 +867,7 @@ PlanBuilder& PlanBuilder::aggregate(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return aggregate(
       parse(groupingKeys),
@@ -973,7 +1002,7 @@ PlanBuilder& PlanBuilder::rollup(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return rollup(parse(groupingKeys), parsedAggregates, groupingSetIndexName);
 }
@@ -1009,7 +1038,7 @@ PlanBuilder& PlanBuilder::cube(
     const std::vector<std::string>& aggregates,
     const std::string& groupingSetIndexName) {
   std::vector<ExprApi> parsedAggregates;
-  parseAggregates(*sqlParser_, aggregates, parsedAggregates);
+  parseAggregates(*context_.sqlParser, aggregates, parsedAggregates);
 
   return cube(parse(groupingKeys), parsedAggregates, groupingSetIndexName);
 }
@@ -1164,7 +1193,7 @@ PlanBuilder& PlanBuilder::join(
     JoinType joinType) {
   std::optional<ExprApi> conditionExpr;
   if (!condition.empty()) {
-    conditionExpr = sqlParser_->parseExpr(condition);
+    conditionExpr = context_.sqlParser->parseExpr(condition);
   }
 
   return join(right, conditionExpr, joinType);
@@ -1453,7 +1482,7 @@ PlanBuilder& PlanBuilder::setOperation(
     SetOperation op,
     const PlanBuilder& other) {
   // Do not use std::move(*this) — that invalidates resolver_ members
-  // (e.g. planNodeIdGenerator_ becomes null), causing crashes when the
+  // (e.g. context_.planNodeIdGenerator becomes null), causing crashes when the
   // builder is used for expression resolution after the set operation.
   VELOX_CHECK_NOT_NULL(node_);
   VELOX_CHECK_NOT_NULL(other.node_);
@@ -1563,7 +1592,7 @@ PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {
   sortingFields.reserve(sortingKeys.size());
 
   for (const auto& key : sortingKeys) {
-    auto orderBy = sqlParser_->parseOrderByExpr(key);
+    auto orderBy = context_.sqlParser->parseOrderByExpr(key);
     auto expr = resolveScalarTypes(orderBy.expr);
 
     sortingFields.push_back(
@@ -1635,7 +1664,7 @@ PlanBuilder& PlanBuilder::tableWrite(
 
   if (kind == WriteKind::kInsert) {
     // Check input types.
-    auto metadata = ConnectorMetadataRegistry::get(connectorId);
+    auto metadata = context_.connectorMetadata(connectorId);
     auto table = metadata->findTable(schemaTableName);
     VELOX_USER_CHECK_NOT_NULL(
         table, "Table not found: {}", schemaTableName.toString());
@@ -1688,8 +1717,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     std::vector<std::string> columnNames,
     folly::F14FastMap<std::string, std::string> options) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Table write node cannot be a leaf node");
-  VELOX_USER_CHECK(defaultConnectorId_.has_value());
-  VELOX_USER_CHECK(defaultSchema_.has_value());
+  VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+  VELOX_USER_CHECK(context_.defaultSchema.has_value());
 
   auto outputColumns = findOrAssignOutputNames();
   std::vector<ExprApi> columnExprs;
@@ -1699,8 +1728,8 @@ PlanBuilder& PlanBuilder::tableWrite(
   }
 
   return tableWrite(
-      defaultConnectorId_.value(),
-      defaultSchema_.value(),
+      context_.defaultConnectorId.value(),
+      context_.defaultSchema.value(),
       std::move(tableName),
       kind,
       std::move(columnNames),
@@ -1837,7 +1866,7 @@ PlanBuilder& PlanBuilder::as(const std::string& alias) {
 }
 
 std::string PlanBuilder::newName(const std::string& hint) {
-  return nameAllocator_->newName(hint);
+  return context_.nameAllocator->newName(hint);
 }
 
 size_t PlanBuilder::numOutput() const {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -114,6 +114,21 @@ class PlanBuilder {
  public:
   /// Shared state across PlanBuilder instances. Pass the same Context to
   /// multiple builders to keep plan-node IDs and column names globally unique.
+  ///
+  /// Example:
+  ///   PlanBuilder::Context ctx("my_connector", "my_schema");
+  ///   auto plan = PlanBuilder(ctx)
+  ///       .tableScan("orders")
+  ///       .filter("o_totalprice > 100")
+  ///       .build();
+  ///
+  /// To use a scoped connector registry (for test isolation), attach the
+  /// registry to a `QueryCtx` and pass it to the Context. The scoped registry
+  /// is looked up under `ConnectorMetadataRegistry::kRegistryKey`.
+  ///
+  /// Invariants:
+  /// - `planNodeIdGenerator` must not be null
+  /// - `nameAllocator` must not be null
   struct Context {
     /// Identifies the connector to use when tableScan omits the catalog prefix.
     std::optional<std::string> defaultConnectorId;

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/ExprResolver.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
@@ -129,8 +131,10 @@ class PlanBuilder {
     /// Context.
     std::shared_ptr<NameAllocator> nameAllocator;
 
-    /// Enables constant folding when set. Also provides a memory pool for
-    /// evaluating constant expressions.
+    /// Enables constant folding (including memory pool) when set.
+    /// Enables a per-query connector metadata registry override (looked up
+    /// under `ConnectorMetadataRegistry::kRegistryKey`); when unset, lookups
+    /// go directly against the global registry.
     std::shared_ptr<velox::core::QueryCtx> queryCtx;
 
     /// Rewrites function calls during expression resolution, e.g. maps
@@ -163,20 +167,21 @@ class PlanBuilder {
         std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser =
             std::make_shared<velox::parse::DuckSqlExpressionsParser>(
                 velox::parse::ParseOptions{.parseInListAsArray = false}),
-        const velox::TypeCoercer* coercer = nullptr)
-        : defaultConnectorId{defaultConnectorId},
-          defaultSchema{defaultSchema},
-          sqlParser{std::move(sqlParser)},
-          planNodeIdGenerator{
-              std::make_shared<velox::core::PlanNodeIdGenerator>()},
-          nameAllocator{std::make_shared<NameAllocator>()},
-          queryCtx{std::move(queryCtxPtr)},
-          hook{std::move(hook)},
-          pool{
-              queryCtx && queryCtx->pool()
-                  ? queryCtx->pool()->addLeafChild("literals")
-                  : nullptr},
-          coercer{coercer} {}
+        const velox::TypeCoercer* coercer = nullptr);
+
+    /// Resolves connector metadata for `connectorId`.
+    ///
+    /// If `queryCtx` is set and has a `ConnectorMetadataRegistry` registered
+    /// under `ConnectorMetadataRegistry::kRegistryKey`, the lookup is
+    /// dispatched to that scoped registry; whether it falls back to the global
+    /// registry depends on the scoped registry's parent chain. Otherwise (no
+    /// `queryCtx`, or no registry override under `kRegistryKey`), the lookup
+    /// goes directly against the global registry. This will not return a
+    /// nullptr: it will throw an exception instead.
+    ///
+    /// @throws VeloxUserException if the connector is not registered.
+    std::shared_ptr<connector::ConnectorMetadata> connectorMetadata(
+        const std::string& connectorId) const;
   };
 
   /// Resolves a column reference from an outer query scope. Used to support
@@ -209,12 +214,8 @@ class PlanBuilder {
       const Context& context,
       bool allowAmbiguousOutputNames = false,
       Scope outerScope = nullptr)
-      : defaultConnectorId_{context.defaultConnectorId},
-        defaultSchema_{context.defaultSchema},
-        planNodeIdGenerator_{context.planNodeIdGenerator},
-        nameAllocator_{context.nameAllocator},
+      : context_{context},
         outerScope_{std::move(outerScope)},
-        sqlParser_{context.sqlParser},
         allowAmbiguousOutputNames_{allowAmbiguousOutputNames},
         coercer_{context.coercer},
         identifierCanonicalizer_{context.identifierCanonicalizer},
@@ -224,8 +225,8 @@ class PlanBuilder {
             context.hook,
             context.pool,
             context.planNodeIdGenerator} {
-    VELOX_CHECK_NOT_NULL(planNodeIdGenerator_);
-    VELOX_CHECK_NOT_NULL(nameAllocator_);
+    VELOX_CHECK_NOT_NULL(context_.planNodeIdGenerator);
+    VELOX_CHECK_NOT_NULL(context_.nameAllocator);
   }
 
   /// Adds a leaf Values node producing literal rows. Must be the first node
@@ -608,11 +609,11 @@ class PlanBuilder {
       std::vector<std::string> columnNames,
       const std::initializer_list<std::string>& columnExprs,
       folly::F14FastMap<std::string, std::string> options = {}) {
-    VELOX_USER_CHECK(defaultConnectorId_.has_value());
-    VELOX_USER_CHECK(defaultSchema_.has_value());
+    VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+    VELOX_USER_CHECK(context_.defaultSchema.has_value());
     return tableWrite(
-        defaultConnectorId_.value(),
-        defaultSchema_.value(),
+        context_.defaultConnectorId.value(),
+        context_.defaultSchema.value(),
         std::move(tableName),
         kind,
         std::move(columnNames),
@@ -627,11 +628,11 @@ class PlanBuilder {
       std::vector<std::string> columnNames,
       const std::vector<std::string>& columnExprs,
       folly::F14FastMap<std::string, std::string> options = {}) {
-    VELOX_USER_CHECK(defaultConnectorId_.has_value());
-    VELOX_USER_CHECK(defaultSchema_.has_value());
+    VELOX_USER_CHECK(context_.defaultConnectorId.has_value());
+    VELOX_USER_CHECK(context_.defaultSchema.has_value());
     return tableWrite(
-        defaultConnectorId_.value(),
-        defaultSchema_.value(),
+        context_.defaultConnectorId.value(),
+        context_.defaultSchema.value(),
         std::move(tableName),
         kind,
         std::move(columnNames),
@@ -811,7 +812,7 @@ class PlanBuilder {
   void setOperationImpl(SetOperation op, std::vector<LogicalPlanNodePtr> nodes);
 
   std::string nextId() {
-    return planNodeIdGenerator_->next();
+    return context_.planNodeIdGenerator->next();
   }
 
   std::string newName(const std::string& hint);
@@ -845,25 +846,14 @@ class PlanBuilder {
       std::vector<AggregateExprPtr>& exprs,
       NameMappings& mappings);
 
-  // Connector ID used when table names omit the catalog prefix.
-  const std::optional<std::string> defaultConnectorId_;
-
-  // Schema used when table names omit the schema prefix.
-  const std::optional<std::string> defaultSchema_;
-
-  // Generates unique plan-node IDs (shared across builders via Context).
-  const std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator_;
-
-  // Allocates unique internal column names (shared across builders via
-  // Context).
-  const std::shared_ptr<NameAllocator> nameAllocator_;
+  // Shared state inherited from the constructor's Context. Sole source of
+  // truth for default connector/schema, ID/name generators, queryCtx, and the
+  // SQL expression parser.
+  const Context context_;
 
   // Resolves column references from the enclosing query for correlated
   // subqueries. Null for top-level queries.
   const Scope outerScope_;
-
-  // Parses SQL expression strings into Velox expression trees.
-  const std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser_;
 
   const bool allowAmbiguousOutputNames_;
 

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -16,9 +16,13 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
+#include "folly/ScopeGuard.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
@@ -734,6 +738,94 @@ TEST_F(PlanBuilderTest, valuesTypeCoercionErrors) {
           {{"CAST(null AS boolean)"}, {"CAST(null AS bigint)"}},
           /*enableCoercions=*/false),
       "All values should have equivalent types: BIGINT vs. ROW<x:BOOLEAN>");
+}
+
+// Builds a QueryCtx with the given scoped connector metadata registry attached
+// under ConnectorMetadataRegistry::kRegistryKey.
+std::shared_ptr<core::QueryCtx> queryCtxWithRegistry(
+    std::shared_ptr<connector::ConnectorMetadataRegistry::Registry> registry) {
+  auto queryCtx = core::QueryCtx::create();
+  queryCtx->setRegistry(
+      connector::ConnectorMetadataRegistry::kRegistryKey, std::move(registry));
+  return queryCtx;
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryTableScan) {
+  // Create an isolated scoped registry (no parent fallback).
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  auto testConnector =
+      std::make_shared<connector::TestConnector>("scoped_connector");
+  registry->insert(testConnector->connectorId(), testConnector->metadata());
+
+  testConnector->addTable(
+      "orders", ROW({"o_custkey", "o_totalprice"}, {BIGINT(), DOUBLE()}));
+
+  PlanBuilder::Context context{
+      std::string("scoped_connector"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  auto plan = PlanBuilder(context).tableScan("orders").build();
+  ASSERT_NE(plan, nullptr);
+  EXPECT_THAT(
+      plan->outputType()->names(),
+      testing::ElementsAre("o_custkey", "o_totalprice"));
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryFrom) {
+  // Verify that from() propagates the scoped registry to subsequent table
+  // scans for the second and later tables.
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  auto testConnector =
+      std::make_shared<connector::TestConnector>("scoped_from");
+  registry->insert(testConnector->connectorId(), testConnector->metadata());
+
+  testConnector->addTable("t1", ROW({"a", "b"}, {BIGINT(), VARCHAR()}));
+  testConnector->addTable("t2", ROW({"c", "d"}, {INTEGER(), DOUBLE()}));
+
+  PlanBuilder::Context context{
+      std::string("scoped_from"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  // from() builds cross joins across t1 and t2. The second table scan
+  // must also use the scoped registry.
+  auto plan = PlanBuilder(context).from({"t1", "t2"}).build();
+  ASSERT_NE(plan, nullptr);
+  EXPECT_THAT(
+      plan->outputType()->names(), testing::ElementsAre("a", "b", "c", "d"));
+}
+
+TEST_F(PlanBuilderTest, scopedRegistryTableNotFound) {
+  // Register a table in the global registry only. A scoped registry without
+  // that table should fail to resolve it.
+  auto globalConnector =
+      std::make_shared<connector::TestConnector>("global_only");
+  connector::ConnectorMetadataRegistry::global().insert(
+      globalConnector->connectorId(), globalConnector->metadata());
+  SCOPE_EXIT {
+    connector::ConnectorMetadataRegistry::global().erase(
+        globalConnector->connectorId());
+  };
+  globalConnector->addTable("global_table", ROW({"x"}, {BIGINT()}));
+
+  // Create an isolated registry with no parent, so it cannot see the global.
+  auto registry =
+      connector::ConnectorMetadataRegistry::create(/*parent=*/nullptr);
+
+  PlanBuilder::Context context{
+      std::string("global_only"),
+      std::string(connector::TestConnector::kDefaultSchema),
+      queryCtxWithRegistry(registry)};
+
+  // The scoped registry does not contain "global_only", so lookup fails.
+  VELOX_ASSERT_THROW(
+      PlanBuilder(context).tableScan("global_table"),
+      "ConnectorMetadata not registered: global_only");
 }
 
 } // namespace

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -36,6 +36,7 @@
 #include "axiom/sql/presto/ast/UpperCaseInputStream.h"
 #include "axiom/sql/presto/grammar/PrestoSqlLexer.h"
 #include "axiom/sql/presto/grammar/PrestoSqlParser.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/WindowFunction.h"
 #include "velox/functions/FunctionRegistry.h"
@@ -47,6 +48,8 @@ namespace {
 
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
+using facebook::axiom::connector::ConnectorMetadataRegistry;
+using Registry = ConnectorMetadataRegistry::Registry;
 
 class ErrorListener : public antlr4::BaseErrorListener {
  public:
@@ -245,10 +248,14 @@ class RelationPlanner : public AstVisitor {
   RelationPlanner(
       const std::string& defaultConnectorId,
       const std::string& defaultSchema,
+      std::shared_ptr<core::QueryCtx> queryCtx,
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql,
       bool friendlySql = true)
-      : context_{makePrestoContext(defaultConnectorId, defaultSchema)},
+      : context_{makePrestoContext(
+            defaultConnectorId,
+            defaultSchema,
+            std::move(queryCtx))},
         defaultSchema_{defaultSchema},
         parseSql_{parseSql},
         builder_(newBuilder()),
@@ -256,11 +263,12 @@ class RelationPlanner : public AstVisitor {
 
   static lp::PlanBuilder::Context makePrestoContext(
       const std::string& defaultConnectorId,
-      const std::string& defaultSchema) {
+      const std::string& defaultSchema,
+      std::shared_ptr<core::QueryCtx> queryCtx = nullptr) {
     lp::PlanBuilder::Context ctx{
         defaultConnectorId,
         defaultSchema,
-        /*queryCtxPtr=*/nullptr,
+        std::move(queryCtx),
         /*hook=*/nullptr,
         std::make_shared<lp::ThrowingSqlExpressionsParser>(),
         &::facebook::velox::functions::prestosql::typeCoercer()};
@@ -454,9 +462,13 @@ class RelationPlanner : public AstVisitor {
       const auto [connectorId, connectorTable] = toConnectorTable(
           *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
 
-      auto metadata =
-          facebook::axiom::connector::ConnectorMetadataRegistry::get(
-              connectorId);
+      auto metadata = context_.connectorMetadata(connectorId);
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          metadata != nullptr,
+          table.location(),
+          table.name()->suffix(),
+          "Catalog not found: {}",
+          connectorId);
 
       if (metadata->findTable(connectorTable) != nullptr) {
         // Drop display names captured from a sibling FROM relation so
@@ -1372,7 +1384,7 @@ class RelationPlanner : public AstVisitor {
     right->accept(this);
     auto rightBuilder = builder_;
 
-    builder_ = leftBuilder;
+    builder_ = std::move(leftBuilder);
     builder_->setOperation(op, *rightBuilder);
     displayNames_.lastNames = std::move(leftDisplayNames);
   }
@@ -1635,15 +1647,29 @@ SqlStatementPtr parseExplain(
       format);
 }
 
+static std::shared_ptr<facebook::axiom::connector::ConnectorMetadata>
+tryGetMetadata(
+    const std::shared_ptr<core::QueryCtx>& queryCtx,
+    const std::string& connectorId) {
+  return queryCtx ? ConnectorMetadataRegistry::tryGet(*queryCtx, connectorId)
+                  : ConnectorMetadataRegistry::tryGet(connectorId);
+}
+
 static facebook::axiom::connector::TablePtr findTable(
     const QualifiedName& name,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   const auto [connectorId, connectorTable] =
       toConnectorTable(name, defaultConnectorId, defaultSchema);
 
-  auto metadata =
-      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = tryGetMetadata(queryCtx, connectorId);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      metadata != nullptr,
+      name.location(),
+      name.suffix(),
+      "Catalog not found: {}",
+      connectorId);
 
   auto table = metadata->findTable(connectorTable);
 
@@ -1661,10 +1687,17 @@ static facebook::axiom::connector::TablePtr findTable(
 static facebook::axiom::connector::TablePtr findTable(
     const QualifiedName& name,
     const std::string& connectorId,
-    const facebook::axiom::SchemaTableName& connectorTable) {
-  auto table =
-      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId)
-          ->findTable(connectorTable);
+    const facebook::axiom::SchemaTableName& connectorTable,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
+  auto metadata = tryGetMetadata(queryCtx, connectorId);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      metadata != nullptr,
+      name.location(),
+      name.suffix(),
+      "Catalog not found: {}",
+      connectorId);
+
+  auto table = metadata->findTable(connectorTable);
   AXIOM_PRESTO_SEMANTIC_CHECK(
       table != nullptr,
       name.location(),
@@ -1690,9 +1723,11 @@ lp::ExprApi makeLikeExpr(
 
 SqlStatementPtr parseShowCatalogs(
     const ShowCatalogs& showCatalogs,
-    const std::string& defaultConnectorId) {
-  const auto connectorIds =
-      facebook::axiom::connector::ConnectorMetadataRegistry::allMetadataIds();
+    const std::string& defaultConnectorId,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
+  const auto connectorIds = queryCtx
+      ? ConnectorMetadataRegistry::allMetadataIds(*queryCtx)
+      : ConnectorMetadataRegistry::allMetadataIds();
 
   std::vector<Variant> data;
   data.reserve(connectorIds.size());
@@ -1700,7 +1735,7 @@ SqlStatementPtr parseShowCatalogs(
     data.emplace_back(Variant::row({id, id, id}));
   }
 
-  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder::Context ctx(defaultConnectorId, std::nullopt, queryCtx);
   lp::PlanBuilder builder(ctx);
   builder.values(
       ROW({"catalog_name", "connector_id", "connector_name"}, VARCHAR()),
@@ -1720,12 +1755,14 @@ SqlStatementPtr parseShowCatalogs(
 SqlStatementPtr parseShowColumns(
     const ShowColumns& showColumns,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   const auto [connectorId, connectorTable] =
       toConnectorTable(*showColumns.table(), defaultConnectorId, defaultSchema);
 
   const auto schema =
-      findTable(*showColumns.table(), connectorId, connectorTable)->type();
+      findTable(*showColumns.table(), connectorId, connectorTable, queryCtx)
+          ->type();
 
   std::vector<Variant> data;
   data.reserve(schema->size());
@@ -1734,7 +1771,7 @@ SqlStatementPtr parseShowColumns(
         Variant::row({schema->nameOf(i), schema->childAt(i)->toString()}));
   }
 
-  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder::Context ctx(defaultConnectorId, std::nullopt, queryCtx);
   return std::make_shared<SelectStatement>(
       lp::PlanBuilder(ctx)
           .values(ROW({"column", "type"}, VARCHAR()), data)
@@ -1785,14 +1822,15 @@ std::string variantToSql(const Variant& value) {
 SqlStatementPtr parseShowCreateTable(
     const ShowCreateTable& showCreateTable,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   using facebook::velox::PrestoTypes;
 
   const auto [connectorId, schemaTableName] = toConnectorTable(
       *showCreateTable.name(), defaultConnectorId, defaultSchema);
 
-  const auto table =
-      findTable(*showCreateTable.name(), connectorId, schemaTableName);
+  const auto table = findTable(
+      *showCreateTable.name(), connectorId, schemaTableName, queryCtx);
   const auto& schema = table->type();
   const auto& options = table->options();
 
@@ -1845,11 +1883,13 @@ SqlStatementPtr parseShowCreateTable(
 SqlStatementPtr parseShowStats(
     const ShowStats& showStats,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   const auto [connectorId, connectorTable] =
       toConnectorTable(*showStats.table(), defaultConnectorId, defaultSchema);
 
-  const auto table = findTable(*showStats.table(), connectorId, connectorTable);
+  const auto table =
+      findTable(*showStats.table(), connectorId, connectorTable, queryCtx);
   const auto schema = table->type();
 
   ShowStatsBuilder builder(static_cast<int64_t>(table->numRows()));
@@ -1887,7 +1927,7 @@ SqlStatementPtr parseShowStats(
         max);
   }
 
-  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder::Context ctx(defaultConnectorId, std::nullopt, queryCtx);
   return std::make_shared<SelectStatement>(
       lp::PlanBuilder(ctx)
           .values(ShowStatsBuilder::outputType(), builder.rows())
@@ -1957,7 +1997,7 @@ SqlStatementPtr parseShowFunctions(
               "Signature",
           },
           VARCHAR()),
-      rows);
+      std::move(rows));
 
   if (showFunctions.getLikePattern().has_value()) {
     builder.filter(makeLikeExpr(
@@ -1984,13 +2024,19 @@ SqlStatementPtr parseInsert(
     const Insert& insert,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema,
+    std::shared_ptr<core::QueryCtx> queryCtx,
     const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
         std::string_view /*sql*/)>& parseSql) {
   const auto [connectorId, connectorTable] =
       toConnectorTable(*insert.target(), defaultConnectorId, defaultSchema);
 
-  auto insertMetadata =
-      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+  auto insertMetadata = tryGetMetadata(queryCtx, connectorId);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      insertMetadata != nullptr,
+      insert.location(),
+      insert.target()->suffix(),
+      "Catalog not found: {}",
+      connectorId);
 
   const auto table = insertMetadata->findTable(connectorTable);
 
@@ -2015,7 +2061,8 @@ SqlStatementPtr parseInsert(
     }
   }
 
-  RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+  RelationPlanner planner(
+      defaultConnectorId, defaultSchema, std::move(queryCtx), parseSql);
   insert.query()->accept(&planner);
 
   auto inputColumns = planner.builder().findOrAssignOutputNames();
@@ -2060,12 +2107,14 @@ SqlStatementPtr parseCreateTableAsSelect(
     const CreateTableAsSelect& ctas,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema,
+    std::shared_ptr<core::QueryCtx> queryCtx,
     const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
         std::string_view /*sql*/)>& parseSql) {
   auto [connectorId, connectorTable] =
       toConnectorTable(*ctas.name(), defaultConnectorId, defaultSchema);
 
-  RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+  RelationPlanner planner(
+      defaultConnectorId, defaultSchema, std::move(queryCtx), parseSql);
   ctas.query()->accept(&planner);
 
   auto properties = parseTableProperties(ctas.properties());
@@ -2133,7 +2182,8 @@ SqlStatementPtr parseCreateTableAsSelect(
 SqlStatementPtr parseCreateTable(
     const CreateTable& createTable,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   auto [connectorId, connectorTable] =
       toConnectorTable(*createTable.name(), defaultConnectorId, defaultSchema);
 
@@ -2161,7 +2211,10 @@ SqlStatementPtr parseCreateTable(
       case NodeType::kLikeClause: {
         auto* likeClause = element->as<LikeClause>();
         auto table = findTable(
-            *likeClause->tableName(), defaultConnectorId, defaultSchema);
+            *likeClause->tableName(),
+            defaultConnectorId,
+            defaultSchema,
+            queryCtx);
 
         auto schema = table->type();
         for (auto i = 0; i < schema->size(); ++i) {
@@ -2297,11 +2350,19 @@ SqlStatementPtr parseDropSchema(
 
 SqlStatementPtr parseShowSchemas(
     const ShowSchemas& showSchemas,
-    const std::string& defaultConnectorId) {
+    const std::string& defaultConnectorId,
+    const std::shared_ptr<core::QueryCtx>& queryCtx) {
   const auto connectorId = showSchemas.catalog().value_or(defaultConnectorId);
 
-  auto metadata =
-      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+  auto metadata = tryGetMetadata(queryCtx, connectorId);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      metadata != nullptr,
+      showSchemas.location(),
+      // Use the user-typed catalog (if any) for the error symbol so that
+      // an implicit defaultConnectorId is not surfaced to the user.
+      showSchemas.catalog().value_or(""),
+      "Catalog not found: {}",
+      connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
       "show-schemas");
   auto schemaNames = metadata->listSchemaNames(session);
@@ -2313,7 +2374,7 @@ SqlStatementPtr parseShowSchemas(
     data.emplace_back(Variant::row({name}));
   }
 
-  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder::Context ctx(defaultConnectorId, std::nullopt, queryCtx);
   lp::PlanBuilder builder(ctx);
   builder.values(ROW({"Schema"}, VARCHAR()), std::move(data));
 
@@ -2414,12 +2475,17 @@ SqlStatementPtr doPlan(
     const std::shared_ptr<Statement>& query,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema,
+    std::shared_ptr<core::QueryCtx> queryCtx,
     const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
         std::string_view /*sql*/)>& parseSql,
     bool friendlySql = true) {
   if (query->is(NodeType::kInsert)) {
     return parseInsert(
-        *query->as<Insert>(), defaultConnectorId, defaultSchema, parseSql);
+        *query->as<Insert>(),
+        defaultConnectorId,
+        defaultSchema,
+        std::move(queryCtx),
+        parseSql);
   }
 
   if (query->is(NodeType::kCreateTableAsSelect)) {
@@ -2427,12 +2493,13 @@ SqlStatementPtr doPlan(
         *query->as<CreateTableAsSelect>(),
         defaultConnectorId,
         defaultSchema,
+        std::move(queryCtx),
         parseSql);
   }
 
   if (query->is(NodeType::kCreateTable)) {
     return parseCreateTable(
-        *query->as<CreateTable>(), defaultConnectorId, defaultSchema);
+        *query->as<CreateTable>(), defaultConnectorId, defaultSchema, queryCtx);
   }
 
   if (query->is(NodeType::kDropTable)) {
@@ -2454,7 +2521,8 @@ SqlStatementPtr doPlan(
   }
 
   if (query->is(NodeType::kShowSchemas)) {
-    return parseShowSchemas(*query->as<ShowSchemas>(), defaultConnectorId);
+    return parseShowSchemas(
+        *query->as<ShowSchemas>(), defaultConnectorId, queryCtx);
   }
 
   if (query->is(NodeType::kShowTables)) {
@@ -2463,27 +2531,32 @@ SqlStatementPtr doPlan(
   }
 
   if (query->is(NodeType::kShowCatalogs)) {
-    return parseShowCatalogs(*query->as<ShowCatalogs>(), defaultConnectorId);
+    return parseShowCatalogs(
+        *query->as<ShowCatalogs>(), defaultConnectorId, queryCtx);
   }
 
   if (query->is(NodeType::kShowCreate)) {
     return parseShowCreateTable(
-        *query->as<ShowCreateTable>(), defaultConnectorId, defaultSchema);
+        *query->as<ShowCreateTable>(),
+        defaultConnectorId,
+        defaultSchema,
+        queryCtx);
   }
 
   if (query->is(NodeType::kShowColumns)) {
     return parseShowColumns(
-        *query->as<ShowColumns>(), defaultConnectorId, defaultSchema);
+        *query->as<ShowColumns>(), defaultConnectorId, defaultSchema, queryCtx);
   }
 
   if (query->is(NodeType::kShowStats)) {
     return parseShowStats(
-        *query->as<ShowStats>(), defaultConnectorId, defaultSchema);
+        *query->as<ShowStats>(), defaultConnectorId, defaultSchema, queryCtx);
   }
 
   if (query->is(NodeType::kShowStatsForQuery)) {
     auto* showStats = query->as<ShowStatsForQuery>();
-    RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+    RelationPlanner planner(
+        defaultConnectorId, defaultSchema, std::move(queryCtx), parseSql);
     showStats->query()->accept(&planner);
     auto innerStatement = std::make_shared<SelectStatement>(
         planner.plan(),
@@ -2499,7 +2572,11 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kQuery)) {
     RelationPlanner planner(
-        defaultConnectorId, defaultSchema, parseSql, friendlySql);
+        defaultConnectorId,
+        defaultSchema,
+        std::move(queryCtx),
+        parseSql,
+        friendlySql);
     query->accept(&planner);
     return std::make_shared<SelectStatement>(
         planner.plan(),
@@ -2513,6 +2590,47 @@ SqlStatementPtr doPlan(
       "Unsupported statement type");
 }
 } // namespace
+
+namespace {
+
+// Wraps 'registry' in a freshly-created QueryCtx as a per-query connector
+// metadata registry override. The QueryCtx is created per parse call so its
+// memory pool dies with the call (any non-null queryCtx causes
+// PlanBuilder::Context to allocate a "literals" leaf pool from it).
+//
+// Lifetime: the returned QueryCtx holds a non-owning shared_ptr to 'registry'
+// (built via the aliasing constructor with an empty owner so the deleter is a
+// no-op). The caller must keep 'registry' alive for as long as the QueryCtx
+// (and any logical plan derived from it) is in use. PrestoParser satisfies
+// this by scoping the QueryCtx to a single doParse call and requiring the
+// caller to keep the Registry alive for the parser's lifetime.
+std::shared_ptr<core::QueryCtx> makeQueryCtxFromRegistry(
+    const Registry& registry) {
+  auto queryCtx = core::QueryCtx::create();
+  queryCtx->setRegistry(
+      ConnectorMetadataRegistry::kRegistryKey,
+      std::shared_ptr<Registry>(
+          std::shared_ptr<const Registry>{}, const_cast<Registry*>(&registry)));
+  return queryCtx;
+}
+
+} // namespace
+
+PrestoParser::PrestoParser(
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema,
+    ParserOptions options,
+    const Registry& registry)
+    : defaultConnectorId_{defaultConnectorId},
+      defaultSchema_{defaultSchema},
+      options_{options},
+      // Normalize the global-registry case to nullptr so doParse can skip
+      // creating a per-call QueryCtx + memory pool. The free-function lookups
+      // (ConnectorMetadataRegistry::tryGet(id), allMetadataIds()) handle the
+      // null case directly.
+      registry_{
+          &registry == &ConnectorMetadataRegistry::global() ? nullptr
+                                                            : &registry} {}
 
 SqlStatementPtr PrestoParser::doParse(
     std::string_view sql,
@@ -2564,12 +2682,18 @@ SqlStatementPtr PrestoParser::doParse(
         std::move(catalog), use->schema()->value());
   }
 
+  // Lazily construct a QueryCtx carrying the scoped registry only when the
+  // parser was given a non-global registry. The QueryCtx (and the memory pool
+  // PlanBuilder::Context derives from it) lives only for this parse call.
+  auto queryCtx = registry_ ? makeQueryCtxFromRegistry(*registry_) : nullptr;
+
   if (query->is(NodeType::kExplain)) {
     auto* explain = query->as<Explain>();
     auto sqlStatement = doPlan(
         explain->statement(),
         defaultConnectorId_,
         defaultSchema_,
+        std::move(queryCtx),
         parseSql,
         options_.friendlySql);
     return parseExplain(*explain, sqlStatement);
@@ -2579,6 +2703,7 @@ SqlStatementPtr PrestoParser::doParse(
       query,
       defaultConnectorId_,
       defaultSchema_,
+      std::move(queryCtx),
       parseSql,
       options_.friendlySql);
 }

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/sql/presto/ParserOptions.h"
 #include "axiom/sql/presto/SqlStatement.h"
 
@@ -23,17 +24,22 @@ namespace axiom::sql::presto {
 /// SQL Parser compatible with PrestoSQL dialect.
 class PrestoParser {
  public:
+  using Registry =
+      facebook::axiom::connector::ConnectorMetadataRegistry::Registry;
+
   /// @param defaultConnectorId Connector ID to use for tables that do not
   /// specify catalog, i.e. SELECT * FROM schema.name.
   /// @param defaultSchema Default schema to use for tables that do not
   /// specify schema, i.e. SELECT * FROM name.
+  /// @param options Parser options controlling dialect extensions.
+  /// @param registry Scoped connector metadata registry for catalog lookups.
+  /// Defaults to the global registry.
   PrestoParser(
       const std::string& defaultConnectorId,
       const std::string& defaultSchema,
-      ParserOptions options = {})
-      : defaultConnectorId_{defaultConnectorId},
-        defaultSchema_{defaultSchema},
-        options_{options} {}
+      ParserOptions options = {},
+      const Registry& registry =
+          facebook::axiom::connector::ConnectorMetadataRegistry::global());
 
   SqlStatementPtr parse(std::string_view sql, bool enableTracing = false);
 
@@ -65,6 +71,12 @@ class PrestoParser {
   const std::string defaultConnectorId_;
   const std::string defaultSchema_;
   const ParserOptions options_;
+  // Per-query connector metadata registry override, or nullptr to use the
+  // global registry. The parser lazily wraps this in a core::QueryCtx inside
+  // doParse so the QueryCtx (and any memory pool it allocates) lives only as
+  // long as a single parse call. Caller must keep the referenced Registry
+  // alive for the lifetime of the parser.
+  const Registry* registry_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
@@ -1831,6 +1834,226 @@ TEST_F(PrestoParserTest, semanticErrorHasMessageTemplate) {
         << "Semantic errors must have a messageTemplate for Scuba grouping";
     EXPECT_EQ(std::string(e.messageTemplate()), "Table not found: {}");
   }
+}
+
+TEST_F(PrestoParserTest, scopedRegistrySelect) {
+  using facebook::axiom::connector::ConnectorMetadataRegistry;
+  using facebook::axiom::connector::TestConnectorMetadata;
+
+  // Create a child registry that falls back to the global registry.
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  // Create a connector and metadata only in the scoped registry.
+  auto scopedConnector =
+      std::make_shared<facebook::axiom::connector::TestConnector>("scoped_cat");
+  auto scopedMetadata =
+      std::make_shared<TestConnectorMetadata>(scopedConnector.get());
+  scopedMetadata->addTable(
+      {"default", "scoped_table"},
+      ROW({"id", "name"}, {INTEGER(), VARCHAR()}),
+      ROW({}));
+  scopedRegistry->insert("scoped_cat", scopedMetadata, /*overwrite=*/true);
+
+  // Parse a SELECT against the scoped table using a parser with the scoped
+  // registry. This should succeed because the scoped registry contains
+  // "scoped_cat".
+  PrestoParser scopedParser(
+      "scoped_cat", "default", ParserOptions{}, *scopedRegistry);
+  auto statement = scopedParser.parse("SELECT * FROM scoped_table");
+  ASSERT_TRUE(statement->isSelect());
+}
+
+TEST_F(PrestoParserTest, scopedRegistryTableNotFoundInGlobal) {
+  using facebook::axiom::connector::ConnectorMetadataRegistry;
+  using facebook::axiom::connector::TestConnectorMetadata;
+
+  // Create a child registry and register a scoped-only connector and table.
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  auto scopedConnector =
+      std::make_shared<facebook::axiom::connector::TestConnector>(
+          "scoped_cat2");
+  auto scopedMetadata =
+      std::make_shared<TestConnectorMetadata>(scopedConnector.get());
+  scopedMetadata->addTable(
+      {"default", "scoped_only"}, ROW({"x"}, {INTEGER()}), ROW({}));
+  scopedRegistry->insert("scoped_cat2", scopedMetadata, /*overwrite=*/true);
+
+  // A parser using the default global registry should not find the table
+  // because "scoped_cat2" only has the test metadata in the scoped registry,
+  // and the global metadata does not have "scoped_only".
+  ConnectorMetadataRegistry::global().insert(
+      scopedConnector->connectorId(), scopedConnector->metadata());
+  SCOPE_EXIT {
+    ConnectorMetadataRegistry::global().erase(scopedConnector->connectorId());
+  };
+  PrestoParser globalParser("scoped_cat2", "default");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      globalParser.parse("SELECT * FROM scoped_only"), "Table not found");
+}
+
+TEST_F(PrestoParserTest, scopedRegistryShowCatalogs) {
+  using facebook::axiom::connector::ConnectorMetadataRegistry;
+  using facebook::axiom::connector::TestConnectorMetadata;
+
+  // Create a child registry and register an extra catalog.
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  auto extraConnector =
+      std::make_shared<facebook::axiom::connector::TestConnector>("extra_cat");
+  auto extraMetadata =
+      std::make_shared<TestConnectorMetadata>(extraConnector.get());
+  scopedRegistry->insert("extra_cat", extraMetadata, /*overwrite=*/true);
+
+  // SHOW CATALOGS through the scoped parser should include "extra_cat".
+  PrestoParser scopedParser(
+      kConnectorId, "default", ParserOptions{}, *scopedRegistry);
+  auto statement = scopedParser.parse("SHOW CATALOGS");
+  ASSERT_TRUE(statement->isSelect());
+
+  auto* selectStatement = statement->as<SelectStatement>();
+  auto plan = selectStatement->plan();
+
+  // Walk the plan tree to find the ValuesNode.
+  auto node = plan;
+  while (!node->inputs().empty()) {
+    node = node->inputAt(0);
+  }
+  ASSERT_TRUE(node->is(lp::NodeKind::kValues));
+  auto values = std::dynamic_pointer_cast<const lp::ValuesNode>(node);
+  ASSERT_NE(values, nullptr);
+
+  // Collect catalog names from the first column of each row.
+  const auto& variants = std::get<lp::ValuesNode::Variants>(values->data());
+  std::vector<std::string> catalogNames;
+  for (const auto& row : variants) {
+    ASSERT_EQ(row.kind(), TypeKind::ROW);
+    catalogNames.push_back(row.row()[0].value<std::string>());
+  }
+
+  EXPECT_THAT(catalogNames, testing::Contains("extra_cat"));
+  EXPECT_THAT(catalogNames, testing::Contains(kConnectorId));
+}
+
+// TODO: When a second test file needs SchemaOnlyTable SingleTableMetadata,
+// extract them to a shared test header (e.g.
+// axiom/connectors/tests/SchemaOnlyTable.h) instead of duplicating.
+//
+// Lightweight Table used in scoped-registry tests. Unlike TestTable, this does
+// not allocate a memory pool, avoiding global pool-name collisions when two
+// tables share the same name.
+class SchemaOnlyTable : public facebook::axiom::connector::Table {
+ public:
+  SchemaOnlyTable(
+      facebook::axiom::SchemaTableName name,
+      const facebook::velox::RowTypePtr& schema)
+      : Table(std::move(name), Table::makeColumns(schema)) {}
+
+  const std::vector<const facebook::axiom::connector::TableLayout*>& layouts()
+      const override {
+    static const std::vector<const facebook::axiom::connector::TableLayout*>
+        kEmpty;
+    return kEmpty;
+  }
+
+  uint64_t numRows() const override {
+    return 0;
+  }
+};
+
+// Minimal ConnectorMetadata backed by a single SchemaOnlyTable. Provides just
+// enough for PrestoParser metadata lookup paths.
+class SingleTableMetadata
+    : public facebook::axiom::connector::ConnectorMetadata {
+ public:
+  SingleTableMetadata(
+      facebook::axiom::SchemaTableName tableName,
+      facebook::velox::RowTypePtr schema)
+      : table_{std::make_shared<SchemaOnlyTable>(
+            std::move(tableName),
+            std::move(schema))} {}
+
+  facebook::axiom::connector::TablePtr findTable(
+      const facebook::axiom::SchemaTableName& tableName) override {
+    if (tableName == table_->name()) {
+      return table_;
+    }
+    return nullptr;
+  }
+
+  facebook::axiom::connector::ConnectorSplitManager* splitManager() override {
+    return nullptr;
+  }
+
+  std::vector<std::string> listSchemaNames(
+      const facebook::axiom::connector::ConnectorSessionPtr&) override {
+    return {table_->name().schema};
+  }
+
+  bool schemaExists(
+      const facebook::axiom::connector::ConnectorSessionPtr&,
+      const std::string& schemaName) override {
+    return schemaName == table_->name().schema;
+  }
+
+  std::vector<std::string> listTableNames(
+      const facebook::axiom::connector::ConnectorSessionPtr&,
+      const std::string& schemaName) override {
+    if (schemaName == table_->name().schema) {
+      return {table_->name().table};
+    }
+    return {};
+  }
+
+ private:
+  std::shared_ptr<SchemaOnlyTable> table_;
+};
+
+TEST_F(PrestoParserTest, scopedRegistryShadowsGlobalSchema) {
+  using facebook::axiom::connector::ConnectorMetadataRegistry;
+
+  auto catConnector =
+      std::make_shared<facebook::axiom::connector::TestConnector>("cat");
+  catConnector->addTable("t", ROW({"a"}, {INTEGER()}));
+  ConnectorMetadataRegistry::global().insert(
+      catConnector->connectorId(), catConnector->metadata());
+
+  SCOPE_EXIT {
+    ConnectorMetadataRegistry::global().erase("cat");
+  };
+
+  auto scopedRegistry =
+      ConnectorMetadataRegistry::create(&ConnectorMetadataRegistry::global());
+
+  // Use SingleTableMetadata to avoid the memory-pool name collision that would
+  // occur if two TestTables both named "t" existed.
+  auto scopedMetadata = std::make_shared<SingleTableMetadata>(
+      facebook::axiom::SchemaTableName{"default", "t"},
+      ROW({"a", "b"}, {INTEGER(), VARCHAR()}));
+  scopedRegistry->insert("cat", scopedMetadata, /*overwrite=*/true);
+
+  PrestoParser scopedParser("cat", "default", ParserOptions{}, *scopedRegistry);
+  auto scopedStatement = scopedParser.parse("SELECT * FROM cat.default.t");
+  ASSERT_TRUE(scopedStatement->isSelect());
+
+  auto* scopedSelect = scopedStatement->as<SelectStatement>();
+  auto scopedOutput = scopedSelect->plan()->outputType();
+
+  EXPECT_EQ(scopedOutput->size(), 2);
+  EXPECT_THAT(scopedOutput->names(), testing::ElementsAre("a", "b"));
+
+  PrestoParser globalParser("cat", "default");
+  auto globalStatement = globalParser.parse("SELECT * FROM cat.default.t");
+  ASSERT_TRUE(globalStatement->isSelect());
+
+  auto* globalSelect = globalStatement->as<SelectStatement>();
+  auto globalOutput = globalSelect->plan()->outputType();
+
+  EXPECT_EQ(globalOutput->size(), 1);
+  EXPECT_THAT(globalOutput->names(), testing::ElementsAre("a"));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
PlanBuilder can now use a per-query connector metadata registry instead of always hitting the global singleton. This enables test isolation: unit tests can spin up a child registry with only the connectors they care about, preventing cross-test pollution when multiple tests register the same connector ID.

PlanBuilder's new `Context::connectorMetadata()` helper resolves against a scoped registry attached to the `QueryCtx`. If no scoped registry is registered, it falls back to the global registry. The scoped registry propagates through `from()` so multi-table scans all see the same scoped state.

Differential Revision: D104608355
