### PR TITLE
fix(optimizer): Treat unknown cardinality as an unknown shuffle margin

### DIFF
--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -75,13 +75,7 @@ float selfCost(ExprCP expr) {
     }
     case PlanType::kCallExpr: {
       auto metadata = expr->as<Call>()->metadata();
-      if (metadata) {
-        if (metadata->costFunc) {
-          return metadata->costFunc(expr->as<Call>());
-        }
-        return metadata->cost;
-      }
-      return 5;
+      return metadata ? metadata->cost : kDefaultCallCost;
     }
     default:
       return 5;

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2148,13 +2148,6 @@ JoinEdgeP toNormalizedRightJoin(JoinEdgeCP fullJoin) {
   return leftJoin;
 }
 
-// Returns true if 'name' is a ranking window function (row_number, rank,
-// dense_rank).
-bool isRankingFunction(Name name, const FunctionNames& names) {
-  return name == names.rowNumber || name == names.rank ||
-      name == names.denseRank;
-}
-
 // Result of analyzing a predicate against a ranking window function output.
 struct RankingPredicate {
   enum class Kind {
@@ -2191,7 +2184,7 @@ RankingPredicate analyzeRankingPredicate(
     return {};
   }
 
-  if (!isRankingFunction(windowFunction->name(), names)) {
+  if (!names.isRanking(windowFunction->name())) {
     return {};
   }
 

--- a/axiom/optimizer/Filters.cpp
+++ b/axiom/optimizer/Filters.cpp
@@ -560,14 +560,13 @@ std::pair<VariantCP, VariantCP> findArrayMinMax(
 }
 
 // Computes the maximum cardinality for an integer range: 1 + (max - min).
-// Operands are cast to double to avoid signed integer overflow when the
-// range spans a large portion of the integer domain.
+// The 1.0 literal forces double arithmetic, avoiding signed integer overflow
+// when the range spans a large portion of the integer domain.
 template <velox::TypeKind KIND>
 float rangeCardinality(VariantCP minPtr, VariantCP maxPtr) {
   auto upperVal = maxPtr->value<KIND>();
   auto lowerVal = minPtr->value<KIND>();
-  return static_cast<float>(
-      1.0 + static_cast<double>(upperVal) - static_cast<double>(lowerVal));
+  return 1.0 + upperVal - lowerVal;
 }
 
 // Returns true if the given TypeKind represents an integer type
@@ -710,8 +709,7 @@ float computeRangeSelectivity(
     exprRange = 1.0;
   }
 
-  float selectivity = static_cast<float>(intersectionRange / exprRange);
-  return std::clamp(selectivity, 0.0f, 1.0f);
+  return std::clamp<float>(intersectionRange / exprRange, 0.0f, 1.0f);
 }
 
 template <velox::TypeKind KIND>
@@ -743,10 +741,10 @@ float rangeSelectivityImpl(
     }
 
     return computeRangeSelectivity(
-        static_cast<double>(exprMin),
-        static_cast<double>(exprMax),
-        static_cast<double>(effectiveLower),
-        static_cast<double>(effectiveUpper),
+        exprMin,
+        exprMax,
+        effectiveLower,
+        effectiveUpper,
         /*discrete=*/!std::is_floating_point_v<T>);
   }
 }
@@ -767,7 +765,7 @@ float rangeSelectivityImpl<velox::TypeKind::VARCHAR>(
     if (str.empty()) {
       return 0;
     }
-    return static_cast<int32_t>(static_cast<unsigned char>(str[0]));
+    return static_cast<unsigned char>(str[0]);
   };
 
   int32_t exprMin = getFirstCharValue(exprValue.min);
@@ -784,11 +782,7 @@ float rangeSelectivityImpl<velox::TypeKind::VARCHAR>(
   }
 
   return computeRangeSelectivity(
-      static_cast<double>(exprMin),
-      static_cast<double>(exprMax),
-      static_cast<double>(effectiveLower),
-      static_cast<double>(effectiveUpper),
-      /*discrete=*/true);
+      exprMin, exprMax, effectiveLower, effectiveUpper, /*discrete=*/true);
 }
 
 // Computes selectivity for comparisons using only cardinality (no range info).
@@ -812,8 +806,8 @@ std::optional<Selectivity> cardinalityBasedSelectivity(
         !rightValue.cardinality.has_value()) {
       return std::nullopt;
     }
