### PR TITLE
refactor(optimizer): Introduce TableObject base for table-shaped nodes (#1532)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1456,7 +1456,8 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
       newQuery(options),
       options,
       [&](const optimizer::DerivedTable& rootDt) {
-        presto::ShowStatsBuilder builder(roundCardinality(rootDt.cardinality));
+        presto::ShowStatsBuilder builder(
+            roundCardinality(rootDt.cardinality()));
 
         for (const auto* column : rootDt.columns) {
           const auto& value = column->value();

--- a/axiom/graphviz/DerivedTableDotPrinter.cpp
+++ b/axiom/graphviz/DerivedTableDotPrinter.cpp
@@ -172,7 +172,8 @@ void printValuesTable(const ValuesTable& table, std::ostream& out) {
 
   // Show cardinality.
   printHighlightedRow(
-      out, fmt::format("{} rows", static_cast<int>(table.cardinality())));
+      out,
+      fmt::format("{} rows", static_cast<int>(table.cardinality().value())));
 
   printTableEnd(out);
 }
@@ -181,6 +182,9 @@ void printUnnestTable(const UnnestTable& table, std::ostream& out) {
   printTableStart(out, &table, std::string(table.cname) + " (UNNEST)");
 
   for (auto* col : table.columns) {
+    if (col == table.ordinalityColumn) {
+      continue;
+    }
     printRow(out, escapeHtml(col->name()));
   }
 

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -143,31 +143,14 @@ void addImpliedSemiEdge(
   }
 }
 
-// Returns the post-filter cardinality for any table type. For BaseTable,
-// this is filteredCardinality (reduced by pushed-down WHERE/HAVING). For
-// DerivedTable, cardinality is already post-filter/post-join.
-std::optional<float> filteredTableCardinality(PlanObjectCP table) {
-  if (table->is(PlanType::kTableNode)) {
-    return table->as<BaseTable>()->filteredCardinality;
-  }
-  if (table->is(PlanType::kValuesTableNode)) {
-    return table->as<ValuesTable>()->cardinality();
-  }
-  if (table->is(PlanType::kUnnestTableNode)) {
-    return table->as<UnnestTable>()->cardinality();
-  }
-  VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
-  return table->as<DerivedTable>()->cardinality;
-}
-
 // Estimates the number of distinct key combinations in 'table' after
-// filtering. For a single key, returns min(NDV, filteredCardinality)
-// directly (no dampening needed). For multiple keys, uses the saturating
-// product formula (max * P / (max + P)) to dampen the independence
-// assumption for correlated keys. Consistent with maxGroups(). Returns nullopt
-// if the table cardinality or any key NDV is unknown.
+// filtering. For a single key, returns min(NDV, cardinality) directly (no
+// dampening needed). For multiple keys, uses the saturating product formula
+// (max * P / (max + P)) to dampen the independence assumption for correlated
+// keys. Consistent with maxGroups(). Returns nullopt if the table cardinality
+// or any key NDV is unknown.
 std::optional<float> compositeNdv(PlanObjectCP table, const ExprVector& keys) {
-  const auto maxOpt = filteredTableCardinality(table);
+  const auto maxOpt = table->as<TableObject>()->cardinality();
   if (!maxOpt.has_value()) {
     return std::nullopt;
   }
@@ -495,19 +478,7 @@ void DerivedTable::checkConsistency() const {
 
   // Layer 1: Base table columns are available.
   for (auto* table : tables) {
-    if (table->is(PlanType::kDerivedTableNode)) {
-      availableColumns.unionObjects(table->as<DerivedTable>()->columns);
-    } else if (table->is(PlanType::kTableNode)) {
-      availableColumns.unionObjects(table->as<BaseTable>()->columns);
-    } else if (table->is(PlanType::kValuesTableNode)) {
-      availableColumns.unionObjects(table->as<ValuesTable>()->columns);
-    } else if (table->is(PlanType::kUnnestTableNode)) {
-      auto* unnest = table->as<UnnestTable>();
-      availableColumns.unionObjects(unnest->columns);
-      if (unnest->ordinalityColumn) {
-        availableColumns.add(unnest->ordinalityColumn);
-      }
-    }
+    availableColumns.unionObjects(table->as<TableObject>()->columns);
   }
 
   auto checkExprAvailable = [&](ExprCP expr, const char* layerName) {
@@ -638,9 +609,9 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
     // Set initial cardinality as the sum of unionInputs's cardinalities so that
     // makeInitialPlan can use it when estimating groups for makeDistinct.
     // The sum is unknown if any child's cardinality is unknown.
-    cardinality = 0;
+    cardinality_ = 0;
     for (const auto* child : unionInputs) {
-      cardinality = add(cardinality, child->cardinality);
+      cardinality_ = add(cardinality_, child->cardinality());
     }
   }
 
@@ -652,7 +623,7 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
 }
 
 void DerivedTable::updateConstraints(const RelationOp& plan) {
-  cardinality = plan.resultCardinality();
+  cardinality_ = plan.resultCardinality();
 
   if (plan.relType() == RelType::kTableWrite) {
     // TableWrite columns are the data columns being written, not the DT's
@@ -1107,16 +1078,8 @@ void DerivedTable::linkTablesToJoins() {
       }
     }
     tables.forEachMutable([&](PlanObjectP table) {
-      if (table->is(PlanType::kTableNode)) {
-        table->as<BaseTable>()->addJoinedBy(join);
-      } else if (table->is(PlanType::kValuesTableNode)) {
-        table->as<ValuesTable>()->addJoinedBy(join);
-      } else if (table->is(PlanType::kUnnestTableNode)) {
-        table->as<UnnestTable>()->addJoinedBy(join);
-      } else {
-        VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
-        table->as<DerivedTable>()->addJoinedBy(join);
-      }
+      VELOX_CHECK(table->isTable());
+      pushBackUnique(table->as<TableObject>()->joinedBy, join);
     });
   }
 }
@@ -2660,10 +2623,6 @@ bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
 
 std::string DerivedTable::toString() const {
   return DerivedTablePrinter::toText(*this);
-}
-
-void DerivedTable::addJoinedBy(JoinEdgeP join) {
-  pushBackUnique(joinedBy, join);
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -19,6 +19,7 @@
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/MemoKey.h"
 #include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraph.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -70,27 +71,24 @@ using WindowPlanCP = const WindowPlan*;
 ///
 /// See docs/DerivedTableLayers.md for the layered column ownership model
 /// and dependency rules validated by checkConsistency.
-struct DerivedTable : public PlanObject {
-  DerivedTable() : PlanObject(PlanType::kDerivedTableNode) {}
+struct DerivedTable : public TableObject {
+  DerivedTable() : TableObject{PlanType::kDerivedTableNode} {}
 
   /// True if this DT is guaranteed to produce exactly one row: a global
   /// aggregation (no grouping keys) with no HAVING clause and a non-zero
   /// limit.
   bool isSingleRow() const;
 
-  /// Estimated number of rows produced by this DerivedTable. Set during
-  /// planning by initializePlans() or makeInitialPlan(). For non-union DTs,
-  /// computed as resultCardinality() of the initial physical plan. For union
-  /// DTs, computed as the sum of resultCardinality() across all children.
-  /// nullopt if the cardinality is unknown.
-  std::optional<float> cardinality{};
+  /// Estimated number of rows this DerivedTable produces. Set during planning
+  /// by `initializePlans()` / `makeInitialPlan()`: for non-union DTs the
+  /// `resultCardinality()` of the initial physical plan, for union DTs the sum
+  /// across children. `nullopt` until planning has run.
+  std::optional<float> cardinality() const override {
+    return cardinality_;
+  }
 
   /// Correlation name.
   Name cname{nullptr};
-
-  /// All columns defined by this DT, including intermediate columns needed for
-  /// HAVING, ORDER BY, etc.
-  ColumnVector columns;
 
   /// Exprs projected out. 1:1 to 'columns' or empty if 'this' is a UNION
   /// ALL (isUnion is true).
@@ -106,9 +104,6 @@ struct DerivedTable : public PlanObject {
   /// at runtime. Set for scalar subqueries that don't naturally guarantee
   /// single-row output (no global aggregation).
   bool enforceSingleRow{false};
-
-  /// References all joins where 'this' is an end point.
-  JoinEdgeVector joinedBy;
 
   /// All tables in FROM, either Table or DerivedTable. If Table, all
   /// filters resolvable with the table alone are in single column filters or
@@ -320,10 +315,6 @@ struct DerivedTable : public PlanObject {
   /// mark column.
   AggregateCP exportSingleAggregate(Name markName);
 
-  bool isTable() const override {
-    return true;
-  }
-
   void addTable(PlanObjectCP table) {
     tables.push_back(table);
     tableSet.add(table);
@@ -426,8 +417,6 @@ struct DerivedTable : public PlanObject {
   /// True if contains one derived table in 'tables' and adds no change to its
   /// result set.
   bool isWrapOnly() const;
-
-  void addJoinedBy(JoinEdgeP join);
 
   /// Asserts invariants about this DerivedTable.
   void checkConsistency() const;
@@ -590,6 +579,9 @@ struct DerivedTable : public PlanObject {
   // Returns true if 'imported' depends only on columns that are partition keys
   // of every window function in windowPlan.
   bool isPartitionKeyFilter(ExprCP imported) const;
+
+ protected:
+  std::optional<float> cardinality_{};
 };
 
 using DerivedTableP = DerivedTable*;

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -186,7 +186,7 @@ std::string visitJoinEdge(const JoinEdge& edge) {
 
 std::string visitDerivedTable(const DerivedTable& dt) {
   std::stringstream out;
-  out << headerLine(dt.cname, dt.cardinality, dt.columns);
+  out << headerLine(dt.cname, dt.cardinality(), dt.columns);
 
   if (dt.isUnion()) {
     VELOX_CHECK_EQ(0, dt.exprs.size());

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -951,11 +951,8 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
     // There are no join edges. There could still be cross joins.
     state.dt->startTables.forEach([&](PlanObjectCP object) {
       if (!state.isPlaced(object) && state.mayConsiderNext(object)) {
-        std::optional<float> fanout = tableCardinality(object);
-        if (object->is(PlanType::kTableNode)) {
-          fanout = object->as<BaseTable>()->filteredCardinality;
-        }
-        candidates.emplace_back(nullptr, object, fanout);
+        candidates.emplace_back(
+            nullptr, object, object->as<TableObject>()->cardinality());
       }
     });
 
@@ -1147,17 +1144,8 @@ RelationOpPtr repartitionForIndex(
 
 PlanObjectSet availableColumns(PlanObjectCP object) {
   PlanObjectSet set;
-  if (object->is(PlanType::kTableNode)) {
-    set.unionObjects(object->as<BaseTable>()->columns);
-  } else if (object->is(PlanType::kValuesTableNode)) {
-    set.unionObjects(object->as<ValuesTable>()->columns);
-  } else if (object->is(PlanType::kUnnestTableNode)) {
-    set.unionObjects(object->as<UnnestTable>()->columns);
-  } else if (object->is(PlanType::kDerivedTableNode)) {
-    set.unionObjects(object->as<DerivedTable>()->columns);
-  } else {
-    VELOX_UNREACHABLE("Joinable must be a table or derived table");
-  }
+  VELOX_CHECK(object->isTable(), "Joinable must be a table or derived table");
+  set.unionObjects(object->as<TableObject>()->columns);
   return set;
 }
 
@@ -2872,11 +2860,10 @@ void Optimization::crossJoinUnnest(
           "Ordinality column must be present");
     }
 
-    // We don't use downstreamColumns() for unnestExprs/unnestedColumns.
+    // We don't use downstreamColumns() for unnestExprs.
     // Because 'unnest-column' should be unnested even when it isn't used.
     // Because it can change cardinality of the all output.
     const auto& unnestExprs = candidate.join->leftKeys();
-    const auto& unnestedColumns = unnestTable->columns;
 
     // Plan is updated here,
     // because we can have multiple unnest joins in single JoinCandidate.
@@ -2888,8 +2875,7 @@ void Optimization::crossJoinUnnest(
         std::move(plan),
         std::move(replicateColumns),
         std::move(unnestColumns),
-        unnestedColumns,
-        unnestTable->ordinalityColumn);
+        unnestTable);
 
     state.replaceColumns(PlanObjectSet::fromObjects(plan->columns()));
     state.addCost(*plan);
@@ -3255,18 +3241,15 @@ PlanP unionPlan(std::vector<PlanState>& states, const RelationOpPtr& result) {
 }
 
 std::optional<float> startingScore(PlanObjectCP table) {
-  if (table->is(PlanType::kTableNode)) {
-    return table->as<BaseTable>()->filteredCardinality;
-  }
-
-  if (table->is(PlanType::kValuesTableNode)) {
-    return table->as<ValuesTable>()->cardinality();
-  }
-
   if (table->is(PlanType::kUnnestTableNode)) {
     VELOX_FAIL("UnnestTable cannot be a starting table");
     // Because it's rigth side of directed inner (cross) join edge.
     // Directed edges are non-commutative, so right side cannot be starting.
+  }
+
+  if (table->is(PlanType::kTableNode) ||
+      table->is(PlanType::kValuesTableNode)) {
+    return table->as<TableObject>()->cardinality();
   }
 
   return 10;

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -581,20 +581,8 @@ PlanP PlanSet::best(
 }
 
 const JoinEdgeVector& joinedBy(PlanObjectCP table) {
-  if (table->is(PlanType::kTableNode)) {
-    return table->as<BaseTable>()->joinedBy;
-  }
-
-  if (table->is(PlanType::kValuesTableNode)) {
-    return table->as<ValuesTable>()->joinedBy;
-  }
-
-  if (table->is(PlanType::kUnnestTableNode)) {
-    return table->as<UnnestTable>()->joinedBy;
-  }
-
-  VELOX_DCHECK(table->is(PlanType::kDerivedTableNode));
-  return table->as<DerivedTable>()->joinedBy;
+  VELOX_DCHECK(table->isTable());
+  return table->as<TableObject>()->joinedBy;
 }
 
 std::pair<JoinSide, JoinSide> JoinCandidate::joinSides() const {

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -85,22 +85,6 @@ Name cname(PlanObjectCP relation) {
   }
 }
 
-std::optional<float> tableCardinality(PlanObjectCP table) {
-  if (table->is(PlanType::kTableNode)) {
-    return table->as<BaseTable>()->schemaTable->cardinality;
-  }
-  if (table->is(PlanType::kValuesTableNode)) {
-    return table->as<ValuesTable>()->cardinality();
-  }
-
-  if (table->is(PlanType::kUnnestTableNode)) {
-    return table->as<UnnestTable>()->cardinality();
-  }
-
-  VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
-  return table->as<DerivedTable>()->cardinality;
-}
-
 std::string Column::toString() const {
   const auto* opt = queryCtx()->optimization();
   if (!opt->cnamesInExpr() || relation_ == nullptr) {
@@ -369,10 +353,6 @@ std::optional<PathSet> SubfieldSet::findSubfields(int32_t id) const {
   return std::nullopt;
 }
 
-void BaseTable::addJoinedBy(JoinEdgeP join) {
-  pushBackUnique(joinedBy, join);
-}
-
 std::optional<int32_t> BaseTable::columnId(Name column) const {
   for (auto i = 0; i < columns.size(); ++i) {
     if (columns[i]->name() == column) {
@@ -402,18 +382,10 @@ std::string BaseTable::toString() const {
   return out.str();
 }
 
-void ValuesTable::addJoinedBy(JoinEdgeP join) {
-  pushBackUnique(joinedBy, join);
-}
-
 std::string ValuesTable::toString() const {
   std::stringstream out;
   out << "{" << PlanObject::toString() << cname << "}";
   return out.str();
-}
-
-void UnnestTable::addJoinedBy(JoinEdgeP join) {
-  pushBackUnique(joinedBy, join);
 }
 
 std::string UnnestTable::toString() const {
@@ -791,11 +763,10 @@ std::optional<float> estimateFanout(
 }
 
 // Estimates the number of matching rows per equality lookup on 'keys' for
-// 'table'. For BaseTable, uses column statistics via estimateFanout and checks
-// uniqueness via SchemaTable::isUnique(). For ValuesTable, UnnestTable, and
-// DerivedTable, estimates cardinality using column statistics. For
-// DerivedTable with an aggregation, sets unique = true when keys cover all
-// grouping keys.
+// 'table'. BaseTable uses column statistics via estimateFanout and checks
+// uniqueness via SchemaTable::isUnique(). DerivedTable uses its post-planning
+// cardinality and marks unique = true when 'keys' cover all grouping keys.
+// Values/Unnest use their cardinality with unique = false.
 JoinFanout joinFanout(
     PlanObjectCP table,
     const ExprVector& keys,
@@ -820,27 +791,19 @@ JoinFanout joinFanout(
     return {fanout, unique};
   }
 
-  if (table->is(PlanType::kValuesTableNode)) {
-    const auto cardinality = table->as<ValuesTable>()->cardinality();
+  if (table->is(PlanType::kDerivedTableNode)) {
+    const auto* dt = table->as<DerivedTable>();
     return {
-        .fanout = estimateFanout(cardinality, keys, otherKeys),
-        .unique = false};
+        .fanout = estimateFanout(dt->cardinality(), keys, otherKeys),
+        .unique = dt->aggregation &&
+            keys.size() >= dt->aggregation->groupingKeys().size(),
+    };
   }
 
-  if (table->is(PlanType::kUnnestTableNode)) {
-    const auto cardinality = table->as<UnnestTable>()->cardinality();
-    return {
-        .fanout = estimateFanout(cardinality, keys, otherKeys),
-        .unique = false};
-  }
-
-  VELOX_CHECK(table->is(PlanType::kDerivedTableNode));
-  const auto* dt = table->as<DerivedTable>();
+  VELOX_CHECK(table->isTable());
+  const auto cardinality = table->as<TableObject>()->cardinality();
   return {
-      .fanout = estimateFanout(dt->cardinality, keys, otherKeys),
-      .unique = dt->aggregation &&
-          keys.size() >= dt->aggregation->groupingKeys().size(),
-  };
+      .fanout = estimateFanout(cardinality, keys, otherKeys), .unique = false};
 }
 
 std::optional<float> baseSelectivity(PlanObjectCP object) {
@@ -883,6 +846,17 @@ void JoinEdge::guessFanout() {
   leftUnique_ = left.unique;
   rightUnique_ = right.unique;
 
+  // PK-FK ratio uses raw (pre-filter) cardinality for BaseTable so that the
+  // filter is re-applied exactly once via `baseSelectivity`. For other table
+  // kinds, only post-filter cardinality exists and `baseSelectivity` returns
+  // 1, so the post-filter value is what feeds the ratio.
+  auto pkFkRatioCardinality = [](PlanObjectCP table) -> std::optional<float> {
+    if (table->is(PlanType::kTableNode)) {
+      return table->as<BaseTable>()->schemaTable->cardinality;
+    }
+    return table->as<TableObject>()->cardinality();
+  };
+
   // If one side has unique join keys, this is a primary key (PK) to foreign
   // key (FK) join. For example, joining orders (PK: orderkey) with lineitem
   // (FK: orderkey), if orders is the left table, then leftUnique_ is true: each
@@ -892,12 +866,16 @@ void JoinEdge::guessFanout() {
   if (leftUnique_) {
     rlFanout_ = mul(left.fanout, baseSelectivity(leftTable_));
     lrFanout_ =
-        mul(divide(tableCardinality(rightTable_), tableCardinality(leftTable_)),
+        mul(divide(
+                pkFkRatioCardinality(rightTable_),
+                pkFkRatioCardinality(leftTable_)),
             baseSelectivity(rightTable_));
   } else if (rightUnique_) {
     lrFanout_ = mul(right.fanout, baseSelectivity(rightTable_));
     rlFanout_ =
-        mul(divide(tableCardinality(leftTable_), tableCardinality(rightTable_)),
+        mul(divide(
+                pkFkRatioCardinality(leftTable_),
+                pkFkRatioCardinality(rightTable_)),
             baseSelectivity(leftTable_));
   } else {
     auto [sampledLeftFanout, sampledRightFanout] = options.sampleJoins

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1017,25 +1017,41 @@ class JoinEdge {
 using JoinEdgeP = JoinEdge*;
 using JoinEdgeVector = QGVector<JoinEdgeP>;
 
+/// Polymorphic base for the table-shaped query-graph nodes. Callers
+/// iterating over `DerivedTable::tables` reach for `columns`, `cardinality`,
+/// or `joinedBy` on the base instead of switching on `PlanType`:
+///
+///   table->as<TableObject>()->columns
+class TableObject : public PlanObject {
+ public:
+  explicit TableObject(PlanType kind) : PlanObject{kind} {}
+
+  /// Estimated number of rows in this table's output, or `nullopt` when
+  /// not yet known.
+  virtual std::optional<float> cardinality() const = 0;
+
+  /// Output columns of this table.
+  ColumnVector columns;
+
+  /// Joins where this table is an end point.
+  JoinEdgeVector joinedBy;
+
+  bool isTable() const final override {
+    return true;
+  }
+};
+
 /// Represents a reference to a table from a query. There is one of these
 /// for each occurrence of the schema table. A TableScan references one
 /// BaseTable but the same BaseTable can be referenced from many TableScans, for
 /// example if accessing different indices in a secondary to primary key lookup.
-struct BaseTable : public PlanObject {
-  BaseTable() : PlanObject(PlanType::kTableNode) {}
+struct BaseTable : public TableObject {
+  BaseTable() : TableObject{PlanType::kTableNode} {}
 
   /// Correlation name, distinguishes between uses of the same schema table.
   Name cname{nullptr};
 
   SchemaTableCP schemaTable{nullptr};
-
-  /// All columns referenced from 'schemaTable' under this correlation name.
-  /// Different indices may have to be combined in different TableScans to cover
-  /// 'columns'.
-  ColumnVector columns;
-
-  /// All joins where 'this' is an end point.
-  JoinEdgeVector joinedBy;
 
   /// Top level conjuncts on single columns and literals, column to the left.
   ExprVector columnFilters;
@@ -1052,11 +1068,9 @@ struct BaseTable : public PlanObject {
 
   SubfieldSet payloadSubfields;
 
-  bool isTable() const override {
-    return true;
+  std::optional<float> cardinality() const override {
+    return filteredCardinality;
   }
-
-  void addJoinedBy(JoinEdgeP join);
 
   /// Adds 'expr' to 'filters' or 'columnFilters'.
   void addFilter(ExprCP expr);
@@ -1076,13 +1090,13 @@ struct BaseTable : public PlanObject {
 
 using BaseTableCP = const BaseTable*;
 
-struct ValuesTable : public PlanObject {
+struct ValuesTable : public TableObject {
   using Variants = const std::vector<velox::Variant>*;
   using Vectors = const std::vector<velox::RowVectorPtr>*;
   using Data = std::variant<Variants, Vectors>;
 
   explicit ValuesTable(const velox::Type* _dataType, Data _data)
-      : PlanObject{PlanType::kValuesTableNode},
+      : TableObject{PlanType::kValuesTableNode},
         dataType{_dataType},
         data{std::move(_data)},
         cardinality_{cardinality(data)} {
@@ -1096,21 +1110,9 @@ struct ValuesTable : public PlanObject {
 
   const Data data;
 
-  /// All columns referenced from this 'ValuesNode'.
-  ColumnVector columns;
-
-  /// All joins where 'this' is an end point.
-  JoinEdgeVector joinedBy;
-
-  float cardinality() const {
+  std::optional<float> cardinality() const override {
     return cardinality_;
   }
-
-  bool isTable() const override {
-    return true;
-  }
-
-  void addJoinedBy(JoinEdgeP join);
 
   std::string toString() const override;
 
@@ -1132,35 +1134,24 @@ struct ValuesTable : public PlanObject {
   float cardinality_;
 };
 
-struct UnnestTable : public PlanObject {
-  explicit UnnestTable() : PlanObject{PlanType::kUnnestTableNode} {}
+struct UnnestTable : public TableObject {
+  explicit UnnestTable() : TableObject{PlanType::kUnnestTableNode} {}
 
   // Correlation name, distinguishes between uses of the same unnest node.
   Name cname{nullptr};
 
-  /// All unnested columns from corresponding unnest node.
-  /// All replicated columns is on other (left) side of the join edge.
-  ColumnVector columns;
-
-  // All joins where 'this' is an end point.
-  JoinEdgeVector joinedBy;
-
   // Ordinality column if ordinality clause is present.
   ColumnCP ordinalityColumn{nullptr};
 
-  float cardinality() const {
+  std::optional<float> cardinality() const override {
     // TODO Should be changed later to actual cardinality.
     return 1;
   }
 
-  bool isTable() const override {
-    return true;
-  }
-
-  void addJoinedBy(JoinEdgeP join);
-
   std::string toString() const override;
 };
+
+using UnnestTableCP = const UnnestTable*;
 
 using TypeVector = QGVector<const velox::Type*>;
 
@@ -1533,9 +1524,5 @@ using WritePlanCP = const WritePlan*;
 /// @return cname of 'relation'. 'relation' must be a BaseTable, ValuesTable,
 /// UnnestTable, or DerivedTable.
 Name cname(PlanObjectCP relation);
-
-/// @return estimated number of rows in 'table', or nullopt if unknown. 'table'
-/// must be a BaseTable, ValuesTable, UnnestTable, or DerivedTable.
-std::optional<float> tableCardinality(PlanObjectCP table);
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -761,19 +761,13 @@ void Repartition::accept(
 }
 
 namespace {
-ColumnVector concatColumns(
-    const ExprVector& lhs,
-    const ColumnVector& rhs,
-    ColumnCP ordinalityColumn) {
+ColumnVector concatColumns(const ExprVector& lhs, const ColumnVector& rhs) {
   ColumnVector result;
-  result.reserve(lhs.size() + rhs.size() + (ordinalityColumn ? 1 : 0));
+  result.reserve(lhs.size() + rhs.size());
   for (const auto& expr : lhs) {
     result.push_back(expr->as<Column>());
   }
   result.insert(result.end(), rhs.begin(), rhs.end());
-  if (ordinalityColumn) {
-    result.push_back(ordinalityColumn);
-  }
   return result;
 }
 } // namespace
@@ -782,13 +776,11 @@ Unnest::Unnest(
     RelationOpPtr input,
     ExprVector replicateColumns,
     ExprVector unnestExprs,
-    ColumnVector unnestedColumns,
-    ColumnCP ordinalityColumn)
-    : RelationOp{RelType::kUnnest, std::move(input), concatColumns(replicateColumns, unnestedColumns, ordinalityColumn)},
+    UnnestTableCP unnestTable)
+    : RelationOp{RelType::kUnnest, std::move(input), concatColumns(replicateColumns, unnestTable->columns)},
       replicateColumns{std::move(replicateColumns)},
       unnestExprs{std::move(unnestExprs)},
-      unnestedColumns{std::move(unnestedColumns)},
-      ordinalityColumn{ordinalityColumn} {
+      unnestTable{unnestTable} {
   cost_.inputCardinality = inputCardinality();
 
   // Use a heuristic for average array/map size.
@@ -813,20 +805,19 @@ void Unnest::initConstraints() {
     }
   }
 
-  // Add constraints for unnested columns.
-  // These come from array/map elements - we don't have detailed info,
-  // so use default constraints from the column's value.
-  for (auto* column : unnestedColumns) {
-    constraints_.emplace(column->id(), column->value());
-  }
-
-  // Add constraint for ordinality column if present.
-  // Ordinality is non-null. Use fanout as an approximation for cardinality.
-  if (ordinalityColumn) {
-    // Unnest always sets a fanout.
-    Value ordValue(ordinalityColumn->value().type, cost_.fanout.value());
-    ordValue.nullable = false;
-    constraints_.emplace(ordinalityColumn->id(), ordValue);
+  // Add constraints for the unnest table's output columns. Unnested values
+  // come from array/map elements (no detailed stats — use the column's
+  // default), and the ordinality column is non-null with fanout as a
+  // cardinality approximation.
+  for (auto* column : unnestTable->columns) {
+    if (column == unnestTable->ordinalityColumn) {
+      // Unnest always sets a fanout.
+      Value ordValue(column->value().type, cost_.fanout.value());
+      ordValue.nullable = false;
+      constraints_.emplace(column->id(), ordValue);
+    } else {
+      constraints_.emplace(column->id(), column->value());
+    }
   }
 }
 
@@ -922,7 +913,7 @@ PlanObjectCP largestTable(const PlanObjectSet& tables) {
   double maxCardinality = 0.0;
 
   tables.forEach([&](const auto& table) {
-    const auto cardinality = tableCardinality(table);
+    const auto cardinality = table->template as<TableObject>()->cardinality();
     if (cardinality.has_value() && *cardinality > maxCardinality) {
       maxCardinality = *cardinality;
       largestTable = table;
@@ -966,7 +957,7 @@ std::optional<double> maxGroups(
   double maxTableCardinality = 0.0;
 
   for (const auto& [table, keys] : tableToKeys) {
-    const auto maxCardinalityOpt = tableCardinality(table);
+    const auto maxCardinalityOpt = table->as<TableObject>()->cardinality();
     // An unknown table cardinality makes the group-count estimate unknown.
     if (!maxCardinalityOpt.has_value()) {
       return std::nullopt;

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -635,16 +635,11 @@ struct Unnest : public RelationOp {
       RelationOpPtr input,
       ExprVector replicateColumns,
       ExprVector unnestExprs,
-      ColumnVector unnestedColumns,
-      ColumnCP ordinalityColumn);
+      UnnestTableCP unnestTable);
 
   const ExprVector replicateColumns;
   const ExprVector unnestExprs;
-
-  // Columns correspond to expressions but not 1:1,
-  // it can be 2:1 (for MAP) and 1:1 (for ARRAY).
-  const ColumnVector unnestedColumns;
-  const ColumnCP ordinalityColumn;
+  UnnestTableCP const unnestTable;
 
   void accept(
       const RelationOpVisitor& visitor,

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1711,6 +1711,7 @@ void ToGraph::addUnnest(const lp::UnnestNode& unnest) {
           unnestTable,
           toValue(velox::BIGINT(), maxCardinality),
           columnName);
+      unnestTable->columns.push_back(column);
       renames_[columnName] = unnestTable->ordinalityColumn = column;
     }
   }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1603,9 +1603,13 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
     std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
 
+  const auto* ordinalityColumn = op.unnestTable->ordinalityColumn;
   std::vector<std::string> unnestNames;
-  unnestNames.reserve(op.unnestedColumns.size());
-  for (const auto* column : op.unnestedColumns) {
+  unnestNames.reserve(op.unnestTable->columns.size());
+  for (const auto* column : op.unnestTable->columns) {
+    if (column == ordinalityColumn) {
+      continue;
+    }
     unnestNames.emplace_back(column->outputName());
   }
 
@@ -1614,8 +1618,8 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
       toFieldRefs(op.replicateColumns),
       toFieldRefs(op.unnestExprs),
       std::move(unnestNames),
-      op.ordinalityColumn
-          ? std::optional<std::string>(op.ordinalityColumn->outputName())
+      ordinalityColumn
+          ? std::optional<std::string>(ordinalityColumn->outputName())
           : std::nullopt,
       std::nullopt,
       std::move(input));


### PR DESCRIPTION
Summary:

`BaseTable`, `ValuesTable`, `UnnestTable`, and `DerivedTable` all carry the same data — output columns, cardinality, join endpoints — but several optimizer passes open-code the dispatch as `is(PlanType::k*TableNode)` / `as<BaseTable>()` chains across half a dozen sites.

Adds an abstract `TableObject : PlanObject` that hoists `columns` and `joinedBy` as public data members and leaves `cardinality()` as the sole virtual. All four table kinds inherit it. Each dispatch site collapses to `table->as<TableObject>()->{columns, joinedBy, cardinality()}`, and call sites keep the full `std::vector` API (`push_back`, `reserve`, `clear`, assignment) instead of going through a mutator layer.

`UnnestTable` previously held its `WITH ORDINALITY` column outside `columns`, in a separate `ordinalityColumn` field. It now goes into `columns` like every other output column; `ordinalityColumn` is reduced to a pointer that identifies which entry it is. That makes `columns` a real shared contract instead of a base member one subclass silently violates — the Velox `UnnestNode` boundary, the one consumer that needs to distinguish, filters by the pointer.

`cardinality()` denotes the effective (post-filter) row estimate for every kind. `BaseTable::cardinality()` returns `filteredCardinality`, not raw `schemaTable->cardinality` — matching the single concept that Values/Unnest/Derived each have. The `tableCardinality` and `filteredTableCardinality` helpers (each branching on `kTableNode` to pick between raw and filtered) disappear; callers fold to `table->as<TableObject>()->cardinality()`. The one site that genuinely wants raw — `guessFanout`'s PK-FK ratio, which pairs with `baseSelectivity` to re-apply the filter — reaches `schemaTable->cardinality` directly via a local lambda. `maxGroups`/`largestTable` move from raw to effective, fixing a latent over-estimate of the group-count cap.

Reviewed By: mbasmanova

Differential Revision: D110113108


