### PR TITLE
refactor(optimizer): Remove dead cost hook and tidy casts

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -75,13 +75,7 @@ float selfCost(ExprCP expr) {
     }
     case PlanType::kCallExpr: {
       auto metadata = expr->as<Call>()->metadata();
-      if (metadata) {
-        if (metadata->costFunc) {
-          return metadata->costFunc(expr->as<Call>());
-        }
-        return metadata->cost;
-      }
-      return 5;
+      return metadata ? metadata->cost : kDefaultCallCost;
     }
     default:
       return 5;

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2148,13 +2148,6 @@ JoinEdgeP toNormalizedRightJoin(JoinEdgeCP fullJoin) {
   return leftJoin;
 }
 
-// Returns true if 'name' is a ranking window function (row_number, rank,
-// dense_rank).
-bool isRankingFunction(Name name, const FunctionNames& names) {
-  return name == names.rowNumber || name == names.rank ||
-      name == names.denseRank;
-}
-
 // Result of analyzing a predicate against a ranking window function output.
 struct RankingPredicate {
   enum class Kind {
@@ -2191,7 +2184,7 @@ RankingPredicate analyzeRankingPredicate(
     return {};
   }
 
-  if (!isRankingFunction(windowFunction->name(), names)) {
+  if (!names.isRanking(windowFunction->name())) {
     return {};
   }
 

--- a/axiom/optimizer/Filters.cpp
+++ b/axiom/optimizer/Filters.cpp
@@ -560,14 +560,13 @@ std::pair<VariantCP, VariantCP> findArrayMinMax(
 }
 
 // Computes the maximum cardinality for an integer range: 1 + (max - min).
-// Operands are cast to double to avoid signed integer overflow when the
-// range spans a large portion of the integer domain.
+// The 1.0 literal forces double arithmetic, avoiding signed integer overflow
+// when the range spans a large portion of the integer domain.
 template <velox::TypeKind KIND>
 float rangeCardinality(VariantCP minPtr, VariantCP maxPtr) {
   auto upperVal = maxPtr->value<KIND>();
   auto lowerVal = minPtr->value<KIND>();
-  return static_cast<float>(
-      1.0 + static_cast<double>(upperVal) - static_cast<double>(lowerVal));
+  return 1.0 + upperVal - lowerVal;
 }
 
 // Returns true if the given TypeKind represents an integer type
@@ -710,8 +709,7 @@ float computeRangeSelectivity(
     exprRange = 1.0;
   }
 
-  float selectivity = static_cast<float>(intersectionRange / exprRange);
-  return std::clamp(selectivity, 0.0f, 1.0f);
+  return std::clamp<float>(intersectionRange / exprRange, 0.0f, 1.0f);
 }
 
 template <velox::TypeKind KIND>
@@ -743,10 +741,10 @@ float rangeSelectivityImpl(
     }
 
     return computeRangeSelectivity(
-        static_cast<double>(exprMin),
-        static_cast<double>(exprMax),
-        static_cast<double>(effectiveLower),
-        static_cast<double>(effectiveUpper),
+        exprMin,
+        exprMax,
+        effectiveLower,
+        effectiveUpper,
         /*discrete=*/!std::is_floating_point_v<T>);
   }
 }
@@ -767,7 +765,7 @@ float rangeSelectivityImpl<velox::TypeKind::VARCHAR>(
     if (str.empty()) {
       return 0;
     }
-    return static_cast<int32_t>(static_cast<unsigned char>(str[0]));
+    return static_cast<unsigned char>(str[0]);
   };
 
   int32_t exprMin = getFirstCharValue(exprValue.min);
@@ -784,11 +782,7 @@ float rangeSelectivityImpl<velox::TypeKind::VARCHAR>(
   }
 
   return computeRangeSelectivity(
-      static_cast<double>(exprMin),
-      static_cast<double>(exprMax),
-      static_cast<double>(effectiveLower),
-      static_cast<double>(effectiveUpper),
-      /*discrete=*/true);
+      exprMin, exprMax, effectiveLower, effectiveUpper, /*discrete=*/true);
 }
 
 // Computes selectivity for comparisons using only cardinality (no range info).
