### PR TITLE
feat(parser): Enable WITH RECURSIVE in the Presto SQL parser (#1471)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2095,18 +2095,33 @@ PlanBuilder& PlanBuilder::fixedPoint(
 
 PlanBuilder& PlanBuilder::recursiveRef(
     const std::string& name,
-    const velox::RowTypePtr& outputType) {
+    const PlanBuilder& anchor) {
   VELOX_USER_CHECK_NULL(node_, "RecursiveRef must be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(
+      anchor.node_, "Anchor plan must be set before calling recursiveRef");
+  const auto& anchorType = anchor.node_->outputType();
+  const auto& anchorMapping = *anchor.outputMapping_;
+  // Rebuild the anchor's mappings under fresh ids so each recursive reference
+  // site has distinct column ids -- two refs joined side by side
+  // (e.g. `r r1 JOIN r r2`) must not collide on shared anchor ids.
   outputMapping_ = std::make_shared<NameMappings>();
-  const auto numColumns = outputType->size();
+  const auto numColumns = anchorType->size();
   std::vector<std::string> outputNames;
   outputNames.reserve(numColumns);
-  for (const auto& columnName : outputType->names()) {
-    outputNames.push_back(newName(columnName));
-    outputMapping_->add(columnName, outputNames.back());
+  for (size_t i = 0; i < numColumns; ++i) {
+    const auto& oldId = anchorType->nameOf(i);
+    auto newId = newName(oldId);
+    for (const auto& qualified : anchorMapping.reverseLookup(oldId)) {
+      outputMapping_->add(qualified, newId);
+    }
+    if (anchorMapping.isHidden(oldId)) {
+      outputMapping_->markHidden(newId);
+    }
+    outputMapping_->copyUserName(newId, anchorMapping);
+    outputNames.push_back(std::move(newId));
   }
   node_ = std::make_shared<RecursiveReferenceNode>(
-      nextId(), name, ROW(std::move(outputNames), outputType->children()));
+      nextId(), name, ROW(std::move(outputNames), anchorType->children()));
   return *this;
 }
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -758,13 +758,13 @@ class PlanBuilder {
       const std::string& name,
       const LogicalPlanNodePtr& step);
 
-  /// Creates a RecursiveReferenceNode leaf with the given output type,
-  /// referencing the enclosing FixedPointNode named `name`. Must be the
-  /// first call on a fresh builder. Each call produces a fresh node id so
-  /// multiple references within a step body compare as distinct.
-  PlanBuilder& recursiveRef(
-      const std::string& name,
-      const velox::RowTypePtr& outputType);
+  /// Creates a RecursiveReferenceNode leaf referencing the enclosing
+  /// FixedPointNode named `name`. Schema and name resolution mirror
+  /// `anchor` -- step-body lookups like `r.x` resolve through a clone of
+  /// the anchor's NameMappings, with each column id reallocated so
+  /// multiple references within a step body compare as distinct. Must be
+  /// the first call on a fresh builder.
+  PlanBuilder& recursiveRef(const std::string& name, const PlanBuilder& anchor);
 
   /// Builds the plan using user-specified names for output columns.
   /// When allowAmbiguousOutputNames is true, creates an OutputNode at the root

--- a/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
@@ -282,22 +282,21 @@ TEST_F(LogicalPlanNodeSerdeTest, tableWriteNode) {
 }
 
 TEST_F(LogicalPlanNodeSerdeTest, fixedPointNode) {
+  auto anchor = PlanBuilder().values(
+      ROW("n", BIGINT()), std::vector<Variant>{Variant::row({1LL})});
   auto step = PlanBuilder()
-                  .recursiveRef("t", ROW("n", BIGINT()))
+                  .recursiveRef("t", anchor)
                   .project({"n + 1 as n"})
                   .planNode();
-  auto plan =
-      PlanBuilder()
-          .values(ROW("n", BIGINT()), std::vector<Variant>{Variant::row({1LL})})
-          .fixedPoint("t", step)
-          .planNode();
+  auto plan = anchor.fixedPoint("t", step).planNode();
   testRoundTrip(plan);
 }
 
 TEST_F(LogicalPlanNodeSerdeTest, recursiveReferenceNode) {
-  auto ref = PlanBuilder()
-                 .recursiveRef("cte", ROW({"x", "y"}, {BIGINT(), VARCHAR()}))
-                 .planNode();
+  auto anchor = PlanBuilder().values(
+      ROW({"x", "y"}, {BIGINT(), VARCHAR()}),
+      std::vector<Variant>{Variant::row({1LL, "a"})});
+  auto ref = PlanBuilder().recursiveRef("cte", anchor).planNode();
   testRoundTrip(ref);
 }
 

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -1597,29 +1597,24 @@ TEST_F(PlanPrinterTest, fixedPointCounter) {
   auto rowType = ROW("n", BIGINT());
   PlanBuilder::Context context;
 
+  auto anchor = PlanBuilder(context).values(
+      rowType, std::vector<Variant>{Variant::row({1LL})});
+
   auto step = PlanBuilder(context)
-                  .recursiveRef("t", rowType)
+                  .recursiveRef("t", anchor)
                   .project({"n + 1 as n"})
                   .planNode();
 
-  auto plan = PlanBuilder(context)
-                  .values(rowType, std::vector<Variant>{Variant::row({1LL})})
-                  .fixedPoint("t", step)
-                  .build();
+  auto plan = anchor.fixedPoint("t", step).build();
 
-  // PlanBuilder uniques column names; build() adds a renaming Project on top
-  // to expose the user-facing 'n'. The interesting structure is the FixedPoint
-  // subtree.
   EXPECT_THAT(
       toLines(plan),
       testing::ElementsAre(
-          testing::StartsWith("- Project:"),
-          testing::HasSubstr("n := "),
-          testing::StartsWith("  - FixedPoint(name=t):"),
-          testing::StartsWith("    - Values:"),
-          testing::StartsWith("    - Project:"),
+          testing::StartsWith("- FixedPoint(name=t):"),
+          testing::StartsWith("  - Values:"),
+          testing::StartsWith("  - Project:"),
           testing::HasSubstr(":= plus("),
-          testing::StartsWith("      - RecursiveReference: name=t"),
+          testing::StartsWith("    - RecursiveReference: name=t"),
           testing::Eq("")));
 }
 
@@ -1634,33 +1629,31 @@ TEST_F(PlanPrinterTest, fixedPointSelfJoin) {
   auto rowType = ROW("n", BIGINT());
   PlanBuilder::Context context;
 
+  auto anchor = PlanBuilder(context).values(
+      rowType, std::vector<Variant>{Variant::row({1LL})});
+
   auto right = PlanBuilder(context, /*allowAmbiguousOutputNames=*/true)
-                   .recursiveRef("r", rowType)
+                   .recursiveRef("r", anchor)
                    .as("r2");
   auto step = PlanBuilder(context, /*allowAmbiguousOutputNames=*/true)
-                  .recursiveRef("r", rowType)
+                  .recursiveRef("r", anchor)
                   .as("r1")
                   .join(right, "r1.n = r2.n", JoinType::kInner)
                   .project({"r1.n as n"})
                   .planNode();
 
-  auto plan = PlanBuilder(context)
-                  .values(rowType, std::vector<Variant>{Variant::row({1LL})})
-                  .fixedPoint("r", step)
-                  .build();
+  auto plan = anchor.fixedPoint("r", step).build();
 
   EXPECT_THAT(
       toLines(plan),
       testing::ElementsAre(
-          testing::StartsWith("- Project:"),
-          testing::HasSubstr("n := "),
-          testing::StartsWith("  - FixedPoint(name=r):"),
-          testing::StartsWith("    - Values:"),
-          testing::StartsWith("    - Project:"),
+          testing::StartsWith("- FixedPoint(name=r):"),
+          testing::StartsWith("  - Values:"),
+          testing::StartsWith("  - Project:"),
           testing::HasSubstr(":= "),
-          testing::StartsWith("      - Join INNER:"),
-          testing::StartsWith("        - RecursiveReference: name=r"),
-          testing::StartsWith("        - RecursiveReference: name=r"),
+          testing::StartsWith("    - Join INNER:"),
+          testing::StartsWith("      - RecursiveReference: name=r"),
+          testing::StartsWith("      - RecursiveReference: name=r"),
           testing::Eq("")));
 }
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -5070,6 +5070,11 @@ void ToGraph::makeQueryGraph(
       wrapInDt(*node.onlyInput(), /*orderObservedAbove=*/false);
       addWrite(*node.as<lp::TableWriteNode>());
     } break;
+    case lp::NodeKind::kFixedPoint:
+    case lp::NodeKind::kRecursiveReference:
+      VELOX_NYI(
+          "Fixed-point (recursive) plan execution is not yet implemented");
+      break;
     default:
       VELOX_NYI(
           "Unsupported PlanNode {}", lp::NodeKindName::toName(node.kind()));

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(
   ExistencePushdownTest.cpp
   FilterPushdownTest.cpp
   FiltersTest.cpp
+  FixedPointTest.cpp
   HiveAggregationQueriesTest.cpp
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp

--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+class FixedPointTest : public test::QueryTestBase {};
+
+// Attempting to execute a recursive plan must fail with a clear NYI error.
+TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
+  auto rowType = ROW("n", BIGINT());
+  logical_plan::PlanBuilder::Context context;
+
+  auto anchor = logical_plan::PlanBuilder(context).values(
+      rowType, std::vector<Variant>{Variant::row({0LL})});
+
+  auto step = logical_plan::PlanBuilder(context)
+                  .recursiveRef("counter", anchor)
+                  .project({"n + 1 as n"})
+                  .planNode();
+
+  auto plan = anchor.fixedPoint("counter", step).build();
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(plan),
+      "Fixed-point (recursive) plan execution is not yet implemented");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   ExpressionPlanner.cpp
   GroupByPlanner.cpp
   ParserOptions.cpp
+  RecursiveCteValidator.cpp
   SortProjection.cpp
   PrestoParser.cpp
   ShowStatsBuilder.cpp

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -29,6 +29,7 @@
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/RecursiveCteValidator.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
 #include "axiom/sql/presto/SortProjection.h"
 #include "axiom/sql/presto/ast/AstBuilder.h"
@@ -396,6 +397,79 @@ class RelationPlanner : public AstVisitor {
     }
   }
 
