### PR TITLE
fix: Resolve higher-order functions over UNKNOWN arguments (#1517)

### DIFF
--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -543,7 +543,10 @@ bool ExprResolver::resolveLambdaArguments(
 
   velox::exec::SignatureBinder binder(
       signature, argTypes, velox::TypeCoercer::defaults());
-  binder.tryBind();
+  // Bind with coercions so an UNKNOWN argument resolves the lambda's type
+  // variables.
+  std::vector<velox::Coercion> coercions;
+  binder.tryBindWithCoercions(coercions);
   for (auto i = 0; i < numArgs; ++i) {
     auto argSignature = signature.argumentTypes()[i];
     if (isLambdaArgument(argSignature)) {

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -54,6 +54,21 @@ class ExprTest : public testing::Test {
     EXPECT_EQ(resolved->looksConstant(), expected);
   }
 
+  ExprPtr resolveScalar(const std::string& sql) {
+    return resolveScalar(sql, schema_);
+  }
+
+  ExprPtr resolveScalar(const std::string& sql, const RowTypePtr& schema) {
+    return ExprResolver(nullptr, &velox::TypeCoercer::defaults())
+        .resolveScalarTypes(Sql(sql).expr(), inputResolver(schema));
+  }
+
+  AggregateExprPtr resolveAggregate(const std::string& sql) {
+    return ExprResolver(nullptr, &velox::TypeCoercer::defaults())
+        .resolveAggregateTypes(
+            Sql(sql).expr(), inputResolver(schema_), nullptr, {}, false);
+  }
+
   RowTypePtr schema_ =
       ROW({"a", "x", "y", "z"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});
 };
@@ -168,6 +183,13 @@ TEST_F(ExprTest, aggregateWithLambda) {
   EXPECT_TRUE(reduceAgg->inputAt(3)->isLambda());
 }
 
+TEST_F(ExprTest, reduceAggOverNull) {
+  auto reduceAgg = resolveAggregate(
+      "reduce_agg(null, 0, (s, x) -> s + x, (s1, s2) -> s1 + s2)");
+
+  VELOX_EXPECT_EQ_TYPES(reduceAgg->type(), BIGINT());
+}
+
 TEST_F(ExprTest, aggregateWithLambdaEquality) {
   auto makeAggregate = [this](const ExprApi& expr) {
     return ExprResolver(nullptr, nullptr)
@@ -243,6 +265,53 @@ TEST_F(ExprTest, aggregateWithLambdaUnknownFunction) {
           Col("x"),
           Lambda({"s", "x"}, Call("plus", Col("s"), Col("x"))))),
       "Cannot resolve Aggregate with lambda arguments: nonexistent_agg");
+}
+
+TEST_F(ExprTest, transformOverNull) {
+  // transform's result element type comes from the lambda body.
+  VELOX_EXPECT_EQ_TYPES(
+      resolveScalar("transform(null, x -> x + 1)")->type(), ARRAY(BIGINT()));
+}
+
+TEST_F(ExprTest, filterOverNull) {
+  // filter returns the input array type, whose element stays unknown.
+  VELOX_EXPECT_EQ_TYPES(
+      resolveScalar("filter(null, x -> x > 0)")->type(), ARRAY(UNKNOWN()));
+}
+
+TEST_F(ExprTest, reduceOverNull) {
+  // reduce returns the accumulator type from the initial state.
+  VELOX_EXPECT_EQ_TYPES(
+      resolveScalar("reduce(null, 0, (s, e) -> s + e, s -> s)")->type(),
+      BIGINT());
+}
+
+TEST_F(ExprTest, scalarLambdaWithTypedInput) {
+  auto schema = ROW({"arr"}, {ARRAY(BIGINT())});
+
+  // A typed (non-UNKNOWN) input still resolves.
+  VELOX_EXPECT_EQ_TYPES(
+      resolveScalar("transform(arr, x -> x + 1)", schema)->type(),
+      ARRAY(BIGINT()));
+}
+
+TEST_F(ExprTest, scalarLambdaWithNonArrayInput) {
+  auto schema = ROW({"i"}, {BIGINT()});
+
+  // transform requires an array argument.
+  VELOX_ASSERT_THROW(
+      resolveScalar("transform(i, x -> x + 1)", schema), "Can't resolve");
+}
+
+TEST_F(ExprTest, nestedLambdaOverEmptyMap) {
+  // Empty map() has UNKNOWN key/value types.
+  VELOX_EXPECT_EQ_TYPES(
+      resolveScalar(
+          "reduce(ARRAY[MAP(ARRAY['a'], ARRAY[1])], map(), "
+          "(s, x) -> map_zip_with(s, x, (k, v1, v2) -> "
+          "COALESCE(v1, 0) + COALESCE(v2, 0)), s -> s)")
+          ->type(),
+      MAP(VARCHAR(), BIGINT()));
 }
 
 TEST_F(ExprTest, windowFrameValidation) {


### PR DESCRIPTION
Summary:

A higher-order function over an `UNKNOWN`-typed argument failed to resolve, e.g.:

`SELECT transform(null, x -> x + 1)` → `NOT_IMPLEMENTED: Can't resolve x -> plus("x", 1)`

**Root cause:** the lambda binder previously bound signatures *without coercions*. With an `UNKNOWN` argument, the lambda's type variables never bound, so parameter types stayed unresolved. Non-lambda functions didn't hit this because they bind via the coercing binder.

**Fix:** the lambda binder now binds *with coercions* too. An `UNKNOWN` argument coerces to the needed concrete type (`array(unknown)`, `map(unknown, unknown)`, …), so:
- lambda parameters resolve, and
- the body resolves via normal coercion.

**Impact:** `transform`, `filter`, `reduce`, and nested `map_zip_with` over `null` or an empty `map()` now resolve.

Reviewed By: mbasmanova

Differential Revision: D109049591
