### PR TITLE
fix(parser): Resolve CTE shadowed by nested WITH to enclosing scope (#1529)

### DIFF
--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -268,6 +268,7 @@ int main(int argc, char** argv) {
   testing::AddGlobalTestEnvironment(new SqlTestEnvironment);
 
   registerQueryFile<"basic">();
+  registerQueryFile<"cte">();
   registerQueryFile<"join">();
   registerQueryFile<"subquery">();
   registerQueryFile<"window">();

--- a/axiom/optimizer/tests/sql/cte.sql
+++ b/axiom/optimizer/tests/sql/cte.sql
@@ -1,0 +1,21 @@
+-- setup_file: common_setup.sql
+
+-- A non-recursive CTE is not in scope within its own body, so a nested
+-- same-name WITH resolves to the enclosing binding. These queries prove the
+-- correctly-bound CTEs return the right values, not just that they parse.
+
+-- Single-level shadowing. Inner body binds to outer t(a), main query to inner
+-- t(b, c): a=1 -> b=1, c=2 -> r=3.
+WITH t(a) AS (SELECT 1)
+SELECT * FROM (
+  WITH t(b, c) AS (SELECT a, a + 1 FROM t)
+  SELECT b + c AS r FROM t) sub
+----
+-- Multi-level shadowing: inner reads mid's b, mid reads outer's a.
+-- DuckDB rejects nested same-name CTEs as a circular reference, so the expected
+-- result is supplied directly.
+-- duckdb: SELECT 1 AS r
+WITH t(a) AS (SELECT 1)
+SELECT * FROM (
+  WITH t(b) AS (SELECT a FROM t)
+  SELECT * FROM (WITH t(c) AS (SELECT b FROM t) SELECT c AS r FROM t) s2) s1

--- a/axiom/sql/presto/CteScope.h
+++ b/axiom/sql/presto/CteScope.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/ScopeGuard.h>
+#include <folly/container/F14Map.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/ast/AstNodesAll.h"
+
+namespace axiom::sql::presto {
+
+namespace lp = facebook::axiom::logical_plan;
+
+/// Resolves CTE names while parsing one query. As the parser descends
+/// through nested WITH clauses, tracks what each in-scope name refers to.
+///
+/// A table name resolves in order:
+///   1. the recursive anchor, if inside a recursive CTE's step body;
+///   2. the in-scope CTE binding;
+///   3. otherwise a base table (resolved by the caller).
+///
+/// Bindings stack per name: a nested WITH that reuses a name pushes a
+/// binding on top of the enclosing one, which reappears when the nested
+/// scope is popped. That is what lets a non-recursive CTE's own body
+/// resolve a same-name reference to the enclosing CTE -- the body hides
+/// only its own binding.
+///
+/// Usage:
+///   auto scope = ctes.enterScope();   // once per query body
+///   ctes.bind(name, {withQuery, isRecursive});
+///   if (auto hidden = ctes.hide(name)) { translate hidden.entry()'s body }
+///
+/// Invariant: a name is a key iff it has a binding in scope.
+class CteScope {
+ public:
+  /// One CTE binding. 'isRecursive' is true when the body refers to itself.
+  /// A recursive body is re-translated at each reference site.
+  struct Entry {
+    std::shared_ptr<WithQuery> withQuery;
+    bool isRecursive{false};
+  };
+
+  /// Hides a name's in-scope binding for the guard's lifetime, so the
+  /// CTE is invisible within its own body. The hidden binding is available
+  /// through entry(). Restores the binding when the guard is destroyed. The
+  /// guard is false when the name had no binding to hide.
+  class [[nodiscard]] Hidden {
+   public:
+    Hidden() = default;
+
+    Hidden(CteScope* owner, std::string name, Entry entry)
+        : owner_{owner}, name_{std::move(name)}, entry_{std::move(entry)} {}
+
+    Hidden(Hidden&& other) noexcept
+        : owner_{std::exchange(other.owner_, nullptr)},
+          name_{std::move(other.name_)},
+          entry_{std::move(other.entry_)} {}
+
+    Hidden& operator=(Hidden&& other) noexcept {
+      if (this != &other) {
+        restore();
+        owner_ = std::exchange(other.owner_, nullptr);
+        name_ = std::move(other.name_);
+        entry_ = std::move(other.entry_);
+      }
+      return *this;
+    }
+
+    ~Hidden() {
+      restore();
+    }
+
+    explicit operator bool() const {
+      return owner_ != nullptr;
+    }
+
+    const Entry& entry() const {
+      return entry_;
+    }
+
+   private:
+    void restore() {
+      if (owner_ != nullptr) {
+        owner_->bindings_[name_].push_back(std::move(entry_));
+        owner_ = nullptr;
+      }
+    }
+
+    CteScope* owner_{nullptr};
+    std::string name_;
+    Entry entry_;
+  };
+
+  /// Saves all bindings and anchors, and restores them when the guard dies.
+  /// Use one per query body so a nested WITH cannot leak outward.
+  [[nodiscard]] auto enterScope() {
+    return folly::makeGuard(
+        [this, bindings = bindings_, anchors = anchors_]() mutable {
+          bindings_ = std::move(bindings);
+          anchors_ = std::move(anchors);
+        });
+  }
+
+  /// Registers a new CTE definition for 'name'. If an outer CTE already uses
+  /// that name, this definition takes precedence until the current query scope
+  /// ends.
+  /// A recursive CTE of the same name is normally matched before bindings, so
+  /// if one is being expanded, its anchor is cleared to let this binding be
+  /// found instead.
+  void bind(std::string name, Entry entry) {
+    anchors_.erase(name);
+    bindings_[std::move(name)].push_back(std::move(entry));
+  }
+
+  /// Hides 'name's in-scope binding and returns it as a Hidden guard. The guard
+  /// is false when 'name' has no binding in scope.
+  [[nodiscard]] Hidden hide(const std::string& name) {
+    auto it = bindings_.find(name);
+    if (it == bindings_.end()) {
+      return Hidden{};
+    }
+    auto entry = std::move(it->second.back());
+    it->second.pop_back();
+    if (it->second.empty()) {
+      bindings_.erase(it);
+    }
+    return Hidden{this, name, std::move(entry)};
+  }
+
+  /// Returns the anchor plan node for a recursive CTE currently being expanded,
+  /// or nullptr when 'name' is not such a CTE.
+  const lp::PlanBuilder* anchorFor(const std::string& name) const {
+    auto it = anchors_.find(name);
+    return it == anchors_.end() ? nullptr : it->second;
+  }
+
+  bool hasAnchors() const {
+    return !anchors_.empty();
+  }
+
+  /// Marks 'name' as a recursive CTE being expanded, with 'anchor' as its
+  /// loop-back point, so references to it resolve as self-references. The
+  /// record is removed when the returned guard dies.
+  [[nodiscard]] auto pushAnchor(
+      std::string name,
+      const lp::PlanBuilder* anchor) {
+    anchors_[name] = anchor;
+    return folly::makeGuard(
+        [this, name = std::move(name)]() mutable { anchors_.erase(name); });
+  }
+
+  /// Hides all anchors for as long as the returned guard lives. An independent
+  /// query, such as a view body, then does not resolve against the caller's
+  /// in-flight recursive anchors. Bindings stay visible.
+  [[nodiscard]] auto suppressAnchors() {
+    auto saved = std::move(anchors_);
+    anchors_.clear();
+    return folly::makeGuard([this, saved = std::move(saved)]() mutable {
+      anchors_ = std::move(saved);
+    });
+  }
+
+ private:
+  using BindingMap = folly::F14FastMap<std::string, std::vector<Entry>>;
+  using AnchorMap = folly::F14FastMap<std::string, const lp::PlanBuilder*>;
+
+  BindingMap bindings_;
+  AnchorMap anchors_;
+};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -25,6 +25,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ColumnsExpansion.h"
+#include "axiom/sql/presto/CteScope.h"
 #include "axiom/sql/presto/DisplayNames.h"
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
@@ -429,7 +430,7 @@ class RelationPlanner : public AstVisitor {
       const WithQuery& withEntry,
       const std::string& cteName) {
     AXIOM_PRESTO_SYNTAX_CHECK(
-        recursiveCteAnchors_.empty(),
+        !ctes_.hasAnchors(),
         withEntry.location(),
         cteName,
         "WITH RECURSIVE does not support nested recursive CTEs");
@@ -455,10 +456,7 @@ class RelationPlanner : public AstVisitor {
     // the anchor so processTable() resolves self-references via
     // recursiveRef using the anchor's name mappings.
     builder_ = newBuilder();
-    recursiveCteAnchors_[cteName] = anchorBuilder.get();
-    SCOPE_EXIT {
-      recursiveCteAnchors_.erase(cteName);
-    };
+    auto anchorGuard = ctes_.pushAnchor(cteName, anchorBuilder.get());
     {
       auto guard = scopedResetLastNames();
       processQueryBody(unionExpr->right());
@@ -501,39 +499,21 @@ class RelationPlanner : public AstVisitor {
   void processTable(const Table& table) {
     const auto tableName = canonicalizeName(table.name()->suffix());
 
-    // Resolution precedence:
-    //   1. In-flight recursive CTE step body -- a self-reference inside
-    //      the step body must emit a RecursiveReferenceNode rather than
-    //      re-entering the WithQuery lookup and re-translating the body.
-    //   2. CTE binding in withQueries_ (recursive or non-recursive). For
-    //      recursive entries, re-translates the body at this reference
-    //      site so each reference yields an independent FixedPointNode
-    //      subtree (execution does not support DAG plans).
-    //   3. Base table.
-    auto recursiveIt = recursiveCteAnchors_.find(tableName);
-    if (recursiveIt != recursiveCteAnchors_.end()) {
+    // A recursive binding re-translates its body at each reference site so
+    // every reference yields an independent FixedPointNode subtree, since
+    // execution does not support DAG plans.
+    if (const auto* anchor = ctes_.anchorFor(tableName)) {
       builder_ = newBuilder();
       // The recursive-ref name must match the enclosing FixedPointNode's
       // name so the optimizer wires this self-reference to that loop state.
-      builder_->recursiveRef(recursiveIt->first, *recursiveIt->second);
+      builder_->recursiveRef(tableName, *anchor);
       builder_->as(tableName);
       displayNames_.accumulate(*builder_, tableName);
       return;
     }
 
-    auto withIt = withQueries_.find(tableName);
-    if (withIt != withQueries_.end()) {
-      // Temporarily remove the CTE from the map while processing its body
-      // to prevent infinite recursion when a CTE has the same name as a
-      // base table it references (e.g. WITH t AS (SELECT * FROM t)).
-      // Recursive CTEs are also pulled out so a sibling outer reference
-      // fired mid-translation cannot re-enter the same body.
-      auto entry = std::move(withIt->second);
-      withQueries_.erase(withIt);
-      SCOPE_EXIT {
-        withQueries_.insert_or_assign(tableName, std::move(entry));
-      };
-
+    if (auto hidden = ctes_.hide(tableName)) {
+      const auto& entry = hidden.entry();
       if (entry.isRecursive) {
         translateRecursiveCteReference(*entry.withQuery, tableName);
       } else {
@@ -577,15 +557,7 @@ class RelationPlanner : public AstVisitor {
 
       VELOX_CHECK_NOT_NULL(parseSql_);
       auto query = parseSql_(view->text());
-      // A view body is an independent query and must not resolve table
-      // references against the caller's in-flight recursive step-body
-      // bindings. Save and restore here so any sibling FROM relations in
-      // this outer query still see the outer bindings.
-      auto savedRecursiveCteAnchors = std::move(recursiveCteAnchors_);
-      recursiveCteAnchors_.clear();
-      SCOPE_EXIT {
-        recursiveCteAnchors_ = std::move(savedRecursiveCteAnchors);
-      };
+      auto suppressed = ctes_.suppressAnchors();
       processQuery(dynamic_cast<Query*>(query.get()));
     } else {
       AXIOM_PRESTO_SEMANTIC_FAIL(
@@ -1314,13 +1286,10 @@ class RelationPlanner : public AstVisitor {
   }
 
   void processQuery(Query* query) {
-    auto savedWithQueries = withQueries_;
+    auto scope = ctes_.enterScope();
     auto savedAccumulatedNames = displayNames_.accumulatedNames;
-    auto savedRecursiveCteAnchors = recursiveCteAnchors_;
     SCOPE_EXIT {
-      withQueries_ = std::move(savedWithQueries);
       displayNames_.accumulatedNames = std::move(savedAccumulatedNames);
-      recursiveCteAnchors_ = std::move(savedRecursiveCteAnchors);
     };
 
     // lastNames is scoped per query; reset so names from a sibling relation
@@ -1338,13 +1307,7 @@ class RelationPlanner : public AstVisitor {
           selfReferential = bodyQuery != nullptr &&
               presto::RecursiveCteValidator::referencesCte(*bodyQuery, cteName);
         }
-        withQueries_.insert_or_assign(
-            cteName, CteEntry{withQuery, selfReferential});
-        // A nested WITH binding shadows any enclosing recursive CTE of the
-        // same name; remove the in-flight step-body entry so processTable
-        // falls through to the new withQueries_ binding. processQuery's
-        // SCOPE_EXIT restores recursiveCteAnchors_ on exit.
-        recursiveCteAnchors_.erase(cteName);
+        ctes_.bind(cteName, CteScope::Entry{withQuery, selfReferential});
       }
     }
 
@@ -1535,19 +1498,7 @@ class RelationPlanner : public AstVisitor {
         return builder_->hasColumn(first) ||
             builder_->hasQualifiedColumn(first, second);
       }};
-  // A CTE binding tracked while translating its enclosing query.
-  // 'isRecursive' is true when the body self-references and therefore
-  // requires FixedPointNode translation at each reference site.
-  struct CteEntry {
-    std::shared_ptr<WithQuery> withQuery;
-    bool isRecursive{false};
-  };
-  std::unordered_map<std::string, CteEntry> withQueries_;
-  // Anchor PlanBuilder pointer for each recursive CTE currently being
-  // translated. processTable consumes this when emitting the matching
-  // RecursiveReferenceNode so step-body self-references inherit anchor
-  // name resolution.
-  folly::F14FastMap<std::string, const lp::PlanBuilder*> recursiveCteAnchors_;
+  CteScope ctes_;
   ViewMap views_;
   std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables_;
   bool friendlySql_;

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -315,6 +315,52 @@ TEST_F(PrestoParserTest, withShadowingCte) {
       matcher);
 }
 
+TEST_F(PrestoParserTest, withNestedSameNameResolvesToOuter) {
+  // A non-recursive CTE is not in scope within its own body, so a nested
+  // same-name WITH resolves to the enclosing binding. The shadowing CTEs differ
+  // in arity and names, so a wrong binding fails to resolve: the inner body
+  // needs the outer t(a), the main query needs the inner t(b, c).
+  testSelect(
+      "WITH t(a) AS (SELECT 1) "
+      "SELECT * FROM ("
+      "  WITH t(b, c) AS (SELECT a, a + 1 FROM t) "
+      "  SELECT b + c AS r FROM t) sub",
+      matchValues()
+          .project()
+          .project()
+          .project({"a", "a + 1"})
+          .project()
+          .project({"b + c"})
+          .output({"r"}));
+
+  // Same rule across nesting levels: each inner body binds to the next
+  // enclosing CTE (inner reads mid's b, mid reads outer's a).
+  testSelect(
+      "WITH t(a) AS (SELECT 1) "
+      "SELECT * FROM ("
+      "  WITH t(b) AS (SELECT a FROM t) "
+      "  SELECT * FROM (WITH t(c) AS (SELECT b FROM t) "
+      "    SELECT c AS r FROM t) s2) s1",
+      matchValues()
+          .project()
+          .project()
+          .project({"a"})
+          .project()
+          .project({"b"})
+          .project()
+          .project()
+          .output({"r"}));
+}
+
+TEST_F(PrestoParserTest, withSelfReferenceFails) {
+  // No enclosing CTE and no base table of that name, so the self-reference
+  // resolves to nothing and must error.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT * FROM (WITH t AS (SELECT * FROM t) SELECT * FROM t) sub"),
+      "Table not found: t");
+}
+
 TEST_F(PrestoParserTest, withNoLeaking) {
   // CTE defined inside a subquery is not visible outside.
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(

--- a/axiom/sql/presto/tests/WithRecursiveTest.cpp
+++ b/axiom/sql/presto/tests/WithRecursiveTest.cpp
@@ -780,6 +780,34 @@ TEST_F(WithRecursiveTest, innerWithInsideStepShadows) {
       matchValues().project().project().fixedPoint(step).output());
 }
 
+// A nested non-recursive CTE shadows an outer recursive CTE and references that
+// name in its body. The reference resolves to the outer recursive CTE and
+// expands into a FixedPointNode. It reads column n, which only the outer CTE
+// provides, so the binding is observable.
+TEST_F(WithRecursiveTest, nestedShadowsRecursiveCte) {
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("r")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE r(n) AS (
+          SELECT CAST(1 AS BIGINT)
+          UNION ALL
+          SELECT n + 1 FROM r WHERE n < 10
+        )
+        SELECT * FROM (WITH r AS (SELECT n AS m FROM r) SELECT m FROM r) sub
+      )",
+      matchValues()
+          .project()
+          .project()
+          .fixedPoint(step, {"n"})
+          .project({"n"})
+          .project()
+          .output({"m"}));
+}
+
 // Constructs that ANSI forbids in the recursive term (DISTINCT, ORDER BY,
 // LIMIT) are allowed inside a FROM-clause subquery within the step, because
 // a subquery is a sealed scope.


### PR DESCRIPTION
Summary:

A non-recursive CTE is not in scope within its own body, so when a nested `WITH` shadows a name from an enclosing scope, a reference to that name inside the nested CTE's body must resolve to the enclosing-scope CTE. The parser overwrote the outer binding when registering the inner one, so neither was resolvable inside the body and it raised a false `Table not found`. Presto resolves these queries, so this was failing real production queries.

`withQueries_` now maps each name to a stack of bindings instead of a single entry. A nested `WITH` pushes a binding that shadows the enclosing one rather than replacing it; `processTable` pops the in-scope binding while translating its body, so the CTE is hidden within itself while the shadowed outer binding (or a base table) stays resolvable.

Reviewed By: mbasmanova

Differential Revision: D109041611