+  void processQueryBody(const QueryBodyPtr& queryBody) {
+    if (queryBody->is(NodeType::kQuerySpecification)) {
+      visitQuerySpecification(
+          queryBody->as<QuerySpecification>(), /*orderBy=*/nullptr);
+    } else {
+      queryBody->accept(this);
+    }
+  }
+
+  // Saves displayNames_ accumulated/last names, clears lastNames, and
+  // restores both on scope exit. Used when translating subplans (anchor,
+  // step) that must not leak their column names into the enclosing scope.
+  auto scopedResetLastNames() {
+    auto guard = folly::makeGuard(
+        [this,
+         savedAccumulated = displayNames_.accumulatedNames,
+         savedLast = std::move(displayNames_.lastNames)]() mutable {
+          displayNames_.accumulatedNames = std::move(savedAccumulated);
+          displayNames_.lastNames = std::move(savedLast);
+        });
+    displayNames_.lastNames.clear();
+    return guard;
+  }
+
+  // Translates a recursive CTE into a fresh FixedPointNode subtree rooted
+  // in the caller's builder_. Anchor sees 'outerScope' (LATERAL resolves);
+  // step does not (correlated refs across the boundary fail). Each outer
+  // reference run this to produce new FixedPointNodes.
+  void translateRecursiveCteReference(
+      const WithQuery& withEntry,
+      const std::string& cteName) {
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        recursiveCteAnchors_.empty(),
+        withEntry.location(),
+        cteName,
+        "WITH RECURSIVE does not support nested recursive CTEs");
+    auto unionExpr =
+        presto::RecursiveCteValidator::extractAndValidateRecursiveUnion(
+            withEntry, cteName);
+
+    // Translate the anchor on a fresh builder inheriting the outer scope
+    // (LATERAL refs resolve through it).
+    auto outerScope = builder_->scope();
+    builder_ = newBuilder(outerScope);
+    {
+      auto guard = scopedResetLastNames();
+      processQueryBody(unionExpr->left());
+    }
+    if (const auto& columnAliases = withEntry.columnNames()) {
+      displayNames_.captureLastNames(*columnAliases);
+      applyColumnAliases(*columnAliases, withEntry.location(), cteName);
+    }
+    auto anchorBuilder = builder_;
+
+    // Translate the step on a fresh builder with no outer scope; register
+    // the anchor so processTable() resolves self-references via
+    // recursiveRef using the anchor's name mappings.
+    builder_ = newBuilder();
+    recursiveCteAnchors_[cteName] = anchorBuilder.get();
+    SCOPE_EXIT {
+      recursiveCteAnchors_.erase(cteName);
+    };
+    {
+      auto guard = scopedResetLastNames();
+      processQueryBody(unionExpr->right());
+    }
+    auto stepNode = builder_->planNode();
+
+    // Restore builder_ to the anchor and emit the FixedPointNode.
+    builder_ = std::move(anchorBuilder);
+    builder_->fixedPoint(/*name=*/cteName, stepNode);
+  }
+
   void processFrom(const RelationPtr& relation) {
     if (relation == nullptr) {
       // SELECT 1; type of query.
@@ -427,69 +501,100 @@ class RelationPlanner : public AstVisitor {
   void processTable(const Table& table) {
     const auto tableName = canonicalizeName(table.name()->suffix());
 
-    auto withIt = withQueries_.find(table.name()->suffix());
-    if (withIt == withQueries_.end()) {
-      withIt = withQueries_.find(tableName);
+    // Resolution precedence:
+    //   1. In-flight recursive CTE step body -- a self-reference inside
+    //      the step body must emit a RecursiveReferenceNode rather than
+    //      re-entering the WithQuery lookup and re-translating the body.
+    //   2. CTE binding in withQueries_ (recursive or non-recursive). For
+    //      recursive entries, re-translates the body at this reference
+    //      site so each reference yields an independent FixedPointNode
+    //      subtree (execution does not support DAG plans).
+    //   3. Base table.
+    auto recursiveIt = recursiveCteAnchors_.find(tableName);
+    if (recursiveIt != recursiveCteAnchors_.end()) {
+      builder_ = newBuilder();
+      // The recursive-ref name must match the enclosing FixedPointNode's
+      // name so the optimizer wires this self-reference to that loop state.
+      builder_->recursiveRef(recursiveIt->first, *recursiveIt->second);
+      builder_->as(tableName);
+      displayNames_.accumulate(*builder_, tableName);
+      return;
     }
 
+    auto withIt = withQueries_.find(tableName);
     if (withIt != withQueries_.end()) {
       // Temporarily remove the CTE from the map while processing its body
       // to prevent infinite recursion when a CTE has the same name as a
       // base table it references (e.g. WITH t AS (SELECT * FROM t)).
-      // Non-recursive CTEs cannot reference themselves in Presto.
-      auto withEntry = std::move(withIt->second);
+      // Recursive CTEs are also pulled out so a sibling outer reference
+      // fired mid-translation cannot re-enter the same body.
+      auto entry = std::move(withIt->second);
       withQueries_.erase(withIt);
       SCOPE_EXIT {
-        withQueries_.insert_or_assign(tableName, std::move(withEntry));
+        withQueries_.insert_or_assign(tableName, std::move(entry));
       };
-      // TODO: Change WithQuery to store Query and not Statement.
-      processQuery(dynamic_cast<Query*>(withEntry->query().get()));
 
-      // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
-      // the underlying SELECT/VALUES output columns to a, b.
-      if (const auto& columnAliases = withEntry->columnNames()) {
-        displayNames_.captureLastNames(*columnAliases);
-        applyColumnAliases(*columnAliases, withEntry->location(), tableName);
-      }
-      displayNames_.accumulate(*builder_, tableName);
-    } else {
-      const auto [connectorId, connectorTable] = toConnectorTable(
-          *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
-
-      auto metadata =
-          facebook::axiom::connector::ConnectorMetadataRegistry::get(
-              connectorId);
-
-      if (metadata->findTable(connectorTable) != nullptr) {
-        // Drop display names captured from a sibling FROM relation so
-        // this table's columns aren't tagged with them.
-        displayNames_.lastNames.clear();
-        inputTables_.insert(
-            facebook::axiom::CatalogSchemaTableName{
-                connectorId, connectorTable});
-        builder_->tableScan(
-            connectorId,
-            connectorTable.schema,
-            connectorTable.table,
-            /*includeHiddenColumns=*/true);
-      } else if (auto view = metadata->findView(connectorTable)) {
-        views_.emplace(
-            facebook::axiom::CatalogSchemaTableName{
-                connectorId, connectorTable},
-            view->text());
-
-        VELOX_CHECK_NOT_NULL(parseSql_);
-        auto query = parseSql_(view->text());
-        processQuery(dynamic_cast<Query*>(query.get()));
+      if (entry.isRecursive) {
+        translateRecursiveCteReference(*entry.withQuery, tableName);
       } else {
-        AXIOM_PRESTO_SEMANTIC_FAIL(
-            table.location(),
-            // Use suffix (unqualified name) as token — the user rarely writes
-            // the fully qualified form.
-            table.name()->suffix(),
-            "Table not found: {}",
-            table.name()->fullyQualifiedName());
+        // TODO: Change WithQuery to store Query and not Statement.
+        processQuery(dynamic_cast<Query*>(entry.withQuery->query().get()));
+
+        // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
+        // the underlying SELECT/VALUES output columns to a, b.
+        if (const auto& columnAliases = entry.withQuery->columnNames()) {
+          displayNames_.captureLastNames(*columnAliases);
+          applyColumnAliases(
+              *columnAliases, entry.withQuery->location(), tableName);
+        }
       }
+      finalizeCteReference(tableName);
+      return;
+    }
+
+    // Regular base-table reference.
+    const auto [connectorId, connectorTable] = toConnectorTable(
+        *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
+
+    auto metadata =
+        facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+
+    if (metadata->findTable(connectorTable) != nullptr) {
+      // Drop display names captured from a sibling FROM relation so
+      // this table's columns aren't tagged with them.
+      displayNames_.lastNames.clear();
+      inputTables_.insert(
+          facebook::axiom::CatalogSchemaTableName{connectorId, connectorTable});
+      builder_->tableScan(
+          connectorId,
+          connectorTable.schema,
+          connectorTable.table,
+          /*includeHiddenColumns=*/true);
+    } else if (auto view = metadata->findView(connectorTable)) {
+      views_.emplace(
+          facebook::axiom::CatalogSchemaTableName{connectorId, connectorTable},
+          view->text());
+
+      VELOX_CHECK_NOT_NULL(parseSql_);
+      auto query = parseSql_(view->text());
+      // A view body is an independent query and must not resolve table
+      // references against the caller's in-flight recursive step-body
+      // bindings. Save and restore here so any sibling FROM relations in
+      // this outer query still see the outer bindings.
+      auto savedRecursiveCteAnchors = std::move(recursiveCteAnchors_);
+      recursiveCteAnchors_.clear();
+      SCOPE_EXIT {
+        recursiveCteAnchors_ = std::move(savedRecursiveCteAnchors);
+      };
+      processQuery(dynamic_cast<Query*>(query.get()));
+    } else {
+      AXIOM_PRESTO_SEMANTIC_FAIL(
+          table.location(),
+          // Use suffix (unqualified name) as token — the user rarely writes
+          // the fully qualified form.
+          table.name()->suffix(),
+          "Table not found: {}",
+          table.name()->fullyQualifiedName());
     }
 
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
@@ -516,6 +621,15 @@ class RelationPlanner : public AstVisitor {
 
     auto percentage = toExpr(sampledRelation.samplePercentage());
     builder_->sample(percentage.expr(), sampleMethod);
+  }
+
+  // Records the relation's user-visible display names under 'tableName', fills
+  // in any missing output-column names, then installs 'tableName' as the
+  // alias so qualified references resolve. CTE-style branches only.
+  void finalizeCteReference(const std::string& tableName) {
+    displayNames_.accumulate(*builder_, tableName);
+    builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
+    builder_->as(tableName);
   }
 
   // Renames the current builder output columns to match a user-supplied
@@ -1202,9 +1316,11 @@ class RelationPlanner : public AstVisitor {
   void processQuery(Query* query) {
     auto savedWithQueries = withQueries_;
     auto savedAccumulatedNames = displayNames_.accumulatedNames;
+    auto savedRecursiveCteAnchors = recursiveCteAnchors_;
     SCOPE_EXIT {
       withQueries_ = std::move(savedWithQueries);
       displayNames_.accumulatedNames = std::move(savedAccumulatedNames);
+      recursiveCteAnchors_ = std::move(savedRecursiveCteAnchors);
     };
 
     // lastNames is scoped per query; reset so names from a sibling relation
@@ -1212,14 +1328,23 @@ class RelationPlanner : public AstVisitor {
     displayNames_.lastNames.clear();
 
     if (const auto& with = query->with()) {
-      AXIOM_PRESTO_SYNTAX_CHECK(
-          !with->isRecursive(),
-          with->location(),
-          "RECURSIVE",
-          "WITH RECURSIVE is not supported");
-      for (const auto& query : with->queries()) {
+      for (const auto& withQuery : with->queries()) {
+        const auto cteName = canonicalizeIdentifier(*withQuery->name());
+        // A CTE in a WITH RECURSIVE block is only recursive if its body
+        // actually references its own name. Otherwise it's a standard union.
+        bool selfReferential = false;
+        if (with->isRecursive()) {
+          auto* bodyQuery = dynamic_cast<Query*>(withQuery->query().get());
+          selfReferential = bodyQuery != nullptr &&
+              presto::RecursiveCteValidator::referencesCte(*bodyQuery, cteName);
+        }
         withQueries_.insert_or_assign(
-            canonicalizeIdentifier(*query->name()), query);
+            cteName, CteEntry{withQuery, selfReferential});
+        // A nested WITH binding shadows any enclosing recursive CTE of the
+        // same name; remove the in-flight step-body entry so processTable
+        // falls through to the new withQueries_ binding. processQuery's
+        // SCOPE_EXIT restores recursiveCteAnchors_ on exit.
+        recursiveCteAnchors_.erase(cteName);
       }
     }
 
@@ -1410,7 +1535,19 @@ class RelationPlanner : public AstVisitor {
         return builder_->hasColumn(first) ||
             builder_->hasQualifiedColumn(first, second);
       }};
-  std::unordered_map<std::string, std::shared_ptr<WithQuery>> withQueries_;
+  // A CTE binding tracked while translating its enclosing query.
+  // 'isRecursive' is true when the body self-references and therefore
+  // requires FixedPointNode translation at each reference site.
+  struct CteEntry {
+    std::shared_ptr<WithQuery> withQuery;
+    bool isRecursive{false};
+  };
+  std::unordered_map<std::string, CteEntry> withQueries_;
+  // Anchor PlanBuilder pointer for each recursive CTE currently being
+  // translated. processTable consumes this when emitting the matching
+  // RecursiveReferenceNode so step-body self-references inherit anchor
+  // name resolution.
+  folly::F14FastMap<std::string, const lp::PlanBuilder*> recursiveCteAnchors_;
   ViewMap views_;
   std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables_;
   bool friendlySql_;

--- a/axiom/sql/presto/RecursiveCteValidator.cpp
+++ b/axiom/sql/presto/RecursiveCteValidator.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/RecursiveCteValidator.h"
+
+#include "axiom/sql/presto/ExpressionPlanner.h"
+#include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
+#include "velox/exec/Aggregate.h"
+
+namespace axiom::sql::presto {
+namespace {
+
+// Detects whether a query body references the table 'cteName' (already
+// canonicalized) -- i.e. whether a WITH RECURSIVE CTE actually recurses.
+// Descent stops at a nested query that redefines the same name, so an inner
+// CTE shadowing the outer name is not mistaken for a self-reference.
+class CteSelfReferenceFinder : public DefaultTraversalVisitor {
+ public:
+  explicit CteSelfReferenceFinder(std::string cteName)
+      : cteName_{std::move(cteName)} {}
+
+  bool found() const {
+    return found_;
+  }
+
+ protected:
+  void visitTable(Table* node) override {
+    if (canonicalizeName(node->name()->suffix()) == cteName_) {
+      found_ = true;
+    }
+  }
+
+  void visitQuery(Query* node) override {
+    if (const auto& with = node->with()) {
+      for (const auto& withQuery : with->queries()) {
+        if (canonicalizeIdentifier(*withQuery->name()) == cteName_) {
+          // The name is shadowed by a nested CTE; references below resolve to
+          // that CTE, not the one we are looking for.
+          return;
+        }
+      }
+    }
+    DefaultTraversalVisitor::visitQuery(node);
+  }
+
+ private:
+  const std::string cteName_;
+  bool found_{false};
+};
+
+// Rejects constructs ANSI forbids in a WITH RECURSIVE recursive term:
+// DISTINCT, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, window functions
+// (FunctionCall with OVER), and aggregate function calls. Stops at
+// TableSubquery boundaries -- subqueries have their own iteration scope
+// and are unrestricted.
+class RecursiveTermValidator : public DefaultTraversalVisitor {
+ public:
+  explicit RecursiveTermValidator(std::string cteName)
+      : cteName_{std::move(cteName)} {}
+
+ protected:
+  void visitQuery(Query* node) override {
+    rejectOrderLimitOffset(
+        node->location(), node->orderBy(), node->limit(), node->offset());
+    DefaultTraversalVisitor::visitQuery(node);
+  }
+
+  void visitQuerySpecification(QuerySpecification* node) override {
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        !node->select()->isDistinct(),
+        node->location(),
+        cteName_,
+        "WITH RECURSIVE recursive term does not support DISTINCT");
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        node->groupBy() == nullptr,
+        node->location(),
+        cteName_,
+        "WITH RECURSIVE recursive term does not support GROUP BY");
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        node->having() == nullptr,
+        node->location(),
+        cteName_,
+        "WITH RECURSIVE recursive term does not support HAVING");
+    rejectOrderLimitOffset(
+        node->location(), node->orderBy(), node->limit(), node->offset());
+    DefaultTraversalVisitor::visitQuerySpecification(node);
+  }
+
+  void visitFunctionCall(FunctionCall* node) override {
+    const auto& name = node->name()->suffix();
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        node->window() == nullptr,
+        node->location(),
+        cteName_,
+        "WITH RECURSIVE recursive term does not support window functions");
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        facebook::velox::exec::getAggregateFunctionEntry(name) == nullptr,
+        node->location(),
+        cteName_,
+        "WITH RECURSIVE recursive term does not support aggregate functions");
+    DefaultTraversalVisitor::visitFunctionCall(node);
+  }
+
+  // FROM-clause subqueries have their own scope; the recursive ref inside
+  // them reads the working table at the current iteration, which is
+  // well-defined. Matches Postgres / DuckDB.
+  void visitTableSubquery(TableSubquery* /*node*/) override {}
+
+  // Scalar / IN / EXISTS / quantified subqueries (`SubqueryExpression`)
+  // resolve the recursive ref per-row of the outer query, which is not
+  // what users mean. Matches Postgres / DuckDB. Stop descent: the
+  // subquery's internal constructs are unrestricted -- only the ref's
+  // presence is forbidden.
+  void visitSubqueryExpression(SubqueryExpression* node) override {
+    if (node->query() != nullptr &&
+        RecursiveCteValidator::referencesCte(*node->query(), cteName_)) {
+      AXIOM_PRESTO_SYNTAX_FAIL(
+          node->location(),
+          cteName_,
+          "WITH RECURSIVE recursive term does not support the recursive reference inside a scalar/IN/EXISTS subquery");
+    }
+  }
+
+  // Per ANSI / Postgres / DuckDB: the recursive ref may not appear on the
+  // nullable side of an outer join -- a NULL-padded row can re-join with
+  // itself on the next iteration, producing spurious infinite growth.
+  void visitJoin(Join* node) override {
+    switch (node->joinType()) {
+      case Join::Type::kLeft:
+        rejectRefOnRightSide(*node);
+        break;
+      case Join::Type::kRight:
+        rejectRefOnLeftSide(*node);
+        break;
+      case Join::Type::kFull:
+        rejectRefOnLeftSide(*node);
+        rejectRefOnRightSide(*node);
+        break;
+      case Join::Type::kInner:
+      case Join::Type::kCross:
+      case Join::Type::kImplicit:
+        break;
+    }
+    DefaultTraversalVisitor::visitJoin(node);
+  }
+
+ private:
+  void rejectRefOnLeftSide(const Join& node) {
+    if (node.left() != nullptr &&
+        RecursiveCteValidator::referencesCte(*node.left(), cteName_)) {
+      AXIOM_PRESTO_SYNTAX_FAIL(
+          node.location(),
+          cteName_,
+          "WITH RECURSIVE recursive reference may not appear on the nullable left side of an outer join");
+    }
+  }
+
+  void rejectRefOnRightSide(const Join& node) {
+    if (node.right() != nullptr &&
+        RecursiveCteValidator::referencesCte(*node.right(), cteName_)) {
+      AXIOM_PRESTO_SYNTAX_FAIL(
+          node.location(),
+          cteName_,
+          "WITH RECURSIVE recursive reference may not appear on the nullable right side of an outer join");
+    }
+  }
+
+  void rejectOrderLimitOffset(
+      const NodeLocation& location,
+      const std::shared_ptr<OrderBy>& orderBy,
+      const std::optional<std::string>& limit,
+      const std::shared_ptr<Offset>& offset) {
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        orderBy == nullptr,
+        location,
+        cteName_,
+        "WITH RECURSIVE does not support ORDER BY in the recursive CTE");
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        !limit.has_value(),
+        location,
+        cteName_,
+        "WITH RECURSIVE does not support LIMIT in the recursive CTE");
+    AXIOM_PRESTO_SYNTAX_CHECK(
+        offset == nullptr,
+        location,
+        cteName_,
+        "WITH RECURSIVE does not support OFFSET in the recursive CTE");
+  }
+
+  const std::string cteName_;
+};
+
+void validateRecursiveTerm(const Node& stepBody, const std::string& cteName) {
+  RecursiveTermValidator validator{cteName};
+  validator.process(const_cast<Node*>(&stepBody));
+}
+
+} // namespace
+
+bool RecursiveCteValidator::referencesCte(
+    const Node& body,
+    const std::string& cteName) {
+  CteSelfReferenceFinder finder{cteName};
+  finder.process(const_cast<Node*>(&body));
+  return finder.found();
+}
+
+const Union* RecursiveCteValidator::extractAndValidateRecursiveUnion(
+    const WithQuery& withEntry,
+    const std::string& cteName) {
+  auto* bodyQuery = dynamic_cast<Query*>(withEntry.query().get());
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      bodyQuery != nullptr,
+      withEntry.location(),
+      cteName,
+      "Recursive CTE body is not a query");
+  const auto& queryBody = bodyQuery->queryBody();
+
+  // Reject set operations other than UNION ALL.
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      queryBody->is(NodeType::kUnion) && !queryBody->as<Union>()->isDistinct(),
+      bodyQuery->location(),
+      cteName,
+      "Recursive CTE '{}' body must be UNION ALL",
+      cteName);
+
+  const auto* unionExpr = queryBody->as<Union>();
+
+  // The self-reference must live in the recursive (right) term. A reference
+  // in the anchor (left) term -- including the left side of a 3+-way UNION
+  // ALL, which parses left-associatively -- is not supported.
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      !RecursiveCteValidator::referencesCte(*unionExpr->left(), cteName),
+      bodyQuery->location(),
+      cteName,
+      "WITH RECURSIVE self-reference must appear in the recursive term "
+      "(right side of UNION ALL), not the anchor term");
+
+  // ORDER BY / LIMIT / OFFSET on the wrapping Query are meaningless in a
+  // recursive CTE (executor decides per-iteration order; ANSI forbids).
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      bodyQuery->orderBy() == nullptr,
+      bodyQuery->location(),
+      cteName,
+      "WITH RECURSIVE does not support ORDER BY in the recursive CTE");
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      !bodyQuery->limit().has_value(),
+      bodyQuery->location(),
+      cteName,
+      "WITH RECURSIVE does not support LIMIT in the recursive CTE");
+  AXIOM_PRESTO_SYNTAX_CHECK(
+      bodyQuery->offset() == nullptr,
+      bodyQuery->location(),
+      cteName,
+      "WITH RECURSIVE does not support OFFSET in the recursive CTE");
+
+  validateRecursiveTerm(*unionExpr->right(), cteName);
+
+  return unionExpr;
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/RecursiveCteValidator.h
+++ b/axiom/sql/presto/RecursiveCteValidator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "axiom/sql/presto/ast/AstNodesAll.h"
+
+namespace axiom::sql::presto {
+
+/// Detection and validation helpers for `WITH RECURSIVE` CTE bodies. The
+/// translation methods (anchor / step / FixedPointNode assembly) live in
+/// `RelationPlanner` -- they touch parser-private state directly.
+class RecursiveCteValidator {
+ public:
+  /// Returns true if `body` references a table named `cteName`
+  /// (canonicalized upstream). Descent stops at a nested query that
+  /// redefines the same name.
+  static bool referencesCte(const Node& body, const std::string& cteName);
+
+  /// Checks that the CTE body is `UNION ALL`, the self-reference is in
+  /// the recursive (right) term only, and the enclosing Query has no
+  /// ORDER BY / LIMIT / OFFSET. Also runs the recursive-term validator on
+  /// the right term (rejects DISTINCT, GROUP BY, HAVING, ORDER BY, LIMIT,
+  /// OFFSET, window functions, aggregate functions, recursive refs in
+  /// scalar / IN / EXISTS subqueries, and recursive refs on the nullable
+  /// side of an outer join). Returns the validated `Union` (always
+  /// non-null on success).
+  static const Union* extractAndValidateRecursiveUnion(
+      const WithQuery& withEntry,
+      const std::string& cteName);
+};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ReferencedTablesTest.cpp
   SortParserTest.cpp
   SplitStatementsTest.cpp
+  WithRecursiveTest.cpp
 )
 
 add_test(axiom_sql_presto_test axiom_sql_presto_test)

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -706,6 +706,126 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::join(
   return *this;
 }
 
