### PR TITLE
test(runner): Harden ProgressReporterTest wait helper

### DIFF
--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -87,7 +87,7 @@ class ProgressReporterTest : public test::LocalRunnerTestBase {
   static constexpr int32_t kRowsPerSplit = 100;
 
   void SetUp() override {
-    rowType_ = velox::ROW({"c0"}, {velox::BIGINT()});
+    rowType_ = velox::ROW("c0", velox::BIGINT());
     makeTables({test::TableSpec{
         .name = "t",
         .columns = rowType_,
@@ -150,7 +150,9 @@ TEST_F(ProgressReporterTest, reportsProgressPerSplit) {
       return !reports.empty() && reports.back().stats.completedSplits > prev;
     });
     EXPECT_TRUE(ok) << "no report past " << prev;
-    return reports.back();
+    // On timeout the predicate never held, so reports may be empty; return a
+    // default rather than dereferencing back() so a hang fails cleanly.
+    return reports.empty() ? QueryProgress{} : reports.back();
   };
 
   {


### PR DESCRIPTION
Summary:
Two follow-up cleanups to `ProgressReporterTest`

- `waitForCompletedPast` returned `reports.back()` unconditionally, but on a 10s `cv.wait_for` timeout the predicate never held and `reports` can still be empty -- so `back()` is undefined behavior. `EXPECT_TRUE(ok)` records the failure but execution falls through into the dereference. Return a default `QueryProgress` when `reports` is empty so a hang fails cleanly through the assertion instead of crashing.
- Build the row type with the single-column `velox::ROW("c0", velox::BIGINT())` overload instead of the vector form.

Reviewed By: mbasmanova

Differential Revision: D109713765


