### PR TITLE
feat: Add validate methods to SessionConfig

### DIFF
--- a/axiom/common/SessionConfig.cpp
+++ b/axiom/common/SessionConfig.cpp
@@ -22,30 +22,110 @@ namespace facebook::axiom {
 
 using velox::config::ConfigPropertyType;
 
+namespace {
+// Returns true if 'value' is a valid integer string (optional leading '-'
+// followed by one or more digits).
+bool isInteger(std::string_view value) {
+  auto start = !value.empty() && value[0] == '-' ? 1u : 0u;
+  return value.size() > start &&
+      std::all_of(value.begin() + start, value.end(), [](char c) {
+           return std::isdigit(c);
+         });
+}
+
+// Returns true if 'value' is a valid double string.
+bool isDouble(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+  auto str = std::string(value);
+  char* end = nullptr;
+  std::strtod(str.c_str(), &end);
+  return end != nullptr && *end == '\0';
+}
+
+// Validates and normalizes 'value' for 'type'. Lowercases booleans,
+// passes through integers, doubles, and strings. Throws on invalid values.
+std::string normalizeType(
+    std::string_view qualifiedName,
+    ConfigPropertyType type,
+    std::string_view value) {
+  switch (type) {
+    case ConfigPropertyType::kBoolean: {
+      auto lower = std::string(value);
+      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+      VELOX_USER_CHECK(
+          lower == "true" || lower == "false",
+          "Expected boolean value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return lower;
+    }
+    case ConfigPropertyType::kInteger:
+      VELOX_USER_CHECK(
+          isInteger(value),
+          "Expected integer value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kDouble:
+      VELOX_USER_CHECK(
+          isDouble(value),
+          "Expected double value for session property: {} = {}",
+          qualifiedName,
+          value);
+      return std::string(value);
+    case ConfigPropertyType::kString:
+      return std::string(value);
+  }
+  VELOX_UNREACHABLE();
+}
+
+struct NormalizedAndDefault {
+  std::string normalizedValue;
+  std::optional<std::string> defaultValue;
+
+  bool normalizedEqualsDefault() const {
+    return defaultValue.has_value() && normalizedValue == defaultValue.value();
+  }
+};
+
+// Resolves 'qualifiedName' and normalizes 'value'.
+// Throws if 'qualifiedName' is not found or 'value' is invalid.
+NormalizedAndDefault resolveAndNormalize(
+    const ConfigRegistry& registry,
+    std::string_view qualifiedName,
+    std::string_view value) {
+  auto resolved = registry.resolve(qualifiedName);
+  auto normalized = normalizeType(qualifiedName, resolved.property.type, value);
+  normalized = resolved.provider->normalize(resolved.property.name, normalized);
+  return {std::move(normalized), std::move(resolved.property.defaultValue)};
+}
+} // namespace
+
 SessionConfig::SessionConfig(std::shared_ptr<const ConfigRegistry> registry)
     : registry_(std::move(registry)) {}
 
 bool SessionConfig::set(
     std::string_view qualifiedName,
     std::string_view value) {
-  auto resolved = registry_->resolve(qualifiedName);
-  auto normalized = normalizeType(qualifiedName, resolved.property.type, value);
-  normalized = resolved.provider->normalize(resolved.property.name, normalized);
-
   auto key = std::string(qualifiedName);
+  auto normalizedAndDefault =
+      resolveAndNormalize(*registry_, qualifiedName, value);
 
   // If the normalized value equals the default, clear any override.
-  if (normalized == resolved.property.defaultValue) {
+  if (normalizedAndDefault.normalizedEqualsDefault()) {
     return overrides_.erase(key) > 0;
   }
 
   // Check if value is same as current override.
   auto it = overrides_.find(key);
-  if (it != overrides_.end() && it->second == normalized) {
+  if (it != overrides_.end() &&
+      it->second == normalizedAndDefault.normalizedValue) {
     return false;
   }
 
-  overrides_[std::move(key)] = std::move(normalized);
+  overrides_[std::move(key)] = std::move(normalizedAndDefault.normalizedValue);
   return true;
 }
 
@@ -60,6 +140,16 @@ bool SessionConfig::reset(std::string_view qualifiedName) {
   // Verify property exists.
   registry_->resolve(qualifiedName);
   return overrides_.erase(qualifiedName) > 0;
+}
+
+void SessionConfig::validate(
+    std::string_view qualifiedName,
+    std::string_view value) const {
+  resolveAndNormalize(*registry_, qualifiedName, value);
+}
+
+void SessionConfig::validate(std::string_view qualifiedName) const {
+  registry_->resolve(qualifiedName);
 }
 
 std::optional<std::string> SessionConfig::effectiveValue(
@@ -109,66 +199,6 @@ std::vector<SessionConfig::Entry> SessionConfig::all() const {
          it != overrides_.end()});
   }
   return result;
-}
-
-namespace {
-
-// Returns true if 'value' is a valid integer string (optional leading '-'
-// followed by one or more digits).
-bool isInteger(std::string_view value) {
-  auto start = !value.empty() && value[0] == '-' ? 1u : 0u;
-  return value.size() > start &&
-      std::all_of(value.begin() + start, value.end(), [](char c) {
-           return std::isdigit(c);
-         });
-}
-
-// Returns true if 'value' is a valid double string.
-bool isDouble(std::string_view value) {
-  if (value.empty()) {
-    return false;
-  }
-  auto str = std::string(value);
-  char* end = nullptr;
-  std::strtod(str.c_str(), &end);
-  return end != nullptr && *end == '\0';
-}
-
-} // namespace
-
-std::string SessionConfig::normalizeType(
-    std::string_view qualifiedName,
-    ConfigPropertyType type,
-    std::string_view value) {
-  switch (type) {
-    case ConfigPropertyType::kBoolean: {
-      auto lower = std::string(value);
-      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-      VELOX_USER_CHECK(
-          lower == "true" || lower == "false",
-          "Expected boolean value for session property: {} = {}",
-          qualifiedName,
-          value);
-      return lower;
-    }
-    case ConfigPropertyType::kInteger:
-      VELOX_USER_CHECK(
-          isInteger(value),
-          "Expected integer value for session property: {} = {}",
-          qualifiedName,
-          value);
-      return std::string(value);
-    case ConfigPropertyType::kDouble:
-      VELOX_USER_CHECK(
-          isDouble(value),
-          "Expected double value for session property: {} = {}",
-          qualifiedName,
-          value);
-      return std::string(value);
-    case ConfigPropertyType::kString:
-      return std::string(value);
-  }
-  VELOX_UNREACHABLE();
 }
 
 } // namespace facebook::axiom

--- a/axiom/common/SessionConfig.h
+++ b/axiom/common/SessionConfig.h
@@ -44,6 +44,15 @@ class SessionConfig {
   /// changed.
   bool reset(std::string_view qualifiedName);
 
+  /// Validates that 'qualifiedName' names a known property and that 'value' is
+  /// a valid value for it (type and domain validation). Throws on failure.
+  /// Does not modify the session.
+  void validate(std::string_view qualifiedName, std::string_view value) const;
+
+  /// Validates that 'qualifiedName' names a known property. Throws on failure.
+  /// Does not modify the session.
+  void validate(std::string_view qualifiedName) const;
+
   /// Returns effective value (override or default) for a single
   /// property. Returns nullopt if no default and not set.
   std::optional<std::string> effectiveValue(
@@ -71,13 +80,6 @@ class SessionConfig {
   std::vector<Entry> all() const;
 
  private:
-  // Validates and normalizes 'value' for 'type'. Lowercases booleans,
-  // passes through integers, doubles, and strings. Throws on invalid values.
-  static std::string normalizeType(
-      std::string_view qualifiedName,
-      velox::config::ConfigPropertyType type,
-      std::string_view value);
-
   std::shared_ptr<const ConfigRegistry> registry_;
   folly::F14FastMap<std::string, std::string> overrides_;
 };

--- a/axiom/common/tests/SessionConfigTest.cpp
+++ b/axiom/common/tests/SessionConfigTest.cpp
@@ -161,6 +161,91 @@ TEST_F(SessionConfigTest, normalize) {
   EXPECT_EQ(config_->effectiveValue("test.label"), "hello");
 }
 
+TEST_F(SessionConfigTest, validateValueValid) {
+  // Valid values pass validation without throwing.
+  EXPECT_NO_THROW(config_->validate("test.flag_a", "false"));
+  EXPECT_NO_THROW(config_->validate("test.count", "42"));
+  EXPECT_NO_THROW(config_->validate("test.ratio", "1.5"));
+  EXPECT_NO_THROW(config_->validate("test.label", "anything"));
+
+  // validate() must not mutate the session: nothing is overridden and
+  // effective values stay at their defaults.
+  EXPECT_EQ(config_->effectiveValue("test.flag_a"), "true");
+  EXPECT_EQ(config_->effectiveValue("test.count"), "10");
+  EXPECT_FALSE(findEntry("flag_a").isOverridden);
+  EXPECT_FALSE(findEntry("count").isOverridden);
+}
+
+TEST_F(SessionConfigTest, validateValueTypeErrors) {
+  // Same type validation as set(), but without mutating state.
+  VELOX_ASSERT_THROW(
+      config_->validate("test.flag_a", "banana"), "Expected boolean value");
+  VELOX_ASSERT_THROW(
+      config_->validate("test.count", "abc"), "Expected integer value");
+  VELOX_ASSERT_THROW(
+      config_->validate("test.ratio", "xyz"), "Expected double value");
+
+  // A failed validation leaves the session unchanged.
+  EXPECT_FALSE(findEntry("flag_a").isOverridden);
+  EXPECT_FALSE(findEntry("count").isOverridden);
+  EXPECT_FALSE(findEntry("ratio").isOverridden);
+}
+
+TEST_F(SessionConfigTest, validateValueUnknownProperty) {
+  VELOX_ASSERT_THROW(
+      config_->validate("test.nonexistent", "1"), "Unknown session property");
+  VELOX_ASSERT_THROW(
+      config_->validate("unknown.flag", "true"),
+      "Unknown session property prefix");
+  VELOX_ASSERT_THROW(
+      config_->validate("noDotPrefix", "x"),
+      "Session property must be prefix-qualified");
+}
+
+TEST_F(SessionConfigTest, validateName) {
+  // Known properties validate without throwing and do not mutate state.
+  EXPECT_NO_THROW(config_->validate("test.flag_a"));
+  EXPECT_NO_THROW(config_->validate("test.label"));
+  EXPECT_FALSE(findEntry("flag_a").isOverridden);
+
+  // Unknown name/prefix/unqualified all throw, mirroring resolve().
+  VELOX_ASSERT_THROW(
+      config_->validate("test.nonexistent"), "Unknown session property");
+  VELOX_ASSERT_THROW(
+      config_->validate("unknown.flag"), "Unknown session property prefix");
+  VELOX_ASSERT_THROW(
+      config_->validate("noDotPrefix"),
+      "Session property must be prefix-qualified");
+}
+
+TEST_F(SessionConfigTest, validateUsesProviderNormalization) {
+  // Provider normalization runs during validation (label is lowercased
+  // internally) but the result is discarded — the session is not modified.
+  EXPECT_NO_THROW(config_->validate("test.label", "Hello"));
+  EXPECT_EQ(config_->effectiveValue("test.label"), std::nullopt);
+  EXPECT_FALSE(findEntry("label").isOverridden);
+}
+
+TEST_F(SessionConfigTest, validateDoesNotAffectSetAndReset) {
+  // Interleaving validate() with set()/reset() does not change their behavior.
+  config_->validate("test.count", "42");
+  EXPECT_EQ(config_->effectiveValue("test.count"), "10"); // still default
+
+  EXPECT_TRUE(config_->set("test.count", "42"));
+  EXPECT_EQ(config_->effectiveValue("test.count"), "42");
+
+  // Validation (valid or invalid) does not disturb an existing override.
+  config_->validate("test.count", "7");
+  VELOX_ASSERT_THROW(
+      config_->validate("test.count", "abc"), "Expected integer value");
+  EXPECT_EQ(config_->effectiveValue("test.count"), "42");
+  EXPECT_TRUE(findEntry("count").isOverridden);
+
+  EXPECT_TRUE(config_->reset("test.count"));
+  EXPECT_EQ(config_->effectiveValue("test.count"), "10");
+  EXPECT_FALSE(config_->reset("test.count"));
+}
+
 TEST_F(SessionConfigTest, duplicatePrefix) {
   auto registry = std::make_shared<ConfigRegistry>();
   registry->add("test", std::make_shared<TestConfigProvider>());


### PR DESCRIPTION
Summary:
To allow property validation when storing SessionConfig as a const.
This is useful for server environment where session properties are passed from
the client and are immutable.

Differential Revision: D107816639


