### PR TITLE
fix: Populate failure_message_template for fb_axiom CLI failures

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -17,6 +17,7 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <cmath>
+#include "velox/common/base/VeloxException.h"
 #include "velox/common/process/ProcessBase.h"
 
 #include "axiom/cli/QueryIdGenerator.h"
@@ -37,6 +38,7 @@
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
+#include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
@@ -428,6 +430,24 @@ std::string SqlQueryRunner::dropSchema(
   return fmt::format("Dropped schema: {}", statement.schemaName());
 }
 
+std::string messageTemplateOf(const std::exception& e) {
+  if (const auto* veloxError = dynamic_cast<const velox::VeloxException*>(&e)) {
+    // An empty template means no explicit format string (e.g. messageless
+    // VELOX_CHECK); key it by the failing expression so these still group.
+    if (veloxError->messageTemplate().empty()) {
+      const auto& expression = veloxError->failingExpression();
+      return expression.empty() ? ""
+                                : fmt::format("Check failed: {}", expression);
+    }
+    return std::string(veloxError->messageTemplate());
+  }
+  if (const auto* prestoError =
+          dynamic_cast<const presto::PrestoSqlError*>(&e)) {
+    return std::string(prestoError->messageTemplate());
+  }
+  return "";
+}
+
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
     std::string_view sql,
     const RunOptions& options) {
@@ -502,7 +522,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     finalize();
     return result;
   } catch (const std::exception& e) {
-    completionInfo.errorInfo = ErrorInfo{e.what()};
+    completionInfo.errorInfo =
+        ErrorInfo{.message = e.what(), .messageTemplate = messageTemplateOf(e)};
     finalize();
     throw;
   }

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -17,6 +17,7 @@
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <chrono>
+#include <exception>
 #include <functional>
 #include "axiom/common/ConfigRegistry.h"
 #include "axiom/common/QueryRuntimeStats.h"
@@ -66,7 +67,20 @@ struct QueryStartInfo {
 struct ErrorInfo {
   /// Human-readable error message from the caught exception.
   std::string message;
+
+  /// Template with placeholders (e.g. "Cannot resolve type {}") for grouping
+  /// similar failures.
+  std::string messageTemplate;
 };
+
+/// Returns a format template (placeholders, not substituted values) for
+/// grouping similar failures. A VeloxException with no explicit template
+/// synthesizes "Check failed: <expr>" from its failing expression (mirroring
+/// QueryError::create); a PrestoSqlError or other exception without a template
+/// yields empty, and the caller omits the field. Caveat: VELOX_FAIL with a
+/// literal message returns that message, because VeloxException cannot
+/// distinguish a literal from a format string; matches AxelQueryLogger.
+std::string messageTemplateOf(const std::exception& e);
 
 /// Per-phase wall-clock timing in microseconds, ordered by lifecycle stage.
 struct QueryTiming {

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -21,11 +21,14 @@
 #include <folly/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdexcept>
 #include <thread>
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
+#include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -990,6 +993,79 @@ TEST_F(SqlQueryRunnerTest, completionCallbackOnError) {
 
   EXPECT_TRUE(captured.errorInfo.has_value());
   EXPECT_FALSE(captured.errorInfo->message.empty());
+}
+
+// Captures the parameterized template, distinct from the substituted message,
+// so similar failures can be grouped.
+TEST_F(SqlQueryRunnerTest, completionCapturesFailureMessageTemplate) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM nonexistent_table",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  ASSERT_TRUE(captured.errorInfo.has_value());
+  EXPECT_EQ(captured.errorInfo->messageTemplate, "Table not found: {}");
+  EXPECT_NE(captured.errorInfo->messageTemplate, captured.errorInfo->message);
+}
+
+TEST(MessageTemplateOfTest, veloxExceptionUsesTemplate) {
+  try {
+    VELOX_USER_FAIL("Not supported: {}", "rank");
+    FAIL() << "expected VeloxUserError";
+  } catch (const VeloxException& e) {
+    EXPECT_EQ(messageTemplateOf(e), "Not supported: {}");
+  }
+}
+
+// A messageless VELOX_CHECK has no template; synthesize a groupable key from
+// its failing expression (mirroring QueryError::create) instead of logging
+// nothing.
+TEST(MessageTemplateOfTest, messagelessVeloxCheckSynthesizesFromExpression) {
+  try {
+    VELOX_CHECK(false);
+    FAIL() << "expected VeloxRuntimeError";
+  } catch (const VeloxException& e) {
+    EXPECT_EQ(messageTemplateOf(e), "Check failed: false");
+  }
+}
+
+// A VELOX_FAIL literal has no template (VeloxException returns the message), so
+// it logs as-is, matching AxelQueryLogger. Pinned so a fix doesn't diverge.
+TEST(MessageTemplateOfTest, veloxFailLiteralReturnsMessageMatchingAxel) {
+  try {
+    VELOX_FAIL("disk full");
+    FAIL() << "expected VeloxRuntimeError";
+  } catch (const VeloxException& e) {
+    EXPECT_EQ(messageTemplateOf(e), "disk full");
+  }
+}
+
+TEST(MessageTemplateOfTest, prestoSqlErrorUsesTemplate) {
+  const presto::PrestoSqlError error(
+      "Table not found: 'orders'",
+      1,
+      0,
+      std::nullopt,
+      presto::PrestoSqlErrorKind::kSemantic,
+      "Table not found: {}");
+  EXPECT_EQ(messageTemplateOf(error), "Table not found: {}");
+}
+
+// A PrestoSqlError without a template returns empty -- a substituted message is
+// not a groupable template, so the caller omits the field.
+TEST(MessageTemplateOfTest, prestoSqlErrorWithoutTemplateReturnsEmpty) {
+  const presto::PrestoSqlError error("some parser error", 1, 0, std::nullopt);
+  EXPECT_TRUE(messageTemplateOf(error).empty());
+}
+
+// Any other exception has no template; returns empty so the field is omitted.
+TEST(MessageTemplateOfTest, plainExceptionReturnsEmpty) {
+  const std::runtime_error error("connection reset");
+  EXPECT_TRUE(messageTemplateOf(error).empty());
 }
 
 TEST_F(SqlQueryRunnerTest, multiStatementTimingPerStatement) {


### PR DESCRIPTION
Summary:
fb_axiom CLI failures left failure_message_template empty (0 of 69M coordinator_type='AxiomCLI' rows in Scuba presto_queries): the CLI logged only e.what() from a bare std::exception, dropping the typed exception's messageTemplate() -- the parameterized form ("Cannot resolve type {}") that groups similar failures.

Add a messageTemplate field to ErrorInfo and a messageTemplateOf() helper, logged from CliQueryLogger. A VeloxException with no explicit template (e.g. a messageless VELOX_CHECK) synthesizes "Check failed: <failingExpression>", mirroring QueryError::create(); empty templates are omitted so only groupable failures populate the column.

VELOX_FAIL with a substituted literal logs that literal (VeloxException can't distinguish a literal from a format string), matching AxelQueryLogger -- a Velox accessor is a follow-up. The error_code/name/category columns stay hardcoded pending a separate classification diff and are independent of this one.

Example, SELECT * FROM nonexistent_table:
Before: failure_message_template empty. After: "Table not found: {}".

Differential Revision: D107916454


