### PR TITLE
fix(optimizer): Propagate unknown stats, sharpen NDVs (#1484)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1380,6 +1380,26 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
   return result;
 }
 
+namespace {
+// Converts an optional to a different scalar type, preserving nullopt.
+template <typename To, typename From>
+std::optional<To> castOpt(const std::optional<From>& value) {
+  if (value.has_value()) {
+    return static_cast<To>(*value);
+  }
+  return std::nullopt;
+}
+
+// Rounds an optional cardinality estimate to an integer count, preserving
+// nullopt for an unknown cardinality.
+std::optional<int64_t> roundCardinality(std::optional<float> cardinality) {
+  if (cardinality.has_value()) {
+    return std::llround(*cardinality);
+  }
+  return std::nullopt;
+}
+} // namespace
+
 std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options) {
@@ -1397,7 +1417,7 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
       newQuery(options),
       options,
       [&](const optimizer::DerivedTable& rootDt) {
-        presto::ShowStatsBuilder builder(std::llround(rootDt.cardinality));
+        presto::ShowStatsBuilder builder(roundCardinality(rootDt.cardinality));
 
         for (const auto* column : rootDt.columns) {
           const auto& value = column->value();
@@ -1405,8 +1425,8 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
           builder.addColumn(
               column->outputName(),
               *value.type,
-              static_cast<double>(value.nullFraction),
-              static_cast<int64_t>(value.cardinality),
+              castOpt<double>(value.nullFraction),
+              roundCardinality(value.cardinality),
               /*avgLength=*/std::nullopt,
               value.min,
               value.max);

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -692,14 +692,15 @@ TEST_F(SqlQueryRunnerTest, showStats) {
     test::assertEqualVectors(expected, result.results[0]);
 
     // SHOW STATS FOR (SELECT * FROM <table>): reports optimizer estimates. The
-    // optimizer always estimates NDV (defaults to numRows when unknown) and
-    // doesn't track avgLength.
+    // optimizer reports its NDV estimate, which is unknown for a column it
+    // cannot estimate (the array z), and doesn't track avgLength.
     expected = makeRowVector({
         expected->childAt(0), // row_count.
         expected->childAt(1), // column_name.
         expected->childAt(2), // nulls_fraction.
-        // distinct_values_count: 100 for z (optimizer defaults to numRows).
-        makeNullableFlatVector<int64_t>({std::nullopt, 100, 7, 100, 75}),
+        // distinct_values_count: NULL for z (array NDV is unknown).
+        makeNullableFlatVector<int64_t>(
+            {std::nullopt, 100, 7, std::nullopt, 75}),
         // avg_length: not tracked by the optimizer.
         makeNullConstant(TypeKind::BIGINT, 5),
         expected->childAt(5), // low_value.
@@ -731,8 +732,9 @@ TEST_F(SqlQueryRunnerTest, showStatsForQueryWithFilter) {
       makeNullableFlatVector<double>({std::nullopt, 0.0, 0.0, 0.0, 0.25}),
       // distinct_values_count: reduced for x and w; y stays at 7 because the
       // optimizer assumes column independence — the filter on x doesn't reduce
-      // y's domain (and 7 < 50 filtered rows, so NDV is not capped).
-      makeNullableFlatVector<int64_t>({std::nullopt, 50, 7, 50, 50}),
+      // y's domain (and 7 < 50 filtered rows, so NDV is not capped). NULL for z
+      // (array NDV is unknown).
+      makeNullableFlatVector<int64_t>({std::nullopt, 50, 7, std::nullopt, 50}),
       // avg_length: not tracked by the optimizer.
       makeNullConstant(TypeKind::BIGINT, 5),
       // low_value: x tightened to 51.

--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -593,7 +593,10 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
       groupId,
       state);
 
-  if (singleAggCost.cost < splitAggCost.cost) {
+  // Decide by cost when both costs are known. When a cost is unknown (a missing
+  // statistic), lessThan is false, so we default to the split (partial+final)
+  // plan.
+  if (lessThan(singleAggCost.cost, splitAggCost.cost)) {
     return {std::move(singleAgg), singleAggCost};
   }
   state.mutableCurrentGroupedLeaves() = std::move(splitMap);

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -146,7 +146,7 @@ void addImpliedSemiEdge(
 // Returns the post-filter cardinality for any table type. For BaseTable,
 // this is filteredCardinality (reduced by pushed-down WHERE/HAVING). For
 // DerivedTable, cardinality is already post-filter/post-join.
-float filteredTableCardinality(PlanObjectCP table) {
+std::optional<float> filteredTableCardinality(PlanObjectCP table) {
   if (table->is(PlanType::kTableNode)) {
     return table->as<BaseTable>()->filteredCardinality;
   }
@@ -164,16 +164,30 @@ float filteredTableCardinality(PlanObjectCP table) {
 // filtering. For a single key, returns min(NDV, filteredCardinality)
 // directly (no dampening needed). For multiple keys, uses the saturating
 // product formula (max * P / (max + P)) to dampen the independence
-// assumption for correlated keys. Consistent with maxGroups().
-float compositeNdv(PlanObjectCP table, const ExprVector& keys) {
-  double max = filteredTableCardinality(table);
-  if (keys.size() == 1) {
-    return static_cast<float>(
-        std::min(max, static_cast<double>(keys[0]->value().cardinality)));
+// assumption for correlated keys. Consistent with maxGroups(). Returns nullopt
+// if the table cardinality or any key NDV is unknown.
+std::optional<float> compositeNdv(PlanObjectCP table, const ExprVector& keys) {
+  const auto maxOpt = filteredTableCardinality(table);
+  if (!maxOpt.has_value()) {
+    return std::nullopt;
   }
+
+  const double max = *maxOpt;
+  if (keys.size() == 1) {
+    const auto keyNdv = keys[0]->value().cardinality;
+    if (!keyNdv.has_value()) {
+      return std::nullopt;
+    }
+    return static_cast<float>(std::min(max, static_cast<double>(*keyNdv)));
+  }
+
   double product = 1.0;
   for (const auto* key : keys) {
-    product *= key->value().cardinality;
+    const auto keyNdv = key->value().cardinality;
+    if (!keyNdv.has_value()) {
+      return std::nullopt;
+    }
+    product *= *keyNdv;
   }
   return static_cast<float>(max * product / (max + product));
 }
@@ -623,9 +637,10 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
 
     // Set initial cardinality as the sum of unionInputs's cardinalities so that
     // makeInitialPlan can use it when estimating groups for makeDistinct.
+    // The sum is unknown if any child's cardinality is unknown.
     cardinality = 0;
     for (const auto* child : unionInputs) {
-      cardinality += child->cardinality;
+      cardinality = add(cardinality, child->cardinality);
     }
   }
 
@@ -1729,10 +1744,11 @@ void DerivedTable::pushExistencesIntoSubquery(const DerivedTable& subquery) {
 
   for (size_t i = previousNumJoins; i < newFirst->joins.size(); ++i) {
     auto* join = newFirst->joins[i];
-    auto pushedNdv = compositeNdv(join->rightTable(), join->rightKeys());
-    auto baseNdv =
-        std::max(1.0f, compositeNdv(join->leftTable(), join->leftKeys()));
-    auto selectivity = std::min(1.0f, pushedNdv / baseNdv);
+    const auto pushedNdv = compositeNdv(join->rightTable(), join->rightKeys());
+    const auto baseNdv =
+        maxOf(compositeNdv(join->leftTable(), join->leftKeys()), 1.0f);
+    // The existence-join selectivity is unknown if either NDV is unknown.
+    const auto selectivity = minOf(divide(pushedNdv, baseNdv), 1.0f);
     join->setFanouts(selectivity, 1);
   }
 

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -82,7 +82,8 @@ struct DerivedTable : public PlanObject {
   /// planning by initializePlans() or makeInitialPlan(). For non-union DTs,
   /// computed as resultCardinality() of the initial physical plan. For union
   /// DTs, computed as the sum of resultCardinality() across all children.
-  float cardinality{};
+  /// nullopt if the cardinality is unknown.
+  std::optional<float> cardinality{};
 
   /// Correlation name.
   Name cname{nullptr};

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -38,13 +38,16 @@ std::string columnNames(const ColumnVector& columns) {
   return out.str();
 }
 
-std::string formatCardinality(float cardinality) {
-  return fmt::format("{:.2f}", cardinality);
+std::string formatCardinality(std::optional<float> cardinality) {
+  if (!cardinality.has_value()) {
+    return "?";
+  }
+  return fmt::format("{:.2f}", *cardinality);
 }
 
 std::string headerLine(
     const std::string& name,
-    float cardinality,
+    std::optional<float> cardinality,
     const ColumnVector& columns) {
   return fmt::format(
       "{}: {} rows, {}\n",
@@ -63,11 +66,11 @@ std::string constraintString(const Value& value) {
   if (value.max != nullptr) {
     out << " max=" << *value.max;
   }
-  if (value.trueFraction != Value::kUnknown) {
-    out << " trueFraction=" << value.trueFraction;
+  if (value.trueFraction.has_value()) {
+    out << " trueFraction=" << *value.trueFraction;
   }
-  if (value.nullFraction != 0) {
-    out << " nullFraction=" << value.nullFraction;
+  if (value.nullFraction.has_value() && *value.nullFraction != 0) {
+    out << " nullFraction=" << *value.nullFraction;
   }
   out << ")";
   return out.str();

--- a/axiom/optimizer/EstimateMath.h
+++ b/axiom/optimizer/EstimateMath.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <optional>
+
+/// Arithmetic over optional statistical estimates (cardinality, fanout, ...).
+/// Unknown (nullopt) propagates: if any operand is unknown, the result is
+/// unknown. This keeps callers from silently treating a missing estimate as a
+/// concrete value. Use these instead of unwrapping at estimate-combining sites.
+namespace facebook::axiom::optimizer {
+
+/// Multiplication.
+inline std::optional<float> mul(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value()) {
+    return *a * *b;
+  }
+  return std::nullopt;
+}
+
+/// Addition.
+inline std::optional<float> add(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value()) {
+    return *a + *b;
+  }
+  return std::nullopt;
+}
+
+/// Division. nullopt if either operand is unknown or the divisor is 0.
+inline std::optional<float> divide(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value() && *b != 0) {
+    return *a / *b;
+  }
+  return std::nullopt;
+}
+
+/// Named maxOf/minOf rather than max/min to avoid ambiguity with std::max/min
+/// under ADL (the operands are std::optional).
+inline std::optional<float> maxOf(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value()) {
+    return std::max(*a, *b);
+  }
+  return std::nullopt;
+}
+
+inline std::optional<float> minOf(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value()) {
+    return std::min(*a, *b);
+  }
+  return std::nullopt;
+}
+
+/// True only when both operands are known and a < b. Unknown operands are not
+/// comparable, so the result is false (an unknown estimate is never the
+/// smaller). Use instead of std::optional's operator<, which treats nullopt as
+/// the smallest value.
+inline bool lessThan(std::optional<float> a, std::optional<float> b) {
+  return a.has_value() && b.has_value() && *a < *b;
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/Filters.cpp
+++ b/axiom/optimizer/Filters.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/QueryGraph.h"
@@ -85,12 +86,12 @@ struct RangeOverlap {
 
 // Forward declarations for internal functions.
 
-Selectivity rangeSelectivity(
+std::optional<Selectivity> rangeSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> exprs,
     bool updateConstraints);
 
-Selectivity cardinalityBasedSelectivity(
+std::optional<Selectivity> cardinalityBasedSelectivity(
     ExprCP left,
     ExprCP right,
     const Value& leftValue,
@@ -101,9 +102,10 @@ Selectivity cardinalityBasedSelectivity(
 
 } // namespace
 
-Selectivity combineConjuncts(std::span<const Selectivity> selectivities) {
+std::optional<Selectivity> combineConjuncts(
+    std::span<const std::optional<Selectivity>> selectivities) {
   if (selectivities.empty()) {
-    return {1.0, 0.0};
+    return Selectivity{1.0, 0.0};
   }
 
   // For AND: result is TRUE only if all are TRUE.
@@ -119,8 +121,13 @@ Selectivity combineConjuncts(std::span<const Selectivity> selectivities) {
   double trueOrNullProduct = 1.0;
 
   for (const auto& selectivity : selectivities) {
-    trueProduct *= selectivity.trueFraction;
-    trueOrNullProduct *= (selectivity.trueFraction + selectivity.nullFraction);
+    // An unknown conjunct makes the combined selectivity unknown.
+    if (!selectivity.has_value()) {
+      return std::nullopt;
+    }
+    trueProduct *= selectivity->trueFraction;
+    trueOrNullProduct *=
+        (selectivity->trueFraction + selectivity->nullFraction);
   }
 
   // Clamp to handle floating-point rounding.
@@ -130,9 +137,10 @@ Selectivity combineConjuncts(std::span<const Selectivity> selectivities) {
   return result;
 }
 
-Selectivity combineDisjuncts(std::span<const Selectivity> selectivities) {
+std::optional<Selectivity> combineDisjuncts(
+    std::span<const std::optional<Selectivity>> selectivities) {
   if (selectivities.empty()) {
-    return {0.0, 0.0};
+    return Selectivity{0.0, 0.0};
   }
 
   // For OR: result is TRUE if any is TRUE.
@@ -148,8 +156,13 @@ Selectivity combineDisjuncts(std::span<const Selectivity> selectivities) {
   double falseProduct = 1.0;
 
   for (const auto& selectivity : selectivities) {
-    notTrueProduct *= (1.0 - selectivity.trueFraction);
-    falseProduct *= (1.0 - selectivity.trueFraction - selectivity.nullFraction);
+    // An unknown disjunct makes the combined selectivity unknown.
+    if (!selectivity.has_value()) {
+      return std::nullopt;
+    }
+    notTrueProduct *= (1.0 - selectivity->trueFraction);
+    falseProduct *=
+        (1.0 - selectivity->trueFraction - selectivity->nullFraction);
   }
 
   double resultTrue = 1.0 - notTrueProduct;
@@ -200,11 +213,12 @@ Value exprConstraint(ExprCP expr, ConstraintMap& constraints, bool update) {
         "Predicate cannot contain an aggregate function call: {}",
         call->toString());
 
-    // No functionConstraint: get max cardinality from args.
-    float maxCardinality = 1.0f;
+    // No functionConstraint: get max cardinality from args. Unknown if any
+    // arg's cardinality is unknown.
+    std::optional<float> maxCardinality = 1.0f;
     for (auto* arg : call->args()) {
       Value argValue = exprConstraint(arg, constraints, update);
-      maxCardinality = std::max(maxCardinality, argValue.cardinality);
+      maxCardinality = maxOf(maxCardinality, argValue.cardinality);
     }
     result = expr->value();
     result.cardinality = maxCardinality;
@@ -222,17 +236,18 @@ Value clampCardinality(const Value& value) {
   Value result = value;
   auto typeKind = result.type->kind();
 
+  // Clamp only when the cardinality is known; unknown stays unknown.
   if (typeKind == velox::TypeKind::BOOLEAN) {
-    result.cardinality = std::min(result.cardinality, 2.0f);
+    result.cardinality = minOf(result.cardinality, 2.0f);
   } else if (typeKind == velox::TypeKind::TINYINT) {
-    result.cardinality = std::min(result.cardinality, 256.0f);
+    result.cardinality = minOf(result.cardinality, 256.0f);
   } else if (typeKind == velox::TypeKind::SMALLINT) {
-    result.cardinality = std::min(result.cardinality, 65536.0f);
+    result.cardinality = minOf(result.cardinality, 65536.0f);
   }
   return result;
 }
 
-Selectivity comparisonSelectivity(
+std::optional<Selectivity> comparisonSelectivity(
     ConstraintMap& constraints,
     ExprCP expr,
     bool updateConstraints) {
@@ -275,7 +290,7 @@ Selectivity comparisonSelectivity(
       constraints);
 }
 
-Selectivity conjunctsSelectivity(
+std::optional<Selectivity> conjunctsSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> conjuncts,
     bool updateConstraints) {
@@ -284,7 +299,7 @@ Selectivity conjunctsSelectivity(
     exprConstraint(conjunct, constraints, true);
   }
 
-  std::vector<Selectivity> selectivities;
+  std::vector<std::optional<Selectivity>> selectivities;
   selectivities.reserve(conjuncts.size());
 
   // Map from left-hand side expression to list of comparison expressions.
@@ -355,21 +370,26 @@ Selectivity literalSelectivity(ExprCP expr) {
   return {1.0, 0.0};
 }
 
-// Computes selectivity for column expressions.
-Selectivity columnSelectivity(ConstraintMap& constraints, ExprCP expr) {
+// Computes selectivity for column expressions. nullopt if a required column
+// stat is missing.
+std::optional<Selectivity> columnSelectivity(
+    ConstraintMap& constraints,
+    ExprCP expr) {
   const auto& exprValue = value(constraints, expr);
+  // nullFraction and trueFraction are secondary scaling stats; only a missing
+  // cardinality (NDV) makes a selectivity unknown.
+  const float nullFraction = exprValue.nullFraction.value_or(0);
   if (exprValue.type->isBoolean()) {
-    if (exprValue.trueFraction != Value::kUnknown) {
-      return {exprValue.trueFraction, exprValue.nullFraction};
-    }
-    return Selectivity::likelyTrue();
+    return {
+        {exprValue.trueFraction.value_or(Selectivity::kUnknown), nullFraction}};
   }
   // For non-boolean columns, selectivity is 1 - nullFraction.
-  return {1.0 - exprValue.nullFraction, exprValue.nullFraction};
+  return {{1.0 - nullFraction, nullFraction}};
 }
 
-// Computes selectivity for call expressions (function calls).
-Selectivity callSelectivity(
+// Computes selectivity for call expressions (function calls). nullopt if a
+// required input stat is missing; a heuristic value for unmodelable predicates.
+std::optional<Selectivity> callSelectivity(
     ConstraintMap& constraints,
     ExprCP expr,
     bool updateConstraints) {
@@ -381,7 +401,10 @@ Selectivity callSelectivity(
   if (funcName == fn.negation) {
     VELOX_CHECK_EQ(call->args().size(), 1, "NOT must have exactly 1 argument");
     auto innerSel = exprSelectivity(constraints, call->args()[0], false);
-    return {innerSel.falseFraction(), innerSel.nullFraction};
+    if (!innerSel.has_value()) {
+      return std::nullopt;
+    }
+    return Selectivity{innerSel->falseFraction(), innerSel->nullFraction};
   }
 
   // AND
@@ -392,7 +415,7 @@ Selectivity callSelectivity(
   // OR
   if (funcName == SpecialFormCallNames::kOr) {
     const auto& args = call->args();
-    std::vector<Selectivity> disjuncts;
+    std::vector<std::optional<Selectivity>> disjuncts;
     disjuncts.reserve(args.size());
     for (auto* arg : args) {
       disjuncts.push_back(exprSelectivity(constraints, arg, false));
@@ -405,7 +428,7 @@ Selectivity callSelectivity(
     VELOX_CHECK_EQ(
         call->args().size(), 1, "isnull must have exactly 1 argument");
     const auto& argValue = value(constraints, call->args()[0]);
-    return {argValue.nullFraction, 0.0};
+    return Selectivity{argValue.nullFraction.value_or(0), 0.0};
   }
 
   // IN operator.
@@ -426,11 +449,11 @@ Selectivity callSelectivity(
     return comparisonSelectivity(constraints, expr, updateConstraints);
   }
 
-  // Other function - default selectivity.
+  // Other (unmodelable) function - heuristic default, stats not the issue.
   return Selectivity::likelyTrue();
 }
 
-Selectivity exprSelectivity(
+std::optional<Selectivity> exprSelectivity(
     ConstraintMap& constraints,
     ExprCP expr,
     bool updateConstraints) {
@@ -560,6 +583,32 @@ bool isIntegerKind(velox::TypeKind kind) {
       return false;
   }
 }
+
+} // namespace
+
+std::optional<float>
+rangeCardinality(TypeCP type, VariantCP min, VariantCP max) {
+  const auto kind = type->kind();
+  if (!isIntegerKind(kind) || min == nullptr || max == nullptr) {
+    return std::nullopt;
+  }
+  switch (kind) {
+    case velox::TypeKind::TINYINT:
+      return rangeCardinality<velox::TypeKind::TINYINT>(min, max);
+    case velox::TypeKind::SMALLINT:
+      return rangeCardinality<velox::TypeKind::SMALLINT>(min, max);
+    case velox::TypeKind::INTEGER:
+      return rangeCardinality<velox::TypeKind::INTEGER>(min, max);
+    case velox::TypeKind::BIGINT:
+      return rangeCardinality<velox::TypeKind::BIGINT>(min, max);
+    case velox::TypeKind::HUGEINT:
+      return rangeCardinality<velox::TypeKind::HUGEINT>(min, max);
+    default:
+      return std::nullopt;
+  }
+}
+
+namespace {
 
 // Extracts the IN list from an IN call expression.
 // The IN list is constructed from all non-first arguments of the call.
@@ -744,7 +793,7 @@ float rangeSelectivityImpl<velox::TypeKind::VARCHAR>(
 
 // Computes selectivity for comparisons using only cardinality (no range info).
 // Used when min/max bounds are not available for one or both sides.
-Selectivity cardinalityBasedSelectivity(
+std::optional<Selectivity> cardinalityBasedSelectivity(
     ExprCP left,
     ExprCP right,
     const Value& leftValue,
@@ -752,14 +801,19 @@ Selectivity cardinalityBasedSelectivity(
     Name funcName,
     bool updateConstraints,
     ConstraintMap& constraints) {
-  double nullFraction =
-      combinedNullFraction(leftValue.nullFraction, rightValue.nullFraction);
+  double nullFraction = combinedNullFraction(
+      leftValue.nullFraction.value_or(0), rightValue.nullFraction.value_or(0));
 
   const auto& fn = queryCtx()->functionNames();
 
   if (funcName == fn.equality) {
-    double ac = std::max(1.0, static_cast<double>(leftValue.cardinality));
-    double bc = std::max(1.0, static_cast<double>(rightValue.cardinality));
+    // Equality selectivity is 1/NDV; a missing NDV makes it unknown.
+    if (!leftValue.cardinality.has_value() ||
+        !rightValue.cardinality.has_value()) {
+      return std::nullopt;
+    }
+    double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
+    double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
     double minCard = std::min(ac, bc);
     double probTrue = minCard / (ac * bc);
 
@@ -771,7 +825,7 @@ Selectivity cardinalityBasedSelectivity(
     }
 
     double trueFraction = probTrue * (1.0 - nullFraction);
-    return {trueFraction, nullFraction};
+    return Selectivity{trueFraction, nullFraction};
   }
 
   if (isComparisonOperator(funcName)) {
@@ -801,7 +855,7 @@ Selectivity cardinalityBasedSelectivity(
 // - P(either null) = na + nb - na×nb
 // - All comparison probabilities are scaled by (1 - P(either null))
 template <velox::TypeKind KIND>
-Selectivity comparisonSelectivityImpl(
+std::optional<Selectivity> comparisonSelectivityImpl(
     ExprCP left,
     ExprCP right,
     const Value& leftValue,
@@ -809,8 +863,13 @@ Selectivity comparisonSelectivityImpl(
     Name funcName,
     bool updateConstraints,
     ConstraintMap& constraints) {
-  double nullFraction =
-      combinedNullFraction(leftValue.nullFraction, rightValue.nullFraction);
+  // Range-overlap selectivity needs both NDVs; a missing one makes it unknown.
+  if (!leftValue.cardinality.has_value() ||
+      !rightValue.cardinality.has_value()) {
+    return std::nullopt;
+  }
+  double nullFraction = combinedNullFraction(
+      leftValue.nullFraction.value_or(0), rightValue.nullFraction.value_or(0));
 
   // Extract min/max as doubles for arithmetic (caller guarantees non-null).
   double al = leftValue.min->value<KIND>();
@@ -818,8 +877,8 @@ Selectivity comparisonSelectivityImpl(
   double bl = rightValue.min->value<KIND>();
   double bh = rightValue.max->value<KIND>();
 
-  double ac = std::max(1.0, static_cast<double>(leftValue.cardinality));
-  double bc = std::max(1.0, static_cast<double>(rightValue.cardinality));
+  double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
+  double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
 
   // Calculate ranges (avoiding zero).
   double rangeA = rangeSize(al, ah);
@@ -902,12 +961,12 @@ Selectivity comparisonSelectivityImpl(
   probTrue = std::clamp(probTrue, 0.0, 1.0);
   double trueFraction = probTrue * (1.0 - nullFraction);
 
-  return {trueFraction, nullFraction};
+  return Selectivity{trueFraction, nullFraction};
 }
 
 } // namespace
 
-Selectivity columnComparisonSelectivity(
+std::optional<Selectivity> columnComparisonSelectivity(
     ExprCP left,
     ExprCP right,
     const Value& leftValue,
@@ -987,7 +1046,7 @@ Selectivity columnComparisonSelectivity(
 // @param lower Lower bound of the range (nullptr means unbounded).
 // @param upper Upper bound of the range (nullptr means unbounded).
 // @return Selectivity with trueFraction and nullFraction.
-Selectivity rangeSelectivity(
+std::optional<Selectivity> rangeSelectivity(
     const ConstraintMap& constraints,
     ExprCP expr,
     VariantCP lower,
@@ -995,8 +1054,7 @@ Selectivity rangeSelectivity(
   const auto& exprValue = value(constraints, expr);
   const auto kind = exprValue.type->kind();
 
-  // Retrieve null fraction from the expression.
-  double nullFraction = exprValue.nullFraction;
+  double nullFraction = exprValue.nullFraction.value_or(0);
 
   // Types without meaningful range semantics.
   switch (kind) {
@@ -1026,7 +1084,7 @@ Selectivity rangeSelectivity(
   // Scale true fraction by (1 - nullFraction) since NULLs cannot match.
   double trueFraction = baseTrueFraction * (1.0 - nullFraction);
 
-  return {trueFraction, nullFraction};
+  return Selectivity{trueFraction, nullFraction};
 }
 
 // Creates a new constraint Value for an expression by tightening bounds and
@@ -1046,31 +1104,11 @@ Value makeConstraint(
   VariantCP minPtr = tightenLowerBound(oldValue.min, lower);
   VariantCP maxPtr = tightenUpperBound(oldValue.max, upper);
 
-  // cardinality is at least 1 distinct value. If the type is an integer type,
-  // then the cardinality is not more than 1 + (max - min).
+  // cardinality is at least 1 distinct value. An integer range caps it at
+  // 1 + (max - min).
   float finalCardinality = std::max(1.0f, cardinality);
-  auto kind = oldValue.type->kind();
-
-  // If the type is an integer type and both upper and lower are set (after
-  // defaulting), adjust cardinality based on range.
-  if (isIntegerKind(kind) && minPtr != nullptr && maxPtr != nullptr) {
-#define INTEGER_CASE(KIND)                                        \
-  case velox::TypeKind::KIND:                                     \
-    finalCardinality = std::min(                                  \
-        finalCardinality,                                         \
-        rangeCardinality<velox::TypeKind::KIND>(minPtr, maxPtr)); \
-    break
-
-    switch (kind) {
-      INTEGER_CASE(TINYINT);
-      INTEGER_CASE(SMALLINT);
-      INTEGER_CASE(INTEGER);
-      INTEGER_CASE(BIGINT);
-      INTEGER_CASE(HUGEINT);
-      default:
-        break;
-    }
-#undef INTEGER_CASE
+  if (const auto rangeCard = rangeCardinality(oldValue.type, minPtr, maxPtr)) {
+    finalCardinality = std::min(finalCardinality, *rangeCard);
   }
 
   Value result(oldValue.type, finalCardinality);
@@ -1178,7 +1216,7 @@ std::optional<Selectivity> processEqualityClause(
 
   if (!rangeConstraints.eqSelectivity.has_value()) {
     rangeConstraints.eqSelectivity =
-        exprValue.cardinality > 0 ? 1.0 / exprValue.cardinality : 1.0;
+        *exprValue.cardinality > 0 ? 1.0 / *exprValue.cardinality : 1.0;
     rangeConstraints.eqValue = &litValue;
   } else {
     if (rangeConstraints.eqValue != nullptr &&
@@ -1364,7 +1402,7 @@ bool hasContradiction(
 }
 
 // Computes selectivity for an equality constraint.
-Selectivity computeEqualitySelectivity(
+std::optional<Selectivity> computeEqualitySelectivity(
     ConstraintMap& constraints,
     ExprCP leftSide,
     const RangeConstraints& rangeConstraints,
@@ -1381,13 +1419,13 @@ Selectivity computeEqualitySelectivity(
             1.0f));
   }
   // Scale by (1 - nullFraction) since NULLs cannot match equality.
-  return {
+  return Selectivity{
       rangeConstraints.eqSelectivity.value() * (1.0 - nullFraction),
       nullFraction};
 }
 
 // Computes selectivity for an IN list constraint.
-Selectivity computeInListSelectivity(
+std::optional<Selectivity> computeInListSelectivity(
     ConstraintMap& constraints,
     ExprCP leftSide,
     const EffectiveBounds& bounds,
@@ -1398,7 +1436,7 @@ Selectivity computeInListSelectivity(
 
   double inListSize = static_cast<double>(array.size());
   double trueFraction =
-      std::clamp(inListSize / exprValue.cardinality, 0.0, 1.0) *
+      std::clamp(inListSize / *exprValue.cardinality, 0.0, 1.0) *
       (1.0 - nullFraction);
 
   if (updateConstraints) {
@@ -1408,11 +1446,11 @@ Selectivity computeInListSelectivity(
         makeConstraint(constraints, leftSide, minVal, maxVal, inListSize));
   }
 
-  return {trueFraction, nullFraction};
+  return Selectivity{trueFraction, nullFraction};
 }
 
 // Computes selectivity for range bounds (lower/upper).
-Selectivity computeBoundsSelectivity(
+std::optional<Selectivity> computeBoundsSelectivity(
     ConstraintMap& constraints,
     ExprCP leftSide,
     const RangeConstraints& rangeConstraints,
@@ -1420,15 +1458,18 @@ Selectivity computeBoundsSelectivity(
     const Value& exprValue,
     double nullFraction,
     bool updateConstraints) {
-  Selectivity selectivity = rangeSelectivity(
+  auto selectivity = rangeSelectivity(
       constraints, leftSide, rangeConstraints.lower, rangeConstraints.upper);
+  if (!selectivity.has_value()) {
+    return std::nullopt;
+  }
 
   // Use baseTrueFraction (before null scaling) for cardinality estimation.
   // Nulls reduce the fraction of rows passing the filter, but don't reduce
   // the number of distinct values in the matching range.
-  double baseTrueFraction = (exprValue.nullFraction < 1.0)
-      ? selectivity.trueFraction / (1.0 - exprValue.nullFraction)
-      : selectivity.trueFraction;
+  double baseTrueFraction = (nullFraction < 1.0)
+      ? selectivity->trueFraction / (1.0 - nullFraction)
+      : selectivity->trueFraction;
 
   if (updateConstraints) {
     constraints.insert_or_assign(
@@ -1438,7 +1479,7 @@ Selectivity computeBoundsSelectivity(
             leftSide,
             rangeConstraints.lower,
             rangeConstraints.upper,
-            exprValue.cardinality * baseTrueFraction));
+            *exprValue.cardinality * baseTrueFraction));
   }
 
   return selectivity;
@@ -1455,7 +1496,7 @@ Selectivity computeBoundsSelectivity(
 // @param updateConstraints If true, updates constraints with refined
 //        value ranges.
 // @return Selectivity with trueFraction and nullFraction.
-Selectivity rangeSelectivity(
+std::optional<Selectivity> rangeSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> exprs,
     bool updateConstraints) {
@@ -1469,9 +1510,12 @@ Selectivity rangeSelectivity(
       firstCall->args().size(), 1, "Call must have at least one argument");
   ExprCP leftSide = firstCall->args()[0];
 
-  // Retrieve null fraction and other statistics from the left-hand side.
+  // A missing NDV (used for equality bounds) makes the selectivity unknown.
   const auto& exprValue = value(constraints, leftSide);
-  double nullFraction = exprValue.nullFraction;
+  if (!exprValue.cardinality.has_value()) {
+    return std::nullopt;
+  }
+  double nullFraction = exprValue.nullFraction.value_or(0);
 
   RangeConstraints rangeConstraints;
   const auto& fn = queryCtx()->functionNames();

--- a/axiom/optimizer/Filters.h
+++ b/axiom/optimizer/Filters.h
@@ -126,6 +126,12 @@ Value exprConstraint(
 /// BOOLEAN: max 2, TINYINT: max 256, SMALLINT: max 65536.
 Value clampCardinality(const Value& value);
 
+/// Returns the maximum number of distinct values an integer column's [min, max]
+/// range can hold (1 + max - min), or nullopt when the type is not an integer
+/// or either bound is unknown.
+std::optional<float>
+rangeCardinality(TypeCP type, VariantCP min, VariantCP max);
+
 /// Computes selectivity for a conjunction of filter expressions.
 ///
 /// Derives constraints for all expressions in the conjuncts and their
@@ -147,7 +153,7 @@ Value clampCardinality(const Value& value);
 /// expression nodes visited by exprConstraint (columns, calls, fields), not
 /// just columns. Callers that iterate the map should match entries against
 /// known column IDs.
-Selectivity conjunctsSelectivity(
+std::optional<Selectivity> conjunctsSelectivity(
     ConstraintMap& constraints,
     std::span<const ExprCP> conjuncts,
     bool updateConstraints);
@@ -177,7 +183,7 @@ Selectivity conjunctsSelectivity(
 /// @param updateConstraints If true, updates constraints with refined
 ///        value ranges based on the expression semantics.
 /// @return Selectivity with trueFraction and nullFraction.
-Selectivity exprSelectivity(
+std::optional<Selectivity> exprSelectivity(
     ConstraintMap& constraints,
     ExprCP expr,
     bool updateConstraints);
@@ -199,7 +205,7 @@ Selectivity exprSelectivity(
 /// @param funcName Comparison operator: "eq", "lt", "lte", "gt", "gte".
 /// @param updateConstraints If true, adds refined constraints to the map.
 /// @param constraints Map to store constraints keyed by expression ID.
-Selectivity columnComparisonSelectivity(
+std::optional<Selectivity> columnComparisonSelectivity(
     ExprCP left,
     ExprCP right,
     const Value& leftValue,
@@ -214,8 +220,10 @@ Selectivity columnComparisonSelectivity(
 // Filters.cpp.
 // ---------------------------------------------------------------------------
 
-Selectivity combineConjuncts(std::span<const Selectivity> selectivities);
+std::optional<Selectivity> combineConjuncts(
+    std::span<const std::optional<Selectivity>> selectivities);
 
-Selectivity combineDisjuncts(std::span<const Selectivity> selectivities);
+std::optional<Selectivity> combineDisjuncts(
+    std::span<const std::optional<Selectivity>> selectivities);
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -208,10 +208,11 @@ float freqs(const KeyFreq& left, const KeyFreq& right) {
   return hits / static_cast<float>(left.size());
 }
 
-float keyCardinality(const ExprVector& keys) {
-  float cardinality = 1;
+// Product of the key NDVs. Returns nullopt if any key's NDV is unknown.
+std::optional<float> keyCardinality(const ExprVector& keys) {
+  std::optional<float> cardinality = 1;
   for (auto& key : keys) {
-    cardinality *= key->value().cardinality;
+    cardinality = mul(cardinality, key->value().cardinality);
   }
   return cardinality;
 }
@@ -233,7 +234,9 @@ std::pair<float, float> sampleJoin(
   int32_t fraction = kMaxCardinality;
   if (leftRows < kMaxCardinality && rightRows < kMaxCardinality) {
     // Sample all.
-  } else if (leftCard > kMaxCardinality && rightCard > kMaxCardinality) {
+  } else if (
+      leftCard.has_value() && rightCard.has_value() &&
+      *leftCard > kMaxCardinality && *rightCard > kMaxCardinality) {
     // Keys have many values, sample a fraction.
     const auto smaller = static_cast<float>(std::min(leftRows, rightRows));
     const float ratio = smaller / (float)kMaxCardinality;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -54,7 +54,10 @@ Optimization::Optimization(
       logicalPlan_(&logicalPlan),
       history_(history),
       veloxQueryCtx_(std::move(veloxQueryCtx)),
-      topState_{*this, nullptr},
+      topState_{
+          *this,
+          nullptr,
+          optimizerSession_->options().syntacticJoinOrder},
       aggregationPlanner_{
           isSingleWorker_,
           isSingleDriver_,
@@ -218,9 +221,11 @@ void Optimization::applyFilteredStats(
     for (size_t i = 0; i < stats->columnStats.size(); ++i) {
       const auto& columnStats = stats->columnStats[i];
       auto& existing = baseTable.columns[columnIndices[i]]->value();
-      Value value(
-          existing.type,
-          std::max<float>(1, columnStats.numDistinct.value_or(1)));
+      // The column cardinality is unknown when the connector reports no NDV.
+      Value value(existing.type);
+      if (columnStats.numDistinct.has_value()) {
+        value.cardinality = std::max<float>(1, columnStats.numDistinct.value());
+      }
       value.min = columnStats.min.has_value()
           ? registerVariant(columnStats.min.value())
           : nullptr;
@@ -260,7 +265,11 @@ void Optimization::applyFilteredStats(
   ConstraintMap constraints;
   auto selectivity = conjunctsSelectivity(constraints, rejectedFilters, true);
 
-  baseTable.filteredCardinality = stats->numRows * selectivity.trueFraction;
+  // Connector-boundary producer: keep emitting a concrete filtered
+  // cardinality. Fall back to the no-op selectivity (1.0) when unknown.
+  const double rejectedSelectivity =
+      selectivity.has_value() ? selectivity->trueFraction : 1.0;
+  baseTable.filteredCardinality = stats->numRows * rejectedSelectivity;
 
   // Update column values with refined constraints from rejected filters.
   for (const auto& [columnId, constrainedValue] : constraints) {
@@ -504,7 +513,7 @@ PlanP Optimization::bestPlan() {
   topState_.dt = root_;
   topState_.setTargetExprsForDt(targetColumns);
 
-  makeJoins(topState_);
+  makeJoinsWithSyntacticFallback(topState_);
 
   auto* winner = topState_.plans.best();
   if (auto it = planGroupedLeaves_.find(winner);
@@ -607,12 +616,13 @@ void reducingJoinsRecursive(
       continue;
     }
 
-    if (other.fanout > maxFanout) {
+    // An unknown fanout cannot participate in reducing-path analysis; skip.
+    if (!other.fanout.has_value() || *other.fanout > maxFanout) {
       continue;
     }
 
     visited.add(other.table);
-    auto fanout = fanoutFromRoot * other.fanout;
+    auto fanout = fanoutFromRoot * *other.fanout;
     auto nextMaxFanout = maxFanout;
     if (fanout < ReducingJoinsMagic::kReducingPathThreshold) {
       result.add(other.table);
@@ -821,7 +831,7 @@ std::optional<JoinCandidate> reducingJoins(
 
   auto fanout = candidate.fanout;
   if (!result.bushyTables.empty()) {
-    fanout *= result.bushyReduction;
+    fanout = mul(fanout, result.bushyReduction);
   }
 
   JoinCandidate reducing(candidate.join, startTable, fanout);
@@ -900,7 +910,8 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   std::vector<JoinCandidate> candidates;
   candidates.reserve(state.dt->tables.size());
   forJoinedTables(
-      state, [&](JoinEdgeP join, PlanObjectCP joined, float fanout) {
+      state,
+      [&](JoinEdgeP join, PlanObjectCP joined, std::optional<float> fanout) {
         if (!state.isPlaced(joined) && state.dt->hasJoin(join) &&
             state.dt->hasTable(joined)) {
           candidates.emplace_back(join, joined, fanout);
@@ -914,7 +925,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
     // There are no join edges. There could still be cross joins.
     state.dt->startTables.forEach([&](PlanObjectCP object) {
       if (!state.isPlaced(object) && state.mayConsiderNext(object)) {
-        auto fanout = tableCardinality(object);
+        std::optional<float> fanout = tableCardinality(object);
         if (object->is(PlanType::kTableNode)) {
           fanout = object->as<BaseTable>()->filteredCardinality;
         }
@@ -928,7 +939,7 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
   // Take the first hand joined tables and bundle them with reducing joins that
   // can go on the build side.
 
-  if (!options().syntacticJoinOrder && !candidates.empty()) {
+  if (!state.syntacticJoinOrder() && !candidates.empty()) {
     std::vector<JoinCandidate> bushes;
     for (auto& candidate : candidates) {
       if (auto bush = reducingJoins(state, candidate)) {
@@ -941,12 +952,20 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
 
   std::ranges::sort(
       candidates, [](const JoinCandidate& left, const JoinCandidate& right) {
-        return left.fanout < right.fanout;
+        // Order by fanout; an unknown fanout sorts last so candidates with a
+        // computable cost are explored first.
+        if (!left.fanout.has_value()) {
+          return false;
+        }
+        if (!right.fanout.has_value()) {
+          return true;
+        }
+        return *left.fanout < *right.fanout;
       });
 
   // Keep only the candidate that matches the next unplaced table in
   // dt->joinOrder.
-  if (options().syntacticJoinOrder && candidates.size() > 1) {
+  if (state.syntacticJoinOrder() && candidates.size() > 1) {
     auto nextIt = std::find_if(
         state.dt->joinOrder.begin(),
         state.dt->joinOrder.end(),
@@ -1896,14 +1915,17 @@ void Optimization::joinByIndex(
       return;
     }
 
-    auto fanout = info.scanCardinality * rightTable->filteredCardinality /
-        rightTable->schemaTable->cardinality;
+    // Index lookup fanout is unknown when the right table's filtered
+    // cardinality is unknown.
+    std::optional<float> fanout = divide(
+        mul(info.scanCardinality, rightTable->filteredCardinality),
+        rightTable->schemaTable->cardinality);
     if (joinType == velox::core::JoinType::kLeft) {
-      fanout = std::max<float>(1, fanout);
+      fanout = maxOf(fanout, 1.0f);
     } else if (joinType == velox::core::JoinType::kLeftSemiProject) {
       fanout = 1;
     } else if (joinType == velox::core::JoinType::kLeftSemiFilter) {
-      fanout = std::min<float>(1, fanout);
+      fanout = minOf(fanout, 1.0f);
     }
 
     auto lookupKeys = left.keys;
@@ -2380,7 +2402,7 @@ void Optimization::joinByHash(
       projectionBuilder.inputColumns());
 
   state.addCost(*join);
-  state.cost.cost += buildState.cost.cost;
+  state.cost.cost = add(state.cost.cost, buildState.cost.cost);
   mergeFragmentMaps(
       state.mutableCurrentGroupedLeaves(),
       std::move(buildState.mutableCurrentGroupedLeaves()));
@@ -2538,7 +2560,7 @@ void Optimization::joinByHashRight(
 
   state.replaceColumns(projectionBuilder.outputColumns());
   state.cost = probeState.cost;
-  state.cost.cost += buildCost.cost;
+  state.cost.cost = add(state.cost.cost, buildCost.cost);
 
   if (!isSingleWorker_) {
     // The build gets shuffled to align with probe. If probe is not
@@ -2642,7 +2664,7 @@ void Optimization::crossJoin(
     buildInput = broadcast;
   }
 
-  state.cost.cost += buildState.cost.cost;
+  state.cost.cost = add(state.cost.cost, buildState.cost.cost);
   mergeFragmentMaps(
       state.mutableCurrentGroupedLeaves(),
       std::move(buildState.mutableCurrentGroupedLeaves()));
@@ -2861,7 +2883,7 @@ void Optimization::addJoin(
 
   std::vector<NextJoin> toTry;
 
-  if (options().syntacticJoinOrder &&
+  if (state.syntacticJoinOrder() &&
       candidate.join->originalJoinType().has_value() &&
       candidate.join->originalJoinType().value() ==
           logical_plan::JoinType::kRight) {
@@ -2872,7 +2894,7 @@ void Optimization::addJoin(
     const auto sizeAfterIndex = toTry.size();
     joinByHash(plan, candidate, state, toTry);
 
-    if (!options().syntacticJoinOrder && toTry.size() > sizeAfterIndex &&
+    if (!state.syntacticJoinOrder() && toTry.size() > sizeAfterIndex &&
         candidate.join->isNonCommutative() &&
         candidate.join->hasRightHashVariant()) {
       // There is a hash based candidate with a non-commutative join. Try a
@@ -2933,7 +2955,7 @@ RelationOpPtr Optimization::placeSingleRowDt(
     rightOp = broadcast;
   }
 
-  state.cost.cost += rightState.cost.cost;
+  state.cost.cost = add(state.cost.cost, rightState.cost.cost);
   mergeFragmentMaps(
       state.mutableCurrentGroupedLeaves(),
       std::move(rightState.mutableCurrentGroupedLeaves()));
@@ -3172,8 +3194,9 @@ PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
   for (auto i = 1; i < states.size(); ++i) {
     const auto& otherCost = states[i].cost;
 
-    firstState.cost.cost += otherCost.cost;
-    firstState.cost.cardinality += otherCost.cardinality;
+    firstState.cost.cost = add(firstState.cost.cost, otherCost.cost);
+    firstState.cost.cardinality =
+        add(firstState.cost.cardinality, otherCost.cardinality);
 
     mergeFragmentMaps(
         firstState.mutableCurrentGroupedLeaves(),
@@ -3182,10 +3205,9 @@ PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
   return make<Plan>(result, states[0]);
 }
 
-float startingScore(PlanObjectCP table) {
+std::optional<float> startingScore(PlanObjectCP table) {
   if (table->is(PlanType::kTableNode)) {
-    auto* baseTable = table->as<BaseTable>();
-    return baseTable->filteredCardinality;
+    return table->as<BaseTable>()->filteredCardinality;
   }
 
   if (table->is(PlanType::kValuesTableNode)) {
@@ -3202,7 +3224,7 @@ float startingScore(PlanObjectCP table) {
 }
 
 std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
-  std::vector<float> scores;
+  std::vector<std::optional<float>> scores;
   scores.reserve(tables.size());
   for (auto table : tables) {
     scores.emplace_back(startingScore(table));
@@ -3211,7 +3233,14 @@ std::vector<int32_t> sortByStartingScore(const PlanObjectVector& tables) {
   std::vector<int32_t> indices(tables.size());
   std::iota(indices.begin(), indices.end(), 0);
   std::ranges::sort(indices, [&](int32_t left, int32_t right) {
-    return scores[left] > scores[right];
+    // Larger starting score first; an unknown score sorts last.
+    if (!scores[left].has_value()) {
+      return false;
+    }
+    if (!scores[right].has_value()) {
+      return true;
+    }
+    return *scores[left] > *scores[right];
   });
 
   return indices;
@@ -3229,7 +3258,7 @@ void Optimization::makeJoins(PlanState& state) {
 
   PlanObjectVector firstTables;
 
-  if (options().syntacticJoinOrder) {
+  if (state.syntacticJoinOrder()) {
     // Single-row derived tables keep their syntactic position but are not valid
     // starting tables. They are appended after the driving table as cross
     // products.
@@ -3302,9 +3331,32 @@ void Optimization::makeJoins(PlanState& state) {
   }
 }
 
+void Optimization::makeJoinsWithSyntacticFallback(PlanState& state) {
+  makeJoins(state);
+  if (state.syntacticJoinOrder()) {
+    return;
+  }
+
+  // Cost-based enumeration drops every partial plan whose cost is unknown, so
+  // an empty plan set means the DT has no costable plan. Re-enumerate it from a
+  // clean state forced to syntactic order.
+  if (state.plans.plans.empty()) {
+    PlanState syntacticState(*this, state.dt, /*syntacticJoinOrder=*/true);
+    syntacticState.targetExprs = state.targetExprs;
+    makeJoins(syntacticState);
+    state.plans = std::move(syntacticState.plans);
+  }
+}
+
 void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
   VELOX_CHECK_NOT_NULL(plan);
   auto dt = state.dt;
+
+  // An unknown-cost partial plan cannot be ranked, so cost-based enumeration
+  // drops it. Syntactic-order enumeration ranks nothing and keeps it.
+  if (!state.syntacticJoinOrder() && !state.cost.cost.has_value()) {
+    return;
+  }
 
   if (state.isOverBest()) {
     trace(OptimizerOptions::kExceededBest, dt->id(), state.cost, *plan);
@@ -3362,7 +3414,7 @@ void Optimization::makeJoins(RelationOpPtr plan, PlanState& state) {
 
 RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   const auto key = dt.memoKey();
-  PlanState state(*this, &dt);
+  PlanState state(*this, &dt, options().syntacticJoinOrder);
   RelationOpPtr result;
 
   if (dt.isUnion()) {
@@ -3384,7 +3436,7 @@ RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   } else {
     // Non-union.
     state.targetExprs.unionObjects(dt.exprs);
-    makeJoins(state);
+    makeJoinsWithSyntacticFallback(state);
     result = state.plans.best()->op;
   }
 
@@ -3454,10 +3506,10 @@ PlanP Optimization::makeUnionPlan(
         // references columns pruned from the scan.
         pruneOutputColumns(tmpDt, inputKey.columns);
 
-        PlanState inner(*this, tmpDt);
+        PlanState inner(*this, tmpDt, options().syntacticJoinOrder);
         inner.setTargetExprsForDt(inputKey.columns);
 
-        makeJoins(inner);
+        makeJoinsWithSyntacticFallback(inner);
         memo_.insert(inputKey, std::move(inner.plans));
         plans = memo_.find(inputKey);
       }
@@ -3591,7 +3643,7 @@ PlanP Optimization::makeDtPlan(
     tmpDt->cname = newCName("tmp_dt");
     tmpDt->import(dt, key.tables, key.firstTable, key.existences, existsFanout);
 
-    PlanState inner(*this, tmpDt);
+    PlanState inner(*this, tmpDt, options().syntacticJoinOrder);
     if (key.firstTable->is(PlanType::kDerivedTableNode) &&
         !tmpDt->columns.empty()) {
       // tmpDt wraps a subquery DT and has output columns from flattening.
@@ -3603,7 +3655,7 @@ PlanP Optimization::makeDtPlan(
       inner.targetExprs = key.columns;
     }
 
-    makeJoins(inner);
+    makeJoinsWithSyntacticFallback(inner);
     memo_.insert(key, std::move(inner.plans));
     plans = memo_.find(key);
   }

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -245,6 +245,14 @@ class Optimization {
 
   void makeJoins(PlanState& state);
 
+  // Enumerates joins for 'state' via makeJoins() and, if the resulting best
+  // plan has an uncomputable cost (a missing statistic tainted the estimate),
+  // re-enumerates the DT in the query's syntactic join order. When the cost
+  // cannot be trusted, the order written in the query is preferred over a
+  // poisoned estimate. No-op second pass when the DT is already syntactic or a
+  // rankable plan exists.
+  void makeJoinsWithSyntacticFallback(PlanState& state);
+
   // Retrieves or makes a plan from 'key'. 'key' specifies a set of top level
   // joined tables or a hash join build side table or join.
   //

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -30,10 +30,13 @@ bool isSingleWorker() {
 
 } // namespace
 
-PlanState::PlanState(Optimization& optimization, DerivedTableCP dt)
+PlanState::PlanState(
+    Optimization& optimization,
+    DerivedTableCP dt,
+    bool syntacticJoinOrder)
     : optimization(optimization),
       dt(dt),
-      syntacticJoinOrder_{optimization.options().syntacticJoinOrder} {}
+      syntacticJoinOrder_{syntacticJoinOrder} {}
 
 PlanState::PlanState(Optimization& optimization, DerivedTableCP dt, PlanP plan)
     : optimization(optimization),
@@ -181,7 +184,9 @@ Plan::Plan(RelationOpPtr op, const PlanState& state)
 }
 
 bool Plan::isStateBetter(const PlanState& state, float margin) const {
-  return cost.cost > state.cost.cost + margin;
+  // Unknown costs are not comparable, so a plan with an unknown cost is never
+  // declared better.
+  return lessThan(add(state.cost.cost, margin), cost.cost);
 }
 
 std::string Plan::printCost() const {
@@ -424,7 +429,11 @@ std::string PlanState::printPlan(RelationOpPtr op, bool detail) const {
 
 PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
   int32_t replaceIndex = -1;
-  const float shuffle = shuffleCost(plan->columns()) * state.cost.cardinality;
+  // Shuffle margin for cost comparisons. 0 when the cardinality is unknown: the
+  // comparisons (isStateBetter) don't rank unknown costs anyway, so the margin
+  // is moot.
+  const float shuffle =
+      shuffleCost(plan->columns()) * state.cost.cardinality.value_or(0);
 
   if (!plans.empty()) {
     // Compare with existing. If there is one with same distribution and new is
@@ -474,8 +483,12 @@ PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
   auto newPlan = std::make_unique<Plan>(std::move(plan), state);
   auto* result = newPlan.get();
 
-  const auto newPlanCost = result->cost.cost + shuffle;
-  bestCostWithShuffle = std::min(bestCostWithShuffle, newPlanCost);
+  // bestCostWithShuffle tracks the cheapest known-cost plan; an unknown-cost
+  // plan does not participate.
+  if (result->cost.cost.has_value()) {
+    bestCostWithShuffle =
+        std::min(bestCostWithShuffle, *result->cost.cost + shuffle);
+  }
   if (replaceIndex >= 0) {
     plans[replaceIndex] = std::move(newPlan);
   } else {
@@ -497,7 +510,12 @@ PlanP PlanSet::best(
   const bool checkDistribution = !isSingleWorker() && distribution.has_value();
 
   for (const auto& plan : plans) {
-    const float cost = plan->cost.cost;
+    // Unknown-cost plans are not rankable by cost; skip them in cost-based
+    // selection (handled by the fallback below).
+    if (!plan->cost.cost.has_value()) {
+      continue;
+    }
+    const float cost = *plan->cost.cost;
 
     auto update = [&](PlanP& current, float& currentCost) {
       if (!current || cost < currentCost) {
@@ -513,7 +531,22 @@ PlanP PlanSet::best(
     }
   }
 
-  VELOX_DCHECK_NOT_NULL(best);
+  // All plans have unknown cost (CBO bailed to syntactic order, which ranks
+  // nothing). Cost-based selection is impossible, but distribution still
+  // matters: prefer a plan already copartitioned with the requested
+  // distribution; otherwise return one and flag that a shuffle is needed.
+  if (best == nullptr) {
+    if (checkDistribution) {
+      for (const auto& plan : plans) {
+        if (plan->op->distribution().isCopartitionedWith(
+                distribution.value())) {
+          return plan.get();
+        }
+      }
+      needsShuffle = true;
+    }
+    return plans.front().get();
+  }
 
   if (!checkDistribution || best == match) {
     return best;
@@ -521,7 +554,7 @@ PlanP PlanSet::best(
 
   if (match) {
     const float shuffle =
-        shuffleCost(best->op->columns()) * best->cost.cardinality;
+        shuffleCost(best->op->columns()) * best->cost.cardinality.value_or(0);
     if (matchCost <= bestCost + shuffle) {
       return match;
     }
@@ -593,12 +626,13 @@ void JoinCandidate::addEdge(
       }
       if (!newEdgeCounted) {
         newEdgeCounted = true;
-        auto preFanout = join->lrFanout();
+        const auto preFanout = join->lrFanout();
         auto [other, newFanout] = edge->otherTable(newPlacedSide.table);
         // We update the lr fanout. The rl fanout will not be used for an inner
-        // join, so we set this to 1.
+        // join, so we set this to 1. The combined fanout is unknown if either
+        // input fanout is unknown.
         join->setFanouts(
-            std::min(newFanout * preFanout, std::min(preFanout, newFanout)), 1);
+            minOf(mul(newFanout, preFanout), minOf(preFanout, newFanout)), 1);
         fanout = join->lrFanout();
       }
       join->addEquality(key, newTableSide.keys[i]);
@@ -627,7 +661,12 @@ bool JoinCandidate::isDominantEdge(PlanState& state, JoinEdgeP edge) {
 std::string JoinCandidate::toString() const {
   std::stringstream out;
   if (join != nullptr) {
-    out << join->toString() << " fanout " << fanout;
+    out << join->toString() << " fanout ";
+    if (fanout.has_value()) {
+      out << *fanout;
+    } else {
+      out << "?";
+    }
   } else {
     out << "x-join: " << tables[0]->toString();
   }
@@ -646,10 +685,14 @@ std::string JoinCandidate::toString() const {
 bool NextJoin::isWorse(const NextJoin& other) const {
   float shuffle = 0;
   if (!plan->distribution().isSamePartition(other.plan->distribution())) {
-    shuffle = other.cost.cardinality * shuffleCost(other.plan->columns());
+    // The shuffle margin only refines a comparison of known costs; an unknown
+    // cardinality contributes 0.
+    shuffle =
+        other.cost.cardinality.value_or(0) * shuffleCost(other.plan->columns());
   }
 
-  return cost.cost > other.cost.cost + shuffle;
+  // Unknown costs are incomparable, so neither variant is declared worse.
+  return lessThan(add(other.cost.cost, shuffle), cost.cost);
 }
 
 velox::core::JoinType reverseJoinType(velox::core::JoinType joinType) {

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -105,7 +105,7 @@ struct PlanSet {
 /// Represents the next table/derived table to join. May consist of several
 /// tables for a bushy build side.
 struct JoinCandidate {
-  JoinCandidate(JoinEdgeP join, PlanObjectCP right, float fanout)
+  JoinCandidate(JoinEdgeP join, PlanObjectCP right, std::optional<float> fanout)
       : join(join), tables({right}), fanout(fanout) {}
 
   /// Returns two join sides. First is the side that contains 'tables' (build).
@@ -146,8 +146,9 @@ struct JoinCandidate {
 
   /// Number of right side hits for one row on the left. The join
   /// selectivity in 'tables' affects this but the selectivity in
-  /// 'existences' does not.
-  float fanout;
+  /// 'existences' does not. nullopt when a missing statistic makes the fanout
+  /// unknown; such a candidate yields an uncomputable join cost.
+  std::optional<float> fanout;
 
   /// Product of the selectivities from 'existences'. Used to set
   /// the fanout on the exists-DT join. 0.2 means existences
@@ -198,7 +199,12 @@ class Optimization;
 /// Tracks the set of tables / columns that have been placed or are still needed
 /// when constructing a partial plan.
 struct PlanState {
-  PlanState(Optimization& optimization, DerivedTableCP dt);
+  /// 'syntacticJoinOrder' enumerates this DT in the query's syntactic join
+  /// order.
+  PlanState(
+      Optimization& optimization,
+      DerivedTableCP dt,
+      bool syntacticJoinOrder);
 
   PlanState(Optimization& optimization, DerivedTableCP dt, PlanP plan);
 
@@ -257,11 +263,15 @@ struct PlanState {
   /// limited to a single conjunct. Returns that conjunct or nullptr.
   ExprCP isDownstreamFilterOnly(ColumnCP column) const;
 
-  /// If OptimizerOptions::syntacticJoinOrder is true, returns true if all
-  /// tables that must be placed before 'table' have been placed. If
-  /// OptimizerOptions::syntacticJoinOrder is false, returns true
-  /// unconditionally.
+  /// In syntactic-order enumeration (syntacticJoinOrder()), returns true only
+  /// if all tables that must be placed before 'table' have been placed.
+  /// Otherwise returns true unconditionally.
   bool mayConsiderNext(PlanObjectCP table) const;
+
+  /// Returns whether this DT is enumerated in the query's syntactic join order.
+  bool syntacticJoinOrder() const {
+    return syntacticJoinOrder_;
+  }
 
   /// Adds a placed join to the set of partial queries to be developed.
   /// No-op if cost exceeds best so far and cutoff is enabled.
@@ -279,7 +289,9 @@ struct PlanState {
   /// True if the costs accumulated so far are so high that this should not be
   /// explored further.
   bool isOverBest() const {
-    return hasCutoff_ && cost.cost > plans.bestCostWithShuffle;
+    // An unknown cost cannot exceed the cutoff, so it is never over best.
+    return hasCutoff_ && cost.cost.has_value() &&
+        cost.cost.value() > plans.bestCostWithShuffle;
   }
 
   void debugSetFirstTable(int32_t id);
@@ -338,6 +350,9 @@ struct PlanState {
   mutable folly::F14FastMap<PlanObjectSet, PlanObjectSet>
       downstreamColumnsCache_;
 
+  // Whether this DT is enumerated in the query's syntactic join order. Set at
+  // construction from OptimizerOptions::syntacticJoinOrder, or true for the
+  // bail-retry state of a DT whose CBO cost is uncomputable.
   const bool syntacticJoinOrder_;
 
   // True if we should backtrack when 'cost' exceeds the best cost with

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -85,7 +85,7 @@ Name cname(PlanObjectCP relation) {
   }
 }
 
-float tableCardinality(PlanObjectCP table) {
+std::optional<float> tableCardinality(PlanObjectCP table) {
   if (table->is(PlanType::kTableNode)) {
     return table->as<BaseTable>()->schemaTable->cardinality;
   }
@@ -743,34 +743,44 @@ PlanObjectSet JoinEdge::allTables() const {
 namespace {
 
 struct JoinFanout {
-  float fanout;
-  bool unique;
+  std::optional<float> fanout;
+  bool unique{false};
 };
 
 // Estimates the number of matching rows per equality lookup on 'keys' given
 // 'scanCardinality' total rows. For each key pair, divides by
 // max(ndv(thisKey), ndv(otherKey)) to account for values on the probe side
-// that have no match on the scan side.
-float estimateFanout(
-    float scanCardinality,
+// that have no match on the scan side. Returns nullopt (unknown) if the scan
+// cardinality or any join-key NDV is unknown.
+std::optional<float> estimateFanout(
+    std::optional<float> scanCardinality,
     const ExprVector& keys,
     const ExprVector& otherKeys) {
+  if (!scanCardinality.has_value()) {
+    return std::nullopt;
+  }
   if (keys.empty()) {
     return scanCardinality;
   }
 
   for (size_t i = 0; i < keys.size(); ++i) {
-    if (keys[i]->value().cardinality == 0 ||
-        otherKeys[i]->value().cardinality == 0) {
+    const auto thisNdv = keys[i]->value().cardinality;
+    const auto otherNdv = otherKeys[i]->value().cardinality;
+    // An unknown join-key NDV makes the fanout unknown.
+    if (!thisNdv.has_value() || !otherNdv.has_value()) {
+      return std::nullopt;
+    }
+    if (*thisNdv == 0 || *otherNdv == 0) {
       return 0;
     }
   }
 
-  auto fanout = scanCardinality /
-      std::max(keys[0]->value().cardinality, otherKeys[0]->value().cardinality);
+  auto fanout = *scanCardinality /
+      std::max(
+          *keys[0]->value().cardinality, *otherKeys[0]->value().cardinality);
   for (size_t i = 1; i < keys.size(); ++i) {
     auto distinctValues = std::max(
-        keys[i]->value().cardinality, otherKeys[i]->value().cardinality);
+        *keys[i]->value().cardinality, *otherKeys[i]->value().cardinality);
     if (distinctValues > fanout) {
       fanout = 1;
     } else {
@@ -833,15 +843,20 @@ JoinFanout joinFanout(
   };
 }
 
-float baseSelectivity(PlanObjectCP object) {
+std::optional<float> baseSelectivity(PlanObjectCP object) {
   if (object->is(PlanType::kTableNode)) {
     auto* baseTable = object->as<BaseTable>();
     const auto baseCardinality = baseTable->schemaTable->cardinality;
+    const auto filteredCardinality = baseTable->filteredCardinality;
+    // An unknown filtered cardinality makes the selectivity unknown.
+    if (!filteredCardinality.has_value()) {
+      return std::nullopt;
+    }
     // filteredCardinality can exceed baseCardinality when the connector
     // returns inconsistent statistics, e.g. Table::numRows() returns 0
     // while co_estimateStats returns the real partition row count.
-    if (baseCardinality > baseTable->filteredCardinality) {
-      return baseTable->filteredCardinality / baseCardinality;
+    if (baseCardinality > *filteredCardinality) {
+      return *filteredCardinality / baseCardinality;
     }
   }
   return 1;
@@ -874,23 +889,28 @@ void JoinEdge::guessFanout() {
   // match many lineitems (lrFanout = cardLineitem / cardOrders). When both
   // sides are unique (1:1 join), leftUnique takes precedence.
   if (leftUnique_) {
-    rlFanout_ = left.fanout * baseSelectivity(leftTable_);
-    lrFanout_ = tableCardinality(rightTable_) / tableCardinality(leftTable_) *
-        baseSelectivity(rightTable_);
+    rlFanout_ = mul(left.fanout, baseSelectivity(leftTable_));
+    lrFanout_ =
+        mul(divide(tableCardinality(rightTable_), tableCardinality(leftTable_)),
+            baseSelectivity(rightTable_));
   } else if (rightUnique_) {
-    lrFanout_ = right.fanout * baseSelectivity(rightTable_);
-    rlFanout_ = tableCardinality(leftTable_) / tableCardinality(rightTable_) *
-        baseSelectivity(leftTable_);
+    lrFanout_ = mul(right.fanout, baseSelectivity(rightTable_));
+    rlFanout_ =
+        mul(divide(tableCardinality(leftTable_), tableCardinality(rightTable_)),
+            baseSelectivity(leftTable_));
   } else {
     auto [sampledLeftFanout, sampledRightFanout] = options.sampleJoins
         ? opt->history().sampleJoin(this)
         : std::pair<float, float>(0, 0);
     if (sampledLeftFanout == 0 && sampledRightFanout == 0) {
-      lrFanout_ = right.fanout * baseSelectivity(rightTable_);
-      rlFanout_ = left.fanout * baseSelectivity(leftTable_);
+      lrFanout_ = mul(right.fanout, baseSelectivity(rightTable_));
+      rlFanout_ = mul(left.fanout, baseSelectivity(leftTable_));
     } else {
-      lrFanout_ = sampledRightFanout * baseSelectivity(rightTable_);
-      rlFanout_ = sampledLeftFanout * baseSelectivity(leftTable_);
+      lrFanout_ =
+          mul(std::optional<float>(sampledRightFanout),
+              baseSelectivity(rightTable_));
+      rlFanout_ = mul(
+          std::optional<float>(sampledLeftFanout), baseSelectivity(leftTable_));
     }
   }
 }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/PathSet.h"
 #include "axiom/optimizer/Schema.h"
@@ -480,7 +481,7 @@ struct Equivalence {
 struct JoinSide {
   PlanObjectCP table;
   const ExprVector& keys;
-  const float fanout;
+  const std::optional<float> fanout;
   const velox::core::JoinType joinType;
   ColumnCP markColumn;
   const bool isUnique;
@@ -734,11 +735,11 @@ class JoinEdge {
     return rightKeys_;
   }
 
-  float lrFanout() const {
+  std::optional<float> lrFanout() const {
     return lrFanout_;
   }
 
-  float rlFanout() const {
+  std::optional<float> rlFanout() const {
     return rlFanout_;
   }
 
@@ -883,13 +884,14 @@ class JoinEdge {
   /// Returns the table on the other side of 'table' and the number of rows in
   /// the returned table for one row in 'table'. Returns {nullptr, 0} if the
   /// 'other' side of the join has multiple tables.
-  std::pair<PlanObjectCP, float> otherTable(PlanObjectCP table) const {
+  std::pair<PlanObjectCP, std::optional<float>> otherTable(
+      PlanObjectCP table) const {
     VELOX_DCHECK_NOT_NULL(table);
     return leftTable_ == table
-        ? std::pair<PlanObjectCP, float>{rightTable_, lrFanout_}
+        ? std::pair<PlanObjectCP, std::optional<float>>{rightTable_, lrFanout_}
         : rightTable_ == table && leftTable_ != nullptr
-        ? std::pair<PlanObjectCP, float>{leftTable_, rlFanout_}
-        : std::pair<PlanObjectCP, float>{nullptr, 0};
+        ? std::pair<PlanObjectCP, std::optional<float>>{leftTable_, rlFanout_}
+        : std::pair<PlanObjectCP, std::optional<float>>{nullptr, 0};
   }
 
   PlanObjectCP otherSide(PlanObjectCP side) const {
@@ -908,7 +910,9 @@ class JoinEdge {
     return filter_;
   }
 
-  void setFanouts(float leftToRight, float rightToLeft) {
+  void setFanouts(
+      std::optional<float> leftToRight,
+      std::optional<float> rightToLeft) {
     fanoutsFixed_ = true;
     lrFanout_ = leftToRight;
     rlFanout_ = rightToLeft;
@@ -943,10 +947,10 @@ class JoinEdge {
   const ExprVector filter_;
 
   // Number of right side rows selected for one row on the left.
-  float lrFanout_{1};
+  std::optional<float> lrFanout_{1};
 
   // Number of left side rows selected for one row on the right.
-  float rlFanout_{1};
+  std::optional<float> rlFanout_{1};
 
   // True if 'lrFanout_' and 'rlFanout_' are set by setFanouts.
   bool fanoutsFixed_{false};
@@ -1019,8 +1023,9 @@ struct BaseTable : public PlanObject {
   ExprVector filter;
 
   /// Estimated number of rows after applying all filters involving this table
-  /// only. Initialized to schemaTable->cardinality (no filtering).
-  float filteredCardinality{0};
+  /// only. Initialized to schemaTable->cardinality (no filtering). nullopt if
+  /// the cardinality is unknown.
+  std::optional<float> filteredCardinality{0};
 
   SubfieldSet controlSubfields;
 
@@ -1508,8 +1513,8 @@ using WritePlanCP = const WritePlan*;
 /// UnnestTable, or DerivedTable.
 Name cname(PlanObjectCP relation);
 
-/// @return estimated number of rows in 'table'. 'table' must be a BaseTable,
-/// ValuesTable, UnnestTable, or DerivedTable.
-float tableCardinality(PlanObjectCP table);
+/// @return estimated number of rows in 'table', or nullopt if unknown. 'table'
+/// must be a BaseTable, ValuesTable, UnnestTable, or DerivedTable.
+std::optional<float> tableCardinality(PlanObjectCP table);
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -29,7 +29,7 @@
 namespace facebook::axiom::optimizer {
 
 void PlanCost::add(RelationOp& op) {
-  cost += op.cost().totalCost();
+  cost = optimizer::add(cost, op.cost().totalCost());
   cardinality = op.resultCardinality();
 }
 
@@ -85,7 +85,7 @@ std::string itemsToString(const T* items, size_t n) {
 // For non-leaf nodes, the fanout represents the change in cardinality (output
 // cardinality / input cardinality), and the unitCost is the per-row cost.
 void updateLeafCost(
-    float cardinality,
+    std::optional<float> cardinality,
     const ColumnVector& columns,
     Cost& cost) {
   cost.fanout = cardinality;
@@ -94,20 +94,21 @@ void updateLeafCost(
   const auto numColumns = static_cast<float>(columns.size());
   const auto rowCost = numColumns * Costs::kColumnRowCost +
       std::max<float>(0, size - 8 * numColumns) * Costs::kColumnByteCost;
-  cost.unitCost += cost.fanout * rowCost;
+  // An unknown cardinality makes the unit cost unknown.
+  cost.unitCost = mul(cost.fanout, rowCost);
 }
 
-float orderPrefixDistance(
+std::optional<float> orderPrefixDistance(
     const RelationOpPtr& input,
     ColumnGroupCP index,
     const ExprVector& keys) {
   const auto& orderKeys = index->distribution.orderKeys();
-  float selection = 1;
+  std::optional<float> selection = 1;
   for (int32_t i = 0; i < input->distribution().orderKeys().size() &&
        i < orderKeys.size() && i < keys.size();
        ++i) {
     if (input->distribution().orderKeys()[i]->sameOrEqual(*keys[i])) {
-      selection *= orderKeys[i]->value().cardinality;
+      selection = mul(selection, orderKeys[i]->value().cardinality);
     }
   }
   return selection;
@@ -135,7 +136,7 @@ TableScan::TableScan(
     Distribution distribution,
     BaseTableCP table,
     ColumnGroupCP index,
-    float fanout,
+    std::optional<float> fanout,
     ColumnVector columns,
     ExprVector lookupKeys,
     velox::core::JoinType joinType,
@@ -161,20 +162,25 @@ TableScan::TableScan(
   }
 
   if (!keys.empty()) {
-    float lookupRange(index->table->cardinality);
-    float orderSelectivity = orderPrefixDistance(input_, index, keys);
-    auto distance = lookupRange / std::max<float>(1, orderSelectivity);
-    float batchSize = std::min<float>(cost_.inputCardinality, 10000);
-    if (orderSelectivity == 1) {
-      // The data does not come in key order.
-      float batchCost = index->lookupCost(lookupRange) +
-          index->lookupCost(lookupRange / batchSize) *
-              std::max<float>(1, batchSize);
-      cost_.unitCost = batchCost / batchSize;
-    } else {
-      float batchCost = index->lookupCost(lookupRange) +
-          index->lookupCost(distance) * std::max<float>(1, batchSize);
-      cost_.unitCost = batchCost / batchSize;
+    const auto orderSelectivityOpt = orderPrefixDistance(input_, index, keys);
+    // The lookup unit cost is unknown if the input cardinality (batch size) or
+    // the order selectivity could not be estimated.
+    if (cost_.inputCardinality.has_value() && orderSelectivityOpt.has_value()) {
+      float lookupRange(index->table->cardinality);
+      float orderSelectivity = *orderSelectivityOpt;
+      auto distance = lookupRange / std::max<float>(1, orderSelectivity);
+      float batchSize = std::min<float>(*cost_.inputCardinality, 10000);
+      if (orderSelectivity == 1) {
+        // The data does not come in key order.
+        float batchCost = index->lookupCost(lookupRange) +
+            index->lookupCost(lookupRange / batchSize) *
+                std::max<float>(1, batchSize);
+        cost_.unitCost = batchCost / batchSize;
+      } else {
+        float batchCost = index->lookupCost(lookupRange) +
+            index->lookupCost(distance) * std::max<float>(1, batchSize);
+        cost_.unitCost = batchCost / batchSize;
+      }
     }
     return;
   }
@@ -182,11 +188,14 @@ TableScan::TableScan(
   const auto cardinality = baseTable->filteredCardinality;
   updateLeafCost(cardinality, columns_, cost_);
 
-  // Cap column cardinalities to the output row count.
-  const auto outputCardinality = resultCardinality();
-  for (auto& [id, constraint] : constraints_) {
-    constraint.cardinality =
-        std::min(constraint.cardinality, outputCardinality);
+  // Cap column cardinalities to the output row count. Skip when the output
+  // cardinality is unknown so a known NDV is not wiped out.
+  const std::optional<float> outputCardinality = resultCardinality();
+  if (outputCardinality.has_value()) {
+    for (auto& [id, constraint] : constraints_) {
+      constraint.cardinality =
+          minOf(constraint.cardinality, *outputCardinality);
+    }
   }
 }
 
@@ -204,30 +213,55 @@ Distribution TableScan::outputDistribution(
   return index->distribution.rename(schemaColumns, columns);
 }
 
+namespace {
+std::string formatNumber(std::optional<float> value) {
+  return value.has_value() ? succinctNumber(*value) : "?";
+}
+
+std::string formatBytes(std::optional<float> value) {
+  return value.has_value() ? velox::succinctBytes(static_cast<uint64_t>(*value))
+                           : "?";
+}
+} // namespace
+
 std::string Cost::toString(bool /*detail*/, bool isUnit) const {
   std::stringstream out;
-  float multiplier = isUnit ? 1 : inputCardinality;
-  out << succinctNumber(fanout * multiplier) << " rows "
-      << succinctNumber(unitCost * multiplier) << "CU";
+  const std::optional<float> multiplier =
+      isUnit ? std::optional<float>(1) : inputCardinality;
+  out << formatNumber(mul(fanout, multiplier)) << " rows "
+      << formatNumber(mul(unitCost, multiplier)) << "CU";
 
-  if (totalBytes > 0) {
-    out << " build= "
-        << velox::succinctBytes(static_cast<uint64_t>(totalBytes));
+  // Show byte volumes when unknown or known-positive; skip a known zero.
+  if (!totalBytes.has_value() || *totalBytes > 0) {
+    out << " build= " << formatBytes(totalBytes);
   }
-  if (transferBytes > 0) {
-    out << " network= "
-        << velox::succinctBytes(static_cast<uint64_t>(transferBytes));
+  if (!transferBytes.has_value() || *transferBytes > 0) {
+    out << " network= " << formatBytes(transferBytes);
   }
   return out.str();
+}
+
+std::string PlanCost::toString() const {
+  const auto format = [](std::optional<float> value) -> std::string {
+    return value.has_value()
+        ? fmt::format(std::locale("en_US.UTF-8"), "{:L}", *value)
+        : "?";
+  };
+  return fmt::format(
+      "cost: {}, cardinality: {}", format(cost), format(cardinality));
 }
 
 void RelationOp::checkInputCardinality() const {
   if (input_ != nullptr) {
     const auto inputCardinality = input_->resultCardinality();
-    VELOX_CHECK(std::isfinite(inputCardinality));
+    // Only validate when the cardinality is known; an unknown estimate
+    // legitimately propagates as nullopt.
+    if (inputCardinality.has_value()) {
+      VELOX_CHECK(std::isfinite(*inputCardinality));
 
-    // TODO Assert that inputCardinality > 0.
-    VELOX_CHECK_GE(inputCardinality, 0);
+      // TODO Assert that inputCardinality > 0.
+      VELOX_CHECK_GE(*inputCardinality, 0);
+    }
   }
 }
 
@@ -263,9 +297,9 @@ std::string RelationOp::toOneline() const {
 void RelationOp::printCost(bool detail, std::stringstream& out) const {
   auto ctx = queryCtx();
   if (ctx && ctx->contextPlan()) {
-    auto planCost = ctx->contextPlan()->cost.cost;
-    auto pct = 100 * cost_.totalCost() / planCost;
-    out << " " << std::fixed << std::setprecision(2) << pct << "% ";
+    const auto planCost = ctx->contextPlan()->cost.cost;
+    const auto pct = divide(mul(cost_.totalCost(), 100), planCost);
+    out << " " << formatNumber(pct) << "% ";
   }
   if (detail) {
     out << " " << cost_.toString(detail, false) << std::endl;
@@ -495,17 +529,23 @@ struct JoinConstraints {
     // any right row = max(0, 1 - ndv(right) / ndv(left)).
     //
     // For RIGHT JOIN: same logic with sides reversed.
-    float leftNullFraction = 0.0f;
-    float rightNullFraction = 0.0f;
+    // Null fraction is unknown when either side's NDV is unknown; otherwise it
+    // defaults to 0 and is refined from the NDV ratio below.
+    const bool cardinalitiesKnown =
+        leftValue.cardinality.has_value() && rightValue.cardinality.has_value();
+    std::optional<float> leftNullFraction =
+        cardinalitiesKnown ? std::optional<float>(0.0f) : std::nullopt;
+    std::optional<float> rightNullFraction =
+        cardinalitiesKnown ? std::optional<float>(0.0f) : std::nullopt;
 
-    if (leftOptional && rightValue.cardinality > 0) {
-      leftNullFraction =
-          std::max(0.0f, 1.0f - leftValue.cardinality / rightValue.cardinality);
+    if (leftOptional && cardinalitiesKnown && *rightValue.cardinality > 0) {
+      leftNullFraction = std::max(
+          0.0f, 1.0f - *leftValue.cardinality / *rightValue.cardinality);
     }
 
-    if (rightOptional && leftValue.cardinality > 0) {
-      rightNullFraction =
-          std::max(0.0f, 1.0f - rightValue.cardinality / leftValue.cardinality);
+    if (rightOptional && cardinalitiesKnown && *leftValue.cardinality > 0) {
+      rightNullFraction = std::max(
+          0.0f, 1.0f - *rightValue.cardinality / *leftValue.cardinality);
     }
 
     if (leftOptional) {
@@ -611,7 +651,7 @@ struct JoinConstraints {
   static void updatePayload(
       const ColumnVector& columns,
       const ExprVector& keys,
-      float nullFraction,
+      std::optional<float> nullFraction,
       ConstraintMap& constraints) {
     auto keyIds = PlanObjectSet::fromObjects(keys);
 
@@ -630,7 +670,7 @@ struct JoinConstraints {
   // Computes the null fraction for the optional side of an outer join.
   // Returns the fraction of rows on the non-optional side that don't
   // find a match, i.e. max(0, 1 - ndv(optional_key) / ndv(non_optional_key)).
-  static float computeNullFraction(
+  static std::optional<float> computeNullFraction(
       const ExprVector& optionalKeys,
       const ExprVector& nonOptionalKeys,
       const ConstraintMap& constraints) {
@@ -638,13 +678,19 @@ struct JoinConstraints {
     for (size_t i = 0; i < optionalKeys.size(); ++i) {
       const auto& optionalValue = value(constraints, optionalKeys[i]);
       const auto& nonOptionalValue = value(constraints, nonOptionalKeys[i]);
-      if (nonOptionalValue.cardinality > 0) {
+      // An unknown NDV on either side makes the null fraction unknown.
+      if (!optionalValue.cardinality.has_value() ||
+          !nonOptionalValue.cardinality.has_value()) {
+        return std::nullopt;
+      }
+      if (*nonOptionalValue.cardinality > 0) {
         nullFraction = std::max(
             nullFraction,
             std::max(
                 0.0f,
                 1.0f -
-                    optionalValue.cardinality / nonOptionalValue.cardinality));
+                    *optionalValue.cardinality /
+                        *nonOptionalValue.cardinality));
       }
     }
     return nullFraction;
@@ -655,8 +701,8 @@ struct JoinConstraints {
   // match. Computes trueFraction from raw fanout and filter selectivity.
   static void addMark(
       const ColumnVector& columns,
-      float fanout,
-      float filterSelectivity,
+      std::optional<float> fanout,
+      std::optional<float> filterSelectivity,
       ConstraintMap& constraints) {
     VELOX_DCHECK(!columns.empty(), "LeftSemiProject must have columns");
 
@@ -665,7 +711,9 @@ struct JoinConstraints {
         markColumn->value().type->isBoolean(), "Mark column must be boolean");
 
     Value markValue = markColumn->value();
-    markValue.trueFraction = std::min<float>(1, fanout) * filterSelectivity;
+    // An unknown fanout or filter selectivity makes the mark's true fraction
+    // unknown.
+    markValue.trueFraction = mul(minOf(fanout, 1.0f), filterSelectivity);
     markValue.nullable = false;
     markValue.nullFraction = 0;
 
@@ -679,9 +727,11 @@ struct JoinConstraints {
       const ColumnVector& columns,
       const ExprVector& keys,
       float selectivity,
-      float numRows,
+      std::optional<float> numRows,
       ConstraintMap& constraints) {
-    if (selectivity >= 1.0f) {
+    // Without a known input row count the scaled NDV cannot be estimated;
+    // leave payload cardinalities unchanged.
+    if (selectivity >= 1.0f || !numRows.has_value()) {
       return;
     }
     auto keyIds = PlanObjectSet::fromObjects(keys);
@@ -690,11 +740,11 @@ struct JoinConstraints {
         continue;
       }
       auto it = constraints.find(column->id());
-      if (it != constraints.end()) {
+      if (it != constraints.end() && it->second.cardinality.has_value()) {
         it->second.cardinality = std::max(
             1.0f,
             (float)expectedNumDistincts(
-                numRows * selectivity, it->second.cardinality));
+                *numRows * selectivity, *it->second.cardinality));
       }
     }
   }
@@ -720,15 +770,21 @@ struct JoinConstraints {
       auto it = constraints.find(leftKeys[i]->id());
       if (it != constraints.end()) {
         auto& value = it->second;
-        const float minNdv =
-            std::min(value.cardinality, rightKeys[i]->value().cardinality);
-        value.cardinality = std::max(1.0f, value.cardinality - minNdv);
+        const auto rightNdv = rightKeys[i]->value().cardinality;
+        // Refine NDV only when both the left and right key NDVs are known.
+        if (value.cardinality.has_value() && rightNdv.has_value()) {
+          const float minNdv = std::min(*value.cardinality, *rightNdv);
+          value.cardinality = std::max(1.0f, *value.cardinality - minNdv);
+        }
 
-        const float survivingFraction =
-            value.nullFraction + (1.0f - value.nullFraction) * antiSelectivity;
-        value.nullFraction = survivingFraction > 0
-            ? value.nullFraction / survivingFraction
-            : 0.0f;
+        // Refine the surviving null fraction only when it is known.
+        if (value.nullFraction.has_value()) {
+          const float survivingFraction = *value.nullFraction +
+              (1.0f - *value.nullFraction) * antiSelectivity;
+          value.nullFraction = survivingFraction > 0
+              ? *value.nullFraction / survivingFraction
+              : 0.0f;
+        }
       }
     }
   }
@@ -784,8 +840,8 @@ Join::Join(
     ExprVector lhsKeys,
     ExprVector rhsKeys,
     ExprVector filterExprs,
-    float fanout,
-    float rlFanout,
+    std::optional<float> fanout,
+    std::optional<float> rlFanout,
     ColumnVector columns)
     : RelationOp{RelType::kJoin, std::move(lhs), std::move(columns)},
       method{method},
@@ -805,12 +861,12 @@ Join::Join(
     VELOX_DCHECK(key->is(PlanType::kColumnExpr));
   }
 #endif
-  float filterSelectivity = computeFilterSelectivity();
+  std::optional<float> filterSelectivity = computeFilterSelectivity();
   initConstraints(fanout, rlFanout, filterSelectivity);
   initCost(fanout, rlFanout, filterSelectivity);
 }
 
-float Join::computeFilterSelectivity() const {
+std::optional<float> Join::computeFilterSelectivity() const {
   if (filter.empty()) {
     return 1.0f;
   }
@@ -818,13 +874,18 @@ float Join::computeFilterSelectivity() const {
   for (const auto& [columnId, constraint] : right->constraints()) {
     inputConstraints.emplace(columnId, constraint);
   }
-  return conjunctsSelectivity(inputConstraints, filter, false).trueFraction;
+  const auto selectivity =
+      conjunctsSelectivity(inputConstraints, filter, false);
+  if (!selectivity.has_value()) {
+    return std::nullopt;
+  }
+  return selectivity->trueFraction;
 }
 
 void Join::initConstraints(
-    float fanout,
-    float rlFanout,
-    float filterSelectivity) {
+    std::optional<float> fanout,
+    std::optional<float> rlFanout,
+    std::optional<float> filterSelectivity) {
   // Add constraints for output columns only.
   auto outputColumnIds = PlanObjectSet::fromObjects(columns_);
   for (const auto& [columnId, constraint] : input_->constraints()) {
@@ -840,16 +901,21 @@ void Join::initConstraints(
 
   if (joinType == velox::core::JoinType::kAnti ||
       joinType == velox::core::JoinType::kCountingAnti) {
-    const float antiSelectivity =
-        std::max(0.0f, 1.0f - fanout * filterSelectivity);
-    JoinConstraints::updateAntiKeys(
-        leftKeys, rightKeys, antiSelectivity, constraints_);
-    JoinConstraints::scalePayloadCardinality(
-        input_->columns(),
-        leftKeys,
-        antiSelectivity,
-        inputCardinality(),
-        constraints_);
+    // Without a known fanout or filter selectivity the anti-join selectivity is
+    // unknown, so key/payload NDV refinements are skipped and constraints flow
+    // through.
+    if (fanout.has_value() && filterSelectivity.has_value()) {
+      const float antiSelectivity =
+          std::max(0.0f, 1.0f - *fanout * *filterSelectivity);
+      JoinConstraints::updateAntiKeys(
+          leftKeys, rightKeys, antiSelectivity, constraints_);
+      JoinConstraints::scalePayloadCardinality(
+          input_->columns(),
+          leftKeys,
+          antiSelectivity,
+          inputCardinality(),
+          constraints_);
+    }
     return;
   }
 
@@ -865,13 +931,13 @@ void Join::initConstraints(
   // Update constraints for optional-side payload columns.
   // This uses the same ndv-based formula as updateKey().
   if (leftOptional) {
-    const float leftNullFraction =
+    const std::optional<float> leftNullFraction =
         JoinConstraints::computeNullFraction(leftKeys, rightKeys, constraints_);
     JoinConstraints::updatePayload(
         input_->columns(), leftKeys, leftNullFraction, constraints_);
   }
   if (rightOptional) {
-    const float rightNullFraction =
+    const std::optional<float> rightNullFraction =
         JoinConstraints::computeNullFraction(rightKeys, leftKeys, constraints_);
     JoinConstraints::updatePayload(
         right->columns(), rightKeys, rightNullFraction, constraints_);
@@ -879,10 +945,11 @@ void Join::initConstraints(
 
   // Scale non-key payload cardinalities when the join eliminates rows.
   // The preserved side of outer joins keeps all rows, so its NDV is unchanged.
+  // An unknown filter selectivity leaves payload NDVs unscaled.
   const bool scaleLeft = leftOptional || isInnerJoin(joinType) ||
       isLeftSemiFilterJoin(joinType) || isCountingLeftSemiFilterJoin(joinType);
-  if (scaleLeft) {
-    const float leftSelectivity = std::min(1.0f, fanout) * filterSelectivity;
+  if (scaleLeft && fanout.has_value() && filterSelectivity.has_value()) {
+    const float leftSelectivity = std::min(1.0f, *fanout) * *filterSelectivity;
     JoinConstraints::scalePayloadCardinality(
         input_->columns(),
         leftKeys,
@@ -893,8 +960,9 @@ void Join::initConstraints(
 
   const bool scaleRight =
       rightOptional || isInnerJoin(joinType) || isRightSemiFilterJoin(joinType);
-  if (scaleRight) {
-    const float rightSelectivity = std::min(1.0f, rlFanout) * filterSelectivity;
+  if (scaleRight && rlFanout.has_value() && filterSelectivity.has_value()) {
+    const float rightSelectivity =
+        std::min(1.0f, *rlFanout) * *filterSelectivity;
     JoinConstraints::scalePayloadCardinality(
         right->columns(),
         rightKeys,
@@ -904,34 +972,50 @@ void Join::initConstraints(
   }
 }
 
-void Join::initCost(float fanout, float rlFanout, float filterSelectivity) {
+void Join::initCost(
+    std::optional<float> fanout,
+    std::optional<float> rlFanout,
+    std::optional<float> filterSelectivity) {
   cost_.inputCardinality = inputCardinality();
-  const float rightToLeftRatio =
-      right->resultCardinality() / cost_.inputCardinality;
-  cost_.fanout = adjustFanoutForJoinType(
-      joinType,
-      fanout * filterSelectivity,
-      rlFanout * filterSelectivity,
-      rightToLeftRatio);
+  const auto buildSizeOpt = right->resultCardinality();
+  // The right-to-left ratio is unknown if either the build cardinality or the
+  // input (probe) cardinality is unknown.
+  const auto rightToLeftRatio = divide(buildSizeOpt, cost_.inputCardinality);
 
-  const float buildSize = right->resultCardinality();
+  // The output fanout is unknown if the raw fanouts, filter selectivity, or the
+  // right-to-left ratio is unknown.
+  const auto adjustedFanout = mul(fanout, filterSelectivity);
+  const auto adjustedRlFanout = mul(rlFanout, filterSelectivity);
+  if (adjustedFanout.has_value() && adjustedRlFanout.has_value() &&
+      rightToLeftRatio.has_value()) {
+    cost_.fanout = adjustFanoutForJoinType(
+        joinType, *adjustedFanout, *adjustedRlFanout, *rightToLeftRatio);
+  }
+
   const auto numKeys = leftKeys.size();
   const auto rowBytes = byteSize(right->columns());
-  const auto rowCost = Costs::hashRowCost(buildSize, rowBytes);
 
-  // For NLJ (kCross), there's no hash table to probe, so the
-  // hashTableCost term — which models per-left-row bucket lookup — must
-  // not be charged.
-  const float probeCost = method == JoinMethod::kCross
-      ? 0.0f
-      : Costs::hashTableCost(buildSize) +
-          // Multiply by min(fanout, 1) because most misses will not compare and
-          // if fanout > 1, there is still only one compare.
-          (Costs::kKeyCompareCost * numKeys *
-           std::min<float>(1, cost_.fanout)) +
-          numKeys * Costs::kHashColumnCost;
+  // The unit cost depends on the build cardinality and the output fanout; it is
+  // unknown if either is unknown.
+  if (buildSizeOpt.has_value() && cost_.fanout.has_value()) {
+    const float buildSize = *buildSizeOpt;
+    const float fanoutValue = *cost_.fanout;
+    const auto rowCost = Costs::hashRowCost(buildSize, rowBytes);
 
-  cost_.unitCost = probeCost + cost_.fanout * rowCost;
+    // For NLJ (kCross), there's no hash table to probe, so the
+    // hashTableCost term — which models per-left-row bucket lookup — must
+    // not be charged.
+    const float probeCost = method == JoinMethod::kCross
+        ? 0.0f
+        : Costs::hashTableCost(buildSize) +
+            // Multiply by min(fanout, 1) because most misses will not compare
+            // and if fanout > 1, there is still only one compare.
+            (Costs::kKeyCompareCost * numKeys *
+             std::min<float>(1, fanoutValue)) +
+            numKeys * Costs::kHashColumnCost;
+
+    cost_.unitCost = probeCost + fanoutValue * rowCost;
+  }
 }
 
 namespace {
@@ -984,8 +1068,8 @@ Join* Join::makeCrossJoin(
     velox::core::JoinType joinType,
     ExprVector filter,
     ColumnVector columns) {
-  float fanout = right->resultCardinality();
-  float rlFanout = input->resultCardinality();
+  std::optional<float> fanout = right->resultCardinality();
+  std::optional<float> rlFanout = input->resultCardinality();
   return make<Join>(
       JoinMethod::kCross,
       joinType,
@@ -1025,7 +1109,7 @@ Repartition::Repartition(
 
   cost_.unitCost = size;
   cost_.transferBytes =
-      cost_.inputCardinality * size * Costs::byteShuffleCost();
+      mul(cost_.inputCardinality, size * Costs::byteShuffleCost());
 
   // Repartition projects all input columns.
   constraints_ = input_->constraints();
@@ -1072,6 +1156,7 @@ Unnest::Unnest(
   // TODO Compute fanout from unnest expression array size statistics when
   // available.
   cost_.fanout = 10;
+  cost_.unitCost = 0;
 
   initConstraints();
 }
@@ -1099,7 +1184,8 @@ void Unnest::initConstraints() {
   // Add constraint for ordinality column if present.
   // Ordinality is non-null. Use fanout as an approximation for cardinality.
   if (ordinalityColumn) {
-    Value ordValue(ordinalityColumn->value().type, cost_.fanout);
+    // Unnest always sets a fanout.
+    Value ordValue(ordinalityColumn->value().type, cost_.fanout.value());
     ordValue.nullable = false;
     constraints_.emplace(ordinalityColumn->id(), ordValue);
   }
@@ -1158,14 +1244,19 @@ double sampledNdv(double ndv, double numRows, double fraction) {
 // distinct values seen.
 void scaleCardinalities(
     ConstraintMap& constraints,
-    float inputCardinality,
-    float fanout) {
-  if (fanout >= 1.0) {
+    std::optional<float> inputCardinality,
+    std::optional<float> fanout) {
+  // Without a known input cardinality and fanout the scaled NDV cannot be
+  // estimated; leave cardinalities unchanged.
+  if (!inputCardinality.has_value() || !fanout.has_value() || *fanout >= 1.0) {
     return;
   }
   for (auto& [columnId, constraint] : constraints) {
-    constraint.cardinality = std::max(
-        1.0, sampledNdv(constraint.cardinality, inputCardinality, fanout));
+    // Per-column NDV that is itself unknown stays unknown.
+    if (constraint.cardinality.has_value()) {
+      constraint.cardinality = std::max(
+          1.0, sampledNdv(*constraint.cardinality, *inputCardinality, *fanout));
+    }
   }
 }
 
@@ -1192,9 +1283,9 @@ PlanObjectCP largestTable(const PlanObjectSet& tables) {
   double maxCardinality = 0.0;
 
   tables.forEach([&](const auto& table) {
-    double cardinality = tableCardinality(table);
-    if (cardinality > maxCardinality) {
-      maxCardinality = cardinality;
+    const auto cardinality = tableCardinality(table);
+    if (cardinality.has_value() && *cardinality > maxCardinality) {
+      maxCardinality = *cardinality;
       largestTable = table;
     }
   });
@@ -1206,7 +1297,7 @@ PlanObjectCP largestTable(const PlanObjectSet& tables) {
 // using saturating product to avoid overflow. When multiple keys come from
 // the same table, cap the maximum cardinality estimate at table's
 // cardinality.
-double maxGroups(
+std::optional<double> maxGroups(
     const ExprVector& groupingKeys,
     const ConstraintMap& constraints) {
   if (groupingKeys.empty()) {
@@ -1236,7 +1327,12 @@ double maxGroups(
   double maxTableCardinality = 0.0;
 
   for (const auto& [table, keys] : tableToKeys) {
-    const double maxCardinality = tableCardinality(table);
+    const auto maxCardinalityOpt = tableCardinality(table);
+    // An unknown table cardinality makes the group-count estimate unknown.
+    if (!maxCardinalityOpt.has_value()) {
+      return std::nullopt;
+    }
+    const double maxCardinality = *maxCardinalityOpt;
 
     maxTableCardinality = std::max(maxTableCardinality, maxCardinality);
 
@@ -1244,14 +1340,21 @@ double maxGroups(
     if (keys.size() == 1) {
       // Single key per table: use min of key cardinality and table
       // cardinality.
-      groupCardinality = std::min<double>(
-          constraints.at(keys[0]->id()).cardinality, maxCardinality);
+      const auto keyNdv = constraints.at(keys[0]->id()).cardinality;
+      if (!keyNdv.has_value()) {
+        return std::nullopt;
+      }
+      groupCardinality = std::min<double>(*keyNdv, maxCardinality);
     } else {
       // Multiple keys: collect cardinalities and use saturatingProduct.
       std::vector<double> keyCardinalities;
       keyCardinalities.reserve(keys.size());
       for (auto key : keys) {
-        keyCardinalities.push_back(constraints.at(key->id()).cardinality);
+        const auto keyNdv = constraints.at(key->id()).cardinality;
+        if (!keyNdv.has_value()) {
+          return std::nullopt;
+        }
+        keyCardinalities.push_back(*keyNdv);
       }
       groupCardinality = saturatingProduct(maxCardinality, keyCardinalities);
     }
@@ -1313,14 +1416,17 @@ Aggregation::Aggregation(
   const auto numKeys = groupingKeys.size();
   if (numKeys > 0) {
     // Input cardinality before the partial aggregation.
-    float inputBeforePartial;
+    std::optional<float> inputBeforePartial;
     if (step == velox::core::AggregationNode::Step::kFinal &&
         input_->is(RelType::kRepartition) &&
         input_->input()->is(RelType::kAggregation)) {
       auto partial = input_->input().get();
 
-      VELOX_CHECK(!std::isnan(partial->cost().inputCardinality));
-      VELOX_CHECK(std::isfinite(partial->cost().inputCardinality));
+      const auto partialInputCardinality = partial->cost().inputCardinality;
+      if (partialInputCardinality.has_value()) {
+        VELOX_CHECK(!std::isnan(*partialInputCardinality));
+        VELOX_CHECK(std::isfinite(*partialInputCardinality));
+      }
 
       inputBeforePartial = partial->inputCardinality();
     } else {
@@ -1332,17 +1438,20 @@ Aggregation::Aggregation(
     // Global aggregation (no grouping keys).
     cost_.unitCost = aggregates.size() * Costs::kSimpleAggregateCost;
 
-    // Avoid division by zero.
-    cost_.fanout = 1.0f / cost_.inputCardinality;
+    // Avoid division by zero. Unknown input cardinality => unknown fanout.
+    cost_.fanout = divide(1.0f, cost_.inputCardinality);
   }
 
-  VELOX_CHECK_LE(cost_.fanout, 1.0f);
+  // cost_.fanout may be unknown; only check when it is known.
+  if (cost_.fanout.has_value()) {
+    VELOX_CHECK_LE(*cost_.fanout, 1.0f);
+  }
 
   initConstraints();
 }
 
 void Aggregation::initConstraints() {
-  float outputCardinality = resultCardinality();
+  const std::optional<float> outputCardinality = resultCardinality();
   const auto numKeys = groupingKeys.size();
 
   for (size_t i = 0; i < columns_.size(); ++i) {
@@ -1361,8 +1470,12 @@ void Aggregation::initConstraints() {
       }
     }();
 
-    constraint.cardinality =
-        std::min(constraint.cardinality, outputCardinality);
+    // Cap the column NDV at the group count. Skip when the output cardinality
+    // is unknown so a known NDV is not wiped out.
+    if (outputCardinality.has_value()) {
+      constraint.cardinality =
+          minOf(constraint.cardinality, *outputCardinality);
+    }
 
     constraints_.emplace(column->id(), constraint);
   }
@@ -1398,15 +1511,27 @@ float sortCost(size_t numKeys, float cardinality) {
 }
 } // namespace
 
-void Aggregation::setCostWithGroups(float inputBeforePartial) {
+void Aggregation::setCostWithGroups(
+    std::optional<float> inputBeforePartialOpt) {
   auto* optimization = queryCtx()->optimization();
   const auto& runnerOptions = optimization->runnerOptions();
 
-  const auto maxCardinality =
-      std::max<double>(1, maxGroups(groupingKeys, input_->constraints()));
+  const auto maxGroupsOpt = maxGroups(groupingKeys, input_->constraints());
+  // The grouping cost is unknown when the input row count or the maximum
+  // number of distinct groups could not be estimated. Leave cost_ fanout,
+  // unitCost, and totalBytes as nullopt so the unknown propagates.
+  if (!inputBeforePartialOpt.has_value() || !maxGroupsOpt.has_value()) {
+    return;
+  }
+  const float inputBeforePartial = *inputBeforePartialOpt;
 
-  const auto numGroups =
-      expectedNumDistincts(inputBeforePartial, maxCardinality);
+  const auto maxCardinality = std::max<double>(1, *maxGroupsOpt);
+
+  // The grouping key NDV already reflects upstream filtering, so the distinct
+  // group count is min(NDV, input rows). Re-applying the coupon-collector
+  // formula here would discount a second time and invent a reduction even for a
+  // unique key.
+  const auto numGroups = std::min<double>(maxCardinality, inputBeforePartial);
 
   const auto numKeys = groupingKeys.size();
   const auto rowBytes =
@@ -1427,9 +1552,11 @@ void Aggregation::setCostWithGroups(float inputBeforePartial) {
 
     // numGroups can be > inputCardinality since this is calculated against
     // the input before partial and inputCardinality is scaled down by partial
-    // reduction.
-    cost_.fanout =
-        std::min<double>(inputCardinality(), numGroups) / inputCardinality();
+    // reduction. Unknown input cardinality => unknown fanout.
+    const auto inputCard = inputCardinality();
+    if (inputCard.has_value() && *inputCard != 0) {
+      cost_.fanout = std::min<double>(*inputCard, numGroups) / *inputCard;
+    }
     cost_.totalBytes = numGroups * rowBytes;
     return;
   }
@@ -1524,13 +1651,16 @@ HashBuild::HashBuild(RelationOpPtr input, ExprVector keysVector, PlanP plan)
   const auto rowBytes = byteSize(columns());
   const auto numColumns = static_cast<float>(columns().size());
   // Per row cost calculates the column hashes twice, once to partition and a
-  // second time to insert.
-  cost_.unitCost = (numKeys * 2 * Costs::kHashColumnCost) +
-      Costs::hashBuildCost(cost_.inputCardinality, rowBytes) +
-      numKeys * Costs::kKeyCompareCost +
-      numColumns * Costs::kHashExtractColumnCost * 2;
+  // second time to insert. The hashBuildCost term depends on the input
+  // cardinality, so the unit cost is unknown when that is unknown.
+  if (cost_.inputCardinality.has_value()) {
+    cost_.unitCost = (numKeys * 2 * Costs::kHashColumnCost) +
+        Costs::hashBuildCost(*cost_.inputCardinality, rowBytes) +
+        numKeys * Costs::kKeyCompareCost +
+        numColumns * Costs::kHashExtractColumnCost * 2;
+  }
 
-  cost_.totalBytes = cost_.inputCardinality * rowBytes;
+  cost_.totalBytes = mul(cost_.inputCardinality, rowBytes);
 
   // HashBuild projects all input columns.
   constraints_ = input_->constraints();
@@ -1551,9 +1681,12 @@ Filter::Filter(RelationOpPtr input, ExprVector exprs)
   // Start with input constraints
   constraints_ = input_->constraints();
 
-  // Compute selectivity using filter analysis, updating constraints_
+  // Compute selectivity using filter analysis, updating constraints_. An
+  // unknown selectivity leaves the fanout unknown.
   auto selectivity = conjunctsSelectivity(constraints_, exprs_, true);
-  cost_.fanout = selectivity.trueFraction;
+  if (selectivity.has_value()) {
+    cost_.fanout = static_cast<float>(selectivity->trueFraction);
+  }
 
   // Scale NDV for all columns using the coupon collector formula.
   // conjunctsSelectivity narrows the value space for filtered columns;
@@ -1619,8 +1752,9 @@ Project::Project(
 
   cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
-
-  // TODO Fill in cost_.unitCost and others.
+  // A projection (in particular a redundant rename) has no per-row cost.
+  // TODO: Model the per-expression evaluation cost.
+  cost_.unitCost = 0;
 }
 
 void Project::accept(
@@ -1667,18 +1801,23 @@ OrderBy::OrderBy(
     cost_.fanout = 1;
   } else {
     const auto cardinality = static_cast<float>(limit);
-    if (cost_.inputCardinality <= cardinality) {
-      // Input cardinality does not exceed the limit. The limit is no-op.
-      // Doesn't change cardinality.
-      cost_.fanout = 1;
-    } else {
-      // Input cardinality exceeds the limit. Calculate fanout to ensure that
-      // fanout * limit = input-cardinality.
-      cost_.fanout = cardinality / cost_.inputCardinality;
+    // An unknown input cardinality leaves the fanout unknown.
+    if (cost_.inputCardinality.has_value()) {
+      if (*cost_.inputCardinality <= cardinality) {
+        // Input cardinality does not exceed the limit. The limit is no-op.
+        // Doesn't change cardinality.
+        cost_.fanout = 1;
+      } else {
+        // Input cardinality exceeds the limit. Calculate fanout to ensure that
+        // fanout * limit = input-cardinality.
+        cost_.fanout = cardinality / *cost_.inputCardinality;
+      }
     }
   }
 
-  // TODO Fill in cost_.unitCost and others.
+  // Modeled with zero per-row cost.
+  // TODO: Model the sort cost.
+  cost_.unitCost = 0;
 
   // OrderBy projects all input columns. When there's a LIMIT, keeping N of M
   // rows is equivalent to sampling with fraction s = N/M. Use the coupon
@@ -1701,14 +1840,17 @@ Limit::Limit(RelationOpPtr input, int64_t limit, int64_t offset)
   cost_.inputCardinality = inputCardinality();
   cost_.unitCost = Costs::kMinimalUnitCost;
   const auto cardinality = static_cast<float>(limit);
-  if (cost_.inputCardinality <= cardinality) {
-    // Input cardinality does not exceed the limit. The limit is no-op.
-    // Doesn't change cardinality.
-    cost_.fanout = 1;
-  } else {
-    // Input cardinality exceeds the limit. Calculate fanout to ensure that
-    // fanout * limit = input-cardinality.
-    cost_.fanout = cardinality / cost_.inputCardinality;
+  // An unknown input cardinality leaves the fanout unknown.
+  if (cost_.inputCardinality.has_value()) {
+    if (*cost_.inputCardinality <= cardinality) {
+      // Input cardinality does not exceed the limit. The limit is no-op.
+      // Doesn't change cardinality.
+      cost_.fanout = 1;
+    } else {
+      // Input cardinality exceeds the limit. Calculate fanout to ensure that
+      // fanout * limit = input-cardinality.
+      cost_.fanout = cardinality / *cost_.inputCardinality;
+    }
   }
 
   // Limit projects all input columns. Keeping N of M rows is equivalent to
@@ -1758,11 +1900,14 @@ UnionAll::UnionAll(RelationOpPtrVector inputsVector)
       inputs{std::move(inputsVector)} {
   cost_.inputCardinality = 0;
   for (auto& input : inputs) {
-    cost_.inputCardinality +=
-        input->cost().inputCardinality * input->cost().fanout;
+    cost_.inputCardinality =
+        add(cost_.inputCardinality,
+            mul(input->cost().inputCardinality, input->cost().fanout));
   }
 
   cost_.fanout = 1;
+  // A union-all has no per-row cost.
+  cost_.unitCost = 0;
 
   initConstraints();
 }
@@ -1809,12 +1954,14 @@ void UnionAll::initConstraints() {
 
     // Get constraint from first input as starting point.
     Value combined = inputConstraint(0);
-    float totalRows = inputs[0]->resultCardinality();
-    float weightedNullFraction = combined.nullFraction * totalRows;
-    float weightedTrueFraction = combined.trueFraction != Value::kUnknown
-        ? combined.trueFraction * totalRows
-        : 0;
-    bool anyUnknownTrueFraction = combined.trueFraction == Value::kUnknown;
+    // Row counts and the weighted fraction accumulators are all unknown if any
+    // leg's cardinality or the corresponding fraction is unknown; the helpers
+    // propagate nullopt.
+    std::optional<float> totalRows = inputs[0]->resultCardinality();
+    std::optional<float> weightedNullFraction =
+        mul(combined.nullFraction, totalRows);
+    std::optional<float> weightedTrueFraction =
+        mul(combined.trueFraction, totalRows);
 
     // Derive min and max across all legs. All-NULL legs contribute no
     // bound. A leg with unknown bound wipes the combined bound — no later
@@ -1845,25 +1992,64 @@ void UnionAll::initConstraints() {
     // Combine remaining fields from inputs beyond the first.
     for (size_t j = 1; j < inputs.size(); ++j) {
       const Value& inputValue = inputConstraint(j);
-      float inputRows = inputs[j]->resultCardinality();
+      const std::optional<float> inputRows = inputs[j]->resultCardinality();
 
-      totalRows += inputRows;
-      // Sum cardinalities as upper bound for distinct count.
-      combined.cardinality += inputValue.cardinality;
-      weightedNullFraction += inputValue.nullFraction * inputRows;
-      if (inputValue.trueFraction == Value::kUnknown) {
-        anyUnknownTrueFraction = true;
-      } else {
-        weightedTrueFraction += inputValue.trueFraction * inputRows;
-      }
+      totalRows = add(totalRows, inputRows);
+      weightedNullFraction =
+          add(weightedNullFraction, mul(inputValue.nullFraction, inputRows));
+      weightedTrueFraction =
+          add(weightedTrueFraction, mul(inputValue.trueFraction, inputRows));
       combined.nullable = combined.nullable || inputValue.nullable;
     }
 
-    combined.nullFraction =
-        totalRows > 0 ? weightedNullFraction / totalRows : 0;
-    combined.trueFraction = anyUnknownTrueFraction
-        ? Value::kUnknown
-        : (totalRows > 0 ? weightedTrueFraction / totalRows : 0);
+    // Estimate the union NDV by inclusion-exclusion over the legs' ranges. Fold
+    // legs left to right; for each leg subtract the values expected to be
+    // shared with the running range, assuming uniform density within each range
+    // and independence across legs. This keeps the summed NDV for disjoint legs
+    // and discounts the overlap otherwise. A leg without an integer range
+    // contributes its full NDV (the disjoint assumption) and clears the running
+    // range so later legs cannot estimate overlap against it.
+    std::optional<float> unionNdv = inputConstraint(0).cardinality;
+    VariantCP runMin = inputConstraint(0).min;
+    VariantCP runMax = inputConstraint(0).max;
+    for (size_t j = 1; j < inputs.size() && unionNdv.has_value(); ++j) {
+      const Value& leg = inputConstraint(j);
+      if (!leg.cardinality.has_value()) {
+        unionNdv = std::nullopt;
+        break;
+      }
+      const auto runRange = rangeCardinality(combined.type, runMin, runMax);
+      const auto legRange = rangeCardinality(combined.type, leg.min, leg.max);
+      float shared = 0;
+      if (runRange.has_value() && legRange.has_value()) {
+        // All four bounds are set here (rangeCardinality returns a value only
+        // when both of its bounds are). Overlap = [max(mins), min(maxs)].
+        VariantCP overlapMin = *runMin < *leg.min ? leg.min : runMin;
+        VariantCP overlapMax = *leg.max < *runMax ? leg.max : runMax;
+        if (!(*overlapMax < *overlapMin)) {
+          if (const auto overlap =
+                  rangeCardinality(combined.type, overlapMin, overlapMax)) {
+            shared = *overlap * (*unionNdv / *runRange) *
+                (*leg.cardinality / *legRange);
+          }
+        }
+        runMin = *leg.min < *runMin ? leg.min : runMin;
+        runMax = *runMax < *leg.max ? leg.max : runMax;
+      } else {
+        // A leg without an integer range clears the running range so later legs
+        // fall back to the disjoint (summed) assumption.
+        runMin = nullptr;
+        runMax = nullptr;
+      }
+      unionNdv = std::max(
+          std::max(*unionNdv, *leg.cardinality),
+          *unionNdv + *leg.cardinality - shared);
+    }
+    combined.cardinality = unionNdv;
+    // Weighted averages are unknown if the accumulators or row count are
+    // unknown; divide also yields nullopt when totalRows is 0.
+    combined.nullFraction = divide(weightedNullFraction, totalRows);
+    combined.trueFraction = divide(weightedTrueFraction, totalRows);
 
     constraints_.emplace(outputColumn->id(), combined);
   }
@@ -1884,6 +2070,7 @@ TableWrite::TableWrite(
       inputColumns{std::move(inputColumns)},
       write{write} {
   cost_.inputCardinality = inputCardinality();
+  cost_.fanout = 1;
   cost_.unitCost = Costs::kMinimalUnitCost;
   VELOX_DCHECK_EQ(
       this->inputColumns.size(), this->write->table().type()->size());
@@ -1902,6 +2089,7 @@ EnforceSingleRow::EnforceSingleRow(RelationOpPtr input)
           input->distribution(),
           input->columns()) {
   // Cardinality neutral: passes through exactly 1 row or fails at runtime.
+  cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
   cost_.unitCost = 0;
 
@@ -1921,11 +2109,12 @@ namespace {
 // cardinality set to min(limit, inputCardinality) and nullable set to false.
 Value rankingColumnValue(
     ColumnCP outputColumn,
-    float inputCardinality,
+    std::optional<float> inputCardinality,
     std::optional<int32_t> limit) {
   auto value = outputColumn->value();
+  // An unknown input cardinality leaves the ranking column's NDV unknown.
   value.cardinality = limit.has_value()
-      ? std::min(static_cast<float>(limit.value()), inputCardinality)
+      ? minOf(static_cast<float>(limit.value()), inputCardinality)
       : inputCardinality;
   value.nullable = false;
   value.nullFraction = 0;
@@ -1954,6 +2143,7 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
           appendColumn(input->columns(), uniqueIdColumn)),
       uniqueIdColumn_(uniqueIdColumn) {
   // Fanout is 1 (cardinality neutral).
+  cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
   cost_.unitCost = Costs::kMinimalUnitCost;
 
@@ -1961,7 +2151,8 @@ AssignUniqueId::AssignUniqueId(RelationOpPtr input, ColumnCP uniqueIdColumn)
   constraints_ = input_->constraints();
 
   // Add constraint for the uniqueId column: one unique value per row,
-  // non-null.
+  // non-null. The NDV equals the row count, which is unknown if the result
+  // cardinality is unknown.
   Value uniqueIdValue(uniqueIdColumn_->value().type, resultCardinality());
   uniqueIdValue.nullable = false;
   constraints_.emplace(uniqueIdColumn_->id(), uniqueIdValue);
@@ -1983,6 +2174,7 @@ EnforceDistinct::EnforceDistinct(
       preGroupedKeys_(std::move(preGroupedKeys)),
       errorMessage_(errorMessage) {
   // Fanout is 1 (cardinality neutral).
+  cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
   // TODO: Review cost for EnforceDistinct.
   cost_.unitCost = 0.01;
@@ -2018,9 +2210,15 @@ Window::Window(
   cost_.fanout = 1;
 
   const auto numKeys = partitionKeys.size() + orderKeys.size();
-  cost_.unitCost =
-      (inputsSorted ? 0 : sortCost(numKeys, cost_.inputCardinality)) +
+  const float windowFunctionCost =
       windowFunctions.size() * Costs::kSimpleAggregateCost;
+  if (inputsSorted) {
+    cost_.unitCost = windowFunctionCost;
+  } else if (cost_.inputCardinality.has_value()) {
+    // Sorting cost depends on the input cardinality; unknown when it is.
+    cost_.unitCost =
+        sortCost(numKeys, *cost_.inputCardinality) + windowFunctionCost;
+  }
 
   initConstraints();
 }
@@ -2078,9 +2276,12 @@ RowNumber::RowNumber(
       outputColumn{_outputColumn} {
   cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
-  // No sorting, just hashing by partition keys.
-  cost_.unitCost = Costs::kHashColumnCost * partitionKeys.size() +
-      Costs::hashTableCost(cost_.inputCardinality);
+  // No sorting, just hashing by partition keys. The hashTableCost term depends
+  // on the input cardinality, so the unit cost is unknown when it is.
+  if (cost_.inputCardinality.has_value()) {
+    cost_.unitCost = Costs::kHashColumnCost * partitionKeys.size() +
+        Costs::hashTableCost(*cost_.inputCardinality);
+  }
 
   // Pass through all input constraints and add a new column for the row number.
   constraints_ = input_->constraints();
@@ -2142,9 +2343,13 @@ TopNRowNumber::TopNRowNumber(
   cost_.fanout = 1;
   // Hash by partition keys + partial sort by order keys with limit-based
   // pruning. Cheaper than a full Window sort because only top N rows are kept.
+  // The sort term depends on the input cardinality, so the unit cost is
+  // unknown when it is.
   const auto numKeys = partitionKeys.size() + orderKeys.size();
-  cost_.unitCost = Costs::kHashColumnCost * partitionKeys.size() +
-      sortCost(numKeys, cost_.inputCardinality);
+  if (cost_.inputCardinality.has_value()) {
+    cost_.unitCost = Costs::kHashColumnCost * partitionKeys.size() +
+        sortCost(numKeys, *cost_.inputCardinality);
+  }
 
   // Pass through all input constraints and add a new column for the ranking
   // result.
@@ -2220,28 +2425,35 @@ MarkDistinct::MarkDistinct(
   // MarkDistinct doesn't reduce rows.
   cost_.fanout = 1;
 
-  const auto maxCardinality =
-      std::max<double>(1, maxGroups(keys_, input_->constraints()));
-  const auto numGroups =
-      expectedNumDistincts(cost_.inputCardinality, maxCardinality);
+  const auto maxGroupsOpt = maxGroups(keys_, input_->constraints());
   const auto maskBitmapBytes = (masks_.size() + 7) / 8;
   const auto rowBytes =
       byteSize(keys_) + Costs::kHashRowBytes + maskBitmapBytes;
-  cost_.totalBytes = numGroups * rowBytes;
 
-  // Cost is similar to a hash aggregation for tracking distinct values. Each
-  // input row probes the hash table to check if its key combination has been
-  // seen, and inserts a new entry if not. Estimated localExchangeCost to be
-  // 1/3 of a remote shuffle, following the same cost modeling of Aggregation.
-  float localExchangeCost = 0;
-  if (runnerOptions.numDrivers > 1) {
-    localExchangeCost = shuffleCost(input_->columns()) / 3;
+  // The group count drives both the memory footprint and the unit cost; both
+  // are unknown when the input cardinality or the max group count is unknown.
+  if (cost_.inputCardinality.has_value() && maxGroupsOpt.has_value()) {
+    const auto maxCardinality = std::max<double>(1, *maxGroupsOpt);
+    // min(NDV, input rows); see the note in Aggregation::setCostWithGroups.
+    const auto numGroups =
+        std::min<double>(maxCardinality, *cost_.inputCardinality);
+    cost_.totalBytes = numGroups * rowBytes;
+
+    // Cost is similar to a hash aggregation for tracking distinct values. Each
+    // input row probes the hash table to check if its key combination has been
+    // seen, and inserts a new entry if not. Estimated localExchangeCost to be
+    // 1/3 of a remote shuffle, following the same cost modeling of Aggregation.
+    float localExchangeCost = 0;
+    if (runnerOptions.numDrivers > 1) {
+      localExchangeCost = shuffleCost(input_->columns()) / 3;
+    }
+    auto markDistinctCost = Costs::kHashColumnCost * keys_.size() +
+        Costs::hashTableCost(numGroups) +
+        Costs::kKeyCompareCost * keys_.size() +
+        Costs::hashRowCost(numGroups, rowBytes) +
+        masks_.size() * Costs::kSimpleAggregateCost;
+    cost_.unitCost = localExchangeCost + markDistinctCost;
   }
-  auto markDistinctCost = Costs::kHashColumnCost * keys_.size() +
-      Costs::hashTableCost(numGroups) + Costs::kKeyCompareCost * keys_.size() +
-      Costs::hashRowCost(numGroups, rowBytes) +
-      masks_.size() * Costs::kSimpleAggregateCost;
-  cost_.unitCost = localExchangeCost + markDistinctCost;
 
   constraints_ = input->constraints();
   for (const auto* marker : markers_) {
@@ -2303,6 +2515,7 @@ GroupId::GroupId(
       "A single grouping set is a regular GROUP BY.");
 
   // Each input row is duplicated once per set.
+  cost_.inputCardinality = inputCardinality();
   cost_.fanout = groupingSets_.size();
   cost_.unitCost = Costs::kMinimalUnitCost * groupingSets_.size();
 

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/Schema.h"
@@ -29,28 +30,31 @@ class RelationOpVisitorContext;
 class RelationOpVisitor;
 class RelationOp;
 
-/// Represents the cost of a plan.
+/// Represents the cost of a plan. cost and cardinality are independent
+/// optionals: a missing statistic (e.g. an unknown NDV) can leave one unknown
+/// while the other is known. For example, a filter with an unknown selectivity
+/// has a known cost (it still scans every input row) but an unknown output
+/// cardinality. An unknown cardinality propagates to the parent's cost on the
+/// next operator.
 struct PlanCost {
-  /// Total cost of the plan.
-  float cost{0};
+  /// Total cost of the plan. nullopt if unknown.
+  std::optional<float> cost{0};
 
-  /// Number of output rows.
-  float cardinality{1};
+  /// Number of output rows. nullopt if unknown.
+  std::optional<float> cardinality{1};
 
   void add(RelationOp& op);
 
   void add(const PlanCost& other) {
-    cost += other.cost;
+    if (cost.has_value() && other.cost.has_value()) {
+      cost = *cost + *other.cost;
+    } else {
+      cost = std::nullopt;
+    }
     cardinality = other.cardinality;
   }
 
-  std::string toString() const {
-    return fmt::format(
-        std::locale("en_US.UTF-8"),
-        "cost: {:L}, cardinality: {:L}",
-        cost,
-        cardinality);
-  }
+  std::string toString() const;
 };
 
 /// Represents the cost of a RelationOp. A Cost has a per-row cost and fanout.
@@ -66,31 +70,42 @@ struct PlanCost {
 /// hits sparsely. An index lookup has no setup cost.
 struct Cost {
   /// Cardinality of the output of the left deep input tree. 1 for a leaf
-  /// scan.
-  float inputCardinality{1};
+  /// scan. nullopt if unknown (an input's cardinality could not be estimated).
+  /// No default: every operator sets it, so a missing value is genuinely
+  /// unknown rather than a silent sentinel.
+  std::optional<float> inputCardinality;
 
   /// Cost of processing one input tuple. Complete cost of the operation for a
-  /// leaf.
-  float unitCost{0};
+  /// leaf. nullopt if unknown (e.g. an index lookup whose unit cost depends on
+  /// an unknown cardinality).
+  std::optional<float> unitCost;
 
   /// 'fanout * inputCardinality' is the number of result rows. For a leaf scan,
-  /// this is the number of rows.
-  float fanout{1};
+  /// this is the number of rows. nullopt if unknown (selectivity could not be
+  /// estimated, e.g. a join key or filter column with unknown NDV). Independent
+  /// of inputCardinality: a join may have a known input but unknown fanout.
+  std::optional<float> fanout;
 
   /// Estimate of total data volume for a hash join build or group / order
   /// by / distinct / repartition. The memory footprint may not be this if the
-  /// operation is streaming or spills.
-  float totalBytes{0};
+  /// operation is streaming or spills. nullopt if unknown.
+  std::optional<float> totalBytes;
 
-  /// Shuffle data volume.
-  float transferBytes{0};
+  /// Shuffle data volume. nullopt if unknown.
+  std::optional<float> transferBytes;
 
-  float totalCost() const {
-    return unitCost * inputCardinality;
+  /// Total CPU cost of this operator. nullopt iff unitCost or inputCardinality
+  /// is unknown (does not depend on fanout). This is the quantity that decides
+  /// whether the cost is known for ranking: the plan's accumulated cost is
+  /// unknown iff some operator's totalCost is unknown (unknown fanout reaches
+  /// it via the parent's inputCardinality).
+  std::optional<float> totalCost() const {
+    return mul(unitCost, inputCardinality);
   }
 
-  float resultCardinality() const {
-    return fanout * inputCardinality;
+  /// Number of output rows. nullopt iff fanout or inputCardinality is unknown.
+  std::optional<float> resultCardinality() const {
+    return mul(fanout, inputCardinality);
   }
 
   /// If 'isUnit' shows the cost/cardinality for one row, else for
@@ -271,16 +286,20 @@ class RelationOp {
     return constraints_;
   }
 
-  /// Returns the number of output rows.
-  float resultCardinality() const {
-    return std::max<float>(1, cost_.resultCardinality());
+  /// Returns the number of output rows, or nullopt if unknown.
+  std::optional<float> resultCardinality() const {
+    const auto cardinality = cost_.resultCardinality();
+    if (!cardinality.has_value()) {
+      return std::nullopt;
+    }
+    return std::max<float>(1, *cardinality);
   }
 
   /// @return 1 for a leaf node, otherwise returns 'resultCardinality()' of the
-  /// input. Nodes with multiple inputs, e.g. Join, UnionAll, return the
-  /// 'resultCardinality()' of the left-most input, which is not the same as
-  /// 'input cardinality'.
-  float inputCardinality() const {
+  /// input, or nullopt if that is unknown. Nodes with multiple inputs, e.g.
+  /// Join, UnionAll, return the 'resultCardinality()' of the left-most input,
+  /// which is not the same as 'input cardinality'.
+  std::optional<float> inputCardinality() const {
     if (input() == nullptr) {
       return 1;
     }
@@ -360,7 +379,7 @@ struct TableScan : public RelationOp {
       Distribution distribution,
       BaseTableCP table,
       ColumnGroupCP index,
-      float fanout,
+      std::optional<float> fanout,
       ColumnVector columns,
       ExprVector lookupKeys,
       velox::core::JoinType joinType,
@@ -541,8 +560,8 @@ struct Join : public RelationOp {
       ExprVector lhsKeys,
       ExprVector rhsKeys,
       ExprVector filterExprs,
-      float fanout,
-      float rlFanout,
+      std::optional<float> fanout,
+      std::optional<float> rlFanout,
       ColumnVector columns);
 
   /// Convenience factory for cross joins (no equi-keys). Sets method to
@@ -571,15 +590,22 @@ struct Join : public RelationOp {
       RelationOpVisitorContext& context) const override;
 
  private:
-  // Computes filter selectivity from input constraints.
-  float computeFilterSelectivity() const;
+  // Computes filter selectivity from input constraints. nullopt if the
+  // selectivity of a non-empty filter could not be estimated.
+  std::optional<float> computeFilterSelectivity() const;
 
   // Initializes constraints_ for output columns.
-  void initConstraints(float fanout, float rlFanout, float filterSelectivity);
+  void initConstraints(
+      std::optional<float> fanout,
+      std::optional<float> rlFanout,
+      std::optional<float> filterSelectivity);
 
   // Initializes cost_ fields. Applies filter selectivity and join-type
   // adjustment to the raw fanout.
-  void initCost(float fanout, float rlFanout, float filterSelectivity);
+  void initCost(
+      std::optional<float> fanout,
+      std::optional<float> rlFanout,
+      std::optional<float> filterSelectivity);
 };
 
 using JoinCP = const Join*;
@@ -691,7 +717,7 @@ struct Aggregation : public RelationOp {
 
  private:
   void initConstraints();
-  void setCostWithGroups(float inputBeforePartial);
+  void setCostWithGroups(std::optional<float> inputBeforePartial);
 };
 
 /// Represents an order by. The order is given by the distribution.

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -22,6 +22,17 @@ namespace facebook::axiom::optimizer {
 
 namespace {
 
+// Renders an optional estimate, printing "?" when the value is unknown.
+template <typename T>
+std::string formatOptional(const std::optional<T>& value) {
+  if (!value.has_value()) {
+    return "?";
+  }
+  std::stringstream out;
+  out << std::fixed << std::setprecision(2) << *value;
+  return out.str();
+}
+
 class ToTextVisitor : public RelationOpVisitor {
  public:
   struct Context : public RelationOpVisitorContext {
@@ -329,16 +340,14 @@ class ToTextVisitor : public RelationOpVisitor {
       context.out << " " << extra;
     }
 
-    context.out << " [" << std::fixed << std::setprecision(2)
-                << op.resultCardinality() << " rows] -> "
-                << columnsToString(op.columns()) << std::endl;
+    context.out << " [" << formatOptional(op.resultCardinality())
+                << " rows] -> " << columnsToString(op.columns()) << std::endl;
 
     if (context.options.includeCost) {
       context.out << toIndentation(context.indent + 1)
-                  << "Estimates: fanout = " << std::fixed
-                  << std::setprecision(2) << op.cost().fanout
-                  << ", cost = " << std::fixed << std::setprecision(2)
-                  << op.cost().totalCost() << std::endl;
+                  << "Estimates: fanout = " << formatOptional(op.cost().fanout)
+                  << ", cost = " << formatOptional(op.cost().totalCost())
+                  << std::endl;
     }
   }
 
@@ -352,17 +361,17 @@ class ToTextVisitor : public RelationOpVisitor {
 
     const auto& value = it->second;
     std::stringstream out;
-    out << " " << value.type->toString() << " (ndv=" << std::fixed
-        << std::setprecision(2) << value.cardinality;
+    out << " " << value.type->toString()
+        << " (ndv=" << formatOptional(value.cardinality);
     if (value.min != nullptr) {
       out << " min=" << *value.min;
     }
     if (value.max != nullptr) {
       out << " max=" << *value.max;
     }
-    if (value.nullFraction > 0) {
+    if (value.nullFraction.has_value() && *value.nullFraction > 0) {
       out << " nulls=" << std::fixed << std::setprecision(0)
-          << (value.nullFraction * 100) << "%";
+          << (*value.nullFraction * 100) << "%";
     }
     out << ")";
     return out.str();

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -87,7 +87,12 @@ float Value::byteSize() const {
 
 std::string Value::toString() const {
   std::stringstream out;
-  out << "<Value type=" << type->toString() << ", cardinality=" << cardinality;
+  out << "<Value type=" << type->toString() << ", cardinality=";
+  if (cardinality.has_value()) {
+    out << *cardinality;
+  } else {
+    out << "?";
+  }
 
   if (min != nullptr) {
     out << " min=" << *min;
@@ -97,12 +102,20 @@ std::string Value::toString() const {
     out << " max=" << *max;
   }
 
-  if (trueFraction != kUnknown) {
-    out << " trueFraction=" << trueFraction;
+  // Surface unknown as "?". Unlike nullFraction, a known 0 is not omitted: a
+  // trueFraction of 0 ("always false") is notable, whereas a nullFraction of 0
+  // ("no nulls") is the unremarkable default.
+  if (trueFraction.has_value()) {
+    out << " trueFraction=" << *trueFraction;
+  } else {
+    out << " trueFraction=?";
   }
 
-  if (nullFraction != 0) {
-    out << " nullFraction=" << nullFraction;
+  // Distinguish unknown null fraction ("?") from a known zero (omitted).
+  if (!nullFraction.has_value()) {
+    out << " nullFraction=?";
+  } else if (*nullFraction != 0) {
+    out << " nullFraction=" << *nullFraction;
   }
 
   out << ">";
@@ -170,25 +183,18 @@ SchemaTableCP Schema::findTable(
   auto& tableColumns = connectorTable->columnMap();
   schemaColumns.reserve(tableColumns.size());
   for (const auto& [columnName, tableColumn] : tableColumns) {
-    const auto cardinality = std::max<float>(
-        1,
-        tableColumn->approxNumDistinct(
-            static_cast<int64_t>(connectorTable->numRows())));
-
-    // Get min/max and null fraction from column statistics if available.
-    const velox::Variant* minPtr = nullptr;
-    const velox::Variant* maxPtr = nullptr;
-    float nullFraction = 0;
+    // Cardinality and null fraction are unknown when the connector has no
+    // corresponding statistic.
+    Value value(toType(tableColumn->type()));
     if (auto* stats = tableColumn->stats()) {
-      minPtr = registerOptionalVariant(stats->min);
-      maxPtr = registerOptionalVariant(stats->max);
-      nullFraction = stats->nullPct / 100.0f;
+      if (stats->numDistinct.has_value()) {
+        value.cardinality = std::max<float>(1, stats->numDistinct.value());
+      }
+      value.min = registerOptionalVariant(stats->min);
+      value.max = registerOptionalVariant(stats->max);
+      value.nullFraction = stats->nullPct / 100.0f;
     }
 
-    Value value(toType(tableColumn->type()), cardinality);
-    value.min = minPtr;
-    value.max = maxPtr;
-    value.nullFraction = nullFraction;
     auto* column =
         make<Column>(toName(columnName), nullptr, clampCardinality(value));
     schemaColumns[column->name()] = column;
@@ -305,8 +311,12 @@ IndexInfo SchemaTable::indexInfo(
 
     covered.add(part);
     if (i < numSorting) {
-      info.scanCardinality =
-          combine(info.scanCardinality, i, orderKey->value().cardinality);
+      // Refine the scan cardinality only when the order key's NDV is known;
+      // otherwise leave it unchanged.
+      const auto orderKeyNdv = orderKey->value().cardinality;
+      if (orderKeyNdv.has_value()) {
+        info.scanCardinality = combine(info.scanCardinality, i, *orderKeyNdv);
+      }
       info.lookupKeys.push_back(part);
     }
     if (i == numUnique - 1) {

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -40,16 +40,20 @@ using TypeCP = const velox::Type*;
 //     TypeCP type;
 //     bool nullable{false};  // schema fact
 //     struct Estimates {
-//       float cardinality{1};
-//       float nullFraction{0};
-//       float trueFraction{kUnknown};
+//       std::optional<float> cardinality;
+//       std::optional<float> nullFraction;
+//       std::optional<float> trueFraction;
 //       VariantCP min{nullptr};
 //       VariantCP max{nullptr};
 //     } estimates;
 //   };
 struct Value {
-  Value(TypeCP type, float cardinality)
+  /// Constructs a Value with the given type and NDV (nullopt = unknown).
+  Value(TypeCP type, std::optional<float> cardinality)
       : type{type}, cardinality{cardinality} {}
+
+  /// Constructs a Value with unknown cardinality (no NDV statistic available).
+  explicit Value(TypeCP type) : type{type} {}
 
   /// Default copy constructor.
   Value(const Value&) = default;
@@ -75,19 +79,18 @@ struct Value {
   VariantCP max{nullptr};
 
   /// Count of distinct values. Is not exact and is used for estimating
-  /// cardinalities of group bys or joins.
-  float cardinality{1};
+  /// cardinalities of group bys or joins. nullopt means the NDV is unknown (no
+  /// statistic available); callers must not silently treat unknown as a value.
+  std::optional<float> cardinality;
 
-  /// Sentinel value for unknown trueFraction.
-  static constexpr float kUnknown = -1.0f;
+  /// Estimate of true fraction for booleans. 0 means always false. This is an
+  /// estimate and 1 or 0 do not allow pruning dependent code paths. nullopt
+  /// means the true fraction is unknown.
+  std::optional<float> trueFraction;
 
-  /// Estimate of true fraction for booleans. 0 means always
-  /// false. This is an estimate and 1 or 0 do not allow pruning
-  /// dependent code paths.
-  float trueFraction{kUnknown};
-
-  /// 0 means no nulls, 0.5 means half are null.
-  float nullFraction{0};
+  /// 0 means no nulls, 0.5 means half are null. nullopt means the null fraction
+  /// is unknown.
+  std::optional<float> nullFraction;
 
   /// True if nulls may occur. 'false' means that plans that allow no nulls may
   /// be generated.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -79,7 +79,7 @@ SubqueryKey subqueryKeyOf(const lp::ExprPtr& expr) {
   return {};
 }
 
-Value toValue(const velox::TypePtr& type, float cardinality) {
+Value toValue(const velox::TypePtr& type, std::optional<float> cardinality) {
   return clampCardinality(Value{toType(type), cardinality});
 }
 
@@ -1270,10 +1270,12 @@ bool hasNullLiteral(const ExprVector& exprs) {
 // cardinality across its arguments, with a minimum of 1.
 // TODO: This underestimates for functions like row_number() that produce
 // unique values per row. Revisit when partition size estimates are available.
-float estimateCallCardinality(const ExprVector& args) {
-  float cardinality = 1;
+// Estimates a call's result NDV as the max of its argument NDVs. Returns
+// nullopt if any argument's NDV is unknown.
+std::optional<float> estimateCallCardinality(const ExprVector& args) {
+  std::optional<float> cardinality = 1;
   for (const auto& arg : args) {
-    cardinality = std::max(cardinality, arg->value().cardinality);
+    cardinality = maxOf(cardinality, arg->value().cardinality);
   }
   return cardinality;
 }
@@ -1550,13 +1552,13 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
 
   const auto& inputs = call->inputs();
   ExprVector args(inputs.size());
-  float cardinality = 1;
+  std::optional<float> cardinality = 1;
   FunctionSet funcs;
   for (auto i = 0; i < inputs.size(); ++i) {
     const auto& input = inputs[i];
     if (allUsed || usedArgs.contains(i)) {
       args[i] = translateExpr(input);
-      cardinality = std::max(cardinality, args[i]->value().cardinality);
+      cardinality = maxOf(cardinality, args[i]->value().cardinality);
       if (args[i]->is(PlanType::kCallExpr)) {
         funcs = funcs | args[i]->as<Call>()->functions();
       }
@@ -1640,7 +1642,7 @@ void ToGraph::addUnnest(const lp::UnnestNode& unnest) {
   PlanObjectCP leftTable = nullptr;
   ExprVector unnestExprs;
   unnestExprs.reserve(unnest.unnestExpressions().size());
-  float maxCardinality = 0;
+  std::optional<float> maxCardinality = 0;
   for (size_t i = 0; i < unnest.unnestExpressions().size(); ++i) {
     const auto* unnestExpr = translateExpr(unnest.unnestExpressions()[i]);
     unnestExprs.push_back(unnestExpr);
@@ -1649,7 +1651,7 @@ void ToGraph::addUnnest(const lp::UnnestNode& unnest) {
     } else if (leftTable && leftTable != unnestExpr->singleTable()) {
       leftTable = nullptr;
     }
-    maxCardinality = std::max(maxCardinality, unnestExpr->value().cardinality);
+    maxCardinality = maxOf(maxCardinality, unnestExpr->value().cardinality);
   }
 
   if (!leftTable) {
@@ -2608,7 +2610,7 @@ SubfieldProjections makeSubfieldColumns(
     BaseTable& baseTable,
     ColumnCP column,
     const PathSet& paths) {
-  const float cardinality = baseTable.filteredCardinality;
+  const std::optional<float> cardinality = baseTable.filteredCardinality;
 
   SubfieldProjections projections;
   paths.forEachPath([&](PathCP path) {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -2391,7 +2391,11 @@ void ToVelox::makePredictionAndHistory(
     const velox::core::PlanNodeId& id,
     const RelationOp* op) {
   nodeHistory_[id] = op->historyKey();
-  prediction_[id] = NodePrediction{.cardinality = op->resultCardinality()};
+  // Only record a prediction when the cardinality is known; NodePrediction
+  // holds a concrete value.
+  if (const auto cardinality = op->resultCardinality()) {
+    prediction_[id] = NodePrediction{.cardinality = *cardinality};
+  }
 }
 
 velox::core::PlanNodePtr ToVelox::makeFragment(

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
@@ -110,7 +111,7 @@ void VeloxHistory::estimateLeafSelectivity(
     const velox::connector::ConnectorTableHandlePtr& tableHandle) {
   auto options = queryCtx()->optimization()->options();
 
-  float conjunctsSelectivityValue = 1.0f;
+  std::optional<float> conjunctsSelectivityValue = 1.0f;
 
   if (!table.columnFilters.empty() || !table.filter.empty()) {
     ExprVector allFilters;
@@ -124,8 +125,11 @@ void VeloxHistory::estimateLeafSelectivity(
 
     ConstraintMap constraints;
 
+    // An unknown selectivity leaves filteredCardinality unknown.
     auto selectivity = conjunctsSelectivity(constraints, allFilters, true);
-    conjunctsSelectivityValue = selectivity.trueFraction;
+    conjunctsSelectivityValue = selectivity.has_value()
+        ? std::optional<float>(selectivity->trueFraction)
+        : std::nullopt;
 
     setBaseTableValues(constraints, table);
   }
@@ -136,7 +140,7 @@ void VeloxHistory::estimateLeafSelectivity(
   if (!options.sampleFilters ||
       !runnerTable->layouts()[0]->supportsSampling()) {
     table.filteredCardinality =
-        table.schemaTable->cardinality * conjunctsSelectivityValue;
+        mul(table.schemaTable->cardinality, conjunctsSelectivityValue);
     return;
   }
 

--- a/axiom/optimizer/docs/CardinalityEstimation.md
+++ b/axiom/optimizer/docs/CardinalityEstimation.md
@@ -100,7 +100,7 @@ row counts and for diagnosing unexpected join orders or performance issues.
 | **Aggregation** | Reduces to group count | Keys clamped to group count; aggregates use own Value |
 | **Limit** | Reduces to `limit` rows | Cardinalities scaled by `sampledNdv(c, limit / \|input\|)` |
 | **OrderBy** | Neutral; reduces to `limit` with LIMIT | With LIMIT, cardinalities scaled by `sampledNdv` |
-| **UnionAll** | Sum of inputs | Cardinalities summed, null fractions averaged, ranges unioned |
+| **UnionAll** | Sum of inputs | NDVs combined by inclusion-exclusion over ranges, null fractions averaged, ranges unioned |
 | **Values** | Literal row count | From literal values |
 | **Unnest** | Expands by heuristic fanout of 10 | Pass-through |
 | **AssignUniqueId** | Neutral | Adds unique ID column (ndv = rowCount, no nulls) |
@@ -252,19 +252,22 @@ inputCardinality = Σ (input[i].inputCardinality × input[i].fanout)
 fanout = 1
 ```
 
-Constraints: cardinalities (NDVs) summed, null fractions weighted-averaged,
-ranges unioned across all inputs.
+Constraints: cardinalities (NDVs) combined by inclusion-exclusion over the
+legs' ranges, null fractions weighted-averaged, ranges unioned across all
+inputs.
 
-**Why sum NDVs?** For a column present in all inputs, the true output NDV is
-the size of the set union: `|S_1 ∪ S_2 ∪ ...| = Σ ndv_i − (overlap)`. This
-lies in the range `[max(ndv_i), Σ ndv_i]`. Summing assumes zero overlap, which
-follows from the optimizer's global independence assumption: model each input as
-drawing distinct values uniformly from a large domain D. The expected output NDV
-is `D × (1 − Π(1 − ndv_i / D))`, which simplifies to `Σ ndv_i` when
-D >> ndv_i. This is the same independence assumption used for filter
-selectivity, join key matching, and aggregation group counts. It is also exact
-for the common case where UnionAll combines data from disjoint sources (e.g.,
-different partitions or time ranges with non-overlapping keys).
+**Combining NDVs.** For a column present in all inputs, the true output NDV is
+the size of the set union: `|S_1 ∪ S_2 ∪ ...| = Σ ndv_i − (overlap)`, which lies
+in `[max(ndv_i), Σ ndv_i]`. The legs are folded left to right; folding a leg
+with NDV `m` and range `[ml, mh]` into a running set with NDV `n` and range
+`[nl, nh]` subtracts the values expected to be shared in the overlap region
+`[max(ml,nl), min(mh,nh)]`: `shared = overlapSize × (n / runRange) × (m /
+legRange)`, assuming values are uniformly distributed within each range and
+independent across legs (the same model used for `columnComparisonSelectivity`).
+Disjoint legs have no overlap, so their NDVs sum — exact for the common case of
+data from disjoint sources (different partitions or time ranges with
+non-overlapping keys). A leg without an integer range contributes its full NDV
+(the disjoint assumption) and clears the running range.
 
 ### Values
 

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -319,6 +319,15 @@ TEST_F(AggregationTest, fanoutPrecisionRegression) {
 TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   auto schema = ROW({"a", "b", "c", "v"}, BIGINT());
   testConnector_->addTable("t", schema);
+  // Unique grouping keys (NDV == row count): grouping does not reduce rows, so
+  // partial pre-aggregation has no benefit and single-stage aggregation wins.
+  testConnector_->setStats(
+      "t",
+      1'000,
+      {{"a", {.numDistinct = 1'000}},
+       {"b", {.numDistinct = 1'000}},
+       {"c", {.numDistinct = 1'000}},
+       {"v", {.numDistinct = 1'000}}});
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -147,16 +147,16 @@ TEST_F(CardinalityEstimationTest, values) {
         const auto& op = *plan.op;
 
         ASSERT_EQ(op.columns().size(), 2);
-        EXPECT_NEAR(op.resultCardinality(), 3, kCardinalityTolerance);
+        EXPECT_NEAR(op.resultCardinality().value(), 3, kCardinalityTolerance);
 
         auto a = findConstraint(op, 0);
         ASSERT_TRUE(a.has_value());
-        EXPECT_NEAR(a->cardinality, 3, kCardinalityTolerance);
+        EXPECT_NEAR(a->cardinality.value(), 3, kCardinalityTolerance);
         AXIOM_ASSERT_NORANGE(*a);
 
         auto b = findConstraint(op, 1);
         ASSERT_TRUE(b.has_value());
-        EXPECT_NEAR(b->cardinality, 3, kCardinalityTolerance);
+        EXPECT_NEAR(b->cardinality.value(), 3, kCardinalityTolerance);
         AXIOM_ASSERT_NORANGE(*b);
       });
 }
@@ -177,17 +177,17 @@ TEST_F(CardinalityEstimationTest, scan) {
     const auto& op = *plan.op;
 
     ASSERT_EQ(op.columns().size(), 2);
-    EXPECT_NEAR(op.resultCardinality(), 1'000, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
     auto a = findConstraint(op, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 100, kCardinalityTolerance);
-    EXPECT_NEAR(a->nullFraction, 0.5, kTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 100, kCardinalityTolerance);
+    EXPECT_NEAR(a->nullFraction.value(), 0.5, kTolerance);
     AXIOM_ASSERT_RANGE(*a, 10, 100);
 
     auto b = findConstraint(op, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 500, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 500, kCardinalityTolerance);
     AXIOM_ASSERT_NORANGE(*b);
   });
 }
@@ -208,16 +208,16 @@ TEST_F(CardinalityEstimationTest, scanWithFilter) {
     ASSERT_EQ(op.columns().size(), 2);
 
     // a > 500 on [1, 1000] should give ~50% selectivity.
-    EXPECT_NEAR(op.resultCardinality(), 500, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 500, kCardinalityTolerance);
 
     auto a = findConstraint(op, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 500, kCardinalityTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 500, kCardinalityTolerance);
     AXIOM_ASSERT_RANGE(*a, 501, 1'000);
 
     auto b = findConstraint(op, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 500, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 500, kCardinalityTolerance);
     AXIOM_ASSERT_NORANGE(*b);
   });
 }
@@ -237,11 +237,11 @@ TEST_F(CardinalityEstimationTest, aggregation) {
       "SELECT a, count(*), sum(b) FROM t GROUP BY a", [](const Plan& plan) {
         const auto& op = *plan.op;
         ASSERT_EQ(op.columns().size(), 3);
-        EXPECT_NEAR(op.resultCardinality(), 50, kCardinalityTolerance);
+        EXPECT_NEAR(op.resultCardinality().value(), 50, kCardinalityTolerance);
 
         auto a = findConstraint(op, 0);
         ASSERT_TRUE(a.has_value());
-        EXPECT_NEAR(a->cardinality, 50, kCardinalityTolerance);
+        EXPECT_NEAR(a->cardinality.value(), 50, kCardinalityTolerance);
         AXIOM_ASSERT_NORANGE(*a);
       });
 }
@@ -252,7 +252,7 @@ TEST_F(CardinalityEstimationTest, globalAggregation) {
 
   verifyPlan("SELECT count(*), sum(a) FROM t", [](const Plan& plan) {
     const auto& op = *plan.op;
-    EXPECT_NEAR(op.resultCardinality(), 1, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 1, kCardinalityTolerance);
   });
 }
 
@@ -273,12 +273,12 @@ TEST_F(CardinalityEstimationTest, globalAggregationOnSubquery) {
       "SELECT count(*) FROM (SELECT a, sum(b) FROM t GROUP BY a) sub",
       [](const Plan& plan) {
         const auto& op = *plan.op;
-        EXPECT_NEAR(op.resultCardinality(), 1, kCardinalityTolerance);
+        EXPECT_NEAR(op.resultCardinality().value(), 1, kCardinalityTolerance);
 
         ASSERT_EQ(op.columns().size(), 1);
         auto count = findConstraint(op, 0);
         ASSERT_TRUE(count.has_value());
-        EXPECT_NEAR(count->cardinality, 1, kCardinalityTolerance);
+        EXPECT_NEAR(count->cardinality.value(), 1, kCardinalityTolerance);
       });
 }
 
@@ -313,20 +313,21 @@ TEST_F(CardinalityEstimationTest, filterOverValues) {
 
         // Filter 'a > 1' uses default selectivity 0.10 (no min/max on VALUES).
         // 3 * 0.10 = 0.3, clamped to at least 1 row.
-        EXPECT_NEAR(filter.resultCardinality(), 1, kCardinalityTolerance);
+        EXPECT_NEAR(
+            filter.resultCardinality().value(), 1, kCardinalityTolerance);
         ASSERT_EQ(filter.columns().size(), 2);
 
         // Filtered column 'a': conjunctsSelectivity sets NDV. sampledNdv
         // preserves it since NDV=1 can't decrease further.
         auto a = findConstraint(filter, 0);
         ASSERT_TRUE(a.has_value());
-        EXPECT_NEAR(a->cardinality, 1, kCardinalityTolerance);
+        EXPECT_NEAR(a->cardinality.value(), 1, kCardinalityTolerance);
 
         // Non-filtered column 'b': sampledNdv(3, 3, 0.10) scales NDV from 3
         // to 1.
         auto b = findConstraint(filter, 1);
         ASSERT_TRUE(b.has_value());
-        EXPECT_NEAR(b->cardinality, 1, kCardinalityTolerance);
+        EXPECT_NEAR(b->cardinality.value(), 1, kCardinalityTolerance);
       });
 }
 
@@ -350,13 +351,14 @@ TEST_F(CardinalityEstimationTest, filterOverUnnest) {
 
         // Unnest produces 10,000 rows (1,000 * fanout 10). Filter 'e > 1'
         // uses default selectivity 0.10 → 1,000 output rows.
-        EXPECT_NEAR(filter.resultCardinality(), 1'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            filter.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
         // Non-filtered replicate column 'b': NDV=800 from table scan.
         // sampledNdv(800, 10000, 0.10) ≈ 571.
         auto b = findConstraint(filter, 0);
         ASSERT_TRUE(b.has_value());
-        EXPECT_LT(b->cardinality, 800);
+        EXPECT_LT(b->cardinality.value(), 800);
       });
 }
 
@@ -390,7 +392,8 @@ TEST_F(CardinalityEstimationTest, filterOverJoin) {
         // Join on a=x: fanout = 10 / max(100, 10) = 0.1.
         // resultCardinality = 1'000 * 0.1 = 100.
         // Filter 'b > y': ~50% selectivity → ~50 rows.
-        EXPECT_NEAR(filter.resultCardinality(), 50, kCardinalityTolerance);
+        EXPECT_NEAR(
+            filter.resultCardinality().value(), 50, kCardinalityTolerance);
 
         // Column 'c' is not referenced in any filter or join key. After the
         // join, c NDV was scaled by sampledNdv to ~94. The Filter should
@@ -430,7 +433,7 @@ TEST_F(CardinalityEstimationTest, innerJoin) {
       EXPECT_EQ(join.joinType, velox::core::JoinType::kInner);
       ASSERT_EQ(join.columns().size(), 4);
       EXPECT_NEAR(
-          join.resultCardinality(),
+          join.resultCardinality().value(),
           expected.resultCardinality,
           kCardinalityTolerance);
 
@@ -438,27 +441,35 @@ TEST_F(CardinalityEstimationTest, innerJoin) {
       auto a = findConstraint(join, 0);
       ASSERT_TRUE(a.has_value());
       EXPECT_NEAR(
-          a->cardinality, expected.keyCardinality, kCardinalityTolerance);
+          a->cardinality.value(),
+          expected.keyCardinality,
+          kCardinalityTolerance);
       EXPECT_EQ(a->nullFraction, 0.0f);
       AXIOM_ASSERT_NORANGE(*a);
 
       auto b = findConstraint(join, 1);
       ASSERT_TRUE(b.has_value());
       EXPECT_NEAR(
-          b->cardinality, expected.payloadBCardinality, kCardinalityTolerance);
+          b->cardinality.value(),
+          expected.payloadBCardinality,
+          kCardinalityTolerance);
       AXIOM_ASSERT_NORANGE(*b);
 
       auto x = findConstraint(join, 2);
       ASSERT_TRUE(x.has_value());
       EXPECT_NEAR(
-          x->cardinality, expected.keyCardinality, kCardinalityTolerance);
+          x->cardinality.value(),
+          expected.keyCardinality,
+          kCardinalityTolerance);
       EXPECT_EQ(x->nullFraction, 0.0f);
       AXIOM_ASSERT_NORANGE(*x);
 
       auto y = findConstraint(join, 3);
       ASSERT_TRUE(y.has_value());
       EXPECT_NEAR(
-          y->cardinality, expected.payloadYCardinality, kCardinalityTolerance);
+          y->cardinality.value(),
+          expected.payloadYCardinality,
+          kCardinalityTolerance);
       AXIOM_ASSERT_NORANGE(*y);
     });
   };
@@ -526,7 +537,7 @@ TEST_F(CardinalityEstimationTest, joinWithFilterOutsideMinMax) {
     SCOPED_TRACE(sql);
     verifyPlan(sql, [](const Plan& plan) {
       const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
-      EXPECT_NEAR(join.resultCardinality(), 1, kCardinalityTolerance);
+      EXPECT_NEAR(join.resultCardinality().value(), 1, kCardinalityTolerance);
     });
   };
 
@@ -578,7 +589,8 @@ TEST_F(CardinalityEstimationTest, innerJoinUniqueRight) {
         // lrFanout = right.fanout * baseSelectivity(rightTable)
         //          = 0.5 * 1 = 0.5.
         // resultCardinality = |t| * 0.5 = 500.
-        EXPECT_NEAR(join.resultCardinality(), 500, kCardinalityTolerance);
+        EXPECT_NEAR(
+            join.resultCardinality().value(), 500, kCardinalityTolerance);
       });
 }
 
@@ -657,24 +669,24 @@ TEST_F(CardinalityEstimationTest, leftJoin) {
 
     // fanout = |u| / max(ndv(t.a), ndv(u.x)) = 100 / max(100, 50) = 1.
     // resultCardinality = |t| * max(1, 1) = 1'000.
-    EXPECT_NEAR(join.resultCardinality(), 1'000, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
     // Left key/payload: not modified (left side is not optional).
     auto a = findConstraint(join, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 100, kCardinalityTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 100, kCardinalityTolerance);
     EXPECT_EQ(a->nullFraction, 0.1f);
 
     auto b = findConstraint(join, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 500, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 500, kCardinalityTolerance);
     EXPECT_EQ(b->nullFraction, 0.0f);
 
     // Right key: cardinality adjusted by updateKey to min(ndv(t.a), ndv(u.x)).
     // nullFraction = 1 - ndv(u.x) / ndv(t.a) = 0.5.
     auto x = findConstraint(join, 2);
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(x->cardinality, 50, kCardinalityTolerance);
+    EXPECT_NEAR(x->cardinality.value(), 50, kCardinalityTolerance);
     EXPECT_EQ(x->nullFraction, 0.5f);
 
     // Right payload: only nullable and nullFraction set by updatePayload.
@@ -682,7 +694,7 @@ TEST_F(CardinalityEstimationTest, leftJoin) {
     // from scan.
     auto y = findConstraint(join, 3);
     ASSERT_TRUE(y.has_value());
-    EXPECT_NEAR(y->cardinality, 100, kCardinalityTolerance);
+    EXPECT_NEAR(y->cardinality.value(), 100, kCardinalityTolerance);
     EXPECT_TRUE(y->nullable);
     EXPECT_EQ(y->nullFraction, 0.5f);
   });
@@ -717,20 +729,21 @@ TEST_F(CardinalityEstimationTest, leftJoinWithFilter) {
         // coalesce() doesn't propagate min/max, so the optimizer uses the
         // default selectivity of 0.5 for column-vs-column comparisons.
         // resultCardinality = |t| * max(1, 5 * 0.5) = 1'000 * 2.5 = 2'500.
-        EXPECT_NEAR(join.resultCardinality(), 2'500, kCardinalityTolerance);
+        EXPECT_NEAR(
+            join.resultCardinality().value(), 2'500, kCardinalityTolerance);
 
         // Left join preserves all left-side rows.
         auto a = findConstraint(join, 0);
         ASSERT_TRUE(a.has_value());
         EXPECT_EQ(a->nullFraction, 0.0f);
-        EXPECT_NEAR(a->cardinality, 100, kCardinalityTolerance);
+        EXPECT_NEAR(a->cardinality.value(), 100, kCardinalityTolerance);
 
         // Right-side key column becomes nullable due to unmatched left rows.
         // nullFraction = 1 - ndv(u.x) / ndv(t.a) = 1 - 50 / 100 = 0.5.
         auto x = findConstraint(join, 2);
         ASSERT_TRUE(x.has_value());
-        EXPECT_NEAR(x->nullFraction, 0.5f, kTolerance);
-        EXPECT_NEAR(x->cardinality, 50, kCardinalityTolerance);
+        EXPECT_NEAR(x->nullFraction.value(), 0.5f, kTolerance);
+        EXPECT_NEAR(x->cardinality.value(), 50, kCardinalityTolerance);
       });
 }
 
@@ -764,7 +777,7 @@ TEST_F(CardinalityEstimationTest, rightJoin) {
     // adjustFanoutForJoinType(kRight) = max(1, rlFanout) * (|t| / |u|)
     //   = 10 * 0.1 = 1.
     // resultCardinality = |u| * 1 = 1'000.
-    EXPECT_NEAR(join.resultCardinality(), 1'000, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
     // The optimizer converts 't LEFT JOIN u' to 'u RIGHT JOIN t'
     // (build smaller t, probe larger u). In the RIGHT join:
@@ -774,19 +787,19 @@ TEST_F(CardinalityEstimationTest, rightJoin) {
     // Right key/payload: not modified (right side is not optional).
     auto a = findConstraint(join, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 100, kCardinalityTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 100, kCardinalityTolerance);
     EXPECT_EQ(a->nullFraction, 0.1f);
 
     auto b = findConstraint(join, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 80, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 80, kCardinalityTolerance);
     EXPECT_EQ(b->nullFraction, 0.0f);
 
     // Left key (u.x): cardinality adjusted by updateKey.
     // nullFraction = max(0, 1 - ndv(u.x) / ndv(t.a)) = 1 - 50 / 100 = 0.5.
     auto x = findConstraint(join, 2);
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(x->cardinality, 50, kCardinalityTolerance);
+    EXPECT_NEAR(x->cardinality.value(), 50, kCardinalityTolerance);
     EXPECT_TRUE(x->nullable);
     EXPECT_EQ(x->nullFraction, 0.5f);
 
@@ -794,7 +807,7 @@ TEST_F(CardinalityEstimationTest, rightJoin) {
     // Cardinality preserved from scan.
     auto y = findConstraint(join, 3);
     ASSERT_TRUE(y.has_value());
-    EXPECT_NEAR(y->cardinality, 500, kCardinalityTolerance);
+    EXPECT_NEAR(y->cardinality.value(), 500, kCardinalityTolerance);
     EXPECT_TRUE(y->nullable);
     EXPECT_EQ(y->nullFraction, 0.5f);
   });
@@ -827,13 +840,14 @@ TEST_F(CardinalityEstimationTest, fullJoin) {
         // fanout = |u| / max(ndv(t.a), ndv(u.x)) = 1'000 / 100 = 10.
         // adjustFanoutForJoinType(kFull) = max(max(1, 10), 1.0) = 10.
         // resultCardinality = |t| * 10 = 10'000.
-        EXPECT_NEAR(join.resultCardinality(), 10'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            join.resultCardinality().value(), 10'000, kCardinalityTolerance);
 
         // Left key: leftOptional = true.
         // nullFraction = max(0, 1 - ndv(t.a) / ndv(u.x)) = 1 - 100/50 < 0 => 0.
         auto a = findConstraint(join, 0);
         ASSERT_TRUE(a.has_value());
-        EXPECT_NEAR(a->cardinality, 50, kCardinalityTolerance);
+        EXPECT_NEAR(a->cardinality.value(), 50, kCardinalityTolerance);
         EXPECT_TRUE(a->nullable);
         EXPECT_EQ(a->nullFraction, 0.0f);
 
@@ -841,7 +855,7 @@ TEST_F(CardinalityEstimationTest, fullJoin) {
         // Cardinality preserved from scan.
         auto b = findConstraint(join, 1);
         ASSERT_TRUE(b.has_value());
-        EXPECT_NEAR(b->cardinality, 500, kCardinalityTolerance);
+        EXPECT_NEAR(b->cardinality.value(), 500, kCardinalityTolerance);
         EXPECT_TRUE(b->nullable);
         EXPECT_EQ(b->nullFraction, 0.0f);
 
@@ -849,7 +863,7 @@ TEST_F(CardinalityEstimationTest, fullJoin) {
         // nullFraction = max(0, 1 - ndv(u.x) / ndv(t.a)) = 1 - 50/100 = 0.5.
         auto x = findConstraint(join, 2);
         ASSERT_TRUE(x.has_value());
-        EXPECT_NEAR(x->cardinality, 50, kCardinalityTolerance);
+        EXPECT_NEAR(x->cardinality.value(), 50, kCardinalityTolerance);
         EXPECT_TRUE(x->nullable);
         EXPECT_EQ(x->nullFraction, 0.5f);
 
@@ -859,7 +873,7 @@ TEST_F(CardinalityEstimationTest, fullJoin) {
         // preserved from scan.
         auto y = findConstraint(join, 3);
         ASSERT_TRUE(y.has_value());
-        EXPECT_NEAR(y->cardinality, 200, kCardinalityTolerance);
+        EXPECT_NEAR(y->cardinality.value(), 200, kCardinalityTolerance);
         EXPECT_TRUE(y->nullable);
         EXPECT_EQ(y->nullFraction, 0.0f);
       });
@@ -883,7 +897,8 @@ TEST_F(CardinalityEstimationTest, semiProjectMark) {
       EXPECT_EQ(join.joinType, velox::core::JoinType::kLeftSemiProject);
 
       // Semi project preserves all left-side rows.
-      EXPECT_NEAR(join.resultCardinality(), 1'000, kCardinalityTolerance);
+      EXPECT_NEAR(
+          join.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
       // The last column of a kLeftSemiProject join is the mark column.
       auto markColumn = join.columns().back();
@@ -891,7 +906,7 @@ TEST_F(CardinalityEstimationTest, semiProjectMark) {
 
       auto mark = findConstraint(join, markColumn);
       ASSERT_TRUE(mark.has_value());
-      EXPECT_NEAR(mark->trueFraction, expectedTrueFraction, kTolerance);
+      EXPECT_NEAR(mark->trueFraction.value(), expectedTrueFraction, kTolerance);
       EXPECT_FALSE(mark->nullable);
       EXPECT_EQ(mark->nullFraction, 0);
     });
@@ -944,7 +959,7 @@ TEST_F(CardinalityEstimationTest, semiFilter) {
       ASSERT_EQ(join.columns().size(), 2);
 
       EXPECT_NEAR(
-          join.resultCardinality(),
+          join.resultCardinality().value(),
           expected.resultCardinality,
           kCardinalityTolerance);
 
@@ -953,7 +968,9 @@ TEST_F(CardinalityEstimationTest, semiFilter) {
       auto a = findConstraint(join, 0);
       ASSERT_TRUE(a.has_value());
       EXPECT_NEAR(
-          a->cardinality, expected.keyCardinality, kCardinalityTolerance);
+          a->cardinality.value(),
+          expected.keyCardinality,
+          kCardinalityTolerance);
       EXPECT_EQ(a->nullFraction, 0.0f);
       AXIOM_ASSERT_NORANGE(*a);
 
@@ -962,7 +979,9 @@ TEST_F(CardinalityEstimationTest, semiFilter) {
       auto b = findConstraint(join, 1);
       ASSERT_TRUE(b.has_value());
       EXPECT_NEAR(
-          b->cardinality, expected.payloadCardinality, kCardinalityTolerance);
+          b->cardinality.value(),
+          expected.payloadCardinality,
+          kCardinalityTolerance);
       EXPECT_EQ(b->nullFraction, 0.0f);
       AXIOM_ASSERT_NORANGE(*b);
     });
@@ -1028,7 +1047,7 @@ TEST_F(CardinalityEstimationTest, antiJoin) {
       ASSERT_EQ(join.columns().size(), 2);
 
       EXPECT_NEAR(
-          join.resultCardinality(),
+          join.resultCardinality().value(),
           expected.resultCardinality,
           kCardinalityTolerance);
 
@@ -1040,9 +1059,12 @@ TEST_F(CardinalityEstimationTest, antiJoin) {
       auto a = findConstraint(join, 0);
       ASSERT_TRUE(a.has_value());
       EXPECT_NEAR(
-          a->cardinality, expected.keyCardinality, kCardinalityTolerance);
+          a->cardinality.value(),
+          expected.keyCardinality,
+          kCardinalityTolerance);
       EXPECT_TRUE(a->nullable);
-      EXPECT_NEAR(a->nullFraction, expected.keyNullFraction, kTolerance);
+      EXPECT_NEAR(
+          a->nullFraction.value(), expected.keyNullFraction, kTolerance);
       AXIOM_ASSERT_NORANGE(*a);
 
       // Payload: cardinality scaled by antiSelectivity (fewer rows => fewer
@@ -1051,7 +1073,9 @@ TEST_F(CardinalityEstimationTest, antiJoin) {
       auto b = findConstraint(join, 1);
       ASSERT_TRUE(b.has_value());
       EXPECT_NEAR(
-          b->cardinality, expected.payloadCardinality, kCardinalityTolerance);
+          b->cardinality.value(),
+          expected.payloadCardinality,
+          kCardinalityTolerance);
       EXPECT_EQ(b->nullFraction, 0.0f);
       AXIOM_ASSERT_NORANGE(*b);
     });
@@ -1104,7 +1128,7 @@ TEST_F(CardinalityEstimationTest, countingSemiFilter) {
   verifyPlan(sql, [](const Plan& plan) {
     const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
     EXPECT_EQ(join.joinType, velox::core::JoinType::kCountingLeftSemiFilter);
-    EXPECT_NEAR(join.resultCardinality(), 1'000, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 1'000, kCardinalityTolerance);
   });
 
   // fanout < 1: resultCardinality = 1'000 * 0.5 = 500.
@@ -1112,7 +1136,7 @@ TEST_F(CardinalityEstimationTest, countingSemiFilter) {
   verifyPlan(sql, [](const Plan& plan) {
     const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
     EXPECT_EQ(join.joinType, velox::core::JoinType::kCountingLeftSemiFilter);
-    EXPECT_NEAR(join.resultCardinality(), 500, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 500, kCardinalityTolerance);
   });
 }
 
@@ -1131,7 +1155,7 @@ TEST_F(CardinalityEstimationTest, countingAnti) {
   verifyPlan(sql, [](const Plan& plan) {
     const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
     EXPECT_EQ(join.joinType, velox::core::JoinType::kCountingAnti);
-    EXPECT_NEAR(join.resultCardinality(), 1, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 1, kCardinalityTolerance);
   });
 
   // fanout < 1: resultCardinality = 1'000 * 0.5 = 500.
@@ -1139,7 +1163,7 @@ TEST_F(CardinalityEstimationTest, countingAnti) {
   verifyPlan(sql, [](const Plan& plan) {
     const auto& join = findOp<Join>(*plan.op, RelType::kJoin);
     EXPECT_EQ(join.joinType, velox::core::JoinType::kCountingAnti);
-    EXPECT_NEAR(join.resultCardinality(), 500, kCardinalityTolerance);
+    EXPECT_NEAR(join.resultCardinality().value(), 500, kCardinalityTolerance);
   });
 }
 
@@ -1159,7 +1183,7 @@ TEST_F(CardinalityEstimationTest, multiKeyAggregation) {
         const auto& op = *plan.op;
         ASSERT_EQ(op.columns().size(), 3);
         // Grouping on (a, b): expected ~10 * 20 = 200 groups.
-        EXPECT_NEAR(op.resultCardinality(), 200, kCardinalityTolerance);
+        EXPECT_NEAR(op.resultCardinality().value(), 200, kCardinalityTolerance);
 
         auto a = findConstraint(op, 0);
         ASSERT_TRUE(a.has_value());
@@ -1195,11 +1219,12 @@ TEST_F(CardinalityEstimationTest, joinThenAggregate) {
         ASSERT_EQ(op.columns().size(), 2);
 
         // After join and group by c_custkey: expect ~1000 groups.
-        EXPECT_NEAR(op.resultCardinality(), 1'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            op.resultCardinality().value(), 1'000, kCardinalityTolerance);
 
         auto custkey = findConstraint(op, 0);
         ASSERT_TRUE(custkey.has_value());
-        EXPECT_NEAR(custkey->cardinality, 1'000, kCardinalityTolerance);
+        EXPECT_NEAR(custkey->cardinality.value(), 1'000, kCardinalityTolerance);
         AXIOM_ASSERT_NORANGE(*custkey);
       });
 }
@@ -1221,14 +1246,15 @@ TEST_F(CardinalityEstimationTest, unnest) {
         const auto& op = findOp(*plan.op, RelType::kUnnest);
 
         // Unnest uses a default fanout of 10.
-        EXPECT_NEAR(op.resultCardinality(), 10'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            op.resultCardinality().value(), 10'000, kCardinalityTolerance);
 
         ASSERT_EQ(op.columns().size(), 2);
 
         // Replicate column 'b' preserves input constraints.
         auto b = findConstraint(op, 0);
         ASSERT_TRUE(b.has_value());
-        EXPECT_NEAR(b->cardinality, 200, kCardinalityTolerance);
+        EXPECT_NEAR(b->cardinality.value(), 200, kCardinalityTolerance);
         AXIOM_ASSERT_RANGE(*b, 1, 500);
 
         // Unnested column 'e' has no detailed statistics.
@@ -1252,21 +1278,21 @@ TEST_F(CardinalityEstimationTest, limit) {
   verifyPlan("SELECT a, b FROM t LIMIT 50", [](const Plan& plan) {
     const auto& op = findOp(*plan.op, RelType::kLimit);
 
-    EXPECT_NEAR(op.resultCardinality(), 50, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 50, kCardinalityTolerance);
     ASSERT_EQ(op.columns().size(), 2);
 
     // sampledNdv(100, 1000, 50/1000) =
     //   100 * (1 - (1 - 1/100)^50) = 100 * 0.395 ≈ 39.5.
     auto a = findConstraint(op, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 39.5, kCardinalityTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 39.5, kCardinalityTolerance);
     AXIOM_ASSERT_RANGE(*a, 1, 500);
 
     // sampledNdv(800, 1000, 50/1000) =
     //   800 * (1 - (1 - 1/800)^50) = 800 * 0.0607 ≈ 48.5.
     auto b = findConstraint(op, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 48.5, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 48.5, kCardinalityTolerance);
   });
 }
 
@@ -1279,7 +1305,7 @@ TEST_F(CardinalityEstimationTest, unionAll) {
               {"a",
                {.nullPct = 10, .min = 1LL, .max = 500LL, .numDistinct = 100}},
               {"b",
-               {.nullPct = 30, .min = 10LL, .max = 200LL, .numDistinct = 400}},
+               {.nullPct = 30, .min = 10LL, .max = 200LL, .numDistinct = 150}},
           });
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
       ->setStats(
@@ -1288,7 +1314,7 @@ TEST_F(CardinalityEstimationTest, unionAll) {
               {"x",
                {.nullPct = 20, .min = 200LL, .max = 800LL, .numDistinct = 200}},
               {"y",
-               {.nullPct = 50, .min = 100LL, .max = 300LL, .numDistinct = 600}},
+               {.nullPct = 50, .min = 100LL, .max = 300LL, .numDistinct = 180}},
           });
 
   verifyPlan(
@@ -1296,20 +1322,27 @@ TEST_F(CardinalityEstimationTest, unionAll) {
         const auto& op = *plan.op;
 
         ASSERT_EQ(op.columns().size(), 2);
-        EXPECT_NEAR(op.resultCardinality(), 3'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            op.resultCardinality().value(), 3'000, kCardinalityTolerance);
 
         auto a = findConstraint(op, 0);
         ASSERT_TRUE(a.has_value());
-        EXPECT_NEAR(a->cardinality, 300, kCardinalityTolerance);
+        // Inclusion-exclusion over the legs' ranges [1, 500] and [200, 800]:
+        // 100 + 200 minus the ~20 distinct values expected to be shared in the
+        // [200, 500] overlap.
+        EXPECT_NEAR(a->cardinality.value(), 280, kCardinalityTolerance);
         // (1000 * 0.1 + 2000 * 0.2) / 3000.
-        EXPECT_NEAR(a->nullFraction, 500.0 / 3000, kTolerance);
+        EXPECT_NEAR(a->nullFraction.value(), 500.0 / 3000, kTolerance);
         AXIOM_ASSERT_RANGE(*a, 1, 800);
 
         auto b = findConstraint(op, 1);
         ASSERT_TRUE(b.has_value());
-        EXPECT_NEAR(b->cardinality, 1'000, kCardinalityTolerance);
+        // Inclusion-exclusion over [10, 200] and [100, 300]: 150 + 180 minus
+        // the ~71 distinct values expected to be shared in the [100, 200]
+        // overlap.
+        EXPECT_NEAR(b->cardinality.value(), 259, kCardinalityTolerance);
         // (1000 * 0.3 + 2000 * 0.5) / 3000.
-        EXPECT_NEAR(b->nullFraction, 1300.0 / 3000, kTolerance);
+        EXPECT_NEAR(b->nullFraction.value(), 1300.0 / 3000, kTolerance);
         AXIOM_ASSERT_RANGE(*b, 10, 300);
       });
 }
@@ -1327,12 +1360,13 @@ TEST_F(CardinalityEstimationTest, unionAllWithNullLiteral) {
       "SELECT a FROM t UNION ALL SELECT NULL FROM t", [](const Plan& plan) {
         const auto& op = *plan.op;
         ASSERT_EQ(op.columns().size(), 1);
-        EXPECT_NEAR(op.resultCardinality(), 2'000, kCardinalityTolerance);
+        EXPECT_NEAR(
+            op.resultCardinality().value(), 2'000, kCardinalityTolerance);
 
         auto a = findConstraint(op, 0);
         ASSERT_TRUE(a.has_value());
         // (1000 * 0.1 + 1000 * 1.0) / 2000 = 0.55.
-        EXPECT_NEAR(a->nullFraction, 0.55, kTolerance);
+        EXPECT_NEAR(a->nullFraction.value(), 0.55, kTolerance);
         // Either leg can produce NULLs.
         EXPECT_TRUE(a->nullable);
         // NULL-literal leg contributes only NULLs and so does not affect
@@ -1358,17 +1392,18 @@ TEST_F(CardinalityEstimationTest, unionDistinct) {
   verifyPlan("SELECT a FROM t UNION SELECT a FROM u", [](const Plan& plan) {
     const auto& op = *plan.op;
     ASSERT_EQ(op.columns().size(), 1);
-    // UNION = UNION ALL + GROUP BY. UNION ALL produces 3'000 rows with
-    // ndv(t.a) + ndv(u.a) = 300 distinct values. GROUP BY reduces to ~300
+    // UNION = UNION ALL + GROUP BY. UNION ALL produces 3'000 rows; the distinct
+    // count is ndv(t.a) + ndv(u.a) minus the ~20 values shared in the [200,
+    // 500] range overlap (inclusion-exclusion) = ~280. GROUP BY reduces to ~280
     // rows.
-    EXPECT_NEAR(op.resultCardinality(), 300, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 280, kCardinalityTolerance);
 
     auto a = findConstraint(op, 0);
     ASSERT_TRUE(a.has_value());
-    // NDV stays at ndv(t.a) + ndv(u.a) = 300.
-    EXPECT_NEAR(a->cardinality, 300, kCardinalityTolerance);
+    // NDV is the inclusion-exclusion union of the two ranges = ~280.
+    EXPECT_NEAR(a->cardinality.value(), 280, kCardinalityTolerance);
     // Combined null fraction: (1'000 * 0.1 + 2'000 * 0.2) / 3'000 = 500/3'000.
-    EXPECT_NEAR(a->nullFraction, 500.0 / 3'000, kTolerance);
+    EXPECT_NEAR(a->nullFraction.value(), 500.0 / 3'000, kTolerance);
     EXPECT_TRUE(a->nullable);
     // Min/max should be the union of both ranges: [1, 800].
     AXIOM_ASSERT_RANGE(*a, 1, 800);
@@ -1389,19 +1424,19 @@ TEST_F(CardinalityEstimationTest, orderByWithLimit) {
   verifyPlan("SELECT a, b FROM t ORDER BY a LIMIT 50", [](const Plan& plan) {
     const auto& op = findOp(*plan.op, RelType::kOrderBy);
 
-    EXPECT_NEAR(op.resultCardinality(), 50, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 50, kCardinalityTolerance);
     ASSERT_EQ(op.columns().size(), 2);
 
     // sampledNdv(100, 1000, 50/1000) ≈ 39.5.
     auto a = findConstraint(op, 0);
     ASSERT_TRUE(a.has_value());
-    EXPECT_NEAR(a->cardinality, 39.5, kCardinalityTolerance);
+    EXPECT_NEAR(a->cardinality.value(), 39.5, kCardinalityTolerance);
     AXIOM_ASSERT_RANGE(*a, 1, 500);
 
     // sampledNdv(800, 1000, 50/1000) ≈ 48.5.
     auto b = findConstraint(op, 1);
     ASSERT_TRUE(b.has_value());
-    EXPECT_NEAR(b->cardinality, 48.5, kCardinalityTolerance);
+    EXPECT_NEAR(b->cardinality.value(), 48.5, kCardinalityTolerance);
   });
 }
 

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -173,9 +173,9 @@ TEST_F(DerivedTablePrinterTest, basic) {
     EXPECT_THAT(
         lines,
         testing::ElementsAre(
-            testing::Eq("dt1: 1.00 rows, a, s"),
+            testing::Eq("dt1: ? rows, a, s"),
             testing::Eq("  output:"),
-            testing::Eq("    a := t2.a INTEGER (cardinality=1.00)"),
+            testing::Eq("    a := t2.a INTEGER (cardinality=?)"),
             testing::Eq("    s := dt1.s BIGINT (cardinality=1.00 min=101)"),
             testing::Eq("  tables: t2"),
             testing::Eq("  aggregates: sum(t2.b) AS s"),
@@ -185,8 +185,8 @@ TEST_F(DerivedTablePrinterTest, basic) {
             testing::Eq(""),
             testing::Eq("t2: 0.50 rows, a, b"),
             testing::Eq("  table: \"default\".\"t\""),
-            testing::Eq("    a INTEGER (cardinality=1.00)"),
-            testing::Eq("    b INTEGER (cardinality=1.00)"),
+            testing::Eq("    a INTEGER (cardinality=?)"),
+            testing::Eq("    b INTEGER (cardinality=?)"),
             testing::Eq("  multi-column filters: gt(t2.a, t2.b)"),
             testing::Eq("")));
   }
@@ -199,9 +199,9 @@ TEST_F(DerivedTablePrinterTest, basic) {
     EXPECT_THAT(
         lines,
         testing::ElementsAre(
-            testing::Eq("dt1: 1.00 rows, a, sum"),
+            testing::Eq("dt1: ? rows, a, sum"),
             testing::Eq("  output:"),
-            testing::Eq("    a := t2.a INTEGER (cardinality=1.00)"),
+            testing::Eq("    a := t2.a INTEGER (cardinality=?)"),
             testing::Eq("    sum := dt1.sum BIGINT (cardinality=1.00)"),
             testing::Eq("  tables: t2, t3"),
             testing::Eq("  joins:"),
@@ -212,13 +212,13 @@ TEST_F(DerivedTablePrinterTest, basic) {
             testing::Eq(""),
             testing::Eq("t2: 1.00 rows, a, b"),
             testing::Eq("  table: \"default\".\"t\""),
-            testing::Eq("    a INTEGER (cardinality=1.00)"),
-            testing::Eq("    b INTEGER (cardinality=1.00)"),
+            testing::Eq("    a INTEGER (cardinality=?)"),
+            testing::Eq("    b INTEGER (cardinality=?)"),
             testing::Eq(""),
             testing::Eq("t3: 1.00 rows, x, y"),
             testing::Eq("  table: \"default\".\"u\""),
-            testing::Eq("    x INTEGER (cardinality=1.00)"),
-            testing::Eq("    y INTEGER (cardinality=1.00)"),
+            testing::Eq("    x INTEGER (cardinality=?)"),
+            testing::Eq("    y INTEGER (cardinality=?)"),
             testing::Eq("")));
   }
 }
@@ -234,8 +234,8 @@ TEST_F(DerivedTablePrinterTest, union) {
         testing::ElementsAre(
             testing::Eq("dt1: 2.00 rows, a, b"),
             testing::Eq("  output:"),
-            testing::Eq("    a := dt2.a INTEGER (cardinality=2.00)"),
-            testing::Eq("    b := dt2.b INTEGER (cardinality=2.00)"),
+            testing::Eq("    a := dt2.a INTEGER (cardinality=?)"),
+            testing::Eq("    b := dt2.b INTEGER (cardinality=?)"),
             testing::Eq("  tables: dt2"),
             testing::Eq(""),
             testing::Eq("dt2: 2.00 rows, a, b"),
@@ -243,25 +243,25 @@ TEST_F(DerivedTablePrinterTest, union) {
             testing::Eq(""),
             testing::Eq("dt3: 1.00 rows, a, b"),
             testing::Eq("  output:"),
-            testing::Eq("    a := t4.a INTEGER (cardinality=2.00)"),
-            testing::Eq("    b := t4.b INTEGER (cardinality=2.00)"),
+            testing::Eq("    a := t4.a INTEGER (cardinality=?)"),
+            testing::Eq("    b := t4.b INTEGER (cardinality=?)"),
             testing::Eq("  tables: t4"),
             testing::Eq(""),
             testing::Eq("t4: 1.00 rows, a, b"),
             testing::Eq("  table: \"default\".\"t\""),
-            testing::Eq("    a INTEGER (cardinality=1.00)"),
-            testing::Eq("    b INTEGER (cardinality=1.00)"),
+            testing::Eq("    a INTEGER (cardinality=?)"),
+            testing::Eq("    b INTEGER (cardinality=?)"),
             testing::Eq(""),
             testing::Eq("dt5: 1.00 rows, a, b"),
             testing::Eq("  output:"),
-            testing::Eq("    a := t6.a INTEGER (cardinality=2.00)"),
-            testing::Eq("    b := t6.b INTEGER (cardinality=2.00)"),
+            testing::Eq("    a := t6.a INTEGER (cardinality=?)"),
+            testing::Eq("    b := t6.b INTEGER (cardinality=?)"),
             testing::Eq("  tables: t6"),
             testing::Eq(""),
             testing::Eq("t6: 1.00 rows, a, b"),
             testing::Eq("  table: \"default\".\"u\""),
-            testing::Eq("    a INTEGER (cardinality=1.00)"),
-            testing::Eq("    b INTEGER (cardinality=1.00)"),
+            testing::Eq("    a INTEGER (cardinality=?)"),
+            testing::Eq("    b INTEGER (cardinality=?)"),
             testing::Eq("")));
   }
 }
@@ -290,14 +290,14 @@ TEST_F(DerivedTablePrinterTest, write) {
           testing::Eq(""),
           testing::Eq("dt2: 1.00 rows, a, b"),
           testing::Eq("  output:"),
-          testing::Eq("    a := t3.a INTEGER (cardinality=1.00)"),
-          testing::Eq("    b := t3.b INTEGER (cardinality=1.00)"),
+          testing::Eq("    a := t3.a INTEGER (cardinality=?)"),
+          testing::Eq("    b := t3.b INTEGER (cardinality=?)"),
           testing::Eq("  tables: t3"),
           testing::Eq(""),
           testing::Eq("t3: 1.00 rows, a, b"),
           testing::Eq("  table: \"default\".\"c\""),
-          testing::Eq("    a INTEGER (cardinality=1.00)"),
-          testing::Eq("    b INTEGER (cardinality=1.00)"),
+          testing::Eq("    a INTEGER (cardinality=?)"),
+          testing::Eq("    b INTEGER (cardinality=?)"),
           testing::Eq("")));
 }
 

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -193,17 +193,15 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {"count(*) as cnt"})
-                             .build(),
-                         core::JoinType::kLeft)
-                     .build();
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kRight)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -262,10 +260,9 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
                                 .hashJoin(
                                     matchScan("v")
                                         .filter("a < 10")
-                                        .partialAggregation({"a"}, {})
                                         .shuffle({"a"})
                                         .localPartition({"a"})
-                                        .finalAggregation({"a"}, {})
+                                        .singleAggregation({"a"}, {})
                                         .build(),
                                     core::JoinType::kInner)
                                 .project()
@@ -467,17 +464,15 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {})
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {})
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -487,19 +482,15 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("t")
-          .filter("b < 100")
+      matchScan("u")
           .hashJoin(
-              matchScan("u")
-                  .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .partialAggregation({"x"}, {})
-                  .shuffle({"x"})
-                  .localPartition({"x"})
-                  .finalAggregation({"x"}, {})
-                  .broadcast()
-                  .build(),
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {})
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -582,18 +573,15 @@ TEST_F(ExistencePushdownTest, joinWithFilter) {
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("t")
-          .filter("c < 100")
+      matchScan("u")
           .hashJoin(
-              matchScan("u")
-                  .hashJoin(
-                      matchScan("t").filter("c < 100").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .shuffle({"x"})
-                  .localPartition({"x"})
-                  .singleAggregation({"x"}, {"count(*) as cnt"})
-                  .broadcast()
-                  .build(),
+              matchScan("t").filter("c < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("t").filter("c < 100").shuffle({"a"}).build(),
               core::JoinType::kInner)
           .filter("b < x")
           .project()
@@ -716,10 +704,9 @@ TEST_F(ExistencePushdownTest, limitOnFirstDt) {
                                 .filter("b < 100")
                                 .hashJoin(
                                     matchScan("u")
-                                        .partialAggregation({"x"}, {})
                                         .shuffle({"x"})
                                         .localPartition({"x"})
-                                        .finalAggregation({"x"}, {})
+                                        .singleAggregation({"x"}, {})
                                         .distributedLimit(0, 10)
                                         .broadcast()
                                         .build(),
@@ -744,37 +731,32 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
-                                 core::JoinType::kLeftSemiFilter)
-                             .singleAggregation({"x"}, {"count(*) as cnt"})
-                             .project()
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("u")
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(),
+              core::JoinType::kLeftSemiFilter)
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("t")
-          .filter("b < 100")
+      matchScan("u")
           .hashJoin(
-              matchScan("u")
-                  .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .shuffle({"x"})
-                  .localPartition({"x"})
-                  .singleAggregation({"x"}, {"count(*) as cnt"})
-                  .project()
-                  .broadcast()
-                  .build(),
+              matchScan("t").filter("b < 100").broadcast().build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .project()
+          .hashJoin(
+              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -940,15 +922,13 @@ TEST_F(ExistencePushdownTest, unnestKey) {
       ")");
 
   // The join key 'n' resolves to an unnest table column. Pushdown is skipped.
-  // The plan has a semi-join between the unnest output and t_no_stats.
-  auto matcher =
-      core::PlanMatcherBuilder{}
-          .values()
-          .unnest()
-          .hashJoin(
-              matchScan("t_no_stats").build(), core::JoinType::kRightSemiFilter)
-          .project()
-          .build();
+  // The plan has a semi-join between t_no_stats and the unnest output.
+  auto matcher = matchScan("t_no_stats")
+                     .hashJoin(
+                         core::PlanMatcherBuilder{}.values().unnest().build(),
+                         core::JoinType::kLeftSemiFilter)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 

--- a/axiom/optimizer/tests/FilteredTableStatsTest.cpp
+++ b/axiom/optimizer/tests/FilteredTableStatsTest.cpp
@@ -79,7 +79,7 @@ class FilteredTableStatsTest : public test::HiveQueriesTestBase {
 TEST_F(FilteredTableStatsTest, noFilter) {
   verifyPlan("SELECT n_nationkey, n_name FROM nation", [](const Plan& plan) {
     const auto& op = *plan.op;
-    EXPECT_NEAR(op.resultCardinality(), 25, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 25, kCardinalityTolerance);
   });
 }
 
@@ -92,7 +92,9 @@ TEST_F(FilteredTableStatsTest, dataFilter) {
         const auto& op = *plan.op;
         // n_nationkey in [0, 24]. n_nationkey > 10 should give ~14/24 of rows.
         EXPECT_NEAR(
-            op.resultCardinality(), 25.0 * 14 / 24, kCardinalityTolerance);
+            op.resultCardinality().value(),
+            25.0 * 14 / 24,
+            kCardinalityTolerance);
       });
 }
 
@@ -102,13 +104,13 @@ TEST_F(FilteredTableStatsTest, partitionFilter) {
   verifyPlan("SELECT a FROM t WHERE k = 0", [](const Plan& plan) {
     const auto& op = *plan.op;
     // Partition k=0 has 9 rows (nationkeys 0,3,6,9,12,15,18,21,24).
-    EXPECT_NEAR(op.resultCardinality(), 9, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 9, kCardinalityTolerance);
   });
 
   verifyPlan("SELECT a FROM t WHERE k IN (1, 2)", [](const Plan& plan) {
     const auto& op = *plan.op;
     // Partitions k=1 and k=2 have 8 rows each (16 total).
-    EXPECT_NEAR(op.resultCardinality(), 16, kCardinalityTolerance);
+    EXPECT_NEAR(op.resultCardinality().value(), 16, kCardinalityTolerance);
   });
 }
 
@@ -119,7 +121,8 @@ TEST_F(FilteredTableStatsTest, partitionAndDataFilter) {
     const auto& op = *plan.op;
     // Partition k=0 has 9 rows with a in [0, 24].
     // a > 10 gives selectivity of 14/24, so ~9 * 14/24 = 5.25 rows.
-    EXPECT_NEAR(op.resultCardinality(), 9.0 * 14 / 24, kCardinalityTolerance);
+    EXPECT_NEAR(
+        op.resultCardinality().value(), 9.0 * 14 / 24, kCardinalityTolerance);
   });
 }
 
@@ -140,7 +143,8 @@ TEST_F(FilteredTableStatsTest, joinKeyWithZeroDistinctValues) {
         // is 25 (left join preserves all left-side rows, no matches on NULLs),
         // but NDV is clamped from 0 to 1, producing fanout = 25 and
         // resultCardinality = 625.
-        EXPECT_NEAR(plan.op->resultCardinality(), 625, kCardinalityTolerance);
+        EXPECT_NEAR(
+            plan.op->resultCardinality().value(), 625, kCardinalityTolerance);
       });
 }
 

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -63,7 +63,7 @@ Selectivity columnComparisonSelectivity(
     const Value& rightValue,
     std::string_view funcName) {
   ConstraintMap unused;
-  return columnComparisonSelectivity(
+  auto selectivity = columnComparisonSelectivity(
       /*left=*/nullptr,
       /*right=*/nullptr,
       leftValue,
@@ -71,6 +71,8 @@ Selectivity columnComparisonSelectivity(
       toName(funcName),
       /*updateConstraints=*/false,
       unused);
+  VELOX_CHECK(selectivity.has_value());
+  return *selectivity;
 }
 
 class FiltersTest : public test::HiveQueriesTestBase {
@@ -166,13 +168,14 @@ class FiltersTest : public test::HiveQueriesTestBase {
 
       auto constraints = makeSchemaConstraints(allFilters);
       auto selectivity = conjunctsSelectivity(constraints, allFilters, true);
+      ASSERT_TRUE(selectivity.has_value());
 
       auto* call = allFilters[0]->as<Call>();
       auto columnId = call->args()[0]->id();
 
       auto it = constraints.find(columnId);
       ASSERT_NE(it, constraints.end());
-      verify(selectivity, it->second);
+      verify(*selectivity, it->second);
     });
   }
 
@@ -211,7 +214,7 @@ class FiltersTest : public test::HiveQueriesTestBase {
 
             if (testCase.expectedCardinality.has_value()) {
               EXPECT_NEAR(
-                  constraint.cardinality,
+                  constraint.cardinality.value(),
                   *testCase.expectedCardinality,
                   kTolerance);
             }
@@ -225,12 +228,12 @@ class FiltersTest : public test::HiveQueriesTestBase {
 // ============================================================
 
 TEST_F(FiltersTest, combineConjunctsBasic) {
-  std::vector<Selectivity> conjuncts = {
-      {0.8, 0.0}, // 80% true, 0% null, 20% false
-      {0.6, 0.0} // 60% true, 0% null, 40% false
+  std::vector<std::optional<Selectivity>> conjuncts = {
+      Selectivity{0.8, 0.0}, // 80% true, 0% null, 20% false
+      Selectivity{0.6, 0.0} // 60% true, 0% null, 40% false
   };
 
-  Selectivity result = combineConjuncts(conjuncts);
+  Selectivity result = combineConjuncts(conjuncts).value();
 
   // P(TRUE) = product of trueFractions.
   EXPECT_NEAR(result.trueFraction, 0.8 * 0.6, kTolerance);
@@ -239,12 +242,12 @@ TEST_F(FiltersTest, combineConjunctsBasic) {
 }
 
 TEST_F(FiltersTest, combineConjunctsWithNulls) {
-  std::vector<Selectivity> conjuncts = {
-      {0.5, 0.2}, // 50% true, 20% null, 30% false
-      {0.6, 0.1} // 60% true, 10% null, 30% false
+  std::vector<std::optional<Selectivity>> conjuncts = {
+      Selectivity{0.5, 0.2}, // 50% true, 20% null, 30% false
+      Selectivity{0.6, 0.1} // 60% true, 10% null, 30% false
   };
 
-  Selectivity result = combineConjuncts(conjuncts);
+  Selectivity result = combineConjuncts(conjuncts).value();
 
   // P(TRUE) = product of trueFractions.
   EXPECT_NEAR(result.trueFraction, 0.5 * 0.6, kTolerance);
@@ -254,13 +257,13 @@ TEST_F(FiltersTest, combineConjunctsWithNulls) {
 }
 
 TEST_F(FiltersTest, combineConjunctsMultiple) {
-  std::vector<Selectivity> conjuncts = {
-      {0.8, 0.1}, // 80% true, 10% null, 10% false
-      {0.7, 0.0}, // 70% true, 0% null, 30% false
-      {0.9, 0.05} // 90% true, 5% null, 5% false
+  std::vector<std::optional<Selectivity>> conjuncts = {
+      Selectivity{0.8, 0.1}, // 80% true, 10% null, 10% false
+      Selectivity{0.7, 0.0}, // 70% true, 0% null, 30% false
+      Selectivity{0.9, 0.05} // 90% true, 5% null, 5% false
   };
 
-  Selectivity result = combineConjuncts(conjuncts);
+  Selectivity result = combineConjuncts(conjuncts).value();
 
   EXPECT_NEAR(result.trueFraction, 0.8 * 0.7 * 0.9, kTolerance);
   EXPECT_NEAR(
@@ -270,31 +273,31 @@ TEST_F(FiltersTest, combineConjunctsMultiple) {
 }
 
 TEST_F(FiltersTest, combineConjunctsEmpty) {
-  std::vector<Selectivity> empty;
-  Selectivity result = combineConjuncts(empty);
+  std::vector<std::optional<Selectivity>> empty;
+  Selectivity result = combineConjuncts(empty).value();
   EXPECT_NEAR(result.trueFraction, 1.0, kTolerance);
   EXPECT_NEAR(result.nullFraction, 0.0, kTolerance);
 }
 
 TEST_F(FiltersTest, combineConjunctsAllNull) {
-  std::vector<Selectivity> conjuncts = {
-      {0.0, 1.0}, // 0% true, 100% null, 0% false
-      {0.0, 1.0} // 0% true, 100% null, 0% false
+  std::vector<std::optional<Selectivity>> conjuncts = {
+      Selectivity{0.0, 1.0}, // 0% true, 100% null, 0% false
+      Selectivity{0.0, 1.0} // 0% true, 100% null, 0% false
   };
 
-  Selectivity result = combineConjuncts(conjuncts);
+  Selectivity result = combineConjuncts(conjuncts).value();
 
   EXPECT_NEAR(result.trueFraction, 0.0, kTolerance);
   EXPECT_NEAR(result.nullFraction, 1.0, kTolerance);
 }
 
 TEST_F(FiltersTest, combineDisjunctsBasic) {
-  std::vector<Selectivity> disjuncts = {
-      {0.3, 0.0}, // 30% true, 0% null, 70% false
-      {0.4, 0.0} // 40% true, 0% null, 60% false
+  std::vector<std::optional<Selectivity>> disjuncts = {
+      Selectivity{0.3, 0.0}, // 30% true, 0% null, 70% false
+      Selectivity{0.4, 0.0} // 40% true, 0% null, 60% false
   };
 
-  Selectivity result = combineDisjuncts(disjuncts);
+  Selectivity result = combineDisjuncts(disjuncts).value();
 
   // P(TRUE) = 1 - product of (1 - trueFraction_i).
   EXPECT_NEAR(result.trueFraction, 1.0 - (1.0 - 0.3) * (1.0 - 0.4), kTolerance);
@@ -302,12 +305,12 @@ TEST_F(FiltersTest, combineDisjunctsBasic) {
 }
 
 TEST_F(FiltersTest, combineDisjunctsWithNulls) {
-  std::vector<Selectivity> disjuncts = {
-      {0.3, 0.2}, // 30% true, 20% null, 50% false
-      {0.4, 0.1} // 40% true, 10% null, 50% false
+  std::vector<std::optional<Selectivity>> disjuncts = {
+      Selectivity{0.3, 0.2}, // 30% true, 20% null, 50% false
+      Selectivity{0.4, 0.1} // 40% true, 10% null, 50% false
   };
 
-  Selectivity result = combineDisjuncts(disjuncts);
+  Selectivity result = combineDisjuncts(disjuncts).value();
 
   // P(TRUE) = 1 - product of (1 - trueFraction_i).
   EXPECT_NEAR(result.trueFraction, 1.0 - (1.0 - 0.3) * (1.0 - 0.4), kTolerance);
@@ -320,13 +323,13 @@ TEST_F(FiltersTest, combineDisjunctsWithNulls) {
 }
 
 TEST_F(FiltersTest, combineDisjunctsMultiple) {
-  std::vector<Selectivity> disjuncts = {
-      {0.2, 0.1}, // 20% true, 10% null, 70% false
-      {0.3, 0.0}, // 30% true, 0% null, 70% false
-      {0.1, 0.05} // 10% true, 5% null, 85% false
+  std::vector<std::optional<Selectivity>> disjuncts = {
+      Selectivity{0.2, 0.1}, // 20% true, 10% null, 70% false
+      Selectivity{0.3, 0.0}, // 30% true, 0% null, 70% false
+      Selectivity{0.1, 0.05} // 10% true, 5% null, 85% false
   };
 
-  Selectivity result = combineDisjuncts(disjuncts);
+  Selectivity result = combineDisjuncts(disjuncts).value();
 
   EXPECT_NEAR(
       result.trueFraction,
@@ -339,19 +342,19 @@ TEST_F(FiltersTest, combineDisjunctsMultiple) {
 }
 
 TEST_F(FiltersTest, combineDisjunctsEmpty) {
-  std::vector<Selectivity> empty;
-  Selectivity result = combineDisjuncts(empty);
+  std::vector<std::optional<Selectivity>> empty;
+  Selectivity result = combineDisjuncts(empty).value();
   EXPECT_NEAR(result.trueFraction, 0.0, kTolerance);
   EXPECT_NEAR(result.nullFraction, 0.0, kTolerance);
 }
 
 TEST_F(FiltersTest, combineDisjunctsAllNull) {
-  std::vector<Selectivity> disjuncts = {
-      {0.0, 1.0}, // 0% true, 100% null, 0% false
-      {0.0, 1.0} // 0% true, 100% null, 0% false
+  std::vector<std::optional<Selectivity>> disjuncts = {
+      Selectivity{0.0, 1.0}, // 0% true, 100% null, 0% false
+      Selectivity{0.0, 1.0} // 0% true, 100% null, 0% false
   };
 
-  Selectivity result = combineDisjuncts(disjuncts);
+  Selectivity result = combineDisjuncts(disjuncts).value();
 
   EXPECT_NEAR(result.trueFraction, 0.0, kTolerance);
   EXPECT_NEAR(result.nullFraction, 1.0, kTolerance);
@@ -569,8 +572,9 @@ TEST_F(FiltersTest, rangeCardinalityMaxMin) {
 
         auto constraints = makeSchemaConstraints(allFilters);
         auto selectivity = conjunctsSelectivity(constraints, allFilters, true);
+        ASSERT_TRUE(selectivity.has_value());
 
-        EXPECT_NEAR(selectivity.trueFraction, 0.5, 0.1);
+        EXPECT_NEAR(selectivity->trueFraction, 0.5, 0.1);
       },
       kTestConnectorId);
 }
@@ -673,7 +677,9 @@ TEST_F(FiltersTest, strictInequalityStringBounds) {
           EXPECT_EQ(constraint.max->value<std::string>(), testCase.expectedMax);
 
           EXPECT_NEAR(
-              constraint.cardinality, testCase.expectedCardinality, 1.0f);
+              constraint.cardinality.value(),
+              testCase.expectedCardinality,
+              1.0f);
         });
   }
 }
@@ -879,9 +885,10 @@ TEST_F(FiltersTest, equalityConstraintPropagation) {
 
         auto constraints = makeSchemaConstraints(allFilters);
         auto selectivity = exprSelectivity(constraints, allFilters[0], true);
+        ASSERT_TRUE(selectivity.has_value());
 
-        EXPECT_GE(selectivity.trueFraction, 0.0);
-        EXPECT_LE(selectivity.trueFraction, 1.0);
+        EXPECT_GE(selectivity->trueFraction, 0.0);
+        EXPECT_LE(selectivity->trueFraction, 1.0);
 
         // Both columns are constrained to the overlapping range [0, 4]
         // (n_regionkey's range).
@@ -910,14 +917,15 @@ TEST_F(FiltersTest, isNullSelectivity) {
 
         auto constraints = makeSchemaConstraints(allFilters);
         auto selectivity = conjunctsSelectivity(constraints, allFilters, true);
+        ASSERT_TRUE(selectivity.has_value());
 
         // ISNULL: trueFraction = argument's nullFraction (0 for non-nullable
         // columns, > 0 for nullable columns).
-        EXPECT_GE(selectivity.trueFraction, 0.0);
-        EXPECT_LE(selectivity.trueFraction, 1.0);
+        EXPECT_GE(selectivity->trueFraction, 0.0);
+        EXPECT_LE(selectivity->trueFraction, 1.0);
         // nullFraction of IS NULL is 0 (the result is always TRUE or FALSE,
         // never NULL).
-        EXPECT_NEAR(selectivity.nullFraction, 0.0, kTolerance);
+        EXPECT_NEAR(selectivity->nullFraction, 0.0, kTolerance);
       });
 }
 
@@ -1054,11 +1062,12 @@ TEST_F(FiltersTest, cardinalityBasedSelectivity) {
           auto constraints = makeSchemaConstraints(allFilters);
           auto selectivity =
               conjunctsSelectivity(constraints, allFilters, true);
+          ASSERT_TRUE(selectivity.has_value());
 
           EXPECT_NEAR(
-              selectivity.trueFraction, expectedSelectivity, kTolerance);
+              selectivity->trueFraction, expectedSelectivity, kTolerance);
           EXPECT_NEAR(
-              selectivity.nullFraction, expectedNullFraction, kTolerance);
+              selectivity->nullFraction, expectedNullFraction, kTolerance);
         },
         kTestConnectorId);
   };

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -73,9 +73,10 @@ TEST_F(JoinTest, pushdownFilterThroughJoin) {
   {
     SCOPED_TRACE("Right Join");
     auto logicalPlan = makePlan(lp::JoinType::kRight);
-    auto matcher = matchScan("u")
-                       .filter("u_data IS NULL")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kLeft)
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").filter("u_data IS NULL").build(),
+                           core::JoinType::kRight)
                        .filter("t_data IS NULL")
                        .project()
                        .build();
@@ -175,11 +176,13 @@ TEST_F(JoinTest, outerJoinWithInnerJoin) {
     auto plan = toSingleNodePlan(logicalPlan);
 
     auto matcher =
-        startMatcher("u")
-            .hashJoin(startMatcher("v").build(), core::JoinType::kInner)
+        startMatcher("t")
+            .filter("b > 50")
             .hashJoin(
-                startMatcher("t").filter("b > 50").build(),
-                core::JoinType::kRight)
+                startMatcher("u")
+                    .hashJoin(startMatcher("v").build(), core::JoinType::kInner)
+                    .build(),
+                core::JoinType::kLeft)
             .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -206,13 +209,17 @@ TEST_F(JoinTest, outerJoinWithInnerJoin) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        startMatcher("u")
-            .hashJoin(startMatcher("v").build())
-            .filter()
-            .hashJoin(startMatcher("t").filter().aggregation().build())
-            .project()
-            .build();
+    auto matcher = startMatcher("t")
+                       .filter()
+                       .aggregation()
+                       .hashJoin(
+                           startMatcher("u")
+                               .hashJoin(startMatcher("v").build())
+                               .filter()
+                               .build(),
+                           core::JoinType::kLeft)
+                       .project()
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -230,12 +237,9 @@ TEST_F(JoinTest, nestedOuterJoins) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   auto matcher =
-      matchScan("region")
-          .hashJoin(
-              matchScan("nation")
-                  .hashJoin(matchScan("region").build(), core::JoinType::kFull)
-                  .build(),
-              core::JoinType::kLeft)
+      matchScan("nation")
+          .hashJoin(matchScan("region").build(), core::JoinType::kFull)
+          .hashJoin(matchScan("region").build(), core::JoinType::kRight)
           .aggregation()
           .project()
           .build();
@@ -251,14 +255,12 @@ TEST_F(JoinTest, joinWithComputedKeys) {
   {
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = matchScan("region")
-                       .hashJoin(
-                           matchScan("nation")
-                               .project({"coalesce(n_regionkey, 1)"})
-                               .build(),
-                           core::JoinType::kLeft)
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchScan("nation")
+            .project({"coalesce(n_regionkey, 1)"})
+            .hashJoin(matchScan("region").build(), core::JoinType::kRight)
+            .aggregation()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -516,11 +518,10 @@ TEST_F(JoinTest, crossThenLeft) {
   SCOPED_TRACE(query);
 
   auto matcher =
-      matchValues()
-          .aggregation()
+      matchScan("u")
+          .nestedLoopJoin(matchScan("t").build())
           .hashJoin(
-              matchScan("u").nestedLoopJoin(matchScan("t").build()).build(),
-              velox::core::JoinType::kRight)
+              matchValues().aggregation().build(), velox::core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -726,9 +727,10 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .filter("y + 1 > 0")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").filter("y + 1 > 0").build(),
+                           core::JoinType::kInner)
                        .project()
                        .build();
 
@@ -743,9 +745,10 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .filter("y + 1 > 0")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").filter("y + 1 > 0").build(),
+                           core::JoinType::kInner)
                        .project()
                        .aggregation()
                        .build();
@@ -810,8 +813,8 @@ TEST_F(JoinTest, leftThenFilter) {
     SCOPED_TRACE(query);
 
     auto matcher =
-        matchScan("card_u")
-            .hashJoin(matchScan("card_t").build(), core::JoinType::kRight)
+        matchScan("card_t")
+            .hashJoin(matchScan("card_u").build(), core::JoinType::kLeft)
             .filter("cardinality(coalesce(y, b)) > 0")
             .build();
 
@@ -1105,9 +1108,12 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
 
 TEST_F(JoinTest, impliedJoins) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
+      ->setStats(
+          10'000,
+          {{"a", {.numDistinct = 10'000}}, {"b", {.numDistinct = 10'000}}});
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+      ->setStats(
+          1'000, {{"x", {.numDistinct = 10}}, {"y", {.numDistinct = 1'000}}});
   testConnector_->addTable("v", ROW({"n", "m"}, BIGINT()))
       ->setStats(100, {{"n", {.numDistinct = 100}}});
 
@@ -1464,10 +1470,8 @@ TEST_F(JoinTest, impliedFilters) {
 
 // Three or more columns from the same table in one equivalence class.
 TEST_F(JoinTest, impliedSameTableEquality) {
-  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()))
-      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
-  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()));
 
   // Three same-table columns produce a = b and a = c filters.
   {
@@ -1476,10 +1480,9 @@ TEST_F(JoinTest, impliedSameTableEquality) {
         "JOIN u ON t.a = u.x AND t.b = u.x AND t.c = u.x";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .hashJoin(
-                           matchScan("t").filter("a = b AND a = c").build(),
-                           core::JoinType::kInner)
+    auto matcher = matchScan("t")
+                       .filter("a = b AND a = c")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1519,24 +1522,19 @@ TEST_F(JoinTest, impliedSameTableEqualityBothSides) {
 // With GROUP BY a, b, the synthesized a = b references only grouping keys
 // and is pushed below the aggregation onto t's scan.
 TEST_F(JoinTest, impliedSameTableEqualityBelowAggregation) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
-  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()));
 
   auto query =
       "SELECT count(*) FROM (SELECT a, b FROM t GROUP BY a, b) AS gb "
       "JOIN u ON gb.a = u.x AND gb.b = u.x";
   SCOPED_TRACE(query);
 
-  auto matcher = matchScan("u")
-                     .hashJoin(
-                         matchScan("t")
-                             .filter("a = b")
-                             .singleAggregation({"a", "b"}, {})
-                             .project()
-                             .build(),
-                         core::JoinType::kInner)
+  auto matcher = matchScan("t")
+                     .filter("a = b")
+                     .singleAggregation({"a", "b"}, {})
+                     .project()
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
                      .aggregation()
                      .build();
 
@@ -1576,10 +1574,8 @@ TEST_F(JoinTest, impliedSameTableEqualityInHaving) {
 // With a LIMIT in the way, the synthesized equality lands as a Filter
 // above the Limit. The redundant join key is still dropped.
 TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimit) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
-  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()));
 
   auto query =
       "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
@@ -1600,10 +1596,8 @@ TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimit) {
 // Explicit WHERE and synthesized equality converge on the same LIMIT DT
 // target. The filter appears exactly once above the Limit.
 TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
-  testConnector_->addTable("u", ROW({"x"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()));
 
   auto query =
       "SELECT count(*) FROM (SELECT a, b FROM t LIMIT 100) AS lim "
@@ -1680,7 +1674,8 @@ TEST_F(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
-      ->setStats(1'000, {{"x", {.numDistinct = 10}}});
+      ->setStats(
+          1'000, {{"x", {.numDistinct = 10}}, {"y", {.numDistinct = 1'000}}});
 
   auto query = "SELECT count(*) FROM u RIGHT JOIN t ON u.x = t.a AND u.y = t.a";
   SCOPED_TRACE(query);
@@ -1822,12 +1817,15 @@ TEST_F(JoinTest, leftToInnerWithAggregation) {
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-  auto matcher = matchScan("u")
-                     .filter("x > 0")
-                     .project()
-                     .unnest()
-                     .project()
-                     .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u")
+                             .filter("x > 0")
+                             .project()
+                             .unnest()
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
                      .project({"cast(y as REAL) as c"})
                      .distinct()
                      .project()
@@ -1855,8 +1853,8 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-    auto matcher = matchScan("u")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kRight)
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
                        .project({"b as x", "b as y"})
                        .build();
 
@@ -1875,8 +1873,8 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-    auto matcher = matchScan("u")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kRight)
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
                        .distinct()
                        .project({"b as x", "b as y"})
                        .build();
@@ -1897,12 +1895,13 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-    auto matcher = matchScan("u")
-                       .filter("a = 1")
-                       .hashJoin(matchScan("t").build(), core::JoinType::kInner)
-                       .distinct()
-                       .project({"b as x", "b as y"})
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("a = 1").build(), core::JoinType::kInner)
+            .distinct()
+            .project({"b as x", "b as y"})
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -969,9 +969,9 @@ TEST_F(PlanTest, zeroLimit) {
         "SELECT * FROM t, (SELECT * FROM u LIMIT 0) s WHERE a = x";
     SCOPED_TRACE(query);
     const auto matcher = core::PlanMatcherBuilder{}
-                             .values()
+                             .tableScan()
                              .hashJoin(
-                                 core::PlanMatcherBuilder{}.tableScan().build(),
+                                 core::PlanMatcherBuilder{}.values().build(),
                                  core::JoinType::kInner)
                              .build();
     AXIOM_ASSERT_PLAN(planSql(query), matcher);

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -360,15 +360,18 @@ TEST_F(RelationOpPrinterTest, markDistinct) {
           testing::HasSubstr("FILTER (WHERE __m0)"),
           testing::HasSubstr("FILTER (WHERE __m1)"),
           testing::StartsWith("    Repartition"),
-          testing::StartsWith("      MarkDistinct"),
-          testing::StartsWith("        Repartition"),
-          testing::StartsWith("          MarkDistinct"),
-          testing::StartsWith("            Repartition"),
-          testing::StartsWith("              TableScan"),
-          testing::StartsWith("                table: \"default\".\"t\""),
+          testing::StartsWith("      Aggregation"),
+          testing::HasSubstr("FILTER (WHERE __m0)"),
+          testing::HasSubstr("FILTER (WHERE __m1)"),
+          testing::StartsWith("        MarkDistinct"),
+          testing::StartsWith("          Repartition"),
+          testing::StartsWith("            MarkDistinct"),
+          testing::StartsWith("              Repartition"),
+          testing::StartsWith("                TableScan"),
+          testing::StartsWith("                  table: \"default\".\"t\""),
           testing::Eq("")));
 
-  EXPECT_EQ("agg(t)", toDistributedOneline(*logicalPlan));
+  EXPECT_EQ("agg(agg(t))", toDistributedOneline(*logicalPlan));
 }
 
 TEST_F(RelationOpPrinterTest, cost) {

--- a/axiom/optimizer/tests/RemoteOutputTest.cpp
+++ b/axiom/optimizer/tests/RemoteOutputTest.cpp
@@ -88,6 +88,12 @@ TEST_F(RemoteOutputTest, simpleAggregation) {
 
 TEST_F(RemoteOutputTest, groupByAggregation) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  // Unique group-by key (NDV == row count): grouping does not reduce rows, so
+  // partial pre-aggregation has no benefit and single-stage aggregation wins.
+  testConnector_->setStats(
+      "t",
+      1'000,
+      {{"a", {.numDistinct = 1'000}}, {"b", {.numDistinct = 1'000}}});
 
   auto logicalPlan =
       parseSelect("SELECT sum(b) FROM t GROUP BY a", kTestConnectorId);

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -654,9 +654,12 @@ TEST_F(SetTest, joinWithUnionAll) {
   auto logicalPlan = parseSelect(sql, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("u")
-                     .localPartition(matchScan("v").project().build())
-                     .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+  auto matcher = matchScan("t")
+                     .hashJoin(
+                         matchScan("u")
+                             .localPartition(matchScan("v").project().build())
+                             .build(),
+                         core::JoinType::kInner)
                      .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -773,7 +776,7 @@ TEST_F(SetTest, nondeterministicFilterAboveUnion) {
         matchHiveScan("nation")
             .project()
             .localPartition(matchHiveScan("region").project().build())
-            .distributedAggregation({"k"}, {})
+            .distributedSingleAggregation({"k"}, {})
             .filter("cast(k as double) > rand()")
             .gather()
             .build());

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -864,6 +864,11 @@ TEST_P(SubfieldTest, subquery) {
                   })}),
       });
 
+  // This test verifies subfield pushdown, not join ordering. The decorrelated
+  // subquery join has two cost-equivalent commutations, so use syntactic join
+  // order to keep the plan shape stable across build environments.
+  optimizerOptions_.syntacticJoinOrder = true;
+
   {
     auto logicalPlan = parseSelect(
         "SELECT a.y FROM t_subquery WHERE a.x = (SELECT 1)", kHiveConnectorId);

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -591,9 +591,13 @@ TEST_F(SubqueryTest, correlatedIn) {
   // does not support null-aware right semi project join with extra filter.
   {
     // Make t small and u large so the optimizer prefers the right-hash variant.
-    testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))->setStats(100, {});
+    testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+        ->setStats(
+            100, {{"a", {.numDistinct = 100}}, {"b", {.numDistinct = 100}}});
     testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
-        ->setStats(10'000, {});
+        ->setStats(
+            10'000,
+            {{"x", {.numDistinct = 10'000}}, {"y", {.numDistinct = 10'000}}});
 
     auto query =
         "SELECT t.a IN ("
@@ -2296,13 +2300,16 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
   // The IN subquery becomes a LEFT SEMI PROJECT (mark) join with v, wrapped
   // in its own DT. The inner join combines u's projection with t. The NOT
   // EXISTS becomes an anti-join with v.
-  auto matcher = matchScan("u")
+  auto matcher = matchScan("t")
                      .hashJoin(
-                         matchScan("v").build(),
-                         core::JoinType::kLeftSemiProject,
-                         {.nullAware = true})
-                     .project()
-                     .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+                         matchScan("u")
+                             .hashJoin(
+                                 matchScan("v").build(),
+                                 core::JoinType::kLeftSemiProject,
+                                 {.nullAware = true})
+                             .project()
+                             .build(),
+                         core::JoinType::kInner)
                      .hashJoin(
                          matchScan("v").build(),
                          core::JoinType::kAnti,
@@ -2323,9 +2330,15 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
   // Make both tables large enough to trigger hash partitioning instead of
   // broadcast.
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(10'000'000, {});
+      ->setStats(
+          10'000'000,
+          {{"a", {.numDistinct = 10'000'000}},
+           {"b", {.numDistinct = 10'000'000}}});
   testConnector_->addTable("u", ROW({"c", "d"}, BIGINT()))
-      ->setStats(1'000'000, {});
+      ->setStats(
+          1'000'000,
+          {{"c", {.numDistinct = 1'000'000}},
+           {"d", {.numDistinct = 1'000'000}}});
 
   // NOT IN: the build side (u) must use replicateNullsAndAny=true.
   {

--- a/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
+++ b/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+// When a join-key NDV is missing the join cost is unknown, so the optimizer
+// falls back to the query's syntactic join order instead of a cost-based one.
+// 't' is large and 'u' is small; 'k' is the join key.
+class UnknownStatsJoinTest : public test::QueryTestBase {
+ protected:
+  velox::core::PlanNodePtr plan(const std::string& sql) {
+    return toSingleNodePlan(parseSelect(sql, kTestConnectorId));
+  }
+};
+
+TEST_F(UnknownStatsJoinTest, singleJoin) {
+  testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+      ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()))
+      ->setStats(1'000, {{"k", {.numDistinct = 1'000}}});
+
+  auto matchJoin = [&](const std::string& probe, const std::string& build) {
+    return matchScan(probe)
+        .hashJoinInner(matchScan(build).build())
+        .aggregation()
+        .build();
+  };
+
+  const auto query = "SELECT count(*) FROM u JOIN t ON t.k = u.k";
+  const auto altQuery = "SELECT count(*) FROM t JOIN u ON t.k = u.k";
+
+  // With statistics the build side is chosen by size, so both join orders build
+  // the smaller 'u'.
+  AXIOM_ASSERT_PLAN(plan(query), matchJoin("t", "u"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+
+  // Drop 'u's column NDV, leaving only its row count. The join cost is now
+  // unknown, so each query falls back to its syntactic join order.
+  testConnector_->setStats("u", 1'000, {});
+
+  AXIOM_ASSERT_PLAN(plan(query), matchJoin("u", "t"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+}
+
+// The fallback is per derived table: an unknown-cost join does not disable
+// cost-based ordering of an independent join elsewhere in the query. A
+// non-deterministic filter between (u JOIN t) and the join with 'v' keeps the
+// two joins in separate derived tables.
+TEST_F(UnknownStatsJoinTest, twoJoins) {
+  const auto query =
+      "SELECT count(*) "
+      "FROM (SELECT u.k AS k FROM u JOIN t ON u.k = t.k WHERE rand() < 0.1) AS s "
+      "   JOIN v ON s.k = v.k";
+
+  const auto altQuery =
+      "SELECT count(*) "
+      "FROM (SELECT u.k AS k FROM t JOIN u ON u.k = t.k WHERE rand() < 0.1) AS s "
+      "   JOIN v ON s.k = v.k";
+
+  // 'innerProbe'/'innerBuild' are the probe and build of the inner (u JOIN t)
+  // join; the outer join always builds 'v'.
+  auto matchPlan = [&](const std::string& innerProbe,
+                       const std::string& innerBuild) {
+    return matchScan(innerProbe)
+        .hashJoinInner(matchScan(innerBuild).build())
+        .filter()
+        .hashJoinInner(matchScan("v").build())
+        .aggregation()
+        .build();
+  };
+
+  testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+      ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()))
+      ->setStats(1'000, {{"k", {.numDistinct = 1'000}}});
+  testConnector_->addTable("v", ROW({"c", "k"}, BIGINT()));
+
+  // 't' and 'u' are statted; 'v' has no statistics. The inner join is still
+  // cost-ordered and builds the smaller 'u'.
+  AXIOM_ASSERT_PLAN(plan(query), matchPlan("t", "u"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchPlan("t", "u"));
+
+  // Drop 't's column NDV. The inner join cost is now unknown, so it falls back
+  // to its syntactic order.
+  testConnector_->setStats("t", 1'000'000, {});
+
+  AXIOM_ASSERT_PLAN(plan(query), matchPlan("u", "t"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchPlan("t", "u"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -677,8 +677,8 @@ TEST_F(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
       "LEFT JOIN u ON u.x = t.x "
       "WHERE t.x = u.x");
 
-  auto matcher = matchScan("u")
-                     .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+  auto matcher = matchScan("t")
+                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
                      .window({"row_number() OVER (ORDER BY y)"})
                      .project()
                      .build();

--- a/axiom/sql/presto/ShowStatsBuilder.cpp
+++ b/axiom/sql/presto/ShowStatsBuilder.cpp
@@ -43,10 +43,10 @@ std::string formatValue(const Variant& value, const Type& type) {
 }
 } // namespace
 
-ShowStatsBuilder::ShowStatsBuilder(int64_t rowCount) {
+ShowStatsBuilder::ShowStatsBuilder(std::optional<int64_t> rowCount) {
   rows_.emplace_back(
       Variant::row({
-          Variant(rowCount),
+          toVariant(rowCount),
           kNullVarchar,
           kNullDouble,
           kNullBigint,

--- a/axiom/sql/presto/ShowStatsBuilder.h
+++ b/axiom/sql/presto/ShowStatsBuilder.h
@@ -41,8 +41,9 @@ namespace axiom::sql::presto {
 ///   high_value (VARCHAR) - maximum value formatted as string.
 class ShowStatsBuilder {
  public:
-  /// @param rowCount Total row count for the summary row.
-  explicit ShowStatsBuilder(int64_t rowCount);
+  /// @param rowCount Total row count for the summary row. nullopt when the row
+  /// count is unknown, producing a NULL row_count.
+  explicit ShowStatsBuilder(std::optional<int64_t> rowCount);
 
   /// Adds a per-column stats row. Min/max Variant values are formatted using
   /// the column type (raw string for VARCHAR, toJson for other types). Null


### PR DESCRIPTION
Summary:

When a statistic needed for cost-based optimization is missing — most often a join or grouping key's distinct-value count (NDV) — the optimizer no longer fabricates a default and plans as if it were real. A fabricated estimate could pick a worse plan than the query as written. A missing statistic now yields an unknown estimate that propagates, and each cost-based decision falls back to a safe default: join ordering reverts to the query's syntactic order, and distributed aggregation defaults to partial+final.

Cardinality, fanout, NDV, and cost are now `std::optional<float>`, and `EstimateMath.h` provides arithmetic that propagates `nullopt`. Cost comparisons go through `lessThan`, so an unknown cost is never treated as the cheapest option.

Two estimates that were inaccurate are also sharpened. The aggregation group count is now `min(NDV, input rows)`: the grouping key NDV already reflects upstream filtering, so the previous coupon-collector formula discounted a second time and invented a reduction for a unique key, which now stays single-stage. A UNION's output NDV is combined by inclusion-exclusion over the legs' ranges — branch NDVs summed, minus the values expected to be shared where ranges overlap — rather than summed blindly; disjoint legs still sum.

Only a missing NDV makes a filter's selectivity unknown; an absent null fraction defaults to no nulls and an absent true fraction to half true. `SHOW STATS` and the CLI print NULL for an unknown row count or unknowable NDV (e.g. an array column) instead of a fabricated number.

Reviewed By: xiaoxmeng

Differential Revision: D108698329
