### PR TITLE
fix(optimizer): Plan IN subquery with constant left side (#1494)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2766,6 +2766,24 @@ ValuesTable* ToGraph::makeValuesTable(
   return valuesTable;
 }
 
+ValuesTable* ToGraph::makeValuesTable(const Literal* literal) {
+  const auto* columnName = newCName("c");
+  const auto veloxType = toTypePtr(literal->value().type);
+
+  std::vector<velox::Variant> rows;
+  rows.emplace_back(velox::Variant::row({literal->literal()}));
+  ValuesTable::Data data =
+      &registerVariant(velox::Variant::array(std::move(rows)))->array();
+
+  auto* valuesTable = make<ValuesTable>(
+      toType(velox::ROW({std::string{columnName}}, {veloxType})), data);
+  valuesTable->cname = newCName("vt");
+  auto* column =
+      make<Column>(columnName, valuesTable, toValue(veloxType, 1), columnName);
+  valuesTable->columns.push_back(column);
+  return valuesTable;
+}
+
 void ToGraph::addProjection(const lp::ProjectNode& project) {
   const auto& input = *project.onlyInput();
 
@@ -3898,8 +3916,13 @@ void ToGraph::processInPredicates(
     SCOPE_EXIT {
       applyContext_.lifted = std::move(savedLifted);
     };
+    // Translate the subquery without adding it to 'currentDt_' yet. The IN
+    // lowers to a semi-join whose build side is this subquery and whose probe
+    // is the left side; Deferring the add lets us register the left side first
+    // to keep the right order for syntactic-join-order mode.
     auto subqueryDt = translateSubquery(
-        *predicate->inputAt(1)->as<lp::SubqueryExpr>()->subquery());
+        *predicate->inputAt(1)->as<lp::SubqueryExpr>()->subquery(),
+        /*finalize=*/false);
     if (applyContext_.lifted.aggregation != nullptr) {
       VELOX_NYI(
           "Outer-column reference in the aggregate body of an IN subquery is not supported yet");
@@ -3932,25 +3955,40 @@ void ToGraph::processInPredicates(
     const bool isCorrelated =
         !applyContext_.lifted.predicates.empty() || inRightHasOuter;
 
-    // Fold `<const> IN (SELECT <proj> WHERE <cond>)` over a no-FROM
-    // subquery into `<cond> AND <const> = <proj>`. A SEMI cannot
-    // represent this case: leftKey has no table to anchor its left side.
-    if (!isCorrelated && leftKey->allTables().empty() &&
-        subqueryDt->isProjectFilterOnly() && subqueryDt->exprs.size() == 1) {
-      ExprCP projection = subqueryDt->exprs.front();
-      ExprVector parts = std::move(subqueryDt->conjuncts);
-      parts.push_back(makeEquality(leftKey, projection));
-      ExprVector guards = std::move(applyContext_.lifted.outerGuards);
-      applyContext_.lifted.outerGuards.clear();
-      currentDt_->removeLastTable(subqueryDt);
-      ExprCP result =
-          wrapMarkInGuards(std::move(guards), makeAnd(std::move(parts)));
-      subqueries_.emplace(predicate, result);
-      if (!result->columns().empty()) {
-        chain.carryForwards.push_back(predicate);
+    // A table-less left side (e.g. a constant) has no table to anchor the IN
+    // semi-join on. Two sub-cases:
+    if (!isCorrelated && leftKey->allTables().empty()) {
+      // No-FROM subquery: fold `<expr> IN (SELECT <proj> WHERE <cond>)` into
+      // `<cond> AND <expr> = <proj>`. No need to add subqueryDt.
+      if (subqueryDt->isProjectFilterOnly() && subqueryDt->exprs.size() == 1) {
+        ExprCP projection = subqueryDt->exprs.front();
+        ExprVector parts = std::move(subqueryDt->conjuncts);
+        parts.push_back(makeEquality(leftKey, projection));
+        ExprVector guards = std::move(applyContext_.lifted.outerGuards);
+        applyContext_.lifted.outerGuards.clear();
+        ExprCP result =
+            wrapMarkInGuards(std::move(guards), makeAnd(std::move(parts)));
+        subqueries_.emplace(predicate, result);
+        if (!result->columns().empty()) {
+          chain.carryForwards.push_back(predicate);
+        }
+        continue;
       }
-      continue;
+
+      // Subquery over a real source: build a one-row probe holding the constant
+      // and add it before the build side. Syntactic enumeration places a table
+      // only after all its join-order predecessors, so the probe must precede
+      // 'subqueryDt'.
+      VELOX_USER_CHECK(
+          leftKey->is(PlanType::kLiteralExpr),
+          "Non-constant table-less left side of IN <subquery> is not supported yet: {}",
+          leftKey->toString());
+      auto* probe = makeValuesTable(leftKey->as<Literal>());
+      currentDt_->addTable(probe);
+      leftKey = probe->columns.front();
     }
+
+    currentDt_->addTable(subqueryDt);
 
     // Velox HashJoin cannot represent a multi-key null-aware join, so the
     // SEMI's left side must be a single table. If correlation reaches more

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -573,6 +573,10 @@ class ToGraph {
       const logical_plan::LogicalPlanNode& node,
       ValuesTable::Data data);
 
+  // Builds a one-row, single-column ValuesTable holding 'literal'. The caller
+  // adds it to the enclosing DerivedTable and picks up its column.
+  ValuesTable* makeValuesTable(const Literal* literal);
+
   void makeEmptyValuesTable(const logical_plan::LogicalPlanNode& node);
 
   // Adds 'node' and descendants to query graph wrapped inside a

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -19,7 +19,6 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
-#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -173,6 +173,26 @@ TEST_F(SubqueryTest, inListWithMixedSubqueries) {
   }
 }
 
+// IN with a constant (table-less) left side over a real source. With no table
+// to anchor the constant on, the optimizer materializes it as a one-row Values
+// relation and runs the IN as a null-aware semi-join against the source.
+TEST_F(SubqueryTest, uncorrelatedInConstantLeftSide) {
+  auto query = "SELECT 1 IN (SELECT r_regionkey FROM region)";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchHiveScan("region")
+          .hashJoin(
+              matchValues().nestedLoopJoin(matchValues().build()).build(),
+              velox::core::JoinType::kRightSemiProject,
+              {.nullAware = true})
+          .project()
+          .build();
+
+  auto plan = toSingleNodePlan(query);
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 TEST_F(SubqueryTest, foldable) {
   testConnector_->addTable("t", ROW({"a", "ds"}, {INTEGER(), VARCHAR()}));
   testConnector_->setDiscreteValues(

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -753,3 +753,13 @@ SELECT t.a NOT IN (SELECT max(u.a) FROM u WHERE u.a > t.a) FROM t
 -- eliminates every body row. Scalar aggregates always emit one
 -- row, so EXISTS sees it → TRUE for every outer.
 SELECT EXISTS (SELECT count(*) FROM u WHERE u.a = t.a + 100) FROM t
+----
+-- Uncorrelated IN with a constant (table-less) left side over a real source.
+-- The optimizer wraps the constant in a one-row probe to anchor the IN
+-- semi-join.
+SELECT 1 IN (SELECT a FROM u)
+----
+-- A non-constant, table-less IN left side (random()) has no plan-time value to
+-- embed as a one-row probe, so planning fails with a clear error.
+-- error: Non-constant table-less left side of IN <subquery> is not supported yet
+SELECT random() IN (SELECT a FROM u)


### PR DESCRIPTION
Summary:

Planning aborted for an uncorrelated `IN` whose left side is a constant when the subquery reads a real source that is also referenced elsewhere in the query. For example:

    SELECT 1 IN (SELECT k FROM <source>)

failed with:

    Failed to place a table

An `IN` lowers to a semi-join anchored on the table of its left value. A constant has no table, so the semi-join has no probe side. Join enumeration only reaches a table by walking out from an already-placed one, so the subquery's build side can never be placed. Wrap the constant in a one-row probe table carrying the value to give the semi-join a real anchor.

A table-less but non-constant left side, such as `random()`, now fails with a clear "not supported yet" error instead of aborting in the optimizer.

IN is the only construct whose semi-join is keyed on an arbitrary user value expression (<expr> IN (subquery)), so only uncorrelated IN subquery needs this fix.

Reviewed By: mbasmanova

Differential Revision: D108703452


