### PR TITLE
refactor(optimizer): Hash-cons expressions by pointer (#1542)

### DIFF
--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-#include "axiom/optimizer/QueryGraph.h"
+#include <ranges>
+
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "folly/hash/Hash.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/expression/ScopedVarSetter.h"
 
 namespace lp = facebook::axiom::logical_plan;
@@ -124,6 +128,148 @@ std::string Call::toString() const {
   }
   out << ")";
   return out.str();
+}
+
+size_t Literal::KeyHash::operator()(const Literal* literal) const {
+  return velox::bits::hashMix(
+      folly::hasher<const velox::Type*>()(literal->value().type),
+      literal->literal().hash());
+}
+
+size_t Literal::KeyHash::operator()(const KeyView& key) const {
+  return velox::bits::hashMix(
+      folly::hasher<const velox::Type*>()(key.type), key.value->hash());
+}
+
+bool Literal::KeyEq::operator()(const Literal* left, const Literal* right)
+    const {
+  return left->value().type == right->value().type &&
+      left->literal() == right->literal();
+}
+
+bool Literal::KeyEq::operator()(const KeyView& key, const Literal* literal)
+    const {
+  return key.type == literal->value().type && *key.value == literal->literal();
+}
+
+bool Literal::KeyEq::operator()(const Literal* literal, const KeyView& key)
+    const {
+  return (*this)(key, literal);
+}
+
+namespace {
+// Hashes a Call's identity: name, result type, and args by pointer.
+template <typename Args>
+size_t hashCallIdentity(Name name, const velox::Type* type, const Args& args) {
+  size_t hash = folly::hasher<Name>()(name);
+  for (const auto* arg : args) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(arg));
+  }
+  return velox::bits::hashMix(hash, folly::hasher<const velox::Type*>()(type));
+}
+} // namespace
+
+size_t Call::KeyHash::operator()(const Call* call) const {
+  return hashCallIdentity(call->name(), call->value().type, call->args());
+}
+
+size_t Call::KeyHash::operator()(const KeyView& key) const {
+  return hashCallIdentity(key.name, key.type, key.args);
+}
+
+bool Call::KeyEq::operator()(const Call* left, const Call* right) const {
+  return left->name() == right->name() &&
+      left->value().type == right->value().type &&
+      std::ranges::equal(left->args(), right->args());
+}
+
+bool Call::KeyEq::operator()(const KeyView& key, const Call* call) const {
+  return key.name == call->name() && key.type == call->value().type &&
+      std::ranges::equal(key.args, call->args());
+}
+
+bool Call::KeyEq::operator()(const Call* call, const KeyView& key) const {
+  return (*this)(key, call);
+}
+
+namespace {
+template <typename Args, typename OrderKeys, typename OrderTypes>
+size_t hashAggregateIdentity(
+    Name name,
+    bool isDistinct,
+    ExprCP condition,
+    const Args& args,
+    const OrderKeys& orderKeys,
+    const OrderTypes& orderTypes) {
+  size_t hash = folly::hasher<Name>()(name);
+  hash = velox::bits::hashMix(hash, folly::hasher<bool>()(isDistinct));
+  if (condition != nullptr) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(condition));
+  }
+  for (const auto* arg : args) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(arg));
+  }
+  for (const auto* key : orderKeys) {
+    hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(key));
+  }
+  for (auto order : orderTypes) {
+    hash = velox::bits::hashMix(hash, folly::hasher<OrderType>()(order));
+  }
+  return hash;
+}
+
+bool aggregateIdentityEq(
+    const Aggregate::KeyView& key,
+    const Aggregate* aggregate) {
+  return key.name == aggregate->name() &&
+      key.isDistinct == aggregate->isDistinct() &&
+      key.condition == aggregate->condition() &&
+      std::ranges::equal(key.args, aggregate->args()) &&
+      std::ranges::equal(key.orderKeys, aggregate->orderKeys()) &&
+      std::ranges::equal(key.orderTypes, aggregate->orderTypes());
+}
+} // namespace
+
+size_t Aggregate::KeyHash::operator()(const Aggregate* aggregate) const {
+  return hashAggregateIdentity(
+      aggregate->name(),
+      aggregate->isDistinct(),
+      aggregate->condition(),
+      aggregate->args(),
+      aggregate->orderKeys(),
+      aggregate->orderTypes());
+}
+
+size_t Aggregate::KeyHash::operator()(const KeyView& key) const {
+  return hashAggregateIdentity(
+      key.name,
+      key.isDistinct,
+      key.condition,
+      key.args,
+      key.orderKeys,
+      key.orderTypes);
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* left, const Aggregate* right)
+    const {
+  return left->name() == right->name() &&
+      left->isDistinct() == right->isDistinct() &&
+      left->condition() == right->condition() &&
+      std::ranges::equal(left->args(), right->args()) &&
+      std::ranges::equal(left->orderKeys(), right->orderKeys()) &&
+      std::ranges::equal(left->orderTypes(), right->orderTypes());
+}
+
+bool Aggregate::KeyEq::operator()(
+    const KeyView& key,
+    const Aggregate* aggregate) const {
+  return aggregateIdentityEq(key, aggregate);
+}
+
+bool Aggregate::KeyEq::operator()(
+    const Aggregate* aggregate,
+    const KeyView& key) const {
+  return aggregateIdentityEq(key, aggregate);
 }
 
 std::string Aggregate::toString() const {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <span>
+
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/FunctionRegistry.h"
@@ -112,6 +114,30 @@ class Literal : public Expr {
   std::string toString() const override {
     return literal_->toJson(*value().type);
   }
+
+  /// Non-owning identity view for interning a `Literal` by content: result type
+  /// (canonical pointer) and the Variant, compared by value.
+  struct KeyView {
+    const velox::Type* type;
+    const velox::Variant* value;
+  };
+
+  /// Transparent hasher for interning `Literal`s; `is_transparent` enables
+  /// heterogeneous lookup by `KeyView` with no per-lookup allocation.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Literal* literal) const;
+    size_t operator()(const KeyView& key) const;
+  };
+
+  /// Transparent equality for interning `Literal`s; the Variant is compared by
+  /// value, so equal values dedup across distinct Variant objects.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Literal* left, const Literal* right) const;
+    bool operator()(const KeyView& key, const Literal* literal) const;
+    bool operator()(const Literal* literal, const KeyView& key) const;
+  };
 
  private:
   const velox::Variant* const literal_;
