### PR TITLE
fix(optimizer): Drop a redundant same-type TRY_CAST

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1354,8 +1354,10 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
     auto* exprType = toType(expr->type());
 
     // Drop redundant cast.
-    //    CAST(x as t) ==> x if typeof(x) == t.
-    if (specialForm && specialForm->form() == lp::SpecialForm::kCast) {
+    //    CAST(x as t) / TRY_CAST(x as t) ==> x if typeof(x) == t.
+    if (specialForm &&
+        (specialForm->form() == lp::SpecialForm::kCast ||
+         specialForm->form() == lp::SpecialForm::kTryCast)) {
       if (args[0]->value().type == exprType) {
         return args[0];
       }

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -295,6 +295,9 @@ TEST_F(PlanTest, specialFormConstantFold) {
        "case when a > 0 then 10 else b + 1 end"},
       {"try(10 / 1)", "10"},
       {"try_cast(1 as BIGINT)", "1"},
+      // A same-type cast over a column is dropped, for CAST and TRY_CAST alike.
+      {"cast(a as bigint) + 1", "a + 1"},
+      {"try_cast(a as bigint) + 1", "a + 1"},
       {"coalesce(1 + 1, a)", "coalesce(2, a)"},
       {"coalesce(cast(null as bigint), 5 * 2)", "10"},
   };


### PR DESCRIPTION
Summary:
The optimizer already dropped a redundant same-type `CAST` but kept a same-type `TRY_CAST`, so a no-op cast survived in the plan. For a `bigint` column `a`, `try_cast(a as bigint) + 1` planned as:

    before:  plus(try_cast(a as bigint), 1)
    after:   plus(a, 1)

Extend the redundant-cast check in `ToGraph` to match `TRY_CAST` as well as `CAST`; a same-type cast never errors, so the two are equivalent. The v2 translator already handles both.

Differential Revision: D108517681


