### PR TITLE
fix: Resolve GROUPING() arguments like column references (#1488)

### DIFF
--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -107,6 +107,9 @@ SELECT a, GROUPING(a), sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
 -- GROUPING() with duplicate grouping sets.
 SELECT a, GROUPING(a), count(*) AS c FROM t GROUP BY GROUPING SETS ((a), (a), (a, b))
 ----
+-- GROUPING() with a column duplicated across a self-join.
+SELECT GROUPING(t1.a, t2.a), count(*) AS c FROM t t1, t t2 WHERE t1.a = t2.a GROUP BY GROUPING SETS ((t1.a), (t2.a))
+----
 -- SELECT aliases are not visible in HAVING (standard SQL — HAVING runs before SELECT).
 -- error: HAVING clause cannot reference column
 SELECT a, GROUPING(a) AS grp, sum(b) AS s FROM t GROUP BY ROLLUP(a) HAVING grp = 0

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1241,7 +1241,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       std::vector<lp::ExprApi> columnArgs;
       columnArgs.reserve(groupingOp->groupingColumns().size());
       for (const auto& column : groupingOp->groupingColumns()) {
-        columnArgs.push_back(lp::Col(canonicalizeName(column->suffix())));
+        columnArgs.push_back(toExpr(column, options));
       }
       return lp::Call(
           std::string(GroupByPlanner::kGroupingFunctionName), columnArgs);

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -374,21 +374,14 @@ void GroupByPlanner::plan(
     const OrderByPtr& orderBy) && {
   // Expand ROLLUP, CUBE, GROUPING SETS into a list of grouping sets, then
   // extract deduplicated grouping keys and per-set index vectors.
-  // Populates: groupingSets_, groupingKeys_, groupingSetsIndices_.
+  // Populates: groupingSets_, groupingKeys_, groupingSetsIndices_,
+  //   groupingKeyToIndex_.
   groupingSets_ = expandGroupingSets(groupingElements, selectExprs);
   deduplicateGroupingKeys();
   // GROUP BY DISTINCT removes duplicate grouping sets after expansion
   // (order-insensitive comparison).
   if (distinct) {
     deduplicateGroupingSets(groupingSetsIndices_);
-  }
-
-  // Populate groupingColumnToIndex_ for GROUPING() resolution.
-  for (size_t i = 0; i < groupingKeys_.size(); ++i) {
-    if (const auto* fieldAccess =
-            core::FieldAccessExpr::tryAsRootColumn(groupingKeys_[i].expr())) {
-      groupingColumnToIndex_[fieldAccess->name()] = static_cast<int32_t>(i);
-    }
   }
 
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
@@ -538,13 +531,12 @@ std::vector<std::vector<lp::ExprApi>> GroupByPlanner::expandGroupingSets(
 }
 
 void GroupByPlanner::deduplicateGroupingKeys() {
-  core::ExprMap<int32_t> exprToIndex;
   for (const auto& groupingSet : groupingSets_) {
     std::vector<int32_t> indices;
     indices.reserve(groupingSet.size());
     for (const auto& expr : groupingSet) {
       int32_t idx = static_cast<int32_t>(groupingKeys_.size());
-      auto [it, inserted] = exprToIndex.try_emplace(expr.expr(), idx);
+      auto [it, inserted] = groupingKeyToIndex_.try_emplace(expr.expr(), idx);
       if (inserted) {
         groupingKeys_.push_back(expr);
       }
@@ -868,12 +860,13 @@ core::ExprPtr GroupByPlanner::rewriteGroupingMarker(const core::ExprPtr& expr) {
     std::vector<int32_t> columnIndices;
     columnIndices.reserve(call->inputs().size());
     for (const auto& input : call->inputs()) {
-      auto* field = core::FieldAccessExpr::tryAsRootColumn(input);
-      VELOX_USER_CHECK_NOT_NULL(
-          field, "GROUPING() arguments must be column references");
-      auto it = groupingColumnToIndex_.find(field->name());
       VELOX_USER_CHECK(
-          it != groupingColumnToIndex_.end(),
+          input->is(core::IExpr::Kind::kFieldAccess),
+          "GROUPING() arguments must be column references");
+      const auto* field = input->as<core::FieldAccessExpr>();
+      auto it = groupingKeyToIndex_.find(input);
+      VELOX_USER_CHECK(
+          it != groupingKeyToIndex_.end(),
           "Not a grouping column: {}",
           field->name());
       columnIndices.push_back(it->second);

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -115,9 +115,8 @@ class GroupByPlanner {
   std::vector<std::vector<lp::ExprApi>> groupingSets_;
   std::vector<lp::ExprApi> groupingKeys_;
   std::vector<std::vector<int32_t>> groupingSetsIndices_;
-  // Maps grouping key column name → index in groupingKeys_ for GROUPING()
-  // resolution.
-  folly::F14FastMap<std::string, int32_t> groupingColumnToIndex_;
+  // Maps each grouping-key expression to its index in groupingKeys_.
+  facebook::velox::core::ExprMap<int32_t> groupingKeyToIndex_;
   std::vector<lp::ExprApi> projections_;
 
   // Deduplicated aggregate expressions. Aggregate options are embedded in

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -2538,10 +2538,20 @@ std::any AstBuilder::visitSearchedCase(
 std::any AstBuilder::visitGroupingOperation(
     PrestoSqlParser::GroupingOperationContext* ctx) {
   trace("visitGroupingOperation");
-  std::vector<std::shared_ptr<QualifiedName>> columns;
+  std::vector<ExpressionPtr> columns;
   columns.reserve(ctx->qualifiedName().size());
   for (auto* qualifiedNameCtx : ctx->qualifiedName()) {
-    columns.push_back(getQualifiedName(qualifiedNameCtx));
+    ExpressionPtr column;
+    for (auto& identifier :
+         visitTyped<Identifier>(qualifiedNameCtx->identifier())) {
+      if (column == nullptr) {
+        column = std::move(identifier);
+      } else {
+        column = std::make_shared<DereferenceExpression>(
+            getLocation(qualifiedNameCtx), column, identifier);
+      }
+    }
+    columns.push_back(std::move(column));
   }
   return std::static_pointer_cast<Expression>(
       std::make_shared<GroupingOperation>(

--- a/axiom/sql/presto/ast/AstFunctions.h
+++ b/axiom/sql/presto/ast/AstFunctions.h
@@ -829,11 +829,11 @@ class GroupingOperation : public Expression {
  public:
   explicit GroupingOperation(
       NodeLocation location,
-      const std::vector<std::shared_ptr<QualifiedName>>& groupingColumns)
+      const std::vector<ExpressionPtr>& groupingColumns)
       : Expression(NodeType::kGroupingOperation, location),
         groupingColumns_(groupingColumns) {}
 
-  const std::vector<std::shared_ptr<QualifiedName>>& groupingColumns() const {
+  const std::vector<ExpressionPtr>& groupingColumns() const {
     return groupingColumns_;
   }
   void accept(AstVisitor* visitor) override;
@@ -849,7 +849,7 @@ class GroupingOperation : public Expression {
   }
 
  private:
-  std::vector<std::shared_ptr<QualifiedName>> groupingColumns_;
+  std::vector<ExpressionPtr> groupingColumns_;
 };
 
 class TableVersionExpression : public Expression {

--- a/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
+++ b/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
@@ -1090,27 +1090,27 @@ TEST(AstEqualityTest, bindExpressionNotEqual) {
 }
 
 TEST(AstEqualityTest, groupingOperationEquals) {
-  auto name1 =
-      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
-  auto name2 =
-      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
   auto a = std::make_shared<GroupingOperation>(
-      loc(0, 0), std::vector<std::shared_ptr<QualifiedName>>{name1});
+      loc(0, 0),
+      std::vector<ExpressionPtr>{
+          std::make_shared<Identifier>(loc(), "a", false)});
   auto b = std::make_shared<GroupingOperation>(
-      loc(5, 5), std::vector<std::shared_ptr<QualifiedName>>{name2});
+      loc(5, 5),
+      std::vector<ExpressionPtr>{
+          std::make_shared<Identifier>(loc(), "a", false)});
   EXPECT_TRUE(*a == *b);
   EXPECT_EQ(a->hash(), b->hash());
 }
 
 TEST(AstEqualityTest, groupingOperationNotEqual) {
-  auto na =
-      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"a"});
-  auto nb =
-      std::make_shared<QualifiedName>(loc(), std::vector<std::string>{"b"});
   auto a = std::make_shared<GroupingOperation>(
-      loc(), std::vector<std::shared_ptr<QualifiedName>>{na});
+      loc(),
+      std::vector<ExpressionPtr>{
+          std::make_shared<Identifier>(loc(), "a", false)});
   auto b = std::make_shared<GroupingOperation>(
-      loc(), std::vector<std::shared_ptr<QualifiedName>>{nb});
+      loc(),
+      std::vector<ExpressionPtr>{
+          std::make_shared<Identifier>(loc(), "b", false)});
   EXPECT_FALSE(*a == *b);
 }
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -398,6 +398,37 @@ TEST_F(AggregationParserTest, groupingFunction) {
           .project(projectExprs({"n_regionkey", grouping({0, 3}), "count"}))
           .output());
 
+  // Two columns with the same leaf name across a join stay distinct grouping
+  // keys, one per grouping set.
+  testSelect(
+      "SELECT GROUPING(t.n_regionkey, u.n_regionkey), count(1) "
+      "FROM nation t, nation u WHERE t.n_nationkey = u.n_nationkey "
+      "GROUP BY GROUPING SETS ((t.n_regionkey), (u.n_regionkey))",
+      matchScan("nation")
+          .join(matchScan("nation").build())
+          .filter()
+          .aggregate({"n_regionkey", "n_regionkey_2"}, {"count(1)"}, {{0}, {1}})
+          .project(projectExprs({grouping({1, 2}), "count"}))
+          .output());
+
+  // A qualified GROUPING() argument that is not a grouping key still fails.
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT GROUPING(t.n_name), count(1) "
+          "FROM nation t, nation u WHERE t.n_nationkey = u.n_nationkey "
+          "GROUP BY GROUPING SETS ((t.n_regionkey), (u.n_regionkey))"),
+      "Not a grouping column: n_name");
+
+  // A struct-field deep qualifier resolves as a GROUPING() argument.
+  connector_->addTable("s", ROW({"k", "x"}, {BIGINT(), ROW("y", BIGINT())}));
+  testSelect(
+      "SELECT GROUPING(s.x.y), count(1) FROM s "
+      "GROUP BY GROUPING SETS ((s.x.y), ())",
+      matchScan("s")
+          .aggregate({"DEREFERENCE(x, y)"}, {"count(1)"}, {{0}, {}})
+          .project(projectExprs({grouping({0, 1}), "count"}))
+          .output());
+
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSelect(
           "SELECT n_regionkey, count(1) "


### PR DESCRIPTION
Summary:

A GROUP BY ... GROUPING SETS query failed after a join introduced the same column name on both sides:

    SELECT GROUPING(t.k, u.k)
    FROM t
    JOIN u ON ...
    GROUP BY GROUPING SETS ((t.k), (u.k))

Error: Not a grouping column: k.

Root cause: GROUPING() arguments were the only column-list construct resolved by hand - the parser modeled them as QualifiedName and the planner walked the dotted parts, dropping qualifiers via suffix(). Every other construct resolves its arguments as expressions through the shared toExpr path. So a GROUPING() argument and its grouping key could resolve to different expressions, and matching by name collapsed t.k and u.k onto one entry.

Fix: GROUPING() arguments are now built as expression nodes (a dereference chain) and resolved through the same toExpr path as any other column reference, and grouping keys are matched by expression instead of by name. The bespoke parts handling is gone, so qualifiers of any depth resolve uniformly - matching Presto, whose GroupingOperation also holds expressions.

Reviewed By: kagamiori

Differential Revision: D108153139


