### PR TITLE
fix(parser): Reject duplicate CTE names within a WITH list (#1531)

### DIFF
--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1297,8 +1297,17 @@ class RelationPlanner : public AstVisitor {
     displayNames_.lastNames.clear();
 
     if (const auto& with = query->with()) {
+      // Names must be unique within a single WITH list. A nested WITH may
+      // still reuse an enclosing name -- that is shadowing, handled below.
+      std::unordered_set<std::string> namesInList;
       for (const auto& withQuery : with->queries()) {
         const auto cteName = canonicalizeIdentifier(*withQuery->name());
+        AXIOM_PRESTO_SEMANTIC_CHECK(
+            namesInList.insert(cteName).second,
+            withQuery->location(),
+            cteName,
+            "WITH query name specified more than once: {}",
+            cteName);
         // A CTE in a WITH RECURSIVE block is only recursive if its body
         // actually references its own name. Otherwise it's a standard union.
         bool selfReferential = false;

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -402,6 +402,27 @@ TEST_F(PrestoParserTest, withColumnAliases) {
       "Column alias list size does not match the number of output columns");
 }
 
+TEST_F(PrestoParserTest, withDuplicateNamesRejected) {
+  // A name may appear at most once within a single WITH list.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "WITH a AS (SELECT 1 AS x), a AS (SELECT 2 AS y) SELECT * FROM a"),
+      "WITH query name specified more than once: a");
+
+  // Case-insensitive: 'A' and 'a' collide.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "WITH a AS (SELECT 1 AS x), A AS (SELECT 2 AS y) SELECT * FROM a"),
+      "WITH query name specified more than once: a");
+
+  // A nested WITH reusing an enclosing name is allowed (shadowing, not a
+  // duplicate within one list).
+  testSelect(
+      "WITH a AS (SELECT 1 AS x) "
+      "SELECT * FROM (WITH a AS (SELECT 2 AS y) SELECT * FROM a) sub",
+      matchValues().project().output({"y"}));
+}
+
 TEST_F(PrestoParserTest, withReferencedMultipleTimes) {
   // Same CTE referenced twice in a JOIN.
   auto matcher = matchScan()


### PR DESCRIPTION
Summary:

Axiom silently accepted a WITH list that defined the same name twice -- e.g. `WITH a AS (SELECT 1), a AS (SELECT 2) SELECT * FROM a` -- resolving the reference to the last definition. Presto rejects this. Fail when a name appears more than once within a single WITH list. A nested WITH reusing an enclosing name remains valid (that is shadowing, not duplication).

The check tracks names seen so far in the current WITH list and fails on a repeat, case-insensitively to match identifier canonicalization.

Reviewed By: natashasehgal

Differential Revision: D109041612


