### PR TITLE
Enforce query timeout in SqlQueryRunner fetchResults (#1514)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -37,6 +37,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/runner/RunnerException.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
@@ -258,11 +259,152 @@ connector::ConnectorProperties collectConnectorProperties(
   return result;
 }
 
-std::vector<velox::RowVectorPtr> fetchResults(runner::LocalRunner& runner) {
-  std::vector<velox::RowVectorPtr> results;
-  while (auto rows = runner.next()) {
-    results.push_back(rows);
+// Aborts 'runner' at most once across threads; later calls are no-ops. abort()
+// is best effort, so exceptions are swallowed.
+void abortRunnerOnce(runner::LocalRunner& runner, std::atomic<bool>& aborted) {
+  bool expected = false;
+  if (aborted.compare_exchange_strong(expected, true)) {
+    try {
+      runner.abort();
+    } catch (...) {
+    }
   }
+}
+
+// Starts a watchdog thread that aborts the runner once the timeout elapses,
+// even if the main thread is blocked in next(). Uses a condition variable with
+// a mutex-protected predicate to avoid the lost-wakeup race between the
+// predicate check and the wait, and an atomic flag to abort at most once across
+// threads.
+//
+// Usage:
+//   std::atomic<bool> aborted{false};
+//   {
+//     TimeoutWatchdog watchdog(runner, std::chrono::seconds(5), aborted);
+//     // ... drain runner.next() ...
+//   } // destructor cancels the thread and joins on scope exit.
+class TimeoutWatchdog {
+ public:
+  TimeoutWatchdog(
+      runner::LocalRunner& runner,
+      std::chrono::microseconds timeout,
+      std::atomic<bool>& abortedFlag)
+      : runner_{runner}, timeout_{timeout}, abortedFlag_{abortedFlag} {
+    thread_ = std::thread([this] { run(); });
+  }
+
+  ~TimeoutWatchdog() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cancelled_ = true;
+    }
+    cv_.notify_all();
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+  }
+
+  TimeoutWatchdog(const TimeoutWatchdog&) = delete;
+  TimeoutWatchdog& operator=(const TimeoutWatchdog&) = delete;
+
+ private:
+  void run() {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      if (cv_.wait_for(lock, timeout_, [this] { return cancelled_; })) {
+        return;
+      }
+    }
+    // Abort outside the lock: abortedFlag_ already serializes the abort across
+    // threads, and holding mutex_ here would block the destructor that needs it
+    // to signal cancellation.
+    abortRunnerOnce(runner_, abortedFlag_);
+  }
+
+  // Runner to abort when the timeout elapses.
+  runner::LocalRunner& runner_;
+  // How long to wait before aborting.
+  std::chrono::microseconds timeout_;
+  // Shared with the main thread so abort happens at most once across both.
+  std::atomic<bool>& abortedFlag_;
+  // Guards cancelled_ and pairs with cv_.
+  std::mutex mutex_;
+  // Wakes the thread early when cancelled_ is set, avoiding a full-timeout
+  // wait.
+  std::condition_variable cv_;
+  // Set by the destructor to cancel the wait before the timeout fires.
+  bool cancelled_{false};
+  // The waiting thread; joined in the destructor.
+  std::thread thread_;
+};
+
+// Drains all result batches from 'runner'. When 'timeoutMicros' > 0, enforces
+// it as a wall-clock execution timeout: a watchdog aborts the runner once the
+// deadline passes, and the query fails with a kQueryTimedOut RunnerException
+// rather than returning partial results. A timeout of 0 waits indefinitely.
+std::vector<velox::RowVectorPtr> fetchResults(
+    runner::LocalRunner& runner,
+    int64_t timeoutMicros) {
+  std::vector<velox::RowVectorPtr> results;
+  const auto start = std::chrono::steady_clock::now();
+  const bool enforceTimeout = timeoutMicros > 0;
+  const auto timeout = std::chrono::microseconds(timeoutMicros);
+
+  std::atomic<bool> aborted{false};
+
+  auto throwTimeoutIfExceeded = [&](const std::exception* original = nullptr) {
+    if (!enforceTimeout) {
+      return;
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    // The watchdog aborts on its own deadline; treat an abort it triggered as a
+    // timeout even if this thread's clock reads just under the limit.
+    if (elapsed <= timeout && !aborted.load()) {
+      return;
+    }
+    abortRunnerOnce(runner, aborted);
+    auto elapsedMicros =
+        std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+    auto timeoutSeconds = timeoutMicros / 1'000'000.0;
+    if (original) {
+      AXIOM_QUERY_TIMEOUT(
+          "Query exceeded maximum time limit of {:.2f}s ({} microseconds elapsed, timeoutMicros={}); original error: {}",
+          timeoutSeconds,
+          elapsedMicros,
+          timeoutMicros,
+          original->what());
+    } else {
+      AXIOM_QUERY_TIMEOUT(
+          "Query exceeded maximum time limit of {:.2f}s ({} microseconds elapsed, timeoutMicros={})",
+          timeoutSeconds,
+          elapsedMicros,
+          timeoutMicros);
+    }
+  };
+
+  std::optional<TimeoutWatchdog> watchdog;
+  if (enforceTimeout) {
+    watchdog.emplace(runner, timeout, aborted);
+  }
+
+  while (true) {
+    velox::RowVectorPtr rows;
+    try {
+      rows = runner.next();
+    } catch (const std::exception& e) {
+      throwTimeoutIfExceeded(&e);
+      throw;
+    }
+    if (!rows) {
+      break;
+    }
+    results.push_back(rows);
+    throwTimeoutIfExceeded();
+  }
+  // next() can return null rather than throwing if the runner treats a
+  // watchdog abort() as graceful end-of-stream; check once more so an aborted
+  // query still fails instead of returning partial results.
+  throwTimeoutIfExceeded();
   return results;
 }
 
@@ -1134,7 +1276,7 @@ std::string SqlQueryRunner::runExplainAnalyze(
         runtimeStats.get(),
         QueryRuntimeStats::kExecuteWallNanos,
         QueryRuntimeStats::kExecuteCpuNanos);
-    auto results = fetchResults(*runner);
+    auto results = fetchResults(*runner, options.executionTimeoutMicros);
   }
 
   std::stringstream out;
