### PR TITLE
fix(optimizer): Convert hyper-edge outer joins to inner

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -18,12 +18,14 @@
 #include <folly/container/F14Map.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
+#include <filesystem>
 #include <iostream>
 #include <set>
 #include "axiom/cli/CatalogProperties.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
 #include "axiom/cli/SystemUser.h"
+#include "axiom/connectors/tests/TestTableJson.h"
 #include "velox/common/base/Exceptions.h"
 
 DEFINE_string(
@@ -85,6 +87,11 @@ int main(int argc, char** argv) {
 
     for (auto& catalogProperties :
          axiom::sql::loadCatalogProperties(FLAGS_etc_dir)) {
+      // Expose the catalog directory so connectors can resolve relative file
+      // paths in their properties (e.g. the test connector's `tables`).
+      catalogProperties.connectorConfig.insert_or_assign(
+          std::string(facebook::axiom::connector::TestTableJson::kConfigDir),
+          std::filesystem::absolute(FLAGS_etc_dir).string());
       registerConnector(
           std::move(catalogProperties.catalogName),
           catalogProperties.connectorName,

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -197,7 +197,7 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerConnector(
   }
 
   if (connectorName == "test") {
-    return registerTestConnector(connectorId);
+    return registerTestConnector(connectorId, connectorConfig);
   }
 
   VELOX_USER_FAIL(
@@ -207,9 +207,14 @@ std::shared_ptr<velox::connector::Connector> Connectors::registerConnector(
 }
 
 std::shared_ptr<velox::connector::Connector> Connectors::registerTestConnector(
-    const std::string& connectorId) {
+    const std::string& connectorId,
+    const folly::F14FastMap<std::string, std::string>& connectorConfig) {
+  auto config = std::make_shared<velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          connectorConfig.begin(), connectorConfig.end()});
+
   connector::TestConnectorFactory factory(connectorId.c_str());
-  auto connector = factory.newConnector(connectorId);
+  auto connector = factory.newConnector(connectorId, std::move(config));
   registerConnector(connector);
 
   auto* testConnector =

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -91,9 +91,13 @@ class Connectors {
       const folly::F14FastMap<std::string, std::string>& connectorConfig,
       const std::string& connectorId);
 
-  /// Registers an in-memory test connector under `connectorId`.
+  /// Registers an in-memory test connector under `connectorId`. The
+  /// `connectorConfig` is passed through to the connector verbatim; the test
+  /// connector interprets its own properties (e.g. `tables` naming JSON files
+  /// of table schemas and statistics to preload).
   std::shared_ptr<velox::connector::Connector> registerTestConnector(
-      const std::string& connectorId = kTestConnectorId);
+      const std::string& connectorId = kTestConnectorId,
+      const folly::F14FastMap<std::string, std::string>& connectorConfig = {});
 
   /// Registers the system connector for the runtime.queries and
   /// metadata.session_properties tables.

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -105,6 +105,40 @@ $ ./axiom_sql --init start.sql
 SQL> select * from t;
 ```
 
+A test catalog can also preload tables with controlled statistics but no row
+data, for reproducing optimizer plans (e.g. a bad plan seen in production)
+without copying the data. Add a `tables` property naming JSON files of table
+schemas and statistics; relative paths and globs resolve against `--etc_dir`:
+
+```properties
+# etc/repro.properties
+connector.name=test
+tables=*.json
+```
+
+Each JSON file describes one table; a missing per-column statistic is left
+unset, so the optimizer applies its no-stat default just as in production:
+
+```json
+{
+  "name": "orders",
+  "numRows": 1500000,
+  "columns": [
+    {"name": "o_orderkey", "type": "BIGINT", "numDistinct": 1500000,
+     "min": 1, "max": 6000000},
+    {"name": "o_orderstatus", "type": "VARCHAR", "numDistinct": 3}
+  ]
+}
+```
+
+```bash
+$ ./axiom_sql --etc_dir etc/ --catalog repro \
+    --query "EXPLAIN (type optimized) SELECT * FROM orders WHERE o_orderkey < 1000"
+```
+
+The internal `fb_axiom/cli/dump_ms_stats.py` script generates these JSON
+files from a production Hive table and partition by reading the metastore.
+
 ## Catalog Configuration Files
 
 Configuration files (`.properties` files) define catalogs for use with `--etc_dir`.

--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_test_connector TestConnector.cpp)
+add_library(axiom_test_connector TestConnector.cpp TestTableJson.cpp)
 
 target_link_libraries(
   axiom_test_connector
   axiom_connectors
   axiom_hive_connector_metadata
   velox_common_base
+  velox_common_config
   velox_memory
   velox_connector
+  velox_presto_type_parser
+  re2::re2
 )
 
 add_executable(axiom_test_connector_test TestConnectorTest.cpp ConnectorMetadataRegistryTest.cpp)
@@ -35,6 +38,22 @@ target_link_libraries(
   velox_connector
   velox_exec
   velox_vector_test_lib
+  GTest::gtest
+  GTest::gtest_main
+)
+
+add_executable(axiom_test_table_json_test TestTableJsonTest.cpp)
+
+add_test(axiom_test_table_json_test axiom_test_table_json_test)
+
+target_link_libraries(
+  axiom_test_table_json_test
+  axiom_test_connector
+  velox_common_base
+  velox_common_config
+  velox_memory
+  velox_test_util
+  velox_type
   GTest::gtest
   GTest::gtest_main
 )

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestTableJson.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
@@ -1246,7 +1247,11 @@ std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(
     std::shared_ptr<const velox::config::ConfigBase> config,
     folly::Executor*,
     folly::Executor*) {
-  return std::make_shared<TestConnector>(id, std::move(config));
+  auto connector = std::make_shared<TestConnector>(id, config);
+  if (config != nullptr) {
+    TestTableJson::loadFromConfig(*connector, *config);
+  }
+  return connector;
 }
 
 void TestDataSink::appendData(velox::RowVectorPtr vector) {

--- a/axiom/connectors/tests/TestTableJson.cpp
+++ b/axiom/connectors/tests/TestTableJson.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestTableJson.h"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include <folly/String.h>
+#include <folly/json.h>
+#include <re2/re2.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "velox/functions/prestosql/types/parser/TypeParser.h"
+
+namespace facebook::axiom::connector {
+namespace {
+
+// Converts a JSON scalar to a Variant matching 'type'. Returns nullopt for
+// types without a natural scalar min/max (e.g. complex types).
+std::optional<velox::Variant> toVariant(
+    const velox::TypePtr& type,
+    const folly::dynamic& value) {
+  switch (type->kind()) {
+    case velox::TypeKind::TINYINT:
+      return velox::Variant(static_cast<int8_t>(value.asInt()));
+    case velox::TypeKind::SMALLINT:
+      return velox::Variant(static_cast<int16_t>(value.asInt()));
+    case velox::TypeKind::INTEGER:
+      return velox::Variant(static_cast<int32_t>(value.asInt()));
+    case velox::TypeKind::BIGINT:
+      return velox::Variant(static_cast<int64_t>(value.asInt()));
+    case velox::TypeKind::REAL:
+      return velox::Variant(static_cast<float>(value.asDouble()));
+    case velox::TypeKind::DOUBLE:
+      return velox::Variant(value.asDouble());
+    case velox::TypeKind::VARCHAR:
+      return velox::Variant(value.asString());
+    case velox::TypeKind::BOOLEAN:
+      return velox::Variant(value.asBool());
+    default:
+      return std::nullopt;
+  }
+}
+
+ColumnStatistics parseColumnStatistics(
+    const velox::TypePtr& type,
+    const folly::dynamic& column,
+    uint64_t numRows) {
+  // ColumnStatistics::name stays empty for a top-level column; it names a
+  // subfield only for struct/map children.
+  ColumnStatistics stats;
+
+  // A missing nullFraction means unknown: leave the null-related fields at
+  // their defaults rather than asserting the column has no nulls.
+  if (auto* nullFraction = column.get_ptr("nullFraction")) {
+    const double fraction = nullFraction->asDouble();
+    stats.nullPct = static_cast<float>(fraction * 100.0);
+    stats.nonNull = fraction == 0.0;
+    stats.numValues =
+        static_cast<int64_t>(static_cast<double>(numRows) * (1.0 - fraction));
+  }
+
+  if (auto* numDistinct = column.get_ptr("numDistinct")) {
+    // The metastore reports NDV per partition, which can exceed a partition's
+    // row count; cap it so setStats' numDistinct <= numRows invariant holds.
+    stats.numDistinct =
+        std::min<int64_t>(numDistinct->asInt(), static_cast<int64_t>(numRows));
+  }
+  if (auto* min = column.get_ptr("min")) {
+    stats.min = toVariant(type, *min);
+  }
+  if (auto* max = column.get_ptr("max")) {
+    stats.max = toVariant(type, *max);
+  }
+  if (auto* maxLength = column.get_ptr("maxLength")) {
+    stats.maxLength = static_cast<int32_t>(maxLength->asInt());
+  }
+  return stats;
+}
+
+// Translates a shell-style glob (supporting '*' and '?') over a single file
+// name into an RE2 pattern. RE2::FullMatch anchors the match, so no surrounding
+// ^...$ is needed.
+std::string globToRe2Pattern(const std::string& glob) {
+  std::string pattern;
+  pattern.reserve(glob.size() * 2);
+  for (const char c : glob) {
+    switch (c) {
+      case '*':
+        pattern += ".*";
+        break;
+      case '?':
+        pattern += '.';
+        break;
+      default:
+        if (std::strchr(".^$+{}[]()|\\", c) != nullptr) {
+          pattern += '\\';
+        }
+        pattern += c;
+    }
+  }
+  return pattern;
+}
+
+// Resolves 'entry' against 'baseDir' and expands it. A plain path returns
+// itself (existence is checked when the file is opened); a glob returns the
+// sorted set of matching files in its directory.
+std::vector<std::string> expandEntry(
+    const std::string& entry,
+    const std::string& baseDir) {
+  std::filesystem::path path(entry);
+  if (path.is_relative() && !baseDir.empty()) {
+    path = std::filesystem::path(baseDir) / path;
+  }
+
+  const std::string name = path.filename().string();
+  if (name.find('*') == std::string::npos &&
+      name.find('?') == std::string::npos) {
+    return {path.string()};
+  }
+
+  const auto directory = path.parent_path();
+  if (!std::filesystem::is_directory(directory)) {
+    return {};
+  }
+  const re2::RE2 regex(globToRe2Pattern(name));
+  std::vector<std::string> matches;
+  for (const auto& dirEntry : std::filesystem::directory_iterator(directory)) {
+    if (dirEntry.is_regular_file() &&
+        re2::RE2::FullMatch(dirEntry.path().filename().string(), regex)) {
+      matches.push_back(dirEntry.path().string());
+    }
+  }
+  std::sort(matches.begin(), matches.end());
+  return matches;
+}
+
+} // namespace
+
+void TestTableJson::load(TestConnector& connector, std::string_view json) {
+  const folly::dynamic table = folly::parseJson(json);
+  const auto name = table["name"].asString();
+  const auto numRows = static_cast<uint64_t>(table["numRows"].asInt());
+
+  const auto& columns = table["columns"];
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(columns.size());
+  types.reserve(columns.size());
+  std::unordered_map<std::string, ColumnStatistics> columnStats;
+  for (const auto& column : columns) {
+    auto columnName = column["name"].asString();
+    auto type =
+        velox::functions::prestosql::parseType(column["type"].asString());
+    columnStats.emplace(
+        columnName, parseColumnStatistics(type, column, numRows));
+    names.push_back(std::move(columnName));
+    types.push_back(std::move(type));
+  }
+
+  connector.addTable(name, velox::ROW(std::move(names), std::move(types)));
+  connector.setStats(name, numRows, columnStats);
+}
+
+void TestTableJson::loadFile(
+    TestConnector& connector,
+    const std::string& path) {
+  std::ifstream input(path);
+  VELOX_USER_CHECK(input, "Failed to open table JSON file: {}", path);
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  load(connector, buffer.str());
+}
+
+void TestTableJson::loadFromConfig(
+    TestConnector& connector,
+    const velox::config::ConfigBase& config) {
+  const auto tables = config.get<std::string>(std::string(kTables));
+  if (!tables.has_value() || tables->empty()) {
+    return;
+  }
+  const auto baseDir =
+      config.get<std::string>(std::string(kConfigDir)).value_or("");
+
+  std::vector<std::string> entries;
+  folly::split(',', tables.value(), entries);
+  for (const auto& entry : entries) {
+    const auto trimmed = folly::trimWhitespace(entry);
+    if (trimmed.empty()) {
+      continue;
+    }
+    for (const auto& path : expandEntry(std::string(trimmed), baseDir)) {
+      loadFile(connector, path);
+    }
+  }
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestTableJson.h
+++ b/axiom/connectors/tests/TestTableJson.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "velox/common/config/Config.h"
+
+namespace facebook::axiom::connector {
+
+class TestConnector;
+
+/// Registers TestConnector tables (schema and statistics, no row data) from
+/// JSON. Used to reproduce optimizer scenarios with controlled statistics, e.g.
+/// a bad plan observed in production, without copying the underlying data.
+///
+/// Each JSON document describes one table:
+///   {
+///     "name": "orders",
+///     "numRows": 1500000,
+///     "columns": [
+///       {"name": "o_orderkey", "type": "BIGINT", "numDistinct": 1500000,
+///        "min": 1, "max": 6000000, "nullFraction": 0.0},
+///       {"name": "o_orderstatus", "type": "VARCHAR", "numDistinct": 3}
+///     ]
+///   }
+///
+/// Per-column fields other than 'name' and 'type' are optional; a missing field
+/// leaves that statistic unset, so the optimizer applies the same default it
+/// would for a column whose statistic is absent in production.
+///
+/// The common entry point reads the file list from a connector config property:
+///   TestTableJson::loadFromConfig(connector, config);
+class TestTableJson {
+ public:
+  /// Connector config property naming the table JSON files: a comma-separated
+  /// list of paths or shell-style globs (e.g. "*.json" or "a.json,b.json").
+  /// Relative entries resolve against kConfigDir.
+  static constexpr std::string_view kTables = "tables";
+
+  /// Connector config property holding the directory that relative kTables
+  /// entries resolve against. The CLI injects it from --etc_dir.
+  static constexpr std::string_view kConfigDir = "catalog.dir";
+
+  /// Parses 'json' describing a single table and registers it in 'connector'
+  /// via addTable() and setStats(). Throws on malformed input.
+  static void load(TestConnector& connector, std::string_view json);
+
+  /// Reads the file at 'path' and load()s its contents.
+  static void loadFile(TestConnector& connector, const std::string& path);
+
+  /// Reads kTables from 'config', resolves and glob-expands each entry against
+  /// kConfigDir, and loadFile()s every match. A no-op when kTables is unset.
+  /// A literal (non-glob) entry that matches no file throws; a glob that
+  /// matches nothing is silently empty.
+  static void loadFromConfig(
+      TestConnector& connector,
+      const velox::config::ConfigBase& config);
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestTableJsonTest.cpp
+++ b/axiom/connectors/tests/TestTableJsonTest.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/tests/TestTableJson.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/Config.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::connector {
+namespace {
+
+using namespace facebook::velox;
+
+class TestTableJsonTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    connector_ = std::make_shared<TestConnector>("test");
+  }
+
+  TablePtr findTable(const std::string& name) {
+    return connector_->metadata()->findTable(
+        {std::string(TestConnector::kDefaultSchema), name});
+  }
+
+  static const ColumnStatistics& columnStats(
+      const TablePtr& table,
+      const std::string& column) {
+    const auto* stats = table->columnMap().at(column)->stats();
+    VELOX_CHECK_NOT_NULL(stats);
+    return *stats;
+  }
+
+  std::shared_ptr<TestConnector> connector_;
+};
+
+TEST_F(TestTableJsonTest, load) {
+  TestTableJson::load(*connector_, R"({
+    "name": "orders",
+    "numRows": 1000,
+    "columns": [
+      {"name": "o_orderkey", "type": "BIGINT", "numDistinct": 1000,
+       "min": 1, "max": 6000, "nullFraction": 0.0},
+      {"name": "o_orderstatus", "type": "VARCHAR", "numDistinct": 3,
+       "nullFraction": 0.5}
+    ]
+  })");
+
+  auto table = findTable("orders");
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->numRows(), 1000);
+
+  const auto& orderkey = columnStats(table, "o_orderkey");
+  EXPECT_EQ(orderkey.numDistinct, 1000);
+  EXPECT_EQ(orderkey.min, Variant(static_cast<int64_t>(1)));
+  EXPECT_EQ(orderkey.max, Variant(static_cast<int64_t>(6000)));
+  EXPECT_TRUE(orderkey.nonNull);
+  EXPECT_EQ(orderkey.nullPct, 0);
+
+  const auto& status = columnStats(table, "o_orderstatus");
+  EXPECT_EQ(status.numDistinct, 3);
+  EXPECT_FALSE(status.nonNull);
+  EXPECT_EQ(status.nullPct, 50);
+}
+
+TEST_F(TestTableJsonTest, columnWithoutStats) {
+  // A column with only name and type leaves every statistic unset, so the
+  // optimizer applies its no-stat defaults just as it would in production.
+  TestTableJson::load(*connector_, R"({
+    "name": "t",
+    "numRows": 100,
+    "columns": [{"name": "c", "type": "BIGINT"}]
+  })");
+
+  const auto& stats = columnStats(findTable("t"), "c");
+  EXPECT_FALSE(stats.numDistinct.has_value());
+  EXPECT_FALSE(stats.min.has_value());
+  EXPECT_FALSE(stats.max.has_value());
+  EXPECT_FALSE(stats.nonNull);
+  EXPECT_EQ(stats.nullPct, 0);
+  EXPECT_EQ(stats.numValues, 0);
+}
+
+TEST_F(TestTableJsonTest, distinctCappedToRowCount) {
+  // The metastore reports NDV per partition, which can exceed a partition's
+  // row count; the loader caps it to satisfy setStats' invariant.
+  TestTableJson::load(*connector_, R"({
+    "name": "t",
+    "numRows": 10,
+    "columns": [{"name": "c", "type": "BIGINT", "numDistinct": 100}]
+  })");
+
+  EXPECT_EQ(columnStats(findTable("t"), "c").numDistinct, 10);
+}
+
+TEST_F(TestTableJsonTest, loadFromConfigGlob) {
+  const auto directory = velox::common::testutil::TempDirectoryPath::create();
+  const std::filesystem::path path = directory->getPath();
+  std::ofstream(path / "a.json")
+      << R"({"name": "a", "numRows": 1, "columns": []})";
+  std::ofstream(path / "b.json")
+      << R"({"name": "b", "numRows": 2, "columns": []})";
+
+  velox::config::ConfigBase config({
+      {std::string(TestTableJson::kTables), "*.json"},
+      {std::string(TestTableJson::kConfigDir), directory->getPath()},
+  });
+  TestTableJson::loadFromConfig(*connector_, config);
+
+  EXPECT_NE(findTable("a"), nullptr);
+  EXPECT_NE(findTable("b"), nullptr);
+}
+
+TEST_F(TestTableJsonTest, loadFromConfigMissingLiteralThrows) {
+  velox::config::ConfigBase config({
+      {std::string(TestTableJson::kTables), "does_not_exist.json"},
+      {std::string(TestTableJson::kConfigDir), "/tmp"},
+  });
+  VELOX_ASSERT_THROW(
+      TestTableJson::loadFromConfig(*connector_, config),
+      "Failed to open table JSON file");
+}
+
+TEST_F(TestTableJsonTest, noTablesProperty) {
+  velox::config::ConfigBase config({});
+  // No 'tables' property: nothing is registered and no error is raised.
+  TestTableJson::loadFromConfig(*connector_, config);
+  EXPECT_TRUE(
+      connector_->metadata()
+          ->listTableNames(
+              /*session=*/nullptr, std::string(TestConnector::kDefaultSchema))
+          .empty());
+}
+
+} // namespace
+} // namespace facebook::axiom::connector

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2070,6 +2070,31 @@ JoinEdgeP toInnerJoin(JoinEdgeCP leftJoin) {
   return innerJoin;
 }
 
+// Replaces outer join 'dt.joins[joinIndex]' with its inner-join equivalent and
+// moves the join's filter into 'dt.conjuncts'. A normal join becomes a single
+// inner JoinEdge. A hyper-edge (leftTable() == nullptr, so its left side spans
+// multiple tables) cannot be a single inner edge, so each equi key is emitted
+// as a free equality conjunct and the edge is dropped; conjunct distribution
+// then rebuilds the inner edges.
+void convertOuterJoinToInner(
+    DerivedTable& dt,
+    JoinEdgeCP join,
+    size_t joinIndex) {
+  if (join->leftTable() != nullptr) {
+    dt.joins[joinIndex] = toInnerJoin(join);
+  } else {
+    auto* optimization = queryCtx()->optimization();
+    for (size_t i = 0; i < join->leftKeys().size(); ++i) {
+      dt.conjuncts.push_back(optimization->makeEquality(
+          join->leftKeys()[i], join->rightKeys()[i]));
+    }
+    dt.joins.erase(dt.joins.begin() + joinIndex);
+  }
+
+  dt.conjuncts.insert(
+      dt.conjuncts.end(), join->filter().begin(), join->filter().end());
+}
+
 // Converts a FULL join to a LEFT join, preserving the filter, join keys, and
 // right-side output columns/expressions.
 // Used when a filter on the left side columns eliminates rows where the left
@@ -2569,10 +2594,7 @@ void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
       // rejects NULLs on both sides, so convert directly to INNER join.
       if (referencesRight && referencesLeft && join->leftOptional() &&
           join->rightOptional()) {
-        joins[joinIndex] = toInnerJoin(join);
-
-        conjuncts.insert(
-            conjuncts.end(), join->filter().begin(), join->filter().end());
+        convertOuterJoinToInner(*this, join, joinIndex);
 
         replaceJoinOutputs(join->rightColumns(), join->rightExprs());
         replaceJoinOutputs(join->leftColumns(), join->leftExprs());
@@ -2581,10 +2603,7 @@ void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
 
       if (referencesRight) {
         if (!join->leftOptional()) {
-          joins[joinIndex] = toInnerJoin(join);
-
-          conjuncts.insert(
-              conjuncts.end(), join->filter().begin(), join->filter().end());
+          convertOuterJoinToInner(*this, join, joinIndex);
         } else {
           // Convert FULL join to (normalized) RIGHT join. The filter
           // references right-side columns and has default null behavior, so

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -104,3 +104,22 @@ WHERE EXISTS (
   SELECT 1 FROM (VALUES (1, 1), (2, 3), (3, 3)) AS u(x, y)
   WHERE u.x = t.a AND u.y = t.a
 )
+----
+-- RIGHT JOIN with a non-equi ON against a FROM-less scalar subquery and a
+-- null-rejecting WHERE on the optional side. Returns the optional-side rows
+-- that pass the predicate.
+SELECT a.*
+FROM t AS a
+RIGHT JOIN (SELECT (SELECT c FROM t LIMIT 1) AS c0) AS u ON a.a < u.c0
+WHERE a.b = 10
+----
+-- RIGHT JOIN with equi-key ON conditions against two FROM-less scalar
+-- subqueries and a null-rejecting WHERE on the optional side. Returns the
+-- single optional-side row whose keys match.
+SELECT a.*
+FROM t AS a
+RIGHT JOIN (
+  SELECT (SELECT a FROM t ORDER BY a LIMIT 1) AS a0,
+         (SELECT b FROM t ORDER BY b LIMIT 1) AS b0
+) AS u ON a.a = u.a0 AND a.b = u.b0
+WHERE a.b = 10


### PR DESCRIPTION
Summary:
The optimizer crashed with a null dereference when converting an outer join to an inner join whose required side spans multiple tables. For example:

    SELECT a.* FROM t AS a
    RIGHT JOIN (SELECT (SELECT c FROM t LIMIT 1) AS c0) AS s ON a.a < s.c0
    WHERE a.b = 1

The FROM-less scalar subquery has no single left table (a hyper-edge), so `tryConvertOuterJoins` passed a null left table to `JoinEdge::makeInner` and segfaulted. The null-rejecting `WHERE` makes the outer join equivalent to an inner join, which triggers the conversion.

A hyper-edge cannot be a single inner `JoinEdge`. Instead of building one, emit each equi key as a free equality conjunct, move the join filter to the derived table, and drop the edge; conjunct distribution then rebuilds the inner edges. Normal joins keep the existing single-edge path.

Differential Revision: D108832359


