### PR TITLE
fix(optimizer): Emit prefix LIKE in EXPLAIN (TYPE IO) (#1547)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -531,6 +531,37 @@ TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
             {"low": {"value": 1, "bound": "EXACTLY"},
              "high": {"value": 10, "bound": "EXACTLY"}}]})")));
 
+  // LIKE with a literal prefix maps to a half-open range [prefix, prefix++),
+  // where the upper bound increments the last byte of the prefix.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05%'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05", "bound": "EXACTLY"},
+             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+
+  // The '_' single-character wildcard also terminates the prefix.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05_'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05", "bound": "EXACTLY"},
+             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+
+  // LIKE with no wildcards degenerates to equality.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05-01'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05-01", "bound": "EXACTLY"},
+             "high": {"value": "2026-05-01", "bound": "EXACTLY"}}]})")));
+
   auto noConstraints = normalizeJson(R"({
     "inputTableColumnInfos": [{
       "table": {
@@ -566,6 +597,19 @@ TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
           "EXPLAIN (TYPE IO) SELECT * FROM t "
           "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
       normalizeJson(R"({"inputTableColumnInfos": []})"));
+
+  // LIKE with a leading wildcard has no usable prefix, so it is dropped.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '%05'"),
+      noConstraints);
+
+  // LIKE with an ESCAPE clause is not converted (escape semantics are not
+  // interpreted), so the column is dropped.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds LIKE '2026-05%' ESCAPE '#'"),
+      noConstraints);
 
   // Mix of convertible and unconvertible filters: unconvertible conjunct is
   // skipped (broader is safe), convertible conjunct is shown.

--- a/axiom/optimizer/Domain.cpp
+++ b/axiom/optimizer/Domain.cpp
@@ -288,6 +288,53 @@ std::vector<Range> Domain::normalize(std::vector<Range> ranges) {
   return result;
 }
 
+namespace {
+
+// Returns the exclusive upper bound for all strings that start with 'prefix':
+// increments the last byte below 0xFF and drops the bytes after it. Returns
+// std::nullopt when every byte is 0xFF, in which case there is no finite upper
+// bound. Comparison is byte-wise, matching VARCHAR ordering.
+std::optional<std::string> prefixUpperBound(std::string_view prefix) {
+  std::string upper{prefix};
+  while (!upper.empty()) {
+    if (static_cast<unsigned char>(upper.back()) != 0xFF) {
+      ++upper.back();
+      return upper;
+    }
+    upper.pop_back();
+  }
+  return std::nullopt;
+}
+
+// Converts a LIKE pattern to a Domain. A pattern with a fixed literal prefix
+// before the first wildcard ('%' or '_') maps to the half-open range
+// [prefix, prefixUpperBound(prefix)); a wildcard-free pattern is exact
+// equality. Returns std::nullopt (broader is safe) when the pattern has no
+// leading literal, i.e. it starts with a wildcard.
+std::optional<Domain> likePatternToDomain(const velox::Variant& pattern) {
+  if (pattern.isNull() || pattern.kind() != velox::TypeKind::VARCHAR) {
+    return std::nullopt;
+  }
+  const auto& text = pattern.value<velox::TypeKind::VARCHAR>();
+  const auto wildcard = text.find_first_of("%_");
+  if (wildcard == std::string::npos) {
+    return Domain::singleValue(pattern);
+  }
+  if (wildcard == 0) {
+    return std::nullopt;
+  }
+  std::string prefix = text.substr(0, wildcard);
+  auto upper = prefixUpperBound(prefix);
+  Domain domain = Domain::greaterThanOrEqual(velox::Variant(std::move(prefix)));
+  if (upper) {
+    domain =
+        domain.intersect(Domain::lessThan(velox::Variant(std::move(*upper))));
+  }
+  return domain;
+}
+
+} // namespace
+
 std::optional<Domain> exprToDomain(ExprCP expr) {
   if (!expr->is(PlanType::kCallExpr)) {
     return std::nullopt;
@@ -351,6 +398,14 @@ std::optional<Domain> exprToDomain(ExprCP expr) {
     const auto& high = call->args()[2]->as<Literal>()->literal();
     return Domain::greaterThanOrEqual(low).intersect(
         Domain::lessThanOrEqual(high));
+  }
+
+  // LIKE(col, pattern) with a literal prefix maps to a prefix range. The 3-arg
+  // form with an ESCAPE character is not interpreted and falls through.
+  if (funcName == functionNames.like && call->args().size() == 2 &&
+      call->args()[0]->is(PlanType::kColumnExpr) &&
+      call->args()[1]->is(PlanType::kLiteralExpr)) {
+    return likePatternToDomain(call->args()[1]->as<Literal>()->literal());
   }
 
   // Comparison of a column with a literal: eq, lt, lte, gt, gte.

--- a/axiom/optimizer/Domain.h
+++ b/axiom/optimizer/Domain.h
@@ -169,6 +169,7 @@ using ExprCP = const Expr*;
 /// Recognized expressions:
 ///   - Comparisons with literals: eq, lt, lte, gt, gte(column, literal)
 ///   - BETWEEN(column, literal, literal) — closed range [low, high]
+///   - LIKE(column, literal) — prefix range, or equality if wildcard-free
 ///   - IN(column, literal, literal, ...)
 ///   - IS NULL(column)
 ///   - AND(expr, expr, ...) — intersects children

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -152,6 +152,15 @@ bool FunctionRegistry::registerBetween(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerLike(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (like_.has_value() && like_.value() != name) {
+    return false;
+  }
+  like_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerRowNumber(std::string_view name) {
   VELOX_USER_CHECK(!name.empty());
   if (rowNumber_.has_value() && rowNumber_.value() != name) {
@@ -388,6 +397,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerGreaterThanOrEqual(fullName("gte"));
   registry->registerIsNull(fullName("is_null"));
   registry->registerBetween(fullName("between"));
+  registry->registerLike(fullName("like"));
   registry->registerRowNumber(fullName("row_number"));
   registry->registerRank(fullName("rank"));
   registry->registerDenseRank(fullName("dense_rank"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -397,6 +397,17 @@ class FunctionRegistry {
     return between_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'like', i.e.
+  /// matches its first argument against a SQL LIKE pattern.
+  /// @return true if successfully registered, false if a different
+  /// 'like' function is already registered.
+  bool registerLike(std::string_view name);
+
+  /// Returns the name of the 'like' function.
+  const std::optional<std::string>& like() const {
+    return like_;
+  }
+
   /// Registers function 'name' that has semantics of 'row_number' window
   /// function, i.e. assigns sequential numbers to rows within a partition.
   /// @return true if successfully registered, false if a different
@@ -510,6 +521,7 @@ class FunctionRegistry {
   std::optional<std::string> greaterThanOrEqual_;
   std::optional<std::string> isNull_;
   std::optional<std::string> between_;
+  std::optional<std::string> like_;
 
   // Aggregate functions.
   std::optional<std::string> arbitrary_;

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -381,6 +381,10 @@ void QueryGraphContext::populateFunctionNames() {
     functionNames_.between = this->toName(between.value());
   }
 
+  if (auto like = registry->like()) {
+    functionNames_.like = this->toName(like.value());
+  }
+
   if (auto rowNumber = registry->rowNumber()) {
     functionNames_.rowNumber = this->toName(rowNumber.value());
   }

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -329,6 +329,7 @@ struct FunctionNames {
   Name gte{nullptr};
   Name isNull{nullptr};
   Name between{nullptr};
+  Name like{nullptr};
 
   /// Aggregate functions.
   Name arbitrary{nullptr};


### PR DESCRIPTION
Summary:

`EXPLAIN (TYPE IO)` dropped partition filters written as `col LIKE 'prefix%'`, even though Presto reports the prefix as a range. For `WHERE ds LIKE '2026-05%'` Axiom emitted no `ds` constraint, so a consumer that sizes and routes a query from this output saw an unconstrained scan and over-estimated the partition set. Axiom now emits `ds = [2026-05, 2026-06)`.

Register `like` as a semantic slot in `FunctionRegistry` (alongside the other operators, so it inherits dialect prefixing), surface it through `FunctionNames`, and convert `like(col, literal)` in `exprToDomain`: a wildcard-free pattern becomes equality; a literal prefix before the first `%`/`_` wildcard becomes the half-open range `[prefix, prefixUpperBound(prefix))`, where the upper bound increments the last byte below `0xFF` (byte-wise, matching VARCHAR ordering) and drops trailing `0xFF` bytes. The conversion is read-only and produces a superset of the match set, which the `Domain` contract requires.

Patterns with a leading wildcard, and the 3-arg `LIKE ... ESCAPE` form, are not converted (the column is dropped, which is the safe/broader result); escape semantics are not interpreted. As with `between`, the optimizer cost model (`Filters.cpp`) still treats `LIKE` as opaque; that is a separate change.

Differential Revision: D111003337


