### PR TITLE
test(optimizer): Split TPC-H plan and result tests (#1482)

### DIFF
--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -1055,6 +1055,161 @@ void TestConnector::addTpchTables() {
   }
 }
 
+namespace {
+
+// TPC-H column statistics for 'table' at 'scaleFactor', following the TPC-H
+// spec. Dates and discrete domains are scale-invariant; key counts scale with
+// the row count, and foreign-key columns take the referenced table's key
+// range.
+std::unordered_map<std::string, connector::ColumnStatistics> tpchColumnStats(
+    velox::tpch::Table table,
+    double scaleFactor) {
+  using velox::tpch::getRowCount;
+  using velox::tpch::Table;
+
+  const int64_t supplierRows = getRowCount(Table::TBL_SUPPLIER, scaleFactor);
+  const int64_t partRows = getRowCount(Table::TBL_PART, scaleFactor);
+  const int64_t partsuppRows = getRowCount(Table::TBL_PARTSUPP, scaleFactor);
+  const int64_t customerRows = getRowCount(Table::TBL_CUSTOMER, scaleFactor);
+  const int64_t ordersRows = getRowCount(Table::TBL_ORDERS, scaleFactor);
+  const int64_t lineitemRows = getRowCount(Table::TBL_LINEITEM, scaleFactor);
+  const int64_t numRows = getRowCount(table, scaleFactor);
+
+  // The o_orderkey domain is sparse: keys span roughly four times the orders
+  // row count.
+  const int64_t orderKeyMax = 4 * ordersRows;
+
+  auto distinct = [&](int64_t count) {
+    connector::ColumnStatistics statistics;
+    statistics.nonNull = true;
+    statistics.numValues = numRows;
+    statistics.numDistinct = std::min<int64_t>(count, numRows);
+    return statistics;
+  };
+
+  auto ranged = [&](int64_t count, velox::Variant min, velox::Variant max) {
+    auto statistics = distinct(count);
+    statistics.min = std::move(min);
+    statistics.max = std::move(max);
+    return statistics;
+  };
+
+  auto asInt32 = [](int32_t value) { return velox::Variant(value); };
+  auto asInt64 = [](int64_t value) { return velox::Variant(value); };
+  auto asDouble = [](double value) { return velox::Variant(value); };
+  auto date = [](const char* text) {
+    return velox::Variant(velox::DATE()->toDays(text));
+  };
+
+  switch (table) {
+    case Table::TBL_REGION:
+      return {
+          {"r_regionkey", ranged(5, asInt64(0), asInt64(4))},
+          {"r_name", distinct(5)},
+          {"r_comment", distinct(5)}};
+    case Table::TBL_NATION:
+      return {
+          {"n_nationkey", ranged(25, asInt64(0), asInt64(24))},
+          {"n_name", distinct(25)},
+          {"n_regionkey", ranged(5, asInt64(0), asInt64(4))},
+          {"n_comment", distinct(25)}};
+    case Table::TBL_SUPPLIER:
+      return {
+          {"s_suppkey",
+           ranged(supplierRows, asInt64(1), asInt64(supplierRows))},
+          {"s_name", distinct(supplierRows)},
+          {"s_address", distinct(supplierRows)},
+          {"s_nationkey", ranged(25, asInt64(0), asInt64(24))},
+          {"s_phone", distinct(supplierRows)},
+          {"s_acctbal",
+           ranged(supplierRows, asDouble(-999.99), asDouble(9999.99))},
+          {"s_comment", distinct(supplierRows)}};
+    case Table::TBL_PART:
+      return {
+          {"p_partkey", ranged(partRows, asInt64(1), asInt64(partRows))},
+          {"p_name", distinct(partRows)},
+          {"p_mfgr", distinct(5)},
+          {"p_brand", distinct(25)},
+          {"p_type", distinct(150)},
+          {"p_size", ranged(50, asInt32(1), asInt32(50))},
+          {"p_container", distinct(40)},
+          {"p_retailprice",
+           ranged(partRows, asDouble(901.0), asDouble(2098.99))},
+          {"p_comment", distinct(partRows)}};
+    case Table::TBL_PARTSUPP:
+      return {
+          {"ps_partkey", ranged(partRows, asInt64(1), asInt64(partRows))},
+          {"ps_suppkey",
+           ranged(supplierRows, asInt64(1), asInt64(supplierRows))},
+          {"ps_availqty", ranged(9999, asInt32(1), asInt32(9999))},
+          {"ps_supplycost", ranged(100000, asDouble(1.0), asDouble(1000.0))},
+          {"ps_comment", distinct(partsuppRows)}};
+    case Table::TBL_CUSTOMER:
+      return {
+          {"c_custkey",
+           ranged(customerRows, asInt64(1), asInt64(customerRows))},
+          {"c_name", distinct(customerRows)},
+          {"c_address", distinct(customerRows)},
+          {"c_nationkey", ranged(25, asInt64(0), asInt64(24))},
+          {"c_phone", distinct(customerRows)},
+          {"c_acctbal",
+           ranged(customerRows, asDouble(-999.99), asDouble(9999.99))},
+          {"c_mktsegment", distinct(5)},
+          {"c_comment", distinct(customerRows)}};
+    case Table::TBL_ORDERS:
+      return {
+          {"o_orderkey", ranged(ordersRows, asInt64(1), asInt64(orderKeyMax))},
+          // Only about two thirds of customers place orders.
+          {"o_custkey",
+           ranged(2 * customerRows / 3, asInt64(1), asInt64(customerRows))},
+          {"o_orderstatus", distinct(3)},
+          {"o_totalprice",
+           ranged(ordersRows, asDouble(857.71), asDouble(600000.0))},
+          {"o_orderdate", ranged(2406, date("1992-01-01"), date("1998-08-02"))},
+          {"o_orderpriority", distinct(5)},
+          {"o_clerk", distinct(std::max<int64_t>(1, 1000 * scaleFactor))},
+          {"o_shippriority", distinct(1)},
+          {"o_comment", distinct(ordersRows)}};
+    case Table::TBL_LINEITEM:
+      return {
+          {"l_orderkey", ranged(ordersRows, asInt64(1), asInt64(orderKeyMax))},
+          {"l_partkey", ranged(partRows, asInt64(1), asInt64(partRows))},
+          {"l_suppkey",
+           ranged(supplierRows, asInt64(1), asInt64(supplierRows))},
+          {"l_linenumber", ranged(7, asInt32(1), asInt32(7))},
+          {"l_quantity", ranged(50, asDouble(1.0), asDouble(50.0))},
+          {"l_extendedprice",
+           ranged(lineitemRows, asDouble(901.0), asDouble(104949.5))},
+          {"l_discount", ranged(11, asDouble(0.0), asDouble(0.10))},
+          {"l_tax", ranged(9, asDouble(0.0), asDouble(0.08))},
+          {"l_returnflag", distinct(3)},
+          {"l_linestatus", distinct(2)},
+          {"l_shipdate", ranged(2526, date("1992-01-02"), date("1998-12-01"))},
+          {"l_commitdate",
+           ranged(2466, date("1992-01-31"), date("1998-10-31"))},
+          {"l_receiptdate",
+           ranged(2554, date("1992-01-03"), date("1998-12-31"))},
+          {"l_shipinstruct", distinct(4)},
+          {"l_shipmode", distinct(7)},
+          {"l_comment", distinct(lineitemRows)}};
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace
+
+void TestConnector::addTpchTables(double scaleFactor) {
+  VELOX_CHECK_GT(scaleFactor, 0, "TPC-H scale factor must be positive");
+  for (auto table : velox::tpch::tables) {
+    const auto name = std::string(velox::tpch::toTableName(table));
+    addTable(name, velox::tpch::getTableSchema(table));
+    setStats(
+        name,
+        velox::tpch::getRowCount(table, scaleFactor),
+        tpchColumnStats(table, scaleFactor));
+  }
+}
+
 void TestConnector::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -857,6 +857,12 @@ class TestConnector : public velox::connector::Connector {
 
   void addTpchTables();
 
+  /// Registers the TPC-H tables with column statistics for the given scale
+  /// factor, without generating any data, so the optimizer can plan TPC-H
+  /// queries at any scale instantly. Row counts, distinct counts, and value
+  /// ranges all follow the TPC-H spec.
+  void addTpchTables(double scaleFactor);
+
   /// Callback receiving the filter expressions the optimizer pushes into a
   /// scan. Installed by tests to inspect the exact form a connector is handed.
   using FilterInspector =

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries(
   Boost::headers
 )
 
-add_executable(axiom_optimizer_tpch_plan_test TpchPlanTest.cpp)
+add_executable(axiom_optimizer_tpch_plan_test TpchPlanTest.cpp TpchResultTest.cpp)
 
 add_test(
   NAME axiom_optimizer_tpch_plan_test
@@ -92,11 +92,13 @@ add_test(
 target_link_libraries(
   axiom_optimizer_tpch_plan_test
   velox_dwio_common_test_utils
+  velox_exec_test_lib
   axiom_optimizer_tests_tpch_data_generator
   axiom_optimizer_tests_tpch_queries
   axiom_optimizer_tests_query_test_base
   axiom_optimizer_tests_hive_queries_test_base
   axiom_runner_tests_utils
+  GTest::gtest
 )
 
 add_executable(

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -337,7 +337,10 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
       ExprMatcher::match(plan.filter(), expected->dropAlias());
     }
 
-    AXIOM_TEST_RETURN
+    // A filter does not rename columns; pass the child's symbols through so
+    // downstream matchers can resolve aliases bound below the filter.
+    AXIOM_TEST_RETURN_IF_FAILURE
+    return MatchResult::success(symbols);
   }
 
  private:

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -198,6 +198,18 @@ class PlanMatcherBuilder {
   /// Matches a Filter node with the specified predicate expression.
   /// Supports symbol rewriting from child matchers.
   /// @param predicate The expected filter predicate (DuckDB SQL syntax).
+  ///
+  /// The predicate is parsed and compared to the plan's filter expression by
+  /// structure, so it must match the optimizer's form, not just be logically
+  /// equivalent. Gotchas:
+  ///   - Conjunctions/disjunctions of three or more terms: the optimizer emits
+  ///     a flat n-ary call, but 'a and b and c' parses as nested binary
+  ///     'and(and(a, b), c)' and will not match. Use the function-call form
+  ///     '"and"(a, b, c)' for a flat call.
+  ///   - Numeric literal type: a literal is compared by both value and type
+  ///     kind. A bare integer such as '24' is INTEGER and will not match a
+  ///     constant the optimizer coerced to the column's type. Write '24.0' to
+  ///     compare against a DOUBLE column.
   PlanMatcherBuilder& filter(const std::string& predicate);
 
   /// Matches any Project node regardless of expressions.
@@ -501,6 +513,10 @@ class PlanMatcherBuilder {
   /// maps the alias to the i-th output column name. nullopt entries are
   /// skipped. Fails at match time if aliases.size() exceeds the matched
   /// node's output column count.
+  ///
+  /// Use lowercase aliases. Downstream expressions are parsed as DuckDB SQL,
+  /// which lowercases unquoted identifiers, so an alias like "myCol" registered
+  /// here would be looked up as "mycol".
   /// @param aliases The aliases to register, indexed by output column
   /// position. Use std::nullopt to skip a column.
   PlanMatcherBuilder& aliases(

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -67,7 +67,7 @@ void QueryTestBase::SetUp() {
   velox::connector::registerConnector(testConnector_);
   connector::ConnectorMetadataRegistry::global().insert(
       kTestConnectorId, testConnector_->metadata());
-  testConnector_->addTpchTables();
+  configureTestConnector();
 
   optimizerPool_ = rootPool_->addLeafChild("optimizer");
 
@@ -79,6 +79,10 @@ void QueryTestBase::SetUp() {
 
   optimizerOptions_ = OptimizerOptions();
   optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
+}
+
+void QueryTestBase::configureTestConnector() {
+  testConnector_->addTpchTables();
 }
 
 void QueryTestBase::TearDown() {

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -95,6 +95,11 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
   /// Unregisters exchange sources.
   void TearDown() override;
 
+  /// Populates 'testConnector_' before each test. The default registers the
+  /// TPC-H tables without statistics. Override to register different tables or
+  /// to attach statistics (e.g. via addTpchTables(scaleFactor)).
+  virtual void configureTestConnector();
+
   logical_plan::LogicalPlanNodePtr parseSelect(
       std::string_view sql,
       const std::string& defaultConnectorId,

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-#include <folly/init/Init.h>
 #include <gtest/gtest.h>
-#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/logical_plan/PlanBuilder.h"
-#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
 #include "axiom/optimizer/tests/TestDataPath.h"
 #include "axiom/optimizer/tests/TpchQueries.h"
-#include "velox/exec/tests/utils/TpchQueryBuilder.h"
-#include "velox/type/tests/SubfieldFiltersBuilder.h"
-
-DEFINE_int32(num_repeats, 1, "Number of repeats for optimization timing");
-
-DECLARE_uint32(optimizer_trace);
-DECLARE_string(history_save_path);
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -35,744 +27,475 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class TpchPlanTest : public virtual test::HiveQueriesTestBase {
+// Asserts the single-node plan shape of each TPC-H query. Statistics are
+// injected via `TestConnector::addTpchTables(scaleFactor)`, so no data is
+// generated and the optimizer plans at any scale instantly. Foreign keys are
+// consistent at every scale, so the plans reflect real TPC-H rather than the
+// data generator's behavior below scale factor 1. Result correctness is checked
+// separately in `TpchResultTest`. Filters become separate nodes here because
+// the test connector does not push them into the scan.
+class TpchPlanTest : public test::QueryTestBase {
  protected:
-  static void SetUpTestCase() {
-    test::HiveQueriesTestBase::SetUpTestCase();
-    createTpchTables(velox::tpch::tables);
+  static constexpr double kScaleFactor = 1.0;
+
+  void configureTestConnector() override {
+    testConnector_->addTpchTables(kScaleFactor);
   }
 
-  static void TearDownTestCase() {
-    if (!FLAGS_history_save_path.empty()) {
-      suiteHistory().saveToFile(FLAGS_history_save_path);
-    }
-    test::HiveQueriesTestBase::TearDownTestCase();
-  }
-
-  void SetUp() override {
-    HiveQueriesTestBase::SetUp();
-
-    referenceBuilder_ =
-        std::make_unique<exec::test::TpchQueryBuilder>(localFileFormat_);
-    referenceBuilder_->initialize(localDataPath_);
-  }
-
-  void TearDown() override {
-    HiveQueriesTestBase::TearDown();
-  }
-
-  lp::LogicalPlanNodePtr parseTpchSql(int32_t query) {
-    auto sql = test::readTpchSql(query);
-
-    auto statement = prestoParser().parse(sql);
-
-    VELOX_CHECK(statement->isSelect());
-
-    auto logicalPlan =
-        statement->as<::axiom::sql::presto::SelectStatement>()->plan();
-    VELOX_CHECK_NOT_NULL(logicalPlan);
-
-    return logicalPlan;
-  }
-
-  void checkTpchSql(int32_t query) {
-    auto sql = test::readTpchSql(query);
-    auto referencePlan = referenceBuilder_->getQueryPlan(query).plan;
-    checkResults(sql, referencePlan);
+  lp::LogicalPlanNodePtr parseTpch(int32_t query) {
+    return parseSelect(test::readTpchSql(query), kTestConnectorId);
   }
 
   velox::core::PlanNodePtr planTpch(int32_t query) {
-    return toSingleNodePlan(parseTpchSql(query));
-  }
-
-  // Parses a named TPC-H query file (e.g. "q9_alt").
-  lp::LogicalPlanNodePtr parseTpchSql(const std::string& name) {
-    return parseSelect(test::readTpchSql(name));
+    return toSingleNodePlan(parseTpch(query));
   }
 
   velox::core::PlanNodePtr planTpch(const std::string& name) {
-    return toSingleNodePlan(parseTpchSql(name));
+    return toSingleNodePlan(
+        parseSelect(test::readTpchSql(name), kTestConnectorId));
   }
-
-  std::unique_ptr<exec::test::TpchQueryBuilder> referenceBuilder_;
 };
 
+// Verifies that the injected statistics produce the expected base-table
+// cardinalities at 'kScaleFactor'. Every node in a bare-scan plan reports the
+// table cardinality since no operator changes the row count.
 TEST_F(TpchPlanTest, stats) {
-  auto verifyStats = [&](const auto& tableName, auto cardinality) {
+  auto verifyStats = [&](const std::string& tableName, int64_t cardinality) {
     SCOPED_TRACE(tableName);
-
-    lp::PlanBuilder::Context ctx{exec::test::kHiveConnectorId, kDefaultSchema};
+    lp::PlanBuilder::Context ctx{kTestConnectorId, "default"};
     auto logicalPlan = lp::PlanBuilder(ctx).tableScan(tableName).build();
-
-    auto planAndStats = planVelox(logicalPlan);
-    auto stats = planAndStats.prediction;
-    ASSERT_FALSE(stats.empty());
-
-    // Every node in a bare-scan plan reports the table cardinality since no
-    // intermediate operator changes the row count.
-    for (const auto& [nodeId, prediction] : stats) {
-      EXPECT_EQ(prediction.cardinality, cardinality);
+    auto prediction = planVelox(logicalPlan).prediction;
+    ASSERT_FALSE(prediction.empty());
+    for (const auto& [nodeId, value] : prediction) {
+      EXPECT_EQ(value.cardinality, cardinality);
     }
   };
 
   verifyStats("region", 5);
   verifyStats("nation", 25);
-  verifyStats("orders", 150'000);
-  verifyStats("lineitem", 600'572);
+  verifyStats("supplier", 10'000);
+  verifyStats("orders", 1'500'000);
+  verifyStats("lineitem", 6'001'215);
 }
 
 TEST_F(TpchPlanTest, q01) {
-  checkTpchSql(1);
-
-  // The query is a simple scan of lineitem with a very low cardinality group
-  // by. All the work is in the table scan (65%) and partial aggregation (30%).
-
-  auto matcher =
-      core::PlanMatcherBuilder()
-          .hiveScan(
-              "lineitem", test::lte("l_shipdate", DATE()->toDays("1998-09-02")))
-          .project()
-          .aggregation()
-          .orderBy()
-          .build();
-
-  auto plan = planTpch(1);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(1)));
+  auto matcher = matchScan("lineitem")
+                     .filter("l_shipdate < date '1998-09-03'")
+                     .project()
+                     .aggregation()
+                     .orderBy()
+                     .build();
+  AXIOM_ASSERT_PLAN(planTpch(1), matcher);
 }
 
 TEST_F(TpchPlanTest, q02) {
-  checkTpchSql(2);
-
-  auto joinNationWithRegion = matchHiveScan("nation").hashJoinInner(
-      core::PlanMatcherBuilder()
-          .hiveScan("region", test::eq("r_name", "EUROPE"))
-          .build());
-
-  // The subquery (min cost per part) is very selective — it matches at most
-  // one partsupp row per part. It is joined before supplier because its low
-  // fanout reduces the row count before the supplier join.
-  //
-  // ((partsupp INNER part)
-  //  INNER
-  //  agg(((supplier INNER (partsupp LEFT SEMI (FILTER) part))
-  //       INNER (nation INNER region)))
-  //  INNER
-  //  (supplier INNER (nation INNER region)))
   auto matcher =
-      matchHiveScan("partsupp")
-          .hashJoinInner(matchHiveScan("part").build())
+      matchScan("partsupp")
+          .hashJoinInner(matchScan("part")
+                             .filter("p_size = 15 and p_type like '%BRASS'")
+                             .build())
           .hashJoinInner(
-              matchHiveScan("partsupp")
-                  .hashJoinLeftSemiFilter(matchHiveScan("part").build())
+              matchScan("supplier")
                   .hashJoinInner(
-                      matchHiveScan("supplier")
-                          .hashJoinInner(joinNationWithRegion.build())
+                      matchScan("nation")
+                          .hashJoinInner(matchScan("region")
+                                             .filter("r_name = 'EUROPE'")
+                                             .build())
+                          .build())
+                  .build())
+          .hashJoinInner(
+              matchScan("partsupp")
+                  .hashJoinLeftSemiFilter(
+                      matchScan("part")
+                          .filter("p_size = 15 and p_type like '%BRASS'")
+                          .build())
+                  .hashJoinInner(
+                      matchScan("supplier")
+                          .hashJoinInner(
+                              matchScan("nation")
+                                  .hashJoinInner(
+                                      matchScan("region")
+                                          .aliases(
+                                              {std::nullopt, "region_name"})
+                                          .filter("region_name = 'EUROPE'")
+                                          .build())
+                                  .build())
                           .build())
                   .aggregation()
                   .project()
                   .build())
-          .hashJoinInner(matchHiveScan("supplier")
-                             .hashJoinInner(joinNationWithRegion.build())
-                             .build())
           .topN()
           .project()
           .build();
-
-  auto plan = planTpch(2);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(2)));
+  AXIOM_ASSERT_PLAN(planTpch(2), matcher);
 }
 
 TEST_F(TpchPlanTest, q03) {
-  checkTpchSql(3);
-
-  // The query is straightforward to do by hash. We select 1/5 of customer and
-  // 1/2 of orders. We first join orders x customer, build on that and then
-  // probe on lineitem. There is anti-correlation between the date filters on
-  // lineitem and orders but that does not affect the best plan choice.
-
   auto matcher =
-      matchHiveScan("lineitem")
+      matchScan("lineitem")
+          .filter("l_shipdate > date '1995-03-15'")
           .hashJoinInner(
-              matchHiveScan("orders")
-                  .hashJoinInner(
-                      matchHiveScan("customer").build(),
-                      {.outputColumnNames =
-                           {{"o_orderkey", "o_orderdate", "o_shippriority"}}})
-                  .build(),
-              {.outputColumnNames =
-                   {{"l_orderkey",
-                     "l_extendedprice",
-                     "l_discount",
-                     "o_orderdate",
-                     "o_shippriority"}}})
+              matchScan("orders")
+                  .filter("o_orderdate < date '1995-03-15'")
+                  .hashJoinInner(matchScan("customer")
+                                     .filter("c_mktsegment = 'BUILDING'")
+                                     .build())
+                  .build())
           .project()
           .aggregation()
           .topN()
           .project()
           .build();
-
-  auto plan = planTpch(3);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(3)));
+  AXIOM_ASSERT_PLAN(planTpch(3), matcher);
 }
 
 TEST_F(TpchPlanTest, q04) {
-  checkTpchSql(4);
-
-  // The trick in q4 is using a right hand semijoin to do the exists. If we
-  // probed with orders and built on lineitem, we would get a much larger build
-  // side. But using the right hand semijoin, we get to build on the smaller
-  // side. If we had shared key order between lineitem and orders we could look
-  // at other plans but in the hash based plan space we have the best outcome.
-
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("lineitem", {}, "l_commitdate < l_receiptdate")
-                     .hashJoinRightSemiFilter(
-                         core::PlanMatcherBuilder()
-                             .hiveScan(
-                                 "orders",
-                                 test::between(
-                                     "o_orderdate",
-                                     DATE()->toDays("1993-07-01"),
-                                     DATE()->toDays("1993-09-30")))
-                             .build())
-                     .aggregation()
-                     .orderBy()
-                     .build();
-
-  auto plan = planTpch(4);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(4)));
-}
-
-TEST_F(TpchPlanTest, q05) {
-  checkTpchSql(5);
-
-  // The filters are on region and order date. There is also a diamond between
-  // supplier and customer, this being that they have the same nation.
-  //
-  // Lineitem is the driving table that is joined to 1/5 of supplier and then
-  // 1/7 of orders. Finally we join with customer on c_custkey and c_nationkey.
-  // The build of customer could have been restricted on c_nationkey being in
-  // the range of s_nationkey but we did not pick this restriction because this
-  // would have gone through a single equality in a join edge of two equalities.
-  // The plan is otherwise good and the extra reduction on customer ends up not
-  // being very important. This is a possible enhancement for completeness.
-
-  // agg((
-  //   (lineitem INNER ((orders INNER customer) INNER (nation INNER region)))
-  //   INNER
-  //   (supplier LEFT SEMI (FILTER) (nation INNER region))
-  // ))
-
-  auto joinNationWithRegion = matchHiveScan("nation").hashJoinInner(
-      core::PlanMatcherBuilder()
-          .hiveScan("region", test::eq("r_name", "ASIA"))
-          .build());
-
   auto matcher =
-      matchHiveScan("lineitem")
-          .hashJoinInner(matchHiveScan("orders")
-                             .hashJoinInner(matchHiveScan("customer").build())
-                             .hashJoinInner(joinNationWithRegion.build())
-                             .build())
-          .hashJoinInner(matchHiveScan("supplier")
-                             .hashJoinLeftSemiFilter(
-                                 joinNationWithRegion.project().build())
-                             .build())
-          .project()
+      matchScan("lineitem")
+          .filter("l_commitdate < l_receiptdate")
+          .hashJoinRightSemiFilter(
+              matchScan("orders")
+                  .filter(
+                      "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'")
+                  .build())
           .aggregation()
           .orderBy()
           .build();
-
-  auto plan = planTpch(5);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(5)));
+  AXIOM_ASSERT_PLAN(planTpch(4), matcher);
 }
 
-TEST_F(TpchPlanTest, q06) {
-  checkTpchSql(6);
-
-  // We have a single scan, so there are no query optimization choices here.
-
-  auto subfieldFilters =
-      velox::common::test::SubfieldFiltersBuilder()
-          .add(
-              "l_shipdate",
-              velox::exec::between(
-                  DATE()->toDays("1994-01-01"), DATE()->toDays("1994-12-31")))
-          .add("l_discount", velox::exec::betweenDouble(0.05, 0.07))
-          .add("l_quantity", velox::exec::lessThanDouble(24))
-          .build();
-
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("lineitem", std::move(subfieldFilters))
-                     .project()
-                     .aggregation()
-                     .build();
-
-  auto plan = planTpch(6);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(6)));
-}
-
-TEST_F(TpchPlanTest, q07) {
-  checkTpchSql(7);
-
-  // TODO Verify the plan.
-
-  ASSERT_NO_THROW(planTpch(7));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(7)));
-}
-
-TEST_F(TpchPlanTest, q08) {
-  checkTpchSql(8);
-
-  // TODO Verify the plan.
-
-  ASSERT_NO_THROW(planTpch(8));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(8)));
-}
-
-TEST_F(TpchPlanTest, q09) {
-  checkTpchSql(9);
-
-  // No plan-shape assertion: q9's `p_name like '%green%'` is not estimable from
-  // column stats, so the optimizer over-estimates it and orders the join
-  // suboptimally. q09Alt locks the optimal shape using an estimable filter of
-  // similar selectivity. See tpch/queries/statistics.md.
-
-  ASSERT_NO_THROW(planTpch(9));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(9)));
-}
-
-TEST_F(TpchPlanTest, q09Alt) {
-  // q9 with `p_name like '%green%'` replaced by the estimable `p_size <= 3`
-  // (~6%, similar selectivity). With an accurate estimate the optimizer reduces
-  // lineitem by the selective `part` first — the optimal join order. See
-  // tpch/queries/statistics.md.
-  //
-  // TODO: Verify results (no TpchQueryBuilder reference exists for this
-  // variant; this asserts plan shape only).
-  auto plan = planTpch("q9_alt");
-
-  // Optimal part-first order:
-  //
-  // agg((
-  //   orders INNER (
-  //     ((partsupp INNER supplier)
-  //        INNER
-  //        ((lineitem INNER part) LEFT SEMI (FILTER) (supplier INNER nation)))
-  //     INNER nation)))
+TEST_F(TpchPlanTest, q05) {
   auto matcher =
-      matchHiveScan("orders")
+      matchScan("lineitem")
           .hashJoinInner(
-              matchHiveScan("partsupp")
-                  .hashJoinInner(matchHiveScan("supplier").build())
+              matchScan("orders")
+                  .filter(
+                      "o_orderdate >= date '1994-01-01' and o_orderdate < date '1995-01-01'")
                   .hashJoinInner(
-                      matchHiveScan("lineitem")
-                          .hashJoinInner(matchHiveScan("part").build())
-                          .hashJoinLeftSemiFilter(
-                              matchHiveScan("supplier")
-                                  .hashJoinInner(
-                                      matchHiveScan("nation").build())
-                                  .project()
+                      matchScan("customer")
+                          .hashJoinInner(
+                              matchScan("nation")
+                                  .hashJoinInner(matchScan("region")
+                                                     .filter("r_name = 'ASIA'")
+                                                     .build())
                                   .build())
                           .build())
-                  .hashJoinInner(matchHiveScan("nation").build())
+                  .build())
+          .hashJoinInner(
+              matchScan("supplier")
+                  .hashJoinLeftSemiFilter(
+                      matchScan("nation")
+                          .hashJoinInner(matchScan("region")
+                                             .filter("r_name = 'ASIA'")
+                                             .build())
+                          .project()
+                          .build())
                   .build())
           .project()
           .aggregation()
           .orderBy()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(5), matcher);
+}
+
+TEST_F(TpchPlanTest, q06) {
+  auto matcher =
+      matchScan("lineitem")
+          .filter(
+              "\"and\"(l_shipdate >= date '1994-01-01', l_shipdate < date '1995-01-01', "
+              "         l_discount between 0.05 and 0.07, l_quantity < 24.0)")
+          .project()
+          .aggregation()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(6), matcher);
+}
+
+TEST_F(TpchPlanTest, q07) {
+  ASSERT_NO_THROW(planTpch(7));
+}
+
+TEST_F(TpchPlanTest, q08) {
+  ASSERT_NO_THROW(planTpch(8));
+}
+
+// No plan-shape assertion: q9's `p_name like '%green%'` is not estimable from
+// column stats, so the optimizer over-estimates it and orders the join
+// suboptimally. q09Alt locks the optimal shape using an estimable filter of
+// similar selectivity. See tpch/queries/statistics.md.
+TEST_F(TpchPlanTest, q09) {
+  ASSERT_NO_THROW(planTpch(9));
+}
+
+// q9 with `p_name like '%green%'` replaced by the estimable `p_size <= 3`
+// (~6%, similar selectivity). With an accurate estimate the optimizer reduces
+// lineitem by the selective `part` first. See tpch/queries/statistics.md.
+TEST_F(TpchPlanTest, q09Alt) {
+  auto matcher =
+      matchScan("orders")
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .hashJoinInner(
+                      matchScan("partsupp")
+                          .hashJoinInner(
+                              matchScan("part").filter("p_size <= 3").build())
+                          .build())
+                  .build())
+          .hashJoinInner(matchScan("supplier").build())
+          .hashJoinInner(matchScan("nation").build())
+          .project()
+          .aggregation()
+          .orderBy()
           .project()
           .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN(planTpch("q9_alt"), matcher);
 }
 
 TEST_F(TpchPlanTest, q10) {
-  checkTpchSql(10);
-
-  // TODO Verify the plan.
-
   ASSERT_NO_THROW(planTpch(10));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(10)));
 }
 
 TEST_F(TpchPlanTest, q11) {
-  checkTpchSql(11);
-
-  // The join order is the usual, from large to small. The only particularity is
-  // the non-correlated subquery that repeats the same join steps. An
-  // optimization opportunity could be to reuse build sides but this is not
-  // something that Velox plans support at this time. Also, practical need for
-  // this is not very high.
-
   auto matcher =
-      matchHiveScan("partsupp")
+      matchScan("partsupp")
           .hashJoinInner(
-              matchHiveScan("supplier")
+              matchScan("supplier")
                   .hashJoinInner(
-                      core::PlanMatcherBuilder()
-                          .hiveScan("nation", test::eq("n_name", "GERMANY"))
-                          .build())
+                      matchScan("nation").filter("n_name = 'GERMANY'").build())
                   .build())
           .project()
           .aggregation()
           .nestedLoopJoin(
-              matchHiveScan("partsupp")
+              matchScan("partsupp")
                   .hashJoinInner(
-                      matchHiveScan("supplier")
+                      matchScan("supplier")
                           .hashJoinInner(
-                              core::PlanMatcherBuilder()
-                                  .hiveScan(
-                                      "nation", test::eq("n_name", "GERMANY"))
+                              matchScan("nation")
+                                  .aliases({std::nullopt, "nation_name"})
+                                  .filter("nation_name = 'GERMANY'")
                                   .build())
                           .build())
                   .project()
                   .aggregation()
                   .project()
                   .build())
