### PR TITLE
docs(connectors): Document the scan filter pushdown contract

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -528,7 +528,8 @@ class TableLayout {
   /// @param filterConjuncts Filter conjuncts applied to the table. This may
   /// be a superset of filters encoded in the table handle. The connector
   /// should report indices of conjuncts it could not account for via
-  /// rejectedFilterIndices.
+  /// rejectedFilterIndices. The conjuncts are in the same canonical form as
+  /// the 'filters' argument of createTableHandle.
   ///
   /// The default implementation returns std::nullopt, meaning the connector
   /// does not support stats estimation. Connectors opt in by overriding.
@@ -571,6 +572,30 @@ class TableLayout {
   /// lookupKeys() in 'layout'. If 'dataColumns' is given, it must have all the
   /// existing columns and may additionally specify casting from maps to structs
   /// by giving a struct in the place of a map.
+  ///
+  /// The optimizer normalizes 'filters' into a canonical form a connector may
+  /// rely on:
+  /// - A top-level conjunction is flattened: 'filters' holds one entry per
+  ///   conjunct, with no nested AND.
+  /// - A comparison against a constant is written column-first, e.g.
+  ///   eq(column, constant). The column is always the first argument and the
+  ///   constant the second, for eq, lt, lte, gt and gte. A connector never
+  ///   sees the constant on the left (e.g. eq(constant, column)).
+  /// - An IN list over constants is a single in() over the column and the
+  ///   constant values, with duplicate values removed. The values may be
+  ///   encoded either as a constant array, in(column, ARRAY[...]), or as
+  ///   variadic arguments, in(column, v1, v2, ...). A connector should handle
+  ///   both forms.
+  ///
+  /// Predicates are NOT combined across conjuncts: 'filters' may contain
+  /// several predicates on the same column (e.g. a = 1 and a = 2), which the
+  /// connector must handle. The optimizer does not fold redundant or
+  /// contradictory same-column predicates.
+  ///
+  /// TODO: Unify the two IN encodings into the varargs form and remove the
+  /// ARRAY encoding.
+  /// TODO: Fold a single-element IN list to an equality, and simplify
+  /// redundant or contradictory same-column predicates, before pushdown.
   virtual velox::connector::ConnectorTableHandlePtr createTableHandle(
       const ConnectorSessionPtr& session,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -674,8 +674,27 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
     std::vector<velox::core::TypedExprPtr>& rejectedFilters,
     velox::RowTypePtr /* dataColumns */,
     std::optional<LookupKeys> /*lookupKeys*/) const {
+  auto* testConnector = dynamic_cast<TestConnector*>(connector());
+  VELOX_CHECK_NOT_NULL(testConnector);
+  if (const auto& inspector = testConnector->onCreateTableHandle()) {
+    inspector(filters);
+  }
   rejectedFilters = std::move(filters);
   return std::make_shared<TestTableHandle>(*this, std::move(columnHandles));
+}
+
+folly::coro::Task<std::optional<FilteredTableStats>>
+TestTableLayout::co_estimateStats(
+    ConnectorSessionPtr /*session*/,
+    velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+    std::vector<std::string> /*columns*/,
+    std::vector<velox::core::TypedExprPtr> filterConjuncts) const {
+  auto* testConnector = dynamic_cast<TestConnector*>(connector());
+  VELOX_CHECK_NOT_NULL(testConnector);
+  if (const auto& inspector = testConnector->onEstimateStats()) {
+    inspector(filterConjuncts);
+  }
+  co_return std::nullopt;
 }
 
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include <functional>
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "velox/core/ITypedExpr.h"
@@ -153,6 +154,14 @@ class TestTableLayout : public TableLayout {
       std::vector<velox::core::TypedExprPtr>& rejectedFilters,
       velox::RowTypePtr dataColumns,
       std::optional<LookupKeys> lookupKeys) const override;
+
+  // Forwards the received conjuncts to the installed estimate-stats inspector,
+  // then returns std::nullopt (no stats), as the base does.
+  folly::coro::Task<std::optional<FilteredTableStats>> co_estimateStats(
+      ConnectorSessionPtr session,
+      velox::connector::ConnectorTableHandlePtr tableHandle,
+      std::vector<std::string> columns,
+      std::vector<velox::core::TypedExprPtr> filterConjuncts) const override;
 
  private:
   std::vector<const Column*> discreteValueColumns_;
@@ -376,25 +385,21 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
       const std::string& connectorId,
       const SchemaTableName& name,
       int64_t size,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      std::vector<velox::core::TypedExprPtr> filters = {})
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles)
       : ConnectorTableHandle(connectorId),
         name_(name),
         size_(size),
         columnHandles_(std::move(columnHandles)),
