### PR TITLE
fix(optimizer): Place base filters before subquery filters (#1521)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3194,7 +3194,37 @@ bool Optimization::placeConjuncts(
   state.dt->singleRowDts.forEach<DerivedTable>(
       [&](auto dt) { columnsAndSingles.unionObjects(dt->columns); });
 
-  ExprVector filters;
+  // Phase 1: place all already-evaluable conjuncts (every column available)
+  // as a single Filter, before phase 2 places any subquery-dependent
+  // conjunct, so these filters land as low as possible in the plan.
+  {
+    ExprVector filters;
+    for (auto& conjunct : state.dt->conjuncts) {
+      if (!allowNondeterministic && conjunct->containsNonDeterministic()) {
+        continue;
+      }
+      if (state.isPlaced(conjunct)) {
+        continue;
+      }
+      if (conjunct->columns().isSubset(state.columns())) {
+        state.placeColumn(conjunct);
+        filters.push_back(conjunct);
+      }
+    }
+
+    if (!filters.empty()) {
+      for (auto& filter : filters) {
+        state.place(filter);
+      }
+      auto* filter = make<Filter>(plan, std::move(filters));
+      state.addCost(*filter);
+      makeJoins(filter, state);
+      return true;
+    }
+  }
+
+  // Phase 2: place a conjunct that depends on placed tables and non-correlated
+  // single row subqueries.
   for (auto& conjunct : state.dt->conjuncts) {
     if (!allowNondeterministic && conjunct->containsNonDeterministic()) {
       continue;
@@ -3202,14 +3232,7 @@ bool Optimization::placeConjuncts(
     if (state.isPlaced(conjunct)) {
       continue;
     }
-    if (conjunct->columns().isSubset(state.columns())) {
-      state.placeColumn(conjunct);
-      filters.push_back(conjunct);
-      continue;
-    }
     if (conjunct->columns().isSubset(columnsAndSingles)) {
-      // The filter depends on placed tables and non-correlated single row
-      // subqueries.
       std::vector<DerivedTableCP> placeable;
       state.dt->singleRowDts.forEach<DerivedTable>([&](auto subquery) {
         // If the subquery provides columns for the filter, place it.
@@ -3235,16 +3258,6 @@ bool Optimization::placeConjuncts(
         return true;
       }
     }
-  }
-
-  if (!filters.empty()) {
-    for (auto& filter : filters) {
-      state.place(filter);
-    }
-    auto* filter = make<Filter>(plan, std::move(filters));
-    state.addCost(*filter);
-    makeJoins(filter, state);
-    return true;
   }
   return false;
 }

--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -254,5 +254,26 @@ TEST_F(FilterPushdownTest, multiTableOrFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// Two base-column predicates (a <> 0 and c = 5) are evaluated below the cross
+// join, on the Values(t) side.
+TEST_F(FilterPushdownTest, belowSingleRowSubqueryCrossJoin) {
+  auto plan = toSingleNodePlan(
+      "WITH t AS (SELECT * FROM (VALUES (0, 5), (1, 5), (2, 99)) AS _(a, c)), "
+      "     u AS (SELECT * FROM (VALUES (10)) AS _(b)) "
+      "SELECT (SELECT max(b) FROM u) / a AS pt "
+      "FROM t WHERE a <> 0 AND c = 5 GROUP BY 1 "
+      "HAVING (SELECT max(b) FROM u) / a > 1");
+
+  auto matcher = matchValues()
+                     .filter("neq(c0, 0) AND eq(c1, 5)")
+                     .nestedLoopJoin(matchValues().singleAggregation().build())
+                     .filter()
+                     .project()
+                     .singleAggregation()
+                     .build();
+
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -476,6 +476,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"cte">();
   registerQueryFile<"datetime">();
   registerQueryFile<"distinctAggregation">();
+  registerQueryFile<"filterPushdown">();
   registerQueryFile<"groupingsets">();
   registerQueryFile<"join">();
   registerQueryFile<"limit">();

--- a/axiom/optimizer/tests/sql/filterPushdown.sql
+++ b/axiom/optimizer/tests/sql/filterPushdown.sql
@@ -1,0 +1,16 @@
+-- The WHERE predicate removes the a = 0 row before the scalar-subquery
+-- expression divides by a. The remaining a = 1 row satisfies HAVING.
+WITH
+t AS (SELECT * FROM (VALUES (0), (1)) AS _(a)),
+u AS (SELECT * FROM (VALUES (10)) AS _(b))
+SELECT (SELECT max(b) FROM u) / a AS pt
+FROM t WHERE a <> 0 GROUP BY 1
+HAVING (SELECT max(b) FROM u) / a > 1
+----
+-- The base-column predicate 1/a > 7 is pushed onto t, so it evaluates on the
+-- a = 0 row before the join predicate can remove that row.
+-- error: division by zero
+WITH
+t AS (SELECT * FROM (VALUES 0, 1) AS _(a)),
+u AS (SELECT * FROM (VALUES 1, 2) AS _(b))
+SELECT * FROM t, u WHERE a >= b AND 1/a > 7


### PR DESCRIPTION
Summary:

`placeConjuncts` did not always push a base-column filter as low as possible. When a derived table also contained a single-row subquery, it could place the subquery-dependent conjunct — emitting the subquery's cross join — before the base-column conjuncts, leaving a base-column filter stranded above the cross join.

Split placement into two phases: place all base-column (already-evaluable) conjuncts first as a single Filter, then the subquery-dependent ones. Base-column conjuncts now install as low as possible, below the single-row subquery cross join.

For example:

    WITH t(a) AS (VALUES 0, 1), u(b) AS (VALUES 10)
    SELECT (SELECT max(b) FROM u) / a AS pt
    FROM t WHERE a <> 0 GROUP BY 1
    HAVING (SELECT max(b) FROM u) / a > 1

`a <> 0` is a base-column predicate on `t`. Before, it was placed above the single-row subquery cross join; now it is pushed below it, onto the scan.

Reviewed By: kagamiori

Differential Revision: D109631529


