### PR TITLE
feat(optimizer): Add v2 optimizer translate pass (#1549)

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -67,3 +67,5 @@ target_link_libraries(
   axiom_runner_local_runner
   velox_connector
 )
+
+add_subdirectory(v2)

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -34,6 +34,7 @@ const auto& planTypeNames() {
       {PlanType::kDerivedTableNode, "DerivedTableNode"},
       {PlanType::kAggregationNode, "AggregationNode"},
       {PlanType::kWindowPlanNode, "WindowPlanNode"},
+      {PlanType::kV2Node, "V2Node"},
   };
   return kNames;
 }
@@ -51,6 +52,10 @@ size_t PlanObject::hash() const {
 
 void PlanObjectSet::unionColumns(ExprCP expr) {
   unionSet(expr->columns());
+}
+
+bool PlanObjectSet::containsColumns(ExprCP expr) const {
+  return expr->columns().isSubset(*this);
 }
 
 void PlanObjectSet::unionColumns(const ExprVector& exprs) {

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -41,6 +41,8 @@ enum class PlanType : uint32_t {
   kAggregationNode,
   kWindowPlanNode,
   kWriteNode,
+  // Node from the v2 tree IR. See axiom/optimizer/v2/Node.h.
+  kV2Node,
 };
 
 AXIOM_DECLARE_ENUM_NAME(PlanType);
@@ -172,6 +174,7 @@ class PlanObjectSet : public BitSet {
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
+  /// True if id of any object in 'objects' is in 'this'.
   template <typename V>
   bool containsAny(const V& objects) const {
     for (const auto& object : objects) {
@@ -180,6 +183,31 @@ class PlanObjectSet : public BitSet {
       }
     }
     return false;
+  }
+
+  /// True if id of every object in 'objects' is in 'this'.
+  template <typename V>
+  bool containsAll(const V& objects) const {
+    for (const auto& object : objects) {
+      if (!contains(object)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// True if every column 'expr' depends on is in 'this' — i.e. 'expr' can be
+  /// evaluated from these columns.
+  bool containsColumns(ExprCP expr) const;
+
+  /// True if every expression in 'exprs' can be evaluated from these columns.
+  bool containsColumns(const ExprVector& exprs) const {
+    for (ExprCP expr : exprs) {
+      if (!containsColumns(expr)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Inserts id of 'object'.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -51,6 +51,23 @@ const char* SpecialFormCallNames::kIn = "__in";
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
 // static
+ColumnCP Column::createForSymbol(Name symbol, const Value& value) {
+  VELOX_DCHECK(
+      queryCtx()->isV2(),
+      "Column::createForSymbol synthesizes a relation-less column, a v2-only idiom");
+  return make<Column>(
+      queryCtx()->newName(symbol),
+      /*relation=*/nullptr,
+      value,
+      /*alias=*/symbol);
+}
+
+// static
+ColumnCP Column::createBoolean(std::string_view prefix) {
+  return create(prefix, Value(toType(velox::BOOLEAN()), /*cardinality=*/2));
+}
+
+// static
 ColumnCP Column::create(std::string_view prefix, const Value& value) {
   VELOX_DCHECK(
       queryCtx()->isV2(),

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -50,6 +50,14 @@ const char* SpecialFormCallNames::kIn = "__in";
 // static
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
+// static
+ColumnCP Column::create(std::string_view prefix, const Value& value) {
+  VELOX_DCHECK(
+      queryCtx()->isV2(),
+      "Column::create synthesizes a relation-less column, a v2-only idiom");
+  return make<Column>(queryCtx()->newName(prefix), /*relation=*/nullptr, value);
+}
+
 void Column::equals(ColumnCP other) const {
   if (!equivalence_ && !other->equivalence_) {
     auto* equiv = make<Equivalence>();
@@ -66,6 +74,10 @@ void Column::equals(ColumnCP other) const {
   }
   if (!equivalence_) {
     other->equals(this);
+    return;
+  }
+  // Already in one class: merging would iterate and grow the same vector.
+  if (equivalence_ == other->equivalence_) {
     return;
   }
   for (auto& column : other->equivalence_->columns) {
@@ -90,6 +102,10 @@ Name cname(PlanObjectCP relation) {
 }
 
 std::string Column::toString() const {
+  if (queryCtx()->isV2()) {
+    return name_;
+  }
+
   const auto* opt = queryCtx()->optimization();
   if (!opt->cnamesInExpr() || relation_ == nullptr) {
     return name_;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -169,6 +169,19 @@ class Column : public Expr {
   /// names pass an `alias` to the full constructor instead.
   static ColumnCP create(std::string_view prefix, const Value& value);
 
+  /// Creates a `Column` named by the logical-plan `symbol` it carries. The
+  /// internal `name` is uniquified for the optimizer's flat namespace, while
+  /// `outputName()` returns `symbol` (the alias), so the emitted plan uses the
+  /// logical-plan name. Use whenever a translated logical-plan node produces a
+  /// named column; synthetic columns use `create`.
+  static ColumnCP createForSymbol(Name symbol, const Value& value);
+
+  /// Synthesizes a `BOOLEAN` column with cardinality 2 (the two valid
+  /// boolean values). Convenience for the recurring pattern of
+  /// creating eligibility / marker columns in rewrites; equivalent to
+  /// `create(prefix, Value(toType(velox::BOOLEAN()), 2))`.
+  static ColumnCP createBoolean(std::string_view prefix);
+
   Name name() const {
     return name_;
   }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -161,6 +161,14 @@ class Column : public Expr {
       ColumnCP topColumn = nullptr,
       PathCP path = nullptr);
 
+  /// Synthesizes a `Column`. The column's `name` is `prefix` with a
+  /// uniqueness suffix appended by `QueryGraphContext::newName`. The
+  /// resulting name appears in plan output (EXPLAIN, `NodePrinter`),
+  /// so pick a descriptive prefix (`"__rownum"`, `"mark"`, etc.).
+  /// `alias` is not set; sites that produce user-visible LP output
+  /// names pass an `alias` to the full constructor instead.
+  static ColumnCP create(std::string_view prefix, const Value& value);
+
   Name name() const {
     return name_;
   }
@@ -1338,6 +1346,8 @@ struct Frame {
   /// Offset expression for the end bound, or nullptr for UNBOUNDED or
   /// CURRENT ROW.
   ExprCP endValue;
+
+  bool operator==(const Frame& other) const = default;
 };
 
 /// Window function call. Stores partition keys, order keys, frame, and

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -393,6 +393,21 @@ class Call : public Expr {
     bool operator()(const Call* call, const KeyView& key) const;
   };
 
+  /// Returns 'base' OR'd with the `FunctionSet` of each argument. Used
+  /// when constructing a new `Call` to propagate flags
+  /// (kNonDeterministic, kAggregate, kWindow, etc.) that downstream
+  /// passes consult via `Expr::containsFunction(...)`. Pair with
+  /// `functionBits(name, specialForm)` to seed `base` with the
+  /// function's own bits.
+  static FunctionSet unionArgFunctions(
+      FunctionSet base,
+      const ExprVector& arguments) {
+    for (const auto* argument : arguments) {
+      base = base | argument->functions();
+    }
+    return base;
+  }
+
  private:
   // Name of function.
   Name const name_;

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include "axiom/common/Enums.h"
@@ -459,6 +460,18 @@ class QueryGraphContext {
     return allVariants_.back().get();
   }
 
+  /// Returns a globally unique interned name `{prefix}{N}` within this query
+  /// context. Example: `newName("a_")` returns `"a_47"`.
+  Name newName(std::string_view prefix) {
+    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+  }
+
+  /// True when the v2 optimizer is driving this query. v2 runs without an
+  /// `Optimization` (a v1 construct), so a null `optimization()` marks v2.
+  bool isV2() const {
+    return optimization_ == nullptr;
+  }
+
  private:
   void populateFunctionNames();
 
@@ -488,6 +501,8 @@ class QueryGraphContext {
   FunctionNames functionNames_;
 
   std::vector<std::unique_ptr<velox::Variant>> allVariants_;
+
+  uint32_t nameCounter_{0};
 };
 
 /// Returns a mutable reference to the calling thread's QueryGraphContext.
@@ -555,5 +570,8 @@ using ExprVector = QGVector<ExprCP>;
 class Column;
 using ColumnCP = const Column*;
 using ColumnVector = QGVector<ColumnCP>;
+
+class Literal;
+using LiteralCP = const Literal*;
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1361,6 +1361,7 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
 
     // Drop redundant cast.
     //    CAST(x as t) / TRY_CAST(x as t) ==> x if typeof(x) == t.
+    // TRY_CAST too: a same-type cast never errors.
     if (specialForm &&
         (specialForm->form() == lp::SpecialForm::kCast ||
          specialForm->form() == lp::SpecialForm::kTryCast)) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -99,7 +99,7 @@ class ToGraph {
           connector::TablePtr> pushdownRoots);
 
   Name newCName(std::string_view prefix) {
-    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+    return queryCtx()->newName(prefix);
   }
 
   /// Creates a new column with a unique name using the given prefix.

--- a/axiom/optimizer/v2/AppendAll.h
+++ b/axiom/optimizer/v2/AppendAll.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Appends every element of `src` to `dst`. Used to concatenate
+/// `ColumnVector` / `ExprVector` when building output column lists or
+/// expression lists for new nodes.
+template <typename Dst, typename Src>
+void appendAll(Dst& dst, const Src& src) {
+  dst.insert(dst.end(), src.begin(), src.end());
+}
+
+/// Returns a new vector containing the first `count` elements of `src`.
+/// Caller must ensure `count <= src.size()`.
+template <typename V>
+V prefix(const V& src, size_t count) {
+  return V(src.begin(), src.begin() + count);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Builder.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+Builder::Builder() : functionNames_{queryCtx()->functionNames()} {
+  const auto& reversibles = FunctionRegistry::instance()->reversibleFunctions();
+  reversibleFunctions_.reserve(reversibles.size() * 2);
+  for (const auto& [name, reverseName] : reversibles) {
+    reversibleFunctions_.emplace(toName(name), toName(reverseName));
+    reversibleFunctions_.emplace(toName(reverseName), toName(name));
+  }
+}
+
+namespace {
+
+// Returns true if `args` should be swapped to put a literal on the
+// right, or — when neither side is a literal — to put the lower-id
+// expression on the left.
+bool shouldInvert(ExprCP left, ExprCP right) {
+  const bool leftIsLiteral = left->is(PlanType::kLiteralExpr);
+  const bool rightIsLiteral = right->is(PlanType::kLiteralExpr);
+  if (leftIsLiteral && !rightIsLiteral) {
+    return true;
+  }
+  if (!leftIsLiteral && !rightIsLiteral && left->id() > right->id()) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace
+
+void Builder::canonicalizeCall(Name& name, ExprVector& args) const {
+  if (args.size() != 2) {
+    return;
+  }
+  auto it = reversibleFunctions_.find(name);
+  if (it == reversibleFunctions_.end()) {
+    return;
+  }
+  if (!shouldInvert(args[0], args[1])) {
+    return;
+  }
+  std::swap(args[0], args[1]);
+  name = it->second;
+}
+
+const Literal*
+Builder::makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality) {
+  const Value value(type, cardinality);
+  // Look up by the caller's Variant first, so a cache hit registers nothing.
+  Literal::KeyView view{type, &variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* registered = queryCtx()->registerVariant(
+      std::make_unique<velox::Variant>(std::move(variant)));
+  auto* literal = optimizer::make<Literal>(value, registered);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Literal* Builder::makeLiteral(
+    const Value& value,
+    const velox::Variant* variant) {
+  Literal::KeyView view{value.type, variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* literal = optimizer::make<Literal>(value, variant);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Call* Builder::makeCall(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions) {
+  if (functions.contains(FunctionSet::kNonDeterministic)) {
+    // Skip dedup: each evaluation of a non-deterministic call produces an
+    // independent value, so identical calls must stay distinct objects.
+    return optimizer::make<Call>(name, value, std::move(args), functions);
+  }
+  canonicalizeCall(name, args);
+  Call::KeyView view{name, value.type, args};
+  if (auto it = calls_.find(view); it != calls_.end()) {
+    return *it;
+  }
+  auto* call = optimizer::make<Call>(name, value, std::move(args), functions);
+  calls_.insert(call);
+  return call;
+}
+
+const optimizer::Aggregate* Builder::makeAggregate(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions,
+    bool isDistinct,
+    ExprCP condition,
+    TypeCP intermediateType,
+    ExprVector orderKeys,
+    OrderTypeVector orderTypes) {
+  optimizer::Aggregate::KeyView view{
+      name, args, isDistinct, condition, orderKeys, orderTypes};
+  if (auto it = aggregateCalls_.find(view); it != aggregateCalls_.end()) {
+    return *it;
+  }
+  auto* aggregate = optimizer::make<optimizer::Aggregate>(
+      name,
+      value,
+      std::move(args),
+      functions,
+      isDistinct,
+      condition,
+      intermediateType,
+      std::move(orderKeys),
+      std::move(orderTypes));
+  aggregateCalls_.insert(aggregate);
+  return aggregate;
+}
+
+void Builder::addEquivalences(const Join::Key& key) {
+  if (key.joinType != velox::core::JoinType::kInner) {
+    return;
+  }
+  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
+    ExprCP leftKey = key.leftKeys[i];
+    ExprCP rightKey = key.rightKeys[i];
+    if (leftKey->isColumn() && rightKey->isColumn()) {
+      leftKey->as<Column>()->equals(rightKey->as<Column>());
+    }
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hash-consing factory for tree-IR nodes and selected Expr leaves. Identical
+/// sub-trees produce the same pointer, so identity equality is O(1) and side-
+/// table lookups keyed by node identity hit one canonical entry per logical
+/// sub-tree.
+///
+/// Everything is interned by pointer: each dedup set stores `const T*` and
+/// recovers identity via `T::KeyHash` / `T::KeyEq`, so a cache hit allocates
+/// nothing. Nodes are constructed from an owning `Key` (e.g. `Scan::Key`)
+/// passed to `make<T>`; the `Expr` leaves `Literal`, `Call`, and
+/// `optimizer::Aggregate` use `makeLiteral` / `makeCall` / `makeAggregate`
+/// (their `KeyHash` / `KeyEq` live on the `Expr` classes themselves). `Column`
+/// is intentionally NOT hash-consed: `Column::equivalence_` is mutable state
+/// mutated by `Column::equals()`, and dedup would leak equivalence classes
+/// across unrelated subtrees.
+class Builder {
+ public:
+  /// Snapshots `queryCtx()` and the function registry; the resulting
+  /// `Builder` is bound to that `QueryGraphContext` for its lifetime.
+  Builder();
+
+  /// Returns a canonical node `T` for 'key', constructing one if not already
+  /// present. Interned by pointer: the dedup set stores `const T*` and recovers
+  /// identity via `T::KeyHash` / `T::KeyEq`. Looks up by the in-flight `key`
+  /// (transparent, no allocation on a hit); on a miss, moves the key into the
+  /// newly constructed node. `Expr` leaves use `makeLiteral` / `makeCall` /
+  /// `makeAggregate`.
+  template <typename T>
+  const T* make(typename T::Key key) {
+    auto& dedup = setFor<T>();
+    if (auto it = dedup.find(key); it != dedup.end()) {
+      return *it;
+    }
+    if constexpr (std::is_same_v<T, Join>) {
+      // Before construction: the Join ctor caches partitioning from these.
+      addEquivalences(key);
+    }
+    const T* node = optimizer::make<T>(std::move(key));
+    dedup.insert(node);
+    return node;
+  }
+
+  /// Registers 'variant' in the `QueryGraphContext` arena and returns a
+  /// canonical `Literal` of 'type' carrying it. Cardinality defaults to
+  /// 1 (a single distinct value — appropriate for literal constants).
+  const Literal*
+  makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality = 1);
+
+  /// Returns a canonical `Literal` of 'value' carrying the already-registered
+  /// 'variant' (owned by the `QueryGraphContext` arena).
+  const Literal* makeLiteral(const Value& value, const velox::Variant* variant);
+
+  /// Returns a canonical `Call`. Non-deterministic calls are never deduped —
+  /// two textually identical `random()` invocations must stay distinct objects
+  /// because each produces an independent value. Reversible binary calls (e.g.
+  /// `lt`/`gt`, `eq`, `plus`) are canonicalized before dedup so equivalent
+  /// forms share one `Call*` (e.g. `2 > a` is rewritten to `a < 2`).
+  /// 'functions' is the call's own bits OR-ed with each arg's `functions()`.
+  const Call* makeCall(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions);
+
+  /// Returns a canonical aggregate `Call`. Result type and 'intermediateType'
+  /// are determined by (name, args), so identity excludes them.
+  const optimizer::Aggregate* makeAggregate(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions,
+      bool isDistinct,
+      ExprCP condition,
+      TypeCP intermediateType,
+      ExprVector orderKeys,
+      OrderTypeVector orderTypes);
+
+  /// Canonical `Literal` for boolean constant 'value'.
+  const Literal* makeBoolean(bool value) {
+    return makeLiteral(velox::Variant(value), toType(velox::BOOLEAN()));
+  }
+
+  /// Canonical `Literal` for SQL NULL of 'type'.
+  const Literal* makeNull(TypeCP type) {
+    return makeLiteral(velox::Variant::null(type->kind()), type);
+  }
+
+  /// `Values` node carrying zero rows with the given output schema.
+  /// Used to replace subtrees a rewrite proved produce no rows.
+  const Values* makeEmptyValues(ColumnVector outputColumns) {
+    return make<Values>({/*source=*/nullptr,
+                         /*rows=*/nullptr,
+                         std::move(outputColumns)});
+  }
+
+  /// Interned `Name`s for well-known functions, snapshotted from the
+  /// active `QueryGraphContext` at construction so callers can compare
+  /// or build calls against well-known operator names by pointer
+  /// equality, without repeated registry lookups.
+  const FunctionNames& functionNames() const {
+    return functionNames_;
+  }
+
+ private:
+  // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
+  // swaps 'args' (and renames to the reverse) when `args[0]` should
+  // come second per the canonical order: literal-on-right, lower-id
+  // expr on left when neither is a literal. No-op otherwise.
+  void canonicalizeCall(Name& name, ExprVector& args) const;
+
+  // Adds an inner join's equi-key columns to one equivalence class (see
+  // `Column::equals`): equated columns hold the same value on every output row,
+  // so any surviving member partitions the output as the dropped key did.
+  // No-op for non-inner joins (an outer join's build key may be null-padded, so
+  // its columns are not equal on every row) and for non-column keys.
+  static void addEquivalences(const Join::Key& key);
+
+  template <typename T>
+  auto& setFor() {
+    if constexpr (std::is_same_v<T, Scan>) {
+      return scans_;
+    } else if constexpr (std::is_same_v<T, Filter>) {
+      return filters_;
+    } else if constexpr (std::is_same_v<T, Project>) {
+      return projects_;
+    } else if constexpr (std::is_same_v<T, Limit>) {
+      return limits_;
+    } else if constexpr (std::is_same_v<T, Sort>) {
+      return sorts_;
+    } else if constexpr (std::is_same_v<T, TopN>) {
+      return topNs_;
+    } else if constexpr (std::is_same_v<T, Aggregate>) {
+      return aggregates_;
+    } else if constexpr (std::is_same_v<T, GroupId>) {
+      return groupIds_;
+    } else if constexpr (std::is_same_v<T, MarkDistinct>) {
+      return markDistincts_;
+    } else if constexpr (std::is_same_v<T, Values>) {
+      return values_;
+    } else if constexpr (std::is_same_v<T, Unnest>) {
+      return unnests_;
+    } else if constexpr (std::is_same_v<T, UnionAll>) {
+      return unions_;
+    } else if constexpr (std::is_same_v<T, Join>) {
+      return joins_;
+    } else if constexpr (std::is_same_v<T, Window>) {
+      return windows_;
+    } else if constexpr (std::is_same_v<T, TopNRowNumber>) {
+      return topNRowNumbers_;
+    } else if constexpr (std::is_same_v<T, Apply>) {
+      return applies_;
+    } else if constexpr (std::is_same_v<T, EnforceSingleRow>) {
+      return enforceSingleRows_;
+    } else if constexpr (std::is_same_v<T, AssignUniqueId>) {
+      return assignUniqueIds_;
+    } else if constexpr (std::is_same_v<T, EnforceDistinct>) {
+      return enforceDistincts_;
+    } else if constexpr (std::is_same_v<T, Exchange>) {
+      return exchanges_;
+    } else if constexpr (std::is_same_v<T, TableWrite>) {
+      return tableWrites_;
+    } else {
+      static_assert(sizeof(T) == 0, "No dedup map for this node type");
+    }
+  }
+
+  const FunctionNames functionNames_;
+
+  // Maps a reversible binary function name to its reverse name.
+  // Symmetric reversibles (e.g. `eq`) map to themselves; asymmetric
+  // ones (e.g. `lt` → `gt`) map across.
+  folly::F14FastMap<Name, Name> reversibleFunctions_;
+
+  // Dedup container for hash-consed `T`: stores canonical `const T*`, keyed by
+  // the node/expr's own identity via transparent `T::KeyHash` / `T::KeyEq`.
+  template <typename T>
+  using DedupSet =
+      folly::F14FastSet<const T*, typename T::KeyHash, typename T::KeyEq>;
+
+  DedupSet<Scan> scans_;
+  DedupSet<Filter> filters_;
+  DedupSet<Project> projects_;
+  DedupSet<Limit> limits_;
+  DedupSet<Sort> sorts_;
+  DedupSet<TopN> topNs_;
+  DedupSet<Aggregate> aggregates_;
+  DedupSet<GroupId> groupIds_;
+  DedupSet<MarkDistinct> markDistincts_;
+  DedupSet<Values> values_;
+  DedupSet<Unnest> unnests_;
+  DedupSet<UnionAll> unions_;
+  DedupSet<Join> joins_;
+  DedupSet<Window> windows_;
+  DedupSet<TopNRowNumber> topNRowNumbers_;
+  DedupSet<Apply> applies_;
+  DedupSet<EnforceSingleRow> enforceSingleRows_;
+  DedupSet<AssignUniqueId> assignUniqueIds_;
+  DedupSet<EnforceDistinct> enforceDistincts_;
+  DedupSet<Exchange> exchanges_;
+  DedupSet<TableWrite> tableWrites_;
+
+  // Expr leaves, interned via `makeLiteral` / `makeCall` / `makeAggregate`.
+  DedupSet<Literal> literals_;
+  DedupSet<Call> calls_;
+  DedupSet<optimizer::Aggregate> aggregateCalls_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(axiom_optimizer_v2 Builder.cpp Node.cpp NodePrinter.cpp PhysicalProperties.cpp)
+
+target_link_libraries(
+  axiom_optimizer_v2
+  axiom_common
+  axiom_connectors
+  axiom_logical_plan
+  axiom_optimizer
+  velox_common_base
+  velox_core
+)

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -18,9 +18,11 @@ add_library(
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
+  JoinCondition.cpp
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp
+  TranslatePass.cpp
 )
 
 target_link_libraries(
@@ -31,6 +33,7 @@ target_link_libraries(
   axiom_optimizer
   velox_common_base
   velox_core
+  velox_exec
   velox_expression
   velox_vector
 )

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_optimizer_v2 Builder.cpp Node.cpp NodePrinter.cpp PhysicalProperties.cpp)
+add_library(
+  axiom_optimizer_v2
+  Builder.cpp
+  ExprEmitter.cpp
+  ExprFactory.cpp
+  ExprSimplifier.cpp
+  Node.cpp
+  NodePrinter.cpp
+  PhysicalProperties.cpp
+)
 
 target_link_libraries(
   axiom_optimizer_v2
@@ -22,4 +31,6 @@ target_link_libraries(
   axiom_optimizer
   velox_common_base
   velox_core
+  velox_expression
+  velox_vector
 )

--- a/axiom/optimizer/v2/ExprEmitter.cpp
+++ b/axiom/optimizer/v2/ExprEmitter.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprEmitter.h"
+
+#include <folly/container/F14Map.h>
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<ColumnNaming, std::string_view>& columnNamingNames() {
+  static const folly::F14FastMap<ColumnNaming, std::string_view> kNames = {
+      {ColumnNaming::kOutputName, "OutputName"},
+      {ColumnNaming::kSchemaName, "SchemaName"},
+  };
+  return kNames;
+}
+
+velox::core::TypedExprPtr columnToTypedExpr(
+    ColumnCP column,
+    ColumnNaming naming) {
+  const std::string name = naming == ColumnNaming::kSchemaName
+      ? std::string{column->name()}
+      : column->outputName();
+  return std::make_shared<velox::core::FieldAccessTypedExpr>(
+      toTypePtr(column->value().type), name);
+}
+
+velox::core::TypedExprPtr literalToTypedExpr(LiteralCP literal) {
+  return std::make_shared<velox::core::ConstantTypedExpr>(
+      toTypePtr(literal->value().type), literal->literal());
+}
+
+// Emits a DEREFERENCE call (resolved at translate time to a numeric field
+// index) as Velox's `DereferenceTypedExpr`.
+velox::core::TypedExprPtr dereferenceToTypedExpr(
+    const Call* call,
+    const std::vector<velox::core::TypedExprPtr>& args) {
+  VELOX_CHECK_EQ(call->args().size(), 2);
+  const auto* index = call->args()[1]->as<Literal>();
+  VELOX_CHECK_NOT_NULL(index);
+  VELOX_CHECK_EQ(index->literal().kind(), velox::TypeKind::INTEGER);
+  return std::make_shared<velox::core::DereferenceTypedExpr>(
+      toTypePtr(call->value().type),
+      args[0],
+      static_cast<uint32_t>(
+          index->literal().value<velox::TypeKind::INTEGER>()));
+}
+
+// Folds an all-literal IN list into `in(col, ARRAY[...])` with one array
+// constant, so Velox binds the set/bitmask-based InPredicate instead of a
+// per-row variadic compare. Returns nullptr when any element is non-literal,
+// leaving the variadic call. Translate folds every single-element IN to
+// equality, so an IN reaching here has >= 2 elements. `column` is the
+// already-lowered first argument.
+velox::core::TypedExprPtr tryLowerConstantIn(
+    const Call* call,
+    const velox::core::TypedExprPtr& column,
+    velox::memory::MemoryPool* pool) {
+  const auto& args = call->args();
+  VELOX_CHECK_GE(args.size(), 3);
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (!args[i]->is(PlanType::kLiteralExpr)) {
+      return nullptr;
+    }
+  }
+
+  const auto elementType = toTypePtr(args[0]->value().type);
+  std::vector<velox::Variant> elements;
+  elements.reserve(args.size() - 1);
+  for (size_t i = 1; i < args.size(); ++i) {
+    elements.push_back(args[i]->as<Literal>()->literal());
+  }
+
+  // Materialize the array through a constant vector, which supports complex
+  // element types.
+  return std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      specialForm(logical_plan::SpecialForm::kIn),
+      column,
+      std::make_shared<velox::core::ConstantTypedExpr>(
+          velox::BaseVector::createConstant(
+              velox::ARRAY(elementType),
+              velox::Variant::array(elements),
+              1,
+              pool)));
+}
+
+velox::core::TypedExprPtr lambdaToTypedExpr(
+    const Lambda* lambda,
+    const velox::core::TypedExprPtr& body) {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(lambda->args().size());
+  types.reserve(lambda->args().size());
+  for (ColumnCP arg : lambda->args()) {
+    names.push_back(arg->outputName());
+    types.push_back(toTypePtr(arg->value().type));
+  }
+  return std::make_shared<velox::core::LambdaTypedExpr>(
+      velox::ROW(std::move(names), std::move(types)), body);
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(ColumnNaming, columnNamingNames);
+
+velox::core::TypedExprPtr ExprEmitter::callToTypedExpr(
+    const Call* call,
+    std::vector<velox::core::TypedExprPtr> args) {
+  auto resultType = toTypePtr(call->value().type);
+  if (auto form = SpecialFormCallNames::tryFromCallName(call->name())) {
+    if (form == logical_plan::SpecialForm::kCast) {
+      return std::make_shared<velox::core::CastTypedExpr>(
+          resultType, std::move(args), /*nullOnFailure=*/false);
+    }
+
+    if (form == logical_plan::SpecialForm::kTryCast) {
+      return std::make_shared<velox::core::CastTypedExpr>(
+          resultType, std::move(args), /*nullOnFailure=*/true);
+    }
+
+    if (form == logical_plan::SpecialForm::kDereference) {
+      return dereferenceToTypedExpr(call, args);
+    }
+
+    if (form == logical_plan::SpecialForm::kNullIf) {
+      // args[2] is a null literal whose type is the common comparison
+      // supertype.
+      VELOX_CHECK_EQ(args.size(), 3);
+      return std::make_shared<velox::core::NullIfTypedExpr>(
+          args[0], args[1], args[2]->type());
+    }
+
+    if (form == logical_plan::SpecialForm::kIn) {
+      // An all-literal IN list lowers to `in(col, ARRAY[...])`; a list with any
+      // non-literal element stays a variadic call.
+      if (auto lowered = tryLowerConstantIn(call, args[0], pool_)) {
+        return lowered;
+      }
+    }
+
+    return std::make_shared<velox::core::CallTypedExpr>(
+        resultType, std::move(args), specialForm(*form));
+  }
+
+  return std::make_shared<velox::core::CallTypedExpr>(
+      resultType, std::move(args), std::string{call->name()});
+}
+
+velox::core::TypedExprPtr ExprEmitter::toTypedExpr(
+    ExprCP expr,
+    ColumnNaming naming) {
+  switch (expr->type()) {
+    case PlanType::kColumnExpr:
+      return columnToTypedExpr(expr->as<Column>(), naming);
+    case PlanType::kLiteralExpr:
+      return literalToTypedExpr(expr->as<Literal>());
+    case PlanType::kCallExpr: {
+      const auto* call = expr->as<Call>();
+      std::vector<velox::core::TypedExprPtr> args;
+      args.reserve(call->args().size());
+      for (ExprCP arg : call->args()) {
+        args.push_back(toTypedExpr(arg, naming));
+      }
+      return callToTypedExpr(call, std::move(args));
+    }
+    case PlanType::kLambdaExpr: {
+      const auto* lambda = expr->as<Lambda>();
+      return lambdaToTypedExpr(lambda, toTypedExpr(lambda->body(), naming));
+    }
+    default:
+      VELOX_NYI("Unsupported expression type: {}", expr->typeName());
+  }
+}
+
+std::vector<velox::core::TypedExprPtr> ExprEmitter::toTypedExprs(
+    const ExprVector& exprs,
+    ColumnNaming naming) {
+  std::vector<velox::core::TypedExprPtr> result;
+  result.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    result.push_back(toTypedExpr(expr, naming));
+  }
+  return result;
+}
+
+velox::core::TypedExprPtr ExprEmitter::makeAnd(
+    const ExprVector& predicates,
+    ColumnNaming naming) {
+  VELOX_DCHECK(!predicates.empty());
+  if (predicates.size() == 1) {
+    return toTypedExpr(predicates[0], naming);
+  }
+  return std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      toTypedExprs(predicates, naming),
+      velox::expression::kAnd);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprEmitter.h
+++ b/axiom/optimizer/v2/ExprEmitter.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::memory {
+class MemoryPool;
+}
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Selects the name a `Column` lowers to in a Velox `FieldAccessTypedExpr`.
+enum class ColumnNaming {
+  /// `Column::outputName()` (post-rename alias).
+  kOutputName,
+  /// `Column::name()` (underlying table column name).
+  kSchemaName,
+};
+
+AXIOM_DECLARE_ENUM_NAME(ColumnNaming);
+
+/// Converts tree-IR expressions (`ExprCP`) into Velox `core::TypedExpr`s.
+/// Used by Emit to lower expressions inside Filter, Project, and connector
+/// handle construction.
+class ExprEmitter {
+ public:
+  /// 'pool' backs constant vectors materialized during lowering (e.g. the
+  /// array constant of an IN list); it must outlive the emitted plan.
+  explicit ExprEmitter(velox::memory::MemoryPool* pool) : pool_{pool} {}
+
+  /// Lowers a single expression. Recursive; throws VELOX_NYI for expression
+  /// kinds not yet handled.
+  velox::core::TypedExprPtr toTypedExpr(
+      ExprCP expr,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+  /// Lowers each expression to a Velox TypedExpr, preserving order.
+  std::vector<velox::core::TypedExprPtr> toTypedExprs(
+      const ExprVector& exprs,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+  /// Returns the conjunction of 'predicates'. Calls toTypedExpr() on each
+  /// predicate, wraps with an `and` Velox call if more than one.
+  /// 'predicates' must be non-empty.
+  velox::core::TypedExprPtr makeAnd(
+      const ExprVector& predicates,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+ private:
+  // Lowers a `Call`. 'args' are the already-lowered arguments.
+  velox::core::TypedExprPtr callToTypedExpr(
+      const Call* call,
+      std::vector<velox::core::TypedExprPtr> args);
+
+  velox::memory::MemoryPool* const pool_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprFactory.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+ExprCP ExprFactory::makeBooleanCall(
+    Name name,
+    ExprVector arguments,
+    bool specialForm) {
+  const Value value(toType(velox::BOOLEAN()), 2);
+  const FunctionSet functions =
+      Call::unionArgFunctions(functionBits(name, specialForm), arguments);
+  return builder_.makeCall(name, value, std::move(arguments), functions);
+}
+
+ExprCP ExprFactory::makeAnd(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      SpecialFormCallNames::kAnd, {lhs, rhs}, /*specialForm=*/true);
+}
+
+namespace {
+
+// Recursively appends conjuncts/disjuncts of `expr` to `out` by
+// descending through calls named `targetName`.
+void flattenInto(ExprCP expr, Name targetName, ExprVector& out) {
+  if (expr->is(PlanType::kCallExpr) && expr->as<Call>()->name() == targetName) {
+    for (ExprCP arg : expr->as<Call>()->args()) {
+      flattenInto(arg, targetName, out);
+    }
+    return;
+  }
+  out.push_back(expr);
+}
+
+} // namespace
+
+ExprVector ExprFactory::flattenAnd(ExprCP expr) {
+  ExprVector conjuncts;
+  flattenInto(expr, SpecialFormCallNames::kAnd, conjuncts);
+  return conjuncts;
+}
+
+void ExprFactory::flattenAnd(ExprCP expr, ExprVector& conjuncts) {
+  flattenInto(expr, SpecialFormCallNames::kAnd, conjuncts);
+}
+
+ExprCP ExprFactory::makeOr(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      SpecialFormCallNames::kOr, {lhs, rhs}, /*specialForm=*/true);
+}
+
+ExprVector ExprFactory::flattenOr(ExprCP expr) {
+  ExprVector disjuncts;
+  flattenInto(expr, SpecialFormCallNames::kOr, disjuncts);
+  return disjuncts;
+}
+
+void ExprFactory::flattenOr(ExprCP expr, ExprVector& disjuncts) {
+  flattenInto(expr, SpecialFormCallNames::kOr, disjuncts);
+}
+
+ExprCP ExprFactory::makeNot(ExprCP arg) {
+  const Name name = builder_.functionNames().negation;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeNot requires not registered via "
+      "FunctionRegistry::registerNegation; the active dialect did not "
+      "register it");
+  return makeBooleanCall(name, {arg}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeEq(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      builder_.functionNames().equality, {lhs, rhs}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeLessThanOrEqual(ExprCP lhs, ExprCP rhs) {
+  const Name name = builder_.functionNames().lte;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeLessThanOrEqual requires lessThanOrEqual registered "
+      "via FunctionRegistry::registerLessThanOrEqual; the active dialect did "
+      "not register it");
+  return makeBooleanCall(name, {lhs, rhs}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeIsNull(ExprCP arg) {
+  const Name name = builder_.functionNames().isNull;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeIsNull requires is_null registered via "
+      "FunctionRegistry::registerIsNull; the active dialect did not "
+      "register it");
+  return makeBooleanCall(name, {arg}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeCoalesce(ExprCP value, ExprCP fallback) {
+  ExprVector arguments{value, fallback};
+  const Name coalesceName = SpecialFormCallNames::kCoalesce;
+  const Value resultValue = value->value();
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(coalesceName, /*specialForm=*/true), arguments);
+  return builder_.makeCall(
+      coalesceName, resultValue, std::move(arguments), functions);
+}
+
+ExprCP ExprFactory::makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr) {
+  ExprVector arguments{condition, thenExpr, elseExpr};
+  const Name ifName = SpecialFormCallNames::kIf;
+  const Value resultValue = thenExpr->value();
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(ifName, /*specialForm=*/true), arguments);
+  return builder_.makeCall(
+      ifName, resultValue, std::move(arguments), functions);
+}
+
+namespace {
+
+// Rebuilds `call` with each argument substituted, sharing the original
+// when no argument changed. Substituted calls go through `Builder::makeCall`
+// so hash-consing stays canonical.
+ExprCP substituteCall(
+    ExprFactory& factory,
+    Builder& builder,
+    const Call* call,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprVector newArgs;
+  newArgs.reserve(call->args().size());
+
+  bool anyChange = false;
+  for (ExprCP arg : call->args()) {
+    ExprCP newArg = factory.substitute(arg, sources, targets);
+    anyChange |= newArg != arg;
+    newArgs.push_back(newArg);
+  }
+
+  if (!anyChange) {
+    return call;
+  }
+
+  const bool specialForm = SpecialFormCallNames::isSpecialForm(call->name());
+  const FunctionSet functions =
+      Call::unionArgFunctions(functionBits(call->name(), specialForm), newArgs);
+  return builder.makeCall(
+      call->name(), call->value(), std::move(newArgs), functions);
+}
+
+// Rebuilds `field` with its base substituted. Field is arena-allocated
+// (not hash-consed in Builder), so it goes through `make`,
+// which is safe in v2-only contexts.
+ExprCP substituteField(
+    ExprFactory& factory,
+    const Field* field,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprCP newBase = factory.substitute(field->base(), sources, targets);
+  if (newBase == field->base()) {
+    return field;
+  }
+  if (field->field() != nullptr) {
+    return make<Field>(field->value().type, newBase, field->field());
+  }
+  return make<Field>(field->value().type, newBase, field->index());
+}
+
+// Rebuilds `lambda` with its body substituted. The lambda's bound args
+// shadow any same-named outer column, so they are removed from the
+// source mapping before recursing — a caller's substitution set can't
+// rebind them.
+ExprCP substituteLambda(
+    ExprFactory& factory,
+    const Lambda* lambda,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ColumnVector filteredSources;
+  ExprVector filteredTargets;
+  filteredSources.reserve(sources.size());
+  filteredTargets.reserve(targets.size());
+  const auto& boundArgs = lambda->args();
+  for (size_t i = 0; i < sources.size(); ++i) {
+    bool isBound = false;
+    for (ColumnCP boundArg : boundArgs) {
+      if (boundArg == sources[i]) {
+        isBound = true;
+        break;
+      }
+    }
+    if (!isBound) {
+      filteredSources.push_back(sources[i]);
+      filteredTargets.push_back(targets[i]);
+    }
+  }
+  ExprCP newBody =
+      factory.substitute(lambda->body(), filteredSources, filteredTargets);
+  if (newBody == lambda->body()) {
+    return lambda;
+  }
+  return make<Lambda>(lambda->args(), lambda->value().type, newBody);
+}
+
+} // namespace
+
+ExprCP ExprFactory::substitute(
+    ExprCP expr,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  if (expr == nullptr) {
+    return nullptr;
+  }
+  switch (expr->type()) {
+    case PlanType::kColumnExpr: {
+      for (size_t i = 0; i < sources.size(); ++i) {
+        if (sources[i] == expr) {
+          return targets[i];
+        }
+      }
+      return expr;
+    }
+    case PlanType::kLiteralExpr:
+      return expr;
+    case PlanType::kCallExpr:
+      return substituteCall(
+          *this, builder_, expr->as<Call>(), sources, targets);
+    case PlanType::kFieldExpr:
+      return substituteField(*this, expr->as<Field>(), sources, targets);
+    case PlanType::kLambdaExpr:
+      return substituteLambda(*this, expr->as<Lambda>(), sources, targets);
+    default:
+      VELOX_NYI(
+          "ExprFactory::substitute: unsupported expression type {}",
+          expr->typeName());
+  }
+}
+
+ExprVector ExprFactory::substitute(
+    const ExprVector& exprs,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprVector substituted;
+  substituted.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    substituted.push_back(substitute(expr, sources, targets));
+  }
+  return substituted;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Constructors for the recurring `Call` expression shapes that
+/// translate, decorrelate, and downstream rewrites need. Holds a
+/// `Builder&` so hash-cons construction goes through the right cache;
+/// construct one per logical "rewrite context" (typically once per
+/// pass / per `Translator`).
+///
+/// Column synthesis lives on the `Column` class itself
+/// (`Column::create(prefix, value)`) since `Column` is arena-allocated,
+/// not hash-consed via `Builder`.
+///
+/// New combinators belong here, not as free functions scattered across
+/// caller files. Each method enforces the shared invariants (correct
+/// `FunctionSet` propagation via `Call::unionArgFunctions`, function
+/// names sourced from `FunctionRegistry`, cardinality conventions for
+/// boolean results) so call sites can't get them wrong.
+///
+/// Combinators do not null-handle their operands; callers that pass
+/// optional predicates should null-check before delegating. Methods
+/// that source their function name from `FunctionRegistry` throw
+/// `VELOX_USER_CHECK` if the active dialect did not register that
+/// function.
+class ExprFactory {
+ public:
+  explicit ExprFactory(Builder& builder) : builder_(builder) {}
+
+  /// Flattens an AND tree into conjuncts. `expr` may be an AND call
+  /// (nested arbitrarily) or any other expression (appended as a
+  /// single conjunct).
+  static ExprVector flattenAnd(ExprCP expr);
+  static void flattenAnd(ExprCP expr, ExprVector& conjuncts);
+
+  /// Flattens an OR tree into disjuncts. `expr` may be an OR call
+  /// (nested arbitrarily) or any other expression (appended as a
+  /// single disjunct).
+  static ExprVector flattenOr(ExprCP expr);
+  static void flattenOr(ExprCP expr, ExprVector& disjuncts);
+
+  /// Builds `lhs AND rhs`.
+  ExprCP makeAnd(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `lhs OR rhs`.
+  ExprCP makeOr(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `not(arg)`. Preserves three-valued logic: `not(NULL)` is
+  /// NULL. Used to turn a semi-project mark into the antijoin predicate.
+  ExprCP makeNot(ExprCP arg);
+
+  /// Builds `lhs = rhs`.
+  ExprCP makeEq(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `lhs <= rhs`.
+  ExprCP makeLessThanOrEqual(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `is_null(arg)`. Result is BOOLEAN and is never NULL —
+  /// returns `true` when 'arg' is NULL and `false` otherwise.
+  ExprCP makeIsNull(ExprCP arg);
+
+  /// Builds `coalesce(value, fallback)`. Both operands must be of the
+  /// same type per Velox's COALESCE rules; the factory does not verify.
+  ExprCP makeCoalesce(ExprCP value, ExprCP fallback);
+
+  /// Builds `if(condition, thenExpr, elseExpr)`. `thenExpr` and
+  /// `elseExpr` must be the same type per Velox's IF rules; the factory
+  /// does not verify.
+  ExprCP makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr);
+
+  /// Substitutes the i-th source `Column*` with the i-th `target`
+  /// Expr in `expr`, returning a rewritten Expr. Handles
+  /// Column/Literal/Call/Field/Lambda. Columns not in `sources` pass
+  /// through unchanged. `Call`s with at least one substituted child
+  /// are rebuilt through `Builder::makeCall` so hash-consing remains
+  /// canonical; Field/Lambda are rebuilt through `make`
+  /// (arena allocator, no dedup table). For Lambda, bound args are
+  /// removed from the source mapping before recursing into the body
+  /// — callers don't need to filter them out.
+  ///
+  /// `kAggregateExpr` substitution is not implemented (aggregates only
+  /// live inside `Aggregate` nodes, not embedded in scalar expressions
+  /// we substitute through); throws `VELOX_NYI` if encountered.
+  ExprCP substitute(
+      ExprCP expr,
+      const ColumnVector& sources,
+      const ExprVector& targets);
+
+  /// Applies `substitute` to each element of `exprs`, returning the
+  /// rewritten vector in the same order.
+  ExprVector substitute(
+      const ExprVector& exprs,
+      const ColumnVector& sources,
+      const ExprVector& targets);
+
+  /// Left-folds a non-empty sequence of boolean predicates with
+  /// `makeAnd`: `[p1, p2, p3]` → `AND(AND(p1, p2), p3)`. Single-element
+  /// input returns the predicate unchanged. The empty case is a
+  /// caller error (no neutral element is constructed).
+  template <typename Range>
+  ExprCP andAll(const Range& predicates) {
+    auto it = std::begin(predicates);
+    auto end = std::end(predicates);
+    VELOX_CHECK(it != end, "andAll requires a non-empty sequence");
+    ExprCP result = *it++;
+    for (; it != end; ++it) {
+      result = makeAnd(result, *it);
+    }
+    return result;
+  }
+
+  /// Left-folds a non-empty sequence of boolean predicates with
+  /// `makeOr`. Single-element input returns the predicate unchanged.
+  /// The empty case is a caller error.
+  template <typename Range>
+  ExprCP orAll(const Range& predicates) {
+    auto it = std::begin(predicates);
+    auto end = std::end(predicates);
+    VELOX_CHECK(it != end, "orAll requires a non-empty sequence");
+    ExprCP result = *it++;
+    for (; it != end; ++it) {
+      result = makeOr(result, *it);
+    }
+    return result;
+  }
+
+ private:
+  // Builds a BOOLEAN-typed (cardinality 2) call named `name` over
+  // `arguments`, seeding the `FunctionSet` from the function's own bits
+  // (`specialForm` selects special-form vs registered-function lookup)
+  // OR'd with each argument's.
+  ExprCP makeBooleanCall(Name name, ExprVector arguments, bool specialForm);
+
+  Builder& builder_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprSimplifier.cpp
+++ b/axiom/optimizer/v2/ExprSimplifier.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprSimplifier.h"
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/ExprEmitter.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "velox/expression/ConstantExpr.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// If `orExpr` is an OR call and its disjuncts share AND-conjuncts,
+// appends those common conjuncts to `common` and sets `*residual` to
+// the rewritten OR (or nullptr when a disjunct was fully subsumed and
+// the OR is trivially true once `common` holds). Returns true iff
+// any factoring was performed; on false, `common` and `*residual`
+// are unmodified.
+bool tryFactorOr(
+    Builder& builder,
+    ExprCP orExpr,
+    ExprVector& common,
+    ExprCP* residual) {
+  if (!orExpr->is(PlanType::kCallExpr) ||
+      orExpr->as<Call>()->name() != SpecialFormCallNames::kOr) {
+    return false;
+  }
+  ExprVector disjuncts = ExprFactory::flattenOr(orExpr);
+
+  // Dedup disjuncts. Hash-cons guarantees pointer equality for
+  // structurally identical exprs.
+  folly::F14FastSet<ExprCP> seen;
+  ExprVector uniqueDisjuncts;
+  uniqueDisjuncts.reserve(disjuncts.size());
+  for (ExprCP disjunct : disjuncts) {
+    if (seen.insert(disjunct).second) {
+      uniqueDisjuncts.push_back(disjunct);
+    }
+  }
+  if (uniqueDisjuncts.size() < 2) {
+    return false;
+  }
+
+  // Flatten each disjunct into its AND-conjuncts.
+  std::vector<ExprVector> perDisjunctConjuncts;
+  perDisjunctConjuncts.reserve(uniqueDisjuncts.size());
+  for (ExprCP disjunct : uniqueDisjuncts) {
+    perDisjunctConjuncts.push_back(ExprFactory::flattenAnd(disjunct));
+  }
+
+  // Intersect across all disjuncts.
+  folly::F14FastSet<ExprCP> commonSet(
+      perDisjunctConjuncts[0].begin(), perDisjunctConjuncts[0].end());
+  for (size_t i = 1; i < perDisjunctConjuncts.size(); ++i) {
+    folly::F14FastSet<ExprCP> next(
+        perDisjunctConjuncts[i].begin(), perDisjunctConjuncts[i].end());
+    folly::F14FastSet<ExprCP> intersected;
+    for (ExprCP conjunct : commonSet) {
+      if (next.contains(conjunct)) {
+        intersected.insert(conjunct);
+      }
+    }
+    commonSet = std::move(intersected);
+  }
+  if (commonSet.empty()) {
+    return false;
+  }
+
+  // Build residuals; any empty residual means that disjunct is fully
+  // subsumed by `common`, so the OR is trivially true given `common`.
+  ExprFactory factory(builder);
+  ExprVector residualDisjuncts;
+  residualDisjuncts.reserve(uniqueDisjuncts.size());
+  bool subsumed = false;
+  for (auto& conjuncts : perDisjunctConjuncts) {
+    ExprVector remaining;
+    remaining.reserve(conjuncts.size());
+    for (ExprCP conjunct : conjuncts) {
+      if (!commonSet.contains(conjunct)) {
+        remaining.push_back(conjunct);
+      }
+    }
+    if (remaining.empty()) {
+      subsumed = true;
+      break;
+    }
+    residualDisjuncts.push_back(factory.andAll(remaining));
+  }
+
+  // Append common in first-disjunct order to keep deterministic output.
+  for (ExprCP conjunct : perDisjunctConjuncts[0]) {
+    if (commonSet.contains(conjunct)) {
+      common.push_back(conjunct);
+    }
+  }
+  *residual = subsumed ? nullptr : factory.orAll(residualDisjuncts);
+  return true;
+}
+
+} // namespace
+
+ExprCP ExprSimplifier::simplify(ExprCP expr) {
+  return tryFoldConstant(expr);
+}
+
+bool ExprSimplifier::simplifyFilter(ExprCP predicate, ExprVector& into) {
+  ExprVector flattened = ExprFactory::flattenAnd(predicate);
+  ExprVector surviving;
+  surviving.reserve(flattened.size());
+  for (ExprCP conjunct : flattened) {
+    ExprCP simplified = simplify(conjunct);
+    if (simplified->is(PlanType::kLiteralExpr)) {
+      const auto& variant = simplified->as<Literal>()->literal();
+      VELOX_CHECK_EQ(
+          variant.kind(),
+          velox::TypeKind::BOOLEAN,
+          "Conjunct simplified to a non-boolean literal");
+      if (variant.isNull() || !variant.value<bool>()) {
+        return true;
+      }
+      // Literal `true` — drop.
+      continue;
+    }
+    ExprCP residual = nullptr;
+    if (tryFactorOr(builder_, simplified, surviving, &residual)) {
+      if (residual != nullptr) {
+        surviving.push_back(residual);
+      }
+      continue;
+    }
+    surviving.push_back(simplified);
+  }
+  appendAll(into, surviving);
+  return false;
+}
+
+ExprCP ExprSimplifier::tryFoldConstant(ExprCP expr) {
+  if (expr->is(PlanType::kLiteralExpr)) {
+    return expr;
+  }
+
+  if (!expr->columns().empty()) {
+    return expr;
+  }
+
+  try {
+    auto typedExpr = ExprEmitter{evaluator_.pool()}.toTypedExpr(expr);
+    auto exprSet = evaluator_.compile(typedExpr);
+    const auto& first = *exprSet->exprs().front();
+    if (!first.isConstant()) {
+      return expr;
+    }
+    const auto& constantExpr =
+        static_cast<const velox::exec::ConstantExpr&>(first);
+    auto variant = constantExpr.value()->variantAt(0);
+    Value value(toType(constantExpr.type()), 1);
+    auto* registered = queryCtx()->registerVariant(
+        std::make_unique<velox::Variant>(std::move(variant)));
+    return builder_.makeLiteral(value, registered);
+  } catch (const velox::VeloxException&) {
+    // Data-dependent evaluation failure on constant args (e.g.
+    // division-by-zero, invalid cast). Leave the call unchanged so the
+    // error surfaces at execution.
+    return expr;
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprSimplifier.h
+++ b/axiom/optimizer/v2/ExprSimplifier.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "velox/core/ExpressionEvaluator.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Reduces expressions to simpler equivalent forms — today constant
+/// folding of column-free expressions; algebraic and boolean identities
+/// (`a + 0 → a`, `true AND f → f`, …) plug in as the rule set grows.
+///
+/// `evaluator` must outlive this `ExprSimplifier` and any IR it
+/// produces: folded constants register `Variant`s in the
+/// `QueryGraphContext`, but vectors produced during compilation are
+/// allocated on the evaluator's pool and may be referenced by Velox
+/// plan nodes that emit later constructs from the same IR.
+class ExprSimplifier {
+ public:
+  ExprSimplifier(Builder& builder, velox::core::ExpressionEvaluator& evaluator)
+      : builder_(builder), evaluator_(evaluator) {}
+
+  /// Returns the simplified `expr`, or `expr` unchanged if no rule
+  /// applies.
+  ExprCP simplify(ExprCP expr);
+
+  /// Splits a filter `predicate` into conjuncts (AND-flattened),
+  /// simplifies each, and applies filter semantics: a literal `true`
+  /// conjunct is dropped; a literal `false` or `NULL` conjunct
+  /// short-circuits (filter passes only on `TRUE`, so `NULL` is
+  /// equivalent to `FALSE`).
+  ///
+  /// Returns true iff the filter is statically known to drop every
+  /// row; on true return `into` is unmodified. Returns false
+  /// otherwise and appends the surviving (flattened, simplified,
+  /// non-trivial) conjuncts to `into`. An empty `into` after a false
+  /// return means `predicate` is statically `true` and the filter can
+  /// be removed.
+  bool simplifyFilter(ExprCP predicate, ExprVector& into);
+
+ private:
+  // Folds `expr` to a `Literal` when it has no column refs and the
+  // evaluator produces a single constant value. Otherwise returns
+  // `expr` unchanged.
+  ExprCP tryFoldConstant(ExprCP expr);
+
+  Builder& builder_;
+  velox::core::ExpressionEvaluator& evaluator_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinCondition.cpp
+++ b/axiom/optimizer/v2/JoinCondition.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinCondition.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+JoinCondition::Split JoinCondition::splitEquiKeys(
+    const ExprVector& conjuncts,
+    const PlanObjectSet& leftColumns,
+    const PlanObjectSet& rightColumns) {
+  Split result;
+  const Name equalityName = toName(FunctionRegistry::instance()->equality());
+  for (ExprCP conjunct : conjuncts) {
+    if (!conjunct->is(PlanType::kCallExpr)) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    const auto* call = conjunct->as<Call>();
+    if (call->name() != equalityName || call->args().size() != 2) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    ExprCP lhs = call->args()[0];
+    ExprCP rhs = call->args()[1];
+    const auto& lhsCols = lhs->columns();
+    const auto& rhsCols = rhs->columns();
+    if (lhsCols.empty() || rhsCols.empty()) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    if (lhsCols.isSubset(leftColumns) && rhsCols.isSubset(rightColumns)) {
+      result.leftKeys.push_back(lhs);
+      result.rightKeys.push_back(rhs);
+      continue;
+    }
+    if (lhsCols.isSubset(rightColumns) && rhsCols.isSubset(leftColumns)) {
+      result.leftKeys.push_back(rhs);
+      result.rightKeys.push_back(lhs);
+      continue;
+    }
+    result.residual.push_back(conjunct);
+  }
+  return result;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinCondition.h
+++ b/axiom/optimizer/v2/JoinCondition.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Normalizes raw join-condition conjuncts into the Join IR's split
+/// form. The invariant `Join` callers rely on: any `eq(leftExpr,
+/// rightExpr)` conjunct whose sides partition cleanly into one side
+/// each lives in `leftKeys` / `rightKeys`, never in `filter`.
+class JoinCondition {
+ public:
+  /// Output of `splitEquiKeys`: paired equi-keys plus the residual
+  /// non-equi conjuncts.
+  struct Split {
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+    ExprVector residual;
+  };
+
+  /// Walks `conjuncts` (typically the flattened AND-conjuncts of a join
+  /// condition). For each `eq(lhs, rhs)` whose `lhs` references only
+  /// `leftColumns` and `rhs` only `rightColumns` (or vice versa, with
+  /// the pair swapped to canonical left/right order), records it as a
+  /// `(leftKey, rightKey)` pair. Anything not matching that pattern
+  /// stays in `residual`.
+  static Split splitEquiKeys(
+      const ExprVector& conjuncts,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/KeyHash.h
+++ b/axiom/optimizer/v2/KeyHash.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hashes a single value. Pointer / integer / enum / range / Frame are
+/// handled generically; pointer-elements of ranges are hashed by address,
+/// matching how `Key::operator==` compares them.
+template <typename T>
+size_t hashOne(const T& value);
+
+// Forward declaration: keeps `hashOf` (template) able to resolve to this
+// non-template overload during phase-1 name lookup; otherwise the generic
+// `hashOne<Frame>` template hits the catch-all static_assert.
+size_t hashOne(const Frame& frame);
+
+/// Hashes a list of fields by combining `hashOne` of each via `hashMix`.
+template <typename... Args>
+size_t hashOf(const Args&... args) {
+  size_t hash = 0;
+  ((hash = velox::bits::hashMix(hash, hashOne(args))), ...);
+  return hash;
+}
+
+inline size_t hashOne(const Frame& frame) {
+  return hashOf(
+      frame.type,
+      frame.startType,
+      frame.startValue,
+      frame.endType,
+      frame.endValue);
+}
+
+template <typename T>
+size_t hashOne(const T& value) {
+  if constexpr (std::is_pointer_v<T>) {
+    return reinterpret_cast<uintptr_t>(value);
+  } else if constexpr (std::is_enum_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (std::is_integral_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (requires {
+                         value.begin();
+                         value.end();
+                       }) {
+    size_t hash = 0;
+    for (const auto& element : value) {
+      hash = velox::bits::hashMix(hash, hashOne(element));
+    }
+    return hash;
+  } else {
+    static_assert(
+        sizeof(T) == 0, "Add a hashOne overload for this type in KeyHash.h");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1,0 +1,1983 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Node.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/KeyHash.h"
+#include "axiom/optimizer/v2/NodePrinter.h"
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+const auto& nodeTypeNames() {
+  static const folly::F14FastMap<NodeType, std::string_view> kNames = {
+      {NodeType::kScan, "Scan"},
+      {NodeType::kFilter, "Filter"},
+      {NodeType::kProject, "Project"},
+      {NodeType::kLimit, "Limit"},
+      {NodeType::kSort, "Sort"},
+      {NodeType::kTopN, "TopN"},
+      {NodeType::kAggregate, "Aggregate"},
+      {NodeType::kGroupId, "GroupId"},
+      {NodeType::kMarkDistinct, "MarkDistinct"},
+      {NodeType::kValues, "Values"},
+      {NodeType::kUnnest, "Unnest"},
+      {NodeType::kUnionAll, "UnionAll"},
+      {NodeType::kJoin, "Join"},
+      {NodeType::kWindow, "Window"},
+      {NodeType::kTopNRowNumber, "TopNRowNumber"},
+      {NodeType::kApply, "Apply"},
+      {NodeType::kEnforceSingleRow, "EnforceSingleRow"},
+      {NodeType::kAssignUniqueId, "AssignUniqueId"},
+      {NodeType::kEnforceDistinct, "EnforceDistinct"},
+      {NodeType::kExchange, "Exchange"},
+      {NodeType::kTableWrite, "TableWrite"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
+
+std::string Node::toString() const {
+  return NodePrinter::toText(this);
+}
+
+namespace {
+
+// Per-operator derivation of per-driver local properties. Each node computes
+// these in its constructor from its already-constructed inputs; distribution
+// and relation-level properties are added with their consumers.
+
+// Keeps the local properties expressible over `columns`: a `kGrouped` entry
+// survives only if all its columns do; a `kSorted` entry is truncated to its
+// leading run of columns in `columns`. A dropped or truncated entry ends the
+// list — nothing nested under a broken outer property still holds.
+LocalPropertyVector projectLocal(
+    const LocalPropertyVector& local,
+    const PlanObjectSet& columns) {
+  LocalPropertyVector result;
+  for (const LocalProperty& property : local) {
+    if (property.kind == LocalPropertyKind::kGrouped) {
+      if (!columns.containsAll(property.columns)) {
+        break;
+      }
+      result.push_back(property);
+      continue;
+    }
+    LocalProperty truncated{.kind = LocalPropertyKind::kSorted};
+    for (size_t i = 0; i < property.columns.size(); ++i) {
+      if (!columns.contains(property.columns[i])) {
+        break;
+      }
+      truncated.columns.push_back(property.columns[i]);
+      truncated.orders.push_back(property.orders[i]);
+    }
+    if (truncated.columns.empty()) {
+      break;
+    }
+    const bool full = truncated.columns.size() == property.columns.size();
+    result.push_back(std::move(truncated));
+    if (!full) {
+      break;
+    }
+  }
+  return result;
+}
+
+// Keeps an input's local properties expressible over `columns` (see
+// `projectLocal`), for a node that emits only a subset of its input.
+LocalPropertyVector retainedLocal(NodeCP input, const ColumnVector& columns) {
+  return projectLocal(
+      input->physicalProperties().local, PlanObjectSet::fromObjects(columns));
+}
+
+// Keeps an input's unique key-sets whose columns all survive in `columns`, for
+// a node that emits only a subset of its input. A key-set with a dropped member
+// is no longer a key of the output, so it is removed whole.
+UniqueKeySetVector retainedUnique(NodeCP input, const ColumnVector& columns) {
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : input->physicalProperties().unique) {
+    if (key.columns.isSubset(columnSet)) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// A single `Sorted` property over the leading run of `keys` that are columns,
+// paired with their orders. A computed sort key is not an output column, so it
+// (and everything after it) is dropped; empty when the first key is not a
+// column.
+LocalPropertyVector sortedLocal(
+    const ExprVector& keys,
+    const OrderTypeVector& orderTypes) {
+  ColumnVector columns;
+  OrderTypeVector orders;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->isColumn()) {
+      break;
+    }
+    columns.push_back(keys[i]->as<Column>());
+    orders.push_back(orderTypes[i]);
+  }
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back(
+      {.kind = LocalPropertyKind::kSorted,
+       .columns = std::move(columns),
+       .orders = std::move(orders)});
+  return result;
+}
+
+// Local ordering an exchange's output carries: an order-preserving gather keeps
+// the merged sort order; every other exchange interleaves rows and keeps none.
+LocalPropertyVector exchangeLocal(const Partitioning& partitioning) {
+  if (partitioning.orderKeys.empty()) {
+    return {};
+  }
+  return sortedLocal(partitioning.orderKeys, partitioning.orderTypes);
+}
+
+// A single `Grouped` property over `columns` (empty when there are none).
+LocalPropertyVector groupedLocal(const ColumnVector& columns) {
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back({.kind = LocalPropertyKind::kGrouped, .columns = columns});
+  return result;
+}
+
+// A single `Grouped` property over one column.
+LocalPropertyVector groupedLocal(ColumnCP column) {
+  ColumnVector columns;
+  columns.push_back(column);
+  return groupedLocal(columns);
+}
+
+// A single global unique key over 'column' (e.g. AssignUniqueId's id).
+UniqueKeySetVector globalUniqueKey(ColumnCP column) {
+  UniqueKeySetVector result;
+  result.push_back(
+      UniqueKeySet{
+          .columns = PlanObjectSet::single(column),
+          .scope = PropertyScope::kGlobal});
+  return result;
+}
+
+// Uniqueness that survives a remote exchange. A repartition/gather moves rows
+// without duplicating them, so global uniqueness holds; but it can gather
+// cross-driver duplicates onto one driver, so driver-scope uniqueness does not
+// survive. A broadcast replicates rows and destroys even global uniqueness.
+UniqueKeySetVector uniqueAcrossExchange(
+    const UniqueKeySetVector& unique,
+    const Partitioning& partitioning) {
+  if (partitioning.is(PartitionKind::kBroadcast)) {
+    return {};
+  }
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : unique) {
+    if (key.scope == PropertyScope::kGlobal) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// Local grouping an inner/left join gains from probe uniqueness: a hash join
+// emits each probe row's matches as one contiguous run, so the output is
+// grouped by any key unique on the probe whose columns all survive —
+// independent of the probe's input order, so this holds even after an exchange
+// erased the probe's own local grouping. Caveat: a spilling probe or a
+// driver-scrambling local exchange breaks it; valid at single-fragment,
+// numDrivers=1.
+void appendProbeUniqueGroupings(
+    NodeCP left,
+    const PlanObjectSet& outputColumns,
+    LocalPropertyVector& local) {
+  for (const UniqueKeySet& key : left->physicalProperties().unique) {
+    if (key.columns.isSubset(outputColumns)) {
+      local.push_back(
+          LocalProperty{
+              .kind = LocalPropertyKind::kGrouped,
+              .columns = key.columns.template toObjects<Column>()});
+    }
+  }
+}
+
+// The probe (left) side's local properties survive an inner / left join within
+// a driver; build-emitting and cross joins drop them.
+// TODO: order through a spillable join is not guaranteed once spilling is
+// enabled; revisit when spilling is modeled.
+LocalPropertyVector joinLocal(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType == velox::core::JoinType::kInner ||
+      joinType == velox::core::JoinType::kLeft) {
+    LocalPropertyVector local = retainedLocal(left, outputColumns);
+    appendProbeUniqueGroupings(
+        left, PlanObjectSet::fromObjects(outputColumns), local);
+    return local;
+  }
+  return {};
+}
+
+// Properties an operator inherits when it neither repartitions nor changes
+// which rows exist in a way that breaks them: the input's distribution (minus
+// its merge order, which belonged to the gather it came from — see
+// `Partitioning::dropOrder`), local properties, and uniqueness. Such an
+// operator keeps all of the input's columns, so every inherited property
+// already references output columns.
+PhysicalProperties passThroughProperties(NodeCP input) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = props.local,
+      .unique = props.unique};
+}
+
+// Properties of an operator that sorts its input on `orderKeys` without moving
+// rows across tasks: it keeps the input's distribution and uniqueness and adds
+// the per-driver sort order. A distributed sort is a per-task sort under a
+// separate gather-merge exchange, and a single-stage sort runs over an
+// already-gathered input — so the sort node itself inherits the input's
+// partitioning either way (it is not the gather).
+PhysicalProperties sortedProperties(
+    NodeCP input,
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = sortedLocal(orderKeys, orderTypes),
+      .unique = props.unique};
+}
+
+// Remaps the input partitioning through a Project's column map: each partition
+// key (an input column) is re-expressed on the output column that projects it,
+// whether identity or rename (`exprs[i]` is a bare reference to the key, so its
+// output column `outputColumns[i]` carries the same values, hence the same hash
+// partition). A key not projected as a bare column — dropped, or appearing only
+// inside a computed expression — drops the partition to unspecified. Gather and
+// unspecified pass through unchanged.
+Partitioning projectGlobalPartition(
+    NodeCP input,
+    const ExprVector& exprs,
+    const ColumnVector& outputColumns) {
+  const Partitioning& partitioning =
+      input->physicalProperties().globalPartition;
+  if (partitioning.kind != PartitionKind::kPartitioned) {
+    return partitioning.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(partitioning.keys.size());
+  for (ExprCP key : partitioning.keys) {
+    ExprCP projected = nullptr;
+    for (size_t i = 0; i < exprs.size(); ++i) {
+      if (exprs[i]->sameOrEqual(*key)) {
+        projected = outputColumns[i];
+        break;
+      }
+    }
+    if (projected == nullptr) {
+      return {};
+    }
+    keys.push_back(projected);
+  }
+  Partitioning result = partitioning;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// An output column equal to 'key', or null. Inner-join equalities merge the
+// equated columns into one equivalence class (see Column::equals); every member
+// holds the same value on every output row, so any surviving class member
+// partitions the output exactly as 'key' does. Only columns form equivalence
+// classes, so a non-column key has no substitute.
+ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
+  if (!key->is(PlanType::kColumnExpr)) {
+    return nullptr;
+  }
+
+  if (const auto* equivalence = key->as<Column>()->equivalence()) {
+    for (ColumnCP column : equivalence->columns) {
+      if (outputColumns.contains(column)) {
+        return column;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+// Output global partitioning of a join. Only an inner or left join keeps the
+// probe (left) rows in their partitions, so only those preserve a probe
+// partition; other join types drop it. If every probe key is still an output
+// column, the output is partitioned exactly as the probe was. Otherwise an
+// inner join recovers each remaining key: it keeps a key whose columns all
+// survive (a join projects columns unchanged, so a surviving column is
+// identity-projected, and an expression over surviving columns still partitions
+// the output), else substitutes an equal output column from the key's
+// inner-join equivalence class. A left join can't recover a key from its
+// null-padded build, so a dropped key makes its partition unspecified. A
+// non-hash distribution (gather / broadcast / arbitrary) carries no keys and is
+// inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
+Partitioning joinGlobalPartition(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType != velox::core::JoinType::kInner &&
+      joinType != velox::core::JoinType::kLeft) {
+    return {};
+  }
+
+  const Partitioning& probe = left->physicalProperties().globalPartition;
+  if (probe.kind != PartitionKind::kPartitioned) {
+    return probe.dropOrder();
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(outputColumns);
+  if (outputSet.containsAll(probe.keys)) {
+    return probe;
+  }
+
+  if (joinType != velox::core::JoinType::kInner) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(probe.keys.size());
+  for (ExprCP key : probe.keys) {
+    if (outputSet.containsColumns(key)) {
+      keys.push_back(key);
+      continue;
+    }
+    ExprCP equiKey = survivingEquiKey(key, outputSet);
+    if (equiKey == nullptr) {
+      return {};
+    }
+    keys.push_back(equiKey);
+  }
+
+  Partitioning result = probe;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// The input's partitioning re-expressed on the aggregate's output. An aggregate
+// streams over its input without moving rows, so it preserves the input's
+// partitioning — but only when that partitioning's keys are all grouping keys
+// (the only input values the aggregate keeps): then those keys are a
+// co-location of the groups and survive in the output, re-expressed on the
+// grouping output columns they map to. An input partitioned on anything else
+// does not co-locate the groups (it should not feed the aggregate at all) and
+// could not be expressed on the output, so the partitioning is unknown. A
+// grouping-set aggregate reads its GroupId, which has no known partitioning, so
+// it falls into the unknown case. A non-hash distribution (gather / broadcast /
+// arbitrary) is inherited by kind only, with its merge order dropped (see
+// `Partitioning::dropOrder`), as the aggregate reorders rows and so does not
+// preserve one. `groupingColumns` are the output columns holding the grouping
+// values, aligned with `groupingKeys`.
+Partitioning aggregateInputPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  const Partitioning& inputPartition =
+      input->physicalProperties().globalPartition;
+  if (inputPartition.kind != PartitionKind::kPartitioned) {
+    return inputPartition.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(inputPartition.keys.size());
+  for (ExprCP key : inputPartition.keys) {
+    const auto it = std::ranges::find(groupingKeys, key);
+    if (it == groupingKeys.end()) {
+      return {};
+    }
+    keys.push_back(groupingColumns[it - groupingKeys.begin()]);
+  }
+  Partitioning result = inputPartition;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// Output partitioning of a complete (single / final) aggregation: a global
+// aggregate gathers to one task; otherwise the input's partitioning
+// re-expressed on the output (see `aggregateInputPartition`).
+Partitioning aggregateGlobalPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  if (groupingKeys.empty()) {
+    return Partitioning::globalGather();
+  }
+  return aggregateInputPartition(input, groupingKeys, groupingColumns);
+}
+
+// Output partitioning of a scan of a bucketed (connector-partitioned) table:
+// the connector's partition function on the output columns matching the
+// layout's partition columns. Unspecified when the table is not partitioned or
+// a partition column is not in the scan's output (so the partitioning can't be
+// expressed over the output).
+Partitioning scanGlobalPartition(const Scan::Key& key) {
+  const auto* schemaTable = key.baseTable->schemaTable;
+  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
+    return {};
+  }
+  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
+  if (layout == nullptr) {
+    return {};
+  }
+  const auto partitionType = layout->partitionType();
+  const auto& partitionColumns = layout->partitionColumns();
+  if (partitionType == nullptr || partitionColumns.empty()) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(partitionColumns.size());
+  for (const auto* partitionColumn : partitionColumns) {
+    ColumnCP match = nullptr;
+    for (ColumnCP column : key.outputColumns) {
+      if (column->name() == partitionColumn->name()) {
+        match = column;
+        break;
+      }
+    }
+    if (match == nullptr) {
+      return {};
+    }
+    keys.push_back(match);
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = partitionType.get(),
+      .keys = std::move(keys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+Scan::Scan(Key key)
+    : Node(
+          NodeType::kScan,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = scanGlobalPartition(key)}),
+      baseTable_(key.baseTable),
+      filters_(std::move(key.filters)) {
+  VELOX_CHECK_NOT_NULL(baseTable_);
+  folly::F14FastSet<std::string_view> schemaNames;
+  folly::F14FastSet<std::string> outputNames;
+  schemaNames.reserve(this->outputColumns().size());
+  outputNames.reserve(this->outputColumns().size());
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        schemaNames.insert(column->name()).second,
+        "Scan outputColumns contains duplicate underlying column name: {}",
+        column->name());
+    VELOX_CHECK(
+        outputNames.insert(column->outputName()).second,
+        "Scan outputColumns contains duplicate output name: {}",
+        column->outputName());
+  }
+}
+
+size_t Scan::KeyHash::operator()(const Scan* node) const {
+  return hashOf(node->baseTable(), node->outputColumns(), node->filters());
+}
+
+size_t Scan::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.baseTable, key.outputColumns, key.filters);
+}
+
+bool Scan::KeyEq::operator()(const Scan* left, const Scan* right) const {
+  return left->baseTable() == right->baseTable() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->filters() == right->filters();
+}
+
+bool Scan::KeyEq::operator()(const Key& key, const Scan* node) const {
+  return key.baseTable == node->baseTable() &&
+      key.outputColumns == node->outputColumns() &&
+      key.filters == node->filters();
+}
+
+bool Scan::KeyEq::operator()(const Scan* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Filter::Filter(Key key)
+    : Node(
+          NodeType::kFilter,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      predicates_(std::move(key.predicates)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!predicates_.empty(), "Filter must have at least one predicate");
+}
+
+size_t Filter::KeyHash::operator()(const Filter* filter) const {
+  return hashOf(filter->input(), filter->predicates());
+}
+
+size_t Filter::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.predicates);
+}
+
+bool Filter::KeyEq::operator()(const Filter* left, const Filter* right) const {
+  return left->input() == right->input() &&
+      left->predicates() == right->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Key& key, const Filter* filter) const {
+  return key.input == filter->input() && key.predicates == filter->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Filter* filter, const Key& key) const {
+  return (*this)(key, filter);
+}
+
+Project::Project(Key key)
+    : Node(
+          NodeType::kProject,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = projectGlobalPartition(
+                  key.input,
+                  key.exprs,
+                  key.outputColumns),
+              .local = retainedLocal(key.input, key.outputColumns),
+              .unique = retainedUnique(key.input, key.outputColumns)}),
+      input_(key.input),
+      exprs_(std::move(key.exprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(this->outputColumns().size(), exprs_.size());
+}
+
+size_t Project::KeyHash::operator()(const Project* node) const {
+  return hashOf(node->input(), node->outputColumns(), node->exprs());
+}
+
+size_t Project::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.outputColumns, key.exprs);
+}
+
+bool Project::KeyEq::operator()(const Project* left, const Project* right)
+    const {
+  return left->input() == right->input() && left->exprs() == right->exprs() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Key& key, const Project* node) const {
+  return key.input == node->input() && key.exprs == node->exprs() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Project* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Limit::Limit(Key key)
+    : Node(
+          NodeType::kLimit,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t Limit::KeyHash::operator()(const Limit* node) const {
+  return hashOf(node->input(), node->offset(), node->count());
+}
+
+size_t Limit::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.offset, key.count);
+}
+
+bool Limit::KeyEq::operator()(const Limit* left, const Limit* right) const {
+  return left->input() == right->input() && left->offset() == right->offset() &&
+      left->count() == right->count();
+}
+
+bool Limit::KeyEq::operator()(const Key& key, const Limit* node) const {
+  return key.input == node->input() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool Limit::KeyEq::operator()(const Limit* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Sort::Sort(Key key)
+    : Node(
+          NodeType::kSort,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "Sort must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Sort::KeyHash::operator()(const Sort* node) const {
+  return hashOf(node->input(), node->orderKeys(), node->orderTypes());
+}
+
+size_t Sort::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.orderKeys, key.orderTypes);
+}
+
+bool Sort::KeyEq::operator()(const Sort* left, const Sort* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Key& key, const Sort* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Sort* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopN::TopN(Key key)
+    : Node(
+          NodeType::kTopN,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopN must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t TopN::KeyHash::operator()(const TopN* node) const {
+  return hashOf(
+      node->input(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->offset(),
+      node->count());
+}
+
+size_t TopN::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.orderKeys, key.orderTypes, key.offset, key.count);
+}
+
+bool TopN::KeyEq::operator()(const TopN* left, const TopN* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->offset() == right->offset() && left->count() == right->count();
+}
+
+bool TopN::KeyEq::operator()(const Key& key, const TopN* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool TopN::KeyEq::operator()(const TopN* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Physical properties of an aggregate's output, by step. A `kPartial`
+// pre-aggregates per task without moving rows or gathering (even for an empty
+// grouping): it keeps the input's partitioning re-expressed on its output, but
+// its keys are not globally unique (the same key recurs across tasks).
+// `kSingle` / `kFinal` produce the complete result — globally unique on the
+// grouping keys, and partitioned on them when the input is (the `kFinal`'s
+// input is the exchange that partitioned the partials).
+PhysicalProperties aggregateProperties(const Aggregate::Key& key) {
+  // The grouping values are materialized as the leading output columns, aligned
+  // one-to-one with `groupingKeys`; properties are expressed over those output
+  // columns, not the (possibly computed) grouping-key expressions.
+  ColumnVector groupingColumns;
+  groupingColumns.reserve(key.groupingKeys.size());
+  for (size_t i = 0; i < key.groupingKeys.size(); ++i) {
+    groupingColumns.push_back(key.outputColumns[i]);
+  }
+  if (key.step == AggregateStep::kPartial) {
+    return PhysicalProperties{
+        .globalPartition = aggregateInputPartition(
+            key.input, key.groupingKeys, groupingColumns),
+        .local = groupedLocal(groupingColumns)};
+  }
+  // An aggregate emits one row per distinct grouping-key combination, so the
+  // grouping output columns are a global unique key (the empty grouping is the
+  // single global row, unique on the empty set; a grouping-set aggregate's
+  // group-id is one of the keys, so distinct key sets stay distinct).
+  return PhysicalProperties{
+      .globalPartition = aggregateGlobalPartition(
+          key.input, key.groupingKeys, groupingColumns),
+      .local = groupedLocal(groupingColumns),
+      .unique = {UniqueKeySet{
+          .columns = PlanObjectSet::fromObjects(groupingColumns),
+          .scope = PropertyScope::kGlobal}}};
+}
+
+} // namespace
+
+Aggregate::Aggregate(Key key)
+    : Node(
+          NodeType::kAggregate,
+          ColumnVector{key.outputColumns},
+          aggregateProperties(key)),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregates_(std::move(key.aggregates)),
+      step_(key.step),
+      groupId_(key.groupId),
+      globalGroupingSets_(std::move(key.globalGroupingSets)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(), groupingKeys_.size() + aggregates_.size());
+  // Velox couples the two: a group-id key is meaningful for empty-input default
+  // rows only alongside the global sets it labels.
+  VELOX_CHECK_EQ(groupId_ != nullptr, !globalGroupingSets_.empty());
+  if (groupId_ != nullptr) {
+    VELOX_CHECK(
+        std::ranges::find(groupingKeys_, groupId_) != groupingKeys_.end(),
+        "groupId must be one of the grouping keys");
+  }
+}
+
+size_t Aggregate::KeyHash::operator()(const Aggregate* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregates(),
+      node->outputColumns());
+  hash = velox::bits::hashMix(hash, hashOf(node->groupId()));
+  for (auto idx : node->globalGroupingSets()) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(node->step()));
+}
+
+size_t Aggregate::KeyHash::operator()(const Key& key) const {
+  size_t hash =
+      hashOf(key.input, key.groupingKeys, key.aggregates, key.outputColumns);
+  hash = velox::bits::hashMix(hash, hashOf(key.groupId));
+  for (auto idx : key.globalGroupingSets) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(key.step));
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* left, const Aggregate* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregates() == right->aggregates() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->step() == right->step() && left->groupId() == right->groupId() &&
+      left->globalGroupingSets() == right->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Key& key, const Aggregate* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregates == node->aggregates() &&
+      key.outputColumns == node->outputColumns() && key.step == node->step() &&
+      key.groupId == node->groupId() &&
+      key.globalGroupingSets == node->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+GroupId::GroupId(Key key)
+    : Node(NodeType::kGroupId, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregationInputs_(std::move(key.aggregationInputs)),
+      groupingSets_(std::move(key.groupingSets)),
+      groupingKeyColumns_(std::move(key.groupingKeyColumns)),
+      groupId_(key.groupId) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(groupId_);
+  VELOX_CHECK_EQ(groupId_->value().type->kind(), velox::TypeKind::BIGINT);
+  VELOX_CHECK_EQ(groupingKeys_.size(), groupingKeyColumns_.size());
+  VELOX_CHECK(!groupingSets_.empty());
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      groupingKeyColumns_.size() + aggregationInputs_.size() + 1);
+}
+
+size_t GroupId::KeyHash::operator()(const GroupId* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregationInputs(),
+      node->groupingKeyColumns(),
+      node->groupId(),
+      node->outputColumns());
+  const auto& groupingSets = node->groupingSets();
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+size_t GroupId::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.groupingKeys,
+      key.aggregationInputs,
+      key.groupingKeyColumns,
+      key.groupId,
+      key.outputColumns);
+  const auto& groupingSets = key.groupingSets;
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* left, const GroupId* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregationInputs() == right->aggregationInputs() &&
+      left->groupingSets() == right->groupingSets() &&
+      left->groupingKeyColumns() == right->groupingKeyColumns() &&
+      left->groupId() == right->groupId() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const Key& key, const GroupId* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregationInputs == node->aggregationInputs() &&
+      key.groupingSets == node->groupingSets() &&
+      key.groupingKeyColumns == node->groupingKeyColumns() &&
+      key.groupId == node->groupId() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+MarkDistinct::MarkDistinct(Key key)
+    : Node(
+          NodeType::kMarkDistinct,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      markers_(std::move(key.markers)),
+      distinctKeys_(std::move(key.distinctKeys)),
+      masks_(std::move(key.masks)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!markers_.empty());
+  const size_t expectedMarkers = masks_.empty() ? 1 : masks_.size() + 1;
+  VELOX_CHECK_EQ(markers_.size(), expectedMarkers);
+  for (ColumnCP marker : markers_) {
+    VELOX_CHECK_EQ(marker->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  for (ColumnCP mask : masks_) {
+    VELOX_CHECK_EQ(mask->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + markers_.size());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const MarkDistinct* node) const {
+  return hashOf(
+      node->input(),
+      node->markers(),
+      node->distinctKeys(),
+      node->masks(),
+      node->outputColumns());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.markers, key.distinctKeys, key.masks, key.outputColumns);
+}
+
+bool MarkDistinct::KeyEq::operator()(
+    const MarkDistinct* left,
+    const MarkDistinct* right) const {
+  return left->input() == right->input() &&
+      left->markers() == right->markers() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->masks() == right->masks() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const Key& key, const MarkDistinct* node)
+    const {
+  return key.input == node->input() && key.markers == node->markers() &&
+      key.distinctKeys == node->distinctKeys() && key.masks == node->masks() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const MarkDistinct* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Values::Values(Key key)
+    : Node(NodeType::kValues, ColumnVector{key.outputColumns}, {}),
+      source_(key.source),
+      rows_(key.rows) {
+  VELOX_CHECK(
+      source_ == nullptr || rows_ == nullptr,
+      "Values cannot carry both a passthrough source and folded rows");
+
+  const auto numColumns = this->outputColumns().size();
+  if (source_ != nullptr) {
+    const auto& rowType = source_->outputType();
+    VELOX_CHECK_EQ(
+        rowType->size(),
+        numColumns,
+        "Values source schema must match outputColumns count");
+    for (size_t i = 0; i < numColumns; ++i) {
+      VELOX_CHECK(
+          rowType->childAt(i)->equivalent(
+              *this->outputColumns()[i]->value().type),
+          "Values source column {} type must match outputColumns",
+          i);
+    }
+  } else if (rows_ != nullptr) {
+    VELOX_CHECK_EQ(
+        rows_->kind(),
+        velox::TypeKind::ARRAY,
+        "Values folded rows must be an array of row variants");
+    for (const auto& row : rows_->array()) {
+      VELOX_CHECK_EQ(
+          row.kind(),
+          velox::TypeKind::ROW,
+          "Values folded rows must be row variants");
+      VELOX_CHECK_EQ(
+          row.row().size(),
+          numColumns,
+          "Values folded row field count must match outputColumns");
+    }
+  }
+}
+
+size_t Values::KeyHash::operator()(const Values* node) const {
+  return hashOf(node->source(), node->rows(), node->outputColumns());
+}
+
+size_t Values::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.source, key.rows, key.outputColumns);
+}
+
+bool Values::KeyEq::operator()(const Values* left, const Values* right) const {
+  return left->source() == right->source() && left->rows() == right->rows() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Key& key, const Values* node) const {
+  return key.source == node->source() && key.rows == node->rows() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Values* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Unnest::Unnest(Key key)
+    : Node(
+          NodeType::kUnnest,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .local = retainedLocal(key.input, key.replicatedColumns)}),
+      input_(key.input),
+      unnestExpressions_(std::move(key.unnestExpressions)),
+      replicatedColumns_(std::move(key.replicatedColumns)),
+      unnestColumns_(std::move(key.unnestColumns)),
+      ordinalityColumn_(key.ordinalityColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !unnestExpressions_.empty(), "Unnest must have at least one expression");
+  VELOX_CHECK_EQ(
+      unnestColumns_.size(),
+      unnestExpressions_.size(),
+      "Unnest unnestColumns must align with unnestExpressions");
+  // Each expression unnests into one result column for an ARRAY, two (key,
+  // value) for a MAP.
+  for (size_t i = 0; i < unnestExpressions_.size(); ++i) {
+    const auto kind = unnestExpressions_[i]->value().type->kind();
+    if (kind == velox::TypeKind::ARRAY) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          1,
+          "Unnest of an ARRAY expression produces one result column");
+    } else if (kind == velox::TypeKind::MAP) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          2,
+          "Unnest of a MAP expression produces two result columns (key, value)");
+    } else {
+      VELOX_FAIL(
+          "Unnest expression must be ARRAY or MAP, got {}",
+          unnestExpressions_[i]->value().type->toString());
+    }
+  }
+  // Every outputColumns entry must be a Column the structured fields produce: a
+  // replicated input column, a per-expression result, or the ordinality column.
+  // Only per-expression results may be pruned from the output; replicated
+  // columns and the ordinality column must all appear.
+  PlanObjectSet produced;
+  for (ColumnCP column : replicatedColumns_) {
+    produced.add(column);
+  }
+  for (const auto& perExpr : unnestColumns_) {
+    for (ColumnCP column : perExpr) {
+      produced.add(column);
+    }
+  }
+  if (ordinalityColumn_ != nullptr) {
+    produced.add(ordinalityColumn_);
+  }
+
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        produced.contains(column),
+        "Unnest outputColumns references a Column not produced by structured fields");
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(this->outputColumns());
+  for (ColumnCP column : replicatedColumns_) {
+    VELOX_CHECK(
+        outputSet.contains(column),
+        "Unnest replicatedColumns must all appear in outputColumns");
+  }
+  VELOX_CHECK(
+      ordinalityColumn_ == nullptr || outputSet.contains(ordinalityColumn_),
+      "Unnest ordinalityColumn must appear in outputColumns");
+}
+
+size_t Unnest::KeyHash::operator()(const Unnest* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->unnestExpressions(),
+      node->outputColumns(),
+      node->replicatedColumns(),
+      node->ordinalityColumn());
+  const auto& unnestColumns = node->unnestColumns();
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t Unnest::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.unnestExpressions,
+      key.outputColumns,
+      key.replicatedColumns,
+      key.ordinalityColumn);
+  const auto& unnestColumns = key.unnestColumns;
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* left, const Unnest* right) const {
+  return left->input() == right->input() &&
+      left->unnestExpressions() == right->unnestExpressions() &&
+      left->replicatedColumns() == right->replicatedColumns() &&
+      left->unnestColumns() == right->unnestColumns() &&
+      left->ordinalityColumn() == right->ordinalityColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Key& key, const Unnest* node) const {
+  return key.input == node->input() &&
+      key.unnestExpressions == node->unnestExpressions() &&
+      key.replicatedColumns == node->replicatedColumns() &&
+      key.unnestColumns == node->unnestColumns() &&
+      key.ordinalityColumn == node->ordinalityColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Output global partitioning of a union: bucketed on the union output columns
+// when every leg is connector-bucketed on leg columns that map (via legColumns)
+// to those same output columns, with copartitionable partitionings. The
+// representative type is the min-partition-count leg's — its count equals the
+// copartition's — reused as a query-lifetime pointer. Unspecified otherwise, so
+// the union then distributes its legs independently.
+Partitioning unionGlobalPartition(const UnionAll::Key& key) {
+  const connector::PartitionType* representative = nullptr;
+  ExprVector outputKeys;
+  for (size_t leg = 0; leg < key.inputs.size(); ++leg) {
+    const Partitioning& part =
+        key.inputs[leg]->physicalProperties().globalPartition;
+    if (part.kind != PartitionKind::kPartitioned ||
+        part.partitionType == nullptr) {
+      return {};
+    }
+    // Map each leg partition key to the union output column at the same index.
+    const ColumnVector& legColumns = key.legColumns[leg];
+    ExprVector legOutputKeys;
+    legOutputKeys.reserve(part.keys.size());
+    for (ExprCP legKey : part.keys) {
+      ExprCP mapped = nullptr;
+      for (size_t i = 0; i < legColumns.size(); ++i) {
+        if (legColumns[i] == legKey) {
+          mapped = key.outputColumns[i];
+          break;
+        }
+      }
+      if (mapped == nullptr) {
+        return {};
+      }
+      legOutputKeys.push_back(mapped);
+    }
+
+    if (leg == 0) {
+      outputKeys = std::move(legOutputKeys);
+      representative = part.partitionType;
+      continue;
+    }
+    if (legOutputKeys.size() != outputKeys.size()) {
+      return {};
+    }
+    for (size_t i = 0; i < outputKeys.size(); ++i) {
+      if (legOutputKeys[i] != outputKeys[i]) {
+        return {};
+      }
+    }
+    // copartition is only a feasibility check; the output reuses the
+    // min-partition-count leg's layout-owned type, whose count equals
+    // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
+    const auto compatible = representative->copartition(*part.partitionType);
+    if (compatible == nullptr) {
+      return {};
+    }
+    if (part.partitionType->numPartitions() < representative->numPartitions()) {
+      representative = part.partitionType;
+    }
+    VELOX_DCHECK_EQ(
+        representative->numPartitions(),
+        compatible->numPartitions(),
+        "Co-bucketed union output must reuse a layout type matching copartition's count");
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = representative,
+      .keys = std::move(outputKeys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+UnionAll::UnionAll(Key key)
+    : Node(
+          NodeType::kUnionAll,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = unionGlobalPartition(key)}),
+      inputs_(std::move(key.inputs)),
+      legColumns_(std::move(key.legColumns)) {
+  VELOX_CHECK_GE(inputs_.size(), 2, "UnionAll requires at least two inputs");
+  for (auto* input : inputs_) {
+    VELOX_CHECK_NOT_NULL(input);
+  }
+  VELOX_CHECK_EQ(
+      legColumns_.size(),
+      inputs_.size(),
+      "UnionAll legColumns must have one entry per input");
+  const auto numOutputs = this->outputColumns().size();
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    VELOX_CHECK_EQ(
+        legColumns_[i].size(),
+        numOutputs,
+        "UnionAll legColumns[i] must align with outputColumns");
+    const auto available =
+        PlanObjectSet::fromObjects(inputs_[i]->outputColumns());
+    for (ColumnCP column : legColumns_[i]) {
+      VELOX_CHECK(
+          available.contains(column),
+          "UnionAll legColumns[{}] references a Column not in inputs[{}]->outputColumns()",
+          i,
+          i);
+    }
+  }
+}
+
+size_t UnionAll::KeyHash::operator()(const UnionAll* node) const {
+  const auto& legColumns = node->legColumns();
+  size_t hash = hashOf(node->inputs(), node->outputColumns());
+  for (size_t legIdx = 0; legIdx < legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, legColumns[legIdx].size());
+    for (const auto* column : legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t UnionAll::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(key.inputs, key.outputColumns);
+  for (size_t legIdx = 0; legIdx < key.legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, key.legColumns[legIdx].size());
+    for (const auto* column : key.legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* left, const UnionAll* right)
+    const {
+  return std::ranges::equal(left->inputs(), right->inputs()) &&
+      left->legColumns() == right->legColumns() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const Key& key, const UnionAll* node) const {
+  return std::ranges::equal(key.inputs, node->inputs()) &&
+      key.legColumns == node->legColumns() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Join::Join(Key key)
+    : Node(
+          NodeType::kJoin,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = joinGlobalPartition(
+                  key.joinType,
+                  key.left,
+                  key.outputColumns),
+              .local = joinLocal(key.joinType, key.left, key.outputColumns)}),
+      inputs_{key.left, key.right},
+      joinType_(key.joinType),
+      leftKeys_(std::move(key.leftKeys)),
+      rightKeys_(std::move(key.rightKeys)),
+      filter_(std::move(key.filter)),
+      nullAware_(key.nullAware),
+      nullAsValue_(key.nullAsValue) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+  VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
+  if (nullAware_) {
+    VELOX_CHECK(
+        joinType_ == velox::core::JoinType::kAnti ||
+            joinType_ == velox::core::JoinType::kLeftSemiProject ||
+            joinType_ == velox::core::JoinType::kRightSemiProject,
+        "nullAware only valid for kAnti / kLeftSemiProject / kRightSemiProject, got: {}",
+        joinType_);
+    // Velox forbids a null-aware right semi project that also carries an
+    // internal filter (velox PlanNode.h). The negated-mark filter of a
+    // reversed antijoin is a separate FilterNode, not this internal filter.
+    VELOX_CHECK(
+        joinType_ != velox::core::JoinType::kRightSemiProject ||
+            filter_.empty(),
+        "Null-aware kRightSemiProject does not support an internal filter");
+  }
+  VELOX_CHECK(
+      !(nullAware_ && nullAsValue_),
+      "nullAware and nullAsValue are mutually exclusive");
+}
+
+size_t Join::KeyHash::operator()(const Join* node) const {
+  return hashOf(
+      node->left(),
+      node->right(),
+      node->joinType(),
+      node->leftKeys(),
+      node->rightKeys(),
+      node->filter(),
+      node->outputColumns(),
+      node->nullAware(),
+      node->nullAsValue());
+}
+
+size_t Join::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.left,
+      key.right,
+      key.joinType,
+      key.leftKeys,
+      key.rightKeys,
+      key.filter,
+      key.outputColumns,
+      key.nullAware,
+      key.nullAsValue);
+}
+
+bool Join::KeyEq::operator()(const Join* left, const Join* right) const {
+  return left->left() == right->left() && left->right() == right->right() &&
+      left->joinType() == right->joinType() &&
+      left->leftKeys() == right->leftKeys() &&
+      left->rightKeys() == right->rightKeys() &&
+      left->filter() == right->filter() &&
+      left->nullAware() == right->nullAware() &&
+      left->nullAsValue() == right->nullAsValue() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Key& key, const Join* node) const {
+  return key.left == node->left() && key.right == node->right() &&
+      key.joinType == node->joinType() && key.leftKeys == node->leftKeys() &&
+      key.rightKeys == node->rightKeys() && key.filter == node->filter() &&
+      key.nullAware == node->nullAware() &&
+      key.nullAsValue == node->nullAsValue() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Join* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Window::Window(Key key)
+    : Node(
+          NodeType::kWindow,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      functions_(std::move(key.functions)),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!functions_.empty(), "Window must have at least one function");
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + functions_.size());
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Window::KeyHash::operator()(const Window* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->outputColumns());
+  for (const auto& function : node->functions()) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+size_t Window::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.outputColumns);
+  for (const auto& function : key.functions) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+bool Window::KeyEq::operator()(const Window* left, const Window* right) const {
+  return left->input() == right->input() &&
+      left->functions() == right->functions() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Key& key, const Window* node) const {
+  return key.input == node->input() && key.functions == node->functions() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Window* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopNRowNumber::TopNRowNumber(Key key)
+    : Node(NodeType::kTopNRowNumber, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      rankFunction_(key.rankFunction),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      limit_(key.limit),
+      rankColumn_(key.rankColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopNRowNumber must have order keys");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GT(limit_, 0);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + (rankColumn_ != nullptr ? 1 : 0));
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const TopNRowNumber* node) const {
+  return hashOf(
+      node->input(),
+      static_cast<int>(node->rankFunction()),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->limit(),
+      node->rankColumn(),
+      node->outputColumns());
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<int>(key.rankFunction),
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.limit,
+      key.rankColumn,
+      key.outputColumns);
+}
+
+bool TopNRowNumber::KeyEq::operator()(
+    const TopNRowNumber* left,
+    const TopNRowNumber* right) const {
+  return left->input() == right->input() &&
+      left->rankFunction() == right->rankFunction() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->limit() == right->limit() &&
+      left->rankColumn() == right->rankColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const Key& key, const TopNRowNumber* node)
+    const {
+  return key.input == node->input() &&
+      key.rankFunction == node->rankFunction() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.limit == node->limit() &&
+      key.rankColumn == node->rankColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const TopNRowNumber* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Apply::Apply(Key key)
+    : Node(NodeType::kApply, ColumnVector{key.outputColumns}, {}),
+      inputs_{key.input, key.body},
+      correlationColumns_(std::move(key.correlationColumns)),
+      kind_(key.kind),
+      filter_(std::move(key.filter)),
+      enforceSingleRow_(key.enforceSingleRow),
+      markColumn_(key.markColumn),
+      inLhs_(key.inLhs),
+      inBodyKey_(key.inBodyKey),
+      includeMarker_(key.includeMarker) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+
+  // Allowed kinds at Apply: correlated scalar (kLeft) and EXISTS/IN
+  // (kLeftSemiProject). Uncorrelated scalars are lowered directly to
+  // cross-join + EnforceSingleRow at translate time — no Apply. kAnti
+  // / kLeftSemiFilter emerge from the post-decorrelate peephole, never
+  // at Apply.
+  const bool isLeft = kind_ == velox::core::JoinType::kLeft;
+  VELOX_CHECK(
+      isLeft || kind_ == velox::core::JoinType::kLeftSemiProject,
+      "Apply.kind must be kLeft / kLeftSemiProject; got: {}",
+      kind_);
+
+  if (isLeft) {
+    VELOX_CHECK_NOT_NULL(
+        includeMarker_, "kLeft Apply requires an includeMarker");
+    VELOX_CHECK_EQ(
+        includeMarker_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "Apply.includeMarker must be BOOLEAN");
+    VELOX_CHECK_NULL(
+        markColumn_,
+        "markColumn is kLeftSemiProject-only; kLeft leaves it null");
+    VELOX_CHECK_NULL(inLhs_, "inLhs is IN-only; non-semi Apply leaves it null");
+    VELOX_CHECK_NULL(
+        inBodyKey_, "inBodyKey is IN-only; non-semi Apply leaves it null");
+  } else {
+    VELOX_CHECK_NULL(
+        includeMarker_, "includeMarker is kLeft-only; kSemi leaves it null");
+    VELOX_CHECK_NOT_NULL(
+        markColumn_, "kLeftSemiProject Apply requires a markColumn");
+    VELOX_CHECK_EQ(
+        markColumn_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "kLeftSemiProject markColumn must be BOOLEAN");
+    VELOX_CHECK(
+        !enforceSingleRow_,
+        "kLeftSemiProject Apply must have enforceSingleRow == false "
+        "(semi/anti has no cardinality assertion)");
+  }
+  // The IN pair is set together: both null (scalar / EXISTS) or both
+  // non-null (IN). Forbid the half-set state.
+  VELOX_CHECK_EQ(
+      inLhs_ == nullptr,
+      inBodyKey_ == nullptr,
+      "Apply.inLhs and Apply.inBodyKey must be set together (both null "
+      "for scalar / EXISTS; both non-null for IN)");
+
+  // outputColumns shape check, per kind:
+  //   kLeft             : input.outputColumns
+  //                       ++ unique(body.outputColumns) ++ includeMarker
+  //   kLeftSemiProject  : input.outputColumns ++ markColumn
+  //
+  // A body column that already appears in input.outputColumns by
+  // Column* identity occupies a single output slot.
+  const auto& inputCols = inputs_[0]->outputColumns();
+  for (size_t i = 0; i < inputCols.size(); ++i) {
+    VELOX_CHECK(
+        outputColumns()[i] == inputCols[i],
+        "Apply.outputColumns prefix must match input.outputColumns");
+  }
+  if (isLeft) {
+    VELOX_CHECK_GE(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeft Apply.outputColumns shorter than input + includeMarker");
+    const size_t bodySlots = outputColumns().size() - inputCols.size() - 1;
+    VELOX_CHECK_LE(
+        bodySlots,
+        inputs_[1]->outputColumns().size(),
+        "Apply body-col slot count exceeds body's outputColumns");
+    PlanObjectSet seen = PlanObjectSet::fromObjects(inputCols);
+    for (size_t i = 0; i < bodySlots; ++i) {
+      ColumnCP column = outputColumns()[inputCols.size() + i];
+      VELOX_CHECK(
+          !seen.contains(column),
+          "Apply.outputColumns body cols must be unique vs input and each other");
+      seen.add(column);
+    }
+    VELOX_CHECK(
+        outputColumns().back() == includeMarker_,
+        "Apply.outputColumns must end with includeMarker for kLeft");
+  } else {
+    VELOX_CHECK_EQ(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeftSemiProject Apply.outputColumns size mismatch");
+    VELOX_CHECK(
+        outputColumns().back() == markColumn_,
+        "Apply.outputColumns must end with markColumn for kLeftSemiProject");
+  }
+}
+
+size_t Apply::KeyHash::operator()(const Apply* node) const {
+  return hashOf(
+      node->input(),
+      node->body(),
+      node->correlationColumns(),
+      node->kind(),
+      node->filter(),
+      node->enforceSingleRow(),
+      node->markColumn(),
+      node->inLhs(),
+      node->inBodyKey(),
+      node->includeMarker(),
+      node->outputColumns());
+}
+
+size_t Apply::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      key.body,
+      key.correlationColumns,
+      key.kind,
+      key.filter,
+      key.enforceSingleRow,
+      key.markColumn,
+      key.inLhs,
+      key.inBodyKey,
+      key.includeMarker,
+      key.outputColumns);
+}
+
+bool Apply::KeyEq::operator()(const Apply* left, const Apply* right) const {
+  return left->input() == right->input() && left->body() == right->body() &&
+      left->correlationColumns() == right->correlationColumns() &&
+      left->kind() == right->kind() && left->filter() == right->filter() &&
+      left->enforceSingleRow() == right->enforceSingleRow() &&
+      left->markColumn() == right->markColumn() &&
+      left->inLhs() == right->inLhs() &&
+      left->inBodyKey() == right->inBodyKey() &&
+      left->includeMarker() == right->includeMarker() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Key& key, const Apply* node) const {
+  return key.input == node->input() && key.body == node->body() &&
+      key.correlationColumns == node->correlationColumns() &&
+      key.kind == node->kind() && key.filter == node->filter() &&
+      key.enforceSingleRow == node->enforceSingleRow() &&
+      key.markColumn == node->markColumn() && key.inLhs == node->inLhs() &&
+      key.inBodyKey == node->inBodyKey() &&
+      key.includeMarker == node->includeMarker() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Apply* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+ColumnVector withIdColumn(const ColumnVector& columns, ColumnCP idColumn) {
+  ColumnVector result;
+  result.reserve(columns.size() + 1);
+  for (ColumnCP column : columns) {
+    result.push_back(column);
+  }
+  result.push_back(idColumn);
+  return result;
+}
+} // namespace
+
+AssignUniqueId::AssignUniqueId(Key key)
+    : Node(
+          NodeType::kAssignUniqueId,
+          withIdColumn(key.input->outputColumns(), key.idColumn),
+          PhysicalProperties{
+              .local = groupedLocal(key.idColumn),
+              .unique = globalUniqueKey(key.idColumn)}),
+      input_(key.input),
+      idColumn_(key.idColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(idColumn_);
+  VELOX_CHECK_EQ(idColumn_->value().type->kind(), velox::TypeKind::BIGINT);
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const AssignUniqueId* node) const {
+  return hashOf(node->input(), node->idColumn());
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.idColumn);
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* left,
+    const AssignUniqueId* right) const {
+  return left->input() == right->input() &&
+      left->idColumn() == right->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const Key& key,
+    const AssignUniqueId* node) const {
+  return key.input == node->input() && key.idColumn == node->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceSingleRow::EnforceSingleRow(Key key)
+    : Node(
+          NodeType::kEnforceSingleRow,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(
+    const EnforceSingleRow* node) const {
+  return hashOf(node->input());
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input);
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* left,
+    const EnforceSingleRow* right) const {
+  return left->input() == right->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const Key& key,
+    const EnforceSingleRow* node) const {
+  return key.input == node->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceDistinct::EnforceDistinct(Key key)
+    : Node(
+          NodeType::kEnforceDistinct,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      distinctKeys_(std::move(key.distinctKeys)),
+      errorMessage_(key.errorMessage) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !distinctKeys_.empty(),
+      "EnforceDistinct must have at least one distinct key");
+  VELOX_CHECK_NOT_NULL(errorMessage_);
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const EnforceDistinct* node) const {
+  return hashOf(node->input(), node->distinctKeys(), node->errorMessage());
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.distinctKeys, key.errorMessage);
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* left,
+    const EnforceDistinct* right) const {
+  return left->input() == right->input() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->errorMessage() == right->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const Key& key,
+    const EnforceDistinct* node) const {
+  return key.input == node->input() &&
+      key.distinctKeys == node->distinctKeys() &&
+      key.errorMessage == node->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+Exchange::Exchange(Key key)
+    : Node(
+          NodeType::kExchange,
+          ColumnVector{key.input->outputColumns()},
+          // A remote exchange drops per-driver local order/grouping (rows
+          // interleave) — except an order-preserving gather, which keeps the
+          // merged sort order. Uniqueness survives per uniqueAcrossExchange
+          // (global-scope only, none under a broadcast).
+          PhysicalProperties{
+              .globalPartition = key.partitioning,
+              .local = exchangeLocal(key.partitioning),
+              .unique = uniqueAcrossExchange(
+                  key.input->physicalProperties().unique,
+                  key.partitioning)}),
+      input_(key.input),
+      partitioning_(std::move(key.partitioning)) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t Exchange::KeyHash::operator()(const Exchange* node) const {
+  const auto& partitioning = node->partitioning();
+  return hashOf(
+      node->input(),
+      static_cast<uint8_t>(partitioning.kind),
+      partitioning.partitionType,
+      partitioning.keys,
+      partitioning.orderKeys,
+      partitioning.orderTypes,
+      static_cast<uint8_t>(partitioning.scope),
+      partitioning.replicateNullsAndAny);
+}
+
+size_t Exchange::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<uint8_t>(key.partitioning.kind),
+      key.partitioning.partitionType,
+      key.partitioning.keys,
+      key.partitioning.orderKeys,
+      key.partitioning.orderTypes,
+      static_cast<uint8_t>(key.partitioning.scope),
+      key.partitioning.replicateNullsAndAny);
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* left, const Exchange* right)
+    const {
+  return left->input() == right->input() &&
+      left->partitioning() == right->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Key& key, const Exchange* node) const {
+  return key.input == node->input() && key.partitioning == node->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TableWrite::TableWrite(Key key)
+    : Node(
+          NodeType::kTableWrite,
+          ColumnVector{Column::create("rows", Value(toType(velox::BIGINT())))},
+          {}),
+      input_(key.input),
+      table_(key.table),
+      kind_(key.kind),
+      columnExprs_(std::move(key.columnExprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(table_);
+  VELOX_CHECK(
+      !columnExprs_.empty(), "TableWrite must write at least one column");
+  VELOX_CHECK_EQ(columnExprs_.size(), table_->type()->size());
+}
+
+size_t TableWrite::KeyHash::operator()(const TableWrite* node) const {
+  return hashOf(
+      node->input(),
+      node->table(),
+      static_cast<uint8_t>(node->kind()),
+      node->columnExprs());
+}
+
+size_t TableWrite::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.table, static_cast<uint8_t>(key.kind), key.columnExprs);
+}
+
+bool TableWrite::KeyEq::operator()(
+    const TableWrite* left,
+    const TableWrite* right) const {
+  return left->input() == right->input() && left->table() == right->table() &&
+      left->kind() == right->kind() &&
+      left->columnExprs() == right->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const Key& key, const TableWrite* node)
+    const {
+  return key.input == node->input() && key.table == node->table() &&
+      key.kind == node->kind() && key.columnExprs == node->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+#define V2_DEFINE_ACCEPT(NodeT)                                               \
+  void NodeT::accept(const NodeVisitor& visitor, NodeVisitorContext& context) \
+      const {                                                                 \
+    visitor.visit(*this, context);                                            \
+  }
+
+V2_DEFINE_ACCEPT(Scan)
+V2_DEFINE_ACCEPT(Filter)
+V2_DEFINE_ACCEPT(Project)
+V2_DEFINE_ACCEPT(Limit)
+V2_DEFINE_ACCEPT(Sort)
+V2_DEFINE_ACCEPT(TopN)
+V2_DEFINE_ACCEPT(Aggregate)
+V2_DEFINE_ACCEPT(GroupId)
+V2_DEFINE_ACCEPT(MarkDistinct)
+V2_DEFINE_ACCEPT(Values)
+V2_DEFINE_ACCEPT(Unnest)
+V2_DEFINE_ACCEPT(UnionAll)
+V2_DEFINE_ACCEPT(Join)
+V2_DEFINE_ACCEPT(Window)
+V2_DEFINE_ACCEPT(TopNRowNumber)
+V2_DEFINE_ACCEPT(Apply)
+V2_DEFINE_ACCEPT(EnforceSingleRow)
+V2_DEFINE_ACCEPT(AssignUniqueId)
+V2_DEFINE_ACCEPT(EnforceDistinct)
+V2_DEFINE_ACCEPT(Exchange)
+V2_DEFINE_ACCEPT(TableWrite)
+
+#undef V2_DEFINE_ACCEPT
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1,0 +1,1800 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/PlanNode.h"
+
+/// Tree-IR for the optimizer.
+///
+/// Nodes are immutable and, like all `PlanObject`s, arena-allocated from the
+/// shared `QueryGraphContext`.
+namespace facebook::axiom::optimizer::v2 {
+
+/// Discriminator for Node subtypes.
+enum class NodeType : uint8_t {
+  kScan,
+  kFilter,
+  kProject,
+  kLimit,
+  kSort,
+  kTopN,
+  kAggregate,
+  kGroupId,
+  kMarkDistinct,
+  kValues,
+  kUnnest,
+  kUnionAll,
+  kJoin,
+  kWindow,
+  kTopNRowNumber,
+  kApply,
+  kEnforceSingleRow,
+  kAssignUniqueId,
+  kEnforceDistinct,
+  kExchange,
+  kTableWrite,
+};
+
+AXIOM_DECLARE_ENUM_NAME(NodeType);
+
+class Node;
+class NodeVisitor;
+class NodeVisitorContext;
+using NodeCP = const Node*;
+using NodeVector = QGVector<NodeCP>;
+
+/// Base class for tree-IR operator nodes. Immutable. All members are const
+/// and initialized via the constructor. Abstract — instantiate via a subclass.
+///
+/// Cross-node references — predicates, join/grouping/sort keys, expression
+/// operands, per-leg layouts — bind by pointer identity, and keys may be
+/// arbitrary expressions, not just columns: `GROUP BY mod(a, 2)` carries a
+/// `Call` grouping key, and sort and partition keys are the same. Positional
+/// indices into a producer's `outputColumns()` are never used: pruning,
+/// duplicate-column collapse, and any other rewrite that reshapes a producer's
+/// `outputColumns` would then force rewiring at every consumer. Same-node
+/// sub-vector indices (e.g., `GroupId::groupingSets` into `groupingKeyColumns`)
+/// are positional and OK — they reference structure internal to the node, not a
+/// producer. The IR never binds by column name; names on `Column::name_` /
+/// `alias_` exist only as display labels for EXPLAIN.
+///
+/// A node's `PhysicalProperties`, by contrast, always reference this node's own
+/// output columns — an invariant each derivation upholds and the base
+/// constructor verifies (`checkReferencesColumns`). Velox's column-key
+/// requirement for aggregation / ordering / windowing / exchange is a separate,
+/// emit-time concern that `PrecomputeProjections` materializes.
+///
+/// Each node kind enforces its own column-identity contract: outputs contain no
+/// duplicate columns, and each kind extends or transforms its input schema in a
+/// specific way. See each subclass's docblock for the exact rules.
+///
+/// Instantiate nodes only through a `Builder` (`builder.make<T>(key)`), never
+/// by constructing a subclass directly: `make` hash-conses on the subclass's
+/// nested `Key` struct (its identity — two nodes of a kind intern to the same
+/// instance iff their `Key`s compare equal: input pointer(s) plus the node's
+/// parameter expression / column pointers). Direct construction bypasses
+/// interning. See `Builder.h`.
+class Node : public PlanObject {
+ public:
+  NodeType nodeType() const {
+    return nodeType_;
+  }
+
+  bool is(NodeType nodeType) const {
+    return nodeType_ == nodeType;
+  }
+
+  std::string_view nodeTypeName() const {
+    return NodeTypeName::toName(nodeType_);
+  }
+
+  /// Columns produced by this node, in output order.
+  const ColumnVector& outputColumns() const {
+    return outputColumns_;
+  }
+
+  /// Physical properties of this node's output: per-driver local ordering /
+  /// grouping, distribution, and relation-level facts. Derived from the inputs
+  /// at construction and immutable. Fields stay unset until decided — e.g.
+  /// distribution is unspecified until an exchange is placed, which mints a new
+  /// node rather than mutating this one.
+  const PhysicalProperties& physicalProperties() const {
+    return physicalProperties_;
+  }
+
+  /// Inputs in dependency order; empty for leaves. Returns a view into
+  /// node-owned storage; callers must not retain it past the node's
+  /// lifetime.
+  virtual std::span<const NodeCP> inputs() const = 0;
+
+  /// Double-dispatch hook for `NodeVisitor`.
+  virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const = 0;
+
+  std::string toString() const override;
+
+ protected:
+  Node(
+      NodeType nodeType,
+      ColumnVector outputColumns,
+      PhysicalProperties properties)
+      : PlanObject(PlanType::kV2Node),
+        nodeType_(nodeType),
+        outputColumns_(std::move(outputColumns)),
+        physicalProperties_(std::move(properties)) {
+    physicalProperties_.checkReferencesColumns(
+        PlanObjectSet::fromObjects(outputColumns_));
+  }
+
+ private:
+  const NodeType nodeType_;
+  const ColumnVector outputColumns_;
+  const PhysicalProperties physicalProperties_;
+};
+
+/// Reads rows from a connector-backed table (`BaseTable`).
+class Scan : public Node {
+ public:
+  struct Key {
+    BaseTableCP baseTable;
+    /// Strict consumer-required output columns; may be empty (e.g.
+    /// `SELECT count(1) FROM t` needs no column values from the table).
+    /// Distinct by pointer; both `outputName()` and the underlying `name()`
+    /// are unique within the vector. `filters` may reference columns that are
+    /// NOT in this set; the connector-side read schema is computed as
+    /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
+    ColumnVector outputColumns;
+    /// Predicates (joined with AND) offered to the connector during planning;
+    /// may be empty. The connector accepts those it can evaluate and rejects
+    /// the rest; rejected predicates are re-applied as a `Filter` node above
+    /// the `TableScan` when building the final Velox plan.
+    ExprVector filters;
+  };
+
+  /// Transparent hasher for interning `Scan`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Scan* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Scan`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Scan* left, const Scan* right) const;
+    bool operator()(const Key& key, const Scan* node) const;
+    bool operator()(const Scan* node, const Key& key) const;
+  };
+
+  explicit Scan(Key key);
+
+  BaseTableCP baseTable() const {
+    return baseTable_;
+  }
+
+  const ExprVector& filters() const {
+    return filters_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const BaseTableCP baseTable_;
+  const ExprVector filters_;
+};
+
+using ScanCP = const Scan*;
+
+/// Selects rows from its input that match all of its predicates (joined with
+/// AND). Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers).
+class Filter : public Node {
+ public:
+  struct Key {
+    /// Input node whose rows are filtered.
+    NodeCP input;
+    /// Predicates joined with AND; non-empty.
+    ExprVector predicates;
+  };
+
+  /// Transparent hasher for interning `Filter`s by identity (input +
+  /// predicates), read from either a stored `Filter*` or a lookup `Key`.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Filter* filter) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Filter`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Filter* left, const Filter* right) const;
+    bool operator()(const Key& key, const Filter* filter) const;
+    bool operator()(const Filter* filter, const Key& key) const;
+  };
+
+  explicit Filter(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  /// Predicates joined with AND. Non-empty.
+  const ExprVector& predicates() const {
+    return predicates_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector predicates_;
+};
+
+using FilterCP = const Filter*;
+
+/// Computes output columns from input expressions. Output schema is
+/// `outputColumns`; the i-th output column is produced by `exprs[i]`.
+///
+/// Example: `SELECT a, b + 1 AS c FROM t` translates to:
+///
+///     Project(input=t, exprs=[t.a, t.b + 1], outputColumns=[t.a, c])
+///
+/// where `t.a` is a pass-through (same `Column*` as the input), and
+/// `c` is a fresh `Column*` for the computed expression.
+class Project : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output expressions, positional with `outputColumns`.
+    ExprVector exprs;
+    /// Output columns, positional with `exprs` (see the class docblock for the
+    /// pass-through vs fresh-column rule).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Project`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Project* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Project`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Project* left, const Project* right) const;
+    bool operator()(const Key& key, const Project* node) const;
+    bool operator()(const Project* node, const Key& key) const;
+  };
+
+  explicit Project(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& exprs() const {
+    return exprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector exprs_;
+};
+
+using ProjectCP = const Project*;
+
+/// Returns up to `count` rows starting from `offset`. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Limit : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    /// `std::numeric_limits<int64_t>::max()` means no limit (e.g. `OFFSET n`
+    /// with no `LIMIT`), 0 means empty result.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `Limit`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Limit* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Limit`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Limit* left, const Limit* right) const;
+    bool operator()(const Key& key, const Limit* node) const;
+    bool operator()(const Limit* node, const Key& key) const;
+  };
+
+  explicit Limit(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using LimitCP = const Limit*;
+
+/// Sorts rows by `orderKeys` with directions in `orderTypes`. Does not change
+/// the schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Sort : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+  };
+
+  /// Transparent hasher for interning `Sort`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Sort* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Sort`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Sort* left, const Sort* right) const;
+    bool operator()(const Key& key, const Sort* node) const;
+    bool operator()(const Sort* node, const Key& key) const;
+  };
+
+  explicit Sort(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using SortCP = const Sort*;
+
+/// Sorts rows by `orderKeys` / `orderTypes` and returns up to `count` rows
+/// starting from `offset` — a bounded Sort. A Limit directly over a Sort fuses
+/// into this. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers).
+class TopN : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `TopN`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopN* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopN`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopN* left, const TopN* right) const;
+    bool operator()(const Key& key, const TopN* node) const;
+    bool operator()(const TopN* node, const Key& key) const;
+  };
+
+  explicit TopN(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using TopNCP = const TopN*;
+
+/// Vector of `optimizer::Aggregate*` (an aggregate-function Call). The
+/// type is distinct from `ExprVector` so consumers don't need to
+/// downcast each element to access aggregate-specific accessors
+/// (`condition`, `orderKeys`, etc.); the `Aggregate` node carries
+/// this type directly.
+using AggregateCallVector = QGVector<const optimizer::Aggregate*>;
+
+/// Stage of a (possibly distributed) aggregation, reusing Velox's enum.
+/// `kSingle` computes the complete result in one pass. `kPartial`
+/// pre-aggregates its input and emits intermediate accumulators (one per
+/// aggregate, typed by `optimizer::Aggregate::intermediateType()`); `kFinal`
+/// consumes those accumulators and emits the final result. A two-stage
+/// distributed aggregate is `kFinal` over a remote `Exchange` over `kPartial`.
+using AggregateStep = velox::core::AggregationNode::Step;
+
+/// Groups input rows by `groupingKeys` and computes `aggregates` per
+/// group. Output schema is `groupingKeys` followed by `aggregates`
+/// (one output column each).
+///
+/// Example: `SELECT a, sum(b) FROM t GROUP BY a` translates to:
+///
+///     Aggregate(input=t, groupingKeys=[t.a], aggregates=[sum(t.b)],
+///               outputColumns=[t.a, sum_b])
+///
+/// One output row per distinct value of `t.a`, with `sum_b` the sum
+/// of `t.b` within that group.
+///
+/// GROUPING SETS / ROLLUP / CUBE have no dedicated representation here: they
+/// are lowered to a `GroupId` input plus a plain aggregate keyed on an explicit
+/// group-id column, so this node has no grouping-set concept of its own. That
+/// group-id column, when present, is also recorded in `groupId` (with
+/// `globalGroupingSets`).
+class Aggregate : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Grouping keys; empty for a global aggregate.
+    ExprVector groupingKeys;
+    /// Aggregate functions, one per output aggregate column.
+    AggregateCallVector aggregates;
+    /// Output columns: the `groupingKeys`, then the `aggregates`, positionally.
+    ColumnVector outputColumns;
+    /// Aggregation stage. For a `kPartial` step, `outputColumns`' aggregate
+    /// positions hold intermediate accumulators (typed by
+    /// `intermediateType()`), not final results.
+    AggregateStep step{AggregateStep::kSingle};
+
+    /// Group-id column from the upstream `GroupId`, or null for a plain
+    /// aggregate. Set iff `globalGroupingSets` is non-empty; when set it also
+    /// appears in `groupingKeys`.
+    ColumnCP groupId{nullptr};
+    /// Group-id values of the global (empty) grouping sets. Non-empty only for
+    /// a GROUPING SETS / ROLLUP / CUBE aggregate with a global `()` set; drives
+    /// Velox's default-row-per-global-set behavior over empty input.
+    QGVector<int32_t> globalGroupingSets;
+  };
+
+  /// Transparent hasher for interning `Aggregate`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Aggregate* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Aggregate`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Aggregate* left, const Aggregate* right) const;
+    bool operator()(const Key& key, const Aggregate* node) const;
+    bool operator()(const Aggregate* node, const Key& key) const;
+  };
+
+  explicit Aggregate(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const AggregateCallVector& aggregates() const {
+    return aggregates_;
+  }
+
+  AggregateStep step() const {
+    return step_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  const QGVector<int32_t>& globalGroupingSets() const {
+    return globalGroupingSets_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const AggregateCallVector aggregates_;
+  const AggregateStep step_;
+  const ColumnCP groupId_;
+  const QGVector<int32_t> globalGroupingSets_;
+};
+
+using AggregateCP = const Aggregate*;
+
+/// Replicates each input row once per grouping set, emitting NULL for keys
+/// inactive in that set and tagging the copy with the set's index. The
+/// downstream `Aggregate` then groups by
+/// `groupingKeyColumns ++ [groupId]` and runs the aggregates over the
+/// replicated rows; the SQL `GROUPING SETS` / `ROLLUP` / `CUBE` semantics
+/// fall out of that grouping.
+///
+/// `outputColumns` = `groupingKeyColumns ++ aggregationInputs' columns ++
+/// [groupId]`. Velox `GroupingKeyInfo` maps each `groupingKeys` expression to
+/// the corresponding `groupingKeyColumns` output name; both vectors are
+/// positionally aligned.
+class GroupId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Input-side expressions whose values populate each replicated grouping
+    /// key; positionally aligned with `groupingKeyColumns`.
+    ExprVector groupingKeys;
+    /// Input columns referenced by the downstream `Aggregate`'s aggregate
+    /// functions; passed through to the output unchanged.
+    ExprVector aggregationInputs;
+    /// Non-empty; each entry lists the `groupingKeyColumns` indices active for
+    /// that set. Inactive keys are emitted as NULL in that set's output rows.
+    QGVector<QGVector<int32_t>> groupingSets;
+    /// Fresh output columns for the (possibly NULL-padded) grouping keys.
+    ColumnVector groupingKeyColumns;
+    /// Output column holding the grouping-set index (BIGINT, zero-based).
+    ColumnCP groupId;
+    /// Output columns: `groupingKeyColumns`, then `aggregationInputs`' columns,
+    /// then `groupId`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `GroupId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const GroupId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `GroupId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const GroupId* left, const GroupId* right) const;
+    bool operator()(const Key& key, const GroupId* node) const;
+    bool operator()(const GroupId* node, const Key& key) const;
+  };
+
+  explicit GroupId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  const QGVector<QGVector<int32_t>>& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeyColumns() const {
+    return groupingKeyColumns_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const QGVector<QGVector<int32_t>> groupingSets_;
+  const ColumnVector groupingKeyColumns_;
+  const ColumnCP groupId_;
+};
+
+using GroupIdCP = const GroupId*;
+
+/// Marks the first occurrence of each `(distinctKeys)` tuple from `input`
+/// with `true` and subsequent occurrences with `false`. Used to lower
+/// `DISTINCT` aggregates to non-distinct ones with a FILTER mask: a
+/// downstream `Aggregate` reads `agg(x) FILTER (marker)` and sees each
+/// `(group, x)` tuple at most once.
+///
+/// One `MarkDistinct` serves all distinct aggregates over the same key set.
+/// `markers[0]` is the no-mask marker: true on the first occurrence of each
+/// tuple overall, read by the unfiltered distinct aggregates. Each `masks[i]`
+/// is the `FILTER` condition of a filtered distinct aggregate, paired with
+/// `markers[i+1]`, which is true on the first occurrence of each tuple among
+/// the rows where `masks[i]` holds. `masks` is empty when no distinct aggregate
+/// over this key set carries a `FILTER`.
+///
+/// `outputColumns` = `input.outputColumns ++ markers` (input columns pass
+/// through unchanged).
+class MarkDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output marker columns (BOOLEAN); `markers[0]` is the no-mask marker.
+    /// See the class doc.
+    ColumnVector markers;
+    /// Columns / expressions tested for distinctness, in positional order.
+    ExprVector distinctKeys;
+    /// FILTER condition per filtered distinct aggregate, positionally aligned
+    /// with `markers[1..]`. Empty when no distinct aggregate over the key set
+    /// carries a FILTER.
+    ColumnVector masks;
+    /// Output columns: `input`'s columns, then `markers`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `MarkDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const MarkDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `MarkDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const MarkDistinct* left, const MarkDistinct* right) const;
+    bool operator()(const Key& key, const MarkDistinct* node) const;
+    bool operator()(const MarkDistinct* node, const Key& key) const;
+  };
+
+  explicit MarkDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ColumnVector& markers() const {
+    return markers_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  const ColumnVector& masks() const {
+    return masks_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnVector markers_;
+  const ExprVector distinctKeys_;
+  const ColumnVector masks_;
+};
+
+using MarkDistinctCP = const MarkDistinct*;
+
+/// Embeds a constant table in the plan. `outputColumns` defines the schema
+/// in all three cases. At most one of `source` / `rows` is non-null:
+///   - `source != nullptr, rows == nullptr`: pass through a
+///     `logical_plan::ValuesNode` whose `Variants` or `Vectors` data is
+///     read when building the final Velox plan.
+///   - `source == nullptr, rows != nullptr`: an arena-allocated
+///     `Variant::array(...)` of row `Variant`s (each element is
+///     `Variant::row(...)`). Produced by translate-time folding of
+///     `lp::ValuesNode::Exprs`.
+///   - `source == nullptr, rows == nullptr`: empty table — zero rows with
+///     schema from `outputColumns`. Used for the `LIMIT 0` rewrite.
+class Values : public Node {
+ public:
+  struct Key {
+    /// Set to pass through a logical-plan `ValuesNode` (see class doc).
+    const logical_plan::ValuesNode* source;
+    /// Set to embed arena-folded row `Variant`s (see class doc).
+    const velox::Variant* rows;
+    /// Output schema (defines the columns in all cases).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Values`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Values* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Values`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Values* left, const Values* right) const;
+    bool operator()(const Key& key, const Values* node) const;
+    bool operator()(const Values* node, const Key& key) const;
+  };
+
+  explicit Values(Key key);
+
+  const logical_plan::ValuesNode* source() const {
+    return source_;
+  }
+
+  const velox::Variant* rows() const {
+    return rows_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const logical_plan::ValuesNode* const source_;
+  const velox::Variant* const rows_;
+};
+
+using ValuesCP = const Values*;
+
+/// Expands array / map expressions row-wise. The output has three disjoint
+/// kinds of columns, exposed as separate accessors so consumers never need
+/// positional decoding: `replicatedColumns` (pass-through input columns),
+/// `unnestColumns[i]` (per-expression result columns), and the optional
+/// `ordinalityColumn`. `outputColumns()` returns the concatenation in that
+/// order, for downstream consumers that need a single vector view.
+class Unnest : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Array / map expressions expanded row-wise, in positional order.
+    ExprVector unnestExpressions;
+    /// Subset of `input->outputColumns()` to pass through; may be empty.
+    ColumnVector replicatedColumns;
+    /// One `ColumnVector` per `unnestExpressions[i]`: the result columns
+    /// produced by that expression (1 for ARRAY, 2 for MAP — key, value).
+    QGVector<ColumnVector> unnestColumns;
+    /// Optional ordinality column; null when this node does not produce
+    /// ordinality.
+    ColumnCP ordinalityColumn;
+    /// Visible schema. Every `Column*` here is a `replicatedColumns` column, a
+    /// column in some `unnestColumns[i]`, or `ordinalityColumn`. All
+    /// `replicatedColumns` and `ordinalityColumn` must appear; only
+    /// per-expression `unnestColumns` may be pruned out.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Unnest`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Unnest* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Unnest`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Unnest* left, const Unnest* right) const;
+    bool operator()(const Key& key, const Unnest* node) const;
+    bool operator()(const Unnest* node, const Key& key) const;
+  };
+
+  explicit Unnest(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& unnestExpressions() const {
+    return unnestExpressions_;
+  }
+
+  const ColumnVector& replicatedColumns() const {
+    return replicatedColumns_;
+  }
+
+  const QGVector<ColumnVector>& unnestColumns() const {
+    return unnestColumns_;
+  }
+
+  ColumnCP ordinalityColumn() const {
+    return ordinalityColumn_;
+  }
+
+  bool withOrdinality() const {
+    return ordinalityColumn_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector unnestExpressions_;
+  const ColumnVector replicatedColumns_;
+  const QGVector<ColumnVector> unnestColumns_;
+  const ColumnCP ordinalityColumn_;
+};
+
+using UnnestCP = const Unnest*;
+
+/// Concatenates rows from all inputs (UNION ALL semantics).
+/// `outputColumns` is a fresh duplicate-free output schema; `legColumns[i]`
+/// maps each output position to a `Column*` from `inputs[i]`.
+///
+/// Example: `SELECT a, b FROM t UNION ALL SELECT x, y FROM u` translates to:
+///
+///     UnionAll(inputs=[t, u],
+///              legColumns=[[t.a, t.b],  // leg 0: which t columns feed outputs
+///                          [u.x, u.y]], // leg 1: which u columns feed outputs
+///              outputColumns=[union_col_0, union_col_1])
+///
+/// `legColumns[i][j]` is the `Column*` from `inputs[i]->outputColumns()`
+/// that supplies values for union output position `j`. The same
+/// `Column*` may repeat within a leg to fan one input column into
+/// multiple union positions (e.g., `SELECT a, a FROM t` after the
+/// translate-time deduplication collapses both selected `a`s to one input
+/// column).
+class UnionAll : public Node {
+ public:
+  struct Key {
+    /// Inputs to concatenate; >= 2.
+    NodeVector inputs;
+    /// Per input, the `Column*`s (from that input's `outputColumns()`) that
+    /// feed each output position: one entry per input, each sized like
+    /// `outputColumns`. See the class doc.
+    QGVector<ColumnVector> legColumns;
+    /// Fresh, duplicate-free output schema.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `UnionAll`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const UnionAll* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `UnionAll`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const UnionAll* left, const UnionAll* right) const;
+    bool operator()(const Key& key, const UnionAll* node) const;
+    bool operator()(const UnionAll* node, const Key& key) const;
+  };
+
+  explicit UnionAll(Key key);
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  const QGVector<ColumnVector>& legColumns() const {
+    return legColumns_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeVector inputs_;
+  const QGVector<ColumnVector> legColumns_;
+};
+
+using UnionAllCP = const UnionAll*;
+
+/// Joins two inputs by `joinType` with paired equi-keys plus an optional
+/// residual `filter`. `outputColumns` projects columns from the inputs; see the
+/// field doc.
+///
+/// Example: `SELECT * FROM t INNER JOIN u ON t.a = u.a AND t.b > u.b`
+/// translates to:
+///
+///     Join(left=t, right=u, joinType=kInner,
+///          leftKeys=[t.a], rightKeys=[u.a],
+///          filter=(t.b > u.b),
+///          outputColumns=[t.a, t.b, u.a, u.b])
+///
+/// `leftKeys[i]` joins against `rightKeys[i]` via equality; the two
+/// vectors must have the same size. The match condition is
+/// `AND(leftKeys[i] = rightKeys[i] for all i) AND AND(filter)`.
+/// `filter` is a flat vector of predicates joined with AND (the producer is
+/// responsible for flattening and for lifting any equi-pairs into the key
+/// vectors).
+///
+/// Lowering depends on key presence:
+///   - `leftKeys` non-empty → `HashJoinNode`, with `filter` as the
+///     optional residual non-equi predicate.
+///   - `leftKeys` empty, `filter` empty → `NestedLoopJoinNode` cross
+///     product.
+///   - `leftKeys` empty, `filter` non-empty → `NestedLoopJoinNode`
+///     filter-only join.
+///
+/// `nullAware` (semi / anti only) enables NULL-aware semantics for
+/// `IN` / `NOT IN`. `nullAsValue` (set ops INTERSECT / EXCEPT) treats
+/// `NULL == NULL` as true on equi-keys. Mutually exclusive.
+class Join : public Node {
+ public:
+  struct Key {
+    /// Left input.
+    NodeCP left;
+    /// Right input.
+    NodeCP right;
+    /// Join type (inner / left / full / semi / anti / ...).
+    velox::core::JoinType joinType;
+    /// Left equi-keys; positional with `rightKeys` and the same size.
+    ExprVector leftKeys;
+    /// Right equi-keys; positional with `leftKeys`.
+    ExprVector rightKeys;
+    /// Residual non-equi predicates joined with AND; may be empty.
+    ExprVector filter;
+    /// NULL-aware semantics for IN / NOT IN (semi / anti only).
+    bool nullAware{false};
+    /// Treats NULL == NULL as true on equi-keys (INTERSECT / EXCEPT).
+    bool nullAsValue{false};
+    /// Output columns, each drawn from the left or right input; semi / anti
+    /// joins draw only from the preserved side. Pruned to what consumers need.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Join`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Join* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Join`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Join* left, const Join* right) const;
+    bool operator()(const Key& key, const Join* node) const;
+    bool operator()(const Join* node, const Key& key) const;
+  };
+
+  explicit Join(Key key);
+
+  NodeCP left() const {
+    return inputs_[0];
+  }
+
+  NodeCP right() const {
+    return inputs_[1];
+  }
+
+  velox::core::JoinType joinType() const {
+    return joinType_;
+  }
+
+  std::string_view joinTypeName() const {
+    return velox::core::JoinTypeName::toName(joinType_);
+  }
+
+  bool isInner() const {
+    return joinType_ == velox::core::JoinType::kInner;
+  }
+
+  bool isLeft() const {
+    return joinType_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isFull() const {
+    return joinType_ == velox::core::JoinType::kFull;
+  }
+
+  const ExprVector& leftKeys() const {
+    return leftKeys_;
+  }
+
+  const ExprVector& rightKeys() const {
+    return rightKeys_;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool nullAware() const {
+    return nullAware_;
+  }
+
+  bool nullAsValue() const {
+    return nullAsValue_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const velox::core::JoinType joinType_;
+  const ExprVector leftKeys_;
+  const ExprVector rightKeys_;
+  const ExprVector filter_;
+  const bool nullAware_;
+  const bool nullAsValue_;
+};
+
+using JoinCP = const Join*;
+
+/// One window function invocation. Frame is per-function (as in Velox
+/// `WindowNode::Function`), so functions sharing a partition / order but
+/// differing only in frame still group under a single `Window` node.
+struct WindowFunction {
+  /// The window function and its arguments.
+  ExprCP call;
+
+  /// The row/range window over which this function is evaluated.
+  Frame frame;
+
+  /// When true, NULL inputs are skipped when evaluating the function
+  /// (e.g. the `IGNORE NULLS` option in SQL frontends).
+  bool ignoreNulls;
+
+  bool operator==(const WindowFunction&) const = default;
+};
+
+using WindowFunctions = QGVector<WindowFunction>;
+
+/// Evaluates one or more window function calls. Output schema is input
+/// columns followed by one output column per window function.
+class Window : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Window function invocations sharing this partition / order; non-empty.
+    /// Each carries its own frame.
+    WindowFunctions functions;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Output columns: `input`'s columns, then one per window function.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Window`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Window* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Window`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Window* left, const Window* right) const;
+    bool operator()(const Key& key, const Window* node) const;
+    bool operator()(const Window* node, const Key& key) const;
+  };
+
+  explicit Window(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const WindowFunctions& functions() const {
+    return functions_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const WindowFunctions functions_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using WindowCP = const Window*;
+
+/// Per-partition top-`limit` rows ranked by a ranking function (row_number /
+/// rank / dense_rank). Produced by fusing
+/// a `Filter(rankColumn <op> n)` over a single-ranking-function `Window`. The
+/// rank column is emitted only when `rankColumn` is set; otherwise the output
+/// is just the input columns.
+class TopNRowNumber : public Node {
+ public:
+  using RankFunction = velox::core::TopNRowNumberNode::RankFunction;
+
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Ranking function (row_number / rank / dense_rank).
+    RankFunction rankFunction;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Per-partition row cap; > 0.
+    int32_t limit;
+    /// Column carrying the ranking-function result in the output, or null to
+    /// omit it (the output is then just the input columns).
+    ColumnCP rankColumn;
+    /// Output columns: `input`'s columns, plus `rankColumn` when set.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `TopNRowNumber`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopNRowNumber* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopNRowNumber`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopNRowNumber* left, const TopNRowNumber* right)
+        const;
+    bool operator()(const Key& key, const TopNRowNumber* node) const;
+    bool operator()(const TopNRowNumber* node, const Key& key) const;
+  };
+
+  explicit TopNRowNumber(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  RankFunction rankFunction() const {
+    return rankFunction_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int32_t limit() const {
+    return limit_;
+  }
+
+  ColumnCP rankColumn() const {
+    return rankColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const RankFunction rankFunction_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int32_t limit_;
+  const ColumnCP rankColumn_;
+};
+
+using TopNRowNumberCP = const TopNRowNumber*;
+
+/// Apply is a "true dependent join" — a relational join whose right side
+/// (`body`, conceptually evaluated per `input` row) may reference `input`'s
+/// columns.
+///
+/// "Body" rather than "subquery": at translate time Apply's right side IS
+/// the translated subquery, but as decorrelate iterates it peels operators
+/// off and `body` evolves. The decorrelate pass and downstream consumers
+/// reason about Apply as a generic dependent-join node whose right side is
+/// `body`; only Translate uses the SQL term "subquery" in its prose.
+///
+/// Example: `SELECT (SELECT max(u.b) FROM u WHERE u.a = t.a) FROM t`
+/// translates to:
+///
+///     Apply(kLeft, input=t,
+///           body=Aggregate(Filter(u.a=t.a, u), max(u.b)),
+///           correlationColumns=[t.a],
+///           filter=null,
+///           enforceSingleRow=false)
+///
+/// Apply is transient: produced by `translate` at every `lp::SubqueryExpr`
+/// site, eliminated by `pass.decorrelate` before any later pass.
+///
+/// Per-kind semantics:
+///
+///   kLeft             Correlated scalar / lateral subquery. Left-outer-join
+///                     semantics. Body may produce N rows per outer. Output:
+///                     `input.outputColumns ++ unique(body.outputColumns)
+///                     ++ [includeMarker]` — a body column already in input
+///                     occupies a single output slot. (NULL-padded for
+///                     outers with no match; `includeMarker` is `true`
+///                     on real rows, NULL on pad rows.)
+///   kLeftSemiProject  EXISTS / IN. Output:
+///                     `input.outputColumns ++ markColumn` — a fresh BOOLEAN
+///                     true iff any body row exists for the outer
+///                     matching `filter` AND (for IN) `inLhs = inBodyKey`.
+///                     NULL-aware for IN.
+///
+/// `kLeftSemiFilter` and `kAnti` never appear at Apply — they emerge only
+/// from a post-decorrelate peephole that recognizes
+/// `Filter(mark, Join(kLeftSemiProject, ..., mark))`.
+class Apply : public Node {
+ public:
+  struct Key {
+    /// Left ("outer") input.
+    NodeCP input;
+    /// Right side, evaluated per `input` row; may reference `input`'s columns.
+    NodeCP body;
+    /// `input` columns the current `body` still references; recomputed by
+    /// decorrelate after each peel. Empty at terminus, where Apply becomes a
+    /// Join.
+    ColumnVector correlationColumns;
+    /// `kLeft` (correlated scalar / lateral) or `kLeftSemiProject` (EXISTS /
+    /// IN).
+    velox::core::JoinType kind;
+    /// Residual predicates joined with AND; become `Join.filter` at terminus.
+    ExprVector filter;
+    /// Assert the body returns 0-or-1 row per outer (>1 rows errors);
+    /// correlated scalar subqueries only.
+    bool enforceSingleRow;
+    /// `kLeftSemiProject` mark output (BOOLEAN); null for `kLeft`.
+    ColumnCP markColumn;
+    /// IN equi-pair left side (the `lhs` of `lhs IN (SELECT ...)`), kept as a
+    /// pair rather than `eq(inLhs, inBodyKey)` so consumers read each side
+    /// directly; drives `nullAware()`. Null unless an IN subquery.
+    ExprCP inLhs;
+    /// IN equi-pair body side; see `inLhs`. Null unless an IN subquery.
+    ExprCP inBodyKey;
+    /// `kLeft` pad-row marker (BOOLEAN); null for `kLeftSemiProject`.
+    ColumnCP includeMarker;
+    /// Output columns; per-kind layout in the class doc.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Apply`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Apply* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Apply`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Apply* left, const Apply* right) const;
+    bool operator()(const Key& key, const Apply* node) const;
+    bool operator()(const Apply* node, const Key& key) const;
+  };
+
+  explicit Apply(Key key);
+
+  NodeCP input() const {
+    return inputs_[0];
+  }
+
+  NodeCP body() const {
+    return inputs_[1];
+  }
+
+  const ColumnVector& correlationColumns() const {
+    return correlationColumns_;
+  }
+
+  velox::core::JoinType kind() const {
+    return kind_;
+  }
+
+  std::string_view kindName() const {
+    return velox::core::JoinTypeName::toName(kind_);
+  }
+
+  bool isLeft() const {
+    return kind_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isLeftSemiProject() const {
+    return kind_ == velox::core::JoinType::kLeftSemiProject;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool enforceSingleRow() const {
+    return enforceSingleRow_;
+  }
+
+  ColumnCP markColumn() const {
+    return markColumn_;
+  }
+
+  ExprCP inLhs() const {
+    return inLhs_;
+  }
+
+  ExprCP inBodyKey() const {
+    return inBodyKey_;
+  }
+
+  ColumnCP includeMarker() const {
+    return includeMarker_;
+  }
+
+  bool nullAware() const {
+    return inLhs_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const ColumnVector correlationColumns_;
+  const velox::core::JoinType kind_;
+  const ExprVector filter_;
+  const bool enforceSingleRow_;
+  const ColumnCP markColumn_;
+  const ExprCP inLhs_;
+  const ExprCP inBodyKey_;
+  const ColumnCP includeMarker_;
+};
+
+using ApplyCP = const Apply*;
+
+/// Asserts the input contains at most one row and passes it through unchanged;
+/// an empty input yields a single all-NULL row, and more than one row raises an
+/// error. Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers). Used to enforce the 0-or-1-row
+/// cardinality of an uncorrelated scalar subquery.
+class EnforceSingleRow : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+  };
+
+  /// Transparent hasher for interning `EnforceSingleRow`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceSingleRow* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceSingleRow`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceSingleRow* left, const EnforceSingleRow* right)
+        const;
+    bool operator()(const Key& key, const EnforceSingleRow* node) const;
+    bool operator()(const EnforceSingleRow* node, const Key& key) const;
+  };
+
+  explicit EnforceSingleRow(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+};
+
+using EnforceSingleRowCP = const EnforceSingleRow*;
+
+/// Emits each input row unchanged, appending `idColumn` — a value unique across
+/// all output rows.
+class AssignUniqueId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Appended id column (BIGINT).
+    ColumnCP idColumn;
+  };
+
+  /// Transparent hasher for interning `AssignUniqueId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const AssignUniqueId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `AssignUniqueId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const AssignUniqueId* left, const AssignUniqueId* right)
+        const;
+    bool operator()(const Key& key, const AssignUniqueId* node) const;
+    bool operator()(const AssignUniqueId* node, const Key& key) const;
+  };
+
+  explicit AssignUniqueId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  ColumnCP idColumn() const {
+    return idColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnCP idColumn_;
+};
+
+using AssignUniqueIdCP = const AssignUniqueId*;
+
+/// Asserts that `distinctKeys` are unique across the input — at most one row
+/// per distinct combination of their values — raising a runtime error carrying
+/// `errorMessage` on the first duplicate. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers). Used to enforce the 0-or-1-row cardinality of a correlated scalar
+/// subquery.
+class EnforceDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Keys asserted unique across the input; non-empty.
+    ExprVector distinctKeys;
+    /// Error message raised on the first duplicate.
+    Name errorMessage;
+  };
+
+  /// Transparent hasher for interning `EnforceDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceDistinct* left, const EnforceDistinct* right)
+        const;
+    bool operator()(const Key& key, const EnforceDistinct* node) const;
+    bool operator()(const EnforceDistinct* node, const Key& key) const;
+  };
+
+  explicit EnforceDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  Name errorMessage() const {
+    return errorMessage_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector distinctKeys_;
+  const Name errorMessage_;
+};
+
+using EnforceDistinctCP = const EnforceDistinct*;
+
+/// Redistributes input rows across tasks with a remote exchange — lowered to a
+/// `PartitionedOutput`→`Exchange` pair straddling a fragment boundary — setting
+/// `partitioning` as the output's global partitioning. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers). The only node that repartitions: it imposes a global
+/// partitioning via a shuffle, whereas other nodes derive theirs from their
+/// input. The distributed memo places it when a consumer needs a partitioning
+/// the input lacks.
+class Exchange : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Global partitioning imposed on the output via the shuffle.
+    Partitioning partitioning;
+  };
+
+  /// Transparent hasher for interning `Exchange`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Exchange* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Exchange`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Exchange* left, const Exchange* right) const;
+    bool operator()(const Key& key, const Exchange* node) const;
+    bool operator()(const Exchange* node, const Key& key) const;
+  };
+
+  explicit Exchange(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const Partitioning& partitioning() const {
+    return partitioning_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const Partitioning partitioning_;
+};
+
+using ExchangeCP = const Exchange*;
+
+/// Writes its input rows to a table (CTAS / INSERT; DELETE / UPDATE deferred).
+/// A root sink: its single BIGINT output column is the
+/// written row count, consumed by no node.
+class TableWrite : public Node {
+ public:
+  struct Key {
+    /// Input node (rows to write).
+    NodeCP input;
+    /// Target table; emit reads its `type()` and `layouts()` for the insert
+    /// handle.
+    const connector::Table* table;
+    /// Write form (INSERT / CTAS / ...).
+    connector::WriteKind kind;
+    /// Per-target-column values, non-empty and 1:1 with the table schema
+    /// (`table->type()`).
+    ExprVector columnExprs;
+  };
+
+  /// Transparent hasher for interning `TableWrite`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TableWrite* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TableWrite`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TableWrite* left, const TableWrite* right) const;
+    bool operator()(const Key& key, const TableWrite* node) const;
+    bool operator()(const TableWrite* node, const Key& key) const;
+  };
+
+  explicit TableWrite(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const connector::Table* table() const {
+    return table_;
+  }
+
+  connector::WriteKind kind() const {
+    return kind_;
+  }
+
+  const ExprVector& columnExprs() const {
+    return columnExprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const connector::Table* const table_;
+  const connector::WriteKind kind_;
+  const ExprVector columnExprs_;
+};
+
+using TableWriteCP = const TableWrite*;
+
+} // namespace facebook::axiom::optimizer::v2
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::v2::NodeType);

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/NodePrinter.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ranges>
+#include <sstream>
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+std::string spaces(size_t depth) {
+  return std::string(depth, ' ');
+}
+
+std::string formatExpr(ExprCP expr) {
+  if (expr == nullptr) {
+    return "<null>";
+  }
+  return expr->toString();
+}
+
+std::string formatColumns(const ColumnVector& columns) {
+  auto formatted =
+      columns | std::views::transform([](ColumnCP c) {
+        return fmt::format("{}:{}", c->toString(), c->value().type->toString());
+      });
+  return fmt::to_string(fmt::join(formatted, ", "));
+}
+
+// Templated so any range of Expr-derived pointers (ExprVector,
+// AggregateCallVector, etc.) formats the same way.
+template <typename Range>
+std::string formatExprs(const Range& exprs) {
+  auto texts = exprs |
+      std::views::transform([](const auto* expr) { return formatExpr(expr); });
+  return fmt::to_string(fmt::join(texts, ", "));
+}
+
+class Printer : public NodeVisitor {
+ public:
+  struct Context : public NodeVisitorContext {
+    std::stringstream out;
+    size_t indent{0};
+  };
+
+  // Bumps `ctx.indent` by 2 on construction, restores on destruction.
+  class IndentGuard {
+   public:
+    explicit IndentGuard(Context& ctx) : ctx_(ctx) {
+      ctx_.indent += 2;
+    }
+    ~IndentGuard() {
+      ctx_.indent -= 2;
+    }
+    IndentGuard(const IndentGuard&) = delete;
+    IndentGuard& operator=(const IndentGuard&) = delete;
+
+   private:
+    Context& ctx_;
+  };
+
+  void visit(const Scan& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx, node, fmt::format("[{}]", node.baseTable()->schemaTable->name()));
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP filter : node.filters()) {
+      ctx.out << pad << "filter: " << formatExpr(filter) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Filter& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP pred : node.predicates()) {
+      ctx.out << pad << "predicate: " << formatExpr(pred) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Project& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& cols = node.outputColumns();
+    const auto& exprs = node.exprs();
+    for (size_t i = 0; i < cols.size(); ++i) {
+      ctx.out << pad << cols[i]->toString() << " := " << formatExpr(exprs[i])
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Limit& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Sort& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopN& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Aggregate& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.groupingKeys().empty()) {
+      ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+              << '\n';
+    }
+    if (!node.aggregates().empty()) {
+      ctx.out << pad << "aggregates: " << formatExprs(node.aggregates())
+              << '\n';
+    }
+    if (!node.globalGroupingSets().empty()) {
+      ctx.out << pad << "globalGroupingSets: "
+              << folly::join(", ", node.globalGroupingSets()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const GroupId& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+            << '\n';
+    if (!node.aggregationInputs().empty()) {
+      ctx.out << pad
+              << "aggregationInputs: " << formatExprs(node.aggregationInputs())
+              << '\n';
+    }
+    ctx.out << pad << "groupingSets: " << node.groupingSets().size()
+            << " set(s)\n";
+    visitInputs(node, ctx);
+  }
+
+  void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (!node.masks().empty()) {
+      ctx.out << pad << "masks: " << formatExprs(node.masks()) << '\n';
+    }
+    ctx.out << pad << "markers: " << formatExprs(node.markers()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Values& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Unnest& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad
+            << "unnestExpressions: " << formatExprs(node.unnestExpressions())
+            << '\n';
+    if (node.withOrdinality()) {
+      ctx.out << pad << "withOrdinality: true\n";
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const UnionAll& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& legColumns = node.legColumns();
+    for (size_t i = 0; i < legColumns.size(); ++i) {
+      ctx.out << pad << "leg[" << i << "] columns: "
+              << formatExprs(
+                     ExprVector(legColumns[i].begin(), legColumns[i].end()))
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Join& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.joinTypeName()};
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.leftKeys().empty()) {
+      ctx.out << pad << "leftKeys: " << formatExprs(node.leftKeys()) << '\n';
+      ctx.out << pad << "rightKeys: " << formatExprs(node.rightKeys()) << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Window& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    if (!node.orderKeys().empty()) {
+      ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[limit {}]", node.limit()));
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Apply& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.kindName()};
+    if (node.enforceSingleRow()) {
+      details += ", enforceSingleRow";
+    }
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.correlationColumns().empty()) {
+      ctx.out << pad
+              << "correlation: " << formatColumns(node.correlationColumns())
+              << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    if (node.markColumn() != nullptr) {
+      ctx.out << pad << "mark: " << node.markColumn()->toString() << '\n';
+    }
+    if (node.inLhs() != nullptr) {
+      ctx.out << pad << "inLhs: " << formatExpr(node.inLhs()) << '\n';
+      ctx.out << pad << "inBodyKey: " << formatExpr(node.inBodyKey()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "idColumn: " << node.idColumn()->toString() << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (node.errorMessage() != nullptr) {
+      ctx.out << pad << "errorMessage: " << node.errorMessage() << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Exchange& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "partitionKeys: " << formatExprs(node.partitioning().keys)
+            << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TableWrite& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "columnExprs: " << formatExprs(node.columnExprs()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+ private:
+  void header(Context& ctx, const Node& node, std::string_view extra = {})
+      const {
+    ctx.out << spaces(ctx.indent) << "- "
+            << NodeTypeName::toName(node.nodeType());
+    if (!extra.empty()) {
+      ctx.out << extra;
+    }
+    ctx.out << " -> " << formatColumns(node.outputColumns()) << '\n';
+  }
+
+  void visitInputs(const Node& node, Context& ctx) const {
+    IndentGuard guard(ctx);
+    NodeVisitor::visitInputs(node, ctx);
+  }
+};
+
+} // namespace
+
+std::string NodePrinter::toText(NodeCP root) {
+  Printer::Context ctx;
+  root->accept(Printer{}, ctx);
+  return ctx.out.str();
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodePrinter.h
+++ b/axiom/optimizer/v2/NodePrinter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Renders an IR tree as indented text.
+class NodePrinter {
+ public:
+  /// Returns 'root' as indented text. Columns are shown by their `name()`
+  /// (the unique synthetic), not `outputName()`, so identity is visible.
+  static std::string toText(NodeCP root);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class NodeVisitorContext {
+ public:
+  virtual ~NodeVisitorContext() = default;
+};
+
+/// Double-dispatch visitor for v2 `Node` subclasses. Mirrors
+/// `logical_plan::PlanNodeVisitor`. Each subclass implements `accept` to
+/// forward to the matching `visit` overload.
+class NodeVisitor {
+ public:
+  virtual ~NodeVisitor() = default;
+
+  virtual void visit(const Scan& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Filter& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Project& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Limit& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Sort& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopN& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Aggregate& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const GroupId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Values& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Unnest& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const UnionAll& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Join& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Window& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Apply& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Exchange& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const TableWrite& node, NodeVisitorContext& context)
+      const = 0;
+
+ protected:
+  void visitInputs(const Node& node, NodeVisitorContext& context) const {
+    for (NodeCP input : node.inputs()) {
+      input->accept(*this, context);
+    }
+  }
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.cpp
+++ b/axiom/optimizer/v2/PhysicalProperties.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<PropertyScope, std::string_view>& propertyScopeNames() {
+  static const folly::F14FastMap<PropertyScope, std::string_view> kNames = {
+      {PropertyScope::kGlobal, "Global"},
+      {PropertyScope::kDriver, "Driver"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<PartitionKind, std::string_view>& partitionKindNames() {
+  static const folly::F14FastMap<PartitionKind, std::string_view> kNames = {
+      {PartitionKind::kUnspecified, "Unspecified"},
+      {PartitionKind::kPartitioned, "Partitioned"},
+      {PartitionKind::kGather, "Gather"},
+      {PartitionKind::kBroadcast, "Broadcast"},
+      {PartitionKind::kArbitrary, "Arbitrary"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<LocalPropertyKind, std::string_view>&
+localPropertyKindNames() {
+  static const folly::F14FastMap<LocalPropertyKind, std::string_view> kNames = {
+      {LocalPropertyKind::kGrouped, "Grouped"},
+      {LocalPropertyKind::kSorted, "Sorted"},
+  };
+  return kNames;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(PropertyScope, propertyScopeNames);
+AXIOM_DEFINE_ENUM_NAME(PartitionKind, partitionKindNames);
+AXIOM_DEFINE_ENUM_NAME(LocalPropertyKind, localPropertyKindNames);
+
+Partitioning Partitioning::globalHash(
+    const ExprVector& keys,
+    bool replicateNullsAndAny) {
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .keys = keys,
+      .scope = PropertyScope::kGlobal,
+      .replicateNullsAndAny = replicateNullsAndAny};
+}
+
+Partitioning Partitioning::globalGather() {
+  return Partitioning{
+      .kind = PartitionKind::kGather, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalGatherMerge(
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  return Partitioning{
+      .kind = PartitionKind::kGather,
+      .orderKeys = orderKeys,
+      .orderTypes = orderTypes,
+      .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalBroadcast() {
+  return Partitioning{
+      .kind = PartitionKind::kBroadcast, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalArbitrary() {
+  return Partitioning{
+      .kind = PartitionKind::kArbitrary, .scope = PropertyScope::kGlobal};
+}
+
+bool Partitioning::coLocates(const ExprVector& columns) const {
+  if (kind != PartitionKind::kPartitioned || keys.empty()) {
+    return false;
+  }
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  for (ExprCP key : keys) {
+    if (!columnSet.contains(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedOn(const ExprVector& otherKeys) const {
+  if (otherKeys.empty() || kind != PartitionKind::kPartitioned ||
+      partitionType == nullptr || keys.size() != otherKeys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->sameOrEqual(*otherKeys[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedCompatibleWith(
+    const ExprVector& otherKeys,
+    const connector::PartitionType& targetType) const {
+  if (!isBucketedOn(otherKeys)) {
+    return false;
+  }
+  const auto compatible = partitionType->copartition(targetType);
+  return compatible != nullptr &&
+      compatible->numPartitions() == partitionType->numPartitions();
+}
+
+bool Partitioning::sameClassAs(const Partitioning& other) const {
+  if (kind != other.kind || partitionType != other.partitionType ||
+      replicateNullsAndAny != other.replicateNullsAndAny ||
+      keys.size() != other.keys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (keys[i] != other.keys[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void PhysicalProperties::checkReferencesColumns(
+    const PlanObjectSet& outputColumns) const {
+  // A partitioning may be on computed expressions (the partition function's
+  // input, e.g. a cast); the requirement is that it is evaluable here — every
+  // column its keys and merge order depend on is an output column.
+  const auto checkPartition = [&](const Partitioning& partition) {
+    VELOX_CHECK(
+        outputColumns.containsColumns(partition.keys) &&
+            outputColumns.containsColumns(partition.orderKeys),
+        "Partitioning depends on a column that is not in the node's output");
+  };
+  checkPartition(globalPartition);
+  checkPartition(driverPartition);
+  // Local orderings / groupings and unique key-sets are columns, not
+  // expressions.
+  for (const LocalProperty& property : local) {
+    VELOX_CHECK(
+        outputColumns.containsAll(property.columns),
+        "Local property references a column that is not in the node's output");
+  }
+  for (const UniqueKeySet& keySet : unique) {
+    VELOX_CHECK(
+        keySet.columns.isSubset(outputColumns),
+        "Unique key-set references a column that is not in the node's output");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+
+/// Physical-property types for the optimizer: the per-operator output ordering,
+/// grouping, uniqueness, and partitioning that cost-based planning derives on
+/// each physical candidate and the property-aware memo keys on. This header
+/// declares the data shapes only; per-operator derivation and the satisfaction
+/// / shuffle-cost queries live alongside the memo that consumes them.
+///
+/// The model splits properties by how they behave under distribution. Three
+/// categories:
+///   - per-driver local: ordering and grouping (`LocalProperty`),
+///   - distribution: two independent partitioning slots, global and driver
+///     (`Partitioning` with a `PropertyScope`),
+///   - relation-level: uniqueness (`UniqueKeySet`).
+namespace facebook::axiom::optimizer::v2 {
+
+/// Scope at which a property holds. The two runtime levels distributed
+/// execution distinguishes: across tasks (`kGlobal`) and across drivers within
+/// one task (`kDriver`).
+///
+/// The scope's algebra differs by property:
+///   - Partitioning carries two *independent* slots, one per scope — global
+///     partitioned does not imply driver partitioned (a remote hash exchange
+///     feeds drivers round-robin), so both are tracked.
+///   - Uniqueness is a *lattice*: global uniqueness implies driver (per-driver)
+///     uniqueness but not the reverse, so a key-set stores the single widest
+///     scope at which it holds.
+enum class PropertyScope : uint8_t {
+  kGlobal,
+  kDriver,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PropertyScope);
+
+/// Kind of data partitioning.
+enum class PartitionKind : uint8_t {
+  /// No specific partitioning is guaranteed.
+  kUnspecified,
+  /// Partitioned on `keys` using `partitionType` (connector-specific) or
+  /// standard Velox hash when `partitionType` is null.
+  kPartitioned,
+  /// All rows on one partition (single task, or single driver at driver scope).
+  kGather,
+  /// Every consumer receives a full copy.
+  kBroadcast,
+  /// Arbitrary / round-robin assignment.
+  kArbitrary,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PartitionKind);
+
+/// Partitioning of a relation's rows at one scope. The same concept serves both
+/// the global (across-tasks) and driver (across-drivers) levels; `scope` says
+/// which. A `PhysicalProperties` carries one `Partitioning` per scope, and the
+/// two are independent.
+///
+/// Invariants:
+///   - `keys` is non-empty only when `kind == kPartitioned`.
+///   - `orderKeys` / `orderTypes` are non-empty only for an order-preserving
+///     `kGather` (see `globalGatherMerge`).
+///   - `partitionType` is null for standard Velox hash partitioning.
+///   - `keys` are expressions (not just columns) to match the partition
+///     function's input.
+struct Partitioning {
+  PartitionKind kind{PartitionKind::kUnspecified};
+
+  /// Connector-specific partition function, or null for standard Velox hash.
+  const connector::PartitionType* partitionType{nullptr};
+
+  /// Partition keys; empty unless `kind == kPartitioned`.
+  ExprVector keys;
+
+  /// Sort keys and their orders that an order-preserving gather merges on
+  /// (lowered to a Velox `MergeExchange`). Non-empty only for a `kGather`
+  /// produced by `globalGatherMerge`; empty for a plain gather.
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+
+  PropertyScope scope{PropertyScope::kGlobal};
+
+  /// When true, the partitioned output replicates null-keyed rows (and one
+  /// arbitrary row) to every partition. Required on the existence side of a
+  /// null-aware anti/semi join (NOT IN / IN) so a null key reaches all probe
+  /// partitions; otherwise NOT IN wrongly admits rows.
+  bool replicateNullsAndAny{false};
+
+  bool operator==(const Partitioning&) const = default;
+
+  bool is(PartitionKind other) const {
+    return kind == other;
+  }
+
+  /// A copy without the merge order (`orderKeys` / `orderTypes`). The merge
+  /// order belongs to the gather-merge exchange that produced it; an operator
+  /// that inherits a distribution without being that exchange keeps the kind
+  /// and keys but not the order (which, if preserved, is carried as a local
+  /// property).
+  Partitioning dropOrder() const {
+    Partitioning result = *this;
+    result.orderKeys = {};
+    result.orderTypes = {};
+    return result;
+  }
+
+  /// A standard global hash partitioning on `keys`. Set `replicateNullsAndAny`
+  /// for the existence side of a null-aware anti/semi join.
+  static Partitioning globalHash(
+      const ExprVector& keys,
+      bool replicateNullsAndAny = false);
+
+  /// A global gather (all rows on one task) partitioning.
+  static Partitioning globalGather();
+
+  /// A global gather that preserves ordering by merging the sorted per-task
+  /// streams (lowered to a Velox `MergeExchange`). `orderKeys` / `orderTypes`
+  /// are the sort keys to merge on.
+  static Partitioning globalGatherMerge(
+      const ExprVector& orderKeys,
+      const OrderTypeVector& orderTypes);
+
+  /// A global broadcast (every task receives a full copy) partitioning.
+  static Partitioning globalBroadcast();
+
+  /// A global arbitrary (round-robin / shared-pool) partitioning.
+  static Partitioning globalArbitrary();
+
+  /// True when this co-locates rows that agree on `columns` — i.e. it
+  /// hash-partitions on a subset of `columns`, so every group of equal
+  /// `columns` is wholly within one partition and an aggregation grouping on
+  /// `columns` needs no repartition. Not a co-partition test for joins: those
+  /// must align corresponding keys across both inputs, so use `sameClassAs`.
+  bool coLocates(const ExprVector& columns) const;
+
+  /// True when this is the same class as `other` — same kind, connector
+  /// function, and keys in order. Like `coLocates`, a pure class test: scope is
+  /// fixed by the containing slot, so it is not compared. Two `kUnspecified`
+  /// partitionings are the same class.
+  bool sameClassAs(const Partitioning& other) const;
+
+  /// True when this is connector-bucketed (`kPartitioned` with a non-null
+  /// `partitionType`) on exactly `otherKeys` — same expressions in the same
+  /// order. False for empty `otherKeys`.
+  bool isBucketedOn(const ExprVector& otherKeys) const;
+
+  /// True when this is bucketed on `otherKeys` (see `isBucketedOn`) with a
+  /// partitioning that copartitions with `targetType` at this bucketing's own
+  /// partition count — i.e. its rows already reach a `targetType`-bucketed
+  /// consumer or write target with no reshuffle.
+  bool isBucketedCompatibleWith(
+      const ExprVector& otherKeys,
+      const connector::PartitionType& targetType) const;
+};
+
+/// Kind of a per-driver local property.
+enum class LocalPropertyKind : uint8_t {
+  /// Rows with equal `columns` are contiguous (not necessarily ordered) within
+  /// a driver, and every such group is wholly within one driver. See
+  /// `LocalProperty` for the confinement contract.
+  kGrouped,
+  /// Rows ordered by `columns`, outermost key first, with the direction of each
+  /// given by the matching entry in `orders`.
+  kSorted,
+};
+
+AXIOM_DECLARE_ENUM_NAME(LocalPropertyKind);
+
+/// One entry in a relation's ordered list of per-driver local properties. The
+/// list order captures nesting: `[Grouped(P), Sorted(o1, o2)]` means grouped by
+/// the set `P`, and within each group ordered by `o1` then `o2`.
+///
+/// A `kGrouped` entry uses `columns` alone (the grouped set; order among its
+/// members is irrelevant) and leaves `orders` empty. A `kSorted` entry uses
+/// both in parallel: `columns` are the sort keys outermost first, and
+/// `orders[i]` is the direction of `columns[i]`.
+///
+/// A local property carries driver-confinement as part of its contract, not
+/// just contiguity: a `kGrouped` set of equal `columns` (or a `kSorted`
+/// equal-key run) is both contiguous within a driver's stream AND wholly
+/// confined to that one driver — no group spans drivers. Producers must attach
+/// a local property only when both hold; a source with mere per-driver
+/// contiguity but no confinement (e.g. a bucketed/sorted scan whose splits
+/// round-robin across drivers) must not. Consumers that decide driver placement
+/// (e.g. skipping a local repartition before a single-stage aggregation) rely
+/// on this directly: a local grouping on the keys means the groups are already
+/// driver-confined.
+struct LocalProperty {
+  LocalPropertyKind kind{LocalPropertyKind::kGrouped};
+  ColumnVector columns;
+  OrderTypeVector orders;
+};
+
+/// A relation's per-driver local properties, outermost first.
+using LocalPropertyVector = QGVector<LocalProperty>;
+
+/// A set of columns that is unique across the relation — i.e., functionally
+/// determines the row — at `scope`. Stored minimal: a key-set whose columns are
+/// a superset of another stored key-set is redundant and not kept, but
+/// independent minimal key-sets (e.g. `{a}` and `{b}` both unique) are all
+/// retained. `columns` is a set (a `PlanObjectSet`) so consumers can test
+/// containment ("is some unique key-set ⊆ the columns I care about?") directly.
+struct UniqueKeySet {
+  PlanObjectSet columns;
+  PropertyScope scope{PropertyScope::kGlobal};
+};
+
+/// Unique key-sets of a relation. May hold several independent minimal
+/// key-sets, each at its own scope.
+using UniqueKeySetVector = QGVector<UniqueKeySet>;
+
+/// The physical properties of one relation — the output of per-operator
+/// derivation and the value the property-aware memo compares. Bundles the three
+/// property categories.
+///
+/// The two partitioning slots are independent (see `PropertyScope`):
+/// `globalPartition.scope == kGlobal` and `driverPartition.scope == kDriver`.
+struct PhysicalProperties {
+  /// Partitioning across tasks; set by a remote exchange.
+  Partitioning globalPartition{.scope = PropertyScope::kGlobal};
+
+  /// Partitioning across drivers within a task; set by a local exchange.
+  Partitioning driverPartition{.scope = PropertyScope::kDriver};
+
+  /// Per-driver ordering and grouping, outermost first.
+  LocalPropertyVector local;
+
+  /// Unique key-sets, relation-level, each scope-tagged.
+  UniqueKeySetVector unique;
+
+  /// Checks the invariant that these properties are expressed over the node's
+  /// own `outputColumns`. A partitioning's keys and merge order may be computed
+  /// expressions (the partition function's input), but every column they depend
+  /// on must be an output column, so the partitioning is evaluable here.
+  /// Local-property columns and every unique key-set must themselves be output
+  /// columns. Fails (`VELOX_CHECK`) on violation. Called by the `Node` base
+  /// constructor.
+  void checkReferencesColumns(const PlanObjectSet& outputColumns) const;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1,0 +1,2281 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/TranslatePass.h"
+
+#include <folly/container/F14Map.h>
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "axiom/optimizer/v2/ExprSimplifier.h"
+#include "axiom/optimizer/v2/JoinCondition.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace lp = logical_plan;
+
+namespace {
+
+// Set of LP-output column names the consumer needs from this translation.
+// Threaded top-down through `translateNode` so producers (Scan, Project,
+// Aggregate, etc.) can mint / keep only the columns downstream actually uses.
+using LpNameSet = folly::F14FastSet<std::string>;
+
+// Returns the set of every column name in `rowType`. Used as the "everything"
+// required-set when the consumer hasn't (yet) narrowed it.
+LpNameSet allNames(const velox::RowType& rowType) {
+  const auto& names = rowType.names();
+  return LpNameSet{names.begin(), names.end()};
+}
+
+void collectUsedNames(const logical_plan::Expr& expr, LpNameSet& out);
+void collectUsedNames(
+    const std::vector<logical_plan::ExprPtr>& exprs,
+    LpNameSet& out);
+
+// Walks every expression carried by `node` and its descendants and adds
+// every referenced `InputReferenceExpr::name` to `out`. Used to capture
+// correlated outer-column references inside subquery bodies — those names
+// are the ones the outer node must preserve in its child's required-set.
+void collectUsedNamesInPlan(
+    const logical_plan::LogicalPlanNode& node,
+    LpNameSet& out) {
+  switch (node.kind()) {
+    case lp::NodeKind::kFilter:
+      collectUsedNames(*node.as<lp::FilterNode>()->predicate(), out);
+      break;
+    case lp::NodeKind::kProject:
+      collectUsedNames(node.as<lp::ProjectNode>()->expressions(), out);
+      break;
+    case lp::NodeKind::kAggregate: {
+      const auto* agg = node.as<lp::AggregateNode>();
+      collectUsedNames(agg->groupingKeys(), out);
+      for (const auto& aggExpr : agg->aggregates()) {
+        collectUsedNames(*aggExpr, out);
+      }
+      break;
+    }
+    case lp::NodeKind::kJoin: {
+      const auto* join = node.as<lp::JoinNode>();
+      if (join->condition() != nullptr) {
+        collectUsedNames(*join->condition(), out);
+      }
+      break;
+    }
+    case lp::NodeKind::kSort:
+      for (const auto& field : node.as<lp::SortNode>()->ordering()) {
+        collectUsedNames(*field.expression, out);
+      }
+      break;
+    case lp::NodeKind::kUnnest:
+      collectUsedNames(node.as<lp::UnnestNode>()->unnestExpressions(), out);
+      break;
+    default:
+      // Scan, Limit, Values, Set, Output: no expression-bearing fields that
+      // could reference outer columns.
+      break;
+  }
+  for (const auto& input : node.inputs()) {
+    collectUsedNamesInPlan(*input, out);
+  }
+}
+
+// Collects every `InputReferenceExpr::name` referenced anywhere in `expr`.
+// Used by translate functions to compute the required-set their input must
+// supply, given the expressions the node itself reads. `WindowExpr`,
+// `AggregateExpr`, `LambdaExpr`, and `SubqueryExpr` carry sub-expressions
+// in side fields outside `inputs()`, so they need explicit handling.
+void collectUsedNames(const logical_plan::Expr& expr, LpNameSet& out) {
+  if (expr.isInputReference()) {
+    out.insert(expr.as<lp::InputReferenceExpr>()->name());
+    return;
+  }
+  for (const auto& child : expr.inputs()) {
+    collectUsedNames(*child, out);
+  }
+  if (expr.isWindow()) {
+    const auto* window = expr.as<lp::WindowExpr>();
+    for (const auto& key : window->partitionKeys()) {
+      collectUsedNames(*key, out);
+    }
+    for (const auto& field : window->ordering()) {
+      collectUsedNames(*field.expression, out);
+    }
+    if (window->frame().startValue != nullptr) {
+      collectUsedNames(*window->frame().startValue, out);
+    }
+    if (window->frame().endValue != nullptr) {
+      collectUsedNames(*window->frame().endValue, out);
+    }
+  } else if (expr.isAggregate()) {
+    const auto* agg = expr.as<lp::AggregateExpr>();
+    if (agg->filter() != nullptr) {
+      collectUsedNames(*agg->filter(), out);
+    }
+    for (const auto& field : agg->ordering()) {
+      collectUsedNames(*field.expression, out);
+    }
+  } else if (expr.kind() == lp::ExprKind::kLambda) {
+    // Lambda body may reference outer columns (captures). Recurse into the
+    // body, then subtract the lambda's signature names (those are
+    // introduced by the lambda itself, not consumed from the outer scope).
+    const auto* lambda = expr.as<lp::LambdaExpr>();
+    LpNameSet bodyNames;
+    collectUsedNames(*lambda->body(), bodyNames);
+    for (const auto& name : lambda->signature()->names()) {
+      bodyNames.erase(name);
+    }
+    out.insert(bodyNames.begin(), bodyNames.end());
+  } else if (expr.kind() == lp::ExprKind::kSubquery) {
+    // Walk the subquery body to surface any correlated outer-column
+    // references. Names not in the outer's outputType are silently ignored
+    // by the consumer (existing policy); names that match outer columns
+    // are the correlations the outer must keep so the body's translate
+    // can resolve them.
+    const auto* subquery = expr.as<lp::SubqueryExpr>();
+    collectUsedNamesInPlan(*subquery->subquery(), out);
+  }
+}
+
+void collectUsedNames(
+    const std::vector<logical_plan::ExprPtr>& exprs,
+    LpNameSet& out) {
+  for (const auto& expr : exprs) {
+    collectUsedNames(*expr, out);
+  }
+}
+
+// Appends columns from `extra` to `base`, skipping any that already
+// appear in `base` (by Column* identity).
+void appendUnique(ColumnVector& base, const ColumnVector& extra) {
+  PlanObjectSet seen = PlanObjectSet::fromObjects(base);
+  for (ColumnCP column : extra) {
+    if (!seen.contains(column)) {
+      seen.add(column);
+      base.push_back(column);
+    }
+  }
+}
+
+// True if 'expr' is or transitively contains an `lp::SubqueryExpr`.
+// Used to decide whether a parent node's IR shape needs adjusting to
+// give the subquery a relational input above which to lift Apply.
+//
+// TODO: walk side-channel children carried by Lambda body / Window
+// partition+order+frame / Aggregate filter+ordering — currently this
+// recursion only follows `Expr::inputs()`, so a subquery buried inside
+// `filter(arr, x -> x = (SELECT ...))` (or similar HOF) is missed. A
+// miss is safe — control falls through to the non-split path with
+// `applyTarget=nullptr` and `liftSubquery` throws NYI rather than
+// silently miscompiling — but coverage is incomplete.
+bool containsSubquery(const logical_plan::Expr& expr) {
+  if (expr.kind() == logical_plan::ExprKind::kSubquery) {
+    return true;
+  }
+  for (const auto& child : expr.inputs()) {
+    if (containsSubquery(*child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Walks 'expr' as a top-level AND chain and appends each non-AND leaf
+// to 'out'.
+void flattenAndConjuncts(
+    const logical_plan::Expr& expr,
+    std::vector<const logical_plan::Expr*>& out) {
+  if (expr.isSpecialForm() &&
+      expr.as<logical_plan::SpecialFormExpr>()->form() ==
+          logical_plan::SpecialForm::kAnd) {
+    for (const auto& child : expr.inputs()) {
+      flattenAndConjuncts(*child, out);
+    }
+    return;
+  }
+  out.push_back(&expr);
+}
+
+// Resolution context for translating expressions in a fixed scope. Maps
+// output column name to the Column that produces it.
+using Scope = folly::F14FastMap<std::string, ColumnCP>;
+
+// Populates 'scope' with one entry per field of 'rowType' pointing at the
+// matching Column in 'columns'. 'columns' must align 1:1 with 'rowType'.
+void populateScope(
+    const velox::RowType& rowType,
+    const ColumnVector& columns,
+    Scope& scope) {
+  VELOX_CHECK_EQ(
+      rowType.size(), columns.size(), "Scope row type / columns mismatch");
+  for (size_t i = 0; i < rowType.size(); ++i) {
+    scope[rowType.nameOf(i)] = columns[i];
+  }
+}
+
+// Builds one fresh Column per field of 'rowType' and populates 'scope' to
+// map each field name to its column.
+ColumnVector makeOutputColumns(
+    const velox::RowType& rowType,
+    float cardinality,
+    Scope& scope) {
+  ColumnVector columns;
+  columns.reserve(rowType.size());
+  for (size_t i = 0; i < rowType.size(); ++i) {
+    Value value(toType(rowType.childAt(i)), cardinality);
+    columns.push_back(
+        Column::createForSymbol(toName(rowType.nameOf(i)), value));
+  }
+  populateScope(rowType, columns, scope);
+  return columns;
+}
+
+struct Translated {
+  NodeCP node;
+  Scope scope;
+};
+
+// Outer-scope chain used while translating subquery bodies, plus the
+// per-nesting-level set of correlated columns referenced so far.
+// `liftSubquery` consumes the captured correlations as `Apply.correlations`.
+//
+// Invariant: `outerScopes_.size() == correlationsStack_.size()`.
+class SubqueryContext {
+ public:
+  // Resolves 'name' against enclosing scopes, innermost-first. Returns
+  // nullptr if not found at any level. Records the hit as a correlation
+  // for the innermost in-flight subquery.
+  ColumnCP resolveOuter(std::string_view name);
+
+  // Enters/leaves the body of a subquery. `pop()` returns the correlated
+  // columns collected during that body, deduplicated.
+  void push(const Scope& outerScope);
+  ColumnVector pop();
+
+ private:
+  std::vector<const Scope*> outerScopes_;
+  std::vector<ColumnVector> correlationsStack_;
+};
+
+ColumnCP SubqueryContext::resolveOuter(std::string_view name) {
+  for (size_t i = outerScopes_.size(); i > 0; --i) {
+    const Scope& scope = *outerScopes_[i - 1];
+    auto found = scope.find(name);
+    if (found == scope.end()) {
+      continue;
+    }
+    VELOX_CHECK_GE(correlationsStack_.size(), i);
+    // Record on every in-flight subquery between the matching outer scope
+    // and the innermost so each intermediate Apply carries the column.
+    for (size_t j = i - 1; j < correlationsStack_.size(); ++j) {
+      correlationsStack_[j].push_back(found->second);
+    }
+    return found->second;
+  }
+  return nullptr;
+}
+
+void SubqueryContext::push(const Scope& outerScope) {
+  outerScopes_.push_back(&outerScope);
+  correlationsStack_.emplace_back();
+}
+
+ColumnVector SubqueryContext::pop() {
+  ColumnVector deduped;
+  folly::F14FastSet<ColumnCP> seen;
+  for (ColumnCP column : correlationsStack_.back()) {
+    if (seen.insert(column).second) {
+      deduped.push_back(column);
+    }
+  }
+  correlationsStack_.pop_back();
+  outerScopes_.pop_back();
+  return deduped;
+}
+
+class Translator {
+ public:
+  Translator(
+      optimizer::Schema& schema,
+      velox::core::ExpressionEvaluator& evaluator,
+      Builder& builder)
+      : schema_(schema),
+        builder_(builder),
+        exprFactory_(builder),
+        simplifier_(builder, evaluator) {}
+
+  TranslatePass::Result run(const lp::LogicalPlanNode& plan) {
+    if (plan.is(lp::NodeKind::kOutput)) {
+      const auto& output = *plan.as<lp::OutputNode>();
+      const auto& child = *output.onlyInput();
+      const auto& childOutputType = *child.outputType();
+      // Seed `required` with just the LP names the OutputNode references.
+      // Names not referenced flow as "unused" through the child translation
+      // and get pruned where producers honor the required-set.
+      LpNameSet required;
+      required.reserve(output.entries().size());
+      for (const auto& entry : output.entries()) {
+        VELOX_CHECK_LT(entry.index, childOutputType.size());
+        required.insert(childOutputType.nameOf(entry.index));
+      }
+      Translated inner = translateNode(child, required);
+      ColumnVector outputColumns;
+      std::vector<std::string> outputNames;
+      outputColumns.reserve(output.entries().size());
+      outputNames.reserve(output.entries().size());
+      for (const auto& entry : output.entries()) {
+        // Resolve via LP-name → Column* scope rather than positionally:
+        // the IR's outputColumns may be narrower than the LP child's
+        // outputType after dup-collapse, and the LP contract is that
+        // same-name == same-thing in a node's outputType.
+        const auto& name = childOutputType.nameOf(entry.index);
+        auto it = inner.scope.find(name);
+        VELOX_CHECK(
+            it != inner.scope.end(),
+            "OutputNode entry name not found in inner scope: {}",
+            name);
+        outputColumns.push_back(it->second);
+        outputNames.push_back(entry.name);
+      }
+      return {inner.node, std::move(outputColumns), std::move(outputNames)};
+    }
+    // Bare plan (no OutputNode): nothing has narrowed the required set, so
+    // request everything the root advertises.
+    Translated translated = translateNode(plan, allNames(*plan.outputType()));
+    std::vector<std::string> outputNames;
+    outputNames.reserve(translated.node->outputColumns().size());
+    for (ColumnCP column : translated.node->outputColumns()) {
+      outputNames.emplace_back(column->outputName());
+    }
+    return {
+        translated.node,
+        ColumnVector{translated.node->outputColumns()},
+        std::move(outputNames)};
+  }
+
+ private:
+  // 'required' is the set of LP-output column names the consumer needs from
+  // this node. Producers (Scan, Project, Aggregate, Window, Unnest, Values)
+  // may emit only outputs in `required`; intermediate nodes propagate it
+  // down, augmented with the names the node itself reads.
+  Translated translateNode(
+      const lp::LogicalPlanNode& node,
+      const LpNameSet& required);
+  Translated translateScan(
+      const lp::TableScanNode& scan,
+      const LpNameSet& required);
+  Translated translateFilter(
+      const lp::FilterNode& filter,
+      const LpNameSet& required);
+  Translated translateProject(
+      const lp::ProjectNode& project,
+      const LpNameSet& required);
+  Translated translateLimit(
+      const lp::LimitNode& limit,
+      const LpNameSet& required);
+  Translated translateSort(const lp::SortNode& sort, const LpNameSet& required);
+  Translated translateAggregate(
+      const lp::AggregateNode& aggregate,
+      const LpNameSet& required);
+  Translated translateValues(
+      const lp::ValuesNode& values,
+      const LpNameSet& required);
+  Translated translateUnnest(
+      const lp::UnnestNode& unnest,
+      const LpNameSet& required);
+  Translated translateSet(const lp::SetNode& set, const LpNameSet& required);
+  Translated translateJoin(const lp::JoinNode& join, const LpNameSet& required);
+  Translated translateTableWrite(
+      const lp::TableWriteNode& tableWrite,
+      const LpNameSet& required);
+  NodeCP maybeWrapInWindow(
+      NodeCP input,
+      const Scope& inputScope,
+      const std::vector<lp::ExprPtr>& projectExprs,
+      const std::vector<std::string>& projectNames,
+      Scope& windowScope);
+  Translated buildUnionAll(
+      const std::vector<lp::LogicalPlanNodePtr>& inputs,
+      const velox::RowTypePtr& outputType,
+      const LpNameSet& required);
+
+  // Translates `predicateExpr` against `scope` (lifting any subqueries
+  // above `input` via Apply) and lowers it onto `input`. Returns an
+  // empty `Values` of `input`'s schema when the predicate is
+  // statically `false`, `input` unchanged when statically `true`, or
+  // a `Filter` otherwise. `scope` is returned unchanged.
+  Translated
+  maybeWrapInFilter(NodeCP input, const lp::Expr& predicateExpr, Scope scope);
+
+  // Translates an lp expression against 'scope'. If the expression
+  // contains an `lp::SubqueryExpr` (bare, or wrapped in
+  // `kExists`/`kIn`/`kNot`), the subquery is materialized as an `Apply`
+  // node lifted above `*applyTarget`, and `*applyTarget` is updated to
+  // point to the new Apply. The returned `ExprCP` references the Apply's
+  // mark / value column at the subquery site.
+  //
+  // `applyTarget` must be non-null at any expression position that may
+  // contain a subquery. Passing `nullptr` declares "no lift possible
+  // here" and the lift path throws if a subquery is encountered
+  // (e.g., row-literal expressions in `VALUES`).
+  ExprCP
+  translateExpr(const lp::Expr& expr, const Scope& scope, NodeCP* applyTarget);
+  ExprCP translateInputReference(
+      const lp::InputReferenceExpr& expr,
+      const Scope& scope);
+  ExprCP translateConstant(const lp::ConstantExpr& expr);
+  ExprCP translateCall(
+      const lp::CallExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+  ExprCP translateSpecialForm(
+      const lp::SpecialFormExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates an EXISTS special form by lifting an `Apply(kLeftSemiProject)`,
+  // with a fast path that folds EXISTS over a scalar Aggregate to constant
+  // TRUE.
+  ExprCP translateExists(
+      const lp::SpecialFormExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Normalizes an IN list. Folds a single-element IN to equality (`a IN (b)` ->
+  // `a = b`, `a IN (NULL)` -> null boolean literal). For a multi-element
+  // constant list, drops duplicate constants from 'args' in place and returns a
+  // folded equality when a single distinct constant remains. Returns nullptr to
+  // let the caller build the (deduplicated) IN through the generic path,
+  // leaving 'args' unchanged when a multi-element list has any non-constant
+  // element.
+  ExprCP normalizeInList(ExprVector& args);
+
+  // Translates a DEREFERENCE special form, resolving a varchar field name to a
+  // numeric field index against the input row type.
+  ExprCP
+  translateDereference(ExprVector args, Name callName, const Value& value);
+
+  ExprCP translateLambda(const lp::LambdaExpr& expr, const Scope& scope);
+
+  // Translates a subquery body, captures correlations, and lifts an
+  // `Apply` above `*applyTarget`. Updates `*applyTarget` to point to
+  // the new Apply (with an `EnforceSingleRow` wrap for uncorrelated
+  // scalar). Returns Apply's result column.
+  //
+  // `kind` is the `Apply.kind` to emit. `inLhs` is the IN expression's
+  // left-hand side, non-null only when shaping an IN-form Apply
+  // (`liftSubquery` stores it together with the body's single output
+  // column as `Apply.inLhs` / `Apply.inBodyKey`). Throws if
+  // `applyTarget` is null.
+  ColumnCP liftSubquery(
+      const lp::SubqueryExpr& subqueryExpr,
+      velox::core::JoinType kind,
+      ExprCP inLhs,
+      const Scope& outerScope,
+      NodeCP* applyTarget);
+
+  // Translates each lp expression in 'expressions' against 'scope'.
+  ExprVector translateAll(
+      const std::vector<lp::ExprPtr>& expressions,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates an lp window frame against 'scope'.
+  Frame toFrame(const lp::WindowExpr::Frame& frame, const Scope& scope);
+
+  // Translates an lp aggregate expression into a QueryGraph `Aggregate`
+  // call. Resolves args / FILTER mask / ORDER BY keys against 'scope'.
+  // `applyTarget` (if non-null) lifts Apply nodes for any subquery in
+  // args / FILTER / ORDER BY above the Aggregate's input.
+  const optimizer::Aggregate* toAggregateCall(
+      const lp::AggregateExpr& aggregateExpr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates each expression in 'exprRows' and, if every one folds to a
+  // `Literal`, returns the row-wise `Variant`s. Returns nullopt if any
+  // entry doesn't fold. `VALUES` expressions cannot reference input
+  // columns, so translation runs against an empty scope.
+  std::optional<std::vector<velox::Variant>> foldExprRowsToVariants(
+      const lp::ValuesNode::Exprs& exprRows);
+
+  SubqueryContext subqueries_;
+  Schema& schema_;
+  Builder& builder_;
+  ExprFactory exprFactory_;
+  ExprSimplifier simplifier_;
+  int32_t baseTableCounter_{0};
+};
+
+Translated Translator::translateTableWrite(
+    const lp::TableWriteNode& tableWrite,
+    const LpNameSet& /*required*/) {
+  const auto kind = static_cast<connector::WriteKind>(tableWrite.writeKind());
+  if (kind != connector::WriteKind::kInsert &&
+      kind != connector::WriteKind::kCreate) {
+    VELOX_NYI(
+        "TableWrite supports only INSERT and CREATE, got {}",
+        connector::WriteKindName::toName(kind));
+  }
+
+  const auto* schemaTable =
+      schema_.findTable(tableWrite.connectorId(), tableWrite.tableName());
+  VELOX_CHECK_NOT_NULL(
+      schemaTable,
+      "Table not found: {} via connector {}",
+      tableWrite.tableName().toString(),
+      tableWrite.connectorId());
+  const auto* connectorTable = schemaTable->connectorTable;
+  VELOX_CHECK_NOT_NULL(connectorTable);
+  const auto& tableSchema = *connectorTable->type();
+
+  // The child must supply every column a write expression reads.
+  LpNameSet childRequired;
+  for (const auto& columnExpr : tableWrite.columnExpressions()) {
+    collectUsedNames(*columnExpr, childRequired);
+  }
+  Translated input = translateNode(*tableWrite.onlyInput(), childRequired);
+  NodeCP currentInput = input.node;
+
+  // One expression per target column, in table-schema order: the statement's
+  // expression where the column is written, else the column's schema default.
+  const auto& writtenNames = tableWrite.columnNames();
+  ExprVector columnExprs;
+  columnExprs.reserve(tableSchema.size());
+  for (uint32_t i = 0; i < tableSchema.size(); ++i) {
+    const auto& columnName = tableSchema.nameOf(i);
+    auto it = std::find(writtenNames.begin(), writtenNames.end(), columnName);
+    if (it != writtenNames.end()) {
+      const auto nth = it - writtenNames.begin();
+      columnExprs.push_back(translateExpr(
+          *tableWrite.columnExpressions()[nth], input.scope, &currentInput));
+    } else {
+      const auto* tableColumn = connectorTable->findColumn(columnName);
+      VELOX_CHECK_NOT_NULL(tableColumn);
+      columnExprs.push_back(builder_.makeLiteral(
+          velox::Variant(tableColumn->defaultValue()),
+          toType(tableColumn->type())));
+    }
+    VELOX_DCHECK(
+        *tableSchema.childAt(i) == *toTypePtr(columnExprs.back()->value().type),
+        "TableWrite column type does not match schema: column {}, schema {}, expr {}",
+        columnName,
+        tableSchema.childAt(i)->toString(),
+        toTypePtr(columnExprs.back()->value().type)->toString());
+  }
+
+  NodeCP writeNode = builder_.make<TableWrite>(
+      {currentInput, connectorTable, kind, std::move(columnExprs)});
+
+  // The single output column is the written row count.
+  Scope scope;
+  const auto& outputType = *tableWrite.outputType();
+  if (outputType.size() == 1) {
+    scope[outputType.nameOf(0)] = writeNode->outputColumns()[0];
+  }
+  return {writeNode, std::move(scope)};
+}
+
+Translated Translator::translateNode(
+    const lp::LogicalPlanNode& node,
+    const LpNameSet& required) {
+  switch (node.kind()) {
+    case lp::NodeKind::kTableScan:
+      return translateScan(*node.as<lp::TableScanNode>(), required);
+    case lp::NodeKind::kFilter:
+      return translateFilter(*node.as<lp::FilterNode>(), required);
+    case lp::NodeKind::kProject:
+      return translateProject(*node.as<lp::ProjectNode>(), required);
+    case lp::NodeKind::kLimit:
+      return translateLimit(*node.as<lp::LimitNode>(), required);
+    case lp::NodeKind::kSort:
+      return translateSort(*node.as<lp::SortNode>(), required);
+    case lp::NodeKind::kAggregate:
+      return translateAggregate(*node.as<lp::AggregateNode>(), required);
+    case lp::NodeKind::kValues:
+      return translateValues(*node.as<lp::ValuesNode>(), required);
+    case lp::NodeKind::kUnnest:
+      return translateUnnest(*node.as<lp::UnnestNode>(), required);
+    case lp::NodeKind::kSet:
+      return translateSet(*node.as<lp::SetNode>(), required);
+    case lp::NodeKind::kJoin:
+      return translateJoin(*node.as<lp::JoinNode>(), required);
+    case lp::NodeKind::kTableWrite:
+      return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
+    case lp::NodeKind::kOutput:
+      VELOX_UNREACHABLE();
+    default:
+      VELOX_NYI(
+          "Unsupported logical plan node kind: {}",
+          lp::NodeKindName::toName(node.kind()));
+  }
+}
+
+Translated Translator::translateScan(
+    const lp::TableScanNode& scan,
+    const LpNameSet& required) {
+  const auto* schemaTable =
+      schema_.findTable(scan.connectorId(), scan.tableName());
+  VELOX_CHECK_NOT_NULL(schemaTable);
+
+  auto* baseTable = make<BaseTable>();
+  baseTable->cname = toName(fmt::format("t{}", baseTableCounter_++));
+  baseTable->schemaTable = schemaTable;
+  // filteredCardinality stays 0 until estimateLeafStats populates it from
+  // connector stats; cardinality estimation falls back to constraint-based
+  // selectivity while it is unset.
+
+  const auto& columnNames = scan.columnNames();
+  const auto& outputType = scan.outputType();
+  ColumnVector outputColumns;
+  outputColumns.reserve(columnNames.size());
+  Scope scope;
+  for (size_t i = 0; i < columnNames.size(); ++i) {
+    const auto& outName = outputType->nameOf(i);
+    if (!required.contains(outName)) {
+      continue;
+    }
+    Name inTableName = toName(columnNames[i]);
+    Name outNameInterned = toName(outName);
+    ColumnCP schemaColumn = schemaTable->findColumn(inTableName);
+    VELOX_CHECK_NOT_NULL(schemaColumn);
+    auto* column = make<Column>(
+        inTableName,
+        baseTable,
+        schemaColumn->value(),
+        outNameInterned,
+        schemaColumn->name());
+    baseTable->columns.push_back(column);
+    outputColumns.push_back(column);
+    scope[outName] = column;
+  }
+  ScanCP scanNode = builder_.make<Scan>(
+      {baseTable, std::move(outputColumns), /*filters=*/{}});
+  return {scanNode, std::move(scope)};
+}
+
+Translated Translator::translateFilter(
+    const lp::FilterNode& filter,
+    const LpNameSet& required) {
+  // Filter is a pass-through: its outputType equals the child's. Forward
+  // `required` plus the names the predicate reads from the child.
+  LpNameSet childRequired = required;
+  collectUsedNames(*filter.predicate(), childRequired);
+  Translated input = translateNode(*filter.onlyInput(), childRequired);
+
+  // Split conjuncts so no-subquery ones land in a Filter below the
+  // Apply, where PushdownAndPrune can carry them into the input
+  // subtree. Subquery-bearing conjuncts must stay above the Apply
+  // (and any decorrelation aggregate atop it).
+  std::vector<const lp::Expr*> conjuncts;
+  flattenAndConjuncts(*filter.predicate(), conjuncts);
+  std::vector<const lp::Expr*> noSubquery;
+  std::vector<const lp::Expr*> withSubquery;
+  noSubquery.reserve(conjuncts.size());
+  withSubquery.reserve(conjuncts.size());
+  for (const auto* conjunct : conjuncts) {
+    if (containsSubquery(*conjunct)) {
+      withSubquery.push_back(conjunct);
+    } else {
+      noSubquery.push_back(conjunct);
+    }
+  }
+  if (noSubquery.empty() || withSubquery.empty()) {
+    return maybeWrapInFilter(
+        input.node, *filter.predicate(), std::move(input.scope));
+  }
+
+  // Translates 'conjuncts' and accumulates simplified results.
+  // Returns nullopt if any conjunct simplifies to constant false.
+  auto translateConjuncts =
+      [&](const std::vector<const lp::Expr*>& conjuncts,
+          NodeCP* applyTarget) -> std::optional<ExprVector> {
+    ExprVector result;
+    result.reserve(conjuncts.size());
+    for (const auto* conjunct : conjuncts) {
+      ExprCP translated = translateExpr(*conjunct, input.scope, applyTarget);
+      if (simplifier_.simplifyFilter(translated, result)) {
+        return std::nullopt;
+      }
+    }
+    return result;
+  };
+
+  auto innerConjuncts = translateConjuncts(noSubquery, /*applyTarget=*/nullptr);
+  if (!innerConjuncts.has_value()) {
+    return {
+        builder_.makeEmptyValues(input.node->outputColumns()),
+        std::move(input.scope)};
+  }
+  NodeCP inner = innerConjuncts->empty()
+      ? input.node
+      : builder_.make<Filter>({input.node, std::move(*innerConjuncts)});
+
+  auto outerConjuncts = translateConjuncts(withSubquery, &inner);
+  if (!outerConjuncts.has_value()) {
+    return {
+        builder_.makeEmptyValues(inner->outputColumns()),
+        std::move(input.scope)};
+  }
+  if (outerConjuncts->empty()) {
+    return {inner, std::move(input.scope)};
+  }
+  return {
+      builder_.make<Filter>({inner, std::move(*outerConjuncts)}),
+      std::move(input.scope)};
+}
+
+Translated Translator::maybeWrapInFilter(
+    NodeCP input,
+    const lp::Expr& predicateExpr,
+    Scope scope) {
+  ExprCP predicate = translateExpr(predicateExpr, scope, &input);
+
+  ExprVector conjuncts;
+  if (simplifier_.simplifyFilter(predicate, conjuncts)) {
+    return {builder_.makeEmptyValues(input->outputColumns()), std::move(scope)};
+  }
+
+  if (conjuncts.empty()) {
+    return {input, std::move(scope)};
+  }
+
+  return {
+      builder_.make<Filter>({input, std::move(conjuncts)}), std::move(scope)};
+}
+
+Translated Translator::translateProject(
+    const lp::ProjectNode& project,
+    const LpNameSet& required) {
+  const auto& names = project.names();
+  const auto& exprs = project.expressions();
+  VELOX_CHECK_EQ(names.size(), exprs.size());
+
+  // Drop output positions not in `required` and compute the names the kept
+  // expressions read from the child.
+  std::vector<size_t> keptIndices;
+  keptIndices.reserve(names.size());
+  LpNameSet childRequired;
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (!required.contains(names[i])) {
+      continue;
+    }
+    keptIndices.push_back(i);
+    collectUsedNames(*exprs[i], childRequired);
+  }
+
+  Translated input = translateNode(*project.onlyInput(), childRequired);
+
+  // maybeWrapInWindow only needs the kept window-function exprs.
+  std::vector<lp::ExprPtr> keptExprs;
+  std::vector<std::string> keptNames;
+  keptExprs.reserve(keptIndices.size());
+  keptNames.reserve(keptIndices.size());
+  for (size_t idx : keptIndices) {
+    keptExprs.push_back(exprs[idx]);
+    keptNames.push_back(names[idx]);
+  }
+  Scope windowScope = input.scope;
+  NodeCP currentInput = maybeWrapInWindow(
+      input.node, input.scope, keptExprs, keptNames, windowScope);
+
+  ColumnVector outputColumns;
+  outputColumns.reserve(keptIndices.size());
+  ExprVector translatedExprs;
+  translatedExprs.reserve(keptIndices.size());
+  Scope newScope;
+  // Output positions producing the same canonical expression collapse to one
+  // output entry; both LP names still resolve to that Column via `newScope`.
+  folly::F14FastMap<ExprCP, ColumnCP> exprToOutput;
+  exprToOutput.reserve(keptIndices.size());
+  for (size_t idx : keptIndices) {
+    const auto& name = names[idx];
+    ExprCP translatedExpr;
+    if (exprs[idx]->isWindow()) {
+      auto it = windowScope.find(name);
+      VELOX_CHECK(it != windowScope.end());
+      translatedExpr = it->second;
+    } else {
+      translatedExpr = translateExpr(*exprs[idx], input.scope, &currentInput);
+    }
+    if (auto seenIt = exprToOutput.find(translatedExpr);
+        seenIt != exprToOutput.end()) {
+      newScope[name] = seenIt->second;
+      continue;
+    }
+    ColumnCP column;
+    if (translatedExpr->is(PlanType::kColumnExpr)) {
+      column = translatedExpr->as<Column>();
+    } else {
+      Name outName = toName(name);
+      column = make<Column>(
+          queryCtx()->newName(outName),
+          /*relation=*/nullptr,
+          translatedExpr->value(),
+          /*alias=*/outName);
+    }
+    exprToOutput.emplace(translatedExpr, column);
+    newScope[name] = column;
+    outputColumns.push_back(column);
+    translatedExprs.push_back(translatedExpr);
+  }
+
+  // Identity Project: pass-through outputs in input order. Skip allocating;
+  // `newScope` carries any LP renames.
+  if (outputColumns.size() == currentInput->outputColumns().size()) {
+    bool identity = true;
+    for (size_t i = 0; i < outputColumns.size(); ++i) {
+      if (outputColumns[i] != currentInput->outputColumns()[i]) {
+        identity = false;
+        break;
+      }
+    }
+    if (identity) {
+      return {currentInput, std::move(newScope)};
+    }
+  }
+
+  ProjectCP projectNode = builder_.make<Project>(
+      {currentInput, std::move(translatedExprs), std::move(outputColumns)});
+  return {projectNode, std::move(newScope)};
+}
+
+OrderType toOrderType(const logical_plan::SortOrder& order) {
+  if (order.isAscending()) {
+    return order.isNullsFirst() ? OrderType::kAscNullsFirst
+                                : OrderType::kAscNullsLast;
+  }
+  return order.isNullsFirst() ? OrderType::kDescNullsFirst
+                              : OrderType::kDescNullsLast;
+}
+
+// Max NDV across 'exprs', propagating unknown: if any operand's NDV is
+// unknown, the derived NDV is unknown (nullopt) rather than a fabricated
+// floor. An empty input has no operand to derive from and is treated as a
+// known 1 (the prior floor), matching a nullary call's degenerate NDV.
+std::optional<float> maxCardinality(const ExprVector& exprs) {
+  std::optional<float> result{1.0f};
+  for (const auto* expr : exprs) {
+    result = optimizer::maxOf(result, expr->value().cardinality);
+  }
+  return result;
+}
+
+ExprVector Translator::translateAll(
+    const std::vector<lp::ExprPtr>& expressions,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector result;
+  result.reserve(expressions.size());
+  for (const auto& expression : expressions) {
+    result.push_back(translateExpr(*expression, scope, applyTarget));
+  }
+  return result;
+}
+
+Frame Translator::toFrame(
+    const lp::WindowExpr::Frame& frame,
+    const Scope& scope) {
+  // Frame bounds are scalar literals (rows/range offsets); no subquery
+  // can appear here, so no lift target needed.
+  return Frame{
+      frame.type,
+      frame.startType,
+      frame.startValue ? translateExpr(*frame.startValue, scope, nullptr)
+                       : nullptr,
+      frame.endType,
+      frame.endValue ? translateExpr(*frame.endValue, scope, nullptr) : nullptr,
+  };
+}
+
+const optimizer::Aggregate* Translator::toAggregateCall(
+    const lp::AggregateExpr& aggregateExpr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector arguments =
+      translateAll(aggregateExpr.inputs(), scope, applyTarget);
+
+  std::vector<velox::TypePtr> argTypes;
+  argTypes.reserve(aggregateExpr.inputs().size());
+  for (const auto& input : aggregateExpr.inputs()) {
+    argTypes.push_back(input->type());
+  }
+
+  TypeCP intermediateType = toType(
+      velox::exec::resolveIntermediateType(aggregateExpr.name(), argTypes));
+
+  ExprCP condition = aggregateExpr.filter() != nullptr
+      ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
+      : nullptr;
+
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  orderKeys.reserve(aggregateExpr.ordering().size());
+  orderTypes.reserve(aggregateExpr.ordering().size());
+  for (const auto& field : aggregateExpr.ordering()) {
+    orderKeys.push_back(translateExpr(*field.expression, scope, applyTarget));
+    orderTypes.push_back(toOrderType(field.order));
+  }
+  Value value(toType(aggregateExpr.type()));
+
+  Name aggName = toName(aggregateExpr.name());
+  const auto& metadata =
+      velox::exec::getAggregateFunctionMetadata(aggregateExpr.name());
+
+  FunctionSet funcs = Call::unionArgFunctions(FunctionSet{}, arguments);
+  if (metadata.ignoreDuplicates) {
+    funcs = funcs | FunctionSet::kIgnoreDuplicatesAggregate;
+  } else if (
+      (aggName == toName("min") || aggName == toName("max")) &&
+      arguments.size() == 1) {
+    // min(x)/max(x) ignore duplicates; min(x, n)/max(x, n) do not.
+    // TODO: Push this distinction into per-signature metadata.
+    funcs = funcs | FunctionSet::kIgnoreDuplicatesAggregate;
+  }
+  if (metadata.orderSensitive) {
+    funcs = funcs | FunctionSet::kOrderSensitiveAggregate;
+  }
+
+  const bool isDistinct =
+      !metadata.ignoreDuplicates && aggregateExpr.isDistinct();
+
+  return builder_.makeAggregate(
+      aggName,
+      value,
+      std::move(arguments),
+      funcs,
+      isDistinct,
+      condition,
+      intermediateType,
+      std::move(orderKeys),
+      std::move(orderTypes));
+}
+
+NodeCP Translator::maybeWrapInWindow(
+    NodeCP input,
+    const Scope& inputScope,
+    const std::vector<lp::ExprPtr>& projectExprs,
+    const std::vector<std::string>& projectNames,
+    Scope& windowScope) {
+  std::vector<size_t> windowIndices;
+  for (size_t i = 0; i < projectExprs.size(); ++i) {
+    if (projectExprs[i]->isWindow()) {
+      windowIndices.push_back(i);
+    }
+  }
+  if (windowIndices.empty()) {
+    return input;
+  }
+
+  // Pre-translate each lp WindowExpr into its effective spec (partition
+  // keys, order keys). Drop sort keys that duplicate a partition key (every
+  // row in a partition shares that value) or repeat an earlier sort key —
+  // both are redundant. Grouping below compares the effective specs, so two
+  // windows that differ only in a dropped order key — or only in frame, which
+  // is per-function — still share a single `Window` node.
+  struct Spec {
+    ExprVector partitionKeys;
+    ExprVector orderKeys;
+    OrderTypeVector orderTypes;
+
+    bool operator==(const Spec&) const = default;
+  };
+  std::vector<Spec> specs(windowIndices.size());
+  for (size_t i = 0; i < windowIndices.size(); ++i) {
+    const auto* windowExpr =
+        projectExprs[windowIndices[i]]->as<lp::WindowExpr>();
+    Spec& spec = specs[i];
+    // Subqueries in window partition / order keys / frame bounds would
+    // need lifting above the Window's input — left as nullptr until
+    // that wiring lands. lp's surface allows them; rare in practice.
+    spec.partitionKeys = translateAll(
+        windowExpr->partitionKeys(), inputScope, /*applyTarget=*/nullptr);
+
+    folly::F14FastSet<ExprCP> seenKeys(
+        spec.partitionKeys.begin(), spec.partitionKeys.end());
+    spec.orderKeys.reserve(windowExpr->ordering().size());
+    spec.orderTypes.reserve(windowExpr->ordering().size());
+    for (const auto& field : windowExpr->ordering()) {
+      ExprCP key =
+          translateExpr(*field.expression, inputScope, /*applyTarget=*/nullptr);
+      if (!seenKeys.insert(key).second) {
+        continue;
+      }
+      spec.orderKeys.push_back(key);
+      spec.orderTypes.push_back(toOrderType(field.order));
+    }
+  }
+
+  // Group windows by their effective spec so each group produces one
+  // `Window` node. Multiple groups are chained.
+  std::vector<std::vector<size_t>> groups;
+  for (size_t i = 0; i < windowIndices.size(); ++i) {
+    bool placed = false;
+    for (auto& group : groups) {
+      if (specs[group.front()] == specs[i]) {
+        group.push_back(i);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      groups.push_back({i});
+    }
+  }
+
+  NodeCP current = input;
+  for (const auto& group : groups) {
+    const Spec& spec = specs[group.front()];
+
+    WindowFunctions functions;
+    functions.reserve(group.size());
+    ColumnVector outputColumns;
+    outputColumns.reserve(current->outputColumns().size() + group.size());
+    for (ColumnCP column : current->outputColumns()) {
+      outputColumns.push_back(column);
+    }
+    for (size_t i : group) {
+      const size_t projectIndex = windowIndices[i];
+      const auto* windowExpr = projectExprs[projectIndex]->as<lp::WindowExpr>();
+      Value value(toType(windowExpr->type()));
+      Name windowName = toName(windowExpr->name());
+      ExprVector windowArgs = translateAll(
+          windowExpr->inputs(), inputScope, /*applyTarget=*/nullptr);
+      // Window functions are non-deterministic with non-default null behavior.
+      FunctionSet windowFuncs =
+          Call::unionArgFunctions(FunctionSet{}, windowArgs) |
+          FunctionSet::kNonDeterministic | FunctionSet::kNonDefaultNullBehavior;
+      auto* call = builder_.makeCall(
+          windowName, value, std::move(windowArgs), windowFuncs);
+      Frame frame = toFrame(windowExpr->frame(), inputScope);
+      functions.push_back(
+          WindowFunction{call, frame, windowExpr->ignoreNulls()});
+
+      const auto& name = projectNames[projectIndex];
+      auto* column = Column::createForSymbol(toName(name), value);
+      outputColumns.push_back(column);
+      windowScope[name] = column;
+    }
+
+    current = builder_.make<Window>(
+        {current,
+         std::move(functions),
+         spec.partitionKeys,
+         spec.orderKeys,
+         spec.orderTypes,
+         std::move(outputColumns)});
+  }
+  return current;
+}
+
+Translated Translator::translateLimit(
+    const lp::LimitNode& limit,
+    const LpNameSet& required) {
+  if (limit.count() == 0) {
+    // LIMIT 0 returns no rows. Skip translating the input entirely and
+    // replace with an empty `Values` carrying the same schema.
+    Scope scope;
+    ColumnVector outputColumns =
+        makeOutputColumns(*limit.outputType(), /*cardinality=*/0, scope);
+    ValuesCP valuesNode =
+        builder_.make<Values>({nullptr, nullptr, std::move(outputColumns)});
+    return {valuesNode, std::move(scope)};
+  }
+  // Limit is a pass-through with no expressions of its own.
+  Translated input = translateNode(*limit.onlyInput(), required);
+  LimitCP limitNode =
+      builder_.make<Limit>({input.node, limit.offset(), limit.count()});
+  return {limitNode, std::move(input.scope)};
+}
+
+Translated Translator::translateSort(
+    const lp::SortNode& sort,
+    const LpNameSet& required) {
+  // Sort is a pass-through; forward `required` plus the names its order keys
+  // read from the child.
+  LpNameSet childRequired = required;
+  for (const auto& field : sort.ordering()) {
+    collectUsedNames(*field.expression, childRequired);
+  }
+  Translated input = translateNode(*sort.onlyInput(), childRequired);
+
+  NodeCP currentInput = input.node;
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  orderKeys.reserve(sort.ordering().size());
+  orderTypes.reserve(sort.ordering().size());
+  for (const auto& field : sort.ordering()) {
+    orderKeys.push_back(
+        translateExpr(*field.expression, input.scope, &currentInput));
+    orderTypes.push_back(toOrderType(field.order));
+  }
+
+  SortCP sortNode = builder_.make<Sort>(
+      {currentInput, std::move(orderKeys), std::move(orderTypes)});
+  return {sortNode, std::move(input.scope)};
+}
+
+Translated Translator::translateAggregate(
+    const lp::AggregateNode& aggregate,
+    const LpNameSet& required) {
+  const auto& names = aggregate.outputNames();
+  const auto& groupingKeyExpressions = aggregate.groupingKeys();
+  const auto& groupingSets = aggregate.groupingSets();
+  const auto& aggregateExpressions = aggregate.aggregates();
+  const size_t groupIdSlots = groupingSets.empty() ? 0 : 1;
+  VELOX_CHECK_EQ(
+      names.size(),
+      groupingKeyExpressions.size() + aggregateExpressions.size() +
+          groupIdSlots);
+
+  // Decide which aggregates to keep (output not in `required`). Grouping keys
+  // and groupId always stay: dropping them would change group cardinality.
+  std::vector<size_t> keptAggregateIndices;
+  keptAggregateIndices.reserve(aggregateExpressions.size());
+  for (size_t i = 0; i < aggregateExpressions.size(); ++i) {
+    if (required.contains(names[groupingKeyExpressions.size() + i])) {
+      keptAggregateIndices.push_back(i);
+    }
+  }
+
+  // Child must supply: every column read by the grouping keys, plus every
+  // column read by the kept aggregates (args, FILTER, ORDER BY).
+  LpNameSet childRequired;
+  collectUsedNames(groupingKeyExpressions, childRequired);
+  for (size_t idx : keptAggregateIndices) {
+    collectUsedNames(*aggregateExpressions[idx], childRequired);
+  }
+  Translated input = translateNode(*aggregate.onlyInput(), childRequired);
+
+  ExprVector groupingKeys;
+  groupingKeys.reserve(groupingKeyExpressions.size());
+  ColumnVector outputColumns;
+  outputColumns.reserve(
+      groupingKeyExpressions.size() + keptAggregateIndices.size() +
+      groupIdSlots);
+  Scope newScope;
+  // Grouping-sets case keeps positional alignment between groupingKeys and
+  // the set indices; only the simple GROUP BY case can dedup safely here.
+  const bool canDedupGroupingKeys = groupingSets.empty();
+  folly::F14FastSet<ColumnCP> seenGroupingOutputs;
+  if (canDedupGroupingKeys) {
+    seenGroupingOutputs.reserve(groupingKeyExpressions.size());
+  }
+
+  NodeCP currentInput = input.node;
+  for (size_t i = 0; i < groupingKeyExpressions.size(); ++i) {
+    ExprCP keyExpr =
+        translateExpr(*groupingKeyExpressions[i], input.scope, &currentInput);
+    // Reuse the input column when the grouping key is a column reference:
+    // Velox `AggregationNode` emits grouping-key output under the input
+    // field-access name. For grouping sets, `GroupIdNode` requires output
+    // names distinct from the input columns for the NULL-padded copies, so
+    // mint a fresh column rather than reusing the (possibly colliding) LP
+    // symbol.
+    ColumnCP column;
+    if (groupingSets.empty() && keyExpr->is(PlanType::kColumnExpr)) {
+      column = keyExpr->as<Column>();
+    } else if (groupingSets.empty()) {
+      column = Column::createForSymbol(toName(names[i]), keyExpr->value());
+    } else {
+      column = Column::create(toName(names[i]), keyExpr->value());
+    }
+    newScope[names[i]] = column;
+    if (canDedupGroupingKeys && !seenGroupingOutputs.insert(column).second) {
+      continue;
+    }
+    groupingKeys.push_back(keyExpr);
+    outputColumns.push_back(column);
+  }
+
+  AggregateCallVector aggregates;
+  aggregates.reserve(keptAggregateIndices.size());
+  folly::F14FastMap<const optimizer::Aggregate*, ColumnCP> aggregateToOutput;
+  aggregateToOutput.reserve(keptAggregateIndices.size());
+  for (size_t idx : keptAggregateIndices) {
+    const auto* aggregateCall =
+        toAggregateCall(*aggregateExpressions[idx], input.scope, &currentInput);
+    const auto& aggregateName = names[groupingKeyExpressions.size() + idx];
+    if (auto it = aggregateToOutput.find(aggregateCall);
+        it != aggregateToOutput.end()) {
+      newScope[aggregateName] = it->second;
+      continue;
+    }
+    aggregates.push_back(aggregateCall);
+    auto* column =
+        Column::createForSymbol(toName(aggregateName), aggregateCall->value());
+    aggregateToOutput.emplace(aggregateCall, column);
+    outputColumns.push_back(column);
+    newScope[aggregateName] = column;
+  }
+
+  if (groupingSets.empty()) {
+    AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
+        .input = currentInput,
+        .groupingKeys = std::move(groupingKeys),
+        .aggregates = std::move(aggregates),
+        .outputColumns = std::move(outputColumns)});
+    return {aggNode, std::move(newScope)};
+  }
+
+  // GROUPING SETS / ROLLUP / CUBE lower to GroupId + a plain aggregate keyed on
+  // an explicit group-id column: a mechanical translation that lets physical
+  // planning treat the aggregate like any other.
+  // Grouping sets keep positional alignment with the set indices (no key
+  // dedup), so `outputColumns` is exactly the key output columns followed by
+  // the aggregate result columns.
+  const size_t numKeys = groupingKeys.size();
+  ColumnVector keyOutputColumns(
+      outputColumns.begin(), outputColumns.begin() + numKeys);
+  ColumnVector aggResultColumns(
+      outputColumns.begin() + numKeys, outputColumns.end());
+
+  // Columns the aggregates read pass through GroupId unchanged.
+  PlanObjectSet aggInputSet;
+  for (const auto* call : aggregates) {
+    for (ExprCP arg : call->args()) {
+      aggInputSet.unionSet(arg->columns());
+    }
+    if (call->condition() != nullptr) {
+      aggInputSet.unionSet(call->condition()->columns());
+    }
+    for (ExprCP orderKey : call->orderKeys()) {
+      aggInputSet.unionSet(orderKey->columns());
+    }
+  }
+
+  // GroupId groups on columns; materialize any non-column key into a Project.
+  ExprVector groupIdInputKeys;
+  groupIdInputKeys.reserve(numKeys);
+  ColumnVector materializedColumns;
+  ExprVector materializedExprs;
+  for (ExprCP keyExpr : groupingKeys) {
+    if (keyExpr->is(PlanType::kColumnExpr)) {
+      groupIdInputKeys.push_back(keyExpr);
+    } else {
+      ColumnCP keyColumn = Column::create("groupingKey", keyExpr->value());
+      materializedColumns.push_back(keyColumn);
+      materializedExprs.push_back(keyExpr);
+      groupIdInputKeys.push_back(keyColumn);
+    }
+  }
+
+  NodeCP groupIdInput = currentInput;
+  if (!materializedExprs.empty()) {
+    PlanObjectSet passthrough = aggInputSet;
+    for (ExprCP keyExpr : groupingKeys) {
+      if (keyExpr->is(PlanType::kColumnExpr)) {
+        passthrough.add(keyExpr->as<Column>());
+      }
+    }
+    ExprVector projectExprs = passthrough.toObjects<Expr>();
+    ColumnVector projectColumns;
+    projectColumns.reserve(projectExprs.size() + materializedColumns.size());
+    for (ExprCP expr : projectExprs) {
+      projectColumns.push_back(expr->as<Column>());
+    }
+    appendAll(projectExprs, materializedExprs);
+    appendAll(projectColumns, materializedColumns);
+    groupIdInput = builder_.make<Project>(
+        {currentInput, std::move(projectExprs), std::move(projectColumns)});
+  }
+
+  ExprVector aggregationInputs = aggInputSet.toObjects<Expr>();
+
+  const auto& groupIdName = names.back();
+  Value groupIdValue(
+      toType(aggregate.outputType()->childAt(names.size() - 1)),
+      static_cast<float>(groupingSets.size()));
+  ColumnCP groupIdColumn =
+      Column::createForSymbol(toName(groupIdName), groupIdValue);
+  newScope[groupIdName] = groupIdColumn;
+
+  ColumnVector groupIdOutputs;
+  groupIdOutputs.reserve(
+      keyOutputColumns.size() + aggregationInputs.size() + 1);
+  appendAll(groupIdOutputs, keyOutputColumns);
+  for (ExprCP expr : aggregationInputs) {
+    groupIdOutputs.push_back(expr->as<Column>());
+  }
+  groupIdOutputs.push_back(groupIdColumn);
+
+  QGVector<QGVector<int32_t>> setsCopy;
+  setsCopy.reserve(groupingSets.size());
+  for (const auto& set : groupingSets) {
+    setsCopy.emplace_back(set.begin(), set.end());
+  }
+
+  NodeCP groupIdNode = builder_.make<GroupId>(GroupId::Key{
+      groupIdInput,
+      groupIdInputKeys,
+      aggregationInputs,
+      setsCopy,
+      keyOutputColumns,
+      groupIdColumn,
+      groupIdOutputs});
+
+  // Aggregate keys: the GroupId key output columns plus the group-id column.
+  ExprVector aggGroupingKeys;
+  aggGroupingKeys.reserve(numKeys + 1);
+  appendAll(aggGroupingKeys, keyOutputColumns);
+  aggGroupingKeys.push_back(groupIdColumn);
+
+  // Empty sets are the global () sets whose group-id values must emit a default
+  // row over empty input; groupId is coupled with them (set together or not).
+  QGVector<int32_t> globalGroupingSets;
+  for (size_t i = 0; i < setsCopy.size(); ++i) {
+    if (setsCopy[i].empty()) {
+      globalGroupingSets.push_back(static_cast<int32_t>(i));
+    }
+  }
+  ColumnCP aggGroupId = globalGroupingSets.empty() ? nullptr : groupIdColumn;
+
+  // Physical output order: keys, group-id, aggregate results.
+  ColumnVector aggOutputColumns;
+  aggOutputColumns.reserve(numKeys + 1 + aggResultColumns.size());
+  appendAll(aggOutputColumns, keyOutputColumns);
+  aggOutputColumns.push_back(groupIdColumn);
+  appendAll(aggOutputColumns, aggResultColumns);
+
+  AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
+      .input = groupIdNode,
+      .groupingKeys = std::move(aggGroupingKeys),
+      .aggregates = std::move(aggregates),
+      .outputColumns = std::move(aggOutputColumns),
+      .step = AggregateStep::kSingle,
+      .groupId = aggGroupId,
+      .globalGroupingSets = std::move(globalGroupingSets)});
+  return {aggNode, std::move(newScope)};
+}
+
+std::optional<std::vector<velox::Variant>> Translator::foldExprRowsToVariants(
+    const lp::ValuesNode::Exprs& exprRows) {
+  Scope emptyScope;
+  std::vector<velox::Variant> rows;
+  rows.reserve(exprRows.size());
+  for (const auto& exprRow : exprRows) {
+    std::vector<velox::Variant> rowValues;
+    rowValues.reserve(exprRow.size());
+    for (const auto& expr : exprRow) {
+      // VALUES literal expressions have no relational input above; lift
+      // forbidden. Subqueries inside VALUES are NYI.
+      ExprCP translated =
+          translateExpr(*expr, emptyScope, /*applyTarget=*/nullptr);
+      if (!translated->is(PlanType::kLiteralExpr)) {
+        return std::nullopt;
+      }
+      rowValues.emplace_back(translated->as<Literal>()->literal());
+    }
+    rows.emplace_back(velox::Variant::row(std::move(rowValues)));
+  }
+  return rows;
+}
+
+Translated Translator::translateValues(
+    const lp::ValuesNode& values,
+    const LpNameSet& /*required*/) {
+  Scope scope;
+  ColumnVector outputColumns =
+      makeOutputColumns(*values.outputType(), values.cardinality(), scope);
+
+  // Fold `Exprs` data to a single `Variant::array(rows)` at translate
+  // time. Constant-foldable rows arrive here as `Literal`s (Call /
+  // SpecialForm translation has already simplified). If any entry
+  // isn't a literal, fall back to passing the source through — emit
+  // will fail loudly on the unsupported shape.
+  const velox::Variant* foldedRows = nullptr;
+  if (const auto* exprRows =
+          std::get_if<lp::ValuesNode::Exprs>(&values.data())) {
+    auto rows = foldExprRowsToVariants(*exprRows);
+    if (rows.has_value()) {
+      foldedRows = queryCtx()->registerVariant(
+          std::make_unique<velox::Variant>(
+              velox::Variant::array(std::move(*rows))));
+    }
+  }
+
+  const lp::ValuesNode* passthrough = foldedRows == nullptr ? &values : nullptr;
+  ValuesCP valuesNode = builder_.make<Values>(
+      {passthrough, foldedRows, std::move(outputColumns)});
+  return {valuesNode, std::move(scope)};
+}
+
+Translated Translator::translateUnnest(
+    const lp::UnnestNode& unnest,
+    const LpNameSet& required) {
+  // Child must supply: every column the unnest expressions read, plus any
+  // replicated input column the consumer still needs.
+  LpNameSet childRequired;
+  collectUsedNames(unnest.unnestExpressions(), childRequired);
+  const auto& inputType = *unnest.onlyInput()->outputType();
+  for (size_t i = 0; i < inputType.size(); ++i) {
+    const auto& name = inputType.nameOf(i);
+    if (required.contains(name)) {
+      childRequired.insert(name);
+    }
+  }
+  Translated input = translateNode(*unnest.onlyInput(), childRequired);
+
+  NodeCP currentInput = input.node;
+  ExprVector unnestExprs =
+      translateAll(unnest.unnestExpressions(), input.scope, &currentInput);
+
+  // TODO: Cardinality of unnested columns also should be multiplied by the
+  // average expected number of elements per unnested row. Other Value
+  // properties also should be computed.
+  const std::optional<float> unnestCardinality = maxCardinality(unnestExprs);
+  const auto& outputType = unnest.outputType();
+  Scope newScope;
+
+  // LP UnnestNode's outputType layout is
+  // [input.outputType ⊕ per-expression unnested-names ⊕ optional ordinality].
+  // Walk in that order, dropping replicated input columns the consumer
+  // doesn't need; always emit unnest-expression outputs and ordinality.
+  ColumnVector replicatedColumns;
+  replicatedColumns.reserve(inputType.size());
+  for (size_t i = 0; i < inputType.size(); ++i) {
+    const auto& name = inputType.nameOf(i);
+    if (!required.contains(name)) {
+      continue;
+    }
+    auto it = input.scope.find(name);
+    VELOX_CHECK(it != input.scope.end());
+    replicatedColumns.push_back(it->second);
+    newScope[name] = it->second;
+  }
+
+  QGVector<ColumnVector> unnestColumns;
+  unnestColumns.reserve(unnest.unnestExpressions().size());
+  size_t outputIndex = inputType.size();
+  for (const auto& names : unnest.unnestedNames()) {
+    ColumnVector perExpr;
+    perExpr.reserve(names.size());
+    for (const auto& name : names) {
+      Value value = clampCardinality(
+          Value{toType(outputType->childAt(outputIndex)), unnestCardinality});
+      auto* column = Column::createForSymbol(toName(name), value);
+      perExpr.push_back(column);
+      newScope[name] = column;
+      ++outputIndex;
+    }
+    unnestColumns.push_back(std::move(perExpr));
+  }
+
+  ColumnCP ordinalityColumn = nullptr;
+  if (unnest.ordinalityName().has_value()) {
+    const auto& name = unnest.ordinalityName().value();
+    Value value(toType(outputType->childAt(outputIndex)), unnestCardinality);
+    ordinalityColumn = Column::createForSymbol(toName(name), value);
+    newScope[name] = ordinalityColumn;
+  }
+
+  ColumnVector outputColumns = replicatedColumns;
+  for (const auto& perExpr : unnestColumns) {
+    for (ColumnCP column : perExpr) {
+      outputColumns.push_back(column);
+    }
+  }
+  if (ordinalityColumn != nullptr) {
+    outputColumns.push_back(ordinalityColumn);
+  }
+
+  UnnestCP unnestNode = builder_.make<Unnest>(
+      {currentInput,
+       std::move(unnestExprs),
+       std::move(replicatedColumns),
+       std::move(unnestColumns),
+       ordinalityColumn,
+       std::move(outputColumns)});
+  return {unnestNode, std::move(newScope)};
+}
+
+Translated Translator::buildUnionAll(
+    const std::vector<lp::LogicalPlanNodePtr>& inputs,
+    const velox::RowTypePtr& outputType,
+    const LpNameSet& required) {
+  NodeVector inputNodes;
+  inputNodes.reserve(inputs.size());
+  QGVector<ColumnVector> legColumns;
+  legColumns.reserve(inputs.size());
+  // Union output positions parent doesn't require are dropped from the union
+  // node entirely. Build a list of kept positions once and reuse it for every
+  // leg's column mapping.
+  std::vector<size_t> keptPositions;
+  keptPositions.reserve(outputType->size());
+  for (size_t j = 0; j < outputType->size(); ++j) {
+    if (required.contains(outputType->nameOf(j))) {
+      keptPositions.push_back(j);
+    }
+  }
+  for (const auto& in : inputs) {
+    // Each leg's required-set is the kept union output names, mapped to that
+    // leg's positional outputType names (legs align 1:1 with the union's
+    // outputType by SQL semantics).
+    LpNameSet legRequired;
+    legRequired.reserve(keptPositions.size());
+    for (size_t j : keptPositions) {
+      legRequired.insert(in->outputType()->nameOf(j));
+    }
+    Translated translated = translateNode(*in, legRequired);
+    ColumnVector cols;
+    cols.reserve(keptPositions.size());
+    for (size_t j : keptPositions) {
+      // Resolve LP-name → IR Column* via the leg's scope; the leg's IR
+      // `outputColumns` may be narrower than its LP outputType after
+      // dup-collapse, but the same Column may legitimately repeat.
+      const auto& legName = in->outputType()->nameOf(j);
+      auto it = translated.scope.find(legName);
+      VELOX_CHECK(
+          it != translated.scope.end(),
+          "UnionAll leg scope missing column: {}",
+          legName);
+      cols.push_back(it->second);
+    }
+    legColumns.push_back(std::move(cols));
+    inputNodes.push_back(translated.node);
+  }
+  Scope scope;
+  ColumnVector outputColumns;
+  outputColumns.reserve(keptPositions.size());
+  for (size_t j : keptPositions) {
+    Value value(toType(outputType->childAt(j)));
+    auto* column =
+        Column::createForSymbol(toName(outputType->nameOf(j)), value);
+    outputColumns.push_back(column);
+    scope[outputType->nameOf(j)] = column;
+  }
+  UnionAllCP unionNode = builder_.make<UnionAll>(
+      {std::move(inputNodes), std::move(legColumns), std::move(outputColumns)});
+  return {unionNode, std::move(scope)};
+}
+
+// Set-op outputs reuse the upstream `Column*`s (left side for
+// INTERSECT/EXCEPT, UnionAll for UNION). Two distinct nodes' `outputColumns`
+// can share Column identity; downstream passes must not assume freshness.
+Translated Translator::translateSet(
+    const lp::SetNode& set,
+    const LpNameSet& required) {
+  switch (set.operation()) {
+    case lp::SetOperation::kUnionAll:
+      return buildUnionAll(set.inputs(), set.outputType(), required);
+    case lp::SetOperation::kUnion: {
+      Translated all = buildUnionAll(
+          set.inputs(), set.outputType(), allNames(*set.outputType()));
+      const ColumnVector& cols = all.node->outputColumns();
+      Scope newScope;
+      populateScope(*set.outputType(), cols, newScope);
+      AggregateCP aggNode = builder_.make<Aggregate>(
+          {all.node,
+           ExprVector{cols.begin(), cols.end()},
+           AggregateCallVector{},
+           ColumnVector{cols}});
+      return {aggNode, std::move(newScope)};
+    }
+    case lp::SetOperation::kIntersect:
+    case lp::SetOperation::kIntersectAll:
+    case lp::SetOperation::kExcept:
+    case lp::SetOperation::kExceptAll: {
+      const bool isAnti = set.operation() == lp::SetOperation::kExcept ||
+          set.operation() == lp::SetOperation::kExceptAll;
+      const bool isDistinct = set.operation() == lp::SetOperation::kIntersect ||
+          set.operation() == lp::SetOperation::kExcept;
+      const velox::core::JoinType joinType = isAnti
+          ? (isDistinct ? velox::core::JoinType::kAnti
+                        : velox::core::JoinType::kCountingAnti)
+          : (isDistinct ? velox::core::JoinType::kLeftSemiFilter
+                        : velox::core::JoinType::kCountingLeftSemiFilter);
+
+      // Set-op via Join: each leg's columns become join keys, so all of each
+      // leg's outputType is consumed.
+      Translated current = {
+          translateNode(
+              *set.inputs().front(),
+              allNames(*set.inputs().front()->outputType()))
+              .node,
+          {}};
+      for (size_t i = 1; i < set.inputs().size(); ++i) {
+        Translated other = {
+            translateNode(
+                *set.inputs()[i], allNames(*set.inputs()[i]->outputType()))
+                .node,
+            {}};
+        const auto& leftColumns = current.node->outputColumns();
+        const auto& rightColumns = other.node->outputColumns();
+        VELOX_CHECK_EQ(leftColumns.size(), rightColumns.size());
+        ExprVector leftKeys;
+        ExprVector rightKeys;
+        leftKeys.reserve(leftColumns.size());
+        rightKeys.reserve(leftColumns.size());
+        for (size_t columnIndex = 0; columnIndex < leftColumns.size();
+             ++columnIndex) {
+          leftKeys.push_back(leftColumns[columnIndex]);
+          rightKeys.push_back(rightColumns[columnIndex]);
+        }
+        ColumnVector outputColumns{leftColumns};
+        current.node = builder_.make<Join>(
+            {current.node,
+             other.node,
+             joinType,
+             std::move(leftKeys),
+             std::move(rightKeys),
+             /*filter=*/ExprVector{},
+             /*nullAware=*/false,
+             /*nullAsValue=*/true,
+             std::move(outputColumns)});
+      }
+
+      // Output schema is the left side's columns flowing through the Join
+      // unchanged.
+      const ColumnVector& outputColumns = current.node->outputColumns();
+      Scope scope;
+      populateScope(*set.outputType(), outputColumns, scope);
+
+      if (isDistinct) {
+        AggregateCP aggNode = builder_.make<Aggregate>(
+            {current.node,
+             ExprVector{outputColumns.begin(), outputColumns.end()},
+             AggregateCallVector{},
+             outputColumns});
+        return {aggNode, std::move(scope)};
+      }
+      return {current.node, std::move(scope)};
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+velox::core::JoinType toVeloxJoinType(lp::JoinType type) {
+  switch (type) {
+    case lp::JoinType::kInner:
+      return velox::core::JoinType::kInner;
+    case lp::JoinType::kLeft:
+      return velox::core::JoinType::kLeft;
+    case lp::JoinType::kRight:
+      return velox::core::JoinType::kRight;
+    case lp::JoinType::kFull:
+      return velox::core::JoinType::kFull;
+  }
+  VELOX_UNREACHABLE();
+}
+
+Translated Translator::translateJoin(
+    const lp::JoinNode& join,
+    const LpNameSet& required) {
+  // Names the join condition reads need to be in both side's scopes; partition
+  // them by which side each name belongs to.
+  LpNameSet conditionNames;
+  if (join.condition() != nullptr) {
+    collectUsedNames(*join.condition(), conditionNames);
+  }
+  const auto& leftType = *join.left()->outputType();
+  const auto& rightType = *join.right()->outputType();
+  LpNameSet leftRequired;
+  LpNameSet rightRequired;
+  for (size_t i = 0; i < leftType.size(); ++i) {
+    const auto& name = leftType.nameOf(i);
+    if (required.contains(name) || conditionNames.contains(name)) {
+      leftRequired.insert(name);
+    }
+  }
+  for (size_t i = 0; i < rightType.size(); ++i) {
+    const auto& name = rightType.nameOf(i);
+    if (required.contains(name) || conditionNames.contains(name)) {
+      rightRequired.insert(name);
+    }
+  }
+  Translated left = translateNode(*join.left(), leftRequired);
+  Translated right = translateNode(*join.right(), rightRequired);
+
+  Scope merged = left.scope;
+  for (auto& [name, column] : right.scope) {
+    merged[name] = column;
+  }
+
+  const velox::core::JoinType joinType = toVeloxJoinType(join.joinType());
+  const bool isInner = joinType == velox::core::JoinType::kInner;
+  const bool conditionHasSubquery =
+      join.condition() != nullptr && containsSubquery(*join.condition());
+
+  // A subquery in the condition can't run inside the join operator;
+  // lift it into a Filter above the join. The lifted Filter reads
+  // condition columns from the join's output, so when lifting keep
+  // the full left+right union as `outputColumns`.
+  const bool liftConditionAbove = isInner && conditionHasSubquery;
+
+  PlanObjectSet requiredColumns;
+  if (!liftConditionAbove) {
+    auto collect = [&](const velox::RowType& type, const Scope& scope) {
+      for (size_t i = 0; i < type.size(); ++i) {
+        const auto& name = type.nameOf(i);
+        if (!required.contains(name)) {
+          continue;
+        }
+        auto it = scope.find(name);
+        VELOX_DCHECK(it != scope.end());
+        requiredColumns.add(it->second);
+      }
+    };
+    collect(leftType, left.scope);
+    collect(rightType, right.scope);
+  }
+
+  ColumnVector outputColumns;
+  for (ColumnCP column : left.node->outputColumns()) {
+    if (liftConditionAbove || requiredColumns.contains(column)) {
+      outputColumns.push_back(column);
+    }
+  }
+  for (ColumnCP column : right.node->outputColumns()) {
+    if (liftConditionAbove || requiredColumns.contains(column)) {
+      outputColumns.push_back(column);
+    }
+  }
+
+  if (liftConditionAbove) {
+    JoinCP joinNode = builder_.make<Join>(
+        {left.node,
+         right.node,
+         joinType,
+         /*leftKeys=*/ExprVector{},
+         /*rightKeys=*/ExprVector{},
+         /*filter=*/ExprVector{},
+         /*nullAware=*/false,
+         /*nullAsValue=*/false,
+         std::move(outputColumns)});
+    return maybeWrapInFilter(joinNode, *join.condition(), std::move(merged));
+  }
+
+  JoinCondition::Split split;
+  if (join.condition() != nullptr) {
+    ExprCP condition =
+        translateExpr(*join.condition(), merged, /*applyTarget=*/nullptr);
+    split = JoinCondition::splitEquiKeys(
+        ExprFactory::flattenAnd(condition),
+        PlanObjectSet::fromObjects(left.node->outputColumns()),
+        PlanObjectSet::fromObjects(right.node->outputColumns()));
+  }
+
+  JoinCP joinNode = builder_.make<Join>(
+      {left.node,
+       right.node,
+       joinType,
+       std::move(split.leftKeys),
+       std::move(split.rightKeys),
+       std::move(split.residual),
+       /*nullAware=*/false,
+       /*nullAsValue=*/false,
+       std::move(outputColumns)});
+  return {joinNode, std::move(merged)};
+}
+
+ExprCP Translator::translateExpr(
+    const lp::Expr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  switch (expr.kind()) {
+    case lp::ExprKind::kInputReference:
+      return translateInputReference(*expr.as<lp::InputReferenceExpr>(), scope);
+    case lp::ExprKind::kConstant:
+      return translateConstant(*expr.as<lp::ConstantExpr>());
+    case lp::ExprKind::kCall:
+      return translateCall(*expr.as<lp::CallExpr>(), scope, applyTarget);
+    case lp::ExprKind::kSpecialForm:
+      return translateSpecialForm(
+          *expr.as<lp::SpecialFormExpr>(), scope, applyTarget);
+    case lp::ExprKind::kLambda:
+      return translateLambda(*expr.as<lp::LambdaExpr>(), scope);
+    case lp::ExprKind::kSubquery: {
+      // Bare subquery in scalar position. `liftSubquery` decides the
+      // lowered shape: uncorrelated → cross-join + EnforceSingleRow
+      // (no Apply), correlated → kLeft Apply. Scalar shape is signaled
+      // by a null `inLhs` (no IN equi to build).
+      const auto& subquery = *expr.as<lp::SubqueryExpr>();
+      return liftSubquery(
+          subquery,
+          velox::core::JoinType::kLeft,
+          /*inLhs=*/nullptr,
+          scope,
+          applyTarget);
+    }
+    default:
+      VELOX_NYI(
+          "Unsupported expression kind: {}", static_cast<int>(expr.kind()));
+  }
+}
+
+ExprCP Translator::translateInputReference(
+    const lp::InputReferenceExpr& expr,
+    const Scope& scope) {
+  const auto& name = expr.name();
+  auto it = scope.find(name);
+  if (it != scope.end()) {
+    return it->second;
+  }
+  if (ColumnCP outer = subqueries_.resolveOuter(name)) {
+    return outer;
+  }
+  VELOX_FAIL("Column not found in scope or outer scopes: {}", name);
+}
+
+ExprCP Translator::translateConstant(const lp::ConstantExpr& expr) {
+  auto* variant = queryCtx()->registerVariant(
+      std::make_unique<velox::Variant>(*expr.value()));
+  Value value(toType(expr.type()), 1);
+  return builder_.makeLiteral(value, variant);
+}
+
+ExprCP Translator::translateCall(
+    const lp::CallExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector args = translateAll(expr.inputs(), scope, applyTarget);
+  Value value =
+      clampCardinality(Value{toType(expr.type()), maxCardinality(args)});
+  Name name = toName(expr.name());
+  FunctionSet funcs =
+      Call::unionArgFunctions(functionBits(name, /*specialForm=*/false), args);
+  auto* call = builder_.makeCall(name, value, std::move(args), funcs);
+  return simplifier_.simplify(call);
+}
+
+// True if 'expr' is `lp::SpecialFormExpr(kIn, [value, SubqueryExpr])` —
+// i.e., the IN-subquery form that lifts to Apply, distinguished from
+// `IN (literal_list)` which lowers as an ordinary in-list expression.
+bool isInSubqueryForm(const lp::Expr& expr) {
+  if (!expr.isSpecialForm()) {
+    return false;
+  }
+  const auto& sf = *expr.as<lp::SpecialFormExpr>();
+  return sf.form() == lp::SpecialForm::kIn && sf.inputs().size() == 2 &&
+      sf.inputAt(1)->isSubquery();
+}
+
+ExprCP Translator::translateSpecialForm(
+    const lp::SpecialFormExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  if (expr.form() == lp::SpecialForm::kExists) {
+    return translateExists(expr, scope, applyTarget);
+  }
+
+  // IN (subquery): translate the lhs, then lift
+  // `Apply(kLeftSemiProject)` passing the lhs — `liftSubquery` records
+  // the lhs and the body's single output column as `Apply.inLhs` /
+  // `Apply.inBodyKey`. `Apply.nullAware()` returns true from
+  // their presence. Plain `IN (literals...)` flows through the
+  // generic path below.
+  if (isInSubqueryForm(expr)) {
+    ExprCP lhs = translateExpr(*expr.inputAt(0), scope, applyTarget);
+    const auto& subquery = *expr.inputAt(1)->as<lp::SubqueryExpr>();
+    return liftSubquery(
+        subquery,
+        velox::core::JoinType::kLeftSemiProject,
+        /*inLhs=*/lhs,
+        scope,
+        applyTarget);
+  }
+
+  // NOT EXISTS / NOT IN come through as `lp::Call("not", [kExists|kIn])`,
+  // not as a `SpecialForm::kNot`. The Call recursion handles the wrap:
+  // translateCall translates the EXISTS/IN arg (which lifts Apply and
+  // returns its mark), then builds `Call("not", [mark])`. The Apply
+  // shape is identical for IN vs NOT IN — null-aware semi-project both
+  // ways; the surrounding NOT inverts the mark.
+
+  ExprVector args = translateAll(expr.inputs(), scope, applyTarget);
+  Value value =
+      clampCardinality(Value{toType(expr.type()), maxCardinality(args)});
+
+  // Drop a redundant cast: CAST(x AS t) => x when typeof(x) == t. TRY_CAST too,
+  // since a same-type cast never errors. Pointer equality on interned types is
+  // exact, so a row-renaming cast (distinct interned type) is kept.
+  if (expr.form() == lp::SpecialForm::kCast ||
+      expr.form() == lp::SpecialForm::kTryCast) {
+    VELOX_CHECK_EQ(args.size(), 1);
+    if (args[0]->value().type == value.type) {
+      return args[0];
+    }
+  }
+
+  // Normalize an IN list: a single element folds to equality (`x IN (a)` is
+  // `x = a`) and a constant list drops duplicates (`x IN (a, a)` is `x IN
+  // (a)`).
+  if (expr.form() == lp::SpecialForm::kIn) {
+    if (ExprCP folded = normalizeInList(args)) {
+      return folded;
+    }
+  }
+
+  // `SpecialFormCallNames::toCallName` returns a static literal that is
+  // pointer-compared in `tryFromCallName`. Do not re-intern via `toName`,
+  // which would allocate a fresh arena copy and break the comparison.
+  Name callName = SpecialFormCallNames::toCallName(expr.form());
+
+  if (expr.form() == lp::SpecialForm::kDereference) {
+    return translateDereference(std::move(args), callName, value);
+  }
+
+  FunctionSet funcs = Call::unionArgFunctions(
+      functionBits(callName, /*specialForm=*/true), args);
+  auto* call = builder_.makeCall(callName, value, std::move(args), funcs);
+  return simplifier_.simplify(call);
+}
+
+ExprCP Translator::translateExists(
+    const lp::SpecialFormExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  VELOX_CHECK_EQ(expr.inputs().size(), 1);
+  const auto& subquery = *expr.inputs()[0]->as<lp::SubqueryExpr>();
+
+  // Fast path — EXISTS over a scalar (non-grouping) Aggregate with no
+  // HAVING above it is provably TRUE per SQL: scalar aggregates always
+  // emit exactly one row, so EXISTS sees that one row regardless of
+  // input cardinality. Fold to a constant before constructing Apply,
+  // matching Presto / modern DuckDB on shapes like
+  // `EXISTS (SELECT count(*) FROM t WHERE p)`. HAVING is the only
+  // operator that can make EXISTS-over-scalar-Agg evaluate to FALSE;
+  // when present (Filter above Aggregate), the root is a FilterNode
+  // and this fast path doesn't fire — Decorrelate's Rule B-EXISTS
+  // Path 1 handles it correctly.
+  //
+  // Walk past output-shaping Project chains (parser typically wraps
+  // `SELECT count(*) FROM ...` as `Project(Aggregate(...))`).
+  const lp::LogicalPlanNode* root = subquery.subquery().get();
+  while (root != nullptr && root->kind() == lp::NodeKind::kProject) {
+    root = root->onlyInput().get();
+  }
+  if (root != nullptr && root->kind() == lp::NodeKind::kAggregate) {
+    const auto* aggNode = root->as<lp::AggregateNode>();
+    if (aggNode->groupingKeys().empty() && aggNode->groupingSets().empty()) {
+      return builder_.makeLiteral(
+          velox::Variant(true), toType(velox::BOOLEAN()));
+    }
+  }
+  return liftSubquery(
+      subquery,
+      velox::core::JoinType::kLeftSemiProject,
+      /*inLhs=*/nullptr,
+      scope,
+      applyTarget);
+}
+
+ExprCP Translator::normalizeInList(ExprVector& args) {
+  VELOX_CHECK_GE(args.size(), 2);
+
+  // Single-element folding is sound in three-valued logic: `a IN (b)` and
+  // `a = b` agree on true, false, and null. The null-literal case folds to a
+  // constant (rather than `eq(a, null)`) so the surrounding expression can fold
+  // further without materializing the column.
+  auto foldSingleElement = [&](ExprCP element) -> ExprCP {
+    if (element->is(PlanType::kLiteralExpr) &&
+        element->as<Literal>()->literal().isNull()) {
+      return builder_.makeLiteral(
+          velox::Variant::null(velox::TypeKind::BOOLEAN),
+          toType(velox::BOOLEAN()));
+    }
+    return simplifier_.simplify(exprFactory_.makeEq(args[0], element));
+  };
+
+  if (args.size() == 2) {
+    return foldSingleElement(args[1]);
+  }
+
+  // A multi-element list can be deduped and lowered to an array constant only
+  // when every element is a literal.
+  if (!std::all_of(args.begin() + 1, args.end(), [](ExprCP arg) {
+        return arg->is(PlanType::kLiteralExpr);
+      })) {
+    return nullptr;
+  }
+
+  // Equal Literals hash-cons to the same Expr, so dedup by identity.
+  ExprVector deduped;
+  deduped.reserve(args.size());
+  deduped.push_back(args[0]);
+  folly::F14FastSet<ExprCP> seen;
+  seen.reserve(args.size() - 1);
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (seen.insert(args[i]).second) {
+      deduped.push_back(args[i]);
+    }
+  }
+
+  // A list of equal literals (`a IN (5, 5)`) collapses to a single value.
+  if (deduped.size() == 2) {
+    return foldSingleElement(deduped[1]);
+  }
+  args = std::move(deduped);
+  return nullptr;
+}
+
+ExprCP Translator::translateDereference(
+    ExprVector args,
+    Name callName,
+    const Value& value) {
+  // Resolve a varchar field name to a numeric field index against the input row
+  // type, so emit only ever sees an integer selector.
+  VELOX_CHECK_EQ(args.size(), 2);
+  VELOX_CHECK(args[1]->is(PlanType::kLiteralExpr));
+  const auto* selector = args[1]->as<Literal>();
+  const auto* baseType = args[0]->value().type;
+  VELOX_CHECK(baseType->isRow());
+  int32_t index;
+  if (selector->literal().kind() == velox::TypeKind::VARCHAR) {
+    const auto& name = selector->literal().value<velox::TypeKind::VARCHAR>();
+    index = baseType->asRow().getChildIdx(name);
+  } else {
+    const int64_t raw = integerValue(&selector->literal());
+    VELOX_CHECK_GE(raw, 0);
+    VELOX_CHECK_LT(raw, baseType->size());
+    index = static_cast<int32_t>(raw);
+  }
+  auto* indexLiteral =
+      builder_.makeLiteral(velox::Variant(index), toType(velox::INTEGER()));
+  ExprVector resolved{args[0], indexLiteral};
+  FunctionSet funcs = Call::unionArgFunctions(
+      functionBits(callName, /*specialForm=*/true), resolved);
+  auto* call = builder_.makeCall(callName, value, std::move(resolved), funcs);
+  return simplifier_.simplify(call);
+}
+
+ExprCP Translator::translateLambda(
+    const lp::LambdaExpr& expr,
+    const Scope& scope) {
+  const auto& signature = expr.signature();
+
+  // TODO: mint canonical `Column*` per `(arg position, arg type)` so
+  // structurally-equal lambdas share one `Lambda*` (and their bodies share
+  // one `Call*` via Call hash-cons). Today each occurrence mints fresh arg
+  // Columns, defeating pointer-keyed dedup.
+  Scope bodyScope = scope;
+  ColumnVector args;
+  args.reserve(signature->size());
+  for (size_t i = 0; i < signature->size(); ++i) {
+    Name argName = toName(signature->nameOf(i));
+    Value argValue(toType(signature->childAt(i)), 1);
+    auto* column = Column::create(argName, argValue);
+    args.push_back(column);
+    bodyScope[signature->nameOf(i)] = column;
+  }
+
+  // Lambdas appear inside higher-order functions; subqueries inside a
+  // lambda body would need lifting above the surrounding higher-order
+  // call's relational input — uncommon and not threaded today.
+  ExprCP body = translateExpr(*expr.body(), bodyScope, /*applyTarget=*/nullptr);
+  return make<Lambda>(std::move(args), toType(expr.type()), body);
+}
+
+// Returns true if 'node' provably produces exactly one row. An EnforceSingleRow
+// over such a node is a no-op: the >1-row assertion can never fire, and the
+// empty-input null row it would synthesize can never be produced. Conservative
+// — returns false when it cannot prove exactly one row.
+bool producesExactlyOneRow(NodeCP node) {
+  switch (node->nodeType()) {
+    case NodeType::kAggregate: {
+      // A global (ungrouped) aggregate emits exactly one row, even over empty
+      // input. A grouping-set aggregate keys on the group-id column, so its
+      // grouping keys are non-empty and it is excluded here.
+      const auto* aggregate = node->as<Aggregate>();
+      return aggregate->groupingKeys().empty();
+    }
+    case NodeType::kEnforceSingleRow:
+      return true;
+    case NodeType::kProject:
+      return producesExactlyOneRow(node->as<Project>()->input());
+    default:
+      return false;
+  }
+}
+
+ColumnCP Translator::liftSubquery(
+    const lp::SubqueryExpr& subqueryExpr,
+    velox::core::JoinType kind,
+    ExprCP inLhs,
+    const Scope& outerScope,
+    NodeCP* applyTarget) {
+  VELOX_USER_CHECK_NOT_NULL(
+      applyTarget,
+      "Subquery encountered in an expression position with no relational "
+      "input above which to lift Apply");
+
+  const bool isSemi = kind == velox::core::JoinType::kLeftSemiProject;
+  // IN is the semi shape that has a non-null `inLhs`. EXISTS is semi
+  // without one. Scalar is non-semi (kInner or kLeft).
+  const bool isIn = isSemi && inLhs != nullptr;
+  const bool isExists = isSemi && !isIn;
+  // EXISTS reads only row presence — empty required-set lets the body
+  // prune all output columns. IN and scalar both need every body
+  // output column kept (IN reads it for the equi predicate; scalar
+  // reads it as the value).
+  const LpNameSet required =
+      isExists ? LpNameSet{} : allNames(*subqueryExpr.subquery()->outputType());
+
+  subqueries_.push(outerScope);
+  Translated inner = translateNode(*subqueryExpr.subquery(), required);
+  ColumnVector correlationColumns = subqueries_.pop();
+
+  NodeCP body = inner.node;
+  ColumnCP markColumn = nullptr;
+  ColumnCP returnedColumn = nullptr;
+  bool enforceSingleRow = false;
+
+  if (isSemi) {
+    // EXISTS / IN: synthesize a fresh BOOLEAN mark. Apply emits it via
+    // `markColumn`; the parent expression site references it.
+    // `enforceSingleRow` is meaningless for semi (cardinality assertion
+    // doesn't apply); kept false.
+    markColumn = Column::createBoolean("mark");
+    returnedColumn = markColumn;
+  } else {
+    // Scalar: body must produce exactly one column. The single body
+    // output col IS the value the parent expression references.
+    const auto& bodyOut = body->outputColumns();
+    VELOX_USER_CHECK_EQ(
+        bodyOut.size(), 1, "Scalar subquery must produce exactly one column");
+    returnedColumn = bodyOut[0];
+    // Shape C fix: if body's
+    // single output column collides by name with any column in
+    // applyTarget's outputColumns (e.g., `SELECT (SELECT a) FROM t`
+    // where body's output and outer t.a are both named "a"), wrap
+    // body in an aliasing Project with a fresh name. The alias becomes
+    // returnedColumn.
+    //
+    // KNOWN LIMITATION: this fix is design-correct at Translate level,
+    // but Decorrelate's Project peel currently exposes the original
+    // body (under the alias wrap) when peeling, and the resulting
+    // inner Apply's outputColumns = input.cols ++ originalBody.cols
+    // brings the duplicate back. Full Shape C handling requires
+    // Decorrelate's Project peel to apply the same aliasing trick to
+    // body cols that collide with input cols. Currently NYI in
+    // Decorrelate; tests like `SELECT (SELECT a) FROM t` still fail
+    // with "Duplicate output column" at PlanConsistencyChecker.
+    {
+      const auto& targetCols = (*applyTarget)->outputColumns();
+      auto hasNameCollision = [&](std::string_view name) {
+        for (ColumnCP c : targetCols) {
+          if (c->name() == name) {
+            return true;
+          }
+        }
+        return false;
+      };
+      if (hasNameCollision(returnedColumn->name())) {
+        ColumnCP alias = Column::create(
+            std::string(returnedColumn->name()) + "__lift",
+            returnedColumn->value());
+        body = builder_.make<Project>(Project::Key{
+            body,
+            ExprVector{returnedColumn},
+            ColumnVector{alias},
+        });
+        returnedColumn = alias;
+      }
+    }
+
+    if (correlationColumns.empty()) {
+      // Uncorrelated scalar: cross-join with the body, which must yield a
+      // single row. Wrap it in EnforceSingleRow unless it already provably
+      // produces exactly one row, in which case the guard is a no-op.
+      NodeCP wrapped = producesExactlyOneRow(body)
+          ? body
+          : builder_.make<EnforceSingleRow>(EnforceSingleRow::Key{body});
+
+      ColumnVector joinOutput = (*applyTarget)->outputColumns();
+      appendUnique(joinOutput, wrapped->outputColumns());
+
+      *applyTarget = builder_.make<Join>(Join::Key{
+          *applyTarget,
+          wrapped,
+          velox::core::JoinType::kInner,
+          /*leftKeys=*/{},
+          /*rightKeys=*/{},
+          /*filter=*/ExprVector{},
+          /*nullAware=*/false,
+          /*nullAsValue=*/false,
+          std::move(joinOutput),
+      });
+      return returnedColumn;
+    }
+
+    // Correlated scalar: kLeft Apply with enforceSingleRow=true.
+    enforceSingleRow = true;
+  }
+
+  // For IN: capture the equi pair `(lhs, body.col)` directly. Apply
+  // stores it as `inLhs` / `inBodyKey`; downstream consumers either
+  // read the pair (decorrelate's semi-recovery extracts the equi-key
+  // pair directly) or reconstruct an `eq` Call (uncorrelated IN
+  // collapse uses it as the resulting Join's filter).
+  ExprCP inBodyKey = nullptr;
+  if (isIn) {
+    const auto& bodyOut = body->outputColumns();
+    VELOX_USER_CHECK_EQ(
+        bodyOut.size(), 1, "IN subquery body must produce exactly one column");
+    inBodyKey = bodyOut[0];
+  }
+
+  // Apply.outputColumns per kind:
+  //   kLeft            : input.outputColumns
+  //                      ++ unique(body.outputColumns) ++ includeMarker
+  //   kLeftSemiProject : input.outputColumns ++ markColumn
+  ColumnVector outputColumns = (*applyTarget)->outputColumns();
+  if (isSemi) {
+    outputColumns.push_back(markColumn);
+  } else {
+    appendUnique(outputColumns, body->outputColumns());
+  }
+  ColumnCP includeMarker = nullptr;
+  if (kind == velox::core::JoinType::kLeft) {
+    includeMarker = Column::createBoolean("_include");
+    outputColumns.push_back(includeMarker);
+  }
+
+  auto* apply = builder_.make<Apply>(
+      {*applyTarget,
+       body,
+       std::move(correlationColumns),
+       kind,
+       /*filter=*/ExprVector{},
+       enforceSingleRow,
+       markColumn,
+       inLhs,
+       inBodyKey,
+       includeMarker,
+       std::move(outputColumns)});
+  *applyTarget = apply;
+  return returnedColumn;
+}
+
+} // namespace
+
+TranslatePass::Result TranslatePass::run(
+    const lp::LogicalPlanNode& plan,
+    optimizer::Schema& schema,
+    velox::core::ExpressionEvaluator& evaluator,
+    Builder& builder) {
+  Translator translator(schema, evaluator, builder);
+  return translator.run(plan);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/TranslatePass.h
+++ b/axiom/optimizer/v2/TranslatePass.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Translates a logical plan into the tree-IR.
+class TranslatePass {
+ public:
+  /// Output of `run`. `outputColumns` and `outputNames` describe the
+  /// user-visible output layout, aligned 1:1 with each other. `outputColumns`
+  /// may contain duplicate `Column*` entries (e.g., `SELECT v, v`).
+  struct Result {
+    NodeCP root;
+    ColumnVector outputColumns;
+    std::vector<std::string> outputNames;
+  };
+
+  /// Translates 'plan' into a tree-IR plus its user-visible output layout.
+  /// Looks up base tables via 'schema' for Scan nodes. Uses 'evaluator' to
+  /// constant-fold call expressions whose arguments are all literals. Uses
+  /// 'builder' to hash-cons tree-IR nodes; share a single Builder across
+  /// translate and downstream rewrites so identical sub-trees dedup across
+  /// passes. Throws VELOX_NYI for logical_plan node or expression types not
+  /// yet supported.
+  ///
+  /// 'schema' must outlive the returned IR (and any Velox plan emitted from
+  /// it). The IR's `BaseTable` nodes hold raw pointers to `TableLayout`s
+  /// owned by `schema`'s connector::Table entries; dropping `schema` before
+  /// emit leaves those pointers dangling.
+  ///
+  /// 'evaluator' and the memory pool it owns must outlive the returned IR
+  /// and any Velox plan derived from it. Compilation of foldable expressions
+  /// can allocate vectors on the evaluator's pool that are then referenced
+  /// from downstream `emit` outputs.
+  static Result run(
+      const logical_plan::LogicalPlanNode& plan,
+      optimizer::Schema& schema,
+      velox::core::ExpressionEvaluator& evaluator,
+      Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2


### PR DESCRIPTION
Summary:

Adds the translate pass — the pipeline's entry point, lowering a logical plan into the tree-IR — and the `JoinCondition` helper it depends on. This is the first pass; it produces the IR that decorrelation and the later rewrites consume.

`TranslatePass::run` walks the logical plan through an internal `Translator`, building canonical IR nodes via the `Builder` hash-cons and constant-folding column-free call expressions. Equi-key conjuncts in a join condition are split from the residual filter by `JoinCondition::splitEquiKeys`. Two shared `Column` factories are added for the columns translation produces: `createForSymbol` for named output columns and `createBoolean` for boolean marker columns.

No test at this layer: translation is observable only once the full pipeline runs, so there is no behavior to assert here.

Reviewed By: amitkdutta

Differential Revision: D111080656
