### PR TITLE
fix(optimizer): Fix left join with 'this' table (#1523)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2520,6 +2520,13 @@ void DerivedTable::distributeConjuncts() {
     }
 
     if (tables.size() == 2) {
+      if (tables[0] == this || tables[1] == this) {
+        // One side references this dt's own output (e.g. the nullable column
+        // of a contained outer join), so this cannot be a base-table join
+        // equality. Leave it in place to evaluate above the join.
+        continue;
+      }
+
       ExprCP left = nullptr;
       ExprCP right = nullptr;
       // expr depends on 2 tables. If it is left = right or right = left and

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -2123,6 +2123,31 @@ TEST_F(SubqueryTest, nonEquiLeftJoinWithScalarSubquery) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// LEFT JOIN with a post-join WHERE equality referencing both sides, where one
+// operand is not default-null propagating.
+TEST_F(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
+  auto query =
+      "SELECT a.x FROM (VALUES 1) a(x) "
+      "LEFT JOIN (VALUES 1) b(y) ON a.x = b.y "
+      "WHERE b.y = TRY(a.x)";
+  SCOPED_TRACE(query);
+
+  // The join keeps 'a.x = b.y' as its key while 'b.y = TRY(a.x)' stays a
+  // post-join filter.
+  auto matcher = matchValues()
+                     .aliases({"x"})
+                     .hashJoin(
+                         matchValues().aliases({"y"}).build(),
+                         core::JoinType::kLeft,
+                         {.keys = {{"x = y"}}})
+                     .filter("eq(y, try(x))")
+                     .project({"x"})
+                     .build();
+
+  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
 TEST_F(SubqueryTest, rightJoinOnSubquery) {
   // RIGHT JOIN is normalized to LEFT JOIN. Subqueries referencing the
   // null-supplying side (left in SQL, right after normalization) are supported.


### PR DESCRIPTION
Summary:

An outer join whose WHERE filter has an equality referencing the null-supplying side failed to plan when the equality contains a function with non-default null behavior, such as `TRY`. For example:

    SELECT a.x FROM (VALUES 1) a(x)
    LEFT JOIN (VALUES 1) b(y) ON a.x = b.y
    WHERE b.y = TRY(a.x)

failed with `Join leftTable is 'this'`.

Root cause:
The optimizer promotes a two-table filter equality to an inner join edge. Here one operand references an outer join's null-supplying column, which the optimizer models as a column of the enclosing derived table. The edge's left table then became the derived table itself, which a consistency check rejects. For a default-null predicate the outer join is first converted to inner and the column is rewritten to its base table, keeping the edge valid. That conversion is skipped for non-default-null predicates like `TRY`.

Fix:
The fix keeps such an equality as a post-join filter instead of promoting it to a join.

Reviewed By: natashasehgal

Differential Revision: D109771350


