### PR TITLE
feat(runner): Report query progress during execution (#1498)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -15,8 +15,14 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/container/F14Map.h>
 #include <folly/system/HardwareConcurrency.h>
+#include <algorithm>
 #include <cmath>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/process/ProcessBase.h"
 
@@ -37,6 +43,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/runner/ProgressReporter.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
@@ -90,6 +97,11 @@ class PhaseTimer {
       runtimeStats_->recordTiming(cpuKey_, std::chrono::nanoseconds(cpuNanos));
     }
   }
+
+  PhaseTimer(const PhaseTimer&) = delete;
+  PhaseTimer& operator=(const PhaseTimer&) = delete;
+  PhaseTimer(PhaseTimer&&) = delete;
+  PhaseTimer& operator=(PhaseTimer&&) = delete;
 
  private:
   QueryRuntimeStats* const runtimeStats_;
@@ -1094,6 +1106,25 @@ connector::ConnectorSessionPtr SqlQueryRunner::makeConnectorSession(
       sessionConfig_->effectiveValues(connectorId));
 }
 
+std::unique_ptr<runner::ProgressReporter> SqlQueryRunner::startProgressReporter(
+    runner::Runner& runner,
+    std::string_view queryId,
+    const RunOptions& options) {
+  if (!options.onProgress) {
+    return nullptr;
+  }
+  VELOX_USER_CHECK_NOT_NULL(
+      progressScheduler_,
+      "onProgress requires a scheduler supplied to SqlQueryRunner");
+  progressScheduler_->start();
+  return std::make_unique<runner::ProgressReporter>(
+      runner,
+      *progressScheduler_,
+      std::string(queryId),
+      options.onProgress,
+      options.progressReportIntervalMs);
+}
+
 std::string SqlQueryRunner::runExplainAnalyze(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
@@ -1134,6 +1165,8 @@ std::string SqlQueryRunner::runExplainAnalyze(
         runtimeStats.get(),
         QueryRuntimeStats::kExecuteWallNanos,
         QueryRuntimeStats::kExecuteCpuNanos);
+    auto progress =
+        startProgressReporter(*runner, queryCtx->queryId(), options);
     auto results = fetchResults(*runner);
   }
 
@@ -1374,6 +1407,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         runtimeStats.get(),
         QueryRuntimeStats::kExecuteWallNanos,
         QueryRuntimeStats::kExecuteCpuNanos);
+    auto progress =
+        startProgressReporter(*runner, queryCtx->queryId(), options);
     result.results = fetchResults(*runner);
   }
 

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -16,15 +16,19 @@
 #pragma once
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/FunctionScheduler.h>
 #include <chrono>
 #include <exception>
 #include <functional>
+#include <vector>
 #include "axiom/common/ConfigRegistry.h"
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/common/SessionConfig.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/ProgressReporter.h"
+#include "axiom/runner/QueryProgress.h"
 #include "axiom/sql/presto/SqlStatement.h"
 #include "velox/common/file/TokenProvider.h"
 
