### PR TITLE
test(optimizer): Cover q16 distributed plan shape

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -726,6 +726,10 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
                 .core::CallExpr::toString());
         AXIOM_TEST_RETURN_IF_FAILURE
 
+        EXPECT_EQ(plan.aggregates()[i].distinct, aggregateExpr->isDistinct())
+            << "DISTINCT mismatch for aggregate " << i;
+        AXIOM_TEST_RETURN_IF_FAILURE
+
         auto expectedMask = aggregateExpr->filter();
         const auto& mask = plan.aggregates()[i].mask;
         EXPECT_EQ(mask != nullptr, expectedMask != nullptr);

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -601,24 +601,51 @@ TEST_F(TpchPlanTest, q15) {
 }
 
 TEST_F(TpchPlanTest, q16) {
+  const auto partFilter =
+      "\"and\"(p_brand <> 'Brand#45', p_type not like 'MEDIUM POLISHED%', "
+      "         p_size in (49, 14, 23, 45, 19, 3, 36, 9))";
   // agg(((partsupp INNER part) ANTI supplier))
   auto matcher =
       matchScan("partsupp")
-          .hashJoinInner(
-              matchScan("part")
-                  .filter(
-                      "\"and\"(p_brand <> 'Brand#45', p_type not like 'MEDIUM POLISHED%', "
-                      "         p_size in (49, 14, 23, 45, 19, 3, 36, 9))")
-                  .build())
+          .hashJoinInner(matchScan("part").filter(partFilter).build())
           .hashJoinAnti(
               matchScan("supplier")
                   .filter("s_comment like '%Customer%Complaints%'")
                   .build(),
               {.nullAware = true})
-          .aggregation()
+          .singleAggregation(
+              {"p_brand", "p_type", "p_size"},
+              {"count(distinct ps_suppkey) as supplier_cnt"})
           .orderBy()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(16), matcher);
+
+  // Distributed: part and supplier broadcast to the partsupp probe (INNER then
+  // null-aware ANTI); the distinct count becomes a dedup aggregation on the
+  // grouping keys plus ps_suppkey feeding a plain count on the grouping keys.
+  auto distributed = [&](bool isMultiThreaded) {
+    return matchScan("partsupp")
+        .multiThreaded(isMultiThreaded)
+        .hashJoinInner(matchScan("part").filter(partFilter).broadcast().build())
+        .hashJoinAnti(
+            matchScan("supplier")
+                .filter("s_comment like '%Customer%Complaints%'")
+                .broadcast()
+                .build(),
+            {.nullAware = true})
+        .distributedSingleAggregation(
+            {"p_brand", "p_type", "p_size", "ps_suppkey"}, {})
+        .distributedSingleAggregation(
+            {"p_brand", "p_type", "p_size"},
+            {"count(ps_suppkey) as supplier_cnt"})
+        .distributedOrderBy(
+            {"supplier_cnt DESC", "p_brand", "p_type", "p_size"})
+        .build();
+  };
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 16, .numDrivers = 1}), distributed(false));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      planTpchMultiNode({.query = 16, .numDrivers = 4}), distributed(true));
 }
 
 TEST_F(TpchPlanTest, q17) {


### PR DESCRIPTION
Summary:
Adds the multi-node plan-shape check for q16 to `TpchPlanTest`. At one node, `count(distinct ps_suppkey)` is a single native distinct aggregation. Once distributed, it becomes a dedup aggregation feeding a plain count.

The aggregation matcher now also verifies each aggregate's DISTINCT flag, which had been left unchecked, so q16's single-node native distinct is actually asserted. The single-node q16 matcher is also tightened from a bare `aggregation()` to explicit grouping keys and the `count(distinct ...)` call.

Differential Revision: D110283756


