### PR TITLE
feat(parser): Support CURRENT_USER (#1464)

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -23,6 +23,7 @@
 #include "axiom/cli/CatalogProperties.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
+#include "axiom/cli/SystemUser.h"
 #include "velox/common/base/Exceptions.h"
 
 DEFINE_string(
@@ -38,7 +39,7 @@ int main(int argc, char** argv) {
       facebook::velox::memory::MemoryManager::Options{});
 
   facebook::axiom::Connectors connectors;
-  axiom::sql::SqlQueryRunner runner;
+  axiom::sql::SqlQueryRunner runner{axiom::sql::SystemUser::resolve()};
   runner.initialize([&]() {
     VELOX_USER_CHECK(
         FLAGS_data_path.empty() || FLAGS_etc_dir.empty(),

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   Console.cpp
   QueryIdGenerator.cpp
   SqlQueryRunner.cpp
+  SystemUser.cpp
   ResultPrinter.cpp
   StdinReader.cpp
   Timing.cpp

--- a/axiom/cli/QueryGraphviz.cpp
+++ b/axiom/cli/QueryGraphviz.cpp
@@ -53,6 +53,7 @@
 #include <sstream>
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/SqlQueryRunner.h"
+#include "axiom/cli/SystemUser.h"
 
 DEFINE_string(
     query,
@@ -179,7 +180,7 @@ int main(int argc, char** argv) {
       facebook::velox::memory::MemoryManager::Options{});
 
   facebook::axiom::Connectors connectors;
-  axiom::sql::SqlQueryRunner runner;
+  axiom::sql::SqlQueryRunner runner{axiom::sql::SystemUser::resolve()};
   runner.initialize([&]() {
     auto defaultConnector = connectors.registerTpchConnector();
     auto defaultSchema = "tiny";

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -142,7 +142,20 @@ class SqlQueryRunner {
   /// "execution.session_timezone").
   static constexpr const char* kExecutionPrefix = "execution";
 
+  /// Constructs the runner with the given session user identity. The user
+  /// must be non-empty; it is exposed by the SQL `CURRENT_USER` function and
+  /// used as the default table owner in DDL.
+  explicit SqlQueryRunner(std::string user) : user_{std::move(user)} {
+    VELOX_USER_CHECK(!user_.empty(), "SqlQueryRunner user must be non-empty");
+  }
+
   virtual ~SqlQueryRunner() = default;
+
+  /// Identity of the user running queries. Used as the table owner in DDL and
+  /// for the SQL `CURRENT_USER` function.
+  const std::string& user() const {
+    return user_;
+  }
 
   /// Initializes the runner with connectors, an optional permission check, and
   /// a query ID generator (defaults to QueryIdGenerator if not provided).
@@ -304,12 +317,6 @@ class SqlQueryRunner {
     return defaultSchema_;
   }
 
-  /// Sets the user identity for DDL operations. Used as the default table
-  /// owner in CREATE TABLE when the WITH clause does not specify one.
-  void setUser(std::string user) {
-    user_ = std::move(user);
-  }
-
  private:
   // Checks permissions for the query via the configured PermissionCheck
   // callback. Returns a TokenProvider for authenticated file system access.
@@ -441,8 +448,7 @@ class SqlQueryRunner {
   std::shared_ptr<facebook::axiom::SessionConfig> sessionConfig_;
   std::string defaultConnectorId_;
   std::string defaultSchema_;
-  // Identity of the user running queries. Used as table owner in CREATE TABLE.
-  std::string user_;
+  const std::string user_;
   std::atomic<int32_t> queryCounter_{0};
 
   // Noop stats instance for code paths that don't track runtime metrics.

--- a/axiom/cli/SystemUser.cpp
+++ b/axiom/cli/SystemUser.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/SystemUser.h"
+
+#include <pwd.h>
+#include <unistd.h>
+
+#include <cstdlib>
+
+namespace axiom::sql {
+
+std::string SystemUser::resolve() {
+  const auto* envUser = std::getenv("USER");
+  if (envUser != nullptr && *envUser != '\0') {
+    return envUser;
+  }
+
+  auto* passwd = getpwuid(getuid());
+  if (passwd != nullptr) {
+    return passwd->pw_name;
+  }
+
+  return "unknown";
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/SystemUser.h
+++ b/axiom/cli/SystemUser.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace axiom::sql {
+
+/// OS-level user identity lookup. Used by CLI entry points to seed the
+/// session user when no application-level identity is available.
+class SystemUser {
+ public:
+  /// Returns the current OS user. Tries `$USER`, then the passwd entry for
+  /// the effective UID, then `"unknown"`. Always returns a non-empty string.
+  static std::string resolve();
+};
+
+} // namespace axiom::sql

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -45,7 +45,7 @@ class ConsoleTest : public ::testing::Test {
 
   std::unique_ptr<SqlQueryRunner> makeRunner(
       PermissionCheck permissionCheck = {}) {
-    auto runner = std::make_unique<SqlQueryRunner>();
+    auto runner = std::make_unique<SqlQueryRunner>("test_user");
 
     runner->initialize(
         [&]() {

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -65,7 +65,7 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
       const std::string& connectorId = "test",
       std::function<std::string()> queryIdGenerator = {},
       PermissionCheck permissionCheck = {}) {
-    auto runner = std::make_unique<SqlQueryRunner>();
+    auto runner = std::make_unique<SqlQueryRunner>("test_user");
 
     auto initConnectors = [&]() {
       testConnector_ =
@@ -152,6 +152,13 @@ TEST_F(SqlQueryRunnerTest, runSingleStatement) {
   test::assertEqualVectors(
       fetchSingleRow("SELECT 1"),
       makeRowVector({makeFlatVector<int32_t>({1})}));
+}
+
+TEST_F(SqlQueryRunnerTest, currentUser) {
+  // CURRENT_USER returns the user passed to the SqlQueryRunner constructor.
+  test::assertEqualVectors(
+      fetchSingleRow("SELECT CURRENT_USER"),
+      makeRowVector({makeFlatVector<std::string>({"test_user"})}));
 }
 
 TEST_F(SqlQueryRunnerTest, runRejectsMultipleStatements) {

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -31,7 +31,7 @@ void TpchDataGenerator::createTables(
     const TableStartingCallback& onTableStarting,
     const TableCreatedCallback& onTableCreated) {
   Connectors connectors;
-  ::axiom::sql::SqlQueryRunner runner;
+  ::axiom::sql::SqlQueryRunner runner{"tpch_data_generator"};
   runner.initialize([&]() {
     connectors.registerTpchConnector();
     connectors.registerLocalHiveConnector(

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1239,6 +1239,15 @@ lp::ExprApi ExpressionPlanner::toExpr(
           std::string(GroupByPlanner::kGroupingFunctionName), columnArgs);
     }
 
+    case NodeType::kCurrentUser: {
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          !user_.empty(),
+          node->location(),
+          std::nullopt,
+          "CURRENT_USER is not available in this context (no session user set)");
+      return lp::Lit(user_);
+    }
+
     default:
       AXIOM_PRESTO_SYNTAX_FAIL(
           node->location(),

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -105,11 +105,13 @@ class ExpressionPlanner {
       std::function<bool(const std::string& first, const std::string& second)>;
 
   ExpressionPlanner(
+      std::string user,
       SubqueryPlanner subqueryPlanner,
       SortingKeyResolver sortingKeyResolver,
       ShouldDropQualifier shouldDropQualifier = nullptr,
       ColumnResolver columnResolver = nullptr)
-      : subqueryPlanner_(std::move(subqueryPlanner)),
+      : user_{std::move(user)},
+        subqueryPlanner_(std::move(subqueryPlanner)),
         sortingKeyResolver_(std::move(sortingKeyResolver)),
         shouldDropQualifier_(std::move(shouldDropQualifier)),
         columnResolver_(std::move(columnResolver)) {}
@@ -231,6 +233,10 @@ class ExpressionPlanner {
       return *lhs == *rhs;
     }
   };
+
+  // Session user used to constant-fold CURRENT_USER at planning time. Empty
+  // when no session context is available; CURRENT_USER translation then fails.
+  const std::string user_;
 
   SubqueryPlanner subqueryPlanner_;
   SortingKeyResolver sortingKeyResolver_;

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -243,6 +243,7 @@ core::ExprPtr replaceInputs(
 class RelationPlanner : public AstVisitor {
  public:
   RelationPlanner(
+      std::string user,
       const std::string& defaultConnectorId,
       const std::string& defaultSchema,
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
@@ -251,6 +252,7 @@ class RelationPlanner : public AstVisitor {
       : context_{makePrestoContext(defaultConnectorId, defaultSchema)},
         defaultSchema_{defaultSchema},
         parseSql_{parseSql},
+        user_{std::move(user)},
         builder_(newBuilder()),
         friendlySql_{friendlySql} {}
 
@@ -1390,8 +1392,10 @@ class RelationPlanner : public AstVisitor {
   const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
       std::string_view /*sql*/)>
       parseSql_;
+  const std::string user_;
   std::shared_ptr<lp::PlanBuilder> builder_;
   ExpressionPlanner exprPlanner_{
+      user_,
       [this](Query* query) { return planSubquery(query); },
       [this](const ExpressionPtr& expr, ExprOptions options) {
         return toSortingKey(expr, options);
@@ -1556,9 +1560,11 @@ lp::ExprPtr PrestoParser::parseExpression(
 }
 
 namespace {
-lp::ExprPtr parseSqlExpression(const ExpressionPtr& expr) {
-  ExpressionPlanner exprPlanner{/*subqueryPlanner=*/nullptr,
-                                /*sortingKeyResolver=*/nullptr};
+lp::ExprPtr parseSqlExpression(
+    const std::string& user,
+    const ExpressionPtr& expr) {
+  ExpressionPlanner exprPlanner{
+      user, /*subqueryPlanner=*/nullptr, /*sortingKeyResolver=*/nullptr};
 
   auto plan = lp::PlanBuilder()
                   .values(ROW({}), {Variant::row({})})
@@ -1981,6 +1987,7 @@ std::vector<lp::ExprApi> toColumnExprs(
 }
 
 SqlStatementPtr parseInsert(
+    const std::string& user,
     const Insert& insert,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema,
@@ -2015,7 +2022,7 @@ SqlStatementPtr parseInsert(
     }
   }
 
-  RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+  RelationPlanner planner(user, defaultConnectorId, defaultSchema, parseSql);
   insert.query()->accept(&planner);
 
   auto inputColumns = planner.builder().findOrAssignOutputNames();
@@ -2039,11 +2046,12 @@ SqlStatementPtr parseInsert(
 }
 
 std::unordered_map<std::string, lp::ExprPtr> parseTableProperties(
+    const std::string& user,
     const std::vector<std::shared_ptr<Property>>& props) {
   std::unordered_map<std::string, lp::ExprPtr> properties;
   for (const auto& p : props) {
     const auto& name = p->name()->value();
-    auto expr = parseSqlExpression(p->value());
+    auto expr = parseSqlExpression(user, p->value());
     AXIOM_PRESTO_SEMANTIC_CHECK(
         expr->looksConstant(),
         p->location(),
@@ -2057,6 +2065,7 @@ std::unordered_map<std::string, lp::ExprPtr> parseTableProperties(
 }
 
 SqlStatementPtr parseCreateTableAsSelect(
+    const std::string& user,
     const CreateTableAsSelect& ctas,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema,
@@ -2065,10 +2074,10 @@ SqlStatementPtr parseCreateTableAsSelect(
   auto [connectorId, connectorTable] =
       toConnectorTable(*ctas.name(), defaultConnectorId, defaultSchema);
 
-  RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+  RelationPlanner planner(user, defaultConnectorId, defaultSchema, parseSql);
   ctas.query()->accept(&planner);
 
-  auto properties = parseTableProperties(ctas.properties());
+  auto properties = parseTableProperties(user, ctas.properties());
 
   auto& planBuilder = planner.builder();
 
@@ -2131,13 +2140,14 @@ SqlStatementPtr parseCreateTableAsSelect(
 }
 
 SqlStatementPtr parseCreateTable(
+    const std::string& user,
     const CreateTable& createTable,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema) {
   auto [connectorId, connectorTable] =
       toConnectorTable(*createTable.name(), defaultConnectorId, defaultSchema);
 
-  auto properties = parseTableProperties(createTable.properties());
+  auto properties = parseTableProperties(user, createTable.properties());
 
   std::vector<std::string> names;
   std::vector<TypePtr> types;
@@ -2245,6 +2255,7 @@ SqlStatementPtr parseAddColumn(
 }
 
 SqlStatementPtr parseCreateSchema(
+    const std::string& user,
     const CreateSchema& createSchema,
     const std::string& defaultConnectorId) {
   const auto& parts = createSchema.schemaName()->parts();
@@ -2260,7 +2271,7 @@ SqlStatementPtr parseCreateSchema(
   std::string connectorId = parts.size() == 2 ? parts[0] : defaultConnectorId;
   std::string schemaName = parts.size() == 2 ? parts[1] : parts[0];
 
-  auto properties = parseTableProperties(createSchema.properties());
+  auto properties = parseTableProperties(user, createSchema.properties());
 
   return std::make_shared<CreateSchemaStatement>(
       std::move(connectorId),
@@ -2417,13 +2428,20 @@ SqlStatementPtr doPlan(
     const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
         std::string_view /*sql*/)>& parseSql,
     const ParserSessionPtr& parserSession) {
+  const auto& user = parserSession->user();
+
   if (query->is(NodeType::kInsert)) {
     return parseInsert(
-        *query->as<Insert>(), defaultConnectorId, defaultSchema, parseSql);
+        user,
+        *query->as<Insert>(),
+        defaultConnectorId,
+        defaultSchema,
+        parseSql);
   }
 
   if (query->is(NodeType::kCreateTableAsSelect)) {
     return parseCreateTableAsSelect(
+        user,
         *query->as<CreateTableAsSelect>(),
         defaultConnectorId,
         defaultSchema,
@@ -2432,7 +2450,7 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kCreateTable)) {
     return parseCreateTable(
-        *query->as<CreateTable>(), defaultConnectorId, defaultSchema);
+        user, *query->as<CreateTable>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kDropTable)) {
@@ -2446,7 +2464,8 @@ SqlStatementPtr doPlan(
   }
 
   if (query->is(NodeType::kCreateSchema)) {
-    return parseCreateSchema(*query->as<CreateSchema>(), defaultConnectorId);
+    return parseCreateSchema(
+        user, *query->as<CreateSchema>(), defaultConnectorId);
   }
 
   if (query->is(NodeType::kDropSchema)) {
@@ -2487,7 +2506,7 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kShowStatsForQuery)) {
     auto* showStats = query->as<ShowStatsForQuery>();
-    RelationPlanner planner(defaultConnectorId, defaultSchema, parseSql);
+    RelationPlanner planner(user, defaultConnectorId, defaultSchema, parseSql);
     showStats->query()->accept(&planner);
     auto innerStatement = std::make_shared<SelectStatement>(
         planner.plan(),
@@ -2503,6 +2522,7 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kQuery)) {
     RelationPlanner planner(
+        user,
         defaultConnectorId,
         defaultSchema,
         parseSql,

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -542,6 +542,14 @@ TEST_F(ExpressionParserTest, specialDateTimeFunctions) {
       "Precision for date/time functions is not supported yet");
 }
 
+TEST_F(ExpressionParserTest, currentUser) {
+  auto expr = parseExpr("CURRENT_USER");
+  ASSERT_TRUE(expr->isConstant());
+  ASSERT_EQ(*expr->type(), *VARCHAR());
+  EXPECT_EQ(
+      expr->as<lp::ConstantExpr>()->value()->value<std::string>(), "test");
+}
+
 TEST_F(ExpressionParserTest, nullif) {
   auto verifyNullIf = [&](const std::string& sql,
                           const TypePtr& expectedType,


### PR DESCRIPTION
Summary:

`SELECT CURRENT_USER` previously failed with `Unsupported expression type: CurrentUser`. It now constant-folds to a VARCHAR literal carrying the session user.

`ExpressionPlanner` gains a required `user` constructor argument, threaded from `ParserSession::user()` through `RelationPlanner` and the DDL parse helpers. The new `kCurrentUser` case in `toExpr` returns `lp::Lit(user_)`; when no session user is set the call fails with `CURRENT_USER is not available in this context`.

`SqlQueryRunner` now requires a non-empty user at construction (replaces the `setUser` mutator). The CLI entry points pass `$USER`, falling back to `"unknown"` when the variable is unset.

Reviewed By: amitkdutta

Differential Revision: D107972121


