### PR TITLE
feat(optimizer): Connector pushdown via co_pushdownPlan (#1480)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -21,6 +21,7 @@
 #include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
 #include "velox/connectors/Connector.h"
@@ -698,9 +699,9 @@ class Table : public std::enable_shared_from_this<Table> {
 
   virtual const std::vector<const TableLayout*>& layouts() const = 0;
 
-  /// Returns an estimate of the number of rows in 'this'. `std::nullopt`
-  /// means the connector has no estimate; downstream cost-based
-  /// decisions fall back to safe defaults rather than a fabricated value.
+  /// Returns an estimate of the number of rows in 'this'. `nullopt`
+  /// if the connector has no estimate; downstream cost-based decisions
+  /// fall back to safe defaults rather than a fabricated value.
   virtual std::optional<uint64_t> numRows() const = 0;
 
   /// Returns the table properties specified at creation time (e.g. format,
@@ -821,6 +822,25 @@ class ConnectorWriteHandle {
 
 using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 
+/// One disjoint root the connector has agreed to execute natively.
+/// The optimizer materialises a scan from `table` in place of
+/// evaluating `root`; the `LogicalPlan` itself is never rewritten.
+/// `table` carries the connector's handle, column statistics, and
+/// row-count estimate via the standard `connector::Table` channel.
+///
+/// EXPERIMENTAL. Negotiates over `LogicalPlan`, which is not normalized.
+/// Expected to migrate to the optimizer's v2 IR once it lands; struct and
+/// method shapes may change.
+struct PushdownRoot {
+  /// Non-owning pointer into the `LogicalPlan` being optimized.
+  /// Valid for the duration of optimization.
+  const logical_plan::LogicalPlanNode* root;
+
+  /// Virtual table representing the pushed-down subtree's output.
+  /// Owned by the optimizer for the duration of optimization.
+  TablePtr table;
+};
+
 class ConnectorMetadata {
  public:
   /// Return the metadata for a given connector ID. Throws if not registered.
@@ -882,6 +902,30 @@ class ConnectorMetadata {
   /// @return nullptr if the type is not found.
   virtual velox::TypePtr findType(const SchemaTypeName& /*typeName*/) {
     return nullptr;
+  }
+
+  /// EXPERIMENTAL. Opt-in gate for connector pushdown. Default false.
+  /// The pushdown pass skips connectors that return false without
+  /// calling `co_pushdownPlan`.
+  virtual bool isPushdownSupported() const {
+    return false;
+  }
+
+  /// EXPERIMENTAL. Returns the disjoint roots this connector will
+  /// execute natively. The optimizer calls this once per maximal
+  /// subtree whose `TableScanNode`s all belong to this connector;
+  /// returned roots must be within `plan`. Each root tells the
+  /// optimizer "scan `table` in place of evaluating `root`." Pushing
+  /// a bare `TableScanNode` will error.
+  ///
+  /// Default `VELOX_FAIL`s. Connectors opting in via
+  /// `isPushdownSupported()` must override this method.
+  ///
+  /// See `PushdownRoot` for the v2-IR migration note.
+  virtual folly::coro::Task<std::vector<PushdownRoot>> co_pushdownPlan(
+      const logical_plan::LogicalPlanNode& /*plan*/) const {
+    VELOX_FAIL(
+        "Connector opted into pushdown via isPushdownSupported() but did not override co_pushdownPlan()");
   }
 
   /// Returns a SplitManager for split enumeration for TableLayouts accessed

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -507,6 +507,18 @@ TablePtr TestConnectorMetadata::findTable(const SchemaTableName& tableName) {
   return findTableInternal(tableName);
 }
 
+void TestConnectorMetadata::setPushdownMatcher(PushdownMatcher matcher) {
+  pushdownMatcher_ = std::move(matcher);
+}
+
+folly::coro::Task<std::vector<PushdownRoot>>
+TestConnectorMetadata::co_pushdownPlan(
+    const logical_plan::LogicalPlanNode& plan) const {
+  VELOX_CHECK_NOT_NULL(
+      pushdownMatcher_, "co_pushdownPlan called with no matcher installed");
+  co_return pushdownMatcher_(plan);
+}
+
 velox::TypePtr TestConnectorMetadata::findType(const SchemaTypeName& typeName) {
   auto it = types_.find(typeName);
   if (it != types_.end()) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -519,6 +519,24 @@ class TestConnectorMetadata : public ConnectorMetadata {
       : connector_(connector),
         splitManager_(std::make_unique<TestSplitManager>()) {}
 
+  /// Signature of a matcher that, for a given plan subtree, returns
+  /// the pushdown roots this connector wants to absorb.
+  using PushdownMatcher = std::function<std::vector<PushdownRoot>(
+      const logical_plan::LogicalPlanNode&)>;
+
+  /// Installs 'matcher' as the connector's pushdown matcher. A non-null
+  /// matcher opts the connector into pushdown and is invoked from
+  /// `co_pushdownPlan`. Passing nullptr clears the matcher and opts
+  /// out of pushdown.
+  void setPushdownMatcher(PushdownMatcher matcher);
+
+  bool isPushdownSupported() const override {
+    return pushdownMatcher_ != nullptr;
+  }
+
+  folly::coro::Task<std::vector<PushdownRoot>> co_pushdownPlan(
+      const logical_plan::LogicalPlanNode& plan) const override;
+
   TablePtr findTable(const SchemaTableName& tableName) override;
 
   /// Non-interface method which supplies a non-const Table reference
@@ -638,6 +656,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   TestConnector* connector_;
   folly::F14FastMap<SchemaTableName, std::shared_ptr<TestTable>> tables_;
   std::unique_ptr<TestSplitManager> splitManager_;
+  PushdownMatcher pushdownMatcher_;
 
   struct ViewDefinition {
     velox::RowTypePtr type;

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -750,6 +750,27 @@ class PlanBuilder {
     return node_;
   }
 
+  /// Captures the current plan node into 'node' so a test can grab a
+  /// pointer to a specific node at the point it is built, instead of
+  /// reaching it later by walking inputs() by index. The captured
+  /// pointer remains valid as long as the resulting plan does.
+  ///
+  /// Example:
+  ///
+  ///   const lp::LogicalPlanNode* filter = nullptr;
+  ///   auto plan = PlanBuilder(ctx)
+  ///     .tableScan("orders")
+  ///     .filter("a > 0")
+  ///     .capturePlanNode(&filter)
+  ///     .aggregate({"a"}, {"sum(b)"})
+  ///     .build();
+  PlanBuilder& capturePlanNode(const LogicalPlanNode** node) {
+    VELOX_USER_CHECK_NOT_NULL(node);
+    VELOX_USER_CHECK_NOT_NULL(node_);
+    *node = node_.get();
+    return *this;
+  }
+
   /// Wraps the current plan (treated as the anchor) and the provided step
   /// plan in a FixedPointNode named `name`. The step must contain at least
   /// one RecursiveReferenceNode named `name`, and anchor and step must

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   axiom_optimizer
   AggregationPlanner.cpp
   BitSet.cpp
+  ConnectorPushdownPass.cpp
   ConstantExprEvaluator.cpp
   Cost.cpp
   DerivedTable.cpp

--- a/axiom/optimizer/ConnectorPushdownPass.cpp
+++ b/axiom/optimizer/ConnectorPushdownPass.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/ConnectorPushdownPass.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "folly/container/F14Map.h"
+#include "folly/container/F14Set.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+namespace lp = facebook::axiom::logical_plan;
+using connector::ConnectorMetadataRegistry;
+using connector::PushdownRoot;
+
+using MaximalRootsByConnector =
+    folly::F14FastMap<std::string, std::vector<const lp::LogicalPlanNode*>>;
+
+// Per-node result of the bottom-up walk. Every maximal root references exactly
+// one connector. Boundaries are recorded at multi-connector cut points;
+// single-connector subtrees pass through to the parent, and the top-level
+// finalize handles plans with no cut point.
+struct NodeInfo {
+  folly::F14FastSet<std::string> connectors;
+  MaximalRootsByConnector maximalRoots;
+};
+
+NodeInfo collect(const lp::LogicalPlanNode& node) {
+  NodeInfo info;
+  if (node.kind() == lp::NodeKind::kTableScan) {
+    info.connectors.insert(node.as<lp::TableScanNode>()->connectorId());
+    return info;
+  }
+
+  const auto& inputs = node.inputs();
+  std::vector<NodeInfo> childInfos;
+  childInfos.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    auto childInfo = collect(*input);
+    info.connectors.insert(
+        childInfo.connectors.begin(), childInfo.connectors.end());
+    childInfos.push_back(std::move(childInfo));
+  }
+
+  if (info.connectors.size() <= 1) {
+    // Passthrough condition, no cut point.
+    return info;
+  }
+
+  // Multi-connector cut point: each single-connector child is a
+  // maximal root for its connector.
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    const auto& childInfo = childInfos.at(i);
+    if (childInfo.connectors.size() == 1) {
+      const auto& connectorId = *childInfo.connectors.begin();
+      info.maximalRoots[connectorId].push_back(inputs[i].get());
+    } else {
+      for (const auto& [connectorId, roots] : childInfo.maximalRoots) {
+        auto& destination = info.maximalRoots[connectorId];
+        destination.insert(destination.end(), roots.begin(), roots.end());
+      }
+    }
+  }
+  return info;
+}
+
+bool contains(
+    const lp::LogicalPlanNode& haystack,
+    const lp::LogicalPlanNode* needle) {
+  for (const auto& input : haystack.inputs()) {
+    if (input.get() == needle) {
+      return true;
+    }
+    if (contains(*input, needle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Checks one connector's `co_pushdownPlan` return: non-null fields,
+// every root within `subtree`, no bare `TableScanNode` roots, and pairwise
+// disjoint within the call. Cross-connector disjointness is structural —
+// connectors only see non-overlapping subtrees.
+void checkPushdownRoots(
+    const std::vector<PushdownRoot>& roots,
+    const lp::LogicalPlanNode& subtree) {
+  for (const auto& root : roots) {
+    VELOX_CHECK_NOT_NULL(root.root, "Connector returned null root");
+    VELOX_CHECK_NOT_NULL(root.table, "Connector returned null table");
+    VELOX_CHECK(
+        root.root == &subtree || contains(subtree, root.root),
+        "Connector returned pushdown root outside the subtree it was given");
+    VELOX_CHECK(
+        root.root->kind() != lp::NodeKind::kTableScan,
+        "Connector returned a bare TableScanNode as a pushdown root; "
+        "the scan already runs on the connector");
+  }
+  for (size_t i = 0; i < roots.size(); ++i) {
+    for (size_t j = i + 1; j < roots.size(); ++j) {
+      VELOX_CHECK(
+          roots[i].root != roots[j].root,
+          "Connector returned the same pushdown root twice");
+      VELOX_CHECK(
+          !contains(*roots[i].root, roots[j].root) &&
+              !contains(*roots[j].root, roots[i].root),
+          "Connector returned overlapping pushdown roots");
+    }
+  }
+}
+
+} // namespace
+
+folly::coro::Task<std::vector<PushdownRoot>> collectConnectorPushdownRoots(
+    const lp::LogicalPlanNode& plan) {
+  auto info = collect(plan);
+
+  // If no connector referenced by the plan opts into pushdown, skip the rest.
+  bool anyOptedIn = false;
+  for (const auto& connectorId : info.connectors) {
+    auto metadata = ConnectorMetadataRegistry::tryGet(connectorId);
+    if (metadata && metadata->isPushdownSupported()) {
+      anyOptedIn = true;
+      break;
+    }
+  }
+  if (!anyOptedIn) {
+    co_return std::vector<PushdownRoot>{};
+  }
+
+  MaximalRootsByConnector maximalRoots;
+  if (info.connectors.size() == 1) {
+    // Whole plan belongs to one connector — the plan itself is the
+    // maximal subtree.
+    maximalRoots[*info.connectors.begin()].push_back(&plan);
+  } else {
+    maximalRoots = std::move(info.maximalRoots);
+  }
+
+  std::vector<PushdownRoot> pushdownRoots;
+  // Iterate connectors in deterministic id order (F14FastMap iteration
+  // is non-deterministic).
+  std::vector<std::string> connectorIds;
+  connectorIds.reserve(maximalRoots.size());
+  for (const auto& [connectorId, _] : maximalRoots) {
+    connectorIds.push_back(connectorId);
+  }
+  std::sort(connectorIds.begin(), connectorIds.end());
+  // TODO: Fan out across connectors / subtrees with
+  // `folly::coro::collectAllRange` so per-connector RPCs run
+  // concurrently, then validate each result per its subtree. Sequential
+  // for now; cheap to revisit while the API is EXPERIMENTAL.
+  for (const auto& connectorId : connectorIds) {
+    const auto& subtrees = maximalRoots.at(connectorId);
+    auto metadata = ConnectorMetadataRegistry::tryGet(connectorId);
+    if (!metadata) {
+      continue;
+    }
+    if (!metadata->isPushdownSupported()) {
+      continue;
+    }
+    for (const auto* subtree : subtrees) {
+      auto roots = co_await metadata->co_pushdownPlan(*subtree);
+      checkPushdownRoots(roots, *subtree);
+      for (auto& root : roots) {
+        pushdownRoots.push_back(std::move(root));
+      }
+    }
+  }
+  co_return pushdownRoots;
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ConnectorPushdownPass.h
+++ b/axiom/optimizer/ConnectorPushdownPass.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "folly/coro/Task.h"
+
+namespace facebook::axiom::optimizer {
+
+/// Calls `co_pushdownPlan` on each connector that implements
+/// `isPushdownSupported()` and returns the list of roots. `VELOX_CHECK`s
+/// pairwise disjointness. The plan is not rewritten.
+folly::coro::Task<std::vector<connector::PushdownRoot>>
+collectConnectorPushdownRoots(const logical_plan::LogicalPlanNode& plan);
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/AggregationPlanner.h"
+#include "axiom/optimizer/ConnectorPushdownPass.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Plan.h"
@@ -35,6 +36,34 @@
 namespace lp = facebook::axiom::logical_plan;
 
 namespace facebook::axiom::optimizer {
+namespace {
+
+// Runs 'task' to completion, hopping to 'executor' first when one is
+// available so the caller doesn't block the producer thread. Used to
+// bridge async connector calls into the synchronous optimizer
+// interface.
+template <typename T>
+T blockingWaitOn(folly::Executor* executor, folly::coro::Task<T> task) {
+  if (executor != nullptr) {
+    return folly::coro::blockingWait(
+        co_withExecutor(executor, std::move(task)));
+  }
+  return folly::coro::blockingWait(std::move(task));
+}
+
+// Reshapes a flat list of pushdown roots into a node-keyed map so the
+// per-node lookup `ToGraph` runs during the walk is O(1).
+folly::F14FastMap<const lp::LogicalPlanNode*, connector::TablePtr>
+toPushdownMap(std::vector<connector::PushdownRoot> roots) {
+  folly::F14FastMap<const lp::LogicalPlanNode*, connector::TablePtr> map;
+  map.reserve(roots.size());
+  for (auto& root : roots) {
+    map.emplace(root.root, std::move(root.table));
+  }
+  return map;
+}
+
+} // namespace
 
 Optimization::Optimization(
     OptimizerSessionPtr optimizerSession,
@@ -51,7 +80,6 @@ Optimization::Optimization(
       runnerOptions_(std::move(runnerOptions)),
       isSingleWorker_(runnerOptions_.numWorkers == 1),
       isSingleDriver_(runnerOptions_.numDrivers == 1),
-      logicalPlan_(&logicalPlan),
       history_(history),
       veloxQueryCtx_(std::move(veloxQueryCtx)),
       aggregationPlanner_{
@@ -62,12 +90,13 @@ Optimization::Optimization(
       toVelox_{optimizerSession_, runnerOptions_},
       runtimeStats_{std::move(runtimeStats)} {
   VELOX_CHECK_NOT_NULL(runnerSession_);
+  VELOX_CHECK_NOT_NULL(veloxQueryCtx_);
   queryCtx()->optimization() = this;
 
-  if (logicalPlan_->is(logical_plan::NodeKind::kOutput)) {
+  if (logicalPlan.is(logical_plan::NodeKind::kOutput)) {
     // Resolve entries to source names so addOutputRenames can look up by
     // name; pruning may invalidate the original ordinals.
-    const auto& output = *logicalPlan_->as<logical_plan::OutputNode>();
+    const auto& output = *logicalPlan.as<logical_plan::OutputNode>();
     const auto& inputType = *output.onlyInput()->outputType();
     outputColumnMappings_.reserve(output.entries().size());
     for (const auto& entry : output.entries()) {
@@ -76,7 +105,9 @@ Optimization::Optimization(
     }
   }
 
-  root_ = toGraph_.makeQueryGraph(*logicalPlan_);
+  auto pushdownRoots = toPushdownMap(blockingWaitOn(
+      veloxQueryCtx_->executor(), collectConnectorPushdownRoots(logicalPlan)));
+  root_ = toGraph_.makeQueryGraph(logicalPlan, std::move(pushdownRoots));
   root_->initializePlans();
 }
 
@@ -138,6 +169,7 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
       continue;
     }
     filterUpdated(baseTable);
+
     const auto* data = toVelox_.leafData(baseTable->id());
 
     // Collect top-level table column names referenced by the query. Subfield
@@ -168,14 +200,12 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
 
   // Wait for all connector stats requests concurrently. Schedule on the
   // query context executor if available, otherwise run inline.
-  auto collectTask = folly::coro::collectAllRange(std::move(tasks));
-  auto* executor = veloxQueryCtx_->executor();
   auto estimateCpuStart = velox::process::threadCpuNanos();
   auto estimateThreadId = std::this_thread::get_id();
   auto estimateStart = std::chrono::steady_clock::now();
-  auto results = executor ? folly::coro::blockingWait(co_withExecutor(
-                                executor, std::move(collectTask)))
-                          : folly::coro::blockingWait(std::move(collectTask));
+  auto results = blockingWaitOn(
+      veloxQueryCtx_->executor(),
+      folly::coro::collectAllRange(std::move(tasks)));
   if (runtimeStats_) {
     recordCpuIfSameThread(
         *runtimeStats_,

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -447,9 +447,6 @@ class Optimization {
 
   const bool isSingleDriver_;
 
-  // Top level plan to optimize.
-  const logical_plan::LogicalPlanNode* const logicalPlan_;
-
   // Resolved root OutputNode entries; empty when there is no OutputNode.
   std::vector<OutputColumnNameMapping> outputColumnMappings_;
 

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -16,11 +16,13 @@
 
 #include "axiom/optimizer/Schema.h"
 
+#include <fmt/format.h>
 #include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "velox/common/process/ProcessBase.h"
+#include "velox/connectors/ConnectorRegistry.h"
 
 #include <numbers>
 
@@ -164,41 +166,17 @@ SchemaTable::SchemaTable(const connector::Table& connectorTable)
     : connectorTable{&connectorTable},
       cardinality{connectorCardinality(connectorTable)} {}
 
-SchemaTableCP Schema::findTable(
-    std::string_view connectorId,
-    const SchemaTableName& tableName) const {
-  auto& tables = connectorTables_.try_emplace(connectorId).first->second;
-  auto& table = tables.try_emplace(tableName, Table{}).first->second;
-  if (table.schemaTable) {
-    return table.schemaTable;
-  }
-
-  VELOX_CHECK_NOT_NULL(source_);
-
-  auto findCpuStart = velox::process::threadCpuNanos();
-  auto findStart = std::chrono::steady_clock::now();
-  auto connectorTable = source_->findTable(std::string(connectorId), tableName);
-  if (runtimeStats_) {
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kFindTableCpuNanos,
-        std::chrono::nanoseconds(
-            velox::process::threadCpuNanos() - findCpuStart));
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kFindTableWallNanos,
-        std::chrono::steady_clock::now() - findStart);
-  }
-  if (!connectorTable) {
-    return nullptr;
-  }
-
-  auto* schemaTable = make<SchemaTable>(*connectorTable);
+SchemaTableCP Schema::buildSchemaTable(
+    const connector::Table& connectorTable) const {
+  auto* schemaTable = make<SchemaTable>(connectorTable);
   auto& schemaColumns = schemaTable->columns;
 
-  auto& tableColumns = connectorTable->columnMap();
+  const auto& tableColumns = connectorTable.columnMap();
   schemaColumns.reserve(tableColumns.size());
   for (const auto& [columnName, tableColumn] : tableColumns) {
-    // Cardinality and null fraction are unknown when the connector has no
-    // corresponding statistic.
+    // Cardinality and null fraction are unknown when the connector
+    // has no corresponding statistic; downstream cost-based decisions
+    // fall back to safe defaults.
     Value value(toType(tableColumn->type()));
     if (auto* stats = tableColumn->stats()) {
       if (stats->numDistinct.has_value()) {
@@ -226,7 +204,7 @@ SchemaTableCP Schema::findTable(
     }
   };
 
-  for (const auto* layout : connectorTable->layouts()) {
+  for (const auto* layout : connectorTable.layouts()) {
     VELOX_CHECK_NOT_NULL(layout);
     ExprVector partition;
     appendColumns(layout->partitionColumns(), partition);
@@ -256,6 +234,45 @@ SchemaTableCP Schema::findTable(
     appendColumns(layout->columns(), columns);
     schemaTable->addIndex(*layout, std::move(distribution), std::move(columns));
   }
+  return schemaTable;
+}
+
+SchemaTableCP Schema::adoptConnectorTable(
+    connector::TablePtr connectorTable) const {
+  VELOX_CHECK_NOT_NULL(connectorTable);
+  auto* schemaTable = buildSchemaTable(*connectorTable);
+  adoptedConnectorTables_.push_back(std::move(connectorTable));
+  return schemaTable;
+}
+
+SchemaTableCP FOLLY_NULLABLE Schema::findTable(
+    std::string_view connectorId,
+    const SchemaTableName& tableName) const {
+  auto& tables = connectorTables_.try_emplace(connectorId).first->second;
+  auto& table = tables.try_emplace(tableName, Table{}).first->second;
+  if (table.schemaTable) {
+    return table.schemaTable;
+  }
+
+  VELOX_CHECK_NOT_NULL(source_);
+
+  auto findCpuStart = velox::process::threadCpuNanos();
+  auto findStart = std::chrono::steady_clock::now();
+  auto connectorTable = source_->findTable(std::string(connectorId), tableName);
+  if (runtimeStats_) {
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kFindTableCpuNanos,
+        std::chrono::nanoseconds(
+            velox::process::threadCpuNanos() - findCpuStart));
+    runtimeStats_->recordTiming(
+        QueryRuntimeStats::kFindTableWallNanos,
+        std::chrono::steady_clock::now() - findStart);
+  }
+  if (!connectorTable) {
+    return nullptr;
+  }
+
+  auto* schemaTable = buildSchemaTable(*connectorTable);
   table = {std::move(connectorTable), schemaTable};
   return schemaTable;
 }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/CppAttributes.h>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/PlanObject.h"
@@ -447,11 +448,23 @@ class Schema {
   /// Returns the table with 'name' or nullptr if not found, using
   /// the connector specified by connectorId to perform table lookups.
   /// An error is thrown if no connector with the specified ID exists.
-  SchemaTableCP findTable(
+  SchemaTableCP FOLLY_NULLABLE findTable(
       std::string_view connectorId,
       const SchemaTableName& tableName) const;
 
+  /// Wraps 'connectorTable' as a `SchemaTable` and takes ownership.
+  /// Bypasses the schema resolver. Pulls per-column stats from
+  /// `connectorTable`'s metadata, and builds one ColumnGroup per
+  /// `connectorTable->layouts()` entry, honouring any partition / order
+  /// columns.
+  SchemaTableCP adoptConnectorTable(connector::TablePtr connectorTable) const;
+
  private:
+  // Builds a `SchemaTable` from `connectorTable` without taking
+  // ownership. Caller retains `connectorTable` for the lifetime of
+  // the returned `SchemaTable`.
+  SchemaTableCP buildSchemaTable(const connector::Table& connectorTable) const;
+
   struct Table {
     connector::TablePtr connectorTable;
     SchemaTableCP schemaTable{nullptr};
@@ -466,6 +479,10 @@ class Schema {
   const connector::SchemaResolver* source_;
   std::shared_ptr<QueryRuntimeStats> runtimeStats_;
   mutable ConnectorMap connectorTables_;
+  // Holds `connector::Table`s whose ownership is given directly to
+  // the Schema rather than resolved through the source. Keeps them
+  // alive for the `SchemaTable`s that hold raw pointers into them.
+  mutable std::vector<connector::TablePtr> adoptedConnectorTables_;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <velox/common/base/Exceptions.h>
 #include <iostream>
 #include <ranges>
@@ -2648,6 +2649,44 @@ SubfieldProjections makeSubfieldColumns(
 }
 } // namespace
 
+namespace {
+// Constructs a fresh `BaseTable` for 'schemaTable', records it as the
+// stand-in for 'planNode', and returns it ready for column wiring.
+// Caller fills `baseTable->columns` and registers per-column renames.
+BaseTable* initBaseTable(
+    const lp::LogicalPlanNode& planNode,
+    SchemaTableCP schemaTable,
+    Name cname,
+    folly::F14FastMap<const lp::LogicalPlanNode*, PlanObjectCP>& planLeaves) {
+  auto* baseTable = make<BaseTable>();
+  baseTable->cname = cname;
+  baseTable->schemaTable = schemaTable;
+  baseTable->filteredCardinality = schemaTable->cardinality;
+  planLeaves[&planNode] = baseTable;
+  return baseTable;
+}
+
+// Wraps 'schemaColumn' as a fresh `Column` on 'baseTable' visible at
+// 'outputName' (the name the plan node uses for this column), and
+// registers the rename from 'outputName' to that `Column`. Returns the
+// new column.
+ColumnCP addBaseTableColumn(
+    BaseTable* baseTable,
+    ColumnCP schemaColumn,
+    Name outputName,
+    folly::F14FastMap<std::string, ExprCP>& renames) {
+  auto* column = make<Column>(
+      schemaColumn->name(),
+      baseTable,
+      schemaColumn->value(),
+      outputName,
+      schemaColumn->name());
+  baseTable->columns.push_back(column);
+  renames[outputName] = column;
+  return column;
+}
+} // namespace
+
 void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
   const auto* schemaTable =
       schema_.findTable(tableScan.connectorId(), tableScan.tableName());
@@ -2657,11 +2696,8 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
       tableScan.tableName().toString(),
       tableScan.connectorId());
 
-  auto* baseTable = make<BaseTable>();
-  baseTable->cname = newCName("t");
-  baseTable->schemaTable = schemaTable;
-  baseTable->filteredCardinality = schemaTable->cardinality;
-  planLeaves_[&tableScan] = baseTable;
+  auto* baseTable =
+      initBaseTable(tableScan, schemaTable, newCName("t"), planLeaves_);
 
   auto channels = usedChannels(tableScan);
   const auto& type = tableScan.outputType();
@@ -2672,14 +2708,8 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
     const auto& name = names[i];
     const auto* columnName = toName(name);
     auto schemaColumn = schemaTable->findColumn(columnName);
-    auto value = schemaColumn->value();
-    auto* column = make<Column>(
-        columnName,
-        baseTable,
-        value,
-        toName(type->nameOf(i)),
-        schemaColumn->name());
-    baseTable->columns.push_back(column);
+    auto* column = addBaseTableColumn(
+        baseTable, schemaColumn, toName(type->nameOf(i)), renames_);
 
     const auto kind = column->value().type->kind();
     if (kind == velox::TypeKind::ARRAY || kind == velox::TypeKind::ROW ||
@@ -2710,8 +2740,39 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
         }
       }
     }
+  }
 
-    renames_[type->nameOf(i)] = column;
+  currentDt_->addTable(baseTable);
+}
+
+void ToGraph::makePushdownBaseTable(
+    const lp::LogicalPlanNode& root,
+    connector::TablePtr connectorTable) {
+  auto* schemaTable = schema_.adoptConnectorTable(std::move(connectorTable));
+  auto* baseTable =
+      initBaseTable(root, schemaTable, newCName("t"), planLeaves_);
+
+  // Subfield pushdown is not applied to absorbed subtrees: the synthetic
+  // SchemaTable wrapping the connector's pushdown table does not carry the
+  // subfield bookkeeping that `makeBaseTable` consults. Subfield-typed
+  // columns flow through as a whole. LP pushdown limitation.
+  const auto channels = usedChannels(root);
+  const auto& type = root.outputType();
+  for (auto i : channels) {
+    VELOX_DCHECK_LT(i, type->size());
+    const auto* outputName = toName(type->nameOf(i));
+    auto* schemaColumn = schemaTable->findColumn(outputName);
+    VELOX_CHECK_NOT_NULL(
+        schemaColumn,
+        "Pushdown root output column not found in synthetic SchemaTable: {}",
+        type->nameOf(i));
+    VELOX_CHECK(
+        type->childAt(i)->equivalent(*schemaColumn->value().type),
+        "Pushdown table column type mismatch for {}: plan {} vs table {}",
+        type->nameOf(i),
+        type->childAt(i)->toString(),
+        schemaColumn->value().type->toString());
+    addBaseTableColumn(baseTable, schemaColumn, outputName, renames_);
   }
 
   currentDt_->addTable(baseTable);
@@ -4827,7 +4888,11 @@ NormalizedJoin normalizeLogicalJoin(const lp::JoinNode& join) {
 
 } // namespace
 
-DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
+DerivedTableP ToGraph::makeQueryGraph(
+    const lp::LogicalPlanNode& logicalPlan,
+    folly::F14FastMap<const lp::LogicalPlanNode*, connector::TablePtr>
+        pushdownRoots) {
+  pendingPushdowns_ = std::move(pushdownRoots);
   auto result = SubfieldTracker([&](const auto& expr) {
                   return tryFoldConstant(expr);
                 }).markAll(logicalPlan);
@@ -4840,6 +4905,10 @@ DerivedTableP ToGraph::makeQueryGraph(const lp::LogicalPlanNode& logicalPlan) {
 
   // TODO Try constant fold the dt.
 
+  VELOX_CHECK(
+      pendingPushdowns_.empty(),
+      "Connector pushdown roots did not match any plan node: {} unmatched",
+      pendingPushdowns_.size());
   return currentDt_;
 }
 
@@ -4945,6 +5014,15 @@ void ToGraph::makeQueryGraph(
     bool orderObservedAbove,
     bool excludeOuterJoins,
     bool excludeWindows) {
+  // Pushdown-root short-circuit. Runs before the allowedInDt /
+  // excludeOuterJoins guards so any node kind can be pushed down
+  // (including FixedPoint, NYI for the switch below).
+  if (auto it = pendingPushdowns_.find(&node); it != pendingPushdowns_.end()) {
+    makePushdownBaseTable(node, std::move(it->second));
+    pendingPushdowns_.erase(it);
+    return;
+  }
+
   if (!contains(allowedInDt, node.kind())) {
     wrapInDt(node, orderObservedAbove);
     return;

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "axiom/common/QueryRuntimeStats.h"
-#include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/PathSet.h"
 #include "axiom/optimizer/QueryGraph.h"
@@ -126,8 +125,17 @@ class ToGraph {
   /// DerivedTable. Strips a root OutputNode after SubfieldTracker prunes
   /// columns it does not export. Surviving columns keep their original
   /// names; positions are not stable — downstream must look up by name.
+  ///
+  /// 'pushdownRoots' maps each plan node a connector has agreed to
+  /// execute natively to the virtual `connector::Table` the optimizer
+  /// should scan in place of it. The walk consumes entries as it
+  /// encounters them and `VELOX_CHECK`s the map is empty at the end,
+  /// so any unmatched root surfaces as a planner bug.
   DerivedTableP makeQueryGraph(
-      const logical_plan::LogicalPlanNode& logicalPlan);
+      const logical_plan::LogicalPlanNode& logicalPlan,
+      folly::F14FastMap<
+          const logical_plan::LogicalPlanNode*,
+          connector::TablePtr> pushdownRoots);
 
   Name newCName(std::string_view prefix) {
     return toName(fmt::format("{}{}", prefix, ++nameCounter_));
@@ -571,6 +579,13 @@ class ToGraph {
   ensureFunctionSubfields(const logical_plan::ExprPtr& expr);
 
   void makeBaseTable(const logical_plan::TableScanNode& tableScan);
+
+  // Materialises a `BaseTable` over 'connectorTable' as the planner's
+  // stand-in for 'root'. EXPERIMENTAL: subfield pushdown is not applied
+  // to absorbed subtrees — see the .cpp for details.
+  void makePushdownBaseTable(
+      const logical_plan::LogicalPlanNode& root,
+      connector::TablePtr connectorTable);
 
   void makeValuesTable(const logical_plan::ValuesNode& values);
 
@@ -1033,6 +1048,14 @@ class ToGraph {
   // Counter for generating unique correlation names for BaseTables and
   // DerivedTables.
   int32_t nameCounter_{0};
+
+  // Pending pushdown roots for the current walk: each entry maps a
+  // plan node a connector has agreed to execute natively to the
+  // virtual `connector::Table` the optimizer should scan in place of
+  // it. Entries are consumed as the walk encounters the node, and the
+  // map is `VELOX_CHECK`ed empty at the end of `makeQueryGraph`.
+  folly::F14FastMap<const logical_plan::LogicalPlanNode*, connector::TablePtr>
+      pendingPushdowns_;
 
   // Column and subfield access info for filters, joins, grouping and other
   // things affecting result row selection.

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -107,6 +107,8 @@ add_executable(
   DistinctAggregationTest.cpp
   OutputNodeTest.cpp
   CardinalityEstimationTest.cpp
+  ConnectorSubtreePushdownTest.cpp
+  ConnectorPushdownPassTest.cpp
   CsvReadWriteTest.cpp
   DerivedTablePrinterTest.cpp
   DomainTest.cpp

--- a/axiom/optimizer/tests/ConnectorPushdownPassTest.cpp
+++ b/axiom/optimizer/tests/ConnectorPushdownPassTest.cpp
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/ConnectorPushdownPass.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "folly/coro/BlockingWait.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+namespace lp = logical_plan;
+using connector::PushdownRoot;
+using PushdownMatcher = connector::TestConnectorMetadata::PushdownMatcher;
+
+// Returns the first PushdownRoot in 'roots' whose 'root' equals 'node',
+// or nullptr if none.
+const PushdownRoot* findRoot(
+    const std::vector<PushdownRoot>& roots,
+    const lp::LogicalPlanNode* node) {
+  for (const auto& root : roots) {
+    if (root.root == node) {
+      return &root;
+    }
+  }
+  return nullptr;
+}
+
+class ConnectorPushdownPassTest : public testing::Test {
+ protected:
+  static constexpr auto kConnectorA = "connector_a";
+  static constexpr auto kConnectorB = "connector_b";
+
+  // A registered connector together with its TestConnectorMetadata,
+  // returned by 'addConnector'.
+  struct RegisteredConnector {
+    std::shared_ptr<connector::TestConnector> connector;
+    connector::TestConnectorMetadata* metadata;
+  };
+
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  void SetUp() override {
+    auto a = addConnector(kConnectorA);
+    connectorA_ = std::move(a.connector);
+    metadataA_ = a.metadata;
+    auto b = addConnector(kConnectorB);
+    connectorB_ = std::move(b.connector);
+    metadataB_ = b.metadata;
+
+    const auto schema = ROW({"a", "b"}, BIGINT());
+    connectorA_->addTable("t", schema);
+    connectorB_->addTable("u", schema);
+  }
+
+  void TearDown() override {
+    removeConnector(kConnectorA);
+    removeConnector(kConnectorB);
+    connectorA_.reset();
+    connectorB_.reset();
+    metadataA_ = nullptr;
+    metadataB_ = nullptr;
+  }
+
+  // Creates a TestConnector under 'connectorId', inserts it into the
+  // connector and metadata registries, and returns it together with
+  // its typed metadata so callers can wire matchers without per-call
+  // dynamic_cast.
+  static RegisteredConnector addConnector(std::string_view connectorId) {
+    auto connector =
+        std::make_shared<connector::TestConnector>(std::string(connectorId));
+    auto* metadata = dynamic_cast<connector::TestConnectorMetadata*>(
+        connector->metadata().get());
+    VELOX_CHECK_NOT_NULL(metadata);
+    velox::connector::ConnectorRegistry::global().insert(
+        connector->connectorId(), connector);
+    connector::ConnectorMetadataRegistry::global().insert(
+        std::string(connectorId), connector->metadata());
+    return {std::move(connector), metadata};
+  }
+
+  static void removeConnector(std::string_view connectorId) {
+    connector::ConnectorMetadataRegistry::global().erase(
+        std::string(connectorId));
+    velox::connector::ConnectorRegistry::global().erase(
+        std::string(connectorId));
+  }
+
+  // Registers a fresh TestTable on 'conn' under 'label' and returns it
+  // as a connector::TablePtr suitable for `PushdownRoot::table`.
+  connector::TablePtr makePushdownTable(
+      connector::TestConnector* conn,
+      std::string_view label) {
+    static const auto kSchema = ROW({"a", "b"}, BIGINT());
+    return conn->addTable(std::string(label), kSchema);
+  }
+
+  static PushdownMatcher onePushdownRoot(
+      const lp::LogicalPlanNode* root,
+      connector::TablePtr table) {
+    return [root, table](const lp::LogicalPlanNode&) {
+      return std::vector<PushdownRoot>{{root, table}};
+    };
+  }
+
+  // Synchronously drives the pushdown pass over 'plan'.
+  static std::vector<PushdownRoot> collectRoots(
+      const lp::LogicalPlanNode& plan) {
+    return folly::coro::blockingWait(collectConnectorPushdownRoots(plan));
+  }
+
+  // Builds a scan over 'tableName' on 'connectorId' in the fixture's
+  // default schema. Threads the shared 'context_' so node IDs and
+  // column names stay globally unique across legs of the same plan.
+  // Exists because PlanBuilder::tableScan(connectorId, schema, table)
+  // overload-resolves ambiguously when the table-name arg is a string
+  // literal; this helper picks the right overload and absorbs the
+  // std::string conversions.
+  lp::PlanBuilder scanOn(
+      std::string_view connectorId,
+      std::string_view tableName,
+      std::string_view schema = connector::TestConnector::kDefaultSchema) {
+    return lp::PlanBuilder(context_).tableScan(
+        std::string(connectorId), std::string(schema), std::string(tableName));
+  }
+
+  // Shared across all builders within one test so plan-node IDs and
+  // column names stay globally unique. Default connector is A; reach
+  // other connectors via 'scanOn'.
+  lp::PlanBuilder::Context context_{
+      std::string(kConnectorA),
+      std::string(connector::TestConnector::kDefaultSchema)};
+  std::shared_ptr<connector::TestConnector> connectorA_;
+  std::shared_ptr<connector::TestConnector> connectorB_;
+  connector::TestConnectorMetadata* metadataA_{nullptr};
+  connector::TestConnectorMetadata* metadataB_{nullptr};
+};
+
+TEST_F(ConnectorPushdownPassTest, absorbsRoot) {
+  // Plan root is a Filter (a non-scan node) so the connector is
+  // executing real work above the scan.
+  auto plan =
+      lp::PlanBuilder(context_).tableScan("t").filter("a > 0").planNode();
+  auto table = makePushdownTable(connectorA_.get(), "v");
+  metadataA_->setPushdownMatcher(onePushdownRoot(plan.get(), table));
+
+  auto roots = collectRoots(*plan);
+  ASSERT_THAT(roots, testing::SizeIs(1));
+  EXPECT_EQ(roots[0].root, plan.get());
+  EXPECT_EQ(roots[0].table.get(), table.get());
+}
+
+TEST_F(ConnectorPushdownPassTest, absorbsDeepSubtree) {
+  // Inner Filter is the absorbed root (non-scan, executes work above
+  // the scan).
+  const lp::LogicalPlanNode* innerFilter = nullptr;
+  auto plan = lp::PlanBuilder(context_)
+                  .tableScan("t")
+                  .filter("a > 0")
+                  .capturePlanNode(&innerFilter)
+                  .filter("b > 0")
+                  .planNode();
+  auto table = makePushdownTable(connectorA_.get(), "v");
+  metadataA_->setPushdownMatcher(onePushdownRoot(innerFilter, table));
+
+  auto roots = collectRoots(*plan);
+  ASSERT_THAT(roots, testing::SizeIs(1));
+  EXPECT_EQ(roots[0].root, innerFilter);
+  EXPECT_EQ(roots[0].table.get(), table.get());
+}
+
+TEST_F(ConnectorPushdownPassTest, crossConnectorRoots) {
+  // Each leg is a Filter over its scan — a real non-scan root the
+  // connector can absorb.
+  const lp::LogicalPlanNode* filterA = nullptr;
+  const lp::LogicalPlanNode* filterB = nullptr;
+  auto plan = lp::PlanBuilder(context_)
+                  .tableScan("t")
+                  .filter("a > 0")
+                  .capturePlanNode(&filterA)
+                  .unionAll(scanOn(kConnectorB, "u")
+                                .filter("a > 0")
+                                .capturePlanNode(&filterB))
+                  .planNode();
+  auto tableA = makePushdownTable(connectorA_.get(), "v");
+  auto tableB = makePushdownTable(connectorB_.get(), "w");
+
+  metadataA_->setPushdownMatcher(onePushdownRoot(filterA, tableA));
+  metadataB_->setPushdownMatcher(onePushdownRoot(filterB, tableB));
+
+  auto roots = collectRoots(*plan);
+  ASSERT_THAT(roots, testing::SizeIs(2));
+  const auto* foundA = findRoot(roots, filterA);
+  const auto* foundB = findRoot(roots, filterB);
+  ASSERT_NE(foundA, nullptr);
+  ASSERT_NE(foundB, nullptr);
+  EXPECT_EQ(foundA->table.get(), tableA.get());
+  EXPECT_EQ(foundB->table.get(), tableB.get());
+}
+
+TEST_F(ConnectorPushdownPassTest, notSupportedSkipped) {
+  // No matcher installed -> connector is opted out of pushdown and the
+  // pass returns no roots.
+  auto plan = lp::PlanBuilder(context_).tableScan("t").planNode();
+  EXPECT_THAT(collectRoots(*plan), testing::IsEmpty());
+}
+
+TEST_F(ConnectorPushdownPassTest, noPushdownRootsReturnsEmpty) {
+  auto plan = lp::PlanBuilder(context_).tableScan("t").planNode();
+  metadataA_->setPushdownMatcher(
+      [](const lp::LogicalPlanNode&) { return std::vector<PushdownRoot>{}; });
+  EXPECT_THAT(collectRoots(*plan), testing::IsEmpty());
+}
+
+TEST_F(ConnectorPushdownPassTest, nestedRootsFails) {
+  const lp::LogicalPlanNode* innerFilter = nullptr;
+  auto plan = lp::PlanBuilder(context_)
+                  .tableScan("t")
+                  .filter("a > 0")
+                  .capturePlanNode(&innerFilter)
+                  .filter("b > 0")
+                  .planNode();
+  auto outer = makePushdownTable(connectorA_.get(), "v");
+  auto inner = makePushdownTable(connectorA_.get(), "w");
+
+  metadataA_->setPushdownMatcher(
+      [innerFilter, outer, inner](const lp::LogicalPlanNode& subtree) {
+        return std::vector<PushdownRoot>{
+            {&subtree, outer},
+            {innerFilter, inner},
+        };
+      });
+
+  VELOX_ASSERT_THROW(collectRoots(*plan), "overlapping pushdown roots");
+}
+
+TEST_F(ConnectorPushdownPassTest, pushdownRootOutsideSubtreeFails) {
+  // Each connector receives only the maximal subtree referencing it.
+  // A connector that returns a root pointing outside that subtree is
+  // malformed; the pass must reject it.
+  auto plan = lp::PlanBuilder(context_)
+                  .tableScan("t")
+                  .unionAll(scanOn(kConnectorB, "u"))
+                  .planNode();
+  auto stolen = makePushdownTable(connectorA_.get(), "v");
+
+  // Connector A's matcher returns the UnionAll root (not within A's
+  // subtree, which is just the scan). Connector B does not install a
+  // matcher, so it stays opted out.
+  metadataA_->setPushdownMatcher(
+      [planPtr = plan.get(), stolen](const lp::LogicalPlanNode&) {
+        return std::vector<PushdownRoot>{{planPtr, stolen}};
+      });
+
+  VELOX_ASSERT_THROW(collectRoots(*plan), "outside the subtree it was given");
+}
+
+TEST_F(ConnectorPushdownPassTest, barePushdownRootFails) {
+  // A bare TableScanNode root is a no-op pushdown: the scan already
+  // runs on the connector. The pass rejects it as a connector bug.
+  auto plan = lp::PlanBuilder(context_).tableScan("t").planNode();
+  auto table = makePushdownTable(connectorA_.get(), "v");
+  metadataA_->setPushdownMatcher(onePushdownRoot(plan.get(), table));
+
+  VELOX_ASSERT_THROW(collectRoots(*plan), "bare TableScanNode");
+}
+
+TEST_F(ConnectorPushdownPassTest, federatedPlanScopedToOwnSubtree) {
+  const lp::LogicalPlanNode* scanANode = nullptr;
+  const lp::LogicalPlanNode* scanBNode = nullptr;
+  auto plan =
+      lp::PlanBuilder(context_)
+          .tableScan("t")
+          .capturePlanNode(&scanANode)
+          .unionAll(scanOn(kConnectorB, "u").capturePlanNode(&scanBNode))
+          .planNode();
+
+  // Record which subtree each connector received.
+  const lp::LogicalPlanNode* seenByA = nullptr;
+  const lp::LogicalPlanNode* seenByB = nullptr;
+  metadataA_->setPushdownMatcher(
+      [&seenByA](const lp::LogicalPlanNode& subtree) {
+        seenByA = &subtree;
+        return std::vector<PushdownRoot>{};
+      });
+  metadataB_->setPushdownMatcher(
+      [&seenByB](const lp::LogicalPlanNode& subtree) {
+        seenByB = &subtree;
+        return std::vector<PushdownRoot>{};
+      });
+
+  collectRoots(*plan);
+  EXPECT_EQ(seenByA, scanANode);
+  EXPECT_EQ(seenByB, scanBNode);
+}
+
+TEST_F(ConnectorPushdownPassTest, singleConnectorUnionAbsorbedAtUnion) {
+  // Both children of the Union belong to connector A. The maximal
+  // single-connector subtree is the Union itself, not the individual
+  // scans — connector A receives the Union.
+  auto plan = lp::PlanBuilder(context_)
+                  .tableScan("t")
+                  .unionAll(lp::PlanBuilder(context_).tableScan("t"))
+                  .planNode();
+
+  const lp::LogicalPlanNode* seenByA = nullptr;
+  metadataA_->setPushdownMatcher(
+      [&seenByA](const lp::LogicalPlanNode& subtree) {
+        seenByA = &subtree;
+        return std::vector<PushdownRoot>{};
+      });
+
+  collectRoots(*plan);
+  EXPECT_EQ(seenByA, plan.get());
+}
+
+TEST_F(ConnectorPushdownPassTest, noTableScansReturnsEmpty) {
+  // No TableScanNodes in the plan — no connectors to ask, even though
+  // a matcher is registered.
+  bool matcherCalled = false;
+  metadataA_->setPushdownMatcher([&matcherCalled](const lp::LogicalPlanNode&) {
+    matcherCalled = true;
+    return std::vector<PushdownRoot>{};
+  });
+
+  auto plan = lp::PlanBuilder(context_).values({"x"}, {{"1"}}).planNode();
+  EXPECT_THAT(collectRoots(*plan), testing::IsEmpty());
+  EXPECT_FALSE(matcherCalled);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/ConnectorSubtreePushdownTest.cpp
+++ b/axiom/optimizer/tests/ConnectorSubtreePushdownTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+using connector::PushdownRoot;
+
+class ConnectorSubtreePushdownTest : public test::QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    testMetadata_ = dynamic_cast<connector::TestConnectorMetadata*>(
+        testConnector_->metadata().get());
+    VELOX_CHECK_NOT_NULL(testMetadata_);
+  }
+
+  // Shared across all builders within one test so plan-node IDs and
+  // column names stay globally unique. Each TEST_F gets a fresh fixture
+  // instance, so a fresh Context per test.
+  lp::PlanBuilder::Context context_{
+      std::string(kTestConnectorId),
+      std::string(kDefaultSchema)};
+
+  // Typed metadata cached at SetUp so tests can install pushdown matchers
+  // without per-call dynamic_cast.
+  connector::TestConnectorMetadata* testMetadata_{nullptr};
+};
+
+// A Filter the connector absorbs collapses into a single scan over the pushdown
+// table while the Aggregation above it survives.
+TEST_F(ConnectorSubtreePushdownTest, absorbsSubtreeUnderAggregation) {
+  const auto schema = ROW({"a", "b"}, BIGINT());
+  testConnector_->addTable("t", schema);
+
+  const lp::LogicalPlanNode* absorbed = nullptr;
+  auto logicalPlan = lp::PlanBuilder(context_)
+                         .tableScan("t")
+                         .filter("a > 0")
+                         .capturePlanNode(&absorbed)
+                         .aggregate({"a"}, {"sum(b)"})
+                         .build();
+
+  auto pushdownTable = testConnector_->addTable("u", schema);
+  testMetadata_->setPushdownMatcher(
+      [absorbed, pushdownTable](const lp::LogicalPlanNode&) {
+        return std::vector<PushdownRoot>{{absorbed, pushdownTable}};
+      });
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher = matchScan("u").singleAggregation({"a"}, {"sum(b)"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// The connector absorbs the Filter+Scan on the left of
+// an inner join; the HashJoin and the build-side scan survive over
+// the pushdown table.
+TEST_F(ConnectorSubtreePushdownTest, absorbsProbeSideOfJoin) {
+  const auto probeSchema = ROW({"a", "b"}, BIGINT());
+  const auto buildSchema = ROW({"c", "d"}, BIGINT());
+  testConnector_->addTable("t", probeSchema);
+  testConnector_->addTable("u", buildSchema);
+
+  const lp::LogicalPlanNode* absorbed = nullptr;
+  auto logicalPlan = lp::PlanBuilder(context_)
+                         .tableScan("t")
+                         .filter("a > 0")
+                         .capturePlanNode(&absorbed)
+                         .join(
+                             lp::PlanBuilder(context_).tableScan("u"),
+                             "a = c",
+                             lp::JoinType::kInner)
+                         .build();
+
+  auto pushdownTable = testConnector_->addTable("v", probeSchema);
+  testMetadata_->setPushdownMatcher(
+      [absorbed, pushdownTable](const lp::LogicalPlanNode&) {
+        return std::vector<PushdownRoot>{{absorbed, pushdownTable}};
+      });
+
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto buildMatcher = matchScan("u").build();
+  auto matcher = matchScan("v").hashJoin(buildMatcher).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

A connector can now claim a subtree of the logical plan and execute it natively. For example, an XDB-style connector receiving:

    SELECT a, sum(b) FROM xdb_table WHERE a > 0 GROUP BY a

can absorb `Filter(a > 0).TableScan(xdb_table)` as one native query and return a virtual `connector::Table` whose scan yields the filtered rows. The Aggregation runs in Velox above. The original `LogicalPlan` is never rewritten.

The negotiation lives on `ConnectorMetadata`:

    virtual bool isPushdownSupported() const;
    virtual folly::coro::Task<std::vector<PushdownRoot>> co_pushdownPlan(
        const LogicalPlanNode& plan) const;

A connector opts in via `isPushdownSupported()` and returns `PushdownRoot { root, table }` entries — the plan node to replace and the virtual `connector::Table` to scan in its place. Column stats and the row-count estimate ride on the standard `connector::Table` channel. The pass walks the plan once and splits at multi-connector cut points, so each connector only sees subtrees that belong to it. Returned roots are `VELOX_CHECK`ed for pairwise disjointness and for staying within the subtree the connector was handed.

The API is marked EXPERIMENTAL. It negotiates over `LogicalPlan`, which is not normalized. Expected to migrate to the optimizer's v2 IR once it lands; struct and method shapes may change.

Reviewed By: mbasmanova

Differential Revision: D108106268


