### PR TITLE
feat(connectors): Add synthetic table scan mechanism (#1539)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -53,6 +53,10 @@ using PartitionFunctionSpecPtr =
 /// metadata, e.g. order, partitioning, bucketing etc.
 namespace facebook::axiom::connector {
 
+namespace synthetic {
+class SyntheticRowProvider;
+}
+
 class TableLayout;
 
 /// Represents statistics of a column. The statistics may represent the column
@@ -892,6 +896,16 @@ class ConnectorMetadata {
   ///
   /// @return nullptr if view doesn't exist.
   virtual ViewPtr findView(const SchemaTableName& /*tableName*/) {
+    return nullptr;
+  }
+
+  /// Returns a row provider for the synthetic relation named 'name' (e.g. an
+  /// information_schema table or a <table>$partitions relation), or nullptr if
+  /// 'name' is not a synthetic relation this catalog serves. A catalog opts
+  /// into synthetic tables by overriding this and routing findTable() through
+  /// synthetic::findSyntheticTable(). The default serves none.
+  virtual std::shared_ptr<const synthetic::SyntheticRowProvider>
+  findSyntheticProvider(const SchemaTableName& /*name*/) {
     return nullptr;
   }
 

--- a/axiom/connectors/synthetic/SyntheticConnector.cpp
+++ b/axiom/connectors/synthetic/SyntheticConnector.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/synthetic/SyntheticConnector.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+std::vector<velox::core::TypedExprPtr> SyntheticRowProvider::acceptFilters(
+    std::vector<velox::core::TypedExprPtr> filters,
+    std::vector<velox::core::TypedExprPtr>& rejected) const {
+  rejected.insert(
+      rejected.end(),
+      std::make_move_iterator(filters.begin()),
+      std::make_move_iterator(filters.end()));
+  return {};
+}
+
+folly::dynamic SyntheticColumnHandle::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = SyntheticColumnHandle::getClassName();
+  obj["columnName"] = name_;
+  return obj;
+}
+
+std::shared_ptr<SyntheticColumnHandle> SyntheticColumnHandle::create(
+    const folly::dynamic& obj) {
+  return std::make_shared<SyntheticColumnHandle>(obj["columnName"].asString());
+}
+
+SyntheticTableHandle::SyntheticTableHandle(
+    std::string_view connectorId,
+    SchemaTableName schemaTableName,
+    std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+    std::vector<velox::core::TypedExprPtr> acceptedFilters,
+    std::string sourceCatalog)
+    : ConnectorTableHandle(std::string(connectorId)),
+      schemaTableName_(std::move(schemaTableName)),
+      qualifiedName_(
+          fmt::format(
+              "{}.{}",
+              schemaTableName_.schema,
+              schemaTableName_.table)),
+      columnHandles_(std::move(columnHandles)),
+      acceptedFilters_(std::move(acceptedFilters)),
+      sourceCatalog_(std::move(sourceCatalog)) {
+  VELOX_CHECK(
+      !sourceCatalog_.empty(),
+      "Synthetic table handle is missing its source catalog: {}",
+      qualifiedName_);
+}
+
+folly::dynamic SyntheticTableHandle::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = SyntheticTableHandle::getClassName();
+  obj["connectorId"] = connectorId();
+  obj["schemaName"] = schemaTableName_.schema;
+  obj["tableName"] = schemaTableName_.table;
+  obj["sourceCatalog"] = sourceCatalog_;
+  folly::dynamic handles = folly::dynamic::array;
+  for (const auto& handle : columnHandles_) {
+    handles.push_back(handle->serialize());
+  }
+  obj["columnHandles"] = std::move(handles);
+  folly::dynamic filters = folly::dynamic::array;
+  for (const auto& filter : acceptedFilters_) {
+    filters.push_back(filter->serialize());
+  }
+  obj["acceptedFilters"] = std::move(filters);
+  return obj;
+}
+
+velox::connector::ConnectorTableHandlePtr SyntheticTableHandle::create(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  auto connectorId = obj["connectorId"].asString();
+  SchemaTableName schemaTableName{
+      obj["schemaName"].asString(), obj["tableName"].asString()};
+  auto sourceCatalog = obj["sourceCatalog"].asString();
+  // False positive: deserialize() move-constructs its returned shared_ptr from
+  // a local unique_ptr, handing off the heap object; no stack reference
+  // escapes.
+  // @lint-ignore INFERCPP USE_AFTER_LIFETIME
+  auto columnHandles = velox::ISerializable::deserialize<
+      std::vector<velox::connector::ColumnHandle>>(obj["columnHandles"]);
+  // @lint-ignore INFERCPP USE_AFTER_LIFETIME
+  auto acceptedFilters =
+      velox::ISerializable::deserialize<std::vector<velox::core::ITypedExpr>>(
+          obj["acceptedFilters"]);
+  return std::make_shared<SyntheticTableHandle>(
+      connectorId,
+      std::move(schemaTableName),
+      std::move(columnHandles),
+      std::move(acceptedFilters),
+      std::move(sourceCatalog));
+}
+
+folly::dynamic SyntheticSplit::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = SyntheticSplit::getClassName();
+  obj["connectorId"] = connectorId;
+  return obj;
+}
+
+std::shared_ptr<SyntheticSplit> SyntheticSplit::create(
+    const folly::dynamic& obj) {
+  return std::make_shared<SyntheticSplit>(obj["connectorId"].asString());
+}
+
+SyntheticDataSource::SyntheticDataSource(
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    std::shared_ptr<const SyntheticRowProvider> provider,
+    std::vector<velox::core::TypedExprPtr> acceptedFilters,
+    velox::memory::MemoryPool* pool)
+    : outputType_(outputType),
+      pool_(pool),
+      provider_(std::move(provider)),
+      acceptedFilters_(std::move(acceptedFilters)) {
+  const auto& fullSchema = provider_->rowType();
+  outputColumnMappings_.reserve(outputType_->size());
+  for (const auto& name : outputType_->names()) {
+    auto it = columnHandles.find(name);
+    VELOX_CHECK(
+        it != columnHandles.end(), "No handle for output column: {}", name);
+    auto idx = fullSchema->getChildIdxIfExists(it->second->name());
+    VELOX_CHECK(idx.has_value(), "Column not found: {}", it->second->name());
+    outputColumnMappings_.push_back(idx.value());
+  }
+}
+
+void SyntheticDataSource::addSplit(
+    std::shared_ptr<velox::connector::ConnectorSplit> split) {
+  split_ = std::dynamic_pointer_cast<SyntheticSplit>(split);
+  VELOX_CHECK_NOT_NULL(split_, "Expected SyntheticSplit");
+  // completedRows_ is a running total across the source's lifetime, so it is
+  // intentionally not reset here.
+  results_ = nullptr;
+  offset_ = 0;
+}
+
+std::optional<velox::RowVectorPtr> SyntheticDataSource::next(
+    uint64_t size,
+    velox::ContinueFuture& /*future*/) {
+  VELOX_CHECK_NOT_NULL(split_, "No split added");
+  if (results_ == nullptr) {
+    results_ = buildResults();
+  }
+  if (offset_ >= results_->size()) {
+    return nullptr;
+  }
+  // 'size' is uint64_t; clamp before narrowing so a value above the
+  // vector_size_t range can't wrap to a negative length.
+  const auto remaining = results_->size() - offset_;
+  const auto length = static_cast<velox::vector_size_t>(
+      std::min<uint64_t>(size, static_cast<uint64_t>(remaining)));
+  auto batch = std::static_pointer_cast<velox::RowVector>(
+      results_->slice(offset_, length));
+  offset_ += length;
+  completedRows_ += length;
+  return batch;
+}
+
+velox::RowVectorPtr SyntheticDataSource::buildResults() {
+  auto full = provider_->buildRows(acceptedFilters_, pool_);
+  VELOX_CHECK_NOT_NULL(full, "Provider returned a null vector");
+  VELOX_CHECK(
+      *full->type() == *provider_->rowType(),
+      "Provider rows do not match its declared schema");
+
+  std::vector<velox::VectorPtr> children;
+  children.reserve(outputColumnMappings_.size());
+  for (auto idx : outputColumnMappings_) {
+    children.push_back(full->childAt(idx));
+  }
+  return std::make_shared<velox::RowVector>(
+      pool_, outputType_, /*nulls=*/nullptr, full->size(), std::move(children));
+}
+
+void registerSyntheticSerDe() {
+  SyntheticTableHandle::registerSerDe();
+  SyntheticColumnHandle::registerSerDe();
+  SyntheticSplit::registerSerDe();
+}
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/SyntheticConnector.h
+++ b/axiom/connectors/synthetic/SyntheticConnector.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/common/SchemaTableName.h"
+#include "velox/connectors/Connector.h"
+#include "velox/core/ITypedExpr.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+/// Produces the rows of a synthetic relation: a relation synthesized from
+/// connector metadata at query time instead of read from storage, such as
+/// information_schema.columns or a table's $partitions.
+///
+/// The provider is the only piece written per relation. The handle, split,
+/// data source, and table around it are generic and shared across all synthetic
+/// relations.
+///
+/// A concrete provider implements rowType() and buildRows(), and overrides
+/// acceptFilters() to opt into predicate pushdown. A catalog returns it from
+/// ConnectorMetadata::findSyntheticProvider().
+///
+/// A provider must be deterministic and hold no per-scan state. acceptFilters()
+/// and buildRows() may run on different provider instances for the same
+/// relation, because a distributed scan rebuilds the provider from the
+/// serialized handle.
+class SyntheticRowProvider {
+ public:
+  virtual ~SyntheticRowProvider() = default;
+
+  /// Returns the full output schema of the synthetic table. buildRows() must
+  /// return a RowVector of exactly this type.
+  virtual const velox::RowTypePtr& rowType() const = 0;
+
+  /// Splits 'filters' into the ones the provider will apply itself and the ones
+  /// it cannot. Returns the former; appends the latter to 'rejected' for the
+  /// engine to re-apply above the scan. Accepting a filter is a promise to
+  /// apply it in buildRows(). The default accepts nothing.
+  virtual std::vector<velox::core::TypedExprPtr> acceptFilters(
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejected) const;
+
+  /// Materializes all rows matching 'acceptedFilters' as a RowVector of
+  /// rowType(). 'acceptedFilters' are exactly the filters returned by a prior
+  /// acceptFilters() call for this scan.
+  virtual velox::RowVectorPtr buildRows(
+      const std::vector<velox::core::TypedExprPtr>& acceptedFilters,
+      velox::memory::MemoryPool* pool) const = 0;
+};
+
+/// Column handle for a synthetic table.
+class SyntheticColumnHandle : public velox::connector::ColumnHandle {
+ public:
+  explicit SyntheticColumnHandle(std::string name) : name_(std::move(name)) {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<SyntheticColumnHandle> create(
+      const folly::dynamic& obj);
+
+  static void registerSerDe() {
+    velox::registerDeserializer<SyntheticColumnHandle>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SyntheticColumnHandle)
+
+ private:
+  const std::string name_;
+};
+
+/// Table handle for a synthetic table. Carries the schema-qualified name, the
+/// selected column handles, and the filters the provider accepted for pushdown
+/// (so the DataSource can hand them back to the provider).
+class SyntheticTableHandle : public velox::connector::ConnectorTableHandle {
+ public:
+  /// 'connectorId' is the shared execution connector that runs the scan (see
+  /// SyntheticExecutionConnector); 'sourceCatalog' is the catalog whose
+  /// metadata produces the rows.
+  SyntheticTableHandle(
+      std::string_view connectorId,
+      SchemaTableName schemaTableName,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      std::vector<velox::core::TypedExprPtr> acceptedFilters,
+      std::string sourceCatalog);
+
+  const std::string& name() const override {
+    return qualifiedName_;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  const SchemaTableName& schemaTableName() const {
+    return schemaTableName_;
+  }
+
+  /// Catalog whose metadata rebuilds the row provider at execution time.
+  const std::string& sourceCatalog() const {
+    return sourceCatalog_;
+  }
+
+  const std::vector<velox::connector::ColumnHandlePtr>& columnHandles() const {
+    return columnHandles_;
+  }
+
+  const std::vector<velox::core::TypedExprPtr>& acceptedFilters() const {
+    return acceptedFilters_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static velox::connector::ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe() {
+    velox::registerDeserializerWithContext<SyntheticTableHandle>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SyntheticTableHandle)
+
+ private:
+  const SchemaTableName schemaTableName_;
+  const std::string qualifiedName_;
+  const std::vector<velox::connector::ColumnHandlePtr> columnHandles_;
+  const std::vector<velox::core::TypedExprPtr> acceptedFilters_;
+  const std::string sourceCatalog_;
+};
+
+/// Split for a synthetic table. A single split covers all rows, which are
+/// produced in-memory from the provider.
+struct SyntheticSplit : public velox::connector::ConnectorSplit {
+  explicit SyntheticSplit(const std::string& connectorId)
+      : ConnectorSplit(connectorId) {}
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<SyntheticSplit> create(const folly::dynamic& obj);
+
+  static void registerSerDe() {
+    velox::registerDeserializer<SyntheticSplit>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(SyntheticSplit)
+};
+
+/// DataSource for a synthetic table. Builds its rows from a
+/// SyntheticRowProvider, which applies the accepted filters, then projects that
+/// full-schema output down to the scan's output columns.
+///
+/// A split must be added before the first next(). The rows are materialized
+/// lazily on that first next(), then handed out in size-bounded slices:
+///
+///   SyntheticDataSource source(outputType, columnHandles, provider, {}, pool);
+///   source.addSplit(split);
+///   auto batch = source.next(size, future); // repeat until it yields nullptr
+class SyntheticDataSource : public velox::connector::DataSource {
+ public:
+  SyntheticDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      std::shared_ptr<const SyntheticRowProvider> provider,
+      std::vector<velox::core::TypedExprPtr> acceptedFilters,
+      velox::memory::MemoryPool* pool);
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override;
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& future) override;
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {}
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ private:
+  // Materializes the provider's rows and projects them onto outputType_.
+  velox::RowVectorPtr buildResults();
+
+  const velox::RowTypePtr outputType_;
+  velox::memory::MemoryPool* const pool_;
+  const std::shared_ptr<const SyntheticRowProvider> provider_;
+  const std::vector<velox::core::TypedExprPtr> acceptedFilters_;
+  // Output column index -> provider rowType() index.
+  std::vector<velox::column_index_t> outputColumnMappings_;
+  std::shared_ptr<SyntheticSplit> split_;
+  // Built lazily on the first next() after a split is added; nullptr until
+  // then.
+  velox::RowVectorPtr results_;
+  velox::vector_size_t offset_{0};
+  uint64_t completedRows_{0};
+};
+
+/// Registers deserializers for SyntheticTableHandle, SyntheticColumnHandle, and
+/// SyntheticSplit. A consuming connector must call this once before any
+/// serialized synthetic handle or split is deserialized.
+void registerSyntheticSerDe();
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/SyntheticExecutionConnector.cpp
+++ b/axiom/connectors/synthetic/SyntheticExecutionConnector.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/synthetic/SyntheticExecutionConnector.h"
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/connectors/ConnectorRegistry.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+std::unique_ptr<velox::connector::DataSource>
+SyntheticExecutionConnector::createDataSource(
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
+  const auto* handle =
+      dynamic_cast<const SyntheticTableHandle*>(tableHandle.get());
+  VELOX_CHECK_NOT_NULL(
+      handle,
+      "Synthetic execution connector expects a SyntheticTableHandle, got: {}",
+      tableHandle->name());
+
+  auto metadata = ConnectorMetadataRegistry::get(handle->sourceCatalog());
+
+  auto provider = metadata->findSyntheticProvider(handle->schemaTableName());
+  VELOX_CHECK_NOT_NULL(
+      provider, "No synthetic provider for routed table: {}", handle->name());
+
+  return std::make_unique<SyntheticDataSource>(
+      outputType,
+      columnHandles,
+      std::move(provider),
+      handle->acceptedFilters(),
+      connectorQueryCtx->memoryPool());
+}
+
+TablePtr findSyntheticTable(
+    const SchemaTableName& name,
+    ConnectorMetadata* metadata,
+    std::string_view catalog) {
+  auto provider = metadata->findSyntheticProvider(name);
+  if (provider == nullptr) {
+    return nullptr;
+  }
+  auto connector = velox::connector::ConnectorRegistry::tryGet(
+      std::string(kSyntheticConnectorId));
+  VELOX_CHECK_NOT_NULL(
+      connector,
+      "Synthetic execution connector is not registered; call "
+      "registerSyntheticExecutionConnector() first");
+  return std::make_shared<SyntheticTable>(
+      name, std::move(provider), connector.get(), std::string(catalog));
+}
+
+namespace {
+bool& registeredFlag() {
+  static bool registered{false};
+  return registered;
+}
+} // namespace
+
+void registerSyntheticExecutionConnector() {
+  if (registeredFlag()) {
+    return;
+  }
+  registerSyntheticSerDe();
+
+  const std::string id{kSyntheticConnectorId};
+  velox::connector::ConnectorRegistry::global().insert(
+      id, std::make_shared<SyntheticExecutionConnector>(id));
+  ConnectorMetadataRegistry::global().insert(
+      id, std::make_shared<SyntheticExecutionMetadata>());
+  registeredFlag() = true;
+}
+
+void unregisterSyntheticExecutionConnector() {
+  if (!registeredFlag()) {
+    return;
+  }
+  const std::string id{kSyntheticConnectorId};
+  ConnectorMetadataRegistry::global().erase(id);
+  velox::connector::ConnectorRegistry::global().erase(id);
+  registeredFlag() = false;
+}
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/SyntheticExecutionConnector.h
+++ b/axiom/connectors/synthetic/SyntheticExecutionConnector.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/synthetic/SyntheticTable.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+/// Connector id under which the shared SyntheticExecutionConnector is
+/// registered.
+inline constexpr std::string_view kSyntheticConnectorId = "$synthetic";
+
+/// Executes the scan for every synthetic table, on behalf of any catalog.
+///
+/// A catalog normally maps to its own connector, which runs its scans. Here a
+/// single "$synthetic" connector serves all catalogs: a catalog opts in through
+/// metadata alone (a findTable() hook, see findSyntheticTable) and needs no
+/// scan path or split manager of its own. findSyntheticTable() stamps
+/// "$synthetic" as the handle's connectorId() so scan and split dispatch
+/// resolve here, and keeps the origin catalog in sourceCatalog() so this
+/// connector can rebuild the row provider from that catalog's metadata.
+///
+/// Usage: call registerSyntheticExecutionConnector() once at startup; a catalog
+/// then routes its findTable() through findSyntheticTable(), and scans of the
+/// returned table dispatch here.
+class SyntheticExecutionConnector : public velox::connector::Connector {
+ public:
+  explicit SyntheticExecutionConnector(const std::string& id) : Connector(id) {}
+
+  /// Rebuilds the row provider over the source catalog's metadata and scans it.
+  /// See kSyntheticConnectorId.
+  std::unique_ptr<velox::connector::DataSource> createDataSource(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::connector::ConnectorQueryCtx* connectorQueryCtx) override;
+
+  /// Synthetic tables are read-only.
+  std::unique_ptr<velox::connector::DataSink> createDataSink(
+      velox::RowTypePtr /*inputType*/,
+      velox::connector::ConnectorInsertTableHandlePtr /*insertTableHandle*/,
+      velox::connector::ConnectorQueryCtx* /*connectorQueryCtx*/,
+      velox::connector::CommitStrategy /*commitStrategy*/) override {
+    VELOX_UNSUPPORTED("Synthetic execution connector does not support writes");
+  }
+};
+
+/// ConnectorMetadata for SyntheticExecutionConnector. A synthetic table is
+/// resolved on its origin catalog; only its execution routes to "$synthetic".
+/// This metadata therefore owns only a split manager, so that split routing
+/// resolves for a synthetic table handle; findTable() and the listing methods
+/// are never reached.
+class SyntheticExecutionMetadata : public ConnectorMetadata {
+ public:
+  TablePtr findTable(const SchemaTableName& /*tableName*/) override {
+    return nullptr;
+  }
+
+  ConnectorSplitManager* splitManager() override {
+    return &splitManager_;
+  }
+
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr& /*session*/) override {
+    return {};
+  }
+
+  bool schemaExists(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return false;
+  }
+
+  bool listTableNamesSupported() const override {
+    return false;
+  }
+
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/) override {
+    return {};
+  }
+
+ private:
+  SyntheticSplitManager splitManager_;
+};
+
+/// Registers the shared execution connector, its metadata, and the synthetic
+/// SerDe under kSyntheticConnectorId. A catalog that serves synthetic tables
+/// must ensure this has run once. Idempotent. Not thread-safe: call from a
+/// single thread (server startup or test setup), never concurrently with itself
+/// or unregisterSyntheticExecutionConnector().
+void registerSyntheticExecutionConnector();
+
+/// Reverses registerSyntheticExecutionConnector. Idempotent, and subject to the
+/// same single-thread requirement.
+void unregisterSyntheticExecutionConnector();
+
+/// Returns a SyntheticTable serving 'name' if 'metadata' recognizes it as a
+/// synthetic relation (via findSyntheticProvider), or nullptr otherwise. A
+/// catalog calls this from its findTable(). 'catalog' is recorded on the
+/// returned table's handles as sourceCatalog().
+///
+/// 'metadata' is read once and not retained. SyntheticExecutionConnector must
+/// be registered before this call and stay registered for the returned table's
+/// lifetime, since the table holds a raw pointer to it.
+TablePtr findSyntheticTable(
+    const SchemaTableName& name,
+    ConnectorMetadata* metadata,
+    std::string_view catalog);
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/SyntheticTable.cpp
+++ b/axiom/connectors/synthetic/SyntheticTable.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/synthetic/SyntheticTable.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+velox::connector::ColumnHandlePtr SyntheticTableLayout::createColumnHandle(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& columnName,
+    std::vector<velox::common::Subfield> /*subfields*/,
+    std::optional<velox::TypePtr> /*castToType*/,
+    SubfieldMapping /*subfieldMapping*/) const {
+  VELOX_CHECK_NOT_NULL(
+      findColumn(columnName), "Column not found: {}", columnName);
+  return std::make_shared<SyntheticColumnHandle>(columnName);
+}
+
+velox::connector::ConnectorTableHandlePtr
+SyntheticTableLayout::createTableHandle(
+    const ConnectorSessionPtr& /*session*/,
+    std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+    velox::core::ExpressionEvaluator& /*evaluator*/,
+    std::vector<velox::core::TypedExprPtr> filters,
+    std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+    velox::RowTypePtr /*dataColumns*/,
+    std::optional<LookupKeys> /*lookupKeys*/) const {
+  auto acceptedFilters =
+      provider_->acceptFilters(std::move(filters), rejectedFilters);
+  return std::make_shared<SyntheticTableHandle>(
+      connectorId(),
+      table().name(),
+      std::move(columnHandles),
+      std::move(acceptedFilters),
+      sourceCatalog_);
+}
+
+SyntheticTable::SyntheticTable(
+    const SchemaTableName& tableName,
+    std::shared_ptr<const SyntheticRowProvider> provider,
+    velox::connector::Connector* connector,
+    std::string sourceCatalog)
+    : Table(tableName, makeColumns(provider->rowType())) {
+  layout_ = std::make_unique<SyntheticTableLayout>(
+      this,
+      connector,
+      allColumns(),
+      std::move(provider),
+      std::move(sourceCatalog));
+  layouts_.push_back(layout_.get());
+}
+
+folly::coro::Task<SplitBatch> SyntheticSplitSource::co_getSplits(
+    uint32_t /*maxSplitCount*/) {
+  SplitBatch batch;
+  if (!done_) {
+    batch.splits.push_back(
+        Split{
+            .connectorSplit = std::make_shared<SyntheticSplit>(connectorId_)});
+    done_ = true;
+  }
+  batch.noMoreSplits = true;
+  co_return batch;
+}
+
+folly::coro::Task<std::vector<PartitionHandlePtr>>
+SyntheticSplitManager::co_listPartitions(
+    const ConnectorSessionPtr& /*session*/,
+    const velox::connector::ConnectorTableHandlePtr& /*tableHandle*/) {
+  co_return std::vector<PartitionHandlePtr>{
+      std::make_shared<PartitionHandle>()};
+}
+
+std::shared_ptr<SplitSource> SyntheticSplitManager::getSplitSource(
+    const ConnectorSessionPtr& /*session*/,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    const std::vector<PartitionHandlePtr>& /*partitions*/,
+    const std::shared_ptr<PartitionType>& /*partitionType*/,
+    QueryRuntimeStats& /*runtimeStats*/) {
+  return std::make_shared<SyntheticSplitSource>(tableHandle->connectorId());
+}
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/SyntheticTable.h
+++ b/axiom/connectors/synthetic/SyntheticTable.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/synthetic/SyntheticConnector.h"
+
+namespace facebook::axiom::connector::synthetic {
+
+/// Table layout for a synthetic table. Constructed by SyntheticTable; the
+/// optimizer calls createTableHandle() to produce the SyntheticTableHandle that
+/// drives the scan. createTableHandle() runs the provider's acceptFilters() to
+/// split the predicates: accepted ones are stored on the handle for pushdown,
+/// the rest go back to the engine to re-apply.
+class SyntheticTableLayout : public TableLayout {
+ public:
+  /// 'connector' executes the scan (SyntheticExecutionConnector).
+  /// 'sourceCatalog' is stored on every handle this layout creates so the
+  /// execution connector can rebuild the provider.
+  SyntheticTableLayout(
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::shared_ptr<const SyntheticRowProvider> provider,
+      std::string sourceCatalog)
+      : TableLayout(
+            "default",
+            table,
+            connector,
+            std::move(columns),
+            /*partitionColumns=*/{},
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            /*lookupKeys=*/{},
+            /*supportsScan=*/true),
+        provider_(std::move(provider)),
+        sourceCatalog_(std::move(sourceCatalog)) {}
+
+  bool supportsSampling() const override {
+    return false;
+  }
+
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& session,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> subfields,
+      std::optional<velox::TypePtr> castToType,
+      SubfieldMapping subfieldMapping) const override;
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<velox::core::TypedExprPtr>& rejectedFilters,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
+
+ private:
+  const std::shared_ptr<const SyntheticRowProvider> provider_;
+  const std::string sourceCatalog_;
+};
+
+/// Table backed by a SyntheticRowProvider. Its schema is the provider's
+/// rowType(), and its single layout (SyntheticTableLayout) handles predicate
+/// pushdown to the provider. Created by findSyntheticTable() and returned as a
+/// TablePtr from a catalog's findTable().
+class SyntheticTable : public Table {
+ public:
+  /// 'sourceCatalog' is the catalog whose metadata rebuilds the provider at
+  /// execution time.
+  SyntheticTable(
+      const SchemaTableName& tableName,
+      std::shared_ptr<const SyntheticRowProvider> provider,
+      velox::connector::Connector* connector,
+      std::string sourceCatalog);
+
+  const std::vector<const TableLayout*>& layouts() const override {
+    return layouts_;
+  }
+
+  std::optional<uint64_t> numRows() const override {
+    return std::nullopt; // Synthesized at query time, unknown.
+  }
+
+ private:
+  // layouts_ holds a raw pointer into layout_, so layout_ is declared first and
+  // must outlive layouts_.
+  std::unique_ptr<SyntheticTableLayout> layout_;
+  std::vector<const TableLayout*> layouts_;
+};
+
+/// SplitSource that emits exactly one SyntheticSplit, since all rows are
+/// produced in a single in-memory batch.
+class SyntheticSplitSource : public SplitSource {
+ public:
+  explicit SyntheticSplitSource(std::string connectorId)
+      : connectorId_(std::move(connectorId)) {}
+
+  folly::coro::Task<SplitBatch> co_getSplits(uint32_t maxSplitCount) override;
+
+ private:
+  const std::string connectorId_;
+  bool done_{false};
+};
+
+/// SplitManager that returns a single partition and a single split.
+class SyntheticSplitManager : public ConnectorSplitManager {
+ public:
+  folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
+      const ConnectorSessionPtr& session,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
+
+  std::shared_ptr<SplitSource> getSplitSource(
+      const ConnectorSessionPtr& session,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const std::vector<PartitionHandlePtr>& partitions,
+      const std::shared_ptr<PartitionType>& partitionType,
+      QueryRuntimeStats& runtimeStats) override;
+};
+
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/tests/SyntheticConnectorSerDeTest.cpp
+++ b/axiom/connectors/synthetic/tests/SyntheticConnectorSerDeTest.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/synthetic/SyntheticExecutionConnector.h"
+
+namespace facebook::axiom::connector::synthetic {
+namespace {
+
+class SyntheticConnectorSerDeTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  SyntheticConnectorSerDeTest() {
+    registerSyntheticSerDe();
+  }
+
+  static void testSerde(const SyntheticColumnHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone = velox::ISerializable::deserialize<SyntheticColumnHandle>(obj);
+    ASSERT_EQ(handle.name(), clone->name());
+  }
+
+  static void testSerde(const SyntheticTableHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone = velox::ISerializable::deserialize<SyntheticTableHandle>(
+        obj, /*context=*/nullptr);
+    auto* cloned = dynamic_cast<const SyntheticTableHandle*>(clone.get());
+    ASSERT_NE(cloned, nullptr);
+    ASSERT_EQ(handle.connectorId(), cloned->connectorId());
+    ASSERT_EQ(handle.schemaTableName(), cloned->schemaTableName());
+    ASSERT_EQ(handle.name(), cloned->name());
+    ASSERT_EQ(handle.sourceCatalog(), cloned->sourceCatalog());
+    ASSERT_EQ(handle.columnHandles().size(), cloned->columnHandles().size());
+    for (size_t i = 0; i < handle.columnHandles().size(); ++i) {
+      auto* original = dynamic_cast<const SyntheticColumnHandle*>(
+          handle.columnHandles()[i].get());
+      auto* clonedColumn = dynamic_cast<const SyntheticColumnHandle*>(
+          cloned->columnHandles()[i].get());
+      ASSERT_NE(original, nullptr);
+      ASSERT_NE(clonedColumn, nullptr);
+      ASSERT_EQ(original->name(), clonedColumn->name());
+    }
+    ASSERT_EQ(
+        handle.acceptedFilters().size(), cloned->acceptedFilters().size());
+  }
+
+  static void testSerde(const SyntheticSplit& split) {
+    auto obj = split.serialize();
+    auto clone = velox::ISerializable::deserialize<SyntheticSplit>(obj);
+    ASSERT_EQ(split.connectorId, clone->connectorId);
+  }
+};
+
+TEST_F(SyntheticConnectorSerDeTest, columnHandle) {
+  testSerde(SyntheticColumnHandle("a"));
+  testSerde(SyntheticColumnHandle("table_schema"));
+  testSerde(SyntheticColumnHandle(""));
+}
+
+TEST_F(SyntheticConnectorSerDeTest, tableHandle) {
+  const std::string connectorId{kSyntheticConnectorId};
+
+  // No column handles.
+  testSerde(SyntheticTableHandle(
+      connectorId,
+      SchemaTableName{"s", "t"},
+      /*columnHandles=*/{},
+      /*acceptedFilters=*/{},
+      /*sourceCatalog=*/"origin"));
+
+  // With column handles.
+  std::vector<velox::connector::ColumnHandlePtr> columns = {
+      std::make_shared<SyntheticColumnHandle>("a"),
+      std::make_shared<SyntheticColumnHandle>("b"),
+  };
+  testSerde(SyntheticTableHandle(
+      connectorId,
+      SchemaTableName{"information_schema", "columns"},
+      std::move(columns),
+      /*acceptedFilters=*/{},
+      /*sourceCatalog=*/"origin"));
+}
+
+TEST_F(SyntheticConnectorSerDeTest, split) {
+  testSerde(SyntheticSplit(std::string(kSyntheticConnectorId)));
+  testSerde(SyntheticSplit("other"));
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::synthetic

--- a/axiom/connectors/synthetic/tests/SyntheticMechanismTest.cpp
+++ b/axiom/connectors/synthetic/tests/SyntheticMechanismTest.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/ScopeGuard.h>
+#include <folly/coro/BlockingWait.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/synthetic/SyntheticExecutionConnector.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/core/Expressions.h"
+#include "velox/expression/Expr.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::axiom::connector::synthetic {
+namespace {
+
+using namespace facebook::velox;
+
+// Provider returning a fixed batch, so the scan mechanism can be exercised
+// without any concrete metadata source.
+class FixedRowProvider : public SyntheticRowProvider {
+ public:
+  explicit FixedRowProvider(RowVectorPtr rows)
+      : rows_{std::move(rows)}, rowType_{asRowType(rows_->type())} {}
+
+  const RowTypePtr& rowType() const override {
+    return rowType_;
+  }
+
+  RowVectorPtr buildRows(
+      const std::vector<core::TypedExprPtr>& /*acceptedFilters*/,
+      memory::MemoryPool* /*pool*/) const override {
+    return rows_;
+  }
+
+ private:
+  const RowVectorPtr rows_;
+  const RowTypePtr rowType_;
+};
+
+// Records the acceptedFilters handed to buildRows, to verify the scan forwards
+// them from the handle down to the provider.
+class RecordingProvider : public SyntheticRowProvider {
+ public:
+  explicit RecordingProvider(RowVectorPtr rows)
+      : rows_{std::move(rows)}, rowType_{asRowType(rows_->type())} {}
+
+  const RowTypePtr& rowType() const override {
+    return rowType_;
+  }
+
+  RowVectorPtr buildRows(
+      const std::vector<core::TypedExprPtr>& acceptedFilters,
+      memory::MemoryPool* /*pool*/) const override {
+    receivedFilters_ = acceptedFilters;
+    return rows_;
+  }
+
+  const std::vector<core::TypedExprPtr>& receivedFilters() const {
+    return receivedFilters_;
+  }
+
+ private:
+  const RowVectorPtr rows_;
+  const RowTypePtr rowType_;
+  mutable std::vector<core::TypedExprPtr> receivedFilters_;
+};
+
+// Declares one schema but returns a different one from buildRows, to exercise
+// the schema-consistency check.
+class MisorderedProvider : public SyntheticRowProvider {
+ public:
+  MisorderedProvider(RowTypePtr declaredType, RowVectorPtr rows)
+      : declaredType_{std::move(declaredType)}, rows_{std::move(rows)} {}
+
+  const RowTypePtr& rowType() const override {
+    return declaredType_;
+  }
+
+  RowVectorPtr buildRows(
+      const std::vector<core::TypedExprPtr>& /*acceptedFilters*/,
+      memory::MemoryPool* /*pool*/) const override {
+    return rows_;
+  }
+
+ private:
+  const RowTypePtr declaredType_;
+  const RowVectorPtr rows_;
+};
+
+// Accepts the first filter for pushdown and rejects the rest, to exercise the
+// accept/reject split in the layout.
+class SplittingProvider : public SyntheticRowProvider {
+ public:
+  explicit SplittingProvider(RowTypePtr rowType)
+      : rowType_{std::move(rowType)} {}
+
+  const RowTypePtr& rowType() const override {
+    return rowType_;
+  }
+
+  std::vector<core::TypedExprPtr> acceptFilters(
+      std::vector<core::TypedExprPtr> filters,
+      std::vector<core::TypedExprPtr>& rejected) const override {
+    std::vector<core::TypedExprPtr> accepted;
+    for (size_t i = 0; i < filters.size(); ++i) {
+      if (i == 0) {
+        accepted.push_back(filters[i]);
+      } else {
+        rejected.push_back(filters[i]);
+      }
+    }
+    return accepted;
+  }
+
+  RowVectorPtr buildRows(
+      const std::vector<core::TypedExprPtr>& /*acceptedFilters*/,
+      memory::MemoryPool* pool) const override {
+    return BaseVector::create<RowVector>(rowType_, 0, pool);
+  }
+
+ private:
+  const RowTypePtr rowType_;
+};
+
+// Serves a single synthetic relation from a fixed provider, to drive the routed
+// scan path end to end.
+class SingleRelationMetadata : public ConnectorMetadata {
+ public:
+  SingleRelationMetadata(
+      SchemaTableName name,
+      std::shared_ptr<const SyntheticRowProvider> provider)
+      : name_{std::move(name)}, provider_{std::move(provider)} {}
+
+  std::shared_ptr<const SyntheticRowProvider> findSyntheticProvider(
+      const SchemaTableName& name) override {
+    return name == name_ ? provider_ : nullptr;
+  }
+
+  TablePtr findTable(const SchemaTableName&) override {
+    return nullptr;
+  }
+
+  ConnectorSplitManager* splitManager() override {
+    return nullptr;
+  }
+
+  std::vector<std::string> listSchemaNames(
+      const ConnectorSessionPtr&) override {
+    return {};
+  }
+
+  bool schemaExists(const ConnectorSessionPtr&, const std::string&) override {
+    return false;
+  }
+
+  std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr&,
+      const std::string&) override {
+    return {};
+  }
+
+ private:
+  const SchemaTableName name_;
+  const std::shared_ptr<const SyntheticRowProvider> provider_;
+};
+
+class SyntheticMechanismTest : public testing::Test,
+                               public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    registerSyntheticExecutionConnector();
+  }
+
+  void TearDown() override {
+    unregisterSyntheticExecutionConnector();
+  }
+
+  static ConnectorSessionPtr makeSession() {
+    return std::make_shared<ConnectorSession>(
+        /*queryId=*/"test", /*user=*/"test", Properties{});
+  }
+
+  static const std::string& kCatalog() {
+    static const std::string kValue{"fixed-catalog"};
+    return kValue;
+  }
+};
+
+// A scan requesting a subset of columns gets the provider's full schema
+// projected down to just those columns.
+TEST_F(SyntheticMechanismTest, columnProjection) {
+  auto provider = std::make_shared<FixedRowProvider>(makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<std::string>({"x", "y", "z"})}));
+
+  // Request only "b" so the data source must project the provider's full-schema
+  // output down to the scan's output columns.
+  auto outputType = ROW({{"b", VARCHAR()}});
+  velox::connector::ColumnHandleMap columnHandles;
+  columnHandles["b"] = std::make_shared<SyntheticColumnHandle>("b");
+
+  SyntheticDataSource dataSource(
+      outputType, columnHandles, provider, /*acceptedFilters=*/{}, pool_.get());
+  dataSource.addSplit(
+      std::make_shared<SyntheticSplit>(std::string(kSyntheticConnectorId)));
+
+  ContinueFuture future;
+  auto batch = dataSource.next(1024, future);
+  ASSERT_TRUE(batch.has_value());
+  test::assertEqualVectors(
+      makeRowVector({"b"}, {makeFlatVector<std::string>({"x", "y", "z"})}),
+      batch.value());
+
+  // A second call signals end-of-data with a null vector; nullopt would instead
+  // mean the source is blocked.
+  auto exhausted = dataSource.next(1024, future);
+  ASSERT_TRUE(exhausted.has_value());
+  EXPECT_EQ(exhausted.value(), nullptr);
+}
+
+// next(size) hands the rows out in batches of at most 'size'.
+TEST_F(SyntheticMechanismTest, batchSize) {
+  auto provider = std::make_shared<FixedRowProvider>(
+      makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})}));
+
+  velox::connector::ColumnHandleMap columnHandles;
+  columnHandles["a"] = std::make_shared<SyntheticColumnHandle>("a");
+
+  SyntheticDataSource dataSource(
+      ROW({{"a", BIGINT()}}),
+      columnHandles,
+      provider,
+      /*acceptedFilters=*/{},
+      pool_.get());
+  dataSource.addSplit(
+      std::make_shared<SyntheticSplit>(std::string(kSyntheticConnectorId)));
+
+  // Five rows requested two at a time arrive as 2 + 2 + 1, not one batch.
+  ContinueFuture future;
+  std::vector<vector_size_t> batchSizes;
+  while (auto batch = dataSource.next(/*size=*/2, future)) {
+    if (batch.value() == nullptr) {
+      break;
+    }
+    batchSizes.push_back(batch.value()->size());
+  }
+  EXPECT_THAT(batchSizes, testing::ElementsAre(2, 2, 1));
+}
+
+// The accepted filters recorded on the handle are forwarded to the provider's
+// buildRows() at scan time.
+TEST_F(SyntheticMechanismTest, acceptedFiltersReachProvider) {
+  auto provider = std::make_shared<RecordingProvider>(
+      makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})}));
+
+  core::TypedExprPtr filter =
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "a");
+  velox::connector::ColumnHandleMap columnHandles;
+  columnHandles["a"] = std::make_shared<SyntheticColumnHandle>("a");
+
+  SyntheticDataSource dataSource(
+      ROW({{"a", BIGINT()}}),
+      columnHandles,
+      provider,
+      /*acceptedFilters=*/{filter},
+      pool_.get());
+  dataSource.addSplit(
+      std::make_shared<SyntheticSplit>(std::string(kSyntheticConnectorId)));
+
+  ContinueFuture future;
+  dataSource.next(1024, future);
+  ASSERT_EQ(provider->receivedFilters().size(), 1);
+  EXPECT_EQ(provider->receivedFilters().at(0), filter);
+}
+
+// buildRows() output whose schema disagrees with the provider's declared
+// rowType() (here, columns in a different order) is rejected.
+TEST_F(SyntheticMechanismTest, providerSchemaMismatch) {
+  auto declaredType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  // Same types, names swapped: this passes the looser equivalent() check (which
+  // ignores names) but must be caught by the stricter *type == *type
+  // comparison.
+  auto rows = makeRowVector(
+      {"b", "a"}, {makeFlatVector<int64_t>({1}), makeFlatVector<int64_t>({2})});
+  auto provider =
+      std::make_shared<MisorderedProvider>(declaredType, std::move(rows));
+
+  velox::connector::ColumnHandleMap columnHandles;
+  columnHandles["a"] = std::make_shared<SyntheticColumnHandle>("a");
+  columnHandles["b"] = std::make_shared<SyntheticColumnHandle>("b");
+
+  SyntheticDataSource dataSource(
+      declaredType,
+      columnHandles,
+      provider,
+      /*acceptedFilters=*/{},
+      pool_.get());
+  dataSource.addSplit(
+      std::make_shared<SyntheticSplit>(std::string(kSyntheticConnectorId)));
+
+  ContinueFuture future;
+  EXPECT_ANY_THROW(dataSource.next(1024, future));
+}
+
+// createTableHandle() delegates the accept/reject split to the provider: the
+// accepted filter is stored on the handle, the rest are returned to the engine.
+TEST_F(SyntheticMechanismTest, filterSplit) {
+  const SchemaTableName name{"s", "t"};
+  auto provider = std::make_shared<SplittingProvider>(
+      ROW({{"a", BIGINT()}, {"b", BIGINT()}}));
+  auto metadata =
+      std::make_shared<SingleRelationMetadata>(name, std::move(provider));
+  ConnectorMetadataRegistry::global().insert(kCatalog(), metadata);
+  auto registryGuard = folly::makeGuard(
+      [&] { ConnectorMetadataRegistry::global().erase(kCatalog()); });
+
+  auto table = findSyntheticTable(name, metadata.get(), kCatalog());
+  ASSERT_NE(table, nullptr);
+  const auto* layout = table->layouts().at(0);
+
+  auto session = makeSession();
+  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
+  for (const auto& columnName : table->type()->names()) {
+    columnHandles.push_back(layout->createColumnHandle(session, columnName));
+  }
+
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool_.get());
+  std::vector<core::TypedExprPtr> filters{
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "a"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "b")};
+  std::vector<core::TypedExprPtr> rejected;
+  auto tableHandle = layout->createTableHandle(
+      session, columnHandles, evaluator, std::move(filters), rejected);
+
+  auto* syntheticHandle =
+      dynamic_cast<const SyntheticTableHandle*>(tableHandle.get());
+  ASSERT_NE(syntheticHandle, nullptr);
+  EXPECT_EQ(syntheticHandle->acceptedFilters().size(), 1);
+  EXPECT_EQ(rejected.size(), 1);
+}
+
+// Drives the full routed scan end to end: findSyntheticTable() through the
+// layout, handle, and split to a DataSource on the shared connector, which
+// rebuilds the provider from the origin catalog's metadata.
+TEST_F(SyntheticMechanismTest, e2eRoutedScan) {
+  const SchemaTableName name{"s", "t"};
+  auto metadata = std::make_shared<SingleRelationMetadata>(
+      name,
+      std::make_shared<FixedRowProvider>(
+          makeRowVector({"a"}, {makeFlatVector<int64_t>({10, 20})})));
+  ConnectorMetadataRegistry::global().insert(kCatalog(), metadata);
+  // Erase even if an assertion below returns early, so the global registry does
+  // not leak this catalog into other tests.
+  auto registryGuard = folly::makeGuard(
+      [&] { ConnectorMetadataRegistry::global().erase(kCatalog()); });
+
+  auto table = findSyntheticTable(name, metadata.get(), kCatalog());
+  ASSERT_NE(table, nullptr);
+  const auto* layout = table->layouts().at(0);
+  const auto& outputType = table->type();
+
+  auto session = makeSession();
+  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
+  velox::connector::ColumnHandleMap columnHandleMap;
+  for (const auto& columnName : outputType->names()) {
+    auto handle = layout->createColumnHandle(session, columnName);
+    columnHandleMap[columnName] = handle;
+    columnHandles.push_back(std::move(handle));
+  }
+
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool_.get());
+  std::vector<core::TypedExprPtr> rejected;
+  auto tableHandle = layout->createTableHandle(
+      session, columnHandles, evaluator, /*filters=*/{}, rejected);
+
+  // The provider lives in the source catalog, but the scan and split routing
+  // resolve to the shared synthetic execution connector.
+  auto* syntheticHandle =
+      dynamic_cast<const SyntheticTableHandle*>(tableHandle.get());
+  ASSERT_NE(syntheticHandle, nullptr);
+  EXPECT_EQ(syntheticHandle->connectorId(), kSyntheticConnectorId);
+  EXPECT_EQ(syntheticHandle->sourceCatalog(), kCatalog());
+
+  auto* splitManager =
+      ConnectorMetadataRegistry::get(tableHandle->connectorId())
+          ->splitManager();
+  auto partitions = folly::coro::blockingWait(
+      splitManager->co_listPartitions(session, tableHandle));
+  QueryRuntimeStats runtimeStats;
+  auto splitSource = splitManager->getSplitSource(
+      session,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      runtimeStats);
+  auto splitBatch = folly::coro::blockingWait(
+      splitSource->co_getSplits(/*maxSplitCount=*/10));
+  ASSERT_EQ(splitBatch.splits.size(), 1);
+  folly::coro::blockingWait(splitSource->co_close());
+
+  auto config = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto connectorQueryCtx =
+      std::make_unique<velox::connector::ConnectorQueryCtx>(
+          pool_.get(),
+          pool_.get(),
+          config.get(),
+          /*spillConfig=*/nullptr,
+          common::PrefixSortConfig{},
+          /*expressionEvaluator=*/nullptr,
+          /*cache=*/nullptr,
+          "test-query",
+          "test-task",
+          "test-plan-node",
+          /*driverId=*/0,
+          /*sessionTimezone=*/"UTC");
+
+  auto dataSource =
+      velox::connector::ConnectorRegistry::tryGet(tableHandle->connectorId())
+          ->createDataSource(
+              outputType,
+              tableHandle,
+              columnHandleMap,
+              connectorQueryCtx.get());
+  dataSource->addSplit(splitBatch.splits.front().connectorSplit);
+
+  ContinueFuture future;
+  auto batch = dataSource->next(1024, future);
+  ASSERT_TRUE(batch.has_value());
+  test::assertEqualVectors(
+      makeRowVector({"a"}, {makeFlatVector<int64_t>({10, 20})}), batch.value());
+}
+
+// findSyntheticTable() returns null for a relation the catalog does not serve.
+TEST_F(SyntheticMechanismTest, unknownRelation) {
+  const SchemaTableName served{"s", "t"};
+  SingleRelationMetadata metadata{
+      served,
+      std::make_shared<FixedRowProvider>(
+          makeRowVector({"a"}, {makeFlatVector<int64_t>({1})}))};
+
+  EXPECT_EQ(
+      findSyntheticTable(SchemaTableName{"s", "u"}, &metadata, kCatalog()),
+      nullptr);
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::synthetic


### PR DESCRIPTION
Summary:

Some SQL metadata relations — the information_schema tables, a table's `$partitions` — are not stored: their rows are synthesized from connector metadata at query time. This adds the generic machinery to expose such a relation through the normal `findTable` -> scan path, so any catalog can serve one without its own scan implementation.

A `SyntheticRowProvider` supplies the rows and declares which predicates it can push into a targeted metadata lookup. A single shared execution connector (`$synthetic`) owns the scan: a catalog opts in by overriding `ConnectorMetadata::findSyntheticProvider` and returning a routed table from `findSyntheticTable`. That table's handle carries `$synthetic` as its `connectorId` — so scan and split routing resolve to the shared connector — and the originating catalog as its `sourceCatalog`, so the shared connector rebuilds the provider over that catalog's metadata. A catalog therefore needs no `createDataSource` or split manager of its own, which is what lets a catalog that delegates execution to a connector it does not control still serve synthetic tables.

No catalog serves any synthetic relation yet; information_schema and `$partitions` build on this mechanism in later diffs.

Differential Revision: D109736875