-        filters_(std::move(filters)),
         nameString_(name.toString()) {}
 
   TestTableHandle(
       const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
-      std::vector<velox::core::TypedExprPtr> filters = {})
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles)
       : TestTableHandle(
             layout.connector()->connectorId(),
             layout.table().name(),
             getTableSize(layout),
-            std::move(columnHandles),
-            std::move(filters)) {}
+            std::move(columnHandles)) {}
 
   static int64_t getTableSize(const TableLayout& layout) {
     auto& table = dynamic_cast<const TestTable&>(layout.table());
@@ -417,10 +422,6 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
     return name();
   }
 
-  const std::vector<velox::core::TypedExprPtr>& filters() const {
-    return filters_;
-  }
-
   const std::vector<velox::connector::ColumnHandlePtr>& columnHandles() const {
     return columnHandles_;
   }
@@ -437,17 +438,12 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
       columns.push_back(handle->serialize());
     }
     obj["columnHandles"] = std::move(columns);
-    folly::dynamic filterArray = folly::dynamic::array;
-    for (const auto& filter : filters_) {
-      filterArray.push_back(filter->serialize());
-    }
-    obj["filters"] = std::move(filterArray);
     return obj;
   }
 
   static velox::connector::ConnectorTableHandlePtr create(
       const folly::dynamic& obj,
-      void* context) {
+      void* /*context*/) {
     auto connectorId = obj["connectorId"].asString();
     auto schema = obj["schemaName"].asString();
     auto tableName = obj["tableName"].asString();
@@ -460,20 +456,11 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
                 col));
       }
     }
-    std::vector<velox::core::TypedExprPtr> filters;
-    if (obj.count("filters")) {
-      for (const auto& f : obj["filters"]) {
-        filters.push_back(
-            velox::ISerializable::deserialize<velox::core::ITypedExpr>(
-                f, context));
-      }
-    }
     return std::make_shared<TestTableHandle>(
         connectorId,
         SchemaTableName(schema, tableName),
         size,
-        std::move(columnHandles),
-        std::move(filters));
+        std::move(columnHandles));
   }
 
   static void registerSerDe() {
@@ -486,7 +473,6 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
   const SchemaTableName name_;
   const int64_t size_;
   const std::vector<velox::connector::ColumnHandlePtr> columnHandles_;
-  const std::vector<velox::core::TypedExprPtr> filters_;
   const std::string nameString_;
 };
 
