### PR TITLE
feat(runner): Plumb session properties to split generation (#1455)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -284,6 +284,7 @@ void onComplete(
 } // namespace
 
 connector::TablePtr SqlQueryRunner::createTable(
+    std::string_view queryId,
     const presto::CreateTableStatement& statement,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
@@ -294,9 +295,8 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   auto table = metadata->createTable(
-      session,
+      makeConnectorSession(queryId, statement.connectorId()),
       statement.tableName(),
       statement.tableSchema(),
       options,
@@ -307,6 +307,7 @@ connector::TablePtr SqlQueryRunner::createTable(
 }
 
 connector::TablePtr SqlQueryRunner::createTable(
+    std::string_view queryId,
     const presto::CreateTableAsSelectStatement& statement,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
@@ -317,9 +318,8 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   auto table = metadata->createTable(
-      session,
+      makeConnectorSession(queryId, statement.connectorId()),
       statement.tableName(),
       statement.tableSchema(),
       options,
@@ -330,14 +330,14 @@ connector::TablePtr SqlQueryRunner::createTable(
 }
 
 std::string SqlQueryRunner::dropTable(
+    std::string_view queryId,
     const presto::DropTableStatement& statement) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   const auto& tableName = statement.tableName();
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   const bool dropped = metadata->dropTable(
-      session,
+      makeConnectorSession(queryId, statement.connectorId()),
       statement.tableName(),
       statement.ifExists(),
       /*explain=*/false);
@@ -350,13 +350,13 @@ std::string SqlQueryRunner::dropTable(
 }
 
 std::string SqlQueryRunner::addColumn(
+    std::string_view queryId,
     const presto::AddColumnStatement& statement,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   auto result = metadata->addColumn(
-      session,
+      makeConnectorSession(queryId, statement.connectorId()),
       statement.tableName(),
       statement.columnName(),
       statement.columnType(),
@@ -381,6 +381,7 @@ std::string SqlQueryRunner::addColumn(
 }
 
 std::string SqlQueryRunner::createSchema(
+    std::string_view queryId,
     const presto::CreateSchemaStatement& statement) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
@@ -390,17 +391,22 @@ std::string SqlQueryRunner::createSchema(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
   metadata->createSchema(
-      session, statement.schemaName(), statement.ifNotExists(), properties);
+      makeConnectorSession(queryId, statement.connectorId()),
+      statement.schemaName(),
+      statement.ifNotExists(),
+      properties);
   return fmt::format("Created schema: {}", statement.schemaName());
 }
 
 std::string SqlQueryRunner::dropSchema(
+    std::string_view queryId,
     const presto::DropSchemaStatement& statement) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
-  auto session = std::make_shared<connector::ConnectorSession>("test", user_);
-  metadata->dropSchema(session, statement.schemaName(), statement.ifExists());
+  metadata->dropSchema(
+      makeConnectorSession(queryId, statement.connectorId()),
+      statement.schemaName(),
+      statement.ifExists());
   return fmt::format("Dropped schema: {}", statement.schemaName());
 }
 
@@ -587,6 +593,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     QueryTiming& timing,
     std::string& planString,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+  const std::string queryId = options.queryId.value_or(queryIdGenerator_());
   if (sqlStatement.isExplain()) {
     const auto* explain = sqlStatement.as<presto::ExplainStatement>();
 
@@ -605,14 +612,15 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
       // EXPLAIN ANALYZE runs the query for real, so createTable must not
       // be in explain mode. Regular EXPLAIN must be side-effect-free.
-      auto table = createTable(*ctas, /*explain=*/!explain->isAnalyze());
+      auto table =
+          createTable(queryId, *ctas, /*explain=*/!explain->isAnalyze());
       schemaResolver = std::make_shared<connector::SchemaResolver>(
           connector::ConnectorMetadataRegistry::global());
       schemaResolver->setTargetTable(
           ctas->connectorId(), ctas->tableName(), table);
     } else if (statement->isCreateTable()) {
       const auto* create = statement->as<presto::CreateTableStatement>();
-      createTable(*create, /*explain=*/true);
+      createTable(queryId, *create, /*explain=*/true);
       return {
           .message = fmt::format(
               "CREATE TABLE {}{}.{}",
@@ -637,7 +645,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
               drop->tableName())};
     } else if (statement->isAddColumn()) {
       const auto* add = statement->as<presto::AddColumnStatement>();
-      addColumn(*add, /*explain=*/true);
+      addColumn(queryId, *add, /*explain=*/true);
       return {
           .message = fmt::format(
               "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
@@ -707,7 +715,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
   if (sqlStatement.isCreateTable()) {
     const auto* create = sqlStatement.as<presto::CreateTableStatement>();
-    auto table = createTable(*create);
+    auto table = createTable(queryId, *create);
     if (!table) {
       return {
           .message = fmt::format(
@@ -720,7 +728,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
 
   if (sqlStatement.isCreateTableAsSelect()) {
     const auto* ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
-    auto table = createTable(*ctas);
+    auto table = createTable(queryId, *ctas);
 
     auto schema = std::make_shared<connector::SchemaResolver>(
         connector::ConnectorMetadataRegistry::global());
@@ -739,23 +747,23 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
   if (sqlStatement.isDropTable()) {
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
-    return {.message = dropTable(*drop)};
+    return {.message = dropTable(queryId, *drop)};
   }
 
   if (sqlStatement.isAddColumn()) {
     const auto* add = sqlStatement.as<presto::AddColumnStatement>();
 
-    return {.message = addColumn(*add)};
+    return {.message = addColumn(queryId, *add)};
   }
 
   if (sqlStatement.isCreateSchema()) {
     const auto* create = sqlStatement.as<presto::CreateSchemaStatement>();
-    return {.message = createSchema(*create)};
+    return {.message = createSchema(queryId, *create)};
   }
 
   if (sqlStatement.isDropSchema()) {
     const auto* drop = sqlStatement.as<presto::DropSchemaStatement>();
-    return {.message = dropSchema(*drop)};
+    return {.message = dropSchema(queryId, *drop)};
   }
 
   if (sqlStatement.isShowStatsForQuery()) {
@@ -1020,6 +1028,34 @@ std::string printPlanWithStats(
         }
       });
 }
+
+} // namespace
+
+connector::ConnectorSessionPtr SqlQueryRunner::makeConnectorSession(
+    std::string_view queryId,
+    std::string_view connectorId) const {
+  return std::make_shared<connector::ConnectorSession>(
+      std::string(queryId),
+      user_,
+      sessionConfig_->effectiveValues(connectorId));
+}
+
+namespace {
+
+// Returns per-connector property maps for connectors with at least one
+// effective value set.
+connector::ConnectorProperties collectConnectorProperties(
+    const SessionConfig& config) {
+  connector::ConnectorProperties result;
+  for (const auto& id :
+       connector::ConnectorMetadataRegistry::allMetadataIds()) {
+    connector::Properties properties = config.effectiveValues(id);
+    if (!properties.empty()) {
+      result.emplace(id, std::move(properties));
+    }
+  }
+  return result;
+}
 } // namespace
 
 std::string SqlQueryRunner::runExplainAnalyze(
@@ -1183,7 +1219,13 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
     const RunOptions& options,
     QueryRuntimeStats& runtimeStats) {
+  auto runnerSession = std::make_shared<runner::RunnerSession>(
+      queryCtx->queryId(),
+      user_,
+      sessionConfig_->effectiveValues("runner"),
+      collectConnectorProperties(*sessionConfig_));
   return std::make_shared<runner::LocalRunner>(
+      std::move(runnerSession),
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -248,22 +248,31 @@ class SqlQueryRunner {
   }
 
   facebook::axiom::connector::TablePtr createTable(
+      std::string_view queryId,
       const presto::CreateTableStatement& statement,
       bool explain = false);
 
   facebook::axiom::connector::TablePtr createTable(
+      std::string_view queryId,
       const presto::CreateTableAsSelectStatement& statement,
       bool explain = false);
 
-  std::string dropTable(const presto::DropTableStatement& statement);
+  std::string dropTable(
+      std::string_view queryId,
+      const presto::DropTableStatement& statement);
 
   std::string addColumn(
+      std::string_view queryId,
       const presto::AddColumnStatement& statement,
       bool explain = false);
 
-  std::string createSchema(const presto::CreateSchemaStatement& statement);
+  std::string createSchema(
+      std::string_view queryId,
+      const presto::CreateSchemaStatement& statement);
 
-  std::string dropSchema(const presto::DropSchemaStatement& statement);
+  std::string dropSchema(
+      std::string_view queryId,
+      const presto::DropSchemaStatement& statement);
 
   /// Returns the default connector ID set during initialization.
   const std::string& defaultConnectorId() const {
@@ -376,6 +385,13 @@ class SqlQueryRunner {
           schemaResolver = nullptr,
       std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
           nullptr);
+
+  // Builds a ConnectorSession for `connectorId` carrying the caller's
+  // queryId, the runner's user, and the connector's effective session
+  // properties from `sessionConfig_`.
+  facebook::axiom::connector::ConnectorSessionPtr makeConnectorSession(
+      std::string_view queryId,
+      std::string_view connectorId) const;
 
   // Wait maxWaitMicros microseconds for the LocalRunner to complete.  If
   // `maxWaitMicros <= 0` this will check if the LocalRunner is completed and

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1324,6 +1324,19 @@ TEST_F(SqlQueryRunnerTest, connectorSessionPropertyEffect) {
   }
 }
 
+// Verifies that a SET SESSION connector property is visible to the
+// connector during execution-time split generation.
+TEST_F(SqlQueryRunnerTest, connectorProperties) {
+  run("CREATE TABLE t AS SELECT x FROM unnest(sequence(1, 3)) AS _(x)");
+  SCOPE_EXIT {
+    run("DROP TABLE IF EXISTS t");
+  };
+
+  run("SET SESSION test.list_partitions_error = 'boom from split-gen'");
+
+  VELOX_ASSERT_THROW(run("SELECT * FROM t"), "boom from split-gen");
+}
+
 TEST_F(SqlQueryRunnerTest, addColumn) {
   auto findTable = [&]() {
     auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::get(

--- a/axiom/common/Session.cpp
+++ b/axiom/common/Session.cpp
@@ -20,6 +20,8 @@ namespace facebook::axiom {
 
 connector::ConnectorSessionPtr Session::toConnectorSession(
     std::string_view /* connectorId */) const {
-  return std::make_shared<connector::ConnectorSession>(queryId_, user_);
+  return std::make_shared<connector::ConnectorSession>(
+      queryId_, user_, connector::Properties{});
 }
+
 } // namespace facebook::axiom

--- a/axiom/common/Session.h
+++ b/axiom/common/Session.h
@@ -20,18 +20,17 @@
 
 namespace facebook::axiom {
 
-/// Read-only query-specific information.
+/// DEPRECATED: transitional shim. Use per-component sessions
+/// (`RunnerSession`, future `OptimizerSession` / `ParserSession`) instead.
 class Session final {
  public:
   Session(std::string queryId, std::string user)
       : queryId_{std::move(queryId)}, user_{std::move(user)} {}
 
-  /// Returns the query identifier.
   const std::string& queryId() const {
     return queryId_;
   }
 
-  /// Returns the identity of the user who submitted the query.
   const std::string& user() const {
     return user_;
   }

--- a/axiom/connectors/BaseSession.h
+++ b/axiom/connectors/BaseSession.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/connectors/ConnectorSession.h"
+
+namespace facebook::axiom::connector {
+
+/// Map of connector id to that connector's property bag.
+using ConnectorProperties = folly::F14FastMap<std::string, Properties>;
+
+/// Base class for component sessions. Holds queryId, user, and the
+/// per-connector property map; spawns ConnectorSessions on demand.
+///
+/// Example:
+///   class OptimizerSession : public BaseSession { ... };
+///   auto cs = optimizerSession.toConnectorSession("hive");
+class BaseSession {
+ public:
+  BaseSession(
+      std::string queryId,
+      std::string user,
+      ConnectorProperties connectorProperties)
+      : queryId_{std::move(queryId)},
+        user_{std::move(user)},
+        connectorProperties_{std::move(connectorProperties)} {}
+
+  virtual ~BaseSession() = default;
+
+  const std::string& queryId() const {
+    return queryId_;
+  }
+
+  const std::string& user() const {
+    return user_;
+  }
+
+  /// Spawns a ConnectorSession for 'connectorId' carrying queryId, user,
+  /// and that connector's property slice (empty when no properties were set
+  /// for it).
+  ConnectorSessionPtr toConnectorSession(std::string_view connectorId) const {
+    return std::make_shared<ConnectorSession>(
+        queryId_, user_, propertiesForConnector(connectorId));
+  }
+
+ private:
+  Properties propertiesForConnector(std::string_view connectorId) const {
+    auto it = connectorProperties_.find(connectorId);
+    if (it == connectorProperties_.end()) {
+      return {};
+    }
+    return it->second;
+  }
+
+  const std::string queryId_;
+  const std::string user_;
+  const ConnectorProperties connectorProperties_;
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -118,7 +118,9 @@ class LocalHiveConnectorMetadataTest
 
   static ConnectorSessionPtr makeSession() {
     return std::make_shared<ConnectorSession>(
-        /*queryId=*/"q-test", /*user=*/"u-test");
+        /*queryId=*/"q-test",
+        /*user=*/"u-test",
+        Properties{});
   }
 
   /// Write the specified data to the table with a TableWrite operation. The

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -162,7 +162,9 @@ class SystemConnectorMetadataTest : public ::testing::Test {
 
   static ConnectorSessionPtr makeSession() {
     return std::make_shared<ConnectorSession>(
-        /*queryId=*/"test", /*user=*/"test");
+        /*queryId=*/"test",
+        /*user=*/"test",
+        Properties{});
   }
 
   // Creates a DataSource for the given schema/table through the connector,

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -429,8 +429,14 @@ const TestTable& findTestTableForHandle(
 
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
-    const ConnectorSessionPtr& /*session*/,
+    const ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& tableHandle) {
+  VELOX_CHECK_NOT_NULL(session);
+  if (auto error = session->property(TestConfigProvider::kListPartitionsError);
+      error.has_value() && !error->empty()) {
+    VELOX_USER_FAIL("{}", *error);
+  }
+
   const auto& testTable = findTestTableForHandle(tableHandle);
   if (!testTable.bucketSpec().has_value()) {
     co_return std::vector<PartitionHandlePtr>{

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -716,12 +716,21 @@ class TestConfigProvider : public velox::config::ConfigProvider {
   static constexpr const char* kCollectColumnStatistics =
       "collect_column_statistics";
 
+  /// When non-empty, TestSplitManager::co_listPartitions throws a user
+  /// error with this value as the message. Used by tests that need to
+  /// verify a session property reaches connector split-generation.
+  static constexpr const char* kListPartitionsError = "list_partitions_error";
+
   std::vector<velox::config::ConfigProperty> properties() const override {
     return {
         {kCollectColumnStatistics,
          velox::config::ConfigPropertyType::kBoolean,
          "true",
          "Collect per-column statistics when writing data to a table."},
+        {kListPartitionsError,
+         velox::config::ConfigPropertyType::kString,
+         "",
+         "Test-only: if non-empty, co_listPartitions throws this message."},
     };
   }
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -56,6 +56,11 @@ class TestConnectorTest : public ::testing::Test, public test::VectorTestBase {
     velox::connector::unregisterConnector(connector_->connectorId());
   }
 
+  static ConnectorSessionPtr makeSession() {
+    return std::make_shared<ConnectorSession>(
+        /*queryId=*/"test", /*user=*/"test", Properties{});
+  }
+
   std::shared_ptr<TestConnector> connector_;
   std::shared_ptr<ConnectorMetadata> metadata_;
 };
@@ -156,11 +161,12 @@ CO_TEST_F(TestConnectorTest, splitManager) {
   auto tableHandle = layout.createTableHandle(
       nullptr, std::move(columns), *evaluator, empty, empty);
 
+  auto session = makeSession();
   auto partitions =
-      co_await splitManager->co_listPartitions(nullptr, tableHandle);
+      co_await splitManager->co_listPartitions(session, tableHandle);
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      nullptr, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
+      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
@@ -613,8 +619,9 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
 
   auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
   auto* splitManager = metadata_->splitManager();
+  auto session = makeSession();
   auto partitions =
-      co_await splitManager->co_listPartitions(nullptr, tableHandle);
+      co_await splitManager->co_listPartitions(session, tableHandle);
   EXPECT_EQ(partitions.size(), kNumBuckets);
 
   // Pass a non-null partitionType with numPartitions < numBuckets so the
@@ -624,7 +631,7 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
   QueryRuntimeStats noopStats;
   auto source = splitManager->getSplitSource(
-      nullptr, tableHandle, partitions, partitionType, noopStats);
+      session, tableHandle, partitions, partitionType, noopStats);
   std::vector<int32_t> observedGroupIds;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
@@ -675,7 +682,7 @@ CO_TEST_F(TestConnectorTest, bucketedTableNumBucketsExceedsNumRows) {
 
   auto tableHandle = makeScanHandle(*table->layouts()[0], {"key"});
   auto partitions = co_await metadata_->splitManager()->co_listPartitions(
-      nullptr, tableHandle);
+      makeSession(), tableHandle);
   EXPECT_EQ(partitions.size(), kNumBuckets);
 }
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -40,7 +40,9 @@ class TpchConnectorMetadataTest : public ::testing::Test {
 
   static ConnectorSessionPtr makeSession() {
     return std::make_shared<ConnectorSession>(
-        /*queryId=*/"test", /*user=*/"test");
+        /*queryId=*/"test",
+        /*user=*/"test",
+        Properties{});
   }
 
   std::unique_ptr<velox::connector::tpch::TpchConnector> connector_;

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -155,7 +155,15 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
   auto plan = optimization->toVelox().toVeloxPlan(
       filter, MultiFragmentPlan::Options::singleNode(), {}, {});
   static QueryRuntimeStats noopStats;
+  // TODO: When Optimization holds a RunnerSession, use it here so that the
+  // sampling runner sees per-query SET SESSION properties.
+  auto sampleSession = std::make_shared<runner::RunnerSession>(
+      optimization->session()->queryId(),
+      optimization->session()->user(),
+      runner::Properties{},
+      connector::ConnectorProperties{});
   return std::make_shared<runner::LocalRunner>(
+      std::move(sampleSession),
       std::move(plan.plan),
       std::move(plan.finishWrite),
       sampleQueryCtx(*optimization->veloxQueryCtx()),

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -385,7 +385,16 @@ std::vector<velox::RowVectorPtr> runConstantPlan(
     PlanAndStats& veloxPlan,
     velox::memory::MemoryPool* pool) {
   QueryRuntimeStats noopStats;
+  // TODO: When Optimization holds a RunnerSession, use it here so that the
+  // constant-evaluation runner sees per-query SET SESSION properties.
+  const auto& parentSession = *queryCtx()->optimization()->session();
+  auto constantEvalSession = std::make_shared<runner::RunnerSession>(
+      parentSession.queryId(),
+      parentSession.user(),
+      runner::Properties{},
+      connector::ConnectorProperties{});
   auto runner = std::make_shared<runner::LocalRunner>(
+      std::move(constantEvalSession),
       veloxPlan.plan,
       std::move(veloxPlan.finishWrite),
       constantQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()),

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -325,8 +325,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
           optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
     }
 
-    auto session =
-        std::make_shared<connector::ConnectorSession>("test", "test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test", "test", connector::Properties{});
     auto table = metadata->createTable(
         session,
         statement.tableName(),
@@ -344,8 +344,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     const auto& tableName = statement.tableName();
 
-    auto session =
-        std::make_shared<connector::ConnectorSession>("test", "test");
+    auto session = std::make_shared<connector::ConnectorSession>(
+        "test", "test", connector::Properties{});
     const bool dropped = metadata->dropTable(
         session, tableName, statement.ifExists(), /*explain=*/false);
 
@@ -651,7 +651,13 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
   std::shared_ptr<runner::LocalRunner> makeRunner(
       optimizer::PlanAndStats& planAndStats,
       const std::shared_ptr<core::QueryCtx>& queryCtx) {
+    auto runnerSession = std::make_shared<runner::RunnerSession>(
+        queryCtx->queryId(),
+        /*user=*/"axiom-sql-benchmark",
+        connector::Properties{},
+        connector::ConnectorProperties{});
     return std::make_shared<runner::LocalRunner>(
+        std::move(runnerSession),
         planAndStats.plan,
         std::move(planAndStats.finishWrite),
         queryCtx,

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -51,7 +51,7 @@ class HiveQueriesTestBase : public QueryTestBase {
 
   static connector::ConnectorSessionPtr makeSession() {
     return std::make_shared<connector::ConnectorSession>(
-        /*queryId=*/"test", /*user=*/"test");
+        /*queryId=*/"test", /*user=*/"test", connector::Properties{});
   }
 
   /// Returns a schema of a table.

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -140,7 +140,13 @@ TestResult QueryTestBase::runVelox(const core::PlanNodePtr& plan) {
 
 TestResult QueryTestBase::runFragmentedPlan(
     optimizer::PlanAndStats& planAndStats) {
+  auto runnerSession = std::make_shared<runner::RunnerSession>(
+      getQueryCtx()->queryId(),
+      "test",
+      connector::Properties{},
+      connector::ConnectorProperties{});
   auto runner = std::make_shared<runner::LocalRunner>(
+      std::move(runnerSession),
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       getQueryCtx(),

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -145,8 +145,14 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   auto best = optimization.bestPlan();
   auto planAndStats = optimization.toVeloxPlan(best->op);
 
+  auto runnerSession = std::make_shared<runner::RunnerSession>(
+      session->queryId(),
+      session->user(),
+      connector::Properties{},
+      connector::ConnectorProperties{});
   static QueryRuntimeStats noopStats;
   return std::make_shared<runner::LocalRunner>(
+      std::move(runnerSession),
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -81,7 +81,9 @@ facebook::axiom::connector::TablePtr createTable(
   auto tableSchema = velox::ROW(std::move(schemaNames), std::move(schemaTypes));
 
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "pyspark_session", /*user=*/"pyspark-optimizer");
+      "pyspark_session",
+      /*user=*/"pyspark-optimizer",
+      facebook::axiom::connector::Properties{});
   auto table = metadata->createTable(
       session,
       writeNode.tableName(),

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -99,6 +99,11 @@ std::vector<velox::RowVectorPtr> LocalRunner::execute(
           runtimeStats_);
 
   auto runner = std::make_shared<facebook::axiom::runner::LocalRunner>(
+      std::make_shared<facebook::axiom::runner::RunnerSession>(
+          queryCtx->queryId(),
+          /*user=*/"pyspark-runner",
+          facebook::axiom::runner::Properties{},
+          facebook::axiom::connector::ConnectorProperties{}),
       plan_,
       std::move(finishWrite_),
       queryCtx,

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -231,6 +231,7 @@ std::vector<optimizer::ExecutableFragment> topologicalSort(
 } // namespace
 
 LocalRunner::LocalRunner(
+    RunnerSessionPtr session,
     optimizer::MultiFragmentPlanPtr plan,
     optimizer::FinishWrite finishWrite,
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
@@ -238,7 +239,8 @@ LocalRunner::LocalRunner(
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
     std::string baseSpillDirectory,
     QueryRuntimeStats& runtimeStats)
-    : plan_{std::move(plan)},
+    : session_{std::move(session)},
+      plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
@@ -250,6 +252,7 @@ LocalRunner::LocalRunner(
     params_.spillDirectory = baseSpillDirectory_;
   }
 
+  VELOX_CHECK_NOT_NULL(session_);
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
 }
@@ -525,8 +528,10 @@ void LocalRunner::makeStages(
             it != fragment.groupedNodes.end()) {
           partitionType = it->second;
         }
-        auto source =
-            splitSourceForScan(/*session=*/nullptr, *scan, partitionType);
+        auto source = splitSourceForScan(
+            session_->toConnectorSession(scan->tableHandle()->connectorId()),
+            *scan,
+            partitionType);
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -22,6 +22,7 @@
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/runner/Runner.h"
+#include "axiom/runner/RunnerSession.h"
 #include "velox/common/base/SpillConfig.h"
 #include "velox/connectors/Connector.h"
 #include "velox/exec/Cursor.h"
@@ -91,6 +92,7 @@ class LocalRunner : public Runner,
   /// spilling at the task level.
   /// @param runtimeStats Optional recorder for split enumeration metrics.
   LocalRunner(
+      RunnerSessionPtr session,
       optimizer::MultiFragmentPlanPtr plan,
       optimizer::FinishWrite finishWrite,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
@@ -175,6 +177,7 @@ class LocalRunner : public Runner,
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;
 
+  const RunnerSessionPtr session_;
   const optimizer::MultiFragmentPlanPtr plan_;
   const std::vector<optimizer::ExecutableFragment> fragments_;
   optimizer::FinishWrite finishWrite_;

--- a/axiom/runner/RunnerSession.h
+++ b/axiom/runner/RunnerSession.h
@@ -21,37 +21,29 @@
 #include <string_view>
 #include <utility>
 
-#include <folly/container/F14Map.h>
+#include "axiom/connectors/BaseSession.h"
 
-namespace facebook::axiom::connector {
+namespace facebook::axiom::runner {
 
-/// Property bag for a single component or connector.
+/// Runner-scoped property bag.
 using Properties = folly::F14FastMap<std::string, std::string>;
 
-class ConnectorSession;
-using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;
-
-/// Read-only query-specific information passed to connectors.
-class ConnectorSession final {
+/// Runner-scoped session view. Carries the shared identity (queryId, user,
+/// connector-session factory) plus the runner's own property slice.
+class RunnerSession final : public connector::BaseSession {
  public:
-  ConnectorSession(std::string queryId, std::string user, Properties properties)
-      : queryId_{std::move(queryId)},
-        user_{std::move(user)},
+  RunnerSession(
+      std::string queryId,
+      std::string user,
+      Properties properties,
+      connector::ConnectorProperties connectorProperties)
+      : BaseSession(
+            std::move(queryId),
+            std::move(user),
+            std::move(connectorProperties)),
         properties_{std::move(properties)} {}
 
-  /// Returns the query identifier.
-  const std::string& queryId() const {
-    return queryId_;
-  }
-
-  /// Returns the identity of the user who submitted the query.
-  const std::string& user() const {
-    return user_;
-  }
-
-  /// Returns the value of session property 'name' if set on this session,
-  /// or std::nullopt otherwise. The returned view is valid for the lifetime
-  /// of this ConnectorSession.
+  /// Returns the value of runner-scoped property 'name' if set.
   std::optional<std::string_view> property(std::string_view name) const {
     auto it = properties_.find(name);
     if (it == properties_.end()) {
@@ -61,9 +53,9 @@ class ConnectorSession final {
   }
 
  private:
-  const std::string queryId_;
-  const std::string user_;
   const Properties properties_;
 };
 
-} // namespace facebook::axiom::connector
+using RunnerSessionPtr = std::shared_ptr<RunnerSession>;
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -133,11 +133,20 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     return fmt::format("q{}", queryCounter_++);
   }
 
+  static axiom::runner::RunnerSessionPtr makeRunnerSession(
+      std::string_view queryId) {
+    return std::make_shared<axiom::runner::RunnerSession>(
+        std::string(queryId),
+        "test",
+        axiom::runner::Properties{},
+        axiom::connector::ConnectorProperties{});
+  }
+
   std::shared_ptr<LocalRunner> makeRunner(
       optimizer::MultiFragmentPlanPtr plan) {
     const auto queryId = plan->options().queryId;
-
     return std::make_shared<LocalRunner>(
+        makeRunnerSession(queryId),
         std::move(plan),
         optimizer::FinishWrite{},
         makeQueryCtx(queryId),
@@ -274,6 +283,7 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
   auto queryCtx = makeQueryCtx(queryId);
 
   auto localRunner = std::make_shared<LocalRunner>(
+      makeRunnerSession(queryId),
       std::move(join),
       optimizer::FinishWrite{},
       std::move(queryCtx),

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -395,6 +395,11 @@ PrestoQueryReplayRunner::run(
 
   auto nodeSplitMap = deserializeConnectorSplits(serializedConnectorSplits);
   auto localRunner = std::make_shared<LocalRunner>(
+      std::make_shared<RunnerSession>(
+          queryId,
+          /*user=*/"presto-replay",
+          runner::Properties{},
+          connector::ConnectorProperties{}),
       std::move(multiFragmentPlan),
       optimizer::FinishWrite{},
       makeQueryCtx(queryId, queryRootPool),

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2303,7 +2303,9 @@ SqlStatementPtr parseShowSchemas(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-schemas", /*user=*/"presto-parser");
+      "show-schemas",
+      /*user=*/"presto-parser",
+      facebook::axiom::connector::Properties{});
   auto schemaNames = metadata->listSchemaNames(session);
   std::sort(schemaNames.begin(), schemaNames.end());
 
@@ -2353,7 +2355,9 @@ SqlStatementPtr parseShowTables(
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-tables", /*user=*/"presto-parser");
+      "show-tables",
+      /*user=*/"presto-parser",
+      facebook::axiom::connector::Properties{});
   VELOX_USER_CHECK(
       metadata->schemaExists(session, schema),
       "Schema does not exist: {}",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/100


The end state: each Axiom component (Parser, Optimizer, Runner) takes a typed session view (`ParserSession`, `OptimizerSession`, `RunnerSession`) inheriting from a shared `BaseSession` and spawning `ConnectorSession`s for the connectors it talks to. This commit lands the **runner piece** so connector session properties reach split generation.

A `SET SESSION <connector>.<key>=<value>` now reaches `co_listPartitions`/`getSplitSource`. Previously `LocalRunner` passed `nullptr` for the session there. The diff adds `BaseSession` + `RunnerSession`, plumbs `RunnerSessionPtr` through `LocalRunner`, and has `SqlQueryRunner` build the session from `SessionConfig`.

Deferred follow-ups: `OptimizerSession` (+ `Optimization` migration), `ParserSession` (+ `PrestoParser` migration). `axiom::Session` (queryId+user only) is marked deprecated as the transitional shim. `JoinSample` and `ToGraph` build an empty-properties `RunnerSession` for sampling/constant-eval; threading a real one is part of the optimizer migration.

bypass-github-export-checks

Reviewed By: amitkdutta

Differential Revision: D107720814