-          .filter()
+          .filter("value > expr")
           .orderBy()
-          .project() // TODO Move this 'project' below the 'orderBy'.
+          .project()
           .build();
-
-  auto plan = planTpch(11);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(11)));
+  AXIOM_ASSERT_PLAN(planTpch(11), matcher);
 }
 
 TEST_F(TpchPlanTest, q12) {
-  checkTpchSql(12);
-
-  // In this query, we end up building on lineitem since the filters on it make
-  // it the smaller of the two tables. Everything else is unsurprising.
-
-  auto subfieldFilters =
-      velox::common::test::SubfieldFiltersBuilder()
-          .add(
-              "l_shipmode",
-              velox::exec::in(std::vector<std::string>{"MAIL", "SHIP"}))
-          .add(
-              "l_receiptdate",
-              velox::exec::between(
-                  DATE()->toDays("1994-01-01"), DATE()->toDays("1994-12-31")))
-          .build();
-
   auto matcher =
-      matchHiveScan("orders")
+      matchScan("orders")
           .hashJoinInner(
-              core::PlanMatcherBuilder()
-                  .hiveScan(
-                      "lineitem",
-                      std::move(subfieldFilters),
-                      "l_commitdate < l_receiptdate AND l_shipdate < l_commitdate")
+              matchScan("lineitem")
+                  .filter(
+                      "\"and\"(l_shipmode in ('MAIL', 'SHIP'), l_receiptdate >= date '1994-01-01', "
+                      "         l_receiptdate < date '1995-01-01', l_commitdate < l_receiptdate, "
+                      "         l_shipdate < l_commitdate)")
                   .build())
           .project()
           .aggregation()
           .orderBy()
           .build();
-
-  auto plan = planTpch(12);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(12)));
+  AXIOM_ASSERT_PLAN(planTpch(12), matcher);
 }
 
 TEST_F(TpchPlanTest, q13) {
-  checkTpchSql(13);
-
-  // This query has only two possible plans, left and right hand outer join. We
-  // correctly produce the right outer join, building on the left, i.e.
-  // customer, as it is much smaller than orders.
-
-  auto matcher = matchHiveScan("orders")
-                     .hashJoinRight(matchHiveScan("customer").build())
+  auto matcher = matchScan("orders")
+                     .filter("o_comment not like '%special%requests%'")
+                     .hashJoinRight(matchScan("customer").build())
                      .aggregation()
                      .project()
                      .aggregation()
                      .orderBy()
                      .build();
-
-  auto plan = planTpch(13);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(13)));
+  AXIOM_ASSERT_PLAN(planTpch(13), matcher);
 }
 
 TEST_F(TpchPlanTest, q14) {
-  checkTpchSql(14);
-
-  // The only noteworthy aspect is that we build on lineitem since its filters
-  // (1 month out of 7 years) make it smaller than part.
-
-  auto matcher = matchHiveScan("part")
-                     .hashJoinInner(
-                         core::PlanMatcherBuilder()
-                             .hiveScan(
-                                 "lineitem",
-                                 test::between(
-                                     "l_shipdate",
-                                     DATE()->toDays("1995-09-01"),
-                                     DATE()->toDays("1995-09-30")))
-                             .build())
-                     .project()
-                     .aggregation()
-                     .project()
-                     .build();
-
-  auto plan = planTpch(14);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(14)));
+  auto matcher =
+      matchScan("part")
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .filter(
+                      "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'")
+                  .build())
+          .project()
+          .aggregation()
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(14), matcher);
 }
 
 TEST_F(TpchPlanTest, q15) {
-  checkTpchSql(15);
-
-  // TODO Verify the plan.
-
   ASSERT_NO_THROW(planTpch(15));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(15)));
 }
 
 TEST_F(TpchPlanTest, q16) {
-  // TODO Fix "DISTINCT option for aggregation is supported only in single
-  // worker, single thread mode" and restore the original text of q16 that uses
-  // count(distinct).
-  checkTpchSql(16);
-
-  // The join is biggest table first, with part joined first because it is quite
-  // selective, more so than the exists with supplier.
-
   auto matcher =
-      matchHiveScan("partsupp")
-          .hashJoinInner(matchHiveScan("part").build())
-          .hashJoinAnti(matchHiveScan("supplier").build(), {.nullAware = true})
+      matchScan("partsupp")
+          .hashJoinInner(
+              matchScan("part")
+                  .filter(
+                      "\"and\"(p_brand <> 'Brand#45', p_type not like 'MEDIUM POLISHED%', "
+                      "         p_size in (49, 14, 23, 45, 19, 3, 36, 9))")
+                  .build())
+          .hashJoinAnti(
+              matchScan("supplier")
+                  .filter("s_comment like '%Customer%Complaints%'")
+                  .build(),
+              {.nullAware = true})
           .aggregation()
           .orderBy()
           .build();
-
-  auto plan = planTpch(16);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(16)));
+  AXIOM_ASSERT_PLAN(planTpch(16), matcher);
 }
 
 TEST_F(TpchPlanTest, q17) {
-  checkTpchSql(17);
-
-  // The trick here is that we have a correlated subquery that flattens into a
-  // group by that aggregates over all of lineitem. We correctly observe that
-  // only lineitems with a very specific part will occur on the probe side, so
-  // we copy the restriction inside the group by as a semijoin (exists).
-
   auto matcher =
-      matchHiveScan("lineitem")
-          .hashJoinInner(matchHiveScan("part").build())
-          .hashJoinLeft(
-              matchHiveScan("lineitem")
-                  .hashJoinLeftSemiFilter(matchHiveScan("part").build())
-                  .aggregation()
-                  .project() // TODO Figure out if it can be removed.
+      matchScan("lineitem")
+          .hashJoinInner(
+              matchScan("part")
+                  .filter("p_brand = 'Brand#23' and p_container = 'MED BOX'")
                   .build())
-          .filter()
+          .hashJoinLeft(
+              matchScan("lineitem")
+                  .hashJoinLeftSemiFilter(
+                      matchScan("part")
+                          .filter(
+                              "p_brand = 'Brand#23' and p_container = 'MED BOX'")
+                          .build())
+                  .aggregation()
+                  .project()
+                  .aliases({std::nullopt, "quantity_limit"})
+                  .build())
+          .filter("l_quantity < quantity_limit")
           .aggregation()
           .project()
           .build();
-
-  auto plan = planTpch(17);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(17)));
+  AXIOM_ASSERT_PLAN(planTpch(17), matcher);
 }
 
 TEST_F(TpchPlanTest, q18) {
-  checkTpchSql(18);
-
-  // The subquery (aggregated lineitem with HAVING sum > 300) is very
-  // selective. It is joined first via an implied semi-join through the
-  // l_orderkey = o_orderkey equivalence class, reducing lineitem before
-  // joining with orders and customer.
-
-  // agg((
-  //   (lineitem INNER (orders INNER customer))
-  //   LEFT SEMI (FILTER)
-  //   agg(lineitem)
-  // ))
-
-  auto matcher =
-      matchHiveScan("lineitem")
-          .hashJoinLeftSemiFilter(matchHiveScan("lineitem")
-                                      .aggregation()
-                                      .filter()
-                                      .project()
-                                      .build())
-          .hashJoinInner(matchHiveScan("orders")
-                             .hashJoinInner(matchHiveScan("customer").build())
-                             .build())
-          .aggregation()
-          .topN()
-          .build();
-
-  auto plan = planTpch(18);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(18)));
+  auto matcher = matchScan("lineitem")
+                     .hashJoinLeftSemiFilter(matchScan("lineitem")
+                                                 .aggregation()
+                                                 .filter("\"sum\" > 300.0")
+                                                 .project()
+                                                 .build())
+                     .hashJoinInner(matchScan("orders").build())
+                     .hashJoinInner(matchScan("customer").build())
+                     .aggregation()
+                     .topN()
+                     .build();
+  AXIOM_ASSERT_PLAN(planTpch(18), matcher);
 }
 
 TEST_F(TpchPlanTest, q19) {
-  checkTpchSql(19);
-
-  // The trick is to extract common pieces to push down into the scan of
-  // lineitem and part from the OR of three ANDs in the single where clause. We
-  // extract the join condition that is present in all three disjuncts of the
-  // or. Then we extract an OR to push down into the scan of part and lineitem.
-  // We build on part, as it is the smaller table.
-
-  auto lineitemFilters =
-      common::test::SubfieldFiltersBuilder()
-          .add("l_shipinstruct", exec::equal("DELIVER IN PERSON"))
-          .add(
-              "l_shipmode",
-              exec::in(std::vector<std::string>{"AIR", "AIR REG"}))
-          .add("l_quantity", exec::betweenDouble(1.0, 30.0))
-          .build();
-
   auto matcher =
-      core::PlanMatcherBuilder()
-          .hiveScan("lineitem", std::move(lineitemFilters))
+      matchScan("lineitem")
+          .filter(
+              "\"and\"(l_shipmode in ('AIR', 'AIR REG'), l_shipinstruct = 'DELIVER IN PERSON', "
+              "       \"or\"(\"and\"(l_quantity >= 20.0, l_quantity <= 30.0), "
+              "             \"or\"(\"and\"(l_quantity >= 1.0, l_quantity <= 11.0), "
+              "                   \"and\"(l_quantity >= 10.0, l_quantity <= 20.0))))")
           .hashJoinInner(
-              core::PlanMatcherBuilder()
-                  .hiveScan(
-                      "part",
-                      {},
-                      "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
-                      "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
-                      "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
+              matchScan("part")
+                  .filter(
+                      "\"or\"(\"and\"(p_size between 1 and 15, \"and\"(p_brand = 'Brand#34', p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
+                      "      \"or\"(\"and\"(p_size between 1 and 5, \"and\"(p_brand = 'Brand#12', p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
+                      "            \"and\"(p_size between 1 and 10, \"and\"(p_brand = 'Brand#23', p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
                   .build())
-          .filter()
+          .filter(
+              "\"or\"(\"and\"(p_size between 1 and 15, \"and\"(l_quantity <= 30.0, \"and\"(l_quantity >= 20.0, \"and\"(p_brand = 'Brand#34', p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))))), "
+              "      \"or\"(\"and\"(p_size between 1 and 5, \"and\"(l_quantity <= 11.0, \"and\"(l_quantity >= 1.0, \"and\"(p_brand = 'Brand#12', p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))))), "
+              "            \"and\"(p_size between 1 and 10, \"and\"(l_quantity <= 20.0, \"and\"(l_quantity >= 10.0, \"and\"(p_brand = 'Brand#23', p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))))")
           .project()
           .aggregation()
           .build();
-
-  auto plan = planTpch(19);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(19)));
+  AXIOM_ASSERT_PLAN(planTpch(19), matcher);
 }
 
 TEST_F(TpchPlanTest, q20) {
-  checkTpchSql(20);
-
-  // The lineitem aggregation (sum of quantity per part+supplier) is joined to
-  // partsupp via a multi-key existence semijoin pushed into the aggregation DT.
-  // The part filter (name LIKE 'forest%') further reduces partsupp rows.
-  //
-  // ((agg(lineitem)
-  //  RIGHT
-  //  (part RIGHT SEMI (FILTER) (partsupp LEFT SEMI (FILTER) (supplier INNER
-  //  nation)))) RIGHT SEMI (FILTER) (supplier INNER nation))
   auto matcher =
-      matchHiveScan("lineitem")
+      matchScan("lineitem")
+          .filter(
+              "l_shipdate >= date '1994-01-01' and l_shipdate < date '1995-01-01'")
           .aggregation()
           .project()
           .hashJoinRight(
-              matchHiveScan("part")
+              matchScan("part")
+                  .filter("p_name like 'forest%'")
                   .hashJoinRightSemiFilter(
-                      matchHiveScan("partsupp")
+                      matchScan("partsupp")
                           .hashJoinLeftSemiFilter(
-                              matchHiveScan("supplier")
+                              matchScan("supplier")
                                   .hashJoinInner(
-                                      matchHiveScan("nation").build())
+                                      matchScan("nation")
+                                          .filter("n_name = 'CANADA'")
+                                          .build())
                                   .project()
                                   .build())
                           .build())
                   .build())
