### PR TITLE
refactor(connectors): Optional `Table::numRows()` (#1495)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -698,8 +698,10 @@ class Table : public std::enable_shared_from_this<Table> {
 
   virtual const std::vector<const TableLayout*>& layouts() const = 0;
 
-  /// Returns an estimate of the number of rows in 'this'.
-  virtual uint64_t numRows() const = 0;
+  /// Returns an estimate of the number of rows in 'this'. `std::nullopt`
+  /// means the connector has no estimate; downstream cost-based
+  /// decisions fall back to safe defaults rather than a fabricated value.
+  virtual std::optional<uint64_t> numRows() const = 0;
 
   /// Returns the table properties specified at creation time (e.g. format,
   /// partitioned_by, bucket_count). Connectors must store all properties

--- a/axiom/connectors/file/core/FileTable.h
+++ b/axiom/connectors/file/core/FileTable.h
@@ -175,8 +175,8 @@ class FileTable : public Table {
     return layouts_;
   }
 
-  uint64_t numRows() const override {
-    return 0;
+  std::optional<uint64_t> numRows() const override {
+    return std::nullopt;
   }
 
  private:

--- a/axiom/connectors/file/core/tests/FileTableTest.cpp
+++ b/axiom/connectors/file/core/tests/FileTableTest.cpp
@@ -78,10 +78,10 @@ class FileTableTest : public ::testing::Test, public test::VectorTestBase {
   std::string parquetPath_;
 };
 
-TEST_F(FileTableTest, numRowsReturnsZero) {
+TEST_F(FileTableTest, numRowsReturnsNullopt) {
   FileConnectorMetadata metadata(connector_.get());
   auto table = metadata.findTable({"parquet", parquetPath_});
-  EXPECT_EQ(table->numRows(), 0);
+  EXPECT_EQ(table->numRows(), std::nullopt);
 }
 
 TEST_F(FileTableTest, hasOneLayout) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -542,7 +542,11 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
       dynamic_cast<const LocalHiveConnectorMetadata*>(metadataPtr.get())
           ->connectorQueryCtx();
 
-  const auto maxRowsToScan = table().numRows() * (pct / 100);
+  // Treat unknown row count as "no cap" (scan all selected files).
+  const auto numRows = table().numRows();
+  const std::optional<int64_t> maxRowsToScan = numRows.has_value()
+      ? std::optional<int64_t>{static_cast<int64_t>(*numRows * (pct / 100))}
+      : std::nullopt;
 
   // Filter files based on $path and $bucket filters from tableHandle.
   auto* hiveTableHandle =
@@ -577,7 +581,8 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
         StatisticsBuilder::updateBuilders(data, builders);
       }
 
-      if (scannedRows + dataSource->getCompletedRows() > maxRowsToScan) {
+      if (maxRowsToScan.has_value() &&
+          scannedRows + dataSource->getCompletedRows() > *maxRowsToScan) {
         scannedRows += dataSource->getCompletedRows();
         break;
       }

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -205,7 +205,7 @@ class LocalTable : public HiveTable {
       std::vector<std::unique_ptr<const FileInfo>> files,
       LocalHiveConnectorMetadata& metadata);
 
-  uint64_t numRows() const override {
+  std::optional<uint64_t> numRows() const override {
     return numRows_;
   }
 

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -84,8 +84,8 @@ class SystemTable : public Table {
     return layouts_;
   }
 
-  uint64_t numRows() const override {
-    return 0; // Dynamic, unknown.
+  std::optional<uint64_t> numRows() const override {
+    return std::nullopt;
   }
 
  private:

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -188,7 +188,7 @@ class TestTable : public Table {
     return layouts_;
   }
 
-  uint64_t numRows() const override {
+  std::optional<uint64_t> numRows() const override {
     return data_.empty() ? numRows_ : dataRows_;
   }
 

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -145,7 +145,7 @@ class TpchTable : public Table {
 
   void makeDefaultLayout(TpchConnectorMetadata& metadata);
 
-  uint64_t numRows() const override {
+  std::optional<uint64_t> numRows() const override {
     return numRows_;
   }
 

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -223,8 +223,13 @@ std::pair<float, float> sampleJoin(
     const ExprVector& leftKeys,
     SchemaTableCP right,
     const ExprVector& rightKeys) {
+  // Skip sampling when row counts are unknown: the cost cannot be estimated
+  // and the sampler would otherwise scan a potentially unbounded input.
   const auto leftRows = left->cardinality;
   const auto rightRows = right->cardinality;
+  if (!leftRows.has_value() || !rightRows.has_value()) {
+    return std::make_pair(0, 0);
+  }
 
   const auto leftCard = keyCardinality(leftKeys);
   const auto rightCard = keyCardinality(rightKeys);
@@ -232,13 +237,13 @@ std::pair<float, float> sampleJoin(
   static const auto kMaxCardinality = 10'000;
 
   int32_t fraction = kMaxCardinality;
-  if (leftRows < kMaxCardinality && rightRows < kMaxCardinality) {
+  if (*leftRows < kMaxCardinality && *rightRows < kMaxCardinality) {
     // Sample all.
   } else if (
       leftCard.has_value() && rightCard.has_value() &&
       *leftCard > kMaxCardinality && *rightCard > kMaxCardinality) {
     // Keys have many values, sample a fraction.
-    const auto smaller = static_cast<float>(std::min(leftRows, rightRows));
+    const auto smaller = static_cast<float>(std::min(*leftRows, *rightRows));
     const float ratio = smaller / (float)kMaxCardinality;
     fraction =
         static_cast<int32_t>(std::max(2.F, (float)kMaxCardinality / ratio));

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -853,10 +853,11 @@ std::optional<float> baseSelectivity(PlanObjectCP object) {
       return std::nullopt;
     }
     // filteredCardinality can exceed baseCardinality when the connector
-    // returns inconsistent statistics, e.g. Table::numRows() returns 0
-    // while co_estimateStats returns the real partition row count.
-    if (baseCardinality > *filteredCardinality) {
-      return *filteredCardinality / baseCardinality;
+    // returns inconsistent statistics, e.g. a known `Table::numRows()`
+    // disagreeing with the partition row count from `co_estimateStats`.
+    if (baseCardinality.has_value() &&
+        *baseCardinality > *filteredCardinality) {
+      return *filteredCardinality / *baseCardinality;
     }
   }
   return 1;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -164,10 +164,11 @@ TableScan::TableScan(
 
   if (!keys.empty()) {
     const auto orderSelectivityOpt = orderPrefixDistance(input_, index, keys);
-    // The lookup unit cost is unknown if the input cardinality (batch size) or
-    // the order selectivity could not be estimated.
-    if (cost_.inputCardinality.has_value() && orderSelectivityOpt.has_value()) {
-      float lookupRange(index->table->cardinality);
+    // The lookup unit cost is unknown if the input cardinality (batch size),
+    // the order selectivity, or the table cardinality could not be estimated.
+    if (cost_.inputCardinality.has_value() && orderSelectivityOpt.has_value() &&
+        index->table->cardinality.has_value()) {
+      float lookupRange(*index->table->cardinality);
       float orderSelectivity = *orderSelectivityOpt;
       auto distance = lookupRange / std::max<float>(1, orderSelectivity);
       float batchSize = std::min<float>(*cost_.inputCardinality, 10000);

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -148,7 +148,21 @@ const velox::Variant* registerOptionalVariant(
   }
   return registerVariant(opt.value());
 }
+// Clamps a known row count to >= 1 so cost math never divides by zero;
+// propagates `nullopt` unchanged.
+std::optional<float> connectorCardinality(
+    const connector::Table& connectorTable) {
+  const auto numRows = connectorTable.numRows();
+  if (!numRows.has_value()) {
+    return std::nullopt;
+  }
+  return std::max<float>(1, static_cast<float>(*numRows));
+}
 } // namespace
+
+SchemaTable::SchemaTable(const connector::Table& connectorTable)
+    : connectorTable{&connectorTable},
+      cardinality{connectorCardinality(connectorTable)} {}
 
 SchemaTableCP Schema::findTable(
     std::string_view connectorId,
@@ -278,14 +292,18 @@ bool SchemaTable::isUnique(CPSpan<Column> columns) const {
 
 namespace {
 
-float combine(float card, size_t ith, float otherCard) {
-  if (ith == 0) {
-    return card / otherCard;
+std::optional<float>
+combine(std::optional<float> card, size_t ith, float otherCard) {
+  if (!card.has_value()) {
+    return std::nullopt;
   }
-  if (otherCard > card) {
+  if (ith == 0) {
+    return *card / otherCard;
+  }
+  if (otherCard > *card) {
     return 1;
   }
-  return card / otherCard;
+  return *card / otherCard;
 }
 } // namespace
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -366,9 +366,10 @@ struct IndexInfo {
   /// is no key order in 'index'.
   bool unique{false};
 
-  /// The number of rows selected after index lookup based on 'lookupKeys'. For
-  /// empty 'lookupKeys', this is the cardinality of 'index'.
-  float scanCardinality;
+  /// The number of rows selected after index lookup based on 'lookupKeys'.
+  /// For empty 'lookupKeys', this is the cardinality of 'index'. `nullopt`
+  /// when the underlying table reports no row-count estimate.
+  std::optional<float> scanCardinality;
 
   /// The lookup columns that match 'index'. These match 1:1 the leading keys
   /// of 'index'. If 'index' has no ordering columns or if the lookup columns
@@ -389,9 +390,7 @@ struct IndexInfo {
 /// partitioned physical representations (ColumnGroups). Not all ColumnGroups
 /// (aka indices) need to contain all columns.
 struct SchemaTable {
-  explicit SchemaTable(const connector::Table& connectorTable)
-      : connectorTable{&connectorTable},
-        cardinality{std::max<float>(1, connectorTable.numRows())} {}
+  explicit SchemaTable(const connector::Table& connectorTable);
 
   ColumnGroupCP addIndex(
       const connector::TableLayout& layout,
@@ -420,7 +419,7 @@ struct SchemaTable {
   /// This is the source-dependent representation from which 'this' was created.
   const connector::Table* const connectorTable;
 
-  const float cardinality;
+  const std::optional<float> cardinality;
 
   /// Maps column name to schema column.
   NameMap<ColumnCP> columns;

--- a/axiom/optimizer/VeloxHistory.cpp
+++ b/axiom/optimizer/VeloxHistory.cpp
@@ -148,7 +148,8 @@ void VeloxHistory::estimateLeafSelectivity(
 
   // Return cached sampled selectivity if available to avoid expensive I/O.
   if (auto cached = findSampledLeafSelectivity(string)) {
-    table.filteredCardinality = table.schemaTable->cardinality * cached.value();
+    table.filteredCardinality =
+        mul(table.schemaTable->cardinality, cached.value());
     return;
   }
 
@@ -171,7 +172,7 @@ void VeloxHistory::estimateLeafSelectivity(
     selectivity = std::max<float>(Selectivity::kLikelyTrue, sample.numMatched) /
         static_cast<float>(sample.numSampled);
   }
-  table.filteredCardinality = table.schemaTable->cardinality * selectivity;
+  table.filteredCardinality = mul(table.schemaTable->cardinality, selectivity);
   recordSampledLeafSelectivity(string, selectivity, false);
 
   bool trace = (options.traceFlags & OptimizerOptions::kSample) != 0;

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -192,6 +192,22 @@ TEST_F(CardinalityEstimationTest, scan) {
   });
 }
 
+TEST_F(CardinalityEstimationTest, scanWithUnknownCardinality) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  verifyPlan("SELECT a, b FROM t WHERE a > 10", [](const Plan& plan) {
+    const auto& op = *plan.op;
+
+    ASSERT_EQ(op.columns().size(), 2);
+    EXPECT_FALSE(op.resultCardinality().has_value());
+
+    auto a = findConstraint(op, 0);
+    ASSERT_TRUE(a.has_value());
+    EXPECT_FALSE(a->cardinality.has_value());
+    AXIOM_ASSERT_NORANGE(*a);
+  });
+}
+
 // Verifies that a range filter tightens constraints: the filtered column
 // should have reduced cardinality.
 TEST_F(CardinalityEstimationTest, scanWithFilter) {

--- a/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
+++ b/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
@@ -106,6 +106,71 @@ TEST_F(UnknownStatsJoinTest, twoJoins) {
   AXIOM_ASSERT_PLAN(plan(query), matchPlan("u", "t"));
   AXIOM_ASSERT_PLAN(plan(altQuery), matchPlan("t", "u"));
 }
+// A base table with no statistics at all must fall back to syntactic join
+// order, not crash on the unknown cardinality.
+TEST_F(UnknownStatsJoinTest, joinWithUnknownTableCardinality) {
+  testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+      ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()));
+
+  auto matchJoin = [&](const std::string& probe, const std::string& build) {
+    return matchScan(probe)
+        .hashJoinInner(matchScan(build).build())
+        .aggregation()
+        .build();
+  };
+
+  const auto query = "SELECT count(*) FROM u JOIN t ON t.k = u.k";
+  const auto altQuery = "SELECT count(*) FROM t JOIN u ON t.k = u.k";
+
+  AXIOM_ASSERT_PLAN(plan(query), matchJoin("u", "t"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+}
+
+// The join sampler must tolerate an unknown build-side cardinality.
+TEST_F(UnknownStatsJoinTest, sampledJoinWithUnknownCardinality) {
+  optimizerOptions_.sampleJoins = true;
+
+  testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+      ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()));
+
+  auto matchJoin = [&](const std::string& probe, const std::string& build) {
+    return matchScan(probe)
+        .hashJoinInner(matchScan(build).build())
+        .aggregation()
+        .build();
+  };
+
+  AXIOM_ASSERT_PLAN(
+      plan("SELECT count(*) FROM u JOIN t ON t.k = u.k"), matchJoin("u", "t"));
+}
+
+// Enabling sampleJoins must not change the chosen plan when a side has
+// unknown cardinality.
+TEST_F(UnknownStatsJoinTest, sampledJoinMatchesUnsampledOnUnknownCardinality) {
+  testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+      ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+  testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()));
+
+  auto matchJoin = [&](const std::string& probe, const std::string& build) {
+    return matchScan(probe)
+        .hashJoinInner(matchScan(build).build())
+        .aggregation()
+        .build();
+  };
+
+  const auto query = "SELECT count(*) FROM u JOIN t ON t.k = u.k";
+  const auto altQuery = "SELECT count(*) FROM t JOIN u ON t.k = u.k";
+
+  AXIOM_ASSERT_PLAN(plan(query), matchJoin("u", "t"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+
+  optimizerOptions_.sampleJoins = true;
+
+  AXIOM_ASSERT_PLAN(plan(query), matchJoin("u", "t"));
+  AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+}
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1995,7 +1995,11 @@ SqlStatementPtr parseShowStats(
   const auto table = findTable(*showStats.table(), connectorId, connectorTable);
   const auto schema = table->type();
 
-  ShowStatsBuilder builder(static_cast<int64_t>(table->numRows()));
+  const auto tableNumRows = table->numRows();
+  ShowStatsBuilder builder(
+      tableNumRows.has_value()
+          ? std::optional<int64_t>{static_cast<int64_t>(*tableNumRows)}
+          : std::nullopt);
   for (auto i = 0; i < schema->size(); ++i) {
     const auto* column = table->columnMap().at(schema->nameOf(i));
     const auto* stats = column->stats();


### PR DESCRIPTION
Summary:

Changes `connector::Table::numRows()` interface to return `std::optional<uint64_t>` rather that sentinal values. Missing row counts propagate as unknown. Aligns with the post-D108698329 stats contract where missing column stats already propagate as `std::nullopt`.

`SchemaTable::cardinality` and `IndexInfo::scanCardinality` become `std::optional<float>` to carry the unknown forward. Downstream `BaseTable::filteredCardinality` is already optional and absorbs the change. `VeloxHistory` selectivity multiplication routes through the existing `EstimateMath::mul` helper.

`JoinSample::sampleJoin` returns `(0, 0)` when either side's row count is unknown, bypassing the sample runners entirely. Without this early return a `sampleJoins=true` query against a now-nullopt connector could try to sample an unbounded streaming source.

Reviewed By: mbasmanova

Differential Revision: D108942038


