### PR TITLE
fix(parser): Resolve views in DESCRIBE / SHOW COLUMNS (#1530)

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1867,8 +1867,20 @@ SqlStatementPtr parseShowColumns(
   const auto [connectorId, connectorTable] =
       toConnectorTable(*showColumns.table(), defaultConnectorId, defaultSchema);
 
-  const auto schema =
-      findTable(*showColumns.table(), connectorId, connectorTable)->type();
+  const auto metadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
+  facebook::velox::RowTypePtr schema;
+  if (const auto table = metadata->findTable(connectorTable)) {
+    schema = table->type();
+  } else if (const auto view = metadata->findView(connectorTable)) {
+    schema = view->type();
+  } else {
+    AXIOM_PRESTO_SEMANTIC_FAIL(
+        showColumns.table()->location(),
+        showColumns.table()->suffix(),
+        "Table not found: {}",
+        showColumns.table()->fullyQualifiedName());
+  }
 
   std::vector<Variant> data;
   data.reserve(schema->size());

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1057,13 +1057,22 @@ TEST_F(PrestoParserTest, showTables) {
       "Schema does not exist");
 }
 
-TEST_F(PrestoParserTest, describe) {
+TEST_F(PrestoParserTest, describeTable) {
   auto matcher = matchValues();
   testSelect("DESCRIBE nation", matcher);
 
   testSelect("DESC orders", matcher);
 
   testSelect("SHOW COLUMNS FROM lineitem", matcher);
+}
+
+TEST_F(PrestoParserTest, describeView) {
+  connector_->createView(
+      facebook::axiom::SchemaTableName{"default", "view"},
+      ROW({"a", "b"}, {INTEGER(), VARCHAR()}),
+      "SELECT 1 AS a, 'x' AS b");
+  testSelect("DESCRIBE view", matchValues());
+  testSelect("SHOW COLUMNS FROM view", matchValues());
 }
 
 TEST_F(PrestoParserTest, showFunctions) {


### PR DESCRIPTION
Summary:

`DESCRIBE <view>` and `SHOW COLUMNS FROM <view>` failed with `Table not found` even though selecting from the same view works. `parseShowColumns` resolved the target via `findTable` only, which returns null for a view.

Fall back to `findView` and read its `type()` for the column list; error only when the name is neither a table nor a view. The SELECT path already resolves views via `findView`, so this brings the column-introspection path in line.

Reviewed By: mbasmanova

Differential Revision: D109327368


