### PR TITLE
fix(optimizer): Correct broadcast and shuffle cost estimates (#1515)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1146,7 +1146,16 @@ PlanObjectSet availableColumns(BaseTableCP baseTable, ColumnGroupCP index) {
 }
 
 bool isBroadcastableSize(PlanP build) {
-  return build->cost.cardinality < 100'000;
+  const auto cardinality = build->cost.cardinality;
+  if (!cardinality.has_value()) {
+    // Unknown size: a broadcast copy might not fit in each worker's memory.
+    return false;
+  }
+  const auto rowBytes = byteSize(build->op->columns());
+  const int64_t limit =
+      queryCtx()->optimization()->options().broadcastSizeLimit;
+  return static_cast<double>(*cardinality) * rowBytes <=
+      static_cast<double>(limit);
 }
 
 // The 'other' side gets shuffled to align with 'input'. If 'input' is not

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -19,6 +19,7 @@
 #include <glog/logging.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -94,6 +95,14 @@ std::vector<ConfigProperty> buildProperties(
           "tables. Greedy is approximate but bounded in planning time.",
       },
       {
+          std::string(OptimizerOptions::kBroadcastSizeLimit),
+          ConfigPropertyType::kString,
+          std::string(OptimizerOptions::kBroadcastSizeLimitDefault),
+          "Maximum estimated build size eligible for broadcast, as a capacity "
+          "string (e.g. \"100MB\", \"1GB\"). A broadcast copy must fit in each "
+          "worker's memory. \"0B\" disables broadcast.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -141,6 +150,10 @@ std::string OptimizerOptions::normalize(
     auto threshold = std::stoi(std::string(value));
     VELOX_USER_CHECK_GE(
         threshold, 1, "greedy_join_threshold must be >= 1: {}", value);
+  } else if (name == kBroadcastSizeLimit) {
+    // Throws if 'value' is not a valid capacity string (e.g. "100MB").
+    velox::config::toCapacity(
+        std::string(value), velox::config::CapacityUnit::BYTE);
   }
   return std::string(value);
 }
@@ -161,6 +174,14 @@ OptimizerOptions OptimizerOptions::from(
     }
   };
 
+  auto setCapacity = [&](std::string_view key, int64_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = static_cast<int64_t>(velox::config::toCapacity(
+          it->second, velox::config::CapacityUnit::BYTE));
+    }
+  };
+
   OptimizerOptions options;
   setBool(kSampleJoins, options.sampleJoins);
   setBool(kSampleFilters, options.sampleFilters);
@@ -172,6 +193,7 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kEnableReducingExistences, options.enableReducingExistences);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
+  setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -49,12 +49,18 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "parallel_project_width";
   static constexpr std::string_view kGreedyJoinThreshold =
       "greedy_join_threshold";
+  static constexpr std::string_view kBroadcastSizeLimit =
+      "broadcast_size_limit";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
   // and properties().
   static constexpr int32_t kParallelProjectWidthDefault = 1;
   static constexpr int32_t kGreedyJoinThresholdDefault = 5;
+  // 100 MB. The string form is the user-facing default and accepts capacity
+  // units; the bytes form initializes the parsed field.
+  static constexpr std::string_view kBroadcastSizeLimitDefault = "100MB";
+  static constexpr int64_t kBroadcastSizeLimitDefaultBytes = 100LL << 20;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -115,6 +121,12 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Use a greedy join-order search instead of exhaustive enumeration when
   /// a single query block contains at least this many joined tables.
   int32_t greedyJoinThreshold{kGreedyJoinThresholdDefault};
