### PR TITLE
test(optimizer): Verify distributed TPC-H plan shapes

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1101,16 +1101,25 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   decideFragmentType(*op.input(), options_, source);
   auto input = makeFragment(op.input(), source, stages);
 
+  // At one driver the per-worker sort yields a single sorted run, so emit a
+  // final sort and skip the LocalMerge; the MergeExchange combines the
+  // per-worker runs.
+  const bool singleDriver = options_.numDrivers == 1;
+
   velox::core::PlanNodePtr node;
   if (op.limit <= 0) {
     node = std::make_shared<velox::core::OrderByNode>(
-        nextId(), keys, sortOrder, true, input);
+        nextId(), keys, sortOrder, /*isPartial=*/!singleDriver, input);
+  } else if (singleDriver) {
+    node = addFinalTopN(nextId(), keys, sortOrder, op.limit + op.offset, input);
   } else {
     node =
         addPartialTopN(nextId(), keys, sortOrder, op.limit + op.offset, input);
   }
 
-  node = addLocalMerge(nextId(), keys, sortOrder, node);
+  if (!singleDriver) {
+    node = addLocalMerge(nextId(), keys, sortOrder, node);
+  }
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
       nextId(), node->outputType(), exchangeSerdeKind_, node);

--- a/axiom/optimizer/tests/ExprMatcher.cpp
+++ b/axiom/optimizer/tests/ExprMatcher.cpp
@@ -218,12 +218,21 @@ bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected) {
     AXIOM_RETURN_FALSE_IF_FAILURE
 
     const auto* expectedCall = expected->as<CallExpr>();
-    EXPECT_EQ(call->name(), expectedCall->name());
-    AXIOM_RETURN_FALSE_IF_FAILURE
+
+    // `if` and `switch` lower to the same SwitchExpr, so accept either name for
+    // a conditional; arity is still enforced by child matching below.
+    const auto isConditional = [](std::string_view name) {
+      return name == "if" || name == "switch";
+    };
+
+    if (!(isConditional(call->name()) && isConditional(expectedCall->name()))) {
+      EXPECT_EQ(call->name(), expectedCall->name());
+      AXIOM_RETURN_FALSE_IF_FAILURE
+    }
 
     // A 2-arg `if(cond, then)` is semantically `if(cond, then, null)`, so it
-    // matches a plan's 3-arg `if` with a typed-null else.
-    if (call->name() == "if" && call->inputs().size() == 3 &&
+    // matches a plan's 3-arg conditional with a typed-null else.
+    if (isConditional(call->name()) && call->inputs().size() == 3 &&
         expectedCall->inputs().size() == 2 &&
         isNullConstant(call->inputs()[2])) {
       matchChildren(

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -586,14 +586,22 @@ class OrderByMatcher : public PlanMatcherImpl<OrderByNode> {
 
   OrderByMatcher(
       const std::shared_ptr<PlanMatcher>& matcher,
-      const std::vector<std::string>& ordering)
-      : PlanMatcherImpl<OrderByNode>({matcher}), ordering_{ordering} {}
+      const std::vector<std::string>& ordering,
+      std::optional<bool> partial = std::nullopt)
+      : PlanMatcherImpl<OrderByNode>({matcher}),
+        ordering_{ordering},
+        partial_{partial} {}
 
   MatchResult matchDetails(
       const OrderByNode& plan,
       const std::unordered_map<std::string, std::string>& symbols)
       const override {
     SCOPED_TRACE(plan.toString(true, false));
+
+    if (partial_.has_value()) {
+      EXPECT_EQ(plan.isPartial(), partial_.value());
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
 
     if (!ordering_.empty()) {
       EXPECT_EQ(plan.sortingOrders().size(), ordering_.size());
@@ -619,6 +627,7 @@ class OrderByMatcher : public PlanMatcherImpl<OrderByNode> {
 
  private:
   const std::vector<std::string> ordering_;
+  const std::optional<bool> partial_;
 };
 
 class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
@@ -973,7 +982,15 @@ class ShuffleBoundaryMatcher : public PlanMatcher {
       : producerMatcher_(std::move(producerMatcher)),
         type_(type),
         keys_(std::move(keys)),
-        replicateNullsAndAny_(replicateNullsAndAny) {}
+        replicateNullsAndAny_(replicateNullsAndAny) {
+    VELOX_CHECK(
+        keys_.empty() || type == ShuffleType::kPartitioned ||
+            type == ShuffleType::kOrdered,
+        "Shuffle keys apply only to partitioned and ordered shuffles");
+    VELOX_CHECK(
+        !replicateNullsAndAny_.has_value() || type == ShuffleType::kPartitioned,
+        "replicateNullsAndAny applies only to a partitioned shuffle");
+  }
 
   MatchResult match(
       const PlanNodePtr& plan,
@@ -988,7 +1005,11 @@ class ShuffleBoundaryMatcher : public PlanMatcher {
  private:
   const std::shared_ptr<PlanMatcher> producerMatcher_;
   const std::optional<ShuffleType> type_;
+  // Type-specific: partition keys for kPartitioned, ORDER BY expressions
+  // (key + optional ASC/DESC and NULLS FIRST/LAST) for kOrdered; empty for
+  // kGather / kBroadcast / kArbitrary (enforced by the constructor).
   const std::vector<std::string> keys_;
+  // Set only for kPartitioned (enforced by the constructor).
   const std::optional<bool> replicateNullsAndAny_;
 };
 
@@ -1010,9 +1031,119 @@ const axiom::optimizer::ExecutableFragment* findProducerFragment(
   return nullptr;
 }
 
-// Implementation of ShuffleBoundaryMatcher::match.
-// When context is set, verifies Exchange and matches producer.
-// Otherwise, throws an error.
+// Verifies the consumer node at a shuffle boundary: a MergeExchange for an
+// ordered shuffle, a plain Exchange otherwise.
+void verifyShuffleConsumer(
+    const PlanNodePtr& plan,
+    std::optional<ShuffleType> type) {
+  if (type == ShuffleType::kOrdered) {
+    EXPECT_TRUE(dynamic_cast<const MergeExchangeNode*>(plan.get()) != nullptr)
+        << "Expected MergeExchange at shuffle boundary, but got "
+        << plan->toString(false, false);
+  } else {
+    EXPECT_TRUE(dynamic_cast<const ExchangeNode*>(plan.get()) != nullptr)
+        << "Expected Exchange at shuffle boundary, but got "
+        << plan->toString(false, false);
+  }
+}
+
+// Verifies the producer PartitionedOutput's kind matches the shuffle type and
+// its replicate-nulls flag matches when specified.
+void verifyShuffleProducer(
+    const PartitionedOutputNode& producer,
+    std::optional<ShuffleType> type,
+    std::optional<bool> replicateNullsAndAny) {
+  if (type.has_value()) {
+    switch (type.value()) {
+      case ShuffleType::kBroadcast:
+        EXPECT_TRUE(producer.isBroadcast())
+            << "Expected broadcast PartitionedOutput";
+        break;
+      case ShuffleType::kGather:
+        EXPECT_EQ(producer.numPartitions(), 1)
+            << "Expected gather (single partition) PartitionedOutput, but got "
+            << producer.numPartitions() << " partitions";
+        break;
+      case ShuffleType::kPartitioned:
+        EXPECT_FALSE(producer.isBroadcast())
+            << "Expected partitioned PartitionedOutput, but got broadcast";
+        AXIOM_TEST_RETURN_IF_FAILURE_VOID
+        EXPECT_GT(producer.numPartitions(), 1)
+            << "Expected partitioned PartitionedOutput with multiple "
+               "partitions, but got "
+            << producer.numPartitions();
+        break;
+      case ShuffleType::kOrdered:
+        // Verified via the MergeExchange consumer.
+        break;
+      case ShuffleType::kArbitrary:
+        EXPECT_TRUE(producer.isArbitrary());
+        break;
+    }
+    AXIOM_TEST_RETURN_IF_FAILURE_VOID
+  }
+
+  if (replicateNullsAndAny.has_value()) {
+    EXPECT_EQ(producer.isReplicateNullsAndAny(), replicateNullsAndAny.value());
+  }
+}
+
+// Verifies the MergeExchange's sort keys and orders against the expected ORDER
+// BY expressions (key + optional ASC/DESC and NULLS FIRST/LAST).
+void verifyMergeOrdering(
+    const MergeExchangeNode& merge,
+    const std::vector<std::string>& ordering,
+    const std::unordered_map<std::string, std::string>& symbols) {
+  EXPECT_EQ(merge.sortingKeys().size(), ordering.size())
+      << "Sorting key count mismatch";
+  AXIOM_TEST_RETURN_IF_FAILURE_VOID
+
+  for (size_t i = 0; i < ordering.size(); ++i) {
+    auto expected =
+        parse::DuckSqlExpressionsParser().parseOrderByExpr(ordering[i]);
+    auto expectedExpr = expected.expr;
+    if (!symbols.empty()) {
+      expectedExpr = rewriteInputNames(expectedExpr, symbols);
+    }
+    EXPECT_EQ(merge.sortingKeys()[i]->toString(), expectedExpr->toString());
+    EXPECT_EQ(merge.sortingOrders()[i].isAscending(), expected.ascending);
+    EXPECT_EQ(merge.sortingOrders()[i].isNullsFirst(), expected.nullsFirst);
+    AXIOM_TEST_RETURN_IF_FAILURE_VOID
+  }
+}
+
+// Verifies the producer PartitionedOutput's partition keys against the expected
+// key names, applying symbol rewriting.
+void verifyPartitionKeys(
+    const PartitionedOutputNode& producer,
+    const std::vector<std::string>& keys,
+    const std::unordered_map<std::string, std::string>& symbols) {
+  const auto& actualKeys = producer.keys();
+  EXPECT_EQ(actualKeys.size(), keys.size())
+      << "Partition key count mismatch: expected " << keys.size() << ", got "
+      << actualKeys.size();
+  AXIOM_TEST_RETURN_IF_FAILURE_VOID
+
+  for (size_t i = 0; i < keys.size(); ++i) {
+    auto expectedKey = keys[i];
+    auto it = symbols.find(expectedKey);
+    if (it != symbols.end()) {
+      expectedKey = it->second;
+    }
+
+    auto fieldAccess =
+        std::dynamic_pointer_cast<const FieldAccessTypedExpr>(actualKeys[i]);
+    EXPECT_TRUE(fieldAccess != nullptr)
+        << "Partition key at index " << i << " is not a field access";
+    AXIOM_TEST_RETURN_IF_FAILURE_VOID
+
+    EXPECT_EQ(fieldAccess->name(), expectedKey)
+        << "Partition key mismatch at index " << i;
+  }
+}
+
+// When context is set, verifies the consumer/producer exchange nodes and
+// matches the producer fragment; otherwise fails.
 PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
     const PlanNodePtr& plan,
     const std::unordered_map<std::string, std::string>& symbols,
@@ -1022,27 +1153,15 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
       "Cannot match PlanMatcher with shuffle boundaries against a single "
       "PlanNodePtr. Use match(MultiFragmentPlan) for distributed plans.");
 
-  // Verify the plan is an Exchange or MergeExchange.
-  if (type_ == ShuffleType::kOrdered) {
-    EXPECT_TRUE(dynamic_cast<const MergeExchangeNode*>(plan.get()) != nullptr)
-        << "Expected MergeExchange at shuffle boundary, but got "
-        << plan->toString(false, false);
-  } else {
-    EXPECT_TRUE(dynamic_cast<const ExchangeNode*>(plan.get()) != nullptr)
-        << "Expected Exchange at shuffle boundary, but got "
-        << plan->toString(false, false);
-  }
+  verifyShuffleConsumer(plan, type_);
   AXIOM_TEST_RETURN_IF_FAILURE
 
-  // Find the producer fragment.
   const auto* producerFragment = findProducerFragment(plan->id(), *context);
   EXPECT_TRUE(producerFragment != nullptr)
       << "Could not find producer fragment for Exchange " << plan->id();
   AXIOM_TEST_RETURN_IF_FAILURE
 
-  // Match the producer fragment (expects PartitionedOutput at root).
   const auto& fragmentPlan = producerFragment->fragment.planNode;
-
   const auto* partitionedOutput =
       dynamic_cast<const PartitionedOutputNode*>(fragmentPlan.get());
   EXPECT_TRUE(partitionedOutput != nullptr)
@@ -1050,51 +1169,11 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
       << fragmentPlan->toString(false, false);
   AXIOM_TEST_RETURN_IF_FAILURE
 
-  // Verify shuffle type specific constraints if type is specified.
-  if (type_.has_value()) {
-    switch (type_.value()) {
-      case ShuffleType::kBroadcast:
-        EXPECT_TRUE(partitionedOutput->isBroadcast())
-            << "Expected broadcast PartitionedOutput, but got "
-            << fragmentPlan->toString(false, false);
-        AXIOM_TEST_RETURN_IF_FAILURE
-        break;
-      case ShuffleType::kGather:
-        EXPECT_EQ(partitionedOutput->numPartitions(), 1)
-            << "Expected gather (single partition) PartitionedOutput, but got "
-            << partitionedOutput->numPartitions() << " partitions";
-        AXIOM_TEST_RETURN_IF_FAILURE
-        break;
-      case ShuffleType::kPartitioned:
-        EXPECT_FALSE(partitionedOutput->isBroadcast())
-            << "Expected partitioned PartitionedOutput, but got broadcast";
-        AXIOM_TEST_RETURN_IF_FAILURE
-        EXPECT_GT(partitionedOutput->numPartitions(), 1)
-            << "Expected partitioned PartitionedOutput with multiple "
-               "partitions, but got "
-            << partitionedOutput->numPartitions();
-        AXIOM_TEST_RETURN_IF_FAILURE
-        break;
-      case ShuffleType::kOrdered:
-        // Already verified above with MergeExchange check.
-        break;
-      case ShuffleType::kArbitrary:
-        EXPECT_TRUE(partitionedOutput->isArbitrary());
-        AXIOM_TEST_RETURN_IF_FAILURE
-        break;
-    }
-  }
+  verifyShuffleProducer(*partitionedOutput, type_, replicateNullsAndAny_);
+  AXIOM_TEST_RETURN_IF_FAILURE
 
-  // Verify replicateNullsAndAny if specified.
-  if (replicateNullsAndAny_.has_value()) {
-    EXPECT_EQ(
-        partitionedOutput->isReplicateNullsAndAny(),
-        replicateNullsAndAny_.value());
-    AXIOM_TEST_RETURN_IF_FAILURE
-  }
-
-  // Match the producer first so its symbols are available for the partition
-  // key lookup below (keys reference producer-fragment column names).
+  // Match the producer first so its symbols are available for the key lookups
+  // below (keys reference producer-fragment column names).
   DistributedMatchContext producerContext{
       context->fragments, producerFragment, context->taskPrefixToFragmentIndex};
   auto producerResult = producerMatcher_->match(
@@ -1104,27 +1183,13 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
   }
 
   if (!keys_.empty()) {
-    const auto& actualKeys = partitionedOutput->keys();
-    EXPECT_EQ(actualKeys.size(), keys_.size())
-        << "Partition key count mismatch: expected " << keys_.size() << ", got "
-        << actualKeys.size();
-    AXIOM_TEST_RETURN_IF_FAILURE
-
-    for (size_t i = 0; i < keys_.size(); ++i) {
-      auto expectedKey = keys_[i];
-      auto it = producerResult.symbols.find(expectedKey);
-      if (it != producerResult.symbols.end()) {
-        expectedKey = it->second;
-      }
-
-      auto fieldAccess =
-          std::dynamic_pointer_cast<const FieldAccessTypedExpr>(actualKeys[i]);
-      EXPECT_TRUE(fieldAccess != nullptr)
-          << "Partition key at index " << i << " is not a field access";
-      AXIOM_TEST_RETURN_IF_FAILURE
-
-      EXPECT_EQ(fieldAccess->name(), expectedKey)
-          << "Partition key mismatch at index " << i;
+    if (type_ == ShuffleType::kOrdered) {
+      verifyMergeOrdering(
+          *static_cast<const MergeExchangeNode*>(plan.get()),
+          keys_,
+          producerResult.symbols);
+    } else {
+      verifyPartitionKeys(*partitionedOutput, keys_, producerResult.symbols);
     }
     AXIOM_TEST_RETURN_IF_FAILURE
   }
@@ -2057,6 +2122,14 @@ PlanMatcherBuilder& PlanMatcherBuilder::shuffleMerge() {
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::shuffleMerge(
+    const std::vector<std::string>& ordering) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
+      matcher_, ShuffleType::kOrdered, ordering);
+  return *this;
+}
+
 PlanMatcherBuilder& PlanMatcherBuilder::broadcast() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
@@ -2247,7 +2320,16 @@ PlanMatcherBuilder& PlanMatcherBuilder::topNRowNumber(
 PlanMatcherBuilder& PlanMatcherBuilder::distributedMarkDistinct(
     const std::vector<std::string>& keys,
     const std::vector<std::string>& markerAliases) {
-  return shuffle().localPartition(keys).markDistinct(keys, markerAliases);
+  shuffle();
+  if (localExchanges_) {
+    localPartition(keys);
+  }
+  return markDistinct(keys, markerAliases);
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::multiThreaded(bool enabled) {
+  localExchanges_ = enabled;
+  return *this;
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::distributedAggregation(
@@ -2255,20 +2337,43 @@ PlanMatcherBuilder& PlanMatcherBuilder::distributedAggregation(
     const std::vector<std::string>& aggregates) {
   partialAggregation(groupingKeys, aggregates);
   if (groupingKeys.empty()) {
-    gather().localGather();
+    gather();
+    if (localExchanges_) {
+      localGather();
+    }
   } else {
-    shuffle(groupingKeys).localPartition(groupingKeys);
+    shuffle(groupingKeys);
+    if (localExchanges_) {
+      localPartition(groupingKeys);
+    }
   }
   return finalAggregation();
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::distributedOrderBy(
+    const std::vector<std::string>& ordering) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<OrderByMatcher>(
+      matcher_, ordering, /*partial=*/localExchanges_);
+  if (localExchanges_) {
+    localMerge();
+  }
+  return shuffleMerge(ordering);
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::distributedSingleAggregation(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates) {
   if (groupingKeys.empty()) {
-    gather().localGather();
+    gather();
+    if (localExchanges_) {
+      localGather();
+    }
   } else {
-    shuffle(groupingKeys).localPartition(groupingKeys);
+    shuffle(groupingKeys);
+    if (localExchanges_) {
+      localPartition(groupingKeys);
+    }
   }
   return singleAggregation(groupingKeys, aggregates);
 }

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -441,6 +441,12 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffleMerge();
 
+  /// Like `shuffleMerge()`, additionally verifying the MergeExchange's sort
+  /// ordering. Each entry is an ORDER BY expression with optional direction,
+  /// e.g. "c" or "c DESC NULLS FIRST". Supports symbol rewriting from the
+  /// producer matcher.
+  PlanMatcherBuilder& shuffleMerge(const std::vector<std::string>& ordering);
+
   /// Matches a broadcast shuffle boundary in a distributed plan.
   /// Verifies that PartitionedOutputNode::isBroadcast() is true.
   PlanMatcherBuilder& broadcast();
@@ -575,23 +581,43 @@ class PlanMatcherBuilder {
       int32_t limit);
 
   /// Matches the distributed mark-distinct pattern:
-  /// shuffle → localPartition(keys) → markDistinct(keys, markerAliases).
+  /// shuffle → localPartition(keys) → markDistinct(keys, markerAliases). The
+  /// localPartition is expected only in multiThreaded() mode.
   PlanMatcherBuilder& distributedMarkDistinct(
       const std::vector<std::string>& keys,
       const std::vector<std::string>& markerAliases);
 
+  /// Sets whether this matcher describes a multi-threaded (numDrivers > 1)
+  /// plan. When enabled (the default for a new builder), the distributed*
+  /// helpers (distributedAggregation, distributedSingleAggregation,
+  /// distributedOrderBy, distributedMarkDistinct) expect the additional
+  /// local-exchange nodes that intra-node parallelism inserts, e.g.
+  /// localPartition/localGather before a final aggregation and a partial sort +
+  /// LocalMerge before a merge boundary. Pass false for a single-driver plan.
+  PlanMatcherBuilder& multiThreaded(bool enabled);
+
   /// Matches the distributed (split) aggregation pattern:
   /// partialAggregation(groupingKeys, aggregates) → shuffle →
   /// localPartition(groupingKeys) → finalAggregation.
-  /// For empty groupingKeys, uses localGather instead of localPartition.
+  /// For empty groupingKeys, uses gather instead of shuffle. The local exchange
+  /// (localPartition / localGather) between the shuffle and the final
+  /// aggregation is expected only in multiThreaded() mode.
   PlanMatcherBuilder& distributedAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
 
+  /// Matches the distributed sort feeding a MergeExchange: an OrderBy on
+  /// 'ordering' followed by the merge boundary (see shuffleMerge). In
+  /// multiThreaded() mode the OrderBy is partial and a LocalMerge precedes the
+  /// boundary; otherwise the OrderBy is final and there is no LocalMerge.
+  PlanMatcherBuilder& distributedOrderBy(
+      const std::vector<std::string>& ordering);
+
   /// Matches the distributed single-step aggregation pattern:
   /// shuffle → localPartition(groupingKeys) → singleAggregation(groupingKeys,
-  /// aggregates). For empty groupingKeys, uses localGather instead of
-  /// localPartition.
+  /// aggregates). For empty groupingKeys, uses gather instead of shuffle. The
+  /// local exchange (localPartition / localGather) between the shuffle and the
+  /// aggregation is expected only in multiThreaded() mode.
   PlanMatcherBuilder& distributedSingleAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
@@ -662,6 +688,11 @@ class PlanMatcherBuilder {
 
  private:
   std::shared_ptr<PlanMatcher> matcher_;
+
+  // When true, distributed helpers expect the local exchanges that
+  // numDrivers > 1 inserts. Defaults to true to match the default multi-driver
+  // plan config; set via multiThreaded(false) for single-driver plans.
+  bool localExchanges_{true};
 };
 
 } // namespace facebook::velox::core

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -61,6 +61,25 @@ class TpchPlanTest : public test::QueryTestBase {
     return toSingleNodePlan(
         parseSelect(test::readTpchSql(name), kTestConnectorId));
   }
+
+  // Options for a multi-node plan-shape check. numWorkers > 1 splits the plan
+  // into fragments; numDrivers > 1 adds intra-node local exchanges.
+  struct MultiNodeOptions {
+    int32_t query;
+    int32_t numWorkers{2};
+    int32_t numDrivers{1};
+  };
+
+  std::shared_ptr<const MultiFragmentPlan> planTpchMultiNode(
+      const MultiNodeOptions& options) {
+    return planVelox(
+               parseTpch(options.query),
+               {
+                   .numWorkers = options.numWorkers,
+                   .numDrivers = options.numDrivers,
+               })
+        .plan;
+  }
 };
 
 // Verifies that the injected statistics produce the expected base-table
@@ -87,13 +106,44 @@ TEST_F(TpchPlanTest, stats) {
 
 TEST_F(TpchPlanTest, q01) {
   // agg(lineitem)
+  const auto filter = "l_shipdate < date '1998-09-03'";
   auto matcher = matchScan("lineitem")
-                     .filter("l_shipdate < date '1998-09-03'")
+                     .filter(filter)
                      .project()
                      .aggregation()
                      .orderBy()
                      .build();
   AXIOM_ASSERT_PLAN(planTpch(1), matcher);
+
+  auto distributed = [&](bool isMultiThreaded) {
+    return matchScan("lineitem")
+        .multiThreaded(isMultiThreaded)
+        .filter(filter)
+        .project(
+            {"l_returnflag",
+             "l_linestatus",
+             "l_quantity",
+             "l_extendedprice",
+             "l_extendedprice * (1.0 - l_discount) as disc_price",
+             "l_extendedprice * (1.0 - l_discount) * (l_tax + 1.0) as charge",
+             "l_discount"})
+        .distributedAggregation(
+            {"l_returnflag", "l_linestatus"},
+            {"sum(l_quantity)",
+             "sum(l_extendedprice)",
+             "sum(disc_price)",
+             "sum(charge)",
+             "avg(l_quantity)",
+             "avg(l_extendedprice)",
+             "avg(l_discount)",
+             "count()"})
+        .distributedOrderBy({"l_returnflag", "l_linestatus"})
+        .build();
+  };
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 1, .numDrivers = 1}), distributed(false));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 1, .numDrivers = 4}), distributed(true));
 }
 
 TEST_F(TpchPlanTest, q02) {
@@ -224,15 +274,25 @@ TEST_F(TpchPlanTest, q05) {
 
 TEST_F(TpchPlanTest, q06) {
   // agg(lineitem)
+  const auto filter =
+      "\"and\"(l_shipdate >= date '1994-01-01', l_shipdate < date '1995-01-01', "
+      "         l_discount between 0.05 and 0.07, l_quantity < 24.0)";
   auto matcher =
-      matchScan("lineitem")
-          .filter(
-              "\"and\"(l_shipdate >= date '1994-01-01', l_shipdate < date '1995-01-01', "
-              "         l_discount between 0.05 and 0.07, l_quantity < 24.0)")
-          .project()
-          .aggregation()
-          .build();
+      matchScan("lineitem").filter(filter).project().aggregation().build();
   AXIOM_ASSERT_PLAN(planTpch(6), matcher);
+
+  auto distributed = [&](bool isMultiThreaded) {
+    return matchScan("lineitem")
+        .multiThreaded(isMultiThreaded)
+        .filter(filter)
+        .project({"l_extendedprice * l_discount as revenue"})
+        .distributedAggregation({}, {"sum(revenue)"})
+        .build();
+  };
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 6, .numDrivers = 1}), distributed(false));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 6, .numDrivers = 4}), distributed(true));
 }
 
 TEST_F(TpchPlanTest, q07) {
@@ -436,20 +496,36 @@ TEST_F(TpchPlanTest, q11) {
 
 TEST_F(TpchPlanTest, q12) {
   // agg((orders INNER lineitem))
+  const auto filter =
+      "\"and\"(l_shipmode in ('MAIL', 'SHIP'), l_receiptdate >= date '1994-01-01', "
+      "         l_receiptdate < date '1995-01-01', l_commitdate < l_receiptdate, "
+      "         l_shipdate < l_commitdate)";
   auto matcher =
       matchScan("orders")
-          .hashJoinInner(
-              matchScan("lineitem")
-                  .filter(
-                      "\"and\"(l_shipmode in ('MAIL', 'SHIP'), l_receiptdate >= date '1994-01-01', "
-                      "         l_receiptdate < date '1995-01-01', l_commitdate < l_receiptdate, "
-                      "         l_shipdate < l_commitdate)")
-                  .build())
+          .hashJoinInner(matchScan("lineitem").filter(filter).build())
           .project()
           .aggregation()
           .orderBy()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(12), matcher);
+
+  auto distributed = [&](bool isMultiThreaded) {
+    return matchScan("orders")
+        .multiThreaded(isMultiThreaded)
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .project(
+            {"l_shipmode",
+             "if(o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH', 1, 0) as high_line_count",
+             "if(o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH', 1, 0) as low_line_count"})
+        .distributedAggregation(
+            {"l_shipmode"}, {"sum(high_line_count)", "sum(low_line_count)"})
+        .distributedOrderBy({"l_shipmode"})
+        .build();
+  };
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 12, .numDrivers = 1}), distributed(false));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 12, .numDrivers = 4}), distributed(true));
 }
 
 TEST_F(TpchPlanTest, q13) {
@@ -467,18 +543,32 @@ TEST_F(TpchPlanTest, q13) {
 
 TEST_F(TpchPlanTest, q14) {
   // agg((part INNER lineitem))
+  const auto filter =
+      "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'";
   auto matcher =
       matchScan("part")
-          .hashJoinInner(
-              matchScan("lineitem")
-                  .filter(
-                      "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'")
-                  .build())
+          .hashJoinInner(matchScan("lineitem").filter(filter).build())
           .project()
           .aggregation()
           .project()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(14), matcher);
+
+  auto distributed = [&](bool isMultiThreaded) {
+    return matchScan("part")
+        .multiThreaded(isMultiThreaded)
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .project(
+            {"if(p_type like 'PROMO%', l_extendedprice * (1.0 - l_discount), 0.0) as promo",
+             "l_extendedprice * (1.0 - l_discount) as disc_price"})
+        .distributedAggregation({}, {"sum(promo)", "sum(disc_price)"})
+        .project()
+        .build();
+  };
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 14, .numDrivers = 1}), distributed(false));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 14, .numDrivers = 4}), distributed(true));
 }
 
 // The `revenue` CTE is computed twice — once as the supplier join's build side


### PR DESCRIPTION
Summary:
Extends the v1 TpchPlanTest to assert the multi-node plan shape for q1, q6, q12, and q14, not just the single-node shape. Each query is now checked in three configurations:

  - single-node
  - multi-node, single-threaded (numDrivers=1)
  - multi-node, multi-threaded (numDrivers=4)

so the checks cover how the plan's remote and local exchanges appear as fragmentation and intra-node parallelism vary.

To express this, PlanMatcher gains a plan-wide `multiThreaded()` setting that the distributed* helpers read to decide whether to expect the local exchanges intra-node parallelism inserts, plus a `distributedOrderBy` helper that owns the sort-then-MergeExchange pattern. `if` and `switch` now match interchangeably, since both lower to the same Velox SwitchExpr.

Also fixes a redundant operator this coverage surfaced: a distributed ORDER BY at one driver emitted an `OrderBy[PARTIAL]` + `LocalMerge` that merged a single sorted run. It now emits a plain final sort feeding the MergeExchange.

Differential Revision: D110266770


