### PR TITLE
feat(runner): Make Runner result iteration coroutine-based (#1527)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/cli/SqlQueryRunner.h"
 #include <folly/container/F14Map.h>
+#include <folly/coro/BlockingWait.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <algorithm>
 #include <cmath>
@@ -268,14 +269,6 @@ connector::ConnectorProperties collectConnectorProperties(
     }
   }
   return result;
-}
-
-std::vector<velox::RowVectorPtr> fetchResults(runner::LocalRunner& runner) {
-  std::vector<velox::RowVectorPtr> results;
-  while (auto rows = runner.next()) {
-    results.push_back(rows);
-  }
-  return results;
 }
 
 int64_t countRows(const std::vector<velox::RowVectorPtr>& results) {
@@ -1156,9 +1149,6 @@ std::string SqlQueryRunner::runExplainAnalyze(
       queryCtx,
       options,
       runtimeStats ? *runtimeStats : noopRuntimeStats_);
-  SCOPE_EXIT {
-    waitForCompletion(runner, options.timeoutMicros);
-  };
 
   {
     PhaseTimer phaseTimer(
@@ -1168,12 +1158,10 @@ std::string SqlQueryRunner::runExplainAnalyze(
         QueryRuntimeStats::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
-    auto results = fetchResults(*runner);
+    // Executed for its runtime stats (printed below); the result batches are
+    // not used, so discard them instead of accumulating the whole result set.
+    runner->drain([](velox::RowVectorPtr) {});
   }
-
-  // Drive the run to completion so operator stats are final before reading
-  // them: draining the output cursor does not guarantee every driver finished.
-  waitForCompletion(runner, options.timeoutMicros);
 
   std::stringstream out;
   out << printPlanWithStats(
@@ -1402,9 +1390,6 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
       queryCtx,
       options,
       runtimeStats ? *runtimeStats : noopRuntimeStats_);
-  SCOPE_EXIT {
-    waitForCompletion(runner, options.timeoutMicros);
-  };
 
   {
     PhaseTimer phaseTimer(
@@ -1414,7 +1399,9 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         QueryRuntimeStats::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
-    result.results = fetchResults(*runner);
+    runner->drain([&](velox::RowVectorPtr batch) {
+      result.results.push_back(std::move(batch));
+    });
   }
 
   return result;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -469,20 +469,6 @@ class SqlQueryRunner {
       std::string_view queryId,
       std::string_view connectorId) const;
 
-  // Wait maxWaitMicros microseconds for the LocalRunner to complete.  If
-  // `maxWaitMicros <= 0` this will check if the LocalRunner is completed and
-  // return immediately.
-  static void waitForCompletion(
-      const std::shared_ptr<facebook::axiom::runner::LocalRunner>& runner,
-      int32_t maxWaitMicros) {
-    if (runner) {
-      try {
-        runner->waitForCompletion(maxWaitMicros);
-      } catch (const std::exception&) {
-      }
-    }
-  }
-
   // Permission check callback invoked before query execution.
   PermissionCheck permissionCheck_;
 

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
+#include <folly/coro/BlockingWait.h>
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/runner/LocalRunner.h"
@@ -175,21 +177,30 @@ std::unique_ptr<KeyFreq> runJoinSample(
   auto result = std::make_unique<folly::F14FastMap<uint32_t, uint32_t>>();
 
   int32_t rowCount = 0;
-  while (auto rows = runner.next()) {
-    rowCount += rows->size();
-    auto hashes = rows->childAt(0)->as<velox::SimpleVector<int64_t>>();
+  // Pull batches one at a time so sampling can stop early once it has enough
+  // rows. blockingWait runs on the optimizer planning thread, not a Velox
+  // executor thread.
+  auto generator = runner.execute();
+  // Early stop is "stop pulling, then co_close()". co_close() must run on every
+  // exit -- including when a pull throws -- so the runner is reaped before it
+  // is destroyed (its destructor asserts co_close() ran). co_close() does not
+  // throw, so this is safe during exception unwinding.
+  SCOPE_EXIT {
+    folly::coro::blockingWait(runner.co_close());
+  };
+  while (auto rows = folly::coro::blockingWait(generator.next())) {
+    const velox::RowVectorPtr& batch = *rows;
+    rowCount += batch->size();
+    auto hashes = batch->childAt(0)->as<velox::SimpleVector<int64_t>>();
     for (auto i = 0; i < hashes->size(); ++i) {
       if (!hashes->isNullAt(i)) {
         ++(*result)[static_cast<uint32_t>(hashes->valueAt(i))];
       }
     }
     if (maxRows && rowCount > maxRows) {
-      runner.abort();
       break;
     }
   }
-
-  runner.waitForCompletion(1'000'000);
   return result;
 }
 

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include <folly/coro/BlockingWait.h>
 #include <velox/common/base/Exceptions.h>
 #include <iostream>
 #include <ranges>
@@ -397,13 +398,14 @@ std::vector<velox::RowVectorPtr> runConstantPlan(
       noopStats);
 
   std::vector<velox::RowVectorPtr> results;
-  while (auto rows = runner->next()) {
-    VELOX_CHECK_GT(rows->size(), 0);
+  runner->drain([&](velox::RowVectorPtr batch) {
+    VELOX_CHECK_GT(batch->size(), 0);
+    // Copy out of the runner's QueryCtx pool: that pool is released when the
+    // runner is closed (drain() reaps before returning).
     results.push_back(
         std::dynamic_pointer_cast<velox::RowVector>(
-            velox::BaseVector::copy(*rows, pool)));
-  }
-  runner->waitForCompletion(1'000'000);
+            velox::BaseVector::copy(*batch, pool)));
+  });
   return results;
 }
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/coro/BlockingWait.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/init/Init.h>
 #include <folly/system/HardwareConcurrency.h>
@@ -292,9 +293,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
       getrusage(RUSAGE_SELF, &start);
       MicrosecondTimer timer(&micros);
 
-      while (auto rows = runner.next()) {
-        results.push_back(rows);
-      }
+      runner.drain(
+          [&](RowVectorPtr batch) { results.push_back(std::move(batch)); });
 
       struct rusage final;
       getrusage(RUSAGE_SELF, &final);
@@ -549,9 +549,6 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     auto planAndStats = optimize(statement.plan(), queryCtx);
 
     auto runner = makeRunner(planAndStats, queryCtx);
-    SCOPE_EXIT {
-      waitForCompletion(runner);
-    };
 
     RunStats unused;
     auto results = runInner(*runner, unused);
@@ -717,9 +714,6 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
 
     try {
       auto runner = makeRunner(planAndStats, queryCtx);
-      SCOPE_EXIT {
-        waitForCompletion(runner);
-      };
 
       RunStats runStats;
       auto results = runInner(*runner, runStats);
@@ -789,15 +783,6 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     } else {
       // Must clear before 'runner' goes out of scope.
       result.clear();
-    }
-  }
-
-  void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner) {
-    if (runner) {
-      try {
-        runner->waitForCompletion(500000);
-      } catch (const std::exception&) {
-      }
     }
   }
 

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -18,6 +18,7 @@
 
 #include <ctime>
 
