### PR TITLE
feat(logical_plan): Add FixedPointNode and RecursiveReferenceNode to the logical plan IR (#1463)

### DIFF
--- a/axiom/graphviz/LogicalPlanDotPrinter.cpp
+++ b/axiom/graphviz/LogicalPlanDotPrinter.cpp
@@ -401,6 +401,17 @@ class DotPrinterVisitor : public PlanNodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const FixedPointNode& /*node*/, PlanNodeVisitorContext& /*ctx*/)
+      const override {
+    VELOX_NYI("FixedPointNode dot printing is not yet implemented");
+  }
+
+  void visit(
+      const RecursiveReferenceNode& /*node*/,
+      PlanNodeVisitorContext& /*ctx*/) const override {
+    VELOX_NYI("RecursiveReferenceNode dot printing is not yet implemented");
+  }
+
  private:
   static void printNodeStart(
       std::ostream& out,

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -36,6 +36,8 @@ const auto& nodeKindNames() {
       {NodeKind::kTableWrite, "TABLE_WRITE"},
       {NodeKind::kSample, "SAMPLE"},
       {NodeKind::kOutput, "OUTPUT"},
+      {NodeKind::kFixedPoint, "FIXED_POINT"},
+      {NodeKind::kRecursiveReference, "RECURSIVE_REFERENCE"},
   };
   return kNames;
 }
