### PR TITLE
fix(optimizer): Allow partial aggregation for multi-driver bucketed group-by (#1538)

### DIFF
--- a/axiom/optimizer/AggregationPlanner.cpp
+++ b/axiom/optimizer/AggregationPlanner.cpp
@@ -905,7 +905,12 @@ void AggregationPlanner::plan(
     return;
   }
 
-  if (isBucketedAggregation && !hasDistinct && !hasOrderBy) {
+  // The input is already partitioned on a subset of the grouping keys, so no
+  // distributed shuffle is needed. With a single driver each partition is
+  // aggregated in one place, so a single-step aggregation is optimal. With
+  // multiple drivers a local exchange is still required, so fall through to the
+  // cost-based choice between split and single aggregation plans.
+  if (isBucketedAggregation && isSingleDriver_ && !hasDistinct && !hasOrderBy) {
     auto* singleAgg = make<Aggregation>(
         plan,
         std::move(groupingKeys),

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -382,6 +382,59 @@ TEST_F(AggregationTest, repartitionForAggPartitionSubset) {
   }
 }
 
+TEST_F(AggregationTest, bucketedAggregation) {
+  // Table 't' bucketed on 'k' with ~100 rows per (k, g) group, so grouping by
+  // [k, g] reduces cardinality ~100x.
+  testConnector_->addTable(
+      "t",
+      ROW({"k", "g", "v"}, {BIGINT(), BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"k"}, 128});
+  testConnector_->setStats(
+      "t",
+      1'000'000,
+      {{"k", {.numDistinct = 1'000}},
+       {"g", {.numDistinct = 10}},
+       {"v", {.numDistinct = 500'000}}});
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = lp::PlanBuilder(makeContext())
+                         .tableScan("t")
+                         .aggregate({"k", "g"}, {"sum(v)"})
+                         .build();
+
+  {
+    SCOPED_TRACE("multiple drivers: partial reduces before the local exchange");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    auto matcher = core::PlanMatcherBuilder()
+                       .tableScan()
+                       .partialAggregation({"k", "g"}, {"sum(v) as s"})
+                       .localPartition({"k", "g"})
+                       .finalAggregation({"k", "g"}, {"sum(s) as s"})
+                       .bucketed()
+                       .fragmentWidth(4)
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+
+  {
+    SCOPED_TRACE("single driver: no local exchange, single-step aggregation");
+    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1});
+    auto matcher = core::PlanMatcherBuilder()
+                       .multiThreaded(false)
+                       .tableScan()
+                       .singleAggregation({"k", "g"}, {"sum(v)"})
+                       .bucketed()
+                       .fragmentWidth(4)
+                       .gather()
+                       .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
+  }
+}
+
 // TODO: Add tests for maybeProject() cost tracking once Project::unitCost is
 // implemented (currently 0, see the TODO in Project::Project). The
 // optimizationCost() helper is available for verifying cost differences between

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -253,8 +253,9 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
+            .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
             .localPartition({"c_nationkey"})
-            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -270,8 +271,11 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
+            .partialAggregation(
+                {"c_nationkey", "c_mktsegment"}, {"count(*) as cnt"})
             .localPartition({"c_nationkey", "c_mktsegment"})
-            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
+            .finalAggregation(
+                {"c_nationkey", "c_mktsegment"}, {"count(cnt) as cnt"})
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -287,10 +291,15 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
-            .localPartition({"c_nationkey"})
-            .singleAggregation(
+            .partialAggregation(
                 {"c_nationkey"},
-                {"count(*)", "min(c_acctbal)", "max(c_acctbal)"})
+                {"count(*) as cnt",
+                 "min(c_acctbal) as mn",
+                 "max(c_acctbal) as mx"})
+            .localPartition({"c_nationkey"})
+            .finalAggregation(
+                {"c_nationkey"},
+                {"count(cnt) as cnt", "min(mn) as mn", "max(mx) as mx"})
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -328,8 +337,9 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
+            .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
             .localPartition({"c_nationkey"})
-            .singleAggregation({"c_nationkey"}, {"count(*) as cnt"})
+            .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
             .filter("cnt > 100")
             .bucketed()
             .fragmentWidth(4)
@@ -368,8 +378,9 @@ TEST_F(HiveBucketedExecutionTest, singleBucket) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       plan.plan,
       matchHiveScan("t")
+          .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
           .localPartition({"c_nationkey"})
-          .singleAggregation({"c_nationkey"}, {"count(*)"})
+          .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
           .bucketed()
           .fragmentWidth(1)
           .gather()
@@ -418,8 +429,11 @@ TEST_F(HiveBucketedExecutionTest, compositeBucketKeys) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
+            .partialAggregation(
+                {"c_nationkey", "c_mktsegment"}, {"count(*) as cnt"})
             .localPartition({"c_nationkey", "c_mktsegment"})
-            .singleAggregation({"c_nationkey", "c_mktsegment"}, {"count(*)"})
+            .finalAggregation(
+                {"c_nationkey", "c_mktsegment"}, {"count(cnt) as cnt"})
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -460,8 +474,9 @@ TEST_F(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
+            .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
             .localPartition({"c_nationkey"})
-            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
             .bucketed()
             .fragmentWidth(5)
             .gather()


### PR DESCRIPTION
Summary:

A GROUP BY over an input already partitioned on a subset of the grouping keys is considered bucketed and planned through a single-step aggregation. However, even if the data is bucketed on one worker, they can be processed in parallel by multiple drivers, so the full input is reshuffled across the node's drivers before being aggregated. Partial aggregation can be beneficial if it is able to collapse many rows into few groups, hence reducing the amount of data shuffled through local exchange afterwards.

Before:

    LocalPartition[REPARTITION HASH(keys)] -> Aggregation[SINGLE]

After:

    Aggregation[PARTIAL] -> LocalPartition[REPARTITION HASH(keys)] -> Aggregation[FINAL]

The bucketed-aggregation path currently forces single-step whenever the input was partitioned on a subset of the grouping keys. That is optimal only with one driver. This fix gates it on the single-driver case. Multi-driver plans now take the cost-based partial-vs-single choice and get the partial when grouping reduces. This fix adds no cross-worker shuffle, because the input is already partitioned on a subset of the grouping keys.

Reviewed By: mbasmanova

Differential Revision: D110510664