+namespace {
+// Matches a FixedPointNode and captures aliases for all output columns.
+class FixedPointAliasMatcher : public LogicalPlanMatcherImpl<FixedPointNode> {
+ public:
+  FixedPointAliasMatcher(
+      const std::vector<std::shared_ptr<LogicalPlanMatcher>>& inputMatchers,
+      std::vector<std::string> outputAliases)
+      : LogicalPlanMatcherImpl<FixedPointNode>(inputMatchers, nullptr),
+        outputAliases_{std::move(outputAliases)} {}
+
+ private:
+  MatchResult matchDetails(
+      const FixedPointNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    const auto& outputType = plan.outputType();
+    if (outputAliases_.size() != outputType->size()) {
+      ADD_FAILURE() << "Expected " << outputAliases_.size()
+                    << " FixedPointNode output columns, got "
+                    << outputType->size();
+      return MatchResult::failure();
+    }
+    auto newSymbols = symbols;
+    for (size_t i = 0; i < outputAliases_.size(); ++i) {
+      newSymbols[outputAliases_[i]] = outputType->nameOf(i);
+    }
+    return MatchResult::success(newSymbols);
+  }
+
+  const std::vector<std::string> outputAliases_;
+};
+
+// Matches a RecursiveReferenceNode leaf with an expected name and,
+// optionally, captures aliases for all output columns.
+class RecursiveReferenceMatcher
+    : public LogicalPlanMatcherImpl<RecursiveReferenceNode> {
+ public:
+  RecursiveReferenceMatcher(
+      std::string expectedName,
+      std::vector<std::string> outputAliases)
+      : LogicalPlanMatcherImpl<RecursiveReferenceNode>(nullptr),
+        expectedName_{std::move(expectedName)},
+        outputAliases_{std::move(outputAliases)} {}
+
+ private:
+  MatchResult matchDetails(
+      const RecursiveReferenceNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    if (expectedName_ != plan.name()) {
+      ADD_FAILURE() << "Expected RecursiveReferenceNode name '" << expectedName_
+                    << "', got '" << plan.name() << "'";
+      return MatchResult::failure();
+    }
+    if (outputAliases_.empty()) {
+      return MatchResult::success(symbols);
+    }
+    const auto& outputType = plan.outputType();
+    if (outputAliases_.size() != outputType->size()) {
+      ADD_FAILURE() << "Expected " << outputAliases_.size()
+                    << " RecursiveReferenceNode output columns, got "
+                    << outputType->size();
+      return MatchResult::failure();
+    }
+    auto newSymbols = symbols;
+    for (size_t i = 0; i < outputAliases_.size(); ++i) {
+      newSymbols[outputAliases_[i]] = outputType->nameOf(i);
+    }
+    return MatchResult::success(newSymbols);
+  }
+
+  const std::string expectedName_;
+  const std::vector<std::string> outputAliases_;
+};
+} // namespace
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::fixedPoint(
+    const std::shared_ptr<LogicalPlanMatcher>& stepMatcher,
+    OnMatchCallback onMatch) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<LogicalPlanMatcherImpl<FixedPointNode>>(
+      std::vector<std::shared_ptr<LogicalPlanMatcher>>{matcher_, stepMatcher},
+      std::move(onMatch));
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::fixedPoint(
+    const std::shared_ptr<LogicalPlanMatcher>& stepMatcher,
+    const std::vector<std::string>& outputAliases) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointAliasMatcher>(
+      std::vector<std::shared_ptr<LogicalPlanMatcher>>{matcher_, stepMatcher},
+      outputAliases);
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::recursiveRef(
+    OnMatchCallback onMatch) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<LogicalPlanMatcherImpl<RecursiveReferenceNode>>(
+      std::move(onMatch));
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::recursiveRef(
+    const std::string& name) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<RecursiveReferenceMatcher>(
+      name, std::vector<std::string>{});
+  return *this;
+}
+
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::recursiveRef(
+    const std::string& name,
+    const std::vector<std::string>& outputAliases) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<RecursiveReferenceMatcher>(name, outputAliases);
+  return *this;
+}
+
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::setOperation(
     SetOperation op,
     const std::shared_ptr<LogicalPlanMatcher>& matcher,

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -189,6 +189,36 @@ class LogicalPlanMatcherBuilder {
       const std::shared_ptr<LogicalPlanMatcher>& rightMatcher,
       const std::vector<std::string>& outputAliases);
 
+  /// Matches a FixedPointNode. The prior chain matches the anchor; the
+  /// given matcher matches the step.
+  LogicalPlanMatcherBuilder& fixedPoint(
+      const std::shared_ptr<LogicalPlanMatcher>& stepMatcher,
+      OnMatchCallback onMatch = nullptr);
+
+  /// Matches a FixedPointNode and captures aliases for all output columns.
+  /// 'outputAliases' must have one entry per output column. Each alias is
+  /// mapped to the actual column name at that position, so subsequent
+  /// matchers can reference these aliases in expressions.
+  LogicalPlanMatcherBuilder& fixedPoint(
+      const std::shared_ptr<LogicalPlanMatcher>& stepMatcher,
+      const std::vector<std::string>& outputAliases);
+
+  /// Matches a RecursiveReferenceNode leaf; must be the first call in a
+  /// chain.
+  LogicalPlanMatcherBuilder& recursiveRef(OnMatchCallback onMatch = nullptr);
+
+  /// Matches a RecursiveReferenceNode leaf and verifies its referenced
+  /// FixedPointNode name.
+  LogicalPlanMatcherBuilder& recursiveRef(const std::string& name);
+
+  /// Matches a RecursiveReferenceNode leaf, verifies its referenced
+  /// FixedPointNode name, and captures aliases for all output columns
+  /// (see fixedPoint(stepMatcher, outputAliases) for the alias-capture
+  /// convention).
+  LogicalPlanMatcherBuilder& recursiveRef(
+      const std::string& name,
+      const std::vector<std::string>& outputAliases);
+
   /// Matches a SetNode with the specified operation and right-side matcher.
   LogicalPlanMatcherBuilder& setOperation(
       SetOperation op,

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -369,12 +369,6 @@ TEST_F(PrestoParserTest, withReferencedMultipleTimes) {
       matcher);
 }
 
-TEST_F(PrestoParserTest, withRecursiveNotSupported) {
-  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
-      parseSql("WITH RECURSIVE t AS (SELECT 1 AS x) SELECT * FROM t"),
-      "WITH RECURSIVE is not supported");
-}
-
 TEST_F(PrestoParserTest, join) {
   {
     auto matcher = matchScan()

--- a/axiom/sql/presto/tests/WithRecursiveTest.cpp
+++ b/axiom/sql/presto/tests/WithRecursiveTest.cpp
@@ -1,0 +1,886 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
+#include "axiom/sql/presto/tests/LogicalPlanMatcher.h"
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+namespace {
+
+class WithRecursiveTest : public PrestoParserTestBase {};
+
+TEST_F(WithRecursiveTest, simpleCounter) {
+  // Self-contained recursion — no base table needed.
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("counter")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE counter(n) AS (
+          SELECT CAST(1 AS BIGINT)
+          UNION ALL
+          SELECT n + 1 FROM counter WHERE n < 10
+        )
+        SELECT * FROM counter
+      )",
+      matchValues().project().project().fixedPoint(step, {"n"}).output());
+}
+
+TEST_F(WithRecursiveTest, joinInStep) {
+  // Step body joins the recursive reference with a base table.
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("anc")
+                  .join(matchScan("nation").build())
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE anc(nation_key, region_key) AS (
+          SELECT n_nationkey, n_regionkey
+          FROM nation
+          WHERE n_regionkey = 0
+          UNION ALL
+          SELECT n.n_nationkey, n.n_regionkey
+          FROM anc a
+          JOIN nation n ON a.nation_key = n.n_nationkey
+        )
+        SELECT nation_key, region_key FROM anc
+      )",
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .fixedPoint(step, {"nation_key", "region_key"})
+          .project()
+          .output());
+}
+
+TEST_F(WithRecursiveTest, qualifiedReferenceToCte) {
+  // Qualified reference (`SELECT r.x FROM r`) to a recursive CTE resolves.
+  const auto sql = R"(
+        WITH RECURSIVE r(x, y) AS (
+          SELECT n_nationkey, n_regionkey FROM nation WHERE n_nationkey = 0
+          UNION ALL
+          SELECT n.n_nationkey, n.n_regionkey FROM r JOIN nation n ON r.x = n.n_nationkey
+        )
+        SELECT r.x, r.y FROM r
+      )";
+
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .join(matchScan("nation").build())
+                  .project()
+                  .build();
+  testSelect(
+      sql,
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .fixedPoint(step, {"x", "y"})
+          .project()
+          .output({"x", "y"}));
+}
+
+TEST_F(WithRecursiveTest, columnAliasesVisibleInOuterQuery) {
+  // Column aliases applied to the anchor must be visible as the
+  // FixedPointNode's output column names and the outer SELECT's output.
+  const auto sql = R"(
+        WITH RECURSIVE r(x, y) AS (
+          SELECT n_nationkey, n_regionkey FROM nation WHERE n_nationkey = 0
+          UNION ALL
+          SELECT n.n_nationkey, n.n_regionkey FROM r JOIN nation n ON r.x = n.n_nationkey
+        )
+        SELECT x, y FROM r
+      )";
+
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .join(matchScan("nation").build())
+                  .project()
+                  .build();
+  testSelect(
+      sql,
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .fixedPoint(step, {"x", "y"})
+          .project()
+          .output({"x", "y"}));
+}
+
+TEST_F(WithRecursiveTest, cteWithOuterFilter) {
+  // WHERE in the outer query must not be pushed into the FixedPointNode.
+  // The anchor matcher chain (matchValues().project().project()) pins the
+  // anchor's exact shape -- a Filter anywhere inside the anchor would fail
+  // the match.
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM r WHERE a < 100
+    )
+    SELECT a FROM r WHERE a > 50
+  )",
+      matchValues()
+          .project()
+          .project()
+          .fixedPoint(step, {"a"})
+          .filter()
+          .project()
+          .output());
+}
+
+TEST_F(WithRecursiveTest, rejectsUnionDistinct) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(1 AS BIGINT)
+          UNION
+          SELECT a + 1 FROM r
+        )
+        SELECT * FROM r
+      )"),
+      "body must be UNION ALL");
+}
+
+TEST_F(WithRecursiveTest, rejectsIntersect) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(1 AS BIGINT)
+          INTERSECT
+          SELECT a + 1 FROM r
+        )
+        SELECT * FROM r
+      )"),
+      "body must be UNION ALL");
+}
+
+TEST_F(WithRecursiveTest, rejectsExcept) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(1 AS BIGINT)
+          EXCEPT
+          SELECT a + 1 FROM r
+        )
+        SELECT * FROM r
+      )"),
+      "body must be UNION ALL");
+}
+
+TEST_F(WithRecursiveTest, rejectsNesting) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE outer_r(a) AS (
+          SELECT CAST(1 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM outer_r WHERE a IN (
+            WITH RECURSIVE inner_r(b) AS (
+              SELECT CAST(1 AS BIGINT)
+              UNION ALL
+              SELECT b + 1 FROM inner_r
+            )
+            SELECT b FROM inner_r
+          )
+        )
+        SELECT * FROM outer_r
+      )"),
+      "WITH RECURSIVE does not support nested recursive CTEs");
+}
+
+// Rejection: SELECT DISTINCT at the top of the recursive term changes the
+// per-iteration semantics (only first-iteration's distinct rows survive),
+// so ANSI forbids it.
+TEST_F(WithRecursiveTest, rejectsDistinctInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT DISTINCT a + 1 FROM r WHERE a < 5
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive term does not support DISTINCT");
+}
+
+// Rejection: GROUP BY at the top of the recursive term implies aggregation
+// across the working table, which ANSI forbids.
+TEST_F(WithRecursiveTest, rejectsGroupByInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a < 5 GROUP BY a
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive term does not support GROUP BY");
+}
+
+// Rejection: ORDER BY inside the recursive term is meaningless (order
+// across iterations is the executor's concern) and ANSI forbids it.
+TEST_F(WithRecursiveTest, rejectsOrderByInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a < 5 ORDER BY a
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE does not support ORDER BY in the recursive CTE");
+}
+
+// Rejection: LIMIT inside the recursive term short-circuits iteration in a
+// way ANSI does not specify; reject so users use max_recursion_depth or an
+// outer LIMIT instead.
+TEST_F(WithRecursiveTest, rejectsLimitInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a < 5 LIMIT 10
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE does not support LIMIT in the recursive CTE");
+}
+
+// Rejection: OFFSET inside the recursive term has the same problems as
+// LIMIT (truncates per-iteration output unpredictably). ANSI forbids it.
+TEST_F(WithRecursiveTest, rejectsOffsetInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a < 5 OFFSET 1
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE does not support OFFSET in the recursive CTE");
+}
+
+// Rejection: HAVING in the recursive term implies aggregation over the
+// working table (the single implicit group), which ANSI forbids alongside
+// GROUP BY.
+TEST_F(WithRecursiveTest, rejectsHavingInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a < 5 HAVING COUNT(*) > 0
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive term does not support HAVING");
+}
+
+// Rejection: window functions in the recursive term have ill-defined
+// semantics -- the PARTITION/ORDER spans only the per-iteration working
+// table, not the accumulated set. ANSI forbids them.
+TEST_F(WithRecursiveTest, rejectsWindowFunctionInRecursiveTerm) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a, rn) AS (
+          SELECT CAST(0 AS BIGINT), CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1, ROW_NUMBER() OVER () FROM r WHERE a < 5
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive term does not support window functions");
+}
+
+// Rejection: aggregate over the recursive reference (e.g. COUNT/SUM/MAX
+// of a column from r). Postgres and DuckDB reject this; non-monotonic over
+// the per-iteration working table so the fixed point is not well-defined.
+TEST_F(WithRecursiveTest, rejectsAggregateOverRecursiveRef) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT MAX(a) + 1 FROM r WHERE a < 5
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive term does not support aggregate functions");
+}
+
+// Rejection: recursive reference inside an EXISTS subquery. The subquery
+// re-reads the working table per outer-row, which is not what users intend.
+// Postgres and DuckDB reject; we follow.
+TEST_F(WithRecursiveTest, rejectsRefInExistsSubquery) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r
+          WHERE a < 5 AND EXISTS (SELECT 1 FROM r WHERE a > 0)
+        )
+        SELECT * FROM r
+      )"),
+      "scalar/IN/EXISTS subquery");
+}
+
+TEST_F(WithRecursiveTest, rejectsRefInScalarSubquery) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + (SELECT a FROM r WHERE a < 1 LIMIT 1)
+          FROM r WHERE a < 5
+        )
+        SELECT * FROM r
+      )"),
+      "scalar/IN/EXISTS subquery");
+}
+
+// Rejection: recursive reference inside an IN subquery.
+TEST_F(WithRecursiveTest, rejectsRefInInSubquery) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT a + 1 FROM r WHERE a IN (SELECT a FROM r)
+        )
+        SELECT * FROM r
+      )"),
+      "scalar/IN/EXISTS subquery");
+}
+
+// Rejection: recursive reference on the nullable side of a LEFT JOIN.
+// A NULL-padded row produced from the right side can re-join with itself in
+// the next iteration, breaking fixed-point monotonicity.
+TEST_F(WithRecursiveTest, rejectsRefOnNullableSideOfLeftJoin) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT t.x FROM (SELECT 1 AS x) t LEFT JOIN r ON t.x = r.a
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive reference may not appear on the nullable right side of an outer join");
+}
+
+TEST_F(WithRecursiveTest, rejectsRefOnNullableSideOfRightJoin) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT t.x FROM r RIGHT JOIN (SELECT 1 AS x) t ON t.x = r.a
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive reference may not appear on the nullable left side of an outer join");
+}
+
+TEST_F(WithRecursiveTest, rejectsRefOnNullableSideOfFullJoin) {
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT CAST(0 AS BIGINT)
+          UNION ALL
+          SELECT t.x FROM r FULL JOIN (SELECT 1 AS x) t ON t.x = r.a
+        )
+        SELECT * FROM r
+      )"),
+      "WITH RECURSIVE recursive reference may not appear on the nullable left side of an outer join");
+}
+
+// Allowed: recursive reference inside an INNER JOIN (neither side is
+// nullable). Pins the kInner case in visitJoin.
+TEST_F(WithRecursiveTest, allowsRefInInnerJoin) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .join(matchValues().project().build())
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT t.x + r.a FROM r INNER JOIN (SELECT 1 AS x) t ON t.x = r.a
+      WHERE r.a < 3
+    )
+    SELECT * FROM r
+  )",
+      matchValues().project().project().fixedPoint(step).output());
+}
+
+// The step branch itself uses a UNION ALL inside a subquery, combining two
+// separate recursive branches before returning them to the accumulator.
+TEST_F(WithRecursiveTest, unionInStepBranch) {
+  auto stepRight = lp::test::LogicalPlanMatcherBuilder()
+                       .recursiveRef("r")
+                       .filter()
+                       .project()
+                       .build();
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .project()
+                  .unionAll(stepRight)
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT new_a
+      FROM (
+        SELECT a + 1 AS new_a FROM r
+        UNION ALL
+        SELECT a + 10 AS new_a FROM r WHERE a < 5
+      ) t
+    )
+    SELECT * FROM r WHERE a < 20
+  )",
+      matchValues().project().project().fixedPoint(step).filter().output());
+}
+
+// A WITH RECURSIVE block that mixes a plain (non-recursive) CTE with a
+// recursive CTE. The recursive CTE's anchor is seeded from the plain CTE.
+TEST_F(WithRecursiveTest, nonRecursiveCteAsAnchorSeed) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE
+          base(nation_key) AS (
+            SELECT n_nationkey FROM nation WHERE n_regionkey = 0
+          ),
+          r(nation_key) AS (
+            SELECT nation_key FROM base
+            UNION ALL
+            SELECT r2.nation_key + 1 AS nation_key
+            FROM r r2
+            WHERE r2.nation_key < 10
+          )
+        SELECT nation_key FROM r
+      )",
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .project()
+          .project()
+          .fixedPoint(step)
+          .project()
+          .output());
+}
+
+// The RecursiveReferenceNode in the step carries the same column types as
+// the anchor and the same name as the enclosing FixedPointNode.
+TEST_F(WithRecursiveTest, refTypesMatchAnchor) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r", {"nation_key", "region_key"})
+                  .join(matchScan("nation").build())
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(nation_key, region_key) AS (
+      SELECT n_nationkey, n_regionkey FROM nation WHERE n_nationkey = 0
+      UNION ALL
+      SELECT n.n_nationkey, n.n_regionkey
+      FROM r
+      JOIN nation n ON r.nation_key = n.n_nationkey
+    )
+    SELECT nation_key, region_key FROM r
+  )",
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .fixedPoint(step, {"nation_key", "region_key"})
+          .project()
+          .output({"nation_key", "region_key"}));
+}
+
+// When CTE column aliases are applied, the FixedPointNode's output type carries
+// the aliased names, and the RecursiveReferenceNode carries the matching types
+// so step-body column resolution (e.g. `r.x`) succeeds.
+TEST_F(WithRecursiveTest, aliasedSchemaConsistency) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r", {"x", "y"})
+                  .join(matchScan("nation").build())
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(x, y) AS (
+      SELECT n_nationkey, n_regionkey FROM nation WHERE n_nationkey = 0
+      UNION ALL
+      SELECT n.n_nationkey, n.n_regionkey
+      FROM r
+      JOIN nation n ON r.x = n.n_nationkey
+    )
+    SELECT x, y FROM r
+  )",
+      matchScan("nation")
+          .filter()
+          .project()
+          .project()
+          .fixedPoint(step, {"x", "y"})
+          .project()
+          .output({"x", "y"}));
+}
+
+// Anchor and step producing incompatible types must be caught at FixedPointNode
+// construction, not silently accepted.
+TEST_F(WithRecursiveTest, typeMismatchRejected) {
+  // The anchor column is BIGINT; the recursive term re-emits it as VARCHAR, so
+  // the FixedPointNode's anchor/step schemas are incompatible.
+  VELOX_ASSERT_THROW(
+      parseSelect(R"(
+        WITH RECURSIVE r(a) AS (
+          SELECT n_nationkey FROM nation WHERE n_nationkey = 0
+          UNION ALL
+          SELECT CAST(a AS VARCHAR) FROM r
+        )
+        SELECT a FROM r
+      )"),
+      "equivalent output schemas");
+}
+
+TEST_F(WithRecursiveTest, columnCountMismatchRejected) {
+  // The anchor produces two columns; the recursive term produces one. The
+  // FixedPointNode constructor must reject the mismatched output arity.
+  VELOX_ASSERT_THROW(
+      parseSelect(R"(
+        WITH RECURSIVE r(a, b) AS (
+          SELECT n_nationkey, n_name FROM nation WHERE n_nationkey = 0
+          UNION ALL
+          SELECT a FROM r
+        )
+        SELECT a FROM r
+      )"),
+      "equivalent output schemas");
+}
+
+TEST_F(WithRecursiveTest, nonSelfReferentialUnionAllIsPlainCte) {
+  // The CTE never references itself, so WITH RECURSIVE here is just a plain
+  // UNION ALL CTE -- the positive matcher pins the plain shape (no
+  // FixedPointNode).
+  testSelect(
+      R"(
+        WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT 2)
+        SELECT * FROM r
+      )",
+      matchValues()
+          .project()
+          .unionAll(matchValues().project().build())
+          .project()
+          .output());
+}
+
+TEST_F(WithRecursiveTest, nonRecursiveIntersectIsPlainCte) {
+  // A non-self-referential INTERSECT in a WITH RECURSIVE block is a valid
+  // ordinary CTE; it must lower as a plain Intersect, not be rejected as
+  // "requires UNION ALL".
+  testSelect(
+      R"(
+        WITH RECURSIVE r(n) AS (SELECT 1 INTERSECT SELECT 1)
+        SELECT * FROM r
+      )",
+      matchValues()
+          .project()
+          .intersect(matchValues().project().build())
+          .project()
+          .output());
+}
+
+TEST_F(WithRecursiveTest, selfReferenceInAnchorRejected) {
+  // The self-reference is in the anchor (left) term, not the recursive term.
+  // This must be rejected with a clear error rather than "Table not found".
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(R"(
+        WITH RECURSIVE r(n) AS (SELECT n FROM r UNION ALL SELECT 1)
+        SELECT * FROM r
+      )"),
+      "self-reference must appear in the recursive term");
+}
+
+TEST_F(WithRecursiveTest, emptyAnchor) {
+  // Empty anchor (anchor produces zero rows): the FixedPoint should still
+  // parse and lower; the executor decides convergence on the first iteration.
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(n) AS (
+      SELECT CAST(1 AS BIGINT) WHERE 1 = 0
+      UNION ALL
+      SELECT n + 1 FROM r WHERE n < 5
+    )
+    SELECT * FROM r
+  )",
+      matchValues().filter().project().project().fixedPoint(step).output());
+}
+
+TEST_F(WithRecursiveTest, multipleSiblings) {
+  // Two recursive CTEs in the same WITH RECURSIVE block; r2's anchor reads
+  // r1's accumulated output. Exercises sibling recursive CTEs being
+  // translated independently without leaking state across them.
+  auto stepR1 = lp::test::LogicalPlanMatcherBuilder()
+                    .recursiveRef("r1")
+                    .filter()
+                    .project()
+                    .build();
+  auto stepR2 = lp::test::LogicalPlanMatcherBuilder()
+                    .recursiveRef("r2")
+                    .filter()
+                    .project()
+                    .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE
+      r1(a) AS (
+        SELECT CAST(0 AS BIGINT)
+        UNION ALL
+        SELECT a + 1 FROM r1 WHERE a < 3
+      ),
+      r2(b) AS (
+        SELECT a FROM r1
+        UNION ALL
+        SELECT b + 10 FROM r2 WHERE b < 30
+      )
+    SELECT b FROM r2
+  )",
+      matchValues()
+          .project()
+          .project()
+          .fixedPoint(stepR1)
+          .project()
+          .project()
+          .fixedPoint(stepR2)
+          .project()
+          .output());
+}
+
+// Presto identifiers are case-insensitive regardless of quoting. The
+// recursive CTE name canonicalizes to lowercase and resolves the same
+// whether the declaration or the references use mixed case or quoting.
+TEST_F(WithRecursiveTest, caseInsensitiveCteName) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("myr")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE "MyR"(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM MYR WHERE a < 3
+    )
+    SELECT * FROM myR
+  )",
+      matchValues().project().project().fixedPoint(step).output());
+}
+
+// Inner WITH (non-recursive) reusing the outer recursive CTE name shadows
+// the outer name: inside the inner SELECT, `r` resolves to the inner CTE,
+// not to the outer recursive CTE. The outer recursive `r` is therefore
+// never referenced and the plan contains no FixedPointNode — the matcher
+// pins the inner CTE's plain values/project shape end-to-end.
+TEST_F(WithRecursiveTest, shadowedByInnerWith) {
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM r WHERE a < 3
+    )
+    SELECT * FROM (
+      WITH r AS (SELECT CAST(99 AS BIGINT) AS x)
+      SELECT x FROM r
+    ) t
+  )",
+      matchValues().project({"99::bigint"}).project().output({"x"}));
+}
+
+// An inner WITH binding inside the recursive step body shadows the outer
+// recursive CTE name -- the step body's `FROM r` inside the subquery
+// resolves to the inner CTE's column `b`, not the outer's column `a`.
+// Without an inner CTE-guard the inner `r` would route through the outer's
+// RecursiveReferenceNode path and surface column `a` instead of the inner CTE's
+// values subtree.
+TEST_F(WithRecursiveTest, innerWithInsideStepShadows) {
+  auto innerCte = matchValues().project().project().build();
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .join(innerCte)
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT r.a + 1 FROM r CROSS JOIN (
+        WITH r AS (SELECT 99 AS b) SELECT b FROM r
+      ) inner_r
+      WHERE r.a < 3
+    )
+    SELECT * FROM r
+  )",
+      matchValues().project().project().fixedPoint(step).output());
+}
+
+// Constructs that ANSI forbids in the recursive term (DISTINCT, ORDER BY,
+// LIMIT) are allowed inside a FROM-clause subquery within the step, because
+// a subquery is a sealed scope.
+TEST_F(WithRecursiveTest, allowsRestrictedConstructsInsideStepSubquery) {
+  auto step =
+      matchValues()
+          .project()
+          .project()
+          .distinct()
+          .sort()
+          .limit(0, 1)
+          .join(lp::test::LogicalPlanMatcherBuilder().recursiveRef("r").build())
+          .filter()
+          .project()
+          .build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM (
+        SELECT DISTINCT n
+        FROM (SELECT 1 AS n) t
+        ORDER BY n
+        LIMIT 1
+      ) sub
+      CROSS JOIN r
+      WHERE a < 3
+    )
+    SELECT * FROM r
+  )",
+      matchValues().project().project().fixedPoint(step).output());
+}
+
+TEST_F(WithRecursiveTest, nonRecursiveCte) {
+  // A plain-SELECT CTE in a WITH RECURSIVE block lowers to the same shape as
+  // an ordinary non-recursive CTE — no FixedPointNode is introduced.
+  testSelect(
+      "WITH RECURSIVE t AS (SELECT 1 AS x) SELECT * FROM t",
+      matchValues().project().output());
+}
+
+// Outer query that references the recursive relation twice via UNION ALL.
+// Each reference must produce its own FixedPointNode subtree -- a shared
+// subtree would silently produce a DAG plan that the execution layer cannot
+// run.
+TEST_F(WithRecursiveTest, doubleReferenceToRecursiveCte) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  auto rightBranch =
+      matchValues().project().project().fixedPoint(step).project().build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM r WHERE a < 3
+    )
+    SELECT a FROM r
+    UNION ALL
+    SELECT a FROM r
+  )",
+      matchValues()
+          .project()
+          .project()
+          .fixedPoint(step)
+          .project()
+          .unionAll(rightBranch)
+          .output());
+}
+
+// Self-join over a recursive CTE: each reference site is independently
+// translated, so the two references have disjoint column ids. A shared
+// FixedPointNode subtree would surface as a JoinNode duplicate-name error.
+TEST_F(WithRecursiveTest, selfJoinOnRecursiveCte) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  auto rightFixedPoint =
+      matchValues().project().project().fixedPoint(step).build();
+  testSelect(
+      R"(
+    WITH RECURSIVE r(a) AS (
+      SELECT CAST(0 AS BIGINT)
+      UNION ALL
+      SELECT a + 1 FROM r WHERE a < 3
+    )
+    SELECT * FROM r r1 JOIN r r2 ON r1.a = r2.a
+  )",
+      matchValues()
+          .project()
+          .project()
+          .fixedPoint(step)
+          .join(rightFixedPoint)
+          .output());
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Adds `WITH RECURSIVE` parsing support. Previously this query threw `WITH RECURSIVE is not supported`:

    WITH RECURSIVE descendants(node_id, parent_id) AS (
      SELECT node_id, parent_id FROM nodes WHERE node_id = 'root'
      UNION ALL
      SELECT child.node_id, child.parent_id
      FROM descendants d JOIN nodes child ON d.node_id = child.parent_id
    )
    SELECT node_id FROM descendants;

