### PR TITLE
refactor: FileFormat's hand-rolled toString() switch to VELOX_DEFINE_ENUM_NAME

### DIFF
--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -877,7 +877,7 @@ folly::dynamic toSchemaJson(
 
   if (options.fileFormat.has_value()) {
     schema["fileFormat"] =
-        velox::dwio::common::toString(options.fileFormat.value());
+        velox::dwio::common::FileFormatName::toName(options.fileFormat.value());
   }
   // Save SerDe options
   if (options.serdeOptions.has_value()) {
@@ -939,7 +939,8 @@ std::shared_ptr<LocalTable> createLocalTable(
 
   if (createTableOptions.fileFormat.has_value()) {
     options[HiveWriteOptions::kFileFormat] = std::string(
-        velox::dwio::common::toString(createTableOptions.fileFormat.value()));
+        velox::dwio::common::FileFormatName::toName(
+            createTableOptions.fileFormat.value()));
   }
 
   if (createTableOptions.serdeOptions.has_value()) {

--- a/axiom/connectors/hive/LocalTableMetadata.cpp
+++ b/axiom/connectors/hive/LocalTableMetadata.cpp
@@ -240,7 +240,8 @@ void writeSchemaFile(
   folly::dynamic schema = folly::dynamic::object;
   schema["dataColumns"] = dataColumns;
   schema["partitionColumns"] = folly::dynamic::array();
-  schema["fileFormat"] = std::string(velox::dwio::common::toString(fileFormat));
+  schema["fileFormat"] =
+      std::string(velox::dwio::common::FileFormatName::toName(fileFormat));
 
   const auto file = schemaPath(tablePath);
   std::ofstream outputFile(file);

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -89,7 +89,7 @@ void HiveQueriesTestBase::setupHiveConnector() {
   std::unordered_map<std::string, std::string> configs;
   configs[connector::hive::HiveMetadataConfig::kLocalDataPath] = localDataPath_;
   configs[connector::hive::HiveMetadataConfig::kLocalFileFormat] =
-      velox::dwio::common::toString(localFileFormat_);
+      velox::dwio::common::FileFormatName::toName(localFileFormat_);
   configs.insert(hiveConfig_.begin(), hiveConfig_.end());
 
   resetHiveConnector(

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -35,7 +35,8 @@ void TpchDataGenerator::createTables(
   runner.initialize([&]() {
     connectors.registerTpchConnector();
     connectors.registerLocalHiveConnector(
-        std::string(path), std::string(velox::dwio::common::toString(format)));
+        std::string(path),
+        std::string(velox::dwio::common::FileFormatName::toName(format)));
     return std::make_pair(
         std::string(Connectors::kLocalHiveConnectorId), std::string("default"));
   });
@@ -54,7 +55,7 @@ void TpchDataGenerator::createTables(
     auto sql = fmt::format(
         "CREATE TABLE {} WITH (file_format = '{}') AS SELECT * FROM tpch.\"{}\".{}",
         tableName,
-        velox::dwio::common::toString(format),
+        velox::dwio::common::FileFormatName::toName(format),
         fmt::format("sf{}", scaleFactor),
         tableName);
 

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -76,7 +76,8 @@ void LocalRunnerTestBase::setupConnector() {
   configs[connector::hive::HiveMetadataConfig::kLocalDataPath] =
       tempDirectory_->getPath();
   configs[connector::hive::HiveMetadataConfig::kLocalFileFormat] =
-      velox::dwio::common::toString(velox::dwio::common::FileFormat::DWRF);
+      velox::dwio::common::FileFormatName::toName(
+          velox::dwio::common::FileFormat::DWRF);
   resetHiveConnector(
       std::make_shared<velox::config::ConfigBase>(std::move(configs)));
 


### PR DESCRIPTION
Summary:
Convert FileFormat's hand-rolled toString() switch to VELOX_DEFINE_ENUM_NAME.
Update call site to use FileFormatName::toName(...).

X-link: https://github.com/facebookincubator/velox/pull/17777

Reviewed By: HuamengJiang

Differential Revision: D107967188

Pulled By: xiaoxmeng


