### PR TITLE
feat: Allow ORDER BY aggregates with global grouping sets (#1502)

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -768,11 +768,6 @@ void AggregationPlanner::addGroupingSetsAggregation(
     const ExprVector& groupingKeys,
     const AggregateVector& aggregates,
     PlanState& state) const {
-  const auto hasOrderBy =
-      std::any_of(aggregates.begin(), aggregates.end(), [](const auto& agg) {
-        return !agg->orderKeys().empty();
-      });
-
   auto* groupIdNode = makeGroupIdNode(plan, aggPlan, groupingKeys, aggregates);
   state.addCost(*groupIdNode);
   plan = groupIdNode;
@@ -793,14 +788,6 @@ void AggregationPlanner::addGroupingSetsAggregation(
     aggGroupingKeys.push_back(groupIdNode->columns()[i]);
   }
   aggGroupingKeys.push_back(aggPlan->groupId());
-
-  // ORDER BY forces single-step aggregation (partial aggregation cannot
-  // preserve ORDER BY semantics), but global grouping sets require split
-  // (partial+final). With kSingle, addLocalPartition creates empty driver
-  // partitions that each emit a spurious default row for the global set.
-  VELOX_USER_CHECK(
-      !hasOrderBy || globalGroupingSets.empty(),
-      "ORDER BY in aggregate functions is not supported with global grouping sets (ROLLUP, CUBE, or GROUPING SETS containing ())");
 
   if (isSingleWorker_ && isSingleDriver_) {
     auto [agg, cost] = makeSingleAggregationPlan(

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -19,7 +19,6 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
-#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -520,26 +519,51 @@ TEST_F(AggregationTest, groupingSetsNoGlobalSet) {
   }
 }
 
-// ORDER BY in aggregates requires single-step aggregation (partial aggregation
-// cannot preserve ORDER BY semantics), but global grouping sets require
-// partial+final. With kSingle, empty driver partitions emit spurious default
-// rows for the global set.
+// Verifies a per-aggregate ORDER BY with a global grouping set plans
+// single-step.
 TEST_F(AggregationTest, groupingSetsOrderByWithGlobalSet) {
   testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
   SCOPE_EXIT {
     testConnector_->dropTableIfExists("t");
   };
 
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("t")
-                         .rollup({"a"}, {"array_agg(b ORDER BY b)"}, "gid")
-                         .build();
+  auto logicalPlan =
+      lp::PlanBuilder(makeContext())
+          .tableScan("t")
+          .rollup({"a"}, {"array_agg(b ORDER BY b) as arr"}, "gid")
+          .build();
 
-  VELOX_ASSERT_THROW(
-      planVelox(
-          logicalPlan,
-          MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4}),
-      "ORDER BY in aggregate functions is not supported with global grouping sets");
+  // Single-node plan shape.
+  {
+    auto plan = toSingleNodePlan(logicalPlan);
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a"}, {}}, {"b"}, "gid")
+            .singleAggregation({"a", "gid"}, {"array_agg(b ORDER BY b) as arr"})
+            .project({"a", "arr", "gid"})
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Distributed plan shape.
+  {
+    auto plan = planVelox(
+        logicalPlan,
+        MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4});
+
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan()
+            .groupId({{"a"}, {}}, {"b"}, "gid")
+            .gather()
+            .localPartition({"a", "gid"})
+            .singleAggregation({"a", "gid"}, {"array_agg(b ORDER BY b) as arr"})
+            .project({"a", "arr", "gid"})
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
 }
 
 // Literal-only aggregate args (count(1)) — aggregation inputs list passed to

--- a/axiom/optimizer/tests/sql/distinctAggregation.sql
+++ b/axiom/optimizer/tests/sql/distinctAggregation.sql
@@ -131,3 +131,9 @@ SELECT a, b, count(DISTINCT c) FROM t GROUP BY GROUPING SETS ((a), (b))
 ----
 -- DISTINCT: ORDER BY with GROUPING SETS, without a global set.
 SELECT a, b, array_agg(DISTINCT c ORDER BY c) FROM t GROUP BY GROUPING SETS ((a), (b))
+----
+-- DISTINCT: ORDER BY with a global grouping set.
+SELECT a, array_agg(DISTINCT b ORDER BY b) FROM t GROUP BY ROLLUP(a)
+----
+-- DISTINCT: ORDER BY with a global grouping set over empty input.
+SELECT a, array_agg(DISTINCT b ORDER BY b) FROM t WHERE a > 1000 GROUP BY ROLLUP(a)

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -121,6 +121,9 @@ SELECT a, GROUPING(a) AS grp, sum(b) AS s FROM t GROUP BY ROLLUP(a) HAVING grp =
 -- error: Not a grouping column
 SELECT a, GROUPING(b), count(*) AS c FROM t GROUP BY ROLLUP(a)
 ----
--- error: ORDER BY in aggregate functions is not supported with global grouping sets
-SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)
+-- ORDER BY in an aggregate with a global grouping set.
+SELECT a, array_agg(b ORDER BY b) AS arr FROM t GROUP BY ROLLUP(a)
+----
+-- ORDER BY in an aggregate with a global grouping set over empty input.
+SELECT a, array_agg(b ORDER BY b) AS arr FROM t WHERE a > 1000 GROUP BY ROLLUP(a)
 ----


### PR DESCRIPTION
Summary:

A per-aggregate ORDER BY combined with a global grouping set (ROLLUP, CUBE, or GROUPING SETS with the `()` set) was rejected with `ORDER BY in aggregate functions is not supported with global grouping sets`. It now plans and runs.

For example:

    SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY ROLLUP(a)

returns one array per `a` plus a grand-total array, instead of failing.

ORDER BY makes an aggregate non-decomposable, so it must run single-step. With single-step now correct for global grouping sets, the planner routes this case to single-step and removes the check that rejected it.

Differential Revision: D108352143