It now lowers to a `FixedPointNode` whose anchor is the base-case scan and whose step contains a `RecursiveReferenceNode` for each self-reference.

Anchor and step are translated separately. The anchor fixes the CTE's output schema; the step is translated on a builder with no outer scope so correlated references across the `WITH RECURSIVE` boundary fail naturally. When the step references the CTE by name, a `RecursiveReferenceNode` is substituted. The completed `FixedPointNode` is saved under the CTE name and re-installed by name on outer-query references.

Detection and ANSI validation helpers live in a new `RecursiveCteTranslator.{h,cpp}`. The translation methods stay in `RelationPlanner` -- they touch private parser state directly and a clean lift requires a larger refactor.

Rejected forms with a clear error:

- Non-UNION-ALL set ops in the CTE body: `UNION DISTINCT`, `INTERSECT`, `EXCEPT`.
- Nested `WITH RECURSIVE`.
- Self-reference in the anchor (left) term.
- In the recursive (right) term: `DISTINCT`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `OFFSET`, window functions, aggregates over the recursive reference, recursive references inside scalar / IN / EXISTS subqueries, and recursive references on the nullable side of an outer join.

Non-recursive CTEs in a `WITH RECURSIVE` block remain valid and follow the ordinary non-recursive path (Presto allows mixing). Execution is still NYI -- the optimizer throws `Fixed-point (recursive) plan execution is not yet implemented`.

Reviewed By: mbasmanova

Differential Revision: D106579296


