### PR TITLE
fix(runner): Report final stats in EXPLAIN ANALYZE

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1170,6 +1170,10 @@ std::string SqlQueryRunner::runExplainAnalyze(
     auto results = fetchResults(*runner);
   }
 
+  // Drive the run to completion so operator stats are final before reading
+  // them: draining the output cursor does not guarantee every driver finished.
+  waitForCompletion(runner, options.timeoutMicros);
+
   std::stringstream out;
   out << printPlanWithStats(
       *runner, planAndStats.prediction, options.debugMode);

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -404,25 +404,49 @@ bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
     splitScopeJoined_ = true;
   }
 
-  std::vector<velox::ContinueFuture> futures;
+  auto& executor = folly::QueuedImmediateExecutor::instance();
+
+  // Wait for every task to stop running, then snapshot final stats while the
+  // tasks are still alive. taskCompletionFuture (unlike taskDeletionFuture)
+  // does not require releasing the tasks, so stats remain readable here.
+  std::vector<velox::ContinueFuture> completionFutures;
   {
     std::lock_guard<std::mutex> l(mutex_);
+    for (auto& stage : stages_) {
+      for (auto& task : stage) {
+        completionFutures.push_back(task->taskCompletionFuture());
+      }
+    }
+  }
+  const bool completed = !folly::collectAll(std::move(completionFutures))
+                              .via(&executor)
+                              .within(std::chrono::microseconds(maxWaitMicros))
+                              .wait()
+                              .hasException();
+
+  // Tear down: capture final stats before the tasks go away, then drop the
+  // cursor and tasks and wait for their deletion so pools are released.
+  std::vector<velox::ContinueFuture> deletionFutures;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (completed && !finalStats_.has_value()) {
+      finalStats_ = aggregatedStats();
+    }
     cursor_.reset();
     for (auto& stage : stages_) {
       for (auto& task : stage) {
-        futures.push_back(task->taskDeletionFuture());
+        deletionFutures.push_back(task->taskDeletionFuture());
       }
       stage.clear();
     }
   }
+  const bool deleted = !folly::collectAll(std::move(deletionFutures))
+                            .via(&executor)
+                            .within(std::chrono::microseconds(maxWaitMicros))
+                            .wait()
+                            .hasException();
 
-  auto& executor = folly::QueuedImmediateExecutor::instance();
-  auto result = folly::collectAll(std::move(futures))
-                    .via(&executor)
-                    .within(std::chrono::microseconds(maxWaitMicros))
-                    .wait();
-
-  return !result.hasException();
+  return completed && deleted;
 }
 
 namespace {
@@ -578,8 +602,15 @@ void LocalRunner::makeStages(
 }
 
 std::vector<velox::exec::TaskStats> LocalRunner::stats() const {
-  std::vector<velox::exec::TaskStats> result;
   std::lock_guard<std::mutex> l(mutex_);
+  if (finalStats_.has_value()) {
+    return *finalStats_;
+  }
+  return aggregatedStats();
+}
+
+std::vector<velox::exec::TaskStats> LocalRunner::aggregatedStats() const {
+  std::vector<velox::exec::TaskStats> result;
   for (const auto& tasks : stages_) {
     VELOX_CHECK(!tasks.empty());
 

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <folly/coro/AsyncScope.h>
 
 #include "axiom/common/QueryRuntimeStats.h"
@@ -123,7 +125,8 @@ class LocalRunner : public Runner,
 
   /// Returns aggregated runtime stats for each fragment in 'fragments()'.
   /// Corresponds 1:1 to 'fragments()'. For multi-task fragments, stats from all
-  /// tasks are aggregated together.
+  /// tasks are aggregated together. While running this is a live snapshot; once
+  /// waitForCompletion() has captured the final stats, it returns those.
   std::vector<velox::exec::TaskStats> stats() const override;
 
   /// Prints the distributed plan annotated with runtime stats. Similar to
@@ -144,9 +147,15 @@ class LocalRunner : public Runner,
   /// Best-effort attempt to cancel the execution.
   void abort() override;
 
-  /// Waits for `maxWaitMicros` microseconds for all tasks to complete.
+  /// Waits for all tasks to complete in two phases (stop running, then release
+  /// resources), each bounded by `maxWaitMicros` microseconds.
   /// If `maxWaitMicros <= 0` this will check if the tasks are completed and
   /// return false immediately if not.
+  /// Captures a final stats snapshot once every task has stopped running, so a
+  /// subsequent stats() returns final stats rather than the in-progress
+  /// snapshot. (Draining the output via next() does not by itself guarantee
+  /// final stats: under multi-threaded execution a producer driver, e.g. a
+  /// probe-side TableScan, may still be closing.)
   /// @pre state() != State::kInitialized
   /// @return true if all tasks completed within the timeout, false otherwise.
   bool waitForCompletion(int32_t maxWaitMicros) override;
@@ -174,6 +183,11 @@ class LocalRunner : public Runner,
       const velox::core::TableScanNode& scan,
       const std::shared_ptr<connector::PartitionType>& partitionType);
 
+  // Aggregates the live per-fragment task stats. This is the in-progress
+  // snapshot returned by stats() before the run completes. Caller must hold
+  // mutex_.
+  std::vector<velox::exec::TaskStats> aggregatedStats() const;
+
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;
 
@@ -188,6 +202,10 @@ class LocalRunner : public Runner,
 
   std::unique_ptr<velox::exec::TaskCursor> cursor_;
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
+  // Final stats captured by waitForCompletion() once all tasks stopped running.
+  // Once set, stats() returns this instead of the live snapshot, which lets
+  // stats() report final stats after the tasks have been torn down.
+  std::optional<std::vector<velox::exec::TaskStats>> finalStats_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
   // Base directory for task spill files. Empty disables spilling.

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -47,8 +47,9 @@ class Runner {
   virtual velox::RowVectorPtr next() = 0;
 
   /// Returns Task stats for each fragment of the plan. The stats correspond 1:1
-  /// to the stages in the MultiFragmentPlan. This may be called at any time
-  /// before waitForCompletion() or abort().
+  /// to the stages in the MultiFragmentPlan. May be called at any time: while
+  /// the query is running it returns an in-progress snapshot; once
+  /// waitForCompletion() has run it returns the final stats.
   virtual std::vector<velox::exec::TaskStats> stats() const = 0;
 
   /// Returns the executable fragments of the plan being run, ordered so that


### PR DESCRIPTION
Summary:
EXPLAIN ANALYZE intermittently printed a dynamic-filtered probe `TableScan` with `Input: 0 rows` and near-zero CPU even though the scan produced rows — the parent join showed the real count. This deflated the summed-CPU metric used for plan-quality baselines.

The runner read operator stats as soon as the output cursor drained. Under multi-threaded execution a producer driver — the probe scan — can still be closing at that point, so `Task::taskStats()` merged a partial live snapshot of it. `LocalRunner::waitForCompletion` now waits on each task's `taskCompletionFuture()` and snapshots final stats while the tasks are still alive. `stats()` returns that snapshot once captured, and EXPLAIN ANALYZE waits for completion before reading. The documented contract now holds: a live snapshot while running, final stats after `waitForCompletion`.

Differential Revision: D109772041