+#include <folly/coro/BlockingWait.h>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/Optimization.h"
@@ -123,16 +124,6 @@ logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
 }
 
 namespace {
-constexpr int32_t kWaitTimeoutUs = 500'000;
-
-void waitForCompletion(const std::shared_ptr<runner::LocalRunner>& runner) {
-  if (runner) {
-    VELOX_CHECK(
-        runner->waitForCompletion(kWaitTimeoutUs),
-        "Timed out waiting for query completion");
-  }
-}
-
 OptimizerSessionPtr makeOptimizerSession(
     const std::string& queryId,
     OptimizerOptions options) {
@@ -182,13 +173,14 @@ TestResult QueryTestBase::runFragmentedPlan(
       runtimeStats_);
 
   SCOPE_EXIT {
-    waitForCompletion(runner);
     queryCtx_.reset();
   };
 
   TestResult result;
-  result.runner = runner;
-  result.results = readCursor(result.runner);
+  result.runner = std::move(runner);
+  result.runner->drain([&](velox::RowVectorPtr batch) {
+    result.results.push_back(std::move(batch));
+  });
   result.stats = result.runner->stats();
   history_->recordVeloxExecution(planAndStats, result.stats);
 
@@ -451,16 +443,6 @@ std::shared_ptr<velox::core::QueryCtx> QueryTestBase::makeQueryCtx(
       /*pool=*/nullptr,
       /*spillExecutor=*/nullptr,
       queryId);
-}
-
-// static
-std::vector<velox::RowVectorPtr> QueryTestBase::readCursor(
-    const std::shared_ptr<runner::LocalRunner>& runner) {
-  std::vector<velox::RowVectorPtr> result;
-  while (auto rowVector = runner->next()) {
-    result.push_back(rowVector);
-  }
-  return result;
 }
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -258,10 +258,6 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
   std::shared_ptr<velox::core::QueryCtx> makeQueryCtx(
       const std::string& queryId);
 
-  /// Fetches all remaining data from the runner.
-  static std::vector<velox::RowVectorPtr> readCursor(
-      const std::shared_ptr<runner::LocalRunner>& runner);
-
   inline static std::unordered_map<std::string, std::string> config_;
 
   OptimizerOptions optimizerOptions_;

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/SqlTestBase.h"
+#include <folly/coro/BlockingWait.h>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/FunctionRegistry.h"
@@ -34,10 +35,6 @@
 namespace facebook::axiom::optimizer::test {
 
 using namespace facebook::velox;
-
-namespace {
-constexpr uint64_t kMaxWaitMicros{50'000};
-} // namespace
 
 void SqlTestBase::SetUpTestCase() {
   OperatorTestBase::SetUpTestCase();
@@ -204,9 +201,7 @@ void SqlTestBase::runSetupStatement(
   }
 
   auto runner = runnerFactory(plan);
-  while (auto batch = runner->next()) {
-  }
-  runner->waitForCompletion(kMaxWaitMicros);
+  runner->drain([](RowVectorPtr) {});
 }
 
 void SqlTestBase::runSetupStatement(const std::string& sql) {
@@ -256,11 +251,8 @@ std::vector<RowVectorPtr> SqlTestBase::runAndCollect(std::string_view sql) {
   auto runner = makeRunner(sql);
 
   std::vector<RowVectorPtr> results;
-  for (auto batch = runner->next(); batch != nullptr; batch = runner->next()) {
-    results.push_back(std::move(batch));
-  }
-
-  runner->waitForCompletion(kMaxWaitMicros);
+  runner->drain(
+      [&](RowVectorPtr batch) { results.push_back(std::move(batch)); });
 
   return results;
 }
@@ -333,15 +325,9 @@ void SqlTestBase::assertOrderedResults(
 
 uint64_t SqlTestBase::run(std::string_view sql) {
   auto runner = makeRunner(sql);
-  SCOPE_EXIT {
-    runner->waitForCompletion(kMaxWaitMicros);
-  };
 
   uint64_t numRows = 0;
-  for (auto batch = runner->next(); batch != nullptr; batch = runner->next()) {
-    numRows += batch->size();
-  }
-
+  runner->drain([&](RowVectorPtr batch) { numRows += batch->size(); });
   return numRows;
 }
 

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/pyspark/runners/LocalRunner.h"
 
+#include <folly/coro/BlockingWait.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -33,17 +34,6 @@ using namespace ::facebook;
 
 namespace axiom::collagen::runner {
 namespace {
-
-void waitForCompletion(
-    const std::shared_ptr<facebook::axiom::runner::LocalRunner>& runner) {
-  if (runner) {
-    try {
-      runner->waitForCompletion(500000);
-    } catch (const std::exception& /*ignore*/) {
-      // Ignore exceptions during wait for completion
-    }
-  }
-}
 
 folly::CPUThreadPoolExecutor* getCPUExecutor() {
   static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
@@ -111,17 +101,8 @@ std::vector<velox::RowVectorPtr> LocalRunner::execute(
       leafPool_,
       /*baseSpillDirectory=*/"",
       runtimeStats_);
-  try {
-    while (auto rows = runner->next()) {
-      results.push_back(rows);
-    }
-  } catch (const std::exception& e) {
-    LOG(WARNING) << "Query terminated with: " << e.what();
-    waitForCompletion(runner);
-    throw;
-  }
-
-  waitForCompletion(runner);
+  runner->drain(
+      [&](velox::RowVectorPtr batch) { results.push_back(std::move(batch)); });
   return results;
 }
 

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -15,8 +15,11 @@
  */
 
 #include "axiom/runner/LocalRunner.h"
+#include <folly/CancellationToken.h>
+#include <folly/coro/AsyncGenerator.h>
 #include <folly/coro/AsyncScope.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/Coroutine.h>
 #include <folly/coro/Task.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
@@ -132,6 +135,10 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     std::function<void(std::exception_ptr)> onError,
     QueryRuntimeStats& runtimeStats) {
   std::exception_ptr ex;
+  // Injected by CancellableAsyncScope::add(); the runner's co_reap() requests
+  // cancellation on teardown so this loop stops enumerating instead of draining
+  // the source to noMoreSplits.
+  const auto cancelToken = co_await folly::coro::co_current_cancellation_token;
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
 
@@ -141,6 +148,11 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     int64_t splitCount = 0;
     size_t taskIdx = 0;
     for (;;) {
+      // Teardown requested: the tasks are being reaped, so remaining splits are
+      // unnecessary. Bounds the reap's split-scope join to one co_getSplits().
+      if (cancelToken.isCancellationRequested()) {
+        break;
+      }
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
         size_t targetTask;
@@ -174,6 +186,9 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
         QueryRuntimeStats::kGetSplitsWallNanos,
         std::chrono::steady_clock::now() - getSplitsStart);
     runtimeStats.recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
+  } catch (const folly::OperationCancelled&) {
+    // co_getSplits() observed the teardown cancellation mid-call. This is a
+    // clean stop, not a query error, so do not propagate it to onError().
   } catch (...) {
     ex = std::current_exception();
   }
@@ -249,6 +264,15 @@ LocalRunner::LocalRunner(
       runtimeStats_(runtimeStats) {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
+  if (params_.outputPool == nullptr) {
+    // Own the cursor's output pool (held by params_ for the runner's lifetime)
+    // rather than letting the cursor create an internal one. Result batches are
+    // allocated here, and reap() releases the cursor while a caller may still
+    // hold batches; a runner-owned pool lets those batches outlive the cursor.
+    // It is freed when the runner is destroyed.
+    params_.outputPool =
+        params_.queryCtx->pool()->addLeafChild("localRunnerOutput");
+  }
   if (!baseSpillDirectory_.empty()) {
     params_.spillDirectory = baseSpillDirectory_;
   }
@@ -259,62 +283,137 @@ LocalRunner::LocalRunner(
 }
 
 LocalRunner::~LocalRunner() {
+  // A started runner must be wound down via co_await co_close() before being
+  // destroyed; the destructor asserts that rather than reaping here, so no drop
+  // ever runs blocking teardown on an executor thread. A never-started runner
+  // (execute() created but never pulled) needs no close.
+  VELOX_CHECK(
+      closed_ || state_ == State::kInitialized,
+      "co_close() must be awaited before destroying a started LocalRunner");
+  // CancellableAsyncScope requires cancelAndJoinAsync()/joinAsync() to complete
+  // before it is destroyed. co_close() already did so for a started runner; for
+  // a never-started one the scope is empty and this returns immediately.
   if (!splitScopeJoined_) {
-    folly::coro::blockingWait(splitScope_.joinAsync());
+    folly::coro::blockingWait(splitScope_.cancelAndJoinAsync());
   }
 }
 
-velox::RowVectorPtr LocalRunner::next() {
-  if (finishWrite_) {
-    return nextWrite();
-  }
-
+folly::coro::Task<velox::RowVectorPtr> LocalRunner::co_pull() {
   if (!cursor_) {
     start();
   }
 
-  if (!cursor_->moveNext()) {
-    state_ = State::kFinished;
-    return nullptr;
+  velox::ContinueFuture future = velox::ContinueFuture::makeEmpty();
+  if (cursor_->moveNext(&future)) {
+    co_return cursor_->current();
+  }
+  if (!future.valid()) {
+    // No future: producers are at end (or a drain boundary).
+    co_return nullptr;
   }
 
-  return cursor_->current();
+  // The cursor wakes the consumer only when a batch is queued or all producers
+  // are finished/drained, so a resolved wait-future implies the next dequeue
+  // yields data-or-terminal -- a single await is enough.
+  co_await std::move(future);
+  if (cursor_->moveNext(&future)) {
+    co_return cursor_->current();
+  }
+  VELOX_CHECK(
+      !future.valid(), "Cursor re-blocked after a resolved wait-future");
+  co_return nullptr;
 }
 
-int64_t LocalRunner::runWrite() {
+folly::coro::AsyncGenerator<velox::RowVectorPtr> LocalRunner::execute() {
+  // Cancelling the awaiting scope cancels the tasks; the next moveNext() then
+  // surfaces the task error. The callback may run on another thread, but
+  // cancelTasks() is safe from any thread. One registration covers the whole
+  // drain, including the write path below.
+  const auto token = co_await folly::coro::co_current_cancellation_token;
+  folly::CancellationCallback cancelCallback{token, [this] { cancelTasks(); }};
+
+  if (finishWrite_) {
+    co_yield makeWriteResult(co_await co_runWrite());
+    co_return;
+  }
+
+  while (auto rows = co_await co_pull()) {
+    co_yield std::move(rows);
+  }
+
+  // Reached end of output cleanly. Move kRunning -> kFinished under 'mutex_' so
+  // it serializes with cancelTasks()/onError: the transition cannot be
+  // interleaved with cancelTasks()'s read-guard-then-write and thus cannot
+  // clobber, or be clobbered by, a terminal state another thread set
+  // concurrently.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ == State::kRunning) {
+      state_ = State::kFinished;
+    }
+  }
+}
+
+folly::coro::Task<int64_t> LocalRunner::co_runWrite() {
   std::vector<velox::RowVectorPtr> result;
   auto finishWrite = std::move(finishWrite_);
-  auto state = State::kError;
-  SCOPE_EXIT {
-    state_ = state;
-  };
+  std::exception_ptr drainError;
   try {
-    start();
-    while (cursor_->moveNext()) {
-      result.push_back(cursor_->current());
+    while (auto rows = co_await co_pull()) {
+      result.push_back(std::move(rows));
     }
   } catch (const std::exception&) {
+    // Capture and handle after the handler: co_await is illegal inside a catch
+    // handler, and the reap below must be awaited.
+    drainError = std::current_exception();
+  }
+  if (drainError) {
+    // The drain failed: cancelTasks() (cancellation) or the task onError
+    // callback already recorded the terminal state. Release the write resources
+    // and rethrow the drain error without touching state_. Both cleanup steps
+    // are best-effort: log their own failures but never mask the drain error.
+    // co_reap() here matches what the owner's co_close() would run; co_close()
+    // is idempotent, so a later close is a no-op.
     try {
-      waitForCompletion(1'000'000);
+      co_await co_reap();
     } catch (const std::exception& e) {
       LOG(ERROR) << e.what()
                  << " while waiting for completion after error in write query";
-      throw;
     }
-    std::move(finishWrite).abort().get();
-    throw;
+    try {
+      std::move(finishWrite).abort().get();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << e.what()
+                 << " while aborting write after error in write query";
+    }
+    std::rethrow_exception(drainError);
   }
 
-  auto rows = std::move(finishWrite).commit(result).get();
-  state = State::kFinished;
-  return rows;
+  int64_t rows{0};
+  try {
+    rows = std::move(finishWrite).commit(result).get();
+  } catch (const std::exception&) {
+    // The commit runs outside the drain, so no cancelTasks()/onError ran for
+    // it; record the failure explicitly (under 'mutex_' to serialize with
+    // cancelTasks()), setting error_ alongside state_ as the other error paths
+    // do so a caller inspecting error_ after a failed commit sees it.
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      state_ = State::kError;
+      error_ = std::current_exception();
+    }
+    throw;
+  }
+  // A successful commit is the point of no return: the write is durable, so
+  // mark finished (under 'mutex_') even if a late cancel raced in.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    state_ = State::kFinished;
+  }
+  co_return rows;
 }
 
-velox::RowVectorPtr LocalRunner::nextWrite() {
-  VELOX_DCHECK(finishWrite_);
-
-  const int64_t rows = runWrite();
-
+velox::RowVectorPtr LocalRunner::makeWriteResult(int64_t rows) {
   auto child = velox::BaseVector::create<velox::FlatVector<int64_t>>(
       velox::BIGINT(), /*size=*/1, params_.outputPool.get());
   child->set(0, rows);
@@ -328,7 +427,16 @@ velox::RowVectorPtr LocalRunner::nextWrite() {
 }
 
 void LocalRunner::start() {
-  VELOX_CHECK_EQ(state_, State::kInitialized);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    // A cancel (or error) that landed before start() leaves the runner terminal
+    // with no cursor; surface that error rather than starting and tripping the
+    // state precondition below.
+    if (error_) {
+      std::rethrow_exception(error_);
+    }
+    VELOX_CHECK_EQ(state_, State::kInitialized);
+  }
 
   params_.maxDrivers = plan_->options().numDrivers;
   params_.planNode = fragments_.back().fragment.planNode;
@@ -343,7 +451,7 @@ void LocalRunner::start() {
   makeStages(cursor->task());
 
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (!error_) {
       cursor_ = std::move(cursor);
       state_ = State::kRunning;
@@ -352,7 +460,7 @@ void LocalRunner::start() {
 
   if (!cursor_) {
     // The cursor was not set because previous fragments had an error.
-    abort();
+    cancelTasks();
     std::rethrow_exception(error_);
   }
 }
@@ -364,71 +472,96 @@ std::shared_ptr<connector::SplitSource> LocalRunner::splitSourceForScan(
   return splitSourceFactory_->splitSourceForScan(session, scan, partitionType);
 }
 
-void LocalRunner::abort() {
-  // If called without previous error, we set the error to be cancellation.
-  if (!error_) {
-    try {
-      state_ = State::kCancelled;
-      VELOX_FAIL("Query cancelled");
-    } catch (const std::exception&) {
-      error_ = std::current_exception();
-    }
-  }
-  VELOX_CHECK(state_ != State::kInitialized);
-
-  // Take a local copy of tasks under the mutex to prevent use-after-free if
-  // waitForCompletion() clears stages_ concurrently.
+void LocalRunner::cancelTasks() {
+  // cancelTasks() may be invoked from any thread via the cancellation callback,
+  // so serialize the error/state mutation under 'mutex_' against start() (which
+  // reads error_ under the same lock) and a second concurrent cancelTasks().
   std::vector<std::shared_ptr<velox::exec::Task>> tasks;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
+    // A completed query stays finished: the cancel callback can fire after
+    // execute() moved to kFinished but before it deregisters, and that late
+    // cancel must neither clobber kFinished nor re-error completed tasks.
+    if (state_ == State::kFinished) {
+      return;
+    }
+    // If called without a previous error, set the error to cancellation.
+    // onError records its own error before calling cancelTasks() to propagate
+    // it, so it must not be overwritten here.
+    if (!error_) {
+      try {
+        state_ = State::kCancelled;
+        VELOX_FAIL("Query cancelled");
+      } catch (const std::exception&) {
+        error_ = std::current_exception();
+      }
+    }
+    // Copy tasks under the lock to prevent use-after-free if reap() clears
+    // stages_ concurrently. Propagate to the cursor here too, under the lock
+    // that guards cursor_.
     for (auto& stage : stages_) {
       for (auto& task : stage) {
         tasks.push_back(task);
       }
     }
+    if (cursor_) {
+      cursor_->setError(error_);
+    }
   }
+  VELOX_CHECK(state_ != State::kInitialized);
 
   for (auto& task : tasks) {
     task->setError(error_);
   }
-  if (cursor_) {
-    cursor_->setError(error_);
-  }
 }
 
-bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
-  VELOX_CHECK_NE(state_, State::kInitialized);
-
+folly::coro::Task<void> LocalRunner::co_reap() {
+  // Cancel and join the split scope first. This is the only teardown step
+  // needed when execute() was created but never pulled (state_ == kInitialized:
+  // no cursor, no tasks); the loops below are then no-ops. Idempotent via
+  // splitScopeJoined_. Awaited (not blockingWait), so it releases the thread
+  // while it waits instead of holding it -- this is what makes teardown safe on
+  // a Velox executor thread. cancelAndJoinAsync() requests cancellation on the
+  // split coroutines (which check the token each iteration) so the join is
+  // bounded to at most one in-flight co_getSplits() rather than draining each
+  // source to noMoreSplits.
   if (!splitScopeJoined_) {
-    folly::coro::blockingWait(splitScope_.joinAsync());
+    // Mark joined before awaiting: cancelAndJoinAsync() sets the scope's own
+    // joined_ once its barrier completes, even if it then rethrows a split
+    // error, so the destructor must not attempt a second join.
     splitScopeJoined_ = true;
+    co_await splitScope_.cancelAndJoinAsync();
   }
-
-  auto& executor = folly::QueuedImmediateExecutor::instance();
 
   // Wait for every task to stop running, then snapshot final stats while the
   // tasks are still alive. taskCompletionFuture (unlike taskDeletionFuture)
   // does not require releasing the tasks, so stats remain readable here.
   std::vector<velox::ContinueFuture> completionFutures;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     for (auto& stage : stages_) {
       for (auto& task : stage) {
         completionFutures.push_back(task->taskCompletionFuture());
       }
     }
   }
-  const bool completed = !folly::collectAll(std::move(completionFutures))
-                              .via(&executor)
-                              .within(std::chrono::microseconds(maxWaitMicros))
-                              .wait()
-                              .hasException();
+  bool completed = true;
+  try {
+    co_await folly::collectAll(std::move(completionFutures))
+        .within(std::chrono::microseconds(kReapTimeoutMicros));
+  } catch (const folly::FutureTimeout&) {
+    completed = false;
+  }
 
   // Tear down: capture final stats before the tasks go away, then drop the
-  // cursor and tasks and wait for their deletion so pools are released.
+  // cursor and tasks and wait for their deletion so their pools are released.
+  // Resetting the cursor here (releasing its output queue) is safe because
+  // result batches are allocated in outputPool -- owned by the runner or the
+  // caller -- which outlives the cursor, so batches the caller still holds stay
+  // valid until the runner is destroyed.
   std::vector<velox::ContinueFuture> deletionFutures;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (completed && !finalStats_.has_value()) {
       finalStats_ = aggregatedStats();
     }
@@ -440,13 +573,40 @@ bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
       stage.clear();
     }
   }
-  const bool deleted = !folly::collectAll(std::move(deletionFutures))
-                            .via(&executor)
-                            .within(std::chrono::microseconds(maxWaitMicros))
-                            .wait()
-                            .hasException();
+  try {
+    co_await folly::collectAll(std::move(deletionFutures))
+        .within(std::chrono::microseconds(kReapTimeoutMicros));
+  } catch (const folly::FutureTimeout&) {
+    // Best effort: pools may linger briefly if a task never stops, but the reap
+    // does not hang unboundedly.
+  }
+}
 
-  return completed && deleted;
+folly::coro::Task<void> LocalRunner::co_close() {
+  // Idempotent: a second close, or one after the co_runWrite() error path
+  // already reaped, is a no-op.
+  if (closed_) {
+    co_return;
+  }
+  // Stop anything still running so the split coroutines and tasks wind down,
+  // then reap. A clean finish is already kFinished and a failure kError; only a
+  // still-running run needs cancelTasks(), which lands a benign kCancelled.
+  if (state_ == State::kRunning) {
+    cancelTasks();
+  }
+  // Teardown must not throw: callers blockingWait(co_close()) on exception
+  // paths (drain()'s error handling, ~AxiomReader, JoinSample's scope guard),
+  // where a throw would mask the query's real error or std::terminate in a
+  // destructor. The query error is already surfaced through the pull; a
+  // split-scope join or task-teardown error here is secondary, so log and
+  // swallow it. closed_ is set regardless so the destructor's assert passes and
+  // it does not re-join.
+  try {
+    co_await co_reap();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Error during LocalRunner teardown: " << e.what();
+  }
+  closed_ = true;
 }
 
 namespace {
@@ -490,16 +650,19 @@ void LocalRunner::makeStages(
       return;
     }
     {
-      std::lock_guard<std::mutex> l(self->mutex_);
+      std::lock_guard<std::mutex> lock(self->mutex_);
       if (self->error_) {
         return;
       }
       self->state_ = State::kError;
       self->error_ = std::move(error);
     }
-    if (self->cursor_) {
-      self->abort();
-    }
+    // Call cancelTasks() unconditionally: reading cursor_ here would race
+    // start() assigning it (onError can fire from a stage task before start()
+    // finishes). cancelTasks() re-locks and no-ops on a null cursor_, still
+    // propagating the error to sibling tasks when the failure precedes cursor
+    // creation.
+    self->cancelTasks();
   };
 
   // Mapping from task prefix to the stage index and whether it is a broadcast.
@@ -507,9 +670,16 @@ void LocalRunner::makeStages(
   for (auto fragmentIndex = 0; fragmentIndex < fragments_.size() - 1;
        ++fragmentIndex) {
     const auto& fragment = fragments_[fragmentIndex];
-    stageMap[fragment.taskPrefix] = {
-        stages_.size(), needsOutputBufferUpdate(fragment.fragment)};
-    stages_.emplace_back();
+    {
+      // Serialize stages_ mutation with cancelTasks()/reap(), which read it
+      // under mutex_ and may run on a task thread (a task started below can
+      // fire onError before makeStages() finishes building the rest of
+      // stages_).
+      std::lock_guard<std::mutex> lock(mutex_);
+      stageMap[fragment.taskPrefix] = {
+          stages_.size(), needsOutputBufferUpdate(fragment.fragment)};
+      stages_.emplace_back();
+    }
 
     auto numTasks = fragment.width.value_or(
         fragment.type == optimizer::FragmentType::kSource
@@ -536,12 +706,18 @@ void LocalRunner::makeStages(
           /*memoryArbitrationPriority=*/0,
           makeSpillDiskOptions(baseSpillDirectory_, taskId),
           onError);
-      stages_.back().push_back(task);
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stages_.back().push_back(task);
+      }
       task->start(plan_->options().numDrivers);
     }
   }
 
-  stages_.push_back({lastStageTask});
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stages_.push_back({lastStageTask});
+  }
 
   try {
     for (auto fragmentIndex = 0; fragmentIndex < fragments_.size();
@@ -602,7 +778,7 @@ void LocalRunner::makeStages(
 }
 
 std::vector<velox::exec::TaskStats> LocalRunner::stats() const {
-  std::lock_guard<std::mutex> l(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   if (finalStats_.has_value()) {
     return *finalStats_;
   }

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -108,8 +108,16 @@ class LocalRunner : public Runner,
   LocalRunner(LocalRunner&&) = delete;
   LocalRunner& operator=(LocalRunner&&) = delete;
 
-  /// First call starts execution.
-  velox::RowVectorPtr next() override;
+  /// Execution starts lazily on the first pull of the returned generator, not
+  /// when execute() is called.
+  folly::coro::AsyncGenerator<velox::RowVectorPtr> execute() override;
+
+  /// Terminal wind-down: cancels any still-running work and reaps it (split
+  /// scope joined, tasks completed, final stats captured, pools released).
+  /// Awaited (never blocks the awaiting thread), so it is safe on a Velox
+  /// executor thread. Idempotent, and safe when execute() was never pulled
+  /// (state() == kInitialized): it just joins the empty split scope.
+  folly::coro::Task<void> co_close() override;
 
   /// Returns a list of fragments from the 'plan' specified in constructor
   /// sorted in topological order.
@@ -126,7 +134,7 @@ class LocalRunner : public Runner,
   /// Returns aggregated runtime stats for each fragment in 'fragments()'.
   /// Corresponds 1:1 to 'fragments()'. For multi-task fragments, stats from all
   /// tasks are aggregated together. While running this is a live snapshot; once
-  /// waitForCompletion() has captured the final stats, it returns those.
+  /// execution has been reaped and the final stats captured, it returns those.
   std::vector<velox::exec::TaskStats> stats() const override;
 
   /// Prints the distributed plan annotated with runtime stats. Similar to
@@ -144,35 +152,45 @@ class LocalRunner : public Runner,
           std::string_view indentation,
           std::ostream& out)>& addContext = nullptr) const;
 
-  /// Best-effort attempt to cancel the execution.
-  void abort() override;
-
-  /// Waits for all tasks to complete in two phases (stop running, then release
-  /// resources), each bounded by `maxWaitMicros` microseconds.
-  /// If `maxWaitMicros <= 0` this will check if the tasks are completed and
-  /// return false immediately if not.
-  /// Captures a final stats snapshot once every task has stopped running, so a
-  /// subsequent stats() returns final stats rather than the in-progress
-  /// snapshot. (Draining the output via next() does not by itself guarantee
-  /// final stats: under multi-threaded execution a producer driver, e.g. a
-  /// probe-side TableScan, may still be closing.)
-  /// @pre state() != State::kInitialized
-  /// @return true if all tasks completed within the timeout, false otherwise.
-  bool waitForCompletion(int32_t maxWaitMicros) override;
-
   State state() const override {
     return state_;
   }
 
  private:
-  // Reads all results and calls commit(...) on the results if successful.
-  // Catches exceptions, calls abort() and rethrows if there is an error.
-  // Returns the number of rows written.
-  [[nodiscard]] int64_t runWrite();
+  // Fixed timeout for co_reap()'s task waits (stop running, then release
+  // resources).
+  static constexpr int32_t kReapTimeoutMicros = 1'000'000;
 
-  // Call runWrite() and returns a single-row vector
-  // with the number of rows written in 'rows' column.
-  [[nodiscard]] velox::RowVectorPtr nextWrite();
+  // Best-effort attempt to cancel the execution. May be invoked from any
+  // thread (via the cancellation callback), without serialization, and is
+  // idempotent. A no-op once execution has finished (state() == kFinished).
+  // Otherwise state() becomes kCancelled and the in-flight or next pull
+  // surfaces the cancellation error.
+  void cancelTasks();
+
+  // Awaited reap shared by co_close() and the co_runWrite() error path. Joins
+  // the split scope, then waits for all tasks to complete in two phases (stop
+  // running, then release resources), each bounded by kReapTimeoutMicros.
+  // Captures a final stats snapshot once every task has stopped running, so a
+  // subsequent stats() returns final stats rather than the in-progress
+  // snapshot. Idempotent (re-entry is a no-op once the scope is joined and
+  // stages_ cleared) and safe when state() == kInitialized (execute() created
+  // but never pulled): in that case it just joins the empty split scope.
+  folly::coro::Task<void> co_reap();
+
+  // Cancelable single-batch pull; starts execution on the first call. Returns
+  // nullptr at end of output.
+  folly::coro::Task<velox::RowVectorPtr> co_pull();
+
+  // Reads all results and calls commit(...) on them if successful. Catches
+  // exceptions, reaps and rethrows on error. Returns the number of rows
+  // written. Drives the cancelable pull, so it honors the awaiting scope's
+  // cancellation during the produce/drain phase (the commit itself is a
+  // point of no return and runs to completion).
+  [[nodiscard]] folly::coro::Task<int64_t> co_runWrite();
+
+  // Builds a single-row vector with 'rows' in a "rows" BIGINT column.
+  velox::RowVectorPtr makeWriteResult(int64_t rows);
 
   void start();
 
@@ -188,7 +206,9 @@ class LocalRunner : public Runner,
   // mutex_.
   std::vector<velox::exec::TaskStats> aggregatedStats() const;
 
-  // Serializes 'cursor_' and 'error_'.
+  // Serializes 'cursor_', 'error_', and mutation of 'stages_' (which
+  // cancelTasks()/reap() read from a task thread while makeStages() is still
+  // building it).
   mutable std::mutex mutex_;
 
   const RunnerSessionPtr session_;
@@ -198,11 +218,11 @@ class LocalRunner : public Runner,
 
   velox::exec::CursorParameters params_;
 
-  velox::tsan_atomic<State> state_{State::kInitialized};
+  std::atomic<State> state_{State::kInitialized};
 
   std::unique_ptr<velox::exec::TaskCursor> cursor_;
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
-  // Final stats captured by waitForCompletion() once all tasks stopped running.
+  // Final stats captured by co_reap() once all tasks stopped running.
   // Once set, stats() returns this instead of the live snapshot, which lets
   // stats() report final stats after the tasks have been torn down.
   std::optional<std::vector<velox::exec::TaskStats>> finalStats_;
@@ -211,8 +231,14 @@ class LocalRunner : public Runner,
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
   QueryRuntimeStats& runtimeStats_;
-  folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};
+  // Cancellable so teardown can stop split enumeration promptly rather than
+  // draining each source to noMoreSplits. co_reap() cancelAndJoinAsync()s it.
+  folly::coro::CancellableAsyncScope splitScope_{/*throwOnJoin=*/true};
   bool splitScopeJoined_{false};
+  // Set once co_close() has reaped. The destructor asserts this (or that
+  // execution never started) rather than reaping itself, so no drop blocks a
+  // thread. See co_close().
+  bool closed_{false};
 };
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/Runner.cpp
+++ b/axiom/runner/Runner.cpp
@@ -16,7 +16,13 @@
 
 #include "axiom/runner/Runner.h"
 
+#include <folly/CancellationToken.h>
 #include <folly/container/F14Map.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Task.h>
+#include <folly/coro/Timeout.h>
+#include <folly/coro/WithCancellation.h>
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::runner {
 
@@ -35,5 +41,48 @@ const auto& stateNames() {
 } // namespace
 
 AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Runner, State, stateNames);
+
+void Runner::drain(
+    const std::function<void(velox::RowVectorPtr)>& onBatch,
+    int64_t timeoutMicros) {
+  // Hold the generator as a local; drain() co_closes the runner below (on this
+  // calling, non-executor thread) so the run is always reaped before return.
+  auto generator = execute();
+  std::atomic<bool> timedOut{false};
+  auto loop = [&]() -> folly::coro::Task<void> {
+    const auto token = co_await folly::coro::co_current_cancellation_token;
+    folly::CancellationCallback onTimeout{token, [&] { timedOut.store(true); }};
+    while (auto batch = co_await generator.next()) {
+      onBatch(std::move(*batch));
+    }
+  };
+
+  std::exception_ptr error;
+  try {
+    if (timeoutMicros > 0) {
+      folly::coro::blockingWait(
+          folly::coro::timeout(
+              loop(), std::chrono::microseconds(timeoutMicros)));
+    } else {
+      folly::coro::blockingWait(loop());
+    }
+  } catch (const std::exception&) {
+    error = std::current_exception();
+  }
+
+  // Reap whether the drain succeeded, timed out, or failed, before surfacing
+  // any error. On a deadline this reaps the cancelled run; VELOX_USER_FAIL is
+  // thrown only after the reap completes.
+  folly::coro::blockingWait(co_close());
+
+  if (error) {
+    if (timedOut.load()) {
+      VELOX_USER_FAIL(
+          "Query exceeded maximum time limit of {:.2f}s",
+          timeoutMicros / 1'000'000.0);
+    }
+    std::rethrow_exception(error);
+  }
+}
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -16,6 +16,11 @@
 
 #pragma once
 
+#include <functional>
+
+#include <folly/coro/AsyncGenerator.h>
+#include <folly/coro/Task.h>
+
 #include "axiom/common/Enums.h"
 #include "velox/exec/TaskStats.h"
 
@@ -40,16 +45,45 @@ class Runner {
 
   virtual ~Runner() = default;
 
-  /// Returns the next batch of results. Returns nullptr when no more results.
-  /// Throws any execution time errors. The result is allocated in the pool of
-  /// QueryCtx given to the Runner implementation. The caller is responsible for
-  /// serializing calls from different threads.
-  virtual velox::RowVectorPtr next() = 0;
+  /// Returns a generator that yields successive result batches until the query
+  /// is done (the generator ends). `co_await gen.next()` rethrows any
+  /// execution-time error. Each batch is backed by a memory pool owned by the
+  /// runner and stays valid only until the runner is destroyed; a caller that
+  /// needs a batch to outlive the runner must copy it out (as optimizer
+  /// constant folding does).
+  ///
+  /// The caller must `co_await co_close()` exactly once when done with the
+  /// generator — whether it drained fully, stopped early, or was unwound by an
+  /// exception — before destroying the runner. To stop early, stop pulling and
+  /// then co_await co_close(); dropping the generator alone does NOT reap.
+  /// External or deadline cancellation still composes through the awaiting
+  /// scope's cancellation token (e.g. folly::coro::timeout or
+  /// co_withCancellation); there is no separate public cancel.
+  ///
+  /// Awaiting the read/produce-drain path never blocks the awaiting thread, so
+  /// it is safe on a Velox executor thread. Exception: on the write path the
+  /// INSERT/CTAS commit is a point of no return that runs to completion, and
+  /// its error-path cleanup waits for tasks to stop — both may block, so a
+  /// write-plan execute() should not be awaited on an executor thread.
+  virtual folly::coro::AsyncGenerator<velox::RowVectorPtr> execute() = 0;
+
+  /// Terminal, owner-scoped wind-down of one execute() run: stops anything
+  /// still running and reaps it (split generation joined, tasks completed,
+  /// final stats captured, pools released), and does not complete until that is
+  /// done. The owner co_awaits this exactly once before destroying the runner,
+  /// whether the generator drained fully or stopped early — the destructor
+  /// asserts it ran rather than doing blocking teardown itself. Because it is
+  /// awaited (not a blocking destructor), it is safe to co_await on a Velox
+  /// executor thread. Idempotent. This is not an external cancel that returns
+  /// before work stops; deadline/scope cancellation still composes through
+  /// execute()'s awaiting token, while co_close() is the owner's lifecycle
+  /// finish.
+  virtual folly::coro::Task<void> co_close() = 0;
 
   /// Returns Task stats for each fragment of the plan. The stats correspond 1:1
   /// to the stages in the MultiFragmentPlan. May be called at any time: while
-  /// the query is running it returns an in-progress snapshot; once
-  /// waitForCompletion() has run it returns the final stats.
+  /// the query is running it returns an in-progress snapshot; once execution
+  /// has been reaped it returns the final stats.
   virtual std::vector<velox::exec::TaskStats> stats() const = 0;
 
   /// Returns the executable fragments of the plan being run, ordered so that
@@ -60,17 +94,19 @@ class Runner {
   /// Returns the state of execution.
   virtual State state() const = 0;
 
-  /// Cancels the possibly pending execution. Returns immediately, thus before
-  /// the execution is actually finished. Use waitForCompletion() to wait for
-  /// all execution resources to be freed. May be called from any thread without
-  /// serialization.
-  virtual void abort() = 0;
-
-  /// Waits up to 'maxWaitMicros' for all activity of the execution to cease.
-  /// This is used in tests to ensure that all pools are empty and unreferenced
-  /// before teardown. Returns true if all activity ceased within the timeout,
-  /// false otherwise.
-  virtual bool waitForCompletion(int32_t maxWaitMicros) = 0;
+  /// Convenience that synchronously drives execute() to completion, invoking
+  /// 'onBatch' for each result batch, then co_closes the runner before
+  /// returning. For callers that are not themselves coroutines — synchronous
+  /// entry points such as the CLI, FFI boundaries, and tests. A coroutine
+  /// caller should await execute() (and co_close()) directly instead. Blocks
+  /// the calling thread, so it must NOT be called from a Velox executor thread
+  /// (blocking there starves the executor).
+  ///
+  /// When 'timeoutMicros' > 0, enforces a wall-clock deadline via cooperative
+  /// cancellation; on the deadline the drain fails with VELOX_USER_FAIL.
+  void drain(
+      const std::function<void(velox::RowVectorPtr)>& onBatch,
+      int64_t timeoutMicros = 0);
 };
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -15,6 +15,12 @@
  */
 
 #include "axiom/runner/LocalRunner.h"
+#include <folly/CancellationToken.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Task.h>
+#include <folly/coro/WithCancellation.h>
+#include <folly/synchronization/Baton.h>
+#include <thread>
 #include "axiom/runner/tests/DistributedPlanBuilder.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -97,7 +103,7 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   }
 
   optimizer::MultiFragmentPlanPtr makeJoinPlan(
-      std::string project = "c0",
+      std::string_view project = "c0",
       bool broadcastBuild = false) {
     optimizer::MultiFragmentPlan::Options options = {
         .queryId = makeQueryId(), .numWorkers = 4, .numDrivers = 2};
@@ -106,7 +112,7 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
     test::DistributedPlanBuilder rootBuilder(
         options, idGenerator_, pool_.get());
     rootBuilder.tableScan("t", rowType_)
-        .project({project})
+        .project({std::string{project}})
         .shufflePartitioned({"c0"}, 3, false)
         .hashJoin(
             {"c0"},
@@ -156,16 +162,6 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
         runtimeStats_);
   }
 
-  // Fetches all remaining data from the runner.
-  static std::vector<velox::RowVectorPtr> readCursor(
-      const std::shared_ptr<LocalRunner>& runner) {
-    std::vector<velox::RowVectorPtr> result;
-    while (auto rowVector = runner->next()) {
-      result.push_back(rowVector);
-    }
-    return result;
-  }
-
   std::shared_ptr<velox::core::PlanNodeIdGenerator> idGenerator_{
       std::make_shared<velox::core::PlanNodeIdGenerator>()};
 
@@ -180,29 +176,138 @@ int64_t extractSingleInt64(const std::vector<velox::RowVectorPtr>& vectors) {
       0);
 }
 
-constexpr int32_t kWaitTimeoutUs = 500'000;
-
 TEST_F(LocalRunnerTest, count) {
   auto join = makeJoinPlan();
   auto localRunner = makeRunner(join);
 
-  auto results = readCursor(localRunner);
+  std::vector<velox::RowVectorPtr> results;
+  localRunner->drain(
+      [&](velox::RowVectorPtr batch) { results.push_back(std::move(batch)); });
   auto stats = localRunner->stats();
   EXPECT_EQ(1, results.size());
   EXPECT_EQ(1, results[0]->size());
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
+}
+
+// execute() yields all result batches and reports kFinished on completion.
+TEST_F(LocalRunnerTest, execute) {
+  auto join = makeJoinPlan();
+  auto localRunner = makeRunner(join);
+
+  std::vector<velox::RowVectorPtr> results;
+  folly::coro::blockingWait([&]() -> folly::coro::Task<void> {
+    auto generator = localRunner->execute();
+    while (auto rows = co_await generator.next()) {
+      results.push_back(std::move(*rows));
+    }
+  }());
+  // Mandatory owner-scoped wind-down before the runner is destroyed.
+  folly::coro::blockingWait(localRunner->co_close());
+
+  EXPECT_EQ(1, results.size());
+  EXPECT_EQ(kNumRows, extractSingleInt64(results));
+  results.clear();
+  EXPECT_EQ(Runner::State::kFinished, localRunner->state());
+}
+
+// Cancelling the awaiting scope interrupts execute() and surfaces the error;
+// the runner still terminates cleanly. A pre-cancelled token makes the abort
+// deterministic.
+TEST_F(LocalRunnerTest, executeCancellation) {
+  auto scan = makeScanPlan(/*numWorkers=*/3);
+  auto localRunner = makeRunner(scan);
+
+  folly::CancellationSource source;
+  source.requestCancellation();
+
+  auto drainLoop = [&]() -> folly::coro::Task<void> {
+    auto generator = localRunner->execute();
+    while (co_await generator.next()) {
+    }
+  };
+  VELOX_ASSERT_THROW(
+      folly::coro::blockingWait(
+          folly::coro::co_withCancellation(source.getToken(), drainLoop())),
+      "cancel");
+  folly::coro::blockingWait(localRunner->co_close());
+
+  EXPECT_EQ(Runner::State::kCancelled, localRunner->state());
+}
+
+// The cancellation callback may fire on a thread other than the one awaiting
+// execute(). Here a separate thread requests cancellation (which runs the
+// registered cancelTasks() synchronously on that thread) while the drain is
+// parked between batches; the next pull must surface the cross-thread
+// cancellation, and teardown stays clean.
+TEST_F(LocalRunnerTest, executeCancellationFromAnotherThread) {
+  auto scan = makeScanPlan(/*numWorkers=*/1);
+  auto localRunner = makeRunner(scan);
+
+  folly::CancellationSource source;
+  folly::Baton<> gotBatch;
+  folly::Baton<> cancelled;
+
+  std::thread canceller([&] {
+    gotBatch.wait();
+    // requestCancellation() invokes the registered callback (cancelTasks())
+    // inline on this thread, so the cancellation genuinely races the awaiting
+    // thread.
+    source.requestCancellation();
+    cancelled.post();
+  });
+
+  auto drainLoop = [&]() -> folly::coro::Task<void> {
+    auto generator = localRunner->execute();
+    auto first = co_await generator.next();
+    EXPECT_TRUE(first.has_value());
+    gotBatch.post();
+    cancelled.wait();
+    while (co_await generator.next()) {
+    }
+  };
+  VELOX_ASSERT_THROW(
+      folly::coro::blockingWait(
+          folly::coro::co_withCancellation(source.getToken(), drainLoop())),
+      "cancel");
+  canceller.join();
+  folly::coro::blockingWait(localRunner->co_close());
+
+  EXPECT_EQ(Runner::State::kCancelled, localRunner->state());
+}
+
+// Early stop is "stop pulling, then co_close()": after one batch the caller
+// drops the generator (which no longer reaps on its own) and awaits co_close(),
+// which cancels the still-running work and reaps without hanging. The runner
+// reaches a terminal kCancelled state.
+TEST_F(LocalRunnerTest, earlyStopClosesAndReaps) {
+  auto scan = makeScanPlan(/*numWorkers=*/3);
+  auto localRunner = makeRunner(scan);
+
+  {
+    auto gen = localRunner->execute();
+    auto first = folly::coro::blockingWait(gen.next());
+    EXPECT_TRUE(first.has_value());
+    // Stop pulling; 'gen' goes out of scope. Dropping it does not reap.
+  }
+  // The still-running run is wound down and reaped here.
+  folly::coro::blockingWait(localRunner->co_close());
+
+  EXPECT_EQ(Runner::State::kCancelled, localRunner->state());
 }
 
 TEST_F(LocalRunnerTest, error) {
   auto join = makeJoinPlan("if (c0 = 111, c0 / 0, c0 + 1) as c0");
   auto localRunner = makeRunner(join);
 
-  VELOX_ASSERT_THROW(readCursor(localRunner), "division by zero");
+  std::vector<velox::RowVectorPtr> results;
+  VELOX_ASSERT_THROW(
+      localRunner->drain([&](velox::RowVectorPtr batch) {
+        results.push_back(std::move(batch));
+      }),
+      "division by zero");
   EXPECT_EQ(Runner::State::kError, localRunner->state());
-  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, scan) {
@@ -211,16 +316,14 @@ TEST_F(LocalRunnerTest, scan) {
     auto localRunner = makeRunner(scan);
 
     {
-      auto results = readCursor(localRunner);
-
       int32_t count = 0;
-      for (auto& rows : results) {
-        count += rows->size();
+      auto generator = localRunner->execute();
+      while (auto rows = folly::coro::blockingWait(generator.next())) {
+        count += (*rows)->size();
       }
+      folly::coro::blockingWait(localRunner->co_close());
       EXPECT_EQ(kNumRows, count);
     }
-
-    ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
   };
 
   checkScanCount(1);
@@ -231,14 +334,15 @@ TEST_F(LocalRunnerTest, broadcast) {
   auto join = makeJoinPlan("c0", true);
   auto localRunner = makeRunner(join);
 
-  auto results = readCursor(localRunner);
+  std::vector<velox::RowVectorPtr> results;
+  localRunner->drain(
+      [&](velox::RowVectorPtr batch) { results.push_back(std::move(batch)); });
   auto stats = localRunner->stats();
   EXPECT_EQ(1, results.size());
   EXPECT_EQ(1, results[0]->size());
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
@@ -254,25 +358,22 @@ TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
                    .tableScan("u", rowType_)
                    .project({"c0 as b0"})
                    .shuffleBroadcastResult();
-  rootBuilder.addNode([&](auto, auto) { return probe; })
+  rootBuilder.addNode([&](const auto&, auto) { return probe; })
       .hashJoin({"c0"}, {"b0"}, build, "", {"c0", "b0"});
 
   auto plan = rootBuilder.build();
 
   auto localRunner = makeRunner(plan);
-  auto results = readCursor(localRunner);
-  auto stats = localRunner->stats();
 
   size_t numRows = 0;
-  for (const auto& result : results) {
-    numRows += result->size();
+  auto generator = localRunner->execute();
+  while (auto rows = folly::coro::blockingWait(generator.next())) {
+    numRows += (*rows)->size();
   }
+  folly::coro::blockingWait(localRunner->co_close());
 
   EXPECT_EQ(kNumRows, numRows);
-
-  results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
-  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 TEST_F(LocalRunnerTest, spillDirectoryWiring) {
@@ -292,7 +393,9 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
       spillDir->getPath(),
       runtimeStats_);
 
-  auto results = readCursor(localRunner);
+  std::vector<velox::RowVectorPtr> results;
+  localRunner->drain(
+      [&](velox::RowVectorPtr batch) { results.push_back(std::move(batch)); });
   EXPECT_EQ(1, results.size());
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/runner/tests/PrestoQueryReplayRunner.h"
+#include <folly/coro/BlockingWait.h>
 #include "axiom/runner/LocalRunner.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -31,14 +32,16 @@ std::shared_ptr<velox::memory::MemoryPool> makeRootPool(
 std::vector<velox::RowVectorPtr> readCursor(
     std::shared_ptr<LocalRunner>& runner,
     velox::memory::MemoryPool* pool) {
-  // We'll check the result after tasks are deleted, so copy the result
-  // vectors to 'pool' that has longer lifetime.
+  // We'll check the result after tasks are deleted, so copy the result vectors
+  // to 'pool' that has longer lifetime. drain() delivers one batch at a time,
+  // so peak memory holds a single source batch plus the copies, not the whole
+  // source result set as well.
   std::vector<velox::RowVectorPtr> result;
-  while (auto rows = runner->next()) {
+  runner->drain([&](velox::RowVectorPtr batch) {
     result.push_back(
         std::dynamic_pointer_cast<velox::RowVector>(
-            velox::BaseVector::copy(*rows, pool)));
-  }
+            velox::BaseVector::copy(*batch, pool)));
+  });
   return result;
 }
 
@@ -411,7 +414,6 @@ PrestoQueryReplayRunner::run(
   std::vector<velox::RowVectorPtr> result;
   try {
     result = readCursor(localRunner, pool_);
-    localRunner->waitForCompletion(kWaitTimeoutUs);
   } catch (const std::exception& e) {
     LOG(ERROR) << "Failed to run query " << queryId << ": " << e.what();
     return std::make_pair(std::nullopt, Status::kError);

--- a/axiom/runner/tests/PrestoQueryReplayRunner.h
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.h
@@ -25,7 +25,6 @@ namespace facebook::axiom::runner {
 
 inline constexpr int32_t kDefaultWidth = 2;
 inline constexpr int32_t kDefaultMaxDrivers = 4;
-inline constexpr int32_t kWaitTimeoutUs = 5'000'000;
 
 using TaskPrefixExtractor = std::string (*)(std::string_view);
 using ConnectorSplitPtr = std::shared_ptr<velox::connector::ConnectorSplit>;

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/runner/ProgressReporter.h"
 
 #include <folly/coro/Baton.h>
+#include <folly/coro/BlockingWait.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <gtest/gtest.h>
 #include <condition_variable>
@@ -175,7 +176,7 @@ TEST_F(ProgressReporterTest, reportsProgressPerSplit) {
     int32_t completedSplits{0};
     int64_t outputRows{0};
     gate->post();
-    while (auto batch = runner->next()) {
+    runner->drain([&](velox::RowVectorPtr batch) {
       outputRows += batch->size();
       ++completedSplits;
       const auto report = waitForCompletedPast(completedSplits - 1);
@@ -185,7 +186,7 @@ TEST_F(ProgressReporterTest, reportsProgressPerSplit) {
       EXPECT_EQ(report.stats.totalSplits, completedSplits);
       EXPECT_EQ(report.stats.scanRows, completedSplits * kRowsPerSplit);
       gate->post();
-    }
+    });
     EXPECT_EQ(completedSplits, kNumSplits);
     EXPECT_EQ(outputRows, kNumSplits * kRowsPerSplit);
   } // ~reporter delivers the final report synchronously.


### PR DESCRIPTION
Summary:

Replaces the synchronous `Runner::next()` with a coroutine `Runner::execute()` returning a `folly::coro::AsyncGenerator<velox::RowVectorPtr>` that streams every result batch. This matches the codebase convention where coroutine methods (`co_getSplits`, `co_listPartitions`, `co_close`) are the only form rather than a sync/async pair, and lets callers consume a real stream (`while (auto batch = co_await gen.next())`). It is the foundation for enforcing a query deadline inside the runner (the dependent CLI diff) instead of a CLI watchdog.

Lifecycle. The owner winds a run down by awaiting `Runner::co_close()` exactly once when done with the generator -- whether it drained fully, stopped early, or was unwound by an exception -- before destroying the runner. co_close() stops anything still running and reaps it (split scope cancelled and joined, tasks completed, final stats captured, pools released); because it is awaited it never blocks the awaiting thread, so it is safe on a Velox executor thread. This mirrors the runner's own dependency `SplitSource::co_close()`: the destructor asserts co_close() ran (VELOX_CHECK) rather than doing blocking teardown itself, so no drop ever runs an unbounded blockingWait on an executor thread. Early stop is "stop pulling, then co_await co_close()". External or deadline cancellation still composes through execute()'s awaiting cancellation token (e.g. `folly::coro::timeout` or `co_withCancellation`); there is no separate public abort() and no manual waitForCompletion().

`LocalRunner::execute()` registers one `folly::CancellationCallback` that calls the internal `cancelTasks()` (to stop in-flight work on external/deadline cancellation), then pulls batches through a shared single-await `co_pull()` over `TaskCursor::moveNext(ContinueFuture*)`. Building on the terminal-only consumer signaling from the Velox fix , a resolved wait-future always yields data-or-terminal, so `co_pull()` is a single `co_await` (guarded by a `VELOX_CHECK` against a spurious re-block). `co_close()` cancels a still-running run (benign `kCancelled`), then `co_reap()` co_awaits `cancelAndJoinAsync()` on the split scope plus the task completion/deletion waits, all awaited (not blockingWait) so the executor thread is released while it waits. The split scope is a `CancellableAsyncScope` and each split coroutine checks the injected token every iteration, so teardown is bounded to at most one in-flight `co_getSplits()` rather than draining each source to noMoreSplits; the task waits are hard-bounded by kReapTimeoutMicros via `.within()`. (A hard `.within()` cap on the scope join, like the task waits, is unsafe: the scope must complete its join before destruction, so an abandoned join would abort or leave coroutines touching freed state.) The runner owns the result output pool when the caller passes none, so co_reap() can reset the cursor while batches the caller still holds stay valid until the runner is destroyed. The write path (INSERT/CTAS) is unified on the same cancelable pull via `co_runWrite()`; the produce/drain phase honors cancellation while the commit is a point of no return.

The one sync bridge, `Runner::drain(onBatch, timeoutMicros = 0)`, drives the generator with `folly::coro::blockingWait`, invokes a per-batch callback, and co_closes the runner on the calling (non-executor) thread before returning -- on success, timeout, or failure. Collect-all callers push into their own vector; folding or discarding callers never materialize a result set. When `timeoutMicros > 0`, drain() wraps the loop in `folly::coro::timeout` and fails with `VELOX_USER_FAIL` on the deadline (after reaping). Streaming callers that stop early -- hold the generator, pull one batch at a time, then `blockingWait(co_close())` on their own non-executor thread. Batches live in a pool owned by the runner, so callers that need a batch to outlive the runner copy it out (`ToGraph` constant folding, `PrestoQueryReplayRunner`). The Velox-side `TaskCursor::moveNext` keeps its sync form (Velox core has no coroutines); only the Axiom runner is coroutine-only.

Cancellation correctness: because the `CancellationCallback` may fire on any thread, all `state_`/`error_` transitions and the `stages_` mutation in `makeStages()` are serialized under `mutex_` -- the latter closes a data race between `makeStages()` populating `stages_` and a task-thread `cancelTasks()` reading it -- with `state_` kept `std::atomic` for lock-free `state()` reads. `cancelTasks()` is idempotent and never clobbers a terminal state: a completed query stays `kFinished`, a pre-start cancel makes `start()` surface the cancellation, an early stop or deadline lands the benign `kCancelled` (distinct from `kError` for a genuine execution failure), and a failed write commit records `error_` alongside `kError`.

Differential Revision: D110007170


