### PR TITLE
test(optimizer): Run SQL tests under both join orders (#1487)

### DIFF
--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -103,7 +103,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Produce trace of plan candidates.
   uint32_t traceFlags{kTraceFlagsDefault};
 
-  /// Disable cost-based join order selection.
+  /// Disable cost-based join order selection: place tables in the order they
+  /// appear in the query. Single-row uncorrelated subqueries are an exception:
+  /// they are always placed after the other tables, regardless of where they
+  /// appear in the query.
   bool syntacticJoinOrder{kSyntacticJoinOrderDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -213,7 +213,14 @@ bool PlanState::mayConsiderNext(PlanObjectCP table) const {
 
   const auto end = it - dt->joinOrder.begin();
   for (auto i = 0; i < end; ++i) {
-    if (!placed_.BitSet::contains(dt->joinOrder[i])) {
+    const auto precedingId = dt->joinOrder[i];
+    // Single-row derived tables are placed after join enumeration, not as join
+    // candidates, so they never become placed during enumeration and must not
+    // gate the tables that follow them in the join order.
+    if (dt->singleRowDts.BitSet::contains(precedingId)) {
+      continue;
+    }
+    if (!placed_.BitSet::contains(precedingId)) {
       return false;
     }
   }

--- a/axiom/optimizer/README.md
+++ b/axiom/optimizer/README.md
@@ -442,7 +442,7 @@ A DerivedTable groups together operations that can be planned as a single unit. 
 
 3. **Dependent subquery joins must be in separate DTs.** When a subquery references a column produced by a prior subquery join (e.g., a mark column from an IN semi-join), the prior join is wrapped in a nested DT. Independent subquery joins can coexist in the same DT.
 
-4. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order.
+4. **Syntactic join order (optional).** When enabled, the right side of each join is wrapped in a nested DT to preserve the SQL-specified join order. Single-row uncorrelated subqueries (e.g. `(SELECT max(x) FROM u)` in the SELECT list) are an exception: they are always placed after the other tables, regardless of where they appear in the query.
 
 > [!NOTE]
 > Some outer join reorderings are semantically valid. For example, `(a JOIN b) LEFT JOIN c ON f(a, c)` can be reordered to `(a LEFT JOIN c ON f(a, c)) JOIN b`. However, Axiom does not implement this optimization today.

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -75,7 +75,10 @@ struct FileName {
 template <FileName Name>
 class SqlTest : public SqlTestBase {
  public:
-  explicit SqlTest(QueryEntry entry) : entry_(std::move(entry)) {}
+  SqlTest(QueryEntry entry, bool syntacticJoinOrder)
+      : entry_(std::move(entry)) {
+    this->syntacticJoinOrder_ = syntacticJoinOrder;
+  }
 
   // Uses SetUpTestCase / TearDownTestCase rather than the modern
   // SetUpTestSuite / TearDownTestSuite synonyms because SqlTestBase already
@@ -231,19 +234,25 @@ void registerQueryFile() {
 
   auto suiteName = fmt::format("SqlTest_{}", baseName);
 
+  // Run every query both with cost-based join ordering (the default) and with
+  // syntactic join ordering, so the optimizer is exercised under both
+  // strategies and must produce the same correct results.
   for (const auto& entry : file.entries) {
-    auto testName = fmt::format("{}_l{}", baseName, entry.lineNumber);
-    auto capturedEntry = entry;
-    testing::RegisterTest(
-        suiteName.c_str(),
-        testName.c_str(),
-        /*type_param=*/nullptr,
-        /*value_param=*/nullptr,
-        path.c_str(),
-        entry.lineNumber,
-        [capturedEntry = std::move(capturedEntry)]() -> SqlTest<Name>* {
-          return new SqlTest<Name>(capturedEntry);
-        });
+    for (const bool syntacticJoinOrder : {false, true}) {
+      auto testName = syntacticJoinOrder
+          ? fmt::format("{}_l{}_syntactic", baseName, entry.lineNumber)
+          : fmt::format("{}_l{}", baseName, entry.lineNumber);
+      testing::RegisterTest(
+          suiteName.c_str(),
+          testName.c_str(),
+          /*type_param=*/nullptr,
+          /*value_param=*/nullptr,
+          path.c_str(),
+          entry.lineNumber,
+          [capturedEntry = entry, syntacticJoinOrder]() -> SqlTest<Name>* {
+            return new SqlTest<Name>(capturedEntry, syntacticJoinOrder);
+          });
+    }
   }
 }
 

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -100,7 +100,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
     const std::shared_ptr<memory::MemoryPool>& rootPool,
     const std::shared_ptr<memory::MemoryPool>& optimizerPool,
     int32_t numWorkers,
-    int32_t numDrivers) {
+    int32_t numDrivers,
+    bool syntacticJoinOrder) {
   static std::atomic<int32_t> queryCounter{0};
   auto queryId = fmt::format("sql_test_{}", ++queryCounter);
   auto queryCtx = core::QueryCtx::create(
@@ -130,8 +131,10 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   options.numDrivers = numDrivers;
   options.queryId = queryId;
 
+  OptimizerOptions optimizerOptions;
+  optimizerOptions.syntacticJoinOrder = syntacticJoinOrder;
   auto optimizerSession = std::make_shared<OptimizerSession>(
-      queryId, "test", OptimizerOptions{}, connector::ConnectorProperties{});
+      queryId, "test", optimizerOptions, connector::ConnectorProperties{});
   auto runnerSession = std::make_shared<runner::RunnerSession>(
       queryId, "test", runner::Properties{}, connector::ConnectorProperties{});
 
@@ -245,7 +248,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
       rootPool_,
       optimizerPool_,
       numWorkers_,
-      numDrivers_);
+      numDrivers_,
+      syntacticJoinOrder_);
 }
 
 std::vector<RowVectorPtr> SqlTestBase::runAndCollect(std::string_view sql) {

--- a/axiom/optimizer/tests/SqlTestBase.h
+++ b/axiom/optimizer/tests/SqlTestBase.h
@@ -107,7 +107,8 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
       const std::shared_ptr<velox::memory::MemoryPool>& rootPool,
       const std::shared_ptr<velox::memory::MemoryPool>& optimizerPool,
       int32_t numWorkers = 4,
-      int32_t numDrivers = 4);
+      int32_t numDrivers = 4,
+      bool syntacticJoinOrder = false);
 
   /// Runs SQL through Axiom and DuckDB, asserts unordered results match.
   /// @param sql SQL query to run through both engines.
@@ -137,6 +138,10 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   // Execution parallelism settings.
   int32_t numWorkers_{4};
   int32_t numDrivers_{4};
+
+  // When true, queries are optimized with cost-based join ordering disabled,
+  // placing tables in the order they appear in the query.
+  bool syntacticJoinOrder_{false};
 
   // Override to false in subclasses that manage the TestConnector lifecycle
   // at suite scope (i.e., create and register the connector once per

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -42,7 +42,9 @@ class SyntacticJoinOrderTest : public test::HiveQueriesTestBase {
     createTpchTables(
         {velox::tpch::Table::TBL_CUSTOMER,
          velox::tpch::Table::TBL_LINEITEM,
-         velox::tpch::Table::TBL_ORDERS});
+         velox::tpch::Table::TBL_NATION,
+         velox::tpch::Table::TBL_ORDERS,
+         velox::tpch::Table::TBL_REGION});
   }
 };
 