@@ -333,6 +359,31 @@ class Call : public Expr {
   FunctionMetadataCP metadata() const {
     return metadata_;
   }
+
+  /// Non-owning identity view for interning a `Call` by content. Holds only
+  /// what defines identity: function name, result type (distinguishes CAST-like
+  /// forms that share name + args), and args by pointer.
+  struct KeyView {
+    Name name;
+    const velox::Type* type;
+    std::span<const ExprCP> args;
+  };
+
+  /// Transparent hasher for interning `Call`s. `is_transparent` enables
+  /// heterogeneous lookup by `KeyView`, so a cache hit needs no allocation.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Call* call) const;
+    size_t operator()(const KeyView& key) const;
+  };
+
+  /// Transparent equality for interning `Call`s by content.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Call* left, const Call* right) const;
+    bool operator()(const KeyView& key, const Call* call) const;
+    bool operator()(const Call* call, const KeyView& key) const;
+  };
 
  private:
   // Name of function.
@@ -1227,6 +1278,34 @@ class Aggregate : public Call {
   const Aggregate* replaceDistinctAndFilterByMarker(ExprCP marker) const;
 
   std::string toString() const override;
+
+  /// Non-owning identity view for interning an `Aggregate` by content. Result
+  /// type and `intermediateType` are determined by (name, args), so they are
+  /// excluded; args / orderKeys are compared by pointer.
+  struct KeyView {
+    Name name;
+    std::span<const ExprCP> args;
+    bool isDistinct;
+    ExprCP condition;
+    std::span<const ExprCP> orderKeys;
+    std::span<const OrderType> orderTypes;
+  };
+
+  /// Transparent hasher for interning `Aggregate`s; `is_transparent` enables
+  /// heterogeneous lookup by `KeyView` with no per-lookup allocation.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Aggregate* aggregate) const;
+    size_t operator()(const KeyView& key) const;
+  };
+
+  /// Transparent equality for interning `Aggregate`s by content.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Aggregate* left, const Aggregate* right) const;
+    bool operator()(const KeyView& key, const Aggregate* aggregate) const;
+    bool operator()(const Aggregate* aggregate, const KeyView& key) const;
+  };
 
  private:
   bool isDistinct_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1110,19 +1110,17 @@ ExprCP ToGraph::deduppedCall(
     ExprVector args,
     bool specialForm) {
   canonicalizeCall(name, args);
-  ExprDedupKey key = {name, args, value.type};
-
-  auto [it, emplaced] = functionDedup_.try_emplace(key);
-  if (it->second) {
-    return it->second;
+  Call::KeyView view{name, value.type, args};
+  if (auto it = functionDedup_.find(view); it != functionDedup_.end()) {
+    return *it;
   }
   FunctionSet flags = functionBits(name, specialForm);
   for (auto* arg : args) {
     flags = flags | arg->functions();
   }
   auto* call = make<Call>(name, value, std::move(args), flags);
-  if (emplaced && !call->containsNonDeterministic()) {
-    it->second = call;
+  if (!call->containsNonDeterministic()) {
+    functionDedup_.insert(call);
   }
   return call;
 }
@@ -1224,27 +1222,30 @@ bool ToGraph::isJoinEquality(
 }
 
 ExprCP ToGraph::makeConstant(const lp::ConstantExpr& constant) {
-  TypedVariant temp{toType(constant.type()), constant.value()};
-  auto it = constantDedup_.find(temp);
-  if (it != constantDedup_.end()) {
-    return it->second;
+  const auto* type = toType(constant.type());
+  Literal::KeyView view{type, constant.value().get()};
+  if (auto it = constantDedup_.find(view); it != constantDedup_.end()) {
+    return *it;
   }
 
-  Value value(temp.type, 1);
-  if (temp.value->isNull()) {
+  // Give the Variant a query-scoped owner (the caller's ConstantExpr may be
+  // temporary, e.g. the null constant built by makeNullConstant).
+  const auto* variant = registerVariant(*constant.value());
+
+  Value value(type, 1);
+  if (variant->isNull()) {
     value.nullFraction = 1.0;
   } else {
     value.nullFraction = 0.0;
     value.nullable = false;
-    if (temp.type->isPrimitiveType()) {
-      value.min = temp.value.get();
-      value.max = temp.value.get();
+    if (type->isPrimitiveType()) {
+      value.min = variant;
+      value.max = variant;
     }
   }
 
-  auto* literal = make<Literal>(value, temp.value.get());
-
-  constantDedup_[std::move(temp)] = literal;
+  auto* literal = make<Literal>(value, variant);
+  constantDedup_.insert(literal);
   return literal;
 }
 
@@ -1726,50 +1727,6 @@ void ToGraph::addUnnest(const lp::UnnestNode& unnest) {
   currentDt_->joins.push_back(edge);
 }
 
-namespace {
-struct AggregateDedupKey {
-  Name func;
-  bool isDistinct;
-  ExprCP condition;
-  std::span<const ExprCP> args;
-  std::span<const ExprCP> orderKeys;
-  std::span<const OrderType> orderTypes;
-
-  bool operator==(const AggregateDedupKey& other) const {
-    return func == other.func && isDistinct == other.isDistinct &&
-        condition == other.condition && std::ranges::equal(args, other.args) &&
-        std::ranges::equal(orderKeys, other.orderKeys) &&
-        std::ranges::equal(orderTypes, other.orderTypes);
-  }
-};
-
-struct AggregateDedupHasher {
-  size_t operator()(const AggregateDedupKey& key) const {
-    size_t hash = folly::hasher<Name>()(key.func);
-
-    hash = velox::bits::hashMix(hash, folly::hasher<bool>()(key.isDistinct));
-
-    if (key.condition != nullptr) {
-      hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(key.condition));
-    }
-
-    for (auto& a : key.args) {
-      hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(a));
-    }
-
-    for (auto& k : key.orderKeys) {
-      hash = velox::bits::hashMix(hash, folly::hasher<ExprCP>()(k));
-    }
-
-    for (auto& t : key.orderTypes) {
-      hash = velox::bits::hashMix(hash, folly::hasher<OrderType>()(t));
-    }
-
-    return hash;
-  }
-};
-} // namespace
-
 ColumnCP ToGraph::createGroupIdColumn(
     Name name,
     const velox::TypePtr& type,
@@ -1898,7 +1855,11 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
   }
 
   AggregateVector deduppedAggregates;
-  folly::F14FastMap<AggregateDedupKey, ColumnCP, AggregateDedupHasher>
+  folly::F14FastMap<
+      const Aggregate*,
+      ColumnCP,
+      Aggregate::KeyHash,
+      Aggregate::KeyEq>
       uniqueAggregates;
 
   // Inside a subquery, allow aggregate arguments to resolve against
@@ -1966,11 +1927,9 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
 
     auto name = toName(agg.outputNames()[channel]);
 
-    AggregateDedupKey key{
-        aggName, isDistinct, condition, args, orderKeys, orderTypes};
-
-    auto it = uniqueAggregates.try_emplace(key).first;
-    if (it->second) {
+    Aggregate::KeyView view{
+        aggName, args, isDistinct, condition, orderKeys, orderTypes};
+    if (auto it = uniqueAggregates.find(view); it != uniqueAggregates.end()) {
       newRenames[name] = it->second;
     } else {
       auto accumulatorType = toType(
@@ -2003,7 +1962,7 @@ AggregationPlanCP ToGraph::translateAggregation(const lp::AggregateNode& agg) {
       intermediateColumns.push_back(intermediateColumn);
 
       deduppedAggregates.push_back(aggregateExpr);
-      it->second = column;
+      uniqueAggregates.emplace(aggregateExpr, column);
       newRenames[name] = column;
     }
   }

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/container/F14Set.h>
+
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/PathSet.h"
@@ -24,52 +26,11 @@
 
 namespace facebook::axiom::optimizer {
 
-struct ExprDedupKey {
-  Name func;
-  std::span<const ExprCP> args;
-  // Canonical return type pointer. Distinguishes calls like CAST(x AS double)
-  // and CAST(x AS varchar) which share the same function name and arguments.
-  const velox::Type* type;
-
-  bool operator==(const ExprDedupKey& other) const {
-    return func == other.func && type == other.type &&
-        std::ranges::equal(args, other.args);
-  }
-};
-
-struct ExprDedupHasher {
-  size_t operator()(const ExprDedupKey& key) const {
-    size_t h = folly::hasher<Name>()(key.func);
-    for (auto& a : key.args) {
-      h = velox::bits::hashMix(h, folly::hasher<ExprCP>()(a));
-    }
-    h = velox::bits::hashMix(h, folly::hasher<const velox::Type*>()(key.type));
-    return h;
-  }
-};
-
-using FunctionDedupMap =
-    folly::F14FastMap<ExprDedupKey, ExprCP, ExprDedupHasher>;
-
-struct TypedVariant {
-  /// Canonical Type pointer returned by QueryGraphContext::toType.
-  const velox::Type* type;
-  std::shared_ptr<const velox::Variant> value;
-};
-
-struct TypedVariantHasher {
-  size_t operator()(const TypedVariant& value) const {
-    return velox::bits::hashMix(
-        std::hash<const velox::Type*>()(value.type), value.value->hash());
-  }
-};
-
-struct TypedVariantComparer {
-  bool operator()(const TypedVariant& left, const TypedVariant& right) const {
-    // Types have been deduped, hence, we compare pointers.
-    return left.type == right.type && *left.value == *right.value;
-  }
-};
+// Interns Calls by content (name, result type, args by pointer) via the
+// transparent `Call::KeyHash` / `Call::KeyEq`, so a lookup uses a non-owning
+// `Call::KeyView` with no per-lookup allocation.
+using FunctionDedupSet =
+    folly::F14FastSet<const Call*, Call::KeyHash, Call::KeyEq>;
 
 /// Represents a path over an Expr of complex type. Used as a key
 /// for a map from unique step to the dedupped Expr that is the getter.
@@ -1038,12 +999,11 @@ class ToGraph {
       SubqueryExprEqual>
       subqueries_;
 
-  folly::
-      F14FastMap<TypedVariant, ExprCP, TypedVariantHasher, TypedVariantComparer>
-          constantDedup_;
+  folly::F14FastSet<const Literal*, Literal::KeyHash, Literal::KeyEq>
+      constantDedup_;
 
   // Dedup map from name + ExprVector to corresponding CallExpr.
-  FunctionDedupMap functionDedup_;
+  FunctionDedupSet functionDedup_;
 
   // Counter for generating unique correlation names for BaseTables and
   // DerivedTables.


### PR DESCRIPTION
Summary:

v1 deduplicated `Call`, `Aggregate`, and `Literal` expressions with side keys whose `std::span` fields aliased the interned object's own buffers. That only held because moving a vector preserves its buffer address and every constructor stored its vectors verbatim — a fragile, silently-unsafe coupling: a small-buffer-optimized vector, or a constructor that normalized its input, would leave a stored key dangling. This interns the expressions by object pointer instead, so dedup no longer depends on buffer addresses or constructor internals. Identity and dedup results are unchanged.

Each expression class gains a non-owning `KeyView` plus a transparent (`is_transparent`) `KeyHash` / `KeyEq` that read the object's own fields. The dedup containers now key on `const T*`, and a lookup builds a `KeyView` over the caller's in-flight data — no allocation on a cache hit, no aliasing. The parallel per-expression dedup-key structs are removed.

Differential Revision: D110925315


