### PR TITLE
test(optimizer): Add TPC-H stats doc and q9 plan-lock test

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -303,6 +303,61 @@ class PlanMatcherBuilder {
       JoinType joinType,
       const HashJoinDetails& details = {});
 
+  /// Typed shortcuts for `hashJoin` with a fixed `JoinType`.
+  PlanMatcherBuilder& hashJoinInner(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kInner, details);
+  }
+
+  PlanMatcherBuilder& hashJoinLeft(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kLeft, details);
+  }
+
+  PlanMatcherBuilder& hashJoinRight(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kRight, details);
+  }
+
+  PlanMatcherBuilder& hashJoinFull(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kFull, details);
+  }
+
+  PlanMatcherBuilder& hashJoinLeftSemiFilter(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kLeftSemiFilter, details);
+  }
+
+  PlanMatcherBuilder& hashJoinLeftSemiProject(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kLeftSemiProject, details);
+  }
+
+  PlanMatcherBuilder& hashJoinRightSemiFilter(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kRightSemiFilter, details);
+  }
+
+  PlanMatcherBuilder& hashJoinRightSemiProject(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kRightSemiProject, details);
+  }
+
+  PlanMatcherBuilder& hashJoinAnti(
+      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      const HashJoinDetails& details = {}) {
+    return hashJoin(rightMatcher, JoinType::kAnti, details);
+  }
+
   /// Matches a NestedLoopJoin node with the specified right side matcher and
   /// join type.
   /// @param rightMatcher Matcher for the right side of the join.

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -85,6 +85,15 @@ class TpchPlanTest : public virtual test::HiveQueriesTestBase {
     return toSingleNodePlan(parseTpchSql(query));
   }
 
+  // Parses a named TPC-H query file (e.g. "q9_alt").
+  lp::LogicalPlanNodePtr parseTpchSql(const std::string& name) {
+    return parseSelect(test::readTpchSql(name));
+  }
+
+  velox::core::PlanNodePtr planTpch(const std::string& name) {
+    return toSingleNodePlan(parseTpchSql(name));
+  }
+
   std::unique_ptr<exec::test::TpchQueryBuilder> referenceBuilder_;
 };
 