+
+  /// A build side is eligible for broadcast only if its estimated size (rows ×
+  /// row width) is at most this many bytes, so a broadcast copy fits in each
+  /// worker's memory. Configured as a capacity string ("100MB", "1GB"); "0B"
+  /// disables broadcast entirely.
+  int64_t broadcastSizeLimit{kBroadcastSizeLimitDefaultBytes};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -733,11 +733,21 @@ Repartition::Repartition(
   cost_.inputCardinality = inputCardinality();
   cost_.fanout = 1;
 
-  auto size = shuffleCost(columns_);
+  auto unitCost = shuffleCost(columns_);
+  auto rowBytes = byteSize(columns_);
 
-  cost_.unitCost = size;
-  cost_.transferBytes =
-      mul(cost_.inputCardinality, size * Costs::byteShuffleCost());
+  // A broadcast replicates the full input to every worker, so its shuffle CPU
+  // and transfer costs scale with the number of workers. 'this->' disambiguates
+  // the accessor from the constructor parameter 'distribution'.
+  if (this->distribution().isBroadcast()) {
+    const auto numWorkers =
+        queryCtx()->optimization()->runnerOptions().numWorkers;
+    unitCost *= numWorkers;
+    rowBytes *= numWorkers;
+  }
+
+  cost_.unitCost = unitCost;
+  cost_.transferBytes = mul(cost_.inputCardinality, rowBytes);
 
   // Repartition projects all input columns.
   constraints_ = input_->constraints();

--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -52,6 +52,13 @@ Exchanges are needed for:
    stays wherever it is (no shuffle), and each task gets a full copy of
    the build side.
 
+   > **Note.** The current optimizer chooses broadcast *structurally*, not by
+   > cost: a build is broadcast whenever it is eligible — its estimated size
+   > (rows × row width) is at most `broadcast_size_limit` (default 100MB) — and
+   > hash-partitioned otherwise. The broadcast cost (replication × number of
+   > workers) therefore feeds join-order ranking, not the broadcast-vs-partition
+   > choice itself. Making that choice cost-based is future work.
+
 4. **Combining independently computed inputs (UNION ALL)** — each UNION
    ALL input may involve its own joins, aggregations, or other operations
    that produce separate fragments. Exchanges connect these fragments to

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -640,9 +640,9 @@ TEST_F(BucketedExecutionTest, innerJoinChainFuses) {
           .build());
 }
 
