### PR TITLE
test(optimizer): Verify the remaining TPC-H query plans (#1483)

### DIFF
--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -429,7 +429,9 @@ class OnelineVisitor : public RelationOpVisitor {
     auto& myCtx = static_cast<Context&>(context);
 
     const auto& table = *op.as<TableScan>()->baseTable;
-    myCtx.out << table.schemaTable->name();
+    // Bare table name (no schema qualifier or quotes) keeps the one-line plan
+    // shape compact and readable.
+    myCtx.out << table.schemaTable->name().table;
   }
 
   void visit(const Repartition& op, RelationOpVisitorContext& context)

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "axiom/optimizer/tests/QueryTestBase.h"
+
+#include <ctime>
+
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/Optimization.h"
@@ -276,6 +279,17 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
       plan, schemaResolver, options, optimizerOptions, planFilePathPrefix);
 }
 
+namespace {
+std::string formatCurrentTime() {
+  const std::time_t now = std::time(nullptr);
+  std::tm localNow{};
+  ::localtime_r(&now, &localNow);
+  char timestamp[64];
+  std::strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", &localNow);
+  return timestamp;
+}
+} // namespace
+
 optimizer::PlanAndStats QueryTestBase::planVelox(
     const logical_plan::LogicalPlanNodePtr& plan,
     const connector::SchemaResolver& schemaResolver,
@@ -298,6 +312,7 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
     planPath = std::make_unique<std::ofstream>(
         fmt::format("{}.plans", planFilePathPrefix.value()));
 
+    *planPath << "generated: " << formatCurrentTime() << " (snapshot)\n";
     *planPath << "numWorkers: " << options.numWorkers << "\n";
     *planPath << "numDrivers: " << options.numDrivers << "\n\n";
   }

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -216,7 +216,7 @@ TEST_F(RelationOpPrinterTest, basic) {
             testing::HasSubstr("gt"), // a > 0
             testing::Eq("")));
 
-    EXPECT_EQ("agg(\"default\".\"t\")", toOneline(sql));
+    EXPECT_EQ("agg(t)", toOneline(sql));
   }
 
   {
@@ -240,12 +240,11 @@ TEST_F(RelationOpPrinterTest, basic) {
             testing::StartsWith("          table: \"default\".\"u\""),
             testing::Eq("")));
 
-    EXPECT_EQ(
-        "agg((\"default\".\"t\" LEFT \"default\".\"u\"))", toOneline(sql));
+    EXPECT_EQ("agg((t LEFT u))", toOneline(sql));
   }
 
   EXPECT_EQ(
-      "agg(((\"default\".\"t\" INNER \"default\".\"u\") INNER \"default\".\"v\"))",
+      "agg(((t INNER u) INNER v))",
       toOneline(
           "SELECT count(*) FROM t, u, v WHERE t_key = u_key AND u_key = v_key"));
 }
@@ -369,7 +368,7 @@ TEST_F(RelationOpPrinterTest, markDistinct) {
           testing::StartsWith("                table: \"default\".\"t\""),
           testing::Eq("")));
 
-  EXPECT_EQ("agg(\"default\".\"t\")", toDistributedOneline(*logicalPlan));
+  EXPECT_EQ("agg(t)", toDistributedOneline(*logicalPlan));
 }
 
 TEST_F(RelationOpPrinterTest, cost) {

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -29,11 +29,9 @@ namespace lp = facebook::axiom::logical_plan;
 
 // Asserts the single-node plan shape of each TPC-H query. Statistics are
 // injected via `TestConnector::addTpchTables(scaleFactor)`, so no data is
-// generated and the optimizer plans at any scale instantly. Foreign keys are
-// consistent at every scale, so the plans reflect real TPC-H rather than the
-// data generator's behavior below scale factor 1. Result correctness is checked
-// separately in `TpchResultTest`. Filters become separate nodes here because
-// the test connector does not push them into the scan.
+// generated and the optimizer plans at any scale instantly. Result correctness
+// is checked separately in `TpchResultTest`. Filters become separate nodes here
+// because the test connector does not push them into the scan.
 class TpchPlanTest : public test::QueryTestBase {
  protected:
   static constexpr double kScaleFactor = 1.0;
@@ -79,6 +77,7 @@ TEST_F(TpchPlanTest, stats) {
 }
 
 TEST_F(TpchPlanTest, q01) {
+  // agg(lineitem)
   auto matcher = matchScan("lineitem")
                      .filter("l_shipdate < date '1998-09-03'")
                      .project()
@@ -89,6 +88,15 @@ TEST_F(TpchPlanTest, q01) {
 }
 
 TEST_F(TpchPlanTest, q02) {
+  // (
+  //   ((partsupp INNER part) INNER (supplier INNER (nation INNER region)))
+  //   INNER
+  //   agg((
+  //     (partsupp LEFT SEMI (FILTER) part)
+  //     INNER
+  //     (supplier INNER (nation INNER region))
+  //   ))
+  // )
   auto matcher =
       matchScan("partsupp")
           .hashJoinInner(matchScan("part")
@@ -131,6 +139,7 @@ TEST_F(TpchPlanTest, q02) {
 }
 
 TEST_F(TpchPlanTest, q03) {
+  // agg((lineitem INNER (orders INNER customer)))
   auto matcher =
       matchScan("lineitem")
           .filter("l_shipdate > date '1995-03-15'")
@@ -150,6 +159,7 @@ TEST_F(TpchPlanTest, q03) {
 }
 
 TEST_F(TpchPlanTest, q04) {
+  // agg((lineitem RIGHT SEMI (FILTER) orders))
   auto matcher =
       matchScan("lineitem")
           .filter("l_commitdate < l_receiptdate")
@@ -165,6 +175,11 @@ TEST_F(TpchPlanTest, q04) {
 }
 
 TEST_F(TpchPlanTest, q05) {
+  // agg((
+  //   (lineitem INNER (orders INNER (customer INNER (nation INNER region))))
+  //   INNER
+  //   (supplier LEFT SEMI (FILTER) (nation INNER region))
+  // ))
   auto matcher =
       matchScan("lineitem")
           .hashJoinInner(
@@ -199,6 +214,7 @@ TEST_F(TpchPlanTest, q05) {
 }
 
 TEST_F(TpchPlanTest, q06) {
+  // agg(lineitem)
   auto matcher =
       matchScan("lineitem")
           .filter(
@@ -211,11 +227,91 @@ TEST_F(TpchPlanTest, q06) {
 }
 
 TEST_F(TpchPlanTest, q07) {
-  ASSERT_NO_THROW(planTpch(7));
+  // agg((
+  //   (lineitem INNER (supplier INNER nation))
+  //   INNER
+  //   (orders INNER (customer INNER nation))
+  // ))
+  auto matcher =
+      matchScan("lineitem")
+          .filter("l_shipdate between date '1995-01-01' and date '1996-12-31'")
+          .hashJoinInner(
+              matchScan("supplier")
+                  .hashJoinInner(
+                      matchScan("nation")
+                          .aliases({std::nullopt, "supp_nation"})
+                          .filter(
+                              "supp_nation = 'FRANCE' or supp_nation = 'GERMANY'")
+                          .build())
+                  .build())
+          .hashJoinInner(
+              matchScan("orders")
+                  .hashJoinInner(
+                      matchScan("customer")
+                          .hashJoinInner(
+                              matchScan("nation")
+                                  .aliases({std::nullopt, "cust_nation"})
+                                  .filter(
+                                      "cust_nation = 'GERMANY' or cust_nation = 'FRANCE'")
+                                  .build())
+                          .build())
+                  .build())
+          .filter(
+              "(supp_nation = 'FRANCE' and cust_nation = 'GERMANY') or "
+              "(supp_nation = 'GERMANY' and cust_nation = 'FRANCE')")
+          .project()
+          .aggregation()
+          .orderBy()
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(7), matcher);
 }
 
 TEST_F(TpchPlanTest, q08) {
-  ASSERT_NO_THROW(planTpch(8));
+  // agg((
+  //   (
+  //     supplier
+  //     INNER
+  //     (
+  //       (lineitem INNER part)
+  //       INNER
+  //       (orders INNER (customer INNER (nation INNER region)))
+  //     )
+  //   )
+  //   INNER
+  //   nation
+  // ))
+  auto matcher =
+      matchScan("supplier")
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .hashJoinInner(
+                      matchScan("part")
+                          .filter("p_type = 'ECONOMY ANODIZED STEEL'")
+                          .build())
+                  .hashJoinInner(
+                      matchScan("orders")
+                          .filter(
+                              "o_orderdate between date '1995-01-01' and date '1996-12-31'")
+                          .hashJoinInner(
+                              matchScan("customer")
+                                  .hashJoinInner(
+                                      matchScan("nation")
+                                          .hashJoinInner(
+                                              matchScan("region")
+                                                  .filter("r_name = 'AMERICA'")
+                                                  .build())
+                                          .build())
+                                  .build())
+                          .build())
+                  .build())
+          .hashJoinInner(matchScan("nation").build())
+          .project()
+          .aggregation()
+          .orderBy()
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(8), matcher);
 }
 
 // No plan-shape assertion: q9's `p_name like '%green%'` is not estimable from
@@ -230,6 +326,11 @@ TEST_F(TpchPlanTest, q09) {
 // (~6%, similar selectivity). With an accurate estimate the optimizer reduces
 // lineitem by the selective `part` first. See tpch/queries/statistics.md.
 TEST_F(TpchPlanTest, q09Alt) {
+  // agg((
+  //   ((orders INNER (lineitem INNER (partsupp INNER part))) INNER supplier)
+  //   INNER
+  //   nation
+  // ))
   auto matcher =
       matchScan("orders")
           .hashJoinInner(
@@ -250,11 +351,50 @@ TEST_F(TpchPlanTest, q09Alt) {
   AXIOM_ASSERT_PLAN(planTpch("q9_alt"), matcher);
 }
 
+// Reduces `lineitem` with a left-semi join against the order keys from
+// `customer ⋈ orders ⋈ nation`, then joins that subtree.
 TEST_F(TpchPlanTest, q10) {
-  ASSERT_NO_THROW(planTpch(10));
+  // agg((
+  //   ((customer INNER orders) INNER nation)
+  //   INNER
+  //   (lineitem LEFT SEMI (FILTER) ((customer INNER orders) INNER nation))
+  // ))
+  auto matcher =
+      matchScan("customer")
+          .hashJoinInner(
+              matchScan("orders")
+                  .filter(
+                      "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'")
+                  .build())
+          .hashJoinInner(matchScan("nation").build())
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .filter("l_returnflag = 'R'")
+                  .hashJoinLeftSemiFilter(
+                      matchScan("customer")
+                          .hashJoinInner(
+                              matchScan("orders")
+                                  .filter(
+                                      "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'")
+                                  .build())
+                          .hashJoinInner(matchScan("nation").build())
+                          .project()
+                          .build())
+                  .build())
+          .project()
+          .aggregation()
+          .topN()
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(10), matcher);
 }
 
 TEST_F(TpchPlanTest, q11) {
+  // (
+  //   agg((partsupp INNER (supplier INNER nation)))
+  //   INNER
+  //   agg((partsupp INNER (supplier INNER nation)))
+  // )
   auto matcher =
       matchScan("partsupp")
           .hashJoinInner(
@@ -286,6 +426,7 @@ TEST_F(TpchPlanTest, q11) {
 }
 
 TEST_F(TpchPlanTest, q12) {
+  // agg((orders INNER lineitem))
   auto matcher =
       matchScan("orders")
           .hashJoinInner(
@@ -303,6 +444,7 @@ TEST_F(TpchPlanTest, q12) {
 }
 
 TEST_F(TpchPlanTest, q13) {
+  // agg(agg((orders RIGHT customer)))
   auto matcher = matchScan("orders")
                      .filter("o_comment not like '%special%requests%'")
                      .hashJoinRight(matchScan("customer").build())
@@ -315,6 +457,7 @@ TEST_F(TpchPlanTest, q13) {
 }
 
 TEST_F(TpchPlanTest, q14) {
+  // agg((part INNER lineitem))
   auto matcher =
       matchScan("part")
           .hashJoinInner(
@@ -329,11 +472,37 @@ TEST_F(TpchPlanTest, q14) {
   AXIOM_ASSERT_PLAN(planTpch(14), matcher);
 }
 
+// The `revenue` CTE is computed twice — once as the supplier join's build side
+// and once inside the `max` subquery — because Velox does not materialize or
+// reuse CTEs.
 TEST_F(TpchPlanTest, q15) {
-  ASSERT_NO_THROW(planTpch(15));
+  // ((supplier INNER agg(lineitem)) INNER agg(agg(lineitem)))
+  auto matchCte = [&]() {
+    return matchScan("lineitem")
+        .aliases({"suppkey", "extendedprice", "discount", "shipdate"})
+        .filter(
+            "shipdate >= date '1996-01-01' and shipdate < date '1996-04-01'")
+        .project(
+            {"suppkey as suppkey",
+             "extendedprice * (1.0 - discount) as volume"})
+        .singleAggregation({"suppkey"}, {"sum(volume) as total_revenue"});
+  };
+
+  auto matcher =
+      matchScan("supplier")
+          .hashJoinInner(matchCte().build())
+          .hashJoinInner(
+              matchCte()
+                  .project({"total_revenue as revenue"})
+                  .singleAggregation({}, {"max(revenue) as max_revenue"})
+                  .build())
+          .orderBy()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(15), matcher);
 }
 
 TEST_F(TpchPlanTest, q16) {
+  // agg(((partsupp INNER part) ANTI supplier))
   auto matcher =
       matchScan("partsupp")
           .hashJoinInner(
@@ -354,6 +523,7 @@ TEST_F(TpchPlanTest, q16) {
 }
 
 TEST_F(TpchPlanTest, q17) {
+  // agg(((lineitem INNER part) LEFT agg((lineitem LEFT SEMI (FILTER) part))))
   auto matcher =
       matchScan("lineitem")
           .hashJoinInner(
@@ -379,6 +549,11 @@ TEST_F(TpchPlanTest, q17) {
 }
 
 TEST_F(TpchPlanTest, q18) {
+  // agg((
+  //   ((lineitem LEFT SEMI (FILTER) agg(lineitem)) INNER orders)
+  //   INNER
+  //   customer
+  // ))
   auto matcher = matchScan("lineitem")
                      .hashJoinLeftSemiFilter(matchScan("lineitem")
                                                  .aggregation()
@@ -394,6 +569,7 @@ TEST_F(TpchPlanTest, q18) {
 }
 
 TEST_F(TpchPlanTest, q19) {
+  // agg((lineitem INNER part))
   auto matcher =
       matchScan("lineitem")
           .filter(
@@ -419,6 +595,19 @@ TEST_F(TpchPlanTest, q19) {
 }
 
 TEST_F(TpchPlanTest, q20) {
+  // (
+  //   (
+  //     agg(lineitem)
+  //     RIGHT
+  //     (
+  //       part
+  //       RIGHT SEMI (FILTER)
+  //       (partsupp LEFT SEMI (FILTER) (supplier INNER nation))
+  //     )
+  //   )
+  //   RIGHT SEMI (FILTER)
+  //   (supplier INNER nation)
+  // )
   auto matcher =
       matchScan("lineitem")
           .filter(
@@ -453,10 +642,53 @@ TEST_F(TpchPlanTest, q20) {
 }
 
 TEST_F(TpchPlanTest, q21) {
-  ASSERT_NO_THROW(planTpch(21));
+  // agg((
+  //   lineitem
+  //   RIGHT SEMI (FILTER)
+  //   (
+  //     lineitem
+  //     RIGHT SEMI (PROJECT)
+  //     ((lineitem INNER (supplier INNER nation)) INNER orders)
+  //   )
+  // ))
+  auto matcher =
+      matchScan("lineitem")
+          .hashJoinRightSemiFilter(
+              matchScan("lineitem")
+                  .aliases(
+                      {std::nullopt, std::nullopt, "commitdate", "receiptdate"})
+                  .filter("commitdate < receiptdate")
+                  .hashJoinRightSemiProject(
+                      matchScan("lineitem")
+                          .aliases(
+                              {std::nullopt,
+                               std::nullopt,
+                               "commitdate",
+                               "receiptdate"})
+                          .filter("commitdate < receiptdate")
+                          .hashJoinInner(
+                              matchScan("supplier")
+                                  .hashJoinInner(
+                                      matchScan("nation")
+                                          .filter("n_name = 'SAUDI ARABIA'")
+                                          .build())
+                                  .build())
+                          .hashJoinInner(matchScan("orders")
+                                             .filter("o_orderstatus = 'F'")
+                                             .build())
+                          .build(),
+                      {.nullAware = false})
+                  .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
+                  .filter("not(mark)")
+                  .build())
+          .singleAggregation({"s_name"}, {"count(*)"})
+          .topN()
+          .build();
+  AXIOM_ASSERT_PLAN(planTpch(21), matcher);
 }
 
 TEST_F(TpchPlanTest, q22) {
+  // agg((orders RIGHT SEMI (PROJECT) (customer INNER agg(customer))))
   auto matcher =
       matchScan("orders")
           .hashJoinRightSemiProject(
@@ -495,6 +727,11 @@ TEST_F(TpchPlanTest, DISABLED_makePlans) {
         /*optimizerOptions=*/std::nullopt,
         fmt::format("{}/q{}", path, query));
   }
+  planVelox(
+      parseSelect(test::readTpchSql("q9_alt"), kTestConnectorId),
+      options,
+      /*optimizerOptions=*/std::nullopt,
+      fmt::format("{}/q9_alt", path));
 }
 
 } // namespace

--- a/axiom/optimizer/tests/tpch/plans/q1.plans
+++ b/axiom/optimizer/tests/tpch/plans/q1.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:30 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,8 +6,8 @@ Query Graph:
 
 dt1: 6.00 rows, l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order
   output:
-    l_returnflag := t2.l_returnflag VARCHAR (cardinality=3.00 min="A" max="R")
-    l_linestatus := t2.l_linestatus VARCHAR (cardinality=2.00 min="F" max="O")
+    l_returnflag := t2.l_returnflag VARCHAR (cardinality=3.00)
+    l_linestatus := t2.l_linestatus VARCHAR (cardinality=2.00)
     sum_qty := dt1.sum_qty DOUBLE (cardinality=1.00)
     sum_base_price := dt1.sum_base_price DOUBLE (cardinality=1.00)
     sum_disc_price := dt1.sum_disc_price DOUBLE (cardinality=1.00)
@@ -20,21 +21,21 @@ dt1: 6.00 rows, l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_pr
   grouping keys: t2.l_returnflag, t2.l_linestatus
   orderBy: t2.l_returnflag ASC NULLS LAST, t2.l_linestatus ASC NULLS LAST
 
-t2: 579165.44 rows, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate
+t2: 5787395.00 rows, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate
   table: "default"."lineitem"
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
     l_tax DOUBLE (cardinality=9.00 min=0 max=0.08)
-    l_returnflag VARCHAR (cardinality=3.00 min="A" max="R")
-    l_linestatus VARCHAR (cardinality=2.00 min="F" max="O")
-    l_shipdate DATE (cardinality=2408.96 min=8037 max=10471)
+    l_returnflag VARCHAR (cardinality=3.00)
+    l_linestatus VARCHAR (cardinality=2.00)
+    l_shipdate DATE (cardinality=2436.00 min=8036 max=10471)
   single-column filters: lt(t2.l_shipdate, "1998-09-03")
 
 
 Optimized plan (oneline):
 
-agg("default"."lineitem")
+agg(lineitem)
 
 Optimized plan:
 
@@ -53,21 +54,21 @@ Project (redundant) [6.00 rows] -> dt1.l_returnflag, dt1.l_linestatus, dt1.sum_q
     Aggregation (t2.l_returnflag, t2.l_linestatus) [6.00 rows] -> t2.l_returnflag, t2.l_linestatus, dt1.sum_qty, dt1.sum_base_price, dt1.sum_disc_price, dt1.sum_charge, dt1.avg_qty, dt1.avg_price, dt1.avg_disc, dt1.count_order
         dt1.sum_qty := sum(t2.l_quantity)
         dt1.sum_base_price := sum(t2.l_extendedprice)
-        dt1.sum_disc_price := sum(dt1.__p43)
-        dt1.sum_charge := sum(dt1.__p52)
+        dt1.sum_disc_price := sum(dt1.__p41)
+        dt1.sum_charge := sum(dt1.__p50)
         dt1.avg_qty := avg(t2.l_quantity)
         dt1.avg_price := avg(t2.l_extendedprice)
         dt1.avg_disc := avg(t2.l_discount)
         dt1.count_order := count()
-      Project [579165.44 rows] -> t2.l_returnflag, t2.l_linestatus, t2.l_quantity, t2.l_extendedprice, dt1.__p43, dt1.__p52, t2.l_discount
+      Project [5787395.00 rows] -> t2.l_returnflag, t2.l_linestatus, t2.l_quantity, t2.l_extendedprice, dt1.__p41, dt1.__p50, t2.l_discount
           t2.l_returnflag := t2.l_returnflag
           t2.l_linestatus := t2.l_linestatus
           t2.l_quantity := t2.l_quantity
           t2.l_extendedprice := t2.l_extendedprice
-          dt1.__p43 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
-          dt1.__p52 := multiply(multiply(t2.l_extendedprice, minus(1, t2.l_discount)), plus(t2.l_tax, 1))
+          dt1.__p41 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+          dt1.__p50 := multiply(multiply(t2.l_extendedprice, minus(1, t2.l_discount)), plus(t2.l_tax, 1))
           t2.l_discount := t2.l_discount
-        TableScan [579165.44 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t2.l_tax, t2.l_returnflag, t2.l_linestatus
+        TableScan [5787395.00 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t2.l_tax, t2.l_returnflag, t2.l_linestatus
           table: "default"."lineitem"
           single-column filters: lt(t2.l_shipdate, "1998-09-03")
 
@@ -75,9 +76,26 @@ Project (redundant) [6.00 rows] -> dt1.l_returnflag, dt1.l_linestatus, dt1.sum_q
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[4][l_returnflag ASC NULLS LAST, l_linestatus ASC NULLS LAST] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+  -- Aggregation[3][SINGLE [l_returnflag, l_linestatus] sum_qty := sum("l_quantity"), sum_base_price := sum("l_extendedprice"), sum_disc_price := sum("dt1.__p41"), sum_charge := sum("dt1.__p50"), avg_qty := avg("l_quantity"), avg_price := avg("l_extendedprice"), avg_disc := avg("l_discount"), count_order := count()] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+    -- Project[2][expressions: (l_returnflag:VARCHAR, "l_returnflag"), (l_linestatus:VARCHAR, "l_linestatus"), (l_quantity:DOUBLE, "l_quantity"), (l_extendedprice:DOUBLE, "l_extendedprice"), (dt1.__p41:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount"))), (dt1.__p50:DOUBLE, multiply(multiply("l_extendedprice",minus(1,"l_discount")),plus("l_tax",1))), (l_discount:DOUBLE, "l_discount")] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, l_quantity:DOUBLE, l_extendedprice:DOUBLE, "dt1.__p41":DOUBLE, "dt1.__p50":DOUBLE, l_discount:DOUBLE
+      -- Filter[1][expression: lt("l_shipdate",1998-09-03)] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_tax:DOUBLE, l_returnflag:VARCHAR, l_linestatus:VARCHAR, l_shipdate:DATE
+        -- TableScan[0]["default"."lineitem"] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_tax:DOUBLE, l_returnflag:VARCHAR, l_linestatus:VARCHAR, l_shipdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[3][l_returnflag ASC NULLS LAST, l_linestatus ASC NULLS LAST] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+   Estimate: 5.99999 rows, 0B peak memory
+   Output: 4 rows (448B, 2 batches), Cpu time: 518.25us, Wall time: 838.34us, Blocked wall time: 0ns, Peak memory: 129.44KB, Memory allocations: 26, Threads: 1, CPU breakdown: B/I/O/F (486.09us/13.29us/11.07us/7.81us)
   -- Aggregation[2][SINGLE [l_returnflag, l_linestatus] sum_qty := sum("l_quantity"), sum_base_price := sum("l_extendedprice"), sum_disc_price := sum("dt1.__p43"), sum_charge := sum("dt1.__p52"), avg_qty := avg("l_quantity"), avg_price := avg("l_extendedprice"), avg_disc := avg("l_discount"), count_order := count()] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, sum_qty:DOUBLE, sum_base_price:DOUBLE, sum_disc_price:DOUBLE, sum_charge:DOUBLE, avg_qty:DOUBLE, avg_price:DOUBLE, avg_disc:DOUBLE, count_order:BIGINT
+     Estimate: 5.99999 rows, 0B peak memory
+     Output: 4 rows (1.12MB, 2 batches), Cpu time: 138.10ms, Wall time: 140.43ms, Blocked wall time: 0ns, Peak memory: 1.51MB, Memory allocations: 32, Threads: 1, CPU breakdown: B/I/O/F (1.52ms/136.09ms/306.86us/182.76us)
     -- Project[1][expressions: (l_returnflag:VARCHAR, "l_returnflag"), (l_linestatus:VARCHAR, "l_linestatus"), (l_quantity:DOUBLE, "l_quantity"), (l_extendedprice:DOUBLE, "l_extendedprice"), (dt1.__p43:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount"))), (dt1.__p52:DOUBLE, multiply(multiply("l_extendedprice",minus(1,"l_discount")),plus("l_tax",1))), (l_discount:DOUBLE, "l_discount")] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, l_quantity:DOUBLE, l_extendedprice:DOUBLE, "dt1.__p43":DOUBLE, "dt1.__p52":DOUBLE, l_discount:DOUBLE
+       Estimate: 5.7874e+06 rows, 0B peak memory
+       Output: 5916591 rows (224.81MB, 1228 batches), Cpu time: 15.29ms, Wall time: 16.55ms, Blocked wall time: 0ns, Peak memory: 192.00KB, Memory allocations: 2456, Threads: 1, CPU breakdown: B/I/O/F (1.38ms/192.61us/13.55ms/169.24us)
       -- TableScan[0][table: lineitem, range filters: [(l_shipdate, BigintRange: [-9223372036854775808, 10471] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_tax:DOUBLE, l_returnflag:VARCHAR, l_linestatus:VARCHAR
+         Estimate: 5.7874e+06 rows, 0B peak memory
+         Input: 5916591 rows (646.12MB, 1228 batches), Raw Input: 6001215 rows (59.02MB), Output: 5916591 rows (646.12MB, 1228 batches), Cpu time: 139.97ms, Wall time: 146.38ms, Blocked wall time: 0ns, Peak memory: 14.82MB, Memory allocations: 17626, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (395.59us/0ns/139.58ms/261ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q10.plans
+++ b/axiom/optimizer/tests/tpch/plans/q10.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,46 +6,46 @@ Query Graph:
 
 dt1: 20.00 rows, c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment
   output:
-    c_custkey := t2.c_custkey BIGINT (cardinality=13.22 min=1 max=15000)
-    c_name := t2.c_name VARCHAR (cardinality=13.14 min="Customer#000000001" max="Customer#000015000")
+    c_custkey := t2.c_custkey BIGINT (cardinality=20.00 min=1 max=150000)
+    c_name := t2.c_name VARCHAR (cardinality=20.00)
     revenue := dt1.revenue DOUBLE (cardinality=1.00)
-    c_acctbal := t2.c_acctbal DOUBLE (cardinality=13.14 min=-999.95 max=9999.72)
-    n_name := t5.n_name VARCHAR (cardinality=11.09 min="ALGERIA" max="VIETNAM")
-    c_address := t2.c_address VARCHAR (cardinality=13.14 min="  3SUEwTaEs35ZDr5dx6P2b" max="zzyQcZpC50YDkK26Pglp")
-    c_phone := t2.c_phone VARCHAR (cardinality=13.14 min="10-103-318-6809" max="34-999-121-7718")
-    c_comment := t2.c_comment VARCHAR (cardinality=13.14 min=" Tiresias among the boldly regular pinto beans wake pending" max="zzle. blithely regular instructions cajol")
+    c_acctbal := t2.c_acctbal DOUBLE (cardinality=20.00 min=-999.99 max=9999.99)
+    n_name := t5.n_name VARCHAR (cardinality=13.95)
+    c_address := t2.c_address VARCHAR (cardinality=20.00)
+    c_phone := t2.c_phone VARCHAR (cardinality=20.00)
+    c_comment := t2.c_comment VARCHAR (cardinality=20.00)
   tables: t2, t3, t4, t5
   joins:
-    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.04, t3 → 0.10]
-    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 1.34, t4 → 0.04]
-    t2 INNER t5 ON t2.c_nationkey = t5.n_nationkey [t2 → 1.00, t5 → 600.00]
-  syntactic join order: 11, 30, 52, 63
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.38, t3 → 1.00]
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 1.33, t4 → 0.04]
+    t2 INNER t5 ON t2.c_nationkey = t5.n_nationkey [t2 → 1.00, t5 → 6000.00]
+  syntactic join order: 9, 26, 46, 55
   aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
   grouping keys: t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment
   orderBy: dt1.revenue DESC NULLS LAST
   limit: 20
 
-t2: 15000.00 rows, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment
+t2: 150000.00 rows, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
-    c_name VARCHAR (cardinality=14717.00 min="Customer#000000001" max="Customer#000015000")
-    c_address VARCHAR (cardinality=14939.00 min="  3SUEwTaEs35ZDr5dx6P2b" max="zzyQcZpC50YDkK26Pglp")
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
+    c_name VARCHAR (cardinality=150000.00)
+    c_address VARCHAR (cardinality=150000.00)
     c_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    c_phone VARCHAR (cardinality=15553.00 min="10-103-318-6809" max="34-999-121-7718")
-    c_acctbal DOUBLE (cardinality=14867.00 min=-999.95 max=9999.72)
-    c_comment VARCHAR (cardinality=14577.00 min=" Tiresias among the boldly regular pinto beans wake pending" max="zzle. blithely regular instructions cajol")
+    c_phone VARCHAR (cardinality=150000.00)
+    c_acctbal DOUBLE (cardinality=150000.00 min=-999.99 max=9999.99)
+    c_comment VARCHAR (cardinality=150000.00)
 
-t3: 5735.66 rows, o_orderkey, o_custkey, o_orderdate
+t3: 57356.61 rows, o_orderkey, o_custkey, o_orderdate
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_orderdate DATE (cardinality=91.08 min=8674 max=8765)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_orderdate DATE (cardinality=92.00 min=8674 max=8765)
   single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(t3.o_orderdate, "1994-01-01")
 
-t4: 200190.67 rows, l_orderkey, l_extendedprice, l_discount, l_returnflag
+t4: 2000405.00 rows, l_orderkey, l_extendedprice, l_discount, l_returnflag
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
     l_returnflag VARCHAR (cardinality=1.00 min="R" max="R")
   single-column filters: eq(t4.l_returnflag, "R")
@@ -52,12 +53,12 @@ t4: 200190.67 rows, l_orderkey, l_extendedprice, l_discount, l_returnflag
 t5: 25.00 rows, n_nationkey, n_name
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
 
 
 Optimized plan (oneline):
 
-agg(("default"."lineitem" INNER (("default"."customer" INNER "default"."orders") INNER "default"."nation")))
+agg((((customer INNER orders) INNER nation) INNER (lineitem LEFT SEMI (FILTER) ((customer INNER orders) INNER nation))))
 
 Optimized plan:
 
@@ -71,9 +72,9 @@ Project [20.00 rows] -> dt1.c_custkey, dt1.c_name, dt1.revenue, dt1.c_acctbal, d
     dt1.c_phone := t2.c_phone
     dt1.c_comment := t2.c_comment
   OrderBy [20.00 rows] -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.revenue
-    Aggregation (t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment) [754.45 rows] -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.revenue
-        dt1.revenue := sum(dt1.__p88)
-      Project [755.75 rows] -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.__p88
+    Aggregation (t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment) [75715.84 rows] -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.revenue
+        dt1.revenue := sum(dt1.__p80)
+      Project [76490.97 rows] -> t2.c_custkey, t2.c_name, t2.c_acctbal, t2.c_phone, t5.n_name, t2.c_address, t2.c_comment, dt1.__p80
           t2.c_custkey := t2.c_custkey
           t2.c_name := t2.c_name
           t2.c_acctbal := t2.c_acctbal
@@ -81,41 +82,106 @@ Project [20.00 rows] -> dt1.c_custkey, dt1.c_name, dt1.revenue, dt1.c_acctbal, d
           t5.n_name := t5.n_name
           t2.c_address := t2.c_address
           t2.c_comment := t2.c_comment
-          dt1.__p88 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
-        Join INNER Hash [755.75 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t4.l_extendedprice, t4.l_discount, t5.n_name
-            t4.l_orderkey = t3.o_orderkey
-          TableScan [200190.67 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
-            table: "default"."lineitem"
-            single-column filters: eq(t4.l_returnflag, "R")
-          HashBuild [565.10 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t5.n_name
-            Join INNER Hash [565.10 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t5.n_name
-                t2.c_nationkey = t5.n_nationkey
-              Join INNER Hash [565.10 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey
-                  t2.c_custkey = t3.o_custkey
-                TableScan [15000.00 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment
-                  table: "default"."customer"
-                HashBuild [5735.66 rows] -> t3.o_orderkey, t3.o_custkey
-                  TableScan [5735.66 rows] -> t3.o_orderkey, t3.o_custkey
-                    table: "default"."orders"
-                    single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(t3.o_orderdate, "1994-01-01")
-              HashBuild [25.00 rows] -> t5.n_nationkey, t5.n_name
-                TableScan [25.00 rows] -> t5.n_nationkey, t5.n_name
-                  table: "default"."nation"
+          dt1.__p80 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash [76490.97 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t4.l_extendedprice, t4.l_discount, t5.n_name
+            t3.o_orderkey = t4.l_orderkey
+          Join INNER Hash [57356.61 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey, t5.n_name
+              t2.c_nationkey = t5.n_nationkey
+            Join INNER Hash [57356.61 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment, t3.o_orderkey
+                t2.c_custkey = t3.o_custkey
+              TableScan [150000.00 rows] -> t2.c_custkey, t2.c_name, t2.c_address, t2.c_nationkey, t2.c_phone, t2.c_acctbal, t2.c_comment
+                table: "default"."customer"
+              HashBuild [57356.61 rows] -> t3.o_orderkey, t3.o_custkey
+                TableScan [57356.61 rows] -> t3.o_orderkey, t3.o_custkey
+                  table: "default"."orders"
+                  single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(t3.o_orderdate, "1994-01-01")
+            HashBuild [25.00 rows] -> t5.n_nationkey, t5.n_name
+              TableScan [25.00 rows] -> t5.n_nationkey, t5.n_name
+                table: "default"."nation"
+          HashBuild [76490.97 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+            Join LEFT SEMI (FILTER) Hash [76490.97 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+                t4.l_orderkey = edt13.edt13.t3.o_orderkey
+              TableScan [2000405.00 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+                table: "default"."lineitem"
+                single-column filters: eq(t4.l_returnflag, "R")
+              HashBuild [57356.61 rows] -> edt13.edt13.t3.o_orderkey
+                Project [57356.61 rows] -> edt13.edt13.t3.o_orderkey
+                    edt13.edt13.t3.o_orderkey := t3.o_orderkey
+                  Join INNER Hash [57356.61 rows] -> t3.o_orderkey
+                      t2.c_nationkey = t5.n_nationkey
+                    Join INNER Hash [57356.61 rows] -> t2.c_nationkey, t3.o_orderkey
+                        t2.c_custkey = t3.o_custkey
+                      TableScan [150000.00 rows] -> t2.c_custkey, t2.c_nationkey
+                        table: "default"."customer"
+                      HashBuild [57356.61 rows] -> t3.o_orderkey, t3.o_custkey
+                        TableScan [57356.61 rows] -> t3.o_orderkey, t3.o_custkey
+                          table: "default"."orders"
+                          single-column filters: gte(t3.o_orderdate, "1993-10-01") and lt(t3.o_orderdate, "1994-01-01")
+                    HashBuild [25.00 rows] -> t5.n_nationkey
+                      TableScan [25.00 rows] -> t5.n_nationkey
+                        table: "default"."nation"
 
 
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- Project[10][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (revenue:DOUBLE, "revenue"), (c_acctbal:DOUBLE, "c_acctbal"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_phone:VARCHAR, "c_phone"), (c_comment:VARCHAR, "c_comment")] -> c_custkey:BIGINT, c_name:VARCHAR, revenue:DOUBLE, c_acctbal:DOUBLE, n_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_comment:VARCHAR
-  -- TopN[9][20 revenue DESC NULLS LAST] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
-    -- Aggregation[8][SINGLE [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] revenue := sum("dt1.__p88")] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
-      -- Project[7][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (c_acctbal:DOUBLE, "c_acctbal"), (c_phone:VARCHAR, "c_phone"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_comment:VARCHAR, "c_comment"), (dt1.__p88:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, "dt1.__p88":DOUBLE
-        -- HashJoin[6][INNER l_orderkey=o_orderkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
-          -- TableScan[0][table: lineitem, range filters: [(l_returnflag, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_returnflag, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+-- Project[20][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (revenue:DOUBLE, "revenue"), (c_acctbal:DOUBLE, "c_acctbal"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_phone:VARCHAR, "c_phone"), (c_comment:VARCHAR, "c_comment")] -> c_custkey:BIGINT, c_name:VARCHAR, revenue:DOUBLE, c_acctbal:DOUBLE, n_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_comment:VARCHAR
+  -- TopN[19][20 revenue DESC NULLS LAST] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+    -- Aggregation[18][SINGLE [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] revenue := sum("dt1.__p80")] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+      -- Project[17][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (c_acctbal:DOUBLE, "c_acctbal"), (c_phone:VARCHAR, "c_phone"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_comment:VARCHAR, "c_comment"), (dt1.__p80:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, "dt1.__p80":DOUBLE
+        -- HashJoin[16][INNER o_orderkey=l_orderkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
           -- HashJoin[5][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, o_orderkey:BIGINT, n_name:VARCHAR
             -- HashJoin[3][INNER c_custkey=o_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, o_orderkey:BIGINT
-              -- TableScan[1][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR
-              -- TableScan[2][table: orders, range filters: [(o_orderdate, BigintRange: [8674, 8765] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
-            -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+              -- TableScan[0]["default"."customer"] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR
+              -- Filter[2][expression: and(gte("o_orderdate",1993-10-01),lt("o_orderdate",1994-01-01))] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                -- TableScan[1]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+            -- TableScan[4]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+          -- HashJoin[15][LEFT SEMI (FILTER) l_orderkey=edt13.edt13.t3.o_orderkey] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+            -- Filter[7][expression: eq("l_returnflag",R)] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_returnflag:VARCHAR
+              -- TableScan[6]["default"."lineitem"] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_returnflag:VARCHAR
+            -- Project[14][expressions: (edt13.edt13.t3.o_orderkey:BIGINT, "o_orderkey")] -> "edt13.edt13.t3.o_orderkey":BIGINT
+              -- HashJoin[13][INNER c_nationkey=n_nationkey] -> o_orderkey:BIGINT
+                -- HashJoin[11][INNER c_custkey=o_custkey] -> c_nationkey:BIGINT, o_orderkey:BIGINT
+                  -- TableScan[8]["default"."customer"] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                  -- Filter[10][expression: and(gte("o_orderdate",1993-10-01),lt("o_orderdate",1994-01-01))] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                    -- TableScan[9]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                -- TableScan[12]["default"."nation"] -> n_nationkey:BIGINT
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[10][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (revenue:DOUBLE, "revenue"), (c_acctbal:DOUBLE, "c_acctbal"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_phone:VARCHAR, "c_phone"), (c_comment:VARCHAR, "c_comment")] -> c_custkey:BIGINT, c_name:VARCHAR, revenue:DOUBLE, c_acctbal:DOUBLE, n_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_comment:VARCHAR
+   Estimate: 20 rows, 0B peak memory
+   Output: 0 rows (0B, 1 batches), Cpu time: 13.61us, Wall time: 22.97us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (13.61us/0ns/0ns/0ns)
+  -- TopN[9][20 revenue DESC NULLS LAST] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+     Estimate: 20 rows, 0B peak memory
+     Output: 20 rows (242.03KB, 2 batches), Cpu time: 947.81us, Wall time: 1.32ms, Blocked wall time: 0ns, Peak memory: 371.25KB, Memory allocations: 30, Threads: 1, CPU breakdown: B/I/O/F (416.52us/498.92us/23.76us/8.60us)
+    -- Aggregation[8][SINGLE [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] revenue := sum("dt1.__p88")] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, revenue:DOUBLE
+       Estimate: 74199.7 rows, 0B peak memory
+       Output: 37967 rows (10.02MB, 8 batches), Cpu time: 56.12ms, Wall time: 58.41ms, Blocked wall time: 0ns, Peak memory: 13.59MB, Memory allocations: 260, Threads: 1, CPU breakdown: B/I/O/F (1.42ms/50.43ms/4.10ms/166.64us)
+      -- Project[7][expressions: (c_custkey:BIGINT, "c_custkey"), (c_name:VARCHAR, "c_name"), (c_acctbal:DOUBLE, "c_acctbal"), (c_phone:VARCHAR, "c_phone"), (n_name:VARCHAR, "n_name"), (c_address:VARCHAR, "c_address"), (c_comment:VARCHAR, "c_comment"), (dt1.__p88:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> c_custkey:BIGINT, c_name:VARCHAR, c_acctbal:DOUBLE, c_phone:VARCHAR, n_name:VARCHAR, c_address:VARCHAR, c_comment:VARCHAR, "dt1.__p88":DOUBLE
+         Estimate: 74943.9 rows, 0B peak memory
+         Output: 114705 rows (165.52MB, 1226 batches), Cpu time: 9.12ms, Wall time: 11.05ms, Blocked wall time: 0ns, Peak memory: 3.00KB, Memory allocations: 1226, Threads: 1, CPU breakdown: B/I/O/F (1.75ms/184.35us/7.03ms/163.36us)
+        -- HashJoin[6][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+           Estimate: 74943.9 rows, 0B peak memory
+           Output: 114705 rows (164.49MB, 1226 batches), Cpu time: 5.50ms, Wall time: 7.77ms, Blocked wall time: 1.67ms, Peak memory: 234.00KB, Memory allocations: 42, CPU breakdown: B/I/O/F (1.77ms/556.04us/2.95ms/231.38us)
+          -- HashJoin[4][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE
+             Estimate: 74943.9 rows, 0B peak memory
+             Output: 114705 rows (134.02MB, 1226 batches), Cpu time: 74.00ms, Wall time: 76.81ms, Blocked wall time: 94.28ms, Peak memory: 39.91MB, Memory allocations: 68, CPU breakdown: B/I/O/F (1.73ms/47.39ms/22.56ms/2.32ms)
+            -- HashJoin[2][INNER l_orderkey=o_orderkey] -> o_custkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+               Estimate: 74145.5 rows, 0B peak memory
+               Output: 114705 rows (1.73MB, 1226 batches), Cpu time: 15.99ms, Wall time: 18.17ms, Blocked wall time: 0ns, Peak memory: 2.74MB, Memory allocations: 31, CPU breakdown: B/I/O/F (2.63ms/10.10ms/1.79ms/1.48ms)
+              -- TableScan[0][table: lineitem, range filters: [(l_returnflag, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_returnflag, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                 Estimate: 2.0004e+06 rows, 0B peak memory
+                 Input: 114705 rows (58.31MB, 1226 batches), Raw Input: 6001215 rows (55.02MB), Output: 114705 rows (58.31MB, 1226 batches), Cpu time: 144.73ms, Wall time: 171.16ms, Blocked wall time: 0ns, Peak memory: 15.09MB, Memory allocations: 13394, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 2, CPU breakdown: B/I/O/F (401.09us/0ns/144.33ms/261ns)
+              -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8674, 8765] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
+                 Estimate: 57356.6 rows, 0B peak memory
+                 Input: 57069 rows (1.08MB, 152 batches), Raw Input: 1500000 rows (8.86MB), Output: 57069 rows (1.08MB, 152 batches), Cpu time: 36.65ms, Wall time: 37.93ms, Blocked wall time: 0ns, Peak memory: 10.47MB, Memory allocations: 840, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (43.08us/0ns/36.61ms/301ns)
+            -- TableScan[3][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR, c_address:VARCHAR, c_nationkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, c_comment:VARCHAR
+               Estimate: 150000 rows, 0B peak memory
+               Input: 150000 rows (36.52MB, 15 batches), Output: 150000 rows (36.52MB, 15 batches), Cpu time: 43.02ms, Wall time: 47.24ms, Blocked wall time: 0ns, Peak memory: 32.20MB, Memory allocations: 974, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (11.05us/0ns/43.01ms/300ns)
+          -- TableScan[5][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+             Estimate: 25 rows, 0B peak memory
+             Input: 25 rows (992B, 1 batches), Output: 25 rows (992B, 1 batches), Cpu time: 261.89us, Wall time: 1.71ms, Blocked wall time: 0ns, Peak memory: 4.06KB, Memory allocations: 15, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.43us/0ns/260.16us/300ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q11.plans
+++ b/axiom/optimizer/tests/tpch/plans/q11.plans
@@ -1,38 +1,39 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt5: 99.24 rows, ps_partkey, value
+dt5: 9775.29 rows, ps_partkey, value
   output:
-    ps_partkey := dt1.ps_partkey BIGINT (cardinality=78.25 min=1 max=20000)
+    ps_partkey := dt1.ps_partkey BIGINT (cardinality=7692.70 min=1 max=200000)
     value := dt1.value DOUBLE (cardinality=1.00)
   tables: dt1, dt6
   filter: gt(dt1.value, dt6.expr)
   orderBy: dt1.value DESC NULLS LAST
 
-dt1: 198.48 rows, ps_partkey, value
+dt1: 19550.58 rows, ps_partkey, value
   output:
-    ps_partkey := t2.ps_partkey BIGINT (cardinality=198.48 min=1 max=20000)
+    ps_partkey := t2.ps_partkey BIGINT (cardinality=19550.58 min=1 max=200000)
     value := dt1.value DOUBLE (cardinality=1.00)
   tables: t2, t3, t4
   joins:
-    t2 INNER t3 ON t2.ps_suppkey = t3.s_suppkey [t2 → 0.10, t3 → 7.87]
-    t3 INNER t4 ON t3.s_nationkey = t4.n_nationkey [t3 → 0.04, t4 → 40.00]
-  syntactic join order: 8, 22, 31
+    t2 INNER t3 ON t2.ps_suppkey = t3.s_suppkey [t2 → 1.00, t3 → 80.00]
+    t3 INNER t4 ON t3.s_nationkey = t4.n_nationkey [t3 → 0.04, t4 → 400.00]
+  syntactic join order: 6, 18, 25
   aggregates: sum(multiply(t2.ps_supplycost, __cast(t2.ps_availqty as DOUBLE))) AS value
   grouping keys: t2.ps_partkey
 
-t2: 80000.00 rows, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost
+t2: 800000.00 rows, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_availqty INTEGER (cardinality=10121.00 min=1 max=9999)
-    ps_supplycost DOUBLE (cardinality=54016.00 min=1.01 max=999.99)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_availqty INTEGER (cardinality=9999.00 min=1 max=9999)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
 
-t3: 1000.00 rows, s_suppkey, s_nationkey
+t3: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t4: 1.00 rows, n_nationkey, n_name
@@ -46,20 +47,20 @@ dt6: 1.00 rows, expr
     expr := multiply(dt6.sum, 0.0001) DOUBLE (cardinality=1.00)
   tables: t7, t8, t9
   joins:
-    t7 INNER t8 ON t7.ps_suppkey = t8.s_suppkey [t7 → 0.10, t8 → 7.87]
-    t8 INNER t9 ON t8.s_nationkey = t9.n_nationkey [t8 → 0.04, t9 → 40.00]
-  syntactic join order: 47, 51, 54
+    t7 INNER t8 ON t7.ps_suppkey = t8.s_suppkey [t7 → 1.00, t8 → 80.00]
+    t8 INNER t9 ON t8.s_nationkey = t9.n_nationkey [t8 → 0.04, t9 → 400.00]
+  syntactic join order: 41, 45, 48
   aggregates: sum(multiply(t7.ps_supplycost, __cast(t7.ps_availqty as DOUBLE))) AS sum
 
-t7: 80000.00 rows, ps_suppkey, ps_availqty, ps_supplycost
+t7: 800000.00 rows, ps_suppkey, ps_availqty, ps_supplycost
   table: "default"."partsupp"
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_availqty INTEGER (cardinality=10121.00 min=1 max=9999)
-    ps_supplycost DOUBLE (cardinality=54016.00 min=1.01 max=999.99)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_availqty INTEGER (cardinality=9999.00 min=1 max=9999)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
 
-t8: 1000.00 rows, s_suppkey, s_nationkey
+t8: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t9: 1.00 rows, n_nationkey, n_name
@@ -71,33 +72,33 @@ t9: 1.00 rows, n_nationkey, n_name
 
 Optimized plan (oneline):
 
-(agg(("default"."partsupp" INNER ("default"."supplier" INNER "default"."nation"))) INNER agg(("default"."partsupp" INNER ("default"."supplier" INNER "default"."nation"))))
+(agg((partsupp INNER (supplier INNER nation))) INNER agg((partsupp INNER (supplier INNER nation))))
 
 Optimized plan:
 
-Project [99.24 rows] -> dt5.ps_partkey, dt5.value
+Project [9775.29 rows] -> dt5.ps_partkey, dt5.value
     dt5.ps_partkey := dt1.ps_partkey
     dt5.value := dt1.value
-  OrderBy [99.24 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
-    Filter [99.24 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
+  OrderBy [9775.29 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
+    Filter [9775.29 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
         gt(dt1.value, dt6.expr)
-      Join INNER Cross [198.48 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
-        Project (redundant) [198.48 rows] -> dt1.ps_partkey, dt1.value
+      Join INNER Cross [19550.58 rows] -> dt1.ps_partkey, dt1.value, dt6.expr
+        Project (redundant) [19550.58 rows] -> dt1.ps_partkey, dt1.value
             dt1.ps_partkey := t2.ps_partkey
             dt1.value := dt1.value
-          Aggregation (t2.ps_partkey) [198.48 rows] -> t2.ps_partkey, dt1.value
-              dt1.value := sum(dt1.__p39)
-            Project [314.74 rows] -> t2.ps_partkey, dt1.__p39
+          Aggregation (t2.ps_partkey) [19550.58 rows] -> t2.ps_partkey, dt1.value
+              dt1.value := sum(dt1.__p33)
+            Project [32000.00 rows] -> t2.ps_partkey, dt1.__p33
                 t2.ps_partkey := t2.ps_partkey
-                dt1.__p39 := multiply(t2.ps_supplycost, __cast(t2.ps_availqty as DOUBLE))
-              Join INNER Hash [314.74 rows] -> t2.ps_partkey, t2.ps_availqty, t2.ps_supplycost
+                dt1.__p33 := multiply(t2.ps_supplycost, __cast(t2.ps_availqty as DOUBLE))
+              Join INNER Hash [32000.00 rows] -> t2.ps_partkey, t2.ps_availqty, t2.ps_supplycost
                   t2.ps_suppkey = t3.s_suppkey
-                TableScan [80000.00 rows] -> t2.ps_partkey, t2.ps_suppkey, t2.ps_availqty, t2.ps_supplycost
+                TableScan [800000.00 rows] -> t2.ps_partkey, t2.ps_suppkey, t2.ps_availqty, t2.ps_supplycost
                   table: "default"."partsupp"
-                HashBuild [40.00 rows] -> t3.s_suppkey
-                  Join INNER Hash [40.00 rows] -> t3.s_suppkey
+                HashBuild [400.00 rows] -> t3.s_suppkey
+                  Join INNER Hash [400.00 rows] -> t3.s_suppkey
                       t3.s_nationkey = t4.n_nationkey
-                    TableScan [1000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+                    TableScan [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
                       table: "default"."supplier"
                     HashBuild [1.00 rows] -> t4.n_nationkey
                       TableScan [1.00 rows] -> t4.n_nationkey
@@ -106,17 +107,17 @@ Project [99.24 rows] -> dt5.ps_partkey, dt5.value
         Project [1.00 rows] -> dt6.expr
             dt6.expr := multiply(dt6.sum, 0.0001)
           Aggregation [1.00 rows] -> dt6.sum
-              dt6.sum := sum(dt6.__p61)
-            Project [314.74 rows] -> dt6.__p61
-                dt6.__p61 := multiply(t7.ps_supplycost, __cast(t7.ps_availqty as DOUBLE))
-              Join INNER Hash [314.74 rows] -> t7.ps_availqty, t7.ps_supplycost
+              dt6.sum := sum(dt6.__p55)
+            Project [32000.00 rows] -> dt6.__p55
+                dt6.__p55 := multiply(t7.ps_supplycost, __cast(t7.ps_availqty as DOUBLE))
+              Join INNER Hash [32000.00 rows] -> t7.ps_availqty, t7.ps_supplycost
                   t7.ps_suppkey = t8.s_suppkey
-                TableScan [80000.00 rows] -> t7.ps_suppkey, t7.ps_availqty, t7.ps_supplycost
+                TableScan [800000.00 rows] -> t7.ps_suppkey, t7.ps_availqty, t7.ps_supplycost
                   table: "default"."partsupp"
-                HashBuild [40.00 rows] -> t8.s_suppkey
-                  Join INNER Hash [40.00 rows] -> t8.s_suppkey
+                HashBuild [400.00 rows] -> t8.s_suppkey
+                  Join INNER Hash [400.00 rows] -> t8.s_suppkey
                       t8.s_nationkey = t9.n_nationkey
-                    TableScan [1000.00 rows] -> t8.s_suppkey, t8.s_nationkey
+                    TableScan [10000.00 rows] -> t8.s_suppkey, t8.s_nationkey
                       table: "default"."supplier"
                     HashBuild [1.00 rows] -> t9.n_nationkey
                       TableScan [1.00 rows] -> t9.n_nationkey
@@ -127,24 +128,87 @@ Project [99.24 rows] -> dt5.ps_partkey, dt5.value
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- Project[18][expressions: (ps_partkey:BIGINT, "ps_partkey"), (value:DOUBLE, "value")] -> ps_partkey:BIGINT, value:DOUBLE
-  -- OrderBy[17][value DESC NULLS LAST] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+-- Project[20][expressions: (ps_partkey:BIGINT, "ps_partkey"), (value:DOUBLE, "value")] -> ps_partkey:BIGINT, value:DOUBLE
+  -- OrderBy[19][value DESC NULLS LAST] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
     -- Filter[0][expression: gt("value","expr")] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+      -- NestedLoopJoin[18][INNER] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+        -- Aggregation[8][SINGLE [ps_partkey] value := sum("dt1.__p33")] -> ps_partkey:BIGINT, value:DOUBLE
+          -- Project[7][expressions: (ps_partkey:BIGINT, "ps_partkey"), (dt1.__p33:DOUBLE, multiply("ps_supplycost",cast("ps_availqty" as DOUBLE)))] -> ps_partkey:BIGINT, "dt1.__p33":DOUBLE
+            -- HashJoin[6][INNER ps_suppkey=s_suppkey] -> ps_partkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+              -- TableScan[1]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+              -- HashJoin[5][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT
+                -- TableScan[2]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                -- Filter[4][expression: eq("n_name",GERMANY)] -> n_nationkey:BIGINT, n_name:VARCHAR
+                  -- TableScan[3]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+        -- Project[17][expressions: (expr:DOUBLE, multiply("sum",0.0001))] -> expr:DOUBLE
+          -- Aggregation[16][SINGLE sum := sum("dt6.__p55")] -> sum:DOUBLE
+            -- Project[15][expressions: (dt6.__p55:DOUBLE, multiply("ps_supplycost_3",cast("ps_availqty_2" as DOUBLE)))] -> "dt6.__p55":DOUBLE
+              -- HashJoin[14][INNER ps_suppkey_1=s_suppkey_5] -> ps_availqty_2:INTEGER, ps_supplycost_3:DOUBLE
+                -- TableScan[9]["default"."partsupp"] -> ps_suppkey_1:BIGINT, ps_availqty_2:INTEGER, ps_supplycost_3:DOUBLE
+                -- HashJoin[13][INNER s_nationkey_8=n_nationkey_12] -> s_suppkey_5:BIGINT
+                  -- TableScan[10]["default"."supplier"] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT
+                  -- Filter[12][expression: eq("n_name_13",GERMANY)] -> n_nationkey_12:BIGINT, n_name_13:VARCHAR
+                    -- TableScan[11]["default"."nation"] -> n_nationkey_12:BIGINT, n_name_13:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[18][expressions: (ps_partkey:BIGINT, "ps_partkey"), (value:DOUBLE, "value")] -> ps_partkey:BIGINT, value:DOUBLE
+   Estimate: 9613.98 rows, 0B peak memory
+   Output: 1048 rows (23.81KB, 1 batches), Cpu time: 19.79us, Wall time: 33.91us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (10.73us/420ns/5.44us/3.20us)
+  -- OrderBy[17][value DESC NULLS LAST] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+     Estimate: 9613.98 rows, 0B peak memory
+     Output: 1048 rows (35.72KB, 1 batches), Cpu time: 204.27us, Wall time: 220.43us, Blocked wall time: 0ns, Peak memory: 188.19KB, Memory allocations: 11, CPU breakdown: B/I/O/F (12.15us/59.93us/13.18us/119.01us)
+    -- Filter[0][expression: gt("value","expr")] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+       Estimate: 9613.98 rows, 0B peak memory
+       Output: 1048 rows (20.24KB, 3 batches), Cpu time: 219.85us, Wall time: 235.03us, Blocked wall time: 0ns, Peak memory: 51.00KB, Memory allocations: 5, CPU breakdown: B/I/O/F (9.78us/912ns/206.10us/3.06us)
       -- NestedLoopJoin[16][INNER] -> ps_partkey:BIGINT, value:DOUBLE, expr:DOUBLE
+         Estimate: 19228 rows, 0B peak memory
+         Output: 29818 rows (575.46KB, 3 batches), Cpu time: 107.17us, Wall time: 1.03ms, Blocked wall time: 17.14ms, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (57.36us/2.50us/19.11us/28.19us)
         -- Aggregation[7][SINGLE [ps_partkey] value := sum("dt1.__p39")] -> ps_partkey:BIGINT, value:DOUBLE
+           Estimate: 19228 rows, 0B peak memory
+           Output: 29818 rows (575.44KB, 3 batches), Cpu time: 5.86ms, Wall time: 6.01ms, Blocked wall time: 0ns, Peak memory: 6.06MB, Memory allocations: 24, CPU breakdown: B/I/O/F (91.55us/5.29ms/451.52us/23.40us)
           -- Project[6][expressions: (ps_partkey:BIGINT, "ps_partkey"), (dt1.__p39:DOUBLE, multiply("ps_supplycost",cast("ps_availqty" as DOUBLE)))] -> ps_partkey:BIGINT, "dt1.__p39":DOUBLE
+             Estimate: 31474.4 rows, 0B peak memory
+             Output: 31680 rows (312.10KB, 81 batches), Cpu time: 593.99us, Wall time: 759.26us, Blocked wall time: 0ns, Peak memory: 4.00KB, Memory allocations: 81, CPU breakdown: B/I/O/F (110.10us/22.24us/439.29us/22.35us)
             -- HashJoin[5][INNER ps_suppkey=s_suppkey] -> ps_partkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+               Estimate: 31474.4 rows, 0B peak memory
+               Output: 31680 rows (0B, 81 batches), Cpu time: 371.89us, Wall time: 540.04us, Blocked wall time: 0ns, Peak memory: 160.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (117.63us/81.48us/97.70us/75.07us)
               -- TableScan[1][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER, ps_supplycost:DOUBLE
+                 Estimate: 800000 rows, 0B peak memory
+                 Input: 31680 rows (8.24MB, 81 batches), Raw Input: 800000 rows (6.45MB), Output: 31680 rows (8.24MB, 81 batches), Cpu time: 16.25ms, Wall time: 17.18ms, Blocked wall time: 0ns, Peak memory: 14.80MB, Memory allocations: 703, Splits: 1, DynamicFilter producer plan nodes: 5, CPU breakdown: B/I/O/F (22.90us/0ns/16.23ms/261ns)
               -- HashJoin[4][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT
+                 Estimate: 400 rows, 0B peak memory
+                 Output: 396 rows (0B, 1 batches), Cpu time: 121.67us, Wall time: 135.43us, Blocked wall time: 1.78ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (27.95us/33.90us/8.34us/51.48us)
                 -- TableScan[2][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                   Estimate: 10000 rows, 0B peak memory
+                   Input: 396 rows (99.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 396 rows (99.81KB, 1 batches), Cpu time: 618.11us, Wall time: 2.71ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 4, CPU breakdown: B/I/O/F (1.94us/0ns/615.70us/460ns)
                 -- TableScan[3][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT
+                   Estimate: 1 rows, 0B peak memory
+                   Input: 1 rows (96B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 1 rows (96B, 1 batches), Cpu time: 300.52us, Wall time: 1.72ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.33us/0ns/298.89us/300ns)
         -- Project[15][expressions: (expr:DOUBLE, multiply("sum",0.0001))] -> expr:DOUBLE
+           Estimate: 1 rows, 0B peak memory
+           Output: 1 rows (32B, 1 batches), Cpu time: 64.27us, Wall time: 116.26us, Blocked wall time: 0ns, Peak memory: 128B, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (50.30us/721ns/9.68us/3.58us)
           -- Aggregation[14][SINGLE sum := sum("dt6.__p61")] -> sum:DOUBLE
+             Estimate: 1 rows, 0B peak memory
+             Output: 1 rows (32B, 1 batches), Cpu time: 460.68us, Wall time: 733.02us, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (164.99us/198.16us/49.62us/47.90us)
             -- Project[13][expressions: (dt6.__p61:DOUBLE, multiply("ps_supplycost_7",cast("ps_availqty_6" as DOUBLE)))] -> "dt6.__p61":DOUBLE
+               Estimate: 31474.4 rows, 0B peak memory
+               Output: 31680 rows (312.10KB, 81 batches), Cpu time: 765.00us, Wall time: 1.02ms, Blocked wall time: 0ns, Peak memory: 4.00KB, Memory allocations: 81, Threads: 1, CPU breakdown: B/I/O/F (198.88us/39.69us/485.61us/40.81us)
               -- HashJoin[12][INNER ps_suppkey_5=s_suppkey_11] -> ps_availqty_6:INTEGER, ps_supplycost_7:DOUBLE
+                 Estimate: 31474.4 rows, 0B peak memory
+                 Output: 31680 rows (0B, 81 batches), Cpu time: 472.75us, Wall time: 774.26us, Blocked wall time: 4.72ms, Peak memory: 160.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (177.84us/71.69us/129.11us/94.11us)
                 -- TableScan[8][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_suppkey_5:BIGINT, ps_availqty_6:INTEGER, ps_supplycost_7:DOUBLE
+                   Estimate: 800000 rows, 0B peak memory
+                   Input: 31680 rows (7.93MB, 81 batches), Raw Input: 800000 rows (5.22MB), Output: 31680 rows (7.93MB, 81 batches), Cpu time: 10.00ms, Wall time: 10.46ms, Blocked wall time: 0ns, Peak memory: 9.64MB, Memory allocations: 529, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 12, CPU breakdown: B/I/O/F (41.26us/0ns/9.96ms/481ns)
                 -- HashJoin[11][INNER s_nationkey_14=n_nationkey_20] -> s_suppkey_11:BIGINT
+                   Estimate: 400 rows, 0B peak memory
+                   Output: 396 rows (0B, 1 batches), Cpu time: 80.50us, Wall time: 89.13us, Blocked wall time: 2.40ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (17.39us/13.92us/6.58us/42.61us)
                   -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey_11:BIGINT, s_nationkey_14:BIGINT
+                     Estimate: 10000 rows, 0B peak memory
+                     Input: 396 rows (99.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 396 rows (99.81KB, 1 batches), Cpu time: 929.34us, Wall time: 2.24ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 11, CPU breakdown: B/I/O/F (1.01us/0ns/928.07us/260ns)
                   -- TableScan[10][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey_20:BIGINT
+                     Estimate: 1 rows, 0B peak memory
+                     Input: 1 rows (96B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 1 rows (96B, 1 batches), Cpu time: 294.19us, Wall time: 2.36ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.42us/0ns/292.47us/301ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q12.plans
+++ b/axiom/optimizer/tests/tpch/plans/q12.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -11,22 +12,22 @@ dt1: 2.00 rows, l_shipmode, high_line_count, low_line_count
   tables: t2, t3
   joins:
     t2 INNER t3 ON t2.o_orderkey = t3.l_orderkey [t2 → 0.03, t3 → 1.00]
-  syntactic join order: 12, 33
+  syntactic join order: 10, 29
   aggregates: sum(__switch(__or(eq(t2.o_orderpriority, "1-URGENT"), eq(t2.o_orderpriority, "2-HIGH")), 1, 0)) AS high_line_count, sum(__switch(__and(neq(t2.o_orderpriority, "1-URGENT"), neq(t2.o_orderpriority, "2-HIGH")), 1, 0)) AS low_line_count
   grouping keys: t3.l_shipmode
   orderBy: t3.l_shipmode ASC NULLS LAST
 
-t2: 150000.00 rows, o_orderkey, o_orderpriority
+t2: 1500000.00 rows, o_orderkey, o_orderpriority
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_orderpriority VARCHAR (cardinality=5.00 min="1-URGENT" max="5-LOW")
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_orderpriority VARCHAR (cardinality=5.00)
 
-t3: 4393.87 rows, l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode
+t3: 43837.20 rows, l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_shipdate DATE (cardinality=2498.00 min=8037 max=10561)
-    l_commitdate DATE (cardinality=2435.00 min=8065 max=10530)
-    l_receiptdate DATE (cardinality=361.14 min=8766 max=9130)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_shipdate DATE (cardinality=2526.00 min=8036 max=10561)
+    l_commitdate DATE (cardinality=2466.00 min=8065 max=10530)
+    l_receiptdate DATE (cardinality=364.86 min=8766 max=9130)
     l_shipmode VARCHAR (cardinality=2.00 min="MAIL" max="SHIP")
   single-column filters: __in(t3.l_shipmode, "MAIL", "SHIP") and gte(t3.l_receiptdate, "1994-01-01") and lt(t3.l_receiptdate, "1995-01-01")
   multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate) and lt(t3.l_shipdate, t3.l_commitdate)
@@ -34,7 +35,7 @@ t3: 4393.87 rows, l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmod
 
 Optimized plan (oneline):
 
-agg(("default"."orders" INNER "default"."lineitem"))
+agg((orders INNER lineitem))
 
 Optimized plan:
 
@@ -44,18 +45,18 @@ Project (redundant) [2.00 rows] -> dt1.l_shipmode, dt1.high_line_count, dt1.low_
     dt1.low_line_count := dt1.low_line_count
   OrderBy [2.00 rows] -> t3.l_shipmode, dt1.high_line_count, dt1.low_line_count
     Aggregation (t3.l_shipmode) [2.00 rows] -> t3.l_shipmode, dt1.high_line_count, dt1.low_line_count
-        dt1.high_line_count := sum(dt1.__p64)
-        dt1.low_line_count := sum(dt1.__p71)
-      Project [4408.38 rows] -> t3.l_shipmode, dt1.__p64, dt1.__p71
+        dt1.high_line_count := sum(dt1.__p60)
+        dt1.low_line_count := sum(dt1.__p67)
+      Project [43837.20 rows] -> t3.l_shipmode, dt1.__p60, dt1.__p67
           t3.l_shipmode := t3.l_shipmode
-          dt1.__p64 := __switch(__or(eq(t2.o_orderpriority, "1-URGENT"), eq(t2.o_orderpriority, "2-HIGH")), 1, 0)
-          dt1.__p71 := __switch(__and(neq(t2.o_orderpriority, "1-URGENT"), neq(t2.o_orderpriority, "2-HIGH")), 1, 0)
-        Join INNER Hash [4408.38 rows] -> t2.o_orderpriority, t3.l_shipmode
+          dt1.__p60 := __switch(__or(eq(t2.o_orderpriority, "1-URGENT"), eq(t2.o_orderpriority, "2-HIGH")), 1, 0)
+          dt1.__p67 := __switch(__and(neq(t2.o_orderpriority, "1-URGENT"), neq(t2.o_orderpriority, "2-HIGH")), 1, 0)
+        Join INNER Hash [43837.20 rows] -> t2.o_orderpriority, t3.l_shipmode
             t2.o_orderkey = t3.l_orderkey
-          TableScan [150000.00 rows] -> t2.o_orderkey, t2.o_orderpriority
+          TableScan [1500000.00 rows] -> t2.o_orderkey, t2.o_orderpriority
             table: "default"."orders"
-          HashBuild [4393.87 rows] -> t3.l_orderkey, t3.l_shipmode
-            TableScan [4393.87 rows] -> t3.l_orderkey, t3.l_shipmode
+          HashBuild [43837.20 rows] -> t3.l_orderkey, t3.l_shipmode
+            TableScan [43837.20 rows] -> t3.l_orderkey, t3.l_shipmode
               table: "default"."lineitem"
               single-column filters: __in(t3.l_shipmode, "MAIL", "SHIP") and gte(t3.l_receiptdate, "1994-01-01") and lt(t3.l_receiptdate, "1995-01-01")
               multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate) and lt(t3.l_shipdate, t3.l_commitdate)
@@ -64,11 +65,34 @@ Project (redundant) [2.00 rows] -> dt1.l_shipmode, dt1.high_line_count, dt1.low_
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[6][l_shipmode ASC NULLS LAST] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+  -- Aggregation[5][SINGLE [l_shipmode] high_line_count := sum("dt1.__p60"), low_line_count := sum("dt1.__p67")] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+    -- Project[4][expressions: (l_shipmode:VARCHAR, "l_shipmode"), (dt1.__p60:INTEGER, switch(or(eq("o_orderpriority",1-URGENT),eq("o_orderpriority",2-HIGH)),1,0)), (dt1.__p67:INTEGER, switch(and(neq("o_orderpriority",1-URGENT),neq("o_orderpriority",2-HIGH)),1,0))] -> l_shipmode:VARCHAR, "dt1.__p60":INTEGER, "dt1.__p67":INTEGER
+      -- HashJoin[3][INNER o_orderkey=l_orderkey] -> o_orderpriority:VARCHAR, l_shipmode:VARCHAR
+        -- TableScan[0]["default"."orders"] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR
+        -- Filter[2][expression: and(in("l_shipmode",{MAIL, SHIP}),gte("l_receiptdate",1994-01-01),lt("l_receiptdate",1995-01-01),lt("l_commitdate","l_receiptdate"),lt("l_shipdate","l_commitdate"))] -> l_orderkey:BIGINT, l_shipmode:VARCHAR, l_shipdate:DATE, l_commitdate:DATE, l_receiptdate:DATE
+          -- TableScan[1]["default"."lineitem"] -> l_orderkey:BIGINT, l_shipmode:VARCHAR, l_shipdate:DATE, l_commitdate:DATE, l_receiptdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[5][l_shipmode ASC NULLS LAST] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+   Estimate: 2 rows, 0B peak memory
+   Output: 2 rows (96B, 1 batches), Cpu time: 77.13us, Wall time: 129.60us, Blocked wall time: 0ns, Peak memory: 128.44KB, Memory allocations: 6, Threads: 1, CPU breakdown: B/I/O/F (56.66us/9.88us/5.59us/5.00us)
   -- Aggregation[4][SINGLE [l_shipmode] high_line_count := sum("dt1.__p64"), low_line_count := sum("dt1.__p71")] -> l_shipmode:VARCHAR, high_line_count:BIGINT, low_line_count:BIGINT
+     Estimate: 2 rows, 0B peak memory
+     Output: 2 rows (383.72KB, 1 batches), Cpu time: 1.39ms, Wall time: 1.66ms, Blocked wall time: 0ns, Peak memory: 458.00KB, Memory allocations: 10, Threads: 1, CPU breakdown: B/I/O/F (166.73us/1.07ms/107.99us/41.66us)
     -- Project[3][expressions: (l_shipmode:VARCHAR, "l_shipmode"), (dt1.__p64:INTEGER, switch(or(eq("o_orderpriority",1-URGENT),eq("o_orderpriority",2-HIGH)),1,0)), (dt1.__p71:INTEGER, switch(and(neq("o_orderpriority",1-URGENT),neq("o_orderpriority",2-HIGH)),1,0))] -> l_shipmode:VARCHAR, "dt1.__p64":INTEGER, "dt1.__p71":INTEGER
+       Estimate: 42509.6 rows, 0B peak memory
+       Output: 30988 rows (980.97KB, 152 batches), Cpu time: 1.40ms, Wall time: 1.75ms, Blocked wall time: 0ns, Peak memory: 768B, Memory allocations: 315, Threads: 1, CPU breakdown: B/I/O/F (210.46us/48.18us/1.10ms/40.62us)
       -- HashJoin[2][INNER o_orderkey=l_orderkey] -> o_orderpriority:VARCHAR, l_shipmode:VARCHAR
+         Estimate: 42509.6 rows, 0B peak memory
+         Output: 30988 rows (593.73KB, 152 batches), Cpu time: 10.75ms, Wall time: 11.89ms, Blocked wall time: 146.44ms, Peak memory: 2.52MB, Memory allocations: 14, CPU breakdown: B/I/O/F (1.16ms/7.20ms/921.20us/1.47ms)
         -- TableScan[0][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR
+           Estimate: 1.5e+06 rows, 0B peak memory
+           Input: 29099 rows (15.09MB, 152 batches), Raw Input: 1500000 rows (2.98MB), Output: 29099 rows (15.09MB, 152 batches), Cpu time: 30.09ms, Wall time: 31.10ms, Blocked wall time: 0ns, Peak memory: 4.81MB, Memory allocations: 1125, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 2, CPU breakdown: B/I/O/F (49.60us/0ns/30.04ms/260ns)
         -- TableScan[1][table: lineitem, range filters: [(l_receiptdate, BigintRange: [8766, 9130] no nulls), (l_shipmode, Filter(BytesValues, deterministic, no nulls))], remaining filter: (and(lt("l_commitdate","l_receiptdate"),lt("l_shipdate","l_commitdate"))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_shipmode:VARCHAR
+           Estimate: 43854.4 rows, 0B peak memory
+           Input: 30988 rows (3.86MB, 612 batches), Raw Input: 6001215 rows (40.71MB), Output: 30988 rows (3.86MB, 612 batches), Cpu time: 86.33ms, Wall time: 137.01ms, Blocked wall time: 0ns, Peak memory: 11.79MB, Memory allocations: 10921, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (212.71us/0ns/86.12ms/311ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q13.plans
+++ b/axiom/optimizer/tests/tpch/plans/q13.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -12,31 +13,31 @@ dt4: 1.00 rows, c_count, custdist
   grouping keys: dt1.c_count
   orderBy: dt4.custdist DESC NULLS LAST, dt1.c_count DESC NULLS LAST
 
-dt1: 9465.03 rows, c_count
+dt1: 129699.84 rows, c_count
   output:
     c_count := dt1.count BIGINT (cardinality=1.00)
   tables: t2, t3
   joins:
-    t2 LEFT t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.20, t3 → 0.10]
-  syntactic join order: 11, 24
+    t2 LEFT t3 ON t2.c_custkey = t3.o_custkey [t2 → 2.00, t3 → 1.00]
+  syntactic join order: 9, 20
   aggregates: count(dt1.o_orderkey) AS count
   grouping keys: t2.c_custkey
 
-t2: 15000.00 rows, c_custkey
+t2: 150000.00 rows, c_custkey
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
 
-t3: 30000.00 rows, o_orderkey, o_custkey, o_comment
+t3: 300000.00 rows, o_orderkey, o_custkey, o_comment
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_comment VARCHAR (cardinality=151541.00 min=" Tiresias about the blithely ironic a" max="zzle. slyly special platele")
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_comment VARCHAR (cardinality=1500000.00)
   single-column filters: not(like(t3.o_comment, "%special%requests%"))
 
 
 Optimized plan (oneline):
 
-agg(agg(("default"."orders" RIGHT "default"."customer")))
+agg(agg((orders RIGHT customer)))
 
 Optimized plan:
 
@@ -46,32 +47,58 @@ Project (redundant) [1.00 rows] -> dt4.c_count, dt4.custdist
   OrderBy [1.00 rows] -> dt1.c_count, dt4.custdist
     Aggregation (dt1.c_count) [1.00 rows] -> dt1.c_count, dt4.custdist
         dt4.custdist := count()
-      Project [9465.03 rows] -> dt1.c_count
+      Project [129699.84 rows] -> dt1.c_count
           dt1.c_count := dt1.count
-        Aggregation (t2.c_custkey) [9465.03 rows] -> t2.c_custkey, dt1.count
+        Aggregation (t2.c_custkey) [129699.84 rows] -> t2.c_custkey, dt1.count
             dt1.count := count(dt1.o_orderkey)
-          Project (redundant) [15000.00 rows] -> t2.c_custkey, dt1.o_orderkey
+          Project (redundant) [300000.00 rows] -> t2.c_custkey, dt1.o_orderkey
               t2.c_custkey := t2.c_custkey
               dt1.o_orderkey := t3.o_orderkey
-            Join RIGHT Hash [15000.00 rows] -> t2.c_custkey, t3.o_orderkey
+            Join RIGHT Hash [300000.00 rows] -> t2.c_custkey, t3.o_orderkey
                 t3.o_custkey = t2.c_custkey
-              TableScan [30000.00 rows] -> t3.o_orderkey, t3.o_custkey
+              TableScan [300000.00 rows] -> t3.o_orderkey, t3.o_custkey
                 table: "default"."orders"
                 single-column filters: not(like(t3.o_comment, "%special%requests%"))
-              HashBuild [15000.00 rows] -> t2.c_custkey
-                TableScan [15000.00 rows] -> t2.c_custkey
+              HashBuild [150000.00 rows] -> t2.c_custkey
+                TableScan [150000.00 rows] -> t2.c_custkey
                   table: "default"."customer"
 
 
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[7][custdist DESC NULLS LAST, c_count DESC NULLS LAST] -> c_count:BIGINT, custdist:BIGINT
+  -- Aggregation[6][SINGLE [c_count] custdist := count()] -> c_count:BIGINT, custdist:BIGINT
+    -- Project[5][expressions: (c_count:BIGINT, "count")] -> c_count:BIGINT
+      -- Aggregation[4][SINGLE [c_custkey] count := count("o_orderkey")] -> c_custkey:BIGINT, count:BIGINT
+        -- HashJoin[3][RIGHT o_custkey=c_custkey] -> c_custkey:BIGINT, o_orderkey:BIGINT
+          -- Filter[1][expression: not(like("o_comment",%special%requests%))] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_comment:VARCHAR
+            -- TableScan[0]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_comment:VARCHAR
+          -- TableScan[2]["default"."customer"] -> c_custkey:BIGINT
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[6][custdist DESC NULLS LAST, c_count DESC NULLS LAST] -> c_count:BIGINT, custdist:BIGINT
+   Estimate: 1 rows, 0B peak memory
+   Output: 42 rows (832B, 1 batches), Cpu time: 50.25us, Wall time: 64.69us, Blocked wall time: 0ns, Peak memory: 129.38KB, Memory allocations: 5, CPU breakdown: B/I/O/F (13.21us/11.17us/10.84us/15.04us)
   -- Aggregation[5][SINGLE [c_count] custdist := count()] -> c_count:BIGINT, custdist:BIGINT
+     Estimate: 1 rows, 0B peak memory
+     Output: 42 rows (191.81KB, 1 batches), Cpu time: 421.05us, Wall time: 454.94us, Blocked wall time: 0ns, Peak memory: 580.00KB, Memory allocations: 8, CPU breakdown: B/I/O/F (21.81us/357.71us/35.24us/6.29us)
     -- Project[4][expressions: (c_count:BIGINT, "count")] -> c_count:BIGINT
+       Estimate: 129169 rows, 0B peak memory
+       Output: 150000 rows (1.40MB, 15 batches), Cpu time: 515.13us, Wall time: 938.16us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (482.53us/5.64us/20.85us/6.11us)
       -- Aggregation[3][SINGLE [c_custkey] count := count("o_orderkey")] -> c_custkey:BIGINT, count:BIGINT
+         Estimate: 129169 rows, 0B peak memory
+         Output: 150000 rows (2.81MB, 15 batches), Cpu time: 37.79ms, Wall time: 40.73ms, Blocked wall time: 0ns, Peak memory: 6.76MB, Memory allocations: 12, CPU breakdown: B/I/O/F (1.37ms/34.24ms/1.75ms/426.84us)
         -- HashJoin[2][RIGHT o_custkey=c_custkey] -> c_custkey:BIGINT, o_orderkey:BIGINT
+           Estimate: 303230 rows, 0B peak memory
+           Output: 1533923 rows (32.03MB, 1549 batches), Cpu time: 65.73ms, Wall time: 67.25ms, Blocked wall time: 16.49ms, Peak memory: 5.76MB, Memory allocations: 63, CPU breakdown: B/I/O/F (618.15us/30.45ms/33.15ms/1.51ms)
           -- TableScan[0][table: orders, remaining filter: (not(like("o_comment",%special%requests%))), data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_comment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
+             Estimate: 300000 rows, 0B peak memory
+             Input: 1483918 rows (28.35MB, 152 batches), Raw Input: 1500000 rows (27.54MB), Output: 1483918 rows (28.35MB, 152 batches), Cpu time: 236.52ms, Wall time: 240.71ms, Blocked wall time: 0ns, Peak memory: 19.60MB, Memory allocations: 4942, Splits: 1, CPU breakdown: B/I/O/F (63.12us/0ns/236.46ms/271ns)
           -- TableScan[1][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT
+             Estimate: 150000 rows, 0B peak memory
+             Input: 150000 rows (1.40MB, 15 batches), Output: 150000 rows (1.40MB, 15 batches), Cpu time: 3.67ms, Wall time: 4.88ms, Blocked wall time: 0ns, Peak memory: 4.04MB, Memory allocations: 39, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (6.75us/0ns/3.66ms/310ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q14.plans
+++ b/axiom/optimizer/tests/tpch/plans/q14.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,47 +6,47 @@ Query Graph:
 
 dt1: 1.00 rows, promo_revenue
   output:
-    promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_2) DOUBLE (cardinality=1.00)
+    promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_0) DOUBLE (cardinality=1.00)
   tables: t2, t3
   joins:
-    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 0.10, t3 → 0.04]
-  syntactic join order: 19, 35
-  aggregates: sum(__switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)) AS sum, sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS sum_2
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 1.00, t3 → 0.36]
+  syntactic join order: 17, 31
+  aggregates: sum(__switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)) AS sum, sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS sum_0
 
-t2: 7135.51 rows, l_partkey, l_extendedprice, l_discount, l_shipdate
+t2: 71273.34 rows, l_partkey, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=29.68 min=9374 max=9403)
+    l_shipdate DATE (cardinality=30.00 min=9374 max=9403)
   single-column filters: gte(t2.l_shipdate, "1995-09-01") and lt(t2.l_shipdate, "1995-10-01")
 
-t3: 20000.00 rows, p_partkey, p_type
+t3: 200000.00 rows, p_partkey, p_type
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_type VARCHAR (cardinality=150.00 min="ECONOMY ANODIZED BRASS" max="STANDARD POLISHED TIN")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_type VARCHAR (cardinality=150.00)
 
 
 Optimized plan (oneline):
 
-agg(("default"."part" INNER "default"."lineitem"))
+agg((part INNER lineitem))
 
 Optimized plan:
 
 Project [1.00 rows] -> dt1.promo_revenue
-    dt1.promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_2)
-  Aggregation [1.00 rows] -> dt1.sum, dt1.sum_2
-      dt1.sum := sum(dt1.__p60)
-      dt1.sum_2 := sum(dt1.__p58)
-    Project [715.73 rows] -> dt1.__p60, dt1.__p58
-        dt1.__p60 := __switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)
-        dt1.__p58 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
-      Join INNER Hash [715.73 rows] -> t2.l_extendedprice, t2.l_discount, t3.p_type
+    dt1.promo_revenue := divide(multiply(dt1.sum, 100), dt1.sum_0)
+  Aggregation [1.00 rows] -> dt1.sum, dt1.sum_0
+      dt1.sum := sum(dt1.__p56)
+      dt1.sum_0 := sum(dt1.__p54)
+    Project [71273.34 rows] -> dt1.__p56, dt1.__p54
+        dt1.__p56 := __switch(like(t3.p_type, "PROMO%"), multiply(t2.l_extendedprice, minus(1, t2.l_discount)), 0)
+        dt1.__p54 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+      Join INNER Hash [71273.34 rows] -> t2.l_extendedprice, t2.l_discount, t3.p_type
           t3.p_partkey = t2.l_partkey
-        TableScan [20000.00 rows] -> t3.p_partkey, t3.p_type
+        TableScan [200000.00 rows] -> t3.p_partkey, t3.p_type
           table: "default"."part"
-        HashBuild [7135.51 rows] -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
-          TableScan [7135.51 rows] -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
+        HashBuild [71273.34 rows] -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
+          TableScan [71273.34 rows] -> t2.l_partkey, t2.l_extendedprice, t2.l_discount
             table: "default"."lineitem"
             single-column filters: gte(t2.l_shipdate, "1995-09-01") and lt(t2.l_shipdate, "1995-10-01")
 
@@ -53,11 +54,34 @@ Project [1.00 rows] -> dt1.promo_revenue
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- Project[6][expressions: (promo_revenue:DOUBLE, divide(multiply("sum",100),"sum_0"))] -> promo_revenue:DOUBLE
+  -- Aggregation[5][SINGLE sum := sum("dt1.__p56"), sum_0 := sum("dt1.__p54")] -> sum:DOUBLE, sum_0:DOUBLE
+    -- Project[4][expressions: (dt1.__p56:DOUBLE, switch(like("p_type",PROMO%),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p54:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p56":DOUBLE, "dt1.__p54":DOUBLE
+      -- HashJoin[3][INNER p_partkey=l_partkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, p_type:VARCHAR
+        -- TableScan[0]["default"."part"] -> p_partkey:BIGINT, p_type:VARCHAR
+        -- Filter[2][expression: and(gte("l_shipdate",1995-09-01),lt("l_shipdate",1995-10-01))] -> l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+          -- TableScan[1]["default"."lineitem"] -> l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- Project[5][expressions: (promo_revenue:DOUBLE, divide(multiply("sum",100),"sum_2"))] -> promo_revenue:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 1 rows (32B, 1 batches), Cpu time: 52.38us, Wall time: 81.45us, Blocked wall time: 0ns, Peak memory: 128B, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (38.02us/510ns/11.61us/2.24us)
   -- Aggregation[4][SINGLE sum := sum("dt1.__p60"), sum_2 := sum("dt1.__p58")] -> sum:DOUBLE, sum_2:DOUBLE
+     Estimate: 1 rows, 0B peak memory
+     Output: 1 rows (64B, 1 batches), Cpu time: 853.26us, Wall time: 1.00ms, Blocked wall time: 0ns, Peak memory: 64.62KB, Memory allocations: 6, Threads: 1, CPU breakdown: B/I/O/F (93.30us/701.74us/34.15us/24.08us)
     -- Project[3][expressions: (dt1.__p60:DOUBLE, switch(like("p_type",PROMO%),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p58:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p60":DOUBLE, "dt1.__p58":DOUBLE
+       Estimate: 72626.4 rows, 0B peak memory
+       Output: 75983 rows (1.76MB, 80 batches), Cpu time: 1.56ms, Wall time: 1.75ms, Blocked wall time: 0ns, Peak memory: 44.38KB, Memory allocations: 264, Threads: 1, CPU breakdown: B/I/O/F (96.62us/23.80us/1.42ms/23.32us)
       -- HashJoin[2][INNER p_partkey=l_partkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, p_type:VARCHAR
+         Estimate: 72626.4 rows, 0B peak memory
+         Output: 75983 rows (5.23MB, 80 batches), Cpu time: 18.56ms, Wall time: 19.12ms, Blocked wall time: 192.60ms, Peak memory: 5.94MB, Memory allocations: 15, CPU breakdown: B/I/O/F (1.15ms/11.92ms/3.75ms/1.75ms)
         -- TableScan[0][table: part, data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_type:VARCHAR
+           Estimate: 200000 rows, 0B peak memory
+           Input: 63112 rows (4.67MB, 20 batches), Raw Input: 200000 rows (5.40MB), Output: 63112 rows (4.67MB, 20 batches), Cpu time: 6.52ms, Wall time: 12.13ms, Blocked wall time: 0ns, Peak memory: 4.87MB, Memory allocations: 180, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 2, CPU breakdown: B/I/O/F (6.92us/0ns/6.51ms/260ns)
         -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9374, 9403] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+           Estimate: 71273.3 rows, 0B peak memory
+           Input: 75983 rows (2.32MB, 613 batches), Raw Input: 6001215 rows (73.14MB), Output: 75983 rows (2.32MB, 613 batches), Cpu time: 154.60ms, Wall time: 178.08ms, Blocked wall time: 0ns, Peak memory: 19.25MB, Memory allocations: 4853, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (175.91us/0ns/154.42ms/330ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q15.plans
+++ b/axiom/optimizer/tests/tpch/plans/q15.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,66 +6,66 @@ Query Graph:
 
 dt1: 1.00 rows, s_suppkey, s_name, s_address, s_phone, total_revenue
   output:
-    s_suppkey := t2.s_suppkey BIGINT (cardinality=1.00 min=1 max=1000)
-    s_name := t2.s_name VARCHAR (cardinality=1.00 min="Supplier#000000001" max="Supplier#000001000")
-    s_address := t2.s_address VARCHAR (cardinality=1.00 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
-    s_phone := t2.s_phone VARCHAR (cardinality=1.00 min="10-108-564-6160" max="34-998-900-4911")
+    s_suppkey := t2.s_suppkey BIGINT (cardinality=1.00 min=1 max=10000)
+    s_name := t2.s_name VARCHAR (cardinality=1.00)
+    s_address := t2.s_address VARCHAR (cardinality=1.00)
+    s_phone := t2.s_phone VARCHAR (cardinality=1.00)
     total_revenue := dt3.total_revenue DOUBLE (cardinality=1.00)
   tables: t2, dt3, dt7
   joins:
-    t2 INNER dt3 ON t2.s_suppkey = dt3.l_suppkey [t2 → 1.00, dt3 → 0.11]
-    dt3 INNER dt7 ON dt3.total_revenue = dt7.max [dt3 → 0.00, dt7 → 8957.56]
-  syntactic join order: 10, 15, 84
+    t2 INNER dt3 ON t2.s_suppkey = dt3.l_suppkey [t2 → 1.00, dt3 → 1.00]
+    dt3 INNER dt7 ON dt3.total_revenue = dt7.max [dt3 → 0.00, dt7 → 10000.00]
+  syntactic join order: 8, 13, 80
   orderBy: t2.s_suppkey ASC NULLS LAST
 
-t2: 1000.00 rows, s_suppkey, s_name, s_address, s_phone
+t2: 10000.00 rows, s_suppkey, s_name, s_address, s_phone
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
-    s_name VARCHAR (cardinality=1016.00 min="Supplier#000000001" max="Supplier#000001000")
-    s_address VARCHAR (cardinality=992.00 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
-    s_phone VARCHAR (cardinality=1023.00 min="10-108-564-6160" max="34-998-900-4911")
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_name VARCHAR (cardinality=10000.00)
+    s_address VARCHAR (cardinality=10000.00)
+    s_phone VARCHAR (cardinality=10000.00)
 
-dt3: 8957.56 rows, l_suppkey, total_revenue
+dt3: 10000.00 rows, l_suppkey, total_revenue
   output:
-    l_suppkey := t4.l_suppkey BIGINT (cardinality=8957.56 min=1 max=10000)
+    l_suppkey := t4.l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     total_revenue := dt3.total_revenue DOUBLE (cardinality=1.00)
   tables: t4
   aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS total_revenue
   grouping keys: t4.l_suppkey
 
-t4: 21644.38 rows, l_suppkey, l_extendedprice, l_discount, l_shipdate
+t4: 216195.80 rows, l_suppkey, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=90.03 min=9496 max=9586)
+    l_shipdate DATE (cardinality=91.00 min=9496 max=9586)
   single-column filters: gte(t4.l_shipdate, "1996-01-01") and lt(t4.l_shipdate, "1996-04-01")
 
 dt7: 1.00 rows, max
   output:
     max := dt7.max DOUBLE (cardinality=1.00)
   tables: dt5
-  aggregates: max(dt5.total_revenue_23) AS max
+  aggregates: max(dt5.total_revenue_19) AS max
 
-dt5: 8957.56 rows, total_revenue_23
+dt5: 10000.00 rows, total_revenue_19
   output:
-    total_revenue_23 := dt5.total_revenue_21 DOUBLE (cardinality=1.00)
+    total_revenue_19 := dt5.total_revenue_17 DOUBLE (cardinality=1.00)
   tables: t6
-  aggregates: sum(multiply(t6.l_extendedprice, minus(1, t6.l_discount))) AS total_revenue_21
+  aggregates: sum(multiply(t6.l_extendedprice, minus(1, t6.l_discount))) AS total_revenue_17
   grouping keys: t6.l_suppkey
 
-t6: 21644.38 rows, l_suppkey, l_extendedprice, l_discount, l_shipdate
+t6: 216195.80 rows, l_suppkey, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=90.03 min=9496 max=9586)
+    l_shipdate DATE (cardinality=91.00 min=9496 max=9586)
   single-column filters: gte(t6.l_shipdate, "1996-01-01") and lt(t6.l_shipdate, "1996-04-01")
 
 
 Optimized plan (oneline):
 
-(("default"."supplier" INNER agg(("default"."lineitem" LEFT SEMI (FILTER) "default"."supplier"))) INNER agg(agg("default"."lineitem")))
+((supplier INNER agg(lineitem)) INNER agg(agg(lineitem)))
 
 Optimized plan:
 
@@ -77,40 +78,35 @@ Project (redundant) [1.00 rows] -> dt1.s_suppkey, dt1.s_name, dt1.s_address, dt1
   OrderBy [1.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
     Join INNER Hash [1.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
         dt3.total_revenue = dt7.max
-      Join INNER Hash [1000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
+      Join INNER Hash [10000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone, dt3.total_revenue
           t2.s_suppkey = dt3.l_suppkey
-        TableScan [1000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone
+        TableScan [10000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_phone
           table: "default"."supplier"
-        HashBuild [886.16 rows] -> dt3.l_suppkey, dt3.total_revenue
-          Project (redundant) [886.16 rows] -> dt3.l_suppkey, dt3.total_revenue
+        HashBuild [10000.00 rows] -> dt3.l_suppkey, dt3.total_revenue
+          Project (redundant) [10000.00 rows] -> dt3.l_suppkey, dt3.total_revenue
               dt3.l_suppkey := t4.l_suppkey
               dt3.total_revenue := dt3.total_revenue
-            Aggregation (t4.l_suppkey) [886.16 rows] -> t4.l_suppkey, dt3.total_revenue
-                dt3.total_revenue := sum(dt3.__p56)
-              Project [2128.89 rows] -> t4.l_suppkey, dt3.__p56
+            Aggregation (t4.l_suppkey) [10000.00 rows] -> t4.l_suppkey, dt3.total_revenue
+                dt3.total_revenue := sum(dt3.__p52)
+              Project [216195.80 rows] -> t4.l_suppkey, dt3.__p52
                   t4.l_suppkey := t4.l_suppkey
-                  dt3.__p56 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
-                Join LEFT SEMI (FILTER) Hash [2128.89 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount
-                    t4.l_suppkey = t2.s_suppkey
-                  TableScan [21644.38 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount
-                    table: "default"."lineitem"
-                    single-column filters: gte(t4.l_shipdate, "1996-01-01") and lt(t4.l_shipdate, "1996-04-01")
-                  HashBuild [1000.00 rows] -> t2.s_suppkey
-                    TableScan [1000.00 rows] -> t2.s_suppkey
-                      table: "default"."supplier"
+                  dt3.__p52 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+                TableScan [216195.80 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                  table: "default"."lineitem"
+                  single-column filters: gte(t4.l_shipdate, "1996-01-01") and lt(t4.l_shipdate, "1996-04-01")
       HashBuild [1.00 rows] -> dt7.max
         Project (redundant) [1.00 rows] -> dt7.max
             dt7.max := dt7.max
           Aggregation [1.00 rows] -> dt7.max
-              dt7.max := max(dt5.total_revenue_23)
-            Project [8957.56 rows] -> dt5.total_revenue_23
-                dt5.total_revenue_23 := dt5.total_revenue_21
-              Aggregation (t6.l_suppkey) [8957.56 rows] -> t6.l_suppkey, dt5.total_revenue_21
-                  dt5.total_revenue_21 := sum(dt5.__p79)
-                Project [21644.38 rows] -> t6.l_suppkey, dt5.__p79
+              dt7.max := max(dt5.total_revenue_19)
+            Project [10000.00 rows] -> dt5.total_revenue_19
+                dt5.total_revenue_19 := dt5.total_revenue_17
+              Aggregation (t6.l_suppkey) [10000.00 rows] -> t6.l_suppkey, dt5.total_revenue_17
+                  dt5.total_revenue_17 := sum(dt5.__p75)
+                Project [216195.80 rows] -> t6.l_suppkey, dt5.__p75
                     t6.l_suppkey := t6.l_suppkey
-                    dt5.__p79 := multiply(t6.l_extendedprice, minus(1, t6.l_discount))
-                  TableScan [21644.38 rows] -> t6.l_suppkey, t6.l_extendedprice, t6.l_discount
+                    dt5.__p75 := multiply(t6.l_extendedprice, minus(1, t6.l_discount))
+                  TableScan [216195.80 rows] -> t6.l_suppkey, t6.l_extendedprice, t6.l_discount
                     table: "default"."lineitem"
                     single-column filters: gte(t6.l_shipdate, "1996-01-01") and lt(t6.l_shipdate, "1996-04-01")
 
@@ -120,17 +116,57 @@ Executable Velox plan:
 Fragment 0: fragment1 SINGLE:
 -- OrderBy[13][s_suppkey ASC NULLS LAST] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
   -- HashJoin[12][INNER total_revenue=max] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
-    -- HashJoin[6][INNER s_suppkey=l_suppkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+    -- HashJoin[5][INNER s_suppkey=l_suppkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+      -- TableScan[0]["default"."supplier"] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR
+      -- Aggregation[4][SINGLE [l_suppkey] total_revenue := sum("dt3.__p52")] -> l_suppkey:BIGINT, total_revenue:DOUBLE
+        -- Project[3][expressions: (l_suppkey:BIGINT, "l_suppkey"), (dt3.__p52:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_suppkey:BIGINT, "dt3.__p52":DOUBLE
+          -- Filter[2][expression: and(gte("l_shipdate",1996-01-01),lt("l_shipdate",1996-04-01))] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+            -- TableScan[1]["default"."lineitem"] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+    -- Aggregation[11][SINGLE max := max("total_revenue_19")] -> max:DOUBLE
+      -- Project[10][expressions: (total_revenue_19:DOUBLE, "total_revenue_17")] -> total_revenue_19:DOUBLE
+        -- Aggregation[9][SINGLE [l_suppkey_2] total_revenue_17 := sum("dt5.__p75")] -> l_suppkey_2:BIGINT, total_revenue_17:DOUBLE
+          -- Project[8][expressions: (l_suppkey_2:BIGINT, "l_suppkey_2"), (dt5.__p75:DOUBLE, multiply("l_extendedprice_5",minus(1,"l_discount_6")))] -> l_suppkey_2:BIGINT, "dt5.__p75":DOUBLE
+            -- Filter[7][expression: and(gte("l_shipdate_10",1996-01-01),lt("l_shipdate_10",1996-04-01))] -> l_suppkey_2:BIGINT, l_extendedprice_5:DOUBLE, l_discount_6:DOUBLE, l_shipdate_10:DATE
+              -- TableScan[6]["default"."lineitem"] -> l_suppkey_2:BIGINT, l_extendedprice_5:DOUBLE, l_discount_6:DOUBLE, l_shipdate_10:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- OrderBy[11][s_suppkey ASC NULLS LAST] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 1 rows (143.88KB, 1 batches), Cpu time: 33.80us, Wall time: 44.41us, Blocked wall time: 0ns, Peak memory: 272.69KB, Memory allocations: 11, Threads: 1, CPU breakdown: B/I/O/F (9.03us/10.81us/9.85us/4.11us)
+  -- HashJoin[10][INNER total_revenue=max] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+     Estimate: 1 rows, 0B peak memory
+     Output: 1 rows (162B, 1 batches), Cpu time: 322.35us, Wall time: 361.63us, Blocked wall time: 141.28ms, Peak memory: 154.62KB, Memory allocations: 13, CPU breakdown: B/I/O/F (32.19us/197.25us/26.92us/65.98us)
+    -- HashJoin[4][INNER s_suppkey=l_suppkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
+       Estimate: 10000 rows, 0B peak memory
+       Output: 10000 rows (1.58MB, 10 batches), Cpu time: 1.17ms, Wall time: 1.34ms, Blocked wall time: 0ns, Peak memory: 2.77MB, Memory allocations: 17, CPU breakdown: B/I/O/F (288.14us/636.27us/146.95us/95.20us)
       -- TableScan[0][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR
-      -- Aggregation[5][SINGLE [l_suppkey] total_revenue := sum("dt3.__p56")] -> l_suppkey:BIGINT, total_revenue:DOUBLE
-        -- Project[4][expressions: (l_suppkey:BIGINT, "l_suppkey"), (dt3.__p56:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_suppkey:BIGINT, "dt3.__p56":DOUBLE
-          -- HashJoin[3][LEFT SEMI (FILTER) l_suppkey=s_suppkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-            -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9586] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-            -- TableScan[2][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT
-    -- Aggregation[11][SINGLE max := max("total_revenue_23")] -> max:DOUBLE
-      -- Project[10][expressions: (total_revenue_23:DOUBLE, "total_revenue_21")] -> total_revenue_23:DOUBLE
-        -- Aggregation[9][SINGLE [l_suppkey_4] total_revenue_21 := sum("dt5.__p79")] -> l_suppkey_4:BIGINT, total_revenue_21:DOUBLE
-          -- Project[8][expressions: (l_suppkey_4:BIGINT, "l_suppkey_4"), (dt5.__p79:DOUBLE, multiply("l_extendedprice_7",minus(1,"l_discount_8")))] -> l_suppkey_4:BIGINT, "dt5.__p79":DOUBLE
-            -- TableScan[7][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9586] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_suppkey_4:BIGINT, l_extendedprice_7:DOUBLE, l_discount_8:DOUBLE
+         Estimate: 10000 rows, 0B peak memory
+         Input: 10000 rows (1.47MB, 1 batches), Output: 10000 rows (1.47MB, 1 batches), Cpu time: 1.46ms, Wall time: 3.08ms, Blocked wall time: 0ns, Peak memory: 3.74MB, Memory allocations: 36, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 4, CPU breakdown: B/I/O/F (1.13us/0ns/1.46ms/271ns)
+      -- Aggregation[3][SINGLE [l_suppkey] total_revenue := sum("dt3.__p56")] -> l_suppkey:BIGINT, total_revenue:DOUBLE
+         Estimate: 10167 rows, 0B peak memory
+         Output: 10000 rows (191.81KB, 1 batches), Cpu time: 5.30ms, Wall time: 6.31ms, Blocked wall time: 0ns, Peak memory: 616.00KB, Memory allocations: 12, Threads: 1, CPU breakdown: B/I/O/F (689.36us/4.13ms/296.29us/182.90us)
+        -- Project[2][expressions: (l_suppkey:BIGINT, "l_suppkey"), (dt3.__p56:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_suppkey:BIGINT, "dt3.__p56":DOUBLE
+           Estimate: 216196 rows, 0B peak memory
+           Output: 225954 rows (2.02MB, 614 batches), Cpu time: 3.79ms, Wall time: 4.71ms, Blocked wall time: 0ns, Peak memory: 6.00KB, Memory allocations: 614, Threads: 1, CPU breakdown: B/I/O/F (678.87us/180.38us/2.76ms/170.44us)
+          -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9586] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+             Estimate: 216196 rows, 0B peak memory
+             Input: 225954 rows (6.14MB, 614 batches), Raw Input: 6001215 rows (61.19MB), Output: 225954 rows (6.14MB, 614 batches), Cpu time: 92.46ms, Wall time: 115.93ms, Blocked wall time: 0ns, Peak memory: 13.71MB, Memory allocations: 4824, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (188.61us/0ns/92.27ms/270ns)
+    -- Aggregation[9][SINGLE max := max("total_revenue_23")] -> max:DOUBLE
+       Estimate: 1 rows, 0B peak memory
+       Output: 1 rows (32B, 1 batches), Cpu time: 45.72us, Wall time: 56.02us, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (7.32us/27.36us/8.41us/2.62us)
+      -- Project[8][expressions: (total_revenue_23:DOUBLE, "total_revenue_21")] -> total_revenue_23:DOUBLE
+         Estimate: 10167 rows, 0B peak memory
+         Output: 10000 rows (95.91KB, 1 batches), Cpu time: 208.98us, Wall time: 401.18us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (201.49us/501ns/4.67us/2.32us)
+        -- Aggregation[7][SINGLE [l_suppkey_4] total_revenue_21 := sum("dt5.__p79")] -> l_suppkey_4:BIGINT, total_revenue_21:DOUBLE
+           Estimate: 10167 rows, 0B peak memory
+           Output: 10000 rows (191.81KB, 1 batches), Cpu time: 6.09ms, Wall time: 7.13ms, Blocked wall time: 0ns, Peak memory: 616.00KB, Memory allocations: 12, Threads: 1, CPU breakdown: B/I/O/F (734.01us/4.84ms/327.42us/188.20us)
+          -- Project[6][expressions: (l_suppkey_4:BIGINT, "l_suppkey_4"), (dt5.__p79:DOUBLE, multiply("l_extendedprice_7",minus(1,"l_discount_8")))] -> l_suppkey_4:BIGINT, "dt5.__p79":DOUBLE
+             Estimate: 216196 rows, 0B peak memory
+             Output: 225954 rows (2.02MB, 614 batches), Cpu time: 4.19ms, Wall time: 5.16ms, Blocked wall time: 0ns, Peak memory: 6.00KB, Memory allocations: 614, Threads: 1, CPU breakdown: B/I/O/F (732.20us/202.06us/3.07ms/189.56us)
+            -- TableScan[5][table: lineitem, range filters: [(l_shipdate, BigintRange: [9496, 9586] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_suppkey_4:BIGINT, l_extendedprice_7:DOUBLE, l_discount_8:DOUBLE
+               Estimate: 216196 rows, 0B peak memory
+               Input: 225954 rows (6.14MB, 614 batches), Raw Input: 6001215 rows (61.19MB), Output: 225954 rows (6.14MB, 614 batches), Cpu time: 103.20ms, Wall time: 126.98ms, Blocked wall time: 0ns, Peak memory: 14.82MB, Memory allocations: 4824, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (192.23us/0ns/103.00ms/350ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q16.plans
+++ b/axiom/optimizer/tests/tpch/plans/q16.plans
@@ -1,77 +1,78 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 1746.05 rows, p_brand, p_type, p_size, supplier_cnt
+dt1: 3790.69 rows, p_brand, p_type, p_size, supplier_cnt
   output:
-    p_brand := t3.p_brand VARCHAR (cardinality=25.00 min="Brand#11" max="Brand#55")
-    p_type := t3.p_type VARCHAR (cardinality=150.00 min="ECONOMY ANODIZED BRASS" max="STANDARD POLISHED TIN")
+    p_brand := t3.p_brand VARCHAR (cardinality=25.00)
+    p_type := t3.p_type VARCHAR (cardinality=150.00)
     p_size := t3.p_size INTEGER (cardinality=8.00 min=3 max=49)
     supplier_cnt := dt1.supplier_cnt BIGINT (cardinality=1.00)
   tables: t2, t3, dt4
   joins:
-    t2 SEMI dt4 ON t2.ps_suppkey = dt4.s_suppkey [t2 → 0.08, dt4 → 7.87]
+    t2 SEMI dt4 ON t2.ps_suppkey = dt4.s_suppkey [t2 → 0.80, dt4 → 80.00]
     t2 INNER t3 ON t2.ps_partkey = t3.p_partkey [t2 → 0.03, t3 → 4.00]
-  syntactic join order: 8, 22, 27
-  aggregates: count(t2.ps_suppkey) AS supplier_cnt
+  syntactic join order: 6, 18, 23
+  aggregates: count(DISTINCT t2.ps_suppkey) AS supplier_cnt
   grouping keys: t3.p_brand, t3.p_type, t3.p_size
   filter: not(dt1.__mark6)
   orderBy: dt1.supplier_cnt DESC NULLS LAST, t3.p_brand ASC NULLS LAST, t3.p_type ASC NULLS LAST, t3.p_size ASC NULLS LAST
 
-t2: 80000.00 rows, ps_partkey, ps_suppkey
+t2: 800000.00 rows, ps_partkey, ps_suppkey
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
 
-t3: 512.00 rows, p_partkey, p_brand, p_type, p_size
+t3: 5120.00 rows, p_partkey, p_brand, p_type, p_size
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_brand VARCHAR (cardinality=25.00 min="Brand#11" max="Brand#55")
-    p_type VARCHAR (cardinality=150.00 min="ECONOMY ANODIZED BRASS" max="STANDARD POLISHED TIN")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_brand VARCHAR (cardinality=25.00)
+    p_type VARCHAR (cardinality=150.00)
     p_size INTEGER (cardinality=8.00 min=3 max=49)
   single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(t3.p_size, 49, 14, 23, 45, 19, 3, 36, 9)
 
-dt4: 800.00 rows, s_suppkey
+dt4: 8000.00 rows, s_suppkey
   output:
-    s_suppkey := t5.s_suppkey BIGINT (cardinality=800.00 min=1 max=1000)
+    s_suppkey := t5.s_suppkey BIGINT (cardinality=8000.00 min=1 max=10000)
   tables: t5
 
-t5: 800.00 rows, s_suppkey, s_comment
+t5: 8000.00 rows, s_suppkey, s_comment
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
-    s_comment VARCHAR (cardinality=1000.00 min=" according to the bravely quick dolphins. deposit" max="ymptotes. blithely regular theodolites are slyly according to the ")
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_comment VARCHAR (cardinality=10000.00)
   single-column filters: like(t5.s_comment, "%Customer%Complaints%")
 
 
 Optimized plan (oneline):
 
-agg((("default"."partsupp" INNER "default"."part") ANTI "default"."supplier"))
+agg(((partsupp INNER part) ANTI supplier))
 
 Optimized plan:
 
-Project (redundant) [1746.05 rows] -> dt1.p_brand, dt1.p_type, dt1.p_size, dt1.supplier_cnt
+Project (redundant) [3790.69 rows] -> dt1.p_brand, dt1.p_type, dt1.p_size, dt1.supplier_cnt
     dt1.p_brand := t3.p_brand
     dt1.p_type := t3.p_type
     dt1.p_size := t3.p_size
     dt1.supplier_cnt := dt1.supplier_cnt
-  OrderBy [1746.05 rows] -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
-    Aggregation (t3.p_brand, t3.p_type, t3.p_size) [1746.05 rows] -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
-        dt1.supplier_cnt := count(t2.ps_suppkey)
-      Join ANTI Hash [1886.85 rows] -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
+  OrderBy [3790.69 rows] -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
+    Aggregation (t3.p_brand, t3.p_type, t3.p_size) [3790.69 rows] -> t3.p_brand, t3.p_type, t3.p_size, dt1.supplier_cnt
+        dt1.supplier_cnt := count(DISTINCT t2.ps_suppkey)
+      Join ANTI Hash [4096.00 rows] -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
           t2.ps_suppkey = dt4.s_suppkey
-        Join INNER Hash [2048.00 rows] -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
+        Join INNER Hash [20480.00 rows] -> t2.ps_suppkey, t3.p_brand, t3.p_type, t3.p_size
             t2.ps_partkey = t3.p_partkey
-          TableScan [80000.00 rows] -> t2.ps_partkey, t2.ps_suppkey
+          TableScan [800000.00 rows] -> t2.ps_partkey, t2.ps_suppkey
             table: "default"."partsupp"
-          HashBuild [512.00 rows] -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
-            TableScan [512.00 rows] -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+          HashBuild [5120.00 rows] -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
+            TableScan [5120.00 rows] -> t3.p_partkey, t3.p_brand, t3.p_type, t3.p_size
               table: "default"."part"
               single-column filters: neq(t3.p_brand, "Brand#45") and not(like(t3.p_type, "MEDIUM POLISHED%")) and __in(t3.p_size, 49, 14, 23, 45, 19, 3, 36, 9)
-        HashBuild [800.00 rows] -> dt4.s_suppkey
-          Project (redundant) [800.00 rows] -> dt4.s_suppkey
+        HashBuild [8000.00 rows] -> dt4.s_suppkey
+          Project (redundant) [8000.00 rows] -> dt4.s_suppkey
               dt4.s_suppkey := t5.s_suppkey
-            TableScan [800.00 rows] -> t5.s_suppkey
+            TableScan [8000.00 rows] -> t5.s_suppkey
               table: "default"."supplier"
               single-column filters: like(t5.s_comment, "%Customer%Complaints%")
 
@@ -79,12 +80,39 @@ Project (redundant) [1746.05 rows] -> dt1.p_brand, dt1.p_type, dt1.p_size, dt1.s
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[8][supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+  -- Aggregation[7][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey") distinct] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+    -- HashJoin[6][ANTI ps_suppkey=s_suppkey, null aware] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+      -- HashJoin[3][INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+        -- TableScan[0]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
+        -- Filter[2][expression: and(neq("p_brand",Brand#45),not(like("p_type",MEDIUM POLISHED%)),in("p_size",{49, 14, 23, 45, 19, ...3 more}))] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+          -- TableScan[1]["default"."part"] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+      -- Filter[5][expression: like("s_comment",%Customer%Complaints%)] -> s_suppkey:BIGINT, s_comment:VARCHAR
+        -- TableScan[4]["default"."supplier"] -> s_suppkey:BIGINT, s_comment:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[6][supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
-  -- Aggregation[5][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+   Estimate: 4089.52 rows, 0B peak memory
+   Output: 18314 rows (1.45MB, 2 batches), Cpu time: 7.16ms, Wall time: 7.30ms, Blocked wall time: 0ns, Peak memory: 5.64MB, Memory allocations: 37, CPU breakdown: B/I/O/F (69.66us/1.57ms/689.53us/4.83ms)
+  -- Aggregation[5][SINGLE [p_brand, p_type, p_size] supplier_cnt := count("ps_suppkey") distinct] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
+     Estimate: 4089.52 rows, 0B peak memory
+     Output: 18314 rows (1.45MB, 2 batches), Cpu time: 23.65ms, Wall time: 24.18ms, Blocked wall time: 0ns, Peak memory: 12.22MB, Memory allocations: 33, CPU breakdown: B/I/O/F (184.25us/18.80ms/4.62ms/44.72us)
     -- HashJoin[4][ANTI ps_suppkey=s_suppkey, null aware] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+       Estimate: 4447.98 rows, 0B peak memory
+       Output: 118274 rows (16.98MB, 161 batches), Cpu time: 1.65ms, Wall time: 2.01ms, Blocked wall time: 4.91ms, Peak memory: 276.00KB, Memory allocations: 12, CPU breakdown: B/I/O/F (212.01us/849.20us/473.53us/119.25us)
       -- HashJoin[2][INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+         Estimate: 20868.8 rows, 0B peak memory
+         Output: 118324 rows (16.99MB, 161 batches), Cpu time: 10.84ms, Wall time: 11.11ms, Blocked wall time: 15.00ms, Peak memory: 6.20MB, Memory allocations: 22, CPU breakdown: B/I/O/F (320.21us/6.52ms/3.17ms/823.81us)
         -- TableScan[0][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
+           Estimate: 800000 rows, 0B peak memory
+           Input: 118324 rows (8.49MB, 81 batches), Raw Input: 800000 rows (2.84MB), Output: 118324 rows (8.49MB, 81 batches), Cpu time: 13.26ms, Wall time: 13.71ms, Blocked wall time: 0ns, Peak memory: 8.09MB, Memory allocations: 354, Splits: 1, DynamicFilter producer plan nodes: 2, CPU breakdown: B/I/O/F (24.94us/0ns/13.24ms/251ns)
         -- TableScan[1][table: part, range filters: [(p_brand, Filter(MultiRange, deterministic, no nulls)), (p_size, Filter(BigintValuesUsingBitmask, deterministic, no nulls))], remaining filter: (not(like("p_type",MEDIUM POLISHED%))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]], HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+           Estimate: 5120 rows, 0B peak memory
+           Input: 29581 rows (3.40MB, 20 batches), Raw Input: 200000 rows (5.66MB), Output: 29581 rows (3.40MB, 20 batches), Cpu time: 7.11ms, Wall time: 12.96ms, Blocked wall time: 0ns, Peak memory: 5.44MB, Memory allocations: 286, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (8.47us/0ns/7.10ms/300ns)
       -- TableScan[3][table: supplier, remaining filter: (like("s_comment",%Customer%Complaints%)), data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: s_comment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> s_suppkey:BIGINT
+         Estimate: 8000 rows, 0B peak memory
+         Input: 4 rows (234.38KB, 1 batches), Raw Input: 10000 rows (841.97KB), Output: 4 rows (234.38KB, 1 batches), Cpu time: 2.66ms, Wall time: 4.81ms, Blocked wall time: 0ns, Peak memory: 2.66MB, Memory allocations: 26, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.40us/0ns/2.66ms/291ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q17.plans
+++ b/axiom/optimizer/tests/tpch/plans/q17.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -9,41 +10,41 @@ dt1: 1.00 rows, avg_yearly
   tables: t2, t3, dt4
   joins:
     t3 LEFT dt4 ON t3.p_partkey = dt4.__gk6 [t3 → 1.00, dt4 → 0.00]
-    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 0.00, t3 → 3.01]
-  syntactic join order: 19, 34, 38
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 0.00, t3 → 30.01]
+  syntactic join order: 17, 30, 34
   aggregates: sum(t2.l_extendedprice) AS sum
   filter: lt(t2.l_quantity, dt4.expr)
 
-t2: 600572.00 rows, l_partkey, l_quantity, l_extendedprice
+t2: 6001215.00 rows, l_partkey, l_quantity, l_extendedprice
   table: "default"."lineitem"
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
 
-t3: 20.00 rows, p_partkey, p_brand, p_container
+t3: 200.00 rows, p_partkey, p_brand, p_container
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     p_brand VARCHAR (cardinality=1.00 min="Brand#23" max="Brand#23")
     p_container VARCHAR (cardinality=1.00 min="MED BOX" max="MED BOX")
   single-column filters: eq(t3.p_brand, "Brand#23") and eq(t3.p_container, "MED BOX")
 
-dt4: 180686.19 rows, __gk6, expr
+dt4: 200000.00 rows, __gk6, expr
   output:
-    __gk6 := t5.l_partkey BIGINT (cardinality=180686.19 min=1 max=200000)
+    __gk6 := t5.l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     expr := multiply(dt4.avg, 0.2) DOUBLE (cardinality=1.00)
   tables: t5
   aggregates: avg(t5.l_quantity) AS avg
   grouping keys: t5.l_partkey
 
-t5: 600572.00 rows, l_partkey, l_quantity
+t5: 6001215.00 rows, l_partkey, l_quantity
   table: "default"."lineitem"
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
 
 
 Optimized plan (oneline):
 
-agg((("default"."lineitem" INNER "default"."part") LEFT agg(("default"."lineitem" LEFT SEMI (FILTER) "default"."part"))))
+agg(((lineitem INNER part) LEFT agg((lineitem LEFT SEMI (FILTER) part))))
 
 Optimized plan:
 
@@ -51,30 +52,30 @@ Project [1.00 rows] -> dt1.avg_yearly
     dt1.avg_yearly := divide(dt1.sum, 7)
   Aggregation [1.00 rows] -> dt1.sum
       dt1.sum := sum(t2.l_extendedprice)
-    Filter [30.49 rows] -> t2.l_quantity, t2.l_extendedprice, dt4.expr
+    Filter [3000.61 rows] -> t2.l_quantity, t2.l_extendedprice, dt4.expr
         lt(t2.l_quantity, dt4.expr)
-      Join LEFT Hash [60.99 rows] -> t2.l_quantity, t2.l_extendedprice, dt4.expr
+      Join LEFT Hash [6001.22 rows] -> t2.l_quantity, t2.l_extendedprice, dt4.expr
           t3.p_partkey = dt4.__gk6
-        Join INNER Hash [60.99 rows] -> t2.l_quantity, t2.l_extendedprice, t3.p_partkey
+        Join INNER Hash [6001.22 rows] -> t2.l_quantity, t2.l_extendedprice, t3.p_partkey
             t2.l_partkey = t3.p_partkey
-          TableScan [600572.00 rows] -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice
+          TableScan [6001215.00 rows] -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice
             table: "default"."lineitem"
-          HashBuild [20.00 rows] -> t3.p_partkey
-            TableScan [20.00 rows] -> t3.p_partkey
+          HashBuild [200.00 rows] -> t3.p_partkey
+            TableScan [200.00 rows] -> t3.p_partkey
               table: "default"."part"
               single-column filters: eq(t3.p_brand, "Brand#23") and eq(t3.p_container, "MED BOX")
-        HashBuild [63.62 rows] -> dt4.__gk6, dt4.expr
-          Project [63.62 rows] -> dt4.__gk6, dt4.expr
+        HashBuild [5912.09 rows] -> dt4.__gk6, dt4.expr
+          Project [5912.09 rows] -> dt4.__gk6, dt4.expr
               dt4.__gk6 := t5.l_partkey
               dt4.expr := multiply(dt4.avg, 0.2)
-            Aggregation (t5.l_partkey) [63.62 rows] -> t5.l_partkey, dt4.avg
+            Aggregation (t5.l_partkey) [5912.09 rows] -> t5.l_partkey, dt4.avg
                 dt4.avg := avg(t5.l_quantity)
-              Join LEFT SEMI (FILTER) Hash [63.73 rows] -> t5.l_partkey, t5.l_quantity
+              Join LEFT SEMI (FILTER) Hash [6001.22 rows] -> t5.l_partkey, t5.l_quantity
                   t5.l_partkey = t3.p_partkey
-                TableScan [600572.00 rows] -> t5.l_partkey, t5.l_quantity
+                TableScan [6001215.00 rows] -> t5.l_partkey, t5.l_quantity
                   table: "default"."lineitem"
-                HashBuild [20.00 rows] -> t3.p_partkey
-                  TableScan [20.00 rows] -> t3.p_partkey
+                HashBuild [200.00 rows] -> t3.p_partkey
+                  TableScan [200.00 rows] -> t3.p_partkey
                     table: "default"."part"
                     single-column filters: eq(t3.p_brand, "Brand#23") and eq(t3.p_container, "MED BOX")
 
@@ -82,17 +83,59 @@ Project [1.00 rows] -> dt1.avg_yearly
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- Project[11][expressions: (avg_yearly:DOUBLE, divide("sum",7))] -> avg_yearly:DOUBLE
-  -- Aggregation[10][SINGLE sum := sum("l_extendedprice")] -> sum:DOUBLE
+-- Project[13][expressions: (avg_yearly:DOUBLE, divide("sum",7))] -> avg_yearly:DOUBLE
+  -- Aggregation[12][SINGLE sum := sum("l_extendedprice")] -> sum:DOUBLE
     -- Filter[0][expression: lt("l_quantity","expr")] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+      -- HashJoin[11][LEFT p_partkey=dt4.__gk6] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+        -- HashJoin[4][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, p_partkey:BIGINT
+          -- TableScan[1]["default"."lineitem"] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE
+          -- Filter[3][expression: and(eq("p_brand",Brand#23),eq("p_container",MED BOX))] -> p_partkey:BIGINT, p_brand:VARCHAR, p_container:VARCHAR
+            -- TableScan[2]["default"."part"] -> p_partkey:BIGINT, p_brand:VARCHAR, p_container:VARCHAR
+        -- Project[10][expressions: (dt4.__gk6:BIGINT, "l_partkey_1"), (expr:DOUBLE, multiply("avg",0.2))] -> "dt4.__gk6":BIGINT, expr:DOUBLE
+          -- Aggregation[9][SINGLE [l_partkey_1] avg := avg("l_quantity_4")] -> l_partkey_1:BIGINT, avg:DOUBLE
+            -- HashJoin[8][LEFT SEMI (FILTER) l_partkey_1=p_partkey] -> l_partkey_1:BIGINT, l_quantity_4:DOUBLE
+              -- TableScan[5]["default"."lineitem"] -> l_partkey_1:BIGINT, l_quantity_4:DOUBLE
+              -- Filter[7][expression: and(eq("p_brand",Brand#23),eq("p_container",MED BOX))] -> p_partkey:BIGINT, p_brand:VARCHAR, p_container:VARCHAR
+                -- TableScan[6]["default"."part"] -> p_partkey:BIGINT, p_brand:VARCHAR, p_container:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[11][expressions: (avg_yearly:DOUBLE, divide("sum",7))] -> avg_yearly:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 1 rows (32B, 1 batches), Cpu time: 229.06us, Wall time: 428.19us, Blocked wall time: 0ns, Peak memory: 128B, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (211.54us/501ns/12.67us/4.35us)
+  -- Aggregation[10][SINGLE sum := sum("l_extendedprice")] -> sum:DOUBLE
+     Estimate: 1 rows, 0B peak memory
+     Output: 1 rows (32B, 1 batches), Cpu time: 2.44ms, Wall time: 3.56ms, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (885.44us/1.15ms/219.83us/186.59us)
+    -- Filter[0][expression: lt("l_quantity","expr")] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+       Estimate: 3057.57 rows, 0B peak memory
+       Output: 587 rows (21.90KB, 371 batches), Cpu time: 4.95ms, Wall time: 7.03ms, Blocked wall time: 0ns, Peak memory: 448B, Memory allocations: 611, Threads: 1, CPU breakdown: B/I/O/F (1.43ms/317.97us/2.90ms/307.67us)
       -- HashJoin[9][LEFT p_partkey=dt4.__gk6] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, expr:DOUBLE
+         Estimate: 6115.14 rows, 0B peak memory
+         Output: 6088 rows (147.16KB, 609 batches), Cpu time: 4.54ms, Wall time: 7.18ms, Blocked wall time: 188.73ms, Peak memory: 1.60MB, Memory allocations: 14, CPU breakdown: B/I/O/F (1.57ms/658.72us/1.48ms/824.16us)
         -- HashJoin[3][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, p_partkey:BIGINT
+           Estimate: 6115.14 rows, 0B peak memory
+           Output: 6088 rows (147.16KB, 609 batches), Cpu time: 4.47ms, Wall time: 6.87ms, Blocked wall time: 0ns, Peak memory: 1.60MB, Memory allocations: 14, CPU breakdown: B/I/O/F (1.26ms/805.66us/1.58ms/824.39us)
           -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE
+             Estimate: 6.00122e+06 rows, 0B peak memory
+             Input: 6088 rows (56.54MB, 609 batches), Raw Input: 6001215 rows (66.25MB), Output: 6088 rows (56.54MB, 609 batches), Cpu time: 204.20ms, Wall time: 233.89ms, Blocked wall time: 0ns, Peak memory: 16.18MB, Memory allocations: 5349, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (338.09us/0ns/203.86ms/471ns)
           -- TableScan[2][table: part, range filters: [(p_brand, Filter(BytesValues, deterministic, no nulls)), (p_container, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_container, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+             Estimate: 200 rows, 0B peak memory
+             Input: 204 rows (2.75KB, 20 batches), Raw Input: 200000 rows (5.48MB), Output: 204 rows (2.75KB, 20 batches), Cpu time: 5.25ms, Wall time: 11.14ms, Blocked wall time: 0ns, Peak memory: 4.77MB, Memory allocations: 113, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (12.87us/0ns/5.24ms/531ns)
         -- Project[8][expressions: (dt4.__gk6:BIGINT, "l_partkey_3"), (expr:DOUBLE, multiply("avg",0.2))] -> "dt4.__gk6":BIGINT, expr:DOUBLE
+           Estimate: 6020.88 rows, 0B peak memory
+           Output: 204 rows (97.81KB, 1 batches), Cpu time: 202.64us, Wall time: 360.70us, Blocked wall time: 0ns, Peak memory: 2.00KB, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (178.84us/421ns/21.08us/2.30us)
           -- Aggregation[7][SINGLE [l_partkey_3] avg := avg("l_quantity_6")] -> l_partkey_3:BIGINT, avg:DOUBLE
+             Estimate: 6020.88 rows, 0B peak memory
+             Output: 204 rows (191.81KB, 1 batches), Cpu time: 3.05ms, Wall time: 3.95ms, Blocked wall time: 0ns, Peak memory: 2.18MB, Memory allocations: 9, Threads: 1, CPU breakdown: B/I/O/F (673.81us/1.87ms/339.63us/161.19us)
             -- HashJoin[6][LEFT SEMI (FILTER) l_partkey_3=p_partkey] -> l_partkey_3:BIGINT, l_quantity_6:DOUBLE
+               Estimate: 6115.14 rows, 0B peak memory
+               Output: 6088 rows (56.18MB, 609 batches), Cpu time: 2.40ms, Wall time: 3.64ms, Blocked wall time: 11.65ms, Peak memory: 1.58MB, Memory allocations: 3, CPU breakdown: B/I/O/F (721.52us/241.02us/561.70us/873.20us)
               -- TableScan[4][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey_3:BIGINT, l_quantity_6:DOUBLE
+                 Estimate: 6.00122e+06 rows, 0B peak memory
+                 Input: 6088 rows (56.26MB, 609 batches), Raw Input: 6001215 rows (27.15MB), Output: 6088 rows (56.26MB, 609 batches), Cpu time: 141.64ms, Wall time: 168.18ms, Blocked wall time: 0ns, Peak memory: 8.15MB, Memory allocations: 2729, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 6, CPU breakdown: B/I/O/F (172.75us/0ns/141.47ms/260ns)
               -- TableScan[5][table: part, range filters: [(p_brand, Filter(BytesValues, deterministic, no nulls)), (p_container, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_container, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+                 Estimate: 200 rows, 0B peak memory
+                 Input: 204 rows (2.75KB, 20 batches), Raw Input: 200000 rows (5.48MB), Output: 204 rows (2.75KB, 20 batches), Cpu time: 5.10ms, Wall time: 10.96ms, Blocked wall time: 0ns, Peak memory: 4.77MB, Memory allocations: 113, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (6.67us/0ns/5.09ms/310ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q18.plans
+++ b/axiom/optimizer/tests/tpch/plans/q18.plans
@@ -1,115 +1,156 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 100.00 rows, c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum_24
+dt1: 100.00 rows, c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum_18
   output:
-    c_name := t2.c_name VARCHAR (cardinality=96.57 min="Customer#000000001" max="Customer#000015000")
-    c_custkey := t2.c_custkey BIGINT (cardinality=99.15 min=1 max=15000)
-    o_orderkey := t3.o_orderkey BIGINT (cardinality=99.15 min=1 max=600000)
-    o_orderdate := t3.o_orderdate DATE (cardinality=97.95 min=8035 max=10440)
-    o_totalprice := t3.o_totalprice DOUBLE (cardinality=99.15 min=917.35 max=496620.48)
-    sum_24 := dt1.sum_24 DOUBLE (cardinality=1.00)
+    c_name := t2.c_name VARCHAR (cardinality=99.97)
+    c_custkey := t2.c_custkey BIGINT (cardinality=99.95 min=1 max=150000)
+    o_orderkey := t3.o_orderkey BIGINT (cardinality=99.99 min=1 max=6000000)
+    o_orderdate := t3.o_orderdate DATE (cardinality=97.97 min=8035 max=10440)
+    o_totalprice := t3.o_totalprice DOUBLE (cardinality=99.99 min=857.71 max=600000)
+    sum_18 := dt1.sum_18 DOUBLE (cardinality=1.00)
   tables: t2, t3, t4, dt5
   joins:
-    t3 SEMI dt5 ON t3.o_orderkey = dt5.l_orderkey_23 [t3 → 0.10, dt5 → 10.00]
-    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.99, t3 → 0.10]
-    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 4.02, t4 → 1.00]
-    t4 SEMI dt5 ON t4.l_orderkey = dt5.l_orderkey_23 [t4 → 0.10, dt5 → 40.04]
-  syntactic join order: 11, 25, 48, 51
-  aggregates: sum(t4.l_quantity) AS sum_24
+    t3 SEMI dt5 ON t3.o_orderkey = dt5.l_orderkey_17 [t3 → 0.10, dt5 → 10.19]
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 10.00, t3 → 1.00]
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 4.00, t4 → 1.00]
+    t4 SEMI dt5 ON t4.l_orderkey = dt5.l_orderkey_17 [t4 → 0.10, dt5 → 40.75]
+  syntactic join order: 9, 21, 42, 45
+  aggregates: sum(t4.l_quantity) AS sum_18
   grouping keys: t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice
   filter: dt1.__mark7
   orderBy: t3.o_totalprice DESC NULLS LAST, t3.o_orderdate ASC NULLS LAST
   limit: 100
 
-t2: 15000.00 rows, c_custkey, c_name
+t2: 150000.00 rows, c_custkey, c_name
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
-    c_name VARCHAR (cardinality=14717.00 min="Customer#000000001" max="Customer#000015000")
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
+    c_name VARCHAR (cardinality=150000.00)
 
-t3: 150000.00 rows, o_orderkey, o_custkey, o_totalprice, o_orderdate
+t3: 1500000.00 rows, o_orderkey, o_custkey, o_totalprice, o_orderdate
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_totalprice DOUBLE (cardinality=147438.00 min=917.35 max=496620.48)
-    o_orderdate DATE (cardinality=2382.00 min=8035 max=10440)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_totalprice DOUBLE (cardinality=1500000.00 min=857.71 max=600000)
+    o_orderdate DATE (cardinality=2406.00 min=8035 max=10440)
 
-t4: 600572.00 rows, l_orderkey, l_quantity
+t4: 6001215.00 rows, l_orderkey, l_quantity
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
 
-dt5: 15000.48 rows, l_orderkey_23
+dt5: 147254.88 rows, l_orderkey_17
   output:
-    l_orderkey_23 := t6.l_orderkey BIGINT (cardinality=14274.89 min=1 max=600000)
+    l_orderkey_17 := t6.l_orderkey BIGINT (cardinality=140131.55 min=1 max=6000000)
   tables: t6
   aggregates: sum(t6.l_quantity) AS sum
   grouping keys: t6.l_orderkey
   having: gt(dt5.sum, 300)
 
-t6: 600572.00 rows, l_orderkey, l_quantity
+t6: 6001215.00 rows, l_orderkey, l_quantity
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
 
 
 Optimized plan (oneline):
 
-agg((("default"."lineitem" LEFT SEMI (FILTER) agg("default"."lineitem")) INNER ("default"."orders" INNER "default"."customer")))
+agg((((lineitem LEFT SEMI (FILTER) agg(lineitem)) INNER orders) INNER customer))
 
 Optimized plan:
 
-Project (redundant) [100.00 rows] -> dt1.c_name, dt1.c_custkey, dt1.o_orderkey, dt1.o_orderdate, dt1.o_totalprice, dt1.sum_24
+Project (redundant) [100.00 rows] -> dt1.c_name, dt1.c_custkey, dt1.o_orderkey, dt1.o_orderdate, dt1.o_totalprice, dt1.sum_18
     dt1.c_name := t2.c_name
     dt1.c_custkey := t2.c_custkey
     dt1.o_orderkey := t3.o_orderkey
     dt1.o_orderdate := t3.o_orderdate
     dt1.o_totalprice := t3.o_totalprice
-    dt1.sum_24 := dt1.sum_24
-  OrderBy [100.00 rows] -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_24
-    Aggregation (t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice) [5812.23 rows] -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_24
-        dt1.sum_24 := sum(t4.l_quantity)
-      Join INNER Hash [5812.24 rows] -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity
-          t4.l_orderkey = t3.o_orderkey
-        Join LEFT SEMI (FILTER) Hash [58871.10 rows] -> t4.l_orderkey, t4.l_quantity
-            t4.l_orderkey = dt5.l_orderkey_23
-          TableScan [600572.00 rows] -> t4.l_orderkey, t4.l_quantity
-            table: "default"."lineitem"
-          HashBuild [15000.48 rows] -> dt5.l_orderkey_23
-            Project [15000.48 rows] -> dt5.l_orderkey_23
-                dt5.l_orderkey_23 := t6.l_orderkey
-              Filter [15000.48 rows] -> t6.l_orderkey, dt5.sum
-                  gt(dt5.sum, 300)
-                Aggregation (t6.l_orderkey) [150004.80 rows] -> t6.l_orderkey, dt5.sum
-                    dt5.sum := sum(t6.l_quantity)
-                  TableScan [600572.00 rows] -> t6.l_orderkey, t6.l_quantity
-                    table: "default"."lineitem"
-        HashBuild [14809.23 rows] -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate
-          Join INNER Hash [14809.23 rows] -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate
-              t3.o_custkey = t2.c_custkey
-            TableScan [150000.00 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
+    dt1.sum_18 := dt1.sum_18
+  OrderBy [100.00 rows] -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_18
+    Aggregation (t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice) [589120.62 rows] -> t2.c_name, t2.c_custkey, t3.o_orderkey, t3.o_orderdate, t3.o_totalprice, dt1.sum_18
+        dt1.sum_18 := sum(t4.l_quantity)
+      Join INNER Hash [589138.75 rows] -> t2.c_custkey, t2.c_name, t3.o_orderkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity
+          t3.o_custkey = t2.c_custkey
+        Join INNER Hash [589138.75 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate, t4.l_quantity
+            t4.l_orderkey = t3.o_orderkey
+          Join LEFT SEMI (FILTER) Hash [589138.75 rows] -> t4.l_orderkey, t4.l_quantity
+              t4.l_orderkey = dt5.l_orderkey_17
+            TableScan [6001215.00 rows] -> t4.l_orderkey, t4.l_quantity
+              table: "default"."lineitem"
+            HashBuild [147254.88 rows] -> dt5.l_orderkey_17
+              Project [147254.88 rows] -> dt5.l_orderkey_17
+                  dt5.l_orderkey_17 := t6.l_orderkey
+                Filter [147254.88 rows] -> t6.l_orderkey, dt5.sum
+                    gt(dt5.sum, 300)
+                  Aggregation (t6.l_orderkey) [1472548.75 rows] -> t6.l_orderkey, dt5.sum
+                      dt5.sum := sum(t6.l_quantity)
+                    TableScan [6001215.00 rows] -> t6.l_orderkey, t6.l_quantity
+                      table: "default"."lineitem"
+          HashBuild [1500000.00 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
+            TableScan [1500000.00 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_totalprice, t3.o_orderdate
               table: "default"."orders"
-            HashBuild [15000.00 rows] -> t2.c_custkey, t2.c_name
-              TableScan [15000.00 rows] -> t2.c_custkey, t2.c_name
-                table: "default"."customer"
+        HashBuild [150000.00 rows] -> t2.c_custkey, t2.c_name
+          TableScan [150000.00 rows] -> t2.c_custkey, t2.c_name
+            table: "default"."customer"
 
 
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- TopN[11][100 o_totalprice DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_18:DOUBLE
+  -- Aggregation[10][SINGLE [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] sum_18 := sum("l_quantity")] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_18:DOUBLE
+    -- HashJoin[9][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
+      -- HashJoin[7][INNER l_orderkey=o_orderkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
+        -- HashJoin[5][LEFT SEMI (FILTER) l_orderkey=l_orderkey_0] -> l_orderkey:BIGINT, l_quantity:DOUBLE
+          -- TableScan[0]["default"."lineitem"] -> l_orderkey:BIGINT, l_quantity:DOUBLE
+          -- Project[4][expressions: (l_orderkey_0:BIGINT, "l_orderkey_0")] -> l_orderkey_0:BIGINT
+            -- Filter[1][expression: gt("sum",300)] -> l_orderkey_0:BIGINT, sum:DOUBLE
+              -- Aggregation[3][SINGLE [l_orderkey_0] sum := sum("l_quantity_4")] -> l_orderkey_0:BIGINT, sum:DOUBLE
+                -- TableScan[2]["default"."lineitem"] -> l_orderkey_0:BIGINT, l_quantity_4:DOUBLE
+        -- TableScan[6]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE
+      -- TableScan[8]["default"."customer"] -> c_custkey:BIGINT, c_name:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- TopN[11][100 o_totalprice DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_24:DOUBLE
+   Estimate: 100 rows, 0B peak memory
+   Output: 57 rows (51.72KB, 1 batches), Cpu time: 79.30us, Wall time: 108.72us, Blocked wall time: 0ns, Peak memory: 180.38KB, Memory allocations: 9, Threads: 1, CPU breakdown: B/I/O/F (31.57us/25.07us/10.60us/12.06us)
   -- Aggregation[10][SINGLE [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] sum_24 := sum("l_quantity")] -> c_name:VARCHAR, c_custkey:BIGINT, o_orderkey:BIGINT, o_orderdate:DATE, o_totalprice:DOUBLE, sum_24:DOUBLE
-    -- HashJoin[9][INNER l_orderkey=o_orderkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
-      -- HashJoin[5][LEFT SEMI (FILTER) l_orderkey=l_orderkey_23] -> l_orderkey:BIGINT, l_quantity:DOUBLE
-        -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_quantity:DOUBLE
-        -- Project[4][expressions: (l_orderkey_23:BIGINT, "l_orderkey_4")] -> l_orderkey_23:BIGINT
-          -- Filter[1][expression: gt("sum",300)] -> l_orderkey_4:BIGINT, sum:DOUBLE
-            -- Aggregation[3][SINGLE [l_orderkey_4] sum := sum("l_quantity_8")] -> l_orderkey_4:BIGINT, sum:DOUBLE
-              -- TableScan[2][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_4:BIGINT, l_quantity_8:DOUBLE
-      -- HashJoin[8][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE
+     Estimate: 575801 rows, 0B peak memory
+     Output: 57 rows (671.34KB, 1 batches), Cpu time: 661.56us, Wall time: 768.66us, Blocked wall time: 0ns, Peak memory: 816.62KB, Memory allocations: 15, Threads: 1, CPU breakdown: B/I/O/F (83.09us/478.77us/79.65us/20.05us)
+    -- HashJoin[9][INNER o_custkey=c_custkey] -> c_custkey:BIGINT, c_name:VARCHAR, o_orderkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
+       Estimate: 575818 rows, 0B peak memory
+       Output: 399 rows (2.61MB, 55 batches), Cpu time: 18.10ms, Wall time: 18.39ms, Blocked wall time: 28.38ms, Peak memory: 13.73MB, Memory allocations: 28, CPU breakdown: B/I/O/F (118.52us/16.15ms/276.34us/1.55ms)
+      -- HashJoin[7][INNER l_orderkey=o_orderkey] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE, l_quantity:DOUBLE
+         Estimate: 569684 rows, 0B peak memory
+         Output: 399 rows (23.44KB, 55 batches), Cpu time: 198.25ms, Wall time: 200.21ms, Blocked wall time: 230.88ms, Peak memory: 98.29MB, Memory allocations: 26, CPU breakdown: B/I/O/F (207.28us/115.57ms/300.69us/82.18ms)
+        -- HashJoin[5][LEFT SEMI (FILTER) l_orderkey=l_orderkey_4] -> l_orderkey:BIGINT, l_quantity:DOUBLE
+           Estimate: 587705 rows, 0B peak memory
+           Output: 399 rows (5.15MB, 55 batches), Cpu time: 461.61us, Wall time: 681.52us, Blocked wall time: 242.78ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (186.99us/99.16us/93.24us/82.21us)
+          -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_quantity:DOUBLE
+             Estimate: 6.00122e+06 rows, 0B peak memory
+             Input: 399 rows (5.16MB, 55 batches), Raw Input: 6001215 rows (16.75MB), Output: 399 rows (5.16MB, 55 batches), Cpu time: 87.26ms, Wall time: 111.55ms, Blocked wall time: 0ns, Peak memory: 5.69MB, Memory allocations: 1061, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 5, CPU breakdown: B/I/O/F (20.86us/0ns/87.24ms/280ns)
+          -- Project[4][expressions: (l_orderkey_4:BIGINT, "l_orderkey_4")] -> l_orderkey_4:BIGINT
+             Estimate: 151544 rows, 0B peak memory
+             Output: 57 rows (519B, 51 batches), Cpu time: 7.86ms, Wall time: 8.45ms, Blocked wall time: 0ns, Peak memory: 51.00KB, Memory allocations: 152, Threads: 1, CPU breakdown: B/I/O/F (452.82us/47.85us/7.32ms/42.46us)
+            -- Filter[1][expression: gt("sum",300)] -> l_orderkey_4:BIGINT, sum:DOUBLE
+               Estimate: 151544 rows, 0B peak memory
+               Output: 57 rows (1.09KB, 51 batches), Cpu time: 0ns, Wall time: 0ns, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)
+              -- Aggregation[3][SINGLE [l_orderkey_4] sum := sum("l_quantity_8")] -> l_orderkey_4:BIGINT, sum:DOUBLE
+                 Estimate: 1.51544e+06 rows, 0B peak memory
+                 Output: 1500000 rows (28.10MB, 150 batches), Cpu time: 367.78ms, Wall time: 371.76ms, Blocked wall time: 0ns, Peak memory: 70.88MB, Memory allocations: 38, Threads: 1, CPU breakdown: B/I/O/F (967.60us/356.29ms/10.24ms/280.87us)
+                -- TableScan[2][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_4:BIGINT, l_quantity_8:DOUBLE
+                   Estimate: 6.00122e+06 rows, 0B peak memory
+                   Input: 6001215 rows (56.20MB, 614 batches), Output: 6001215 rows (56.20MB, 614 batches), Cpu time: 93.18ms, Wall time: 120.70ms, Blocked wall time: 0ns, Peak memory: 5.39MB, Memory allocations: 2031, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (316.54us/0ns/92.86ms/280ns)
         -- TableScan[6][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_totalprice:DOUBLE, o_orderdate:DATE
-        -- TableScan[7][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR
+           Estimate: 1.5e+06 rows, 0B peak memory
+           Input: 1500000 rows (49.08MB, 152 batches), Output: 1500000 rows (49.08MB, 152 batches), Cpu time: 57.53ms, Wall time: 59.71ms, Blocked wall time: 0ns, Peak memory: 17.13MB, Memory allocations: 1311, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (53.70us/0ns/57.47ms/310ns)
+      -- TableScan[8][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_name:VARCHAR
+         Estimate: 150000 rows, 0B peak memory
+         Input: 150000 rows (7.39MB, 15 batches), Output: 150000 rows (7.39MB, 15 batches), Cpu time: 8.88ms, Wall time: 10.57ms, Blocked wall time: 0ns, Peak memory: 8.35MB, Memory allocations: 167, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (14.47us/0ns/8.87ms/310ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q19.plans
+++ b/axiom/optimizer/tests/tpch/plans/q19.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -8,51 +9,51 @@ dt1: 1.00 rows, revenue
     revenue := dt1.revenue DOUBLE (cardinality=1.00)
   tables: t2, t3
   joins:
-    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 0.00, t3 → 0.11]
-  syntactic join order: 19, 37
+    t2 INNER t3 ON t2.l_partkey = t3.p_partkey [t2 → 0.01, t3 → 1.06]
+  syntactic join order: 17, 33
   aggregates: sum(multiply(t2.l_extendedprice, minus(1, t2.l_discount))) AS revenue
   filter: __or(__and(between(t3.p_size, 1, 15), __and(lte(t2.l_quantity, 30), __and(gte(t2.l_quantity, 20), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))))), __or(__and(between(t3.p_size, 1, 5), __and(lte(t2.l_quantity, 11), __and(gte(t2.l_quantity, 1), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))))), __and(between(t3.p_size, 1, 10), __and(lte(t2.l_quantity, 20), __and(gte(t2.l_quantity, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))))
 
-t2: 21268.69 rows, l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode
+t2: 212527.38 rows, l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode
   table: "default"."lineitem"
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
     l_shipinstruct VARCHAR (cardinality=1.00 min="DELIVER IN PERSON" max="DELIVER IN PERSON")
     l_shipmode VARCHAR (cardinality=2.00 min="AIR" max="AIR REG")
   single-column filters: __in(t2.l_shipmode, "AIR", "AIR REG") and eq(t2.l_shipinstruct, "DELIVER IN PERSON") and __or(__and(gte(t2.l_quantity, 20), lte(t2.l_quantity, 30)), __or(__and(gte(t2.l_quantity, 1), lte(t2.l_quantity, 11)), __and(gte(t2.l_quantity, 10), lte(t2.l_quantity, 20))))
 
-t3: 191.39 rows, p_partkey, p_brand, p_size, p_container
+t3: 1913.86 rows, p_partkey, p_brand, p_size, p_container
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_brand VARCHAR (cardinality=25.00 min="Brand#11" max="Brand#55")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_brand VARCHAR (cardinality=25.00)
     p_size INTEGER (cardinality=50.00 min=1 max=50)
-    p_container VARCHAR (cardinality=40.00 min="JUMBO BAG" max="WRAP PKG")
+    p_container VARCHAR (cardinality=40.00)
   multi-column filters: __or(__and(between(t3.p_size, 1, 15), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))), __or(__and(between(t3.p_size, 1, 5), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))), __and(between(t3.p_size, 1, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))
 
 
 Optimized plan (oneline):
 
-agg(("default"."lineitem" INNER "default"."part"))
+agg((lineitem INNER part))
 
 Optimized plan:
 
 Project (redundant) [1.00 rows] -> dt1.revenue
     dt1.revenue := dt1.revenue
   Aggregation [1.00 rows] -> dt1.revenue
-      dt1.revenue := sum(dt1.__p134)
-    Project [1.00 rows] -> dt1.__p134
-        dt1.__p134 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
-      Filter [1.00 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
+      dt1.revenue := sum(dt1.__p130)
+    Project [5.74 rows] -> dt1.__p130
+        dt1.__p130 := multiply(t2.l_extendedprice, minus(1, t2.l_discount))
+      Filter [5.74 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
           __or(__and(between(t3.p_size, 1, 15), __and(lte(t2.l_quantity, 30), __and(gte(t2.l_quantity, 20), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))))), __or(__and(between(t3.p_size, 1, 5), __and(lte(t2.l_quantity, 11), __and(gte(t2.l_quantity, 1), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))))), __and(between(t3.p_size, 1, 10), __and(lte(t2.l_quantity, 20), __and(gte(t2.l_quantity, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))))
-        Join INNER Hash [20.67 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
+        Join INNER Hash [2033.74 rows] -> t2.l_quantity, t2.l_extendedprice, t2.l_discount, t3.p_brand, t3.p_size, t3.p_container
             t2.l_partkey = t3.p_partkey
-          TableScan [21268.69 rows] -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice, t2.l_discount
+          TableScan [212527.38 rows] -> t2.l_partkey, t2.l_quantity, t2.l_extendedprice, t2.l_discount
             table: "default"."lineitem"
             single-column filters: __in(t2.l_shipmode, "AIR", "AIR REG") and eq(t2.l_shipinstruct, "DELIVER IN PERSON") and __or(__and(gte(t2.l_quantity, 20), lte(t2.l_quantity, 30)), __or(__and(gte(t2.l_quantity, 1), lte(t2.l_quantity, 11)), __and(gte(t2.l_quantity, 10), lte(t2.l_quantity, 20))))
-          HashBuild [191.39 rows] -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
-            TableScan [191.39 rows] -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
+          HashBuild [1913.86 rows] -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
+            TableScan [1913.86 rows] -> t3.p_partkey, t3.p_brand, t3.p_size, t3.p_container
               table: "default"."part"
               multi-column filters: __or(__and(between(t3.p_size, 1, 15), __and(eq(t3.p_brand, "Brand#34"), __in(t3.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"))), __or(__and(between(t3.p_size, 1, 5), __and(eq(t3.p_brand, "Brand#12"), __in(t3.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"))), __and(between(t3.p_size, 1, 10), __and(eq(t3.p_brand, "Brand#23"), __in(t3.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")))))
 
@@ -60,11 +61,35 @@ Project (redundant) [1.00 rows] -> dt1.revenue
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- Aggregation[5][SINGLE revenue := sum("dt1.__p134")] -> revenue:DOUBLE
-  -- Project[4][expressions: (dt1.__p134:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p134":DOUBLE
+-- Aggregation[7][SINGLE revenue := sum("dt1.__p130")] -> revenue:DOUBLE
+  -- Project[6][expressions: (dt1.__p130:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p130":DOUBLE
     -- Filter[0][expression: or(and(between("p_size",1,15),and(lte("l_quantity",30),and(gte("l_quantity",20),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))))),or(and(between("p_size",1,5),and(lte("l_quantity",11),and(gte("l_quantity",1),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))))),and(between("p_size",1,10),and(lte("l_quantity",20),and(gte("l_quantity",10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))))] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+      -- HashJoin[5][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+        -- Filter[2][expression: and(in("l_shipmode",{AIR, AIR REG}),eq("l_shipinstruct",DELIVER IN PERSON),or(and(gte("l_quantity",20),lte("l_quantity",30)),or(and(gte("l_quantity",1),lte("l_quantity",11)),and(gte("l_quantity",10),lte("l_quantity",20)))))] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipinstruct:VARCHAR, l_shipmode:VARCHAR
+          -- TableScan[1]["default"."lineitem"] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipinstruct:VARCHAR, l_shipmode:VARCHAR
+        -- Filter[4][expression: or(and(between("p_size",1,15),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between("p_size",1,5),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between("p_size",1,10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+          -- TableScan[3]["default"."part"] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Aggregation[5][SINGLE revenue := sum("dt1.__p134")] -> revenue:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 1 rows (32B, 1 batches), Cpu time: 550.22us, Wall time: 900.04us, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (255.32us/175.78us/71.34us/47.77us)
+  -- Project[4][expressions: (dt1.__p134:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p134":DOUBLE
+     Estimate: 5.85003 rows, 0B peak memory
+     Output: 121 rows (2.96KB, 104 batches), Cpu time: 4.42ms, Wall time: 5.11ms, Blocked wall time: 0ns, Peak memory: 1.75KB, Memory allocations: 1187, Threads: 1, CPU breakdown: B/I/O/F (480.73us/107.29us/3.72ms/111.45us)
+    -- Filter[0][expression: or(and(between("p_size",1,15),and(lte("l_quantity",30),and(gte("l_quantity",20),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))))),or(and(between("p_size",1,5),and(lte("l_quantity",11),and(gte("l_quantity",1),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))))),and(between("p_size",1,10),and(lte("l_quantity",20),and(gte("l_quantity",10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))))] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+       Estimate: 5.85003 rows, 0B peak memory
+       Output: 121 rows (25.64KB, 104 batches), Cpu time: 0ns, Wall time: 0ns, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)
       -- HashJoin[3][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+         Estimate: 2072.35 rows, 0B peak memory
+         Output: 323 rows (68.44KB, 246 batches), Cpu time: 2.80ms, Wall time: 3.67ms, Blocked wall time: 17.84ms, Peak memory: 1.62MB, Memory allocations: 16, CPU breakdown: B/I/O/F (563.62us/552.20us/1.04ms/641.81us)
         -- TableScan[1][table: lineitem, range filters: [(l_quantity, DoubleRange: [1.000000, 30.000000] no nulls), (l_shipinstruct, Filter(BytesValues, deterministic, no nulls)), (l_shipmode, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_quantity, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipinstruct, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipmode, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+           Estimate: 212527 rows, 0B peak memory
+           Input: 323 rows (23.04MB, 246 batches), Raw Input: 6001215 rows (72.35MB), Output: 323 rows (23.04MB, 246 batches), Cpu time: 196.39ms, Wall time: 226.99ms, Blocked wall time: 0ns, Peak memory: 20.00MB, Memory allocations: 4398, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (116.03us/0ns/196.27ms/491ns)
         -- TableScan[2][table: part, remaining filter: (or(and(between("p_size",1,15),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between("p_size",1,5),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between("p_size",1,10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_container, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_brand, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
+           Estimate: 1913.86 rows, 0B peak memory
+           Input: 485 rows (2.36MB, 20 batches), Raw Input: 200000 rows (5.62MB), Output: 485 rows (2.36MB, 20 batches), Cpu time: 11.37ms, Wall time: 17.34ms, Blocked wall time: 0ns, Peak memory: 5.75MB, Memory allocations: 599, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (6.91us/0ns/11.36ms/301ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q2.plans
+++ b/axiom/optimizer/tests/tpch/plans/q2.plans
@@ -1,58 +1,59 @@
+generated: 2026-06-14 18:29:30 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 1.00 rows, s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
+dt1: 100.00 rows, s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
   output:
-    s_acctbal := t3.s_acctbal DOUBLE (cardinality=18.69 min=-966.2 max=9993.460000000001)
-    s_name := t3.s_name VARCHAR (cardinality=18.69 min="Supplier#000000001" max="Supplier#000001000")
-    n_name := t5.n_name VARCHAR (cardinality=4.58 min="ALGERIA" max="VIETNAM")
-    p_partkey := t2.p_partkey BIGINT (cardinality=1.00 min=1 max=20000)
-    p_mfgr := t2.p_mfgr VARCHAR (cardinality=1.00 min="Manufacturer#1" max="Manufacturer#5")
-    s_address := t3.s_address VARCHAR (cardinality=18.69 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
-    s_phone := t3.s_phone VARCHAR (cardinality=18.69 min="10-108-564-6160" max="34-998-900-4911")
-    s_comment := t3.s_comment VARCHAR (cardinality=18.69 min=" according to the bravely quick dolphins. deposit" max="ymptotes. blithely regular theodolites are slyly according to the ")
+    s_acctbal := t3.s_acctbal DOUBLE (cardinality=96.18 min=-999.99 max=9999.99)
+    s_name := t3.s_name VARCHAR (cardinality=96.18)
+    n_name := t5.n_name VARCHAR (cardinality=4.62)
+    p_partkey := t2.p_partkey BIGINT (cardinality=96.13 min=1 max=200000)
+    p_mfgr := t2.p_mfgr VARCHAR (cardinality=5.00)
+    s_address := t3.s_address VARCHAR (cardinality=96.18)
+    s_phone := t3.s_phone VARCHAR (cardinality=96.18)
+    s_comment := t3.s_comment VARCHAR (cardinality=96.18)
   tables: t2, t3, t4, t5, t6, dt7
   joins:
-    t2 LEFT dt7 ON t2.p_partkey = dt7.__gk12 [t2 → 0.05, dt7 → 0.33]
+    t2 LEFT dt7 ON t2.p_partkey = dt7.__gk12 [t2 → 0.42, dt7 → 0.04]
     t2 INNER t4 ON t2.p_partkey = t4.ps_partkey [t2 → 4.00, t4 → 0.02]
-    t3 INNER t4 ON t3.s_suppkey = t4.ps_suppkey [t3 → 7.87, t4 → 0.10]
-    t3 INNER t5 ON t3.s_nationkey = t5.n_nationkey [t3 → 1.00, t5 → 40.00]
+    t3 INNER t4 ON t3.s_suppkey = t4.ps_suppkey [t3 → 80.00, t4 → 1.00]
+    t3 INNER t5 ON t3.s_nationkey = t5.n_nationkey [t3 → 1.00, t5 → 400.00]
     t5 INNER t6 ON t5.n_regionkey = t6.r_regionkey [t5 → 0.20, t6 → 5.00]
-    t4 INNER dt7 ON t4.ps_supplycost = dt7.min [t4 → 0.02, dt7 → 81.77]
-  syntactic join order: 12, 26, 41, 51, 60, 63
+    t4 INNER dt7 ON t4.ps_supplycost = dt7.min [t4 → 0.84, dt7 → 9.48]
+  syntactic join order: 10, 22, 35, 43, 50, 53
   orderBy: t3.s_acctbal DESC NULLS LAST, t5.n_name ASC NULLS LAST, t3.s_name ASC NULLS LAST, t2.p_partkey ASC NULLS LAST
   limit: 100
 
-t2: 320.00 rows, p_partkey, p_mfgr, p_type, p_size
+t2: 3200.00 rows, p_partkey, p_mfgr, p_type, p_size
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_mfgr VARCHAR (cardinality=5.00 min="Manufacturer#1" max="Manufacturer#5")
-    p_type VARCHAR (cardinality=150.00 min="ECONOMY ANODIZED BRASS" max="STANDARD POLISHED TIN")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_mfgr VARCHAR (cardinality=5.00)
+    p_type VARCHAR (cardinality=150.00)
     p_size INTEGER (cardinality=1.00 min=15 max=15)
   single-column filters: eq(t2.p_size, 15) and like(t2.p_type, "%BRASS")
 
-t3: 1000.00 rows, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment
+t3: 10000.00 rows, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
-    s_name VARCHAR (cardinality=1016.00 min="Supplier#000000001" max="Supplier#000001000")
-    s_address VARCHAR (cardinality=992.00 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_name VARCHAR (cardinality=10000.00)
+    s_address VARCHAR (cardinality=10000.00)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    s_phone VARCHAR (cardinality=1023.00 min="10-108-564-6160" max="34-998-900-4911")
-    s_acctbal DOUBLE (cardinality=1024.00 min=-966.2 max=9993.460000000001)
-    s_comment VARCHAR (cardinality=1000.00 min=" according to the bravely quick dolphins. deposit" max="ymptotes. blithely regular theodolites are slyly according to the ")
+    s_phone VARCHAR (cardinality=10000.00)
+    s_acctbal DOUBLE (cardinality=10000.00 min=-999.99 max=9999.99)
+    s_comment VARCHAR (cardinality=10000.00)
 
-t4: 80000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
+t4: 800000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_supplycost DOUBLE (cardinality=54016.00 min=1.01 max=999.99)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
 
 t5: 25.00 rows, n_nationkey, n_name, n_regionkey
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
     n_regionkey BIGINT (cardinality=5.00 min=0 max=4)
 
 t6: 1.00 rows, r_regionkey, r_name
@@ -61,28 +62,28 @@ t6: 1.00 rows, r_regionkey, r_name
     r_name VARCHAR (cardinality=1.00 min="EUROPE" max="EUROPE")
   single-column filters: eq(t6.r_name, "EUROPE")
 
-dt7: 978.33 rows, __gk12, min
+dt7: 84371.77 rows, __gk12, min
   output:
-    __gk12 := t8.ps_partkey BIGINT (cardinality=978.33 min=1 max=20000)
+    __gk12 := t8.ps_partkey BIGINT (cardinality=84371.77 min=1 max=200000)
     min := dt7.min DOUBLE (cardinality=1.00)
   tables: t8, t9, t10, t11
   joins:
-    t8 INNER t9 ON t8.ps_suppkey = t9.s_suppkey [t8 → 0.10, t9 → 7.87]
-    t9 INNER t10 ON t9.s_nationkey = t10.n_nationkey [t9 → 1.00, t10 → 40.00]
+    t8 INNER t9 ON t8.ps_suppkey = t9.s_suppkey [t8 → 1.00, t9 → 80.00]
+    t9 INNER t10 ON t9.s_nationkey = t10.n_nationkey [t9 → 1.00, t10 → 400.00]
     t10 INNER t11 ON t10.n_regionkey = t11.r_regionkey [t10 → 0.20, t11 → 5.00]
-  syntactic join order: 64, 68, 71, 74
+  syntactic join order: 54, 58, 61, 64
   aggregates: min(t8.ps_supplycost) AS min
   grouping keys: t8.ps_partkey
 
-t8: 80000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
+t8: 800000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_supplycost DOUBLE (cardinality=54016.00 min=1.01 max=999.99)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
 
-t9: 1000.00 rows, s_suppkey, s_nationkey
+t9: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t10: 25.00 rows, n_nationkey, n_regionkey
@@ -99,11 +100,11 @@ t11: 1.00 rows, r_regionkey, r_name
 
 Optimized plan (oneline):
 
-((("default"."partsupp" INNER "default"."part") INNER agg((("default"."partsupp" LEFT SEMI (FILTER) "default"."part") INNER ("default"."supplier" INNER ("default"."nation" INNER "default"."region"))))) INNER ("default"."supplier" INNER ("default"."nation" INNER "default"."region")))
+(((partsupp INNER part) INNER (supplier INNER (nation INNER region))) INNER agg(((partsupp LEFT SEMI (FILTER) part) INNER (supplier INNER (nation INNER region)))))
 
 Optimized plan:
 
-Project [1.00 rows] -> dt1.s_acctbal, dt1.s_name, dt1.n_name, dt1.p_partkey, dt1.p_mfgr, dt1.s_address, dt1.s_phone, dt1.s_comment
+Project [100.00 rows] -> dt1.s_acctbal, dt1.s_name, dt1.n_name, dt1.p_partkey, dt1.p_mfgr, dt1.s_address, dt1.s_phone, dt1.s_comment
     dt1.s_acctbal := t3.s_acctbal
     dt1.s_name := t3.s_name
     dt1.n_name := t5.n_name
@@ -112,89 +113,166 @@ Project [1.00 rows] -> dt1.s_acctbal, dt1.s_name, dt1.n_name, dt1.p_partkey, dt1
     dt1.s_address := t3.s_address
     dt1.s_phone := t3.s_phone
     dt1.s_comment := t3.s_comment
-  OrderBy [1.00 rows] -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
-    Join INNER Hash [1.00 rows] -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
-        t4.ps_suppkey = t3.s_suppkey
-      Join INNER Hash [23.18 rows] -> t2.p_partkey, t2.p_mfgr, t4.ps_suppkey
-          t4.ps_supplycost = dt7.min
-        Join INNER Hash [1280.00 rows] -> t2.p_partkey, t2.p_mfgr, t4.ps_suppkey, t4.ps_supplycost
+  OrderBy [100.00 rows] -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+    Join INNER Hash [2159.92 rows] -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+        t4.ps_supplycost = dt7.min
+      Join INNER Hash [2560.00 rows] -> t2.p_partkey, t2.p_mfgr, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t4.ps_supplycost, t5.n_name
+          t4.ps_suppkey = t3.s_suppkey
+        Join INNER Hash [12800.00 rows] -> t2.p_partkey, t2.p_mfgr, t4.ps_suppkey, t4.ps_supplycost
             t4.ps_partkey = t2.p_partkey
-          TableScan [80000.00 rows] -> t4.ps_partkey, t4.ps_suppkey, t4.ps_supplycost
+          TableScan [800000.00 rows] -> t4.ps_partkey, t4.ps_suppkey, t4.ps_supplycost
             table: "default"."partsupp"
-          HashBuild [320.00 rows] -> t2.p_partkey, t2.p_mfgr
-            TableScan [320.00 rows] -> t2.p_partkey, t2.p_mfgr
+          HashBuild [3200.00 rows] -> t2.p_partkey, t2.p_mfgr
+            TableScan [3200.00 rows] -> t2.p_partkey, t2.p_mfgr
               table: "default"."part"
               single-column filters: eq(t2.p_size, 15) and like(t2.p_type, "%BRASS")
-        HashBuild [16.36 rows] -> dt7.min
-          Project [16.36 rows] -> dt7.min
-              dt7.min := dt7.min
-            Aggregation (t8.ps_partkey) [16.36 rows] -> t8.ps_partkey, dt7.min
-                dt7.min := min(t8.ps_supplycost)
-              Join INNER Hash [25.60 rows] -> t8.ps_partkey, t8.ps_supplycost
-                  t8.ps_suppkey = t9.s_suppkey
-                Join LEFT SEMI (FILTER) Hash [1301.14 rows] -> t8.ps_partkey, t8.ps_suppkey, t8.ps_supplycost
-                    t8.ps_partkey = t2.p_partkey
-                  TableScan [80000.00 rows] -> t8.ps_partkey, t8.ps_suppkey, t8.ps_supplycost
-                    table: "default"."partsupp"
-                  HashBuild [320.00 rows] -> t2.p_partkey
-                    TableScan [320.00 rows] -> t2.p_partkey
-                      table: "default"."part"
-                      single-column filters: eq(t2.p_size, 15) and like(t2.p_type, "%BRASS")
-                HashBuild [200.00 rows] -> t9.s_suppkey
-                  Join INNER Hash [200.00 rows] -> t9.s_suppkey
-                      t9.s_nationkey = t10.n_nationkey
-                    TableScan [1000.00 rows] -> t9.s_suppkey, t9.s_nationkey
-                      table: "default"."supplier"
-                    HashBuild [5.00 rows] -> t10.n_nationkey
-                      Join INNER Hash [5.00 rows] -> t10.n_nationkey
-                          t10.n_regionkey = t11.r_regionkey
-                        TableScan [25.00 rows] -> t10.n_nationkey, t10.n_regionkey
-                          table: "default"."nation"
-                        HashBuild [1.00 rows] -> t11.r_regionkey
-                          TableScan [1.00 rows] -> t11.r_regionkey
-                            table: "default"."region"
-                            single-column filters: eq(t11.r_name, "EUROPE")
-      HashBuild [200.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
-        Join INNER Hash [200.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
-            t3.s_nationkey = t5.n_nationkey
-          TableScan [1000.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_nationkey, t3.s_phone, t3.s_acctbal, t3.s_comment
-            table: "default"."supplier"
-          HashBuild [5.00 rows] -> t5.n_nationkey, t5.n_name
-            Join INNER Hash [5.00 rows] -> t5.n_nationkey, t5.n_name
-                t5.n_regionkey = t6.r_regionkey
-              TableScan [25.00 rows] -> t5.n_nationkey, t5.n_name, t5.n_regionkey
-                table: "default"."nation"
-              HashBuild [1.00 rows] -> t6.r_regionkey
-                TableScan [1.00 rows] -> t6.r_regionkey
-                  table: "default"."region"
-                  single-column filters: eq(t6.r_name, "EUROPE")
+        HashBuild [2000.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+          Join INNER Hash [2000.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_phone, t3.s_acctbal, t3.s_comment, t5.n_name
+              t3.s_nationkey = t5.n_nationkey
+            TableScan [10000.00 rows] -> t3.s_suppkey, t3.s_name, t3.s_address, t3.s_nationkey, t3.s_phone, t3.s_acctbal, t3.s_comment
+              table: "default"."supplier"
+            HashBuild [5.00 rows] -> t5.n_nationkey, t5.n_name
+              Join INNER Hash [5.00 rows] -> t5.n_nationkey, t5.n_name
+                  t5.n_regionkey = t6.r_regionkey
+                TableScan [25.00 rows] -> t5.n_nationkey, t5.n_name, t5.n_regionkey
+                  table: "default"."nation"
+                HashBuild [1.00 rows] -> t6.r_regionkey
+                  TableScan [1.00 rows] -> t6.r_regionkey
+                    table: "default"."region"
+                    single-column filters: eq(t6.r_name, "EUROPE")
+      HashBuild [1614.08 rows] -> dt7.min
+        Project [1614.08 rows] -> dt7.min
+            dt7.min := dt7.min
+          Aggregation (t8.ps_partkey) [1614.08 rows] -> t8.ps_partkey, dt7.min
+              dt7.min := min(t8.ps_supplycost)
+            Join INNER Hash [2560.00 rows] -> t8.ps_partkey, t8.ps_supplycost
+                t8.ps_suppkey = t9.s_suppkey
+              Join LEFT SEMI (FILTER) Hash [12800.00 rows] -> t8.ps_partkey, t8.ps_suppkey, t8.ps_supplycost
+                  t8.ps_partkey = t2.p_partkey
+                TableScan [800000.00 rows] -> t8.ps_partkey, t8.ps_suppkey, t8.ps_supplycost
+                  table: "default"."partsupp"
+                HashBuild [3200.00 rows] -> t2.p_partkey
+                  TableScan [3200.00 rows] -> t2.p_partkey
+                    table: "default"."part"
+                    single-column filters: eq(t2.p_size, 15) and like(t2.p_type, "%BRASS")
+              HashBuild [2000.00 rows] -> t9.s_suppkey
+                Join INNER Hash [2000.00 rows] -> t9.s_suppkey
+                    t9.s_nationkey = t10.n_nationkey
+                  TableScan [10000.00 rows] -> t9.s_suppkey, t9.s_nationkey
+                    table: "default"."supplier"
+                  HashBuild [5.00 rows] -> t10.n_nationkey
+                    Join INNER Hash [5.00 rows] -> t10.n_nationkey
+                        t10.n_regionkey = t11.r_regionkey
+                      TableScan [25.00 rows] -> t10.n_nationkey, t10.n_regionkey
+                        table: "default"."nation"
+                      HashBuild [1.00 rows] -> t11.r_regionkey
+                        TableScan [1.00 rows] -> t11.r_regionkey
+                          table: "default"."region"
+                          single-column filters: eq(t11.r_name, "EUROPE")
 
 
 Executable Velox plan:
 
-Fragment 0: fragment7 SINGLE:
--- Project[40][expressions: (s_acctbal:DOUBLE, "s_acctbal"), (s_name:VARCHAR, "s_name"), (n_name:VARCHAR, "n_name"), (p_partkey:BIGINT, "p_partkey"), (p_mfgr:VARCHAR, "p_mfgr"), (s_address:VARCHAR, "s_address"), (s_phone:VARCHAR, "s_phone"), (s_comment:VARCHAR, "s_comment")] -> s_acctbal:DOUBLE, s_name:VARCHAR, n_name:VARCHAR, p_partkey:BIGINT, p_mfgr:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_comment:VARCHAR
-  -- TopN[39][100 s_acctbal DESC NULLS LAST, n_name ASC NULLS LAST, s_name ASC NULLS LAST, p_partkey ASC NULLS LAST] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
-    -- HashJoin[38][INNER ps_suppkey=s_suppkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
-      -- HashJoin[32][INNER ps_supplycost=min] -> p_partkey:BIGINT, p_mfgr:VARCHAR, ps_suppkey:BIGINT
-        -- HashJoin[20][INNER ps_partkey=p_partkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
-          -- TableScan[18][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
-          -- TableScan[19][table: part, range filters: [(p_size, BigintRange: [15, 15] no nulls)], remaining filter: (like("p_type",%BRASS)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_mfgr:VARCHAR
-        -- Project[31][expressions: (min:DOUBLE, "min")] -> min:DOUBLE
-          -- Aggregation[30][SINGLE [ps_partkey_8] min := min("ps_supplycost_11")] -> ps_partkey_8:BIGINT, min:DOUBLE
-            -- HashJoin[29][INNER ps_suppkey_9=s_suppkey_15] -> ps_partkey_8:BIGINT, ps_supplycost_11:DOUBLE
-              -- HashJoin[23][LEFT SEMI (FILTER) ps_partkey_8=p_partkey] -> ps_partkey_8:BIGINT, ps_suppkey_9:BIGINT, ps_supplycost_11:DOUBLE
-                -- TableScan[21][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey_8:BIGINT, ps_suppkey_9:BIGINT, ps_supplycost_11:DOUBLE
-                -- TableScan[22][table: part, range filters: [(p_size, BigintRange: [15, 15] no nulls)], remaining filter: (like("p_type",%BRASS)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
-              -- HashJoin[28][INNER s_nationkey_18=n_nationkey_24] -> s_suppkey_15:BIGINT
-                -- TableScan[24][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey_15:BIGINT, s_nationkey_18:BIGINT
-                -- HashJoin[27][INNER n_regionkey_26=r_regionkey_30] -> n_nationkey_24:BIGINT
-                  -- TableScan[25][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_24:BIGINT, n_regionkey_26:BIGINT
-                  -- TableScan[26][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey_30:BIGINT
-      -- HashJoin[37][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
-        -- TableScan[33][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR
-        -- HashJoin[36][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
-          -- TableScan[34][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
-          -- TableScan[35][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+Fragment 0: fragment1 SINGLE:
+-- Project[26][expressions: (s_acctbal:DOUBLE, "s_acctbal"), (s_name:VARCHAR, "s_name"), (n_name:VARCHAR, "n_name"), (p_partkey:BIGINT, "p_partkey"), (p_mfgr:VARCHAR, "p_mfgr"), (s_address:VARCHAR, "s_address"), (s_phone:VARCHAR, "s_phone"), (s_comment:VARCHAR, "s_comment")] -> s_acctbal:DOUBLE, s_name:VARCHAR, n_name:VARCHAR, p_partkey:BIGINT, p_mfgr:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_comment:VARCHAR
+  -- TopN[25][100 s_acctbal DESC NULLS LAST, n_name ASC NULLS LAST, s_name ASC NULLS LAST, p_partkey ASC NULLS LAST] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+    -- HashJoin[24][INNER ps_supplycost=min] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+      -- HashJoin[10][INNER ps_suppkey=s_suppkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, ps_supplycost:DOUBLE, n_name:VARCHAR
+        -- HashJoin[3][INNER ps_partkey=p_partkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+          -- TableScan[0]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+          -- Filter[2][expression: and(eq("p_size",15),like("p_type",%BRASS))] -> p_partkey:BIGINT, p_mfgr:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+            -- TableScan[1]["default"."part"] -> p_partkey:BIGINT, p_mfgr:VARCHAR, p_type:VARCHAR, p_size:INTEGER
+        -- HashJoin[9][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+          -- TableScan[4]["default"."supplier"] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR
+          -- HashJoin[8][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
+            -- TableScan[5]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+            -- Filter[7][expression: eq("r_name",EUROPE)] -> r_regionkey:BIGINT, r_name:VARCHAR
+              -- TableScan[6]["default"."region"] -> r_regionkey:BIGINT, r_name:VARCHAR
+      -- Project[23][expressions: (min:DOUBLE, "min")] -> min:DOUBLE
+        -- Aggregation[22][SINGLE [ps_partkey_0] min := min("ps_supplycost_3")] -> ps_partkey_0:BIGINT, min:DOUBLE
+          -- HashJoin[21][INNER ps_suppkey_1=s_suppkey_5] -> ps_partkey_0:BIGINT, ps_supplycost_3:DOUBLE
+            -- HashJoin[14][LEFT SEMI (FILTER) ps_partkey_0=p_partkey] -> ps_partkey_0:BIGINT, ps_suppkey_1:BIGINT, ps_supplycost_3:DOUBLE
+              -- TableScan[11]["default"."partsupp"] -> ps_partkey_0:BIGINT, ps_suppkey_1:BIGINT, ps_supplycost_3:DOUBLE
+              -- Filter[13][expression: and(eq("p_size",15),like("p_type",%BRASS))] -> p_partkey:BIGINT, p_type:VARCHAR, p_size:INTEGER
+                -- TableScan[12]["default"."part"] -> p_partkey:BIGINT, p_type:VARCHAR, p_size:INTEGER
+            -- HashJoin[20][INNER s_nationkey_8=n_nationkey_12] -> s_suppkey_5:BIGINT
+              -- TableScan[15]["default"."supplier"] -> s_suppkey_5:BIGINT, s_nationkey_8:BIGINT
+              -- HashJoin[19][INNER n_regionkey_14=r_regionkey_16] -> n_nationkey_12:BIGINT
+                -- TableScan[16]["default"."nation"] -> n_nationkey_12:BIGINT, n_regionkey_14:BIGINT
+                -- Filter[18][expression: eq("r_name_17",EUROPE)] -> r_regionkey_16:BIGINT, r_name_17:VARCHAR
+                  -- TableScan[17]["default"."region"] -> r_regionkey_16:BIGINT, r_name_17:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[22][expressions: (s_acctbal:DOUBLE, "s_acctbal"), (s_name:VARCHAR, "s_name"), (n_name:VARCHAR, "n_name"), (p_partkey:BIGINT, "p_partkey"), (p_mfgr:VARCHAR, "p_mfgr"), (s_address:VARCHAR, "s_address"), (s_phone:VARCHAR, "s_phone"), (s_comment:VARCHAR, "s_comment")] -> s_acctbal:DOUBLE, s_name:VARCHAR, n_name:VARCHAR, p_partkey:BIGINT, p_mfgr:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_comment:VARCHAR
+   Estimate: 100 rows, 0B peak memory
+   Output: 100 rows (300.69KB, 1 batches), Cpu time: 47.09us, Wall time: 88.98us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (35.57us/370ns/8.19us/2.96us)
+  -- TopN[21][100 s_acctbal DESC NULLS LAST, n_name ASC NULLS LAST, s_name ASC NULLS LAST, p_partkey ASC NULLS LAST] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+     Estimate: 100 rows, 0B peak memory
+     Output: 100 rows (300.69KB, 1 batches), Cpu time: 535.20us, Wall time: 711.07us, Blocked wall time: 0ns, Peak memory: 430.00KB, Memory allocations: 16, Threads: 1, CPU breakdown: B/I/O/F (118.40us/308.82us/60.52us/47.45us)
+    -- HashJoin[20][INNER ps_supplycost=min] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+       Estimate: 2105.51 rows, 0B peak memory
+       Output: 464 rows (17.18MB, 81 batches), Cpu time: 744.02us, Wall time: 935.13us, Blocked wall time: 47.22ms, Peak memory: 115.75KB, Memory allocations: 19, CPU breakdown: B/I/O/F (148.61us/255.64us/254.63us/85.14us)
+      -- HashJoin[8][INNER ps_suppkey=s_suppkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, ps_supplycost:DOUBLE, n_name:VARCHAR
+         Estimate: 2565.75 rows, 0B peak memory
+         Output: 642 rows (22.89MB, 81 batches), Cpu time: 1.71ms, Wall time: 1.96ms, Blocked wall time: 0ns, Peak memory: 2.85MB, Memory allocations: 40, CPU breakdown: B/I/O/F (187.13us/981.99us/453.42us/90.32us)
+        -- HashJoin[2][INNER ps_partkey=p_partkey] -> p_partkey:BIGINT, p_mfgr:VARCHAR, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+           Estimate: 13043 rows, 0B peak memory
+           Output: 642 rows (3.85MB, 81 batches), Cpu time: 1.60ms, Wall time: 1.85ms, Blocked wall time: 0ns, Peak memory: 1.73MB, Memory allocations: 20, CPU breakdown: B/I/O/F (198.19us/294.25us/276.56us/829.55us)
+          -- TableScan[0][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+             Estimate: 800000 rows, 0B peak memory
+             Input: 642 rows (7.52MB, 81 batches), Raw Input: 800000 rows (5.07MB), Output: 642 rows (7.52MB, 81 batches), Cpu time: 19.59ms, Wall time: 20.60ms, Blocked wall time: 0ns, Peak memory: 12.73MB, Memory allocations: 623, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 2,8, CPU breakdown: B/I/O/F (26.84us/0ns/19.56ms/431ns)
+          -- TableScan[1][table: part, range filters: [(p_size, BigintRange: [15, 15] no nulls)], remaining filter: (like("p_type",%BRASS)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT, p_mfgr:VARCHAR
+             Estimate: 3200 rows, 0B peak memory
+             Input: 747 rows (186.49KB, 20 batches), Raw Input: 200000 rows (5.61MB), Output: 747 rows (186.49KB, 20 batches), Cpu time: 5.62ms, Wall time: 19.25ms, Blocked wall time: 0ns, Peak memory: 5.13MB, Memory allocations: 321, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (11.78us/0ns/5.61ms/541ns)
+        -- HashJoin[7][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR, n_name:VARCHAR
+           Estimate: 2000 rows, 0B peak memory
+           Output: 1987 rows (645.80KB, 2 batches), Cpu time: 293.32us, Wall time: 309.20us, Blocked wall time: 4.63ms, Peak memory: 350.00KB, Memory allocations: 17, CPU breakdown: B/I/O/F (26.72us/65.11us/154.13us/47.36us)
+          -- TableScan[3][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT, s_phone:VARCHAR, s_acctbal:DOUBLE, s_comment:VARCHAR
+             Estimate: 10000 rows, 0B peak memory
+             Input: 1987 rows (598.09KB, 1 batches), Raw Input: 10000 rows (1.22MB), Output: 1987 rows (598.09KB, 1 batches), Cpu time: 4.46ms, Wall time: 20.86ms, Blocked wall time: 0ns, Peak memory: 5.63MB, Memory allocations: 59, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 7, CPU breakdown: B/I/O/F (1.83us/0ns/4.45ms/511ns)
+          -- HashJoin[6][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
+             Estimate: 5 rows, 0B peak memory
+             Output: 5 rows (0B, 1 batches), Cpu time: 126.55us, Wall time: 176.77us, Blocked wall time: 1.64ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (30.19us/15.60us/8.94us/71.81us)
+            -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+               Estimate: 25 rows, 0B peak memory
+               Input: 5 rows (524B, 1 batches), Raw Input: 25 rows (3.34KB), Output: 5 rows (524B, 1 batches), Cpu time: 354.12us, Wall time: 2.05ms, Blocked wall time: 0ns, Peak memory: 4.88KB, Memory allocations: 24, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 6, CPU breakdown: B/I/O/F (1.32us/0ns/352.52us/280ns)
+            -- TableScan[5][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+               Estimate: 1 rows, 0B peak memory
+               Input: 1 rows (96B, 1 batches), Raw Input: 5 rows (1.81KB), Output: 1 rows (96B, 1 batches), Cpu time: 321.09us, Wall time: 1.99ms, Blocked wall time: 0ns, Peak memory: 2.56KB, Memory allocations: 16, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.03us/0ns/318.53us/521ns)
+      -- Project[19][expressions: (min:DOUBLE, "min")] -> min:DOUBLE
+         Estimate: 1617.62 rows, 0B peak memory
+         Output: 460 rows (95.91KB, 1 batches), Cpu time: 43.53us, Wall time: 75.16us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (33.11us/350ns/7.29us/2.77us)
+        -- Aggregation[18][SINGLE [ps_partkey_8] min := min("ps_supplycost_11")] -> ps_partkey_8:BIGINT, min:DOUBLE
+           Estimate: 1617.62 rows, 0B peak memory
+           Output: 460 rows (191.81KB, 1 batches), Cpu time: 5.59ms, Wall time: 5.74ms, Blocked wall time: 0ns, Peak memory: 3.72MB, Memory allocations: 23, Threads: 1, CPU breakdown: B/I/O/F (97.84us/4.97ms/496.63us/24.91us)
+          -- HashJoin[17][INNER ps_suppkey_9=s_suppkey_15] -> ps_partkey_8:BIGINT, ps_supplycost_11:DOUBLE
+             Estimate: 2565.75 rows, 0B peak memory
+             Output: 642 rows (7.48MB, 81 batches), Cpu time: 617.06us, Wall time: 814.26us, Blocked wall time: 21.32ms, Peak memory: 160.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (154.25us/241.42us/96.01us/125.38us)
+            -- HashJoin[11][LEFT SEMI (FILTER) ps_partkey_8=p_partkey] -> ps_partkey_8:BIGINT, ps_suppkey_9:BIGINT, ps_supplycost_11:DOUBLE
+               Estimate: 13043 rows, 0B peak memory
+               Output: 642 rows (7.51MB, 81 batches), Cpu time: 1.07ms, Wall time: 1.28ms, Blocked wall time: 0ns, Peak memory: 1.60MB, Memory allocations: 3, CPU breakdown: B/I/O/F (167.09us/128.48us/84.51us/690.20us)
+              -- TableScan[9][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey_8:BIGINT, ps_suppkey_9:BIGINT, ps_supplycost_11:DOUBLE
+                 Estimate: 800000 rows, 0B peak memory
+                 Input: 642 rows (7.52MB, 81 batches), Raw Input: 800000 rows (5.07MB), Output: 642 rows (7.52MB, 81 batches), Cpu time: 17.31ms, Wall time: 18.27ms, Blocked wall time: 0ns, Peak memory: 12.73MB, Memory allocations: 542, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 11,17, CPU breakdown: B/I/O/F (24.52us/0ns/17.28ms/260ns)
+              -- TableScan[10][table: part, range filters: [(p_size, BigintRange: [15, 15] no nulls)], remaining filter: (like("p_type",%BRASS)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+                 Estimate: 3200 rows, 0B peak memory
+                 Input: 747 rows (39.99KB, 20 batches), Raw Input: 200000 rows (5.54MB), Output: 747 rows (39.99KB, 20 batches), Cpu time: 5.05ms, Wall time: 18.97ms, Blocked wall time: 0ns, Peak memory: 4.87MB, Memory allocations: 212, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (6.38us/0ns/5.04ms/311ns)
+            -- HashJoin[16][INNER s_nationkey_18=n_nationkey_24] -> s_suppkey_15:BIGINT
+               Estimate: 2000 rows, 0B peak memory
+               Output: 1987 rows (0B, 1 batches), Cpu time: 110.85us, Wall time: 128.82us, Blocked wall time: 2.64ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (30.81us/14.15us/13.56us/52.33us)
+              -- TableScan[12][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey_15:BIGINT, s_nationkey_18:BIGINT
+                 Estimate: 10000 rows, 0B peak memory
+                 Input: 1987 rows (111.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 1987 rows (111.81KB, 1 batches), Cpu time: 803.52us, Wall time: 17.32ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 16, CPU breakdown: B/I/O/F (1.50us/0ns/801.66us/360ns)
+              -- HashJoin[15][INNER n_regionkey_26=r_regionkey_30] -> n_nationkey_24:BIGINT
+                 Estimate: 5 rows, 0B peak memory
+                 Output: 5 rows (0B, 1 batches), Cpu time: 153.17us, Wall time: 1.14ms, Blocked wall time: 1.68ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (24.44us/35.74us/8.50us/84.49us)
+                -- TableScan[13][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_24:BIGINT, n_regionkey_26:BIGINT
+                   Estimate: 25 rows, 0B peak memory
+                   Input: 5 rows (384B, 1 batches), Raw Input: 25 rows (3.06KB), Output: 5 rows (384B, 1 batches), Cpu time: 251.22us, Wall time: 1.53ms, Blocked wall time: 0ns, Peak memory: 4.00KB, Memory allocations: 17, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 15, CPU breakdown: B/I/O/F (1.57us/0ns/249.02us/621ns)
+                -- TableScan[14][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey_30:BIGINT
+                   Estimate: 1 rows, 0B peak memory
+                   Input: 1 rows (96B, 1 batches), Raw Input: 5 rows (1.81KB), Output: 1 rows (96B, 1 batches), Cpu time: 347.19us, Wall time: 1.43ms, Blocked wall time: 0ns, Peak memory: 2.56KB, Memory allocations: 16, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.67us/0ns/345.21us/311ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q20.plans
+++ b/axiom/optimizer/tests/tpch/plans/q20.plans
@@ -1,25 +1,26 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 40.00 rows, s_name, s_address
+dt1: 400.00 rows, s_name, s_address
   output:
-    s_name := t2.s_name VARCHAR (cardinality=39.23 min="Supplier#000000001" max="Supplier#000001000")
-    s_address := t2.s_address VARCHAR (cardinality=39.22 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
+    s_name := t2.s_name VARCHAR (cardinality=392.12)
+    s_address := t2.s_address VARCHAR (cardinality=392.12)
   tables: t2, t3, dt4
   joins:
-    t2 SEMI dt4 ON t2.s_suppkey = dt4.ps_suppkey [t2 → 3.34, dt4 → 0.10]
-    t2 INNER t3 ON t2.s_nationkey = t3.n_nationkey [t2 → 0.04, t3 → 40.00]
-  syntactic join order: 10, 21, 24
+    t2 SEMI dt4 ON t2.s_suppkey = dt4.ps_suppkey [t2 → 32.00, dt4 → 1.00]
+    t2 INNER t3 ON t2.s_nationkey = t3.n_nationkey [t2 → 0.04, t3 → 400.00]
+  syntactic join order: 8, 17, 20
   filter: dt1.__mark13
   orderBy: t2.s_name ASC NULLS LAST
 
-t2: 1000.00 rows, s_suppkey, s_name, s_address, s_nationkey
+t2: 10000.00 rows, s_suppkey, s_name, s_address, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
-    s_name VARCHAR (cardinality=1016.00 min="Supplier#000000001" max="Supplier#000001000")
-    s_address VARCHAR (cardinality=992.00 min="  Bg4GNb1 64E,NhHOTBsSLegFZL2l" max="zuWWhrxl0hEvZ")
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_name VARCHAR (cardinality=10000.00)
+    s_address VARCHAR (cardinality=10000.00)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t3: 1.00 rows, n_nationkey, n_name
@@ -28,107 +29,107 @@ t3: 1.00 rows, n_nationkey, n_name
     n_name VARCHAR (cardinality=1.00 min="CANADA" max="CANADA")
   single-column filters: eq(t3.n_name, "CANADA")
 
-dt4: 32528.59 rows, ps_suppkey
+dt4: 320000.00 rows, ps_suppkey
   output:
-    ps_suppkey := t5.ps_suppkey BIGINT (cardinality=9738.38 min=1 max=10000)
+    ps_suppkey := t5.ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
   tables: t5, dt6, dt10
   joins:
     t5 LEFT dt6 ON t5.ps_partkey = dt6.__gk8 AND t5.ps_suppkey = dt6.__gk9 [t5 → 1.00, dt6 → 0.99]
-    t5 SEMI dt10 ON t5.ps_partkey = dt10.p_partkey [t5 → 0.81, dt10 → 4.07]
-  syntactic join order: 32, 36, 86
+    t5 SEMI dt10 ON t5.ps_partkey = dt10.p_partkey [t5 → 0.80, dt10 → 4.00]
+  syntactic join order: 26, 30, 78
   filter: dt4.__mark12 and lt(dt6.expr, __cast(t5.ps_availqty as DOUBLE))
 
-t5: 80000.00 rows, ps_partkey, ps_suppkey, ps_availqty
+t5: 800000.00 rows, ps_partkey, ps_suppkey, ps_availqty
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_availqty INTEGER (cardinality=10121.00 min=1 max=9999)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_availqty INTEGER (cardinality=9999.00 min=1 max=9999)
 
-dt6: 80828.50 rows, __gk8, __gk9, expr
+dt6: 807248.75 rows, __gk8, __gk9, expr
   output:
-    __gk8 := t7.l_partkey BIGINT (cardinality=80828.50 min=1 max=200000)
-    __gk9 := t7.l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    __gk8 := t7.l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    __gk9 := t7.l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     expr := multiply(dt6.sum, 0.5) DOUBLE (cardinality=1.00)
   tables: t7
   aggregates: sum(t7.l_quantity) AS sum
   grouping keys: t7.l_partkey, t7.l_suppkey
 
-t7: 86815.36 rows, l_partkey, l_suppkey, l_quantity, l_shipdate
+t7: 867158.94 rows, l_partkey, l_suppkey, l_quantity, l_shipdate
   table: "default"."lineitem"
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
-    l_shipdate DATE (cardinality=361.10 min=8766 max=9130)
+    l_shipdate DATE (cardinality=365.00 min=8766 max=9130)
   single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(t7.l_shipdate, "1995-01-01")
 
-dt10: 16000.00 rows, p_partkey
+dt10: 160000.00 rows, p_partkey
   output:
-    p_partkey := t11.p_partkey BIGINT (cardinality=16000.00 min=1 max=20000)
+    p_partkey := t11.p_partkey BIGINT (cardinality=160000.00 min=1 max=200000)
   tables: t11
 
-t11: 16000.00 rows, p_partkey, p_name
+t11: 160000.00 rows, p_partkey, p_name
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_name VARCHAR (cardinality=19378.00 min="almond antique metallic honeydew green" max="yellow white red chiffon tan")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_name VARCHAR (cardinality=200000.00)
   single-column filters: like(t11.p_name, "forest%")
 
 
 Optimized plan (oneline):
 
-((agg("default"."lineitem") RIGHT ("default"."part" RIGHT SEMI (FILTER) ("default"."partsupp" LEFT SEMI (FILTER) ("default"."supplier" INNER "default"."nation")))) RIGHT SEMI (FILTER) ("default"."supplier" INNER "default"."nation"))
+((agg(lineitem) RIGHT (part RIGHT SEMI (FILTER) (partsupp LEFT SEMI (FILTER) (supplier INNER nation)))) RIGHT SEMI (FILTER) (supplier INNER nation))
 
 Optimized plan:
 
-Project (redundant) [40.00 rows] -> dt1.s_name, dt1.s_address
+Project (redundant) [400.00 rows] -> dt1.s_name, dt1.s_address
     dt1.s_name := t2.s_name
     dt1.s_address := t2.s_address
-  OrderBy [40.00 rows] -> t2.s_name, t2.s_address
-    Join RIGHT SEMI (FILTER) Hash [40.00 rows] -> t2.s_name, t2.s_address
+  OrderBy [400.00 rows] -> t2.s_name, t2.s_address
+    Join RIGHT SEMI (FILTER) Hash [400.00 rows] -> t2.s_name, t2.s_address
         dt4.ps_suppkey = t2.s_suppkey
-      Project [125.51 rows] -> dt4.ps_suppkey
+      Project [12547.99 rows] -> dt4.ps_suppkey
           dt4.ps_suppkey := t5.ps_suppkey
-        Filter [125.51 rows] -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
+        Filter [12547.99 rows] -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
             lt(dt6.expr, __cast(t5.ps_availqty as DOUBLE))
-          Join RIGHT Hash [251.03 rows] -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
+          Join RIGHT Hash [25095.99 rows] -> t5.ps_suppkey, t5.ps_availqty, dt6.expr
               dt6.__gk8 = t5.ps_partkey
               dt6.__gk9 = t5.ps_suppkey
-            Project [80828.50 rows] -> dt6.__gk8, dt6.__gk9, dt6.expr
+            Project [807248.75 rows] -> dt6.__gk8, dt6.__gk9, dt6.expr
                 dt6.__gk8 := t7.l_partkey
                 dt6.__gk9 := t7.l_suppkey
                 dt6.expr := multiply(dt6.sum, 0.5)
-              Aggregation (t7.l_partkey, t7.l_suppkey) [80828.50 rows] -> t7.l_partkey, t7.l_suppkey, dt6.sum
+              Aggregation (t7.l_partkey, t7.l_suppkey) [807248.75 rows] -> t7.l_partkey, t7.l_suppkey, dt6.sum
                   dt6.sum := sum(t7.l_quantity)
-                TableScan [86815.36 rows] -> t7.l_partkey, t7.l_suppkey, t7.l_quantity
+                TableScan [867158.94 rows] -> t7.l_partkey, t7.l_suppkey, t7.l_quantity
                   table: "default"."lineitem"
                   single-column filters: gte(t7.l_shipdate, "1994-01-01") and lt(t7.l_shipdate, "1995-01-01")
-            HashBuild [251.03 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
-              Join RIGHT SEMI (FILTER) Hash [251.03 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+            HashBuild [25095.99 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+              Join RIGHT SEMI (FILTER) Hash [25095.99 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
                   dt10.p_partkey = t5.ps_partkey
-                Project (redundant) [16000.00 rows] -> dt10.p_partkey
+                Project (redundant) [160000.00 rows] -> dt10.p_partkey
                     dt10.p_partkey := t11.p_partkey
-                  TableScan [16000.00 rows] -> t11.p_partkey
+                  TableScan [160000.00 rows] -> t11.p_partkey
                     table: "default"."part"
                     single-column filters: like(t11.p_name, "forest%")
-                HashBuild [308.68 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
-                  Join LEFT SEMI (FILTER) Hash [308.68 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                HashBuild [31369.98 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                  Join LEFT SEMI (FILTER) Hash [31369.98 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
                       t5.ps_suppkey = edt16.edt16.t2.s_suppkey
-                    TableScan [80000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
+                    TableScan [800000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_availqty
                       table: "default"."partsupp"
-                    HashBuild [40.00 rows] -> edt16.edt16.t2.s_suppkey
-                      Project [40.00 rows] -> edt16.edt16.t2.s_suppkey
+                    HashBuild [400.00 rows] -> edt16.edt16.t2.s_suppkey
+                      Project [400.00 rows] -> edt16.edt16.t2.s_suppkey
                           edt16.edt16.t2.s_suppkey := t2.s_suppkey
-                        Join INNER Hash [40.00 rows] -> t2.s_suppkey
+                        Join INNER Hash [400.00 rows] -> t2.s_suppkey
                             t2.s_nationkey = t3.n_nationkey
-                          TableScan [1000.00 rows] -> t2.s_suppkey, t2.s_nationkey
+                          TableScan [10000.00 rows] -> t2.s_suppkey, t2.s_nationkey
                             table: "default"."supplier"
                           HashBuild [1.00 rows] -> t3.n_nationkey
                             TableScan [1.00 rows] -> t3.n_nationkey
                               table: "default"."nation"
                               single-column filters: eq(t3.n_name, "CANADA")
-      HashBuild [40.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address
-        Join INNER Hash [40.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address
+      HashBuild [400.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address
+        Join INNER Hash [400.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address
             t2.s_nationkey = t3.n_nationkey
-          TableScan [1000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_nationkey
+          TableScan [10000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_address, t2.s_nationkey
             table: "default"."supplier"
           HashBuild [1.00 rows] -> t3.n_nationkey
             TableScan [1.00 rows] -> t3.n_nationkey
@@ -139,24 +140,89 @@ Project (redundant) [40.00 rows] -> dt1.s_name, dt1.s_address
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- OrderBy[18][s_name ASC NULLS LAST] -> s_name:VARCHAR, s_address:VARCHAR
-  -- HashJoin[17][RIGHT SEMI (FILTER) ps_suppkey=s_suppkey] -> s_name:VARCHAR, s_address:VARCHAR
-    -- Project[13][expressions: (ps_suppkey:BIGINT, "ps_suppkey")] -> ps_suppkey:BIGINT
+-- OrderBy[22][s_name ASC NULLS LAST] -> s_name:VARCHAR, s_address:VARCHAR
+  -- HashJoin[21][RIGHT SEMI (FILTER) ps_suppkey=s_suppkey] -> s_name:VARCHAR, s_address:VARCHAR
+    -- Project[16][expressions: (ps_suppkey:BIGINT, "ps_suppkey")] -> ps_suppkey:BIGINT
       -- Filter[0][expression: lt("expr",cast("ps_availqty" as DOUBLE))] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+        -- HashJoin[15][RIGHT dt6.__gk8=ps_partkey AND dt6.__gk9=ps_suppkey] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+          -- Project[4][expressions: (dt6.__gk8:BIGINT, "l_partkey"), (dt6.__gk9:BIGINT, "l_suppkey"), (expr:DOUBLE, multiply("sum",0.5))] -> "dt6.__gk8":BIGINT, "dt6.__gk9":BIGINT, expr:DOUBLE
+            -- Aggregation[3][SINGLE [l_partkey, l_suppkey] sum := sum("l_quantity")] -> l_partkey:BIGINT, l_suppkey:BIGINT, sum:DOUBLE
+              -- Filter[2][expression: and(gte("l_shipdate",1994-01-01),lt("l_shipdate",1995-01-01))] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_shipdate:DATE
+                -- TableScan[1]["default"."lineitem"] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_shipdate:DATE
+          -- HashJoin[14][RIGHT SEMI (FILTER) p_partkey=ps_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+            -- Filter[6][expression: like("p_name",forest%)] -> p_partkey:BIGINT, p_name:VARCHAR
+              -- TableScan[5]["default"."part"] -> p_partkey:BIGINT, p_name:VARCHAR
+            -- HashJoin[13][LEFT SEMI (FILTER) ps_suppkey=edt16.edt16.t2.s_suppkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+              -- TableScan[7]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+              -- Project[12][expressions: (edt16.edt16.t2.s_suppkey:BIGINT, "s_suppkey")] -> "edt16.edt16.t2.s_suppkey":BIGINT
+                -- HashJoin[11][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT
+                  -- TableScan[8]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                  -- Filter[10][expression: eq("n_name",CANADA)] -> n_nationkey:BIGINT, n_name:VARCHAR
+                    -- TableScan[9]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+    -- HashJoin[20][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR
+      -- TableScan[17]["default"."supplier"] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT
+      -- Filter[19][expression: eq("n_name",CANADA)] -> n_nationkey:BIGINT, n_name:VARCHAR
+        -- TableScan[18]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- OrderBy[18][s_name ASC NULLS LAST] -> s_name:VARCHAR, s_address:VARCHAR
+   Estimate: 400 rows, 0B peak memory
+   Output: 186 rows (101.62KB, 1 batches), Cpu time: 85.93us, Wall time: 101.16us, Blocked wall time: 0ns, Peak memory: 231.50KB, Memory allocations: 9, Threads: 1, CPU breakdown: B/I/O/F (11.38us/22.80us/15.73us/36.01us)
+  -- HashJoin[17][RIGHT SEMI (FILTER) ps_suppkey=s_suppkey] -> s_name:VARCHAR, s_address:VARCHAR
+     Estimate: 400 rows, 0B peak memory
+     Output: 186 rows (101.62KB, 1 batches), Cpu time: 255.85us, Wall time: 277.02us, Blocked wall time: 5.72ms, Peak memory: 354.00KB, Memory allocations: 13, CPU breakdown: B/I/O/F (25.80us/119.13us/33.37us/77.56us)
+    -- Project[13][expressions: (ps_suppkey:BIGINT, "ps_suppkey")] -> ps_suppkey:BIGINT
+       Estimate: 12576.2 rows, 0B peak memory
+       Output: 263 rows (2.91KB, 1 batches), Cpu time: 59.38us, Wall time: 72.08us, Blocked wall time: 0ns, Peak memory: 4.88KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (8.93us/801ns/46.72us/2.92us)
+      -- Filter[0][expression: lt("expr",cast("ps_availqty" as DOUBLE))] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+         Estimate: 12576.2 rows, 0B peak memory
+         Output: 263 rows (8.29KB, 1 batches), Cpu time: 0ns, Wall time: 0ns, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)
         -- HashJoin[12][RIGHT dt6.__gk8=ps_partkey AND dt6.__gk9=ps_suppkey] -> ps_suppkey:BIGINT, ps_availqty:INTEGER, expr:DOUBLE
+           Estimate: 25152.4 rows, 0B peak memory
+           Output: 366 rows (11.54KB, 2 batches), Cpu time: 449.49us, Wall time: 500.09us, Blocked wall time: 40.35ms, Peak memory: 743.50KB, Memory allocations: 13, CPU breakdown: B/I/O/F (74.66us/70.92us/41.06us/262.85us)
           -- Project[3][expressions: (dt6.__gk8:BIGINT, "l_partkey"), (dt6.__gk9:BIGINT, "l_suppkey"), (expr:DOUBLE, multiply("sum",0.5))] -> "dt6.__gk8":BIGINT, "dt6.__gk9":BIGINT, expr:DOUBLE
+             Estimate: 807248 rows, 0B peak memory
+             Output: 263 rows (194.72KB, 1 batches), Cpu time: 177.49us, Wall time: 336.88us, Blocked wall time: 0ns, Peak memory: 3.00KB, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (158.34us/431ns/17.12us/1.59us)
             -- Aggregation[2][SINGLE [l_partkey, l_suppkey] sum := sum("l_quantity")] -> l_partkey:BIGINT, l_suppkey:BIGINT, sum:DOUBLE
+               Estimate: 807248 rows, 0B peak memory
+               Output: 263 rows (287.72KB, 1 batches), Cpu time: 2.59ms, Wall time: 3.26ms, Blocked wall time: 0ns, Peak memory: 1.11MB, Memory allocations: 29, Threads: 1, CPU breakdown: B/I/O/F (422.13us/1.80ms/220.24us/138.37us)
               -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE
+                 Estimate: 867159 rows, 0B peak memory
+                 Input: 433 rows (4.44MB, 314 batches), Raw Input: 6001215 rows (46.24MB), Output: 433 rows (4.44MB, 314 batches), Cpu time: 106.28ms, Wall time: 130.69ms, Blocked wall time: 0ns, Peak memory: 13.84MB, Memory allocations: 3357, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 12, CPU breakdown: B/I/O/F (145.48us/0ns/106.14ms/270ns)
           -- HashJoin[11][RIGHT SEMI (FILTER) p_partkey=ps_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+             Estimate: 25152.4 rows, 0B peak memory
+             Output: 366 rows (7.72KB, 1 batches), Cpu time: 4.94ms, Wall time: 5.17ms, Blocked wall time: 23.59ms, Peak memory: 3.82MB, Memory allocations: 18, CPU breakdown: B/I/O/F (372.99us/3.55ms/174.60us/840.84us)
             -- TableScan[4][table: part, remaining filter: (like("p_name",forest%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+               Estimate: 160000 rows, 0B peak memory
+               Input: 342 rows (21.17KB, 20 batches), Raw Input: 200000 rows (7.27MB), Output: 342 rows (21.17KB, 20 batches), Cpu time: 16.18ms, Wall time: 21.73ms, Blocked wall time: 0ns, Peak memory: 10.23MB, Memory allocations: 181, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 11, CPU breakdown: B/I/O/F (11.63us/0ns/16.16ms/491ns)
             -- HashJoin[10][LEFT SEMI (FILTER) ps_suppkey=edt16.edt16.t2.s_suppkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+               Estimate: 30854.7 rows, 0B peak memory
+               Output: 32960 rows (7.48MB, 81 batches), Cpu time: 550.87us, Wall time: 917.01us, Blocked wall time: 4.38ms, Peak memory: 160.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (207.88us/75.95us/121.08us/145.96us)
               -- TableScan[5][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_availqty:INTEGER
+                 Estimate: 800000 rows, 0B peak memory
+                 Input: 32960 rows (7.93MB, 81 batches), Raw Input: 800000 rows (4.22MB), Output: 32960 rows (7.93MB, 81 batches), Cpu time: 12.67ms, Wall time: 13.62ms, Blocked wall time: 0ns, Peak memory: 10.15MB, Memory allocations: 529, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 10, CPU breakdown: B/I/O/F (44.61us/0ns/12.62ms/480ns)
               -- Project[9][expressions: (edt16.edt16.t2.s_suppkey:BIGINT, "s_suppkey")] -> "edt16.edt16.t2.s_suppkey":BIGINT
+                 Estimate: 400 rows, 0B peak memory
+                 Output: 412 rows (0B, 1 batches), Cpu time: 18.45us, Wall time: 31.43us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (8.55us/921ns/5.89us/3.08us)
                 -- HashJoin[8][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT
+                   Estimate: 400 rows, 0B peak memory
+                   Output: 412 rows (0B, 1 batches), Cpu time: 88.37us, Wall time: 103.56us, Blocked wall time: 1.67ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (23.15us/12.91us/8.51us/43.80us)
                   -- TableScan[6][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                     Estimate: 10000 rows, 0B peak memory
+                     Input: 412 rows (99.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 412 rows (99.81KB, 1 batches), Cpu time: 945.67us, Wall time: 1.91ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 8, CPU breakdown: B/I/O/F (1.74us/0ns/943.43us/490ns)
                   -- TableScan[7][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT
+                     Estimate: 1 rows, 0B peak memory
+                     Input: 1 rows (96B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 1 rows (96B, 1 batches), Cpu time: 270.78us, Wall time: 1.72ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.93us/0ns/268.31us/531ns)
     -- HashJoin[16][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR
+       Estimate: 400 rows, 0B peak memory
+       Output: 412 rows (0B, 1 batches), Cpu time: 126.28us, Wall time: 147.45us, Blocked wall time: 1.28ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (25.74us/31.63us/9.11us/59.80us)
       -- TableScan[14][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_nationkey:BIGINT
+         Estimate: 10000 rows, 0B peak memory
+         Input: 412 rows (141.98KB, 1 batches), Raw Input: 10000 rows (914.20KB), Output: 412 rows (141.98KB, 1 batches), Cpu time: 1.87ms, Wall time: 3.76ms, Blocked wall time: 0ns, Peak memory: 2.40MB, Memory allocations: 36, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 16, CPU breakdown: B/I/O/F (1.75us/0ns/1.86ms/471ns)
       -- TableScan[15][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT
+         Estimate: 1 rows, 0B peak memory
+         Input: 1 rows (96B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 1 rows (96B, 1 batches), Cpu time: 330.00us, Wall time: 1.76ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.08us/0ns/327.37us/550ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q21.plans
+++ b/axiom/optimizer/tests/tpch/plans/q21.plans
@@ -1,43 +1,44 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 3.79 rows, s_name, numwait
+dt1: 100.00 rows, s_name, numwait
   output:
-    s_name := t2.s_name VARCHAR (cardinality=3.79 min="Supplier#000000001" max="Supplier#000001000")
+    s_name := t2.s_name VARCHAR (cardinality=88.37)
     numwait := dt1.numwait BIGINT (cardinality=1.00)
   tables: t2, t3, t4, t5, dt6, dt9
   joins:
-    t3 SEMI dt6 ON t3.l_orderkey = dt6.l_orderkey FILTER neq(dt6.l_suppkey, t3.l_suppkey) [t3 → 3.92, dt6 → 1.99]
-    t3 SEMI dt9 ON t3.l_orderkey = dt9.l_orderkey FILTER neq(dt9.l_suppkey, t3.l_suppkey) [t3 → 1.99, dt9 → 1.99]
-    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey [t2 → 29.88, t3 → 0.10]
+    t3 SEMI dt6 ON t3.l_orderkey = dt6.l_orderkey FILTER neq(dt6.l_suppkey, t3.l_suppkey) [t3 → 4.00, dt6 → 2.03]
+    t3 SEMI dt9 ON t3.l_orderkey = dt9.l_orderkey FILTER neq(dt9.l_suppkey, t3.l_suppkey) [t3 → 2.03, dt9 → 2.03]
+    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey [t2 → 303.94, t3 → 1.00]
     t3 INNER t4 ON t3.l_orderkey = t4.o_orderkey [t3 → 0.33, t4 → 2.03]
-    t2 INNER t5 ON t2.s_nationkey = t5.n_nationkey [t2 → 0.04, t5 → 40.00]
-  syntactic join order: 10, 32, 48, 57, 60, 71
+    t2 INNER t5 ON t2.s_nationkey = t5.n_nationkey [t2 → 0.04, t5 → 400.00]
+  syntactic join order: 8, 28, 42, 49, 52, 63
   aggregates: count() AS numwait
   grouping keys: t2.s_name
   filter: dt1.__mark8 and not(dt1.__mark11)
   orderBy: dt1.numwait DESC NULLS LAST, t2.s_name ASC NULLS LAST
   limit: 100
 
-t2: 1000.00 rows, s_suppkey, s_name, s_nationkey
+t2: 10000.00 rows, s_suppkey, s_name, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
-    s_name VARCHAR (cardinality=1016.00 min="Supplier#000000001" max="Supplier#000001000")
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_name VARCHAR (cardinality=10000.00)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
-t3: 303820.16 rows, l_orderkey, l_suppkey, l_commitdate, l_receiptdate
+t3: 3039378.00 rows, l_orderkey, l_suppkey, l_commitdate, l_receiptdate
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_commitdate DATE (cardinality=2435.00 min=8065 max=10530)
-    l_receiptdate DATE (cardinality=2523.00 min=8038 max=10587)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_commitdate DATE (cardinality=2466.00 min=8065 max=10530)
+    l_receiptdate DATE (cardinality=2554.00 min=8037 max=10591)
   multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate)
 
-t4: 50000.00 rows, o_orderkey, o_orderstatus
+t4: 500000.00 rows, o_orderkey, o_orderstatus
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
     o_orderstatus VARCHAR (cardinality=1.00 min="F" max="F")
   single-column filters: eq(t4.o_orderstatus, "F")
 
@@ -47,83 +48,83 @@ t5: 1.00 rows, n_nationkey, n_name
     n_name VARCHAR (cardinality=1.00 min="SAUDI ARABIA" max="SAUDI ARABIA")
   single-column filters: eq(t5.n_name, "SAUDI ARABIA")
 
-dt6: 600572.00 rows, l_orderkey, l_suppkey
+dt6: 6001215.00 rows, l_orderkey, l_suppkey
   output:
-    l_orderkey := t7.l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey := t7.l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    l_orderkey := t7.l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey := t7.l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
   tables: t7
 
-t7: 600572.00 rows, l_orderkey, l_suppkey
+t7: 6001215.00 rows, l_orderkey, l_suppkey
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
 
-dt9: 303820.16 rows, l_orderkey, l_suppkey
+dt9: 3039378.00 rows, l_orderkey, l_suppkey
   output:
-    l_orderkey := t10.l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey := t10.l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    l_orderkey := t10.l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey := t10.l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
   tables: t10
 
-t10: 303820.16 rows, l_orderkey, l_suppkey, l_commitdate, l_receiptdate
+t10: 3039378.00 rows, l_orderkey, l_suppkey, l_commitdate, l_receiptdate
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_commitdate DATE (cardinality=2435.00 min=8065 max=10530)
-    l_receiptdate DATE (cardinality=2523.00 min=8038 max=10587)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_commitdate DATE (cardinality=2466.00 min=8065 max=10530)
+    l_receiptdate DATE (cardinality=2554.00 min=8037 max=10591)
   multi-column filters: lt(t10.l_commitdate, t10.l_receiptdate)
 
 
 Optimized plan (oneline):
 
-agg(("default"."lineitem" RIGHT SEMI (FILTER) ("default"."lineitem" RIGHT SEMI (PROJECT) (("default"."lineitem" INNER ("default"."supplier" INNER "default"."nation")) INNER "default"."orders"))))
+agg((lineitem RIGHT SEMI (FILTER) (lineitem RIGHT SEMI (PROJECT) ((lineitem INNER (supplier INNER nation)) INNER orders))))
 
 Optimized plan:
 
-Project (redundant) [3.79 rows] -> dt1.s_name, dt1.numwait
+Project (redundant) [100.00 rows] -> dt1.s_name, dt1.numwait
     dt1.s_name := t2.s_name
     dt1.numwait := dt1.numwait
-  OrderBy [3.79 rows] -> t2.s_name, dt1.numwait
-    Aggregation (t2.s_name) [3.79 rows] -> t2.s_name, dt1.numwait
+  OrderBy [100.00 rows] -> t2.s_name, dt1.numwait
+    Aggregation (t2.s_name) [392.12 rows] -> t2.s_name, dt1.numwait
         dt1.numwait := count()
-      Join RIGHT SEMI (FILTER) Hash [79.69 rows] -> t2.s_name
+      Join RIGHT SEMI (FILTER) Hash [8105.01 rows] -> t2.s_name
           dt6.l_orderkey = t3.l_orderkey
           neq(dt6.l_suppkey, t3.l_suppkey)
-        Project (redundant) [600572.00 rows] -> dt6.l_orderkey, dt6.l_suppkey
+        Project (redundant) [6001215.00 rows] -> dt6.l_orderkey, dt6.l_suppkey
             dt6.l_orderkey := t7.l_orderkey
             dt6.l_suppkey := t7.l_suppkey
-          TableScan [600572.00 rows] -> t7.l_orderkey, t7.l_suppkey
+          TableScan [6001215.00 rows] -> t7.l_orderkey, t7.l_suppkey
             table: "default"."lineitem"
-        HashBuild [79.69 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
-          Filter [79.69 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
+        HashBuild [8105.01 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
+          Filter [8105.01 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
               not(dt1.__mark11)
-            Join RIGHT SEMI (PROJECT) Hash [398.44 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
+            Join RIGHT SEMI (PROJECT) Hash [40525.04 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey, dt1.__mark11
                 dt9.l_orderkey = t3.l_orderkey
                 neq(dt9.l_suppkey, t3.l_suppkey)
-              Project (redundant) [303820.16 rows] -> dt9.l_orderkey, dt9.l_suppkey
+              Project (redundant) [3039378.00 rows] -> dt9.l_orderkey, dt9.l_suppkey
                   dt9.l_orderkey := t10.l_orderkey
                   dt9.l_suppkey := t10.l_suppkey
-                TableScan [303820.16 rows] -> t10.l_orderkey, t10.l_suppkey
+                TableScan [3039378.00 rows] -> t10.l_orderkey, t10.l_suppkey
                   table: "default"."lineitem"
                   multi-column filters: lt(t10.l_commitdate, t10.l_receiptdate)
-              HashBuild [398.44 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
-                Join INNER Hash [398.44 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
+              HashBuild [40525.04 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
+                Join INNER Hash [40525.04 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
                     t3.l_orderkey = t4.o_orderkey
-                  Join INNER Hash [1195.32 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
+                  Join INNER Hash [121575.12 rows] -> t2.s_name, t3.l_orderkey, t3.l_suppkey
                       t3.l_suppkey = t2.s_suppkey
-                    TableScan [303820.16 rows] -> t3.l_orderkey, t3.l_suppkey
+                    TableScan [3039378.00 rows] -> t3.l_orderkey, t3.l_suppkey
                       table: "default"."lineitem"
                       multi-column filters: lt(t3.l_commitdate, t3.l_receiptdate)
-                    HashBuild [40.00 rows] -> t2.s_suppkey, t2.s_name
-                      Join INNER Hash [40.00 rows] -> t2.s_suppkey, t2.s_name
+                    HashBuild [400.00 rows] -> t2.s_suppkey, t2.s_name
+                      Join INNER Hash [400.00 rows] -> t2.s_suppkey, t2.s_name
                           t2.s_nationkey = t5.n_nationkey
-                        TableScan [1000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_nationkey
+                        TableScan [10000.00 rows] -> t2.s_suppkey, t2.s_name, t2.s_nationkey
                           table: "default"."supplier"
                         HashBuild [1.00 rows] -> t5.n_nationkey
                           TableScan [1.00 rows] -> t5.n_nationkey
                             table: "default"."nation"
                             single-column filters: eq(t5.n_name, "SAUDI ARABIA")
-                  HashBuild [50000.00 rows] -> t4.o_orderkey
-                    TableScan [50000.00 rows] -> t4.o_orderkey
+                  HashBuild [500000.00 rows] -> t4.o_orderkey
+                    TableScan [500000.00 rows] -> t4.o_orderkey
                       table: "default"."orders"
                       single-column filters: eq(t4.o_orderstatus, "F")
 
@@ -131,19 +132,69 @@ Project (redundant) [3.79 rows] -> dt1.s_name, dt1.numwait
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- TopN[13][100 numwait DESC NULLS LAST, s_name ASC NULLS LAST] -> s_name:VARCHAR, numwait:BIGINT
-  -- Aggregation[12][SINGLE [s_name] numwait := count()] -> s_name:VARCHAR, numwait:BIGINT
-    -- HashJoin[11][RIGHT SEMI (FILTER) l_orderkey_6=l_orderkey, filter: neq("l_suppkey_8","l_suppkey")] -> s_name:VARCHAR
-      -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_6:BIGINT, l_suppkey_8:BIGINT
+-- TopN[17][100 numwait DESC NULLS LAST, s_name ASC NULLS LAST] -> s_name:VARCHAR, numwait:BIGINT
+  -- Aggregation[16][SINGLE [s_name] numwait := count()] -> s_name:VARCHAR, numwait:BIGINT
+    -- HashJoin[15][RIGHT SEMI (FILTER) l_orderkey_0=l_orderkey, filter: neq("l_suppkey_2","l_suppkey")] -> s_name:VARCHAR
+      -- TableScan[0]["default"."lineitem"] -> l_orderkey_0:BIGINT, l_suppkey_2:BIGINT
       -- Filter[1][expression: not("dt1.__mark11")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark11":BOOLEAN
+        -- HashJoin[14][RIGHT SEMI (PROJECT) l_orderkey_16=l_orderkey, filter: neq("l_suppkey_18","l_suppkey")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark11":BOOLEAN
+          -- Filter[3][expression: lt("l_commitdate_27","l_receiptdate_28")] -> l_orderkey_16:BIGINT, l_suppkey_18:BIGINT, l_commitdate_27:DATE, l_receiptdate_28:DATE
+            -- TableScan[2]["default"."lineitem"] -> l_orderkey_16:BIGINT, l_suppkey_18:BIGINT, l_commitdate_27:DATE, l_receiptdate_28:DATE
+          -- HashJoin[13][INNER l_orderkey=o_orderkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+            -- HashJoin[10][INNER l_suppkey=s_suppkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+              -- Filter[5][expression: lt("l_commitdate","l_receiptdate")] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_commitdate:DATE, l_receiptdate:DATE
+                -- TableScan[4]["default"."lineitem"] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_commitdate:DATE, l_receiptdate:DATE
+              -- HashJoin[9][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR
+                -- TableScan[6]["default"."supplier"] -> s_suppkey:BIGINT, s_name:VARCHAR, s_nationkey:BIGINT
+                -- Filter[8][expression: eq("n_name",SAUDI ARABIA)] -> n_nationkey:BIGINT, n_name:VARCHAR
+                  -- TableScan[7]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+            -- Filter[12][expression: eq("o_orderstatus",F)] -> o_orderkey:BIGINT, o_orderstatus:VARCHAR
+              -- TableScan[11]["default"."orders"] -> o_orderkey:BIGINT, o_orderstatus:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- TopN[13][100 numwait DESC NULLS LAST, s_name ASC NULLS LAST] -> s_name:VARCHAR, numwait:BIGINT
+   Estimate: 100 rows, 0B peak memory
+   Output: 100 rows (50.72KB, 1 batches), Cpu time: 109.94us, Wall time: 121.71us, Blocked wall time: 0ns, Peak memory: 179.00KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (9.93us/67.11us/7.95us/24.96us)
+  -- Aggregation[12][SINGLE [s_name] numwait := count()] -> s_name:VARCHAR, numwait:BIGINT
+     Estimate: 248.534 rows, 0B peak memory
+     Output: 411 rows (335.72KB, 1 batches), Cpu time: 527.77us, Wall time: 700.75us, Blocked wall time: 0ns, Peak memory: 512.00KB, Memory allocations: 10, Threads: 1, CPU breakdown: B/I/O/F (192.16us/278.66us/53.09us/3.87us)
+    -- HashJoin[11][RIGHT SEMI (FILTER) l_orderkey_6=l_orderkey, filter: neq("l_suppkey_8","l_suppkey")] -> s_name:VARCHAR
+       Estimate: 7730.46 rows, 0B peak memory
+       Output: 4141 rows (359.06KB, 5 batches), Cpu time: 6.44ms, Wall time: 7.31ms, Blocked wall time: 389.97ms, Peak memory: 2.60MB, Memory allocations: 625, CPU breakdown: B/I/O/F (1.41ms/1.91ms/2.76ms/364.53us)
+      -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey_6:BIGINT, l_suppkey_8:BIGINT
+         Estimate: 6.00122e+06 rows, 0B peak memory
+         Input: 14907 rows (56.32MB, 606 batches), Raw Input: 6001215 rows (22.83MB), Output: 14907 rows (56.32MB, 606 batches), Cpu time: 108.31ms, Wall time: 136.16ms, Blocked wall time: 0ns, Peak memory: 7.07MB, Memory allocations: 3304, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 11, CPU breakdown: B/I/O/F (171.00us/0ns/108.14ms/261ns)
+      -- Filter[1][expression: not("dt1.__mark11")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark11":BOOLEAN
+         Estimate: 7730.46 rows, 0B peak memory
+         Output: 6923 rows (651.99KB, 75 batches), Cpu time: 493.28us, Wall time: 806.62us, Blocked wall time: 0ns, Peak memory: 6.50KB, Memory allocations: 77, Threads: 1, CPU breakdown: B/I/O/F (253.45us/20.58us/189.41us/29.84us)
         -- HashJoin[10][RIGHT SEMI (PROJECT) l_orderkey_24=l_orderkey, filter: neq("l_suppkey_26","l_suppkey")] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT, "dt1.__mark11":BOOLEAN
+           Estimate: 38652.3 rows, 0B peak memory
+           Output: 75871 rows (7.02MB, 75 batches), Cpu time: 37.50ms, Wall time: 39.86ms, Blocked wall time: 266.13ms, Peak memory: 7.20MB, Memory allocations: 638, CPU breakdown: B/I/O/F (1.58ms/21.10ms/11.78ms/3.04ms)
           -- TableScan[2][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey_24:BIGINT, l_suppkey_26:BIGINT
+             Estimate: 3.04057e+06 rows, 0B peak memory
+             Input: 250515 rows (42.68MB, 612 batches), Raw Input: 6001215 rows (40.23MB), Output: 250515 rows (42.68MB, 612 batches), Cpu time: 89.23ms, Wall time: 99.59ms, Blocked wall time: 0ns, Peak memory: 11.38MB, Memory allocations: 7846, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 10, CPU breakdown: B/I/O/F (168.24us/0ns/89.06ms/260ns)
           -- HashJoin[9][INNER l_orderkey=o_orderkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+             Estimate: 38652.3 rows, 0B peak memory
+             Output: 75871 rows (33.63MB, 612 batches), Cpu time: 80.57ms, Wall time: 82.92ms, Blocked wall time: 96.34ms, Peak memory: 26.30MB, Memory allocations: 16, CPU breakdown: B/I/O/F (1.10ms/40.00ms/1.71ms/37.76ms)
             -- HashJoin[7][INNER l_suppkey=s_suppkey] -> s_name:VARCHAR, l_orderkey:BIGINT, l_suppkey:BIGINT
+               Estimate: 119625 rows, 0B peak memory
+               Output: 156739 rows (67.91MB, 614 batches), Cpu time: 6.75ms, Wall time: 8.34ms, Blocked wall time: 0ns, Peak memory: 306.00KB, Memory allocations: 13, CPU breakdown: B/I/O/F (813.22us/1.48ms/4.21ms/243.07us)
               -- TableScan[3][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_suppkey:BIGINT
+                 Estimate: 3.04057e+06 rows, 0B peak memory
+                 Input: 156739 rows (38.24MB, 614 batches), Raw Input: 6001215 rows (40.23MB), Output: 156739 rows (38.24MB, 614 batches), Cpu time: 80.45ms, Wall time: 127.74ms, Blocked wall time: 0ns, Peak memory: 11.59MB, Memory allocations: 7825, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 7, CPU breakdown: B/I/O/F (206.29us/0ns/80.24ms/261ns)
               -- HashJoin[6][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, s_name:VARCHAR
+                 Estimate: 400 rows, 0B peak memory
+                 Output: 411 rows (0B, 1 batches), Cpu time: 113.02us, Wall time: 126.08us, Blocked wall time: 1.64ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (22.82us/20.73us/8.55us/60.91us)
                 -- TableScan[4][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_name:VARCHAR, s_nationkey:BIGINT
+                   Estimate: 10000 rows, 0B peak memory
+                   Input: 411 rows (118.22KB, 1 batches), Raw Input: 10000 rows (682.24KB), Output: 411 rows (118.22KB, 1 batches), Cpu time: 1.03ms, Wall time: 2.49ms, Blocked wall time: 0ns, Peak memory: 1.18MB, Memory allocations: 28, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 6, CPU breakdown: B/I/O/F (2.26us/0ns/1.02ms/491ns)
                 -- TableScan[5][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT
+                   Estimate: 1 rows, 0B peak memory
+                   Input: 1 rows (96B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 1 rows (96B, 1 batches), Cpu time: 285.65us, Wall time: 1.56ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.51us/0ns/283.83us/311ns)
             -- TableScan[8][table: orders, range filters: [(o_orderstatus, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderstatus, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT
+               Estimate: 500000 rows, 0B peak memory
+               Input: 729413 rows (7.01MB, 152 batches), Raw Input: 1500000 rows (2.71MB), Output: 729413 rows (7.01MB, 152 batches), Cpu time: 26.02ms, Wall time: 27.28ms, Blocked wall time: 0ns, Peak memory: 4.39MB, Memory allocations: 516, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (46.26us/0ns/25.97ms/321ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q22.plans
+++ b/axiom/optimizer/tests/tpch/plans/q22.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -10,18 +11,18 @@ dt1: 1.00 rows, cntrycode, numcust, totacctbal
     totacctbal := dt1.totacctbal DOUBLE (cardinality=1.00)
   tables: t2, dt3, dt5
   joins:
-    t2 SEMI dt5 ON t2.c_custkey = dt5.o_custkey [t2 → 2.05, dt5 → 0.00]
-  syntactic join order: 11, 15, 36
+    t2 SEMI dt5 ON t2.c_custkey = dt5.o_custkey [t2 → 10.00, dt5 → 0.00]
+  syntactic join order: 9, 13, 34
   aggregates: count() AS numcust, sum(t2.c_acctbal) AS totacctbal
   grouping keys: substr(t2.c_phone, 1, 2)
   filter: gt(t2.c_acctbal, dt3.avg) and not(dt1.__mark7)
   orderBy: dt1.cntrycode ASC NULLS LAST
 
-t2: 6.75 rows, c_custkey, c_phone, c_acctbal
+t2: 7.00 rows, c_custkey, c_phone, c_acctbal
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
-    c_phone VARCHAR (cardinality=15553.00 min="10-103-318-6809" max="34-999-121-7718")
-    c_acctbal DOUBLE (cardinality=14867.00 min=-999.95 max=9999.72)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
+    c_phone VARCHAR (cardinality=150000.00)
+    c_acctbal DOUBLE (cardinality=150000.00 min=-999.99 max=9999.99)
   single-column filters: __in(substr(t2.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
 
 dt3: 1.00 rows, avg
@@ -30,25 +31,25 @@ dt3: 1.00 rows, avg
   tables: t4
   aggregates: avg(t4.c_acctbal) AS avg
 
-t4: 6.14 rows, c_phone, c_acctbal
+t4: 6.36 rows, c_phone, c_acctbal
   table: "default"."customer"
-    c_phone VARCHAR (cardinality=15553.00 min="10-103-318-6809" max="34-999-121-7718")
-    c_acctbal DOUBLE (cardinality=13515.48 min=0 max=9999.72)
+    c_phone VARCHAR (cardinality=150000.00)
+    c_acctbal DOUBLE (cardinality=136363.75 min=0 max=9999.99)
   single-column filters: gt(t4.c_acctbal, 0) and __in(substr(t4.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
 
-dt5: 150000.00 rows, o_custkey
+dt5: 1500000.00 rows, o_custkey
   output:
-    o_custkey := t6.o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
+    o_custkey := t6.o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
   tables: t6
 
-t6: 150000.00 rows, o_custkey
+t6: 1500000.00 rows, o_custkey
   table: "default"."orders"
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
 
 
 Optimized plan (oneline):
 
-agg(("default"."orders" RIGHT SEMI (PROJECT) ("default"."customer" INNER agg("default"."customer"))))
+agg((orders RIGHT SEMI (PROJECT) (customer INNER agg(customer))))
 
 Optimized plan:
 
@@ -57,32 +58,32 @@ Project (redundant) [1.00 rows] -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
     dt1.numcust := dt1.numcust
     dt1.totacctbal := dt1.totacctbal
   OrderBy [1.00 rows] -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
-    Aggregation (dt1.__p54) [1.00 rows] -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
+    Aggregation (dt1.__p50) [1.00 rows] -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
         dt1.numcust := count()
         dt1.totacctbal := sum(t2.c_acctbal)
-      Project [1.00 rows] -> dt1.__p54, t2.c_acctbal
-          dt1.__p54 := substr(t2.c_phone, 1, 2)
+      Project [1.00 rows] -> dt1.__p50, t2.c_acctbal
+          dt1.__p50 := substr(t2.c_phone, 1, 2)
           t2.c_acctbal := t2.c_acctbal
         Filter [1.00 rows] -> t2.c_phone, t2.c_acctbal, dt1.__mark7
             not(dt1.__mark7)
-          Join RIGHT SEMI (PROJECT) Hash [3.38 rows] -> t2.c_phone, t2.c_acctbal, dt1.__mark7
+          Join RIGHT SEMI (PROJECT) Hash [3.50 rows] -> t2.c_phone, t2.c_acctbal, dt1.__mark7
               dt5.o_custkey = t2.c_custkey
-            Project (redundant) [150000.00 rows] -> dt5.o_custkey
+            Project (redundant) [1500000.00 rows] -> dt5.o_custkey
                 dt5.o_custkey := t6.o_custkey
-              TableScan [150000.00 rows] -> t6.o_custkey
+              TableScan [1500000.00 rows] -> t6.o_custkey
                 table: "default"."orders"
-            HashBuild [3.38 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
-              Filter [3.38 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
+            HashBuild [3.50 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
+              Filter [3.50 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
                   gt(t2.c_acctbal, dt3.avg)
-                Join INNER Cross [6.75 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
-                  TableScan [6.75 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal
+                Join INNER Cross [7.00 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal, dt3.avg
+                  TableScan [7.00 rows] -> t2.c_custkey, t2.c_phone, t2.c_acctbal
                     table: "default"."customer"
                     single-column filters: __in(substr(t2.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
                   Project (redundant) [1.00 rows] -> dt3.avg
                       dt3.avg := dt3.avg
                     Aggregation [1.00 rows] -> dt3.avg
                         dt3.avg := avg(t4.c_acctbal)
-                      TableScan [6.14 rows] -> t4.c_acctbal
+                      TableScan [6.36 rows] -> t4.c_acctbal
                         table: "default"."customer"
                         single-column filters: gt(t4.c_acctbal, 0) and __in(substr(t4.c_phone, 1, 2), "13", "31", "23", "29", "30", "18", "17")
 
@@ -90,16 +91,55 @@ Project (redundant) [1.00 rows] -> dt1.cntrycode, dt1.numcust, dt1.totacctbal
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
--- OrderBy[10][cntrycode ASC NULLS LAST] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
-  -- Aggregation[9][SINGLE [cntrycode] numcust := count(), totacctbal := sum("c_acctbal")] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
-    -- Project[8][expressions: (cntrycode:VARCHAR, substr("c_phone",1,2)), (c_acctbal:DOUBLE, "c_acctbal")] -> cntrycode:VARCHAR, c_acctbal:DOUBLE
+-- OrderBy[12][cntrycode ASC NULLS LAST] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+  -- Aggregation[11][SINGLE [cntrycode] numcust := count(), totacctbal := sum("c_acctbal")] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+    -- Project[10][expressions: (cntrycode:VARCHAR, substr("c_phone",1,2)), (c_acctbal:DOUBLE, "c_acctbal")] -> cntrycode:VARCHAR, c_acctbal:DOUBLE
       -- Filter[0][expression: not("dt1.__mark7")] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark7":BOOLEAN
-        -- HashJoin[7][RIGHT SEMI (PROJECT) o_custkey=c_custkey] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark7":BOOLEAN
-          -- TableScan[1][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_custkey:BIGINT
+        -- HashJoin[9][RIGHT SEMI (PROJECT) o_custkey=c_custkey] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark7":BOOLEAN
+          -- TableScan[1]["default"."orders"] -> o_custkey:BIGINT
           -- Filter[2][expression: gt("c_acctbal","avg")] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+            -- NestedLoopJoin[8][INNER] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+              -- Filter[4][expression: in(substr("c_phone",1,2),{13, 31, 23, 29, 30, ...2 more})] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE
+                -- TableScan[3]["default"."customer"] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE
+              -- Aggregation[7][SINGLE avg := avg("c_acctbal_5")] -> avg:DOUBLE
+                -- Filter[6][expression: and(gt("c_acctbal_5",0),in(substr("c_phone_4",1,2),{13, 31, 23, 29, 30, ...2 more}))] -> c_acctbal_5:DOUBLE, c_phone_4:VARCHAR
+                  -- TableScan[5]["default"."customer"] -> c_acctbal_5:DOUBLE, c_phone_4:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- OrderBy[10][cntrycode ASC NULLS LAST] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 7 rows (352B, 1 batches), Cpu time: 423.44us, Wall time: 796.25us, Blocked wall time: 0ns, Peak memory: 128.69KB, Memory allocations: 6, CPU breakdown: B/I/O/F (249.80us/9.08us/81.64us/82.91us)
+  -- Aggregation[9][SINGLE [cntrycode] numcust := count(), totacctbal := sum("c_acctbal")] -> cntrycode:VARCHAR, numcust:BIGINT, totacctbal:DOUBLE
+     Estimate: 1 rows, 0B peak memory
+     Output: 7 rows (383.72KB, 1 batches), Cpu time: 675.81us, Wall time: 1.10ms, Blocked wall time: 0ns, Peak memory: 498.00KB, Memory allocations: 9, CPU breakdown: B/I/O/F (262.91us/187.56us/141.80us/83.54us)
+    -- Project[8][expressions: (cntrycode:VARCHAR, substr("c_phone",1,2)), (c_acctbal:DOUBLE, "c_acctbal")] -> cntrycode:VARCHAR, c_acctbal:DOUBLE
+       Estimate: 1 rows, 0B peak memory
+       Output: 6384 rows (527.09KB, 19 batches), Cpu time: 857.51us, Wall time: 1.36ms, Blocked wall time: 0ns, Peak memory: 30.25KB, Memory allocations: 40, CPU breakdown: B/I/O/F (351.07us/9.62us/412.86us/83.96us)
+      -- Filter[0][expression: not("dt1.__mark7")] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark7":BOOLEAN
+         Estimate: 1 rows, 0B peak memory
+         Output: 6384 rows (535.46KB, 19 batches), Cpu time: 0ns, Wall time: 0ns, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)
+        -- HashJoin[7][RIGHT SEMI (PROJECT) o_custkey=c_custkey] -> c_phone:VARCHAR, c_acctbal:DOUBLE, "dt1.__mark7":BOOLEAN
+           Estimate: 3.43784 rows, 0B peak memory
+           Output: 0 rows (0B, 19 batches), Cpu time: 4.35ms, Wall time: 4.85ms, Blocked wall time: 0ns, Peak memory: 5.80MB, Memory allocations: 21, CPU breakdown: B/I/O/F (721.68us/3.05ms/11.31us/563.62us)
+          -- TableScan[1][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_custkey:BIGINT
+             Estimate: 1.5e+06 rows, 0B peak memory
+             Input: 190069 rows (14.03MB, 304 batches), Raw Input: 1500000 rows (4.45MB), Output: 190069 rows (14.03MB, 304 batches), Cpu time: 17.69ms, Wall time: 19.16ms, Blocked wall time: 0ns, Peak memory: 4.99MB, Memory allocations: 658, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 7, CPU breakdown: B/I/O/F (302.56us/0ns/17.39ms/471ns)
+          -- Filter[2][expression: gt("c_acctbal","avg")] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+             Estimate: 3.43784 rows, 0B peak memory
+             Output: 19000 rows (1.05MB, 15 batches), Cpu time: 1.10ms, Wall time: 1.19ms, Blocked wall time: 0ns, Peak memory: 13.00KB, Memory allocations: 17, Threads: 1, CPU breakdown: B/I/O/F (44.63us/15.95us/1.03ms/9.65us)
             -- NestedLoopJoin[6][INNER] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE, avg:DOUBLE
+               Estimate: 6.87569 rows, 0B peak memory
+               Output: 42015 rows (2.32MB, 15 batches), Cpu time: 413.36us, Wall time: 825.62us, Blocked wall time: 19.99ms, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (62.14us/268.49us/47.85us/34.88us)
               -- TableScan[3][table: customer, remaining filter: (in(substr("c_phone",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_phone, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> c_custkey:BIGINT, c_phone:VARCHAR, c_acctbal:DOUBLE
+                 Estimate: 6.87569 rows, 0B peak memory
+                 Input: 42015 rows (4.12MB, 15 batches), Raw Input: 150000 rows (2.83MB), Output: 42015 rows (4.12MB, 15 batches), Cpu time: 22.06ms, Wall time: 22.97ms, Blocked wall time: 0ns, Peak memory: 15.34MB, Memory allocations: 318, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (10.36us/0ns/22.05ms/480ns)
               -- Aggregation[5][SINGLE avg := avg("c_acctbal_5")] -> avg:DOUBLE
+                 Estimate: 1 rows, 0B peak memory
+                 Output: 1 rows (32B, 1 batches), Cpu time: 120.36us, Wall time: 167.64us, Blocked wall time: 0ns, Peak memory: 64.62KB, Memory allocations: 6, Threads: 1, CPU breakdown: B/I/O/F (25.17us/70.47us/15.17us/9.55us)
                 -- TableScan[4][table: customer, range filters: [(c_acctbal, DoubleRange: (0.000000, nan) no nulls)], remaining filter: (in(substr("c_phone",1,2),{13, 31, 23, 29, 30, ...2 more})), data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_phone, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]], HiveColumnHandle [name: c_acctbal, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]]]] -> c_acctbal_5:DOUBLE
+                   Estimate: 6.25063 rows, 0B peak memory
+                   Input: 38120 rows (402.30KB, 15 batches), Raw Input: 150000 rows (2.43MB), Output: 38120 rows (402.30KB, 15 batches), Cpu time: 19.06ms, Wall time: 20.18ms, Blocked wall time: 0ns, Peak memory: 11.93MB, Memory allocations: 167, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (9.59us/0ns/19.05ms/471ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q3.plans
+++ b/axiom/optimizer/tests/tpch/plans/q3.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,46 +6,46 @@ Query Graph:
 
 dt1: 10.00 rows, l_orderkey, revenue, o_orderdate, o_shippriority
   output:
-    l_orderkey := t4.l_orderkey BIGINT (cardinality=9.99 min=1 max=600000)
+    l_orderkey := t4.l_orderkey BIGINT (cardinality=10.00 min=1 max=6000000)
     revenue := dt1.revenue DOUBLE (cardinality=1.00)
-    o_orderdate := t3.o_orderdate DATE (cardinality=9.91 min=8035 max=9203)
-    o_shippriority := t3.o_shippriority INTEGER (cardinality=1.00 min=0 max=0)
+    o_orderdate := t3.o_orderdate DATE (cardinality=9.96 min=8035 max=9203)
+    o_shippriority := t3.o_shippriority INTEGER (cardinality=1.00)
   tables: t2, t3, t4
   joins:
-    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.48, t3 → 0.02]
-    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 2.16, t4 → 0.49]
-  syntactic join order: 11, 25, 48
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 4.86, t3 → 0.20]
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 2.15, t4 → 0.49]
+  syntactic join order: 9, 21, 42
   aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
   grouping keys: t4.l_orderkey, t3.o_orderdate, t3.o_shippriority
   orderBy: dt1.revenue DESC NULLS LAST, t3.o_orderdate ASC NULLS LAST
   limit: 10
 
-t2: 3000.00 rows, c_custkey, c_mktsegment
+t2: 30000.00 rows, c_custkey, c_mktsegment
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
     c_mktsegment VARCHAR (cardinality=1.00 min="BUILDING" max="BUILDING")
   single-column filters: eq(t2.c_mktsegment, "BUILDING")
 
-t3: 72880.30 rows, o_orderkey, o_custkey, o_orderdate, o_shippriority
+t3: 728803.00 rows, o_orderkey, o_custkey, o_orderdate, o_shippriority
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_orderdate DATE (cardinality=1157.34 min=8035 max=9203)
-    o_shippriority INTEGER (cardinality=1.00 min=0 max=0)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_orderdate DATE (cardinality=1169.00 min=8035 max=9203)
+    o_shippriority INTEGER (cardinality=1.00)
   single-column filters: lt(t3.o_orderdate, "1995-03-15")
 
-t4: 322762.88 rows, l_orderkey, l_extendedprice, l_discount, l_shipdate
+t4: 3223930.50 rows, l_orderkey, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=1342.49 min=9205 max=10561)
+    l_shipdate DATE (cardinality=1357.00 min=9205 max=10561)
   single-column filters: gt(t4.l_shipdate, "1995-03-15")
 
 
 Optimized plan (oneline):
 
-agg(("default"."lineitem" INNER ("default"."orders" INNER "default"."customer")))
+agg((lineitem INNER (orders INNER customer)))
 
 Optimized plan:
 
@@ -54,41 +55,75 @@ Project [10.00 rows] -> dt1.l_orderkey, dt1.revenue, dt1.o_orderdate, dt1.o_ship
     dt1.o_orderdate := t3.o_orderdate
     dt1.o_shippriority := t3.o_shippriority
   OrderBy [10.00 rows] -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.revenue
-    Aggregation (t4.l_orderkey, t3.o_orderdate, t3.o_shippriority) [3096.45 rows] -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.revenue
-        dt1.revenue := sum(dt1.__p70)
-      Project [3096.52 rows] -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.__p70
+    Aggregation (t4.l_orderkey, t3.o_orderdate, t3.o_shippriority) [313248.47 rows] -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.revenue
+        dt1.revenue := sum(dt1.__p64)
+      Project [313281.38 rows] -> t4.l_orderkey, t3.o_orderdate, t3.o_shippriority, dt1.__p64
           t4.l_orderkey := t4.l_orderkey
           t3.o_orderdate := t3.o_orderdate
           t3.o_shippriority := t3.o_shippriority
-          dt1.__p70 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
-        Join INNER Hash [3096.52 rows] -> t3.o_orderdate, t3.o_shippriority, t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+          dt1.__p64 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash [313281.38 rows] -> t3.o_orderdate, t3.o_shippriority, t4.l_orderkey, t4.l_extendedprice, t4.l_discount
             t4.l_orderkey = t3.o_orderkey
-          TableScan [322762.88 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
+          TableScan [3223930.50 rows] -> t4.l_orderkey, t4.l_extendedprice, t4.l_discount
             table: "default"."lineitem"
             single-column filters: gt(t4.l_shipdate, "1995-03-15")
-          HashBuild [1439.07 rows] -> t3.o_orderkey, t3.o_orderdate, t3.o_shippriority
-            Join INNER Hash [1439.07 rows] -> t3.o_orderkey, t3.o_orderdate, t3.o_shippriority
+          HashBuild [145760.61 rows] -> t3.o_orderkey, t3.o_orderdate, t3.o_shippriority
+            Join INNER Hash [145760.61 rows] -> t3.o_orderkey, t3.o_orderdate, t3.o_shippriority
                 t3.o_custkey = t2.c_custkey
-              TableScan [72880.30 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_orderdate, t3.o_shippriority
+              TableScan [728803.00 rows] -> t3.o_orderkey, t3.o_custkey, t3.o_orderdate, t3.o_shippriority
                 table: "default"."orders"
                 single-column filters: lt(t3.o_orderdate, "1995-03-15")
-              HashBuild [3000.00 rows] -> t2.c_custkey
-                TableScan [3000.00 rows] -> t2.c_custkey
+              HashBuild [30000.00 rows] -> t2.c_custkey
+                TableScan [30000.00 rows] -> t2.c_custkey
                   table: "default"."customer"
                   single-column filters: eq(t2.c_mktsegment, "BUILDING")
 
 
 Executable Velox plan:
 
-Fragment 0: fragment5 SINGLE:
--- Project[20][expressions: (l_orderkey:BIGINT, "l_orderkey"), (revenue:DOUBLE, "revenue"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority")] -> l_orderkey:BIGINT, revenue:DOUBLE, o_orderdate:DATE, o_shippriority:INTEGER
-  -- TopN[19][10 revenue DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
-    -- Aggregation[18][SINGLE [l_orderkey, o_orderdate, o_shippriority] revenue := sum("dt1.__p70")] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
-      -- Project[17][expressions: (l_orderkey:BIGINT, "l_orderkey"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority"), (dt1.__p70:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, "dt1.__p70":DOUBLE
-        -- HashJoin[16][INNER l_orderkey=o_orderkey] -> o_orderdate:DATE, o_shippriority:INTEGER, l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-          -- TableScan[12][table: lineitem, range filters: [(l_shipdate, BigintRange: [9205, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-          -- HashJoin[15][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
-            -- TableScan[13][table: orders, range filters: [(o_orderdate, BigintRange: [-9223372036854775808, 9203] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
-            -- TableScan[14][table: customer, range filters: [(c_mktsegment, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_mktsegment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> c_custkey:BIGINT
+Fragment 0: fragment1 SINGLE:
+-- Project[11][expressions: (l_orderkey:BIGINT, "l_orderkey"), (revenue:DOUBLE, "revenue"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority")] -> l_orderkey:BIGINT, revenue:DOUBLE, o_orderdate:DATE, o_shippriority:INTEGER
+  -- TopN[10][10 revenue DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+    -- Aggregation[9][SINGLE [l_orderkey, o_orderdate, o_shippriority] revenue := sum("dt1.__p64")] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+      -- Project[8][expressions: (l_orderkey:BIGINT, "l_orderkey"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority"), (dt1.__p64:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, "dt1.__p64":DOUBLE
+        -- HashJoin[7][INNER l_orderkey=o_orderkey] -> o_orderdate:DATE, o_shippriority:INTEGER, l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- Filter[1][expression: gt("l_shipdate",1995-03-15)] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+            -- TableScan[0]["default"."lineitem"] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+          -- HashJoin[6][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+            -- Filter[3][expression: lt("o_orderdate",1995-03-15)] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+              -- TableScan[2]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+            -- Filter[5][expression: eq("c_mktsegment",BUILDING)] -> c_custkey:BIGINT, c_mktsegment:VARCHAR
+              -- TableScan[4]["default"."customer"] -> c_custkey:BIGINT, c_mktsegment:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[8][expressions: (l_orderkey:BIGINT, "l_orderkey"), (revenue:DOUBLE, "revenue"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority")] -> l_orderkey:BIGINT, revenue:DOUBLE, o_orderdate:DATE, o_shippriority:INTEGER
+   Estimate: 10 rows, 0B peak memory
+   Output: 10 rows (384B, 1 batches), Cpu time: 20.24us, Wall time: 31.65us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (9.62us/771ns/6.85us/3.00us)
+  -- TopN[7][10 revenue DESC NULLS LAST, o_orderdate ASC NULLS LAST] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+     Estimate: 10 rows, 0B peak memory
+     Output: 10 rows (384B, 1 batches), Cpu time: 418.95us, Wall time: 602.77us, Blocked wall time: 0ns, Peak memory: 64.75KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (235.40us/166.49us/11.70us/5.37us)
+    -- Aggregation[6][SINGLE [l_orderkey, o_orderdate, o_shippriority] revenue := sum("dt1.__p70")] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, revenue:DOUBLE
+       Estimate: 306914 rows, 0B peak memory
+       Output: 11620 rows (575.25KB, 2 batches), Cpu time: 65.41ms, Wall time: 67.74ms, Blocked wall time: 0ns, Peak memory: 13.69MB, Memory allocations: 50, Threads: 1, CPU breakdown: B/I/O/F (840.75us/63.71ms/670.35us/186.02us)
+      -- Project[5][expressions: (l_orderkey:BIGINT, "l_orderkey"), (o_orderdate:DATE, "o_orderdate"), (o_shippriority:INTEGER, "o_shippriority"), (dt1.__p70:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> l_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER, "dt1.__p70":DOUBLE
+         Estimate: 306945 rows, 0B peak memory
+         Output: 30519 rows (1.02MB, 607 batches), Cpu time: 13.35ms, Wall time: 18.33ms, Blocked wall time: 0ns, Peak memory: 50.00KB, Memory allocations: 1821, Threads: 1, CPU breakdown: B/I/O/F (994.73us/217.61us/11.95ms/188.27us)
+        -- HashJoin[4][INNER l_orderkey=o_orderkey] -> o_orderdate:DATE, o_shippriority:INTEGER, l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+           Estimate: 306945 rows, 0B peak memory
+           Output: 30519 rows (757.81KB, 607 batches), Cpu time: 87.99ms, Wall time: 105.56ms, Blocked wall time: 161.91ms, Peak memory: 8.50MB, Memory allocations: 22, CPU breakdown: B/I/O/F (1.10ms/71.06ms/6.22ms/9.61ms)
+          -- TableScan[0][table: lineitem, range filters: [(l_shipdate, BigintRange: [9205, 9223372036854775807] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+             Estimate: 3.22393e+06 rows, 0B peak memory
+             Input: 3241776 rows (95.31MB, 614 batches), Raw Input: 6001215 rows (62.74MB), Output: 3241776 rows (95.31MB, 614 batches), Cpu time: 166.70ms, Wall time: 252.81ms, Blocked wall time: 0ns, Peak memory: 16.71MB, Memory allocations: 9069, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (244.51us/0ns/166.46ms/270ns)
+          -- HashJoin[3][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+             Estimate: 147330 rows, 0B peak memory
+             Output: 147126 rows (7.01MB, 152 batches), Cpu time: 9.44ms, Wall time: 10.10ms, Blocked wall time: 13.63ms, Peak memory: 3.41MB, Memory allocations: 7, CPU breakdown: B/I/O/F (1.93ms/6.21ms/374.89us/923.97us)
+            -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [-9223372036854775808, 9203] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE, o_shippriority:INTEGER
+               Estimate: 728803 rows, 0B peak memory
+               Input: 147126 rows (15.95MB, 152 batches), Raw Input: 1500000 rows (8.86MB), Output: 147126 rows (15.95MB, 152 batches), Cpu time: 74.74ms, Wall time: 94.37ms, Blocked wall time: 0ns, Peak memory: 10.17MB, Memory allocations: 1318, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (87.49us/0ns/74.65ms/350ns)
+            -- TableScan[2][table: customer, range filters: [(c_mktsegment, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: c_mktsegment, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> c_custkey:BIGINT
+               Estimate: 30000 rows, 0B peak memory
+               Input: 30142 rows (270.59KB, 15 batches), Raw Input: 150000 rows (718.71KB), Output: 30142 rows (270.59KB, 15 batches), Cpu time: 5.55ms, Wall time: 6.49ms, Blocked wall time: 0ns, Peak memory: 4.29MB, Memory allocations: 65, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (8.23us/0ns/5.54ms/350ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q4.plans
+++ b/axiom/optimizer/tests/tpch/plans/q4.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,40 +6,40 @@ Query Graph:
 
 dt1: 5.00 rows, o_orderpriority, order_count
   output:
-    o_orderpriority := t2.o_orderpriority VARCHAR (cardinality=5.00 min="1-URGENT" max="5-LOW")
+    o_orderpriority := t2.o_orderpriority VARCHAR (cardinality=5.00)
     order_count := dt1.order_count BIGINT (cardinality=1.00)
   tables: t2, dt3
   joins:
-    t2 SEMI dt3 ON t2.o_orderkey = dt3.l_orderkey [t2 → 1.99, dt3 → 0.04]
-  syntactic join order: 12, 16
+    t2 SEMI dt3 ON t2.o_orderkey = dt3.l_orderkey [t2 → 2.03, dt3 → 0.04]
+  syntactic join order: 10, 14
   aggregates: count() AS order_count
   grouping keys: t2.o_orderpriority
   filter: dt1.__mark5
   orderBy: t2.o_orderpriority ASC NULLS LAST
 
-t2: 5735.66 rows, o_orderkey, o_orderdate, o_orderpriority
+t2: 57356.61 rows, o_orderkey, o_orderdate, o_orderpriority
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_orderdate DATE (cardinality=91.08 min=8582 max=8673)
-    o_orderpriority VARCHAR (cardinality=5.00 min="1-URGENT" max="5-LOW")
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_orderdate DATE (cardinality=92.00 min=8582 max=8673)
+    o_orderpriority VARCHAR (cardinality=5.00)
   single-column filters: gte(t2.o_orderdate, "1993-07-01") and lt(t2.o_orderdate, "1993-10-01")
 
-dt3: 303820.16 rows, l_orderkey
+dt3: 3039378.00 rows, l_orderkey
   output:
-    l_orderkey := t4.l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
+    l_orderkey := t4.l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
   tables: t4
 
-t4: 303820.16 rows, l_orderkey, l_commitdate, l_receiptdate
+t4: 3039378.00 rows, l_orderkey, l_commitdate, l_receiptdate
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_commitdate DATE (cardinality=2435.00 min=8065 max=10530)
-    l_receiptdate DATE (cardinality=2523.00 min=8038 max=10587)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_commitdate DATE (cardinality=2466.00 min=8065 max=10530)
+    l_receiptdate DATE (cardinality=2554.00 min=8037 max=10591)
   multi-column filters: lt(t4.l_commitdate, t4.l_receiptdate)
 
 
 Optimized plan (oneline):
 
-agg(("default"."lineitem" RIGHT SEMI (FILTER) "default"."orders"))
+agg((lineitem RIGHT SEMI (FILTER) orders))
 
 Optimized plan:
 
@@ -48,15 +49,15 @@ Project (redundant) [5.00 rows] -> dt1.o_orderpriority, dt1.order_count
   OrderBy [5.00 rows] -> t2.o_orderpriority, dt1.order_count
     Aggregation (t2.o_orderpriority) [5.00 rows] -> t2.o_orderpriority, dt1.order_count
         dt1.order_count := count()
-      Join RIGHT SEMI (FILTER) Hash [5735.66 rows] -> t2.o_orderpriority
+      Join RIGHT SEMI (FILTER) Hash [57356.61 rows] -> t2.o_orderpriority
           dt3.l_orderkey = t2.o_orderkey
-        Project (redundant) [303820.16 rows] -> dt3.l_orderkey
+        Project (redundant) [3039378.00 rows] -> dt3.l_orderkey
             dt3.l_orderkey := t4.l_orderkey
-          TableScan [303820.16 rows] -> t4.l_orderkey
+          TableScan [3039378.00 rows] -> t4.l_orderkey
             table: "default"."lineitem"
             multi-column filters: lt(t4.l_commitdate, t4.l_receiptdate)
-        HashBuild [5735.66 rows] -> t2.o_orderkey, t2.o_orderpriority
-          TableScan [5735.66 rows] -> t2.o_orderkey, t2.o_orderpriority
+        HashBuild [57356.61 rows] -> t2.o_orderkey, t2.o_orderpriority
+          TableScan [57356.61 rows] -> t2.o_orderkey, t2.o_orderpriority
             table: "default"."orders"
             single-column filters: gte(t2.o_orderdate, "1993-07-01") and lt(t2.o_orderdate, "1993-10-01")
 
@@ -64,10 +65,31 @@ Project (redundant) [5.00 rows] -> dt1.o_orderpriority, dt1.order_count
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[6][o_orderpriority ASC NULLS LAST] -> o_orderpriority:VARCHAR, order_count:BIGINT
+  -- Aggregation[5][SINGLE [o_orderpriority] order_count := count()] -> o_orderpriority:VARCHAR, order_count:BIGINT
+    -- HashJoin[4][RIGHT SEMI (FILTER) l_orderkey=o_orderkey] -> o_orderpriority:VARCHAR
+      -- Filter[1][expression: lt("l_commitdate","l_receiptdate")] -> l_orderkey:BIGINT, l_commitdate:DATE, l_receiptdate:DATE
+        -- TableScan[0]["default"."lineitem"] -> l_orderkey:BIGINT, l_commitdate:DATE, l_receiptdate:DATE
+      -- Filter[3][expression: and(gte("o_orderdate",1993-07-01),lt("o_orderdate",1993-10-01))] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR, o_orderdate:DATE
+        -- TableScan[2]["default"."orders"] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR, o_orderdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[4][o_orderpriority ASC NULLS LAST] -> o_orderpriority:VARCHAR, order_count:BIGINT
+   Estimate: 5 rows, 0B peak memory
+   Output: 5 rows (48.09KB, 2 batches), Cpu time: 67.06us, Wall time: 105.93us, Blocked wall time: 0ns, Peak memory: 176.44KB, Memory allocations: 12, Threads: 1, CPU breakdown: B/I/O/F (42.78us/8.90us/9.09us/6.29us)
   -- Aggregation[3][SINGLE [o_orderpriority] order_count := count()] -> o_orderpriority:VARCHAR, order_count:BIGINT
+     Estimate: 5 rows, 0B peak memory
+     Output: 5 rows (335.72KB, 2 batches), Cpu time: 2.17ms, Wall time: 2.61ms, Blocked wall time: 0ns, Peak memory: 508.00KB, Memory allocations: 20, Threads: 1, CPU breakdown: B/I/O/F (439.22us/1.49ms/225.05us/16.28us)
     -- HashJoin[2][RIGHT SEMI (FILTER) l_orderkey=o_orderkey] -> o_orderpriority:VARCHAR
+       Estimate: 57356.6 rows, 0B peak memory
+       Output: 52523 rows (3.65MB, 104 batches), Cpu time: 20.69ms, Wall time: 22.67ms, Blocked wall time: 40.09ms, Peak memory: 5.05MB, Memory allocations: 31, CPU breakdown: B/I/O/F (3.67ms/13.76ms/1.78ms/1.48ms)
       -- TableScan[0][table: lineitem, remaining filter: (lt("l_commitdate","l_receiptdate")), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_receiptdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]], HiveColumnHandle [name: l_commitdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT
+         Estimate: 3.04057e+06 rows, 0B peak memory
+         Input: 144869 rows (35.44MB, 1226 batches), Raw Input: 6001215 rows (29.84MB), Output: 144869 rows (35.44MB, 1226 batches), Cpu time: 86.13ms, Wall time: 131.14ms, Blocked wall time: 0ns, Peak memory: 8.55MB, Memory allocations: 9328, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 2, CPU breakdown: B/I/O/F (347.03us/0ns/85.78ms/270ns)
       -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8582, 8673] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_orderpriority:VARCHAR
+         Estimate: 57356.6 rows, 0B peak memory
+         Input: 57218 rows (2.63MB, 152 batches), Raw Input: 1500000 rows (5.14MB), Output: 57218 rows (2.63MB, 152 batches), Cpu time: 28.60ms, Wall time: 29.97ms, Blocked wall time: 0ns, Peak memory: 6.49MB, Memory allocations: 845, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (44.75us/0ns/28.55ms/310ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q5.plans
+++ b/axiom/optimizer/tests/tpch/plans/q5.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,50 +6,50 @@ Query Graph:
 
 dt1: 4.62 rows, n_name, revenue
   output:
-    n_name := t6.n_name VARCHAR (cardinality=4.62 min="ALGERIA" max="VIETNAM")
+    n_name := t6.n_name VARCHAR (cardinality=4.62)
     revenue := dt1.revenue DOUBLE (cardinality=1.00)
   tables: t2, t3, t4, t5, t6, t7
   joins:
-    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 0.15, t3 → 0.10]
-    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 4.02, t4 → 0.15]
-    t4 INNER t5 ON t4.l_suppkey = t5.s_suppkey [t4 → 0.10, t5 → 59.07]
-    t2 INNER t5 ON t2.c_nationkey = t5.s_nationkey [t2 → 40.00, t5 → 600.00]
-    t5 INNER t6 ON t5.s_nationkey = t6.n_nationkey [t5 → 1.00, t6 → 40.00]
+    t2 INNER t3 ON t2.c_custkey = t3.o_custkey [t2 → 1.52, t3 → 1.00]
+    t3 INNER t4 ON t3.o_orderkey = t4.l_orderkey [t3 → 4.00, t4 → 0.15]
+    t4 INNER t5 ON t4.l_suppkey = t5.s_suppkey [t4 → 1.00, t5 → 600.12]
+    t2 INNER t5 ON t2.c_nationkey = t5.s_nationkey [t2 → 400.00, t5 → 6000.00]
+    t5 INNER t6 ON t5.s_nationkey = t6.n_nationkey [t5 → 1.00, t6 → 400.00]
     t6 INNER t7 ON t6.n_regionkey = t7.r_regionkey [t6 → 0.20, t7 → 5.00]
-    t2 INNER t6 ON t2.c_nationkey = t6.n_nationkey [t2 → 1.00, t6 → 600.00]
-  syntactic join order: 11, 25, 47, 61, 70, 79
+    t2 INNER t6 ON t2.c_nationkey = t6.n_nationkey [t2 → 1.00, t6 → 6000.00]
+  syntactic join order: 9, 21, 41, 53, 60, 67
   aggregates: sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS revenue
   grouping keys: t6.n_name
   orderBy: dt1.revenue DESC NULLS LAST
 
-t2: 15000.00 rows, c_custkey, c_nationkey
+t2: 150000.00 rows, c_custkey, c_nationkey
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
     c_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
-t3: 22755.61 rows, o_orderkey, o_custkey, o_orderdate
+t3: 227556.11 rows, o_orderkey, o_custkey, o_orderdate
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_orderdate DATE (cardinality=361.36 min=8766 max=9130)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_orderdate DATE (cardinality=365.00 min=8766 max=9130)
   single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
 
-t4: 600572.00 rows, l_orderkey, l_suppkey, l_extendedprice, l_discount
+t4: 6001215.00 rows, l_orderkey, l_suppkey, l_extendedprice, l_discount
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
 
-t5: 1000.00 rows, s_suppkey, s_nationkey
+t5: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t6: 25.00 rows, n_nationkey, n_name, n_regionkey
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
     n_regionkey BIGINT (cardinality=5.00 min=0 max=4)
 
 t7: 1.00 rows, r_regionkey, r_name
@@ -60,7 +61,7 @@ t7: 1.00 rows, r_regionkey, r_name
 
 Optimized plan (oneline):
 
-agg((("default"."lineitem" INNER (("default"."orders" INNER "default"."customer") INNER ("default"."nation" INNER "default"."region"))) INNER ("default"."supplier" LEFT SEMI (FILTER) ("default"."nation" INNER "default"."region"))))
+agg(((lineitem INNER (orders INNER (customer INNER (nation INNER region)))) INNER (supplier LEFT SEMI (FILTER) (nation INNER region))))
 
 Optimized plan:
 
@@ -69,45 +70,45 @@ Project (redundant) [4.62 rows] -> dt1.n_name, dt1.revenue
     dt1.revenue := dt1.revenue
   OrderBy [4.62 rows] -> t6.n_name, dt1.revenue
     Aggregation (t6.n_name) [4.62 rows] -> t6.n_name, dt1.revenue
-        dt1.revenue := sum(dt1.__p107)
-      Project [176.95 rows] -> t6.n_name, dt1.__p107
+        dt1.revenue := sum(dt1.__p95)
+      Project [182081.75 rows] -> t6.n_name, dt1.__p95
           t6.n_name := t6.n_name
-          dt1.__p107 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
-        Join INNER Hash [176.95 rows] -> t4.l_extendedprice, t4.l_discount, t6.n_name
+          dt1.__p95 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash [182081.75 rows] -> t4.l_extendedprice, t4.l_discount, t6.n_name
             t2.c_nationkey = t5.s_nationkey
             t4.l_suppkey = t5.s_suppkey
-          Join INNER Hash [1799.01 rows] -> t2.c_nationkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t6.n_nationkey, t6.n_name
+          Join INNER Hash [182081.75 rows] -> t2.c_nationkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t6.n_nationkey, t6.n_name
               t4.l_orderkey = t3.o_orderkey
-            TableScan [600572.00 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+            TableScan [6001215.00 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
               table: "default"."lineitem"
-            HashBuild [449.32 rows] -> t2.c_nationkey, t3.o_orderkey, t6.n_nationkey, t6.n_name
-              Join INNER Hash [449.32 rows] -> t2.c_nationkey, t3.o_orderkey, t6.n_nationkey, t6.n_name
-                  t2.c_nationkey = t6.n_nationkey
-                Join INNER Hash [2246.62 rows] -> t2.c_nationkey, t3.o_orderkey
-                    t3.o_custkey = t2.c_custkey
-                  TableScan [22755.61 rows] -> t3.o_orderkey, t3.o_custkey
-                    table: "default"."orders"
-                    single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
-                  HashBuild [15000.00 rows] -> t2.c_custkey, t2.c_nationkey
-                    TableScan [15000.00 rows] -> t2.c_custkey, t2.c_nationkey
+            HashBuild [45511.22 rows] -> t2.c_nationkey, t3.o_orderkey, t6.n_nationkey, t6.n_name
+              Join INNER Hash [45511.22 rows] -> t2.c_nationkey, t3.o_orderkey, t6.n_nationkey, t6.n_name
+                  t3.o_custkey = t2.c_custkey
+                TableScan [227556.11 rows] -> t3.o_orderkey, t3.o_custkey
+                  table: "default"."orders"
+                  single-column filters: gte(t3.o_orderdate, "1994-01-01") and lt(t3.o_orderdate, "1995-01-01")
+                HashBuild [30000.00 rows] -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name
+                  Join INNER Hash [30000.00 rows] -> t2.c_custkey, t2.c_nationkey, t6.n_nationkey, t6.n_name
+                      t2.c_nationkey = t6.n_nationkey
+                    TableScan [150000.00 rows] -> t2.c_custkey, t2.c_nationkey
                       table: "default"."customer"
-                HashBuild [5.00 rows] -> t6.n_nationkey, t6.n_name
-                  Join INNER Hash [5.00 rows] -> t6.n_nationkey, t6.n_name
-                      t6.n_regionkey = t7.r_regionkey
-                    TableScan [25.00 rows] -> t6.n_nationkey, t6.n_name, t6.n_regionkey
-                      table: "default"."nation"
-                    HashBuild [1.00 rows] -> t7.r_regionkey
-                      TableScan [1.00 rows] -> t7.r_regionkey
-                        table: "default"."region"
-                        single-column filters: eq(t7.r_name, "ASIA")
-          HashBuild [200.00 rows] -> t5.s_suppkey, t5.s_nationkey
-            Join LEFT SEMI (FILTER) Hash [200.00 rows] -> t5.s_suppkey, t5.s_nationkey
-                t5.s_nationkey = edt23.edt23.t6.n_nationkey
-              TableScan [1000.00 rows] -> t5.s_suppkey, t5.s_nationkey
+                    HashBuild [5.00 rows] -> t6.n_nationkey, t6.n_name
+                      Join INNER Hash [5.00 rows] -> t6.n_nationkey, t6.n_name
+                          t6.n_regionkey = t7.r_regionkey
+                        TableScan [25.00 rows] -> t6.n_nationkey, t6.n_name, t6.n_regionkey
+                          table: "default"."nation"
+                        HashBuild [1.00 rows] -> t7.r_regionkey
+                          TableScan [1.00 rows] -> t7.r_regionkey
+                            table: "default"."region"
+                            single-column filters: eq(t7.r_name, "ASIA")
+          HashBuild [2000.00 rows] -> t5.s_suppkey, t5.s_nationkey
+            Join LEFT SEMI (FILTER) Hash [2000.00 rows] -> t5.s_suppkey, t5.s_nationkey
+                t5.s_nationkey = edt16.edt16.t6.n_nationkey
+              TableScan [10000.00 rows] -> t5.s_suppkey, t5.s_nationkey
                 table: "default"."supplier"
-              HashBuild [5.00 rows] -> edt23.edt23.t6.n_nationkey
-                Project [5.00 rows] -> edt23.edt23.t6.n_nationkey
-                    edt23.edt23.t6.n_nationkey := t6.n_nationkey
+              HashBuild [5.00 rows] -> edt16.edt16.t6.n_nationkey
+                Project [5.00 rows] -> edt16.edt16.t6.n_nationkey
+                    edt16.edt16.t6.n_nationkey := t6.n_nationkey
                   Join INNER Hash [5.00 rows] -> t6.n_nationkey
                       t6.n_regionkey = t7.r_regionkey
                     TableScan [25.00 rows] -> t6.n_nationkey, t6.n_regionkey
@@ -121,24 +122,88 @@ Project (redundant) [4.62 rows] -> dt1.n_name, dt1.revenue
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- OrderBy[21][revenue DESC NULLS LAST] -> n_name:VARCHAR, revenue:DOUBLE
+  -- Aggregation[20][SINGLE [n_name] revenue := sum("dt1.__p95")] -> n_name:VARCHAR, revenue:DOUBLE
+    -- Project[19][expressions: (n_name:VARCHAR, "n_name"), (dt1.__p95:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, "dt1.__p95":DOUBLE
+      -- HashJoin[18][INNER c_nationkey=s_nationkey AND l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+        -- HashJoin[10][INNER l_orderkey=o_orderkey] -> c_nationkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_nationkey:BIGINT, n_name:VARCHAR
+          -- TableScan[0]["default"."lineitem"] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+          -- HashJoin[9][INNER o_custkey=c_custkey] -> c_nationkey:BIGINT, o_orderkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+            -- Filter[2][expression: and(gte("o_orderdate",1994-01-01),lt("o_orderdate",1995-01-01))] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+              -- TableScan[1]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+            -- HashJoin[8][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+              -- TableScan[3]["default"."customer"] -> c_custkey:BIGINT, c_nationkey:BIGINT
+              -- HashJoin[7][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
+                -- TableScan[4]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+                -- Filter[6][expression: eq("r_name",ASIA)] -> r_regionkey:BIGINT, r_name:VARCHAR
+                  -- TableScan[5]["default"."region"] -> r_regionkey:BIGINT, r_name:VARCHAR
+        -- HashJoin[17][LEFT SEMI (FILTER) s_nationkey=edt16.edt16.t6.n_nationkey] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+          -- TableScan[11]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+          -- Project[16][expressions: (edt16.edt16.t6.n_nationkey:BIGINT, "n_nationkey")] -> "edt16.edt16.t6.n_nationkey":BIGINT
+            -- HashJoin[15][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
+              -- TableScan[12]["default"."nation"] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+              -- Filter[14][expression: eq("r_name",ASIA)] -> r_regionkey:BIGINT, r_name:VARCHAR
+                -- TableScan[13]["default"."region"] -> r_regionkey:BIGINT, r_name:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- OrderBy[18][revenue DESC NULLS LAST] -> n_name:VARCHAR, revenue:DOUBLE
+   Estimate: 4.61568 rows, 0B peak memory
+   Output: 5 rows (192B, 1 batches), Cpu time: 210.73us, Wall time: 370.90us, Blocked wall time: 0ns, Peak memory: 128.44KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (185.69us/11.59us/7.24us/6.22us)
   -- Aggregation[17][SINGLE [n_name] revenue := sum("dt1.__p107")] -> n_name:VARCHAR, revenue:DOUBLE
+     Estimate: 4.61568 rows, 0B peak memory
+     Output: 5 rows (287.81KB, 1 batches), Cpu time: 2.14ms, Wall time: 3.20ms, Blocked wall time: 0ns, Peak memory: 357.25KB, Memory allocations: 11, Threads: 1, CPU breakdown: B/I/O/F (675.78us/1.05ms/249.35us/162.16us)
     -- Project[16][expressions: (n_name:VARCHAR, "n_name"), (dt1.__p107:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, "dt1.__p107":DOUBLE
+       Estimate: 175469 rows, 0B peak memory
+       Output: 7243 rows (301.47KB, 605 batches), Cpu time: 6.03ms, Wall time: 7.08ms, Blocked wall time: 0ns, Peak memory: 1.38KB, Memory allocations: 1813, Threads: 1, CPU breakdown: B/I/O/F (820.81us/177.25us/4.87ms/159.49us)
       -- HashJoin[15][INNER c_nationkey=s_nationkey AND l_suppkey=s_suppkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, n_name:VARCHAR
+         Estimate: 175469 rows, 0B peak memory
+         Output: 7243 rows (229.30KB, 605 batches), Cpu time: 3.82ms, Wall time: 5.23ms, Blocked wall time: 5.61ms, Peak memory: 1.31MB, Memory allocations: 12, CPU breakdown: B/I/O/F (868.52us/1.14ms/1.24ms/569.22us)
         -- HashJoin[8][INNER l_orderkey=o_orderkey] -> c_nationkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, n_nationkey:BIGINT, n_name:VARCHAR
+           Estimate: 178399 rows, 0B peak memory
+           Output: 36718 rows (3.94MB, 613 batches), Cpu time: 14.28ms, Wall time: 16.00ms, Blocked wall time: 64.04ms, Peak memory: 4.64MB, Memory allocations: 21, CPU breakdown: B/I/O/F (1.21ms/9.28ms/2.29ms/1.50ms)
           -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-          -- HashJoin[7][INNER c_nationkey=n_nationkey] -> c_nationkey:BIGINT, o_orderkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
-            -- HashJoin[3][INNER o_custkey=c_custkey] -> c_nationkey:BIGINT, o_orderkey:BIGINT
-              -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
+             Estimate: 6.00122e+06 rows, 0B peak memory
+             Input: 36718 rows (58.88MB, 613 batches), Raw Input: 6001215 rows (64.42MB), Output: 36718 rows (58.88MB, 613 batches), Cpu time: 150.89ms, Wall time: 195.43ms, Blocked wall time: 0ns, Peak memory: 15.62MB, Memory allocations: 9699, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 8,15, CPU breakdown: B/I/O/F (178.73us/0ns/150.71ms/270ns)
+          -- HashJoin[7][INNER o_custkey=c_custkey] -> c_nationkey:BIGINT, o_orderkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+             Estimate: 46001.3 rows, 0B peak memory
+             Output: 46008 rows (1.74MB, 152 batches), Cpu time: 8.36ms, Wall time: 9.17ms, Blocked wall time: 14.18ms, Peak memory: 3.45MB, Memory allocations: 16, CPU breakdown: B/I/O/F (707.20us/4.68ms/2.24ms/740.61us)
+            -- TableScan[1][table: orders, range filters: [(o_orderdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT
+               Estimate: 227556 rows, 0B peak memory
+               Input: 46008 rows (2.45MB, 152 batches), Raw Input: 1500000 rows (8.86MB), Output: 46008 rows (2.45MB, 152 batches), Cpu time: 40.80ms, Wall time: 42.20ms, Blocked wall time: 0ns, Peak memory: 10.00MB, Memory allocations: 842, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 7, CPU breakdown: B/I/O/F (78.73us/0ns/40.72ms/470ns)
+            -- HashJoin[6][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT, c_nationkey:BIGINT, n_nationkey:BIGINT, n_name:VARCHAR
+               Estimate: 30000 rows, 0B peak memory
+               Output: 30183 rows (2.82MB, 33 batches), Cpu time: 644.02us, Wall time: 724.65us, Blocked wall time: 3.44ms, Peak memory: 234.00KB, Memory allocations: 15, CPU breakdown: B/I/O/F (63.24us/98.53us/438.63us/43.62us)
               -- TableScan[2][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
-            -- HashJoin[6][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
-              -- TableScan[4][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
-              -- TableScan[5][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
-        -- HashJoin[14][LEFT SEMI (FILTER) s_nationkey=edt23.edt23.t6.n_nationkey] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                 Estimate: 150000 rows, 0B peak memory
+                 Input: 30183 rows (1.67MB, 15 batches), Raw Input: 150000 rows (761.36KB), Output: 30183 rows (1.67MB, 15 batches), Cpu time: 4.69ms, Wall time: 4.96ms, Blocked wall time: 0ns, Peak memory: 4.37MB, Memory allocations: 80, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 6, CPU breakdown: B/I/O/F (10.13us/0ns/4.68ms/481ns)
+              -- HashJoin[5][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT, n_name:VARCHAR
+                 Estimate: 5 rows, 0B peak memory
+                 Output: 5 rows (0B, 1 batches), Cpu time: 103.70us, Wall time: 123.78us, Blocked wall time: 1.88ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (31.89us/18.73us/7.62us/45.47us)
+                -- TableScan[3][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR, n_regionkey:BIGINT
+                   Estimate: 25 rows, 0B peak memory
+                   Input: 5 rows (524B, 1 batches), Raw Input: 25 rows (3.34KB), Output: 5 rows (524B, 1 batches), Cpu time: 230.02us, Wall time: 1.41ms, Blocked wall time: 0ns, Peak memory: 4.88KB, Memory allocations: 24, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 5, CPU breakdown: B/I/O/F (1.71us/0ns/227.83us/470ns)
+                -- TableScan[4][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+                   Estimate: 1 rows, 0B peak memory
+                   Input: 1 rows (96B, 1 batches), Raw Input: 5 rows (1.81KB), Output: 1 rows (96B, 1 batches), Cpu time: 269.10us, Wall time: 1.79ms, Blocked wall time: 0ns, Peak memory: 2.56KB, Memory allocations: 16, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.51us/0ns/267.28us/310ns)
+        -- HashJoin[14][LEFT SEMI (FILTER) s_nationkey=edt16.edt16.t6.n_nationkey] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+           Estimate: 2000 rows, 0B peak memory
+           Output: 2003 rows (95.91KB, 1 batches), Cpu time: 113.26us, Wall time: 148.43us, Blocked wall time: 2.88ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (33.02us/17.91us/9.54us/52.79us)
           -- TableScan[9][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
-          -- Project[13][expressions: (edt23.edt23.t6.n_nationkey:BIGINT, "n_nationkey")] -> "edt23.edt23.t6.n_nationkey":BIGINT
+             Estimate: 10000 rows, 0B peak memory
+             Input: 2003 rows (111.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 2003 rows (111.81KB, 1 batches), Cpu time: 535.04us, Wall time: 2.09ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 14, CPU breakdown: B/I/O/F (951ns/0ns/533.83us/261ns)
+          -- Project[13][expressions: (edt16.edt16.t6.n_nationkey:BIGINT, "n_nationkey")] -> "edt16.edt16.t6.n_nationkey":BIGINT
+             Estimate: 5 rows, 0B peak memory
+             Output: 5 rows (0B, 1 batches), Cpu time: 19.36us, Wall time: 33.00us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (9.17us/551ns/6.28us/3.36us)
             -- HashJoin[12][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
+               Estimate: 5 rows, 0B peak memory
+               Output: 5 rows (0B, 1 batches), Cpu time: 144.14us, Wall time: 168.13us, Blocked wall time: 986.00us, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (33.89us/36.47us/10.89us/62.90us)
               -- TableScan[10][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+                 Estimate: 25 rows, 0B peak memory
+                 Input: 5 rows (384B, 1 batches), Raw Input: 25 rows (3.06KB), Output: 5 rows (384B, 1 batches), Cpu time: 339.26us, Wall time: 1.33ms, Blocked wall time: 0ns, Peak memory: 4.00KB, Memory allocations: 17, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 12, CPU breakdown: B/I/O/F (2.19us/0ns/336.58us/481ns)
               -- TableScan[11][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+                 Estimate: 1 rows, 0B peak memory
+                 Input: 1 rows (96B, 1 batches), Raw Input: 5 rows (1.81KB), Output: 1 rows (96B, 1 batches), Cpu time: 386.72us, Wall time: 1.33ms, Blocked wall time: 0ns, Peak memory: 2.56KB, Memory allocations: 16, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.51us/0ns/383.69us/520ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q6.plans
+++ b/axiom/optimizer/tests/tpch/plans/q6.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -9,28 +10,28 @@ dt1: 1.00 rows, revenue
   tables: t2
   aggregates: sum(multiply(t2.l_extendedprice, t2.l_discount)) AS revenue
 
-t2: 32600.05 rows, l_quantity, l_extendedprice, l_discount, l_shipdate
+t2: 325627.06 rows, l_quantity, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
     l_quantity DOUBLE (cardinality=23.47 min=1 max=24)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=361.10 min=8766 max=9130)
+    l_shipdate DATE (cardinality=365.00 min=8766 max=9130)
   single-column filters: gte(t2.l_shipdate, "1994-01-01") and lt(t2.l_shipdate, "1995-01-01") and between(t2.l_discount, 0.049999999999999996, 0.07) and lt(t2.l_quantity, 24)
 
 
 Optimized plan (oneline):
 
-agg("default"."lineitem")
+agg(lineitem)
 
 Optimized plan:
 
 Project (redundant) [1.00 rows] -> dt1.revenue
     dt1.revenue := dt1.revenue
   Aggregation [1.00 rows] -> dt1.revenue
-      dt1.revenue := sum(dt1.__p57)
-    Project [32600.05 rows] -> dt1.__p57
-        dt1.__p57 := multiply(t2.l_extendedprice, t2.l_discount)
-      TableScan [32600.05 rows] -> t2.l_extendedprice, t2.l_discount
+      dt1.revenue := sum(dt1.__p55)
+    Project [325627.06 rows] -> dt1.__p55
+        dt1.__p55 := multiply(t2.l_extendedprice, t2.l_discount)
+      TableScan [325627.06 rows] -> t2.l_extendedprice, t2.l_discount
         table: "default"."lineitem"
         single-column filters: gte(t2.l_shipdate, "1994-01-01") and lt(t2.l_shipdate, "1995-01-01") and between(t2.l_discount, 0.049999999999999996, 0.07) and lt(t2.l_quantity, 24)
 
@@ -38,8 +39,22 @@ Project (redundant) [1.00 rows] -> dt1.revenue
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- Aggregation[3][SINGLE revenue := sum("dt1.__p55")] -> revenue:DOUBLE
+  -- Project[2][expressions: (dt1.__p55:DOUBLE, multiply("l_extendedprice","l_discount"))] -> "dt1.__p55":DOUBLE
+    -- Filter[1][expression: and(gte("l_shipdate",1994-01-01),lt("l_shipdate",1995-01-01),between("l_discount",0.049999999999999996,0.07),lt("l_quantity",24))] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_quantity:DOUBLE, l_shipdate:DATE
+      -- TableScan[0]["default"."lineitem"] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_quantity:DOUBLE, l_shipdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- Aggregation[2][SINGLE revenue := sum("dt1.__p57")] -> revenue:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 1 rows (32B, 1 batches), Cpu time: 3.19ms, Wall time: 5.46ms, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (1.40ms/1.08ms/374.25us/331.54us)
   -- Project[1][expressions: (dt1.__p57:DOUBLE, multiply("l_extendedprice","l_discount"))] -> "dt1.__p57":DOUBLE
+     Estimate: 325627 rows, 0B peak memory
+     Output: 114160 rows (1.03MB, 613 batches), Cpu time: 4.75ms, Wall time: 6.97ms, Blocked wall time: 0ns, Peak memory: 2.00KB, Memory allocations: 613, Threads: 1, CPU breakdown: B/I/O/F (1.35ms/360.36us/2.71ms/332.54us)
     -- TableScan[0][table: lineitem, range filters: [(l_discount, DoubleRange: [0.050000, 0.070000] no nulls), (l_quantity, DoubleRange: (-inf, 24.000000) no nulls), (l_shipdate, BigintRange: [8766, 9130] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_quantity, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_discount, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]], HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_extendedprice:DOUBLE, l_discount:DOUBLE
+       Estimate: 325627 rows, 0B peak memory
+       Input: 114160 rows (31.04MB, 613 batches), Raw Input: 6001215 rows (55.11MB), Output: 114160 rows (31.04MB, 613 batches), Cpu time: 112.22ms, Wall time: 118.28ms, Blocked wall time: 0ns, Peak memory: 11.91MB, Memory allocations: 4211, Threads: 1, Splits: 2, CPU breakdown: B/I/O/F (355.30us/0ns/111.87ms/471ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q7.plans
+++ b/axiom/optimizer/tests/tpch/plans/q7.plans
@@ -1,110 +1,111 @@
+generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
 Query Graph:
 
-dt1: 3.75 rows, supp_nation, cust_nation, l_year, revenue
+dt1: 3.84 rows, supp_nation, cust_nation, l_year, revenue
   output:
-    supp_nation := t6.n_name VARCHAR (cardinality=1.95 min="ALGERIA" max="VIETNAM")
-    cust_nation := t7.n_name VARCHAR (cardinality=1.96 min="ALGERIA" max="VIETNAM")
-    l_year := dt1.l_year BIGINT (cardinality=3.75)
+    supp_nation := t6.n_name VARCHAR (cardinality=1.96)
+    cust_nation := t7.n_name VARCHAR (cardinality=1.96)
+    l_year := dt1.l_year BIGINT (cardinality=3.84)
     revenue := dt1.revenue DOUBLE (cardinality=1.00)
   tables: t2, t3, t4, t5, t6, t7
   joins:
-    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey [t2 → 47.26, t3 → 0.10]
-    t3 INNER t4 ON t3.l_orderkey = t4.o_orderkey [t3 → 1.00, t4 → 3.21]
-    t4 INNER t5 ON t4.o_custkey = t5.c_custkey [t4 → 0.10, t5 → 0.99]
-    t2 INNER t6 ON t2.s_nationkey = t6.n_nationkey [t2 → 0.08, t6 → 40.00]
-    t5 INNER t7 ON t5.c_nationkey = t7.n_nationkey [t5 → 0.08, t7 → 600.00]
-  syntactic join order: 10, 31, 48, 61, 70, 73
+    t2 INNER t3 ON t2.s_suppkey = t3.l_suppkey [t2 → 480.10, t3 → 1.00]
+    t3 INNER t4 ON t3.l_orderkey = t4.o_orderkey [t3 → 1.00, t4 → 3.20]
+    t4 INNER t5 ON t4.o_custkey = t5.c_custkey [t4 → 1.00, t5 → 10.00]
+    t2 INNER t6 ON t2.s_nationkey = t6.n_nationkey [t2 → 0.08, t6 → 400.00]
+    t5 INNER t7 ON t5.c_nationkey = t7.n_nationkey [t5 → 0.08, t7 → 6000.00]
+  syntactic join order: 8, 27, 42, 53, 60, 63
   aggregates: sum(multiply(t3.l_extendedprice, minus(1, t3.l_discount))) AS revenue
   grouping keys: t6.n_name, t7.n_name, year(t3.l_shipdate)
   filter: __or(__and(eq(t6.n_name, "FRANCE"), eq(t7.n_name, "GERMANY")), __and(eq(t6.n_name, "GERMANY"), eq(t7.n_name, "FRANCE")))
   orderBy: t6.n_name ASC NULLS LAST, t7.n_name ASC NULLS LAST, dt1.l_year ASC NULLS LAST
 
-t2: 1000.00 rows, s_suppkey, s_nationkey
+t2: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
-t3: 480457.59 rows, l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate
+t3: 4800972.00 rows, l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
-    l_shipdate DATE (cardinality=2498.00 min=8037 max=10561)
+    l_shipdate DATE (cardinality=2526.00 min=8036 max=10561)
   single-column filters: between(t3.l_shipdate, "1995-01-01", "1996-12-31")
 
-t4: 150000.00 rows, o_orderkey, o_custkey
+t4: 1500000.00 rows, o_orderkey, o_custkey
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
 
-t5: 15000.00 rows, c_custkey, c_nationkey
+t5: 150000.00 rows, c_custkey, c_nationkey
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
     c_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t6: 1.96 rows, n_nationkey, n_name
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
   single-column filters: __or(eq(t6.n_name, "FRANCE"), eq(t6.n_name, "GERMANY"))
 
 t7: 1.96 rows, n_nationkey, n_name
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
   single-column filters: __or(eq(t7.n_name, "GERMANY"), eq(t7.n_name, "FRANCE"))
 
 
 Optimized plan (oneline):
 
-agg((("default"."lineitem" INNER ("default"."supplier" INNER "default"."nation")) INNER ("default"."orders" INNER ("default"."customer" INNER "default"."nation"))))
+agg(((lineitem INNER (supplier INNER nation)) INNER (orders INNER (customer INNER nation))))
 
 Optimized plan:
 
-Project [8.75 rows] -> dt1.supp_nation, dt1.cust_nation, dt1.l_year, dt1.revenue
+Project [14.76 rows] -> dt1.supp_nation, dt1.cust_nation, dt1.l_year, dt1.revenue
     dt1.supp_nation := t6.n_name
     dt1.cust_nation := t7.n_name
     dt1.l_year := dt1.l_year
     dt1.revenue := dt1.revenue
-  OrderBy [8.75 rows] -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
-    Aggregation (t6.n_name, t7.n_name, dt1.__p99) [8.75 rows] -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
-        dt1.revenue := sum(dt1.__p105)
-      Project [13.03 rows] -> t6.n_name, t7.n_name, dt1.__p99, dt1.__p105
+  OrderBy [14.76 rows] -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
+    Aggregation (t6.n_name, t7.n_name, dt1.__p89) [14.76 rows] -> t6.n_name, t7.n_name, dt1.l_year, dt1.revenue
+        dt1.revenue := sum(dt1.__p95)
+      Project [13363.54 rows] -> t6.n_name, t7.n_name, dt1.__p89, dt1.__p95
           t6.n_name := t6.n_name
           t7.n_name := t7.n_name
-          dt1.__p99 := year(t3.l_shipdate)
-          dt1.__p105 := multiply(t3.l_extendedprice, minus(1, t3.l_discount))
-        Filter [13.03 rows] -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
+          dt1.__p89 := year(t3.l_shipdate)
+          dt1.__p95 := multiply(t3.l_extendedprice, minus(1, t3.l_discount))
+        Filter [13363.54 rows] -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
             __or(__and(eq(t6.n_name, "FRANCE"), eq(t7.n_name, "GERMANY")), __and(eq(t6.n_name, "GERMANY"), eq(t7.n_name, "FRANCE")))
-          Join INNER Hash [28.68 rows] -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
+          Join INNER Hash [29509.46 rows] -> t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name, t7.n_name
               t3.l_orderkey = t4.o_orderkey
-            Join INNER Hash [3704.92 rows] -> t3.l_orderkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name
+            Join INNER Hash [376396.22 rows] -> t3.l_orderkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate, t6.n_name
                 t3.l_suppkey = t2.s_suppkey
-              TableScan [480457.59 rows] -> t3.l_orderkey, t3.l_suppkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate
+              TableScan [4800972.00 rows] -> t3.l_orderkey, t3.l_suppkey, t3.l_extendedprice, t3.l_discount, t3.l_shipdate
                 table: "default"."lineitem"
                 single-column filters: between(t3.l_shipdate, "1995-01-01", "1996-12-31")
-              HashBuild [78.40 rows] -> t2.s_suppkey, t6.n_name
-                Join INNER Hash [78.40 rows] -> t2.s_suppkey, t6.n_name
+              HashBuild [784.00 rows] -> t2.s_suppkey, t6.n_name
+                Join INNER Hash [784.00 rows] -> t2.s_suppkey, t6.n_name
                     t2.s_nationkey = t6.n_nationkey
-                  TableScan [1000.00 rows] -> t2.s_suppkey, t2.s_nationkey
+                  TableScan [10000.00 rows] -> t2.s_suppkey, t2.s_nationkey
                     table: "default"."supplier"
                   HashBuild [1.96 rows] -> t6.n_nationkey, t6.n_name
                     TableScan [1.96 rows] -> t6.n_nationkey, t6.n_name
                       table: "default"."nation"
                       single-column filters: __or(eq(t6.n_name, "FRANCE"), eq(t6.n_name, "GERMANY"))
-            HashBuild [1161.04 rows] -> t4.o_orderkey, t7.n_name
-              Join INNER Hash [1161.04 rows] -> t4.o_orderkey, t7.n_name
+            HashBuild [117600.00 rows] -> t4.o_orderkey, t7.n_name
+              Join INNER Hash [117600.00 rows] -> t4.o_orderkey, t7.n_name
                   t4.o_custkey = t5.c_custkey
-                TableScan [150000.00 rows] -> t4.o_orderkey, t4.o_custkey
+                TableScan [1500000.00 rows] -> t4.o_orderkey, t4.o_custkey
                   table: "default"."orders"
-                HashBuild [1176.00 rows] -> t5.c_custkey, t7.n_name
-                  Join INNER Hash [1176.00 rows] -> t5.c_custkey, t7.n_name
+                HashBuild [11760.00 rows] -> t5.c_custkey, t7.n_name
+                  Join INNER Hash [11760.00 rows] -> t5.c_custkey, t7.n_name
                       t5.c_nationkey = t7.n_nationkey
-                    TableScan [15000.00 rows] -> t5.c_custkey, t5.c_nationkey
+                    TableScan [150000.00 rows] -> t5.c_custkey, t5.c_nationkey
                       table: "default"."customer"
                     HashBuild [1.96 rows] -> t7.n_nationkey, t7.n_name
                       TableScan [1.96 rows] -> t7.n_nationkey, t7.n_name
@@ -115,21 +116,76 @@ Project [8.75 rows] -> dt1.supp_nation, dt1.cust_nation, dt1.l_year, dt1.revenue
 Executable Velox plan:
 
 Fragment 0: fragment1 SINGLE:
+-- Project[18][expressions: (supp_nation:VARCHAR, "n_name"), (cust_nation:VARCHAR, "n_name_1"), (l_year:BIGINT, "l_year"), (revenue:DOUBLE, "revenue")] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+  -- OrderBy[17][n_name ASC NULLS LAST, n_name_1 ASC NULLS LAST, l_year ASC NULLS LAST] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+    -- Aggregation[16][SINGLE [n_name, n_name_1, l_year] revenue := sum("dt1.__p95")] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+      -- Project[15][expressions: (n_name:VARCHAR, "n_name"), (n_name_1:VARCHAR, "n_name_1"), (l_year:BIGINT, year("l_shipdate")), (dt1.__p95:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, n_name_1:VARCHAR, l_year:BIGINT, "dt1.__p95":DOUBLE
+        -- Filter[0][expression: or(and(eq("n_name",FRANCE),eq("n_name_1",GERMANY)),and(eq("n_name",GERMANY),eq("n_name_1",FRANCE)))] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_1:VARCHAR
+          -- HashJoin[14][INNER l_orderkey=o_orderkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_1:VARCHAR
+            -- HashJoin[7][INNER l_suppkey=s_suppkey] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR
+              -- Filter[2][expression: between("l_shipdate",1995-01-01,1996-12-31)] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+                -- TableScan[1]["default"."lineitem"] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+              -- HashJoin[6][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, n_name:VARCHAR
+                -- TableScan[3]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                -- Filter[5][expression: or(eq("n_name",FRANCE),eq("n_name",GERMANY))] -> n_nationkey:BIGINT, n_name:VARCHAR
+                  -- TableScan[4]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+            -- HashJoin[13][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, n_name_1:VARCHAR
+              -- TableScan[8]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT
+              -- HashJoin[12][INNER c_nationkey=n_nationkey_0] -> c_custkey:BIGINT, n_name_1:VARCHAR
+                -- TableScan[9]["default"."customer"] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                -- Filter[11][expression: or(eq("n_name_1",GERMANY),eq("n_name_1",FRANCE))] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+                  -- TableScan[10]["default"."nation"] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
 -- Project[15][expressions: (supp_nation:VARCHAR, "n_name"), (cust_nation:VARCHAR, "n_name_9"), (l_year:BIGINT, "l_year"), (revenue:DOUBLE, "revenue")] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+   Estimate: 14.7579 rows, 0B peak memory
+   Output: 4 rows (256B, 1 batches), Cpu time: 18.72us, Wall time: 30.72us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (9.61us/321ns/5.78us/3.01us)
   -- OrderBy[14][n_name ASC NULLS LAST, n_name_9 ASC NULLS LAST, l_year ASC NULLS LAST] -> n_name:VARCHAR, n_name_9:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+     Estimate: 14.7579 rows, 0B peak memory
+     Output: 4 rows (256B, 1 batches), Cpu time: 215.53us, Wall time: 374.52us, Blocked wall time: 0ns, Peak memory: 128.69KB, Memory allocations: 7, CPU breakdown: B/I/O/F (192.45us/11.19us/6.08us/5.81us)
     -- Aggregation[13][SINGLE [n_name, n_name_9, l_year] revenue := sum("dt1.__p105")] -> n_name:VARCHAR, n_name_9:VARCHAR, l_year:BIGINT, revenue:DOUBLE
+       Estimate: 14.7579 rows, 0B peak memory
+       Output: 4 rows (575.62KB, 1 batches), Cpu time: 3.11ms, Wall time: 4.25ms, Blocked wall time: 0ns, Peak memory: 644.75KB, Memory allocations: 11, CPU breakdown: B/I/O/F (712.01us/1.96ms/274.91us/164.89us)
       -- Project[12][expressions: (n_name:VARCHAR, "n_name"), (n_name_9:VARCHAR, "n_name_9"), (l_year:BIGINT, year("l_shipdate")), (dt1.__p105:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> n_name:VARCHAR, n_name_9:VARCHAR, l_year:BIGINT, "dt1.__p105":DOUBLE
+         Estimate: 12878.2 rows, 0B peak memory
+         Output: 5924 rows (428.32KB, 607 batches), Cpu time: 13.17ms, Wall time: 14.19ms, Blocked wall time: 0ns, Peak memory: 7.88KB, Memory allocations: 8019, CPU breakdown: B/I/O/F (853.17us/169.28us/11.98ms/166.81us)
         -- Filter[0][expression: or(and(eq("n_name",FRANCE),eq("n_name_9",GERMANY)),and(eq("n_name",GERMANY),eq("n_name_9",FRANCE)))] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_9:VARCHAR
+           Estimate: 12878.2 rows, 0B peak memory
+           Output: 5924 rows (418.35KB, 607 batches), Cpu time: 0ns, Wall time: 0ns, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)
           -- HashJoin[11][INNER l_orderkey=o_orderkey] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR, n_name_9:VARCHAR
+             Estimate: 28437.7 rows, 0B peak memory
+             Output: 0 rows (0B, 610 batches), Cpu time: 20.92ms, Wall time: 22.31ms, Blocked wall time: 0ns, Peak memory: 8.30MB, Memory allocations: 18, CPU breakdown: B/I/O/F (1.12ms/14.31ms/86.81us/5.40ms)
             -- HashJoin[5][INNER l_suppkey=s_suppkey] -> l_orderkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE, n_name:VARCHAR
+               Estimate: 370214 rows, 0B peak memory
+               Output: 145703 rows (5.16MB, 1228 batches), Cpu time: 6.47ms, Wall time: 8.53ms, Blocked wall time: 0ns, Peak memory: 254.12KB, Memory allocations: 1377, CPU breakdown: B/I/O/F (1.58ms/1.17ms/3.49ms/227.08us)
               -- TableScan[1][table: lineitem, range filters: [(l_shipdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: l_shipdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:DATE
+                 Estimate: 4.80097e+06 rows, 0B peak memory
+                 Input: 145703 rows (64.07MB, 1228 batches), Raw Input: 6001215 rows (73.13MB), Output: 145703 rows (64.07MB, 1228 batches), Cpu time: 155.84ms, Wall time: 186.74ms, Blocked wall time: 0ns, Peak memory: 17.82MB, Memory allocations: 23320, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 5, CPU breakdown: B/I/O/F (396.02us/0ns/155.44ms/261ns)
               -- HashJoin[4][INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, n_name:VARCHAR
+                 Estimate: 784 rows, 0B peak memory
+                 Output: 798 rows (15.91KB, 1 batches), Cpu time: 150.73us, Wall time: 435.72us, Blocked wall time: 1.78ms, Peak memory: 146.00KB, Memory allocations: 10, CPU breakdown: B/I/O/F (39.40us/27.58us/33.92us/49.82us)
                 -- TableScan[2][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                   Estimate: 10000 rows, 0B peak memory
+                   Input: 798 rows (103.81KB, 1 batches), Raw Input: 10000 rows (659.75KB), Output: 798 rows (103.81KB, 1 batches), Cpu time: 473.26us, Wall time: 1.74ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 20, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 4, CPU breakdown: B/I/O/F (1.73us/0ns/471.05us/481ns)
                 -- TableScan[3][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey:BIGINT, n_name:VARCHAR
+                   Estimate: 1.96 rows, 0B peak memory
+                   Input: 2 rows (152B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 2 rows (152B, 1 batches), Cpu time: 300.37us, Wall time: 1.44ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 18, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.30us/0ns/297.55us/521ns)
             -- HashJoin[10][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, n_name_9:VARCHAR
+               Estimate: 118866 rows, 0B peak memory
+               Output: 121324 rows (2.36MB, 152 batches), Cpu time: 6.54ms, Wall time: 7.34ms, Blocked wall time: 9.83ms, Peak memory: 3.47MB, Memory allocations: 14, CPU breakdown: B/I/O/F (457.31us/2.28ms/3.17ms/633.16us)
               -- TableScan[6][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_custkey:BIGINT
+                 Estimate: 1.5e+06 rows, 0B peak memory
+                 Input: 121324 rows (15.18MB, 152 batches), Raw Input: 1500000 rows (6.69MB), Output: 121324 rows (15.18MB, 152 batches), Cpu time: 42.22ms, Wall time: 43.21ms, Blocked wall time: 0ns, Peak memory: 8.00MB, Memory allocations: 663, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 10, CPU breakdown: B/I/O/F (87.75us/0ns/42.13ms/481ns)
               -- HashJoin[9][INNER c_nationkey=n_nationkey_8] -> c_custkey:BIGINT, n_name_9:VARCHAR
+                 Estimate: 11760 rows, 0B peak memory
+                 Output: 12008 rows (238.59KB, 15 batches), Cpu time: 384.70us, Wall time: 426.36us, Blocked wall time: 1.35ms, Peak memory: 146.00KB, Memory allocations: 10, CPU breakdown: B/I/O/F (47.83us/87.06us/189.90us/59.92us)
                 -- TableScan[7][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                   Estimate: 150000 rows, 0B peak memory
+                   Input: 12008 rows (1.52MB, 15 batches), Raw Input: 150000 rows (761.36KB), Output: 12008 rows (1.52MB, 15 batches), Cpu time: 5.27ms, Wall time: 5.99ms, Blocked wall time: 0ns, Peak memory: 4.34MB, Memory allocations: 79, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 9, CPU breakdown: B/I/O/F (5.67us/0ns/5.27ms/270ns)
                 -- TableScan[8][table: nation, range filters: [(n_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: n_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> n_nationkey_8:BIGINT, n_name_9:VARCHAR
+                   Estimate: 1.96 rows, 0B peak memory
+                   Input: 2 rows (152B, 1 batches), Raw Input: 25 rows (3.20KB), Output: 2 rows (152B, 1 batches), Cpu time: 328.53us, Wall time: 1.32ms, Blocked wall time: 0ns, Peak memory: 4.38KB, Memory allocations: 18, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.19us/0ns/325.79us/550ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q8.plans
+++ b/axiom/optimizer/tests/tpch/plans/q8.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -6,50 +7,50 @@ Query Graph:
 dt1: 1.00 rows, o_year, mkt_share
   output:
     o_year := dt1.o_year BIGINT (cardinality=1.00)
-    mkt_share := divide(dt1.sum, dt1.sum_18) DOUBLE (cardinality=1.00)
+    mkt_share := divide(dt1.sum, dt1.sum_4) DOUBLE (cardinality=1.00)
   tables: t2, t3, t4, t5, t6, t7, t8, t9
   joins:
-    t2 INNER t4 ON t2.p_partkey = t4.l_partkey [t2 → 3.01, t4 → 0.00]
-    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey [t3 → 59.07, t4 → 0.10]
-    t4 INNER t5 ON t4.l_orderkey = t5.o_orderkey [t4 → 0.80, t5 → 4.02]
-    t5 INNER t6 ON t5.o_custkey = t6.c_custkey [t5 → 0.10, t6 → 0.79]
-    t6 INNER t7 ON t6.c_nationkey = t7.n_nationkey [t6 → 1.00, t7 → 600.00]
+    t2 INNER t4 ON t2.p_partkey = t4.l_partkey [t2 → 30.01, t4 → 0.01]
+    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey [t3 → 600.12, t4 → 1.00]
+    t4 INNER t5 ON t4.l_orderkey = t5.o_orderkey [t4 → 0.80, t5 → 4.00]
+    t5 INNER t6 ON t5.o_custkey = t6.c_custkey [t5 → 1.00, t6 → 8.00]
+    t6 INNER t7 ON t6.c_nationkey = t7.n_nationkey [t6 → 1.00, t7 → 6000.00]
     t7 INNER t9 ON t7.n_regionkey = t9.r_regionkey [t7 → 0.20, t9 → 5.00]
-    t3 INNER t8 ON t3.s_nationkey = t8.n_nationkey [t3 → 1.00, t8 → 40.00]
-  syntactic join order: 12, 24, 45, 62, 76, 85, 88, 96
-  aggregates: sum(__switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)) AS sum, sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS sum_18
+    t3 INNER t8 ON t3.s_nationkey = t8.n_nationkey [t3 → 1.00, t8 → 400.00]
+  syntactic join order: 10, 20, 39, 54, 66, 73, 76, 82
+  aggregates: sum(__switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)) AS sum, sum(multiply(t4.l_extendedprice, minus(1, t4.l_discount))) AS sum_4
   grouping keys: year(t5.o_orderdate)
   orderBy: dt1.o_year ASC NULLS LAST
 
-t2: 133.33 rows, p_partkey, p_type
+t2: 1333.33 rows, p_partkey, p_type
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
     p_type VARCHAR (cardinality=1.00 min="ECONOMY ANODIZED STEEL" max="ECONOMY ANODIZED STEEL")
   single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
 
-t3: 1000.00 rows, s_suppkey, s_nationkey
+t3: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
-t4: 600572.00 rows, l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount
+t4: 6001215.00 rows, l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
 
-t5: 120000.00 rows, o_orderkey, o_custkey, o_orderdate
+t5: 1200000.00 rows, o_orderkey, o_custkey, o_orderdate
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_custkey BIGINT (cardinality=73171.00 min=1 max=149999)
-    o_orderdate DATE (cardinality=2382.00 min=8035 max=10440)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_custkey BIGINT (cardinality=100000.00 min=1 max=150000)
+    o_orderdate DATE (cardinality=2406.00 min=8035 max=10440)
   single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
 
-t6: 15000.00 rows, c_custkey, c_nationkey
+t6: 150000.00 rows, c_custkey, c_nationkey
   table: "default"."customer"
-    c_custkey BIGINT (cardinality=14936.00 min=1 max=15000)
+    c_custkey BIGINT (cardinality=150000.00 min=1 max=150000)
     c_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
 t7: 25.00 rows, n_nationkey, n_regionkey
@@ -60,7 +61,7 @@ t7: 25.00 rows, n_nationkey, n_regionkey
 t8: 25.00 rows, n_nationkey, n_name
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
 
 t9: 1.00 rows, r_regionkey, r_name
   table: "default"."region"
@@ -71,58 +72,58 @@ t9: 1.00 rows, r_regionkey, r_name
 
 Optimized plan (oneline):
 
-agg((((("default"."lineitem" INNER "default"."part") INNER ("default"."orders" INNER ("default"."customer" INNER ("default"."nation" INNER "default"."region")))) INNER "default"."supplier") INNER "default"."nation"))
+agg(((supplier INNER ((lineitem INNER part) INNER (orders INNER (customer INNER (nation INNER region))))) INNER nation))
 
 Optimized plan:
 
 Project [1.00 rows] -> dt1.o_year, dt1.mkt_share
     dt1.o_year := dt1.o_year
-    dt1.mkt_share := divide(dt1.sum, dt1.sum_18)
-  OrderBy [1.00 rows] -> dt1.o_year, dt1.sum, dt1.sum_18
-    Aggregation (dt1.__p119) [1.00 rows] -> dt1.o_year, dt1.sum, dt1.sum_18
-        dt1.sum := sum(dt1.__p130)
-        dt1.sum_18 := sum(dt1.__p125)
-      Project [1.00 rows] -> dt1.__p119, dt1.__p130, dt1.__p125
-          dt1.__p119 := year(t5.o_orderdate)
-          dt1.__p130 := __switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)
-          dt1.__p125 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
-        Join INNER Hash [1.00 rows] -> t4.l_extendedprice, t4.l_discount, t5.o_orderdate, t8.n_name
+    dt1.mkt_share := divide(dt1.sum, dt1.sum_4)
+  OrderBy [1.00 rows] -> dt1.o_year, dt1.sum, dt1.sum_4
+    Aggregation (dt1.__p105) [1.00 rows] -> dt1.o_year, dt1.sum, dt1.sum_4
+        dt1.sum := sum(dt1.__p116)
+        dt1.sum_4 := sum(dt1.__p111)
+      Project [6401.30 rows] -> dt1.__p105, dt1.__p116, dt1.__p111
+          dt1.__p105 := year(t5.o_orderdate)
+          dt1.__p116 := __switch(eq(t8.n_name, "BRAZIL"), multiply(t4.l_extendedprice, minus(1, t4.l_discount)), 0)
+          dt1.__p111 := multiply(t4.l_extendedprice, minus(1, t4.l_discount))
+        Join INNER Hash [6401.30 rows] -> t4.l_extendedprice, t4.l_discount, t5.o_orderdate, t8.n_name
             t3.s_nationkey = t8.n_nationkey
-          Join INNER Hash [1.00 rows] -> t3.s_nationkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
-              t4.l_suppkey = t3.s_suppkey
-            Join INNER Hash [6.42 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
-                t4.l_orderkey = t5.o_orderkey
-              Join INNER Hash [406.58 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
-                  t4.l_partkey = t2.p_partkey
-                TableScan [600572.00 rows] -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
-                  table: "default"."lineitem"
-                HashBuild [133.33 rows] -> t2.p_partkey
-                  TableScan [133.33 rows] -> t2.p_partkey
-                    table: "default"."part"
-                    single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
-              HashBuild [2369.48 rows] -> t5.o_orderkey, t5.o_orderdate
-                Join INNER Hash [2369.48 rows] -> t5.o_orderkey, t5.o_orderdate
-                    t5.o_custkey = t6.c_custkey
-                  TableScan [120000.00 rows] -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate
-                    table: "default"."orders"
-                    single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
-                  HashBuild [3000.00 rows] -> t6.c_custkey
-                    Join INNER Hash [3000.00 rows] -> t6.c_custkey
-                        t6.c_nationkey = t7.n_nationkey
-                      TableScan [15000.00 rows] -> t6.c_custkey, t6.c_nationkey
-                        table: "default"."customer"
-                      HashBuild [5.00 rows] -> t7.n_nationkey
-                        Join INNER Hash [5.00 rows] -> t7.n_nationkey
-                            t7.n_regionkey = t9.r_regionkey
-                          TableScan [25.00 rows] -> t7.n_nationkey, t7.n_regionkey
-                            table: "default"."nation"
-                          HashBuild [1.00 rows] -> t9.r_regionkey
-                            TableScan [1.00 rows] -> t9.r_regionkey
-                              table: "default"."region"
-                              single-column filters: eq(t9.r_name, "AMERICA")
-            HashBuild [1000.00 rows] -> t3.s_suppkey, t3.s_nationkey
-              TableScan [1000.00 rows] -> t3.s_suppkey, t3.s_nationkey
-                table: "default"."supplier"
+          Join INNER Hash [6401.30 rows] -> t3.s_nationkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
+              t3.s_suppkey = t4.l_suppkey
+            TableScan [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+              table: "default"."supplier"
+            HashBuild [6401.30 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
+              Join INNER Hash [6401.30 rows] -> t4.l_suppkey, t4.l_extendedprice, t4.l_discount, t5.o_orderdate
+                  t4.l_orderkey = t5.o_orderkey
+                Join INNER Hash [40008.10 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                    t4.l_partkey = t2.p_partkey
+                  TableScan [6001215.00 rows] -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_extendedprice, t4.l_discount
+                    table: "default"."lineitem"
+                  HashBuild [1333.33 rows] -> t2.p_partkey
+                    TableScan [1333.33 rows] -> t2.p_partkey
+                      table: "default"."part"
+                      single-column filters: eq(t2.p_type, "ECONOMY ANODIZED STEEL")
+                HashBuild [240000.00 rows] -> t5.o_orderkey, t5.o_orderdate
+                  Join INNER Hash [240000.00 rows] -> t5.o_orderkey, t5.o_orderdate
+                      t5.o_custkey = t6.c_custkey
+                    TableScan [1200000.00 rows] -> t5.o_orderkey, t5.o_custkey, t5.o_orderdate
+                      table: "default"."orders"
+                      single-column filters: between(t5.o_orderdate, "1995-01-01", "1996-12-31")
+                    HashBuild [30000.00 rows] -> t6.c_custkey
+                      Join INNER Hash [30000.00 rows] -> t6.c_custkey
+                          t6.c_nationkey = t7.n_nationkey
+                        TableScan [150000.00 rows] -> t6.c_custkey, t6.c_nationkey
+                          table: "default"."customer"
+                        HashBuild [5.00 rows] -> t7.n_nationkey
+                          Join INNER Hash [5.00 rows] -> t7.n_nationkey
+                              t7.n_regionkey = t9.r_regionkey
+                            TableScan [25.00 rows] -> t7.n_nationkey, t7.n_regionkey
+                              table: "default"."nation"
+                            HashBuild [1.00 rows] -> t9.r_regionkey
+                              TableScan [1.00 rows] -> t9.r_regionkey
+                                table: "default"."region"
+                                single-column filters: eq(t9.r_name, "AMERICA")
           HashBuild [25.00 rows] -> t8.n_nationkey, t8.n_name
             TableScan [25.00 rows] -> t8.n_nationkey, t8.n_name
               table: "default"."nation"
@@ -130,25 +131,89 @@ Project [1.00 rows] -> dt1.o_year, dt1.mkt_share
 
 Executable Velox plan:
 
-Fragment 0: fragment3 SINGLE:
--- Project[24][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_18"))] -> o_year:BIGINT, mkt_share:DOUBLE
-  -- OrderBy[23][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_18:DOUBLE
-    -- Aggregation[22][SINGLE [o_year] sum := sum("dt1.__p130"), sum_18 := sum("dt1.__p125")] -> o_year:BIGINT, sum:DOUBLE, sum_18:DOUBLE
-      -- Project[21][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p130:DOUBLE, switch(eq("n_name_11",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p125:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p130":DOUBLE, "dt1.__p125":DOUBLE
-        -- HashJoin[20][INNER s_nationkey=n_nationkey_10] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_11:VARCHAR
-          -- HashJoin[18][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
-            -- HashJoin[16][INNER l_orderkey=o_orderkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
-              -- HashJoin[8][INNER l_partkey=p_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-                -- TableScan[6][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
-                -- TableScan[7][table: part, range filters: [(p_type, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
-              -- HashJoin[15][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:DATE
-                -- TableScan[9][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
-                -- HashJoin[14][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT
-                  -- TableScan[10][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
-                  -- HashJoin[13][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
-                    -- TableScan[11][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
-                    -- TableScan[12][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
-            -- TableScan[17][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
-          -- TableScan[19][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_10:BIGINT, n_name_11:VARCHAR
+Fragment 0: fragment1 SINGLE:
+-- Project[21][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_4"))] -> o_year:BIGINT, mkt_share:DOUBLE
+  -- OrderBy[20][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+    -- Aggregation[19][SINGLE [o_year] sum := sum("dt1.__p116"), sum_4 := sum("dt1.__p111")] -> o_year:BIGINT, sum:DOUBLE, sum_4:DOUBLE
+      -- Project[18][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p116:DOUBLE, switch(eq("n_name_1",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p111:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p116":DOUBLE, "dt1.__p111":DOUBLE
+        -- HashJoin[17][INNER s_nationkey=n_nationkey_0] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_1:VARCHAR
+          -- HashJoin[15][INNER s_suppkey=l_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+            -- TableScan[0]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+            -- HashJoin[14][INNER l_orderkey=o_orderkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+              -- HashJoin[4][INNER l_partkey=p_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- TableScan[1]["default"."lineitem"] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- Filter[3][expression: eq("p_type",ECONOMY ANODIZED STEEL)] -> p_partkey:BIGINT, p_type:VARCHAR
+                  -- TableScan[2]["default"."part"] -> p_partkey:BIGINT, p_type:VARCHAR
+              -- HashJoin[13][INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:DATE
+                -- Filter[6][expression: between("o_orderdate",1995-01-01,1996-12-31)] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                  -- TableScan[5]["default"."orders"] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                -- HashJoin[12][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT
+                  -- TableScan[7]["default"."customer"] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                  -- HashJoin[11][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
+                    -- TableScan[8]["default"."nation"] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+                    -- Filter[10][expression: eq("r_name",AMERICA)] -> r_regionkey:BIGINT, r_name:VARCHAR
+                      -- TableScan[9]["default"."region"] -> r_regionkey:BIGINT, r_name:VARCHAR
+          -- TableScan[16]["default"."nation"] -> n_nationkey_0:BIGINT, n_name_1:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[18][expressions: (o_year:BIGINT, "o_year"), (mkt_share:DOUBLE, divide("sum","sum_18"))] -> o_year:BIGINT, mkt_share:DOUBLE
+   Estimate: 1 rows, 0B peak memory
+   Output: 2 rows (64B, 1 batches), Cpu time: 48.27us, Wall time: 81.61us, Blocked wall time: 0ns, Peak memory: 128B, Memory allocations: 1, Threads: 1, CPU breakdown: B/I/O/F (24.48us/731ns/15.50us/7.56us)
+  -- OrderBy[17][o_year ASC NULLS LAST] -> o_year:BIGINT, sum:DOUBLE, sum_18:DOUBLE
+     Estimate: 1 rows, 0B peak memory
+     Output: 2 rows (96B, 1 batches), Cpu time: 135.06us, Wall time: 242.10us, Blocked wall time: 0ns, Peak memory: 128.44KB, Memory allocations: 6, Threads: 1, CPU breakdown: B/I/O/F (106.89us/9.07us/9.69us/9.40us)
+    -- Aggregation[16][SINGLE [o_year] sum := sum("dt1.__p130"), sum_18 := sum("dt1.__p125")] -> o_year:BIGINT, sum:DOUBLE, sum_18:DOUBLE
+       Estimate: 1 rows, 0B peak memory
+       Output: 2 rows (287.72KB, 1 batches), Cpu time: 877.45us, Wall time: 1.40ms, Blocked wall time: 0ns, Peak memory: 357.25KB, Memory allocations: 11, Threads: 1, CPU breakdown: B/I/O/F (321.53us/337.11us/139.09us/79.73us)
+      -- Project[15][expressions: (o_year:BIGINT, year("o_orderdate")), (dt1.__p130:DOUBLE, switch(eq("n_name_11",BRAZIL),multiply("l_extendedprice",minus(1,"l_discount")),0)), (dt1.__p125:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> o_year:BIGINT, "dt1.__p130":DOUBLE, "dt1.__p125":DOUBLE
+         Estimate: 6182.66 rows, 0B peak memory
+         Output: 2603 rows (71.55KB, 152 batches), Cpu time: 2.04ms, Wall time: 2.70ms, Blocked wall time: 0ns, Peak memory: 1.88KB, Memory allocations: 730, Threads: 1, CPU breakdown: B/I/O/F (391.69us/77.46us/1.50ms/77.19us)
+        -- HashJoin[14][INNER s_nationkey=n_nationkey_10] -> l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE, n_name_11:VARCHAR
+           Estimate: 6182.66 rows, 0B peak memory
+           Output: 2603 rows (14.40MB, 152 batches), Cpu time: 1.14ms, Wall time: 1.80ms, Blocked wall time: 1.85ms, Peak memory: 216.50KB, Memory allocations: 17, CPU breakdown: B/I/O/F (392.20us/162.97us/456.58us/127.61us)
+          -- HashJoin[12][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+             Estimate: 6182.66 rows, 0B peak memory
+             Output: 2603 rows (7.23MB, 152 batches), Cpu time: 1.93ms, Wall time: 2.60ms, Blocked wall time: 3.10ms, Peak memory: 2.36MB, Memory allocations: 19, CPU breakdown: B/I/O/F (378.30us/943.93us/415.73us/194.06us)
+            -- HashJoin[10][INNER o_custkey=c_custkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_orderdate:DATE
+               Estimate: 6285.91 rows, 0B peak memory
+               Output: 2603 rows (7.23MB, 152 batches), Cpu time: 3.95ms, Wall time: 4.65ms, Blocked wall time: 6.59ms, Peak memory: 3.41MB, Memory allocations: 7, CPU breakdown: B/I/O/F (691.10us/2.32ms/254.59us/678.01us)
+              -- HashJoin[4][INNER o_orderkey=l_orderkey] -> l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE, o_custkey:BIGINT, o_orderdate:DATE
+                 Estimate: 31094.7 rows, 0B peak memory
+                 Output: 2603 rows (11.34MB, 152 batches), Cpu time: 14.75ms, Wall time: 15.99ms, Blocked wall time: 282.21ms, Peak memory: 2.62MB, Memory allocations: 253, CPU breakdown: B/I/O/F (1.76ms/10.51ms/955.69us/1.53ms)
+                -- TableScan[0][table: orders, range filters: [(o_orderdate, BigintRange: [9131, 9861] no nulls)], data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: o_orderdate, columnType: Regular, dataType: DATE, requiredSubfields: [ ]]]] -> o_orderkey:BIGINT, o_custkey:BIGINT, o_orderdate:DATE
+                   Estimate: 1.2e+06 rows, 0B peak memory
+                   Input: 2567 rows (11.92MB, 152 batches), Raw Input: 1500000 rows (8.86MB), Output: 2567 rows (11.92MB, 152 batches), Cpu time: 42.30ms, Wall time: 43.80ms, Blocked wall time: 0ns, Peak memory: 10.35MB, Memory allocations: 1150, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 4,10, CPU breakdown: B/I/O/F (80.57us/0ns/42.22ms/481ns)
+                -- HashJoin[3][INNER l_partkey=p_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                   Estimate: 40767.6 rows, 0B peak memory
+                   Output: 43693 rows (0B, 614 batches), Cpu time: 4.04ms, Wall time: 6.64ms, Blocked wall time: 12.46ms, Peak memory: 1.61MB, Memory allocations: 3, CPU breakdown: B/I/O/F (1.42ms/513.24us/1.13ms/973.45us)
+                  -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                     Estimate: 6.00122e+06 rows, 0B peak memory
+                     Input: 43693 rows (57.85MB, 614 batches), Raw Input: 6001215 rows (86.77MB), Output: 43693 rows (57.85MB, 614 batches), Cpu time: 228.01ms, Wall time: 261.50ms, Blocked wall time: 0ns, Peak memory: 20.86MB, Memory allocations: 6800, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (351.36us/0ns/227.66ms/481ns)
+                  -- TableScan[2][table: part, range filters: [(p_type, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_type, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+                     Estimate: 1333.33 rows, 0B peak memory
+                     Input: 1451 rows (13.87KB, 20 batches), Raw Input: 200000 rows (5.40MB), Output: 1451 rows (13.87KB, 20 batches), Cpu time: 4.51ms, Wall time: 11.56ms, Blocked wall time: 0ns, Peak memory: 4.76MB, Memory allocations: 81, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (11.41us/0ns/4.50ms/521ns)
+              -- HashJoin[9][INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT
+                 Estimate: 30000 rows, 0B peak memory
+                 Output: 29952 rows (0B, 15 batches), Cpu time: 119.29us, Wall time: 172.94us, Blocked wall time: 3.61ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (38.48us/14.95us/25.34us/40.52us)
+                -- TableScan[5][table: customer, data columns: ROW<c_custkey:BIGINT,c_name:VARCHAR,c_address:VARCHAR,c_nationkey:BIGINT,c_phone:VARCHAR,c_acctbal:DOUBLE,c_mktsegment:VARCHAR,c_comment:VARCHAR>] -> c_custkey:BIGINT, c_nationkey:BIGINT
+                   Estimate: 150000 rows, 0B peak memory
+                   Input: 29952 rows (1.66MB, 15 batches), Raw Input: 150000 rows (761.36KB), Output: 29952 rows (1.66MB, 15 batches), Cpu time: 4.88ms, Wall time: 5.18ms, Blocked wall time: 0ns, Peak memory: 4.37MB, Memory allocations: 80, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 9, CPU breakdown: B/I/O/F (5.08us/0ns/4.87ms/261ns)
+                -- HashJoin[8][INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
+                   Estimate: 5 rows, 0B peak memory
+                   Output: 5 rows (0B, 1 batches), Cpu time: 98.83us, Wall time: 123.56us, Blocked wall time: 1.65ms, Peak memory: 84.00KB, Memory allocations: 3, CPU breakdown: B/I/O/F (23.05us/17.45us/7.74us/50.60us)
+                  -- TableScan[6][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_regionkey:BIGINT
+                     Estimate: 25 rows, 0B peak memory
+                     Input: 5 rows (384B, 1 batches), Raw Input: 25 rows (3.06KB), Output: 5 rows (384B, 1 batches), Cpu time: 211.89us, Wall time: 1.49ms, Blocked wall time: 0ns, Peak memory: 4.00KB, Memory allocations: 17, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 8, CPU breakdown: B/I/O/F (1.75us/0ns/209.64us/491ns)
+                  -- TableScan[7][table: region, range filters: [(r_name, Filter(BytesValues, deterministic, no nulls))], data columns: ROW<r_regionkey:BIGINT,r_name:VARCHAR,r_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: r_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> r_regionkey:BIGINT
+                     Estimate: 1 rows, 0B peak memory
+                     Input: 1 rows (96B, 1 batches), Raw Input: 5 rows (1.81KB), Output: 1 rows (96B, 1 batches), Cpu time: 333.52us, Wall time: 1.61ms, Blocked wall time: 0ns, Peak memory: 2.56KB, Memory allocations: 16, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.35us/0ns/331.83us/341ns)
+            -- TableScan[11][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+               Estimate: 10000 rows, 0B peak memory
+               Input: 10000 rows (191.81KB, 1 batches), Output: 10000 rows (191.81KB, 1 batches), Cpu time: 664.76us, Wall time: 3.90ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (2.20us/0ns/662.03us/521ns)
+          -- TableScan[13][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey_10:BIGINT, n_name_11:VARCHAR
+             Estimate: 25 rows, 0B peak memory
+             Input: 25 rows (992B, 1 batches), Output: 25 rows (992B, 1 batches), Cpu time: 309.26us, Wall time: 1.96ms, Blocked wall time: 0ns, Peak memory: 4.06KB, Memory allocations: 15, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.42us/0ns/307.53us/311ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q9.plans
+++ b/axiom/optimizer/tests/tpch/plans/q9.plans
@@ -1,3 +1,4 @@
+generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
 numWorkers: 1
 numDrivers: 1
 
@@ -5,125 +6,175 @@ Query Graph:
 
 dt1: 25.00 rows, nation, o_year, sum_profit
   output:
-    nation := t7.n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    nation := t7.n_name VARCHAR (cardinality=25.00)
     o_year := dt1.o_year BIGINT (cardinality=25.00)
     sum_profit := dt1.sum_profit DOUBLE (cardinality=1.00)
   tables: t2, t3, t4, t5, t6, t7
   joins:
-    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey [t3 → 59.07, t4 → 0.10]
-    t4 INNER t5 ON t4.l_suppkey = t5.ps_suppkey AND t4.l_partkey = t5.ps_partkey [t4 → 0.10, t5 → 0.74]
-    t2 INNER t4 ON t2.p_partkey = t4.l_partkey [t2 → 3.01, t4 → 0.08]
-    t4 INNER t6 ON t4.l_orderkey = t6.o_orderkey [t4 → 1.00, t6 → 4.02]
-    t3 INNER t7 ON t3.s_nationkey = t7.n_nationkey [t3 → 1.00, t7 → 40.00]
-    t3 INNER t5 ON t3.s_suppkey = t5.ps_suppkey [t3 → 7.87, t5 → 0.10]
+    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey [t3 → 600.12, t4 → 1.00]
+    t4 INNER t5 ON t4.l_suppkey = t5.ps_suppkey AND t4.l_partkey = t5.ps_partkey [t4 → 1.00, t5 → 1.00]
+    t2 INNER t4 ON t2.p_partkey = t4.l_partkey [t2 → 30.01, t4 → 0.80]
+    t4 INNER t6 ON t4.l_orderkey = t6.o_orderkey [t4 → 1.00, t6 → 4.00]
+    t3 INNER t7 ON t3.s_nationkey = t7.n_nationkey [t3 → 1.00, t7 → 400.00]
+    t3 INNER t5 ON t3.s_suppkey = t5.ps_suppkey [t3 → 80.00, t5 → 1.00]
     t5 INNER t2 ON t5.ps_partkey = t2.p_partkey [t5 → 0.80, t2 → 4.00]
-  syntactic join order: 12, 24, 45, 59, 74, 83
+  syntactic join order: 10, 20, 39, 51, 64, 71
   aggregates: sum(minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))) AS sum_profit
   grouping keys: t7.n_name, year(t6.o_orderdate)
   orderBy: t7.n_name ASC NULLS LAST, dt1.o_year DESC NULLS LAST
 
-t2: 16000.00 rows, p_partkey, p_name
+t2: 160000.00 rows, p_partkey, p_name
   table: "default"."part"
-    p_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    p_name VARCHAR (cardinality=19378.00 min="almond antique metallic honeydew green" max="yellow white red chiffon tan")
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_name VARCHAR (cardinality=200000.00)
   single-column filters: like(t2.p_name, "%green%")
 
-t3: 1000.00 rows, s_suppkey, s_nationkey
+t3: 10000.00 rows, s_suppkey, s_nationkey
   table: "default"."supplier"
-    s_suppkey BIGINT (cardinality=1008.00 min=1 max=1000)
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
 
-t4: 600572.00 rows, l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount
+t4: 6001215.00 rows, l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount
   table: "default"."lineitem"
-    l_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    l_partkey BIGINT (cardinality=188473.00 min=1 max=200000)
-    l_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
     l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
-    l_extendedprice DOUBLE (cardinality=444713.00 min=901 max=104899.5)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
     l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
 
-t5: 80000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
+t5: 800000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
   table: "default"."partsupp"
-    ps_partkey BIGINT (cardinality=19675.00 min=1 max=20000)
-    ps_suppkey BIGINT (cardinality=10167.00 min=1 max=10000)
-    ps_supplycost DOUBLE (cardinality=54016.00 min=1.01 max=999.99)
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
 
-t6: 150000.00 rows, o_orderkey, o_orderdate
+t6: 1500000.00 rows, o_orderkey, o_orderdate
   table: "default"."orders"
-    o_orderkey BIGINT (cardinality=153027.00 min=1 max=600000)
-    o_orderdate DATE (cardinality=2382.00 min=8035 max=10440)
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_orderdate DATE (cardinality=2406.00 min=8035 max=10440)
 
 t7: 25.00 rows, n_nationkey, n_name
   table: "default"."nation"
     n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
-    n_name VARCHAR (cardinality=25.00 min="ALGERIA" max="VIETNAM")
+    n_name VARCHAR (cardinality=25.00)
 
 
 Optimized plan (oneline):
 
-agg(("default"."orders" INNER ("default"."lineitem" INNER ((("default"."partsupp" INNER "default"."supplier") INNER "default"."part") INNER "default"."nation"))))
+agg(((((lineitem INNER (partsupp INNER part)) INNER supplier) INNER nation) INNER orders))
 
 Optimized plan:
 
-Project [624.67 rows] -> dt1.nation, dt1.o_year, dt1.sum_profit
+Project [625.00 rows] -> dt1.nation, dt1.o_year, dt1.sum_profit
     dt1.nation := t7.n_name
     dt1.o_year := dt1.o_year
     dt1.sum_profit := dt1.sum_profit
-  OrderBy [624.67 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
-    Aggregation (t7.n_name, dt1.__p94) [624.67 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
-        dt1.sum_profit := sum(dt1.__p102)
-      Project [4717.84 rows] -> t7.n_name, dt1.__p94, dt1.__p102
+  OrderBy [625.00 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
+    Aggregation (t7.n_name, dt1.__p82) [625.00 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
+        dt1.sum_profit := sum(dt1.__p90)
+      Project [4800972.00 rows] -> t7.n_name, dt1.__p82, dt1.__p90
           t7.n_name := t7.n_name
-          dt1.__p94 := year(t6.o_orderdate)
-          dt1.__p102 := minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))
-        Join INNER Hash [4717.84 rows] -> t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate, t7.n_name
-            t6.o_orderkey = t4.l_orderkey
-          TableScan [150000.00 rows] -> t6.o_orderkey, t6.o_orderdate
-            table: "default"."orders"
-          HashBuild [4702.31 rows] -> t4.l_orderkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t7.n_name
-            Join INNER Hash [4702.31 rows] -> t4.l_orderkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t7.n_name
-                t4.l_suppkey = t5.ps_suppkey
-                t4.l_partkey = t5.ps_partkey
-              TableScan [600572.00 rows] -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount
-                table: "default"."lineitem"
-              HashBuild [6294.88 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost, t7.n_name
-                Join INNER Hash [6294.88 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost, t7.n_name
-                    t3.s_nationkey = t7.n_nationkey
-                  Join INNER Hash [6294.88 rows] -> t3.s_nationkey, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+          dt1.__p82 := year(t6.o_orderdate)
+          dt1.__p90 := minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))
+        Join INNER Hash [4800972.00 rows] -> t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate, t7.n_name
+            t4.l_orderkey = t6.o_orderkey
+          Join INNER Hash [4800972.00 rows] -> t4.l_orderkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t7.n_name
+              t3.s_nationkey = t7.n_nationkey
+            Join INNER Hash [4800972.00 rows] -> t3.s_nationkey, t4.l_orderkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost
+                t4.l_suppkey = t3.s_suppkey
+              Join INNER Hash [4800972.00 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_suppkey, t5.ps_supplycost
+                  t4.l_suppkey = t5.ps_suppkey
+                  t4.l_partkey = t5.ps_partkey
+                TableScan [6001215.00 rows] -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount
+                  table: "default"."lineitem"
+                HashBuild [640000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                  Join INNER Hash [640000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
                       t5.ps_partkey = t2.p_partkey
-                    Join INNER Hash [7868.59 rows] -> t3.s_nationkey, t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
-                        t5.ps_suppkey = t3.s_suppkey
-                      TableScan [80000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
-                        table: "default"."partsupp"
-                      HashBuild [1000.00 rows] -> t3.s_suppkey, t3.s_nationkey
-                        TableScan [1000.00 rows] -> t3.s_suppkey, t3.s_nationkey
-                          table: "default"."supplier"
-                    HashBuild [16000.00 rows] -> t2.p_partkey
-                      TableScan [16000.00 rows] -> t2.p_partkey
+                    TableScan [800000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                      table: "default"."partsupp"
+                    HashBuild [160000.00 rows] -> t2.p_partkey
+                      TableScan [160000.00 rows] -> t2.p_partkey
                         table: "default"."part"
                         single-column filters: like(t2.p_name, "%green%")
-                  HashBuild [25.00 rows] -> t7.n_nationkey, t7.n_name
-                    TableScan [25.00 rows] -> t7.n_nationkey, t7.n_name
-                      table: "default"."nation"
+              HashBuild [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+                TableScan [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+                  table: "default"."supplier"
+            HashBuild [25.00 rows] -> t7.n_nationkey, t7.n_name
+              TableScan [25.00 rows] -> t7.n_nationkey, t7.n_name
+                table: "default"."nation"
+          HashBuild [1500000.00 rows] -> t6.o_orderkey, t6.o_orderdate
+            TableScan [1500000.00 rows] -> t6.o_orderkey, t6.o_orderdate
+              table: "default"."orders"
 
 
 Executable Velox plan:
 
-Fragment 0: fragment7 SINGLE:
--- Project[32][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
-  -- OrderBy[31][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
-    -- Aggregation[30][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p102")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
-      -- Project[29][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p102:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p102":DOUBLE
-        -- HashJoin[28][INNER o_orderkey=l_orderkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
-          -- TableScan[18][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderdate:DATE
-          -- HashJoin[27][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> l_orderkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, n_name:VARCHAR
-            -- TableScan[19][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
-            -- HashJoin[26][INNER s_nationkey=n_nationkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE, n_name:VARCHAR
-              -- HashJoin[24][INNER ps_partkey=p_partkey] -> s_nationkey:BIGINT, ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
-                -- HashJoin[22][INNER ps_suppkey=s_suppkey] -> s_nationkey:BIGINT, ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
-                  -- TableScan[20][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
-                  -- TableScan[21][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
-                -- TableScan[23][table: part, remaining filter: (like("p_name",%green%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
-              -- TableScan[25][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+Fragment 0: fragment1 SINGLE:
+-- Project[15][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+  -- OrderBy[14][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+    -- Aggregation[13][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p90")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+      -- Project[12][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p90:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p90":DOUBLE
+        -- HashJoin[11][INNER l_orderkey=o_orderkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
+          -- HashJoin[9][INNER s_nationkey=n_nationkey] -> l_orderkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, n_name:VARCHAR
+            -- HashJoin[7][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_orderkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE
+              -- HashJoin[5][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                -- TableScan[0]["default"."lineitem"] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- HashJoin[4][INNER ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- TableScan[1]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- Filter[3][expression: like("p_name",%green%)] -> p_partkey:BIGINT, p_name:VARCHAR
+                    -- TableScan[2]["default"."part"] -> p_partkey:BIGINT, p_name:VARCHAR
+              -- TableScan[6]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+            -- TableScan[8]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+          -- TableScan[10]["default"."orders"] -> o_orderkey:BIGINT, o_orderdate:DATE
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[14][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+   Estimate: 625 rows, 0B peak memory
+   Output: 175 rows (53.62KB, 1 batches), Cpu time: 26.41us, Wall time: 46.27us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (14.32us/461ns/7.30us/4.32us)
+  -- OrderBy[13][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+     Estimate: 625 rows, 0B peak memory
+     Output: 175 rows (53.62KB, 1 batches), Cpu time: 316.52us, Wall time: 487.50us, Blocked wall time: 0ns, Peak memory: 183.38KB, Memory allocations: 9, Threads: 1, CPU breakdown: B/I/O/F (237.85us/22.72us/10.72us/45.22us)
+    -- Aggregation[12][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p102")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+       Estimate: 625 rows, 0B peak memory
+       Output: 175 rows (431.62KB, 1 batches), Cpu time: 13.79ms, Wall time: 15.02ms, Blocked wall time: 0ns, Peak memory: 588.00KB, Memory allocations: 13, Threads: 1, CPU breakdown: B/I/O/F (752.60us/12.59ms/280.30us/169.70us)
+      -- Project[11][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p102:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p102":DOUBLE
+         Estimate: 4.5876e+06 rows, 0B peak memory
+         Output: 319404 rows (42.68MB, 614 batches), Cpu time: 28.68ms, Wall time: 29.74ms, Blocked wall time: 0ns, Peak memory: 18.00KB, Memory allocations: 1559, Threads: 1, CPU breakdown: B/I/O/F (874.10us/176.91us/27.45ms/173.01us)
+        -- HashJoin[10][INNER s_nationkey=n_nationkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
+           Estimate: 4.5876e+06 rows, 0B peak memory
+           Output: 319404 rows (41.12MB, 614 batches), Cpu time: 7.76ms, Wall time: 9.37ms, Blocked wall time: 3.54ms, Peak memory: 254.00KB, Memory allocations: 19, CPU breakdown: B/I/O/F (869.04us/1.86ms/4.81ms/214.31us)
+          -- HashJoin[8][INNER l_orderkey=o_orderkey] -> s_nationkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE
+             Estimate: 4.5876e+06 rows, 0B peak memory
+             Output: 319404 rows (8.80MB, 614 batches), Cpu time: 186.09ms, Wall time: 189.38ms, Blocked wall time: 197.43ms, Peak memory: 74.33MB, Memory allocations: 651, CPU breakdown: B/I/O/F (993.41us/86.64ms/3.61ms/94.84ms)
+            -- HashJoin[6][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_orderkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE
+               Estimate: 4.73272e+06 rows, 0B peak memory
+               Output: 319404 rows (7.08MB, 614 batches), Cpu time: 10.50ms, Wall time: 12.27ms, Blocked wall time: 0ns, Peak memory: 2.41MB, Memory allocations: 20, CPU breakdown: B/I/O/F (897.85us/3.72ms/5.61ms/270.79us)
+              -- HashJoin[4][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                 Estimate: 4.81176e+06 rows, 0B peak memory
+                 Output: 319404 rows (10.46MB, 614 batches), Cpu time: 24.43ms, Wall time: 26.06ms, Blocked wall time: 0ns, Peak memory: 2.84MB, Memory allocations: 23, CPU breakdown: B/I/O/F (966.05us/14.02ms/7.44ms/2.00ms)
+                -- TableScan[0][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                   Estimate: 6.00122e+06 rows, 0B peak memory
+                   Input: 319404 rows (73.10MB, 614 batches), Raw Input: 6001215 rows (91.07MB), Output: 319404 rows (73.10MB, 614 batches), Cpu time: 237.96ms, Wall time: 257.84ms, Blocked wall time: 0ns, Peak memory: 21.86MB, Memory allocations: 11172, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 4,6, CPU breakdown: B/I/O/F (207.17us/0ns/237.76ms/431ns)
+                -- HashJoin[3][INNER ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                   Estimate: 652150 rows, 0B peak memory
+                   Output: 42656 rows (7.48MB, 81 batches), Cpu time: 1.75ms, Wall time: 1.97ms, Blocked wall time: 29.73ms, Peak memory: 3.79MB, Memory allocations: 7, CPU breakdown: B/I/O/F (229.32us/811.73us/97.62us/615.19us)
+                  -- TableScan[1][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                     Estimate: 800000 rows, 0B peak memory
+                     Input: 42656 rows (8.33MB, 81 batches), Raw Input: 800000 rows (5.07MB), Output: 42656 rows (8.33MB, 81 batches), Cpu time: 17.33ms, Wall time: 17.84ms, Blocked wall time: 0ns, Peak memory: 12.73MB, Memory allocations: 528, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (33.75us/0ns/17.29ms/261ns)
+                  -- TableScan[2][table: part, remaining filter: (like("p_name",%green%)), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_name, columnType: Regular, dataType: VARCHAR, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+                     Estimate: 160000 rows, 0B peak memory
+                     Input: 10664 rows (2.17MB, 20 batches), Raw Input: 200000 rows (7.27MB), Output: 10664 rows (2.17MB, 20 batches), Cpu time: 21.93ms, Wall time: 28.29ms, Blocked wall time: 0ns, Peak memory: 10.70MB, Memory allocations: 435, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (13.07us/0ns/21.92ms/521ns)
+              -- TableScan[5][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+                 Estimate: 10000 rows, 0B peak memory
+                 Input: 10000 rows (191.81KB, 1 batches), Output: 10000 rows (191.81KB, 1 batches), Cpu time: 736.81us, Wall time: 3.85ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.53us/0ns/734.97us/310ns)
+            -- TableScan[7][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderdate:DATE
+               Estimate: 1.5e+06 rows, 0B peak memory
+               Input: 1500000 rows (21.03MB, 152 batches), Output: 1500000 rows (21.03MB, 152 batches), Cpu time: 27.00ms, Wall time: 30.75ms, Blocked wall time: 0ns, Peak memory: 6.14MB, Memory allocations: 657, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (50.02us/0ns/26.95ms/311ns)
+          -- TableScan[9][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+             Estimate: 25 rows, 0B peak memory
+             Input: 25 rows (992B, 1 batches), Output: 25 rows (992B, 1 batches), Cpu time: 306.65us, Wall time: 3.60ms, Blocked wall time: 0ns, Peak memory: 4.06KB, Memory allocations: 15, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.41us/0ns/304.93us/311ns)
 
 ___END___

--- a/axiom/optimizer/tests/tpch/plans/q9_alt.plans
+++ b/axiom/optimizer/tests/tpch/plans/q9_alt.plans
@@ -1,0 +1,180 @@
+generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
+numWorkers: 1
+numDrivers: 1
+
+Query Graph:
+
+dt1: 25.00 rows, nation, o_year, sum_profit
+  output:
+    nation := t7.n_name VARCHAR (cardinality=25.00)
+    o_year := dt1.o_year BIGINT (cardinality=25.00)
+    sum_profit := dt1.sum_profit DOUBLE (cardinality=1.00)
+  tables: t2, t3, t4, t5, t6, t7
+  joins:
+    t3 INNER t4 ON t3.s_suppkey = t4.l_suppkey [t3 → 600.12, t4 → 1.00]
+    t4 INNER t5 ON t4.l_suppkey = t5.ps_suppkey AND t4.l_partkey = t5.ps_partkey [t4 → 1.00, t5 → 1.00]
+    t2 INNER t4 ON t2.p_partkey = t4.l_partkey [t2 → 30.01, t4 → 0.06]
+    t4 INNER t6 ON t4.l_orderkey = t6.o_orderkey [t4 → 1.00, t6 → 4.00]
+    t3 INNER t7 ON t3.s_nationkey = t7.n_nationkey [t3 → 1.00, t7 → 400.00]
+    t3 INNER t5 ON t3.s_suppkey = t5.ps_suppkey [t3 → 80.00, t5 → 1.00]
+    t5 INNER t2 ON t5.ps_partkey = t2.p_partkey [t5 → 0.06, t2 → 4.00]
+  syntactic join order: 10, 20, 39, 51, 64, 71
+  aggregates: sum(minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))) AS sum_profit
+  grouping keys: t7.n_name, year(t6.o_orderdate)
+  orderBy: t7.n_name ASC NULLS LAST, dt1.o_year DESC NULLS LAST
+
+t2: 12000.00 rows, p_partkey, p_size
+  table: "default"."part"
+    p_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    p_size INTEGER (cardinality=3.00 min=1 max=3)
+  single-column filters: lte(t2.p_size, 3)
+
+t3: 10000.00 rows, s_suppkey, s_nationkey
+  table: "default"."supplier"
+    s_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    s_nationkey BIGINT (cardinality=25.00 min=0 max=24)
+
+t4: 6001215.00 rows, l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount
+  table: "default"."lineitem"
+    l_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    l_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    l_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    l_quantity DOUBLE (cardinality=50.00 min=1 max=50)
+    l_extendedprice DOUBLE (cardinality=6001215.00 min=901 max=104949.5)
+    l_discount DOUBLE (cardinality=11.00 min=0 max=0.1)
+
+t5: 800000.00 rows, ps_partkey, ps_suppkey, ps_supplycost
+  table: "default"."partsupp"
+    ps_partkey BIGINT (cardinality=200000.00 min=1 max=200000)
+    ps_suppkey BIGINT (cardinality=10000.00 min=1 max=10000)
+    ps_supplycost DOUBLE (cardinality=100000.00 min=1 max=1000)
+
+t6: 1500000.00 rows, o_orderkey, o_orderdate
+  table: "default"."orders"
+    o_orderkey BIGINT (cardinality=1500000.00 min=1 max=6000000)
+    o_orderdate DATE (cardinality=2406.00 min=8035 max=10440)
+
+t7: 25.00 rows, n_nationkey, n_name
+  table: "default"."nation"
+    n_nationkey BIGINT (cardinality=25.00 min=0 max=24)
+    n_name VARCHAR (cardinality=25.00)
+
+
+Optimized plan (oneline):
+
+agg((((orders INNER (lineitem INNER (partsupp INNER part))) INNER supplier) INNER nation))
+
+Optimized plan:
+
+Project [625.00 rows] -> dt1.nation, dt1.o_year, dt1.sum_profit
+    dt1.nation := t7.n_name
+    dt1.o_year := dt1.o_year
+    dt1.sum_profit := dt1.sum_profit
+  OrderBy [625.00 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
+    Aggregation (t7.n_name, dt1.__p82) [625.00 rows] -> t7.n_name, dt1.o_year, dt1.sum_profit
+        dt1.sum_profit := sum(dt1.__p90)
+      Project [360072.91 rows] -> t7.n_name, dt1.__p82, dt1.__p90
+          t7.n_name := t7.n_name
+          dt1.__p82 := year(t6.o_orderdate)
+          dt1.__p90 := minus(multiply(t4.l_extendedprice, minus(1, t4.l_discount)), multiply(t4.l_quantity, t5.ps_supplycost))
+        Join INNER Hash [360072.91 rows] -> t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate, t7.n_name
+            t3.s_nationkey = t7.n_nationkey
+          Join INNER Hash [360072.91 rows] -> t3.s_nationkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_supplycost, t6.o_orderdate
+              t4.l_suppkey = t3.s_suppkey
+            Join INNER Hash [360072.91 rows] -> t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_suppkey, t5.ps_supplycost, t6.o_orderdate
+                t6.o_orderkey = t4.l_orderkey
+              TableScan [1500000.00 rows] -> t6.o_orderkey, t6.o_orderdate
+                table: "default"."orders"
+              HashBuild [360072.91 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_suppkey, t5.ps_supplycost
+                Join INNER Hash [360072.91 rows] -> t4.l_orderkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount, t5.ps_suppkey, t5.ps_supplycost
+                    t4.l_suppkey = t5.ps_suppkey
+                    t4.l_partkey = t5.ps_partkey
+                  TableScan [6001215.00 rows] -> t4.l_orderkey, t4.l_partkey, t4.l_suppkey, t4.l_quantity, t4.l_extendedprice, t4.l_discount
+                    table: "default"."lineitem"
+                  HashBuild [48000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                    Join INNER Hash [48000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                        t5.ps_partkey = t2.p_partkey
+                      TableScan [800000.00 rows] -> t5.ps_partkey, t5.ps_suppkey, t5.ps_supplycost
+                        table: "default"."partsupp"
+                      HashBuild [12000.00 rows] -> t2.p_partkey
+                        TableScan [12000.00 rows] -> t2.p_partkey
+                          table: "default"."part"
+                          single-column filters: lte(t2.p_size, 3)
+            HashBuild [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+              TableScan [10000.00 rows] -> t3.s_suppkey, t3.s_nationkey
+                table: "default"."supplier"
+          HashBuild [25.00 rows] -> t7.n_nationkey, t7.n_name
+            TableScan [25.00 rows] -> t7.n_nationkey, t7.n_name
+              table: "default"."nation"
+
+
+Executable Velox plan:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[15][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+  -- OrderBy[14][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+    -- Aggregation[13][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p90")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+      -- Project[12][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p90:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p90":DOUBLE
+        -- HashJoin[11][INNER s_nationkey=n_nationkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
+          -- HashJoin[9][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE
+            -- HashJoin[7][INNER o_orderkey=l_orderkey] -> l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE, o_orderdate:DATE
+              -- TableScan[0]["default"."orders"] -> o_orderkey:BIGINT, o_orderdate:DATE
+              -- HashJoin[6][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                -- TableScan[1]["default"."lineitem"] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                -- HashJoin[5][INNER ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- TableScan[2]["default"."partsupp"] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                  -- Filter[4][expression: lte("p_size",3)] -> p_partkey:BIGINT, p_size:INTEGER
+                    -- TableScan[3]["default"."part"] -> p_partkey:BIGINT, p_size:INTEGER
+            -- TableScan[8]["default"."supplier"] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+          -- TableScan[10]["default"."nation"] -> n_nationkey:BIGINT, n_name:VARCHAR
+
+EXPLAIN ANALYZE:
+
+Fragment 0: fragment1 SINGLE:
+-- Project[14][expressions: (nation:VARCHAR, "n_name"), (o_year:BIGINT, "o_year"), (sum_profit:DOUBLE, "sum_profit")] -> nation:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+   Estimate: 625 rows, 0B peak memory
+   Output: 175 rows (53.62KB, 1 batches), Cpu time: 36.88us, Wall time: 65.49us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (20.05us/631ns/9.81us/6.38us)
+  -- OrderBy[13][n_name ASC NULLS LAST, o_year DESC NULLS LAST] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+     Estimate: 625 rows, 0B peak memory
+     Output: 175 rows (53.62KB, 1 batches), Cpu time: 337.89us, Wall time: 586.60us, Blocked wall time: 0ns, Peak memory: 183.38KB, Memory allocations: 9, CPU breakdown: B/I/O/F (261.55us/22.15us/12.15us/42.03us)
+    -- Aggregation[12][SINGLE [n_name, o_year] sum_profit := sum("dt1.__p102")] -> n_name:VARCHAR, o_year:BIGINT, sum_profit:DOUBLE
+       Estimate: 625 rows, 0B peak memory
+       Output: 175 rows (431.62KB, 1 batches), Cpu time: 15.65ms, Wall time: 17.30ms, Blocked wall time: 0ns, Peak memory: 608.00KB, Memory allocations: 11, CPU breakdown: B/I/O/F (922.00us/14.21ms/305.24us/220.32us)
+      -- Project[11][expressions: (n_name:VARCHAR, "n_name"), (o_year:BIGINT, year("o_orderdate")), (dt1.__p102:DOUBLE, minus(multiply("l_extendedprice",minus(1,"l_discount")),multiply("l_quantity","ps_supplycost")))] -> n_name:VARCHAR, o_year:BIGINT, "dt1.__p102":DOUBLE
+         Estimate: 344070 rows, 0B peak memory
+         Output: 365696 rows (40.03MB, 450 batches), Cpu time: 15.00ms, Wall time: 17.08ms, Blocked wall time: 0ns, Peak memory: 42.00KB, Memory allocations: 1051, CPU breakdown: B/I/O/F (1.12ms/233.40us/13.42ms/217.66us)
+        -- HashJoin[10][INNER s_nationkey=n_nationkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE, n_name:VARCHAR
+           Estimate: 344070 rows, 0B peak memory
+           Output: 365696 rows (54.45MB, 450 batches), Cpu time: 6.85ms, Wall time: 8.91ms, Blocked wall time: 2.02ms, Peak memory: 284.00KB, Memory allocations: 16, CPU breakdown: B/I/O/F (1.13ms/880.49us/4.57ms/280.68us)
+          -- HashJoin[8][INNER l_suppkey=s_suppkey] -> s_nationkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_supplycost:DOUBLE, o_orderdate:DATE
+             Estimate: 344070 rows, 0B peak memory
+             Output: 0 rows (0B, 450 batches), Cpu time: 2.05ms, Wall time: 2.99ms, Blocked wall time: 0ns, Peak memory: 2.46MB, Memory allocations: 18, CPU breakdown: B/I/O/F (962.22us/982.45us/1.23us/107.94us)
+            -- HashJoin[6][INNER o_orderkey=l_orderkey] -> l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE, o_orderdate:DATE
+               Estimate: 349816 rows, 0B peak memory
+               Output: 365696 rows (33.35MB, 900 batches), Cpu time: 125.90ms, Wall time: 128.49ms, Blocked wall time: 404.14ms, Peak memory: 30.80MB, Memory allocations: 933, CPU breakdown: B/I/O/F (1.51ms/88.43ms/16.73ms/19.23ms)
+              -- TableScan[0][table: orders, data columns: ROW<o_orderkey:BIGINT,o_custkey:BIGINT,o_orderstatus:VARCHAR,o_totalprice:DOUBLE,o_orderdate:DATE,o_orderpriority:VARCHAR,o_clerk:VARCHAR,o_shippriority:INTEGER,o_comment:VARCHAR>] -> o_orderkey:BIGINT, o_orderdate:DATE
+                 Estimate: 1.5e+06 rows, 0B peak memory
+                 Input: 1500000 rows (22.09MB, 304 batches), Output: 1500000 rows (22.09MB, 304 batches), Cpu time: 27.32ms, Wall time: 28.85ms, Blocked wall time: 0ns, Peak memory: 6.15MB, Memory allocations: 3134, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (189.42us/0ns/27.13ms/480ns)
+              -- HashJoin[5][INNER l_suppkey=ps_suppkey AND l_partkey=ps_partkey] -> l_orderkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                 Estimate: 366908 rows, 0B peak memory
+                 Output: 365696 rows (10.55MB, 614 batches), Cpu time: 27.38ms, Wall time: 29.18ms, Blocked wall time: 41.10ms, Peak memory: 3.35MB, Memory allocations: 20, CPU breakdown: B/I/O/F (1.14ms/15.05ms/8.77ms/2.42ms)
+                -- TableScan[1][table: lineitem, data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_orderkey:BIGINT, l_partkey:BIGINT, l_suppkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
+                   Estimate: 6.00122e+06 rows, 0B peak memory
+                   Input: 365696 rows (73.52MB, 614 batches), Raw Input: 6001215 rows (91.07MB), Output: 365696 rows (73.52MB, 614 batches), Cpu time: 242.42ms, Wall time: 265.12ms, Blocked wall time: 0ns, Peak memory: 21.86MB, Memory allocations: 8102, Threads: 1, Splits: 2, DynamicFilter producer plan nodes: 5, CPU breakdown: B/I/O/F (196.48us/0ns/242.22ms/261ns)
+                -- HashJoin[4][INNER ps_partkey=p_partkey] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                   Estimate: 48911.2 rows, 0B peak memory
+                   Output: 48812 rows (7.48MB, 81 batches), Cpu time: 2.06ms, Wall time: 2.40ms, Blocked wall time: 14.23ms, Peak memory: 3.79MB, Memory allocations: 7, CPU breakdown: B/I/O/F (333.32us/879.17us/137.62us/714.04us)
+                  -- TableScan[2][table: partsupp, data columns: ROW<ps_partkey:BIGINT,ps_suppkey:BIGINT,ps_availqty:INTEGER,ps_supplycost:DOUBLE,ps_comment:VARCHAR>] -> ps_partkey:BIGINT, ps_suppkey:BIGINT, ps_supplycost:DOUBLE
+                     Estimate: 800000 rows, 0B peak memory
+                     Input: 48812 rows (8.39MB, 81 batches), Raw Input: 800000 rows (5.07MB), Output: 48812 rows (8.39MB, 81 batches), Cpu time: 17.44ms, Wall time: 18.27ms, Blocked wall time: 0ns, Peak memory: 12.73MB, Memory allocations: 530, Threads: 1, Splits: 1, DynamicFilter producer plan nodes: 4, CPU breakdown: B/I/O/F (42.38us/0ns/17.40ms/481ns)
+                  -- TableScan[3][table: part, range filters: [(p_size, BigintRange: [-9223372036854775808, 3] no nulls)], data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>, filter column handles: [HiveColumnHandle [name: p_size, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]]]] -> p_partkey:BIGINT
+                     Estimate: 12000 rows, 0B peak memory
+                     Input: 12203 rows (118.12KB, 20 batches), Raw Input: 200000 rows (5.37MB), Output: 12203 rows (118.12KB, 20 batches), Cpu time: 4.81ms, Wall time: 12.67ms, Blocked wall time: 0ns, Peak memory: 4.76MB, Memory allocations: 79, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (6.89us/0ns/4.81ms/301ns)
+            -- TableScan[7][table: supplier, data columns: ROW<s_suppkey:BIGINT,s_name:VARCHAR,s_address:VARCHAR,s_nationkey:BIGINT,s_phone:VARCHAR,s_acctbal:DOUBLE,s_comment:VARCHAR>] -> s_suppkey:BIGINT, s_nationkey:BIGINT
+               Estimate: 10000 rows, 0B peak memory
+               Input: 10000 rows (191.81KB, 1 batches), Output: 10000 rows (191.81KB, 1 batches), Cpu time: 655.39us, Wall time: 4.32ms, Blocked wall time: 0ns, Peak memory: 640.00KB, Memory allocations: 17, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.13us/0ns/653.95us/310ns)
+          -- TableScan[9][table: nation, data columns: ROW<n_nationkey:BIGINT,n_name:VARCHAR,n_regionkey:BIGINT,n_comment:VARCHAR>] -> n_nationkey:BIGINT, n_name:VARCHAR
+             Estimate: 25 rows, 0B peak memory
+             Input: 25 rows (992B, 1 batches), Output: 25 rows (992B, 1 batches), Cpu time: 328.44us, Wall time: 2.11ms, Blocked wall time: 0ns, Peak memory: 4.06KB, Memory allocations: 15, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (1.92us/0ns/326.01us/510ns)
+
+___END___


### PR DESCRIPTION
Summary:

Replaces the `ASSERT_NO_THROW` stubs for q07, q08, q10, q15, and q21 with full plan-shape matchers, so every TPC-H query except q09 now asserts its optimized shape. q09 stays an intentional gap: its `like '%green%'` filter is not estimable from column statistics, so the optimizer misorders the joins; q09Alt locks the optimal shape using an estimable substitute filter.

Each matcher test also carries a one-line plan-shape diagram as a comment for a readable overview above the detailed matcher. To make those legible, `RelationOp::toOneline` now prints a scan as just its table name rather than the schema-qualified, quoted `"default"."lineitem"`. For example, q07 is:

    agg((
      (lineitem INNER (supplier INNER nation))
      INNER
      (orders INNER (customer INNER nation))
    ))

`makePlans` now stamps each `.plans` snapshot with a generation timestamp and also emits `q9_alt`. The snapshots gain a trailing `EXPLAIN ANALYZE` section at scale factor 1, so the injected-statistics estimates can be compared against real row counts and runtimes.

bypass-github-export-checks

Reviewed By: amitkdutta

Differential Revision: D108570074


