### PR TITLE
feat(optimizer): Add v2 optimizer tree-IR core (#1543)

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -67,3 +67,5 @@ target_link_libraries(
   axiom_runner_local_runner
   velox_connector
 )
+
+add_subdirectory(v2)

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -34,6 +34,7 @@ const auto& planTypeNames() {
       {PlanType::kDerivedTableNode, "DerivedTableNode"},
       {PlanType::kAggregationNode, "AggregationNode"},
       {PlanType::kWindowPlanNode, "WindowPlanNode"},
+      {PlanType::kV2Node, "V2Node"},
   };
   return kNames;
 }
@@ -51,6 +52,10 @@ size_t PlanObject::hash() const {
 
 void PlanObjectSet::unionColumns(ExprCP expr) {
   unionSet(expr->columns());
+}
+
+bool PlanObjectSet::containsColumns(ExprCP expr) const {
+  return expr->columns().isSubset(*this);
 }
 
 void PlanObjectSet::unionColumns(const ExprVector& exprs) {

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -41,6 +41,8 @@ enum class PlanType : uint32_t {
   kAggregationNode,
   kWindowPlanNode,
   kWriteNode,
+  // Node from the v2 tree IR. See axiom/optimizer/v2/Node.h.
+  kV2Node,
 };
 
 AXIOM_DECLARE_ENUM_NAME(PlanType);
@@ -172,6 +174,7 @@ class PlanObjectSet : public BitSet {
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
+  /// True if id of any object in 'objects' is in 'this'.
   template <typename V>
   bool containsAny(const V& objects) const {
     for (const auto& object : objects) {
@@ -180,6 +183,31 @@ class PlanObjectSet : public BitSet {
       }
     }
     return false;
+  }
+
+  /// True if id of every object in 'objects' is in 'this'.
+  template <typename V>
+  bool containsAll(const V& objects) const {
+    for (const auto& object : objects) {
+      if (!contains(object)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// True if every column 'expr' depends on is in 'this' — i.e. 'expr' can be
+  /// evaluated from these columns.
+  bool containsColumns(ExprCP expr) const;
+
+  /// True if every expression in 'exprs' can be evaluated from these columns.
+  bool containsColumns(const ExprVector& exprs) const {
+    for (ExprCP expr : exprs) {
+      if (!containsColumns(expr)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Inserts id of 'object'.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -50,6 +50,14 @@ const char* SpecialFormCallNames::kIn = "__in";
 // static
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
+// static
+ColumnCP Column::create(std::string_view prefix, const Value& value) {
+  VELOX_DCHECK(
+      queryCtx()->isV2(),
+      "Column::create synthesizes a relation-less column, a v2-only idiom");
+  return make<Column>(queryCtx()->newName(prefix), /*relation=*/nullptr, value);
+}
+
 void Column::equals(ColumnCP other) const {
   if (!equivalence_ && !other->equivalence_) {
     auto* equiv = make<Equivalence>();
@@ -66,6 +74,10 @@ void Column::equals(ColumnCP other) const {
   }
   if (!equivalence_) {
     other->equals(this);
+    return;
+  }
+  // Already in one class: merging would iterate and grow the same vector.
+  if (equivalence_ == other->equivalence_) {
     return;
   }
   for (auto& column : other->equivalence_->columns) {
@@ -90,6 +102,10 @@ Name cname(PlanObjectCP relation) {
 }
 
 std::string Column::toString() const {
+  if (queryCtx()->isV2()) {
+    return name_;
+  }
+
   const auto* opt = queryCtx()->optimization();
   if (!opt->cnamesInExpr() || relation_ == nullptr) {
     return name_;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -161,6 +161,14 @@ class Column : public Expr {
       ColumnCP topColumn = nullptr,
       PathCP path = nullptr);
 
+  /// Synthesizes a `Column`. The column's `name` is `prefix` with a
+  /// uniqueness suffix appended by `QueryGraphContext::newName`. The
+  /// resulting name appears in plan output (EXPLAIN, `NodePrinter`),
+  /// so pick a descriptive prefix (`"__rownum"`, `"mark"`, etc.).
+  /// `alias` is not set; sites that produce user-visible LP output
+  /// names pass an `alias` to the full constructor instead.
+  static ColumnCP create(std::string_view prefix, const Value& value);
+
   Name name() const {
     return name_;
   }
@@ -1338,6 +1346,8 @@ struct Frame {
   /// Offset expression for the end bound, or nullptr for UNBOUNDED or
   /// CURRENT ROW.
   ExprCP endValue;
+
+  bool operator==(const Frame& other) const = default;
 };
 
 /// Window function call. Stores partition keys, order keys, frame, and

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include "axiom/common/Enums.h"
@@ -459,6 +460,18 @@ class QueryGraphContext {
     return allVariants_.back().get();
   }
 
+  /// Returns a globally unique interned name `{prefix}{N}` within this query
+  /// context. Example: `newName("a_")` returns `"a_47"`.
+  Name newName(std::string_view prefix) {
+    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+  }
+
+  /// True when the v2 optimizer is driving this query. v2 runs without an
+  /// `Optimization` (a v1 construct), so a null `optimization()` marks v2.
+  bool isV2() const {
+    return optimization_ == nullptr;
+  }
+
  private:
   void populateFunctionNames();
 
@@ -488,6 +501,8 @@ class QueryGraphContext {
   FunctionNames functionNames_;
 
   std::vector<std::unique_ptr<velox::Variant>> allVariants_;
+
+  uint32_t nameCounter_{0};
 };
 
 /// Returns a mutable reference to the calling thread's QueryGraphContext.
@@ -555,5 +570,8 @@ using ExprVector = QGVector<ExprCP>;
 class Column;
 using ColumnCP = const Column*;
 using ColumnVector = QGVector<ColumnCP>;
+
+class Literal;
+using LiteralCP = const Literal*;
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1361,6 +1361,7 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
 
     // Drop redundant cast.
     //    CAST(x as t) / TRY_CAST(x as t) ==> x if typeof(x) == t.
+    // TRY_CAST too: a same-type cast never errors.
     if (specialForm &&
         (specialForm->form() == lp::SpecialForm::kCast ||
          specialForm->form() == lp::SpecialForm::kTryCast)) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -99,7 +99,7 @@ class ToGraph {
           connector::TablePtr> pushdownRoots);
 
   Name newCName(std::string_view prefix) {
-    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+    return queryCtx()->newName(prefix);
   }
 
   /// Creates a new column with a unique name using the given prefix.

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Builder.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+Builder::Builder() : functionNames_{queryCtx()->functionNames()} {
+  const auto& reversibles = FunctionRegistry::instance()->reversibleFunctions();
+  reversibleFunctions_.reserve(reversibles.size() * 2);
+  for (const auto& [name, reverseName] : reversibles) {
+    reversibleFunctions_.emplace(toName(name), toName(reverseName));
+    reversibleFunctions_.emplace(toName(reverseName), toName(name));
+  }
+}
+
+namespace {
+
+// Returns true if `args` should be swapped to put a literal on the
+// right, or — when neither side is a literal — to put the lower-id
+// expression on the left.
+bool shouldInvert(ExprCP left, ExprCP right) {
+  const bool leftIsLiteral = left->is(PlanType::kLiteralExpr);
+  const bool rightIsLiteral = right->is(PlanType::kLiteralExpr);
+  if (leftIsLiteral && !rightIsLiteral) {
+    return true;
+  }
+  if (!leftIsLiteral && !rightIsLiteral && left->id() > right->id()) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace
+
+void Builder::canonicalizeCall(Name& name, ExprVector& args) const {
+  if (args.size() != 2) {
+    return;
+  }
+  auto it = reversibleFunctions_.find(name);
+  if (it == reversibleFunctions_.end()) {
+    return;
+  }
+  if (!shouldInvert(args[0], args[1])) {
+    return;
+  }
+  std::swap(args[0], args[1]);
+  name = it->second;
+}
+
+const Literal*
+Builder::makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality) {
+  const Value value(type, cardinality);
+  // Look up by the caller's Variant first, so a cache hit registers nothing.
+  Literal::KeyView view{type, &variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* registered = queryCtx()->registerVariant(
+      std::make_unique<velox::Variant>(std::move(variant)));
+  auto* literal = optimizer::make<Literal>(value, registered);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Literal* Builder::makeLiteral(
+    const Value& value,
+    const velox::Variant* variant) {
+  Literal::KeyView view{value.type, variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* literal = optimizer::make<Literal>(value, variant);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Call* Builder::makeCall(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions) {
+  if (functions.contains(FunctionSet::kNonDeterministic)) {
+    // Skip dedup: each evaluation of a non-deterministic call produces an
+    // independent value, so identical calls must stay distinct objects.
+    return optimizer::make<Call>(name, value, std::move(args), functions);
+  }
+  canonicalizeCall(name, args);
+  Call::KeyView view{name, value.type, args};
+  if (auto it = calls_.find(view); it != calls_.end()) {
+    return *it;
+  }
+  auto* call = optimizer::make<Call>(name, value, std::move(args), functions);
+  calls_.insert(call);
+  return call;
+}
+
+const optimizer::Aggregate* Builder::makeAggregate(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions,
+    bool isDistinct,
+    ExprCP condition,
+    TypeCP intermediateType,
+    ExprVector orderKeys,
+    OrderTypeVector orderTypes) {
+  optimizer::Aggregate::KeyView view{
+      name, args, isDistinct, condition, orderKeys, orderTypes};
+  if (auto it = aggregateCalls_.find(view); it != aggregateCalls_.end()) {
+    return *it;
+  }
+  auto* aggregate = optimizer::make<optimizer::Aggregate>(
+      name,
+      value,
+      std::move(args),
+      functions,
+      isDistinct,
+      condition,
+      intermediateType,
+      std::move(orderKeys),
+      std::move(orderTypes));
+  aggregateCalls_.insert(aggregate);
+  return aggregate;
+}
+
+void Builder::addEquivalences(const Join::Key& key) {
+  if (key.joinType != velox::core::JoinType::kInner) {
+    return;
+  }
+  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
+    ExprCP leftKey = key.leftKeys[i];
+    ExprCP rightKey = key.rightKeys[i];
+    if (leftKey->isColumn() && rightKey->isColumn()) {
+      leftKey->as<Column>()->equals(rightKey->as<Column>());
+    }
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hash-consing factory for tree-IR nodes and selected Expr leaves. Identical
+/// sub-trees produce the same pointer, so identity equality is O(1) and side-
+/// table lookups keyed by node identity hit one canonical entry per logical
+/// sub-tree.
+///
+/// Everything is interned by pointer: each dedup set stores `const T*` and
+/// recovers identity via `T::KeyHash` / `T::KeyEq`, so a cache hit allocates
+/// nothing. Nodes are constructed from an owning `Key` (e.g. `Scan::Key`)
+/// passed to `make<T>`; the `Expr` leaves `Literal`, `Call`, and
+/// `optimizer::Aggregate` use `makeLiteral` / `makeCall` / `makeAggregate`
+/// (their `KeyHash` / `KeyEq` live on the `Expr` classes themselves). `Column`
+/// is intentionally NOT hash-consed: `Column::equivalence_` is mutable state
+/// mutated by `Column::equals()`, and dedup would leak equivalence classes
+/// across unrelated subtrees.
+class Builder {
+ public:
+  /// Snapshots `queryCtx()` and the function registry; the resulting
+  /// `Builder` is bound to that `QueryGraphContext` for its lifetime.
+  Builder();
+
+  /// Returns a canonical node `T` for 'key', constructing one if not already
+  /// present. Interned by pointer: the dedup set stores `const T*` and recovers
+  /// identity via `T::KeyHash` / `T::KeyEq`. Looks up by the in-flight `key`
+  /// (transparent, no allocation on a hit); on a miss, moves the key into the
+  /// newly constructed node. `Expr` leaves use `makeLiteral` / `makeCall` /
+  /// `makeAggregate`.
+  template <typename T>
+  const T* make(typename T::Key key) {
+    auto& dedup = setFor<T>();
+    if (auto it = dedup.find(key); it != dedup.end()) {
+      return *it;
+    }
+    if constexpr (std::is_same_v<T, Join>) {
+      // Before construction: the Join ctor caches partitioning from these.
+      addEquivalences(key);
+    }
+    const T* node = optimizer::make<T>(std::move(key));
+    dedup.insert(node);
+    return node;
+  }
+
+  /// Registers 'variant' in the `QueryGraphContext` arena and returns a
+  /// canonical `Literal` of 'type' carrying it. Cardinality defaults to
+  /// 1 (a single distinct value — appropriate for literal constants).
+  const Literal*
+  makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality = 1);
+
+  /// Returns a canonical `Literal` of 'value' carrying the already-registered
+  /// 'variant' (owned by the `QueryGraphContext` arena).
+  const Literal* makeLiteral(const Value& value, const velox::Variant* variant);
+
+  /// Returns a canonical `Call`. Non-deterministic calls are never deduped —
+  /// two textually identical `random()` invocations must stay distinct objects
+  /// because each produces an independent value. Reversible binary calls (e.g.
+  /// `lt`/`gt`, `eq`, `plus`) are canonicalized before dedup so equivalent
+  /// forms share one `Call*` (e.g. `2 > a` is rewritten to `a < 2`).
+  /// 'functions' is the call's own bits OR-ed with each arg's `functions()`.
+  const Call* makeCall(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions);
+
+  /// Returns a canonical aggregate `Call`. Result type and 'intermediateType'
+  /// are determined by (name, args), so identity excludes them.
+  const optimizer::Aggregate* makeAggregate(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions,
+      bool isDistinct,
+      ExprCP condition,
+      TypeCP intermediateType,
+      ExprVector orderKeys,
+      OrderTypeVector orderTypes);
+
+  /// Canonical `Literal` for boolean constant 'value'.
+  const Literal* makeBoolean(bool value) {
+    return makeLiteral(velox::Variant(value), toType(velox::BOOLEAN()));
+  }
+
+  /// Canonical `Literal` for SQL NULL of 'type'.
+  const Literal* makeNull(TypeCP type) {
+    return makeLiteral(velox::Variant::null(type->kind()), type);
+  }
+
+  /// `Values` node carrying zero rows with the given output schema.
+  /// Used to replace subtrees a rewrite proved produce no rows.
+  const Values* makeEmptyValues(ColumnVector outputColumns) {
+    return make<Values>({/*source=*/nullptr,
+                         /*rows=*/nullptr,
+                         std::move(outputColumns)});
+  }
+
+  /// Interned `Name`s for well-known functions, snapshotted from the
+  /// active `QueryGraphContext` at construction so callers can compare
+  /// or build calls against well-known operator names by pointer
+  /// equality, without repeated registry lookups.
+  const FunctionNames& functionNames() const {
+    return functionNames_;
+  }
+
+ private:
+  // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
+  // swaps 'args' (and renames to the reverse) when `args[0]` should
+  // come second per the canonical order: literal-on-right, lower-id
+  // expr on left when neither is a literal. No-op otherwise.
+  void canonicalizeCall(Name& name, ExprVector& args) const;
+
+  // Adds an inner join's equi-key columns to one equivalence class (see
+  // `Column::equals`): equated columns hold the same value on every output row,
+  // so any surviving member partitions the output as the dropped key did.
+  // No-op for non-inner joins (an outer join's build key may be null-padded, so
+  // its columns are not equal on every row) and for non-column keys.
+  static void addEquivalences(const Join::Key& key);
+
+  template <typename T>
+  auto& setFor() {
+    if constexpr (std::is_same_v<T, Scan>) {
+      return scans_;
+    } else if constexpr (std::is_same_v<T, Filter>) {
+      return filters_;
+    } else if constexpr (std::is_same_v<T, Project>) {
+      return projects_;
+    } else if constexpr (std::is_same_v<T, Limit>) {
+      return limits_;
+    } else if constexpr (std::is_same_v<T, Sort>) {
+      return sorts_;
+    } else if constexpr (std::is_same_v<T, TopN>) {
+      return topNs_;
+    } else if constexpr (std::is_same_v<T, Aggregate>) {
+      return aggregates_;
+    } else if constexpr (std::is_same_v<T, GroupId>) {
+      return groupIds_;
+    } else if constexpr (std::is_same_v<T, MarkDistinct>) {
+      return markDistincts_;
+    } else if constexpr (std::is_same_v<T, Values>) {
+      return values_;
+    } else if constexpr (std::is_same_v<T, Unnest>) {
+      return unnests_;
+    } else if constexpr (std::is_same_v<T, UnionAll>) {
+      return unions_;
+    } else if constexpr (std::is_same_v<T, Join>) {
+      return joins_;
+    } else if constexpr (std::is_same_v<T, Window>) {
+      return windows_;
+    } else if constexpr (std::is_same_v<T, TopNRowNumber>) {
+      return topNRowNumbers_;
+    } else if constexpr (std::is_same_v<T, Apply>) {
+      return applies_;
+    } else if constexpr (std::is_same_v<T, EnforceSingleRow>) {
+      return enforceSingleRows_;
+    } else if constexpr (std::is_same_v<T, AssignUniqueId>) {
+      return assignUniqueIds_;
+    } else if constexpr (std::is_same_v<T, EnforceDistinct>) {
+      return enforceDistincts_;
+    } else if constexpr (std::is_same_v<T, Exchange>) {
+      return exchanges_;
+    } else if constexpr (std::is_same_v<T, TableWrite>) {
+      return tableWrites_;
+    } else {
+      static_assert(sizeof(T) == 0, "No dedup map for this node type");
+    }
+  }
+
+  const FunctionNames functionNames_;
+
+  // Maps a reversible binary function name to its reverse name.
+  // Symmetric reversibles (e.g. `eq`) map to themselves; asymmetric
+  // ones (e.g. `lt` → `gt`) map across.
+  folly::F14FastMap<Name, Name> reversibleFunctions_;
+
+  // Dedup container for hash-consed `T`: stores canonical `const T*`, keyed by
+  // the node/expr's own identity via transparent `T::KeyHash` / `T::KeyEq`.
+  template <typename T>
+  using DedupSet =
+      folly::F14FastSet<const T*, typename T::KeyHash, typename T::KeyEq>;
+
+  DedupSet<Scan> scans_;
+  DedupSet<Filter> filters_;
+  DedupSet<Project> projects_;
+  DedupSet<Limit> limits_;
+  DedupSet<Sort> sorts_;
+  DedupSet<TopN> topNs_;
+  DedupSet<Aggregate> aggregates_;
+  DedupSet<GroupId> groupIds_;
+  DedupSet<MarkDistinct> markDistincts_;
+  DedupSet<Values> values_;
+  DedupSet<Unnest> unnests_;
+  DedupSet<UnionAll> unions_;
+  DedupSet<Join> joins_;
+  DedupSet<Window> windows_;
+  DedupSet<TopNRowNumber> topNRowNumbers_;
+  DedupSet<Apply> applies_;
+  DedupSet<EnforceSingleRow> enforceSingleRows_;
+  DedupSet<AssignUniqueId> assignUniqueIds_;
+  DedupSet<EnforceDistinct> enforceDistincts_;
+  DedupSet<Exchange> exchanges_;
+  DedupSet<TableWrite> tableWrites_;
+
+  // Expr leaves, interned via `makeLiteral` / `makeCall` / `makeAggregate`.
+  DedupSet<Literal> literals_;
+  DedupSet<Call> calls_;
+  DedupSet<optimizer::Aggregate> aggregateCalls_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(axiom_optimizer_v2 Builder.cpp Node.cpp NodePrinter.cpp PhysicalProperties.cpp)
+
+target_link_libraries(
+  axiom_optimizer_v2
+  axiom_common
+  axiom_connectors
+  axiom_logical_plan
+  axiom_optimizer
+  velox_common_base
+  velox_core
+)

--- a/axiom/optimizer/v2/KeyHash.h
+++ b/axiom/optimizer/v2/KeyHash.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hashes a single value. Pointer / integer / enum / range / Frame are
+/// handled generically; pointer-elements of ranges are hashed by address,
+/// matching how `Key::operator==` compares them.
+template <typename T>
+size_t hashOne(const T& value);
+
+// Forward declaration: keeps `hashOf` (template) able to resolve to this
+// non-template overload during phase-1 name lookup; otherwise the generic
+// `hashOne<Frame>` template hits the catch-all static_assert.
+size_t hashOne(const Frame& frame);
+
+/// Hashes a list of fields by combining `hashOne` of each via `hashMix`.
+template <typename... Args>
+size_t hashOf(const Args&... args) {
+  size_t hash = 0;
+  ((hash = velox::bits::hashMix(hash, hashOne(args))), ...);
+  return hash;
+}
+
+inline size_t hashOne(const Frame& frame) {
+  return hashOf(
+      frame.type,
+      frame.startType,
+      frame.startValue,
+      frame.endType,
+      frame.endValue);
+}
+
+template <typename T>
+size_t hashOne(const T& value) {
+  if constexpr (std::is_pointer_v<T>) {
+    return reinterpret_cast<uintptr_t>(value);
+  } else if constexpr (std::is_enum_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (std::is_integral_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (requires {
+                         value.begin();
+                         value.end();
+                       }) {
+    size_t hash = 0;
+    for (const auto& element : value) {
+      hash = velox::bits::hashMix(hash, hashOne(element));
+    }
+    return hash;
+  } else {
+    static_assert(
+        sizeof(T) == 0, "Add a hashOne overload for this type in KeyHash.h");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1,0 +1,1983 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Node.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/KeyHash.h"
+#include "axiom/optimizer/v2/NodePrinter.h"
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+const auto& nodeTypeNames() {
+  static const folly::F14FastMap<NodeType, std::string_view> kNames = {
+      {NodeType::kScan, "Scan"},
+      {NodeType::kFilter, "Filter"},
+      {NodeType::kProject, "Project"},
+      {NodeType::kLimit, "Limit"},
+      {NodeType::kSort, "Sort"},
+      {NodeType::kTopN, "TopN"},
+      {NodeType::kAggregate, "Aggregate"},
+      {NodeType::kGroupId, "GroupId"},
+      {NodeType::kMarkDistinct, "MarkDistinct"},
+      {NodeType::kValues, "Values"},
+      {NodeType::kUnnest, "Unnest"},
+      {NodeType::kUnionAll, "UnionAll"},
+      {NodeType::kJoin, "Join"},
+      {NodeType::kWindow, "Window"},
+      {NodeType::kTopNRowNumber, "TopNRowNumber"},
+      {NodeType::kApply, "Apply"},
+      {NodeType::kEnforceSingleRow, "EnforceSingleRow"},
+      {NodeType::kAssignUniqueId, "AssignUniqueId"},
+      {NodeType::kEnforceDistinct, "EnforceDistinct"},
+      {NodeType::kExchange, "Exchange"},
+      {NodeType::kTableWrite, "TableWrite"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
+
+std::string Node::toString() const {
+  return NodePrinter::toText(this);
+}
+
+namespace {
+
+// Per-operator derivation of per-driver local properties. Each node computes
+// these in its constructor from its already-constructed inputs; distribution
+// and relation-level properties are added with their consumers.
+
+// Keeps the local properties expressible over `columns`: a `kGrouped` entry
+// survives only if all its columns do; a `kSorted` entry is truncated to its
+// leading run of columns in `columns`. A dropped or truncated entry ends the
+// list — nothing nested under a broken outer property still holds.
+LocalPropertyVector projectLocal(
+    const LocalPropertyVector& local,
+    const PlanObjectSet& columns) {
+  LocalPropertyVector result;
+  for (const LocalProperty& property : local) {
+    if (property.kind == LocalPropertyKind::kGrouped) {
+      if (!columns.containsAll(property.columns)) {
+        break;
+      }
+      result.push_back(property);
+      continue;
+    }
+    LocalProperty truncated{.kind = LocalPropertyKind::kSorted};
+    for (size_t i = 0; i < property.columns.size(); ++i) {
+      if (!columns.contains(property.columns[i])) {
+        break;
+      }
+      truncated.columns.push_back(property.columns[i]);
+      truncated.orders.push_back(property.orders[i]);
+    }
+    if (truncated.columns.empty()) {
+      break;
+    }
+    const bool full = truncated.columns.size() == property.columns.size();
+    result.push_back(std::move(truncated));
+    if (!full) {
+      break;
+    }
+  }
+  return result;
+}
+
+// Keeps an input's local properties expressible over `columns` (see
+// `projectLocal`), for a node that emits only a subset of its input.
+LocalPropertyVector retainedLocal(NodeCP input, const ColumnVector& columns) {
+  return projectLocal(
+      input->physicalProperties().local, PlanObjectSet::fromObjects(columns));
+}
+
+// Keeps an input's unique key-sets whose columns all survive in `columns`, for
+// a node that emits only a subset of its input. A key-set with a dropped member
+// is no longer a key of the output, so it is removed whole.
+UniqueKeySetVector retainedUnique(NodeCP input, const ColumnVector& columns) {
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : input->physicalProperties().unique) {
+    if (key.columns.isSubset(columnSet)) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// A single `Sorted` property over the leading run of `keys` that are columns,
+// paired with their orders. A computed sort key is not an output column, so it
+// (and everything after it) is dropped; empty when the first key is not a
+// column.
+LocalPropertyVector sortedLocal(
+    const ExprVector& keys,
+    const OrderTypeVector& orderTypes) {
+  ColumnVector columns;
+  OrderTypeVector orders;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->isColumn()) {
+      break;
+    }
+    columns.push_back(keys[i]->as<Column>());
+    orders.push_back(orderTypes[i]);
+  }
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back(
+      {.kind = LocalPropertyKind::kSorted,
+       .columns = std::move(columns),
+       .orders = std::move(orders)});
+  return result;
+}
+
+// Local ordering an exchange's output carries: an order-preserving gather keeps
+// the merged sort order; every other exchange interleaves rows and keeps none.
+LocalPropertyVector exchangeLocal(const Partitioning& partitioning) {
+  if (partitioning.orderKeys.empty()) {
+    return {};
+  }
+  return sortedLocal(partitioning.orderKeys, partitioning.orderTypes);
+}
+
+// A single `Grouped` property over `columns` (empty when there are none).
+LocalPropertyVector groupedLocal(const ColumnVector& columns) {
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back({.kind = LocalPropertyKind::kGrouped, .columns = columns});
+  return result;
+}
+
+// A single `Grouped` property over one column.
+LocalPropertyVector groupedLocal(ColumnCP column) {
+  ColumnVector columns;
+  columns.push_back(column);
+  return groupedLocal(columns);
+}
+
+// A single global unique key over 'column' (e.g. AssignUniqueId's id).
+UniqueKeySetVector globalUniqueKey(ColumnCP column) {
+  UniqueKeySetVector result;
+  result.push_back(
+      UniqueKeySet{
+          .columns = PlanObjectSet::single(column),
+          .scope = PropertyScope::kGlobal});
+  return result;
+}
+
+// Uniqueness that survives a remote exchange. A repartition/gather moves rows
+// without duplicating them, so global uniqueness holds; but it can gather
+// cross-driver duplicates onto one driver, so driver-scope uniqueness does not
+// survive. A broadcast replicates rows and destroys even global uniqueness.
+UniqueKeySetVector uniqueAcrossExchange(
+    const UniqueKeySetVector& unique,
+    const Partitioning& partitioning) {
+  if (partitioning.is(PartitionKind::kBroadcast)) {
+    return {};
+  }
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : unique) {
+    if (key.scope == PropertyScope::kGlobal) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// Local grouping an inner/left join gains from probe uniqueness: a hash join
+// emits each probe row's matches as one contiguous run, so the output is
+// grouped by any key unique on the probe whose columns all survive —
+// independent of the probe's input order, so this holds even after an exchange
+// erased the probe's own local grouping. Caveat: a spilling probe or a
+// driver-scrambling local exchange breaks it; valid at single-fragment,
+// numDrivers=1.
+void appendProbeUniqueGroupings(
+    NodeCP left,
+    const PlanObjectSet& outputColumns,
+    LocalPropertyVector& local) {
+  for (const UniqueKeySet& key : left->physicalProperties().unique) {
+    if (key.columns.isSubset(outputColumns)) {
+      local.push_back(
+          LocalProperty{
+              .kind = LocalPropertyKind::kGrouped,
+              .columns = key.columns.template toObjects<Column>()});
+    }
+  }
+}
+
+// The probe (left) side's local properties survive an inner / left join within
+// a driver; build-emitting and cross joins drop them.
+// TODO: order through a spillable join is not guaranteed once spilling is
+// enabled; revisit when spilling is modeled.
+LocalPropertyVector joinLocal(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType == velox::core::JoinType::kInner ||
+      joinType == velox::core::JoinType::kLeft) {
+    LocalPropertyVector local = retainedLocal(left, outputColumns);
+    appendProbeUniqueGroupings(
+        left, PlanObjectSet::fromObjects(outputColumns), local);
+    return local;
+  }
+  return {};
+}
+
+// Properties an operator inherits when it neither repartitions nor changes
+// which rows exist in a way that breaks them: the input's distribution (minus
+// its merge order, which belonged to the gather it came from — see
+// `Partitioning::dropOrder`), local properties, and uniqueness. Such an
+// operator keeps all of the input's columns, so every inherited property
+// already references output columns.
+PhysicalProperties passThroughProperties(NodeCP input) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = props.local,
+      .unique = props.unique};
+}
+
+// Properties of an operator that sorts its input on `orderKeys` without moving
+// rows across tasks: it keeps the input's distribution and uniqueness and adds
+// the per-driver sort order. A distributed sort is a per-task sort under a
+// separate gather-merge exchange, and a single-stage sort runs over an
+// already-gathered input — so the sort node itself inherits the input's
+// partitioning either way (it is not the gather).
+PhysicalProperties sortedProperties(
+    NodeCP input,
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = sortedLocal(orderKeys, orderTypes),
+      .unique = props.unique};
+}
+
+// Remaps the input partitioning through a Project's column map: each partition
+// key (an input column) is re-expressed on the output column that projects it,
+// whether identity or rename (`exprs[i]` is a bare reference to the key, so its
+// output column `outputColumns[i]` carries the same values, hence the same hash
+// partition). A key not projected as a bare column — dropped, or appearing only
+// inside a computed expression — drops the partition to unspecified. Gather and
+// unspecified pass through unchanged.
+Partitioning projectGlobalPartition(
+    NodeCP input,
+    const ExprVector& exprs,
+    const ColumnVector& outputColumns) {
+  const Partitioning& partitioning =
+      input->physicalProperties().globalPartition;
+  if (partitioning.kind != PartitionKind::kPartitioned) {
+    return partitioning.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(partitioning.keys.size());
+  for (ExprCP key : partitioning.keys) {
+    ExprCP projected = nullptr;
+    for (size_t i = 0; i < exprs.size(); ++i) {
+      if (exprs[i]->sameOrEqual(*key)) {
+        projected = outputColumns[i];
+        break;
+      }
+    }
+    if (projected == nullptr) {
+      return {};
+    }
+    keys.push_back(projected);
+  }
+  Partitioning result = partitioning;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// An output column equal to 'key', or null. Inner-join equalities merge the
+// equated columns into one equivalence class (see Column::equals); every member
+// holds the same value on every output row, so any surviving class member
+// partitions the output exactly as 'key' does. Only columns form equivalence
+// classes, so a non-column key has no substitute.
+ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
+  if (!key->is(PlanType::kColumnExpr)) {
+    return nullptr;
+  }
+
+  if (const auto* equivalence = key->as<Column>()->equivalence()) {
+    for (ColumnCP column : equivalence->columns) {
+      if (outputColumns.contains(column)) {
+        return column;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+// Output global partitioning of a join. Only an inner or left join keeps the
+// probe (left) rows in their partitions, so only those preserve a probe
+// partition; other join types drop it. If every probe key is still an output
+// column, the output is partitioned exactly as the probe was. Otherwise an
+// inner join recovers each remaining key: it keeps a key whose columns all
+// survive (a join projects columns unchanged, so a surviving column is
+// identity-projected, and an expression over surviving columns still partitions
+// the output), else substitutes an equal output column from the key's
+// inner-join equivalence class. A left join can't recover a key from its
+// null-padded build, so a dropped key makes its partition unspecified. A
+// non-hash distribution (gather / broadcast / arbitrary) carries no keys and is
+// inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
+Partitioning joinGlobalPartition(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType != velox::core::JoinType::kInner &&
+      joinType != velox::core::JoinType::kLeft) {
+    return {};
+  }
+
+  const Partitioning& probe = left->physicalProperties().globalPartition;
+  if (probe.kind != PartitionKind::kPartitioned) {
+    return probe.dropOrder();
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(outputColumns);
+  if (outputSet.containsAll(probe.keys)) {
+    return probe;
+  }
+
+  if (joinType != velox::core::JoinType::kInner) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(probe.keys.size());
+  for (ExprCP key : probe.keys) {
+    if (outputSet.containsColumns(key)) {
+      keys.push_back(key);
+      continue;
+    }
+    ExprCP equiKey = survivingEquiKey(key, outputSet);
+    if (equiKey == nullptr) {
+      return {};
+    }
+    keys.push_back(equiKey);
+  }
+
+  Partitioning result = probe;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// The input's partitioning re-expressed on the aggregate's output. An aggregate
+// streams over its input without moving rows, so it preserves the input's
+// partitioning — but only when that partitioning's keys are all grouping keys
+// (the only input values the aggregate keeps): then those keys are a
+// co-location of the groups and survive in the output, re-expressed on the
+// grouping output columns they map to. An input partitioned on anything else
+// does not co-locate the groups (it should not feed the aggregate at all) and
+// could not be expressed on the output, so the partitioning is unknown. A
+// grouping-set aggregate reads its GroupId, which has no known partitioning, so
+// it falls into the unknown case. A non-hash distribution (gather / broadcast /
+// arbitrary) is inherited by kind only, with its merge order dropped (see
+// `Partitioning::dropOrder`), as the aggregate reorders rows and so does not
+// preserve one. `groupingColumns` are the output columns holding the grouping
+// values, aligned with `groupingKeys`.
+Partitioning aggregateInputPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  const Partitioning& inputPartition =
+      input->physicalProperties().globalPartition;
+  if (inputPartition.kind != PartitionKind::kPartitioned) {
+    return inputPartition.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(inputPartition.keys.size());
+  for (ExprCP key : inputPartition.keys) {
+    const auto it = std::ranges::find(groupingKeys, key);
+    if (it == groupingKeys.end()) {
+      return {};
+    }
+    keys.push_back(groupingColumns[it - groupingKeys.begin()]);
+  }
+  Partitioning result = inputPartition;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// Output partitioning of a complete (single / final) aggregation: a global
+// aggregate gathers to one task; otherwise the input's partitioning
+// re-expressed on the output (see `aggregateInputPartition`).
+Partitioning aggregateGlobalPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  if (groupingKeys.empty()) {
+    return Partitioning::globalGather();
+  }
+  return aggregateInputPartition(input, groupingKeys, groupingColumns);
+}
+
+// Output partitioning of a scan of a bucketed (connector-partitioned) table:
+// the connector's partition function on the output columns matching the
+// layout's partition columns. Unspecified when the table is not partitioned or
+// a partition column is not in the scan's output (so the partitioning can't be
+// expressed over the output).
+Partitioning scanGlobalPartition(const Scan::Key& key) {
+  const auto* schemaTable = key.baseTable->schemaTable;
+  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
+    return {};
+  }
+  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
+  if (layout == nullptr) {
+    return {};
+  }
+  const auto partitionType = layout->partitionType();
+  const auto& partitionColumns = layout->partitionColumns();
+  if (partitionType == nullptr || partitionColumns.empty()) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(partitionColumns.size());
+  for (const auto* partitionColumn : partitionColumns) {
+    ColumnCP match = nullptr;
+    for (ColumnCP column : key.outputColumns) {
+      if (column->name() == partitionColumn->name()) {
+        match = column;
+        break;
+      }
+    }
+    if (match == nullptr) {
+      return {};
+    }
+    keys.push_back(match);
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = partitionType.get(),
+      .keys = std::move(keys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+Scan::Scan(Key key)
+    : Node(
+          NodeType::kScan,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = scanGlobalPartition(key)}),
+      baseTable_(key.baseTable),
+      filters_(std::move(key.filters)) {
+  VELOX_CHECK_NOT_NULL(baseTable_);
+  folly::F14FastSet<std::string_view> schemaNames;
+  folly::F14FastSet<std::string> outputNames;
+  schemaNames.reserve(this->outputColumns().size());
+  outputNames.reserve(this->outputColumns().size());
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        schemaNames.insert(column->name()).second,
+        "Scan outputColumns contains duplicate underlying column name: {}",
+        column->name());
+    VELOX_CHECK(
+        outputNames.insert(column->outputName()).second,
+        "Scan outputColumns contains duplicate output name: {}",
+        column->outputName());
+  }
+}
+
+size_t Scan::KeyHash::operator()(const Scan* node) const {
+  return hashOf(node->baseTable(), node->outputColumns(), node->filters());
+}
+
+size_t Scan::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.baseTable, key.outputColumns, key.filters);
+}
+
+bool Scan::KeyEq::operator()(const Scan* left, const Scan* right) const {
+  return left->baseTable() == right->baseTable() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->filters() == right->filters();
+}
+
+bool Scan::KeyEq::operator()(const Key& key, const Scan* node) const {
+  return key.baseTable == node->baseTable() &&
+      key.outputColumns == node->outputColumns() &&
+      key.filters == node->filters();
+}
+
+bool Scan::KeyEq::operator()(const Scan* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Filter::Filter(Key key)
+    : Node(
+          NodeType::kFilter,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      predicates_(std::move(key.predicates)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!predicates_.empty(), "Filter must have at least one predicate");
+}
+
+size_t Filter::KeyHash::operator()(const Filter* filter) const {
+  return hashOf(filter->input(), filter->predicates());
+}
+
+size_t Filter::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.predicates);
+}
+
+bool Filter::KeyEq::operator()(const Filter* left, const Filter* right) const {
+  return left->input() == right->input() &&
+      left->predicates() == right->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Key& key, const Filter* filter) const {
+  return key.input == filter->input() && key.predicates == filter->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Filter* filter, const Key& key) const {
+  return (*this)(key, filter);
+}
+
+Project::Project(Key key)
+    : Node(
+          NodeType::kProject,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = projectGlobalPartition(
+                  key.input,
+                  key.exprs,
+                  key.outputColumns),
+              .local = retainedLocal(key.input, key.outputColumns),
+              .unique = retainedUnique(key.input, key.outputColumns)}),
+      input_(key.input),
+      exprs_(std::move(key.exprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(this->outputColumns().size(), exprs_.size());
+}
+
+size_t Project::KeyHash::operator()(const Project* node) const {
+  return hashOf(node->input(), node->outputColumns(), node->exprs());
+}
+
+size_t Project::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.outputColumns, key.exprs);
+}
+
+bool Project::KeyEq::operator()(const Project* left, const Project* right)
+    const {
+  return left->input() == right->input() && left->exprs() == right->exprs() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Key& key, const Project* node) const {
+  return key.input == node->input() && key.exprs == node->exprs() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Project* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Limit::Limit(Key key)
+    : Node(
+          NodeType::kLimit,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t Limit::KeyHash::operator()(const Limit* node) const {
+  return hashOf(node->input(), node->offset(), node->count());
+}
+
+size_t Limit::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.offset, key.count);
+}
+
+bool Limit::KeyEq::operator()(const Limit* left, const Limit* right) const {
+  return left->input() == right->input() && left->offset() == right->offset() &&
+      left->count() == right->count();
+}
+
+bool Limit::KeyEq::operator()(const Key& key, const Limit* node) const {
+  return key.input == node->input() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool Limit::KeyEq::operator()(const Limit* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Sort::Sort(Key key)
+    : Node(
+          NodeType::kSort,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "Sort must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Sort::KeyHash::operator()(const Sort* node) const {
+  return hashOf(node->input(), node->orderKeys(), node->orderTypes());
+}
+
+size_t Sort::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.orderKeys, key.orderTypes);
+}
+
+bool Sort::KeyEq::operator()(const Sort* left, const Sort* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Key& key, const Sort* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Sort* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopN::TopN(Key key)
+    : Node(
+          NodeType::kTopN,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopN must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t TopN::KeyHash::operator()(const TopN* node) const {
+  return hashOf(
+      node->input(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->offset(),
+      node->count());
+}
+
+size_t TopN::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.orderKeys, key.orderTypes, key.offset, key.count);
+}
+
+bool TopN::KeyEq::operator()(const TopN* left, const TopN* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->offset() == right->offset() && left->count() == right->count();
+}
+
+bool TopN::KeyEq::operator()(const Key& key, const TopN* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool TopN::KeyEq::operator()(const TopN* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Physical properties of an aggregate's output, by step. A `kPartial`
+// pre-aggregates per task without moving rows or gathering (even for an empty
+// grouping): it keeps the input's partitioning re-expressed on its output, but
+// its keys are not globally unique (the same key recurs across tasks).
+// `kSingle` / `kFinal` produce the complete result — globally unique on the
+// grouping keys, and partitioned on them when the input is (the `kFinal`'s
+// input is the exchange that partitioned the partials).
+PhysicalProperties aggregateProperties(const Aggregate::Key& key) {
+  // The grouping values are materialized as the leading output columns, aligned
+  // one-to-one with `groupingKeys`; properties are expressed over those output
+  // columns, not the (possibly computed) grouping-key expressions.
+  ColumnVector groupingColumns;
+  groupingColumns.reserve(key.groupingKeys.size());
+  for (size_t i = 0; i < key.groupingKeys.size(); ++i) {
+    groupingColumns.push_back(key.outputColumns[i]);
+  }
+  if (key.step == AggregateStep::kPartial) {
+    return PhysicalProperties{
+        .globalPartition = aggregateInputPartition(
+            key.input, key.groupingKeys, groupingColumns),
+        .local = groupedLocal(groupingColumns)};
+  }
+  // An aggregate emits one row per distinct grouping-key combination, so the
+  // grouping output columns are a global unique key (the empty grouping is the
+  // single global row, unique on the empty set; a grouping-set aggregate's
+  // group-id is one of the keys, so distinct key sets stay distinct).
+  return PhysicalProperties{
+      .globalPartition = aggregateGlobalPartition(
+          key.input, key.groupingKeys, groupingColumns),
+      .local = groupedLocal(groupingColumns),
+      .unique = {UniqueKeySet{
+          .columns = PlanObjectSet::fromObjects(groupingColumns),
+          .scope = PropertyScope::kGlobal}}};
+}
+
+} // namespace
+
+Aggregate::Aggregate(Key key)
+    : Node(
+          NodeType::kAggregate,
+          ColumnVector{key.outputColumns},
+          aggregateProperties(key)),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregates_(std::move(key.aggregates)),
+      step_(key.step),
+      groupId_(key.groupId),
+      globalGroupingSets_(std::move(key.globalGroupingSets)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(), groupingKeys_.size() + aggregates_.size());
+  // Velox couples the two: a group-id key is meaningful for empty-input default
+  // rows only alongside the global sets it labels.
+  VELOX_CHECK_EQ(groupId_ != nullptr, !globalGroupingSets_.empty());
+  if (groupId_ != nullptr) {
+    VELOX_CHECK(
+        std::ranges::find(groupingKeys_, groupId_) != groupingKeys_.end(),
+        "groupId must be one of the grouping keys");
+  }
+}
+
+size_t Aggregate::KeyHash::operator()(const Aggregate* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregates(),
+      node->outputColumns());
+  hash = velox::bits::hashMix(hash, hashOf(node->groupId()));
+  for (auto idx : node->globalGroupingSets()) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(node->step()));
+}
+
+size_t Aggregate::KeyHash::operator()(const Key& key) const {
+  size_t hash =
+      hashOf(key.input, key.groupingKeys, key.aggregates, key.outputColumns);
+  hash = velox::bits::hashMix(hash, hashOf(key.groupId));
+  for (auto idx : key.globalGroupingSets) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(key.step));
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* left, const Aggregate* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregates() == right->aggregates() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->step() == right->step() && left->groupId() == right->groupId() &&
+      left->globalGroupingSets() == right->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Key& key, const Aggregate* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregates == node->aggregates() &&
+      key.outputColumns == node->outputColumns() && key.step == node->step() &&
+      key.groupId == node->groupId() &&
+      key.globalGroupingSets == node->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+GroupId::GroupId(Key key)
+    : Node(NodeType::kGroupId, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregationInputs_(std::move(key.aggregationInputs)),
+      groupingSets_(std::move(key.groupingSets)),
+      groupingKeyColumns_(std::move(key.groupingKeyColumns)),
+      groupId_(key.groupId) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(groupId_);
+  VELOX_CHECK_EQ(groupId_->value().type->kind(), velox::TypeKind::BIGINT);
+  VELOX_CHECK_EQ(groupingKeys_.size(), groupingKeyColumns_.size());
+  VELOX_CHECK(!groupingSets_.empty());
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      groupingKeyColumns_.size() + aggregationInputs_.size() + 1);
+}
+
+size_t GroupId::KeyHash::operator()(const GroupId* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregationInputs(),
+      node->groupingKeyColumns(),
+      node->groupId(),
+      node->outputColumns());
+  const auto& groupingSets = node->groupingSets();
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+size_t GroupId::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.groupingKeys,
+      key.aggregationInputs,
+      key.groupingKeyColumns,
+      key.groupId,
+      key.outputColumns);
+  const auto& groupingSets = key.groupingSets;
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* left, const GroupId* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregationInputs() == right->aggregationInputs() &&
+      left->groupingSets() == right->groupingSets() &&
+      left->groupingKeyColumns() == right->groupingKeyColumns() &&
+      left->groupId() == right->groupId() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const Key& key, const GroupId* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregationInputs == node->aggregationInputs() &&
+      key.groupingSets == node->groupingSets() &&
+      key.groupingKeyColumns == node->groupingKeyColumns() &&
+      key.groupId == node->groupId() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+MarkDistinct::MarkDistinct(Key key)
+    : Node(
+          NodeType::kMarkDistinct,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      markers_(std::move(key.markers)),
+      distinctKeys_(std::move(key.distinctKeys)),
+      masks_(std::move(key.masks)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!markers_.empty());
+  const size_t expectedMarkers = masks_.empty() ? 1 : masks_.size() + 1;
+  VELOX_CHECK_EQ(markers_.size(), expectedMarkers);
+  for (ColumnCP marker : markers_) {
+    VELOX_CHECK_EQ(marker->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  for (ColumnCP mask : masks_) {
+    VELOX_CHECK_EQ(mask->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + markers_.size());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const MarkDistinct* node) const {
+  return hashOf(
+      node->input(),
+      node->markers(),
+      node->distinctKeys(),
+      node->masks(),
+      node->outputColumns());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.markers, key.distinctKeys, key.masks, key.outputColumns);
+}
+
+bool MarkDistinct::KeyEq::operator()(
+    const MarkDistinct* left,
+    const MarkDistinct* right) const {
+  return left->input() == right->input() &&
+      left->markers() == right->markers() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->masks() == right->masks() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const Key& key, const MarkDistinct* node)
+    const {
+  return key.input == node->input() && key.markers == node->markers() &&
+      key.distinctKeys == node->distinctKeys() && key.masks == node->masks() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const MarkDistinct* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Values::Values(Key key)
+    : Node(NodeType::kValues, ColumnVector{key.outputColumns}, {}),
+      source_(key.source),
+      rows_(key.rows) {
+  VELOX_CHECK(
+      source_ == nullptr || rows_ == nullptr,
+      "Values cannot carry both a passthrough source and folded rows");
+
+  const auto numColumns = this->outputColumns().size();
+  if (source_ != nullptr) {
+    const auto& rowType = source_->outputType();
+    VELOX_CHECK_EQ(
+        rowType->size(),
+        numColumns,
+        "Values source schema must match outputColumns count");
+    for (size_t i = 0; i < numColumns; ++i) {
+      VELOX_CHECK(
+          rowType->childAt(i)->equivalent(
+              *this->outputColumns()[i]->value().type),
+          "Values source column {} type must match outputColumns",
+          i);
+    }
+  } else if (rows_ != nullptr) {
+    VELOX_CHECK_EQ(
+        rows_->kind(),
+        velox::TypeKind::ARRAY,
+        "Values folded rows must be an array of row variants");
+    for (const auto& row : rows_->array()) {
+      VELOX_CHECK_EQ(
+          row.kind(),
+          velox::TypeKind::ROW,
+          "Values folded rows must be row variants");
+      VELOX_CHECK_EQ(
+          row.row().size(),
+          numColumns,
+          "Values folded row field count must match outputColumns");
+    }
+  }
+}
+
+size_t Values::KeyHash::operator()(const Values* node) const {
+  return hashOf(node->source(), node->rows(), node->outputColumns());
+}
+
+size_t Values::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.source, key.rows, key.outputColumns);
+}
+
+bool Values::KeyEq::operator()(const Values* left, const Values* right) const {
+  return left->source() == right->source() && left->rows() == right->rows() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Key& key, const Values* node) const {
+  return key.source == node->source() && key.rows == node->rows() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Values* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Unnest::Unnest(Key key)
+    : Node(
+          NodeType::kUnnest,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .local = retainedLocal(key.input, key.replicatedColumns)}),
+      input_(key.input),
+      unnestExpressions_(std::move(key.unnestExpressions)),
+      replicatedColumns_(std::move(key.replicatedColumns)),
+      unnestColumns_(std::move(key.unnestColumns)),
+      ordinalityColumn_(key.ordinalityColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !unnestExpressions_.empty(), "Unnest must have at least one expression");
+  VELOX_CHECK_EQ(
+      unnestColumns_.size(),
+      unnestExpressions_.size(),
+      "Unnest unnestColumns must align with unnestExpressions");
+  // Each expression unnests into one result column for an ARRAY, two (key,
+  // value) for a MAP.
+  for (size_t i = 0; i < unnestExpressions_.size(); ++i) {
+    const auto kind = unnestExpressions_[i]->value().type->kind();
+    if (kind == velox::TypeKind::ARRAY) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          1,
+          "Unnest of an ARRAY expression produces one result column");
+    } else if (kind == velox::TypeKind::MAP) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          2,
+          "Unnest of a MAP expression produces two result columns (key, value)");
+    } else {
+      VELOX_FAIL(
+          "Unnest expression must be ARRAY or MAP, got {}",
+          unnestExpressions_[i]->value().type->toString());
+    }
+  }
+  // Every outputColumns entry must be a Column the structured fields produce: a
+  // replicated input column, a per-expression result, or the ordinality column.
+  // Only per-expression results may be pruned from the output; replicated
+  // columns and the ordinality column must all appear.
+  PlanObjectSet produced;
+  for (ColumnCP column : replicatedColumns_) {
+    produced.add(column);
+  }
+  for (const auto& perExpr : unnestColumns_) {
+    for (ColumnCP column : perExpr) {
+      produced.add(column);
+    }
+  }
+  if (ordinalityColumn_ != nullptr) {
+    produced.add(ordinalityColumn_);
+  }
+
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        produced.contains(column),
+        "Unnest outputColumns references a Column not produced by structured fields");
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(this->outputColumns());
+  for (ColumnCP column : replicatedColumns_) {
+    VELOX_CHECK(
+        outputSet.contains(column),
+        "Unnest replicatedColumns must all appear in outputColumns");
+  }
+  VELOX_CHECK(
+      ordinalityColumn_ == nullptr || outputSet.contains(ordinalityColumn_),
+      "Unnest ordinalityColumn must appear in outputColumns");
+}
+
+size_t Unnest::KeyHash::operator()(const Unnest* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->unnestExpressions(),
+      node->outputColumns(),
+      node->replicatedColumns(),
+      node->ordinalityColumn());
+  const auto& unnestColumns = node->unnestColumns();
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t Unnest::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.unnestExpressions,
+      key.outputColumns,
+      key.replicatedColumns,
+      key.ordinalityColumn);
+  const auto& unnestColumns = key.unnestColumns;
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* left, const Unnest* right) const {
+  return left->input() == right->input() &&
+      left->unnestExpressions() == right->unnestExpressions() &&
+      left->replicatedColumns() == right->replicatedColumns() &&
+      left->unnestColumns() == right->unnestColumns() &&
+      left->ordinalityColumn() == right->ordinalityColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Key& key, const Unnest* node) const {
+  return key.input == node->input() &&
+      key.unnestExpressions == node->unnestExpressions() &&
+      key.replicatedColumns == node->replicatedColumns() &&
+      key.unnestColumns == node->unnestColumns() &&
+      key.ordinalityColumn == node->ordinalityColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Output global partitioning of a union: bucketed on the union output columns
+// when every leg is connector-bucketed on leg columns that map (via legColumns)
+// to those same output columns, with copartitionable partitionings. The
+// representative type is the min-partition-count leg's — its count equals the
+// copartition's — reused as a query-lifetime pointer. Unspecified otherwise, so
+// the union then distributes its legs independently.
+Partitioning unionGlobalPartition(const UnionAll::Key& key) {
+  const connector::PartitionType* representative = nullptr;
+  ExprVector outputKeys;
+  for (size_t leg = 0; leg < key.inputs.size(); ++leg) {
+    const Partitioning& part =
+        key.inputs[leg]->physicalProperties().globalPartition;
+    if (part.kind != PartitionKind::kPartitioned ||
+        part.partitionType == nullptr) {
+      return {};
+    }
+    // Map each leg partition key to the union output column at the same index.
+    const ColumnVector& legColumns = key.legColumns[leg];
+    ExprVector legOutputKeys;
+    legOutputKeys.reserve(part.keys.size());
+    for (ExprCP legKey : part.keys) {
+      ExprCP mapped = nullptr;
+      for (size_t i = 0; i < legColumns.size(); ++i) {
+        if (legColumns[i] == legKey) {
+          mapped = key.outputColumns[i];
+          break;
+        }
+      }
+      if (mapped == nullptr) {
+        return {};
+      }
+      legOutputKeys.push_back(mapped);
+    }
+
+    if (leg == 0) {
+      outputKeys = std::move(legOutputKeys);
+      representative = part.partitionType;
+      continue;
+    }
+    if (legOutputKeys.size() != outputKeys.size()) {
+      return {};
+    }
+    for (size_t i = 0; i < outputKeys.size(); ++i) {
+      if (legOutputKeys[i] != outputKeys[i]) {
+        return {};
+      }
+    }
+    // copartition is only a feasibility check; the output reuses the
+    // min-partition-count leg's layout-owned type, whose count equals
+    // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
+    const auto compatible = representative->copartition(*part.partitionType);
+    if (compatible == nullptr) {
+      return {};
+    }
+    if (part.partitionType->numPartitions() < representative->numPartitions()) {
+      representative = part.partitionType;
+    }
+    VELOX_DCHECK_EQ(
+        representative->numPartitions(),
+        compatible->numPartitions(),
+        "Co-bucketed union output must reuse a layout type matching copartition's count");
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = representative,
+      .keys = std::move(outputKeys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+UnionAll::UnionAll(Key key)
+    : Node(
+          NodeType::kUnionAll,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = unionGlobalPartition(key)}),
+      inputs_(std::move(key.inputs)),
+      legColumns_(std::move(key.legColumns)) {
+  VELOX_CHECK_GE(inputs_.size(), 2, "UnionAll requires at least two inputs");
+  for (auto* input : inputs_) {
+    VELOX_CHECK_NOT_NULL(input);
+  }
+  VELOX_CHECK_EQ(
+      legColumns_.size(),
+      inputs_.size(),
+      "UnionAll legColumns must have one entry per input");
+  const auto numOutputs = this->outputColumns().size();
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    VELOX_CHECK_EQ(
+        legColumns_[i].size(),
+        numOutputs,
+        "UnionAll legColumns[i] must align with outputColumns");
+    const auto available =
+        PlanObjectSet::fromObjects(inputs_[i]->outputColumns());
+    for (ColumnCP column : legColumns_[i]) {
+      VELOX_CHECK(
+          available.contains(column),
+          "UnionAll legColumns[{}] references a Column not in inputs[{}]->outputColumns()",
+          i,
+          i);
+    }
+  }
+}
+
+size_t UnionAll::KeyHash::operator()(const UnionAll* node) const {
+  const auto& legColumns = node->legColumns();
+  size_t hash = hashOf(node->inputs(), node->outputColumns());
+  for (size_t legIdx = 0; legIdx < legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, legColumns[legIdx].size());
+    for (const auto* column : legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t UnionAll::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(key.inputs, key.outputColumns);
+  for (size_t legIdx = 0; legIdx < key.legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, key.legColumns[legIdx].size());
+    for (const auto* column : key.legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* left, const UnionAll* right)
+    const {
+  return std::ranges::equal(left->inputs(), right->inputs()) &&
+      left->legColumns() == right->legColumns() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const Key& key, const UnionAll* node) const {
+  return std::ranges::equal(key.inputs, node->inputs()) &&
+      key.legColumns == node->legColumns() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Join::Join(Key key)
+    : Node(
+          NodeType::kJoin,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = joinGlobalPartition(
+                  key.joinType,
+                  key.left,
+                  key.outputColumns),
+              .local = joinLocal(key.joinType, key.left, key.outputColumns)}),
+      inputs_{key.left, key.right},
+      joinType_(key.joinType),
+      leftKeys_(std::move(key.leftKeys)),
+      rightKeys_(std::move(key.rightKeys)),
+      filter_(std::move(key.filter)),
+      nullAware_(key.nullAware),
+      nullAsValue_(key.nullAsValue) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+  VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
+  if (nullAware_) {
+    VELOX_CHECK(
+        joinType_ == velox::core::JoinType::kAnti ||
+            joinType_ == velox::core::JoinType::kLeftSemiProject ||
+            joinType_ == velox::core::JoinType::kRightSemiProject,
+        "nullAware only valid for kAnti / kLeftSemiProject / kRightSemiProject, got: {}",
+        joinType_);
+    // Velox forbids a null-aware right semi project that also carries an
+    // internal filter (velox PlanNode.h). The negated-mark filter of a
+    // reversed antijoin is a separate FilterNode, not this internal filter.
+    VELOX_CHECK(
+        joinType_ != velox::core::JoinType::kRightSemiProject ||
+            filter_.empty(),
+        "Null-aware kRightSemiProject does not support an internal filter");
+  }
+  VELOX_CHECK(
+      !(nullAware_ && nullAsValue_),
+      "nullAware and nullAsValue are mutually exclusive");
+}
+
+size_t Join::KeyHash::operator()(const Join* node) const {
+  return hashOf(
+      node->left(),
+      node->right(),
+      node->joinType(),
+      node->leftKeys(),
+      node->rightKeys(),
+      node->filter(),
+      node->outputColumns(),
+      node->nullAware(),
+      node->nullAsValue());
+}
+
+size_t Join::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.left,
+      key.right,
+      key.joinType,
+      key.leftKeys,
+      key.rightKeys,
+      key.filter,
+      key.outputColumns,
+      key.nullAware,
+      key.nullAsValue);
+}
+
+bool Join::KeyEq::operator()(const Join* left, const Join* right) const {
+  return left->left() == right->left() && left->right() == right->right() &&
+      left->joinType() == right->joinType() &&
+      left->leftKeys() == right->leftKeys() &&
+      left->rightKeys() == right->rightKeys() &&
+      left->filter() == right->filter() &&
+      left->nullAware() == right->nullAware() &&
+      left->nullAsValue() == right->nullAsValue() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Key& key, const Join* node) const {
+  return key.left == node->left() && key.right == node->right() &&
+      key.joinType == node->joinType() && key.leftKeys == node->leftKeys() &&
+      key.rightKeys == node->rightKeys() && key.filter == node->filter() &&
+      key.nullAware == node->nullAware() &&
+      key.nullAsValue == node->nullAsValue() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Join* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Window::Window(Key key)
+    : Node(
+          NodeType::kWindow,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      functions_(std::move(key.functions)),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!functions_.empty(), "Window must have at least one function");
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + functions_.size());
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Window::KeyHash::operator()(const Window* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->outputColumns());
+  for (const auto& function : node->functions()) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+size_t Window::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.outputColumns);
+  for (const auto& function : key.functions) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+bool Window::KeyEq::operator()(const Window* left, const Window* right) const {
+  return left->input() == right->input() &&
+      left->functions() == right->functions() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Key& key, const Window* node) const {
+  return key.input == node->input() && key.functions == node->functions() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Window* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopNRowNumber::TopNRowNumber(Key key)
+    : Node(NodeType::kTopNRowNumber, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      rankFunction_(key.rankFunction),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      limit_(key.limit),
+      rankColumn_(key.rankColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopNRowNumber must have order keys");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GT(limit_, 0);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + (rankColumn_ != nullptr ? 1 : 0));
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const TopNRowNumber* node) const {
+  return hashOf(
+      node->input(),
+      static_cast<int>(node->rankFunction()),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->limit(),
+      node->rankColumn(),
+      node->outputColumns());
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<int>(key.rankFunction),
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.limit,
+      key.rankColumn,
+      key.outputColumns);
+}
+
+bool TopNRowNumber::KeyEq::operator()(
+    const TopNRowNumber* left,
+    const TopNRowNumber* right) const {
+  return left->input() == right->input() &&
+      left->rankFunction() == right->rankFunction() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->limit() == right->limit() &&
+      left->rankColumn() == right->rankColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const Key& key, const TopNRowNumber* node)
+    const {
+  return key.input == node->input() &&
+      key.rankFunction == node->rankFunction() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.limit == node->limit() &&
+      key.rankColumn == node->rankColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const TopNRowNumber* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Apply::Apply(Key key)
+    : Node(NodeType::kApply, ColumnVector{key.outputColumns}, {}),
+      inputs_{key.input, key.body},
+      correlationColumns_(std::move(key.correlationColumns)),
+      kind_(key.kind),
+      filter_(std::move(key.filter)),
+      enforceSingleRow_(key.enforceSingleRow),
+      markColumn_(key.markColumn),
+      inLhs_(key.inLhs),
+      inBodyKey_(key.inBodyKey),
+      includeMarker_(key.includeMarker) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+
+  // Allowed kinds at Apply: correlated scalar (kLeft) and EXISTS/IN
+  // (kLeftSemiProject). Uncorrelated scalars are lowered directly to
+  // cross-join + EnforceSingleRow at translate time — no Apply. kAnti
+  // / kLeftSemiFilter emerge from the post-decorrelate peephole, never
+  // at Apply.
+  const bool isLeft = kind_ == velox::core::JoinType::kLeft;
+  VELOX_CHECK(
+      isLeft || kind_ == velox::core::JoinType::kLeftSemiProject,
+      "Apply.kind must be kLeft / kLeftSemiProject; got: {}",
+      kind_);
+
+  if (isLeft) {
+    VELOX_CHECK_NOT_NULL(
+        includeMarker_, "kLeft Apply requires an includeMarker");
+    VELOX_CHECK_EQ(
+        includeMarker_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "Apply.includeMarker must be BOOLEAN");
+    VELOX_CHECK_NULL(
+        markColumn_,
+        "markColumn is kLeftSemiProject-only; kLeft leaves it null");
+    VELOX_CHECK_NULL(inLhs_, "inLhs is IN-only; non-semi Apply leaves it null");
+    VELOX_CHECK_NULL(
+        inBodyKey_, "inBodyKey is IN-only; non-semi Apply leaves it null");
+  } else {
+    VELOX_CHECK_NULL(
+        includeMarker_, "includeMarker is kLeft-only; kSemi leaves it null");
+    VELOX_CHECK_NOT_NULL(
+        markColumn_, "kLeftSemiProject Apply requires a markColumn");
+    VELOX_CHECK_EQ(
+        markColumn_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "kLeftSemiProject markColumn must be BOOLEAN");
+    VELOX_CHECK(
+        !enforceSingleRow_,
+        "kLeftSemiProject Apply must have enforceSingleRow == false "
+        "(semi/anti has no cardinality assertion)");
+  }
+  // The IN pair is set together: both null (scalar / EXISTS) or both
+  // non-null (IN). Forbid the half-set state.
+  VELOX_CHECK_EQ(
+      inLhs_ == nullptr,
+      inBodyKey_ == nullptr,
+      "Apply.inLhs and Apply.inBodyKey must be set together (both null "
+      "for scalar / EXISTS; both non-null for IN)");
+
+  // outputColumns shape check, per kind:
+  //   kLeft             : input.outputColumns
+  //                       ++ unique(body.outputColumns) ++ includeMarker
+  //   kLeftSemiProject  : input.outputColumns ++ markColumn
+  //
+  // A body column that already appears in input.outputColumns by
+  // Column* identity occupies a single output slot.
+  const auto& inputCols = inputs_[0]->outputColumns();
+  for (size_t i = 0; i < inputCols.size(); ++i) {
+    VELOX_CHECK(
+        outputColumns()[i] == inputCols[i],
+        "Apply.outputColumns prefix must match input.outputColumns");
+  }
+  if (isLeft) {
+    VELOX_CHECK_GE(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeft Apply.outputColumns shorter than input + includeMarker");
+    const size_t bodySlots = outputColumns().size() - inputCols.size() - 1;
+    VELOX_CHECK_LE(
+        bodySlots,
+        inputs_[1]->outputColumns().size(),
+        "Apply body-col slot count exceeds body's outputColumns");
+    PlanObjectSet seen = PlanObjectSet::fromObjects(inputCols);
+    for (size_t i = 0; i < bodySlots; ++i) {
+      ColumnCP column = outputColumns()[inputCols.size() + i];
+      VELOX_CHECK(
+          !seen.contains(column),
+          "Apply.outputColumns body cols must be unique vs input and each other");
+      seen.add(column);
+    }
+    VELOX_CHECK(
+        outputColumns().back() == includeMarker_,
+        "Apply.outputColumns must end with includeMarker for kLeft");
+  } else {
+    VELOX_CHECK_EQ(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeftSemiProject Apply.outputColumns size mismatch");
+    VELOX_CHECK(
+        outputColumns().back() == markColumn_,
+        "Apply.outputColumns must end with markColumn for kLeftSemiProject");
+  }
+}
+
+size_t Apply::KeyHash::operator()(const Apply* node) const {
+  return hashOf(
+      node->input(),
+      node->body(),
+      node->correlationColumns(),
+      node->kind(),
+      node->filter(),
+      node->enforceSingleRow(),
+      node->markColumn(),
+      node->inLhs(),
+      node->inBodyKey(),
+      node->includeMarker(),
+      node->outputColumns());
+}
+
+size_t Apply::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      key.body,
+      key.correlationColumns,
+      key.kind,
+      key.filter,
+      key.enforceSingleRow,
+      key.markColumn,
+      key.inLhs,
+      key.inBodyKey,
+      key.includeMarker,
+      key.outputColumns);
+}
+
+bool Apply::KeyEq::operator()(const Apply* left, const Apply* right) const {
+  return left->input() == right->input() && left->body() == right->body() &&
+      left->correlationColumns() == right->correlationColumns() &&
+      left->kind() == right->kind() && left->filter() == right->filter() &&
+      left->enforceSingleRow() == right->enforceSingleRow() &&
+      left->markColumn() == right->markColumn() &&
+      left->inLhs() == right->inLhs() &&
+      left->inBodyKey() == right->inBodyKey() &&
+      left->includeMarker() == right->includeMarker() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Key& key, const Apply* node) const {
+  return key.input == node->input() && key.body == node->body() &&
+      key.correlationColumns == node->correlationColumns() &&
+      key.kind == node->kind() && key.filter == node->filter() &&
+      key.enforceSingleRow == node->enforceSingleRow() &&
+      key.markColumn == node->markColumn() && key.inLhs == node->inLhs() &&
+      key.inBodyKey == node->inBodyKey() &&
+      key.includeMarker == node->includeMarker() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Apply* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+ColumnVector withIdColumn(const ColumnVector& columns, ColumnCP idColumn) {
+  ColumnVector result;
+  result.reserve(columns.size() + 1);
+  for (ColumnCP column : columns) {
+    result.push_back(column);
+  }
+  result.push_back(idColumn);
+  return result;
+}
+} // namespace
+
+AssignUniqueId::AssignUniqueId(Key key)
+    : Node(
+          NodeType::kAssignUniqueId,
+          withIdColumn(key.input->outputColumns(), key.idColumn),
+          PhysicalProperties{
+              .local = groupedLocal(key.idColumn),
+              .unique = globalUniqueKey(key.idColumn)}),
+      input_(key.input),
+      idColumn_(key.idColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(idColumn_);
+  VELOX_CHECK_EQ(idColumn_->value().type->kind(), velox::TypeKind::BIGINT);
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const AssignUniqueId* node) const {
+  return hashOf(node->input(), node->idColumn());
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.idColumn);
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* left,
+    const AssignUniqueId* right) const {
+  return left->input() == right->input() &&
+      left->idColumn() == right->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const Key& key,
+    const AssignUniqueId* node) const {
+  return key.input == node->input() && key.idColumn == node->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceSingleRow::EnforceSingleRow(Key key)
+    : Node(
+          NodeType::kEnforceSingleRow,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(
+    const EnforceSingleRow* node) const {
+  return hashOf(node->input());
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input);
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* left,
+    const EnforceSingleRow* right) const {
+  return left->input() == right->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const Key& key,
+    const EnforceSingleRow* node) const {
+  return key.input == node->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceDistinct::EnforceDistinct(Key key)
+    : Node(
+          NodeType::kEnforceDistinct,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      distinctKeys_(std::move(key.distinctKeys)),
+      errorMessage_(key.errorMessage) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !distinctKeys_.empty(),
+      "EnforceDistinct must have at least one distinct key");
+  VELOX_CHECK_NOT_NULL(errorMessage_);
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const EnforceDistinct* node) const {
+  return hashOf(node->input(), node->distinctKeys(), node->errorMessage());
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.distinctKeys, key.errorMessage);
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* left,
+    const EnforceDistinct* right) const {
+  return left->input() == right->input() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->errorMessage() == right->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const Key& key,
+    const EnforceDistinct* node) const {
+  return key.input == node->input() &&
+      key.distinctKeys == node->distinctKeys() &&
+      key.errorMessage == node->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+Exchange::Exchange(Key key)
+    : Node(
+          NodeType::kExchange,
+          ColumnVector{key.input->outputColumns()},
+          // A remote exchange drops per-driver local order/grouping (rows
+          // interleave) — except an order-preserving gather, which keeps the
+          // merged sort order. Uniqueness survives per uniqueAcrossExchange
+          // (global-scope only, none under a broadcast).
+          PhysicalProperties{
+              .globalPartition = key.partitioning,
+              .local = exchangeLocal(key.partitioning),
+              .unique = uniqueAcrossExchange(
+                  key.input->physicalProperties().unique,
+                  key.partitioning)}),
+      input_(key.input),
+      partitioning_(std::move(key.partitioning)) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t Exchange::KeyHash::operator()(const Exchange* node) const {
+  const auto& partitioning = node->partitioning();
+  return hashOf(
+      node->input(),
+      static_cast<uint8_t>(partitioning.kind),
+      partitioning.partitionType,
+      partitioning.keys,
+      partitioning.orderKeys,
+      partitioning.orderTypes,
+      static_cast<uint8_t>(partitioning.scope),
+      partitioning.replicateNullsAndAny);
+}
+
+size_t Exchange::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<uint8_t>(key.partitioning.kind),
+      key.partitioning.partitionType,
+      key.partitioning.keys,
+      key.partitioning.orderKeys,
+      key.partitioning.orderTypes,
+      static_cast<uint8_t>(key.partitioning.scope),
+      key.partitioning.replicateNullsAndAny);
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* left, const Exchange* right)
+    const {
+  return left->input() == right->input() &&
+      left->partitioning() == right->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Key& key, const Exchange* node) const {
+  return key.input == node->input() && key.partitioning == node->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TableWrite::TableWrite(Key key)
+    : Node(
+          NodeType::kTableWrite,
+          ColumnVector{Column::create("rows", Value(toType(velox::BIGINT())))},
+          {}),
+      input_(key.input),
+      table_(key.table),
+      kind_(key.kind),
+      columnExprs_(std::move(key.columnExprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(table_);
+  VELOX_CHECK(
+      !columnExprs_.empty(), "TableWrite must write at least one column");
+  VELOX_CHECK_EQ(columnExprs_.size(), table_->type()->size());
+}
+
+size_t TableWrite::KeyHash::operator()(const TableWrite* node) const {
+  return hashOf(
+      node->input(),
+      node->table(),
+      static_cast<uint8_t>(node->kind()),
+      node->columnExprs());
+}
+
+size_t TableWrite::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.table, static_cast<uint8_t>(key.kind), key.columnExprs);
+}
+
+bool TableWrite::KeyEq::operator()(
+    const TableWrite* left,
+    const TableWrite* right) const {
+  return left->input() == right->input() && left->table() == right->table() &&
+      left->kind() == right->kind() &&
+      left->columnExprs() == right->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const Key& key, const TableWrite* node)
+    const {
+  return key.input == node->input() && key.table == node->table() &&
+      key.kind == node->kind() && key.columnExprs == node->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+#define V2_DEFINE_ACCEPT(NodeT)                                               \
+  void NodeT::accept(const NodeVisitor& visitor, NodeVisitorContext& context) \
+      const {                                                                 \
+    visitor.visit(*this, context);                                            \
+  }
+
+V2_DEFINE_ACCEPT(Scan)
+V2_DEFINE_ACCEPT(Filter)
+V2_DEFINE_ACCEPT(Project)
+V2_DEFINE_ACCEPT(Limit)
+V2_DEFINE_ACCEPT(Sort)
+V2_DEFINE_ACCEPT(TopN)
+V2_DEFINE_ACCEPT(Aggregate)
+V2_DEFINE_ACCEPT(GroupId)
+V2_DEFINE_ACCEPT(MarkDistinct)
+V2_DEFINE_ACCEPT(Values)
+V2_DEFINE_ACCEPT(Unnest)
+V2_DEFINE_ACCEPT(UnionAll)
+V2_DEFINE_ACCEPT(Join)
+V2_DEFINE_ACCEPT(Window)
+V2_DEFINE_ACCEPT(TopNRowNumber)
+V2_DEFINE_ACCEPT(Apply)
+V2_DEFINE_ACCEPT(EnforceSingleRow)
+V2_DEFINE_ACCEPT(AssignUniqueId)
+V2_DEFINE_ACCEPT(EnforceDistinct)
+V2_DEFINE_ACCEPT(Exchange)
+V2_DEFINE_ACCEPT(TableWrite)
+
+#undef V2_DEFINE_ACCEPT
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1,0 +1,1800 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/PlanNode.h"
+
+/// Tree-IR for the optimizer.
+///
+/// Nodes are immutable and, like all `PlanObject`s, arena-allocated from the
+/// shared `QueryGraphContext`.
+namespace facebook::axiom::optimizer::v2 {
+
+/// Discriminator for Node subtypes.
+enum class NodeType : uint8_t {
+  kScan,
+  kFilter,
+  kProject,
+  kLimit,
+  kSort,
+  kTopN,
+  kAggregate,
+  kGroupId,
+  kMarkDistinct,
+  kValues,
+  kUnnest,
+  kUnionAll,
+  kJoin,
+  kWindow,
+  kTopNRowNumber,
+  kApply,
+  kEnforceSingleRow,
+  kAssignUniqueId,
+  kEnforceDistinct,
+  kExchange,
+  kTableWrite,
+};
+
+AXIOM_DECLARE_ENUM_NAME(NodeType);
+
+class Node;
+class NodeVisitor;
+class NodeVisitorContext;
+using NodeCP = const Node*;
+using NodeVector = QGVector<NodeCP>;
+
+/// Base class for tree-IR operator nodes. Immutable. All members are const
+/// and initialized via the constructor. Abstract — instantiate via a subclass.
+///
+/// Cross-node references — predicates, join/grouping/sort keys, expression
+/// operands, per-leg layouts — bind by pointer identity, and keys may be
+/// arbitrary expressions, not just columns: `GROUP BY mod(a, 2)` carries a
+/// `Call` grouping key, and sort and partition keys are the same. Positional
+/// indices into a producer's `outputColumns()` are never used: pruning,
+/// duplicate-column collapse, and any other rewrite that reshapes a producer's
+/// `outputColumns` would then force rewiring at every consumer. Same-node
+/// sub-vector indices (e.g., `GroupId::groupingSets` into `groupingKeyColumns`)
+/// are positional and OK — they reference structure internal to the node, not a
+/// producer. The IR never binds by column name; names on `Column::name_` /
+/// `alias_` exist only as display labels for EXPLAIN.
+///
+/// A node's `PhysicalProperties`, by contrast, always reference this node's own
+/// output columns — an invariant each derivation upholds and the base
+/// constructor verifies (`checkReferencesColumns`). Velox's column-key
+/// requirement for aggregation / ordering / windowing / exchange is a separate,
+/// emit-time concern that `PrecomputeProjections` materializes.
+///
+/// Each node kind enforces its own column-identity contract: outputs contain no
+/// duplicate columns, and each kind extends or transforms its input schema in a
+/// specific way. See each subclass's docblock for the exact rules.
+///
+/// Instantiate nodes only through a `Builder` (`builder.make<T>(key)`), never
+/// by constructing a subclass directly: `make` hash-conses on the subclass's
+/// nested `Key` struct (its identity — two nodes of a kind intern to the same
+/// instance iff their `Key`s compare equal: input pointer(s) plus the node's
+/// parameter expression / column pointers). Direct construction bypasses
+/// interning. See `Builder.h`.
+class Node : public PlanObject {
+ public:
+  NodeType nodeType() const {
+    return nodeType_;
+  }
+
+  bool is(NodeType nodeType) const {
+    return nodeType_ == nodeType;
+  }
+
+  std::string_view nodeTypeName() const {
+    return NodeTypeName::toName(nodeType_);
+  }
+
+  /// Columns produced by this node, in output order.
+  const ColumnVector& outputColumns() const {
+    return outputColumns_;
+  }
+
+  /// Physical properties of this node's output: per-driver local ordering /
+  /// grouping, distribution, and relation-level facts. Derived from the inputs
+  /// at construction and immutable. Fields stay unset until decided — e.g.
+  /// distribution is unspecified until an exchange is placed, which mints a new
+  /// node rather than mutating this one.
+  const PhysicalProperties& physicalProperties() const {
+    return physicalProperties_;
+  }
+
+  /// Inputs in dependency order; empty for leaves. Returns a view into
+  /// node-owned storage; callers must not retain it past the node's
+  /// lifetime.
+  virtual std::span<const NodeCP> inputs() const = 0;
+
+  /// Double-dispatch hook for `NodeVisitor`.
+  virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const = 0;
+
+  std::string toString() const override;
+
+ protected:
+  Node(
+      NodeType nodeType,
+      ColumnVector outputColumns,
+      PhysicalProperties properties)
+      : PlanObject(PlanType::kV2Node),
+        nodeType_(nodeType),
+        outputColumns_(std::move(outputColumns)),
+        physicalProperties_(std::move(properties)) {
+    physicalProperties_.checkReferencesColumns(
+        PlanObjectSet::fromObjects(outputColumns_));
+  }
+
+ private:
+  const NodeType nodeType_;
+  const ColumnVector outputColumns_;
+  const PhysicalProperties physicalProperties_;
+};
+
+/// Reads rows from a connector-backed table (`BaseTable`).
+class Scan : public Node {
+ public:
+  struct Key {
+    BaseTableCP baseTable;
+    /// Strict consumer-required output columns; may be empty (e.g.
+    /// `SELECT count(1) FROM t` needs no column values from the table).
+    /// Distinct by pointer; both `outputName()` and the underlying `name()`
+    /// are unique within the vector. `filters` may reference columns that are
+    /// NOT in this set; the connector-side read schema is computed as
+    /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
+    ColumnVector outputColumns;
+    /// Predicates (joined with AND) offered to the connector during planning;
+    /// may be empty. The connector accepts those it can evaluate and rejects
+    /// the rest; rejected predicates are re-applied as a `Filter` node above
+    /// the `TableScan` when building the final Velox plan.
+    ExprVector filters;
+  };
+
+  /// Transparent hasher for interning `Scan`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Scan* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Scan`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Scan* left, const Scan* right) const;
+    bool operator()(const Key& key, const Scan* node) const;
+    bool operator()(const Scan* node, const Key& key) const;
+  };
+
+  explicit Scan(Key key);
+
+  BaseTableCP baseTable() const {
+    return baseTable_;
+  }
+
+  const ExprVector& filters() const {
+    return filters_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const BaseTableCP baseTable_;
+  const ExprVector filters_;
+};
+
+using ScanCP = const Scan*;
+
+/// Selects rows from its input that match all of its predicates (joined with
+/// AND). Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers).
+class Filter : public Node {
+ public:
+  struct Key {
+    /// Input node whose rows are filtered.
+    NodeCP input;
+    /// Predicates joined with AND; non-empty.
+    ExprVector predicates;
+  };
+
+  /// Transparent hasher for interning `Filter`s by identity (input +
+  /// predicates), read from either a stored `Filter*` or a lookup `Key`.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Filter* filter) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Filter`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Filter* left, const Filter* right) const;
+    bool operator()(const Key& key, const Filter* filter) const;
+    bool operator()(const Filter* filter, const Key& key) const;
+  };
+
+  explicit Filter(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  /// Predicates joined with AND. Non-empty.
+  const ExprVector& predicates() const {
+    return predicates_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector predicates_;
+};
+
+using FilterCP = const Filter*;
+
+/// Computes output columns from input expressions. Output schema is
+/// `outputColumns`; the i-th output column is produced by `exprs[i]`.
+///
+/// Example: `SELECT a, b + 1 AS c FROM t` translates to:
+///
+///     Project(input=t, exprs=[t.a, t.b + 1], outputColumns=[t.a, c])
+///
+/// where `t.a` is a pass-through (same `Column*` as the input), and
+/// `c` is a fresh `Column*` for the computed expression.
+class Project : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output expressions, positional with `outputColumns`.
+    ExprVector exprs;
+    /// Output columns, positional with `exprs` (see the class docblock for the
+    /// pass-through vs fresh-column rule).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Project`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Project* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Project`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Project* left, const Project* right) const;
+    bool operator()(const Key& key, const Project* node) const;
+    bool operator()(const Project* node, const Key& key) const;
+  };
+
+  explicit Project(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& exprs() const {
+    return exprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector exprs_;
+};
+
+using ProjectCP = const Project*;
+
+/// Returns up to `count` rows starting from `offset`. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Limit : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    /// `std::numeric_limits<int64_t>::max()` means no limit (e.g. `OFFSET n`
+    /// with no `LIMIT`), 0 means empty result.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `Limit`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Limit* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Limit`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Limit* left, const Limit* right) const;
+    bool operator()(const Key& key, const Limit* node) const;
+    bool operator()(const Limit* node, const Key& key) const;
+  };
+
+  explicit Limit(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using LimitCP = const Limit*;
+
+/// Sorts rows by `orderKeys` with directions in `orderTypes`. Does not change
+/// the schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Sort : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+  };
+
+  /// Transparent hasher for interning `Sort`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Sort* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Sort`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Sort* left, const Sort* right) const;
+    bool operator()(const Key& key, const Sort* node) const;
+    bool operator()(const Sort* node, const Key& key) const;
+  };
+
+  explicit Sort(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using SortCP = const Sort*;
+
+/// Sorts rows by `orderKeys` / `orderTypes` and returns up to `count` rows
+/// starting from `offset` — a bounded Sort. A Limit directly over a Sort fuses
+/// into this. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers).
+class TopN : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `TopN`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopN* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopN`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopN* left, const TopN* right) const;
+    bool operator()(const Key& key, const TopN* node) const;
+    bool operator()(const TopN* node, const Key& key) const;
+  };
+
+  explicit TopN(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using TopNCP = const TopN*;
+
+/// Vector of `optimizer::Aggregate*` (an aggregate-function Call). The
+/// type is distinct from `ExprVector` so consumers don't need to
+/// downcast each element to access aggregate-specific accessors
+/// (`condition`, `orderKeys`, etc.); the `Aggregate` node carries
+/// this type directly.
+using AggregateCallVector = QGVector<const optimizer::Aggregate*>;
+
+/// Stage of a (possibly distributed) aggregation, reusing Velox's enum.
+/// `kSingle` computes the complete result in one pass. `kPartial`
+/// pre-aggregates its input and emits intermediate accumulators (one per
+/// aggregate, typed by `optimizer::Aggregate::intermediateType()`); `kFinal`
+/// consumes those accumulators and emits the final result. A two-stage
+/// distributed aggregate is `kFinal` over a remote `Exchange` over `kPartial`.
+using AggregateStep = velox::core::AggregationNode::Step;
+
+/// Groups input rows by `groupingKeys` and computes `aggregates` per
+/// group. Output schema is `groupingKeys` followed by `aggregates`
+/// (one output column each).
+///
+/// Example: `SELECT a, sum(b) FROM t GROUP BY a` translates to:
+///
+///     Aggregate(input=t, groupingKeys=[t.a], aggregates=[sum(t.b)],
+///               outputColumns=[t.a, sum_b])
+///
+/// One output row per distinct value of `t.a`, with `sum_b` the sum
+/// of `t.b` within that group.
+///
+/// GROUPING SETS / ROLLUP / CUBE have no dedicated representation here: they
+/// are lowered to a `GroupId` input plus a plain aggregate keyed on an explicit
+/// group-id column, so this node has no grouping-set concept of its own. That
+/// group-id column, when present, is also recorded in `groupId` (with
+/// `globalGroupingSets`).
+class Aggregate : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Grouping keys; empty for a global aggregate.
+    ExprVector groupingKeys;
+    /// Aggregate functions, one per output aggregate column.
+    AggregateCallVector aggregates;
+    /// Output columns: the `groupingKeys`, then the `aggregates`, positionally.
+    ColumnVector outputColumns;
+    /// Aggregation stage. For a `kPartial` step, `outputColumns`' aggregate
+    /// positions hold intermediate accumulators (typed by
+    /// `intermediateType()`), not final results.
+    AggregateStep step{AggregateStep::kSingle};
+
+    /// Group-id column from the upstream `GroupId`, or null for a plain
+    /// aggregate. Set iff `globalGroupingSets` is non-empty; when set it also
+    /// appears in `groupingKeys`.
+    ColumnCP groupId{nullptr};
+    /// Group-id values of the global (empty) grouping sets. Non-empty only for
+    /// a GROUPING SETS / ROLLUP / CUBE aggregate with a global `()` set; drives
+    /// Velox's default-row-per-global-set behavior over empty input.
+    QGVector<int32_t> globalGroupingSets;
+  };
+
+  /// Transparent hasher for interning `Aggregate`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Aggregate* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Aggregate`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Aggregate* left, const Aggregate* right) const;
+    bool operator()(const Key& key, const Aggregate* node) const;
+    bool operator()(const Aggregate* node, const Key& key) const;
+  };
+
+  explicit Aggregate(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const AggregateCallVector& aggregates() const {
+    return aggregates_;
+  }
+
+  AggregateStep step() const {
+    return step_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  const QGVector<int32_t>& globalGroupingSets() const {
+    return globalGroupingSets_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const AggregateCallVector aggregates_;
+  const AggregateStep step_;
+  const ColumnCP groupId_;
+  const QGVector<int32_t> globalGroupingSets_;
+};
+
+using AggregateCP = const Aggregate*;
+
+/// Replicates each input row once per grouping set, emitting NULL for keys
+/// inactive in that set and tagging the copy with the set's index. The
+/// downstream `Aggregate` then groups by
+/// `groupingKeyColumns ++ [groupId]` and runs the aggregates over the
+/// replicated rows; the SQL `GROUPING SETS` / `ROLLUP` / `CUBE` semantics
+/// fall out of that grouping.
+///
+/// `outputColumns` = `groupingKeyColumns ++ aggregationInputs' columns ++
+/// [groupId]`. Velox `GroupingKeyInfo` maps each `groupingKeys` expression to
+/// the corresponding `groupingKeyColumns` output name; both vectors are
+/// positionally aligned.
+class GroupId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Input-side expressions whose values populate each replicated grouping
+    /// key; positionally aligned with `groupingKeyColumns`.
+    ExprVector groupingKeys;
+    /// Input columns referenced by the downstream `Aggregate`'s aggregate
+    /// functions; passed through to the output unchanged.
+    ExprVector aggregationInputs;
+    /// Non-empty; each entry lists the `groupingKeyColumns` indices active for
+    /// that set. Inactive keys are emitted as NULL in that set's output rows.
+    QGVector<QGVector<int32_t>> groupingSets;
+    /// Fresh output columns for the (possibly NULL-padded) grouping keys.
+    ColumnVector groupingKeyColumns;
+    /// Output column holding the grouping-set index (BIGINT, zero-based).
+    ColumnCP groupId;
+    /// Output columns: `groupingKeyColumns`, then `aggregationInputs`' columns,
+    /// then `groupId`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `GroupId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const GroupId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `GroupId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const GroupId* left, const GroupId* right) const;
+    bool operator()(const Key& key, const GroupId* node) const;
+    bool operator()(const GroupId* node, const Key& key) const;
+  };
+
+  explicit GroupId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  const QGVector<QGVector<int32_t>>& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeyColumns() const {
+    return groupingKeyColumns_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const QGVector<QGVector<int32_t>> groupingSets_;
+  const ColumnVector groupingKeyColumns_;
+  const ColumnCP groupId_;
+};
+
+using GroupIdCP = const GroupId*;
+
+/// Marks the first occurrence of each `(distinctKeys)` tuple from `input`
+/// with `true` and subsequent occurrences with `false`. Used to lower
+/// `DISTINCT` aggregates to non-distinct ones with a FILTER mask: a
+/// downstream `Aggregate` reads `agg(x) FILTER (marker)` and sees each
+/// `(group, x)` tuple at most once.
+///
+/// One `MarkDistinct` serves all distinct aggregates over the same key set.
+/// `markers[0]` is the no-mask marker: true on the first occurrence of each
+/// tuple overall, read by the unfiltered distinct aggregates. Each `masks[i]`
+/// is the `FILTER` condition of a filtered distinct aggregate, paired with
+/// `markers[i+1]`, which is true on the first occurrence of each tuple among
+/// the rows where `masks[i]` holds. `masks` is empty when no distinct aggregate
+/// over this key set carries a `FILTER`.
+///
+/// `outputColumns` = `input.outputColumns ++ markers` (input columns pass
+/// through unchanged).
+class MarkDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output marker columns (BOOLEAN); `markers[0]` is the no-mask marker.
+    /// See the class doc.
+    ColumnVector markers;
+    /// Columns / expressions tested for distinctness, in positional order.
+    ExprVector distinctKeys;
+    /// FILTER condition per filtered distinct aggregate, positionally aligned
+    /// with `markers[1..]`. Empty when no distinct aggregate over the key set
+    /// carries a FILTER.
+    ColumnVector masks;
+    /// Output columns: `input`'s columns, then `markers`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `MarkDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const MarkDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `MarkDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const MarkDistinct* left, const MarkDistinct* right) const;
+    bool operator()(const Key& key, const MarkDistinct* node) const;
+    bool operator()(const MarkDistinct* node, const Key& key) const;
+  };
+
+  explicit MarkDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ColumnVector& markers() const {
+    return markers_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  const ColumnVector& masks() const {
+    return masks_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnVector markers_;
+  const ExprVector distinctKeys_;
+  const ColumnVector masks_;
+};
+
+using MarkDistinctCP = const MarkDistinct*;
+
+/// Embeds a constant table in the plan. `outputColumns` defines the schema
+/// in all three cases. At most one of `source` / `rows` is non-null:
+///   - `source != nullptr, rows == nullptr`: pass through a
+///     `logical_plan::ValuesNode` whose `Variants` or `Vectors` data is
+///     read when building the final Velox plan.
+///   - `source == nullptr, rows != nullptr`: an arena-allocated
+///     `Variant::array(...)` of row `Variant`s (each element is
+///     `Variant::row(...)`). Produced by translate-time folding of
+///     `lp::ValuesNode::Exprs`.
+///   - `source == nullptr, rows == nullptr`: empty table — zero rows with
+///     schema from `outputColumns`. Used for the `LIMIT 0` rewrite.
+class Values : public Node {
+ public:
+  struct Key {
+    /// Set to pass through a logical-plan `ValuesNode` (see class doc).
+    const logical_plan::ValuesNode* source;
+    /// Set to embed arena-folded row `Variant`s (see class doc).
+    const velox::Variant* rows;
+    /// Output schema (defines the columns in all cases).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Values`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Values* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Values`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Values* left, const Values* right) const;
+    bool operator()(const Key& key, const Values* node) const;
+    bool operator()(const Values* node, const Key& key) const;
+  };
+
+  explicit Values(Key key);
+
+  const logical_plan::ValuesNode* source() const {
+    return source_;
+  }
+
+  const velox::Variant* rows() const {
+    return rows_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const logical_plan::ValuesNode* const source_;
+  const velox::Variant* const rows_;
+};
+
+using ValuesCP = const Values*;
+
+/// Expands array / map expressions row-wise. The output has three disjoint
+/// kinds of columns, exposed as separate accessors so consumers never need
+/// positional decoding: `replicatedColumns` (pass-through input columns),
+/// `unnestColumns[i]` (per-expression result columns), and the optional
+/// `ordinalityColumn`. `outputColumns()` returns the concatenation in that
+/// order, for downstream consumers that need a single vector view.
+class Unnest : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Array / map expressions expanded row-wise, in positional order.
+    ExprVector unnestExpressions;
+    /// Subset of `input->outputColumns()` to pass through; may be empty.
+    ColumnVector replicatedColumns;
+    /// One `ColumnVector` per `unnestExpressions[i]`: the result columns
+    /// produced by that expression (1 for ARRAY, 2 for MAP — key, value).
+    QGVector<ColumnVector> unnestColumns;
+    /// Optional ordinality column; null when this node does not produce
+    /// ordinality.
+    ColumnCP ordinalityColumn;
+    /// Visible schema. Every `Column*` here is a `replicatedColumns` column, a
+    /// column in some `unnestColumns[i]`, or `ordinalityColumn`. All
+    /// `replicatedColumns` and `ordinalityColumn` must appear; only
+    /// per-expression `unnestColumns` may be pruned out.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Unnest`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Unnest* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Unnest`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Unnest* left, const Unnest* right) const;
+    bool operator()(const Key& key, const Unnest* node) const;
+    bool operator()(const Unnest* node, const Key& key) const;
+  };
+
+  explicit Unnest(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& unnestExpressions() const {
+    return unnestExpressions_;
+  }
+
+  const ColumnVector& replicatedColumns() const {
+    return replicatedColumns_;
+  }
+
+  const QGVector<ColumnVector>& unnestColumns() const {
+    return unnestColumns_;
+  }
+
+  ColumnCP ordinalityColumn() const {
+    return ordinalityColumn_;
+  }
+
+  bool withOrdinality() const {
+    return ordinalityColumn_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector unnestExpressions_;
+  const ColumnVector replicatedColumns_;
+  const QGVector<ColumnVector> unnestColumns_;
+  const ColumnCP ordinalityColumn_;
+};
+
+using UnnestCP = const Unnest*;
+
+/// Concatenates rows from all inputs (UNION ALL semantics).
+/// `outputColumns` is a fresh duplicate-free output schema; `legColumns[i]`
+/// maps each output position to a `Column*` from `inputs[i]`.
+///
+/// Example: `SELECT a, b FROM t UNION ALL SELECT x, y FROM u` translates to:
+///
+///     UnionAll(inputs=[t, u],
+///              legColumns=[[t.a, t.b],  // leg 0: which t columns feed outputs
+///                          [u.x, u.y]], // leg 1: which u columns feed outputs
+///              outputColumns=[union_col_0, union_col_1])
+///
+/// `legColumns[i][j]` is the `Column*` from `inputs[i]->outputColumns()`
+/// that supplies values for union output position `j`. The same
+/// `Column*` may repeat within a leg to fan one input column into
+/// multiple union positions (e.g., `SELECT a, a FROM t` after the
+/// translate-time deduplication collapses both selected `a`s to one input
+/// column).
+class UnionAll : public Node {
+ public:
+  struct Key {
+    /// Inputs to concatenate; >= 2.
+    NodeVector inputs;
+    /// Per input, the `Column*`s (from that input's `outputColumns()`) that
+    /// feed each output position: one entry per input, each sized like
+    /// `outputColumns`. See the class doc.
+    QGVector<ColumnVector> legColumns;
+    /// Fresh, duplicate-free output schema.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `UnionAll`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const UnionAll* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `UnionAll`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const UnionAll* left, const UnionAll* right) const;
+    bool operator()(const Key& key, const UnionAll* node) const;
+    bool operator()(const UnionAll* node, const Key& key) const;
+  };
+
+  explicit UnionAll(Key key);
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  const QGVector<ColumnVector>& legColumns() const {
+    return legColumns_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeVector inputs_;
+  const QGVector<ColumnVector> legColumns_;
+};
+
+using UnionAllCP = const UnionAll*;
+
+/// Joins two inputs by `joinType` with paired equi-keys plus an optional
+/// residual `filter`. `outputColumns` projects columns from the inputs; see the
+/// field doc.
+///
+/// Example: `SELECT * FROM t INNER JOIN u ON t.a = u.a AND t.b > u.b`
+/// translates to:
+///
+///     Join(left=t, right=u, joinType=kInner,
+///          leftKeys=[t.a], rightKeys=[u.a],
+///          filter=(t.b > u.b),
+///          outputColumns=[t.a, t.b, u.a, u.b])
+///
+/// `leftKeys[i]` joins against `rightKeys[i]` via equality; the two
+/// vectors must have the same size. The match condition is
+/// `AND(leftKeys[i] = rightKeys[i] for all i) AND AND(filter)`.
+/// `filter` is a flat vector of predicates joined with AND (the producer is
+/// responsible for flattening and for lifting any equi-pairs into the key
+/// vectors).
+///
+/// Lowering depends on key presence:
+///   - `leftKeys` non-empty → `HashJoinNode`, with `filter` as the
+///     optional residual non-equi predicate.
+///   - `leftKeys` empty, `filter` empty → `NestedLoopJoinNode` cross
+///     product.
+///   - `leftKeys` empty, `filter` non-empty → `NestedLoopJoinNode`
+///     filter-only join.
+///
+/// `nullAware` (semi / anti only) enables NULL-aware semantics for
+/// `IN` / `NOT IN`. `nullAsValue` (set ops INTERSECT / EXCEPT) treats
+/// `NULL == NULL` as true on equi-keys. Mutually exclusive.
+class Join : public Node {
+ public:
+  struct Key {
+    /// Left input.
+    NodeCP left;
+    /// Right input.
+    NodeCP right;
+    /// Join type (inner / left / full / semi / anti / ...).
+    velox::core::JoinType joinType;
+    /// Left equi-keys; positional with `rightKeys` and the same size.
+    ExprVector leftKeys;
+    /// Right equi-keys; positional with `leftKeys`.
+    ExprVector rightKeys;
+    /// Residual non-equi predicates joined with AND; may be empty.
+    ExprVector filter;
+    /// NULL-aware semantics for IN / NOT IN (semi / anti only).
+    bool nullAware{false};
+    /// Treats NULL == NULL as true on equi-keys (INTERSECT / EXCEPT).
+    bool nullAsValue{false};
+    /// Output columns, each drawn from the left or right input; semi / anti
+    /// joins draw only from the preserved side. Pruned to what consumers need.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Join`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Join* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Join`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Join* left, const Join* right) const;
+    bool operator()(const Key& key, const Join* node) const;
+    bool operator()(const Join* node, const Key& key) const;
+  };
+
+  explicit Join(Key key);
+
+  NodeCP left() const {
+    return inputs_[0];
+  }
+
+  NodeCP right() const {
+    return inputs_[1];
+  }
+
+  velox::core::JoinType joinType() const {
+    return joinType_;
+  }
+
+  std::string_view joinTypeName() const {
+    return velox::core::JoinTypeName::toName(joinType_);
+  }
+
+  bool isInner() const {
+    return joinType_ == velox::core::JoinType::kInner;
+  }
+
+  bool isLeft() const {
+    return joinType_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isFull() const {
+    return joinType_ == velox::core::JoinType::kFull;
+  }
+
+  const ExprVector& leftKeys() const {
+    return leftKeys_;
+  }
+
+  const ExprVector& rightKeys() const {
+    return rightKeys_;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool nullAware() const {
+    return nullAware_;
+  }
+
+  bool nullAsValue() const {
+    return nullAsValue_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const velox::core::JoinType joinType_;
+  const ExprVector leftKeys_;
+  const ExprVector rightKeys_;
+  const ExprVector filter_;
+  const bool nullAware_;
+  const bool nullAsValue_;
+};
+
+using JoinCP = const Join*;
+
+/// One window function invocation. Frame is per-function (as in Velox
+/// `WindowNode::Function`), so functions sharing a partition / order but
+/// differing only in frame still group under a single `Window` node.
+struct WindowFunction {
+  /// The window function and its arguments.
+  ExprCP call;
+
+  /// The row/range window over which this function is evaluated.
+  Frame frame;
+
+  /// When true, NULL inputs are skipped when evaluating the function
+  /// (e.g. the `IGNORE NULLS` option in SQL frontends).
+  bool ignoreNulls;
+
+  bool operator==(const WindowFunction&) const = default;
+};
+
+using WindowFunctions = QGVector<WindowFunction>;
+
+/// Evaluates one or more window function calls. Output schema is input
+/// columns followed by one output column per window function.
+class Window : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Window function invocations sharing this partition / order; non-empty.
+    /// Each carries its own frame.
+    WindowFunctions functions;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Output columns: `input`'s columns, then one per window function.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Window`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Window* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Window`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Window* left, const Window* right) const;
+    bool operator()(const Key& key, const Window* node) const;
+    bool operator()(const Window* node, const Key& key) const;
+  };
+
+  explicit Window(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const WindowFunctions& functions() const {
+    return functions_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const WindowFunctions functions_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using WindowCP = const Window*;
+
+/// Per-partition top-`limit` rows ranked by a ranking function (row_number /
+/// rank / dense_rank). Produced by fusing
+/// a `Filter(rankColumn <op> n)` over a single-ranking-function `Window`. The
+/// rank column is emitted only when `rankColumn` is set; otherwise the output
+/// is just the input columns.
+class TopNRowNumber : public Node {
+ public:
+  using RankFunction = velox::core::TopNRowNumberNode::RankFunction;
+
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Ranking function (row_number / rank / dense_rank).
+    RankFunction rankFunction;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Per-partition row cap; > 0.
+    int32_t limit;
+    /// Column carrying the ranking-function result in the output, or null to
+    /// omit it (the output is then just the input columns).
+    ColumnCP rankColumn;
+    /// Output columns: `input`'s columns, plus `rankColumn` when set.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `TopNRowNumber`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopNRowNumber* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopNRowNumber`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopNRowNumber* left, const TopNRowNumber* right)
+        const;
+    bool operator()(const Key& key, const TopNRowNumber* node) const;
+    bool operator()(const TopNRowNumber* node, const Key& key) const;
+  };
+
+  explicit TopNRowNumber(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  RankFunction rankFunction() const {
+    return rankFunction_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int32_t limit() const {
+    return limit_;
+  }
+
+  ColumnCP rankColumn() const {
+    return rankColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const RankFunction rankFunction_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int32_t limit_;
+  const ColumnCP rankColumn_;
+};
+
+using TopNRowNumberCP = const TopNRowNumber*;
+
+/// Apply is a "true dependent join" — a relational join whose right side
+/// (`body`, conceptually evaluated per `input` row) may reference `input`'s
+/// columns.
+///
+/// "Body" rather than "subquery": at translate time Apply's right side IS
+/// the translated subquery, but as decorrelate iterates it peels operators
+/// off and `body` evolves. The decorrelate pass and downstream consumers
+/// reason about Apply as a generic dependent-join node whose right side is
+/// `body`; only Translate uses the SQL term "subquery" in its prose.
+///
+/// Example: `SELECT (SELECT max(u.b) FROM u WHERE u.a = t.a) FROM t`
+/// translates to:
+///
+///     Apply(kLeft, input=t,
+///           body=Aggregate(Filter(u.a=t.a, u), max(u.b)),
+///           correlationColumns=[t.a],
+///           filter=null,
+///           enforceSingleRow=false)
+///
+/// Apply is transient: produced by `translate` at every `lp::SubqueryExpr`
+/// site, eliminated by `pass.decorrelate` before any later pass.
+///
+/// Per-kind semantics:
+///
+///   kLeft             Correlated scalar / lateral subquery. Left-outer-join
+///                     semantics. Body may produce N rows per outer. Output:
+///                     `input.outputColumns ++ unique(body.outputColumns)
+///                     ++ [includeMarker]` — a body column already in input
+///                     occupies a single output slot. (NULL-padded for
+///                     outers with no match; `includeMarker` is `true`
+///                     on real rows, NULL on pad rows.)
+///   kLeftSemiProject  EXISTS / IN. Output:
+///                     `input.outputColumns ++ markColumn` — a fresh BOOLEAN
+///                     true iff any body row exists for the outer
+///                     matching `filter` AND (for IN) `inLhs = inBodyKey`.
+///                     NULL-aware for IN.
+///
+/// `kLeftSemiFilter` and `kAnti` never appear at Apply — they emerge only
+/// from a post-decorrelate peephole that recognizes
+/// `Filter(mark, Join(kLeftSemiProject, ..., mark))`.
+class Apply : public Node {
+ public:
+  struct Key {
+    /// Left ("outer") input.
+    NodeCP input;
+    /// Right side, evaluated per `input` row; may reference `input`'s columns.
+    NodeCP body;
+    /// `input` columns the current `body` still references; recomputed by
+    /// decorrelate after each peel. Empty at terminus, where Apply becomes a
+    /// Join.
+    ColumnVector correlationColumns;
+    /// `kLeft` (correlated scalar / lateral) or `kLeftSemiProject` (EXISTS /
+    /// IN).
+    velox::core::JoinType kind;
+    /// Residual predicates joined with AND; become `Join.filter` at terminus.
+    ExprVector filter;
+    /// Assert the body returns 0-or-1 row per outer (>1 rows errors);
+    /// correlated scalar subqueries only.
+    bool enforceSingleRow;
+    /// `kLeftSemiProject` mark output (BOOLEAN); null for `kLeft`.
+    ColumnCP markColumn;
+    /// IN equi-pair left side (the `lhs` of `lhs IN (SELECT ...)`), kept as a
+    /// pair rather than `eq(inLhs, inBodyKey)` so consumers read each side
+    /// directly; drives `nullAware()`. Null unless an IN subquery.
+    ExprCP inLhs;
+    /// IN equi-pair body side; see `inLhs`. Null unless an IN subquery.
+    ExprCP inBodyKey;
+    /// `kLeft` pad-row marker (BOOLEAN); null for `kLeftSemiProject`.
+    ColumnCP includeMarker;
+    /// Output columns; per-kind layout in the class doc.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Apply`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Apply* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Apply`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Apply* left, const Apply* right) const;
+    bool operator()(const Key& key, const Apply* node) const;
+    bool operator()(const Apply* node, const Key& key) const;
+  };
+
+  explicit Apply(Key key);
+
+  NodeCP input() const {
+    return inputs_[0];
+  }
+
+  NodeCP body() const {
+    return inputs_[1];
+  }
+
+  const ColumnVector& correlationColumns() const {
+    return correlationColumns_;
+  }
+
+  velox::core::JoinType kind() const {
+    return kind_;
+  }
+
+  std::string_view kindName() const {
+    return velox::core::JoinTypeName::toName(kind_);
+  }
+
+  bool isLeft() const {
+    return kind_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isLeftSemiProject() const {
+    return kind_ == velox::core::JoinType::kLeftSemiProject;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool enforceSingleRow() const {
+    return enforceSingleRow_;
+  }
+
+  ColumnCP markColumn() const {
+    return markColumn_;
+  }
+
+  ExprCP inLhs() const {
+    return inLhs_;
+  }
+
+  ExprCP inBodyKey() const {
+    return inBodyKey_;
+  }
+
+  ColumnCP includeMarker() const {
+    return includeMarker_;
+  }
+
+  bool nullAware() const {
+    return inLhs_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const ColumnVector correlationColumns_;
+  const velox::core::JoinType kind_;
+  const ExprVector filter_;
+  const bool enforceSingleRow_;
+  const ColumnCP markColumn_;
+  const ExprCP inLhs_;
+  const ExprCP inBodyKey_;
+  const ColumnCP includeMarker_;
+};
+
+using ApplyCP = const Apply*;
+
+/// Asserts the input contains at most one row and passes it through unchanged;
+/// an empty input yields a single all-NULL row, and more than one row raises an
+/// error. Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers). Used to enforce the 0-or-1-row
+/// cardinality of an uncorrelated scalar subquery.
+class EnforceSingleRow : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+  };
+
+  /// Transparent hasher for interning `EnforceSingleRow`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceSingleRow* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceSingleRow`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceSingleRow* left, const EnforceSingleRow* right)
+        const;
+    bool operator()(const Key& key, const EnforceSingleRow* node) const;
+    bool operator()(const EnforceSingleRow* node, const Key& key) const;
+  };
+
+  explicit EnforceSingleRow(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+};
+
+using EnforceSingleRowCP = const EnforceSingleRow*;
+
+/// Emits each input row unchanged, appending `idColumn` — a value unique across
+/// all output rows.
+class AssignUniqueId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Appended id column (BIGINT).
+    ColumnCP idColumn;
+  };
+
+  /// Transparent hasher for interning `AssignUniqueId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const AssignUniqueId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `AssignUniqueId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const AssignUniqueId* left, const AssignUniqueId* right)
+        const;
+    bool operator()(const Key& key, const AssignUniqueId* node) const;
+    bool operator()(const AssignUniqueId* node, const Key& key) const;
+  };
+
+  explicit AssignUniqueId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  ColumnCP idColumn() const {
+    return idColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnCP idColumn_;
+};
+
+using AssignUniqueIdCP = const AssignUniqueId*;
+
+/// Asserts that `distinctKeys` are unique across the input — at most one row
+/// per distinct combination of their values — raising a runtime error carrying
+/// `errorMessage` on the first duplicate. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers). Used to enforce the 0-or-1-row cardinality of a correlated scalar
+/// subquery.
+class EnforceDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Keys asserted unique across the input; non-empty.
+    ExprVector distinctKeys;
+    /// Error message raised on the first duplicate.
+    Name errorMessage;
+  };
+
+  /// Transparent hasher for interning `EnforceDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceDistinct* left, const EnforceDistinct* right)
+        const;
+    bool operator()(const Key& key, const EnforceDistinct* node) const;
+    bool operator()(const EnforceDistinct* node, const Key& key) const;
+  };
+
+  explicit EnforceDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  Name errorMessage() const {
+    return errorMessage_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector distinctKeys_;
+  const Name errorMessage_;
+};
+
+using EnforceDistinctCP = const EnforceDistinct*;
+
+/// Redistributes input rows across tasks with a remote exchange — lowered to a
+/// `PartitionedOutput`→`Exchange` pair straddling a fragment boundary — setting
+/// `partitioning` as the output's global partitioning. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers). The only node that repartitions: it imposes a global
+/// partitioning via a shuffle, whereas other nodes derive theirs from their
+/// input. The distributed memo places it when a consumer needs a partitioning
+/// the input lacks.
+class Exchange : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Global partitioning imposed on the output via the shuffle.
+    Partitioning partitioning;
+  };
+
+  /// Transparent hasher for interning `Exchange`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Exchange* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Exchange`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Exchange* left, const Exchange* right) const;
+    bool operator()(const Key& key, const Exchange* node) const;
+    bool operator()(const Exchange* node, const Key& key) const;
+  };
+
+  explicit Exchange(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const Partitioning& partitioning() const {
+    return partitioning_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const Partitioning partitioning_;
+};
+
+using ExchangeCP = const Exchange*;
+
+/// Writes its input rows to a table (CTAS / INSERT; DELETE / UPDATE deferred).
+/// A root sink: its single BIGINT output column is the
+/// written row count, consumed by no node.
+class TableWrite : public Node {
+ public:
+  struct Key {
+    /// Input node (rows to write).
+    NodeCP input;
+    /// Target table; emit reads its `type()` and `layouts()` for the insert
+    /// handle.
+    const connector::Table* table;
+    /// Write form (INSERT / CTAS / ...).
+    connector::WriteKind kind;
+    /// Per-target-column values, non-empty and 1:1 with the table schema
+    /// (`table->type()`).
+    ExprVector columnExprs;
+  };
+
+  /// Transparent hasher for interning `TableWrite`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TableWrite* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TableWrite`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TableWrite* left, const TableWrite* right) const;
+    bool operator()(const Key& key, const TableWrite* node) const;
+    bool operator()(const TableWrite* node, const Key& key) const;
+  };
+
+  explicit TableWrite(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const connector::Table* table() const {
+    return table_;
+  }
+
+  connector::WriteKind kind() const {
+    return kind_;
+  }
+
+  const ExprVector& columnExprs() const {
+    return columnExprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const connector::Table* const table_;
+  const connector::WriteKind kind_;
+  const ExprVector columnExprs_;
+};
+
+using TableWriteCP = const TableWrite*;
+
+} // namespace facebook::axiom::optimizer::v2
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::v2::NodeType);

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/NodePrinter.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ranges>
+#include <sstream>
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+std::string spaces(size_t depth) {
+  return std::string(depth, ' ');
+}
+
+std::string formatExpr(ExprCP expr) {
+  if (expr == nullptr) {
+    return "<null>";
+  }
+  return expr->toString();
+}
+
+std::string formatColumns(const ColumnVector& columns) {
+  auto formatted =
+      columns | std::views::transform([](ColumnCP c) {
+        return fmt::format("{}:{}", c->toString(), c->value().type->toString());
+      });
+  return fmt::to_string(fmt::join(formatted, ", "));
+}
+
+// Templated so any range of Expr-derived pointers (ExprVector,
+// AggregateCallVector, etc.) formats the same way.
+template <typename Range>
+std::string formatExprs(const Range& exprs) {
+  auto texts = exprs |
+      std::views::transform([](const auto* expr) { return formatExpr(expr); });
+  return fmt::to_string(fmt::join(texts, ", "));
+}
+
+class Printer : public NodeVisitor {
+ public:
+  struct Context : public NodeVisitorContext {
+    std::stringstream out;
+    size_t indent{0};
+  };
+
+  // Bumps `ctx.indent` by 2 on construction, restores on destruction.
+  class IndentGuard {
+   public:
+    explicit IndentGuard(Context& ctx) : ctx_(ctx) {
+      ctx_.indent += 2;
+    }
+    ~IndentGuard() {
+      ctx_.indent -= 2;
+    }
+    IndentGuard(const IndentGuard&) = delete;
+    IndentGuard& operator=(const IndentGuard&) = delete;
+
+   private:
+    Context& ctx_;
+  };
+
+  void visit(const Scan& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx, node, fmt::format("[{}]", node.baseTable()->schemaTable->name()));
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP filter : node.filters()) {
+      ctx.out << pad << "filter: " << formatExpr(filter) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Filter& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP pred : node.predicates()) {
+      ctx.out << pad << "predicate: " << formatExpr(pred) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Project& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& cols = node.outputColumns();
+    const auto& exprs = node.exprs();
+    for (size_t i = 0; i < cols.size(); ++i) {
+      ctx.out << pad << cols[i]->toString() << " := " << formatExpr(exprs[i])
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Limit& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Sort& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopN& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Aggregate& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.groupingKeys().empty()) {
+      ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+              << '\n';
+    }
+    if (!node.aggregates().empty()) {
+      ctx.out << pad << "aggregates: " << formatExprs(node.aggregates())
+              << '\n';
+    }
+    if (!node.globalGroupingSets().empty()) {
+      ctx.out << pad << "globalGroupingSets: "
+              << folly::join(", ", node.globalGroupingSets()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const GroupId& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+            << '\n';
+    if (!node.aggregationInputs().empty()) {
+      ctx.out << pad
+              << "aggregationInputs: " << formatExprs(node.aggregationInputs())
+              << '\n';
+    }
+    ctx.out << pad << "groupingSets: " << node.groupingSets().size()
+            << " set(s)\n";
+    visitInputs(node, ctx);
+  }
+
+  void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (!node.masks().empty()) {
+      ctx.out << pad << "masks: " << formatExprs(node.masks()) << '\n';
+    }
+    ctx.out << pad << "markers: " << formatExprs(node.markers()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Values& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Unnest& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad
+            << "unnestExpressions: " << formatExprs(node.unnestExpressions())
+            << '\n';
+    if (node.withOrdinality()) {
+      ctx.out << pad << "withOrdinality: true\n";
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const UnionAll& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& legColumns = node.legColumns();
+    for (size_t i = 0; i < legColumns.size(); ++i) {
+      ctx.out << pad << "leg[" << i << "] columns: "
+              << formatExprs(
+                     ExprVector(legColumns[i].begin(), legColumns[i].end()))
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Join& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.joinTypeName()};
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.leftKeys().empty()) {
+      ctx.out << pad << "leftKeys: " << formatExprs(node.leftKeys()) << '\n';
+      ctx.out << pad << "rightKeys: " << formatExprs(node.rightKeys()) << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Window& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    if (!node.orderKeys().empty()) {
+      ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[limit {}]", node.limit()));
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Apply& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.kindName()};
+    if (node.enforceSingleRow()) {
+      details += ", enforceSingleRow";
+    }
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.correlationColumns().empty()) {
+      ctx.out << pad
+              << "correlation: " << formatColumns(node.correlationColumns())
+              << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    if (node.markColumn() != nullptr) {
+      ctx.out << pad << "mark: " << node.markColumn()->toString() << '\n';
+    }
+    if (node.inLhs() != nullptr) {
+      ctx.out << pad << "inLhs: " << formatExpr(node.inLhs()) << '\n';
+      ctx.out << pad << "inBodyKey: " << formatExpr(node.inBodyKey()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "idColumn: " << node.idColumn()->toString() << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (node.errorMessage() != nullptr) {
+      ctx.out << pad << "errorMessage: " << node.errorMessage() << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Exchange& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "partitionKeys: " << formatExprs(node.partitioning().keys)
+            << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TableWrite& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "columnExprs: " << formatExprs(node.columnExprs()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+ private:
+  void header(Context& ctx, const Node& node, std::string_view extra = {})
+      const {
+    ctx.out << spaces(ctx.indent) << "- "
+            << NodeTypeName::toName(node.nodeType());
+    if (!extra.empty()) {
+      ctx.out << extra;
+    }
+    ctx.out << " -> " << formatColumns(node.outputColumns()) << '\n';
+  }
+
+  void visitInputs(const Node& node, Context& ctx) const {
+    IndentGuard guard(ctx);
+    NodeVisitor::visitInputs(node, ctx);
+  }
+};
+
+} // namespace
+
+std::string NodePrinter::toText(NodeCP root) {
+  Printer::Context ctx;
+  root->accept(Printer{}, ctx);
+  return ctx.out.str();
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodePrinter.h
+++ b/axiom/optimizer/v2/NodePrinter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Renders an IR tree as indented text.
+class NodePrinter {
+ public:
+  /// Returns 'root' as indented text. Columns are shown by their `name()`
+  /// (the unique synthetic), not `outputName()`, so identity is visible.
+  static std::string toText(NodeCP root);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class NodeVisitorContext {
+ public:
+  virtual ~NodeVisitorContext() = default;
+};
+
+/// Double-dispatch visitor for v2 `Node` subclasses. Mirrors
+/// `logical_plan::PlanNodeVisitor`. Each subclass implements `accept` to
+/// forward to the matching `visit` overload.
+class NodeVisitor {
+ public:
+  virtual ~NodeVisitor() = default;
+
+  virtual void visit(const Scan& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Filter& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Project& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Limit& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Sort& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopN& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Aggregate& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const GroupId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Values& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Unnest& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const UnionAll& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Join& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Window& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Apply& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Exchange& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const TableWrite& node, NodeVisitorContext& context)
+      const = 0;
+
+ protected:
+  void visitInputs(const Node& node, NodeVisitorContext& context) const {
+    for (NodeCP input : node.inputs()) {
+      input->accept(*this, context);
+    }
+  }
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.cpp
+++ b/axiom/optimizer/v2/PhysicalProperties.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<PropertyScope, std::string_view>& propertyScopeNames() {
+  static const folly::F14FastMap<PropertyScope, std::string_view> kNames = {
+      {PropertyScope::kGlobal, "Global"},
+      {PropertyScope::kDriver, "Driver"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<PartitionKind, std::string_view>& partitionKindNames() {
+  static const folly::F14FastMap<PartitionKind, std::string_view> kNames = {
+      {PartitionKind::kUnspecified, "Unspecified"},
+      {PartitionKind::kPartitioned, "Partitioned"},
+      {PartitionKind::kGather, "Gather"},
+      {PartitionKind::kBroadcast, "Broadcast"},
+      {PartitionKind::kArbitrary, "Arbitrary"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<LocalPropertyKind, std::string_view>&
+localPropertyKindNames() {
+  static const folly::F14FastMap<LocalPropertyKind, std::string_view> kNames = {
+      {LocalPropertyKind::kGrouped, "Grouped"},
+      {LocalPropertyKind::kSorted, "Sorted"},
+  };
+  return kNames;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(PropertyScope, propertyScopeNames);
+AXIOM_DEFINE_ENUM_NAME(PartitionKind, partitionKindNames);
+AXIOM_DEFINE_ENUM_NAME(LocalPropertyKind, localPropertyKindNames);
+
+Partitioning Partitioning::globalHash(
+    const ExprVector& keys,
+    bool replicateNullsAndAny) {
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .keys = keys,
+      .scope = PropertyScope::kGlobal,
+      .replicateNullsAndAny = replicateNullsAndAny};
+}
+
+Partitioning Partitioning::globalGather() {
+  return Partitioning{
+      .kind = PartitionKind::kGather, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalGatherMerge(
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  return Partitioning{
+      .kind = PartitionKind::kGather,
+      .orderKeys = orderKeys,
+      .orderTypes = orderTypes,
+      .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalBroadcast() {
+  return Partitioning{
+      .kind = PartitionKind::kBroadcast, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalArbitrary() {
+  return Partitioning{
+      .kind = PartitionKind::kArbitrary, .scope = PropertyScope::kGlobal};
+}
+
+bool Partitioning::coLocates(const ExprVector& columns) const {
+  if (kind != PartitionKind::kPartitioned || keys.empty()) {
+    return false;
+  }
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  for (ExprCP key : keys) {
+    if (!columnSet.contains(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedOn(const ExprVector& otherKeys) const {
+  if (otherKeys.empty() || kind != PartitionKind::kPartitioned ||
+      partitionType == nullptr || keys.size() != otherKeys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->sameOrEqual(*otherKeys[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedCompatibleWith(
+    const ExprVector& otherKeys,
+    const connector::PartitionType& targetType) const {
+  if (!isBucketedOn(otherKeys)) {
+    return false;
+  }
+  const auto compatible = partitionType->copartition(targetType);
+  return compatible != nullptr &&
+      compatible->numPartitions() == partitionType->numPartitions();
+}
+
+bool Partitioning::sameClassAs(const Partitioning& other) const {
+  if (kind != other.kind || partitionType != other.partitionType ||
+      replicateNullsAndAny != other.replicateNullsAndAny ||
+      keys.size() != other.keys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (keys[i] != other.keys[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void PhysicalProperties::checkReferencesColumns(
+    const PlanObjectSet& outputColumns) const {
+  // A partitioning may be on computed expressions (the partition function's
+  // input, e.g. a cast); the requirement is that it is evaluable here — every
+  // column its keys and merge order depend on is an output column.
+  const auto checkPartition = [&](const Partitioning& partition) {
+    VELOX_CHECK(
+        outputColumns.containsColumns(partition.keys) &&
+            outputColumns.containsColumns(partition.orderKeys),
+        "Partitioning depends on a column that is not in the node's output");
+  };
+  checkPartition(globalPartition);
+  checkPartition(driverPartition);
+  // Local orderings / groupings and unique key-sets are columns, not
+  // expressions.
+  for (const LocalProperty& property : local) {
+    VELOX_CHECK(
+        outputColumns.containsAll(property.columns),
+        "Local property references a column that is not in the node's output");
+  }
+  for (const UniqueKeySet& keySet : unique) {
+    VELOX_CHECK(
+        keySet.columns.isSubset(outputColumns),
+        "Unique key-set references a column that is not in the node's output");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+
+/// Physical-property types for the optimizer: the per-operator output ordering,
+/// grouping, uniqueness, and partitioning that cost-based planning derives on
+/// each physical candidate and the property-aware memo keys on. This header
+/// declares the data shapes only; per-operator derivation and the satisfaction
+/// / shuffle-cost queries live alongside the memo that consumes them.
+///
+/// The model splits properties by how they behave under distribution. Three
+/// categories:
+///   - per-driver local: ordering and grouping (`LocalProperty`),
+///   - distribution: two independent partitioning slots, global and driver
+///     (`Partitioning` with a `PropertyScope`),
+///   - relation-level: uniqueness (`UniqueKeySet`).
+namespace facebook::axiom::optimizer::v2 {
+
+/// Scope at which a property holds. The two runtime levels distributed
+/// execution distinguishes: across tasks (`kGlobal`) and across drivers within
+/// one task (`kDriver`).
+///
+/// The scope's algebra differs by property:
+///   - Partitioning carries two *independent* slots, one per scope — global
+///     partitioned does not imply driver partitioned (a remote hash exchange
+///     feeds drivers round-robin), so both are tracked.
+///   - Uniqueness is a *lattice*: global uniqueness implies driver (per-driver)
+///     uniqueness but not the reverse, so a key-set stores the single widest
+///     scope at which it holds.
+enum class PropertyScope : uint8_t {
+  kGlobal,
+  kDriver,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PropertyScope);
+
+/// Kind of data partitioning.
+enum class PartitionKind : uint8_t {
+  /// No specific partitioning is guaranteed.
+  kUnspecified,
+  /// Partitioned on `keys` using `partitionType` (connector-specific) or
+  /// standard Velox hash when `partitionType` is null.
+  kPartitioned,
+  /// All rows on one partition (single task, or single driver at driver scope).
+  kGather,
+  /// Every consumer receives a full copy.
+  kBroadcast,
+  /// Arbitrary / round-robin assignment.
+  kArbitrary,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PartitionKind);
+
+/// Partitioning of a relation's rows at one scope. The same concept serves both
+/// the global (across-tasks) and driver (across-drivers) levels; `scope` says
+/// which. A `PhysicalProperties` carries one `Partitioning` per scope, and the
+/// two are independent.
+///
+/// Invariants:
+///   - `keys` is non-empty only when `kind == kPartitioned`.
+///   - `orderKeys` / `orderTypes` are non-empty only for an order-preserving
+///     `kGather` (see `globalGatherMerge`).
+///   - `partitionType` is null for standard Velox hash partitioning.
+///   - `keys` are expressions (not just columns) to match the partition
+///     function's input.
+struct Partitioning {
+  PartitionKind kind{PartitionKind::kUnspecified};
+
+  /// Connector-specific partition function, or null for standard Velox hash.
+  const connector::PartitionType* partitionType{nullptr};
+
+  /// Partition keys; empty unless `kind == kPartitioned`.
+  ExprVector keys;
+
+  /// Sort keys and their orders that an order-preserving gather merges on
+  /// (lowered to a Velox `MergeExchange`). Non-empty only for a `kGather`
+  /// produced by `globalGatherMerge`; empty for a plain gather.
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+
+  PropertyScope scope{PropertyScope::kGlobal};
+
+  /// When true, the partitioned output replicates null-keyed rows (and one
+  /// arbitrary row) to every partition. Required on the existence side of a
+  /// null-aware anti/semi join (NOT IN / IN) so a null key reaches all probe
+  /// partitions; otherwise NOT IN wrongly admits rows.
+  bool replicateNullsAndAny{false};
+
+  bool operator==(const Partitioning&) const = default;
+
+  bool is(PartitionKind other) const {
+    return kind == other;
+  }
+
+  /// A copy without the merge order (`orderKeys` / `orderTypes`). The merge
+  /// order belongs to the gather-merge exchange that produced it; an operator
+  /// that inherits a distribution without being that exchange keeps the kind
+  /// and keys but not the order (which, if preserved, is carried as a local
+  /// property).
+  Partitioning dropOrder() const {
+    Partitioning result = *this;
+    result.orderKeys = {};
+    result.orderTypes = {};
+    return result;
+  }
+
+  /// A standard global hash partitioning on `keys`. Set `replicateNullsAndAny`
+  /// for the existence side of a null-aware anti/semi join.
+  static Partitioning globalHash(
+      const ExprVector& keys,
+      bool replicateNullsAndAny = false);
+
+  /// A global gather (all rows on one task) partitioning.
+  static Partitioning globalGather();
+
+  /// A global gather that preserves ordering by merging the sorted per-task
+  /// streams (lowered to a Velox `MergeExchange`). `orderKeys` / `orderTypes`
+  /// are the sort keys to merge on.
+  static Partitioning globalGatherMerge(
+      const ExprVector& orderKeys,
+      const OrderTypeVector& orderTypes);
+
+  /// A global broadcast (every task receives a full copy) partitioning.
+  static Partitioning globalBroadcast();
+
+  /// A global arbitrary (round-robin / shared-pool) partitioning.
+  static Partitioning globalArbitrary();
+
+  /// True when this co-locates rows that agree on `columns` — i.e. it
+  /// hash-partitions on a subset of `columns`, so every group of equal
+  /// `columns` is wholly within one partition and an aggregation grouping on
+  /// `columns` needs no repartition. Not a co-partition test for joins: those
+  /// must align corresponding keys across both inputs, so use `sameClassAs`.
+  bool coLocates(const ExprVector& columns) const;
+
+  /// True when this is the same class as `other` — same kind, connector
+  /// function, and keys in order. Like `coLocates`, a pure class test: scope is
+  /// fixed by the containing slot, so it is not compared. Two `kUnspecified`
+  /// partitionings are the same class.
+  bool sameClassAs(const Partitioning& other) const;
+
+  /// True when this is connector-bucketed (`kPartitioned` with a non-null
+  /// `partitionType`) on exactly `otherKeys` — same expressions in the same
+  /// order. False for empty `otherKeys`.
+  bool isBucketedOn(const ExprVector& otherKeys) const;
+
+  /// True when this is bucketed on `otherKeys` (see `isBucketedOn`) with a
+  /// partitioning that copartitions with `targetType` at this bucketing's own
+  /// partition count — i.e. its rows already reach a `targetType`-bucketed
+  /// consumer or write target with no reshuffle.
+  bool isBucketedCompatibleWith(
+      const ExprVector& otherKeys,
+      const connector::PartitionType& targetType) const;
+};
+
+/// Kind of a per-driver local property.
+enum class LocalPropertyKind : uint8_t {
+  /// Rows with equal `columns` are contiguous (not necessarily ordered) within
+  /// a driver, and every such group is wholly within one driver. See
+  /// `LocalProperty` for the confinement contract.
+  kGrouped,
+  /// Rows ordered by `columns`, outermost key first, with the direction of each
+  /// given by the matching entry in `orders`.
+  kSorted,
+};
+
+AXIOM_DECLARE_ENUM_NAME(LocalPropertyKind);
+
+/// One entry in a relation's ordered list of per-driver local properties. The
+/// list order captures nesting: `[Grouped(P), Sorted(o1, o2)]` means grouped by
+/// the set `P`, and within each group ordered by `o1` then `o2`.
+///
+/// A `kGrouped` entry uses `columns` alone (the grouped set; order among its
+/// members is irrelevant) and leaves `orders` empty. A `kSorted` entry uses
+/// both in parallel: `columns` are the sort keys outermost first, and
+/// `orders[i]` is the direction of `columns[i]`.
+///
+/// A local property carries driver-confinement as part of its contract, not
+/// just contiguity: a `kGrouped` set of equal `columns` (or a `kSorted`
+/// equal-key run) is both contiguous within a driver's stream AND wholly
+/// confined to that one driver — no group spans drivers. Producers must attach
+/// a local property only when both hold; a source with mere per-driver
+/// contiguity but no confinement (e.g. a bucketed/sorted scan whose splits
+/// round-robin across drivers) must not. Consumers that decide driver placement
+/// (e.g. skipping a local repartition before a single-stage aggregation) rely
+/// on this directly: a local grouping on the keys means the groups are already
+/// driver-confined.
+struct LocalProperty {
+  LocalPropertyKind kind{LocalPropertyKind::kGrouped};
+  ColumnVector columns;
+  OrderTypeVector orders;
+};
+
+/// A relation's per-driver local properties, outermost first.
+using LocalPropertyVector = QGVector<LocalProperty>;
+
+/// A set of columns that is unique across the relation — i.e., functionally
+/// determines the row — at `scope`. Stored minimal: a key-set whose columns are
+/// a superset of another stored key-set is redundant and not kept, but
+/// independent minimal key-sets (e.g. `{a}` and `{b}` both unique) are all
+/// retained. `columns` is a set (a `PlanObjectSet`) so consumers can test
+/// containment ("is some unique key-set ⊆ the columns I care about?") directly.
+struct UniqueKeySet {
+  PlanObjectSet columns;
+  PropertyScope scope{PropertyScope::kGlobal};
+};
+
+/// Unique key-sets of a relation. May hold several independent minimal
+/// key-sets, each at its own scope.
+using UniqueKeySetVector = QGVector<UniqueKeySet>;
+
+/// The physical properties of one relation — the output of per-operator
+/// derivation and the value the property-aware memo compares. Bundles the three
+/// property categories.
+///
+/// The two partitioning slots are independent (see `PropertyScope`):
+/// `globalPartition.scope == kGlobal` and `driverPartition.scope == kDriver`.
+struct PhysicalProperties {
+  /// Partitioning across tasks; set by a remote exchange.
+  Partitioning globalPartition{.scope = PropertyScope::kGlobal};
+
+  /// Partitioning across drivers within a task; set by a local exchange.
+  Partitioning driverPartition{.scope = PropertyScope::kDriver};
+
+  /// Per-driver ordering and grouping, outermost first.
+  LocalPropertyVector local;
+
+  /// Unique key-sets, relation-level, each scope-tagged.
+  UniqueKeySetVector unique;
+
+  /// Checks the invariant that these properties are expressed over the node's
+  /// own `outputColumns`. A partitioning's keys and merge order may be computed
+  /// expressions (the partition function's input), but every column they depend
+  /// on must be an output column, so the partitioning is evaluable here.
+  /// Local-property columns and every unique key-set must themselves be output
+  /// columns. Fails (`VELOX_CHECK`) on violation. Called by the `Node` base
+  /// constructor.
+  void checkReferencesColumns(const PlanObjectSet& outputColumns) const;
+};
+
+} // namespace facebook::axiom::optimizer::v2


### PR DESCRIPTION
Summary:

The v2 optimizer represents a query as an immutable tree of operator nodes — `Node` and its subclasses (`Scan`, `Filter`, `Join`, `Aggregate`, `Exchange`, ...) — in place of v1's `DerivedTable`-centric graph. This change adds those node types, a hash-consing factory (`Builder`), a `NodeVisitor`, and a text printer, in a new `axiom/optimizer/v2` library. No caller builds or reads the IR yet, so there is no behavior change.

Nodes are immutable, arena-allocated `PlanObject`s built only through `Builder::make<T>(key)`. Each subclass nests a `Key` struct that is its identity; `make` hash-conses on the `Key`, so structurally identical subtrees share one pointer. Each node derives its output columns and physical properties — ordering, grouping, partitioning, uniqueness — from its inputs in its constructor.

Supporting changes in the shared `axiom/optimizer` foundation: a `kV2Node` `PlanType`, expression `Key` structs so `Literal` / `Call` / `Aggregate` hash-cons, and `Column::create` for synthesizing relation-less columns. Relation-less columns are a v2-only idiom, so `Column::create` asserts a new `QueryGraphContext::isV2()` debug flag.

No tests: nothing drives the IR yet — no caller builds it from a query — so there is no observable behavior to test.

Reviewed By: amitkdutta

Differential Revision: D110850581


