### PR TITLE
fix(optimizer): Start syntactic joins from valid table (#1470)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3230,10 +3230,18 @@ void Optimization::makeJoins(PlanState& state) {
   PlanObjectVector firstTables;
 
   if (options().syntacticJoinOrder) {
-    const auto firstTableId = state.dt->joinOrder[0];
-    VELOX_CHECK(state.dt->startTables.BitSet::contains(firstTableId));
+    // Single-row derived tables keep their syntactic position but are not valid
+    // starting tables. They are appended after the driving table as cross
+    // products.
+    const auto firstStartTableIt =
+        std::ranges::find_if(state.dt->joinOrder, [&](int32_t tableId) {
+          return state.dt->startTables.BitSet::contains(tableId);
+        });
+    VELOX_CHECK(
+        firstStartTableIt != state.dt->joinOrder.end(),
+        "Syntactic join order has no start table");
 
-    firstTables.push_back(queryCtx()->objectAt(firstTableId));
+    firstTables.push_back(queryCtx()->objectAt(*firstStartTableIt));
   } else {
     firstTables = state.dt->startTables.toObjects();
 

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -295,6 +295,38 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
   }
 }
 
+TEST_F(SyntacticJoinOrderTest, crossJoinStartsWithSingleRowSubqueries) {
+  optimizerOptions_.sampleJoins = false;
+
+  auto logicalPlan = parseSelect(
+      "WITH "
+      "t AS (SELECT count(*) AS c FROM orders), "
+      "u AS (SELECT count(*) AS c FROM lineitem), "
+      "v AS (SELECT o_orderstatus, count(*) AS s FROM orders GROUP BY o_orderstatus) "
+      "SELECT t.c, u.c, v.s FROM t, u, v");
+
+  optimizerOptions_.syntacticJoinOrder = false;
+  auto referenceResults = runVelox(logicalPlan).results;
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher =
+      matchHiveScan("orders")
+          .aliases({"status"})
+          .singleAggregation({"status"}, {"count(*) as s"})
+          .project()
+          .nestedLoopJoin(matchHiveScan("orders")
+                              .singleAggregation({}, {"count(*) as c"})
+                              .build())
+          .nestedLoopJoin(matchHiveScan("lineitem")
+                              .singleAggregation({}, {"count(*) as c"})
+                              .build())
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+  checkSame(logicalPlan, referenceResults);
+}
+
 // 12-way inner-join chain. Without the per-step restriction that keeps
 // the optimizer on the SQL-written order, the recursion enumerates
 // candidates and strategies at every level and the optimization does


### PR DESCRIPTION
Summary:

A query can put one or more single-row subqueries before a grouped input in a cross product:

    WITH
      t AS (SELECT count(*) AS c FROM orders),
      u AS (SELECT count(*) AS c FROM lineitem),
      v AS (SELECT o_orderstatus, count(*) AS s FROM orders GROUP BY o_orderstatus)
    SELECT t.c, u.c, v.s FROM t, u, v

With `syntacticJoinOrder` enabled, planning used the first syntactic input as the driving table. Single-row derived tables are not valid starting tables because they are appended later as cross products, so planning failed at `state.dt->startTables.BitSet::contains(firstTableId)` before execution.

The fix chooses the first syntactic table that is still in `startTables`. Leading single-row inputs keep their relative order and are added through the existing cross-product path. The regression test uses CTE aliases `t`, `u`, and `v` and checks that planning starts from `v`, then appends `t` and `u`.

Reviewed By: mbasmanova

Differential Revision: D106890217


