### PR TITLE
fix(optimizer): Propagate non-deterministic flag through Field and Lambda (#1496)

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -215,7 +215,8 @@ class Field : public Expr {
       : Expr(PlanType::kFieldExpr, Value(type, 1)),
         field_(field),
         index_(0),
-        base_(base) {
+        base_(base),
+        functions_(base->functions()) {
     columns_ = base->columns();
     subexpressions_ = base->subexpressions();
   }
@@ -224,7 +225,8 @@ class Field : public Expr {
       : Expr(PlanType::kFieldExpr, Value(type, 1)),
         field_(nullptr),
         index_(index),
-        base_(base) {
+        base_(base),
+        functions_(base->functions()) {
     columns_ = base->columns();
     subexpressions_ = base->subexpressions();
   }
@@ -243,10 +245,19 @@ class Field : public Expr {
     return base_;
   }
 
+  bool containsFunction(uint64_t set) const override {
+    return functions_.contains(set);
+  }
+
+  const FunctionSet& functions() const override {
+    return functions_;
+  }
+
  private:
   Name field_;
   int32_t index_;
   ExprCP base_;
+  const FunctionSet functions_;
 };
 
 struct SubfieldSet {
@@ -437,7 +448,8 @@ class Lambda : public Expr {
   Lambda(ColumnVector args, const velox::Type* type, ExprCP body)
       : Expr(PlanType::kLambdaExpr, Value(type, 1)),
         args_(std::move(args)),
-        body_(body) {
+        body_(body),
+        functions_(body->functions()) {
     auto columns = body_->columns();
     for (auto arg : args_) {
       columns.erase(arg);
@@ -454,9 +466,18 @@ class Lambda : public Expr {
     return body_;
   }
 
+  bool containsFunction(uint64_t set) const override {
+    return functions_.contains(set);
+  }
+
+  const FunctionSet& functions() const override {
+    return functions_;
+  }
+
  private:
   ColumnVector args_;
   ExprCP body_;
+  const FunctionSet functions_;
 };
 
 /// Represens a set of transitively equal columns.

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ add_executable(
   HiveQueriesTest.cpp
   JoinTest.cpp
   MultiFragmentPlanTest.cpp
+  NonDeterministicFlagTest.cpp
   TpchDataGenerator.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp

--- a/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
+++ b/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+
+// Verifies that Field and Lambda propagate the non-deterministic flag from
+// their sub-expressions. A Field over a struct that hides rand(), or a Lambda
+// whose body draws rand(), must still report non-determinism.
+class NonDeterministicFlagTest : public test::QueryTestBase {
+ protected:
+  void configureTestConnector() override {
+    testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  }
+
+  // Returns whether the single projected expression is deterministic.
+  // Wraps `expr` in SELECT <expr> AS p FROM t and inspects the query graph
+  // directly (before ToVelox) because the flag is not observable in the
+  // rendered Velox plan.
+  bool isDeterministic(std::string_view expr) {
+    auto sql = "SELECT " + std::string(expr) + " AS p FROM t";
+    bool result = true;
+    auto plan = parseSelect(sql, kTestConnectorId);
+    verifyOptimization(*plan, [&](Optimization& opt) {
+      const auto& dt = *opt.rootDt();
+      ASSERT_EQ(dt.exprs.size(), 1);
+      result = !dt.exprs[0]->containsNonDeterministic();
+    });
+    return result;
+  }
+};
+
+TEST_F(NonDeterministicFlagTest, fieldWithoutSubfieldPruning) {
+  // With a cast, subfield decomposition is blocked, so the Field over the
+  // whole struct is conservatively tainted by the rand() in field1 — even
+  // when reading the deterministic field0.
+  EXPECT_FALSE(
+      isDeterministic("cast(row(a, rand()) AS row(x bigint, y double)).x + 1"));
+
+  // With a cast, reading the rand()-bearing field1 is non-deterministic as
+  // the whole struct is non-deterministic.
+  EXPECT_FALSE(
+      isDeterministic("cast(row(a, rand()) AS row(x bigint, y double)).y"));
+}
+
+TEST_F(NonDeterministicFlagTest, fieldWithSubfieldPruning) {
+  // Without a cast, row_constructor subfield decomposition drops the
+  // unaccessed rand() in field1, so reading field0 is deterministic.
+  EXPECT_TRUE(isDeterministic("row(a, rand()).field0 + 1"));
+
+  // Without a cast, reading the rand()-bearing field1 is non-deterministic.
+  EXPECT_FALSE(isDeterministic("row(a, rand()).field1"));
+}
+
+TEST_F(NonDeterministicFlagTest, lambda) {
+  // A Lambda whose body draws rand() propagates non-determinism through the
+  // enclosing higher-order call.
+  EXPECT_FALSE(isDeterministic(
+      "transform(array[a], e -> e + cast(rand() * 10 AS bigint))"));
+
+  // Deterministic lambda body reports determinism.
+  EXPECT_TRUE(isDeterministic("transform(array[a], e -> e + b)"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:

`Expr::containsNonDeterministic()` delegates to the virtual `containsFunction()`, which was only overridden on `Call`. `Field` and `Lambda` inherited the base `Expr` implementation that unconditionally returns `false`, so non-determinism hidden behind a struct field getter or a lambda body was invisible to the flag.

This caused all callers of `containsNonDeterministic()` to silently miss non-determinism in these cases. The affected callers are conservative guards that skip optimizations (filter pushdown, implied predicates, OR-flattening, call deduplication) when non-determinism is present — under-reporting meant those optimizations were incorrectly applied.

Fix `Field` and `Lambda` to store and propagate `FunctionSet` from their sub-expression (`base_` and `body_` respectively), and override `containsFunction()` and `functions()`. This makes the flag propagation chain complete: `Call` propagates from its args, `Field` from its base, `Lambda` from its body.

Reviewed By: mbasmanova

Differential Revision: D108976071


