### PR TITLE
fix(optimizer): Emit BETWEEN ranges in EXPLAIN (TYPE IO)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -428,8 +428,8 @@ TEST_F(SqlQueryRunnerTest, explainIo) {
 }
 
 TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
-  run("CREATE TABLE t (x BIGINT, ds VARCHAR, region VARCHAR) "
-      "WITH (explain_io = ARRAY['ds', 'region'])");
+  run("CREATE TABLE t (x BIGINT, n BIGINT, ds VARCHAR, region VARCHAR) "
+      "WITH (explain_io = ARRAY['n', 'ds', 'region'])");
   SCOPE_EXIT {
     run("DROP TABLE t");
   };
@@ -509,6 +509,28 @@ TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
             {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
              "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
 
+  // BETWEEN maps to a closed range, inclusive on both ends.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+
+  // BETWEEN on an integer column produces the same closed range.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE n BETWEEN 1 AND 10"),
+      makeTable(makeConstraint(
+          "n",
+          "BIGINT",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": 1, "bound": "EXACTLY"},
+             "high": {"value": 10, "bound": "EXACTLY"}}]})")));
+
   auto noConstraints = normalizeJson(R"({
     "inputTableColumnInfos": [{
       "table": {
@@ -529,6 +551,21 @@ TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
   ASSERT_EQ(
       getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds <> 'foo'"),
       noConstraints);
+
+  // NOT BETWEEN (parsed as not(between(...))) is unconvertible and drops the
+  // column, same as other negations.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
+      noConstraints);
+
+  // BETWEEN with low > high is an empty range, so the whole table is excluded.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
+      normalizeJson(R"({"inputTableColumnInfos": []})"));
 
   // Mix of convertible and unconvertible filters: unconvertible conjunct is
   // skipped (broader is safe), convertible conjunct is shown.

--- a/axiom/optimizer/Domain.cpp
+++ b/axiom/optimizer/Domain.cpp
@@ -342,6 +342,17 @@ std::optional<Domain> exprToDomain(ExprCP expr) {
     return Domain::in(std::move(values));
   }
 
+  // BETWEEN(col, low, high) maps to the closed range [low, high].
+  if (funcName == functionNames.between && call->args().size() == 3 &&
+      call->args()[0]->is(PlanType::kColumnExpr) &&
+      call->args()[1]->is(PlanType::kLiteralExpr) &&
+      call->args()[2]->is(PlanType::kLiteralExpr)) {
+    const auto& low = call->args()[1]->as<Literal>()->literal();
+    const auto& high = call->args()[2]->as<Literal>()->literal();
+    return Domain::greaterThanOrEqual(low).intersect(
+        Domain::lessThanOrEqual(high));
+  }
+
   // Comparison of a column with a literal: eq, lt, lte, gt, gte.
   if (call->args().size() == 2 && call->args()[0]->is(PlanType::kColumnExpr) &&
       call->args()[1]->is(PlanType::kLiteralExpr)) {

--- a/axiom/optimizer/Domain.h
+++ b/axiom/optimizer/Domain.h
@@ -168,6 +168,7 @@ using ExprCP = const Expr*;
 ///
 /// Recognized expressions:
 ///   - Comparisons with literals: eq, lt, lte, gt, gte(column, literal)
+///   - BETWEEN(column, literal, literal) — closed range [low, high]
 ///   - IN(column, literal, literal, ...)
 ///   - IS NULL(column)
 ///   - AND(expr, expr, ...) — intersects children

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -143,6 +143,15 @@ bool FunctionRegistry::registerIsNull(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerBetween(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (between_.has_value() && between_.value() != name) {
+    return false;
+  }
+  between_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerRowNumber(std::string_view name) {
   VELOX_USER_CHECK(!name.empty());
   if (rowNumber_.has_value() && rowNumber_.value() != name) {
@@ -378,6 +387,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerGreaterThan(fullName("gt"));
   registry->registerGreaterThanOrEqual(fullName("gte"));
   registry->registerIsNull(fullName("is_null"));
+  registry->registerBetween(fullName("between"));
   registry->registerRowNumber(fullName("row_number"));
   registry->registerRank(fullName("rank"));
   registry->registerDenseRank(fullName("dense_rank"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -385,6 +385,18 @@ class FunctionRegistry {
     return isNull_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'between', i.e.
+  /// returns true if the first argument is within the inclusive range bounded
+  /// by the second and third arguments.
+  /// @return true if successfully registered, false if a different
+  /// 'between' function is already registered.
+  bool registerBetween(std::string_view name);
+
+  /// Returns the name of the 'between' function.
+  const std::optional<std::string>& between() const {
+    return between_;
+  }
+
   /// Registers function 'name' that has semantics of 'row_number' window
   /// function, i.e. assigns sequential numbers to rows within a partition.
   /// @return true if successfully registered, false if a different
@@ -497,6 +509,7 @@ class FunctionRegistry {
   std::optional<std::string> greaterThan_;
   std::optional<std::string> greaterThanOrEqual_;
   std::optional<std::string> isNull_;
+  std::optional<std::string> between_;
 
   // Aggregate functions.
   std::optional<std::string> arbitrary_;

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -377,6 +377,10 @@ void QueryGraphContext::populateFunctionNames() {
     functionNames_.isNull = this->toName(isNull.value());
   }
 
+  if (auto between = registry->between()) {
+    functionNames_.between = this->toName(between.value());
+  }
+
   if (auto rowNumber = registry->rowNumber()) {
     functionNames_.rowNumber = this->toName(rowNumber.value());
   }

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -328,6 +328,7 @@ struct FunctionNames {
   Name gt{nullptr};
   Name gte{nullptr};
   Name isNull{nullptr};
+  Name between{nullptr};
 
   /// Aggregate functions.
   Name arbitrary{nullptr};


### PR DESCRIPTION
Summary:
`EXPLAIN (TYPE IO)` omitted partition filters written as `col BETWEEN a AND b`, even though the equivalent `col >= a AND col <= b` was reported. For `WHERE ds BETWEEN '2026-05-01' AND '2026-06-01'` Axiom emitted no `ds` constraint at all, so a consumer that sizes and routes a query from this output saw an unconstrained scan and over-estimated the partition set. Presto reports the range.

`exprToDomain` recognized `eq`/`lt`/`lte`/`gt`/`gte`, `IN`, and `IS NULL`, but not the ternary `between(value, low, high)` call the SQL front-end emits, so the conjunct was skipped and the column dropped. Register `between` as a semantic function slot in `FunctionRegistry` (alongside the other comparison operators, so it inherits dialect prefixing), surface it through `FunctionNames`, and convert `between(col, literal, literal)` to the closed range `[low, high]` in `exprToDomain`. The conversion is read-only: it computes a `Domain` for reporting and never rewrites the executed expression, so BETWEEN's single-evaluation semantics are preserved.

`NOT BETWEEN` (parsed as `not(between(...))`) and other non-domain predicates such as `<>`, prefix `LIKE`, and cross-column `OR` remain unreported, consistent with existing behavior; those need separate handling (negation would require a `Domain` complement operator).

Differential Revision: D110950754