-          .filter()
+          .filter("expr < cast(ps_availqty as double)")
           .project()
           .hashJoinRightSemiFilter(
-              matchHiveScan("supplier")
-                  .hashJoinInner(matchHiveScan("nation").build())
+              matchScan("supplier")
+                  .hashJoinInner(
+                      matchScan("nation").filter("n_name = 'CANADA'").build())
                   .build())
           .orderBy()
           .build();
-
-  auto plan = planTpch(20);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(20)));
+  AXIOM_ASSERT_PLAN(planTpch(20), matcher);
 }
 
 TEST_F(TpchPlanTest, q21) {
-  checkTpchSql(21);
-
-  // TODO Verify the plan.
-
   ASSERT_NO_THROW(planTpch(21));
-  ASSERT_NO_THROW(planVelox(parseTpchSql(21)));
 }
 
 TEST_F(TpchPlanTest, q22) {
-  checkTpchSql(22);
-
-  // The query is straightforward, with the not exists resolved with a right
-  // semijoin and the non-correlated subquery becoming a cross join to the one
-  // row result set of the non-grouped aggregation.
-
   auto matcher =
-      matchHiveScan("orders")
+      matchScan("orders")
           .hashJoinRightSemiProject(
-              matchHiveScan("customer")
+              matchScan("customer")
+                  .filter(
+                      "substr(c_phone, 1, 2) in ('13', '31', '23', '29', '30', '18', '17')")
                   .nestedLoopJoin(
-                      matchHiveScan("customer").aggregation().build())
-                  .filter()
+                      matchScan("customer")
+                          .aliases({"acctbal", "phone"})
+                          .filter(
+                              "acctbal > 0.0 and substr(phone, 1, 2) in ('13', '31', '23', '29', '30', '18', '17')")
+                          .singleAggregation(
+                              {}, {"avg(acctbal) as avg_acctbal"})
+                          .build())
+                  .filter("c_acctbal > avg_acctbal")
                   .build(),
               {.nullAware = false})
