### PR TITLE
feat(optimizer): Lower WITH RECURSIVE to FixedPointNode

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -266,6 +266,16 @@ void DerivedTable::checkConsistency() const {
     return;
   }
 
+  if (isFixedPoint()) {
+    VELOX_CHECK_NOT_NULL(
+        fixedPoint.anchor, "FixedPoint DT missing anchor: {}", cname);
+    VELOX_CHECK_NOT_NULL(
+        fixedPoint.step, "FixedPoint DT missing step: {}", cname);
+    fixedPoint.anchor->checkConsistency();
+    fixedPoint.step->checkConsistency();
+    return;
+  }
+
   // Verifies that all tables referenced by expressions in 'exprs' are in
   // tableSet or 'this'.
   auto checkTableReferences = [&](const ExprVector& expressions,
@@ -571,7 +581,14 @@ void DerivedTable::initializePlans() {
 void DerivedTable::distributeAllConjuncts() {
   distributeConjuncts();
 
-  if (!isUnion()) {
+  if (isUnion()) {
+    for (auto* child : unionInputs) {
+      child->distributeAllConjuncts();
+    }
+  } else if (isFixedPoint()) {
+    fixedPoint.anchor->distributeAllConjuncts();
+    fixedPoint.step->distributeAllConjuncts();
+  } else {
     for (auto* table : tables) {
       if (table->is(PlanType::kDerivedTableNode)) {
         const_cast<PlanObject*>(table)
@@ -579,28 +596,13 @@ void DerivedTable::distributeAllConjuncts() {
             ->distributeAllConjuncts();
       }
     }
-  } else {
-    for (auto* child : unionInputs) {
-      child->distributeAllConjuncts();
-    }
   }
 }
 
 void DerivedTable::finalizeJoinsAndMakePlans() {
-  if (!isUnion()) {
-    VELOX_CHECK(!tables.empty());
-    VELOX_CHECK(unionInputs.empty());
-
-    for (auto* table : tables) {
-      if (table->is(PlanType::kDerivedTableNode)) {
-        const_cast<PlanObject*>(table)
-            ->as<DerivedTable>()
-            ->finalizeJoinsAndMakePlans();
-      }
-    }
-  } else {
+  if (isUnion()) {
     VELOX_CHECK(tables.empty());
-    VELOX_CHECK(!unionInputs.empty());
+    VELOX_CHECK_GE(unionInputs.size(), 2);
 
     for (auto* child : unionInputs) {
       child->finalizeJoinsAndMakePlans();
@@ -612,6 +614,27 @@ void DerivedTable::finalizeJoinsAndMakePlans() {
     cardinality_ = 0;
     for (const auto* child : unionInputs) {
       cardinality_ = add(cardinality_, child->cardinality());
+    }
+  } else if (isFixedPoint()) {
+    VELOX_CHECK(tables.empty());
+    VELOX_CHECK(unionInputs.empty());
+
+    fixedPoint.anchor->finalizeJoinsAndMakePlans();
+    fixedPoint.step->finalizeJoinsAndMakePlans();
+
+    // See FixedPoint::FixedPoint for cost rationale.
+    cardinality_ =
+        add(fixedPoint.anchor->cardinality(), fixedPoint.step->cardinality());
+  } else {
+    VELOX_CHECK(!tables.empty());
+    VELOX_CHECK(unionInputs.empty());
+
+    for (auto* table : tables) {
+      if (table->is(PlanType::kDerivedTableNode)) {
+        const_cast<PlanObject*>(table)
+            ->as<DerivedTable>()
+            ->finalizeJoinsAndMakePlans();
+      }
     }
   }
 
@@ -1206,6 +1229,7 @@ void DerivedTable::import(
   VELOX_DCHECK(!superTables.empty());
   VELOX_DCHECK(superTables.contains(primaryTable));
   VELOX_DCHECK(!super.isUnion(), "Cannot import from a union DT");
+  VELOX_DCHECK(!super.isFixedPoint(), "Cannot import from a FixedPoint DT");
 
   copySubset(super, superTables);
 
@@ -2321,6 +2345,17 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
     return false;
   }
 
+  // Pushing a filter into the FixedPoint's step changes what feeds back
+  // into the next iteration and can alter the fixpoint. Push a copy into
+  // the anchor as a pre-filter (always safe — the anchor runs once like any
+  // non-recursive base) but always keep the conjunct on the enclosing DT
+  // so the step's per-iteration output is filtered too.
+  // TODO: Push iteration-invariant predicates into the step as well.
+  if (isFixedPoint()) {
+    fixedPoint.anchor->addFilter(conjunct);
+    return false;
+  }
+
   if (isUnion()) {
     for (auto i = 0; i < unionInputs.size(); ++i) {
       if (!unionInputs[i]->addFilter(conjunct)) {
@@ -2614,6 +2649,12 @@ bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
       return false;
     }
     return true;
+  }
+
+  if (table->is(PlanType::kWorkingTableNode)) {
+    // No own filter accumulator. Conjunct stays on the enclosing DT and
+    // lowers as a Filter RelOp on top of WorkingTableScan.
+    return false;
   }
 
   VELOX_CHECK(table->is(PlanType::kTableNode));

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -157,6 +157,21 @@ struct DerivedTable : public TableObject {
     return isUnion() && aggregation == nullptr;
   }
 
+  /// FixedPoint sub-DTs and name. When `anchor` is non-null, all three
+  /// fields are bound and `name` matches `lp::FixedPointNode::name()`.
+  struct FixedPointFields {
+    DerivedTable* anchor{nullptr};
+    DerivedTable* step{nullptr};
+    Name name{nullptr};
+  };
+  FixedPointFields fixedPoint;
+
+  /// True if this DT is a FixedPoint — the optimizer-side counterpart of
+  /// `logical_plan::FixedPointNode`.
+  bool isFixedPoint() const {
+    return fixedPoint.anchor != nullptr;
+  }
+
   /// Single-row DTs (see isSingleRow()) that have no join dependencies in
   /// this DT — not referenced by any join's keys, sides, or filter.
   /// These can be appended at the end of the plan via cross-join, or

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -84,6 +84,8 @@ std::string tableName(PlanObjectCP table) {
       return table->as<ValuesTable>()->cname;
     case PlanType::kUnnestTableNode:
       return table->as<UnnestTable>()->cname;
+    case PlanType::kWorkingTableNode:
+      return table->as<WorkingTable>()->name;
     case PlanType::kDerivedTableNode:
       return table->as<DerivedTable>()->cname;
     default:
@@ -124,6 +126,17 @@ std::string visitUnnestTable(const UnnestTable& unnest) {
   std::stringstream out;
   out << headerLine(unnest.cname, unnest.cardinality(), unnest.columns);
   for (const auto& column : unnest.columns) {
+    out << "  " << column->name() << " " << constraintString(column->value())
+        << std::endl;
+  }
+  return out.str();
+}
+
+std::string visitWorkingTable(const WorkingTable& workingTable) {
+  std::stringstream out;
+  out << headerLine(
+      workingTable.name, workingTable.cardinality(), workingTable.columns);
+  for (const auto& column : workingTable.columns) {
     out << "  " << column->name() << " " << constraintString(column->value())
         << std::endl;
   }
@@ -190,11 +203,11 @@ std::string visitDerivedTable(const DerivedTable& dt) {
 
   if (dt.isUnion()) {
     VELOX_CHECK_EQ(0, dt.exprs.size());
-  } else {
+  } else if (!dt.isFixedPoint()) {
     VELOX_CHECK_EQ(dt.columns.size(), dt.exprs.size());
   }
 
-  if (!dt.isUnion()) {
+  if (!dt.isUnion() && !dt.isFixedPoint()) {
     out << "  output:" << std::endl;
     for (auto i = 0; i < dt.columns.size(); ++i) {
       out << "    " << dt.columns.at(i)->name()
@@ -294,6 +307,9 @@ std::string visitDerivedTable(const DerivedTable& dt) {
       case PlanType::kUnnestTableNode:
         out << visitUnnestTable(*table->as<UnnestTable>());
         break;
+      case PlanType::kWorkingTableNode:
+        out << visitWorkingTable(*table->as<WorkingTable>());
+        break;
       case PlanType::kDerivedTableNode:
         out << visitDerivedTable(*table->as<DerivedTable>());
         break;
@@ -318,6 +334,13 @@ std::string visitDerivedTable(const DerivedTable& dt) {
       out << std::endl;
       out << visitDerivedTable(*child);
     }
+  } else if (dt.isFixedPoint()) {
+    out << "  FIXED POINT: " << dt.fixedPoint.anchor->cname << ", "
+        << dt.fixedPoint.step->cname << std::endl;
+    out << std::endl;
+    out << visitDerivedTable(*dt.fixedPoint.anchor);
+    out << std::endl;
+    out << visitDerivedTable(*dt.fixedPoint.step);
   }
 
   return out.str();

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -126,6 +126,9 @@ void collectBaseTables(DerivedTable* dt, std::vector<BaseTable*>& baseTables) {
     for (auto* child : dt->unionInputs) {
       collectBaseTables(child, baseTables);
     }
+  } else if (dt->isFixedPoint()) {
+    collectBaseTables(dt->fixedPoint.anchor, baseTables);
+    collectBaseTables(dt->fixedPoint.step, baseTables);
   } else {
     for (auto* table : dt->tables) {
       if (table->is(PlanType::kTableNode)) {
@@ -3430,6 +3433,14 @@ void Optimization::makeJoins(PlanState& state) {
       auto* scan = make<Values>(*valuesTable, std::move(columns));
       state.addCost(*scan);
       makeJoins(scan, state);
+    } else if (from->is(PlanType::kWorkingTableNode)) {
+      const auto* workingTable = from->as<WorkingTable>();
+      PlanStateSaver save{state};
+      state.place(workingTable);
+      state.placeColumns(workingTable->columns);
+      auto* scan = make<WorkingTableScan>(*workingTable, workingTable->columns);
+      state.addCost(*scan);
+      makeJoins(scan, state);
     } else if (from->is(PlanType::kUnnestTableNode)) {
       VELOX_FAIL("UnnestTable cannot be a starting table");
       // Because it's rigth side of directed inner (cross) join edge.
@@ -3513,7 +3524,20 @@ RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   PlanState state(*this, &dt, options().syntacticJoinOrder);
   RelationOpPtr result;
 
-  if (dt.isUnion()) {
+  if (dt.isFixedPoint()) {
+    auto* anchorPlans = memo_.find(dt.fixedPoint.anchor->memoKey());
+    auto* stepPlans = memo_.find(dt.fixedPoint.step->memoKey());
+    VELOX_CHECK(
+        anchorPlans != nullptr && anchorPlans->best() != nullptr,
+        "FixedPoint anchor has no planned entry");
+    VELOX_CHECK(
+        stepPlans != nullptr && stepPlans->best() != nullptr,
+        "FixedPoint step has no planned entry");
+
+    result = make<FixedPoint>(
+        dt.fixedPoint.name, anchorPlans->best()->op, stepPlans->best()->op);
+    state.plans.addPlan(result, state);
+  } else if (dt.isUnion()) {
     // Union: assemble from already-planned children.
     RelationOpPtrVector childOps;
     for (auto* childDt : dt.unionInputs) {

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -108,6 +108,12 @@ std::vector<ConfigProperty> buildProperties(
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
           "Bit mask for optimizer trace output: 1=retained, 2=exceeded best, 4=sample, 8=preprocess.",
       },
+      {
+          std::string(OptimizerOptions::kFixedPointMaxIterations),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kFixedPointMaxIterationsDefault),
+          "Safety bound on iterations for a recursive CTE FixedPoint. Must be >= 1.",
+      },
   };
 
   if (configOverrides.empty()) {
@@ -154,6 +160,10 @@ std::string OptimizerOptions::normalize(
     // Throws if 'value' is not a valid capacity string (e.g. "100MB").
     velox::config::toCapacity(
         std::string(value), velox::config::CapacityUnit::BYTE);
+  } else if (name == kFixedPointMaxIterations) {
+    auto iterations = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        iterations, 1, "fixed_point_max_iterations must be >= 1: {}", value);
   }
   return std::string(value);
 }
@@ -194,6 +204,7 @@ OptimizerOptions OptimizerOptions::from(
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
+  setInt(kFixedPointMaxIterations, options.fixedPointMaxIterations);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -53,6 +53,9 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "broadcast_size_limit";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
+  static constexpr std::string_view kFixedPointMaxIterations =
+      "fixed_point_max_iterations";
+
   // Default values — single source of truth for field initializers
   // and properties().
   static constexpr int32_t kParallelProjectWidthDefault = 1;
@@ -70,6 +73,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr uint32_t kTraceFlagsDefault = 0;
   static constexpr bool kSyntacticJoinOrderDefault = false;
   static constexpr bool kAlwaysPlanPartialAggregationDefault = false;
+  static constexpr int32_t kFixedPointMaxIterationsDefault = 1'000;
 
   /// Constructs with code defaults only.
   OptimizerOptions();
@@ -135,6 +139,12 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.
   bool explain{false};
+
+  /// Maximum iterations before a FixedPoint loop errors out as a safety
+  /// bound. Must be >= 1. Matches Presto/Trino/MySQL WITH RECURSIVE
+  /// semantics: exceeding the cap raises rather than silently truncating.
+  /// Forwarded to `velox::core::ConvergenceConfig::maxIterations`.
+  int32_t fixedPointMaxIterations{kFixedPointMaxIterationsDefault};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "sample_joins").

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -31,6 +31,7 @@ const auto& planTypeNames() {
       {PlanType::kTableNode, "TableNode"},
       {PlanType::kValuesTableNode, "ValuesTableNode"},
       {PlanType::kUnnestTableNode, "UnnestTableNode"},
+      {PlanType::kWorkingTableNode, "WorkingTableNode"},
       {PlanType::kDerivedTableNode, "DerivedTableNode"},
       {PlanType::kAggregationNode, "AggregationNode"},
       {PlanType::kWindowPlanNode, "WindowPlanNode"},

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -37,6 +37,7 @@ enum class PlanType : uint32_t {
   kTableNode,
   kValuesTableNode,
   kUnnestTableNode,
+  kWorkingTableNode,
   kDerivedTableNode,
   kAggregationNode,
   kWindowPlanNode,

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -78,6 +78,8 @@ Name cname(PlanObjectCP relation) {
       return relation->as<ValuesTable>()->cname;
     case PlanType::kUnnestTableNode:
       return relation->as<UnnestTable>()->cname;
+    case PlanType::kWorkingTableNode:
+      return relation->as<WorkingTable>()->name;
     case PlanType::kDerivedTableNode:
       return relation->as<DerivedTable>()->cname;
     default:
@@ -391,6 +393,12 @@ std::string ValuesTable::toString() const {
 std::string UnnestTable::toString() const {
   std::stringstream out;
   out << "{" << PlanObject::toString() << cname << "}";
+  return out.str();
+}
+
+std::string WorkingTable::toString() const {
+  std::stringstream out;
+  out << "{" << PlanObject::toString() << "fp:" << name << "}";
   return out.str();
 }
 

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1153,6 +1153,26 @@ struct UnnestTable : public TableObject {
 
 using UnnestTableCP = const UnnestTable*;
 
+/// Placeholder for a reference to the recursive working table of an enclosing
+/// FixedPoint DerivedTable, used inside the FixedPoint's step DT. Stands in
+/// for the LP's `RecursiveReferenceNode` so the step DT can name and consume
+/// the in-progress accumulator the way any other table is named in a `FROM`.
+struct WorkingTable : public TableObject {
+  WorkingTable(Name _name)
+      : TableObject{PlanType::kWorkingTableNode}, name{_name} {}
+
+  /// Name of the enclosing FixedPoint (matches its `fixedPoint.name`).
+  const Name name;
+
+  std::optional<float> cardinality() const override {
+    // Per-iteration frontier is small and workload-dependent. Returning 1
+    // steers the join enumerator to place the working table as the probe.
+    return 1;
+  }
+
+  std::string toString() const override;
+};
+
 using TypeVector = QGVector<const velox::Type*>;
 
 // Aggregate function. The aggregation and arguments are in the

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -59,6 +59,8 @@ const auto& relTypeNames() {
       {RelType::kTopNRowNumber, "TopNRowNumber"},
       {RelType::kMarkDistinct, "MarkDistinct"},
       {RelType::kGroupId, "GroupId"},
+      {RelType::kFixedPoint, "FixedPoint"},
+      {RelType::kWorkingTableScan, "WorkingTableScan"},
   };
 
   return kNames;
@@ -2174,6 +2176,80 @@ GroupId::GroupId(
 }
 
 void GroupId::accept(
+    const RelationOpVisitor& visitor,
+    RelationOpVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+WorkingTableScan::WorkingTableScan(
+    const WorkingTable& workingTable,
+    ColumnVector columns)
+    : RelationOp{
+          RelType::kWorkingTableScan,
+          /*input=*/nullptr,
+          Distribution::gather(),
+          std::move(columns)},
+      name{workingTable.name} {
+  cost_.inputCardinality = 1;
+  updateLeafCost(workingTable.cardinality(), columns_, cost_);
+  for (auto* column : columns_) {
+    constraints_.emplace(column->id(), column->value());
+  }
+}
+
+const QGString& WorkingTableScan::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  key_ = sanitizeHistoryKey(fmt::format("workingscan({})", name));
+  return key_;
+}
+
+void WorkingTableScan::accept(
+    const RelationOpVisitor& visitor,
+    RelationOpVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+FixedPoint::FixedPoint(
+    Name name,
+    RelationOpPtr anchorOp,
+    RelationOpPtr stepOp)
+    : RelationOp{
+          RelType::kFixedPoint,
+          /*input=*/nullptr,
+          anchorOp->distribution(),
+          anchorOp->columns()},
+      name{name},
+      anchor{std::move(anchorOp)},
+      step{std::move(stepOp)} {
+  VELOX_CHECK_NOT_NULL(step);
+  // Single-pass cost over anchor + step. The per-iteration multiplier is
+  // intentionally not applied — convergence depth is workload-dependent and
+  // an arbitrary maxIterations overestimate would push the FP onto the build
+  // side of every enclosing join.
+  cost_.inputCardinality =
+      add(mul(anchor->cost().inputCardinality, anchor->cost().fanout),
+          mul(step->cost().inputCardinality, step->cost().fanout));
+  cost_.fanout = 1;
+  cost_.unitCost = 0;
+  constraints_ = anchor->constraints();
+}
+
+const QGString& FixedPoint::historyKey() const {
+  if (!key_.empty()) {
+    return key_;
+  }
+  key_ = sanitizeHistoryKey(
+      fmt::format(
+          "fixedpoint({},{},{})",
+          name,
+          anchor->historyKey(),
+          step->historyKey()));
+  return key_;
+}
+
+void FixedPoint::accept(
     const RelationOpVisitor& visitor,
     RelationOpVisitorContext& context) const {
   visitor.visit(*this, context);

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -142,6 +142,8 @@ enum class RelType {
   kTopNRowNumber,
   kMarkDistinct,
   kGroupId,
+  kFixedPoint,
+  kWorkingTableScan,
 };
 
 AXIOM_DECLARE_ENUM_NAME(RelType)
@@ -1074,4 +1076,48 @@ struct GroupId : public RelationOp {
 };
 
 using GroupIdCP = const GroupId*;
+
+/// Leaf RelOp that produces rows from the recursive working table of an
+/// enclosing FixedPoint. Appears in the step RelOp tree wherever the LP
+/// had a `lp::RecursiveReferenceNode`.
+struct WorkingTableScan : public RelationOp {
+  WorkingTableScan(const WorkingTable& workingTable, ColumnVector columns);
+
+  const QGString& historyKey() const override;
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+
+  /// Name of the enclosing FixedPoint (matches its `fixedPoint.name`).
+  const Name name;
+};
+
+using WorkingTableScanCP = const WorkingTableScan*;
+
+/// Iterates `step` over a working table seeded by `anchor` until convergence
+/// or a max-iteration bound is hit. The output schema matches
+/// `anchor->columns()`.
+struct FixedPoint : public RelationOp {
+  FixedPoint(Name name, RelationOpPtr anchor, RelationOpPtr step);
+
+  const QGString& historyKey() const override;
+
+  void accept(
+      const RelationOpVisitor& visitor,
+      RelationOpVisitorContext& context) const override;
+
+  /// Name of this FixedPoint (matches `lp::FixedPointNode::name()`).
+  const Name name;
+
+  /// Lowered anchor sub-plan.
+  const RelationOpPtr anchor;
+
+  /// Lowered step sub-plan. Reads the working table via a `WorkingTableScan`
+  /// leaf somewhere in its tree.
+  const RelationOpPtr step;
+};
+
+using FixedPointCP = const FixedPoint*;
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/RelationOpPrinter.cpp
+++ b/axiom/optimizer/RelationOpPrinter.cpp
@@ -315,6 +315,25 @@ class ToTextVisitor : public RelationOpVisitor {
     printInput(*op.input(), myCtx);
   }
 
+  void visit(const WorkingTableScan& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    printHeader(op, myCtx, fmt::format("name={}", op.name));
+    printConstraints(op, myCtx);
+  }
+
+  void visit(const FixedPoint& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    printHeader(op, myCtx, fmt::format("name={}", op.name));
+    printConstraints(op, myCtx);
+    const auto indentation = toIndentation(myCtx.indent + 2);
+    myCtx.out << indentation << "anchor:" << std::endl;
+    printInput(*op.anchor, myCtx);
+    myCtx.out << indentation << "step:" << std::endl;
+    printInput(*op.step, myCtx);
+  }
+
  private:
   static std::string toIndentation(size_t indent) {
     return std::string(indent * 2, ' ');
@@ -553,6 +572,22 @@ class OnelineVisitor : public RelationOpVisitor {
     auto& myCtx = static_cast<Context&>(context);
     myCtx.out << "groupid(";
     op.input()->accept(*this, context);
+    myCtx.out << ")";
+  }
+
+  void visit(const WorkingTableScan& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    myCtx.out << "workingscan(" << op.name << ")";
+  }
+
+  void visit(const FixedPoint& op, RelationOpVisitorContext& context)
+      const override {
+    auto& myCtx = static_cast<Context&>(context);
+    myCtx.out << "fixedpoint(";
+    op.anchor->accept(*this, context);
+    myCtx.out << " => ";
+    op.step->accept(*this, context);
     myCtx.out << ")";
   }
 

--- a/axiom/optimizer/RelationOpVisitor.h
+++ b/axiom/optimizer/RelationOpVisitor.h
@@ -93,6 +93,13 @@ class RelationOpVisitor {
 
   virtual void visit(const GroupId& op, RelationOpVisitorContext& context)
       const = 0;
+
+  virtual void visit(
+      const WorkingTableScan& op,
+      RelationOpVisitorContext& context) const = 0;
+
+  virtual void visit(const FixedPoint& op, RelationOpVisitorContext& context)
+      const = 0;
 };
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -258,6 +258,20 @@ void SubfieldTracker::markFieldAccessed(
 }
 
 void SubfieldTracker::markFieldAccessed(
+    const lp::FixedPointNode& fixedPoint,
+    int32_t ordinal,
+    std::vector<Step>& steps,
+    bool isControl,
+    const MarkFieldsAccessedContext& context) {
+  // Both legs contribute to every output column; mark the same ordinal on
+  // each input.
+  for (const auto& input : fixedPoint.inputs()) {
+    const auto ctx = fromNode(input).append(context);
+    markFieldAccessed(ctx.sources[0], ordinal, steps, isControl, ctx.toCtx());
+  }
+}
+
+void SubfieldTracker::markFieldAccessed(
     const LogicalContextSource& source,
     int32_t ordinal,
     std::vector<Step>& steps,
@@ -317,6 +331,12 @@ void SubfieldTracker::markFieldAccessed(
   if (kind == lp::NodeKind::kSet) {
     const auto* set = source.planNode->as<lp::SetNode>();
     markFieldAccessed(*set, ordinal, steps, isControl, context);
+    return;
+  }
+
+  if (kind == lp::NodeKind::kFixedPoint) {
+    const auto* fixedPoint = source.planNode->as<lp::FixedPointNode>();
+    markFieldAccessed(*fixedPoint, ordinal, steps, isControl, context);
     return;
   }
 

--- a/axiom/optimizer/SubfieldTracker.h
+++ b/axiom/optimizer/SubfieldTracker.h
@@ -141,6 +141,13 @@ class SubfieldTracker {
       const MarkFieldsAccessedContext& context);
 
   void markFieldAccessed(
+      const logical_plan::FixedPointNode& fixedPoint,
+      int32_t ordinal,
+      std::vector<Step>& steps,
+      bool isControl,
+      const MarkFieldsAccessedContext& context);
+
+  void markFieldAccessed(
       const LogicalContextSource& source,
       int32_t ordinal,
       std::vector<Step>& steps,

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4865,6 +4865,121 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
   }
 }
 
+void ToGraph::translateFixedPoint(const lp::FixedPointNode& fixedPoint) {
+  VELOX_USER_CHECK(
+      !fixedPointScope_.has_value(),
+      "Nested FixedPoint translation is not yet implemented");
+  auto* fixedPointDt = currentDt_;
+
+  const auto* recursionName = toName(fixedPoint.name());
+  auto renames = std::move(renames_);
+
+  // Translates one leg (anchor or step) into a fresh sub-DT and returns it.
+  // Each leg has its own renames_, subquery cache, and lifted-correlation
+  // state so siblings don't bleed into each other.
+  auto translateLeg = [&](const lp::LogicalPlanNode& input) -> DerivedTable* {
+    renames_ = renames;
+    currentDt_ = newDt();
+    auto savedLifted = applyContext_.saveAndClearLifted();
+    auto savedSubqueries = std::move(subqueries_);
+    subqueries_.clear();
+    SCOPE_EXIT {
+      applyContext_.lifted = std::move(savedLifted);
+      subqueries_ = std::move(savedSubqueries);
+    };
+    makeQueryGraph(input, kAllAllowedInDt, /*orderObservedAbove=*/false);
+    if (!applyContext_.lifted.empty()) {
+      VELOX_NYI(
+          "Correlated reference inside a FixedPoint leg is not supported yet");
+    }
+    return std::exchange(currentDt_, fixedPointDt);
+  };
+
+  // Anchor first — it defines the output schema of the FixedPoint.
+  auto* anchorDt = translateLeg(*fixedPoint.anchor());
+
+  const auto& anchorType = fixedPoint.anchor()->outputType();
+  for (auto i : usedChannels(*fixedPoint.anchor())) {
+    const auto& name = anchorType->nameOf(i);
+    ExprCP inner = translateColumn(name);
+    anchorDt->exprs.push_back(inner);
+    const auto* columnName = toName(name);
+    auto* outer =
+        make<Column>(columnName, fixedPointDt, inner->value(), columnName);
+    fixedPointDt->columns.push_back(outer);
+    anchorDt->columns.push_back(outer);
+  }
+
+  // Bind the enclosing scope so RecursiveReferenceNodes inside the step
+  // resolve to a WorkingTable whose columns match the anchor.
+  fixedPointScope_.emplace(
+      FixedPointScope{
+          .name = recursionName, .anchorColumns = fixedPointDt->columns});
+  SCOPE_EXIT {
+    fixedPointScope_.reset();
+  };
+  auto* stepDt = translateLeg(*fixedPoint.step());
+
+  // Step exprs feed the same output columns as the anchor; SubfieldTracker
+  // marks both legs identically so usedChannels matches.
+  const auto& stepType = fixedPoint.step()->outputType();
+  for (auto i : usedChannels(*fixedPoint.step())) {
+    ExprCP inner = translateColumn(stepType->nameOf(i));
+    stepDt->exprs.push_back(inner);
+  }
+  stepDt->columns = fixedPointDt->columns;
+
+  fixedPointDt->outputColumns = fixedPointDt->columns;
+  anchorDt->outputColumns = fixedPointDt->columns;
+  stepDt->outputColumns = fixedPointDt->columns;
+  fixedPointDt->fixedPoint.name = recursionName;
+  fixedPointDt->fixedPoint.anchor = anchorDt;
+  fixedPointDt->fixedPoint.step = stepDt;
+
+  renames_ = std::move(renames);
+  for (const auto* column : fixedPointDt->columns) {
+    renames_[column->name()] = column;
+  }
+}
+
+void ToGraph::translateRecursiveRef(const lp::RecursiveReferenceNode& ref) {
+  const auto* recursionName = toName(ref.name());
+  VELOX_USER_CHECK(
+      fixedPointScope_.has_value(),
+      "RecursiveReferenceNode outside any enclosing FixedPoint: {}",
+      ref.name());
+  const auto& scope = *fixedPointScope_;
+  VELOX_USER_CHECK_EQ(
+      scope.name,
+      recursionName,
+      "RecursiveReferenceNode name does not match enclosing FixedPoint");
+
+  const auto& schema = ref.outputType();
+  VELOX_CHECK_EQ(
+      schema->size(),
+      scope.anchorColumns.size(),
+      "RecursiveReference schema size mismatches enclosing FixedPoint anchor");
+
+  // The LP's `recursiveRef` deliberately renames the anchor's columns
+  // (e.g. `n` -> `n_0`) so multiple self-references can carry distinct
+  // column ids. Keep the LP's renamed names as `renames_` keys (so the
+  // step's filter/project resolve as the LP intended), but name the
+  // WorkingTable's columns to match the anchor.
+  auto* workingTable = make<WorkingTable>(recursionName);
+  for (auto i = 0; i < schema->size(); ++i) {
+    const auto* anchorColumnName = scope.anchorColumns[i]->name();
+    auto* column = make<Column>(
+        anchorColumnName,
+        workingTable,
+        toConstantValue(schema->childAt(i)),
+        anchorColumnName);
+    workingTable->columns.push_back(column);
+    renames_[schema->nameOf(i)] = column;
+  }
+
+  currentDt_->addTable(workingTable);
+}
+
 namespace {
 
 // Normalized join with left/right sides and join type. RIGHT joins are
@@ -5206,11 +5321,15 @@ void ToGraph::makeQueryGraph(
       wrapInDt(*node.onlyInput(), /*orderObservedAbove=*/false);
       addWrite(*node.as<lp::TableWriteNode>());
     } break;
-    case lp::NodeKind::kFixedPoint:
-    case lp::NodeKind::kRecursiveReference:
-      VELOX_NYI(
-          "Fixed-point (recursive) plan execution is not yet implemented");
-      break;
+    case lp::NodeKind::kFixedPoint: {
+      auto* outerDt = std::exchange(currentDt_, newDt());
+      translateFixedPoint(*node.as<lp::FixedPointNode>());
+      outerDt->addTable(currentDt_);
+      currentDt_ = outerDt;
+    } break;
+    case lp::NodeKind::kRecursiveReference: {
+      translateRecursiveRef(*node.as<lp::RecursiveReferenceNode>());
+    } break;
     default:
       VELOX_NYI(
           "Unsupported PlanNode {}", lp::NodeKindName::toName(node.kind()));

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -503,6 +503,14 @@ class ToGraph {
   // Example: u(a, u(b, c)) -> u(a, b, c)
   void translateUnion(const logical_plan::SetNode& set);
 
+  // Translates an LP `FixedPointNode` into a FixedPoint DerivedTable rooted
+  // at `currentDt_`. Nested FixedPoints are NYI.
+  void translateFixedPoint(const logical_plan::FixedPointNode& fixedPoint);
+
+  // Translates an LP `RecursiveReferenceNode` into a `WorkingTable` inside
+  // the enclosing FixedPoint's step. Fails if outside any FixedPoint.
+  void translateRecursiveRef(const logical_plan::RecursiveReferenceNode& ref);
+
   void addUnnest(const logical_plan::UnnestNode& unnest);
 
   // Creates a Column for the grouping set ID with the given name, type, and
@@ -964,6 +972,15 @@ class ToGraph {
 
   // Innermost DerivedTable when making a QueryGraph from PlanNode.
   DerivedTableP currentDt_{nullptr};
+
+  // Enclosing FixedPoint scope, set while translating its step. Pairs the
+  // FP's name with the anchor's columns. `std::optional` because nested
+  // FixedPoints are NYI; widen to a stack when nesting ships.
+  struct FixedPointScope {
+    Name name;
+    ColumnVector anchorColumns;
+  };
+  std::optional<FixedPointScope> fixedPointScope_;
 
   // Source LogicalPlanNode's for the node currently being processed. Used to
   // translate expressions that involve subfields. Contains just one node if

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -19,6 +19,7 @@
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/WriteStatsBuilder.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/core/PlanConsistencyChecker.h"
 #include "velox/core/PlanNode.h"
 #include "velox/core/TableWriteTraits.h"
@@ -2421,6 +2422,120 @@ void ToVelox::makePredictionAndHistory(
   }
 }
 
+namespace {
+
+// Builds a Velox ROW type from a RelOp's `columns()`.
+velox::RowTypePtr toRowType(const ColumnVector& columns) {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(columns.size());
+  types.reserve(columns.size());
+  for (const auto* column : columns) {
+    names.push_back(column->outputName());
+    types.push_back(toTypePtr(column->value().type));
+  }
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+} // namespace
+
+velox::core::PlanNodePtr ToVelox::makeEmptyDeltaConvergence(
+    const std::string& stateName,
+    const velox::RowTypePtr& schema) {
+  static constexpr std::string_view kConvergedCountName = "__converged_count";
+  static constexpr std::string_view kConvergedColumnName = "converged";
+
+  auto source = std::make_shared<velox::core::StateSourceNode>(
+      nextId(), stateName, schema, /*delta=*/true);
+
+  const auto& functionNames = queryCtx()->functionNames();
+
+  auto countCall = std::make_shared<velox::core::CallTypedExpr>(
+      velox::BIGINT(),
+      std::vector<velox::core::TypedExprPtr>{},
+      std::string(functionNames.count));
+  velox::core::AggregationNode::Aggregate countAggregate{
+      .call = std::move(countCall),
+      .rawInputTypes = {},
+      .mask = nullptr,
+      .sortingKeys = {},
+      .sortingOrders = {},
+      .distinct = false,
+  };
+  auto aggregation = std::make_shared<velox::core::AggregationNode>(
+      nextId(),
+      velox::core::AggregationNode::Step::kSingle,
+      std::vector<velox::core::FieldAccessTypedExprPtr>{},
+      std::vector<velox::core::FieldAccessTypedExprPtr>{},
+      std::vector<std::string>{std::string(kConvergedCountName)},
+      std::vector<velox::core::AggregationNode::Aggregate>{
+          std::move(countAggregate)},
+      std::vector<velox::vector_size_t>{},
+      std::optional<velox::core::FieldAccessTypedExprPtr>{},
+      /*ignoreNullKeys=*/false,
+      /*noGroupsSpanBatches=*/false,
+      std::move(source));
+
+  auto countRef = std::make_shared<velox::core::FieldAccessTypedExpr>(
+      velox::BIGINT(), std::string(kConvergedCountName));
+  auto zeroConst = std::make_shared<velox::core::ConstantTypedExpr>(
+      velox::BIGINT(), velox::Variant(int64_t{0}));
+  auto eqExpr = std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      std::vector<velox::core::TypedExprPtr>{
+          std::move(countRef), std::move(zeroConst)},
+      std::string(functionNames.equality));
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(),
+      std::vector<std::string>{std::string(kConvergedColumnName)},
+      std::vector<velox::core::TypedExprPtr>{std::move(eqExpr)},
+      std::move(aggregation));
+}
+
+velox::core::PlanNodePtr ToVelox::makeFixedPoint(
+    const FixedPoint& fp,
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
+  // Same fragment + stages so nested makeRepartition can push sub-fragments.
+  auto anchorPlan = makeFragment(fp.anchor, fragment, stages);
+  auto stepPlan = makeFragment(fp.step, fragment, stages);
+
+  // State entry schema = FP output schema = anchor schema.
+  auto schema = toRowType(fp.columns());
+
+  const std::string stateNameString{fp.name};
+
+  velox::core::ConvergenceConfig convergence;
+  convergence.plan = makeEmptyDeltaConvergence(stateNameString, schema);
+  convergence.maxIterations =
+      optimizerSession_->options().fixedPointMaxIterations;
+
+  std::vector<velox::core::StateDeclarationPtr> stateDeclarations;
+  stateDeclarations.push_back(
+      std::make_shared<velox::core::VectorStateDeclaration>(
+          stateNameString, schema, std::move(anchorPlan), /*append=*/true));
+  std::vector<velox::core::PlanNodePtr> plans;
+  plans.push_back(std::move(stepPlan));
+
+  auto node = std::make_shared<velox::core::FixedPointNode>(
+      nextId(),
+      std::move(stateDeclarations),
+      std::move(plans),
+      std::move(convergence),
+      stateNameString);
+  makePredictionAndHistory(node->id(), &fp);
+  return node;
+}
+
+velox::core::PlanNodePtr ToVelox::makeWorkingTableScan(
+    const WorkingTableScan& scan) {
+  auto schema = toRowType(scan.columns());
+  auto node = std::make_shared<velox::core::StateSourceNode>(
+      nextId(), std::string(scan.name), schema, /*delta=*/true);
+  makePredictionAndHistory(node->id(), &scan);
+  return node;
+}
+
 velox::core::PlanNodePtr ToVelox::makeFragment(
     const RelationOpPtr& op,
     ExecutableFragment& fragment,
@@ -2495,6 +2610,12 @@ velox::core::PlanNodePtr ToVelox::makeFragment(
       break;
     case RelType::kGroupId:
       result = makeGroupId(*op->as<GroupId>(), fragment, stages);
+      break;
+    case RelType::kFixedPoint:
+      result = makeFixedPoint(*op->as<FixedPoint>(), fragment, stages);
+      break;
+    case RelType::kWorkingTableScan:
+      result = makeWorkingTableScan(*op->as<WorkingTableScan>());
       break;
     default:
       VELOX_FAIL(

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -242,6 +242,26 @@ class ToVelox {
       const Values& values,
       ExecutableFragment& fragment);
 
+  // Lowers a WorkingTableScan RelOp to a Velox StateSourceNode reading the
+  // enclosing FixedPoint's vector state entry in delta mode.
+  velox::core::PlanNodePtr makeWorkingTableScan(const WorkingTableScan& scan);
+
+  // Lowers a FixedPoint RelOp to a Velox FixedPointNode.
+  velox::core::PlanNodePtr makeFixedPoint(
+      const FixedPoint& fp,
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
+
+  // Builds the convergence sub-plan for a FixedPoint's ConvergenceConfig:
+  //   StateSource(stateName, schema, delta=true)
+  //     -> AggregationNode(count() AS __converged_count)
+  //     -> ProjectNode("converged" = eq(__converged_count, 0))
+  // delta=true so the source sees only the rows the most recent iteration
+  // appended; an empty delta produces count=0 and marks convergence.
+  velox::core::PlanNodePtr makeEmptyDeltaConvergence(
+      const std::string& stateName,
+      const velox::RowTypePtr& schema);
+
   velox::core::PlanNodePtr makeWrite(
       const TableWrite& write,
       ExecutableFragment& fragment,

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -266,6 +266,21 @@ TEST_F(DerivedTablePrinterTest, union) {
   }
 }
 
+TEST_F(DerivedTablePrinterTest, fixedPoint) {
+  auto context = makeContext();
+  auto anchor = lp::PlanBuilder(context).values(
+      ROW({"n"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+  auto step = lp::PlanBuilder(context)
+                  .recursiveRef("counter", anchor)
+                  .filter("n < 10")
+                  .project({"n + 1 as n"})
+                  .planNode();
+  auto plan = anchor.fixedPoint("counter", step).build();
+
+  auto lines = toLines(*plan);
+  EXPECT_THAT(lines, testing::Contains(testing::HasSubstr("FIXED POINT:")));
+}
+
 TEST_F(DerivedTablePrinterTest, write) {
   connector_->addTable("c", ROW({"a", "b"}, INTEGER()));
   connector_->addTable("z", ROW({"x", "y"}, INTEGER()));

--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -16,34 +16,174 @@
 
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
-
-using namespace facebook::velox;
 
 namespace facebook::axiom::optimizer {
 namespace {
 
-class FixedPointTest : public test::QueryTestBase {};
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
 
-// Attempting to execute a recursive plan must fail with a clear NYI error.
-TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
-  auto rowType = ROW("n", BIGINT());
-  logical_plan::PlanBuilder::Context context;
+class FixedPointTest : public test::QueryTestBase {
+ protected:
+  // Builds the canonical recursive-CTE counter: seed n=1, step n+1, filter
+  // n<10 (so the frontier empties after iteration 10).
+  static lp::LogicalPlanNodePtr makeCounter() {
+    lp::PlanBuilder::Context context;
+    auto anchor = lp::PlanBuilder(context).values(
+        ROW({"n"}, {BIGINT()}),
+        std::vector<Variant>{Variant::row({int64_t{1}})});
+    auto step = lp::PlanBuilder(context)
+                    .recursiveRef("counter", anchor)
+                    .filter("n < 10")
+                    .project({"n + 1 as n"})
+                    .planNode();
+    return anchor.fixedPoint("counter", step).build();
+  }
+};
 
-  auto anchor = logical_plan::PlanBuilder(context).values(
-      rowType, std::vector<Variant>{Variant::row({0LL})});
+// Asserts the lowered plan shape: anchor is Values; step is
+// WorkingTableScan + Filter + Project.
+TEST_F(FixedPointTest, planShape) {
+  auto plan = toSingleNodePlan(makeCounter());
 
-  auto step = logical_plan::PlanBuilder(context)
+  core::FixedPointDetails details;
+  details.name = "counter";
+  details.anchor = core::PlanMatcherBuilder().values().build();
+  details.step = core::PlanMatcherBuilder()
+                     .workingTableScan({.name = "counter"})
+                     .filter()
+                     .project()
+                     .build();
+
+  auto matcher = core::PlanMatcherBuilder().fixedPoint(details).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Lowers and runs the counter; expects {1, 2, ..., 10}. DISABLED until
+// LocalRunner / TaskCursor thread a per-iteration subTaskId through
+// FixedPointTaskOptions (currently FixedPointTask::drainPlan aborts).
+TEST_F(FixedPointTest, DISABLED_executableRoundTrip) {
+  auto plan = toSingleNodePlan(makeCounter());
+
+  auto result = runVelox(plan);
+  ASSERT_FALSE(result.results.empty());
+  std::vector<int64_t> rows;
+  for (const auto& batch : result.results) {
+    auto* values = batch->childAt(0)->asFlatVector<int64_t>();
+    ASSERT_NE(values, nullptr);
+    for (vector_size_t i = 0; i < batch->size(); ++i) {
+      rows.push_back(values->valueAt(i));
+    }
+  }
+  std::ranges::sort(rows);
+  const std::vector<int64_t> expected{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  EXPECT_EQ(rows, expected);
+}
+
+// Cross join in the step lowers to NestedLoopJoin.
+TEST_F(FixedPointTest, crossJoinInStepPlanShape) {
+  lp::PlanBuilder::Context context;
+  auto anchor = lp::PlanBuilder(context).values(
+      ROW({"n"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+
+  auto rightLeg = lp::PlanBuilder(context).values(
+      ROW({"m"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+
+  auto step = lp::PlanBuilder(context)
                   .recursiveRef("counter", anchor)
+                  .crossJoin(rightLeg)
                   .project({"n + 1 as n"})
                   .planNode();
 
   auto plan = anchor.fixedPoint("counter", step).build();
 
+  core::FixedPointDetails details;
+  details.name = "counter";
+  details.anchor = core::PlanMatcherBuilder().values().build();
+  details.step =
+      core::PlanMatcherBuilder()
+          .workingTableScan({.name = "counter"})
+          .nestedLoopJoin(core::PlanMatcherBuilder().values().build())
+          .project()
+          .build();
+
+  auto matcher = core::PlanMatcherBuilder().fixedPoint(details).build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(plan), matcher);
+}
+
+// A RecursiveReferenceNode outside any FixedPoint must fail with a clear
+// user error.
+TEST_F(FixedPointTest, recursiveRefWithoutFixedPointFails) {
+  lp::PlanBuilder::Context context;
+  auto anchor = lp::PlanBuilder(context).values(
+      ROW({"n"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+
+  auto orphan =
+      lp::PlanBuilder(context).recursiveRef("counter", anchor).build();
+
   VELOX_ASSERT_THROW(
-      toSingleNodePlan(plan),
-      "Fixed-point (recursive) plan execution is not yet implemented");
+      toSingleNodePlan(orphan),
+      "RecursiveReferenceNode outside any enclosing FixedPoint");
+}
+
+// An outer filter on a FixedPoint is retained on the FP output (correctness:
+// step's per-iteration rows must still be filtered) and is also pushed into
+// the anchor as a pre-filter (safe: the anchor runs once).
+TEST_F(FixedPointTest, outerFilterOnFixedPointRetained) {
+  lp::PlanBuilder::Context context;
+  auto anchor = lp::PlanBuilder(context).values(
+      ROW({"n"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+  auto step = lp::PlanBuilder(context)
+                  .recursiveRef("counter", anchor)
+                  .filter("n < 10")
+                  .project({"n + 1 as n"})
+                  .planNode();
+  auto plan =
+      anchor.fixedPoint("counter", step).filter("n < 5").project({"n"}).build();
+
+  core::FixedPointDetails details;
+  details.name = "counter";
+  details.anchor = core::PlanMatcherBuilder().values().filter().build();
+  details.step = core::PlanMatcherBuilder()
+                     .workingTableScan({.name = "counter"})
+                     .filter()
+                     .project()
+                     .build();
+
+  auto matcher =
+      core::PlanMatcherBuilder().fixedPoint(details).filter().build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(plan), matcher);
+}
+
+// Nested FixedPoints must fail at translation with a clear NYI message.
+TEST_F(FixedPointTest, nestedFixedPointNyi) {
+  const auto rowType = ROW({"n"}, {BIGINT()});
+  const std::vector<Variant> oneRow{Variant::row({int64_t{1}})};
+
+  auto innerAnchor =
+      std::make_shared<lp::ValuesNode>("v_inner", rowType, oneRow);
+  auto innerStep =
+      std::make_shared<lp::RecursiveReferenceNode>("r_inner", "inner", rowType);
+  auto innerFp = std::make_shared<lp::FixedPointNode>(
+      "fp_inner", "inner", innerAnchor, innerStep);
+
+  auto outerAnchor =
+      std::make_shared<lp::ValuesNode>("v_outer", rowType, oneRow);
+  auto outerRef =
+      std::make_shared<lp::RecursiveReferenceNode>("r_outer", "outer", rowType);
+  auto outerStep = std::make_shared<lp::SetNode>(
+      "set_step",
+      std::vector<lp::LogicalPlanNodePtr>{outerRef, innerFp},
+      lp::SetOperation::kUnionAll);
+  auto outerFp = std::make_shared<lp::FixedPointNode>(
+      "fp_outer", "outer", outerAnchor, outerStep);
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(outerFp),
+      "Nested FixedPoint translation is not yet implemented");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -96,6 +96,9 @@ TEST(OptimizerOptionsTest, normalizeRejectsInvalidValues) {
   VELOX_ASSERT_THROW(
       options.normalize(OptimizerOptions::kBroadcastSizeLimit, "100"),
       "Invalid capacity string");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kFixedPointMaxIterations, "0"),
+      "fixed_point_max_iterations must be >= 1");
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -15,11 +15,13 @@
  */
 
 #include "axiom/optimizer/tests/PlanMatcher.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/tests/ExprMatcher.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/parse/ExprRewriter.h"
@@ -317,6 +319,86 @@ class ValuesMatcher : public PlanMatcherImpl<ValuesNode> {
 
  private:
   const RowTypePtr outputType_;
+};
+
+// Matches a StateSourceNode. See WorkingTableScanDetails for per-field
+// semantics.
+class WorkingTableScanMatcher : public PlanMatcherImpl<StateSourceNode> {
+ public:
+  WorkingTableScanMatcher() = default;
+
+  explicit WorkingTableScanMatcher(WorkingTableScanDetails details)
+      : PlanMatcherImpl<StateSourceNode>{}, details_{std::move(details)} {}
+
+  MatchResult matchDetails(
+      const StateSourceNode& plan,
+      const std::unordered_map<std::string, std::string>& /*symbols*/)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    if (details_.name.has_value()) {
+      EXPECT_EQ(plan.stateName(), *details_.name);
+    }
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  const WorkingTableScanDetails details_;
+};
+
+// Matches a FixedPointNode against LP-level fields. See FixedPointDetails.
+class FixedPointMatcher : public PlanMatcherImpl<FixedPointNode> {
+ public:
+  FixedPointMatcher() = default;
+
+  explicit FixedPointMatcher(FixedPointDetails details)
+      : PlanMatcherImpl<FixedPointNode>{}, details_{std::move(details)} {}
+
+  int32_t shuffleBoundaryCount() const override {
+    int32_t count = PlanMatcherImpl<FixedPointNode>::shuffleBoundaryCount();
+    if (details_.anchor != nullptr) {
+      count += details_.anchor->shuffleBoundaryCount();
+    }
+    if (details_.step != nullptr) {
+      count += details_.step->shuffleBoundaryCount();
+    }
+    return count;
+  }
+
+  MatchResult matchDetails(
+      const FixedPointNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    if (details_.name.has_value()) {
+      EXPECT_EQ(plan.outputStateEntry(), *details_.name);
+    }
+    if (details_.anchor != nullptr) {
+      EXPECT_FALSE(plan.stateDeclarations().empty());
+      AXIOM_TEST_RETURN_IF_FAILURE
+      // The working table is the first state declaration; its initialPlan
+      // is the lowered anchor.
+      auto result = details_.anchor->match(
+          plan.stateDeclarations()[0]->initialPlan(),
+          symbols,
+          /*context=*/nullptr);
+      if (!result.match) {
+        return MatchResult::failure();
+      }
+    }
+    if (details_.step != nullptr) {
+      EXPECT_THAT(plan.plans(), testing::SizeIs(1));
+      AXIOM_TEST_RETURN_IF_FAILURE
+      auto result =
+          details_.step->match(plan.plans()[0], symbols, /*context=*/nullptr);
+      if (!result.match) {
+        return MatchResult::failure();
+      }
+    }
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  const FixedPointDetails details_;
 };
 
 class FilterMatcher : public PlanMatcherImpl<FilterNode> {
@@ -1883,6 +1965,32 @@ PlanMatcherBuilder& PlanMatcherBuilder::values() {
 PlanMatcherBuilder& PlanMatcherBuilder::values(const RowTypePtr& outputType) {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<ValuesMatcher>(outputType);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::workingTableScan() {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<WorkingTableScanMatcher>();
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::workingTableScan(
+    const WorkingTableScanDetails& details) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<WorkingTableScanMatcher>(details);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint() {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>();
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint(
+    const FixedPointDetails& details) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>(details);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -137,6 +137,28 @@ class PlanMatcher {
   std::vector<std::optional<std::string>> aliases_;
 };
 
+/// Match details for a FixedPoint node. Mirrors the fields on
+/// `lp::FixedPointNode` (name, anchor, step); ignores Velox-side lowering
+/// artifacts (convergence config, state declarations). Each field is
+/// optional.
+struct FixedPointDetails {
+  /// When set, asserts `lp::FixedPointNode::name()`.
+  std::optional<std::string> name;
+
+  /// When set, runs against `lp::FixedPointNode::anchor()`.
+  std::shared_ptr<PlanMatcher> anchor;
+
+  /// When set, runs against `lp::FixedPointNode::step()`.
+  std::shared_ptr<PlanMatcher> step;
+};
+
+/// Match details for a WorkingTableScan. Lowers to `StateSourceNode`.
+struct WorkingTableScanDetails {
+  /// When set, asserts the working table's name -- same as the enclosing
+  /// `FixedPointDetails::name`.
+  std::optional<std::string> name;
+};
+
 /// Match details for a HashJoin node beyond join type. Each field is
 /// optional: leave as nullopt to skip the check, set a value to assert it.
 struct HashJoinDetails {
@@ -197,6 +219,18 @@ class PlanMatcherBuilder {
   /// Matches a Values node with the specified output type.
   /// @param outputType The expected output type of the Values node.
   PlanMatcherBuilder& values(const RowTypePtr& outputType);
+
+  /// Matches any WorkingTableScan.
+  PlanMatcherBuilder& workingTableScan();
+
+  /// Matches a WorkingTableScan with the specified details.
+  PlanMatcherBuilder& workingTableScan(const WorkingTableScanDetails& details);
+
+  /// Matches any FixedPoint.
+  PlanMatcherBuilder& fixedPoint();
+
+  /// Matches a FixedPoint with the specified details.
+  PlanMatcherBuilder& fixedPoint(const FixedPointDetails& details);
 
   /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -26,6 +26,7 @@
 #include "axiom/optimizer/tests/TestDataPath.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/exec/FixedPointOperators.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/Expr.h"
@@ -48,6 +49,7 @@ namespace facebook::axiom::optimizer::test {
 void QueryTestBase::SetUpTestCase() {
   HiveConnectorTestBase::SetUpTestCase();
   velox::window::prestosql::registerAllWindowFunctions();
+  velox::exec::registerFixedPointOperators();
 
   executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(4);
   optimizer::FunctionRegistry::registerPrestoFunctions();

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -507,5 +507,31 @@ TEST_F(RelationOpPrinterTest, groupId) {
   EXPECT_THAT(oneline, testing::HasSubstr("groupid("));
 }
 
+TEST_F(RelationOpPrinterTest, fixedPoint) {
+  lp::PlanBuilder::Context context;
+  auto anchor = lp::PlanBuilder(context).values(
+      ROW({"n"}, {BIGINT()}), std::vector<Variant>{Variant::row({int64_t{1}})});
+  auto step = lp::PlanBuilder(context)
+                  .recursiveRef("counter", anchor)
+                  .filter("n < 10")
+                  .project({"n + 1 as n"})
+                  .planNode();
+  auto plan = anchor.fixedPoint("counter", step).build();
+
+  auto lines = toLines(*plan);
+  EXPECT_THAT(
+      lines,
+      testing::AllOf(
+          testing::Contains(testing::HasSubstr("FixedPoint")),
+          testing::Contains(testing::HasSubstr("name=counter")),
+          testing::Contains(testing::HasSubstr("anchor:")),
+          testing::Contains(testing::HasSubstr("step:")),
+          testing::Contains(testing::HasSubstr("WorkingTableScan"))));
+
+  auto oneline = toOneline(*plan);
+  EXPECT_THAT(oneline, testing::HasSubstr("fixedpoint("));
+  EXPECT_THAT(oneline, testing::HasSubstr("workingscan(counter)"));
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer


### PR DESCRIPTION
Summary:
Translates SQL `WITH RECURSIVE` into a Velox `FixedPointNode`. The canonical counter

    WITH RECURSIVE c(n) AS (
      SELECT 1 UNION ALL SELECT n + 1 FROM c WHERE n < 10
    ) SELECT * FROM c

lowers to a single-state plan whose step iterates over the prior iteration's rows until the delta is empty.

The step body's reference to `c` becomes a `WorkingTable` placeholder in the query graph — a peer of the existing table kinds. Joins involving `c` participate in enumeration like any other small leaf. The whole shape lowers to Velox's fixed-point operator: the anchor seeds a `VectorStateDeclaration` that the step reads via a `StateSourceNode`. A small convergence sub-plan (`StateSource → count → eq-zero`) stops the loop when the last iteration appended nothing.

`ConvergenceConfig`'s default `errorWhenMaxIterationReached = true` is left intact, matching Presto/Trino/MySQL WITH RECURSIVE semantics: exceeding `fixed_point_max_iterations` raises rather than silently truncating.

Deferred:
  - Executable round-trip: `FixedPointTask::drainPlan` requires a per-iteration `subTaskId` that `LocalRunner` / `TaskCursor` don't yet thread through `FixedPointTaskOptions`. A follow-on wires this and re-enables `executableRoundTrip`.
  - Equi-joins in the step lower to `HashJoinNode`, which the fixed-point operator can't run. A follow-on emits `StateHashJoinNode` against a pre-built `HashTableStateDeclaration`.
  - Nested FixedPoints reject at translation time.

Differential Revision: D109251127


