### PR TITLE
feat(parser): Plumb session properties through PrestoParser (#1457)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -205,6 +205,8 @@ void SqlQueryRunner::initialize(
       kOptimizerPrefix,
       std::make_shared<facebook::axiom::optimizer::OptimizerOptions>());
   configRegistry_->add(
+      kParserPrefix, std::make_shared<presto::ParserOptions>());
+  configRegistry_->add(
       kExecutionPrefix,
       std::make_shared<facebook::velox::core::QueryConfigProvider>());
   configRegistry_->add(
@@ -238,6 +240,22 @@ void SqlQueryRunner::initialize(
 }
 
 namespace {
+
+// Returns per-connector property maps for connectors with at least one
+// effective value set.
+connector::ConnectorProperties collectConnectorProperties(
+    const SessionConfig& config) {
+  connector::ConnectorProperties result;
+  for (const auto& id :
+       connector::ConnectorMetadataRegistry::allMetadataIds()) {
+    connector::Properties properties = config.effectiveValues(id);
+    if (!properties.empty()) {
+      result.emplace(id, std::move(properties));
+    }
+  }
+  return result;
+}
+
 std::vector<velox::RowVectorPtr> fetchResults(runner::LocalRunner& runner) {
   std::vector<velox::RowVectorPtr> results;
   while (auto rows = runner.next()) {
@@ -562,8 +580,14 @@ std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
       options.defaultConnectorId.value_or(defaultConnectorId_);
   const auto& defaultSchema = options.defaultSchema.value_or(defaultSchema_);
 
-  auto prestoParser =
-      std::make_unique<presto::PrestoParser>(defaultConnectorId, defaultSchema);
+  auto parserSession = std::make_shared<presto::ParserSession>(
+      options.queryId.value_or(queryIdGenerator_()),
+      user_,
+      presto::ParserOptions::from(
+          sessionConfig_->effectiveValues(kParserPrefix)),
+      collectConnectorProperties(*sessionConfig_));
+  auto prestoParser = std::make_unique<presto::PrestoParser>(
+      defaultConnectorId, defaultSchema, std::move(parserSession));
   return prestoParser->parseMultiple(sql, /*enableTracing=*/options.debugMode);
 }
 
@@ -1039,24 +1063,6 @@ connector::ConnectorSessionPtr SqlQueryRunner::makeConnectorSession(
       user_,
       sessionConfig_->effectiveValues(connectorId));
 }
-
-namespace {
-
-// Returns per-connector property maps for connectors with at least one
-// effective value set.
-connector::ConnectorProperties collectConnectorProperties(
-    const SessionConfig& config) {
-  connector::ConnectorProperties result;
-  for (const auto& id :
-       connector::ConnectorMetadataRegistry::allMetadataIds()) {
-    connector::Properties properties = config.effectiveValues(id);
-    if (!properties.empty()) {
-      result.emplace(id, std::move(properties));
-    }
-  }
-  return result;
-}
-} // namespace
 
 std::string SqlQueryRunner::runExplainAnalyze(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -121,6 +121,9 @@ class SqlQueryRunner {
   /// Prefix for runner session properties.
   static constexpr const char* kRunnerPrefix = "runner";
 
+  /// Prefix for parser session properties (e.g., "parser.friendly_sql").
+  static constexpr const char* kParserPrefix = "parser";
+
   /// Prefix for Velox execution session properties (e.g.,
   /// "execution.session_timezone").
   static constexpr const char* kExecutionPrefix = "execution";

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -182,7 +182,12 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
         connector_->connectorId(),
         std::string(
-            connector::hive::LocalHiveConnectorMetadata::kDefaultSchema));
+            connector::hive::LocalHiveConnectorMetadata::kDefaultSchema),
+        std::make_shared<::axiom::sql::presto::ParserSession>(
+            /*queryId=*/"axiom-sql-benchmark",
+            /*user=*/"axiom-sql-benchmark",
+            ::axiom::sql::presto::ParserOptions{},
+            connector::ConnectorProperties{}));
 
     history_ = std::make_unique<optimizer::VeloxHistory>();
 

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -65,7 +65,14 @@ class DerivedTablePrinterTest : public ::testing::Test {
   }
 
   std::vector<std::string> toLines(const std::string& sql) {
-    ::axiom::sql::presto::PrestoParser parser{kTestConnectorId, kDefaultSchema};
+    ::axiom::sql::presto::PrestoParser parser{
+        kTestConnectorId,
+        kDefaultSchema,
+        std::make_shared<::axiom::sql::presto::ParserSession>(
+            /*queryId=*/"test",
+            /*user=*/"test",
+            ::axiom::sql::presto::ParserOptions{},
+            connector::ConnectorProperties{})};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -61,7 +61,12 @@ void HiveQueriesTestBase::SetUp() {
 
   prestoParser_ = std::make_unique<::axiom::sql::presto::PrestoParser>(
       exec::test::kHiveConnectorId,
-      std::string(connector::hive::LocalHiveConnectorMetadata::kDefaultSchema));
+      std::string(connector::hive::LocalHiveConnectorMetadata::kDefaultSchema),
+      std::make_shared<::axiom::sql::presto::ParserSession>(
+          /*queryId=*/"test",
+          /*user=*/"test",
+          ::axiom::sql::presto::ParserOptions{},
+          connector::ConnectorProperties{}));
 }
 
 // static

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -100,7 +100,14 @@ logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
     std::string_view sql,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema) {
-  ::axiom::sql::presto::PrestoParser parser(defaultConnectorId, defaultSchema);
+  ::axiom::sql::presto::PrestoParser parser(
+      defaultConnectorId,
+      defaultSchema,
+      std::make_shared<::axiom::sql::presto::ParserSession>(
+          /*queryId=*/"test",
+          /*user=*/"test",
+          ::axiom::sql::presto::ParserOptions{},
+          connector::ConnectorProperties{}));
 
   auto statement = parser.parse(sql);
 

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -116,7 +116,14 @@ class RelationOpPrinterTest : public ::testing::Test {
   }
 
   lp::LogicalPlanNodePtr parse(const std::string& sql) {
-    ::axiom::sql::presto::PrestoParser parser{kTestConnectorId, kDefaultSchema};
+    ::axiom::sql::presto::PrestoParser parser{
+        kTestConnectorId,
+        kDefaultSchema,
+        std::make_shared<::axiom::sql::presto::ParserSession>(
+            /*queryId=*/"test",
+            /*user=*/"test",
+            ::axiom::sql::presto::ParserOptions{},
+            connector::ConnectorProperties{})};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -169,7 +169,13 @@ void SqlTestBase::runSetupStatement(
   duckDb.execute(sql);
 
   ::axiom::sql::presto::PrestoParser parser(
-      kTestConnectorId, std::string(connector::TestConnector::kDefaultSchema));
+      kTestConnectorId,
+      std::string(connector::TestConnector::kDefaultSchema),
+      std::make_shared<::axiom::sql::presto::ParserSession>(
+          /*queryId=*/"test",
+          /*user=*/"test",
+          ::axiom::sql::presto::ParserOptions{},
+          connector::ConnectorProperties{}));
   auto stmt = parser.parse(sql, /*enableTracing=*/true);
 
   if (stmt->isCreateTable()) {
@@ -214,7 +220,13 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
     std::string_view sql) {
   // Parse SQL to logical plan.
   ::axiom::sql::presto::PrestoParser parser(
-      kTestConnectorId, std::string(connector::TestConnector::kDefaultSchema));
+      kTestConnectorId,
+      std::string(connector::TestConnector::kDefaultSchema),
+      std::make_shared<::axiom::sql::presto::ParserSession>(
+          /*queryId=*/"test",
+          /*user=*/"test",
+          ::axiom::sql::presto::ParserOptions{},
+          connector::ConnectorProperties{}));
   auto statement = parser.parse(sql, true);
 
   VELOX_CHECK(

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   DisplayNames.cpp
   ExpressionPlanner.cpp
   GroupByPlanner.cpp
+  ParserOptions.cpp
   SortProjection.cpp
   PrestoParser.cpp
   ShowStatsBuilder.cpp
@@ -38,6 +39,7 @@ target_link_libraries(
   axiom_sql_presto_ast
   axiom_sql_presto_error
   velox_common_base
+  velox_common_config
   velox_presto_types
   antlr4_shared
   re2::re2

--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/ParserOptions.h"
+
+#include <fmt/format.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace axiom::sql::presto {
+
+using facebook::velox::config::ConfigProperty;
+using facebook::velox::config::ConfigPropertyType;
+
+namespace {
+
+std::vector<ConfigProperty> buildProperties(
+    const std::unordered_map<std::string, std::string>& configOverrides) {
+  std::vector<ConfigProperty> properties = {
+      {
+          std::string(ParserOptions::kFriendlySql),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(ParserOptions::kFriendlySqlDefault),
+          "Enable Friendly SQL extensions: named ROW constructors, trailing "
+          "commas, FROM-first syntax, etc.",
+      },
+      {
+          std::string(ParserOptions::kParseDecimalLiteralAsDouble),
+          ConfigPropertyType::kBoolean,
+          fmt::to_string(ParserOptions::kParseDecimalLiteralAsDoubleDefault),
+          "Parse decimal literals (e.g. 1.5) as DOUBLE. When false, parse as "
+          "DECIMAL with inferred precision and scale.",
+      },
+  };
+
+  if (configOverrides.empty()) {
+    return properties;
+  }
+
+  std::unordered_map<std::string, size_t> propertyIndex;
+  for (size_t i = 0; i < properties.size(); ++i) {
+    propertyIndex[properties[i].name] = i;
+  }
+  for (const auto& [key, value] : configOverrides) {
+    auto it = propertyIndex.find(key);
+    VELOX_USER_CHECK(
+        it != propertyIndex.end(),
+        "Unknown session property in parser config: {}",
+        key);
+    properties[it->second].defaultValue = value;
+  }
+
+  return properties;
+}
+
+} // namespace
+
+ParserOptions::ParserOptions() : properties_(buildProperties({})) {}
+
+ParserOptions::ParserOptions(
+    const std::unordered_map<std::string, std::string>& configOverrides)
+    : properties_(buildProperties(configOverrides)) {}
+
+std::string ParserOptions::normalize(
+    std::string_view /*name*/,
+    std::string_view value) const {
+  return std::string(value);
+}
+
+ParserOptions ParserOptions::from(
+    const folly::F14FastMap<std::string, std::string>& properties) {
+  auto setBool = [&](std::string_view key, bool& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = it->second == "true";
+    }
+  };
+
+  ParserOptions options;
+  setBool(kFriendlySql, options.friendlySql);
+  setBool(kParseDecimalLiteralAsDouble, options.parseDecimalLiteralAsDouble);
+  return options;
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -15,19 +15,58 @@
  */
 #pragma once
 
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "velox/common/config/ConfigProvider.h"
+
 namespace axiom::sql::presto {
 
 /// Options controlling SQL parsing behavior.
-struct ParserOptions {
+struct ParserOptions : public facebook::velox::config::ConfigProvider {
+  static constexpr std::string_view kFriendlySql = "friendly_sql";
+  static constexpr std::string_view kParseDecimalLiteralAsDouble =
+      "parse_decimal_literal_as_double";
+
+  static constexpr bool kFriendlySqlDefault = true;
+  static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
+
+  ParserOptions();
+
+  /// Overrides code defaults with values from `configOverrides`.
+  explicit ParserOptions(
+      const std::unordered_map<std::string, std::string>& configOverrides);
+
   /// Enables Friendly SQL extensions inspired by DuckDB: named ROW
   /// constructors, trailing commas, FROM-first syntax, etc.
-  bool friendlySql{true};
+  bool friendlySql{kFriendlySqlDefault};
 
   /// When true, decimal literals (e.g., 1.5) are parsed as DOUBLE. When
   /// false, they are parsed as DECIMAL with precision and scale inferred
   /// from the literal. Matches Presto's decimal_literal_result_type session
   /// property.
-  bool parseDecimalLiteralAsDouble{true};
+  bool parseDecimalLiteralAsDouble{kParseDecimalLiteralAsDoubleDefault};
+
+  /// Constructs options from session property name-value pairs.
+  /// Keys are unqualified property names (e.g., "friendly_sql").
+  /// Missing keys use struct defaults.
+  static ParserOptions from(
+      const folly::F14FastMap<std::string, std::string>& properties);
+
+  std::vector<facebook::velox::config::ConfigProperty> properties()
+      const override {
+    return properties_;
+  }
+
+  std::string normalize(std::string_view name, std::string_view value)
+      const override;
+
+ private:
+  std::vector<facebook::velox::config::ConfigProperty> properties_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ParserSession.h
+++ b/axiom/sql/presto/ParserSession.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "axiom/connectors/BaseSession.h"
+#include "axiom/sql/presto/ParserOptions.h"
+
+namespace axiom::sql::presto {
+
+/// Parser-scoped session view. Carries the shared identity (queryId, user,
+/// per-connector properties) plus the typed ParserOptions for this query.
+class ParserSession final : public facebook::axiom::connector::BaseSession {
+ public:
+  ParserSession(
+      std::string queryId,
+      std::string user,
+      ParserOptions options,
+      facebook::axiom::connector::ConnectorProperties connectorProperties)
+      : BaseSession(
+            std::move(queryId),
+            std::move(user),
+            std::move(connectorProperties)),
+        options_{std::move(options)} {}
+
+  const ParserOptions& options() const {
+    return options_;
+  }
+
+ private:
+  const ParserOptions options_;
+};
+
+using ParserSessionPtr = std::shared_ptr<ParserSession>;
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2297,15 +2297,13 @@ SqlStatementPtr parseDropSchema(
 
 SqlStatementPtr parseShowSchemas(
     const ShowSchemas& showSchemas,
-    const std::string& defaultConnectorId) {
+    const std::string& defaultConnectorId,
+    const ParserSessionPtr& parserSession) {
   const auto connectorId = showSchemas.catalog().value_or(defaultConnectorId);
 
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
-  auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-schemas",
-      /*user=*/"presto-parser",
-      facebook::axiom::connector::Properties{});
+  auto session = parserSession->toConnectorSession(connectorId);
   auto schemaNames = metadata->listSchemaNames(session);
   std::sort(schemaNames.begin(), schemaNames.end());
 
@@ -2331,7 +2329,8 @@ SqlStatementPtr parseShowSchemas(
 SqlStatementPtr parseShowTables(
     const ShowTables& showTables,
     const std::string& defaultConnectorId,
-    const std::string& defaultSchema) {
+    const std::string& defaultSchema,
+    const ParserSessionPtr& parserSession) {
   static constexpr std::string_view kTableColumnName = "Table";
 
   std::string connectorId = defaultConnectorId;
@@ -2354,10 +2353,7 @@ SqlStatementPtr parseShowTables(
 
   auto metadata =
       facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
-  auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
-      "show-tables",
-      /*user=*/"presto-parser",
-      facebook::axiom::connector::Properties{});
+  auto session = parserSession->toConnectorSession(connectorId);
   VELOX_USER_CHECK(
       metadata->schemaExists(session, schema),
       "Schema does not exist: {}",
@@ -2420,7 +2416,7 @@ SqlStatementPtr doPlan(
     const std::string& defaultSchema,
     const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
         std::string_view /*sql*/)>& parseSql,
-    bool friendlySql = true) {
+    const ParserSessionPtr& parserSession) {
   if (query->is(NodeType::kInsert)) {
     return parseInsert(
         *query->as<Insert>(), defaultConnectorId, defaultSchema, parseSql);
@@ -2458,12 +2454,16 @@ SqlStatementPtr doPlan(
   }
 
   if (query->is(NodeType::kShowSchemas)) {
-    return parseShowSchemas(*query->as<ShowSchemas>(), defaultConnectorId);
+    return parseShowSchemas(
+        *query->as<ShowSchemas>(), defaultConnectorId, parserSession);
   }
 
   if (query->is(NodeType::kShowTables)) {
     return parseShowTables(
-        *query->as<ShowTables>(), defaultConnectorId, defaultSchema);
+        *query->as<ShowTables>(),
+        defaultConnectorId,
+        defaultSchema,
+        parserSession);
   }
 
   if (query->is(NodeType::kShowCatalogs)) {
@@ -2503,7 +2503,10 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kQuery)) {
     RelationPlanner planner(
-        defaultConnectorId, defaultSchema, parseSql, friendlySql);
+        defaultConnectorId,
+        defaultSchema,
+        parseSql,
+        parserSession->options().friendlySql);
     query->accept(&planner);
     return std::make_shared<SelectStatement>(
         planner.plan(),
@@ -2525,7 +2528,7 @@ SqlStatementPtr PrestoParser::doParse(
     ParserHelper helper(sql);
     auto* context = helper.parse();
 
-    AstBuilder astBuilder(options_, enableTracing);
+    AstBuilder astBuilder(session_->options(), enableTracing);
     auto query =
         std::any_cast<std::shared_ptr<Statement>>(astBuilder.visit(context));
 
@@ -2575,16 +2578,11 @@ SqlStatementPtr PrestoParser::doParse(
         defaultConnectorId_,
         defaultSchema_,
         parseSql,
-        options_.friendlySql);
+        session_);
     return parseExplain(*explain, sqlStatement);
   }
 
-  return doPlan(
-      query,
-      defaultConnectorId_,
-      defaultSchema_,
-      parseSql,
-      options_.friendlySql);
+  return doPlan(query, defaultConnectorId_, defaultSchema_, parseSql, session_);
 }
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -15,8 +15,9 @@
  */
 #pragma once
 
-#include "axiom/sql/presto/ParserOptions.h"
+#include "axiom/sql/presto/ParserSession.h"
 #include "axiom/sql/presto/SqlStatement.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace axiom::sql::presto {
 
@@ -27,13 +28,17 @@ class PrestoParser {
   /// specify catalog, i.e. SELECT * FROM schema.name.
   /// @param defaultSchema Default schema to use for tables that do not
   /// specify schema, i.e. SELECT * FROM name.
+  /// @param session Parser-scoped session used to spawn ConnectorSessions
+  /// for parse-time metadata calls.
   PrestoParser(
       const std::string& defaultConnectorId,
       const std::string& defaultSchema,
-      ParserOptions options = {})
+      ParserSessionPtr session)
       : defaultConnectorId_{defaultConnectorId},
         defaultSchema_{defaultSchema},
-        options_{options} {}
+        session_{std::move(session)} {
+    VELOX_CHECK_NOT_NULL(session_);
+  }
 
   SqlStatementPtr parse(std::string_view sql, bool enableTracing = false);
 
@@ -64,7 +69,7 @@ class PrestoParser {
 
   const std::string defaultConnectorId_;
   const std::string defaultSchema_;
-  const ParserOptions options_;
+  const ParserSessionPtr session_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/docs/PrestoSqlExtensions.md
+++ b/axiom/sql/presto/docs/PrestoSqlExtensions.md
@@ -8,8 +8,9 @@ SQL dialect.
 
 Some extensions are gated behind the `friendlySql` flag in `ParserOptions`.
 These are inspired by [DuckDB's Friendly SQL](https://duckdb.org/docs/sql/dialect/friendly_sql)
-and are enabled by default. To disable them, construct `PrestoParser` with
-`ParserOptions{.friendlySql = false}`.
+and are enabled by default. To disable them, set `friendlySql = false` on
+the `ParserOptions` passed to `ParserSession`, or use
+`SET SESSION parser.friendly_sql = false` at the CLI.
 
 Friendly SQL features:
 

--- a/axiom/sql/presto/example/CMakeLists.txt
+++ b/axiom/sql/presto/example/CMakeLists.txt
@@ -14,4 +14,9 @@
 
 add_executable(axiom_sql_presto_example ParserExample.cpp)
 
-target_link_libraries(axiom_sql_presto_example axiom_sql_presto_ast Folly::folly)
+target_link_libraries(
+  axiom_sql_presto_example
+  axiom_sql_presto_ast
+  axiom_sql_presto_parser
+  Folly::folly
+)

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -257,10 +257,10 @@ TEST_F(ExpressionParserTest, decimalLiteralAsDecimal) {
   VELOX_EXPECT_EQ_TYPES(expr->type(), DOUBLE());
 
   // With parseDecimalLiteralAsDouble=false, 1.5 is parsed as DECIMAL(2, 1).
+  ParserOptions options;
+  options.parseDecimalLiteralAsDouble = false;
   PrestoParser parser(
-      kConnectorId,
-      "default",
-      ParserOptions{.parseDecimalLiteralAsDouble = false});
+      kConnectorId, "default", makeParserSession(std::move(options)));
   expr = parser.parseExpression("1.5");
   VELOX_EXPECT_EQ_TYPES(expr->type(), DECIMAL(2, 1));
 

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -121,15 +121,25 @@ class PrestoParserTestBase : public testing::Test {
         .values();
   }
 
+  static ParserSessionPtr makeParserSession(ParserOptions options = {}) {
+    return std::make_shared<ParserSession>(
+        /*queryId=*/"test",
+        /*user=*/"test",
+        std::move(options),
+        facebook::axiom::connector::ConnectorProperties{});
+  }
+
   /// Creates a PrestoParser configured with the test connector.
   PrestoParser makeParser() {
-    return PrestoParser(kConnectorId, "default");
+    return PrestoParser(kConnectorId, "default", makeParserSession());
   }
 
   /// Creates a PrestoParser with Friendly SQL disabled.
   PrestoParser makeStrictParser() {
+    ParserOptions options;
+    options.friendlySql = false;
     return PrestoParser(
-        kConnectorId, "default", ParserOptions{.friendlySql = false});
+        kConnectorId, "default", makeParserSession(std::move(options)));
   }
 
   /// Test connector with TPC-H table schemas. Supports addTable, createView,


### PR DESCRIPTION
Summary:

Completes the per-component session migration. `PrestoParser` now takes a `ParserSessionPtr` carrying the typed `ParserOptions` and the per-connector property slices; parse-time `SHOW SCHEMAS` / `SHOW TABLES` reach the connector with the same per-query session view as runtime metadata calls. `ParserSession` is the third leg of the `OptimizerSession` / `RunnerSession` / `ParserSession` trio that replaced `axiom::Session`.

`SET SESSION parser.<key>=<value>` now flows through to the parser. Example:

    > SET SESSION parser.friendly_sql=false;
    > SELECT 1, 2,
    Query failed: Syntax error at 0:0 near ',': Trailing commas in SELECT list require Friendly SQL mode.

`ParserOptions` becomes a `ConfigProvider`, registered in the CLI under the `parser` prefix alongside `optimizer` and `runner`. Unknown properties under the prefix fail loudly. Two properties are wired today: `friendly_sql` and `parse_decimal_literal_as_double`.

Reviewed By: amitkdutta

Differential Revision: D107733482


