### PR TITLE
test: PlanMatcher sample-rate check and alias passthrough

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -225,11 +225,13 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
   HiveScanMatcher(
       const std::string& tableName,
       common::SubfieldFilters subfieldFilters,
-      const std::string& remainingFilter)
+      const std::string& remainingFilter,
+      std::optional<double> sampleRate)
       : PlanMatcherImpl<TableScanNode>(),
         tableName_{tableName},
         subfieldFilters_{std::move(subfieldFilters)},
-        remainingFilter_{remainingFilter} {}
+        remainingFilter_{remainingFilter},
+        sampleRate_{sampleRate} {}
 
   MatchResult matchDetails(
       const TableScanNode& plan,
@@ -278,6 +280,10 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
       EXPECT_EQ(remainingFilter->toString(), expected->toString());
     }
 
+    // Hive's `sampleRate == 1.0` means no sampling — the default the
+    // matcher asserts when the caller didn't opt in.
+    EXPECT_EQ(hiveTableHandle->sampleRate(), sampleRate_.value_or(1.0));
+
     AXIOM_TEST_RETURN
   }
 
@@ -285,6 +291,7 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
   const std::string tableName_;
   const common::SubfieldFilters subfieldFilters_;
   const std::string remainingFilter_;
+  const std::optional<double> sampleRate_;
 };
 
 class ValuesMatcher : public PlanMatcherImpl<ValuesNode> {
@@ -368,8 +375,11 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
     if (!expressions_.empty()) {
       EXPECT_EQ(plan.projections().size(), expressions_.size());
       AXIOM_TEST_RETURN_IF_FAILURE
+    }
 
-      for (auto i = 0; i < expressions_.size(); ++i) {
+    for (auto i = 0; i < plan.projections().size(); ++i) {
+      // Verify the expression (if one was given) and capture its alias.
+      if (!expressions_.empty()) {
         auto expected =
             parse::DuckSqlExpressionsParser().parseExpr(expressions_[i]);
         if (expected->alias()) {
@@ -383,18 +393,18 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
         ExprMatcher::match(plan.projections()[i], expected->dropAlias());
         AXIOM_TEST_RETURN_IF_FAILURE
       }
-    } else {
-      // No expressions to verify. Remap symbols through the project's
-      // column mapping. For identity projections (field access), update
-      // the symbol to use the project's output name. Symbols for computed
-      // projections are dropped.
-      for (const auto& [alias, childName] : symbols) {
-        for (auto i = 0; i < plan.projections().size(); ++i) {
-          if (auto* field = dynamic_cast<const FieldAccessTypedExpr*>(
-                  plan.projections()[i].get());
-              field && field->name() == childName) {
+
+      // For an identity projection (a top-level input-column field access,
+      // not a subfield dereference like `a.b`), propagate the child's alias
+      // for that column, now bound to the project's output name, so a
+      // passthrough of an aliased column stays referenceable in parent
+      // matchers. Computed projections drop the symbol.
+      if (auto* field =
+              plan.projections()[i]->asUnchecked<FieldAccessTypedExpr>();
+          field != nullptr && field->isInputColumn()) {
+        for (const auto& [alias, childName] : symbols) {
+          if (childName == field->name()) {
             newSymbols[alias] = plan.names()[i];
-            break;
           }
         }
       }
@@ -1787,10 +1797,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::tableScan(
 PlanMatcherBuilder& PlanMatcherBuilder::hiveScan(
     const std::string& tableName,
     common::SubfieldFilters subfieldFilters,
-    const std::string& remainingFilter) {
+    const std::string& remainingFilter,
+    std::optional<double> sampleRate) {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<HiveScanMatcher>(
-      tableName, std::move(subfieldFilters), remainingFilter);
+      tableName, std::move(subfieldFilters), remainingFilter, sampleRate);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -180,10 +180,13 @@ class PlanMatcherBuilder {
   /// filters.
   /// @param remainingFilter Optional filter expression that couldn't be pushed
   /// down into the scan.
+  /// @param sampleRate When set, asserts the scan's sample rate equals
+  /// this value (Hive's `rand() < k` encoding).
   PlanMatcherBuilder& hiveScan(
       const std::string& tableName,
       common::SubfieldFilters subfieldFilters,
-      const std::string& remainingFilter = "");
+      const std::string& remainingFilter = "",
+      std::optional<double> sampleRate = std::nullopt);
 
   /// Matches any Values node regardless of type.
   PlanMatcherBuilder& values();
@@ -484,7 +487,10 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& orderBy();
 
   /// Matches an OrderBy node with the specified ordering.
-  /// @param ordering List of sort keys (e.g., {"a ASC", "b DESC"}).
+  /// @param ordering List of sort keys (e.g., {"a ASC", "b DESC"}). Parsed by
+  /// the DuckDB SQL parser: an omitted direction defaults to `ASC` and an
+  /// omitted null ordering to `NULLS LAST`. So "c" means "c ASC NULLS LAST" and
+  /// "c DESC" means "c DESC NULLS LAST".
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
 
   /// Matches any TableWrite node.


### PR DESCRIPTION
Summary:
Two capabilities here. `hiveScan()` can now assert a scan's sample rate: pass `sampleRate` to check that a `TABLESAMPLE` lowered to the expected Hive rate, or omit it to assert no sampling (1.0). The project matcher now carries an identity projection's alias to the project's output name even when expression matchers are also supplied, so a parent matcher can still reference a passed-through aliased column. Before, that only happened when the projection had no expression matchers.

Also clarifies the `orderBy()` doc: an omitted direction parses as `ASC` and an omitted null ordering as `NULLS LAST`.

Differential Revision: D109333082


