### PR TITLE
feat: Propagate Axiom CLI failure error codes (#1465)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -521,7 +521,16 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     completionInfo.numOutputRows = countRows(result.results);
     finalize();
     return result;
+  } catch (const velox::VeloxException& e) {
+    completionInfo.errorInfo = ErrorInfo{
+        .message = e.what(),
+        .messageTemplate = messageTemplateOf(e),
+        .errorCode = e.errorCode(),
+        .errorSource = e.errorSource()};
+    finalize();
+    throw;
   } catch (const std::exception& e) {
+    // Non-Velox exceptions carry no error code or source.
     completionInfo.errorInfo =
         ErrorInfo{.message = e.what(), .messageTemplate = messageTemplateOf(e)};
     finalize();

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -71,6 +71,14 @@ struct ErrorInfo {
   /// Template with placeholders (e.g. "Cannot resolve type {}") for grouping
   /// similar failures.
   std::string messageTemplate;
+
+  /// Raw Velox error code (e.g. "INVALID_ARGUMENT", "MEM_CAP_EXCEEDED") from
+  /// the caught VeloxException. Empty for non-Velox exceptions.
+  std::string errorCode;
+
+  /// Raw Velox error source (e.g. "USER", "RUNTIME", "SYSTEM", "EXTERNAL") from
+  /// the caught VeloxException. Empty for non-Velox exceptions.
+  std::string errorSource;
 };
 
 /// Returns a format template (placeholders, not substituted values) for


### PR DESCRIPTION
Summary:

The CLI previously collapsed all failures into a single generic internal error.

This change preserves the underlying Velox exception type by keeping the exception’s `errorCode` and `errorSource` on `ErrorInfo`. Non-Velox exceptions don’t include these fields and will continue to be reported as generic errors.

Reviewed By: mbasmanova

Differential Revision: D107960317
