### PR TITLE
refactor(optimizer): Trim vector helpers from PlanUtils

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <algorithm>
+
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/DerivedTableFlattener.h"
 #include "axiom/optimizer/DerivedTablePrinter.h"
@@ -1048,6 +1050,17 @@ JoinEdgeP makeExists(PlanObjectCP table, const PlanObjectSet& tables) {
     }
   }
   VELOX_UNREACHABLE("No join to make an exists build side restriction");
+}
+
+// Adds 'element' to 'vector' if not already present. Returns true if it was
+// appended, false if it already existed.
+template <typename V, typename E>
+bool pushBackUnique(V& vector, E& element) {
+  if (std::find(vector.begin(), vector.end(), element) != vector.end()) {
+    return false;
+  }
+  vector.push_back(element);
+  return true;
 }
 
 } // namespace

--- a/axiom/optimizer/PlanUtils.h
+++ b/axiom/optimizer/PlanUtils.h
@@ -22,13 +22,6 @@
 
 namespace facebook::axiom::optimizer {
 
-template <typename T, typename U>
-void appendToVector(T& destination, U& source) {
-  for (auto i : source) {
-    destination.push_back(i);
-  }
-}
-
 /// Prints a number with precision' digits followed by a scale letter (n, u, m,
 /// k, M, G T, P).
 std::string succinctNumber(double value, int32_t precision = 2);
@@ -50,18 +43,6 @@ Target transform(const V& set, Func func) {
     result.push_back(func(elt));
   }
   return result;
-}
-
-/// Adds 'element' to 'vector' if it is not in it. Return 'true' if element was
-/// appended, 'false' if it already existed.
-template <typename V, typename E>
-inline bool pushBackUnique(V& vector, E& element) {
-  if (std::find(vector.begin(), vector.end(), element) != vector.end()) {
-    return false;
-  }
-
-  vector.push_back(element);
-  return true;
 }
 
 /// Returns the integer value of 'variant'. The variant must be non-null and


### PR DESCRIPTION
Summary: Removes `appendToVector`, which had no callers, and moves `pushBackUnique` into `DerivedTable.cpp` — its only caller — as a file-local function. `PlanUtils.h` no longer carries generic vector helpers.

Differential Revision: D111001723