@@ -136,11 +145,10 @@ TEST_F(TpchPlanTest, q01) {
 TEST_F(TpchPlanTest, q02) {
   checkTpchSql(2);
 
-  auto joinNationWithRegion = matchHiveScan("nation").hashJoin(
+  auto joinNationWithRegion = matchHiveScan("nation").hashJoinInner(
       core::PlanMatcherBuilder()
           .hiveScan("region", test::eq("r_name", "EUROPE"))
-          .build(),
-      core::JoinType::kInner);
+          .build());
 
   // The subquery (min cost per part) is very selective — it matches at most
   // one partsupp row per part. It is joined before supplier because its low
@@ -154,29 +162,20 @@ TEST_F(TpchPlanTest, q02) {
   //  (supplier INNER (nation INNER region)))
   auto matcher =
       matchHiveScan("partsupp")
-          .hashJoin(matchHiveScan("part").build(), core::JoinType::kInner)
-          .hashJoin(
+          .hashJoinInner(matchHiveScan("part").build())
+          .hashJoinInner(
               matchHiveScan("partsupp")
-                  .hashJoin(
-                      matchHiveScan("part").build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .hashJoin(
+                  .hashJoinLeftSemiFilter(matchHiveScan("part").build())
+                  .hashJoinInner(
                       matchHiveScan("supplier")
-                          .hashJoin(
-                              joinNationWithRegion.build(),
-                              core::JoinType::kInner)
-                          .build(),
-                      core::JoinType::kInner)
+                          .hashJoinInner(joinNationWithRegion.build())
+                          .build())
                   .aggregation()
                   .project()
-                  .build(),
-              core::JoinType::kInner)
-          .hashJoin(
-              matchHiveScan("supplier")
-                  .hashJoin(
-                      joinNationWithRegion.build(), core::JoinType::kInner)
-                  .build(),
-              core::JoinType::kInner)
+                  .build())
+          .hashJoinInner(matchHiveScan("supplier")
+                             .hashJoinInner(joinNationWithRegion.build())
+                             .build())
           .topN()
           .project()
           .build();
@@ -195,21 +194,15 @@ TEST_F(TpchPlanTest, q03) {
   // probe on lineitem. There is anti-correlation between the date filters on
   // lineitem and orders but that does not affect the best plan choice.
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   auto matcher =
-      startMatcher("lineitem")
-          .hashJoin(
-              startMatcher("orders")
-                  .hashJoin(
-                      startMatcher("customer").build(),
-                      core::JoinType::kInner,
+      matchHiveScan("lineitem")
+          .hashJoinInner(
+              matchHiveScan("orders")
+                  .hashJoinInner(
+                      matchHiveScan("customer").build(),
                       {.outputColumnNames =
                            {{"o_orderkey", "o_orderdate", "o_shippriority"}}})
                   .build(),
-              core::JoinType::kInner,
               {.outputColumnNames =
                    {{"l_orderkey",
                      "l_extendedprice",
@@ -239,7 +232,7 @@ TEST_F(TpchPlanTest, q04) {
 
   auto matcher = core::PlanMatcherBuilder()
                      .hiveScan("lineitem", {}, "l_commitdate < l_receiptdate")
-                     .hashJoin(
+                     .hashJoinRightSemiFilter(
                          core::PlanMatcherBuilder()
                              .hiveScan(
                                  "orders",
@@ -247,8 +240,7 @@ TEST_F(TpchPlanTest, q04) {
                                      "o_orderdate",
                                      DATE()->toDays("1993-07-01"),
                                      DATE()->toDays("1993-09-30")))
-                             .build(),
-                         core::JoinType::kRightSemiFilter)
+                             .build())
                      .aggregation()
                      .orderBy()
                      .build();
@@ -273,36 +265,27 @@ TEST_F(TpchPlanTest, q05) {
   // The plan is otherwise good and the extra reduction on customer ends up not
   // being very important. This is a possible enhancement for completeness.
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   // agg((
   //   (lineitem INNER ((orders INNER customer) INNER (nation INNER region)))
   //   INNER
   //   (supplier LEFT SEMI (FILTER) (nation INNER region))
   // ))
 
-  auto joinNationWithRegion = startMatcher("nation").hashJoin(
+  auto joinNationWithRegion = matchHiveScan("nation").hashJoinInner(
       core::PlanMatcherBuilder()
           .hiveScan("region", test::eq("r_name", "ASIA"))
-          .build(),
-      core::JoinType::kInner);
+          .build());
 
   auto matcher =
-      startMatcher("lineitem")
-          .hashJoin(
-              startMatcher("orders")
-                  .hashJoin(
-                      startMatcher("customer").build(), core::JoinType::kInner)
-                  .hashJoin(
-                      joinNationWithRegion.build(), core::JoinType::kInner)
-                  .build())
-          .hashJoin(startMatcher("supplier")
-                        .hashJoin(
-                            joinNationWithRegion.project().build(),
-                            core::JoinType::kLeftSemiFilter)
-                        .build())
+      matchHiveScan("lineitem")
+          .hashJoinInner(matchHiveScan("orders")
+                             .hashJoinInner(matchHiveScan("customer").build())
+                             .hashJoinInner(joinNationWithRegion.build())
+                             .build())
+          .hashJoinInner(matchHiveScan("supplier")
+                             .hashJoinLeftSemiFilter(
+                                 joinNationWithRegion.project().build())
+                             .build())
           .project()
           .aggregation()
           .orderBy()
@@ -362,10 +345,56 @@ TEST_F(TpchPlanTest, q08) {
 TEST_F(TpchPlanTest, q09) {
   checkTpchSql(9);
 
-  // TODO Verify the plan.
+  // No plan-shape assertion: q9's `p_name like '%green%'` is not estimable from
+  // column stats, so the optimizer over-estimates it and orders the join
+  // suboptimally. q09Alt locks the optimal shape using an estimable filter of
+  // similar selectivity. See tpch/queries/statistics.md.
 
   ASSERT_NO_THROW(planTpch(9));
   ASSERT_NO_THROW(planVelox(parseTpchSql(9)));
+}
+
+TEST_F(TpchPlanTest, q09Alt) {
+  // q9 with `p_name like '%green%'` replaced by the estimable `p_size <= 3`
+  // (~6%, similar selectivity). With an accurate estimate the optimizer reduces
+  // lineitem by the selective `part` first — the optimal join order. See
+  // tpch/queries/statistics.md.
+  //
+  // TODO: Verify results (no TpchQueryBuilder reference exists for this
+  // variant; this asserts plan shape only).
+  auto plan = planTpch("q9_alt");
+
+  // Optimal part-first order:
+  //
+  // agg((
+  //   orders INNER (
+  //     ((partsupp INNER supplier)
+  //        INNER
+  //        ((lineitem INNER part) LEFT SEMI (FILTER) (supplier INNER nation)))
+  //     INNER nation)))
+  auto matcher =
+      matchHiveScan("orders")
+          .hashJoinInner(
+              matchHiveScan("partsupp")
+                  .hashJoinInner(matchHiveScan("supplier").build())
+                  .hashJoinInner(
+                      matchHiveScan("lineitem")
+                          .hashJoinInner(matchHiveScan("part").build())
+                          .hashJoinLeftSemiFilter(
+                              matchHiveScan("supplier")
+                                  .hashJoinInner(
+                                      matchHiveScan("nation").build())
+                                  .project()
+                                  .build())
+                          .build())
+                  .hashJoinInner(matchHiveScan("nation").build())
+                  .build())
+          .project()
+          .aggregation()
+          .orderBy()
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 TEST_F(TpchPlanTest, q10) {
@@ -386,35 +415,27 @@ TEST_F(TpchPlanTest, q11) {
   // something that Velox plans support at this time. Also, practical need for
   // this is not very high.
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   auto matcher =
-      startMatcher("partsupp")
-          .hashJoin(
-              startMatcher("supplier")
-                  .hashJoin(
+      matchHiveScan("partsupp")
+          .hashJoinInner(
+              matchHiveScan("supplier")
+                  .hashJoinInner(
                       core::PlanMatcherBuilder()
                           .hiveScan("nation", test::eq("n_name", "GERMANY"))
-                          .build(),
-                      core::JoinType::kInner)
-                  .build(),
-              core::JoinType::kInner)
+                          .build())
+                  .build())
           .project()
           .aggregation()
           .nestedLoopJoin(
-              startMatcher("partsupp")
-                  .hashJoin(
-                      startMatcher("supplier")
-                          .hashJoin(
+              matchHiveScan("partsupp")
+                  .hashJoinInner(
+                      matchHiveScan("supplier")
+                          .hashJoinInner(
                               core::PlanMatcherBuilder()
                                   .hiveScan(
                                       "nation", test::eq("n_name", "GERMANY"))
-                                  .build(),
-                              core::JoinType::kInner)
-                          .build(),
-                      core::JoinType::kInner)
+                                  .build())
+                          .build())
                   .project()
                   .aggregation()
                   .project()
@@ -448,16 +469,14 @@ TEST_F(TpchPlanTest, q12) {
           .build();
 
   auto matcher =
-      core::PlanMatcherBuilder()
-          .tableScan("orders")
-          .hashJoin(
+      matchHiveScan("orders")
+          .hashJoinInner(
               core::PlanMatcherBuilder()
                   .hiveScan(
                       "lineitem",
                       std::move(subfieldFilters),
                       "l_commitdate < l_receiptdate AND l_shipdate < l_commitdate")
-                  .build(),
-              core::JoinType::kInner)
+                  .build())
           .project()
           .aggregation()
           .orderBy()
@@ -476,18 +495,13 @@ TEST_F(TpchPlanTest, q13) {
   // correctly produce the right outer join, building on the left, i.e.
   // customer, as it is much smaller than orders.
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
-  auto matcher =
-      startMatcher("orders")
-          .hashJoin(startMatcher("customer").build(), core::JoinType::kRight)
-          .aggregation()
-          .project()
-          .aggregation()
-          .orderBy()
-          .build();
+  auto matcher = matchHiveScan("orders")
+                     .hashJoinRight(matchHiveScan("customer").build())
+                     .aggregation()
+                     .project()
+                     .aggregation()
+                     .orderBy()
+                     .build();
 
   auto plan = planTpch(13);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -501,9 +515,8 @@ TEST_F(TpchPlanTest, q14) {
   // The only noteworthy aspect is that we build on lineitem since its filters
   // (1 month out of 7 years) make it smaller than part.
 
-  auto matcher = core::PlanMatcherBuilder()
-                     .tableScan("part")
-                     .hashJoin(
+  auto matcher = matchHiveScan("part")
+                     .hashJoinInner(
                          core::PlanMatcherBuilder()
                              .hiveScan(
                                  "lineitem",
@@ -511,8 +524,7 @@ TEST_F(TpchPlanTest, q14) {
                                      "l_shipdate",
                                      DATE()->toDays("1995-09-01"),
                                      DATE()->toDays("1995-09-30")))
-                             .build(),
-                         core::JoinType::kInner)
+                             .build())
                      .project()
                      .aggregation()
                      .project()
@@ -542,17 +554,10 @@ TEST_F(TpchPlanTest, q16) {
   // The join is biggest table first, with part joined first because it is quite
   // selective, more so than the exists with supplier.
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   auto matcher =
-      startMatcher("partsupp")
-          .hashJoin(startMatcher("part").build(), core::JoinType::kInner)
-          .hashJoin(
-              startMatcher("supplier").build(),
-              core::JoinType::kAnti,
-              {.nullAware = true})
+      matchHiveScan("partsupp")
+          .hashJoinInner(matchHiveScan("part").build())
+          .hashJoinAnti(matchHiveScan("supplier").build(), {.nullAware = true})
           .aggregation()
           .orderBy()
           .build();
@@ -571,22 +576,15 @@ TEST_F(TpchPlanTest, q17) {
   // only lineitems with a very specific part will occur on the probe side, so
   // we copy the restriction inside the group by as a semijoin (exists).
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   auto matcher =
-      startMatcher("lineitem")
-          .hashJoin(startMatcher("part").build(), core::JoinType::kInner)
-          .hashJoin(
-              startMatcher("lineitem")
-                  .hashJoin(
-                      startMatcher("part").build(),
-                      core::JoinType::kLeftSemiFilter)
+      matchHiveScan("lineitem")
+          .hashJoinInner(matchHiveScan("part").build())
+          .hashJoinLeft(
+              matchHiveScan("lineitem")
+                  .hashJoinLeftSemiFilter(matchHiveScan("part").build())
                   .aggregation()
                   .project() // TODO Figure out if it can be removed.
-                  .build(),
-              core::JoinType::kLeft)
+                  .build())
           .filter()
           .aggregation()
           .project()
@@ -614,19 +612,14 @@ TEST_F(TpchPlanTest, q18) {
 
   auto matcher =
       matchHiveScan("lineitem")
-          .hashJoin(
-              matchHiveScan("lineitem")
-                  .aggregation()
-                  .filter()
-                  .project()
-                  .build(),
-              core::JoinType::kLeftSemiFilter)
-          .hashJoin(
-              matchHiveScan("orders")
-                  .hashJoin(
-                      matchHiveScan("customer").build(), core::JoinType::kInner)
-                  .build(),
-              core::JoinType::kInner)
+          .hashJoinLeftSemiFilter(matchHiveScan("lineitem")
+                                      .aggregation()
+                                      .filter()
+                                      .project()
+                                      .build())
+          .hashJoinInner(matchHiveScan("orders")
+                             .hashJoinInner(matchHiveScan("customer").build())
+                             .build())
           .aggregation()
           .topN()
           .build();
@@ -658,7 +651,7 @@ TEST_F(TpchPlanTest, q19) {
   auto matcher =
       core::PlanMatcherBuilder()
           .hiveScan("lineitem", std::move(lineitemFilters))
-          .hashJoin(
+          .hashJoinInner(
               core::PlanMatcherBuilder()
                   .hiveScan(
                       "part",
@@ -666,8 +659,7 @@ TEST_F(TpchPlanTest, q19) {
                       "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
                       "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
                       "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
-                  .build(),
-              core::JoinType::kInner)
+                  .build())
           .filter()
           .project()
           .aggregation()
@@ -694,30 +686,24 @@ TEST_F(TpchPlanTest, q20) {
       matchHiveScan("lineitem")
           .aggregation()
           .project()
-          .hashJoin(
+          .hashJoinRight(
               matchHiveScan("part")
-                  .hashJoin(
+                  .hashJoinRightSemiFilter(
                       matchHiveScan("partsupp")
-                          .hashJoin(
+                          .hashJoinLeftSemiFilter(
                               matchHiveScan("supplier")
-                                  .hashJoin(
-                                      matchHiveScan("nation").build(),
-                                      core::JoinType::kInner)
+                                  .hashJoinInner(
+                                      matchHiveScan("nation").build())
                                   .project()
-                                  .build(),
-                              core::JoinType::kLeftSemiFilter)
-                          .build(),
-                      core::JoinType::kRightSemiFilter)
-                  .build(),
-              core::JoinType::kRight)
+                                  .build())
+                          .build())
+                  .build())
           .filter()
           .project()
-          .hashJoin(
+          .hashJoinRightSemiFilter(
               matchHiveScan("supplier")
-                  .hashJoin(
-                      matchHiveScan("nation").build(), core::JoinType::kInner)
-                  .build(),
-              core::JoinType::kRightSemiFilter)
+                  .hashJoinInner(matchHiveScan("nation").build())
+                  .build())
           .orderBy()
           .build();
 
@@ -739,28 +725,24 @@ TEST_F(TpchPlanTest, q21) {
 TEST_F(TpchPlanTest, q22) {
   checkTpchSql(22);
 
-  auto startMatcher = [&](const std::string& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
-  };
-
   // The query is straightforward, with the not exists resolved with a right
   // semijoin and the non-correlated subquery becoming a cross join to the one
   // row result set of the non-grouped aggregation.
 
-  auto matcher = startMatcher("orders")
-                     .hashJoin(
-                         startMatcher("customer")
-                             .nestedLoopJoin(
-                                 startMatcher("customer").aggregation().build())
-                             .filter()
-                             .build(),
-                         velox::core::JoinType::kRightSemiProject,
-                         {.nullAware = false})
-                     .filter()
-                     .project()
-                     .aggregation()
-                     .orderBy()
-                     .build();
+  auto matcher =
+      matchHiveScan("orders")
+          .hashJoinRightSemiProject(
+              matchHiveScan("customer")
+                  .nestedLoopJoin(
+                      matchHiveScan("customer").aggregation().build())
+                  .filter()
+                  .build(),
+              {.nullAware = false})
+          .filter()
+          .project()
+          .aggregation()
+          .orderBy()
+          .build();
 
   auto plan = planTpch(22);
   AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/TpchQueries.cpp
+++ b/axiom/optimizer/tests/TpchQueries.cpp
@@ -44,14 +44,24 @@ std::string readSqlFromFile(const std::string& filePath) {
   return sql;
 }
 
-std::string readTpchSql(int32_t query) {
-  auto sql = readSqlFromFile(fmt::format("tpch/queries/q{}.sql", query));
+namespace {
+std::string readAndTrim(const std::string& path) {
+  auto sql = readSqlFromFile(path);
 
   boost::trim_right(sql);
   if (!sql.empty() && sql.back() == ';') {
     sql.pop_back();
   }
   return sql;
+}
+} // namespace
+
+std::string readTpchSql(int32_t query) {
+  return readAndTrim(fmt::format("tpch/queries/q{}.sql", query));
+}
+
+std::string readTpchSql(std::string_view name) {
+  return readAndTrim(fmt::format("tpch/queries/{}.sql", name));
 }
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/TpchQueries.h
+++ b/axiom/optimizer/tests/TpchQueries.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace facebook::axiom::optimizer::test {
 
@@ -24,5 +25,9 @@ std::string readSqlFromFile(const std::string& filePath);
 
 /// Reads and returns the SQL for the given TPC-H query number.
 std::string readTpchSql(int32_t query);
+
+/// Reads and returns the SQL for a named TPC-H query or variant file, e.g.
+/// "q9_alt" reads "tpch/queries/q9_alt.sql".
+std::string readTpchSql(std::string_view name);
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/tpch/queries/q9_alt.sql
+++ b/axiom/optimizer/tests/tpch/queries/q9_alt.sql
@@ -1,0 +1,37 @@
+-- TPC-H Q9 variant: `p_name like '%green%'` replaced with `p_size <= 3`, an
+-- estimable filter of similar selectivity (~6% vs green's ~5%). The `like`
+-- predicate is not estimable from column stats, so the optimizer over-estimates
+-- it and joins `supplier` before the selective `part`; with an estimable filter
+-- it reduces lineitem by `part` first — the optimal order. See statistics.md.
+select
+	nation,
+	o_year,
+	sum(amount) as sum_profit
+from
+	(
+		select
+			n.n_name as nation,
+			extract(year from o.o_orderdate) as o_year,
+			l.l_extendedprice * (1 - l.l_discount) - ps.ps_supplycost * l.l_quantity as amount
+		from
+			part as p,
+			supplier as s,
+			lineitem as l,
+			partsupp as ps,
+			orders as o,
+			nation as n
+		where
+			s.s_suppkey = l.l_suppkey
+			and ps.ps_suppkey = l.l_suppkey
+			and ps.ps_partkey = l.l_partkey
+			and p.p_partkey = l.l_partkey
+			and o.o_orderkey = l.l_orderkey
+			and s.s_nationkey = n.n_nationkey
+			and p.p_size <= 3
+	) as profit
+group by
+	nation,
+	o_year
+order by
+	nation,
+	o_year desc;

--- a/axiom/optimizer/tests/tpch/queries/statistics.md
+++ b/axiom/optimizer/tests/tpch/queries/statistics.md
@@ -1,0 +1,181 @@
+# TPC-H Statistics (companion to `schemas`)
+
+Per-column statistics (`SHOW STATS FOR <table>`) and measured cardinalities, to
+ground cardinality / join-order reasoning about TPC-H plans. **TPC-H data has no
+NULLs** (`nulls_fraction` = 0 for every column), so it is omitted below.
+
+## Scale and foreign-key integrity
+
+Row counts scale with the scale factor: region and nation are fixed; every other
+table is its base size × SF (see Table sizes). In standard TPC-H, foreign keys are
+valid by construction — every fact-table key references an existing dimension row,
+so a fact-to-dimension join on a key is non-reducing (it only filters out rows the
+other predicates already removed).
+
+**sf0.1 violates this — but as a generator bug, not a property of TPC-H.** Velox's
+TPC-H generator clamps the scale factor to 1 when computing value ranges for any
+SF<1, while still emitting the reduced row counts. So at sf0.1 the fact tables
+carry keys spanning the **SF=1** domain (`l_partkey` → 200,000, `l_suppkey` →
+10,000) while the dimensions are sized for SF=0.1 (part 20,000, supplier 1,000).
+~90% of `lineitem`/`partsupp` part/supplier keys then reference non-existent rows,
+and those joins **reduce the fact table ~10×**. Only `part` and `supplier` are
+affected; `orders`/`customer`/`nation` keys stay valid. See
+https://github.com/facebookincubator/velox/issues/16399. Measured survival:
+
+| join | survives | of | ≈ |
+|---|---|---|---|
+| lineitem-part | 59,765 | 600,572 | 10% |
+| lineitem-supplier | 60,154 | 600,572 | 10% |
+| partsupp-supplier | 8,000 | 80,000 | 10% |
+| lineitem-orders | 600,572 | 600,572 | 100% |
+| orders-customer | 14,882 | 15,000 | ~99% |
+| partsupp-part, supplier-nation, customer-nation | — | — | 100% |
+
+The bug only mis-fires for SF<1 (the clamp is a no-op at SF≥1), so at sf1 and sf10
+all FKs are valid (verified: at sf1, lineitem-part and lineitem-supplier both
+survive 6,001,215 / 6,001,215).
+
+**Consequence — plans on sf0.1 data can differ from plans on correct data.** With
+the bug, the part/supplier joins are ~10× reducers, so the cost-optimal join order
+on sf0.1 can differ from the order on FK-valid data (SF≥1, or sf0.1 once the bug is
+fixed). A plan validated against the current sf0.1 data is not necessarily the plan
+for correct TPC-H, so plan-shape expectations must state which data they assume.
+Any join-order reasoning that hinges on the part/supplier reduction (e.g. q9) is a
+property of the bug, not of TPC-H.
+
+## Table sizes
+
+Standard TPC-H scaling (region/nation are scale-independent; the rest are
+base × SF). Measured spot-checks match.
+
+| table | sf0.1 | sf1 | sf10 |
+|---|---|---|---|
+| region | 5 | 5 | 5 |
+| nation | 25 | 25 | 25 |
+| supplier | 1,000 | 10,000 | 100,000 |
+| customer | 15,000 | 150,000 | 1,500,000 |
+| part | 20,000 | 200,000 | 2,000,000 |
+| partsupp | 80,000 | 800,000 | 8,000,000 |
+| orders | 150,000 | 1,500,000 | 15,000,000 |
+| lineitem | 600,572 | 6,001,215 | ~60,000,000 |
+
+## Per-column statistics (sf0.1)
+
+String `low`/`high` are truncated. For other scales, NDV of key/dimension columns
+scales with the table; `low`/`high` ranges are stable except where the sf0.1 FK
+mismatch applies (e.g. `l_partkey`/`l_suppkey` high values already span the SF=1
+domain at sf0.1).
+
+### region — 5 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| r_regionkey | 5 | 0 | 4 |
+| r_name | 5 | AFRICA | MIDDLE EAST |
+
+### nation — 25 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| n_nationkey | 25 | 0 | 24 |
+| n_name | 25 | ALGERIA | VIETNAM |
+| n_regionkey | 5 | 0 | 4 |
+
+### supplier — 1,000 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| s_suppkey | 1000 | 1 | 1000 |
+| s_nationkey | 25 | 0 | 24 |
+| s_acctbal | 999 | -966.2 | 9993.46 |
+
+### customer — 15,000 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| c_custkey | 15000 | 1 | 15000 |
+| c_nationkey | 25 | 0 | 24 |
+| c_acctbal | 14985 | -999.95 | 9999.72 |
+| c_mktsegment | 5 | AUTOMOBILE | MACHINERY |
+
+### part — 20,000 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| p_partkey | 20000 | 1 | 20000 |
+| p_mfgr | 5 | Manufacturer#1 | Manufacturer#5 |
+| p_brand | 25 | Brand#11 | Brand#55 |
+| p_type | 1000 | ECONOMY ANODIZED … | STANDARD POLISHED … |
+| p_size | 50 | 1 | 50 |
+| p_container | 40 | JUMBO BAG | WRAP PKG |
+| p_retailprice | 7993 | 901 | 1918.99 |
+
+### partsupp — 80,000 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| ps_partkey | 20000 | 1 | 20000 |
+| ps_suppkey | 9749 | 1 | 10000 |
+| ps_availqty | 9995 | 1 | 9999 |
+| ps_supplycost | 76346 | 1.01 | 999.99 |
+
+### orders — 150,000 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| o_orderkey | 150000 | 1 | 600000 |
+| o_custkey | 138196 | 1 | 149999 |
+| o_orderstatus | 3 | F | P |
+| o_totalprice | 149943 | 917.35 | 496620.48 |
+| o_orderdate | 2405 | 1992-01-01 | 1998-08-02 |
+| o_orderpriority | 5 | 1-URGENT | 5-LOW |
+| o_shippriority | 1 | 0 | 0 |
+
+### lineitem — 600,572 rows
+| column | ndv | low | high |
+|---|---|---|---|
+| l_orderkey | 149788 | 1 | 600000 |
+| l_partkey | 199998 | 1 | 200000 |
+| l_suppkey | 9999 | 1 | 10000 |
+| l_linenumber | 7 | 1 | 7 |
+| l_quantity | 50 | 1 | 50 |
+| l_extendedprice | 579906 | 901 | 104899.5 |
+| l_discount | 11 | 0 | 0.1 |
+| l_tax | 9 | 0 | 0.08 |
+| l_returnflag | 3 | A | R |
+| l_linestatus | 2 | F | O |
+| l_shipdate | 2521 | 1992-01-03 | 1998-12-01 |
+| l_commitdate | 2460 | 1992-01-31 | 1998-10-31 |
+| l_receiptdate | 2542 | 1992-01-04 | 1998-12-27 |
+| l_shipinstruct | 4 | COLLECT COD | TAKE BACK RETURN |
+| l_shipmode | 7 | AIR | TRUCK |
+
+## Hard-to-estimate filters
+
+Predicates whose selectivity is **impossible to estimate from per-column stats
+alone** — it needs history or sampling — so the optimizer falls back to a default,
+making the query's plan **estimation-sensitive**. This is not a bug in the
+estimator: nothing in the column stats (ndv, min/max) tells you how many `p_name`
+values contain `green`. In q9 the `like` default (~0.8 × table) over-estimates
+`p_name like '%green%'` at ≈16,000 vs the true ~1,075, so the optimizer joins
+`supplier` before the more selective `part` (a suboptimal order). See the q9
+analysis in
+[../../../v2/docs/TpchV1V2PlanComparison.md](../../../v2/docs/TpchV1V2PlanComparison.md).
+
+Each row gives the filter's true selectivity and an **estimable substitute** of
+similar selectivity — a range over a uniform column (or a key range) the optimizer
+estimates accurately. Swapping the substitute in (as `q9_alt.sql` does) isolates a
+query's plan from the estimation gap and locks the optimal join order. Scan-filter
+selectivities are scale-invariant, so a substitute chosen here holds at every scale.
+
+| query | hard predicate | true selectivity | estimable substitute (~selectivity) |
+|---|---|---|---|
+| q2 | `p_type like '%BRASS'` | 4,017 / 20,000 = 20% | `p_size <= 10` (20%) |
+| q9 | `p_name like '%green%'` | 1,075 / 20,000 = 5.4% | `p_size <= 3` (6%) |
+| q13 | `o_comment not like '%special%requests%'` | 148,318 / 150,000 = 99% | `o_orderkey < 594000` (99%) |
+| q14 | `p_type like 'PROMO%'` | 3,309 / 20,000 = 17% | `p_size <= 8` (16%) |
+| q16 | `p_type not like 'MEDIUM POLISHED%'` | 19,358 / 20,000 = 97% | `p_size <= 48` (96%) |
+| q16 | `s_comment like '%Customer%Complaints%'` | 1 / 1,000 = 0.1% | `s_suppkey <= 1` (0.1%) |
+| q20 | `p_name like 'forest%'` | 190 / 20,000 = 0.95% | `p_partkey <= 200` (1%) |
+| q4 | `l_commitdate < l_receiptdate` | 379,809 / 600,572 = 63% | `l_quantity <= 32` (64%) |
+| q12 | `l_commitdate < l_receiptdate AND l_shipdate < l_commitdate` | 72,009 / 600,572 = 12% | `l_quantity <= 6` (12%) |
+| q21 | `l_receiptdate > l_commitdate` | 379,809 / 600,572 = 63% | `l_quantity <= 32` (64%) |
+| q22 | `substring(c_phone, 1, 2) in (...)` | 4,115 / 15,000 = 27% | `c_nationkey <= 6` (28%) |
+
+The hard predicates are substring/prefix `like` (no per-column stat applies),
+column-to-column compares (need cross-column correlation), and expressions over a
+column. The substitutes use `p_size`, `l_quantity`, and `c_nationkey` (uniform, so
+`<= k` is exactly k/ndv) or dense key ranges (`p_partkey`, `s_suppkey`, `o_orderkey`).


### PR DESCRIPTION
Summary:
The standard q9 has no plan-shape assertion: its `p_name like '%green%'` filter is not estimable from column stats, so the optimizer over-estimates it and picks a suboptimal join order. q9_alt is q9 with that filter replaced by the estimable `p_size <= 3` (~6%, similar selectivity), which lets the optimizer reduce lineitem by `part` first — the optimal part-first order — and locks it with a matcher.

Adds statistics.md, a companion to the `schemas` file, documenting per-column stats, table sizes, and a table of hard-to-estimate filters (each query's true selectivity plus an estimable substitute for building `*_alt` variants). It records that the sf0.1 foreign-key mismatch is Velox generator bug https://github.com/facebookincubator/velox/issues/16399, not a property of TPC-H, so any reasoning that leans on the part/supplier reduction is a property of the bug.

Adds typed hashJoinInner/Left/Right/... shortcuts to `PlanMatcherBuilder` so matchers name the join type instead of passing `JoinType::kXxx`, and adopts them with `matchHiveScan` across the TPC-H matchers.

Differential Revision: D108561872