@@ -871,6 +857,32 @@ class TestConnector : public velox::connector::Connector {
 
   void addTpchTables();
 
+  /// Callback receiving the filter expressions the optimizer pushes into a
+  /// scan. Installed by tests to inspect the exact form a connector is handed.
+  using FilterInspector =
+      std::function<void(const std::vector<velox::core::TypedExprPtr>&)>;
+
+  /// Installs a callback invoked with the 'filters' argument of every
+  /// TestTableLayout::createTableHandle call.
+  void setOnCreateTableHandle(FilterInspector inspector) {
+    onCreateTableHandle_ = std::move(inspector);
+  }
+
+  /// Installs a callback invoked with the 'filterConjuncts' argument of every
+  /// TestTableLayout::co_estimateStats call.
+  void setOnEstimateStats(FilterInspector inspector) {
+    onEstimateStats_ = std::move(inspector);
+  }
+
+  // Returns the installed inspector, or an empty std::function if none was set.
+  const FilterInspector& onCreateTableHandle() const {
+    return onCreateTableHandle_;
+  }
+
+  const FilterInspector& onEstimateStats() const {
+    return onEstimateStats_;
+  }
+
   /// Register a view with the given name, output schema, and SQL text.
   void createView(
       const SchemaTableName& viewName,
@@ -883,6 +895,8 @@ class TestConnector : public velox::connector::Connector {
  private:
   const std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   const std::shared_ptr<TestConnectorMetadata> metadata_;
+  FilterInspector onCreateTableHandle_;
+  FilterInspector onEstimateStats_;
 };
 
 /// The ConnectorFactory for the TestConnector can be configured with

--- a/axiom/connectors/tests/TestConnectorSerDeTest.cpp
+++ b/axiom/connectors/tests/TestConnectorSerDeTest.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
-#include "velox/core/Expressions.h"
 #include "velox/type/Type.h"
 
 namespace facebook::axiom::connector {
@@ -63,11 +62,6 @@ class TestConnectorSerDeTest : public testing::Test {
       ASSERT_EQ(original->name(), cloned->name());
       ASSERT_EQ(*original->type(), *cloned->type());
     }
-    ASSERT_EQ(handle.filters().size(), clone->filters().size());
-    for (size_t i = 0; i < handle.filters().size(); ++i) {
-      ASSERT_EQ(
-          handle.filters()[i]->toString(), clone->filters()[i]->toString());
-    }
   }
 
   static void testSerde(const TestConnectorSplit& split) {
@@ -102,20 +96,6 @@ TEST_F(TestConnectorSerDeTest, tableHandle) {
   auto handle2 = TestTableHandle(
       connectorId, SchemaTableName{"schema2", "table2"}, 5, std::move(columns));
   testSerde(handle2);
-
-  // With filters.
-  auto filterExpr =
-      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1");
-  std::vector<velox::connector::ColumnHandlePtr> columns2 = {
-      std::make_shared<TestColumnHandle>("c1", BIGINT()),
-  };
-  auto handle3 = TestTableHandle(
-      connectorId,
-      SchemaTableName{"schema3", "table3"},
-      3,
-      std::move(columns2),
-      {filterExpr});
-  testSerde(handle3);
 
   // Empty schema and name.
   auto handle4 = TestTableHandle(connectorId, SchemaTableName{"", ""}, 0, {});

--- a/axiom/optimizer/tests/ConnectorPushdownTest.cpp
+++ b/axiom/optimizer/tests/ConnectorPushdownTest.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/ScopeGuard.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/ExprMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/parse/ExpressionsParser.h"
+
+namespace facebook::axiom::optimizer::test {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+// Verifies the canonical form of the filter expressions the optimizer hands to
+// a connector for pushdown. This shape is the contract documented on
+// ConnectorMetadata::createTableHandle and co_estimateStats; connector authors
+// rely on it. Each scenario asserts both APIs receive the same form so the
+// single contract cannot be silently broken for one of them.
+class ConnectorPushdownTest : public QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    testConnector_->addTable(
+        "t",
+        ROW({"a", "b", "c", "s"}, {BIGINT(), BIGINT(), BIGINT(), VARCHAR()}));
+  }
+
+  // Optimizes 'scan t where <filter>' and returns the pushed conjuncts captured
+  // separately from createTableHandle and from co_estimateStats.
+  std::pair<std::vector<core::TypedExprPtr>, std::vector<core::TypedExprPtr>>
+  pushedFilters(const std::string& filter) {
+    std::vector<core::TypedExprPtr> createHandle;
+    std::vector<core::TypedExprPtr> estimateStats;
+    testConnector_->setOnCreateTableHandle(
+        [&](const std::vector<core::TypedExprPtr>& filters) {
+          createHandle = filters;
+        });
+    testConnector_->setOnEstimateStats(
+        [&](const std::vector<core::TypedExprPtr>& filters) {
+          estimateStats = filters;
+        });
+    SCOPE_EXIT {
+      testConnector_->setOnCreateTableHandle(nullptr);
+      testConnector_->setOnEstimateStats(nullptr);
+    };
+
+    lp::PlanBuilder::Context context(kTestConnectorId, kDefaultSchema);
+    auto logicalPlan =
+        lp::PlanBuilder(context).tableScan("t").filter(filter).build();
+    toSingleNodePlan(logicalPlan);
+
+    return {std::move(createHandle), std::move(estimateStats)};
+  }
+
+  // Asserts the pushed conjuncts structurally match 'expected' (each an
+  // expression in SQL syntax), and that createTableHandle and co_estimateStats
+  // agree.
+  void expectPushed(
+      const std::string& filter,
+      const std::vector<std::string>& expected) {
+    SCOPED_TRACE("filter: " + filter);
+    auto [createHandle, estimateStats] = pushedFilters(filter);
+    matchAll(createHandle, expected);
+    matchAll(estimateStats, expected);
+  }
+
+  void matchAll(
+      const std::vector<core::TypedExprPtr>& actual,
+      const std::vector<std::string>& expected) {
+    ASSERT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+      core::ExprMatcher::match(actual[i], parser_.parseExpr(expected[i]));
+    }
+  }
+
+  parse::DuckSqlExpressionsParser parser_;
+};
+
+// Equality is canonicalized with the column as the first argument, regardless
+// of how the predicate was written.
+TEST_F(ConnectorPushdownTest, equality) {
+  expectPushed("a = 5", {"a = 5"});
+  expectPushed("5 = a", {"a = 5"});
+  expectPushed("s = 'x'", {"s = 'x'"});
+}
+
+// Reversible comparisons also put the column first, flipping the operator when
+// the constant was written on the left.
+TEST_F(ConnectorPushdownTest, comparison) {
+  expectPushed("a < 10", {"a < 10"});
+  expectPushed("10 > a", {"a < 10"});
+  expectPushed("a > 5", {"a > 5"});
+  expectPushed("5 < a", {"a > 5"});
+  expectPushed("a <= 10", {"a <= 10"});
+  expectPushed("10 >= a", {"a <= 10"});
+  expectPushed("a >= 5", {"a >= 5"});
+  expectPushed("5 <= a", {"a >= 5"});
+}
+
+// An all-literal IN list is pushed as a deduplicated IN. v1 emits the constant
+// array form (the contract also permits varargs); a single-element list stays
+// an IN, not folded to an equality.
+TEST_F(ConnectorPushdownTest, inList) {
+  expectPushed("a in (1, 2, 3)", {"a in (1, 2, 3)"});
+  expectPushed("a in (5, 5)", {"a in (5)"});
+}
+
+// Predicates are not combined across conjuncts: a connector may receive several
+// predicates on the same column and must handle them.
+TEST_F(ConnectorPushdownTest, duplicateColumnPredicates) {
+  expectPushed("a = 1 and a = 2", {"a = 1", "a = 2"});
+}
+
+// A top-level conjunction is flattened: each leaf predicate is a separate
+// conjunct, even when nested.
+TEST_F(ConnectorPushdownTest, nestedAndFlattened) {
+  expectPushed(
+      "a = 1 and (b = 2 and (c = 3 and s = 'x'))",
+      {"a = 1", "b = 2", "c = 3", "s = 'x'"});
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::test


### PR DESCRIPTION
Summary:
Document the canonical form of the filter expressions the optimizer pushes into a connector scan, on `ConnectorMetadata::createTableHandle` and `co_estimateStats`. There was no stated contract, so connector authors guessed and wrote defensive code against shapes the optimizer never produces, such as a constant on the left of an equality. The contract:
- a top-level conjunction is flattened into one conjunct per entry;
- a comparison against a constant is column-first, e.g. `eq(column, constant)`;
- an IN list is a deduplicated `in()` over the column and its constant values;
- predicates are not combined across conjuncts, so a connector may receive several predicates on the same column and must handle them.

Add two inspection hooks to the test connector, `setOnCreateTableHandle` and `setOnEstimateStats`, that capture the expressions each API is handed, and override `TestTableLayout::co_estimateStats` to fire one. Remove the dead `filters_` member from `TestTableHandle`, which nothing populated outside its own serde test.

The optimizer emits the IN list as a constant array today. The documented contract also permits the varargs form so connectors are ready for the planned switch to varargs. Unifying on varargs, folding a single-element IN to an equality, and folding contradictory same-column predicates are left as TODOs.

Differential Revision: D108521867


