### PR TITLE
feat(optimizer): Support DISTINCT aggregation with GROUPING SETS (#1461)

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -530,6 +530,36 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
     QGVector<int32_t> globalGroupingSets,
     ColumnCP groupId,
     PlanState& state) const {
+  const bool requiresSingleStep =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto* agg) {
+        return agg->isDistinct() || !agg->orderKeys().empty();
+      });
+
+  if (!globalGroupingSets.empty()) {
+    return makeSplitAggregationPlan(
+        plan,
+        groupingKeys,
+        aggregates,
+        intermediateColumns,
+        outputColumns,
+        std::move(globalGroupingSets),
+        groupId,
+        state);
+  }
+
+  if (requiresSingleStep) {
+    return makeSingleAggregationPlan(
+        plan,
+        groupingKeys,
+        aggregates,
+        intermediateColumns,
+        outputColumns,
+        /*globalGroupingSets=*/{},
+        groupId,
+        state);
+  }
+
+  // Otherwise pick the cheaper of split and single-step plans by cost.
   // Both alternatives may insert Repartitions via maybeRepartition, which
   // mutates state.currentGroupedLeaves_ via commitGroupedLeavesForRepartition.
   // Snapshot+restore around each alternative so the second one starts from
@@ -570,6 +600,44 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
   return {std::move(splitAggPlan), splitAggCost};
 }
 
