### PR TITLE
refactor(test): Replace HashJoin leftKeys/rightKeys with keys

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -130,6 +130,33 @@ class PlanMatcherImpl : public PlanMatcher {
   const std::vector<std::shared_ptr<PlanMatcher>> sourceMatchers_;
 };
 
+// Parses `"a = b"` into a pair of column names `(a, b)`. Requires
+// both sides to be plain column references.
+std::pair<std::string, std::string> parseEqualityColumnPair(
+    const std::string& equality) {
+  const auto parsed = parse::DuckSqlExpressionsParser().parseExpr(equality);
+  const auto* call = dynamic_cast<const core::CallExpr*>(parsed.get());
+  VELOX_USER_CHECK_NOT_NULL(
+      call, "Expected equality expression of the form `a = b`: {}", equality);
+  VELOX_USER_CHECK_EQ(
+      call->name(),
+      "eq",
+      "Expected equality expression of the form `a = b`: {}",
+      equality);
+  VELOX_USER_CHECK_EQ(
+      call->inputs().size(),
+      2,
+      "Expected equality expression of the form `a = b`: {}",
+      equality);
+  const auto* lhs = core::FieldAccessExpr::tryAsRootColumn(call->inputs()[0]);
+  const auto* rhs = core::FieldAccessExpr::tryAsRootColumn(call->inputs()[1]);
+  VELOX_USER_CHECK_NOT_NULL(
+      lhs, "Left side must be a plain column reference: {}", equality);
+  VELOX_USER_CHECK_NOT_NULL(
+      rhs, "Right side must be a plain column reference: {}", equality);
+  return {lhs->name(), rhs->name()};
+}
+
 velox::core::ExprPtr rewriteInputNames(
     const velox::core::ExprPtr& expr,
     const std::unordered_map<std::string, std::string>& mapping) {
@@ -782,17 +809,9 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
       : PlanMatcherImpl<HashJoinNode>({left, right}),
         joinType_{joinType},
         nullAware_{details.nullAware},
-        leftKeys_{details.leftKeys},
-        rightKeys_{details.rightKeys},
+        keys_{details.keys},
         filter_{details.filter},
-        outputColumnNames_{details.outputColumnNames} {
-    if (leftKeys_.has_value() && rightKeys_.has_value()) {
-      VELOX_CHECK_EQ(
-          leftKeys_->size(),
-          rightKeys_->size(),
-          "leftKeys and rightKeys must have the same size");
-    }
-  }
+        outputColumnNames_{details.outputColumnNames} {}
 
   MatchResult matchDetails(
       const HashJoinNode& plan,
@@ -812,26 +831,18 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
 
     AXIOM_TEST_RETURN_IF_FAILURE
 
-    if (leftKeys_.has_value()) {
-      EXPECT_EQ(plan.leftKeys().size(), leftKeys_->size());
+    if (keys_.has_value()) {
+      EXPECT_EQ(plan.leftKeys().size(), keys_->size());
       AXIOM_TEST_RETURN_IF_FAILURE
 
-      for (auto i = 0; i < leftKeys_->size(); ++i) {
-        auto it = symbols.find((*leftKeys_)[i]);
-        auto expected = it != symbols.end() ? it->second : (*leftKeys_)[i];
-        EXPECT_EQ(plan.leftKeys()[i]->name(), expected);
-      }
-      AXIOM_TEST_RETURN_IF_FAILURE
-    }
-
-    if (rightKeys_.has_value()) {
-      EXPECT_EQ(plan.rightKeys().size(), rightKeys_->size());
-      AXIOM_TEST_RETURN_IF_FAILURE
-
-      for (auto i = 0; i < rightKeys_->size(); ++i) {
-        auto it = symbols.find((*rightKeys_)[i]);
-        auto expected = it != symbols.end() ? it->second : (*rightKeys_)[i];
-        EXPECT_EQ(plan.rightKeys()[i]->name(), expected);
+      auto resolve = [&](const std::string& name) {
+        auto it = symbols.find(name);
+        return it != symbols.end() ? it->second : name;
+      };
+      for (size_t i = 0; i < keys_->size(); ++i) {
+        const auto [lhs, rhs] = parseEqualityColumnPair((*keys_)[i]);
+        EXPECT_EQ(plan.leftKeys()[i]->name(), resolve(lhs));
+        EXPECT_EQ(plan.rightKeys()[i]->name(), resolve(rhs));
       }
       AXIOM_TEST_RETURN_IF_FAILURE
     }
@@ -885,8 +896,7 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
  private:
   const std::optional<JoinType> joinType_;
   const std::optional<bool> nullAware_;
-  const std::optional<std::vector<std::string>> leftKeys_;
-  const std::optional<std::vector<std::string>> rightKeys_;
+  const std::optional<std::vector<std::string>> keys_;
   const std::optional<std::string> filter_;
   const std::optional<std::vector<std::string>> outputColumnNames_;
 };

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -140,13 +140,12 @@ struct HashJoinDetails {
   /// When set, asserts plan.isNullAware() matches.
   std::optional<bool> nullAware;
 
-  /// When set, asserts left-side join keys (must have same size as
-  /// rightKeys when both are set).
-  std::optional<std::vector<std::string>> leftKeys;
-
-  /// When set, asserts right-side join keys (must have same size as
-  /// leftKeys when both are set).
-  std::optional<std::vector<std::string>> rightKeys;
+  /// When set, asserts the join's equi-keys. Each entry is a single
+  /// equality expression written as "<left> = <right>" (DuckDB SQL
+  /// syntax). The LHS of each `=` matches `plan.leftKeys()[i]`; the
+  /// RHS matches `plan.rightKeys()[i]`. Supports alias rewriting from
+  /// child matchers.
+  std::optional<std::vector<std::string>> keys;
 
   /// When set, asserts the join filter expression (e.g., "a = b AND c > 0").
   /// Empty string asserts no filter.

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -631,16 +631,14 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
         "  WHERE u.y = t.b"
         ") FROM t";
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").build(),
-                           core::JoinType::kLeftSemiProject,
-                           {.nullAware = true,
-                            .leftKeys = std::vector<std::string>{"a"},
-                            .rightKeys = std::vector<std::string>{"x"},
-                            .filter = "b = y"})
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").build(),
+                core::JoinType::kLeftSemiProject,
+                {.nullAware = true, .keys = {{"a = x"}}, .filter = "b = y"})
+            .project()
+            .build();
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -658,8 +656,7 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
                            matchScan("u").build(),
                            core::JoinType::kLeftSemiProject,
                            {.nullAware = true,
-                            .leftKeys = std::vector<std::string>{"a"},
-                            .rightKeys = std::vector<std::string>{"x"},
+                            .keys = {{"a = x"}},
                             .filter = "b = y AND c = z"})
                        .project()
                        .build();
@@ -685,8 +682,7 @@ TEST_F(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
                          matchScan("u").build(),
                          core::JoinType::kLeftSemiProject,
                          {.nullAware = true,
-                          .leftKeys = std::vector<std::string>{"a"},
-                          .rightKeys = std::vector<std::string>{"x"},
+                          .keys = {{"a = x"}},
                           .filter = "c > z AND b = y"})
                      .project()
                      .build();
@@ -709,10 +705,7 @@ TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
                      .hashJoin(
                          matchScan("u").build(),
                          core::JoinType::kLeftSemiProject,
-                         {.nullAware = true,
-                          .leftKeys = std::vector<std::string>{"a"},
-                          .rightKeys = std::vector<std::string>{"x"},
-                          .filter = ""})
+                         {.nullAware = true, .keys = {{"a = x"}}, .filter = ""})
                      .project()
                      .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));


### PR DESCRIPTION
Summary:
PlanMatcher's HashJoin assertion required two parallel vectors `leftKeys` and `rightKeys` even for a single key pair. Replace both with a single `keys` field whose entries are equality strings parsed by the existing DuckDB SQL parser. Each entry's LHS matches `plan.leftKeys()[i]`; its RHS matches `plan.rightKeys()[i]`. Mismatched sizes become impossible to express, and LHS-vs-RHS is unambiguous from the `=` sign.

Before:

    {.leftKeys = std::vector<std::string>{"a"}, .rightKeys = std::vector<std::string>{"x"}}

After:

    {.keys = {"a = x"}}

Differential Revision: D108165486


