### PR TITLE
refactor: Breaking - Make common writer options format-agnostic

### DIFF
--- a/axiom/connectors/file/core/tests/FileTableTest.cpp
+++ b/axiom/connectors/file/core/tests/FileTableTest.cpp
@@ -54,7 +54,7 @@ class FileTableTest : public ::testing::Test, public test::VectorTestBase {
     auto rowVector = makeRowVector({"id", "name"}, {ids, names});
     auto schema = asRowType(rowVector->type());
 
-    parquet::WriterOptions writerOptions;
+    dwio::common::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
     auto sink = dwio::common::FileSink::create(
         fmt::format("file:{}", parquetPath_), {.pool = rootPool_.get()});

--- a/axiom/connectors/file/tests/FileConnectorTest.cpp
+++ b/axiom/connectors/file/tests/FileConnectorTest.cpp
@@ -67,7 +67,7 @@ class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
          makeFlatVector<StringView>({"alpha", "beta", "gamma"})});
     auto schema = asRowType(rowVector->type());
 
-    parquet::WriterOptions writerOptions;
+    dwio::common::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
     auto sink = dwio::common::FileSink::create(
         fmt::format("file:{}", path), {.pool = rootPool_.get()});


### PR DESCRIPTION
Summary:
**BREAKING CHANGE**

This is the contineous PR for refactoring format-specific options from dwio:common to format owned data structure, this PR refactor parquet writer options.

`dwio::common::WriterOptions` now owns only format-agnostic writer settings, while format-specific settings are carried through `FormatSpecificOptions`, matching the reader-side pattern. 

Before this change, Parquet writer configuration lived in a Parquet-specific `WriterOptions` type that inherited from `dwio::common::WriterOptions`. This kept format-specific state mixed into the common writer option object.

After this change, common writer options stay format-agnostic and carry optional `FormatSpecificOptions`. The Parquet writer factory now builds `ParquetWriterOptions` from format-scoped connector/session configs, matching the reader factory pattern.

Parquet writer config keys are also consolidated into `ParquetConfig`, alongside the existing Parquet reader config keys. This keeps Parquet config ownership in one place and lets Hive/Iceberg pass prefix-scoped configs into the format factory consistently for both reads and writes.

This intentionally changes the Parquet writer session property names to use the same format-scoped session prefix pattern as Parquet reader options:

| Old session property | New session property |
| --- | --- |
| `hive.parquet.writer.timestamp_unit` | `parquet_writer_timestamp_unit` |
| `hive.parquet.writer.enable_dictionary` | `parquet_writer_enable_dictionary` |
| `hive.parquet.writer.enable_store_decimal_as_integer` | `parquet_writer_enable_store_decimal_as_integer` |
| `hive.parquet.writer.dictionary_page_size_limit` | `parquet_writer_dictionary_page_size_limit` |
| `hive.parquet.writer.datapage_version` | `parquet_writer_datapage_version` |
| `hive.parquet.writer.page_size` | `parquet_writer_page_size` |
| `hive.parquet.writer.batch_size` | `parquet_writer_batch_size` |

X-link: https://github.com/facebookincubator/velox/pull/17858

Reviewed By: xiaoxmeng

Differential Revision: D108945456

Pulled By: kagamiori


