### PR TITLE
refactor(common): Require user in Session ctor (#1454)

### DIFF
--- a/axiom/common/Session.h
+++ b/axiom/common/Session.h
@@ -23,7 +23,7 @@ namespace facebook::axiom {
 /// Read-only query-specific information.
 class Session final {
  public:
-  explicit Session(std::string queryId, std::string user = {})
+  Session(std::string queryId, std::string user)
       : queryId_{std::move(queryId)}, user_{std::move(user)} {}
 
   /// Returns the query identifier.

--- a/axiom/connectors/ConnectorSession.h
+++ b/axiom/connectors/ConnectorSession.h
@@ -24,7 +24,7 @@ namespace facebook::axiom::connector {
 /// Read-only query-specific information passed to connectors.
 class ConnectorSession final {
  public:
-  explicit ConnectorSession(std::string queryId, std::string user = {})
+  ConnectorSession(std::string queryId, std::string user)
       : queryId_{std::move(queryId)}, user_{std::move(user)} {}
 
   /// Returns the query identifier.
@@ -32,8 +32,7 @@ class ConnectorSession final {
     return queryId_;
   }
 
-  /// Returns the identity of the user who submitted the query. Empty when
-  /// user context is unavailable.
+  /// Returns the identity of the user who submitted the query.
   const std::string& user() const {
     return user_;
   }

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -116,6 +116,11 @@ class LocalHiveConnectorMetadataTest
     compareTableLayout(*getLayout(expected), *getLayout(table));
   }
 
+  static ConnectorSessionPtr makeSession() {
+    return std::make_shared<ConnectorSession>(
+        /*queryId=*/"q-test", /*user=*/"u-test");
+  }
+
   /// Write the specified data to the table with a TableWrite operation. The
   /// 'kind' specifies the type of write, for which only kCreate (new table) and
   /// kInsert (existing table) writes are supported. 'format' specifies the
@@ -126,7 +131,7 @@ class LocalHiveConnectorMetadataTest
       WriteKind kind,
       dwio::common::FileFormat format) {
     std::string outputPath = metadata_->tablePath(table->name());
-    auto session = std::make_shared<ConnectorSession>("q-test");
+    auto session = makeSession();
     auto handle =
         metadata_->beginWrite(session, table, kind, /*explain=*/false);
 
@@ -317,7 +322,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
       {HiveWriteOptions::kFileFormat, "parquet"},
       {HiveWriteOptions::kCompressionKind, "zstd"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "test"},
@@ -406,7 +411,7 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
       {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
       {HiveWriteOptions::kFileFormat, "parquet"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "add_col_test"},
@@ -524,7 +529,7 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumnExplain) {
   folly::F14FastMap<std::string, velox::Variant> options = {
       {HiveWriteOptions::kFileFormat, "parquet"}};
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   metadata_->createTable(
       session,
       {kDefaultSchema, "explain_add_col_test"},
@@ -620,7 +625,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createEmptyTable) {
        {"ts", VARCHAR()},
        {"ds", VARCHAR()}});
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   auto table = metadata_->createTable(
       session,
       {kDefaultSchema, "test_empty"},
@@ -655,7 +660,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
   auto tableType =
       ROW({{"key1", BIGINT()}, {"key2", BIGINT()}, {"ds", VARCHAR()}});
 
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   auto staged = metadata_->createTable(
       session,
       {kDefaultSchema, "test_insert"},
@@ -704,7 +709,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
 TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
   auto tableType =
       ROW({{"key1", BIGINT()}, {"key2", BIGINT()}, {"ds", VARCHAR()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
   std::string tablePath = metadata_->tablePath({kDefaultSchema, "test_abort"});
 
   auto table = metadata_->createTable(
@@ -748,7 +753,7 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExists) {
   auto tableType = ROW({{"col1", BIGINT()}, {"col2", VARCHAR()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
 
   auto table = metadata_->createTable(
       session,
@@ -781,7 +786,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExists) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsNewTable) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
 
   auto table = metadata_->createTable(
       session,
@@ -798,7 +803,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsNewTable) {
 
 TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
 
   auto table = metadata_->createTable(
       session,
@@ -834,7 +839,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTableIfNotExistsExplain) {
 
 TEST_F(LocalHiveConnectorMetadataTest, dropTableIfExists) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
 
   auto table = metadata_->createTable(
       session,
@@ -869,7 +874,7 @@ TEST_F(LocalHiveConnectorMetadataTest, dropTableIfExists) {
 
 TEST_F(LocalHiveConnectorMetadataTest, dropTableExplain) {
   auto tableType = ROW({{"col1", BIGINT()}});
-  auto session = std::make_shared<ConnectorSession>("q-test");
+  auto session = makeSession();
 
   auto table = metadata_->createTable(
       session,

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -160,6 +160,11 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     connector_.reset();
   }
 
+  static ConnectorSessionPtr makeSession() {
+    return std::make_shared<ConnectorSession>(
+        /*queryId=*/"test", /*user=*/"test");
+  }
+
   // Creates a DataSource for the given schema/table through the connector,
   // adds a split, and returns the first batch of results.
   velox::RowVectorPtr readTable(
@@ -168,7 +173,7 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     auto table = metadata_->findTable(tableName);
     VELOX_CHECK_NOT_NULL(table);
 
-    auto session = std::make_shared<ConnectorSession>("test-query");
+    auto session = makeSession();
     velox::exec::SimpleExpressionEvaluator evaluator(
         queryCtx_.get(), pool_.get());
 
@@ -284,7 +289,7 @@ TEST_F(SystemConnectorMetadataTest, tableLayout) {
   EXPECT_EQ(layouts[0]->connectorId(), kSystemCatalog);
 
   // Verify column handle creation.
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = makeSession();
   auto columnHandle = layouts[0]->createColumnHandle(session, "query_id");
   ASSERT_NE(columnHandle, nullptr);
   EXPECT_EQ(columnHandle->name(), "query_id");
@@ -297,7 +302,7 @@ TEST_F(SystemConnectorMetadataTest, tableHandle) {
   const auto& layouts = table->layouts();
   ASSERT_EQ(layouts.size(), 1);
 
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = makeSession();
   auto columnHandle = layouts[0]->createColumnHandle(session, "query_id");
 
   velox::exec::SimpleExpressionEvaluator evaluator(
@@ -316,7 +321,7 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
   auto table = metadata_->findTable(kQueriesTable);
   ASSERT_NE(table, nullptr);
 
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = makeSession();
 
   velox::exec::SimpleExpressionEvaluator evaluator(
       queryCtx_.get(), pool_.get());
@@ -481,7 +486,7 @@ TEST_F(SystemConnectorMetadataTest, sessionPropertiesSchema) {
 }
 
 TEST_F(SystemConnectorMetadataTest, schemas) {
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = makeSession();
   EXPECT_THAT(
       metadata_->listSchemaNames(session),
       testing::UnorderedElementsAre(
@@ -492,7 +497,7 @@ TEST_F(SystemConnectorMetadataTest, schemas) {
 }
 
 TEST_F(SystemConnectorMetadataTest, listTableNames) {
-  auto session = std::make_shared<ConnectorSession>("test-query");
+  auto session = makeSession();
   EXPECT_THAT(
       metadata_->listTableNames(session, std::string(kRuntimeSchema)),
       testing::ElementsAre(kQueriesTable.table));

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -38,6 +38,11 @@ class TpchConnectorMetadataTest : public ::testing::Test {
     metadata_ = std::make_unique<TpchConnectorMetadata>(connector_.get());
   }
 
+  static ConnectorSessionPtr makeSession() {
+    return std::make_shared<ConnectorSession>(
+        /*queryId=*/"test", /*user=*/"test");
+  }
+
   std::unique_ptr<velox::connector::tpch::TpchConnector> connector_;
   std::unique_ptr<TpchConnectorMetadata> metadata_;
 };
@@ -158,7 +163,7 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = makeSession();
   auto tables = metadata_->listTableNames(session, "tiny");
   EXPECT_THAT(
       tables,
@@ -174,7 +179,7 @@ TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = makeSession();
   auto tables = metadata_->listTableNames(session, "sf1");
   ASSERT_EQ(tables.size(), 8);
   for (const auto& table : tables) {
@@ -183,7 +188,7 @@ TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
 }
 
 TEST_F(TpchConnectorMetadataTest, listTablesInvalidSchema) {
-  auto session = std::make_shared<ConnectorSession>("test");
+  auto session = makeSession();
   auto tables = metadata_->listTableNames(session, "invalid");
   EXPECT_THAT(tables, testing::IsEmpty());
 }

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -449,6 +449,7 @@ PlanAndStats Optimization::toVeloxPlan(RelationOpPtr plan) {
 
 // static
 PlanAndStats Optimization::toVeloxPlan(
+    SessionPtr session,
     const logical_plan::LogicalPlanNode& logicalPlan,
     velox::memory::MemoryPool& pool,
     OptimizerOptions options,
@@ -468,10 +469,8 @@ PlanAndStats Optimization::toVeloxPlan(
 
   VeloxHistory history;
 
-  auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
-
   Optimization opt{
-      session,
+      std::move(session),
       logicalPlan,
       *schemaResolver,
       history,

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -48,6 +48,7 @@ class Optimization {
 
   /// Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
+      SessionPtr session,
       const logical_plan::LogicalPlanNode& logicalPlan,
       velox::memory::MemoryPool& pool,
       OptimizerOptions options = {},

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -325,7 +325,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
           optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
     }
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session =
+        std::make_shared<connector::ConnectorSession>("test", "test");
     auto table = metadata->createTable(
         session,
         statement.tableName(),
@@ -343,7 +344,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     const auto& tableName = statement.tableName();
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session =
+        std::make_shared<connector::ConnectorSession>("test", "test");
     const bool dropped = metadata->dropTable(
         session, tableName, statement.ifExists(), /*explain=*/false);
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -592,7 +592,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     exec::SimpleExpressionEvaluator evaluator(
         queryCtx.get(), optimizerPool_.get());
 
-    auto session = std::make_shared<Session>(queryCtx->queryId());
+    auto session = std::make_shared<Session>(
+        queryCtx->queryId(), /*user=*/"axiom-sql-benchmark");
 
     optimizer::OptimizerOptions optimizerOptions;
     optimizerOptions.traceFlags = FLAGS_optimizer_trace;

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -93,7 +93,7 @@ class DerivedTablePrinterTest : public ::testing::Test {
     auto schemaResolver = std::make_shared<connector::SchemaResolver>(
         connector::ConnectorMetadataRegistry::global());
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(veloxQueryCtx->queryId(), "test");
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -161,7 +161,7 @@ void HiveQueriesTestBase::createEmptyTable(
     const folly::F14FastMap<std::string, velox::Variant>& options) {
   hiveMetadata().dropTableIfExists({kDefaultSchema, name});
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = makeSession();
   auto table = hiveMetadata().createTable(
       session,
       {kDefaultSchema, name},
@@ -195,7 +195,7 @@ void HiveQueriesTestBase::createTableFromFiles(
         << "File does not exist: " << filePath;
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = makeSession();
   hiveMetadata().createTable(
       session,
       {kDefaultSchema, tableName},
@@ -231,7 +231,7 @@ void HiveQueriesTestBase::runCtas(const std::string& sql) {
     options[key] = ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test");
+  auto session = makeSession();
   auto table = hiveMetadata().createTable(
       session,
       ctasStatement->tableName(),

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -49,6 +49,11 @@ class HiveQueriesTestBase : public QueryTestBase {
   /// Unregisters Parquet reader and writer.
   static void TearDownTestCase();
 
+  static connector::ConnectorSessionPtr makeSession() {
+    return std::make_shared<connector::ConnectorSession>(
+        /*queryId=*/"test", /*user=*/"test");
+  }
+
   /// Returns a schema of a table.
   velox::RowTypePtr getSchema(std::string_view tableName);
 

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -65,7 +65,7 @@ class PrecomputeProjectionTest : public ::testing::Test {
     auto schemaResolver = std::make_shared<connector::SchemaResolver>(
         connector::ConnectorMetadataRegistry::global());
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(veloxQueryCtx->queryId(), "test");
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -186,7 +186,7 @@ PlanCost QueryTestBase::optimizationCost(
   };
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
-  auto session = std::make_shared<Session>(queryCtx->queryId());
+  auto session = std::make_shared<Session>(queryCtx->queryId(), "test");
   connector::SchemaResolver schemaResolver{
       connector::ConnectorMetadataRegistry::global()};
   Optimization opt(
@@ -217,7 +217,7 @@ void QueryTestBase::verifyOptimization(
   exec::SimpleExpressionEvaluator evaluator(
       veloxQueryCtx.get(), optimizerPool_.get());
 
-  auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+  auto session = std::make_shared<Session>(veloxQueryCtx->queryId(), "test");
 
   connector::SchemaResolver schemaResolver{
       connector::ConnectorMetadataRegistry::global()};
@@ -264,7 +264,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
-  auto session = std::make_shared<Session>(queryCtx->queryId());
+  auto session = std::make_shared<Session>(queryCtx->queryId(), "test");
 
   std::unique_ptr<std::ofstream> planPath;
   if (planFilePathPrefix.has_value()) {

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -145,7 +145,7 @@ class RelationOpPrinterTest : public ::testing::Test {
     auto schemaResolver = std::make_shared<connector::SchemaResolver>(
         connector::ConnectorMetadataRegistry::global());
 
-    auto session = std::make_shared<Session>(veloxQueryCtx->queryId());
+    auto session = std::make_shared<Session>(veloxQueryCtx->queryId(), "test");
 
     Optimization opt{
         session,

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool.get());
 
-  auto session = std::make_shared<Session>(queryId);
+  auto session = std::make_shared<Session>(queryId, "test");
   connector::SchemaResolver schemaResolver{
       connector::ConnectorMetadataRegistry::global()};
   VeloxHistory history;

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -75,7 +75,7 @@ class WriteTest : public test::HiveQueriesTestBase {
     auto& metadata = hiveMetadata();
     dropTableIfExists(name);
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = makeSession();
     auto table = metadata.createTable(
         session,
         {kDefaultSchema, name},
@@ -99,7 +99,7 @@ class WriteTest : public test::HiveQueriesTestBase {
       options[key] = ConstantExprEvaluator::evaluateConstantExpr(*value);
     }
 
-    auto session = std::make_shared<connector::ConnectorSession>("test");
+    auto session = makeSession();
     auto table = metadata.createTable(
         session,
         statement.tableName(),

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -131,8 +131,8 @@ facebook::axiom::optimizer::PlanAndStats optimize(
   auto queryCtx = velox::core::QueryCtx::create();
   velox::exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool);
 
-  auto session =
-      std::make_shared<facebook::axiom::Session>(queryCtx->queryId());
+  auto session = std::make_shared<facebook::axiom::Session>(
+      queryCtx->queryId(), /*user=*/"pyspark-optimizer");
 
   facebook::axiom::optimizer::Optimization opt(
       session,

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -81,7 +81,7 @@ facebook::axiom::connector::TablePtr createTable(
   auto tableSchema = velox::ROW(std::move(schemaNames), std::move(schemaTypes));
 
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "pyspark_session");
+      "pyspark_session", /*user=*/"pyspark-optimizer");
   auto table = metadata->createTable(
       session,
       writeNode.tableName(),

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2303,7 +2303,7 @@ SqlStatementPtr parseShowSchemas(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-schemas");
+      "show-schemas", /*user=*/"presto-parser");
   auto schemaNames = metadata->listSchemaNames(session);
   std::sort(schemaNames.begin(), schemaNames.end());
 
@@ -2353,7 +2353,7 @@ SqlStatementPtr parseShowTables(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-tables");
+      "show-tables", /*user=*/"presto-parser");
   VELOX_USER_CHECK(
       metadata->schemaExists(session, schema),
       "Schema does not exist: {}",


### PR DESCRIPTION
Summary:

Removes the empty-string default for `user` on `Session::Session(queryId, user)`, mirroring the recent `ConnectorSession` cleanup. Same audit conclusion: every site that omitted `user` was missing-plumbing, not a legitimate anonymous query.

Reviewed By: amitkdutta

Differential Revision: D107673050