-// Same shape with a LEFT join: no equivalence forms, so the chain stays split
-// with a remote hash exchange. Regression guard for if outer joins ever start
-// forming equivalences.
+// Same shape with a LEFT join: the outer join forms no equivalence, so t cannot
+// bucket-align with the chain and joins across a remote exchange. Regression
+// guard for if outer joins ever start forming equivalences.
 TEST_F(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
   addBucketedTable("t", {"k"}, 16, ROW({"k"}, BIGINT()));
   addBucketedTable("u", {"k"}, 16, ROW({"k"}, BIGINT()));
@@ -671,8 +671,7 @@ TEST_F(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
       planDistributed(parseSelect(sql, kTestConnectorId)).plan,
       matchScan("u")
           .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-          .shuffle()
-          .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").broadcast().build(), core::JoinType::kInner)
           .gather()
           .build());
 }

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -311,34 +311,31 @@ TEST_F(ExistencePushdownTest, chainJoin) {
   auto distributedPlan = planVelox(logicalPlan);
 
   auto distributedMatcher =
-      matchScan("r")
-          .filter("b < 100")
+      matchScan("u")
+          .hashJoin(
+              matchScan("r")
+                  .filter("b < 100")
+                  .hashJoin(
+                      matchScan("s")
+                          .aliases({"s_a"})
+                          .filter("s_a < 100")
+                          .broadcast()
+                          .build(),
+                      core::JoinType::kInner)
+                  .project()
+                  .broadcast()
+                  .build(),
+              core::JoinType::kLeftSemiFilter)
+          .shuffle({"x"})
+          .localPartition({"x"})
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("r").filter("b < 100").shuffle({"a"}).build(),
+              core::JoinType::kInner)
           .hashJoin(
               matchScan("s")
                   .aliases({"s_a"})
                   .filter("s_a < 100")
-                  .broadcast()
-                  .build(),
-              core::JoinType::kInner)
-          .hashJoin(
-              matchScan("u")
-                  .hashJoin(
-                      matchScan("r")
-                          .filter("b < 100")
-                          .hashJoin(
-                              matchScan("s")
-                                  .aliases({"s_a"})
-                                  .filter("s_a < 100")
-                                  .broadcast()
-                                  .build(),
-                              core::JoinType::kInner)
-                          .project()
-                          .broadcast()
-                          .build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .shuffle({"x"})
-                  .localPartition({"x"})
-                  .singleAggregation({"x"}, {"count(*) as cnt"})
                   .broadcast()
                   .build(),
               core::JoinType::kInner)
@@ -385,13 +382,19 @@ TEST_F(ExistencePushdownTest, multipleTables) {
   auto distributedMatcher =
       matchScan("s")
           .hashJoin(
-              matchScan("u")
+              matchScan("s")
+                  .shuffle({"a_0"})
                   .hashJoin(
-                      matchScan("r").filter("b < 100").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
-                  .hashJoin(
-                      matchScan("s").broadcast().build(),
-                      core::JoinType::kLeftSemiFilter)
+                      matchScan("u")
+                          .hashJoin(
+                              matchScan("r")
+                                  .filter("b < 100")
+                                  .broadcast()
+                                  .build(),
+                              core::JoinType::kLeftSemiFilter)
+                          .shuffle({"y"})
+                          .build(),
+                      core::JoinType::kRightSemiFilter)
                   .shuffle({"x", "y"})
                   .localPartition({"x", "y"})
                   .singleAggregation({"x", "y"}, {})

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -284,6 +284,55 @@ TEST_F(JoinTest, joinWithComputedKeys) {
   }
 }
 
+TEST_F(JoinTest, broadcastSizeLimitGatesBroadcast) {
+  testConnector_->addTable("probe", ROW({"p_key", "p_data"}, BIGINT()))
+      ->setStats(100'000, {{"p_key", {.numDistinct = 100'000}}});
+  testConnector_->addTable("build", ROW({"b_key", "b_data"}, BIGINT()))
+      ->setStats(1'000, {{"b_key", {.numDistinct = 1'000}}});
+
+  OptimizerOptions options;
+  options.syntacticJoinOrder = true;
+
+  auto ctx = makeContext();
+  auto logicalPlan = lp::PlanBuilder{ctx}
+                         .tableScan("probe")
+                         .join(
+                             lp::PlanBuilder{ctx}.tableScan("build"),
+                             "p_key = b_key",
+                             lp::JoinType::kInner)
+                         .build();
+
+  // The 1000-row build (~16KB) is well under the default 100MB limit, so it is
+  // broadcast rather than hash-partitioned.
+  {
+    auto distributedPlan =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
+    auto matcher =
+        matchScan("probe")
+            .hashJoin(
+                matchScan("build").broadcast().build(), core::JoinType::kInner)
+            .gather()
+            .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+  }
+
+  // Lowering the limit below the build size makes it ineligible for broadcast,
+  // so both sides are hash-partitioned on the join key.
+  {
+    options.broadcastSizeLimit = 1024;
+    auto distributedPlan =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
+    auto matcher = matchScan("probe")
+                       .shuffle({"p_key"})
+                       .hashJoin(
+                           matchScan("build").shuffle({"b_key"}).build(),
+                           core::JoinType::kInner)
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+  }
+}
+
 TEST_F(JoinTest, crossJoin) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -46,6 +47,7 @@ TEST(OptimizerOptionsTest, codeDefaults) {
   EXPECT_EQ(getDefault(props, OptimizerOptions::kTraceFlags), "0");
   EXPECT_EQ(
       getDefault(props, OptimizerOptions::kUseFilteredTableStats), "true");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kBroadcastSizeLimit), "100MB");
 }
 
 TEST(OptimizerOptionsTest, configOverrides) {
@@ -64,21 +66,36 @@ TEST(OptimizerOptionsTest, from) {
       {std::string(OptimizerOptions::kSampleJoins), "true"},
       {std::string(OptimizerOptions::kParallelProjectWidth), "8"},
       {std::string(OptimizerOptions::kTraceFlags), "5"},
+      {std::string(OptimizerOptions::kBroadcastSizeLimit), "5GB"},
   };
   auto options = OptimizerOptions::from(props);
 
   EXPECT_TRUE(options.sampleJoins);
   EXPECT_EQ(options.parallelProjectWidth, 8);
   EXPECT_EQ(options.traceFlags, 5);
+  EXPECT_EQ(options.broadcastSizeLimit, 5LL << 30);
   EXPECT_FALSE(options.syntacticJoinOrder);
   EXPECT_FALSE(options.sampleFilters);
 }
 
