### PR TITLE
feat(file-connector): Query a directory of files as one table (#1526)

### DIFF
--- a/axiom/connectors/file/CMakeLists.txt
+++ b/axiom/connectors/file/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
     velox_connector
     velox_memory
     velox_common_base
+    velox_file
     Folly::folly
 )
 

--- a/axiom/connectors/file/FileHandler.cpp
+++ b/axiom/connectors/file/FileHandler.cpp
@@ -16,10 +16,12 @@
 
 #include "axiom/connectors/file/FileHandler.h"
 
+#include <algorithm>
 #include <map>
 
 #include "axiom/connectors/file/core/FileTable.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/file/FileSystems.h"
 
 namespace facebook::axiom::connector::file {
 
@@ -78,6 +80,48 @@ const velox::RowTypePtr& FileHandler::metadataSchema(
   VELOX_USER_CHECK(
       it != metadataTables_.end(), "Unsupported metadata table: {}", suffix);
   return it->second.schema;
+}
+
+std::vector<std::string> FileHandler::listFiles(const std::string& path) const {
+  if (path.empty() || path.back() != '/') {
+    return {path};
+  }
+
+  auto fileSystem = velox::filesystems::getFileSystem(path, /*config=*/nullptr);
+  auto entries = fileSystem->list(path);
+  std::vector<std::string> files;
+  files.reserve(entries.size());
+  for (auto& entry : entries) {
+    const auto slash = entry.find_last_of('/');
+    const std::string_view baseName = std::string_view(entry).substr(
+        slash == std::string::npos ? 0 : slash + 1);
+    if (baseName.empty() || baseName.front() == '_' ||
+        baseName.front() == '.') {
+      continue;
+    }
+    // Skip nested directories, detected from filesystem metadata rather than by
+    // trying to read them, so genuine read errors on real files are not
+    // swallowed as "not a data file".
+    if (fileSystem->isDirectory(entry)) {
+      continue;
+    }
+    // Let the handler's isDataFile() reject entries that are not data files of
+    // its format (e.g. foreign formats). The base accepts every entry.
+    if (!isDataFile(*fileSystem, entry)) {
+      continue;
+    }
+    files.push_back(std::move(entry));
+  }
+  std::sort(files.begin(), files.end());
+  VELOX_USER_CHECK(
+      !files.empty(), "No data files found in directory: {}", path);
+  return files;
+}
+
+bool FileHandler::isDataFile(
+    velox::filesystems::FileSystem& /*fileSystem*/,
+    const std::string& /*filePath*/) const {
+  return true;
 }
 
 std::unique_ptr<velox::connector::DataSource> FileHandler::create(

--- a/axiom/connectors/file/FileHandler.h
+++ b/axiom/connectors/file/FileHandler.h
@@ -24,6 +24,10 @@
 
 #include "velox/connectors/Connector.h"
 
+namespace facebook::velox::filesystems {
+class FileSystem;
+}
+
 namespace facebook::axiom::connector::file {
 
 /// Factory function that creates a metadata DataSource.
@@ -60,6 +64,14 @@ class FileHandler {
   /// Returns the fixed schema for a metadata table by $-suffix.
   const velox::RowTypePtr& metadataSchema(const std::string& suffix) const;
 
+  /// Lists the data files for 'path'. A path that does not end in '/' is a
+  /// single file and yields itself. A path ending in '/' is a directory; its
+  /// entries are returned sorted, so a directory of files can be queried as one
+  /// table. Entries whose base name begins with '.' or '_', nested
+  /// subdirectories, and entries rejected by isDataFile() are skipped, so a
+  /// directory may freely hold sidecar files and nested partitions.
+  std::vector<std::string> listFiles(const std::string& path) const;
+
   /// Creates a DataSource for reading from a file. Dispatches to
   /// createDataSource() for row data or the registered factory for
   /// metadata tables.
@@ -84,6 +96,14 @@ class FileHandler {
       const velox::RowTypePtr& fullSchema,
       const velox::connector::ColumnHandleMap& columnHandles,
       velox::memory::MemoryPool* pool) const = 0;
+
+  // Returns whether 'filePath' is a file of this handler's format, used by
+  // listFiles() to skip entries that are not data files. The base accepts every
+  // entry; formats override this to recognize their own files (e.g. Parquet by
+  // its "PAR1" magic).
+  virtual bool isDataFile(
+      velox::filesystems::FileSystem& fileSystem,
+      const std::string& filePath) const;
 
  private:
   struct MetadataTable {

--- a/axiom/connectors/file/README.md
+++ b/axiom/connectors/file/README.md
@@ -19,6 +19,7 @@ what synthetic metadata tables to expose. See the `FileHandler` interface in
 
 **Reads:**
 - Scan row data from a supported file via its absolute file path.
+- Scan a directory of files (trailing-slash path) as one logical table.
 - Auto-detect schema from the file header.
 - Column projection — only the requested columns are decoded.
 - Streaming reads — row data is returned one batch at a time, not buffered in
@@ -45,6 +46,25 @@ FROM file."parquet"."/data/file.parquet"
 WHERE name = 'alpha';
 ```
 
+### Reading a directory of files
+
+A path ending in `/` is treated as a directory. The connector reads every file
+in it as one logical table, taking the schema from the first file. Every other
+file is validated against that schema during planning, so a directory holding a
+file with a different schema fails upfront rather than mid-read. File extensions
+are not required — the schema already selects the format.
+
+```sql
+-- Read all Parquet files under a directory.
+SELECT * FROM file."parquet"."/data/parquet/";
+```
+
+Over a directory, metadata tables emit rows for every file. Per-file identifiers
+such as a Parquet `row_group_id` restart at 0 in each file, so the metadata
+tables carry a `file_path` column to disambiguate them.
+
+Key or join metadata rows on `(file_path, row_group_id)` — not `row_group_id` alone — or rows from different files will collide.
+
 ### Inspecting file metadata
 
 Append a `$`-suffix to the file path to query a synthetic metadata table. No
@@ -70,7 +90,7 @@ A table name is a file path with an optional metadata-table suffix:
 ```
 
 - A plain path (no `$` suffix) maps to the **data table** — row data from the
-  file.
+  file, or from every file in the directory when the path ends in `/`.
 - A path ending with a recognized `$`-suffix maps to the corresponding
   **metadata table** (e.g. `$row_groups`, `$column_chunks`).
 - An unrecognized `$`-suffix produces an error from the handler.
@@ -96,7 +116,8 @@ Lists one row per row group with size and row-count statistics.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `row_group_id` | BIGINT | Zero-based row group index within the file. |
+| `file_path` | VARCHAR | Name of the file the row group belongs to, relative to the queried directory. |
+| `row_group_id` | BIGINT | Row group index within its file. Restarts at 0 in each file, so over a directory it is unique only together with `file_path`. |
 | `num_rows` | BIGINT | Number of rows in the row group. |
 | `total_byte_size` | BIGINT | Total uncompressed byte size of all column data in the row group. |
 | `total_compressed_size` | BIGINT | Total compressed byte size of all column data in the row group. |
@@ -121,7 +142,8 @@ compression codec, byte sizes, value count, and column-chunk statistics.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `row_group_id` | BIGINT | Zero-based row group index. |
+| `file_path` | VARCHAR | Name of the file the column chunk belongs to, relative to the queried directory. |
+| `row_group_id` | BIGINT | Row group index within its file. Restarts at 0 in each file, so over a directory it is unique only together with `file_path`. |
 | `column_id` | BIGINT | Zero-based column index within the row group. |
 | `path` | ARRAY<VARCHAR> | Leaf column-chunk physical `path_in_schema` as ordered segments (e.g. `['address', 'city']`, `['tags', 'list', 'element']`, `['lookup', 'key_value', 'key']`). See [Nested column paths](#nested-column-paths). |
 | `compression` | VARCHAR | Compression codec (e.g. `none`, `zstd`, `snappy`, `gzip`). |

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -23,14 +23,14 @@
 namespace facebook::axiom::connector::file {
 
 folly::coro::Task<SplitBatch> FileSplitSource::co_getSplits(
-    uint32_t /*maxSplitCount*/) {
+    uint32_t maxSplitCount) {
   SplitBatch batch;
-  if (!done_) {
+  while (next_ < filePaths_.size() && batch.splits.size() < maxSplitCount) {
     batch.splits.emplace_back(
-        std::make_shared<FileSplit>(connectorId_, filePath_));
-    done_ = true;
+        std::make_shared<FileSplit>(connectorId_, filePaths_[next_]));
+    ++next_;
   }
-  batch.noMoreSplits = true;
+  batch.noMoreSplits = next_ == filePaths_.size();
   co_return batch;
 }
 
@@ -38,11 +38,37 @@ TablePtr FileConnectorMetadata::findTable(const SchemaTableName& tableName) {
   auto& fileHandler = handler(tableName.schema);
   auto [filePath, suffix] = FileTable::parseName(tableName.table);
 
-  auto schema = suffix.empty() ? fileHandler.resolve(filePath, pool_.get())
-                               : fileHandler.metadataSchema(suffix);
+  velox::RowTypePtr schema;
+  std::vector<std::string> filePaths;
+  if (suffix.empty()) {
+    // Data table: resolve the path to its data files once, here during
+    // planning, and thread the list through the table handle to split
+    // generation, so the directory is listed — and each entry's format probed —
+    // only once per query. A directory takes its schema from the first file;
+    // validate every other file against it here so a mismatched directory fails
+    // upfront rather than mid-read after emitting rows from earlier files.
+    filePaths = fileHandler.listFiles(filePath);
+    schema = fileHandler.resolve(filePaths.front(), pool_.get());
+    for (size_t i = 1; i < filePaths.size(); ++i) {
+      const auto fileType = fileHandler.resolve(filePaths[i], pool_.get());
+      VELOX_USER_CHECK(
+          *fileType == *schema,
+          "Directory file schema does not match the table schema {}, found {}: {}",
+          schema->toString(),
+          fileType->toString(),
+          filePaths[i]);
+    }
+  } else {
+    // Metadata table: validate the suffix BEFORE probing the path. Otherwise an
+    // unsupported suffix on a missing or empty directory fails while listing
+    // ("No data files found in directory: ...") instead of with the accurate
+    // "Unsupported metadata table: ...".
+    schema = fileHandler.metadataSchema(suffix);
+    filePaths = fileHandler.listFiles(filePath);
+  }
 
   return std::make_shared<FileTable>(
-      tableName, schema, connector_, filePath, suffix);
+      tableName, schema, connector_, filePath, std::move(filePaths), suffix);
 }
 
 std::vector<std::string> FileConnectorMetadata::listSchemaNames(
@@ -73,8 +99,10 @@ FileConnectorMetadata::SplitManager::getSplitSource(
     QueryRuntimeStats& /*runtimeStats*/) {
   auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
   VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
+  // The file list was resolved once during planning (see findTable); reuse it
+  // rather than listing the directory again here.
   return std::make_shared<FileSplitSource>(
-      tableHandle->connectorId(), fileHandle->filePath());
+      tableHandle->connectorId(), fileHandle->filePaths());
 }
 
 } // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/core/FileConnectorMetadata.h
+++ b/axiom/connectors/file/core/FileConnectorMetadata.h
@@ -22,18 +22,20 @@
 
 namespace facebook::axiom::connector::file {
 
-/// Emits exactly one FileSplit per file.
+/// Emits one FileSplit per file path, in order.
 class FileSplitSource : public SplitSource {
  public:
-  FileSplitSource(const std::string& connectorId, std::string filePath)
-      : connectorId_(connectorId), filePath_(std::move(filePath)) {}
+  FileSplitSource(
+      const std::string& connectorId,
+      std::vector<std::string> filePaths)
+      : connectorId_(connectorId), filePaths_(std::move(filePaths)) {}
 
   folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
 
  private:
   const std::string connectorId_;
-  const std::string filePath_;
-  bool done_{false};
+  const std::vector<std::string> filePaths_;
+  size_t next_{0};
 };
 
 /// Resolves file paths as table names.

--- a/axiom/connectors/file/core/FileDataSources.h
+++ b/axiom/connectors/file/core/FileDataSources.h
@@ -121,6 +121,14 @@ class MetadataDataSource : public FileDataSource {
     }
   }
 
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override {
+    FileDataSource::addSplit(std::move(split));
+    // Each split is a separate file whose metadata must be emitted, so the
+    // single-batch build() runs once per split.
+    needData_ = true;
+  }
+
   std::optional<velox::RowVectorPtr> next(
       uint64_t /*size*/,
       velox::ContinueFuture& /*future*/) override {

--- a/axiom/connectors/file/core/FileTable.cpp
+++ b/axiom/connectors/file/core/FileTable.cpp
@@ -43,6 +43,7 @@ FileTableLayout::FileTableLayout(
     velox::connector::Connector* connector,
     std::vector<const Column*> columns,
     std::string filePath,
+    std::vector<std::string> filePaths,
     std::string suffix)
     : TableLayout(
           table->name().schema,
@@ -55,6 +56,7 @@ FileTableLayout::FileTableLayout(
           /*lookupKeys=*/{},
           /*supportsScan=*/true),
       filePath_(std::move(filePath)),
+      filePaths_(std::move(filePaths)),
       suffix_(std::move(suffix)) {}
 
 velox::connector::ColumnHandlePtr FileTableLayout::createColumnHandle(
@@ -81,6 +83,7 @@ velox::connector::ConnectorTableHandlePtr FileTableLayout::createTableHandle(
       connectorId(),
       table().name(),
       filePath_,
+      filePaths_,
       suffix_,
       table().type(),
       std::move(columnHandles));
@@ -91,10 +94,16 @@ FileTable::FileTable(
     const RowTypePtr& schema,
     velox::connector::Connector* connector,
     std::string filePath,
+    std::vector<std::string> filePaths,
     std::string suffix)
     : Table(tableName, makeColumns(schema)) {
   layout_ = std::make_unique<FileTableLayout>(
-      this, connector, allColumns(), std::move(filePath), std::move(suffix));
+      this,
+      connector,
+      allColumns(),
+      std::move(filePath),
+      std::move(filePaths),
+      std::move(suffix));
   layouts_.push_back(layout_.get());
 }
 

--- a/axiom/connectors/file/core/FileTable.h
+++ b/axiom/connectors/file/core/FileTable.h
@@ -25,7 +25,10 @@
 
 namespace facebook::axiom::connector::file {
 
-/// Carries the file path for a single file read.
+/// Carries the file path for a single file read. For a directory query, the
+/// file path disambiguates file-local metadata (e.g. a Parquet row group index,
+/// which restarts at 0 in each file) so rows from different files can be told
+/// apart and joined safely.
 struct FileSplit : public velox::connector::ConnectorSplit {
   FileSplit(const std::string& connectorId, std::string filePath)
       : ConnectorSplit(connectorId), filePath(std::move(filePath)) {}
@@ -54,12 +57,14 @@ class FileTableHandle : public velox::connector::ConnectorTableHandle {
       const std::string& connectorId,
       SchemaTableName schemaTableName,
       std::string filePath,
+      std::vector<std::string> filePaths,
       std::string suffix,
       velox::RowTypePtr fullSchema,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles)
       : ConnectorTableHandle(connectorId),
         schemaTableName_(std::move(schemaTableName)),
         filePath_(std::move(filePath)),
+        filePaths_(std::move(filePaths)),
         suffix_(std::move(suffix)),
         fullSchema_(std::move(fullSchema)),
         qualifiedName_(
@@ -85,6 +90,13 @@ class FileTableHandle : public velox::connector::ConnectorTableHandle {
     return filePath_;
   }
 
+  /// The data files backing this table: the single file, or every data file in
+  /// the directory, resolved once during planning and reused for split
+  /// generation so the directory is listed only once per query.
+  const std::vector<std::string>& filePaths() const {
+    return filePaths_;
+  }
+
   /// Metadata table suffix (e.g. "encodings"). Empty for data tables.
   const std::string& suffix() const {
     return suffix_;
@@ -102,6 +114,7 @@ class FileTableHandle : public velox::connector::ConnectorTableHandle {
  private:
   const SchemaTableName schemaTableName_;
   const std::string filePath_;
+  const std::vector<std::string> filePaths_;
   const std::string suffix_;
   const velox::RowTypePtr fullSchema_;
   const std::string qualifiedName_;
@@ -116,6 +129,7 @@ class FileTableLayout : public TableLayout {
       velox::connector::Connector* connector,
       std::vector<const Column*> columns,
       std::string filePath,
+      std::vector<std::string> filePaths,
       std::string suffix);
 
   bool supportsSampling() const override {
@@ -140,6 +154,7 @@ class FileTableLayout : public TableLayout {
 
  private:
   std::string filePath_;
+  std::vector<std::string> filePaths_;
   std::string suffix_;
 };
 
@@ -151,6 +166,7 @@ class FileTable : public Table {
       const velox::RowTypePtr& schema,
       velox::connector::Connector* connector,
       std::string filePath,
+      std::vector<std::string> filePaths,
       std::string suffix);
 
   /// Splits "<path>$<suffix>" into {path, suffix}. Takes the part after the

--- a/axiom/connectors/file/parquet/ParquetFileHandler.cpp
+++ b/axiom/connectors/file/parquet/ParquetFileHandler.cpp
@@ -39,8 +39,45 @@ namespace {
 constexpr const char* kColumnChunks = "column_chunks";
 constexpr const char* kRowGroups = "row_groups";
 
+// Parquet files begin and end with this 4-byte magic.
+constexpr std::string_view kParquetMagic = "PAR1";
+
+// Returns whether 'file' carries the 4-byte Parquet magic at 'offset'. The
+// caller must ensure 'file' spans at least kParquetMagic.size() bytes from
+// 'offset'.
+bool hasParquetMagic(velox::ReadFile& file, uint64_t offset) {
+  return file.pread(offset, kParquetMagic.size()) == kParquetMagic;
+}
+
+// Returns whether 'filePath' is a Parquet file: it both begins and ends with
+// the 4-byte magic.
+bool isParquetFile(
+    velox::filesystems::FileSystem& fileSystem,
+    const std::string& filePath) {
+  auto file = fileSystem.openFileForRead(filePath);
+  const auto size = file->size();
+  // A valid Parquet file carries the magic at BOTH the start and the end. A
+  // header-only check would admit truncated files or foreign files that merely
+  // begin with "PAR1"; also require the trailing magic. Need room for two
+  // non-overlapping copies.
+  return size >= 2 * kParquetMagic.size() && hasParquetMagic(*file, 0) &&
+      hasParquetMagic(*file, size - kParquetMagic.size());
+}
+
+// Returns the file name (the segment after the last '/') of 'path'. The
+// metadata tables store this rather than the full path: the queried directory
+// is already known from the query, and its entries are unique, so (file_path,
+// row_group_id) still identifies a row without repeating the directory prefix
+// on every row.
+std::string_view fileName(const std::string& path) {
+  const auto slash = path.find_last_of('/');
+  return slash == std::string::npos ? std::string_view(path)
+                                    : std::string_view(path).substr(slash + 1);
+}
+
 const RowTypePtr& rowGroupsSchema() {
   static auto kSchema = ROW({
+      {"file_path", VARCHAR()},
       {"row_group_id", BIGINT()},
       {"num_rows", BIGINT()},
       {"total_byte_size", BIGINT()},
@@ -51,6 +88,7 @@ const RowTypePtr& rowGroupsSchema() {
 
 const RowTypePtr& columnChunksSchema() {
   static auto kSchema = ROW({
+      {"file_path", VARCHAR()},
       {"row_group_id", BIGINT()},
       {"column_id", BIGINT()},
       {"path", ARRAY(VARCHAR())},
@@ -72,6 +110,19 @@ std::unique_ptr<parquet::ParquetReader> openFile(
   dwio::common::ReaderOptions readerOptions(pool);
   auto fileSystem = filesystems::getFileSystem(filePath, /*config=*/nullptr);
   auto readFile = fileSystem->openFileForRead(filePath);
+
+  // Parquet files begin with the 4-byte magic "PAR1"; validate it up
+  // front.
+  VELOX_USER_CHECK_GE(
+      readFile->size(),
+      kParquetMagic.size(),
+      "Not a Parquet file (too small): {}",
+      filePath);
+  VELOX_USER_CHECK(
+      hasParquetMagic(*readFile, 0),
+      "Not a Parquet file (missing PAR1 magic): {}",
+      filePath);
+
   auto input =
       std::make_unique<dwio::common::BufferedInput>(std::move(readFile), *pool);
   return std::make_unique<parquet::ParquetReader>(
@@ -141,6 +192,8 @@ class RowGroupsDataSource : public MetadataDataSource {
     auto fileMetadata = reader->fileMetaData();
     auto numRowGroups = static_cast<vector_size_t>(fileMetadata.numRowGroups());
 
+    auto filePaths = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), numRowGroups, pool_);
     auto rowGroupIds =
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRowGroups, pool_);
     auto numRows =
@@ -152,6 +205,7 @@ class RowGroupsDataSource : public MetadataDataSource {
 
     for (vector_size_t i = 0; i < numRowGroups; ++i) {
       auto rowGroup = fileMetadata.rowGroup(i);
+      filePaths->set(i, StringView(fileName(split_->filePath)));
       rowGroupIds->set(i, static_cast<int64_t>(i));
       numRows->set(i, rowGroup.numRows());
       totalByteSize->set(i, rowGroup.totalByteSize());
@@ -164,7 +218,11 @@ class RowGroupsDataSource : public MetadataDataSource {
         nullptr,
         numRowGroups,
         std::vector<VectorPtr>{
-            rowGroupIds, numRows, totalByteSize, totalCompressedSize});
+            filePaths,
+            rowGroupIds,
+            numRows,
+            totalByteSize,
+            totalCompressedSize});
   }
 };
 
@@ -282,6 +340,8 @@ class ColumnChunksDataSource : public MetadataDataSource {
       totalRows += fileMetadata.rowGroup(rg).numColumns();
     }
 
+    auto filePaths =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), totalRows, pool_);
     auto rowGroupIds =
         BaseVector::create<FlatVector<int64_t>>(BIGINT(), totalRows, pool_);
     auto columnIds =
@@ -327,6 +387,7 @@ class ColumnChunksDataSource : public MetadataDataSource {
 
         auto stats = readColumnChunkStats(chunk, leafType, rowGroup.numRows());
 
+        filePaths->set(row, StringView(fileName(split_->filePath)));
         rowGroupIds->set(row, static_cast<int64_t>(rg));
         columnIds->set(row, static_cast<int64_t>(col));
         // Physical path_in_schema as ordered segments, including the
@@ -350,6 +411,7 @@ class ColumnChunksDataSource : public MetadataDataSource {
         nullptr,
         row,
         std::vector<VectorPtr>{
+            filePaths,
             rowGroupIds,
             columnIds,
             makeStringArray(paths),
@@ -434,15 +496,7 @@ void registerParquetHandler() {
 velox::RowTypePtr ParquetFileHandler::resolve(
     const std::string& filePath,
     velox::memory::MemoryPool* pool) const {
-  velox::dwio::common::ReaderOptions readerOptions(pool);
-  auto fileSystem =
-      velox::filesystems::getFileSystem(filePath, /*config=*/nullptr);
-  auto readFile = fileSystem->openFileForRead(filePath);
-  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
-      std::move(readFile), *pool);
-  auto reader = std::make_unique<velox::parquet::ParquetReader>(
-      std::move(input), readerOptions);
-  return reader->rowType();
+  return openFile(filePath, pool)->rowType();
 }
 
 std::unique_ptr<velox::connector::DataSource>
@@ -453,6 +507,12 @@ ParquetFileHandler::createDataSource(
     velox::memory::MemoryPool* pool) const {
   return std::make_unique<ParquetDataSource>(
       outputType, fullSchema, columnHandles, pool);
+}
+
+bool ParquetFileHandler::isDataFile(
+    velox::filesystems::FileSystem& fileSystem,
+    const std::string& filePath) const {
+  return isParquetFile(fileSystem, filePath);
 }
 
 } // namespace facebook::axiom::connector::file

--- a/axiom/connectors/file/parquet/ParquetFileHandler.h
+++ b/axiom/connectors/file/parquet/ParquetFileHandler.h
@@ -36,6 +36,12 @@ class ParquetFileHandler : public FileHandler {
       const velox::RowTypePtr& fullSchema,
       const velox::connector::ColumnHandleMap& columnHandles,
       velox::memory::MemoryPool* pool) const override;
+
+  // Treats only files beginning with the Parquet "PAR1" magic as data files, so
+  // directory listing skips subdirectories and non-Parquet sidecar files.
+  bool isDataFile(
+      velox::filesystems::FileSystem& fileSystem,
+      const std::string& filePath) const override;
 };
 
 /// Registers the Parquet handler under the "parquet" schema name.

--- a/axiom/connectors/file/tests/FileConnectorTest.cpp
+++ b/axiom/connectors/file/tests/FileConnectorTest.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <filesystem>
+#include <fstream>
+
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -22,6 +25,8 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/common/file/tests/FaultyFileSystemOperations.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
@@ -40,6 +45,7 @@ class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     velox::filesystems::registerLocalFileSystem();
+    velox::tests::utils::registerFaultyFileSystem();
   }
 
   void SetUp() override {
@@ -134,6 +140,19 @@ class FileConnectorTest : public ::testing::Test, public test::VectorTestBase {
     // A two-row row-group limit splits the five rows into three row groups
     // (2, 2, 1).
     writeParquetFile(path, testData(), /*rowsInRowGroup=*/2);
+  }
+
+  // Writes a single-row-group file with an (id, name) schema. Used to populate
+  // a directory with several files sharing one schema.
+  void writeRows(
+      const std::string& path,
+      const std::vector<int64_t>& ids,
+      const std::vector<StringView>& names) {
+    writeParquetFile(
+        path,
+        makeRowVector(
+            {"id", "name"},
+            {makeFlatVector<int64_t>(ids), makeFlatVector<StringView>(names)}));
   }
 
   // Fails with the query's own error message if it reported one.
@@ -390,11 +409,12 @@ TEST_F(FileConnectorTest, describe) {
   // the data file's schema.
   assertDescribeTable(
       metadataTable("row_groups"),
-      ROW({"row_group_id",
+      ROW({"file_path",
+           "row_group_id",
            "num_rows",
            "total_byte_size",
            "total_compressed_size"},
-          {BIGINT(), BIGINT(), BIGINT(), BIGINT()}));
+          {VARCHAR(), BIGINT(), BIGINT(), BIGINT(), BIGINT()}));
 }
 
 TEST_F(FileConnectorTest, describeErrors) {
@@ -416,10 +436,369 @@ TEST_F(FileConnectorTest, describeErrors) {
       "No such file or directory: /tmp/axiom_no_such_file.parquet");
 }
 
+TEST_F(FileConnectorTest, multipleFilesInDirectory) {
+  // A trailing-slash path is a directory; the connector reads every Parquet
+  // file it contains as one logical table.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getPath()), {1, 3}, {"alpha", "gamma"});
+  writeRows(
+      fmt::format("{}/b.parquet", dir->getPath()), {2, 4}, {"beta", "delta"});
+
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath())),
+      makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({1, 2, 3, 4}),
+           makeFlatVector<StringView>({"alpha", "beta", "gamma", "delta"})}));
+}
+
+TEST_F(FileConnectorTest, rowGroupsAcrossFilesInDirectory) {
+  // Metadata over a directory emits rows for every file. Each file's
+  // row_group_id restarts at 0 (both files here are a single row group), so
+  // file_path is what keeps rows from different files distinct. file_path is
+  // the name relative to the queried directory, not the full path.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getPath()), {1, 2}, {"alpha", "beta"});
+  writeRows(
+      fmt::format("{}/b.parquet", dir->getPath()), {3, 4, 5}, {"c", "d", "e"});
+
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT file_path, row_group_id, num_rows "
+              "FROM file.\"parquet\".\"{}/$row_groups\" ORDER BY file_path",
+              dir->getPath())),
+      makeRowVector(
+          {"file_path", "row_group_id", "num_rows"},
+          {makeFlatVector<std::string>({"a.parquet", "b.parquet"}),
+           makeFlatVector<int64_t>({0, 0}),
+           makeFlatVector<int64_t>({2, 3})}));
+}
+
+TEST_F(FileConnectorTest, columnChunksAcrossFilesInDirectory) {
+  // column_chunks over a directory also restarts row_group_id at 0 per file.
+  // file_path keeps each file's chunks distinct, so keying on
+  // (file_path, row_group_id) does not mix metadata across files. file_path is
+  // the name relative to the queried directory, not the full path.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getPath()), {1, 2}, {"alpha", "beta"});
+  writeRows(fmt::format("{}/b.parquet", dir->getPath()), {3, 4}, {"c", "d"});
+
+  test::assertEqualVectors(
+      query(
+          fmt::format(
+              "SELECT file_path, row_group_id, column_id, path "
+              "FROM file.\"parquet\".\"{}/$column_chunks\" "
+              "ORDER BY file_path, column_id",
+              dir->getPath())),
+      makeRowVector(
+          {"file_path", "row_group_id", "column_id", "path"},
+          {makeFlatVector<std::string>(
+               {"a.parquet", "a.parquet", "b.parquet", "b.parquet"}),
+           makeFlatVector<int64_t>({0, 0, 0, 0}),
+           makeFlatVector<int64_t>({0, 1, 0, 1}),
+           makeArrayVector<std::string>(
+               {{"id"}, {"name"}, {"id"}, {"name"}})}));
+}
+
+TEST_F(FileConnectorTest, emptyDirectoryFails) {
+  // A directory with no data files has nothing to scan.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format("SELECT * FROM file.\"parquet\".\"{}/\"", dir->getPath()),
+          {}),
+      "No data files found in directory");
+}
+
+TEST_F(FileConnectorTest, directoryReadsExtensionlessFilesAndSkipsMarkers) {
+  // Data-lake directories often hold extensionless part files alongside writer
+  // marker files (e.g. _SUCCESS, .crc). The scan reads every file regardless of
+  // extension but skips names beginning with '_' or '.'.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/part-00000", dir->getPath()), {1, 2}, {"alpha", "beta"});
+  writeRows(fmt::format("{}/part-00001", dir->getPath()), {3}, {"gamma"});
+
+  // Marker files with non-Parquet content: reading them as data would throw, so
+  // a passing test proves they are skipped.
+  for (const auto* marker : {"_SUCCESS", ".part-00000.crc"}) {
+    std::ofstream{fmt::format("{}/{}", dir->getPath(), marker)}
+        << "not parquet";
+  }
+
+  exec::test::assertEqualResults(
+      {makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<std::string>({"alpha", "beta", "gamma"})})},
+      queryAll(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\"", dir->getPath())));
+}
+
+TEST_F(FileConnectorTest, directorySkipsNonDataEntries) {
+  // The '_'/'.' name rule does not cover a visible non-Parquet sidecar file or
+  // a nested partition directory. The sidecar is skipped by the Parquet magic
+  // check (it would otherwise fail the reader); the subdirectory is skipped as
+  // a directory during listing. The subdirectory holds its own Parquet file to
+  // confirm listing does not recurse into it.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getPath()), {1, 2}, {"alpha", "beta"});
+
+  // Visible non-Parquet sidecar (no '_'/'.' prefix to hide it).
+  std::ofstream{fmt::format("{}/manifest.json", dir->getPath())}
+      << "{\"not\": \"parquet\"}";
+
+  // Nested directory with its own Parquet file; its rows must not appear.
+  const auto subDir = fmt::format("{}/nested", dir->getPath());
+  std::filesystem::create_directory(subDir);
+  writeRows(fmt::format("{}/b.parquet", subDir), {3}, {"gamma"});
+
+  exec::test::assertEqualResults(
+      {makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({1, 2}),
+           makeFlatVector<std::string>({"alpha", "beta"})})},
+      queryAll(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\"", dir->getPath())));
+}
+
+TEST_F(FileConnectorTest, directoryReadErrorPropagates) {
+  // A genuine I/O error while probing a directory entry must propagate, not be
+  // swallowed as "not a data file" — otherwise the file is silently dropped and
+  // the query returns incomplete results with no error. Inject a read failure
+  // on one file's magic-bytes probe and confirm the query fails with it.
+  auto dir = velox::common::testutil::TempDirectoryPath::create(
+      /*enableFaultInjection=*/true);
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getDelegatePath()), {1}, {"alpha"});
+  writeRows(fmt::format("{}/b.parquet", dir->getDelegatePath()), {2}, {"beta"});
+
+  const auto faultyB = fmt::format("{}/b.parquet", dir->getPath());
+  auto faultyFs = velox::tests::utils::faultyFileSystem();
+  faultyFs->setFileInjectionHook(
+      [faultyB](velox::tests::utils::FaultFileOperation* op) {
+        if (op->path == faultyB) {
+          VELOX_FAIL("Injected read failure");
+        }
+      });
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "Injected read failure");
+
+  faultyFs->clearFileFaultInjections();
+}
+
+TEST_F(FileConnectorTest, nonParquetFileFails) {
+  // Without extension filtering, a non-Parquet file reaches the reader. It must
+  // fail with a clear error naming the file rather than a cryptic reader error.
+  auto path = fmt::format("{}/data.bin", tempDir_->getPath());
+  std::ofstream{path} << "this is not a parquet file";
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format("SELECT * FROM file.\"parquet\".\"{}\"", path), {}),
+      "Not a Parquet file");
+}
+
+TEST_F(FileConnectorTest, directorySkipsFileWithoutFooterMagic) {
+  // A file that begins with the "PAR1" magic but lacks the trailing footer
+  // magic is not a valid Parquet file. The directory-listing filter checks both
+  // the header and the footer, so it skips this file rather than treating it as
+  // data and failing the reader.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(
+      fmt::format("{}/a.parquet", dir->getPath()), {1, 2}, {"alpha", "beta"});
+  // Header-only "Parquet-looking" file: starts with PAR1, but no footer magic.
+  std::ofstream{fmt::format("{}/b.parquet", dir->getPath())}
+      << "PAR1 header only, missing the trailing magic";
+
+  exec::test::assertEqualResults(
+      {makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({1, 2}),
+           makeFlatVector<std::string>({"alpha", "beta"})})},
+      queryAll(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\"", dir->getPath())));
+}
+
+TEST_F(FileConnectorTest, mismatchedSchemaInDirectoryFails) {
+  // The table schema is taken from the first file (a.parquet). A later file
+  // whose column types differ must fail clearly rather than misreading it as
+  // the table's type.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(fmt::format("{}/a.parquet", dir->getPath()), {1}, {"alpha"});
+  // b.parquet shares the column names but 'name' is BIGINT, not VARCHAR.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({2}), makeFlatVector<int64_t>({99})}));
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
+TEST_F(FileConnectorTest, missingColumnInDirectoryFails) {
+  // A directory file missing a column from the table schema (taken from the
+  // first file) fails clearly rather than silently reading nulls.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(fmt::format("{}/a.parquet", dir->getPath()), {1}, {"alpha"});
+  // b.parquet has only 'id' — it is missing 'name'.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector({"id"}, {makeFlatVector<int64_t>({2})}));
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
+TEST_F(FileConnectorTest, directorySchemaValidatedUpfrontForAllColumns) {
+  // Validation runs at plan time against the full table schema, so a directory
+  // with a type-mismatched column fails before any rows are read — even when
+  // the query does not project that column.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(fmt::format("{}/a.parquet", dir->getPath()), {1}, {"alpha"});
+  // b.parquet shares the column names but 'name' is BIGINT, not VARCHAR.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector(
+          {"id", "name"},
+          {makeFlatVector<int64_t>({2}), makeFlatVector<int64_t>({99})}));
+
+  // 'name' is not selected, yet planning still validates it and fails upfront.
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT id FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
+TEST_F(FileConnectorTest, extraColumnInDirectoryFails) {
+  // A directory file with an extra column not in the table schema (taken from
+  // the first file) fails clearly rather than silently dropping the column.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(fmt::format("{}/a.parquet", dir->getPath()), {1}, {"alpha"});
+  // b.parquet has an additional 'score' column.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector(
+          {"id", "name", "score"},
+          {makeFlatVector<int64_t>({2}),
+           makeFlatVector<StringView>({"beta"}),
+           makeFlatVector<int64_t>({99})}));
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
+TEST_F(FileConnectorTest, renamedNestedFieldInDirectoryFails) {
+  // A directory file whose nested struct field is renamed must fail: the field
+  // types are equivalent but the names differ, so reading it under the table
+  // schema (taken from the first file) would misread the field by name.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeParquetFile(
+      fmt::format("{}/a.parquet", dir->getPath()),
+      makeRowVector(
+          {"id", "address"},
+          {makeFlatVector<int64_t>({1}),
+           makeRowVector(
+               {"city", "zip"},
+               {makeFlatVector<StringView>({"nyc"}),
+                makeFlatVector<int64_t>({10001})})}));
+  // b.parquet renames the nested 'city' field to 'town'.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector(
+          {"id", "address"},
+          {makeFlatVector<int64_t>({2}),
+           makeRowVector(
+               {"town", "zip"},
+               {makeFlatVector<StringView>({"sf"}),
+                makeFlatVector<int64_t>({94016})})}));
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
+TEST_F(FileConnectorTest, reorderedColumnsInDirectoryFails) {
+  // The table schema, including column order, is taken from the first file.
+  // Schema equality is positional, so a later file with the same columns in a
+  // different order is rejected upfront rather than read under a mismatched
+  // order.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  writeRows(fmt::format("{}/a.parquet", dir->getPath()), {1}, {"alpha"});
+  // b.parquet has the same columns as a.parquet but in (name, id) order.
+  writeParquetFile(
+      fmt::format("{}/b.parquet", dir->getPath()),
+      makeRowVector(
+          {"name", "id"},
+          {makeFlatVector<StringView>({"beta"}),
+           makeFlatVector<int64_t>({2})}));
+
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/\" ORDER BY id",
+              dir->getPath()),
+          {}),
+      "does not match the table schema");
+}
+
 TEST_F(FileConnectorTest, unsupportedMetadataTableFails) {
   VELOX_ASSERT_THROW(
       runner_->run(
           fmt::format("SELECT * FROM {}", metadataTable("stripes")), {}),
+      "Unsupported metadata table: stripes");
+}
+
+TEST_F(FileConnectorTest, unsupportedMetadataTableOnDirectoryFails) {
+  // The metadata suffix is validated before the path is probed, so an
+  // unsupported suffix on an empty directory fails with "Unsupported metadata
+  // table" — not with the "No data files found in directory" listing error that
+  // probing the empty directory would otherwise raise first.
+  auto dir = velox::common::testutil::TempDirectoryPath::create();
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          fmt::format(
+              "SELECT * FROM file.\"parquet\".\"{}/$stripes\"", dir->getPath()),
+          {}),
       "Unsupported metadata table: stripes");
 }
 


### PR DESCRIPTION
Summary:

A path ending in `/` is now read as a directory: the connector scans every data file in it and returns them as one logical table. Previously only a single file path resolved to a table. For example:

    SELECT * FROM file."parquet"."/data/parquet/";

The directory is listed once during planning, sorted, and each remaining file becomes one split. Entries skipped from the listing:

- Names beginning with `_` or `.`.
- Subdirectories, detected from filesystem metadata during listing.
- Entries the handler's format probe rejects — for Parquet, anything without `PAR1` magic at both ends.

The table schema is taken from the first file. Every other file is validated against it during planning: the file schema must match exactly — a missing, extra, renamed, or reordered column, or a column at a different type, fails upfront naming the offending file, before any rows are read. A genuine I/O error while probing an entry propagates rather than the file being silently dropped.

The `$row_groups` and `$column_chunks` metadata tables gain a `file_path` column. Per-file identifiers such as `row_group_id` restart at 0 in each file, so `(file_path, row_group_id)` is what keeps rows from different files distinct.

Reviewed By: mbasmanova

Differential Revision: D109189535