+std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeDistinctAggregation(
+    RelationOpPtr plan,
+    const ExprVector& groupingKeys,
+    const AggregateVector& aggregates,
+    AggregationPlanCP aggPlan,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId,
+    PlanState& state) const {
+  // When a groupId column is supplied, the caller must have already added it to
+  // groupingKeys.
+  VELOX_DCHECK(
+      groupId == nullptr ||
+          std::find(groupingKeys.begin(), groupingKeys.end(), groupId) !=
+              groupingKeys.end(),
+      "groupId must be one of the groupingKeys when present");
+
+  if (auto distinctArgs = getCommonDistinctArgs(aggregates)) {
+    return makeDistinctToGroupByPlan(
+        std::move(plan),
+        groupingKeys,
+        *distinctArgs,
+        aggregates,
+        aggPlan,
+        std::move(globalGroupingSets),
+        groupId,
+        state);
+  }
+
+  return makeDistinctToMarkDistinctPlan(
+      std::move(plan),
+      groupingKeys,
+      aggregates,
+      aggPlan,
+      std::move(globalGroupingSets),
+      groupId,
+      state);
+}
+
 std::pair<RelationOpPtr, PlanCost>
 AggregationPlanner::makeDistinctToGroupByPlan(
     RelationOpPtr plan,
@@ -577,7 +645,8 @@ AggregationPlanner::makeDistinctToGroupByPlan(
     const ExprVector& distinctArgs,
     const AggregateVector& aggregates,
     AggregationPlanCP aggPlan,
-    bool hasOrderBy,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId,
     PlanState& state) const {
   // Build inner GROUP BY keys: groupingKeys union distinctArgs. We put
   // groupingKeys at the beginning, followed by distinctArgs not appearing in
@@ -601,46 +670,36 @@ AggregationPlanner::makeDistinctToGroupByPlan(
   }
 
   PlanCost totalCost;
+  // Inner level deduplication only, so it does not apply grouping-set behavior;
+  // the groupId column (already in groupingKeys) acts as a plain grouping key.
   auto [innerAgg, innerAggCost] = makeSplitOrSingleAggregationPlan(
       plan,
       innerKeys,
       AggregateVector{},
       innerColumns,
       innerColumns,
-      {},
-      nullptr,
+      /*globalGroupingSets=*/{},
+      /*groupId=*/nullptr,
       state);
   totalCost.add(innerAggCost);
   plan = std::move(innerAgg);
 
-  // Make non-distinct aggregation calls for the outer level.
+  // Make non-distinct aggregation calls for the outer level. The outer
+  // aggregation is the result-producing node, so it carries grouping-set
+  // semantics.
   auto nonDistinctAggregates = dropDistinctFromAggregates(aggregates);
 
-  if (hasOrderBy) {
-    auto [outerPlan, outerCost] = makeSingleAggregationPlan(
-        plan,
-        groupingKeys,
-        nonDistinctAggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
-        {},
-        nullptr,
-        state);
-    plan = std::move(outerPlan);
-    totalCost.add(outerCost);
-  } else {
-    auto [outerPlan, outerCost] = makeSplitOrSingleAggregationPlan(
-        plan,
-        groupingKeys,
-        nonDistinctAggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
-        {},
-        nullptr,
-        state);
-    plan = std::move(outerPlan);
-    totalCost.add(outerCost);
-  }
+  auto [outerPlan, outerCost] = makeSplitOrSingleAggregationPlan(
+      plan,
+      groupingKeys,
+      nonDistinctAggregates,
+      aggPlan->intermediateColumns(),
+      aggPlan->columns(),
+      std::move(globalGroupingSets),
+      groupId,
+      state);
+  plan = std::move(outerPlan);
+  totalCost.add(outerCost);
 
   return {plan, totalCost};
 }
@@ -651,7 +710,8 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     AggregationPlanCP aggPlan,
-    bool hasOrderBy,
+    QGVector<int32_t> globalGroupingSets,
+    ColumnCP groupId,
     PlanState& state) const {
   auto [markedPlan, newAggregates, markCost] = addMarkDistinctNodes(
       std::move(plan), groupingKeys, aggregates, isSingleWorker_, state);
@@ -659,38 +719,17 @@ AggregationPlanner::makeDistinctToMarkDistinctPlan(
   PlanCost totalCost;
   totalCost.add(markCost);
 
-  // Use single-step aggregation if any aggregate has ORDER BY or if any
-  // aggregate still has isDistinct. Partial aggregation does not support
-  // DISTINCT or ORDER BY.
-  const auto hasRemainingDistinct = std::any_of(
-      newAggregates.begin(), newAggregates.end(), [](const auto* agg) {
-        return agg->isDistinct();
-      });
-  if (hasOrderBy || hasRemainingDistinct) {
-    const auto& [aggregation, aggCost] = makeSingleAggregationPlan(
-        markedPlan,
-        groupingKeys,
-        newAggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
-        {},
-        nullptr,
-        state);
-    totalCost.add(aggCost);
-    return {aggregation, totalCost};
-  }
-
-  const auto& [aggregation, aggCost] = makeSplitOrSingleAggregationPlan(
+  auto [aggregation, aggCost] = makeSplitOrSingleAggregationPlan(
       markedPlan,
       groupingKeys,
       newAggregates,
       aggPlan->intermediateColumns(),
       aggPlan->columns(),
-      {},
-      nullptr,
+      std::move(globalGroupingSets),
+      groupId,
       state);
   totalCost.add(aggCost);
-  return {aggregation, totalCost};
+  return {std::move(aggregation), totalCost};
 }
 
 AggregationPlanner::AggregationPlanner(
@@ -726,9 +765,12 @@ void AggregationPlanner::addGroupingSetsAggregation(
     RelationOpPtr& plan,
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
-    PlanState& state,
-    bool useSingleStep,
-    bool hasOrderBy) const {
+    PlanState& state) const {
+  const auto hasOrderBy =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
+        return !agg->orderKeys().empty();
+      });
+
   auto* groupIdNode = makeGroupIdNode(plan, aggPlan, groupingKeys, aggregates);
   state.addCost(*groupIdNode);
   plan = groupIdNode;
@@ -758,7 +800,7 @@ void AggregationPlanner::addGroupingSetsAggregation(
       !hasOrderBy || globalGroupingSets.empty(),
       "ORDER BY in aggregate functions is not supported with global grouping sets (ROLLUP, CUBE, or GROUPING SETS containing ())");
 
-  if (useSingleStep || hasOrderBy) {
+  if (isSingleWorker_ && isSingleDriver_) {
     auto [agg, cost] = makeSingleAggregationPlan(
         plan,
         aggGroupingKeys,
@@ -773,16 +815,16 @@ void AggregationPlanner::addGroupingSetsAggregation(
     return;
   }
 
-  // TODO: Remove forced split once Velox handles global grouping sets
-  // in kSingle without spurious default rows from empty partitions.
-  // https://github.com/facebookincubator/velox/issues/17312
-  if (alwaysPlanPartialAggregation_ || !globalGroupingSets.empty()) {
-    auto [agg, cost] = makeSplitAggregationPlan(
+  const auto hasDistinct =
+      std::any_of(aggregates.begin(), aggregates.end(), [](const auto* agg) {
+        return agg->isDistinct();
+      });
+  if (hasDistinct) {
+    auto [agg, cost] = makeDistinctAggregation(
         plan,
         aggGroupingKeys,
         aggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
+        aggPlan,
         std::move(globalGroupingSets),
         aggGroupId,
         state);
@@ -797,8 +839,8 @@ void AggregationPlanner::addGroupingSetsAggregation(
       aggregates,
       aggPlan->intermediateColumns(),
       aggPlan->columns(),
-      {},
-      nullptr,
+      std::move(globalGroupingSets),
+      aggGroupId,
       state);
   state.cost.add(cost);
   plan = std::move(agg);
@@ -829,8 +871,6 @@ void AggregationPlanner::plan(
   plan = std::move(precompute).maybeProject();
   state.place(aggPlan);
 
-  const bool useSingleStep = isSingleWorker_ && isSingleDriver_;
-
   // ORDER BY aggregates force single-step because partial aggregation cannot
   // preserve ORDER BY semantics.
   const auto hasOrderBy =
@@ -844,24 +884,12 @@ void AggregationPlanner::plan(
       });
 
   if (aggPlan->hasGroupingSets()) {
-    // TODO: Support DISTINCT aggregation with grouping sets. Requires
-    // integrating transformDistinctToGroupBy with GroupId.
-    VELOX_USER_CHECK(
-        !hasDistinct,
-        "DISTINCT aggregation with grouping sets is not supported yet");
-    addGroupingSetsAggregation(
-        aggPlan,
-        plan,
-        groupingKeys,
-        aggregates,
-        state,
-        useSingleStep,
-        hasOrderBy);
+    addGroupingSetsAggregation(aggPlan, plan, groupingKeys, aggregates, state);
     return;
   }
 
   auto preGroupedKeys = computePreGroupedKeys(*plan, groupingKeys);
-  if (useSingleStep || !preGroupedKeys.empty()) {
+  if ((isSingleWorker_ && isSingleDriver_) || !preGroupedKeys.empty()) {
     auto* singleAgg = make<Aggregation>(
         plan,
         std::move(groupingKeys),
@@ -889,42 +917,16 @@ void AggregationPlanner::plan(
   }
 
   if (hasDistinct) {
-    auto distinctArgs = getCommonDistinctArgs(aggregates);
-    if (distinctArgs.has_value()) {
-      auto [result, cost] = makeDistinctToGroupByPlan(
-          plan,
-          groupingKeys,
-          *distinctArgs,
-          aggregates,
-          aggPlan,
-          hasOrderBy,
-          state);
-      plan = std::move(result);
-      state.cost.add(cost);
-      return;
-    }
-
-    auto [result, cost] = makeDistinctToMarkDistinctPlan(
-        plan, groupingKeys, aggregates, aggPlan, hasOrderBy, state);
-    plan = std::move(result);
-    state.cost.add(cost);
-    return;
-  }
-
-  // Check if any aggregate has ORDER BY keys. If so, we must use single-step
-  // aggregation because partial aggregation cannot preserve global ordering.
-  if (hasOrderBy) {
-    const auto& [singleAgg, singleAggCost] = makeSingleAggregationPlan(
+    auto [result, cost] = makeDistinctAggregation(
         plan,
         groupingKeys,
         aggregates,
-        aggPlan->intermediateColumns(),
-        aggPlan->columns(),
-        {},
-        nullptr,
+        aggPlan,
+        /*globalGroupingSets=*/{},
+        /*groupId=*/nullptr,
         state);
-    plan = singleAgg;
-    state.cost.add(singleAggCost);
+    plan = std::move(result);
+    state.cost.add(cost);
     return;
   }
 
@@ -934,8 +936,8 @@ void AggregationPlanner::plan(
       aggregates,
       aggPlan->intermediateColumns(),
       aggPlan->columns(),
-      {},
-      nullptr,
+      /*globalGroupingSets=*/{},
+      /*groupId=*/nullptr,
       state);
   plan = selectedPlan;
   state.cost.add(selectedCost);

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -95,13 +95,33 @@ class AggregationPlanner {
       ColumnCP groupId,
       PlanState& state) const;
 
-  // Chooses between split and single aggregation plans based on cost.
+  // Builds the distributed aggregation, choosing split (partial + final) and
+  // single-step plans based on the shape of 'aggregates' and the cost.
+  //   1. If 'globalGroupingSets' is non-empty, generates split plan.
+  //   2. If any of 'aggregates' has ORDER BY or is DISTINCT, generates
+  //   single-step plan.
+  //   3. Otherwise compare split and single by cost.
+  // For non-grouping-sets aggregation, set 'globalGroupingSets' and 'groupId'
+  // to {} and nullptr.
   std::pair<RelationOpPtr, PlanCost> makeSplitOrSingleAggregationPlan(
       const RelationOpPtr& plan,
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       const ColumnVector& intermediateColumns,
       const ColumnVector& outputColumns,
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
+      PlanState& state) const;
+
+  // Returns a plan for distinct aggregations with its cost. Distinct
+  // aggregations are handled through Distinct-to-GroupBy or
+  // Distinct-to-MarkDistinct transformations. For non-grouping-sets
+  // aggregation, set 'globalGroupingSets' and 'groupId' to {} and nullptr.
+  std::pair<RelationOpPtr, PlanCost> makeDistinctAggregation(
+      RelationOpPtr plan,
+      const ExprVector& groupingKeys,
+      const AggregateVector& aggregates,
+      AggregationPlanCP aggPlan,
       QGVector<int32_t> globalGroupingSets,
       ColumnCP groupId,
       PlanState& state) const;
@@ -114,7 +134,8 @@ class AggregationPlanner {
       const ExprVector& distinctArgs,
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan,
-      bool hasOrderBy,
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
       PlanState& state) const;
 
   // Transforms distinct aggregations into a plan with MarkDistinct and
@@ -124,7 +145,8 @@ class AggregationPlanner {
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
       AggregationPlanCP aggPlan,
-      bool hasOrderBy,
+      QGVector<int32_t> globalGroupingSets,
+      ColumnCP groupId,
       PlanState& state) const;
 
   // Handles aggregation with grouping sets (ROLLUP, CUBE, GROUPING SETS).
@@ -134,9 +156,7 @@ class AggregationPlanner {
       RelationOpPtr& plan,
       const ExprVector& groupingKeys,
       const AggregateVector& aggregates,
-      PlanState& state,
-      bool useSingleStep,
-      bool hasOrderBy) const;
+      PlanState& state) const;
 
   bool isSingleWorker_;
   bool isSingleDriver_;

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -533,24 +533,6 @@ TEST_F(AggregationTest, groupingSetsOrderByWithGlobalSet) {
       "ORDER BY in aggregate functions is not supported with global grouping sets");
 }
 
-TEST_F(AggregationTest, groupingSetsDistinctAggregation) {
-  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
-  SCOPE_EXIT {
-    testConnector_->dropTableIfExists("t");
-  };
-
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("t")
-                         .rollup({"a"}, {"count(DISTINCT b)"}, "gid")
-                         .build();
-
-  VELOX_ASSERT_THROW(
-      planVelox(
-          logicalPlan,
-          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
-      "DISTINCT aggregation with grouping sets is not supported yet");
-}
-
 // Literal-only aggregate args (count(1)) — aggregation inputs list passed to
 // GroupId should be empty since literals are not column references.
 TEST_F(AggregationTest, groupingSetsLiteralArgs) {

--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -1108,5 +1108,140 @@ TEST_F(
   }
 }
 
+TEST_F(DistinctAggregationTest, groupingSetsDistinctToGroupBy) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .rollup({"a"}, {"count(DISTINCT b) as cnt"}, "gid")
+                         .build();
+
+  // Distributed plan. ROLLUP(a) contains the global set (), so the outer
+  // aggregation is forced split (partial + final).
+  {
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .groupId({{"a"}, {}}, {"b"}, "gid")
+            .distributedAggregation({"a", "gid", "b"}, {})
+            .distributedAggregation({"a", "gid"}, {"count(b) as cnt"})
+            .project({"a", "cnt", "gid"})
+            .gather()
+            .build());
+  }
+
+  // Single-node plan: a single aggregation computes DISTINCT natively.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchScan("t")
+            .groupId({{"a"}, {}}, {"b"}, "gid")
+            .singleAggregation({"a", "gid"}, {"count(DISTINCT b) as cnt"})
+            .project({"a", "cnt", "gid"})
+            .build());
+  }
+}
+
+TEST_F(DistinctAggregationTest, groupingSetsDistinctToMarkDistinct) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .rollup(
+              {"a"},
+              {"count(DISTINCT b) as a0", "sum(DISTINCT c) as a1"},
+              "gid")
+          .build();
+
+  // Distributed plan.
+  {
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .groupId({{"a"}, {}}, {"b", "c"}, "gid")
+            .distributedMarkDistinct({"a", "gid", "b"}, {"m0"})
+            .distributedMarkDistinct({"a", "gid", "c"}, {"m1"})
+            .distributedAggregation(
+                {"a", "gid"},
+                {"count(b) filter (where m0) as a0",
+                 "sum(c) filter (where m1) as a1"})
+            .project({"a", "a0", "a1", "gid"})
+            .gather()
+            .build());
+  }
+
+  // Single-node plan: one kSingle Aggregation computes the DISTINCT aggregates
+  // natively.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchScan("t")
+            .groupId({{"a"}, {}}, {"b", "c"}, "gid")
+            .singleAggregation(
+                {"a", "gid"},
+                {"count(DISTINCT b) as a0", "sum(DISTINCT c) as a1"})
+            .project({"a", "a0", "a1", "gid"})
+            .build());
+  }
+}
+
+// DISTINCT aggregate combined with ORDER BY and grouping sets without a global
+// set. ORDER BY forces the result-producing aggregation to single-step.
+TEST_F(DistinctAggregationTest, groupingSetsDistinctWithOrderBy) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .aggregate(
+              {{"a"}, {"b"}}, {"array_agg(DISTINCT c ORDER BY c) as a0"}, "gid")
+          .build();
+
+  // Distributed plan.
+  {
+    auto plan = planVelox(logicalPlan, runnerOptions_, optimizerOptions_);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("t")
+            .groupId({{"a"}, {"b"}}, {"c"}, "gid")
+            .distributedAggregation({"a", "b", "gid", "c"}, {})
+            .shuffle()
+            .localPartition()
+            .singleAggregation(
+                {"a", "b", "gid"}, {"array_agg(c ORDER BY c) as a0"})
+            .project({"a", "b", "a0", "gid"})
+            .gather()
+            .build());
+  }
+
+  // Single-node plan: one kSingle Aggregation computes DISTINCT + ORDER BY
+  // natively.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchScan("t")
+            .groupId({{"a"}, {"b"}}, {"c"}, "gid")
+            .singleAggregation(
+                {"a", "b", "gid"}, {"array_agg(DISTINCT c ORDER BY c) as a0"})
+            .project({"a", "b", "a0", "gid"})
+            .build());
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/distinctAggregation.sql
+++ b/axiom/optimizer/tests/sql/distinctAggregation.sql
@@ -119,3 +119,15 @@ SELECT count(DISTINCT c), count(DISTINCT 1) FROM t
 ----
 -- DISTINCT: the first MarkDistinct key is a subset of the second, hence no shuffle between multiple MarkDistincts.
 SELECT a, count(DISTINCT b), covar_pop(DISTINCT b, c) FROM t GROUP BY a
+----
+-- DISTINCT: single argument set with ROLLUP.
+SELECT b, count(DISTINCT a) FROM t GROUP BY ROLLUP(b)
+----
+-- DISTINCT: multiple argument sets with ROLLUP.
+SELECT a, count(DISTINCT b), count(DISTINCT c) FROM t GROUP BY ROLLUP(a)
+----
+-- DISTINCT: GROUPING SETS without a global set.
+SELECT a, b, count(DISTINCT c) FROM t GROUP BY GROUPING SETS ((a), (b))
+----
+-- DISTINCT: ORDER BY with GROUPING SETS, without a global set.
+SELECT a, b, array_agg(DISTINCT c ORDER BY c) FROM t GROUP BY GROUPING SETS ((a), (b))

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -115,9 +115,6 @@ SELECT a, GROUPING(a) AS grp, sum(b) AS s FROM t GROUP BY ROLLUP(a) HAVING grp =
 -- error: Not a grouping column
 SELECT a, GROUPING(b), count(*) AS c FROM t GROUP BY ROLLUP(a)
 ----
--- error: DISTINCT aggregation with grouping sets is not supported yet
-SELECT b, count(DISTINCT a) AS c FROM t GROUP BY ROLLUP(b)
-----
 -- error: ORDER BY in aggregate functions is not supported with global grouping sets
 SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)
 ----