-    double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
-    double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
+    double ac = std::max<double>(1.0, *leftValue.cardinality);
+    double bc = std::max<double>(1.0, *rightValue.cardinality);
     double minCard = std::min(ac, bc);
     double probTrue = minCard / (ac * bc);
 
@@ -877,8 +871,8 @@ std::optional<Selectivity> comparisonSelectivityImpl(
   double bl = rightValue.min->value<KIND>();
   double bh = rightValue.max->value<KIND>();
 
-  double ac = std::max(1.0, static_cast<double>(*leftValue.cardinality));
-  double bc = std::max(1.0, static_cast<double>(*rightValue.cardinality));
+  double ac = std::max<double>(1.0, *leftValue.cardinality);
+  double bc = std::max<double>(1.0, *rightValue.cardinality);
 
   // Calculate ranges (avoiding zero).
   double rangeA = rangeSize(al, ah);
@@ -1434,7 +1428,7 @@ std::optional<Selectivity> computeInListSelectivity(
     bool updateConstraints) {
   const auto& array = bounds.inList->array();
 
-  double inListSize = static_cast<double>(array.size());
+  double inListSize = array.size();
   double trueFraction =
       std::clamp(inListSize / *exprValue.cardinality, 0.0, 1.0) *
       (1.0 - nullFraction);

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -122,6 +122,10 @@ struct LambdaInfo {
 
 class Call;
 
+/// Per-row cost of a function call that has no specific cost. Used both when a
+/// call has no metadata and when its metadata leaves the cost at the default.
+constexpr float kDefaultCallCost = 5;
+
 /// Describes functions accepting lambdas and functions with special treatment
 /// of subfields.
 struct FunctionMetadata {
@@ -174,13 +178,8 @@ struct FunctionMetadata {
   /// Bits of FunctionSet for the function.
   FunctionSet functionSet;
 
-  /// Static fixed cost for processing one row. use 'costFunc' for non-constant
-  /// cost.
-  float cost{1};
-
-  /// Function for evaluating the per-row cost when the cost depends on
-  /// arguments and their stats.
-  std::function<float(const Call*)> costFunc;
+  /// Static fixed cost for processing one row.
+  float cost{kDefaultCallCost};
 
   /// Translates a set of paths into path, expression pairs if the complex type
   /// returning function is decomposable into per-path subexpressions. Suppose

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -183,7 +183,8 @@ Plan::Plan(RelationOpPtr op, const PlanState& state)
   state.optimization.planGroupedLeaves()[this] = state.currentGroupedLeaves();
 }
 
-bool Plan::isStateBetter(const PlanState& state, float margin) const {
+bool Plan::isStateBetter(const PlanState& state, std::optional<float> margin)
+    const {
   // Unknown costs are not comparable, so a plan with an unknown cost is never
   // declared better.
   return lessThan(add(state.cost.cost, margin), cost.cost);
@@ -436,11 +437,11 @@ std::string PlanState::printPlan(RelationOpPtr op, bool detail) const {
 
 PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
   int32_t replaceIndex = -1;
-  // Shuffle margin for cost comparisons. 0 when the cardinality is unknown: the
-  // comparisons (isStateBetter) don't rank unknown costs anyway, so the margin
-  // is moot.
-  const float shuffle =
-      shuffleCost(plan->columns()) * state.cost.cardinality.value_or(0);
+  // Shuffle margin for cost comparisons. Unknown when the cardinality is
+  // unknown, which makes the shuffle-adjusted comparisons unknown so they do
+  // not delete or reject a plan based on a shuffle priced at zero.
+  const std::optional<float> shuffle =
+      mul(state.cost.cardinality, shuffleCost(plan->columns()));
 
   if (!plans.empty()) {
     // Compare with existing. If there is one with same distribution and new is
@@ -479,8 +480,8 @@ PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
         continue;
       }
 
-      if (plan->distribution().orderKeys().empty() &&
-          !old->isStateBetter(state, -shuffle)) {
+      if (plan->distribution().orderKeys().empty() && shuffle.has_value() &&
+          !old->isStateBetter(state, -*shuffle)) {
         // New has no order and old would beat it even after adding shuffle.
         return nullptr;
       }
@@ -490,11 +491,11 @@ PlanP PlanSet::addPlan(RelationOpPtr plan, PlanState& state) {
   auto newPlan = std::make_unique<Plan>(std::move(plan), state);
   auto* result = newPlan.get();
 
-  // bestCostWithShuffle tracks the cheapest known-cost plan; an unknown-cost
-  // plan does not participate.
-  if (result->cost.cost.has_value()) {
+  // bestCostWithShuffle tracks the cheapest known-cost plan; a plan with an
+  // unknown cost or shuffle margin does not participate.
+  if (result->cost.cost.has_value() && shuffle.has_value()) {
     bestCostWithShuffle =
-        std::min(bestCostWithShuffle, *result->cost.cost + shuffle);
+        std::min(bestCostWithShuffle, *result->cost.cost + *shuffle);
   }
   if (replaceIndex >= 0) {
     plans[replaceIndex] = std::move(newPlan);
@@ -560,9 +561,11 @@ PlanP PlanSet::best(
   }
 
   if (match) {
-    const float shuffle =
-        shuffleCost(best->op->columns()) * best->cost.cardinality.value_or(0);
-    if (matchCost <= bestCost + shuffle) {
+    const std::optional<float> shuffle =
+        mul(best->cost.cardinality, shuffleCost(best->op->columns()));
+    // When the shuffle cost is unknown, prefer the copartitioned plan rather
+    // than reject it for a shuffle we cannot price.
+    if (!shuffle.has_value() || matchCost <= bestCost + *shuffle) {
       return match;
     }
   }
@@ -690,15 +693,15 @@ std::string JoinCandidate::toString() const {
 }
 
 bool NextJoin::isWorse(const NextJoin& other) const {
-  float shuffle = 0;
+  std::optional<float> shuffle = 0;
   if (!plan->distribution().isSamePartition(other.plan->distribution())) {
-    // The shuffle margin only refines a comparison of known costs; an unknown
-    // cardinality contributes 0.
-    shuffle =
-        other.cost.cardinality.value_or(0) * shuffleCost(other.plan->columns());
+    // An unknown cardinality makes the shuffle margin unknown, so the
+    // comparison below is unknown and neither variant is declared worse.
+    shuffle = mul(other.cost.cardinality, shuffleCost(other.plan->columns()));
   }
 
-  // Unknown costs are incomparable, so neither variant is declared worse.
+  // Unknown costs or an unknown shuffle margin are incomparable, so neither
+  // variant is declared worse.
   return lessThan(add(other.cost.cost, shuffle), cost.cost);
 }
 

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -38,9 +38,12 @@ using HashBuildVector = std::vector<HashBuildCP>;
 struct Plan {
   Plan(RelationOpPtr op, const PlanState& state);
 
-  /// True if 'state' has a lower cost than 'this'. If 'margin' is given,
-  /// then 'other' must win by margin.
-  bool isStateBetter(const PlanState& state, float margin = 0) const;
+  /// True if 'state' has a lower cost than 'this'. 'margin' is added to
+  /// 'state's cost before the comparison (e.g. a shuffle the alternative must
+  /// pay), so 'state' must win by 'margin'. An unknown 'margin' makes the
+  /// comparison unknown, so 'state' is not declared better.
+  bool isStateBetter(const PlanState& state, std::optional<float> margin = 0)
+      const;
 
   /// Root of the plan tree.
   const RelationOpPtr op;

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -337,6 +337,12 @@ struct FunctionNames {
   Name rowNumber{nullptr};
   Name rank{nullptr};
   Name denseRank{nullptr};
+
+  /// True if 'name' is a ranking window function (row_number, rank,
+  /// dense_rank).
+  bool isRanking(Name name) const {
+    return name == rowNumber || name == rank || name == denseRank;
+  }
 };
 
 /// Context for making a query plan. Owns all memory associated to


### PR DESCRIPTION
Summary: The cost comparisons that add a shuffle margin priced an unknown cardinality as a zero-cost shuffle (`cardinality.value_or(0)`), so a copartitioned plan could be deleted or rejected because the alternative's shuffle looked free. Compute the margin with `mul(cardinality, shuffleCost(...))` so an unknown cardinality yields an unknown margin; the shuffle-adjusted comparisons then stay unknown and neither delete a plan nor reject a copartitioned match. `Plan::isStateBetter` takes an optional margin to carry this through.

Differential Revision: D108880001


