### PR TITLE
refactor: Consolidate coercion into a recursive coerce() (#1519)

### DIFF
--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -331,13 +331,13 @@ ExprPtr tryResolveSpecialForm(
           continue;
         }
 
-        if (coercer->coercible(newType, type)) {
+        if (coercer->coerce(newType, type)) {
           resolvedInputs[i] =
               applyCoercion(resolvedInputs[i], type, planNodeIdGenerator);
           continue;
         }
 
-        if (coercer->coercible(type, newType)) {
+        if (coercer->coerce(type, newType)) {
           type = newType;
 
           for (auto j = 0; j < i; ++j) {

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1654,7 +1654,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       const auto& schemaType = schema->childAt(index.value());
 
       if (!schemaType->equivalent(*inputType)) {
-        if (coercer_ != nullptr && coercer_->coercible(inputType, schemaType)) {
+        if (coercer_ != nullptr && coercer_->coerce(inputType, schemaType)) {
           columnExpressions[i] =
               applyCoercion(columnExpressions[i], schemaType);
         } else {
@@ -1734,7 +1734,7 @@ PlanBuilder& PlanBuilder::sample(
 
   if (!expr->type()->isDouble()) {
     if (coercer_ != nullptr) {
-      if (coercer_->coercible(expr->type(), velox::DOUBLE())) {
+      if (coercer_->coerce(expr->type(), velox::DOUBLE())) {
         expr = applyCoercion(expr, velox::DOUBLE());
       } else {
         VELOX_USER_FAIL(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17921

**Issue:**
Currently, the coercion logic is spread across three overlapping functions: coerceTypeBase(), coerce(), and coercible() that can be simplified. Also coerce() does not recurse into containers.

This change makes coerce() the single recursive function for coercion.

**Fix:**
In coerce() -
- Scalars go through the rule table
- Bare UNKNOWN coerces to any resolved target
- Containers recurse element-wise and sum the child costs.

For the other two functions
- coercible() is removed; its callers now call coerce() directly
- coerceTypeBase() is now private, the scalar lookup that coerce() calls.

The SignatureBinder coercion paths (scalar formal, UNKNOWN to parameterized) also merge into one: resolve the formal type, then call coerce().

This feeds overload resolution, but no overload resolves differently.

**Follow Up:**
Letting a non-UNKNOWN value coerce into a parameterized formal is a *behavior change*, so it is left out of this diff. e.g. `INTEGER` → `DECIMAL(p,s)` would cast into DECIMAL(p,s) instead of current REAL behavior.

Differential Revision: D109596959