@@ -320,6 +322,37 @@ TEST_F(SyntacticJoinOrderTest, crossJoinStartsWithSingleRowSubqueries) {
                               .build())
           .nestedLoopJoin(matchHiveScan("lineitem")
                               .singleAggregation({}, {"count(*) as c"})
+                              .build())
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+  checkSame(logicalPlan, referenceResults);
+}
+
+// A single-row uncorrelated subquery that is not the first table in the
+// syntactic join order must not block the tables placed after it. Here the
+// max() subquery sits between the base table and a later correlated subquery.
+TEST_F(SyntacticJoinOrderTest, singleRowSubqueryInMiddleOfJoinOrder) {
+  optimizerOptions_.sampleJoins = false;
+
+  auto logicalPlan = parseSelect(
+      "SELECT "
+      "  (SELECT max(l_quantity) FROM lineitem) AS x, "
+      "  (SELECT count(*) FROM nation WHERE n_regionkey = r.r_regionkey) AS y "
+      "FROM region r");
+
+  optimizerOptions_.syntacticJoinOrder = false;
+  auto referenceResults = runVelox(logicalPlan).results;
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  auto plan = toSingleNodePlan(logicalPlan);
+  auto matcher =
+      matchHiveScan("region")
+          .hashJoin(
+              matchHiveScan("nation").singleAggregation().project().build(),
+              core::JoinType::kLeft)
+          .nestedLoopJoin(matchHiveScan("lineitem")
+                              .singleAggregation({}, {"max(l_quantity)"})
                               .build())
           .project()
           .build();


### PR DESCRIPTION
Summary:

The SqlTest suite ran every .sql query only with cost-based join ordering. It now runs each query twice — once cost-based, once with `syntactic_join_order` — so the optimizer is checked for correct results under both strategies. This is what would have caught the single-row-subquery placement failure that the function-result-NDV change exposed.

Each query registers a second gtest case with a `_syntactic` suffix, and a flag threads through `makeLocalRunner` into `OptimizerOptions::syntacticJoinOrder`.

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D108768358