@@ -1374,7 +1516,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         runtimeStats.get(),
         QueryRuntimeStats::kExecuteWallNanos,
         QueryRuntimeStats::kExecuteCpuNanos);
-    result.results = fetchResults(*runner);
+    result.results = fetchResults(*runner, options.executionTimeoutMicros);
   }
 
   return result;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -179,9 +179,14 @@ class SqlQueryRunner {
     int32_t numDrivers{4};
     uint64_t splitTargetBytes{16 << 20};
 
-    /// Microseconds to wait for query to complete. 0 means check for completion
-    /// then timeout immediately if not complete.
+    /// Microseconds to wait for query to complete during cleanup phase.
+    /// 0 means check for completion then timeout immediately if not complete.
     int32_t timeoutMicros{500'000};
+
+    /// Microseconds to enforce as query execution timeout. 0 means no timeout
+    /// (wait indefinitely). When set, SqlQueryRunner aborts the query if
+    /// execution exceeds this duration.
+    int64_t executionTimeoutMicros{0};
 
     std::optional<std::string> defaultConnectorId;
     std::optional<std::string> defaultSchema;
@@ -429,8 +434,7 @@ class SqlQueryRunner {
       std::string_view connectorId) const;
 
   // Wait maxWaitMicros microseconds for the LocalRunner to complete.  If
-  // `maxWaitMicros <= 0` this will check if the LocalRunner is completed and
-  // return immediately.
+  // `maxWaitMicros <= 0` this will return immediately without waiting.
   static void waitForCompletion(
       const std::shared_ptr<facebook::axiom::runner::LocalRunner>& runner,
       int32_t maxWaitMicros) {

--- a/axiom/runner/RunnerException.cpp
+++ b/axiom/runner/RunnerException.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/runner/RunnerException.h"
+
+namespace facebook::axiom::runner {
+
+namespace {
+const auto& runnerErrorKindNames() {
+  static const folly::F14FastMap<RunnerErrorKind, std::string_view> kNames = {
+      {RunnerErrorKind::kQueryTimedOut, "QUERY_TIMED_OUT"},
+      {RunnerErrorKind::kCancelled, "CANCELLED"},
+      {RunnerErrorKind::kExecutionError, "EXECUTION_ERROR"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(RunnerErrorKind, runnerErrorKindNames);
+
+RunnerException::RunnerException(
+    RunnerErrorKind kind,
+    std::string message,
+    std::string messageTemplate)
+    : kind_{kind},
+      message_{std::move(message)},
+      messageTemplate_{std::move(messageTemplate)},
+      formatted_{formatWhat(kind_, message_)} {}
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/RunnerException.h
+++ b/axiom/runner/RunnerException.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <exception>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <folly/Likely.h>
+#include "axiom/common/Enums.h"
+
+namespace facebook::axiom::runner {
+
+/// Classifies the reason for runner-level failure.
+enum class RunnerErrorKind {
+  /// Query execution exceeded configured time limit.
+  kQueryTimedOut,
+  /// Query was cancelled via abort().
+  kCancelled,
+  /// Generic execution failure.
+  kExecutionError,
+};
+
+AXIOM_DECLARE_ENUM_NAME(RunnerErrorKind);
+
+/// Exception thrown from Runner implementations for query-level failures
+/// that originate at the coordinator / SQL runner layer rather than at
+/// individual Velox worker tasks.
+///
+/// Throw via the macros below rather than constructing directly; they populate
+/// messageTemplate from the format string for programmatic categorization:
+///   AXIOM_QUERY_TIMEOUT("Query exceeded maximum time limit of {:.2f}s", 5.0);
+///   AXIOM_RUNNER_FAIL(RunnerErrorKind::kCancelled, "Query {} cancelled", id);
+///   AXIOM_RUNNER_CHECK(ok, "Unexpected state: {}", state);
+class RunnerException : public std::exception {
+ public:
+  /// Constructs from an already-formatted `message` and the raw format-string
+  /// `messageTemplate` it was rendered from. The template enables programmatic
+  /// categorization regardless of which macro raised the error. Prefer the
+  /// AXIOM_QUERY_TIMEOUT / AXIOM_RUNNER_FAIL / AXIOM_RUNNER_CHECK macros over
+  /// constructing directly.
+  RunnerException(
+      RunnerErrorKind kind,
+      std::string message,
+      std::string messageTemplate);
+
+  RunnerErrorKind kind() const noexcept {
+    return kind_;
+  }
+
+  /// Raw error description without prefix.
+  std::string_view message() const noexcept {
+    return message_;
+  }
+
+  /// Raw format string before argument substitution for programmatic
+  /// categorization.
+  std::string_view messageTemplate() const noexcept {
+    return messageTemplate_;
+  }
+
+  const char* what() const noexcept override {
+    return formatted_.c_str();
+  }
+
+ private:
+  static std::string formatWhat(
+      RunnerErrorKind kind,
+      std::string_view message) {
+    return fmt::format("{}: {}", RunnerErrorKindName::toName(kind), message);
+  }
+
+  // Reason for the failure.
+  RunnerErrorKind kind_;
+  // Raw error description without the kind prefix.
+  std::string message_;
+  // Format string before argument substitution, for programmatic
+  // categorization.
+  std::string messageTemplate_;
+  // Pre-formatted what() string combining the kind name and message, built once
+  // in the constructor.
+  std::string formatted_;
+};
+
+// In all three macros below, 'fmt_str' must be a string literal format string.
+// It is used both to format the message and as the messageTemplate, so callers
+// can categorize errors by the raw template regardless of which macro raised
+// them.
+
+/// Throws RunnerException if condition is false.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_RUNNER_CHECK(condition, fmt_str, ...)                    \
+  do {                                                                 \
+    if (FOLLY_UNLIKELY(!(condition))) {                                \
+      throw ::facebook::axiom::runner::RunnerException(                \
+          ::facebook::axiom::runner::RunnerErrorKind::kExecutionError, \
+          fmt::format(fmt_str, ##__VA_ARGS__),                         \
+          fmt_str);                                                    \
+    }                                                                  \
+  } while (0)
+
+/// Unconditionally throws RunnerException with specified kind.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_RUNNER_FAIL(kind, fmt_str, ...)                \
+  do {                                                       \
+    throw ::facebook::axiom::runner::RunnerException(        \
+        kind, fmt::format(fmt_str, ##__VA_ARGS__), fmt_str); \
+  } while (0)
+
+/// Throws RunnerException with kQueryTimedOut kind.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_QUERY_TIMEOUT(fmt_str, ...)                           \
+  do {                                                              \
+    throw ::facebook::axiom::runner::RunnerException(               \
+        ::facebook::axiom::runner::RunnerErrorKind::kQueryTimedOut, \
+        fmt::format(fmt_str, ##__VA_ARGS__),                        \
+        fmt_str);                                                   \
+  } while (0)
+
+} // namespace facebook::axiom::runner
+
+// Provide formatter specialization for RunnerErrorKind.
+AXIOM_ENUM_FORMATTER(facebook::axiom::runner::RunnerErrorKind);


### PR DESCRIPTION
Summary:

Axiom SqlQueryRunner RunOptions.timeoutMicros is used for post-execution waitForCompletion cleanup, not for aborting running queries. As a result queries with 1s timeout run 72s to completion.

This change adds proper timeout enforcement at Axiom query runner level. Adds generic RunnerException in axiom/runner usable by any runner type (LocalRunner, SqlQueryRunner, etc).

Differential Revision: D109355308


