### PR TITLE
feat(cli): Show live query progress in the CLI (#1499)

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/ranges.h>
 #include <folly/container/F14Map.h>
+#include <folly/executors/FunctionScheduler.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <filesystem>
@@ -41,7 +42,10 @@ int main(int argc, char** argv) {
       facebook::velox::memory::MemoryManager::Options{});
 
   facebook::axiom::Connectors connectors;
-  axiom::sql::SqlQueryRunner runner{axiom::sql::SystemUser::resolve()};
+  // Progress-polling scheduler for the console's live progress bar.
+  folly::FunctionScheduler progressScheduler;
+  axiom::sql::SqlQueryRunner runner{
+      axiom::sql::SystemUser::resolve(), &progressScheduler};
   runner.initialize([&]() {
     VELOX_USER_CHECK(
         FLAGS_data_path.empty() || FLAGS_etc_dir.empty(),

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   CatalogProperties.cpp
   Connectors.cpp
   Console.cpp
+  LiveProgressDisplay.cpp
   QueryIdGenerator.cpp
   SqlQueryRunner.cpp
   SystemUser.cpp

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -17,12 +17,14 @@
 #include "axiom/cli/Console.h"
 #include <fmt/core.h>
 #include <folly/FileUtil.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 #include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <optional>
 #include <set>
+#include "axiom/cli/LiveProgressDisplay.h"
 #include "axiom/cli/ResultPrinter.h"
 #include "axiom/cli/StdinReader.h"
 #include "axiom/cli/Timing.h"
@@ -66,6 +68,13 @@ DEFINE_bool(
     "Print per-statement timing (parse / optimize / execute). Always on in "
     "interactive mode.");
 
+DEFINE_bool(
+    show_live_progress,
+    false,
+    "Draw the live progress grid for --query and piped-stdin runs (when stderr "
+    "is a terminal). The interactive REPL always shows it; this only opts the "
+    "non-interactive paths in.");
+
 DEFINE_int32(
     repeat,
     1,
@@ -77,6 +86,22 @@ DEFINE_int32(
 using namespace facebook::velox;
 
 namespace {
+// Terminal width assumed when the real width cannot be queried (output is not a
+// tty or the ioctl fails).
+constexpr int kDefaultTerminalWidth = 80;
+
+// Returns the terminal width for `fileDescriptor`, or kDefaultTerminalWidth if
+// it cannot be determined. Re-queried per progress frame so the grid tracks a
+// live terminal resize.
+int terminalWidth(int fileDescriptor) {
+  struct winsize windowSize{};
+  if (ioctl(fileDescriptor, TIOCGWINSZ, &windowSize) == 0 &&
+      windowSize.ws_col > 0) {
+    return windowSize.ws_col;
+  }
+  return kDefaultTerminalWidth;
+}
+
 // Extracts a file path argument from a dot-command string like ".run <file>".
 // Returns the trimmed path, or empty string if none.
 std::string parseDotCommandPath(const std::string& command, size_t prefixLen) {
@@ -126,10 +151,17 @@ void Console::run() {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
     VELOX_USER_CHECK(success, "Cannot open init file: {}", FLAGS_init);
-    runMultiple(sql, FLAGS_print_timing);
+    runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false);
   }
 
   const bool interactive = isatty(STDIN_FILENO);
+
+  // The live progress grid renders on stderr and is erased before results
+  // print, so it needs stderr to be a terminal and the runner to report
+  // progress. The interactive REPL shows it by default; the non-interactive
+  // paths (--query, piped stdin) only opt in via --show_live_progress.
+  const bool terminalProgress =
+      isatty(STDERR_FILENO) != 0 && runner_.supportsProgress();
 
   // Pick the user-SQL source: --query first, then piped stdin.
   std::string userSql;
@@ -141,9 +173,14 @@ void Console::run() {
 
   if (!userSql.empty()) {
     if (repeatInfo.is_default) {
-      runMultiple(userSql, FLAGS_print_timing);
+      runMultiple(
+          userSql,
+          FLAGS_print_timing,
+          FLAGS_show_live_progress && terminalProgress);
     } else {
-      // Explicit --repeat: treat the input as a single statement.
+      // Explicit --repeat: treat the input as a single statement. Skip the
+      // progress grid so its periodic redraws do not perturb the timing this
+      // mode exists to measure.
       runRepeat(userSql, FLAGS_repeat, FLAGS_print_timing);
     }
     return;
@@ -157,7 +194,7 @@ void Console::run() {
                  "Type .help for available commands."
               << std::endl;
   }
-  readCommands("SQL> ", interactive || FLAGS_print_timing);
+  readCommands("SQL> ", interactive || FLAGS_print_timing, terminalProgress);
 }
 
 namespace {
@@ -173,7 +210,10 @@ std::string formatTiming(
 }
 } // namespace
 
-bool Console::runOnce(std::string_view sql, bool printTiming) {
+bool Console::runOnce(
+    std::string_view sql,
+    bool printTiming,
+    bool showProgress) {
   QueryCompletionInfo completionInfo;
 
   SqlQueryRunner::RunOptions options{
@@ -185,10 +225,28 @@ bool Console::runOnce(std::string_view sql, bool printTiming) {
           [&](const QueryCompletionInfo& info) { completionInfo = info; },
   };
 
+  // When enabled by the caller, draw a live status grid on stderr while the
+  // query runs.
+  std::optional<cli::LiveProgressDisplay> progress;
+  if (showProgress) {
+    progress.emplace(
+        std::cerr,
+        cli::LiveProgressDisplay::Options{
+            .showSplitAndCpuDetail = FLAGS_debug});
+    options.onProgress =
+        [&](const facebook::axiom::runner::QueryProgress& info) {
+          progress->update(info, terminalWidth(STDERR_FILENO));
+        };
+  }
+
   cli::Timing cpuTiming;
   try {
     auto result = cli::time<SqlQueryRunner::SqlResult>(
         [&]() { return runner_.run(sql, options); }, cpuTiming);
+
+    if (progress) {
+      progress->clear();
+    }
 
     if (result.message.has_value()) {
       std::cout << result.message.value() << std::endl;
@@ -205,6 +263,9 @@ bool Console::runOnce(std::string_view sql, bool printTiming) {
     }
     return true;
   } catch (const std::exception&) {
+    if (progress) {
+      progress->clear();
+    }
     // run() threw after firing the completion callback, so telemetry was
     // captured.
     std::cerr << "Query failed: " << completionInfo.errorInfo->message
@@ -217,7 +278,10 @@ bool Console::runOnce(std::string_view sql, bool printTiming) {
   }
 }
 
-void Console::runMultiple(std::string_view sql, bool printTiming) {
+void Console::runMultiple(
+    std::string_view sql,
+    bool printTiming,
+    bool showProgress) {
   // Parse and execute statements one at a time so that DDL statements
   // (e.g. CREATE TABLE) take effect before subsequent statements (e.g.
   // INSERT) are parsed.
@@ -225,7 +289,7 @@ void Console::runMultiple(std::string_view sql, bool printTiming) {
     if (sqlText.empty()) {
       continue;
     }
-    if (!runOnce(sqlText, printTiming)) {
+    if (!runOnce(sqlText, printTiming, showProgress)) {
       return;
     }
   }
@@ -233,13 +297,16 @@ void Console::runMultiple(std::string_view sql, bool printTiming) {
 
 void Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
   for (int i = 0; i < repeat; ++i) {
-    if (!runOnce(sql, printTiming)) {
+    if (!runOnce(sql, printTiming, /*showProgress=*/false)) {
       return;
     }
   }
 }
 
-void Console::readCommands(const std::string& prompt, bool printTiming) {
+void Console::readCommands(
+    const std::string& prompt,
+    bool printTiming,
+    bool showProgress) {
   linenoiseSetMultiLine(1);
   linenoiseHistorySetMaxLen(1024);
 
@@ -255,7 +322,7 @@ void Console::readCommands(const std::string& prompt, bool printTiming) {
     std::string command = cli::readCommand(prompt, atEnd);
     if (atEnd) {
       if (!command.empty()) {
-        runMultiple(command, printTiming);
+        runMultiple(command, printTiming, showProgress);
       }
       break;
     }
@@ -305,7 +372,7 @@ void Console::readCommands(const std::string& prompt, bool printTiming) {
         std::cerr << "Cannot open file: " << filePath << std::endl;
         continue;
       }
-      runMultiple(sql, printTiming);
+      runMultiple(sql, printTiming, showProgress);
       continue;
     }
 
@@ -383,7 +450,7 @@ void Console::readCommands(const std::string& prompt, bool printTiming) {
       continue;
     }
 
-    runMultiple(command, printTiming);
+    runMultiple(command, printTiming, showProgress);
   }
 }
 } // namespace axiom::sql

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -24,8 +24,31 @@ DECLARE_bool(debug);
 
 namespace axiom::sql {
 
-/// SQL console that executes queries from command-line flags, files, or
-/// interactive stdin input.
+/// Executes SQL through a SqlQueryRunner, driven from command-line flags, an
+/// init/`.run` file, piped stdin, or an interactive REPL, and prints results
+/// and timing to stdout/stderr.
+///
+/// A live progress grid is drawn on stderr while a query runs when stderr is a
+/// terminal and `runner` was built with a progress scheduler
+/// (SqlQueryRunner::supportsProgress()). The interactive REPL shows it by
+/// default; the non-interactive paths (`--query`, piped stdin) opt in via
+/// `--show_live_progress`. It is erased before results print, so redirected
+/// stdout stays clean, and it is hidden when stderr is redirected (scripted or
+/// captured runs). `--init` and `--repeat` never draw it.
+///
+/// @code
+///   folly::FunctionScheduler scheduler;  // enables progress reporting
+///   SqlQueryRunner runner{user, &scheduler};
+///   Console console{runner};
+///   console.initialize();
+///   console.run();
+/// @endcode
+///
+/// Invariants:
+/// - `runner` must outlive the Console.
+/// - run() owns process-wide stdin/stdout/stderr while it executes; do not
+///   write to them concurrently.
+/// - Query failures are caught and printed; only invalid CLI flags throw.
 class Console {
  public:
   explicit Console(SqlQueryRunner& runner);
@@ -44,19 +67,22 @@ class Console {
 
  private:
   // Runs a single SQL statement and prints results/timing. Returns true on
-  // success, false if the query threw.
-  bool runOnce(std::string_view sql, bool printTiming);
+  // success, false if the query threw. Draws the live progress grid when
+  // 'showProgress' is set.
+  bool runOnce(std::string_view sql, bool printTiming, bool showProgress);
 
   // Splits 'sql' into individual statements and runs each one in sequence.
-  // Stops on the first failure.
-  void runMultiple(std::string_view sql, bool printTiming);
+  // Stops on the first failure. Passes 'showProgress' through to each.
+  void runMultiple(std::string_view sql, bool printTiming, bool showProgress);
 
   // Runs 'sql' (a single SQL statement) 'repeat' times back-to-back.
   // Stops on the first failure.
   void runRepeat(std::string_view sql, int repeat, bool printTiming);
 
   // Reads and executes commands from standard input in interactive mode.
-  void readCommands(const std::string& prompt, bool printTiming);
+  // Passes 'showProgress' through to the statements it runs.
+  void
+  readCommands(const std::string& prompt, bool printTiming, bool showProgress);
 
   SqlQueryRunner& runner_;
 };

--- a/axiom/cli/LiveProgressDisplay.cpp
+++ b/axiom/cli/LiveProgressDisplay.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/LiveProgressDisplay.h"
+
+#include <fmt/core.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "axiom/runner/QueryProgress.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace axiom::cli {
+
+namespace runner = facebook::axiom::runner;
+
+namespace {
+
+// Drops trailing zeros and a now-trailing decimal point, e.g. 1.50 -> "1.5",
+// 2.00 -> "2".
+std::string trimZeros(std::string text) {
+  if (text.find('.') == std::string::npos) {
+    return text;
+  }
+  while (!text.empty() && text.back() == '0') {
+    text.pop_back();
+  }
+  if (!text.empty() && text.back() == '.') {
+    text.pop_back();
+  }
+  return text;
+}
+
+// Formats with 3 significant digits: two decimals below 10, one below 100, none
+// above.
+std::string formatDecimal(double value) {
+  if (value < 10) {
+    return trimZeros(fmt::format("{:.2f}", value));
+  }
+  if (value < 100) {
+    return trimZeros(fmt::format("{:.1f}", value));
+  }
+  return fmt::format("{:.0f}", value);
+}
+
+// Formats a count with decimal SI-style suffixes (K/M/B/T/Q) on a 1000
+// boundary.
+std::string formatCount(int64_t count) {
+  double fractional = static_cast<double>(count);
+  const char* unit = "";
+  if (fractional >= 1'000) {
+    fractional /= 1'000;
+    unit = "K";
+  }
+  if (fractional >= 1'000) {
+    fractional /= 1'000;
+    unit = "M";
+  }
+  if (fractional >= 1'000) {
+    fractional /= 1'000;
+    unit = "B";
+  }
+  if (fractional >= 1'000) {
+    fractional /= 1'000;
+    unit = "T";
+  }
+  if (fractional >= 1'000) {
+    fractional /= 1'000;
+    unit = "Q";
+  }
+  return formatDecimal(fractional) + unit;
+}
+
+// Formats a byte size with binary suffixes (K/M/G/T/P) on a 1024 boundary. When
+// `longForm`, suffixes carry a trailing 'B' (e.g. "1.97GB").
+std::string formatDataSize(int64_t bytes, bool longForm) {
+  double fractional = static_cast<double>(bytes);
+  std::string unit;
+  bool scaled{false};
+  for (const char* unitSuffix : {"K", "M", "G", "T", "P"}) {
+    if (fractional >= 1'024) {
+      fractional /= 1'024;
+      unit = unitSuffix;
+      scaled = true;
+    } else {
+      break;
+    }
+  }
+  if (!scaled) {
+    unit = "B";
+  } else if (longForm) {
+    unit += "B";
+  }
+  return formatDecimal(fractional) + unit;
+}
+
+// Formats a per-second count rate.
+std::string formatCountRate(double count, double seconds, bool longForm) {
+  double rate = count / seconds;
+  if (std::isnan(rate) || std::isinf(rate)) {
+    rate = 0;
+  }
+  std::string formatted = formatCount(static_cast<int64_t>(rate));
+  if (longForm) {
+    formatted += "/s";
+  }
+  return formatted;
+}
+
+// Formats a per-second byte rate.
+std::string formatDataRate(int64_t bytes, double seconds, bool longForm) {
+  double rate = static_cast<double>(bytes) / seconds;
+  if (std::isnan(rate) || std::isinf(rate)) {
+    rate = 0;
+  }
+  std::string formatted = formatDataSize(static_cast<int64_t>(rate), false);
+  if (longForm) {
+    if (formatted.empty() || formatted.back() != 'B') {
+      formatted += "B";
+    }
+    formatted += "/s";
+  }
+  return formatted;
+}
+
+// Formats a duration: sub-second as "<n>ms", otherwise "<min>:<ss>". Switches
+// on the raw microseconds so e.g. 600ms renders as "600ms", not "0:01".
+std::string formatTime(int64_t micros) {
+  if (micros < 1'000'000) {
+    return fmt::format("{}ms", llround(static_cast<double>(micros) / 1'000));
+  }
+  const int64_t totalSeconds = micros / 1'000'000;
+  return fmt::format("{}:{:02d}", totalSeconds / 60, totalSeconds % 60);
+}
+
+// Ceiling of integer division. Takes int64_t so callers can multiply split
+// counts by the bar width without overflowing int.
+int64_t ceilDiv(int64_t dividend, int64_t divisor) {
+  return ((dividend + divisor) - 1) / divisor;
+}
+
+// Builds a determinate progress bar: split the width across complete ("="),
+// running (">"), and pending (" ") segments.
+std::string formatProgressBar(int width, int complete, int running, int total) {
+  if (total == 0) {
+    return std::string(width, ' ');
+  }
+  const int pending = std::max(0, total - complete - running);
+
+  int completeLength = static_cast<int>(std::min<int64_t>(
+      width, ceilDiv(static_cast<int64_t>(complete) * width, total)));
+  int pendingLength = static_cast<int>(std::min<int64_t>(
+      width, ceilDiv(static_cast<int64_t>(pending) * width, total)));
+
+  const int minRunningLength = (running > 0) ? 1 : 0;
+  int runningLength = std::max(
+      static_cast<int>(std::min<int64_t>(
+          width, ceilDiv(static_cast<int64_t>(running) * width, total))),
+      minRunningLength);
+
+  if (((completeLength + runningLength + pendingLength) != width) &&
+      (pending > 0)) {
+    pendingLength = std::max(0, width - completeLength - runningLength);
+  }
+  if ((completeLength + runningLength + pendingLength) != width) {
+    runningLength =
+        std::max(minRunningLength, width - completeLength - pendingLength);
+  }
+  if (((completeLength + runningLength + pendingLength) > width) &&
+      (complete > 0)) {
+    completeLength = std::max(0, width - runningLength - pendingLength);
+  }
+
+  return std::string(completeLength, '=') + std::string(runningLength, '>') +
+      std::string(pendingLength, ' ');
+}
+
+// Builds an indeterminate progress bar: a "<=>" marker that bounces back and
+// forth as `tick` advances.
+std::string formatProgressBar(int width, int tick) {
+  constexpr int kMarkerWidth = 3; // "<=>"
+  const int range = width - kMarkerWidth;
+  if (range <= 0) {
+    return std::string(std::max(0, width), ' ');
+  }
+  int lower = tick % range;
+  if (((tick / range) % 2) != 0) {
+    lower = range - lower;
+  }
+  return std::string(lower, ' ') + "<=>" +
+      std::string(width - (lower + kMarkerWidth), ' ');
+}
+
+std::string pluralize(std::string_view word, int count) {
+  return count != 1 ? std::string(word) + "s" : std::string(word);
+}
+
+// Total source rows processed: rows scanned from storage plus rows received
+// over exchanges. A stage draws from a single source, so one term is zero.
+int64_t sourceRows(const runner::ExecutionStats& stats) {
+  return stats.scanRows + stats.shuffleRows;
+}
+
+// Total source bytes processed; see sourceRows.
+int64_t sourceBytes(const runner::ExecutionStats& stats) {
+  return stats.scanBytes + stats.shuffleBytes;
+}
+
+// Single-character state glyph for the compact stage grid.
+char stateChar(runner::ExecutionState state) {
+  switch (state) {
+    case runner::ExecutionState::kRunning:
+      return 'R';
+    case runner::ExecutionState::kFinished:
+      return 'F';
+    case runner::ExecutionState::kPlanned:
+      return 'P';
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Returns each stage's depth from the root (0 = root) by following producer
+// edges, so the renderer can indent the stage tree. Roots are stages no other
+// stage produces for. The stage graph is a tree -- each stage feeds exactly one
+// consumer -- so a producer's depth is one past its consumer's. Out-of-range
+// producer indexes (a transient mid-poll gap) and already-visited stages (which
+// only a malformed cyclic snapshot would yield) are skipped.
+std::vector<int32_t> stageDepths(
+    const std::vector<runner::StageProgress>& stages) {
+  const auto count = static_cast<int32_t>(stages.size());
+  const auto valid = [&](int32_t index) { return index >= 0 && index < count; };
+
+  std::vector<bool> isProducer(stages.size(), false);
+  for (const auto& stage : stages) {
+    for (const int32_t producer : stage.producers) {
+      if (valid(producer)) {
+        isProducer.at(producer) = true;
+      }
+    }
+  }
+
+  std::vector<int32_t> depths(stages.size(), 0);
+  std::vector<bool> visited(stages.size(), false);
+  std::vector<int32_t> queue;
+  for (int32_t i = 0; i < count; ++i) {
+    if (!isProducer.at(i)) {
+      visited.at(i) = true;
+      queue.push_back(i);
+    }
+  }
+  for (size_t head = 0; head < queue.size(); ++head) {
+    const int32_t consumer = queue.at(head);
+    for (const int32_t producer : stages.at(consumer).producers) {
+      if (valid(producer) && !visited.at(producer)) {
+        visited.at(producer) = true;
+        depths.at(producer) = depths.at(consumer) + 1;
+        queue.push_back(producer);
+      }
+    }
+  }
+  return depths;
+}
+
+} // namespace
+
+LiveProgressDisplay::LiveProgressDisplay(std::ostream& out, Options options)
+    : out_{out}, options_{options} {}
+
+LiveProgressDisplay::~LiveProgressDisplay() {
+  // A destructor is implicitly noexcept; swallow any terminal-write failure
+  // from clear() so it cannot escape during stack unwinding and call
+  // std::terminate.
+  try {
+    clear();
+  } catch (...) {
+  }
+}
+
+namespace {
+
+// Appends one rendered line to the current frame; the caller's emitter erases
+// the line first and counts the rows drawn.
+using LineEmitter = std::function<void(std::string_view)>;
+
+// Renders the one-line fallback used when the terminal is too narrow for the
+// grid.
+void renderNarrowSummary(
+    const LineEmitter& emit,
+    const runner::QueryProgress& info,
+    const std::string& wall) {
+  if (info.stats.totalSplits > 0) {
+    emit(
+        fmt::format(
+            "{} {}/{}",
+            wall,
+            formatCount(info.stats.completedSplits),
+            formatCount(info.stats.totalSplits)));
+  } else {
+    emit(wall);
+  }
+}
+
+// Renders the query header, the optional split/CPU detail lines, and the
+// progress bar.
+void renderSummary(
+    const LineEmitter& emit,
+    const runner::QueryProgress& info,
+    int width,
+    const std::string& wall,
+    double seconds,
+    bool showSplitAndCpuDetail) {
+  emit("");
+  emit(
+      fmt::format(
+          "Query {}, {}, {} {}",
+          info.queryId,
+          runner::ExecutionStateName::toName(info.stats.state),
+          info.stats.totalSplits,
+          pluralize("split", info.stats.totalSplits)));
+
+  if (showSplitAndCpuDetail) {
+    emit(
+        fmt::format(
+            "Splits:   {} queued, {} running, {} done",
+            info.stats.queuedSplits,
+            info.stats.runningSplits,
+            info.stats.completedSplits));
+    const double cpuSeconds =
+        static_cast<double>(info.stats.cpuTimeMicros) / 1'000'000;
+    emit(
+        fmt::format(
+            "CPU Time: {:.1f}s total, {} rows/s, {}",
+            cpuSeconds,
+            formatCountRate(sourceRows(info.stats), cpuSeconds, false),
+            formatDataRate(sourceBytes(info.stats), cpuSeconds, true)));
+  }
+
+  // Progress bar width: terminal width (capped at 100) minus the summary's
+  // fixed non-bar characters (~75), plus a 17-char base, then shortened by any
+  // time prefix wider than the usual 5 ("MM:SS").
+  int progressWidth = (std::min(width, 100) - 75) + 17;
+  if (wall.size() > 5) {
+    progressWidth -= static_cast<int>(wall.size()) - 5;
+  }
+  progressWidth = std::max(1, progressWidth);
+
+  if (info.stats.totalSplits > 0) {
+    const std::string bar = formatProgressBar(
+        progressWidth,
+        info.stats.completedSplits,
+        std::max(0, info.stats.runningSplits),
+        info.stats.totalSplits);
+    emit(
+        fmt::format(
+            "{} [{} rows, {}] [{} rows/s, {}] [{}] {}/{}",
+            wall,
+            formatCount(sourceRows(info.stats)),
+            formatDataSize(sourceBytes(info.stats), true),
+            formatCountRate(sourceRows(info.stats), seconds, false),
+            formatDataRate(sourceBytes(info.stats), seconds, true),
+            bar,
+            formatCount(info.stats.completedSplits),
+            formatCount(info.stats.totalSplits)));
+  } else {
+    // No splits scheduled yet: show an indeterminate marker driven by elapsed
+    // time at decisecond resolution, so it keeps moving between sub-second
+    // polls.
+    const std::string bar =
+        formatProgressBar(progressWidth, static_cast<int>(seconds * 10));
+    emit(
+        fmt::format(
+            "{} [{} rows, {}] [{} rows/s, {}] [{}]",
+            wall,
+            formatCount(sourceRows(info.stats)),
+            formatDataSize(sourceBytes(info.stats), true),
+            formatCountRate(sourceRows(info.stats), seconds, false),
+            formatDataRate(sourceBytes(info.stats), seconds, true),
+            bar));
+  }
+}
+
+// Renders the per-stage grid: a header row and one row per stage, ordered
+// shallowest (root) first and indented by depth.
+void renderStageGrid(
+    const LineEmitter& emit,
+    const runner::QueryProgress& info,
+    double seconds) {
+  if (info.stages.empty()) {
+    return;
+  }
+  emit("");
+  emit(
+      fmt::format(
+          "{:>10}{:>1}  {:>5}  {:>6}  {:>5}  {:>7}  {:>6}  {:>5}  {:>5}",
+          "STAGE",
+          "S",
+          "ROWS",
+          "ROWS/s",
+          "BYTES",
+          "BYTES/s",
+          "QUEUED",
+          "RUN",
+          "DONE"));
+
+  // The display label numbers stages in root-first order; the model's index is
+  // the raw fragment index.
+  const auto depths = stageDepths(info.stages);
+  std::vector<size_t> order(info.stages.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::stable_sort(order.begin(), order.end(), [&](size_t lhs, size_t rhs) {
+    return depths[lhs] < depths[rhs];
+  });
+
+  int32_t displayLabel{0};
+  for (const size_t idx : order) {
+    const auto& stage = info.stages[idx];
+
+    // Stage label: depth-indent + sequential label, dot-padded to
+    // kStageLabelWidth columns. Deep trees whose indent + label exceed the
+    // column are truncated so the fixed-width grid stays aligned.
+    constexpr size_t kStageLabelWidth = 10;
+    std::string name =
+        std::string(static_cast<size_t>(std::max(0, depths[idx])) * 2, ' ') +
+        std::to_string(displayLabel);
+    if (name.size() < kStageLabelWidth) {
+      name += std::string(kStageLabelWidth - name.size(), '.');
+    } else if (name.size() > kStageLabelWidth) {
+      name.resize(kStageLabelWidth);
+    }
+    ++displayLabel;
+
+    // Finished stages report a zero rate.
+    const bool done = stage.stats.state == runner::ExecutionState::kFinished;
+    const std::string rowsPerSecond = done
+        ? formatCountRate(0, 0, false)
+        : formatCountRate(sourceRows(stage.stats), seconds, false);
+    const std::string bytesPerSecond = done
+        ? formatDataRate(0, 0, false)
+        : formatDataRate(sourceBytes(stage.stats), seconds, false);
+
+    emit(
+        fmt::format(
+            "{:>10}{:>1}  {:>5}  {:>6}  {:>5}  {:>7}  {:>6}  {:>5}  {:>5}",
+            name,
+            std::string(1, stateChar(stage.stats.state)),
+            formatCount(sourceRows(stage.stats)),
+            rowsPerSecond,
+            formatDataSize(sourceBytes(stage.stats), false),
+            bytesPerSecond,
+            stage.stats.queuedSplits,
+            stage.stats.runningSplits,
+            stage.stats.completedSplits));
+  }
+}
+
+} // namespace
+
+void LiveProgressDisplay::update(const runner::QueryProgress& info, int width) {
+  auto lines = lines_.wlock();
+
+  // Build the whole frame in one buffer and write it once, so a slow or SSH
+  // terminal never renders a half-drawn frame and we issue a single flush.
+  std::string frame;
+  if (*lines > 0) {
+    // Move to the top of the previous block (CSI nA) and erase from there to
+    // the end of the screen (CSI 0J). Clearing the whole block keeps surplus
+    // rows from a taller previous frame from lingering below the new content.
+    frame += fmt::format("\x1b[{}A\x1b[0J", *lines);
+  }
+
+  int drawn{0};
+  // Erases the line (CSI 2K) before each rewrite and counts the rows drawn.
+  const LineEmitter emit = [&](std::string_view line) {
+    frame += "\x1b[2K";
+    frame += line;
+    frame += '\n';
+    ++drawn;
+  };
+
+  const double seconds = static_cast<double>(info.wallTimeMicros) / 1'000'000;
+  const std::string wall = formatTime(info.wallTimeMicros);
+
+  // Narrow terminals cannot fit the grid; fall back to a one-line summary.
+  if (width < 75) {
+    renderNarrowSummary(emit, info, wall);
+  } else {
+    renderSummary(
+        emit, info, width, wall, seconds, options_.showSplitAndCpuDetail);
+    renderStageGrid(emit, info, seconds);
+  }
+
+  out_ << frame;
+  out_.flush();
+  *lines = drawn;
+}
+
+void LiveProgressDisplay::clear() {
+  auto lines = lines_.wlock();
+  if (*lines == 0) {
+    return;
+  }
+  // Move back to the top of the block and erase everything below the cursor
+  // (CSI 0J), clearing the status display before results are printed.
+  out_ << fmt::format("\x1b[{}A\x1b[0J", *lines);
+  out_.flush();
+  *lines = 0;
+}
+
+} // namespace axiom::cli

--- a/axiom/cli/LiveProgressDisplay.h
+++ b/axiom/cli/LiveProgressDisplay.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Synchronized.h>
+#include <ostream>
+
+namespace facebook::axiom::runner {
+struct QueryProgress;
+} // namespace facebook::axiom::runner
+
+namespace axiom::cli {
+
+/// Renders live query progress as an in-place status block on a stream. Each
+/// update() redraws the block -- a summary line, optional detail, and a
+/// per-stage grid -- over the previous one; clear() erases it so it does not
+/// linger before query results are printed.
+///
+/// This class always renders: the caller decides whether progress should be
+/// shown at all (e.g. only for an interactive REPL with a terminal stderr) and
+/// only then constructs one. It draws to a stream and takes the target width
+/// per update(), so it has no file-descriptor or terminal dependency of its
+/// own; the caller supplies the width (re-query it each call to track a live
+/// terminal resize).
+///
+/// update() runs on the background progress-poller thread while clear() runs on
+/// the main thread; a lock serializes them and the cursor/line state they
+/// share.
+///
+/// @code
+///   cli::LiveProgressDisplay display(std::cerr, /*options=*/{});
+///   // Feed it a snapshot whenever progress is reported:
+///   display.update(progress, /*width=*/80);
+///   // ...repeat as progress advances...
+///   display.clear();  // erase the block before printing results
+/// @endcode
+///
+/// Invariant the caller must uphold: update()/clear() are the only writers to
+/// `out` while a query runs.
+class LiveProgressDisplay {
+ public:
+  /// Display knobs; defaults render the compact view.
+  struct Options {
+    /// When true, also draws the per-split and CPU-time detail lines.
+    bool showSplitAndCpuDetail{false};
+  };
+
+  /// @param out Stream to draw on (typically std::cerr).
+  /// @param options Display knobs.
+  LiveProgressDisplay(std::ostream& out, Options options);
+
+  /// Erases any drawn status block so an exception that bypasses the explicit
+  /// clear() call still restores the terminal. Idempotent with clear().
+  ~LiveProgressDisplay();
+
+  LiveProgressDisplay(const LiveProgressDisplay&) = delete;
+  LiveProgressDisplay& operator=(const LiveProgressDisplay&) = delete;
+  LiveProgressDisplay(LiveProgressDisplay&&) = delete;
+  LiveProgressDisplay& operator=(LiveProgressDisplay&&) = delete;
+
+  /// Redraws the status block in place from a progress snapshot, laid out for a
+  /// terminal `width` columns wide.
+  void update(const facebook::axiom::runner::QueryProgress& info, int width);
+
+  /// Erases the status block. Call once after the query completes, before
+  /// printing results. No-op when nothing has been drawn yet.
+  void clear();
+
+ private:
+  // Stream receiving the ANSI status output (typically std::cerr).
+  std::ostream& out_;
+  // Display knobs decided once at construction.
+  const Options options_;
+
+  // Rows drawn in the current block, reset to 0 once it is cleared. Held under
+  // the lock across the whole frame so the poller and main threads never
+  // interleave terminal writes.
+  folly::Synchronized<int> lines_{0};
+};
+
+} // namespace axiom::cli

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -35,7 +35,8 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 | `--num_workers` | `4` | Number of in-process workers. |
 | `--num_drivers` | `4` | Number of drivers per worker (parallelism). |
 | `--max_rows` | `100` | Maximum number of printed result rows. |
-| `--debug` | `false` | Enable debug mode (logging to stderr). |
+| `--show_live_progress` | `false` | Draw the [live progress](#live-progress) grid for `--query` and piped-stdin runs (when stderr is a terminal). The interactive REPL always shows it; this only opts the non-interactive paths in. |
+| `--debug` | `false` | Enable debug mode (logging to stderr; adds per-split and CPU-time detail lines to the live progress display). |
 
 ## Connectors
 
@@ -231,6 +232,44 @@ input N times back-to-back. Useful for perf measurements, re-running
 flaky queries, or queries with non-deterministic results. The input
 must be a single statement; multi-statement input is rejected. Stops
 on the first error. Not supported in interactive mode.
+
+## Live Progress
+
+While a query runs, the CLI can draw a live, in-place status block on stderr — a
+summary line, a progress bar, and a per-stage grid — refreshed as the query
+advances and erased before results are printed, so redirected stdout stays clean.
+
+It is shown only when stderr is a terminal:
+
+- **Interactive REPL** — on by default.
+- **`--query` and piped stdin** — opt in with `--show_live_progress`.
+- **`--init` and `--repeat`** — never draw it.
+
+When stderr is redirected (scripted or captured runs), nothing is drawn. Pass
+`--debug` to add per-split and CPU-time detail lines.
+
+```
+$ ./axiom_sql --show_live_progress --schema sf10 --query "
+    SELECT n.n_name, sum(l.l_extendedprice * (1 - l.l_discount)) AS revenue
+    FROM customer c
+    JOIN orders o ON o.o_custkey = c.c_custkey
+    JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+    JOIN nation n ON n.n_nationkey = c.c_nationkey
+    GROUP BY n.n_name ORDER BY revenue DESC"
+
+Query 20260622_184329_00000_b3udk, RUNNING, 32 splits
+0:17 [32.5M rows, 6.11GB] [1.91M rows/s, 368MB/s] [===============>>>>>>>>>>>>>>] 14/32
+
+     STAGES   ROWS  ROWS/s  BYTES  BYTES/s  QUEUED    RUN   DONE
+0.........R  13.5M    793K   206M    12.1M       0      4      4
+  1.......R  10.6M    624K  4.32G     260M       2      4      0
+  2.......F   4.5M       0  1.37G       0B       0      0      1
+```
+
+The per-stage grid lists one row per execution stage, indented by depth (the
+root stage that produces the final result first), with a single-letter state
+(`P`lanned, `R`unning, `F`inished) and per-stage row/byte counts, rates, and
+split tallies.
 
 ## Exit Status
 

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -176,6 +176,13 @@ class SqlQueryRunner {
     return user_;
   }
 
+  /// Whether live progress reporting is available, i.e. a progress scheduler
+  /// was supplied at construction. A query that sets RunOptions::onProgress
+  /// requires this; callers gate progress display on it.
+  bool supportsProgress() const {
+    return progressScheduler_ != nullptr;
+  }
+
   /// Initializes the runner with connectors, an optional permission check, and
   /// a query ID generator (defaults to QueryIdGenerator if not provided).
   /// Call once before running queries.

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   SqlQueryRunnerTest.cpp
   StdinReaderTest.cpp
   ConsoleTest.cpp
+  LiveProgressDisplayTest.cpp
   QueryIdGeneratorTest.cpp
 )
 

--- a/axiom/cli/tests/LiveProgressDisplayTest.cpp
+++ b/axiom/cli/tests/LiveProgressDisplayTest.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/LiveProgressDisplay.h"
+
+#include <fmt/core.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cctype>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "axiom/runner/QueryProgress.h"
+
+using ::testing::ElementsAre;
+
+namespace axiom::cli {
+
+namespace runner = facebook::axiom::runner;
+
+namespace {
+
+// Fixed render width so the laid-out frame is deterministic.
+constexpr int kWidth = 80;
+
+// The per-stage grid header, shared by every grid-rendering case.
+constexpr const char* kGridHeader =
+    "     STAGES   ROWS  ROWS/s  BYTES  BYTES/s  QUEUED    RUN   DONE";
+
+// Removes ANSI CSI escape sequences (ESC '[' ... final-letter) that update()
+// emits for cursor moves and line erases, then splits the remaining text into
+// lines (dropping the trailing empty piece after the last newline). The result
+// is the visible text of the frame, one entry per drawn row.
+std::vector<std::string> renderLines(const std::string& frame) {
+  std::string text;
+  for (size_t i = 0; i < frame.size();) {
+    if (frame[i] == '\x1b' && i + 1 < frame.size() && frame[i + 1] == '[') {
+      i += 2;
+      while (i < frame.size() &&
+             std::isalpha(static_cast<unsigned char>(frame[i])) == 0) {
+        ++i;
+      }
+      if (i < frame.size()) {
+        ++i; // the final letter
+      }
+    } else {
+      text += frame[i++];
+    }
+  }
+
+  std::vector<std::string> lines;
+  size_t start = 0;
+  while (start <= text.size()) {
+    const size_t newline = text.find('\n', start);
+    if (newline == std::string::npos) {
+      if (start < text.size()) {
+        lines.push_back(text.substr(start));
+      }
+      break;
+    }
+    lines.push_back(text.substr(start, newline - start));
+    start = newline + 1;
+  }
+  return lines;
+}
+
+// Renders one frame for `info` at kWidth and returns its visible lines.
+std::vector<std::string> render(
+    const runner::QueryProgress& info,
+    LiveProgressDisplay::Options options = {}) {
+  std::ostringstream out;
+  LiveProgressDisplay display(out, options);
+  display.update(info, kWidth);
+  return renderLines(out.str());
+}
+
+// Builds a single-stage running snapshot whose only stage mirrors the
+// query-level stats.
+runner::QueryProgress makeProgress(
+    int32_t completedSplits,
+    int32_t totalSplits,
+    int64_t scanRows,
+    int64_t scanBytes,
+    int64_t wallMicros) {
+  runner::QueryProgress info;
+  info.queryId = "q1";
+  info.wallTimeMicros = wallMicros;
+  info.stats.state = runner::ExecutionState::kRunning;
+  info.stats.totalSplits = totalSplits;
+  info.stats.completedSplits = completedSplits;
+  info.stats.scanRows = scanRows;
+  info.stats.scanBytes = scanBytes;
+  runner::StageProgress only;
+  only.stats = info.stats;
+  info.stages.push_back(only);
+  return info;
+}
+
+TEST(LiveProgressDisplayTest, rendersGridFrame) {
+  EXPECT_THAT(
+      render(makeProgress(
+          /*completedSplits=*/1,
+          /*totalSplits=*/4,
+          /*scanRows=*/100,
+          /*scanBytes=*/0,
+          /*wallMicros=*/2'000'000)),
+      ElementsAre(
+          "",
+          "Query q1, RUNNING, 4 splits",
+          "0:02 [100 rows, 0B] [50 rows/s, 0B/s] [======                ] 1/4",
+          "",
+          kGridHeader,
+          "0.........R    100      50     0B       0B       0      0      1"));
+}
+
+TEST(LiveProgressDisplayTest, formatsSiUnits) {
+  EXPECT_THAT(
+      render(makeProgress(
+          /*completedSplits=*/2,
+          /*totalSplits=*/4,
+          /*scanRows=*/1'500'000,
+          /*scanBytes=*/6'560'000'000,
+          /*wallMicros=*/2'000'000)),
+      ElementsAre(
+          "",
+          "Query q1, RUNNING, 4 splits",
+          "0:02 [1.5M rows, 6.11GB] [750K rows/s, 3.05GB/s] [===========           ] 2/4",
+          "",
+          kGridHeader,
+          "0.........R   1.5M    750K  6.11G    3.05G       0      0      2"));
+}
+
+TEST(LiveProgressDisplayTest, debugAddsSplitAndCpuLines) {
+  runner::QueryProgress info = makeProgress(1, 4, 100, 0, 2'000'000);
+  info.stats.queuedSplits = 1;
+  info.stats.runningSplits = 2;
+  info.stats.cpuTimeMicros = 4'000'000;
+
+  EXPECT_THAT(
+      render(info, {.showSplitAndCpuDetail = true}),
+      ElementsAre(
+          "",
+          "Query q1, RUNNING, 4 splits",
+          "Splits:   1 queued, 2 running, 1 done",
+          "CPU Time: 4.0s total, 25 rows/s, 0B/s",
+          "0:02 [100 rows, 0B] [50 rows/s, 0B/s] [======>>>>>>>>>>>     ] 1/4",
+          "",
+          kGridHeader,
+          "0.........R    100      50     0B       0B       0      0      1"));
+}
+
+TEST(LiveProgressDisplayTest, ordersStagesRootFirstAndIndentsByDepth) {
+  // Stage 0 (root) consumes stage 1; the grid lists the root first and indents
+  // the deeper stage by two spaces.
+  runner::QueryProgress info;
+  info.queryId = "q1";
+  info.wallTimeMicros = 2'000'000;
+  info.stats.state = runner::ExecutionState::kRunning;
+
+  runner::StageProgress root;
+  root.producers = {1};
+  root.stats.state = runner::ExecutionState::kRunning;
+  root.stats.scanRows = 200;
+  runner::StageProgress leaf;
+  leaf.stats.state = runner::ExecutionState::kFinished;
+  leaf.stats.scanRows = 100;
+  info.stages = {root, leaf};
+
+  EXPECT_THAT(
+      render(info),
+      ElementsAre(
+          "",
+          "Query q1, RUNNING, 0 splits",
+          "0:02 [0 rows, 0B] [0 rows/s, 0B/s] [                  <=> ]",
+          "",
+          kGridHeader,
+          "0.........R    200     100     0B       0B       0      0      0",
+          "  1.......F    100       0     0B       0B       0      0      0"));
+}
+
+TEST(LiveProgressDisplayTest, clearErasesTheDrawnBlock) {
+  std::ostringstream out;
+  LiveProgressDisplay display(out, /*options=*/{});
+  display.update(makeProgress(1, 4, 100, 0, 2'000'000), kWidth);
+  const size_t drawnRows = renderLines(out.str()).size();
+
+  out.str("");
+  display.clear();
+
+  // clear() moves up over every drawn row and erases to end of screen.
+  EXPECT_EQ(out.str(), fmt::format("\x1b[{}A\x1b[0J", drawnRows));
+}
+
+} // namespace
+} // namespace axiom::cli


### PR DESCRIPTION
Summary:

Subscribes the axiom CLI to the `onProgress` callback and renders a live, in-place status display while a query runs, mirroring the Presto CLI: a summary line, a progress bar, and a per-stage grid. Output goes to stderr.

`Console` owns the decision of whether to show progress, gated on stderr being a terminal and the runner being able to report progress (`SqlQueryRunner::supportsProgress()`, true when a `folly::FunctionScheduler` was supplied). The interactive REPL shows the grid by default; the non-interactive paths (`--query`, piped stdin) opt in via `--show_live_progress`, and `--init` (setup statements) and `--repeat` (perf-measurement runs) never draw it. The grid renders on stderr and is erased before results print, so redirected stdout stays clean, and it is hidden when stderr is redirected (scripted or captured runs).

The renderer itself, `LiveProgressDisplay`, just draws to a stream -- it has no file-descriptor or terminal dependency. `Console` passes the target width to each `update()` (re-queried per frame so the grid tracks a terminal resize), which keeps the renderer testable against a plain stream and keeps the terminal policy in one place. `Console` is constructed with just the runner, so a runner built without a scheduler reports `supportsProgress() == false` and gets no display -- callers that cannot report progress (such as tests) need no extra wiring.

`LiveProgressDisplay` exposes `update(info, width)` to redraw the block and `clear()` to erase it before results print; display knobs live in a small `Options` struct (`showSplitAndCpuDetail`). The stage-depth walk that indents the grid is a private detail of the renderer: the stage graph is a tree (each stage feeds exactly one consumer), so a stage's depth is one past its consumer's.

A representative mid-execution frame:

```
Query 20260622_184329_00000_b3udk, RUNNING, 32 splits
0:17 [32.5M rows, 6.11GB] [1.91M rows/s, 368MB/s] [===================>>>>>>>>>>>>>>>>>>>>>  ] 14/32

     STAGES   ROWS  ROWS/s  BYTES  BYTES/s  QUEUED    RUN   DONE
0.........P      0       0     0B       0B       0      0      4
  1.......P      0       0     0B       0B       0      4      0
    2.....R  3.45M    203K  54.8M    3.22M       0      4      4
      3...R  13.5M    793K   206M    12.1M       0      4      4
      4...F   450K       0   169M       0B       0      0      1
        5.R  10.6M    624K  4.32G     260M       2      4      0
        6.F   4.5M       0  1.37G       0B       0      0      1
```
Final frame after completion (live display cleared, only results remain on stdout):

```
-------------+--------------+----------+-----------+------------------
l_returnflag | l_linestatus |      cnt |       qty |               rev
-------------+--------------+----------+-----------+------------------
A            | F            |  7403889 | 188818373 | 283107483036.1195
N            | F            |   192439 |   4913382 | 7364213967.950009
N            | O            | 14997114 | 382400594 | 573408429286.9312
R            | F            |  7406353 | 188960009 | 283310887148.1993
(4 rows in 1 batches)
```

Reviewed By: mbasmanova

Differential Revision: D108945711