### PR DESCRIPTION
Summary:

Previously, the Axiom optimizer rejected any DISTINCT aggregation combined with grouping sets, throwing an UNSUPPORTED error. DISTINCT was only handled for plain GROUP BY, via paths that didn't account for the GroupId node grouping sets introduce.

This diff removes that restriction by treating the GroupId gid column as an ordinary grouping key. Since GroupId distinguishes per-set row copies only by gid, deduplicating on [grouping keys…, gid, distinct args] after the GroupId node gives correct per-set DISTINCT, reusing the existing DistinctToGroupBy and DistinctToMarkDistinct transformations.

E.g.,
```
SELECT a, count(DISTINCT b) FROM t GROUP BY ROLLUP(a)
```
becomes
```
Scan(t)
  → GroupId(groupingSets=[[a], []], aggInputs=[b], gid)
  → MarkDistinct(keys=[a, gid, b], markers=[m0])
  → Aggregation(group=[a, gid], aggs=[count(b) FILTER (WHERE m0)], gid)
```

Remaining gap: in distributed execution, global grouping sets combined with an aggregate requiring single-step (ORDER BY or residual DISTINCT) is still unsupported and now throws VELOX_UNSUPPORTED and will be fixed in another PR.

Reviewed By: mbasmanova

Differential Revision: D107475273