-TEST(OptimizerOptionsTest, normalizeRejectsInvalidWidth) {
+TEST(OptimizerOptionsTest, broadcastSizeLimitDefaultsAgree) {
+  // The string default and the byte default must denote the same size.
+  auto options = OptimizerOptions::from(
+      {{std::string(OptimizerOptions::kBroadcastSizeLimit),
+        std::string(OptimizerOptions::kBroadcastSizeLimitDefault)}});
+  EXPECT_EQ(
+      options.broadcastSizeLimit,
+      OptimizerOptions::kBroadcastSizeLimitDefaultBytes);
+}
+
+TEST(OptimizerOptionsTest, normalizeRejectsInvalidValues) {
   OptimizerOptions options;
-  EXPECT_THROW(
+  VELOX_ASSERT_THROW(
       options.normalize(OptimizerOptions::kParallelProjectWidth, "0"),
-      facebook::velox::VeloxUserError);
+      "parallel_project_width must be >= 1");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kBroadcastSizeLimit, "100"),
+      "Invalid capacity string");
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -2347,8 +2347,11 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
 //   NOT IN: workers missing the NULL incorrectly return rows.
 //   IN: workers missing the NULL produce false instead of NULL for the mark.
 TEST_F(SubqueryTest, inReplicateNullsAndAny) {
-  // Make both tables large enough to trigger hash partitioning instead of
-  // broadcast.
+  // replicateNullsAndAny only appears on a hash-partitioned build. Cap the
+  // broadcast size limit low so the build is hash partitioned regardless of its
+  // size.
+  optimizerOptions_.broadcastSizeLimit = 1024;
+
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(
           10'000'000,

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -826,6 +826,10 @@ TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
                        .hashJoin(matchScan("t").shuffle({"a"}).build())
                        .gather()
                        .build();
+    // Cap the broadcast size limit low so the union build stays hash
+    // partitioned (the scenario under test) rather than the small probe being
+    // broadcast.
+    optimizerOptions_.broadcastSizeLimit = 1024;
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }


### PR DESCRIPTION
Summary:

The optimizer mis-estimated broadcast and shuffle costs in three ways. A build side was eligible for broadcast based on row count (fewer than 100,000 rows), ignoring row width, so 100,000 wide rows looked broadcastable even when huge; eligibility is now byte-based against a configurable limit (default 100MB), so a wide build is hash-partitioned instead. A broadcast was priced like a single partitioned shuffle even though it replicates the build to every worker; it now costs that replication times the number of workers. The `Repartition` `transferBytes` field folded the shuffle CPU multiplier and the transfer-rate constant into a value labeled as bytes; it now holds the actual byte volume (used only for diagnostics).

The broadcast size limit is an `OptimizerOptions` session property, `broadcast_size_limit`, given as a capacity string such as `"100MB"` or `"1GB"` (`"0B"` disables broadcast) and parsed with Velox `toCapacity`. `isBroadcastableSize` now gates on estimated bytes (cardinality times row width); a build of unknown cardinality is not broadcast.

The broadcast-vs-partition choice in the current optimizer is still structural: a build is broadcast whenever it is eligible, so the per-worker broadcast cost affects join-order ranking rather than the broadcast/partition decision itself. Making that decision cost-based is left for the v2 optimizer.

bypass-github-export-checks

Differential Revision: D109575218


