### PR TITLE
fix: Handle nested leaf columns by dotted path (#1525)

### DIFF
--- a/axiom/connectors/file/README.md
+++ b/axiom/connectors/file/README.md
@@ -123,9 +123,9 @@ compression codec, byte sizes, value count, and column-chunk statistics.
 |--------|------|-------------|
 | `row_group_id` | BIGINT | Zero-based row group index. |
 | `column_id` | BIGINT | Zero-based column index within the row group. |
-| `name` | VARCHAR | Column name from the file schema. |
+| `path` | ARRAY<VARCHAR> | Leaf column-chunk physical `path_in_schema` as ordered segments (e.g. `['address', 'city']`, `['tags', 'list', 'element']`, `['lookup', 'key_value', 'key']`). See [Nested column paths](#nested-column-paths). |
 | `compression` | VARCHAR | Compression codec (e.g. `none`, `zstd`, `snappy`, `gzip`). |
-| `encodings` | VARCHAR | Comma-separated Parquet page encodings (e.g. `RLE,PLAIN`, `RLE_DICTIONARY`). |
+| `encodings` | ARRAY<VARCHAR> | Parquet page encodings as a list (e.g. `['RLE', 'PLAIN']`, `['RLE_DICTIONARY']`). |
 | `compressed_size` | BIGINT | Total compressed byte size of the column chunk. |
 | `uncompressed_size` | BIGINT | Total uncompressed byte size of the column chunk. |
 | `num_values` | BIGINT | Number of values (including nulls) in the column chunk. |
@@ -139,26 +139,42 @@ leave it unset.
 
 ```sql
 -- Inspect encodings and compression for every column chunk.
-SELECT row_group_id, name, encodings, compression
+SELECT row_group_id, path, encodings, compression
 FROM file."parquet"."/data/file.parquet$column_chunks";
 
 -- Find columns with high compression ratios.
-SELECT name, compression,
+SELECT path, compression,
        uncompressed_size / NULLIF(compressed_size, 0) AS ratio
 FROM file."parquet"."/data/file.parquet$column_chunks"
 WHERE compressed_size > 0
 ORDER BY ratio DESC;
 
 -- Inspect per-column value ranges.
-SELECT name, min, max, null_count
+SELECT path, min, max, null_count
 FROM file."parquet"."/data/file.parquet$column_chunks";
 ```
 
 Example output:
 
 ```
- row_group_id | column_id | name | compression | encodings          | compressed_size | uncompressed_size | num_values | min   | max  | null_count
---------------+-----------+------+-------------+--------------------+-----------------+-------------------+------------+-------+------+-----------
-            0 |         0 | id   | zstd        | RLE,PLAIN          |             187 |               305 |         25 | 1     | 25   |          0
-            0 |         1 | name | zstd        | RLE,RLE_DICTIONARY |             279 |               360 |         25 | alpha | zeta |          0
+ row_group_id | column_id | path     | compression | encodings             | compressed_size | uncompressed_size | num_values | min   | max  | null_count
+--------------+-----------+----------+-------------+-----------------------+-----------------+-------------------+------------+-------+------+-----------
+            0 |         0 | [id]     | zstd        | [RLE, PLAIN]          |             187 |               305 |         25 | 1     | 25   |          0
+            0 |         1 | [name]   | zstd        | [RLE, RLE_DICTIONARY] |             279 |               360 |         25 | alpha | zeta |          0
 ```
+
+##### Nested column paths
+
+Nested columns flatten to one row per leaf, identified by its physical
+`path_in_schema` as ordered segments (arrays add `list`/`element`, maps add
+`key_value`/`key`/`value`):
+
+```
+address ROW(city, zip)  → ['address', 'city'], ['address', 'zip']
+tags    ARRAY(INT)      → ['tags', 'list', 'element']
+lookup  MAP(STR, INT)   → ['lookup', 'key_value', 'key'], ['lookup', 'key_value', 'value']
+```
+
+Exposing the path as an array (rather than a dot-joined string) avoids ambiguity
+when a field name itself contains a `.`, and keeps the synthetic repeated-group
+levels (`list`, `key_value`) as distinct segments.

--- a/axiom/connectors/file/core/tests/FileTableTest.cpp
+++ b/axiom/connectors/file/core/tests/FileTableTest.cpp
@@ -107,7 +107,7 @@ TEST_F(FileTableTest, metadataTableColumnMap) {
   const auto& columns = table->columnMap();
   EXPECT_TRUE(columns.contains("row_group_id"));
   EXPECT_TRUE(columns.contains("column_id"));
-  EXPECT_TRUE(columns.contains("name"));
+  EXPECT_TRUE(columns.contains("path"));
   EXPECT_TRUE(columns.contains("compression"));
   EXPECT_TRUE(columns.contains("encodings"));
   EXPECT_TRUE(columns.contains("compressed_size"));

--- a/axiom/connectors/file/parquet/ParquetFileHandler.cpp
+++ b/axiom/connectors/file/parquet/ParquetFileHandler.cpp
@@ -26,6 +26,7 @@
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/parquet/reader/Metadata.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
+#include "velox/type/Variant.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -52,9 +53,9 @@ const RowTypePtr& columnChunksSchema() {
   static auto kSchema = ROW({
       {"row_group_id", BIGINT()},
       {"column_id", BIGINT()},
-      {"name", VARCHAR()},
+      {"path", ARRAY(VARCHAR())},
       {"compression", VARCHAR()},
-      {"encodings", VARCHAR()},
+      {"encodings", ARRAY(VARCHAR())},
       {"compressed_size", BIGINT()},
       {"uncompressed_size", BIGINT()},
       {"num_values", BIGINT()},
@@ -167,24 +168,22 @@ class RowGroupsDataSource : public MetadataDataSource {
   }
 };
 
-// Joins a column chunk's page encodings into a comma-separated string of
-// Parquet encoding names (e.g. "RLE,PLAIN").
-std::string encodingsToString(
+// Maps a column chunk's page encodings to their Parquet encoding names (e.g.
+// "RLE", "PLAIN"), falling back to the numeric code for unknown encodings.
+std::vector<std::string> encodingNames(
     const std::vector<parquet::thrift::Encoding>& encodings) {
-  std::string result;
+  std::vector<std::string> names;
+  names.reserve(encodings.size());
   for (auto encoding : encodings) {
     std::string_view name;
-    if (!result.empty()) {
-      result += ',';
-    }
     if (apache::thrift::TEnumTraits<parquet::thrift::Encoding>::findName(
             encoding, &name)) {
-      result.append(name);
+      names.emplace_back(name);
     } else {
-      result += std::to_string(static_cast<int32_t>(encoding));
+      names.push_back(std::to_string(static_cast<int32_t>(encoding)));
     }
   }
-  return result;
+  return names;
 }
 
 // Column-chunk statistics formatted for display. Empty optionals mean the
@@ -238,6 +237,26 @@ ColumnChunkStats readColumnChunkStats(
   return stats;
 }
 
+// Flattens 'type' into its leaf types in schema document order, matching the
+// order of the per-leaf column chunks in a Parquet row group. A type with no
+// children is a leaf; every other type recurses over its children in order,
+// which for ROW, ARRAY and MAP is the same order Parquet lays out the leaf
+// column chunks (row fields, array element, then map key followed by value).
+// Leaf names are not derived here: they come from each chunk's physical
+// path_in_schema metadata (see ColumnChunksDataSource::build), which carries
+// the synthetic repeated-group levels ("list"/"key_value") that the logical row
+// type omits. Only the leaf types are collected, to decode each chunk's
+// statistics.
+void collectLeafTypes(const TypePtr& type, std::vector<TypePtr>& leafTypes) {
+  if (type->size() == 0) {
+    leafTypes.push_back(type);
+    return;
+  }
+  for (auto i = 0; i < type->size(); ++i) {
+    collectLeafTypes(type->childAt(i), leafTypes);
+  }
+}
+
 class ColumnChunksDataSource : public MetadataDataSource {
  public:
   ColumnChunksDataSource(
@@ -254,7 +273,9 @@ class ColumnChunksDataSource : public MetadataDataSource {
   RowVectorPtr build() override {
     auto reader = openFile(split_->filePath, pool_);
     auto fileMetadata = reader->fileMetaData();
-    const auto& schema = reader->rowType();
+
+    std::vector<TypePtr> leafTypes;
+    collectLeafTypes(reader->rowType(), leafTypes);
 
     vector_size_t totalRows = 0;
     for (int rg = 0; rg < fileMetadata.numRowGroups(); ++rg) {
@@ -265,11 +286,7 @@ class ColumnChunksDataSource : public MetadataDataSource {
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
     auto columnIds =
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
-    auto names =
-        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
     auto compressions =
-        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
-    auto encodings =
         BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
     auto compressedSizes =
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
@@ -284,28 +301,39 @@ class ColumnChunksDataSource : public MetadataDataSource {
     auto nullCounts =
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
 
+    std::vector<std::vector<std::string>> paths;
+    paths.reserve(totalRows);
+    std::vector<std::vector<std::string>> encodings;
+    encodings.reserve(totalRows);
+
     vector_size_t row = 0;
     for (int rg = 0; rg < fileMetadata.numRowGroups(); ++rg) {
       auto rowGroup = fileMetadata.rowGroup(rg);
+      // Column chunks and 'leafTypes' are both in schema document order (a
+      // depth-first walk of the leaves), so column 'col' below and
+      // leafTypes[col] refer to the same schema leaf: the chunk supplies the
+      // path, the leaf type decodes the statistics. The two orders derive from
+      // the same schema, so the only way they can diverge is a leaf-count
+      // disagreement; reject that here rather than mislabel the chunks.
+      VELOX_USER_CHECK_EQ(
+          rowGroup.numColumns(),
+          static_cast<int>(leafTypes.size()),
+          "Parquet row group column-chunk count does not match the file schema's leaf count: {}",
+          split_->filePath);
       for (int col = 0; col < rowGroup.numColumns(); ++col) {
         auto chunk = rowGroup.columnChunk(col);
-        auto columnName = col < static_cast<int>(schema->size())
-            ? std::string(schema->nameOf(col))
-            : fmt::format("column_{}", col);
+        const auto& leafType = leafTypes.at(col);
         auto compression = common::compressionKindToString(chunk.compression());
-        auto encoding = encodingsToString(chunk.encodings());
 
-        auto columnType = col < static_cast<int>(schema->size())
-            ? schema->childAt(col)
-            : nullptr;
-        auto stats =
-            readColumnChunkStats(chunk, columnType, rowGroup.numRows());
+        auto stats = readColumnChunkStats(chunk, leafType, rowGroup.numRows());
 
         rowGroupIds->set(row, static_cast<int64_t>(rg));
         columnIds->set(row, static_cast<int64_t>(col));
-        names->set(row, StringView(columnName));
+        // Physical path_in_schema as ordered segments, including the
+        // "list"/"key_value" group levels Parquet inserts for arrays and maps.
+        paths.push_back(chunk.pathInSchema());
+        encodings.push_back(encodingNames(chunk.encodings()));
         compressions->set(row, StringView(compression));
-        encodings->set(row, StringView(encoding));
         compressedSizes->set(row, chunk.totalCompressedSize());
         uncompressedSizes->set(row, chunk.totalUncompressedSize());
         numValues->set(row, chunk.numValues());
@@ -324,9 +352,9 @@ class ColumnChunksDataSource : public MetadataDataSource {
         std::vector<VectorPtr>{
             rowGroupIds,
             columnIds,
-            names,
+            makeStringArray(paths),
             compressions,
-            encodings,
+            makeStringArray(encodings),
             compressedSizes,
             uncompressedSizes,
             numValues,
@@ -356,6 +384,23 @@ class ColumnChunksDataSource : public MetadataDataSource {
     } else {
       vector.setNull(row, true);
     }
+  }
+
+  // Builds an ARRAY<VARCHAR> vector with one array per row from the per-row
+  // string lists (used for both the path segments and the encoding names).
+  VectorPtr makeStringArray(
+      const std::vector<std::vector<std::string>>& rows) const {
+    std::vector<Variant> arrays;
+    arrays.reserve(rows.size());
+    for (const auto& row : rows) {
+      std::vector<Variant> elements;
+      elements.reserve(row.size());
+      for (const auto& value : row) {
+        elements.emplace_back(value);
+      }
+      arrays.push_back(Variant::array(std::move(elements)));
+    }
+    return BaseVector::createFromVariants(ARRAY(VARCHAR()), arrays, pool_);
   }
 };
 

--- a/axiom/connectors/file/tests/FileConnectorTest.cpp
+++ b/axiom/connectors/file/tests/FileConnectorTest.cpp
@@ -61,30 +61,79 @@ class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
     connectors_.reset();
   }
 
-  // Writes the standard five-row test fixture to 'path' as a Parquet file. A
-  // two-row row-group limit splits it into three row groups (2, 2, 1), and
-  // 'score' carries nulls so null_count statistics are non-zero.
-  void writeTestParquetFile(const std::string& path) {
-    auto data = makeRowVector(
-        {"id", "name", "score"},
-        {makeFlatVector<int64_t>({3, 1, 5, 2, 4}),
-         makeFlatVector<std::string>(
-             {"gamma", "alpha", "epsilon", "beta", "delta"}),
-         makeNullableFlatVector<int64_t>(
-             {std::nullopt, 100, std::nullopt, 200, 300})});
-
+  // Writes 'data' to 'path' as a Parquet file. A positive 'rowsInRowGroup'
+  // caps each row group at that many rows; 0 leaves the whole file in one row
+  // group.
+  void writeParquetFile(
+      const std::string& path,
+      const RowVectorPtr& data,
+      int32_t rowsInRowGroup = 0) {
     dwio::common::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
-    writerOptions.flushPolicyFactory = [] {
-      return std::make_unique<parquet::DefaultFlushPolicy>(
-          /*rowsInRowGroup=*/2, /*bytesInRowGroup=*/128 << 20);
-    };
+    if (rowsInRowGroup > 0) {
+      writerOptions.flushPolicyFactory = [rowsInRowGroup] {
+        return std::make_unique<parquet::DefaultFlushPolicy>(
+            rowsInRowGroup, /*bytesInRowGroup=*/128 << 20);
+      };
+    }
     auto sink = dwio::common::FileSink::create(
         fmt::format("file:{}", path), {.pool = rootPool_.get()});
     auto writer = std::make_unique<parquet::Writer>(
         std::move(sink), writerOptions, data->rowType());
     writer->write(data);
     writer->close();
+  }
+
+  // The standard test data: three scalar columns plus a struct, an array, a
+  // map, and an array-of-struct, so a single fixture exercises every leaf kind
+  // (scalar, ROW child, ARRAY element, MAP key/value, and recursion through an
+  // ARRAY into a ROW). 'score' carries nulls so null_count statistics are
+  // non-zero. Each array and map holds exactly one element per row, so every
+  // leaf column chunk has the same value count as its row group's row count.
+  RowVectorPtr testData() {
+    auto address = makeRowVector(
+        {"city", "zip"},
+        {makeFlatVector<StringView>({"nyc", "sf", "la", "dc", "atx"}),
+         makeFlatVector<int64_t>({10001, 94016, 90001, 20001, 73301})});
+    auto tags = makeArrayVector<int32_t>({{1}, {2}, {3}, {4}, {5}});
+    auto lookup = makeMapVector<StringView, int64_t>(
+        {{{"a", 10}}, {{"b", 20}}, {{"c", 30}}, {{"d", 40}}, {{"e", 50}}});
+    auto eventElements = makeRowVector(
+        {"kind", "count"},
+        {makeFlatVector<StringView>(
+             {"click", "view", "buy", "scroll", "hover"}),
+         makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+    auto events = makeArrayVector({0, 1, 2, 3, 4}, eventElements);
+    return makeRowVector(
+        {"id", "name", "score", "address", "tags", "lookup", "events"},
+        {makeFlatVector<int64_t>({3, 1, 5, 2, 4}),
+         makeFlatVector<std::string>(
+             {"gamma", "alpha", "epsilon", "beta", "delta"}),
+         makeNullableFlatVector<int64_t>(
+             {std::nullopt, 100, std::nullopt, 200, 300}),
+         address,
+         tags,
+         lookup,
+         events});
+  }
+
+  // The schema of testData(), used to assert DESC on the data table.
+  static RowTypePtr testSchema() {
+    return ROW(
+        {"id", "name", "score", "address", "tags", "lookup", "events"},
+        {BIGINT(),
+         VARCHAR(),
+         BIGINT(),
+         ROW({"city", "zip"}, {VARCHAR(), BIGINT()}),
+         ARRAY(INTEGER()),
+         MAP(VARCHAR(), BIGINT()),
+         ARRAY(ROW({"kind", "count"}, {VARCHAR(), BIGINT()}))});
+  }
+
+  void writeTestParquetFile(const std::string& path) {
+    // A two-row row-group limit splits the five rows into three row groups
+    // (2, 2, 1).
+    writeParquetFile(path, testData(), /*rowsInRowGroup=*/2);
   }
 
   // Fails with the query's own error message if it reported one.
@@ -167,14 +216,7 @@ class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
 
 TEST_F(FileConnectorTest, fullScan) {
   exec::test::assertEqualResults(
-      {makeRowVector(
-          {"id", "name", "score"},
-          {makeFlatVector<int64_t>({3, 1, 5, 2, 4}),
-           makeFlatVector<std::string>(
-               {"gamma", "alpha", "epsilon", "beta", "delta"}),
-           makeNullableFlatVector<int64_t>(
-               {std::nullopt, 100, std::nullopt, 200, 300})})},
-      queryAll(fmt::format("SELECT * FROM {}", table())));
+      {testData()}, queryAll(fmt::format("SELECT * FROM {}", table())));
 }
 
 TEST_F(FileConnectorTest, projection) {
@@ -206,15 +248,7 @@ TEST_F(FileConnectorTest, streamingMultipleBatches) {
     EXPECT_EQ(batch->size(), 1);
   }
 
-  exec::test::assertEqualResults(
-      {makeRowVector(
-          {"id", "name", "score"},
-          {makeFlatVector<int64_t>({3, 1, 5, 2, 4}),
-           makeFlatVector<std::string>(
-               {"gamma", "alpha", "epsilon", "beta", "delta"}),
-           makeNullableFlatVector<int64_t>(
-               {std::nullopt, 100, std::nullopt, 200, 300})})},
-      results);
+  exec::test::assertEqualResults({testData()}, results);
 }
 
 TEST_F(FileConnectorTest, rowGroupsMetadata) {
@@ -230,50 +264,108 @@ TEST_F(FileConnectorTest, rowGroupsMetadata) {
 }
 
 TEST_F(FileConnectorTest, columnChunksMetadata) {
+  // One row per leaf column chunk. The struct, array, map, and array-of-struct
+  // columns each flatten to one chunk per leaf, identified by its physical
+  // path_in_schema as ordered segments (arrays carry the "list"/"element"
+  // levels, maps carry "key_value"/"key"/"value"). Three row groups (2, 2, 1
+  // rows) with one element per array/map entry give every leaf a num_values
+  // equal to its row group's row count.
+  const std::vector<std::vector<std::string>> leafPaths = {
+      {"id"},
+      {"name"},
+      {"score"},
+      {"address", "city"},
+      {"address", "zip"},
+      {"tags", "list", "element"},
+      {"lookup", "key_value", "key"},
+      {"lookup", "key_value", "value"},
+      {"events", "list", "element", "kind"},
+      {"events", "list", "element", "count"}};
+  const std::vector<int64_t> rowGroupRowCounts = {2, 2, 1};
+
+  std::vector<int64_t> rowGroupIds;
+  std::vector<int64_t> columnIds;
+  std::vector<std::vector<std::string>> paths;
+  std::vector<int64_t> numValues;
+  for (size_t rg = 0; rg < rowGroupRowCounts.size(); ++rg) {
+    for (size_t col = 0; col < leafPaths.size(); ++col) {
+      rowGroupIds.push_back(static_cast<int64_t>(rg));
+      columnIds.push_back(static_cast<int64_t>(col));
+      paths.push_back(leafPaths[col]);
+      numValues.push_back(rowGroupRowCounts[rg]);
+    }
+  }
+
   exec::test::assertEqualResults(
       {makeRowVector(
-          {"row_group_id", "column_id", "name", "num_values"},
-          {makeFlatVector<int64_t>({0, 0, 0, 1, 1, 1, 2, 2, 2}),
-           makeFlatVector<int64_t>({0, 1, 2, 0, 1, 2, 0, 1, 2}),
-           makeFlatVector<std::string>(
-               {"id",
-                "name",
-                "score",
-                "id",
-                "name",
-                "score",
-                "id",
-                "name",
-                "score"}),
-           makeFlatVector<int64_t>({2, 2, 2, 2, 2, 2, 1, 1, 1})})},
+          {"row_group_id", "column_id", "path", "num_values"},
+          {makeFlatVector<int64_t>(rowGroupIds),
+           makeFlatVector<int64_t>(columnIds),
+           makeArrayVector<std::string>(paths),
+           makeFlatVector<int64_t>(numValues)})},
       queryAll(
           fmt::format(
-              "SELECT row_group_id, column_id, name, num_values FROM {}",
+              "SELECT row_group_id, column_id, path, num_values FROM {}",
               metadataTable("column_chunks"))));
 }
 
 TEST_F(FileConnectorTest, columnChunksStatistics) {
-  // 'score' is null once in each of the first two row groups, so their
-  // null_count is 1.
+  // Per-row-group statistics decoded from the Parquet column-chunk metadata,
+  // including the nested struct leaves address.city and address.zip: a nested
+  // leaf reports its typed min/max instead of falling back to no statistics.
+  // 'score' has one null in each of the first two row groups. Restricted to the
+  // scalar and struct leaves (column_id < 5), whose values are fully determined
+  // by the fixture (array and map leaf statistics are writer-dependent, so they
+  // are not asserted here).
+  const std::vector<std::vector<std::string>> scalarAndStructPaths = {
+      {"id"}, {"name"}, {"score"}, {"address", "city"}, {"address", "zip"}};
+  std::vector<std::vector<std::string>> paths;
+  for (int rg = 0; rg < 3; ++rg) {
+    paths.insert(
+        paths.end(), scalarAndStructPaths.begin(), scalarAndStructPaths.end());
+  }
+
   exec::test::assertEqualResults(
       {makeRowVector(
-          {"min", "max", "null_count"},
-          {makeFlatVector<std::string>(
-               {"1", "alpha", "100", "2", "beta", "200", "4", "delta", "300"}),
+          {"path", "min", "max", "null_count"},
+          {makeArrayVector<std::string>(paths),
+           makeFlatVector<std::string>(
+               {"1",
+                "alpha",
+                "100",
+                "nyc",
+                "10001",
+                "2",
+                "beta",
+                "200",
+                "dc",
+                "20001",
+                "4",
+                "delta",
+                "300",
+                "atx",
+                "73301"}),
            makeFlatVector<std::string>(
                {"3",
                 "gamma",
                 "100",
+                "sf",
+                "94016",
                 "5",
                 "epsilon",
                 "200",
+                "la",
+                "90001",
                 "4",
                 "delta",
-                "300"}),
-           makeFlatVector<int64_t>({0, 0, 1, 0, 0, 1, 0, 0, 0})})},
+                "300",
+                "atx",
+                "73301"}),
+           makeFlatVector<int64_t>(
+               {0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0})})},
       queryAll(
           fmt::format(
-              "SELECT min, max, null_count FROM {}",
+              "SELECT path, min, max, null_count FROM {} WHERE column_id < 5",
               metadataTable("column_chunks"))));
 }
 
@@ -290,8 +382,9 @@ TEST_F(FileConnectorTest, showSchemas) {
 }
 
 TEST_F(FileConnectorTest, describe) {
-  assertDescribeTable(
-      table(), ROW({"id", "name", "score"}, {BIGINT(), VARCHAR(), BIGINT()}));
+  // DESC resolves the file path through the handler and reports the file schema
+  // as (column, type) rows in file-schema order, including the nested columns.
+  assertDescribeTable(table(), testSchema());
 
   // A $-suffix metadata table reports that table's fixed metadata schema, not
   // the data file's schema.
@@ -337,14 +430,7 @@ TEST_F(FileConnectorTest, separatorInFileName) {
   writeTestParquetFile(path);
 
   exec::test::assertEqualResults(
-      {makeRowVector(
-          {"id", "name", "score"},
-          {makeFlatVector<int64_t>({3, 1, 5, 2, 4}),
-           makeFlatVector<std::string>(
-               {"gamma", "alpha", "epsilon", "beta", "delta"}),
-           makeNullableFlatVector<int64_t>(
-               {std::nullopt, 100, std::nullopt, 200, 300})})},
-      queryAll(fmt::format("SELECT * FROM {}", table(path))));
+      {testData()}, queryAll(fmt::format("SELECT * FROM {}", table(path))));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17979


Fixes how column names show up for nested fields (structs, lists, maps) when you inspect a Parquet file's per-column details. Now each nested column is labeled by its real path inside the file.

Example:
```
  SELECT column_id, path, encodings
  FROM file."parquet"."nested.parquet$column_chunks" ORDER BY column_id;

   column_id | path                      | encodings
  -----------+---------------------------+-----------------------
   0         | [id]                      | [RLE, PLAIN]
   3         | [address, city]           | [RLE, PLAIN]
   5         | [tags, list, element]     | [RLE, RLE_DICTIONARY]
   6         | [lookup, key_value, key]  | [RLE, RLE_DICTIONARY]
```

Reviewed By: mbasmanova

Differential Revision: D109186690