@@ -177,6 +179,8 @@ void LogicalPlanNode::registerSerDe() {
   registry.Register("TableWriteNode", TableWriteNode::create);
   registry.Register("SampleNode", SampleNode::create);
   registry.Register("OutputNode", OutputNode::create);
+  registry.Register("FixedPointNode", FixedPointNode::create);
+  registry.Register("RecursiveReferenceNode", RecursiveReferenceNode::create);
 }
 
 folly::dynamic ValuesNode::serialize() const {
@@ -1182,6 +1186,169 @@ LogicalPlanNodePtr OutputNode::create(
 
   return std::make_shared<OutputNode>(
       obj["id"].asString(), inputs[0], std::move(entries));
+}
+
+namespace {
+
+// Checks every RecursiveReferenceNode reachable from 'node': it must name
+// 'name' and carry 'stateSchema'. Sets *found if at least one matching
+// reference is seen. Does not descend into a nested FixedPointNode, whose
+// recursive references resolve against that inner loop.
+void checkRecursiveReferences(
+    const LogicalPlanNodePtr& node,
+    const std::string& name,
+    const velox::RowTypePtr& stateSchema,
+    bool* found) {
+  if (node == nullptr) {
+    return;
+  }
+  if (node->is(NodeKind::kRecursiveReference)) {
+    const auto* ref = node->as<RecursiveReferenceNode>();
+    VELOX_USER_CHECK_EQ(
+        ref->name(),
+        name,
+        "RecursiveReferenceNode names an unknown fixed-point state");
+    VELOX_USER_CHECK(
+        ref->outputType()->equivalent(*stateSchema),
+        "RecursiveReferenceNode schema does not match state '{}': {} vs. {}",
+        name,
+        ref->outputType()->toString(),
+        stateSchema->toString());
+    *found = true;
+    return;
+  }
+  if (node->is(NodeKind::kFixedPoint)) {
+    return;
+  }
+  for (const auto& input : node->inputs()) {
+    checkRecursiveReferences(input, name, stateSchema, found);
+  }
+}
+
+// Rejects any RecursiveReferenceNode reachable from 'node' that names
+// 'name'. Used on the anchor, which produces seed rows before any
+// iteration and so cannot reference its own enclosing FixedPointNode. Does
+// not descend into a nested FixedPointNode -- its refs resolve to that inner
+// loop's state.
+void rejectAnchorRecursiveReference(
+    const LogicalPlanNodePtr& node,
+    const std::string& name) {
+  if (node == nullptr) {
+    return;
+  }
+  if (node->is(NodeKind::kRecursiveReference)) {
+    const auto* ref = node->as<RecursiveReferenceNode>();
+    VELOX_USER_CHECK_NE(
+        ref->name(),
+        name,
+        "FixedPointNode anchor must not reference its own state");
+    return;
+  }
+  if (node->is(NodeKind::kFixedPoint)) {
+    return;
+  }
+  for (const auto& input : node->inputs()) {
+    rejectAnchorRecursiveReference(input, name);
+  }
+}
+} // namespace
+
+FixedPointNode::FixedPointNode(
+    std::string id,
+    std::string name,
+    LogicalPlanNodePtr anchor,
+    LogicalPlanNodePtr step)
+    : LogicalPlanNode{NodeKind::kFixedPoint, std::move(id), {anchor, step}, anchor->outputType()},
+      name_{std::move(name)} {
+  VELOX_USER_CHECK(!name_.empty(), "FixedPointNode name must be non-empty");
+  // Equivalence (types only), not strict name equality. Anchor and step
+  // schemas may carry different canonical column ids -- e.g. when the step's
+  // final projection allocates fresh names from the shared NameAllocator --
+  // so tightening this to name-equality would break valid recursive plans
+  // whose anchor and step differ only by id.
+  VELOX_USER_CHECK(
+      anchor->outputType()->equivalent(*step->outputType()),
+      "Anchor and step branches of FixedPointNode must have equivalent output schemas: {} vs. {}",
+      anchor->outputType()->toString(),
+      step->outputType()->toString());
+
+  rejectAnchorRecursiveReference(anchor, name_);
+  bool found = false;
+  checkRecursiveReferences(step, name_, anchor->outputType(), &found);
+  VELOX_USER_CHECK(
+      found,
+      "FixedPointNode step must contain at least one RecursiveReferenceNode named '{}'",
+      name_);
+}
+
+void FixedPointNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+bool FixedPointNode::equalTo(const LogicalPlanNode& other) const {
+  // LogicalPlanNode::operator== compares inputs() before delegating here, so
+  // equalTo only needs to compare the fixed-point metadata.
+  return name_ == other.as<FixedPointNode>()->name_;
+}
+
+folly::dynamic FixedPointNode::serialize() const {
+  auto obj = serializeBase("FixedPointNode");
+  obj["recursiveName"] = name_;
+  return obj;
+}
+
+// static
+LogicalPlanNodePtr FixedPointNode::create(
+    const folly::dynamic& obj,
+    void* context) {
+  auto inputs = deserializeNodeInputs(obj, context);
+  VELOX_USER_CHECK_EQ(
+      inputs.size(),
+      2,
+      "FixedPointNode requires exactly two inputs (anchor, step)");
+  return std::make_shared<FixedPointNode>(
+      obj["id"].asString(),
+      obj["recursiveName"].asString(),
+      std::move(inputs[0]),
+      std::move(inputs[1]));
+}
+
+RecursiveReferenceNode::RecursiveReferenceNode(
+    std::string id,
+    std::string name,
+    velox::RowTypePtr outputType)
+    : LogicalPlanNode{NodeKind::kRecursiveReference, std::move(id), {}, std::move(outputType)},
+      name_{std::move(name)} {
+  VELOX_USER_CHECK(
+      !name_.empty(), "RecursiveReferenceNode name must be non-empty");
+}
+
+void RecursiveReferenceNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+bool RecursiveReferenceNode::equalTo(const LogicalPlanNode& other) const {
+  return id() == other.id();
+}
+
+folly::dynamic RecursiveReferenceNode::serialize() const {
+  auto obj = serializeBase("RecursiveReferenceNode");
+  obj["recursiveName"] = name_;
+  return obj;
+}
+
+// static
+LogicalPlanNodePtr RecursiveReferenceNode::create(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  return std::make_shared<RecursiveReferenceNode>(
+      obj["id"].asString(),
+      obj["recursiveName"].asString(),
+      deserializeOutputType(obj));
 }
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -38,6 +38,8 @@ enum class NodeKind {
   kTableWrite = 10,
   kSample = 11,
   kOutput = 12,
+  kFixedPoint = 13,
+  kRecursiveReference = 14,
 };
 
 AXIOM_DECLARE_ENUM_NAME(NodeKind)
@@ -122,7 +124,9 @@ class LogicalPlanNode : public velox::ISerializable {
   }
 
   /// Returns true if two plan nodes are structurally equal. Node IDs are
-  /// allowed to differ.
+  /// allowed to differ, except for RecursiveReferenceNode, which compares by
+  /// id: distinct references are never equal even when structurally identical
+  /// (see RecursiveReferenceNode::equalTo).
   bool operator==(const LogicalPlanNode& other) const;
 
   std::string toString() const;
@@ -964,6 +968,105 @@ class OutputNode : public LogicalPlanNode {
 };
 
 using OutputNodePtr = std::shared_ptr<const OutputNode>;
+
+/// Iterative fixed-point evaluation node. Models a linear recursive CTE: an
+/// 'anchor' subplan produces the initial rows; a 'step' subplan is re-run on
+/// each iteration to produce additional rows. Inside 'step', a
+/// RecursiveReferenceNode with matching 'name' stands for the rows produced
+/// by the previous iteration. The fixed point converges when 'step' returns
+/// no rows; the node emits the UNION ALL of the anchor's rows and every step
+/// iteration's rows.
+///
+/// For SQL the mapping is:
+///
+///   WITH RECURSIVE t(n) AS (
+///     SELECT 1                          -- anchor
+///     UNION ALL
+///     SELECT n + 1 FROM t WHERE n < 10  -- step; the reference to t is a
+///                                       --   RecursiveReferenceNode named "t"
+///   )
+///
+class FixedPointNode : public LogicalPlanNode {
+ public:
+  /// 'name' is the recursive relation's name and must be non-empty. The
+  /// step must contain at least one RecursiveReferenceNode with this name.
+  /// 'anchor' and 'step' must produce equivalent output schemas; that schema
+  /// is the node's output type.
+  FixedPointNode(
+      std::string id,
+      std::string name,
+      LogicalPlanNodePtr anchor,
+      LogicalPlanNodePtr step);
+
+  /// Initial (base-case) subplan.
+  const LogicalPlanNodePtr& anchor() const {
+    return inputs()[0];
+  }
+
+  /// Per-iteration subplan.
+  const LogicalPlanNodePtr& step() const {
+    return inputs()[1];
+  }
+
+  /// Name of the recursive relation. RecursiveReferenceNodes inside the step
+  /// match this name to refer to the previous iteration.
+  const std::string& name() const {
+    return name_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+  folly::dynamic serialize() const override;
+
+  static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
+  const std::string name_;
+};
+
+using FixedPointNodePtr = std::shared_ptr<const FixedPointNode>;
+
+/// Leaf placeholder inside the step branch of a FixedPointNode. Represents a
+/// back-reference to the previous iteration's output at execution time.
+/// Identity equality is by node id, not schema, so passes that fold
+/// equal-comparing nodes (memo lookups, plan-tree equality) cannot collapse
+/// two distinct self-references in a step body into one leaf (e.g.
+/// `SELECT * FROM r r1 JOIN r r2 ON ...`).
+class RecursiveReferenceNode : public LogicalPlanNode {
+ public:
+  /// @param id Unique plan node ID. Each self-reference in a step body must
+  ///     receive its own fresh id so distinct references compare as distinct.
+  /// @param name Name of the enclosing FixedPointNode whose previous
+  ///     iteration this reference reads. Must be non-empty.
+  /// @param outputType Schema of the recursive CTE (after alias application).
+  RecursiveReferenceNode(
+      std::string id,
+      std::string name,
+      velox::RowTypePtr outputType);
+
+  /// Name of the FixedPointNode whose previous iteration this reference reads.
+  const std::string& name() const {
+    return name_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+  folly::dynamic serialize() const override;
+
+  static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  // Two RecursiveReferenceNodes are equal only when they share the same id.
+  bool equalTo(const LogicalPlanNode& other) const override;
+
+  const std::string name_;
+};
+
+using RecursiveReferenceNodePtr = std::shared_ptr<const RecursiveReferenceNode>;
 
 } // namespace facebook::axiom::logical_plan
 

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2081,4 +2081,33 @@ LogicalPlanNodePtr PlanBuilder::build(
   return buildRenameProject();
 }
 
+PlanBuilder& PlanBuilder::fixedPoint(
+    const std::string& name,
+    const LogicalPlanNodePtr& step) {
+  VELOX_USER_CHECK_NOT_NULL(
+      node_, "Anchor plan must be set before calling fixedPoint");
+  VELOX_USER_CHECK_NOT_NULL(step);
+  node_ = std::make_shared<FixedPointNode>(nextId(), name, node_, step);
+  // FixedPointNode's constructor enforces that anchor and step output schemas
+  // are equivalent, so outputMapping_ (built from the anchor) stays valid.
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::recursiveRef(
+    const std::string& name,
+    const velox::RowTypePtr& outputType) {
+  VELOX_USER_CHECK_NULL(node_, "RecursiveRef must be a leaf node");
+  outputMapping_ = std::make_shared<NameMappings>();
+  const auto numColumns = outputType->size();
+  std::vector<std::string> outputNames;
+  outputNames.reserve(numColumns);
+  for (const auto& columnName : outputType->names()) {
+    outputNames.push_back(newName(columnName));
+    outputMapping_->add(columnName, outputNames.back());
+  }
+  node_ = std::make_shared<RecursiveReferenceNode>(
+      nextId(), name, ROW(std::move(outputNames), outputType->children()));
+  return *this;
+}
+
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -750,6 +750,22 @@ class PlanBuilder {
     return node_;
   }
 
+  /// Wraps the current plan (treated as the anchor) and the provided step
+  /// plan in a FixedPointNode named `name`. The step must contain at least
+  /// one RecursiveReferenceNode named `name`, and anchor and step must
+  /// produce equivalent schemas.
+  PlanBuilder& fixedPoint(
+      const std::string& name,
+      const LogicalPlanNodePtr& step);
+
+  /// Creates a RecursiveReferenceNode leaf with the given output type,
+  /// referencing the enclosing FixedPointNode named `name`. Must be the
+  /// first call on a fresh builder. Each call produces a fresh node id so
+  /// multiple references within a step body compare as distinct.
+  PlanBuilder& recursiveRef(
+      const std::string& name,
+      const velox::RowTypePtr& outputType);
+
   /// Builds the plan using user-specified names for output columns.
   /// When allowAmbiguousOutputNames is true, creates an OutputNode at the root
   /// that supports duplicate and empty names. Otherwise, creates a ProjectNode

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::logical_plan {
 
@@ -67,6 +68,18 @@ class PlanNodeVisitor {
 
   virtual void visit(const OutputNode& node, PlanNodeVisitorContext& context)
       const = 0;
+
+  virtual void visit(
+      const FixedPointNode& /*node*/,
+      PlanNodeVisitorContext& /*context*/) const {
+    VELOX_NYI("PlanNodeVisitor does not support FixedPointNode");
+  }
+
+  virtual void visit(
+      const RecursiveReferenceNode& /*node*/,
+      PlanNodeVisitorContext& /*context*/) const {
+    VELOX_NYI("PlanNodeVisitor does not support RecursiveReferenceNode");
+  }
 
  protected:
   void visitInputs(const LogicalPlanNode& node, PlanNodeVisitorContext& ctx)

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -251,6 +251,22 @@ class ToTextVisitor : public PlanNodeVisitor {
     appendInputs(node, myContext);
   }
 
+  void visit(const FixedPointNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    myContext.out << makeIndent(myContext.indent)
+                  << "- FixedPoint(name=" << node.name() << "):";
+    appendOutputType(node, myContext);
+    myContext.out << std::endl;
+    appendInputs(node, myContext);
+  }
+
+  void visit(
+      const RecursiveReferenceNode& node,
+      PlanNodeVisitorContext& context) const override {
+    appendNode("RecursiveReference", node, "name=" + node.name(), context);
+  }
+
  private:
   static std::string makeIndent(size_t size) {
     return std::string(size * 2, ' ');
@@ -436,6 +452,17 @@ class CollectExprStatsPlanNodeVisitor : public PlanNodeVisitor {
   void visit(const OutputNode& node, PlanNodeVisitorContext& context)
       const override {
     visitInputs(node, context);
+  }
+
+  void visit(const FixedPointNode& node, PlanNodeVisitorContext& context)
+      const override {
+    visitInputs(node, context);
+  }
+
+  void visit(
+      const RecursiveReferenceNode& /*node*/,
+      PlanNodeVisitorContext& /*context*/) const override {
+    // Leaf node — nothing to collect.
   }
 
  private:
@@ -763,6 +790,19 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
     auto& myContext = static_cast<Context&>(context);
     appendHeader(node, myContext);
     appendInputs(node, myContext);
+  }
+
+  void visit(const FixedPointNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(node, context);
+  }
+
+  void visit(
+      const RecursiveReferenceNode& node,
+      PlanNodeVisitorContext& context) const override {
+    auto& myContext = static_cast<Context&>(context);
+    appendHeader(node, myContext);
+    // Leaf node — no inputs to recurse into.
   }
 
  private:

--- a/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
@@ -72,6 +72,8 @@ class LogicalPlanNodeSerdeTest : public testing::Test {
         ISerializable::deserialize<LogicalPlanNode>(serialized, context);
     ASSERT_NE(deserialized, nullptr);
     EXPECT_EQ(node->toString(), deserialized->toString());
+    // Sructural equality verifies the full round trip.
+    EXPECT_EQ(*node, *deserialized);
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -277,6 +279,26 @@ TEST_F(LogicalPlanNodeSerdeTest, tableWriteNode) {
                       {{"compression", "gzip"}})
                   .build();
   testRoundTrip(plan);
+}
+
+TEST_F(LogicalPlanNodeSerdeTest, fixedPointNode) {
+  auto step = PlanBuilder()
+                  .recursiveRef("t", ROW("n", BIGINT()))
+                  .project({"n + 1 as n"})
+                  .planNode();
+  auto plan =
+      PlanBuilder()
+          .values(ROW("n", BIGINT()), std::vector<Variant>{Variant::row({1LL})})
+          .fixedPoint("t", step)
+          .planNode();
+  testRoundTrip(plan);
+}
+
+TEST_F(LogicalPlanNodeSerdeTest, recursiveReferenceNode) {
+  auto ref = PlanBuilder()
+                 .recursiveRef("cte", ROW({"x", "y"}, {BIGINT(), VARCHAR()}))
+                 .planNode();
+  testRoundTrip(ref);
 }
 
 } // namespace

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -35,7 +35,7 @@ class PlanPrinterTest : public testing::Test {
   static constexpr auto kDefaultSchema =
       connector::TestConnector::kDefaultSchema;
 
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
@@ -1586,6 +1586,82 @@ TEST_F(PlanPrinterTest, tableWrite) {
             testing::Eq("        connector: test"),
             testing::Eq("")));
   }
+}
+
+TEST_F(PlanPrinterTest, fixedPointCounter) {
+  // WITH RECURSIVE t(n) AS (
+  //   SELECT 1
+  //   UNION ALL
+  //   SELECT n + 1 FROM t
+  // )
+  auto rowType = ROW("n", BIGINT());
+  PlanBuilder::Context context;
+
+  auto step = PlanBuilder(context)
+                  .recursiveRef("t", rowType)
+                  .project({"n + 1 as n"})
+                  .planNode();
+
+  auto plan = PlanBuilder(context)
+                  .values(rowType, std::vector<Variant>{Variant::row({1LL})})
+                  .fixedPoint("t", step)
+                  .build();
+
+  // PlanBuilder uniques column names; build() adds a renaming Project on top
+  // to expose the user-facing 'n'. The interesting structure is the FixedPoint
+  // subtree.
+  EXPECT_THAT(
+      toLines(plan),
+      testing::ElementsAre(
+          testing::StartsWith("- Project:"),
+          testing::HasSubstr("n := "),
+          testing::StartsWith("  - FixedPoint(name=t):"),
+          testing::StartsWith("    - Values:"),
+          testing::StartsWith("    - Project:"),
+          testing::HasSubstr(":= plus("),
+          testing::StartsWith("      - RecursiveReference: name=t"),
+          testing::Eq("")));
+}
+
+TEST_F(PlanPrinterTest, fixedPointSelfJoin) {
+  // A step body that joins the recursive relation against itself, producing
+  // two distinct RecursiveReferenceNodes in the same step:
+  //   WITH RECURSIVE r(n) AS (
+  //     SELECT 1
+  //     UNION ALL
+  //     SELECT r1.n FROM r r1 JOIN r r2 ON r1.n = r2.n
+  //   )
+  auto rowType = ROW("n", BIGINT());
+  PlanBuilder::Context context;
+
+  auto right = PlanBuilder(context, /*allowAmbiguousOutputNames=*/true)
+                   .recursiveRef("r", rowType)
+                   .as("r2");
+  auto step = PlanBuilder(context, /*allowAmbiguousOutputNames=*/true)
+                  .recursiveRef("r", rowType)
+                  .as("r1")
+                  .join(right, "r1.n = r2.n", JoinType::kInner)
+                  .project({"r1.n as n"})
+                  .planNode();
+
+  auto plan = PlanBuilder(context)
+                  .values(rowType, std::vector<Variant>{Variant::row({1LL})})
+                  .fixedPoint("r", step)
+                  .build();
+
+  EXPECT_THAT(
+      toLines(plan),
+      testing::ElementsAre(
+          testing::StartsWith("- Project:"),
+          testing::HasSubstr("n := "),
+          testing::StartsWith("  - FixedPoint(name=r):"),
+          testing::StartsWith("    - Values:"),
+          testing::StartsWith("    - Project:"),
+          testing::HasSubstr(":= "),
+          testing::StartsWith("      - Join INNER:"),
+          testing::StartsWith("        - RecursiveReference: name=r"),
+          testing::StartsWith("        - RecursiveReference: name=r"),
+          testing::Eq("")));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/104


Adds the logical-plan IR for recursive evaluation. The planner has no way to model fixed-point iteration today, so a bounded recursive walk  (SQL `WITH RECURSIVE`, Cypher-style variable-length path traversals) can only be expressed as N chained `UNION ALL`s. These two nodes are the foundation a future parser change will lower onto.

`FixedPointNode` carries:
- A name (cte name).
- An anchor subplan: seeds the output rows.
- A step subplan:  re-run on each iteration, references state-named `RecursiveReferenceNode`

The fixed point converges when step returns no rows; the node emits the UNION ALL of the anchor and every step iteration. Anchor and step must produce equivalent schemas; that schema is the node's output type. `RecursiveReferenceNode` is a leaf whose identity equality is by node id, not schema, so two distinct self-references in the same step body (e.g. `SELECT * FROM r r1 JOIN r r2 ON ...`) cannot collapse to one leaf.

For example, the counter CTE

    WITH RECURSIVE t(n) AS (
      SELECT 1
      UNION ALL
      SELECT n + 1 FROM t WHERE n < 10
    )
    SELECT * FROM t;

lowers to

    FixedPoint(stateName=t)
      - anchor: Values([1])
      - step:   Project(n + 1)
                  Filter(n < 10)
                    RecursiveReference(stateName=t)

`PlanBuilder` gains `fixedPoint(step, stateName)` and `recursiveRef(outputType, stateName)` so the plan above can be built directly, e.g.

    auto step = PlanBuilder()
                    .recursiveRef(ROW("n", BIGINT()), /*stateName=*/"t")
                    .filter("n < 10")
                    .project({"n + 1 as n"})
                    .planNode();

    auto plan = PlanBuilder()
                    .values(ROW("n", BIGINT()), {Variant::row({1LL})})
                    .fixedPoint(step, /*stateName=*/"t")
                    .planNode();

Scope: logical plan only. Storage kind, iteration bound, error-on-bound policy, and accumulation strategy are execution concerns and live in the lowered/physical plan. Parser, optimizer, and execution support land separately.

Reviewed By: mbasmanova

Differential Revision: D106579297