@@ -812,8 +806,8 @@ std::optional<Selectivity> cardinalityBasedSelectivity(
         !rightValue.cardinality.has_value()) {
       return std::nullopt;
     }
-    double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
-    double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
+    double ac = std::max<double>(1.0, *leftValue.cardinality);
+    double bc = std::max<double>(1.0, *rightValue.cardinality);
     double minCard = std::min(ac, bc);
     double probTrue = minCard / (ac * bc);
 
@@ -877,8 +871,8 @@ std::optional<Selectivity> comparisonSelectivityImpl(
   double bl = rightValue.min->value<KIND>();
   double bh = rightValue.max->value<KIND>();
 
-  double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
-  double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
+  double ac = std::max<double>(1.0, *leftValue.cardinality);
+  double bc = std::max<double>(1.0, *rightValue.cardinality);
 
   // Calculate ranges (avoiding zero).
   double rangeA = rangeSize(al, ah);
@@ -1434,7 +1428,7 @@ std::optional<Selectivity> computeInListSelectivity(
     bool updateConstraints) {
   const auto& array = bounds.inList->array();
 
-  double inListSize = static_cast<double>(array.size());
+  double inListSize = array.size();
   double trueFraction =
       std::clamp(inListSize / *exprValue.cardinality, 0.0, 1.0) *
       (1.0 - nullFraction);

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -122,6 +122,10 @@ struct LambdaInfo {
 
 class Call;
 
+/// Per-row cost of a function call that has no specific cost. Used both when a
+/// call has no metadata and when its metadata leaves the cost at the default.
+constexpr float kDefaultCallCost = 5;
+
 /// Describes functions accepting lambdas and functions with special treatment
 /// of subfields.
 struct FunctionMetadata {
@@ -174,13 +178,8 @@ struct FunctionMetadata {
   /// Bits of FunctionSet for the function.
   FunctionSet functionSet;
 
-  /// Static fixed cost for processing one row. use 'costFunc' for non-constant
-  /// cost.
-  float cost{1};
-
-  /// Function for evaluating the per-row cost when the cost depends on
-  /// arguments and their stats.
-  std::function<float(const Call*)> costFunc;
+  /// Static fixed cost for processing one row.
+  float cost{kDefaultCallCost};
 
   /// Translates a set of paths into path, expression pairs if the complex type
   /// returning function is decomposable into per-path subexpressions. Suppose

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -337,6 +337,12 @@ struct FunctionNames {
   Name rowNumber{nullptr};
   Name rank{nullptr};
   Name denseRank{nullptr};
+
+  /// True if 'name' is a ranking window function (row_number, rank,
+  /// dense_rank).
+  bool isRanking(Name name) const {
+    return name == rowNumber || name == rank || name == denseRank;
+  }
 };
 
 /// Context for making a query plan. Owns all memory associated to


### PR DESCRIPTION
Summary:
Behavior-neutral cleanups:

- Delete the unused `FunctionMetadata::costFunc` hook and the `Cost.cpp` branch that called it; a call's per-row cost is now `metadata->cost` or `kDefaultCallCost`.
- Move the ranking-function check (`row_number`, `rank`, `dense_rank`) into `FunctionNames::isRanking` and call it from `DerivedTable`.
- Drop redundant `static_cast<double>`/`static_cast<float>` in the `Filters` range and cardinality math, relying on a leading `1.0` literal or `std::max<double>`/`std::clamp<float>`.

One intended behavior change rides along: the default `FunctionMetadata::cost` is now `kDefaultCallCost` (5) instead of 1, so a function that registers metadata without an explicit cost (today only `row_constructor`) costs 5 per row, matching the no-metadata default.

Differential Revision: D108879650