@@ -153,7 +157,14 @@ class SqlQueryRunner {
   /// Constructs the runner with the given session user identity. The user
   /// must be non-empty; it is exposed by the SQL `CURRENT_USER` function and
   /// used as the default table owner in DDL.
-  explicit SqlQueryRunner(std::string user) : user_{std::move(user)} {
+  ///
+  /// `progressScheduler` (not owned, must outlive this runner) drives progress
+  /// polling for queries that set RunOptions::onProgress. If null, such a query
+  /// fails loudly rather than running without the progress it asked for.
+  explicit SqlQueryRunner(
+      std::string user,
+      folly::FunctionScheduler* progressScheduler = nullptr)
+      : user_{std::move(user)}, progressScheduler_{progressScheduler} {
     VELOX_USER_CHECK(!user_.empty(), "SqlQueryRunner user must be non-empty");
   }
 
@@ -205,6 +216,16 @@ class SqlQueryRunner {
     /// Called before parsing. Receives query metadata (query ID, SQL text,
     /// creation time, and session catalog/schema).
     QueryStartCallback onStart;
+
+    /// Called to report progress while the query runs; see
+    /// progressReportIntervalMs for cadence.
+    facebook::axiom::runner::QueryProgressCallback onProgress;
+
+    /// Approximate interval between progress reports, in milliseconds (plus a
+    /// best-effort final report at completion). Clamped up to
+    /// runner::ProgressReporter::kMinProgressReportIntervalMs.
+    int32_t progressReportIntervalMs{facebook::axiom::runner::ProgressReporter::
+                                         kDefaultProgressReportIntervalMs};
 
     /// Called after execution completes (success or failure). Carries
     /// telemetry only: timing, query ID, error info, row counts. Results
@@ -393,6 +414,16 @@ class SqlQueryRunner {
       const RunOptions& options,
       facebook::axiom::QueryRuntimeStats& runtimeStats);
 
+  // Returns a ProgressReporter polling `runner` (starting the shared scheduler
+  // first) when options.onProgress is set, otherwise nullptr. Held behind a
+  // unique_ptr because ProgressReporter is non-movable; keep it in scope for as
+  // long as progress should be reported.
+  std::unique_ptr<facebook::axiom::runner::ProgressReporter>
+  startProgressReporter(
+      facebook::axiom::runner::Runner& runner,
+      std::string_view queryId,
+      const RunOptions& options);
+
   // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
   // and the serialized Velox plan into 'planString'.
   SqlResult runUnchecked(
@@ -458,6 +489,10 @@ class SqlQueryRunner {
   std::string defaultSchema_;
   const std::string user_;
   std::atomic<int32_t> queryCounter_{0};
+
+  // Progress-polling scheduler (see constructor). Started idempotently before
+  // each progress-reporting query.
+  folly::FunctionScheduler* const progressScheduler_;
 
   // Noop stats instance for code paths that don't track runtime metrics.
   facebook::axiom::QueryRuntimeStats noopRuntimeStats_;

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -16,7 +16,7 @@
 
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/dynamic.h>
-// NOLINTNEXTLINE(facebook-unused-include-check)
+#include <folly/executors/FunctionScheduler.h>
 #include <folly/init/Init.h>
 #include <folly/json.h>
 #include <gmock/gmock.h>
@@ -26,6 +26,7 @@
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/runner/QueryProgress.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/VeloxException.h"
@@ -38,6 +39,8 @@ using namespace facebook::velox;
 
 namespace axiom::sql {
 namespace {
+
+namespace runner = facebook::axiom::runner;
 
 class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
  protected:
@@ -65,7 +68,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
       const std::string& connectorId = "test",
       std::function<std::string()> queryIdGenerator = {},
       PermissionCheck permissionCheck = {}) {
-    auto runner = std::make_unique<SqlQueryRunner>("test_user");
+    auto runner =
+        std::make_unique<SqlQueryRunner>("test_user", &progressScheduler_);
 
     auto initConnectors = [&]() {
       testConnector_ =
@@ -141,6 +145,9 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         expectedDefault);
   }
 
+  // Drives progress polling for runners built by makeRunner(); declared before
+  // runner_ so it outlives any reporter a query starts.
+  folly::FunctionScheduler progressScheduler_;
   std::unique_ptr<SqlQueryRunner> runner_;
   std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
 
@@ -949,6 +956,7 @@ TEST_F(SqlQueryRunnerTest, completionCallbackReceivesTiming) {
 TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletion) {
   std::string startQueryId;
   std::string completionQueryId;
+  std::string progressQueryId;
 
   runner_->run(
       "SELECT 1",
@@ -957,6 +965,10 @@ TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletion) {
              startQueryId = info.queryId;
              EXPECT_EQ(info.query, "SELECT 1");
            },
+       .onProgress =
+           [&](const runner::QueryProgress& info) {
+             progressQueryId = info.queryId;
+           },
        .onComplete =
            [&](const QueryCompletionInfo& info) {
              completionQueryId = info.startInfo.queryId;
@@ -964,6 +976,9 @@ TEST_F(SqlQueryRunnerTest, startCallbackFiredBeforeCompletion) {
 
   EXPECT_FALSE(startQueryId.empty());
   EXPECT_EQ(startQueryId, completionQueryId);
+  // run() forwards onProgress to the runner; the teardown report carries the
+  // id.
+  EXPECT_EQ(progressQueryId, startQueryId);
 }
 
 TEST_F(SqlQueryRunnerTest, callbacksReceiveQueryMetadata) {

--- a/axiom/runner/CMakeLists.txt
+++ b/axiom/runner/CMakeLists.txt
@@ -16,7 +16,14 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_runner_local_runner LocalRunner.cpp Runner.cpp)
+add_library(
+  axiom_runner_local_runner
+  LocalRunner.cpp
+  ProgressReporter.cpp
+  QueryProgress.cpp
+  QueryProgressBuilder.cpp
+  Runner.cpp
+)
 
 target_link_libraries(
   axiom_runner_local_runner

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -117,7 +117,7 @@ class LocalRunner : public Runner,
   /// appears before B in the sequence. It's essentially a way to arrange tasks
   /// or items with dependencies so that all prerequisites are completed before
   /// the dependent tasks.
-  const std::vector<optimizer::ExecutableFragment>& fragments() const {
+  const std::vector<optimizer::ExecutableFragment>& fragments() const override {
     return fragments_;
   }
 

--- a/axiom/runner/ProgressReporter.cpp
+++ b/axiom/runner/ProgressReporter.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/runner/ProgressReporter.h"
+
+#include <fmt/core.h>
+#include <folly/executors/FunctionScheduler.h>
+#include <glog/logging.h>
+#include <algorithm>
+#include <atomic>
+
+#include "axiom/runner/QueryProgressBuilder.h"
+#include "axiom/runner/Runner.h"
+
+namespace facebook::axiom::runner {
+namespace {
+
+// Process-wide source of unique scheduler function names. Shared schedulers run
+// one function per registered query, so the names must not collide.
+std::string nextName() {
+  static std::atomic<uint64_t> counter{0};
+  return fmt::format("axiom.progress.{}", counter.fetch_add(1));
+}
+
+} // namespace
+
+ProgressReporter::ProgressReporter(
+    Runner& runner,
+    folly::FunctionScheduler& scheduler,
+    std::string queryId,
+    QueryProgressCallback onProgress,
+    int32_t intervalMs)
+    : runner_(runner),
+      scheduler_(scheduler),
+      queryId_(std::move(queryId)),
+      onProgress_(std::move(onProgress)),
+      startTime_(std::chrono::steady_clock::now()) {
+  if (!onProgress_) {
+    return;
+  }
+  stages_ = QueryProgressBuilder::toStageTopology(runner_.fragments());
+  const auto interval = std::chrono::milliseconds(
+      std::max(intervalMs, kMinProgressReportIntervalMs));
+  auto name = nextName();
+  scheduler_.addFunction([this]() { poll(); }, interval, name);
+  // name_ records that a poll is registered, so the destructor knows whether to
+  // cancel one; set it only after addFunction registers the poll.
+  name_ = std::move(name);
+}
+
+ProgressReporter::~ProgressReporter() {
+  // name_ is set only after the poll is registered, so an empty name means
+  // there is nothing to tear down (no callback, or registration never
+  // happened).
+  if (name_.empty()) {
+    return;
+  }
+  // Blocks until the poller is no longer touching this query, so the final
+  // report below is single-threaded and safe even past kRunning.
+  scheduler_.cancelFunctionAndWait(name_);
+  // This destructor may run while the stack unwinds from a query failure, so it
+  // must not throw: swallow any error from building or delivering the final
+  // report (including a builder VELOX_CHECK on a teardown-time stats snapshot).
+  try {
+    const auto wallMicros =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - startTime_)
+            .count();
+    const bool finished = runner_.state() == Runner::State::kFinished;
+    onProgress_(
+        QueryProgressBuilder::computeProgress(
+            stages_, runner_.stats(), queryId_, wallMicros, finished));
+  } catch (const std::exception& ex) {
+    LOG(WARNING) << "Final progress report failed: " << ex.what();
+  }
+}
+
+void ProgressReporter::poll() {
+  if (runner_.state() != Runner::State::kRunning) {
+    return;
+  }
+  const auto wallMicros = std::chrono::duration_cast<std::chrono::microseconds>(
+                              std::chrono::steady_clock::now() - startTime_)
+                              .count();
+  reportProgress(
+      QueryProgressBuilder::computeProgress(
+          stages_, runner_.stats(), queryId_, wallMicros, /*finished=*/false));
+}
+
+void ProgressReporter::reportProgress(const QueryProgress& progress) {
+  try {
+    onProgress_(progress);
+  } catch (const std::exception& ex) {
+    LOG(WARNING) << "Progress report failed: " << ex.what();
+  }
+}
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/ProgressReporter.h
+++ b/axiom/runner/ProgressReporter.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "axiom/runner/QueryProgress.h"
+#include "axiom/runner/QueryProgressBuilder.h"
+
+namespace folly {
+class FunctionScheduler;
+} // namespace folly
+
+namespace facebook::axiom::runner {
+
+class Runner;
+
+/// RAII periodic reporter of one query's progress.
+///
+/// While alive it polls `runner` on the supplied `scheduler` every `intervalMs`
+/// (clamped up to kMinProgressReportIntervalMs) and invokes `onProgress` from a
+/// scheduler thread; the destructor stops polling -- waiting out any in-flight
+/// poll -- then emits one final report from the calling thread, which by then
+/// is single-threaded with respect to this query. The user callback never
+/// throws into the query: an exception from it is logged and skipped.
+///
+/// @code
+///   folly::FunctionScheduler scheduler;
+///   scheduler.start();
+///   {
+///     ProgressReporter reporter(runner, scheduler, queryId, onProgress, 500);
+///     fetchResults(runner); // reporter polls while the query runs
+///   } // ~reporter stops polling and emits the final report
+/// @endcode
+///
+/// Invariants the caller must uphold:
+/// - `scheduler` is started before construction and outlives this object.
+/// - `runner` outlives this object; the final report reads it during teardown.
+/// - `onProgress` must not deregister this query -- that would deadlock the
+/// poll.
+///
+/// When `onProgress` is empty nothing is registered and the scheduler is
+/// untouched.
+class ProgressReporter {
+ public:
+  /// Default target interval between progress reports, in milliseconds.
+  static constexpr int32_t kDefaultProgressReportIntervalMs = 500;
+
+  /// Minimum interval between progress reports, in milliseconds. Caller-set
+  /// intervals are clamped up to this to bound stats() aggregation overhead.
+  static constexpr int32_t kMinProgressReportIntervalMs = 50;
+
+  ProgressReporter(
+      Runner& runner,
+      folly::FunctionScheduler& scheduler,
+      std::string queryId,
+      QueryProgressCallback onProgress,
+      int32_t intervalMs);
+
+  ~ProgressReporter();
+
+  ProgressReporter(const ProgressReporter&) = delete;
+  ProgressReporter& operator=(const ProgressReporter&) = delete;
+  ProgressReporter(ProgressReporter&&) = delete;
+  ProgressReporter& operator=(ProgressReporter&&) = delete;
+
+ private:
+  // Invokes onProgress_ with a caller-built snapshot, logging and swallowing
+  // any exception the user callback throws. Building the snapshot stays with
+  // the caller, so this guards only the callback. poll() builds outside this
+  // guard so a builder invariant violation surfaces during execution; the
+  // destructor builds inside its own catch since it must not throw while a
+  // failing query unwinds.
+  void reportProgress(const QueryProgress& progress);
+
+  // Builds a snapshot and reports it. Does nothing until the runner is running.
+  void poll();
+
+  Runner& runner_;
+  folly::FunctionScheduler& scheduler_;
+  std::string queryId_;
+  QueryProgressCallback onProgress_;
+  std::chrono::steady_clock::time_point startTime_;
+  // Stage topology, derived once from the plan and reused by every poll and the
+  // final report.
+  std::vector<QueryProgressBuilder::StageTopology> stages_;
+  // Scheduler function handle; empty when nothing is registered.
+  std::string name_;
+};
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/QueryProgress.cpp
+++ b/axiom/runner/QueryProgress.cpp
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-#include "axiom/runner/Runner.h"
+#include "axiom/runner/QueryProgress.h"
 
 #include <folly/container/F14Map.h>
 
 namespace facebook::axiom::runner {
-
 namespace {
-const auto& stateNames() {
-  static const folly::F14FastMap<Runner::State, std::string_view> kNames = {
-      {Runner::State::kInitialized, "initialized"},
-      {Runner::State::kRunning, "running"},
-      {Runner::State::kCancelled, "cancelled"},
-      {Runner::State::kError, "error"},
-      {Runner::State::kFinished, "finished"},
-  };
 
+const auto& executionStateNames() {
+  static const folly::F14FastMap<ExecutionState, std::string_view> kNames = {
+      {ExecutionState::kPlanned, "PLANNED"},
+      {ExecutionState::kRunning, "RUNNING"},
+      {ExecutionState::kFinished, "FINISHED"},
+  };
   return kNames;
 }
+
 } // namespace
 
-AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Runner, State, stateNames);
+AXIOM_DEFINE_ENUM_NAME(ExecutionState, executionStateNames);
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/QueryProgress.h
+++ b/axiom/runner/QueryProgress.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "axiom/common/Enums.h"
+
+namespace facebook::axiom::runner {
+
+/// Execution state of a query or a stage. Models successful progress only;
+/// query failure and cancellation are reported through the completion callback
+/// (QueryCompletionInfo), not here, so a failed query's final progress report
+/// reflects its last observed state.
+enum class ExecutionState {
+  /// No split or driver has started yet.
+  kPlanned,
+  /// At least one split or driver is executing.
+  kRunning,
+  /// All splits and drivers have completed.
+  kFinished,
+};
+
+AXIOM_DECLARE_ENUM_NAME(ExecutionState);
+
+/// Execution counters for a query or a single stage.
+struct ExecutionStats {
+  /// Overall completion of the query or stage. Already accounts for the
+  /// runner's finished flag and driver completion, not just the split counts
+  /// below.
+  ExecutionState state{ExecutionState::kPlanned};
+
+  /// Rows/bytes read from storage by table scans.
+  int64_t scanRows{0};
+  int64_t scanBytes{0};
+  /// Rows/bytes received from exchanges (shuffled in from producer stages).
+  int64_t shuffleRows{0};
+  int64_t shuffleBytes{0};
+  /// Operator CPU time, in microseconds.
+  int64_t cpuTimeMicros{0};
+
+  /// Splits seen so far. The runner adds splits during execution, so this grows
+  /// over time and is not a fixed denominator; it only bounds its substates
+  /// (>= queued + running + completed), which aggregate across concurrently
+  /// updating tasks.
+  int32_t totalSplits{0};
+  int32_t queuedSplits{0};
+  int32_t runningSplits{0};
+  int32_t completedSplits{0};
+};
+
+/// Execution counters for one stage, with its place in the stage tree.
+struct StageProgress {
+  /// Indexes of the stages feeding this one over an exchange, by position in
+  /// `QueryProgress::stages`. The stages form a tree; these are its producer
+  /// edges. Empty for a connector-only leaf. Entries must not be reordered or
+  /// filtered, or these references break.
+  std::vector<int32_t> producers;
+
+  ExecutionStats stats;
+};
+
+/// Live progress of a query during execution.
+struct QueryProgress {
+  /// Unique identifier for this query execution.
+  std::string queryId;
+
+  /// Query-level counters: each numeric field is the sum across stages. Read
+  /// `stats.state` directly for overall completion.
+  ExecutionStats stats;
+
+  /// Wall-clock microseconds since query start.
+  int64_t wallTimeMicros{0};
+
+  /// Per-stage detail, one entry per task in the runner's stats() and
+  /// positionally 1:1 with it.
+  std::vector<StageProgress> stages;
+};
+
+/// Reports progress while the query runs. Periodic reports come from a
+/// scheduler (background) thread; the final report on teardown is invoked
+/// synchronously on the thread that destroys the ProgressReporter, so a caller
+/// may see it on its own thread. Keep it cheap and thread-safe; it must not
+/// block the query. It must not deregister its own query from within the
+/// callback -- that waits on the poll it is running inside and deadlocks.
+using QueryProgressCallback = std::function<void(const QueryProgress&)>;
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/QueryProgressBuilder.cpp
+++ b/axiom/runner/QueryProgressBuilder.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/runner/QueryProgressBuilder.h"
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/exec/OperatorType.h"
+#include "velox/exec/TaskStats.h"
+
+namespace velox = facebook::velox;
+namespace optimizer = facebook::axiom::optimizer;
+
+namespace facebook::axiom::runner {
+namespace {
+
+// Normalizes a finished frame so it is internally consistent -- nothing left
+// queued or running.
+void markFinished(ExecutionStats& stats) {
+  stats.state = ExecutionState::kFinished;
+  stats.completedSplits = stats.totalSplits;
+  stats.runningSplits = 0;
+  stats.queuedSplits = 0;
+}
+
+} // namespace
+
+std::vector<QueryProgressBuilder::StageTopology>
+QueryProgressBuilder::toStageTopology(
+    const std::vector<optimizer::ExecutableFragment>& fragments) {
+  // Map each fragment's task prefix to its index so the exchange inputs (named
+  // by producer task prefix) resolve to stage indexes.
+  folly::F14FastMap<std::string, int32_t> indexByPrefix;
+  indexByPrefix.reserve(fragments.size());
+  for (size_t i = 0; i < fragments.size(); ++i) {
+    indexByPrefix.emplace(fragments[i].taskPrefix, static_cast<int32_t>(i));
+  }
+
+  std::vector<StageTopology> stages;
+  stages.reserve(fragments.size());
+  for (size_t i = 0; i < fragments.size(); ++i) {
+    StageTopology stage;
+    for (const auto& input : fragments[i].inputStages) {
+      const auto it = indexByPrefix.find(input.producerTaskPrefix);
+      // Every exchange input must resolve to a known producer fragment.
+      VELOX_CHECK(
+          it != indexByPrefix.end(),
+          "Exchange input names an unknown producer task prefix. stage: {}, prefix: {}",
+          i,
+          input.producerTaskPrefix);
+      stage.producers.push_back(it->second);
+    }
+    stages.push_back(std::move(stage));
+  }
+  return stages;
+}
+
+QueryProgress QueryProgressBuilder::computeProgress(
+    const std::vector<StageTopology>& stages,
+    const std::vector<velox::exec::TaskStats>& taskStats,
+    std::string_view queryId,
+    int64_t wallMicros,
+    bool finished) {
+  // The topology is positionally 1:1 with the snapshot by fragment order.
+  VELOX_CHECK_EQ(
+      stages.size(),
+      taskStats.size(),
+      "Stage topology and task-stats snapshot disagree in size. topology: {}, snapshot: {}",
+      stages.size(),
+      taskStats.size());
+
+  ExecutionStats queryStats;
+  // Driver counts distinguish a started/in-flight scan-less query (no splits)
+  // from one that has not begun. Typed to match TaskStats' unsigned counts;
+  // only their > 0 state is read.
+  uint64_t completedDrivers{0};
+  uint64_t runningDrivers{0};
+  // CPU is summed in nanoseconds and converted once; a per-operator /1'000
+  // would truncate sub-microsecond remainders.
+  int64_t queryCpuNanos{0};
+
+  std::vector<StageProgress> stageProgress;
+  stageProgress.reserve(taskStats.size());
+  for (size_t i = 0; i < taskStats.size(); ++i) {
+    const auto& task = taskStats[i];
+
+    ExecutionStats stats;
+    stats.totalSplits = task.numTotalSplits;
+    stats.queuedSplits = task.numQueuedSplits;
+    stats.runningSplits = task.numRunningSplits;
+    stats.completedSplits = task.numFinishedSplits;
+
+    int64_t stageCpuNanos{0};
+    for (const auto& pipeline : task.pipelineStats) {
+      for (const auto& op : pipeline.operatorStats) {
+        if (op.operatorType == velox::exec::OperatorType::kTableScan) {
+          stats.scanRows += op.rawInputPositions;
+          stats.scanBytes += op.rawInputBytes;
+        } else if (
+            op.operatorType == velox::exec::OperatorType::kExchange ||
+            op.operatorType == velox::exec::OperatorType::kMergeExchange) {
+          stats.shuffleRows += op.rawInputPositions;
+          stats.shuffleBytes += op.rawInputBytes;
+        } else {
+          // Only scan and exchange sources contribute raw input; any other
+          // source reporting raw input would be dropped from the totals.
+          VELOX_CHECK(
+              op.rawInputPositions == 0 && op.rawInputBytes == 0,
+              "Unclassified source operator reports input. operator: {}, rows: {}, bytes: {}",
+              op.operatorType,
+              op.rawInputPositions,
+              op.rawInputBytes);
+        }
+        const auto it =
+            op.runtimeStats.find(velox::exec::OperatorStats::kDriverCpuTime);
+        if (it != op.runtimeStats.end()) {
+          stageCpuNanos += it->second.sum;
+        }
+      }
+    }
+    stats.cpuTimeMicros = stageCpuNanos / 1'000;
+
+    if (task.numTotalDrivers > 0 &&
+        task.numCompletedDrivers == task.numTotalDrivers) {
+      stats.state = ExecutionState::kFinished;
+    } else if (task.numRunningDrivers > 0 || task.numCompletedDrivers > 0) {
+      // Any started driver makes the stage kRunning, matching the query-level
+      // rule; a stage with some but not all drivers done is not kPlanned.
+      stats.state = ExecutionState::kRunning;
+    }
+
+    queryStats.scanRows += stats.scanRows;
+    queryStats.scanBytes += stats.scanBytes;
+    queryStats.shuffleRows += stats.shuffleRows;
+    queryStats.shuffleBytes += stats.shuffleBytes;
+    queryStats.totalSplits += stats.totalSplits;
+    queryStats.queuedSplits += stats.queuedSplits;
+    queryStats.runningSplits += stats.runningSplits;
+    queryStats.completedSplits += stats.completedSplits;
+    queryCpuNanos += stageCpuNanos;
+    completedDrivers += task.numCompletedDrivers;
+    runningDrivers += task.numRunningDrivers;
+
+    StageProgress stage;
+    stage.producers = stages[i].producers;
+    stage.stats = stats;
+    stageProgress.push_back(std::move(stage));
+  }
+  queryStats.cpuTimeMicros = queryCpuNanos / 1'000;
+
+  // kFinished comes only from the runner's finished flag; otherwise the query
+  // is kRunning once any split or driver has started, else kPlanned.
+  if (finished) {
+    queryStats.state = ExecutionState::kFinished;
+  } else if (
+      queryStats.runningSplits > 0 || queryStats.completedSplits > 0 ||
+      runningDrivers > 0 || completedDrivers > 0) {
+    queryStats.state = ExecutionState::kRunning;
+  }
+
+  // On a clean finish, make the frame internally consistent so no per-stage row
+  // shows running/queued splits in a query reported as finished.
+  if (finished) {
+    markFinished(queryStats);
+    for (auto& stage : stageProgress) {
+      markFinished(stage.stats);
+    }
+  }
+
+  QueryProgress progress;
+  progress.queryId = std::string(queryId);
+  progress.stats = queryStats;
+  progress.wallTimeMicros = wallMicros;
+  progress.stages = std::move(stageProgress);
+  return progress;
+}
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/QueryProgressBuilder.h
+++ b/axiom/runner/QueryProgressBuilder.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+#include "axiom/runner/QueryProgress.h"
+
+namespace facebook::velox::exec {
+struct TaskStats;
+} // namespace facebook::velox::exec
+
+namespace facebook::axiom::optimizer {
+struct ExecutableFragment;
+} // namespace facebook::axiom::optimizer
+
+namespace facebook::axiom::runner {
+
+/// Stateless functions that build a QueryProgress from a runner's plan
+/// fragments and a task-stats snapshot. Derive the stage topology once, then
+/// combine it with each stats snapshot:
+///
+/// @code
+///   auto stages = QueryProgressBuilder::toStageTopology(runner.fragments());
+///   auto progress = QueryProgressBuilder::computeProgress(
+///       stages, runner.stats(), queryId, wallMicros, finished);
+/// @endcode
+class QueryProgressBuilder {
+ public:
+  /// One stage's topology: the indexes of the stages that feed it over an
+  /// exchange.
+  struct StageTopology {
+    /// Indexes of the stages feeding this one over an exchange, by position in
+    /// the returned vector (which matches stats()); empty for a leaf.
+    std::vector<int32_t> producers;
+  };
+
+  /// Converts the plan's fragments to per-stage topology, where stage i
+  /// corresponds to fragments[i] and to stats()[i]. Every exchange input must
+  /// name a known producer fragment; an unresolved prefix throws.
+  static std::vector<StageTopology> toStageTopology(
+      const std::vector<facebook::axiom::optimizer::ExecutableFragment>&
+          fragments);
+
+  /// Combines the stage topology with a task-stats snapshot into a
+  /// QueryProgress. `stages` is positionally 1:1 with `taskStats` by fragment
+  /// order; a size mismatch throws. `wallMicros` is elapsed time since query
+  /// start. `finished` is whether the runner has completed; on a clean finish
+  /// the counters are normalized to a consistent completed frame.
+  static QueryProgress computeProgress(
+      const std::vector<StageTopology>& stages,
+      const std::vector<facebook::velox::exec::TaskStats>& taskStats,
+      std::string_view queryId,
+      int64_t wallMicros,
+      bool finished);
+};
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -19,6 +19,10 @@
 #include "axiom/common/Enums.h"
 #include "velox/exec/TaskStats.h"
 
+namespace facebook::axiom::optimizer {
+struct ExecutableFragment;
+} // namespace facebook::axiom::optimizer
+
 /// Base classes for multifragment Velox query execution.
 namespace facebook::axiom::runner {
 
@@ -43,9 +47,14 @@ class Runner {
   virtual velox::RowVectorPtr next() = 0;
 
   /// Returns Task stats for each fragment of the plan. The stats correspond 1:1
-  /// to the stages in the MultiFragmentPlan. This may be called at any time.
+  /// to the stages in the MultiFragmentPlan. This may be called at any time
   /// before waitForCompletion() or abort().
   virtual std::vector<velox::exec::TaskStats> stats() const = 0;
+
+  /// Returns the executable fragments of the plan being run, ordered so that
+  /// fragments()[i] corresponds to stats()[i].
+  virtual const std::vector<optimizer::ExecutableFragment>& fragments()
+      const = 0;
 
   /// Returns the state of execution.
   virtual State state() const = 0;

--- a/axiom/runner/tests/CMakeLists.txt
+++ b/axiom/runner/tests/CMakeLists.txt
@@ -76,3 +76,28 @@ target_link_libraries(
   velox_exec
   GTest::gtest
 )
+
+add_executable(axiom_runner_progress_test QueryProgressBuilderTest.cpp Main.cpp)
+
+add_test(axiom_runner_progress_test axiom_runner_progress_test)
+
+target_link_libraries(
+  axiom_runner_progress_test
+  axiom_runner_local_runner
+  axiom_optimizer_multifragment_plan
+  velox_exec
+  GTest::gtest
+)
+
+add_executable(axiom_runner_progress_reporter_test ProgressReporterTest.cpp Main.cpp)
+
+add_test(axiom_runner_progress_reporter_test axiom_runner_progress_reporter_test)
+
+target_link_libraries(
+  axiom_runner_progress_reporter_test
+  axiom_runner_tests_utils
+  axiom_runner_local_runner
+  velox_exec_test_lib
+  velox_exec
+  GTest::gtest
+)

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/runner/ProgressReporter.h"
+
+#include <folly/coro/Baton.h>
+#include <folly/executors/FunctionScheduler.h>
+#include <gtest/gtest.h>
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+#include "axiom/connectors/ConnectorSplitManager.h"
+#include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/tests/DistributedPlanBuilder.h"
+#include "axiom/runner/tests/LocalRunnerTestBase.h"
+
+namespace facebook::axiom::runner {
+namespace {
+
+namespace velox = facebook::velox;
+
+// Releases scan splits one at a time. Each co_getSplits awaits 'gate', so the
+// runner blocks between splits until the test posts it -- letting the test
+// observe one split's worth of progress per release.
+class GatedSplitSource : public connector::SplitSource {
+ public:
+  GatedSplitSource(
+      std::shared_ptr<connector::SplitSource> inner,
+      std::shared_ptr<folly::coro::Baton> gate)
+      : inner_{std::move(inner)}, gate_{std::move(gate)} {}
+
+  folly::coro::Task<connector::SplitBatch> co_getSplits(
+      uint32_t /*maxSplitCount*/) override {
+    co_await *gate_;
+    gate_->reset();
+    co_return co_await inner_->co_getSplits(1);
+  }
+
+ protected:
+  folly::coro::Task<void> co_closeImpl() noexcept override {
+    co_await inner_->co_close();
+  }
+
+ private:
+  std::shared_ptr<connector::SplitSource> inner_;
+  std::shared_ptr<folly::coro::Baton> gate_;
+};
+
+// Wraps ConnectorSplitSourceFactory so the scan's splits flow through a gate.
+class GatedSplitSourceFactory : public SplitSourceFactory {
+ public:
+  GatedSplitSourceFactory(
+      QueryRuntimeStats& runtimeStats,
+      std::shared_ptr<folly::coro::Baton> gate)
+      : inner_{runtimeStats}, gate_{std::move(gate)} {}
+
+  std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType) override {
+    return std::make_shared<GatedSplitSource>(
+        inner_.splitSourceForScan(session, scan, partitionType), gate_);
+  }
+
+ private:
+  ConnectorSplitSourceFactory inner_;
+  std::shared_ptr<folly::coro::Baton> gate_;
+};
+
+class ProgressReporterTest : public test::LocalRunnerTestBase {
+ protected:
+  static constexpr int32_t kNumSplits = 4;
+  static constexpr int32_t kRowsPerSplit = 100;
+
+  void SetUp() override {
+    rowType_ = velox::ROW({"c0"}, {velox::BIGINT()});
+    makeTables({test::TableSpec{
+        .name = "t",
+        .columns = rowType_,
+        .rowsPerVector = kRowsPerSplit,
+        .numVectorsPerFile = 1,
+        .numFiles = kNumSplits}});
+    LocalRunnerTestBase::SetUp();
+  }
+
+  optimizer::MultiFragmentPlanPtr makeScanPlan() {
+    optimizer::MultiFragmentPlan::Options options = {
+        .queryId = "progress-q", .numWorkers = 1, .numDrivers = 1};
+    test::DistributedPlanBuilder builder(options, idGenerator_, pool_.get());
+    builder.tableScan("t", rowType_);
+    return builder.build();
+  }
+
+  static RunnerSessionPtr makeRunnerSession(std::string_view queryId) {
+    return std::make_shared<RunnerSession>(
+        std::string(queryId),
+        "test",
+        Properties{},
+        connector::ConnectorProperties{});
+  }
+
+  velox::RowTypePtr rowType_;
+  std::shared_ptr<velox::core::PlanNodeIdGenerator> idGenerator_{
+      std::make_shared<velox::core::PlanNodeIdGenerator>()};
+  QueryRuntimeStats runtimeStats_;
+};
+
+// Releases scan splits one at a time and asserts the scheduler's periodic poll
+// observes each one through the callback. With a single worker and driver the
+// runner blocks between splits, so each poll lands on a stable, advanced
+// snapshot -- no sleeps, no flaky timing.
+TEST_F(ProgressReporterTest, reportsProgressPerSplit) {
+  auto gate = std::make_shared<folly::coro::Baton>();
+  auto plan = makeScanPlan();
+  const auto queryId = plan->options().queryId;
+  auto runner = std::make_shared<LocalRunner>(
+      makeRunnerSession(queryId),
+      std::move(plan),
+      optimizer::FinishWrite{},
+      makeQueryCtx(queryId),
+      std::make_shared<GatedSplitSourceFactory>(runtimeStats_, gate),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      runtimeStats_);
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::vector<QueryProgress> reports;
+
+  folly::FunctionScheduler scheduler;
+  scheduler.start();
+
+  auto waitForCompletedPast = [&](int32_t prev) {
+    std::unique_lock<std::mutex> lock(mutex);
+    const bool ok = cv.wait_for(lock, std::chrono::seconds(10), [&] {
+      return !reports.empty() && reports.back().stats.completedSplits > prev;
+    });
+    EXPECT_TRUE(ok) << "no report past " << prev;
+    return reports.back();
+  };
+
+  {
+    ProgressReporter reporter(
+        *runner,
+        scheduler,
+        "progress-q",
+        [&](const QueryProgress& report) {
+          {
+            std::lock_guard<std::mutex> lock(mutex);
+            reports.push_back(report);
+          }
+          cv.notify_all();
+        },
+        ProgressReporter::kMinProgressReportIntervalMs);
+
+    // Splits are released and enumerated lazily, so after the i-th release
+    // exactly i splits are known and all i are completed (the runner is blocked
+    // requesting the next), with i splits' worth of rows scanned.
+    int32_t completedSplits{0};
+    int64_t outputRows{0};
+    gate->post();
+    while (auto batch = runner->next()) {
+      outputRows += batch->size();
+      ++completedSplits;
+      const auto report = waitForCompletedPast(completedSplits - 1);
+      EXPECT_EQ(report.queryId, "progress-q");
+      EXPECT_EQ(report.stats.state, ExecutionState::kRunning);
+      EXPECT_EQ(report.stats.completedSplits, completedSplits);
+      EXPECT_EQ(report.stats.totalSplits, completedSplits);
+      EXPECT_EQ(report.stats.scanRows, completedSplits * kRowsPerSplit);
+      gate->post();
+    }
+    EXPECT_EQ(completedSplits, kNumSplits);
+    EXPECT_EQ(outputRows, kNumSplits * kRowsPerSplit);
+  } // ~reporter delivers the final report synchronously.
+
+  // The teardown report is the last one: all splits completed, finished.
+  const auto& teardown = reports.back();
+  EXPECT_EQ(teardown.stats.state, ExecutionState::kFinished);
+  EXPECT_EQ(teardown.stats.completedSplits, kNumSplits);
+  EXPECT_EQ(teardown.stats.totalSplits, kNumSplits);
+  EXPECT_EQ(teardown.stats.scanRows, kNumSplits * kRowsPerSplit);
+  ASSERT_EQ(teardown.stages.size(), 1);
+  EXPECT_TRUE(teardown.stages[0].producers.empty());
+  EXPECT_EQ(teardown.stages[0].stats.completedSplits, kNumSplits);
+  EXPECT_EQ(teardown.stages[0].stats.scanRows, kNumSplits * kRowsPerSplit);
+}
+
+} // namespace
+} // namespace facebook::axiom::runner

--- a/axiom/runner/tests/QueryProgressBuilderTest.cpp
+++ b/axiom/runner/tests/QueryProgressBuilderTest.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/runner/QueryProgressBuilder.h"
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/runner/QueryProgress.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/TaskStats.h"
+
+namespace facebook::axiom::runner {
+namespace {
+
+namespace optimizer = facebook::axiom::optimizer;
+namespace velox = facebook::velox;
+
+using StageTopology = QueryProgressBuilder::StageTopology;
+
+optimizer::ExecutableFragment fragment(
+    const std::string& taskPrefix,
+    const std::vector<std::string>& producerTaskPrefixes) {
+  std::vector<optimizer::InputStage> inputStages;
+  inputStages.reserve(producerTaskPrefixes.size());
+  for (size_t i = 0; i < producerTaskPrefixes.size(); ++i) {
+    // Each producer feeds its own exchange node, so give every input a distinct
+    // consumerNodeId rather than sharing one.
+    inputStages.push_back(
+        {.consumerNodeId = taskPrefix + "_exchange_" + std::to_string(i),
+         .producerTaskPrefix = producerTaskPrefixes[i]});
+  }
+  return optimizer::ExecutableFragment{
+      .taskPrefix = taskPrefix, .inputStages = std::move(inputStages)};
+}
+
+velox::exec::OperatorStats op(
+    const std::string& operatorType,
+    int64_t rows,
+    int64_t bytes,
+    int64_t cpuNanos) {
+  velox::exec::OperatorStats stats;
+  stats.operatorType = operatorType;
+  stats.rawInputPositions = rows;
+  stats.rawInputBytes = bytes;
+  if (cpuNanos != 0) {
+    velox::RuntimeMetric metric;
+    metric.sum = cpuNanos;
+    metric.count = 1;
+    stats.runtimeStats[velox::exec::OperatorStats::kDriverCpuTime] = metric;
+  }
+  return stats;
+}
+
+// Wires `operators` into a single pipeline on a designated-initialized
+// TaskStats. PipelineStats is not an aggregate, so the pipeline is built here
+// while the split and driver counts are set inline at the call site.
+velox::exec::TaskStats task(
+    velox::exec::TaskStats stats,
+    std::vector<velox::exec::OperatorStats> operators) {
+  velox::exec::PipelineStats pipeline(
+      /*inputPipeline=*/true, /*outputPipeline=*/true);
+  pipeline.operatorStats = std::move(operators);
+  stats.pipelineStats.push_back(std::move(pipeline));
+  return stats;
+}
+
+TEST(QueryProgressBuilderTest, toStageTopologyLinearChain) {
+  const auto stages = QueryProgressBuilder::toStageTopology(
+      {fragment("leaf", {}),
+       fragment("mid", {"leaf"}),
+       fragment("root", {"mid"})});
+
+  ASSERT_EQ(stages.size(), 3);
+  EXPECT_TRUE(stages[0].producers.empty());
+  EXPECT_EQ(stages[1].producers, std::vector<int32_t>{0});
+  EXPECT_EQ(stages[2].producers, std::vector<int32_t>{1});
+}
+
+TEST(QueryProgressBuilderTest, toStageTopologyThrowsOnUnknownProducer) {
+  // An exchange input naming a fragment that does not exist is a malformed
+  // plan; the builder fails loudly rather than dropping the edge.
+  VELOX_ASSERT_THROW(
+      QueryProgressBuilder::toStageTopology(
+          {fragment("a", {}), fragment("b", {"a", "ghost"})}),
+      "Exchange input names an unknown producer task prefix. stage: 1, prefix: ghost");
+}
+
+TEST(QueryProgressBuilderTest, splitsScanAndShuffleBySourceOperator) {
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalSplits = 4,
+       .numFinishedSplits = 1,
+       .numRunningSplits = 2,
+       .numQueuedSplits = 1,
+       .numTotalDrivers = 4,
+       .numRunningDrivers = 2},
+      {op("TableScan", 100, 1'000, 5'000),
+       op("Exchange", 40, 400, 3'000),
+       op("FilterProject", 0, 0, 2'000)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages,
+      taskStats,
+      "q",
+      /*wallMicros=*/0,
+      /*finished=*/false);
+
+  // Scan counters come from TableScan, shuffle from Exchange; the non-source
+  // FilterProject reports no raw input and contributes only CPU.
+  EXPECT_EQ(progress.stats.scanRows, 100);
+  EXPECT_EQ(progress.stats.scanBytes, 1'000);
+  EXPECT_EQ(progress.stats.shuffleRows, 40);
+  EXPECT_EQ(progress.stats.shuffleBytes, 400);
+  // CPU is summed across every operator: (5'000 + 3'000 + 2'000) / 1'000.
+  EXPECT_EQ(progress.stats.cpuTimeMicros, 10);
+  EXPECT_EQ(progress.stats.totalSplits, 4);
+  EXPECT_EQ(progress.stats.completedSplits, 1);
+  EXPECT_EQ(progress.stats.runningSplits, 2);
+  EXPECT_EQ(progress.stats.queuedSplits, 1);
+  EXPECT_EQ(progress.stats.state, ExecutionState::kRunning);
+
+  ASSERT_EQ(progress.stages.size(), 1);
+  EXPECT_TRUE(progress.stages[0].producers.empty());
+  EXPECT_EQ(progress.stages[0].stats.scanRows, 100);
+  EXPECT_EQ(progress.stages[0].stats.shuffleRows, 40);
+}
+
+TEST(QueryProgressBuilderTest, cpuConvertedOncePerQueryNotPerStage) {
+  const std::vector<StageTopology> stages = {StageTopology{}, StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {
+      task(
+          {.numTotalDrivers = 1, .numRunningDrivers = 1},
+          {op("TableScan", 0, 0, 1'500)}),
+      task(
+          {.numTotalDrivers = 1, .numRunningDrivers = 1},
+          {op("TableScan", 0, 0, 1'500)})};
+
+  const auto progress =
+      QueryProgressBuilder::computeProgress(stages, taskStats, "q", 0, false);
+
+  // Each stage truncates 1'500ns to 1us, but the query sums nanoseconds first:
+  // (1'500 + 1'500) / 1'000 = 3us, not 1 + 1 = 2us.
+  EXPECT_EQ(progress.stages[0].stats.cpuTimeMicros, 1);
+  EXPECT_EQ(progress.stages[1].stats.cpuTimeMicros, 1);
+  EXPECT_EQ(progress.stats.cpuTimeMicros, 3);
+}
+
+TEST(QueryProgressBuilderTest, plannedWhenNothingStarted) {
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalSplits = 4, .numQueuedSplits = 4, .numTotalDrivers = 4},
+      {op("TableScan", 0, 0, 0)})};
+
+  const auto progress =
+      QueryProgressBuilder::computeProgress(stages, taskStats, "q", 0, false);
+
+  EXPECT_EQ(progress.stats.state, ExecutionState::kPlanned);
+  EXPECT_EQ(progress.stages[0].stats.state, ExecutionState::kPlanned);
+}
+
+TEST(QueryProgressBuilderTest, runningWhenDriversRunning) {
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalDrivers = 4, .numRunningDrivers = 2}, {op("Values", 0, 0, 0)})};
+
+  const auto progress =
+      QueryProgressBuilder::computeProgress(stages, taskStats, "q", 0, false);
+
+  EXPECT_EQ(progress.stats.state, ExecutionState::kRunning);
+  EXPECT_EQ(progress.stages[0].stats.state, ExecutionState::kRunning);
+}
+
+TEST(QueryProgressBuilderTest, splitsCompleteWithoutFinishFlagStayRunning) {
+  // Snapshot completion (all known splits done) does not infer kFinished -- the
+  // runner adds splits over time, so completion comes only from its finished
+  // flag.
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalSplits = 10, .numFinishedSplits = 10},
+      {op("TableScan", 100, 1'000, 0)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages, taskStats, "q", 0, /*finished=*/false);
+
+  EXPECT_EQ(progress.stats.state, ExecutionState::kRunning);
+}
+
+TEST(QueryProgressBuilderTest, driversCompleteWithoutFinishFlagStayRunning) {
+  // A scan-less query whose drivers are all done still reports kRunning until
+  // the runner's finished flag is set, though a single stage may be finished.
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalDrivers = 4, .numCompletedDrivers = 4},
+      {op("Values", 0, 0, 0)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages, taskStats, "q", 0, /*finished=*/false);
+
+  EXPECT_EQ(progress.stats.totalSplits, 0);
+  EXPECT_EQ(progress.stats.state, ExecutionState::kRunning);
+  EXPECT_EQ(progress.stages[0].stats.state, ExecutionState::kFinished);
+}
+
+TEST(QueryProgressBuilderTest, stageWithSomeDriversDoneIsRunning) {
+  // Some drivers finished, none running, not all done: the stage is kRunning,
+  // not kPlanned -- mirrors the query-level rule that any started work runs.
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalDrivers = 4, .numCompletedDrivers = 2, .numRunningDrivers = 0},
+      {op("Values", 0, 0, 0)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages, taskStats, "q", 0, /*finished=*/false);
+
+  EXPECT_EQ(progress.stages[0].stats.state, ExecutionState::kRunning);
+}
+
+TEST(QueryProgressBuilderTest, finishedFlagOverridesRunningCounts) {
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalSplits = 4,
+       .numRunningSplits = 2,
+       .numTotalDrivers = 4,
+       .numRunningDrivers = 2},
+      {op("TableScan", 50, 500, 0)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages, taskStats, "q", 0, /*finished=*/true);
+
+  // The finish flag wins over the running counts, and the frame is normalized
+  // so neither the query nor its stages show running/queued splits.
+  EXPECT_EQ(progress.stats.state, ExecutionState::kFinished);
+  EXPECT_EQ(progress.stats.completedSplits, 4);
+  EXPECT_EQ(progress.stats.runningSplits, 0);
+  EXPECT_EQ(progress.stats.queuedSplits, 0);
+  ASSERT_EQ(progress.stages.size(), 1);
+  EXPECT_EQ(progress.stages[0].stats.state, ExecutionState::kFinished);
+  EXPECT_EQ(progress.stages[0].stats.completedSplits, 4);
+  EXPECT_EQ(progress.stages[0].stats.runningSplits, 0);
+}
+
+TEST(QueryProgressBuilderTest, computeProgressThrowsOnTopologySizeMismatch) {
+  // Non-empty topology must be positionally 1:1 with the snapshot; a size
+  // mismatch is a bug, not a recoverable state to paper over.
+  const std::vector<StageTopology> stages = {
+      StageTopology{}, StageTopology{.producers = {0}}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalSplits = 2, .numFinishedSplits = 1},
+      {op("Exchange", 7, 70, 0)})};
+
+  VELOX_ASSERT_THROW(
+      QueryProgressBuilder::computeProgress(stages, taskStats, "q", 0, false),
+      "Stage topology and task-stats snapshot disagree in size. topology: 2, snapshot: 1");
+}
+
+TEST(QueryProgressBuilderTest, computeProgressThrowsOnUnclassifiedSource) {
+  // A source operator outside the scan/exchange buckets that reports raw input
+  // would silently drop rows/bytes from the totals; the builder fails loudly.
+  const std::vector<StageTopology> stages = {StageTopology{}};
+  const std::vector<velox::exec::TaskStats> taskStats = {task(
+      {.numTotalDrivers = 1, .numRunningDrivers = 1},
+      {op("SomeNewSource", 5, 50, 0)})};
+
+  VELOX_ASSERT_THROW(
+      QueryProgressBuilder::computeProgress(stages, taskStats, "q", 0, false),
+      "Unclassified source operator reports input. operator: SomeNewSource, rows: 5, bytes: 50");
+}
+
+TEST(QueryProgressBuilderTest, multiStageSumsWithResolvedTopology) {
+  const auto stages = QueryProgressBuilder::toStageTopology(
+      {fragment("leaf", {}), fragment("root", {"leaf"})});
+  const std::vector<velox::exec::TaskStats> taskStats = {
+      task(
+          {.numTotalSplits = 8,
+           .numFinishedSplits = 8,
+           .numTotalDrivers = 2,
+           .numCompletedDrivers = 2},
+          {op("TableScan", 1'000, 8'000, 4'000)}),
+      task(
+          {.numTotalDrivers = 1, .numCompletedDrivers = 1},
+          {op("Exchange", 1'000, 8'000, 2'000)})};
+
+  const auto progress = QueryProgressBuilder::computeProgress(
+      stages, taskStats, "q", /*wallMicros=*/777, /*finished=*/false);
+
+  EXPECT_EQ(progress.wallTimeMicros, 777);
+  EXPECT_EQ(progress.stats.scanRows, 1'000);
+  EXPECT_EQ(progress.stats.shuffleRows, 1'000);
+  EXPECT_EQ(progress.stats.cpuTimeMicros, 6); // (4'000 + 2'000) / 1'000.
+  EXPECT_EQ(progress.stats.totalSplits, 8);
+  EXPECT_EQ(progress.stats.state, ExecutionState::kRunning);
+
+  ASSERT_EQ(progress.stages.size(), 2);
+  EXPECT_TRUE(progress.stages[0].producers.empty());
+  ASSERT_EQ(progress.stages[1].producers.size(), 1);
+  EXPECT_EQ(progress.stages[1].producers[0], 0);
+  EXPECT_EQ(progress.stages[0].stats.scanRows, 1'000);
+  EXPECT_EQ(progress.stages[1].stats.shuffleRows, 1'000);
+}
+
+} // namespace
+} // namespace facebook::axiom::runner


### PR DESCRIPTION
Summary:

Adds query progress reporting in `axiom/runner` and wires it into the CLI: `SqlQueryRunner::RunOptions` gains an `onProgress` callback that fires while a query runs. Each report carries query-level and per-stage counters: rows and bytes read from storage (scan) and received over exchanges (shuffle), split counts (queued/running/completed), operator CPU time, and an `ExecutionState` (planned/running/finished; failure and cancellation are reported via the completion callback, not here). There is no percentage: the runner adds splits during execution, so a split-based percentage can run backward.

The reporting lives next to the runner it observes and depends only on the `Runner` interface, split into:
- `QueryProgressBuilder` -- stateless `toStageTopology()` (plan fragments to per-stage producer edges) and `computeProgress()` (a `Runner::stats()` snapshot to a `QueryProgress`), both static and unit-tested directly on synthetic stats and fragments. Scan vs shuffle is keyed off `velox::exec::OperatorType` constants. Malformed input fails loudly instead of degrading silently: an operator outside those buckets that reports raw input, an unresolved producer task prefix, and a topology/stats size mismatch are each a `VELOX_CHECK` (with the runtime values at the end of the message, per the coding-style rule). Stages are referenced purely by position -- `producers` are indexes into the stage vector, so no redundant per-stage index is stored. Completion is taken only from the runner's finished flag -- not inferred from snapshot split counts, which grow over time -- and a clean finish normalizes the frame so no stage is left showing running/queued splits.
- `ProgressReporter` -- the RAII handle that polls a `Runner` on a supplied `folly::FunctionScheduler` and emits a final report on teardown from the live `Runner::stats()` (still present until `waitForCompletion`). A misbehaving `onProgress` callback cannot disrupt the query -- its exceptions are logged and swallowed. `poll()` builds the snapshot outside that guard so a builder invariant violation surfaces during execution; the destructor builds inside its own catch because it can run while a failed query unwinds the stack and must never throw.

`fragments()` is pure-virtual on `Runner` and always exposes the plan topology, so `computeProgress()` is always given a stage tree positionally 1:1 with `Runner::stats()`. `SqlQueryRunner` does not own a scheduler -- it takes an optional, non-owned `folly::FunctionScheduler*` constructor arg; a query that sets `onProgress` without a supplied scheduler fails loudly (`VELOX_USER_CHECK_NOT_NULL`) instead of the runner spinning up a hidden thread. `startProgressReporter()` returns the reporter behind a `std::unique_ptr` (`ProgressReporter` is non-movable because its poll closure captures `this`).

The CLI renderer that turns these frames into a live bar is the next diff in the stack.

Differential Revision: D108909838