-          .filter()
+          .aliases({std::nullopt, std::nullopt, "exists_mark"})
+          .filter("not(exists_mark)")
           .project()
           .aggregation()
           .orderBy()
           .build();
-
-  auto plan = planTpch(22);
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  ASSERT_NO_THROW(planVelox(parseTpchSql(22)));
+  AXIOM_ASSERT_PLAN(planTpch(22), matcher);
 }
 
-// Use to re-generate the plans stored in tpch/plans directory.
+// Use to re-generate the plans stored in the tpch/plans directory.
 TEST_F(TpchPlanTest, DISABLED_makePlans) {
   const auto path = test::getTestFilePath("tpch/plans");
-
   const MultiFragmentPlan::Options options{.numWorkers = 1, .numDrivers = 1};
-
-  for (auto q = 1; q <= 22; ++q) {
-    LOG(ERROR) << "q" << q;
-
-    auto logicalPlan = parseTpchSql(q);
+  for (int32_t query = 1; query <= 22; ++query) {
+    LOG(ERROR) << "q" << query;
     planVelox(
-        logicalPlan,
+        parseTpch(query),
         options,
         /*optimizerOptions=*/std::nullopt,
-        fmt::format("{}/q{}", path, q));
+        fmt::format("{}/q{}", path, query));
   }
 }
 
 } // namespace
 } // namespace facebook::axiom::optimizer
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  folly::Init init(&argc, &argv, false);
-  return RUN_ALL_TESTS();
-}

