### PR TITLE
fix(optimizer): Reject reused non-deterministic sources (#1497)

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -215,7 +215,8 @@ class Field : public Expr {
       : Expr(PlanType::kFieldExpr, Value(type, 1)),
         field_(field),
         index_(0),
-        base_(base) {
+        base_(base),
+        functions_(base->functions()) {
     columns_ = base->columns();
     subexpressions_ = base->subexpressions();
   }
@@ -224,7 +225,8 @@ class Field : public Expr {
       : Expr(PlanType::kFieldExpr, Value(type, 1)),
         field_(nullptr),
         index_(index),
-        base_(base) {
+        base_(base),
+        functions_(base->functions()) {
     columns_ = base->columns();
     subexpressions_ = base->subexpressions();
   }
@@ -243,10 +245,19 @@ class Field : public Expr {
     return base_;
   }
 
+  bool containsFunction(uint64_t set) const override {
+    return functions_.contains(set);
+  }
+
+  const FunctionSet& functions() const override {
+    return functions_;
+  }
+
  private:
   Name field_;
   int32_t index_;
   ExprCP base_;
+  const FunctionSet functions_;
 };
 
 struct SubfieldSet {
@@ -437,7 +448,8 @@ class Lambda : public Expr {
   Lambda(ColumnVector args, const velox::Type* type, ExprCP body)
       : Expr(PlanType::kLambdaExpr, Value(type, 1)),
         args_(std::move(args)),
-        body_(body) {
+        body_(body),
+        functions_(body->functions()) {
     auto columns = body_->columns();
     for (auto arg : args_) {
       columns.erase(arg);
@@ -454,9 +466,18 @@ class Lambda : public Expr {
     return body_;
   }
 
+  bool containsFunction(uint64_t set) const override {
+    return functions_.contains(set);
+  }
+
+  const FunctionSet& functions() const override {
+    return functions_;
+  }
+
  private:
   ColumnVector args_;
   ExprCP body_;
+  const FunctionSet functions_;
 };
 
 /// Represens a set of transitively equal columns.

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1600,12 +1600,27 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
   return callExpr;
 }
 
+void ToGraph::rejectIfReusedNonDeterministic(std::string_view name, ExprCP expr)
+    const {
+  if (expr == nullptr || !expr->containsNonDeterministic()) {
+    return;
+  }
+  if (!nonDeterministicResolutions_.insert(NameExprKey{toName(name), expr})
+           .second) {
+    VELOX_USER_FAIL(
+        "Non-deterministic expression reused across multiple references is not "
+        "supported yet: {}",
+        name);
+  }
+}
+
 ExprCP ToGraph::translateColumn(std::string_view name) const {
   if (auto it = lambdaSignature_.find(name); it != lambdaSignature_.end()) {
     return it->second;
   }
 
   if (auto it = renames_.find(name); it != renames_.end()) {
+    rejectIfReusedNonDeterministic(name, it->second);
     return it->second;
   }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -405,6 +405,14 @@ class ToGraph {
   // expression.
   ExprCP translateColumn(std::string_view name) const;
 
+  // Fails the query if 'name' resolves to a non-deterministic inline binding
+  // 'expr' that has already been resolved under the same binding. That is a
+  // single non-deterministic source inlined at more than one reference site,
+  // which would draw the value independently per reference instead of once.
+  // Keyed on (name, expr) so distinct textual draws (different expr) and
+  // rename chains (different name) are not flagged.
+  void rejectIfReusedNonDeterministic(std::string_view name, ExprCP expr) const;
+
   //  Applies translateExpr to a 'source'.
   ExprVector translateExprs(const std::vector<logical_plan::ExprPtr>& source);
 
@@ -956,6 +964,32 @@ class ToGraph {
   // Values may be null when a subfield path is not materialized (see
   // intersectWithSkyline in makeGettersOverSkyline).
   folly::F14FastMap<std::string, ExprCP> renames_;
+
+  // Identifies one resolution of a column name to a specific resolved Expr.
+  // Seeing the same (name, expr) twice means a single non-deterministic source
+  // is inlined at more than one reference site. The name is part of the key
+  // because a rename chain (SELECT y AS z FROM (SELECT x AS y FROM ...))
+  // resolves the same Expr pointer under a different name at each level — that
+  // is propagation, not reuse. Genuine reuse (SELECT u AS a, u AS b) resolves
+  // the same pointer under the same name twice.
+  struct NameExprKey {
+    Name name;
+    ExprCP expr;
+    bool operator==(const NameExprKey& other) const = default;
+  };
+
+  struct NameExprKeyHasher {
+    size_t operator()(const NameExprKey& key) const {
+      return velox::bits::hashMix(
+          folly::hasher<Name>()(key.name), folly::hasher<ExprCP>()(key.expr));
+    }
+  };
+
+  // The (name, binding) pairs resolved via 'renames_' to a non-deterministic
+  // inline binding. A repeat of the same pair means one non-deterministic
+  // source is inlined at multiple reference sites.
+  mutable folly::F14FastSet<NameExprKey, NameExprKeyHasher>
+      nonDeterministicResolutions_;
 
   // Symbols from the 'outer' query. Used when processing correlated subqueries.
   const folly::F14FastMap<std::string, ExprCP>* correlations_{nullptr};

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ add_executable(
   HiveQueriesTest.cpp
   JoinTest.cpp
   MultiFragmentPlanTest.cpp
+  NonDeterministicFlagTest.cpp
   TpchDataGenerator.cpp
   PrecomputeProjectionTest.cpp
   PlanTest.cpp

--- a/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
+++ b/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+
+// Verifies that Field and Lambda propagate the non-deterministic flag from
+// their sub-expressions. A Field over a struct that hides rand(), or a Lambda
+// whose body draws rand(), must still report non-determinism.
+class NonDeterministicFlagTest : public test::QueryTestBase {
+ protected:
+  void configureTestConnector() override {
+    testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  }
+
+  // Returns whether the single projected expression is deterministic.
+  // Wraps `expr` in SELECT <expr> AS p FROM t and inspects the query graph
+  // directly (before ToVelox) because the flag is not observable in the
+  // rendered Velox plan.
+  bool isDeterministic(std::string_view expr) {
+    auto sql = "SELECT " + std::string(expr) + " AS p FROM t";
+    bool result = true;
+    auto plan = parseSelect(sql, kTestConnectorId);
+    verifyOptimization(*plan, [&](Optimization& opt) {
+      const auto& dt = *opt.rootDt();
+      ASSERT_EQ(dt.exprs.size(), 1);
+      result = !dt.exprs[0]->containsNonDeterministic();
+    });
+    return result;
+  }
+};
+
+TEST_F(NonDeterministicFlagTest, fieldWithoutSubfieldPruning) {
+  // With a cast, subfield decomposition is blocked, so the Field over the
+  // whole struct is conservatively tainted by the rand() in field1 — even
+  // when reading the deterministic field0.
+  EXPECT_FALSE(
+      isDeterministic("cast(row(a, rand()) AS row(x bigint, y double)).x + 1"));
+
+  // With a cast, reading the rand()-bearing field1 is non-deterministic as
+  // the whole struct is non-deterministic.
+  EXPECT_FALSE(
+      isDeterministic("cast(row(a, rand()) AS row(x bigint, y double)).y"));
+}
+
+TEST_F(NonDeterministicFlagTest, fieldWithSubfieldPruning) {
+  // Without a cast, row_constructor subfield decomposition drops the
+  // unaccessed rand() in field1, so reading field0 is deterministic.
+  EXPECT_TRUE(isDeterministic("row(a, rand()).field0 + 1"));
+
+  // Without a cast, reading the rand()-bearing field1 is non-deterministic.
+  EXPECT_FALSE(isDeterministic("row(a, rand()).field1"));
+}
+
+TEST_F(NonDeterministicFlagTest, lambda) {
+  // A Lambda whose body draws rand() propagates non-determinism through the
+  // enclosing higher-order call.
+  EXPECT_FALSE(isDeterministic(
+      "transform(array[a], e -> e + cast(rand() * 10 AS bigint))"));
+
+  // Deterministic lambda body reports determinism.
+  EXPECT_TRUE(isDeterministic("transform(array[a], e -> e + b)"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -281,6 +281,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"unionAll">();
   registerQueryFile<"unionAllFlatten">();
   registerQueryFile<"groupingsets">();
+  registerQueryFile<"nondeterministic">();
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -280,7 +280,7 @@ class SubfieldTest : public HiveQueriesTestBase,
             .project({"r as r1"})
             .project({"r1 as r2"})
             .project(
-                {"make_named_row('f1b', r2.f1 + 1::REAL, 'f2b', r2.f2 + 2::REAL + cast(rand() as real)) as named"})
+                {"make_named_row('f1b', r2.f1 + 1::REAL, 'f2b', r2.f2 + 2::REAL) as named"})
             .project({"named as named1"})
             .project(
                 {"make_named_row('f1b', named1.f1b, 'f2b', named1.f2b + 3::REAL) as named3"})

--- a/axiom/optimizer/tests/sql/nondeterministic.sql
+++ b/axiom/optimizer/tests/sql/nondeterministic.sql
@@ -1,0 +1,81 @@
+-- setup_file: common_setup.sql
+
+-- Reject: both references resolve to one shared inline expression that would be
+-- re-drawn.
+-- error: Non-deterministic expression reused
+SELECT u AS x, u AS y
+FROM (SELECT cast(uuid() AS varchar) AS u FROM t)
+----
+-- Reject: a reused complex-typed non-deterministic source read through
+-- subfields.
+-- error: Non-deterministic expression reused
+SELECT s[1] AS x, s[1] AS y
+FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+----
+-- Reject: a non-deterministic source read by both a filter and a projection is
+-- reused.
+-- error: Non-deterministic expression reused
+SELECT r FROM (SELECT rand() AS r FROM t) WHERE r > 0.5
+----
+-- Reject: a reused complex source read once as a whole value and once via a
+-- subfield.
+-- error: Non-deterministic expression reused
+SELECT s AS x, s[1] AS y
+FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+----
+-- Reject: a reused lambda result.
+-- error: Non-deterministic expression reused
+SELECT v AS x, v AS y
+FROM (SELECT transform(sequence(1, 3), e -> e + cast(rand() * 1000000 AS bigint)) AS v FROM t)
+----
+-- Reject: reuse of a name bound to a struct field read out of a
+-- non-deterministic source.
+-- error: Non-deterministic expression reused
+SELECT s AS x, s AS y
+FROM (SELECT shuffle(array[cast(row(a, a) AS row(f1 bigint, f2 bigint))])[1].f1 AS s FROM t)
+----
+-- Reject: nested non-deterministic subscript over a non-deterministic call.
+-- error: Non-deterministic expression reused
+SELECT s[1] AS x, s[1] AS y
+FROM (SELECT shuffle(array[sequence(1, 5)])[1] AS s FROM t)
+----
+-- Known conservative over-rejection: reading more than one subfield of a struct
+-- that carries a non-deterministic field.
+-- error: Non-deterministic expression reused
+SELECT n.x AS p, n.y AS q
+FROM (SELECT cast(row(a, rand()) AS row(x bigint, y double)) AS n FROM t)
+----
+-- Known conservative over-rejection: a single use of an aliased
+-- non-deterministic subscript index.
+-- error: Non-deterministic expression reused
+SELECT s[i] AS u
+FROM (SELECT array[10, 20, 30, 40, 50] AS s, cast(rand() * 3 AS integer) + 1 AS i FROM t)
+----
+-- Accept: two independent non-deterministic draws.
+-- count 15
+SELECT uuid() AS x, uuid() AS y FROM t
+----
+-- Accept: a non-deterministic source used only once in a filter.
+-- count 15
+SELECT a FROM t WHERE rand() < 2.0
+----
+-- Accept: a non-deterministic source referenced once without rename.
+-- count 15
+SELECT r FROM (SELECT rand() AS r FROM t)
+----
+-- Accept: a non-deterministic source referenced once, through a single rename.
+-- count 15
+SELECT r AS x FROM (SELECT rand() AS r FROM t)
+----
+-- Accept: a non-deterministic source renamed across nested projections but used
+-- once.
+-- count 15
+SELECT y AS z FROM (SELECT x AS y FROM (SELECT rand() AS x FROM t))
+----
+-- Accept: a complex source read by a single subfield.
+-- count 15
+SELECT s[1] AS x FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+----
+-- Accept: a deterministic complex value reused via subfield.
+-- count 15
+SELECT s[1] AS x, s[1] AS y FROM (SELECT sequence(1, 5) AS s FROM t)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/120


A non-deterministic value defined once and referenced more than once was inlined and re-evaluated at each reference, so the references diverged instead of sharing one draw. For example:

    SELECT u AS a, u AS b FROM (SELECT uuid() AS u FROM t)

returned different values for `a` and `b`, though the query names `u` once.

This PR is a mitigation, to be removed once a proper fix is in place: at column-name resolution, fail the query when one non-deterministic binding is resolved at more than one reference site. Reuse is keyed on the `(name, binding)` pair so that two textual draws and rename chains are not flagged. A single draw can be resolved many times yet still represent one logical use, e.g., a rename chain (`SELECT y AS z FROM (SELECT x AS y FROM (SELECT rand() AS x))`) resolves the same `Expr` pointer at every level but under a different name each time (`x`, `y`, `z`). Genuine reuse (`SELECT u AS a, u AS b`) resolves the same pointer under the same name (`u`) twice. Keying on `(name, expr)` is what distinguishes these: distinct names mean rename propagation (allowed); the same name repeated means one value read twice (rejected).

The guard is conservative: it errs toward rejecting to never return wrong results. It over-rejects two cases that are in fact safe:

* Reading more than one subfield of a struct that carries a non-deterministic field, even when each subfield is read once:
  `SELECT n.x AS p, n.y AS q FROM (SELECT cast(row(a, rand()) AS row(x bigint, y double)) AS n FROM t)`
* A single use of an aliased non-deterministic subscript index:
  `SELECT s[i] AS u FROM (SELECT array[10,20,30] AS s, cast(rand()*3 AS integer)+1 AS i FROM t)`

Differential Revision: D108819526


