### PR TITLE
test(tpch): Reuse pre-generated TPC-H data across test runs

### DIFF
--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include <gflags/gflags.h>
+#include <optional>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -24,7 +26,30 @@
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 
+DEFINE_string(
+    tpch_data_path,
+    "",
+    "If set, TPC-H tests reuse pre-generated sf0.1 Parquet data in this "
+    "directory (one subdirectory per table, with .stats files) and skip data "
+    "generation. If empty, falls back to the AXIOM_TPCH_DATA_PATH environment "
+    "variable (which survives `buck test`, where --flags do not); if that is "
+    "also empty, data is generated into a temporary directory on each run.");
+
 namespace facebook::axiom::optimizer::test {
+
+namespace {
+// Resolves the reuse directory from --tpch_data_path, else the
+// AXIOM_TPCH_DATA_PATH environment variable. std::nullopt means generate.
+std::optional<std::string> tpchDataPath() {
+  if (!FLAGS_tpch_data_path.empty()) {
+    return FLAGS_tpch_data_path;
+  }
+  if (const char* fromEnv = std::getenv("AXIOM_TPCH_DATA_PATH")) {
+    return std::string{fromEnv};
+  }
+  return std::nullopt;
+}
+} // namespace
 
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
@@ -36,9 +61,12 @@ const std::string kDefaultSchema{
 void HiveQueriesTestBase::SetUpTestCase() {
   test::QueryTestBase::SetUpTestCase();
 
-  gTempDirectory = common::testutil::TempDirectoryPath::create();
-
-  localDataPath_ = gTempDirectory->getPath();
+  if (const auto dataPath = tpchDataPath()) {
+    localDataPath_ = *dataPath;
+  } else {
+    gTempDirectory = common::testutil::TempDirectoryPath::create();
+    localDataPath_ = gTempDirectory->getPath();
+  }
   localFileFormat_ = velox::dwio::common::FileFormat::PARQUET;
 
   velox::parquet::registerParquetReaderFactory();
@@ -72,6 +100,11 @@ void HiveQueriesTestBase::SetUp() {
 // static
 void HiveQueriesTestBase::createTpchTables(
     const std::vector<velox::tpch::Table>& tables) {
+  if (tpchDataPath().has_value()) {
+    LOG(INFO) << "Reusing TPC-H data from " << localDataPath_
+              << "; skipping generation";
+    return;
+  }
   VELOX_CHECK(gTempDirectory != nullptr, "SetUpTestCase not called");
   TpchDataGenerator::createTables(
       tables, gTempDirectory->getPath(), /*scaleFactor=*/0.1, localFileFormat_);

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -33,7 +33,9 @@ class HiveQueriesTestBase : public QueryTestBase {
   /// Creates a temporary data directory and sets 'localDataPath_' and
   /// 'localFileFormat_' (Parquet by default). Registers Parquet reader and
   /// writer. Subclasses should call this, then use createTpchTables() to
-  /// populate test tables.
+  /// populate test tables. If --tpch_data_path or the AXIOM_TPCH_DATA_PATH
+  /// environment variable is set, 'localDataPath_' points at that pre-generated
+  /// directory instead and no temporary directory is created.
   static void SetUpTestCase();
 
   /// Sets up the Hive connector with LocalHiveConnectorMetadata, and
@@ -41,6 +43,8 @@ class HiveQueriesTestBase : public QueryTestBase {
   void SetUp() override;
 
   /// Generates TPC-H data for the specified tables using 'localFileFormat_'.
+  /// Skipped (data is reused as-is) when a pre-generated data directory is
+  /// configured; see SetUpTestCase().
   static void createTpchTables(const std::vector<velox::tpch::Table>& tables);
 
   /// Unregisters Hive connector metadata.


### PR DESCRIPTION
Summary:
TPC-H tests regenerate the sf0.1 Parquet data set into a fresh temporary directory on every run, which dominates wall-clock for the plan tests. Add an opt-in to point them at a pre-generated directory and skip generation: set `--tpch_data_path` (a gflag) or `AXIOM_TPCH_DATA_PATH` (an environment variable, which `buck test` forwards via `--env` where command-line flags are not). When set, `HiveQueriesTestBase` uses that directory as `localDataPath_` and `createTpchTables` returns without generating. Default behavior is unchanged — an empty setting still generates into a temporary directory, so CI stays hermetic.

Usage:

    buck test //axiom/optimizer/v2/tests:tpch_plan -- --env AXIOM_TPCH_DATA_PATH=$HOME/tpch/sf0.1

To filter to one query, put the positional filter before `--env` (which is variadic and would otherwise eat it):

    buck test //axiom/optimizer/v2/tests:tpch_plan -- 'TpchPlanTest.q03' --env AXIOM_TPCH_DATA_PATH=$HOME/tpch/sf0.1

With reuse, the suite roughly halves in wall-clock (~53s to ~28s).

Differential Revision: D108522413


