### PR TITLE
fix(optimizer): Unblock joins after single-row subqueries (#1486)

### DIFF
--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -103,7 +103,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Produce trace of plan candidates.
   uint32_t traceFlags{kTraceFlagsDefault};
 
-  /// Disable cost-based join order selection.
+  /// Disable cost-based join order selection: place tables in the order they
+  /// appear in the query. Single-row uncorrelated subqueries are an exception:
+  /// they are always placed after the other tables, regardless of where they
+  /// appear in the query.
   bool syntacticJoinOrder{kSyntacticJoinOrderDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -213,7 +213,14 @@ bool PlanState::mayConsiderNext(PlanObjectCP table) const {
 
   const auto end = it - dt->joinOrder.begin();
   for (auto i = 0; i < end; ++i) {
-    if (!placed_.BitSet::contains(dt->joinOrder[i])) {
+    const auto precedingId = dt->joinOrder[i];
+    // Single-row derived tables are placed after join enumeration, not as join
+    // candidates, so they never become placed during enumeration and must not
+    // gate the tables that follow them in the join order.
+    if (dt->singleRowDts.BitSet::contains(precedingId)) {
+      continue;
+    }
+    if (!placed_.BitSet::contains(precedingId)) {
       return false;
     }
   }

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -442,7 +442,7 @@ A DerivedTable groups together operations that can be planned as a single unit. 
 
 3. **Dependent subquery joins must be in separate DTs.** When a subquery references a column produced by a prior subquery join (e.g., a mark column from an IN semi-join), the prior join is wrapped in a nested DT. Independent subquery joins can coexist in the same DT.
 
-4. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order.
+4. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order. Single-row uncorrelated subqueries (e.g. `(SELECT max(x) FROM u)` in the SELECT list) are an exception: they are always placed after the other tables, regardless of where they appear in the query.
 
 > [!NOTE]
 > Some outer join reorderings are semantically valid. For example, `(a JOIN b) LEFT JOIN c ON f(a, c)` can be reordered to `(a LEFT JOIN c ON f(a, c)) JOIN b`. However, Axiom does not implement this optimization today.

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -42,7 +42,9 @@ class SyntacticJoinOrderTest : public test::HiveQueriesTestBase {
     createTpchTables(
         {velox::tpch::Table::TBL_CUSTOMER,
          velox::tpch::Table::TBL_LINEITEM,
-         velox::tpch::Table::TBL_ORDERS});
+         velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_ORDERS,
+         velox::tpch::Table::TBL_REGION});
   }
 };
 
@@ -320,6 +322,37 @@ TEST_F(SyntacticJoinOrderTest, crossJoinStartsWithSingleRowSubqueries) {
                               .build())
           .nestedLoopJoin(matchHiveScan("lineitem")
                               .singleAggregation({}, {"count(*) as c"})
+                              .build())
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+  checkSame(logicalPlan, referenceResults);
+}
+
+// A single-row uncorrelated subquery that is not the first table in the
+// syntactic join order must not block the tables placed after it. Here the
+// max() subquery sits between the base table and a later correlated subquery.
+TEST_F(SyntacticJoinOrderTest, singleRowSubqueryInMiddleOfJoinOrder) {
+  optimizerOptions_.sampleJoins = false;
+
+  auto logicalPlan = parseSelect(
+      "SELECT "
+      "  (SELECT max(l_quantity) FROM lineitem) AS x, "
+      "  (SELECT count(*) FROM nation WHERE n_regionkey = r.r_regionkey) AS y "
+      "FROM region r");
+
+  optimizerOptions_.syntacticJoinOrder = false;
+  auto referenceResults = runVelox(logicalPlan).results;
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher =
+      matchHiveScan("region")
+          .hashJoin(
+              matchHiveScan("nation").singleAggregation().project().build(),
+              core::JoinType::kLeft)
+          .nestedLoopJoin(matchHiveScan("lineitem")
+                              .singleAggregation({}, {"max(l_quantity)"})
                               .build())
           .project()
           .build();


### PR DESCRIPTION
Summary:

With cost-based join ordering disabled (`syntactic_join_order`), planning a query that selects a single-row uncorrelated subquery alongside another table failed with:

    Failed to place a table

For example:

    SELECT
        (SELECT max(u.a) FROM u) AS x,
        (SELECT count(*) FROM u WHERE u.a = t.a) AS y
    FROM t

In syntactic mode a table is placed only after every table ahead of it in the query is placed. A single-row uncorrelated subquery is always placed after the other tables, never as a join candidate. So when such a subquery sat ahead of another table, that rule blocked the later table from ever being placed.

`mayConsiderNext` now skips single-row subqueries when it checks whether the preceding tables are placed.

Reviewed By: xiaoxmeng

Differential Revision: D108766870


