### PR TITLE
feat(connectors): Match bucketed group ID given non-divisible worker counts

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -80,7 +80,7 @@ velox::core::PartitionFunctionSpecPtr HivePartitionType::makeSpec(
   if (numPartitions_ != numBuckets_) {
     bucketToPartition.reserve(numBuckets_);
     for (int32_t bucket = 0; bucket < numBuckets_; ++bucket) {
-      bucketToPartition.push_back(bucket % numPartitions_);
+      bucketToPartition.push_back(mapBucketToPartition(bucket));
     }
   }
   return std::make_shared<velox::connector::hive::HivePartitionFunctionSpec>(

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -87,6 +87,11 @@ class HivePartitionType : public connector::PartitionType {
     return numBuckets_;
   }
 
+  /// Maps a native bucket index to a partition index.
+  int32_t mapBucketToPartition(int32_t bucket) const {
+    return (bucket % numBuckets_) % numPartitions_;
+  }
+
   std::string toString() const override;
 
  private:

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -388,7 +388,10 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
         VELOX_CHECK(
             info->bucketNumber.has_value(),
             "Bucketed scan requires bucketNumber on every file");
-        groupId = info->bucketNumber.value() % partitionType_->numPartitions();
+        const auto* hivePartitionType = partitionType_->as<HivePartitionType>();
+        VELOX_CHECK_NOT_NULL(hivePartitionType, "Expected HivePartitionType");
+        groupId =
+            hivePartitionType->mapBucketToPartition(info->bucketNumber.value());
       }
       batch.splits.push_back(
           Split{.connectorSplit = builder.build(), .groupId = groupId});

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -438,6 +438,30 @@ TEST_F(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
   }
 }
 
+TEST_F(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
+  // numPartitions=3 divides neither 16 nor 8.
+  createBucketedTable(
+      "fan_big",
+      "CREATE TABLE fan_big "
+      "WITH (bucket_count = 16, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "fan_small",
+      "CREATE TABLE fan_small "
+      "WITH (bucket_count = 8, bucketed_by = ARRAY['c_nationkey']) "
+      "AS SELECT DISTINCT c_nationkey, "
+      "cast(c_nationkey AS varchar) AS label FROM customer");
+
+  auto logicalPlan = parseSelect(
+      "SELECT * FROM fan_big JOIN fan_small "
+      "ON fan_big.c_nationkey = fan_small.c_nationkey");
+  auto referencePlan = planVelox(
+      logicalPlan, MultiFragmentPlan::Options::singleNode(), optimizerOptions_);
+  auto reference = runFragmentedPlan(referencePlan).results;
+  ASSERT_GT(reference.size(), 0);
+  checkSame(logicalPlan, reference, {.numWorkers = 3, .numDrivers = 4});
+}
+
 TEST_F(HiveBucketedExecutionTest, unionall) {
   // Different bucket keys (same type) — must not co-fragment.
   createBucketedTable(


### PR DESCRIPTION
Summary:
`HivePartitionType::scaleDown` clamps to `min(numBuckets, maxPartitions)` and `makeSpec` installs an explicit `bucketToPartition` lookup so a hash exchange routes correctly when `numPartitions` does not divide `numBuckets`. The bucketed-scan split sources still tag each split's `groupId` with the bare `tableBucketNumber % numPartitions`. When two scans in a colocated bucketed join have different native bucket counts and `numPartitions` divides neither, the larger side's `groupId` disagrees with the smaller side's for matching keys and the join silently drops rows.

Worked example with native bucket counts 16 and 8: `copartition` returns a folded type with `numBuckets = 8`, `scaleDown(3)` reduces `numPartitions` to 3, and a key with `hash%8 == 4` lives in B's bucket 4 (`groupId = 4 % 3 = 1`) and in A's buckets 4 and 12 (`groupIds = 4 % 3 = 1` and `12 % 3 = 0`). A's bucket-12 data lands on task 0 while B's bucket-4 data lives on task 1, and the matches are lost.

This adds `HivePartitionType::mapBucketToPartition(bucket)` returning `(bucket % numBuckets_) % numPartitions_`, switches `makeSpec` to use it, and switches the bucketed-scan split source to use it. Producer-side `groupId` tagging now matches consumer-side hash-exchange routing.

Differential Revision: D109334755


