### PR TITLE
test: Match a 2-arg if to a 3-arg if with null else

### DIFF
--- a/axiom/optimizer/tests/ExprMatcher.cpp
+++ b/axiom/optimizer/tests/ExprMatcher.cpp
@@ -32,6 +32,11 @@ namespace {
     return false;                              \
   }
 
+bool isNullConstant(const TypedExprPtr& expr) {
+  return expr->isConstantKind() &&
+      expr->asUnchecked<ConstantTypedExpr>()->isNull();
+}
+
 bool isWildcard(const ExprPtr& expr) {
   if (!expr->is(IExpr::Kind::kCall)) {
     return false;
@@ -215,6 +220,16 @@ bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected) {
     const auto* expectedCall = expected->as<CallExpr>();
     EXPECT_EQ(call->name(), expectedCall->name());
     AXIOM_RETURN_FALSE_IF_FAILURE
+
+    // A 2-arg `if(cond, then)` is semantically `if(cond, then, null)`, so it
+    // matches a plan's 3-arg `if` with a typed-null else.
+    if (call->name() == "if" && call->inputs().size() == 3 &&
+        expectedCall->inputs().size() == 2 &&
+        isNullConstant(call->inputs()[2])) {
+      matchChildren(
+          {call->inputs()[0], call->inputs()[1]}, expectedCall->inputs());
+      return !::testing::Test::HasNonfatalFailure();
+    }
 
     matchChildren(call->inputs(), expectedCall->inputs());
     return !::testing::Test::HasNonfatalFailure();

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -36,6 +36,9 @@ namespace facebook::velox::core {
 /// parsed as DuckDB SQL. Use DuckDB-compatible syntax for expressions.
 /// See https://duckdb.org/docs/stable/sql/functions/overview for reference.
 ///
+/// To match any subexpression, use the ExprMatcher wildcard written as
+/// `"any"()` — double-quoted, since DuckDB rejects the bare identifier `any`.
+///
 /// Symbol Rewriting:
 /// -----------------
 /// PlanMatcher supports symbol (alias) capture and rewriting to allow


### PR DESCRIPTION
Summary:
PlanMatcher expectations are written as DuckDB SQL, and the parser folds a literal-null else into the 2-arg `if(cond, then)` form. A plan node like `if(cond, then, null)` — for example a decorrelation projection wrap — could not be matched, because the expected expression carried two arguments and the actual carried three. ExprMatcher now treats a 2-arg `if` as a 3-arg `if` whose else is a typed null, so the two match.

Also documents that the `"any"()` wildcard must be double-quoted in PlanMatcher SQL strings.

Differential Revision: D109456903


