### PR TITLE
fix: Emit global grouping set default row on empty input

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -453,13 +453,16 @@ std::pair<RelationOpPtr, PlanCost> AggregationPlanner::makeSplitAggregationPlan(
     PlanState& state) const {
   PlanCost splitAggCost;
 
+  // The raw-input partial step emits the empty-input default row.
   plan = make<Aggregation>(
       plan,
       groupingKeys,
       /*preGroupedKeys*/ ExprVector{},
       aggregates,
       velox::core::AggregationNode::Step::kPartial,
-      intermediateColumns);
+      intermediateColumns,
+      globalGroupingSets,
+      groupId);
   splitAggCost.add(*plan);
 
   ColumnVector partitionKeys(
@@ -498,12 +501,18 @@ AggregationPlanner::makeSingleAggregationPlan(
     PlanState& state) const {
   PlanCost singleAggCost;
 
-  ColumnVector partitionKeys(
-      intermediateColumns.begin(),
-      intermediateColumns.begin() + groupingKeys.size());
   PlanCost repartitionCost;
-  std::tie(plan, repartitionCost) =
-      repartitionForAgg(plan, partitionKeys, state);
+  if (!globalGroupingSets.empty()) {
+    // Gather to one task so the default row is emitted once, not per worker.
+    std::tie(plan, repartitionCost) =
+        repartitionForAgg(plan, /*partitionKeys=*/{}, state);
+  } else {
+    ColumnVector partitionKeys(
+        intermediateColumns.begin(),
+        intermediateColumns.begin() + groupingKeys.size());
+    std::tie(plan, repartitionCost) =
+        repartitionForAgg(plan, partitionKeys, state);
+  }
   singleAggCost.add(repartitionCost);
 
   auto* singleAgg = make<Aggregation>(
@@ -535,18 +544,8 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
         return agg->isDistinct() || !agg->orderKeys().empty();
       });
 
-  if (!globalGroupingSets.empty()) {
-    return makeSplitAggregationPlan(
-        plan,
-        groupingKeys,
-        aggregates,
-        intermediateColumns,
-        outputColumns,
-        std::move(globalGroupingSets),
-        groupId,
-        state);
-  }
-
+  // ORDER BY / DISTINCT aggregates cannot be split, so use single-step even
+  // with global grouping sets.
   if (requiresSingleStep) {
     return makeSingleAggregationPlan(
         plan,
@@ -554,7 +553,7 @@ AggregationPlanner::makeSplitOrSingleAggregationPlan(
         aggregates,
         intermediateColumns,
         outputColumns,
-        /*globalGroupingSets=*/{},
+        std::move(globalGroupingSets),
         groupId,
         state);
   }

--- a/axiom/optimizer/AggregationPlanner.h
+++ b/axiom/optimizer/AggregationPlanner.h
@@ -83,8 +83,8 @@ class AggregationPlanner {
       ColumnCP groupId,
       PlanState& state) const;
 
-  // Creates a single-phase aggregation plan following repartitioning by
-  // groupingKeys.
+  // Creates a single-phase aggregation plan. Repartitions by groupingKeys,
+  // except for global grouping sets, which are gathered onto a single task.
   std::pair<RelationOpPtr, PlanCost> makeSingleAggregationPlan(
       RelationOpPtr plan,
       const ExprVector& groupingKeys,
@@ -95,12 +95,12 @@ class AggregationPlanner {
       ColumnCP groupId,
       PlanState& state) const;
 
-  // Builds the distributed aggregation, choosing split (partial + final) and
-  // single-step plans based on the shape of 'aggregates' and the cost.
-  //   1. If 'globalGroupingSets' is non-empty, generates split plan.
-  //   2. If any of 'aggregates' has ORDER BY or is DISTINCT, generates
+  // Builds the distributed aggregation, choosing between a split (partial +
+  // final) and a single-step plan based on the shape of 'aggregates' and the
+  // cost.
+  //   1. If any of 'aggregates' has ORDER BY or is DISTINCT, generates a
   //   single-step plan.
-  //   3. Otherwise compare split and single by cost.
+  //   2. Otherwise compares split and single by cost.
   // For non-grouping-sets aggregation, set 'globalGroupingSets' and 'groupId'
   // to {} and nullptr.
   std::pair<RelationOpPtr, PlanCost> makeSplitOrSingleAggregationPlan(

--- a/axiom/optimizer/tests/sql/groupingsets.sql
+++ b/axiom/optimizer/tests/sql/groupingsets.sql
@@ -29,6 +29,9 @@ SELECT a, sum(b) AS s FROM t GROUP BY CUBE(a)
 -- Explicit GROUPING SETS.
 SELECT a, sum(b) AS s FROM t GROUP BY GROUPING SETS ((a), ())
 ----
+-- Global grouping set over empty input emits one default row.
+SELECT a, sum(b) AS s FROM t WHERE a > 1000 GROUP BY ROLLUP(a)
+----
 -- ROLLUP with multiple keys.
 SELECT a, b, count(*) AS s FROM t GROUP BY ROLLUP(a, b)
 ----


### PR DESCRIPTION
Summary:
A global grouping set (ROLLUP, CUBE, or GROUPING SETS with the `()` set) over empty input returned no rows instead of the single default row. For example:

    SELECT a, sum(b) FROM t WHERE a > 1000 GROUP BY ROLLUP(a)

returned 0 rows when it should return one `(NULL, NULL)` row.

Velox emits that default row only from the raw-input step (partial or single) that carries the global grouping sets. The split plan built the partial step without them, so on empty input neither the partial (no global sets) nor the final (not raw input) produced the row. The partial step now carries the global grouping sets and groupId, matching the single-step plan and Presto.

This builds on no longer forcing the split plan for global grouping sets: after the Velox fix https://github.com/facebookincubator/velox/pull/17785 made single-step aggregation correct for them, they go through the same cost-based split-versus-single choice as plain aggregations, and a single-step aggregation over a global grouping set is gathered onto one task so the default `()` row is produced once instead of once per worker.

Reviewed By: kagamiori

Differential Revision: D110087295


