### PR TITLE
misc: Add table references to completions

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -500,6 +500,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
       parseCpuNanos = velox::process::threadCpuNanos() - cpuStart;
     }
     completionInfo.startInfo.queryType = statement->kind();
+    completionInfo.referencedTables = statement->referencedTables();
     completionInfo.runtimeStats->recordTiming(
         QueryRuntimeStats::kParseWallNanos,
         std::chrono::microseconds(completionInfo.timing.parse));

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -112,6 +112,9 @@ struct QueryCompletionInfo {
   /// Carries query ID, SQL text, and creation timestamp from the start event.
   QueryStartInfo startInfo;
 
+  /// Tables referenced by the parsed statement. Unset when parsing fails.
+  std::optional<presto::ReferencedTables> referencedTables;
+
   /// Contains error details when the query fails; std::nullopt on success.
   std::optional<ErrorInfo> errorInfo;
 


### PR DESCRIPTION
Summary:
Query completion consumers need referenced-table information so they can make decisions based on whether the query referenced any table and which catalogs those tables came from. For example, query logging can skip certain lineage logging when no table is referenced, or when a catalog such as tpch is the only catalog used by the query.
This also lets consumers tell a parsed no-table statement from a query whose references are unknown. For example, VALUES (1) parses successfully and has no table references; a parse failure does not know whether the query touched a table.
Adds ReferencedTables to QueryCompletionInfo and fills it after SqlStatement parsing succeeds. QueryStartInfo stays unchanged because it is emitted before parsing.

Differential Revision: D110271541