--- a/axiom/optimizer/tests/TpchResultTest.cpp
+++ b/axiom/optimizer/tests/TpchResultTest.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/tests/TpchQueries.h"
+#include "velox/exec/tests/utils/TpchQueryBuilder.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+
+// Runs each TPC-H query end-to-end on generated data and checks the results
+// against a reference plan from `TpchQueryBuilder`. Plan shape is asserted
+// separately in `TpchPlanTest`, which uses injected statistics and needs no
+// data. CI generates scale factor 0.1; other scales can be supplied via
+// `--tpch_data_path` (see `HiveQueriesTestBase`).
+class TpchResultTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(velox::tpch::tables);
+  }
+
+  void SetUp() override {
+    HiveQueriesTestBase::SetUp();
+    referenceBuilder_ =
+        std::make_unique<exec::test::TpchQueryBuilder>(localFileFormat_);
+    referenceBuilder_->initialize(localDataPath_);
+  }
+
+  void checkTpchQuery(int32_t query) {
+    checkResults(
+        test::readTpchSql(query), referenceBuilder_->getQueryPlan(query).plan);
+  }
+
+  std::unique_ptr<exec::test::TpchQueryBuilder> referenceBuilder_;
+};
+
+TEST_F(TpchResultTest, q01) {
+  checkTpchQuery(1);
+}
+
+TEST_F(TpchResultTest, q02) {
+  checkTpchQuery(2);
+}
+
+TEST_F(TpchResultTest, q03) {
+  checkTpchQuery(3);
+}
+
+TEST_F(TpchResultTest, q04) {
+  checkTpchQuery(4);
+}
+
+TEST_F(TpchResultTest, q05) {
+  checkTpchQuery(5);
+}
+
+TEST_F(TpchResultTest, q06) {
+  checkTpchQuery(6);
+}
+
+TEST_F(TpchResultTest, q07) {
+  checkTpchQuery(7);
+}
+
+TEST_F(TpchResultTest, q08) {
+  checkTpchQuery(8);
+}
+
+TEST_F(TpchResultTest, q09) {
+  checkTpchQuery(9);
+}
+
+// q9 with `p_name like '%green%'` replaced by the estimable `p_size <= 3`. The
+// reference comes from `getAltPlan(9)`.
+TEST_F(TpchResultTest, q09Alt) {
+  checkResults(
+      test::readTpchSql("q9_alt"), referenceBuilder_->getAltPlan(9).plan);
+}
+
+TEST_F(TpchResultTest, q10) {
+  checkTpchQuery(10);
+}
+
+TEST_F(TpchResultTest, q11) {
+  checkTpchQuery(11);
+}
+
+TEST_F(TpchResultTest, q12) {
+  checkTpchQuery(12);
+}
+
+TEST_F(TpchResultTest, q13) {
+  checkTpchQuery(13);
+}
+
+TEST_F(TpchResultTest, q14) {
+  checkTpchQuery(14);
+}
+
+TEST_F(TpchResultTest, q15) {
+  checkTpchQuery(15);
+}
+
+TEST_F(TpchResultTest, q16) {
+  checkTpchQuery(16);
+}
+
+TEST_F(TpchResultTest, q17) {
+  checkTpchQuery(17);
+}
+
+TEST_F(TpchResultTest, q18) {
+  checkTpchQuery(18);
+}
+
+TEST_F(TpchResultTest, q19) {
+  checkTpchQuery(19);
+}
+
+TEST_F(TpchResultTest, q20) {
+  checkTpchQuery(20);
+}
+
+TEST_F(TpchResultTest, q21) {
+  checkTpchQuery(21);
+}
+
+TEST_F(TpchResultTest, q22) {
+  checkTpchQuery(22);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  // TPC-H data generation instantiates a folly Singleton (DBGenBackend), which
+  // requires folly::Init to have run registrationComplete().
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/axiom/optimizer/tests/tpch/queries/q16.sql
+++ b/axiom/optimizer/tests/tpch/queries/q16.sql
@@ -5,9 +5,7 @@ select
 	p.p_brand,
 	p.p_type,
 	p.p_size,
-	-- TODO Restore 'distinct' aggregation after adding support
-	-- for planning distinct aggregations in multi-threaded multi-node environment.
-	count(/*distinct*/ ps.ps_suppkey) as supplier_cnt
+	count(distinct ps.ps_suppkey) as supplier_cnt
 from
 	partsupp as ps,
 	part as p


### PR DESCRIPTION
Summary:

Splits the TPC-H optimizer test into two, one per concern. `TpchPlanTest` asserts plan shape and runs with no data — it drives the optimizer off injected statistics, so it works anywhere without generated tables. `TpchResultTest` checks query results against a small generated dataset. Previously one suite mixed both, forcing the plan-shape checks to depend on real data.

Plan-shape tests get their cardinalities from a new `TestConnector::addTpchTables(scaleFactor)`, which registers the TPC-H tables with statistics derived from the spec — row counts, per-column distinct counts, and value ranges — and zero rows. `QueryTestBase` gains a `configureTestConnector()` hook so a suite can pick stats-only or data-backed tables.

Verifying the filter predicates in `TpchPlanTest` required a fix to the plan matcher: the `Filter` matcher dropped the aliases its child bound, so a column aliased on a scan could not be named in an aggregate above a filter. A filter does not rename columns, so it now passes the child's symbols through.

Also restores `count(distinct ps_suppkey)` in q16, which now plans in the multi-node case.

bypass-github-export-checks

Differential Revision: D108567589
