### PR TITLE
fix: Preserve bucketed distribution across equi-join projection so chained co-bucketed joins fuse (#1460)

### DIFF
--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -23,44 +23,6 @@
 namespace facebook::axiom::optimizer {
 
 template <typename T, typename U>
-bool isSubset(const T& subset, const U& superset) {
-  for (auto item : subset) {
-    if (std::find(superset.begin(), superset.end(), item) == superset.end()) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Returns how many leading members of 'ordered' are covered by 'set'
-template <typename Ordered, typename Set>
-uint32_t prefixSize(Ordered ordered, Set set) {
-  for (auto i = 0; i < ordered.size(); ++i) {
-    if (std::find(set.begin(), set.end(), ordered[i]) == set.end()) {
-      return i;
-    }
-  }
-  return ordered.size();
-}
-
-// Replaces each element of 'set' that matches an element of 'originals' with
-// the corresponding element of 'replaceWith'. Returns true if all elements were
-// replaced.
-template <typename Set, typename Old, typename New>
-bool replace(Set& set, Old& originals, New replaceWith) {
-  bool allReplaced = true;
-  for (auto& element : set) {
-    auto it = std::find(originals.begin(), originals.end(), element);
-    if (it == originals.end()) {
-      allReplaced = false;
-      continue;
-    }
-    element = replaceWith[it - originals.begin()];
-  }
-  return allReplaced;
-}
-
-template <typename T, typename U>
 void appendToVector(T& destination, U& source) {
   for (auto i : source) {
     destination.push_back(i);

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -195,36 +195,13 @@ Distribution TableScan::outputDistribution(
     const BaseTable* baseTable,
     ColumnGroupCP index,
     const ColumnVector& columns) {
-  auto schemaColumns = transform<ColumnVector>(
+  // Re-express the index's distribution over the scan's output columns. At scan
+  // time no equivalence classes exist, so rename matches schema columns to
+  // output columns by identity.
+  auto schemaColumns = transform<ExprVector>(
       columns, [](auto& column) { return column->schemaColumn(); });
 
-  const auto& distribution = index->distribution;
-
-  ExprVector partitionKeys;
-  ExprVector orderKeys;
-  OrderTypeVector orderTypes;
-  // if all partitioning columns are projected, the output is partitioned.
-  if (isSubset(distribution.partitionKeys(), schemaColumns)) {
-    partitionKeys = distribution.partitionKeys();
-    replace(partitionKeys, schemaColumns, columns.data());
-  }
-
-  auto numPrefix = prefixSize(distribution.orderKeys(), schemaColumns);
-  if (numPrefix > 0) {
-    orderKeys = distribution.orderKeys();
-    orderKeys.resize(numPrefix);
-    orderTypes = distribution.orderTypes();
-    orderTypes.resize(numPrefix);
-    replace(orderKeys, schemaColumns, columns.data());
-  }
-
-  return Distribution(
-      distribution.partitionType(),
-      std::move(partitionKeys),
-      std::move(orderKeys),
-      std::move(orderTypes),
-      distribution.numKeysUnique() <= numPrefix ? distribution.numKeysUnique()
-                                                : 0);
+  return index->distribution.rename(schemaColumns, columns);
 }
 
 std::string Cost::toString(bool /*detail*/, bool isUnit) const {

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -421,42 +421,70 @@ bool Distribution::isSameOrder(const Distribution& other) const {
   return true;
 }
 
+namespace {
+
+// Returns the lowest index 'i' such that 'key' is sameOrEqual to 'exprs[i]', or
+// nullopt if none.
+std::optional<size_t> findEquivalentIndex(ExprCP key, const ExprVector& exprs) {
+  for (size_t i = 0; i < exprs.size(); ++i) {
+    if (key->sameOrEqual(*exprs[i])) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
 Distribution Distribution::rename(
     const ExprVector& exprs,
     const ColumnVector& names) const {
-  // Broadcast and arbitrary describe the kind of exchange a Repartition emits
-  // and are not inherited by downstream operators (rename produces a
-  // Distribution for a non-Repartition consumer).
+  VELOX_DCHECK_EQ(exprs.size(), names.size());
+
+  // Broadcast and arbitrary are exchange kinds, not properties a downstream
+  // consumer inherits.
   if (isBroadcast() || isArbitrary()) {
     return Distribution{};
   }
 
-  // Partitioning survives projection if all partitioning columns are projected
-  // out.
-  ExprVector partitionKeys = partitionKeys_;
-  if (!replace(partitionKeys, exprs, names)) {
-    partitionKeys.clear();
+  // Each key is remapped onto any output column it is value-equal to, not only
+  // the identical column. This is safe because column equivalences come only
+  // from inner-join equalities (see Column::equals): an equi-equal column holds
+  // the same value on every row, so the distribution property is preserved.
+  ExprVector partitionKeys;
+  partitionKeys.reserve(partitionKeys_.size());
+  for (const auto& key : partitionKeys_) {
+    auto index = findEquivalentIndex(key, exprs);
+    if (!index.has_value()) {
+      partitionKeys.clear();
+      break;
+    }
+    partitionKeys.push_back(names[*index]);
   }
 
-  // Ordering survives if a prefix of the previous order continues to be
-  // projected out.
-  ExprVector orderKeys = orderKeys_;
-  OrderTypeVector orderTypes = orderTypes_;
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  for (size_t i = 0; i < orderKeys_.size(); ++i) {
+    auto index = findEquivalentIndex(orderKeys_[i], exprs);
+    if (!index.has_value()) {
+      break;
+    }
+    orderKeys.push_back(names[*index]);
+    orderTypes.push_back(orderTypes_[i]);
+  }
 
-  const auto newOrderSize = prefixSize(orderKeys_, exprs);
-  orderKeys.resize(newOrderSize);
-  orderTypes.resize(newOrderSize);
-  replace(orderKeys, exprs, names);
-  VELOX_DCHECK_EQ(orderKeys.size(), orderTypes.size());
-
-  // Clustering survives for any cluster keys that continue to be projected out.
   ExprVector clusterKeys;
+  clusterKeys.reserve(clusterKeys_.size());
   for (const auto& key : clusterKeys_) {
-    auto it = std::find(exprs.begin(), exprs.end(), key);
-    if (it != exprs.end()) {
-      clusterKeys.push_back(names[it - exprs.begin()]);
+    auto index = findEquivalentIndex(key, exprs);
+    if (index.has_value()) {
+      clusterKeys.push_back(names[*index]);
     }
   }
+
+  const auto numKeysUnique =
+      orderKeys.size() >= static_cast<size_t>(numKeysUnique_) ? numKeysUnique_
+                                                              : 0;
 
   return Distribution(
       kind_,
@@ -464,7 +492,7 @@ Distribution Distribution::rename(
       std::move(partitionKeys),
       std::move(orderKeys),
       std::move(orderTypes),
-      numKeysUnique_,
+      numKeysUnique,
       std::move(clusterKeys));
 }
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -273,6 +273,14 @@ struct Distribution {
     return clusterKeys_;
   }
 
+  /// Re-expresses this distribution's keys over a projection's output. 'exprs'
+  /// and 'names' are parallel arrays: a key matching 'exprs[i]' (by
+  /// sameOrEqual, value-equivalence) is re-pointed to 'names[i]'. Per property:
+  ///   - partition keys survive all-or-nothing,
+  ///   - order keys survive as the leading prefix with a surviving equivalent,
+  ///   - cluster keys survive individually.
+  /// numKeysUnique carries through only if the whole unique order prefix
+  /// survives, else resets to 0.
   Distribution rename(const ExprVector& exprs, const ColumnVector& names) const;
 
   std::string toString() const;

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -598,6 +598,85 @@ TEST_F(BucketedExecutionTest, threeWayCoBucketed) {
   EXPECT_TRUE(found);
 }
 
+// A chain of inner joins on a shared bucket key fuses into one bucketed
+// fragment: all three scans local, no remote hash exchange.
+TEST_F(BucketedExecutionTest, innerJoinChainFuses) {
+  addBucketedTable("t", {"k"}, 16, ROW({"k"}, BIGINT()));
+  addBucketedTable("u", {"k"}, 16, ROW({"k"}, BIGINT()));
+  addBucketedTable("v", {"k"}, 16, ROW({"k"}, BIGINT()));
+
+  // Both syntactic and reordered join orderings fuse into one bucketed
+  // fragment.
+  const std::string sql =
+      "SELECT t.k FROM t, "
+      "(SELECT v.k FROM u, v WHERE u.k = v.k) sub "
+      "WHERE t.k = sub.k";
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
+      matchScan("t")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+                  .build(),
+              core::JoinType::kInner)
+          .bucketed()
+          .bucketedScans(3)
+          .fragmentWidth(4)
+          .gather()
+          .build());
+
+  optimizerOptions_.syntacticJoinOrder = false;
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
+      matchScan("u")
+          .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+          .bucketed()
+          .bucketedScans(3)
+          .fragmentWidth(4)
+          .gather()
+          .build());
+}
+
+// Same shape with a LEFT join: no equivalence forms, so the chain stays split
+// with a remote hash exchange. Regression guard for if outer joins ever start
+// forming equivalences.
+TEST_F(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
+  addBucketedTable("t", {"k"}, 16, ROW({"k"}, BIGINT()));
+  addBucketedTable("u", {"k"}, 16, ROW({"k"}, BIGINT()));
+  addBucketedTable("v", {"k"}, 16, ROW({"k"}, BIGINT()));
+
+  const std::string sql =
+      "SELECT t.k FROM t, "
+      "(SELECT v.k FROM u LEFT JOIN v ON u.k = v.k) sub "
+      "WHERE t.k = sub.k";
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
+      matchScan("t")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+                  .shuffle()
+                  .build(),
+              core::JoinType::kInner)
+          .gather()
+          .build());
+
+  optimizerOptions_.syntacticJoinOrder = false;
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
+      matchScan("u")
+          .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+          .shuffle()
+          .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+          .gather()
+          .build());
+}
+
 TEST_F(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
   addBucketedTable("ab_orders", {"customer_id"}, 16);
   addBucketedTable(


### PR DESCRIPTION
Summary:

A chain of co-bucketed joins (all inputs bucketed on the same key) should run in one grouped fragment with local exchanges, but Axiom split the chain at an intermediate join and inserted a remote PartitionedOutput -> Exchange, re-shuffling the whole build subtree over the network.

Example - t, u, v all bucketed on the join key:

  SELECT t.k
  FROM t
  JOIN (SELECT v.k FROM u JOIN v ON u.k = v.k) sub
  ON t.k = sub.k

The inner join (u JOIN v) keeps only its build-side copy of the key (sub.k, from v).

Root cause: when a join's output is projected to keep only the build-side copy of the join key, Distribution::rename dropped the inherited partition key. It matched keys to surviving columns by identity; the inherited key lived on the inner probe side and was projected away, while only its equi-equal twin survived, so all partition keys were cleared and the distribution lost its bucketing. isCopartitionedWith then bails on empty keys, so the outer co-bucketed join fell back to a remote hash repartition.

Fix: in Distribution::rename, match keys by sameOrEqual (equivalence-aware) instead of identity, so partitioning, ordering and clustering survive on the equi-equal surviving column (numKeysUnique resets only when the unique order prefix is truncated). The same equivalence-aware rename now also backs scan-time output distribution, replacing the identity-based key helpers. Equivalences are formed only from inner-join equalities, so outer joins are unaffected.

Reviewed By: mbasmanova

Differential Revision: D107785074
