### PR TITLE
refactor(optimizer): Extract SetDt subclass from DerivedTable

### DIFF
--- a/axiom/graphviz/DerivedTableDotPrinter.cpp
+++ b/axiom/graphviz/DerivedTableDotPrinter.cpp
@@ -195,68 +195,62 @@ void printUnnestTable(const UnnestTable& table, std::ostream& out) {
   printTableEnd(out);
 }
 
-// Prints table ID nodes and join edges inside a DerivedTable cluster.
-//
-// Table ID nodes are small shapes representing tables participating in joins:
-// - Circles for base tables
-// - Rounded squares for nested DerivedTables
-//
-// Layout:
-// - {rank=same; ...} forces all table ID nodes to be horizontally aligned
-// - Invisible edge from header to middle table ID node positions the nodes
-//   below the header
-//
-// Join edges connect table ID nodes with ordinal numbers matching the
-// JOINS list in the header.
-void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
-  // Table ID nodes arranged horizontally.
-  out << "    {rank=same;";
-  for (auto* table : dt.tables) {
-    out << " dt" << dt.id() << "_" << cname(table) << ";";
+// Prints one table ID node inside a DerivedTable cluster: a small shape
+// representing a child table participating in joins or union legs.
+// - Circles for base tables.
+// - Rounded squares for nested DerivedTables (including union legs).
+void printTableIdNode(
+    const DerivedTable& parent,
+    PlanObjectCP table,
+    std::ostream& out) {
+  out << "    dt" << parent.id() << "_" << cname(table) << " [label=\""
+      << cname(table) << "\", ";
+  if (table->type() == PlanType::kDerivedTableNode) {
+    out << "shape=rect, style=\"filled,rounded\", width=0.4, height=0.4, ";
+  } else {
+    out << "shape=circle, width=0.4, fixedsize=true, style=filled, ";
   }
+  out << "fillcolor=\"" << kPalette.circles << "\", color=\"" << kPalette.text
+      << "\"];\n";
+}
 
-  for (auto* table : dt.unionInputs) {
-    out << " dt" << dt.id() << "_" << cname(table) << ";";
+// Prints an invisible edge from the cluster header to the middle table ID
+// node to keep the nodes positioned below the header.
+void printHeaderAnchor(
+    const DerivedTable& parent,
+    const PlanObjectVector& children,
+    std::ostream& out) {
+  if (children.empty()) {
+    return;
+  }
+  out << "    dt" << parent.id() << "_header -> dt" << parent.id() << "_"
+      << cname(children[children.size() / 2]) << " [style=invis];\n\n";
+}
+
+// Arranges 'children' as horizontally aligned table ID nodes inside the
+// 'parent' cluster.
+void printTableIdRow(
+    const DerivedTable& parent,
+    const PlanObjectVector& children,
+    std::ostream& out) {
+  out << "    {rank=same;";
+  for (auto* child : children) {
+    out << " dt" << parent.id() << "_" << cname(child) << ";";
   }
   out << "}\n\n";
 
-  // Table ID nodes.
-  for (auto* table : dt.tables) {
-    out << "    dt" << dt.id() << "_" << cname(table) << " [label=\""
-        << cname(table) << "\", ";
-    if (table->type() == PlanType::kDerivedTableNode) {
-      // Rounded square for derived tables.
-      out << "shape=rect, style=\"filled,rounded\", width=0.4, height=0.4, ";
-    } else {
-      // Circle for base tables.
-      out << "shape=circle, width=0.4, fixedsize=true, style=filled, ";
-    }
-    out << "fillcolor=\"" << kPalette.circles << "\", color=\"" << kPalette.text
-        << "\"];\n";
+  for (auto* child : children) {
+    printTableIdNode(parent, child, out);
   }
-
-  for (auto* table : dt.unionInputs) {
-    out << "    dt" << dt.id() << "_" << cname(table) << " [label=\""
-        << cname(table) << "\", ";
-    // Rounded square for derived tables.
-    out << "shape=rect, style=\"filled,rounded\", width=0.4, height=0.4, ";
-    out << "fillcolor=\"" << kPalette.circles << "\", color=\"" << kPalette.text
-        << "\"];\n";
-  }
-
   out << "\n";
+}
 
-  // Invisible edge from header to first table ID to maintain ordering.
-  if (!dt.tables.empty()) {
-    out << "    dt" << dt.id() << "_header -> dt" << dt.id() << "_"
-        << cname(dt.tables[dt.tables.size() / 2]) << " [style=invis];\n\n";
-  }
-
-  if (!dt.unionInputs.empty()) {
-    out << "    dt" << dt.id() << "_header -> dt" << dt.id() << "_"
-        << cname(dt.unionInputs[dt.unionInputs.size() / 2])
-        << " [style=invis];\n\n";
-  }
+// Prints table ID nodes and join edges inside a regular DerivedTable
+// cluster. Join edges connect table ID nodes with ordinal numbers matching
+// the JOINS list in the header.
+void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
+  printTableIdRow(dt, dt.tables, out);
+  printHeaderAnchor(dt, dt.tables, out);
 
   int joinNum = 1;
   for (auto* join : dt.joins) {
@@ -279,9 +273,13 @@ void printJoinEdges(const DerivedTable& dt, std::ostream& out) {
   }
 }
 
-void printDerivedTableCluster(
+// Emits the shared header row + cluster preamble (subgraph, styling,
+// header cell). Returns after the "<B>..." title cell so the caller can
+// append set-specific text before closing the title.
+void printClusterHeaderStart(
     const DerivedTable& dt,
     bool isRoot,
+    size_t numChildren,
     std::ostream& out) {
   out << "  // DerivedTable cluster for " << dt.cname << "\n";
   out << "  subgraph cluster_" << dt.id() << " {\n";
@@ -291,45 +289,45 @@ void printDerivedTableCluster(
   out << "    bgcolor=white;\n";
   out << "    margin=8;\n\n";
 
-  // Use thicker border for root DerivedTable.
   if (isRoot) {
     out << "    penwidth=3;\n";
   }
 
-  // Calculate header width based on number of tables.
-  int headerWidth = std::max(300, static_cast<int>(dt.tables.size()) * 70);
+  int headerWidth = std::max(300, static_cast<int>(numChildren) * 70);
 
-  // Build HTML label for header node with output columns, GROUP BY, AGG, ORDER
-  // BY, and JOINS.
   out << "    dt" << dt.id() << "_header [shape=none, margin=0, label=<\n";
   out << "      <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" "
          "CELLPADDING=\"4\">\n";
   out << "        <TR><TD BGCOLOR=\"" << kPalette.header << "\" WIDTH=\""
       << headerWidth << "\"><B>" << escapeHtml(dt.cname);
-  if (dt.isUnion()) {
-    out << " UNION ALL";
-  }
+}
+
+// Closes the header cell and the outer HTML table opened by
+// printClusterHeaderStart.
+void printClusterHeaderEnd(std::ostream& out) {
+  out << "      </TABLE>\n";
+  out << "    >];\n\n";
+}
+
+void printDerivedTableCluster(
+    const DerivedTable& dt,
+    bool isRoot,
+    std::ostream& out) {
+  printClusterHeaderStart(dt, isRoot, dt.tables.size(), out);
   out << "</B></TD></TR>\n";
 
-  // Output columns.
-  if (dt.isUnion()) {
-    for (auto* col : dt.columns) {
+  // Output columns: "col := expr" when the expression differs from the
+  // column name.
+  for (size_t i = 0; i < dt.columns.size(); ++i) {
+    auto* col = dt.columns[i];
+    auto* expr = dt.exprs[i];
+    if (expr->toString() != col->name()) {
+      printRow(
+          out,
+          escapeHtml(col->name()) +
+              " := " + escapeHtml(truncate(expr->toString())));
+    } else {
       printRow(out, escapeHtml(col->name()));
-    }
-  } else {
-    for (size_t i = 0; i < dt.columns.size(); ++i) {
-      auto* col = dt.columns[i];
-      auto* expr = dt.exprs[i];
-      // Show "col := expr" if expression differs from just the column
-      // reference.
-      if (expr->toString() != col->name()) {
-        printRow(
-            out,
-            escapeHtml(col->name()) +
-                " := " + escapeHtml(truncate(expr->toString())));
-      } else {
-        printRow(out, escapeHtml(col->name()));
-      }
     }
   }
 
@@ -359,8 +357,8 @@ void printDerivedTableCluster(
     return result;
   });
 
-  // JOINS section header and numbered join conditions.
-  // Only show join type for non-INNER joins to save space.
+  // JOINS section header and numbered join conditions. Only show join type
+  // for non-INNER joins to save space.
   printSection(out, "JOIN", dt.joins, [](size_t i, auto* join) {
     auto type = joinTypeLabel(*join);
     auto condition = joinCondition(*join);
@@ -375,11 +373,34 @@ void printDerivedTableCluster(
     return escapeHtml(truncate(expr->toString()));
   });
 
-  out << "      </TABLE>\n";
-  out << "    >];\n\n";
+  printClusterHeaderEnd(out);
 
-  // Join edges with ordinal numbers.
   printJoinEdges(dt, out);
+
+  out << "  }\n\n";
+}
+
+// Prints a SetDt (UNION ALL / UNION DISTINCT) as a cluster. Each union leg
+// is represented by a table ID node; the leg's own DerivedTable cluster is
+// printed separately by the caller.
+void printSetDtCluster(
+    const SetDt& setDt,
+    const PlanObjectVector& legs,
+    bool isRoot,
+    std::ostream& out) {
+  printClusterHeaderStart(setDt, isRoot, legs.size(), out);
+  out << (setDt.isUnionAll() ? " UNION ALL" : " UNION DISTINCT")
+      << "</B></TD></TR>\n";
+
+  // Output columns (names only; per-leg exprs live on the leg DTs).
+  for (auto* col : setDt.columns) {
+    printRow(out, escapeHtml(col->name()));
+  }
+
+  printClusterHeaderEnd(out);
+
+  printTableIdRow(setDt, legs, out);
+  printHeaderAnchor(setDt, legs, out);
 
   out << "  }\n\n";
 }
@@ -459,25 +480,29 @@ void printDerivedTableWithChildren(
     const DerivedTable& dt,
     bool isRoot,
     std::ostream& out) {
-  // Print the DerivedTable as a cluster.
+  if (const auto* setDt = dt.asUnion()) {
+    PlanObjectVector legs;
+    legs.reserve(setDt->inputs.size());
+    for (auto* leg : setDt->inputs) {
+      legs.push_back(leg);
+    }
+
+    printSetDtCluster(*setDt, legs, isRoot, out);
+
+    for (auto* leg : legs) {
+      printAllTables(leg, out);
+    }
+    printTableLayout(dt.id(), legs, out);
+    return;
+  }
+
   printDerivedTableCluster(dt, isRoot, out);
 
-  // Print all tables (recursively handling nested DerivedTables).
   for (auto* table : dt.tables) {
     printAllTables(table, out);
   }
 
-  for (const auto* child : dt.unionInputs) {
-    printAllTables(child, out);
-  }
-
-  auto children = dt.tables;
-  for (const auto* child : dt.unionInputs) {
-    children.push_back(child);
-  }
-
-  // Print layout constraints for this DerivedTable's base tables.
-  printTableLayout(dt.id(), children, out);
+  printTableLayout(dt.id(), dt.tables, out);
 }
 
 void printAllTables(PlanObjectCP table, std::ostream& out) {

--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -25,6 +25,123 @@
 namespace facebook::axiom::optimizer {
 namespace {
 
+// Wraps a set-operation child in a new DT that holds 'conjunct' above
+// it. Used when the child itself refuses to absorb the filter (e.g. it
+// has a window or LIMIT).
+DerivedTable* wrapChildWithFilter(DerivedTable* child, ExprCP conjunct) {
+  auto* wrapper = make<DerivedTable>();
+  wrapper->cname = queryCtx()->optimization()->newCName("wdt");
+
+  // In a set operation, all inputs share Column objects whose relation_
+  // points to the parent set DT. Create new intermediate columns with relation_
+  // = child so that the wrapper's importExpr translates the conjunct into
+  // child-column space. Without this, the conjunct would reference the set DT
+  // (not in the wrapper's tables), causing an infinite pushdown loop between
+  // the wrapper and the set DT.
+  auto sharedColumns = child->columns;
+
+  ColumnVector childColumns;
+  childColumns.reserve(sharedColumns.size());
+  for (const auto* col : sharedColumns) {
+    childColumns.push_back(
+        make<Column>(col->name(), child, col->value(), col->alias()));
+  }
+
+  child->columns = childColumns;
+  child->outputColumns = childColumns;
+
+  wrapper->addTable(child);
+  wrapper->columns = sharedColumns;
+  wrapper->exprs.assign(childColumns.begin(), childColumns.end());
+  wrapper->outputColumns = std::move(sharedColumns);
+  wrapper->conjuncts.push_back(wrapper->importExpr(conjunct));
+  return wrapper;
+}
+
+// Asserts invariants specific to union / union-all DerivedTables.
+void checkUnionShape(const SetDt& dt) {
+  const auto* cname = dt.cname;
+  VELOX_CHECK_EQ(
+      dt.tables.size(), 0, "tables must be empty for union: {}", cname);
+  VELOX_CHECK(dt.exprs.empty(), "exprs must be empty for union: {}", cname);
+  VELOX_CHECK_GE(
+      dt.inputs.size(),
+      2,
+      "set operation must have at least 2 inputs: {}",
+      cname);
+
+  // The only aggregation allowed is UNION DISTINCT's dedup: GROUP BY all
+  // output columns, no aggregates.
+  if (dt.aggregation != nullptr) {
+    VELOX_CHECK(
+        dt.aggregation->aggregates().empty(),
+        "Union DT aggregation must have no aggregates (only grouping keys "
+        "for UNION DISTINCT dedup): {}",
+        cname);
+  }
+  VELOX_CHECK_NULL(
+      dt.windowPlan, "Union DT must not have windowPlan: {}", cname);
+  VELOX_CHECK(dt.having.empty(), "Union DT must not have having: {}", cname);
+  VELOX_CHECK(
+      dt.conjuncts.empty(), "Union DT must not have conjuncts: {}", cname);
+  VELOX_CHECK(dt.joins.empty(), "Union DT must not have joins: {}", cname);
+  VELOX_CHECK(
+      dt.startTables.empty(), "Union DT must not have startTables: {}", cname);
+  VELOX_CHECK(
+      dt.singleRowDts.empty(),
+      "Union DT must not have singleRowDts: {}",
+      cname);
+  VELOX_CHECK(
+      dt.importedExistences.empty(),
+      "Union DT must not have importedExistences: {}",
+      cname);
+
+  VELOX_CHECK(
+      dt.outputColumns.has_value(),
+      "Union DT outputColumns not set: {}",
+      cname);
+  VELOX_CHECK_EQ(
+      dt.outputColumns->size(),
+      dt.columns.size(),
+      "Union DT outputColumns must match columns: {}",
+      cname);
+
+  for (const auto* child : dt.inputs) {
+    VELOX_CHECK_GE(
+        child->columns.size(),
+        dt.columns.size(),
+        "Union child has fewer columns than parent: {}, child {}",
+        cname,
+        child->cname);
+    auto childColumnSet = PlanObjectSet::fromObjects(child->columns);
+    for (const auto* column : dt.columns) {
+      VELOX_CHECK(
+          childColumnSet.contains(column),
+          "Union child missing parent column: {}, child {}, {}",
+          cname,
+          child->cname,
+          column->toString());
+    }
+    VELOX_CHECK_EQ(
+        child->exprs.size(),
+        child->columns.size(),
+        "Union child exprs/columns size mismatch: {}, child {}",
+        cname,
+        child->cname);
+    for (auto* expr : child->exprs) {
+      expr->allTables().forEach([&](PlanObjectCP table) {
+        VELOX_CHECK(
+            child->tableSet.contains(table) || table == child,
+            "Union child expr references table not in child's tableSet: "
+            "{}, child {}, {}",
+            cname,
+            child->cname,
+            expr->toString());
+      });
+    }
+  }
+}
+
 // Adds an equijoin edge between 'left' and 'right'.
 void addJoinEquality(ExprCP left, ExprCP right, JoinEdgeVector& joins) {
   auto leftTable = left->singleTable();
@@ -179,94 +296,8 @@ std::optional<float> compositeNdv(PlanObjectCP table, const ExprVector& keys) {
 
 } // namespace
 
-void DerivedTable::checkUnionConsistency() const {
-  VELOX_CHECK(
-      isUnion(), "checkUnionConsistency called on non-union DT: {}", cname);
-  VELOX_CHECK_EQ(tables.size(), 0, "tables must be empty for union: {}", cname);
-  VELOX_CHECK(exprs.empty(), "exprs must be empty for union: {}", cname);
-  VELOX_CHECK_GE(
-      unionInputs.size(),
-      2,
-      "set operation must have at least 2 unionInputs: {}",
-      cname);
-
-  // The only aggregation allowed is UNION DISTINCT's dedup: GROUP BY all
-  // output columns, no aggregates.
-  if (aggregation != nullptr) {
-    VELOX_CHECK(
-        aggregation->aggregates().empty(),
-        "Union DT aggregation must have no aggregates (only grouping keys "
-        "for UNION DISTINCT dedup): {}",
-        cname);
-  }
-  VELOX_CHECK_NULL(windowPlan, "Union DT must not have windowPlan: {}", cname);
-  VELOX_CHECK(having.empty(), "Union DT must not have having: {}", cname);
-  VELOX_CHECK(conjuncts.empty(), "Union DT must not have conjuncts: {}", cname);
-  VELOX_CHECK(joins.empty(), "Union DT must not have joins: {}", cname);
-  VELOX_CHECK(
-      startTables.empty(), "Union DT must not have startTables: {}", cname);
-  VELOX_CHECK(
-      singleRowDts.empty(), "Union DT must not have singleRowDts: {}", cname);
-  VELOX_CHECK(
-      importedExistences.empty(),
-      "Union DT must not have importedExistences: {}",
-      cname);
-
-  // Union DT: outputColumns must equal columns (no intermediate columns).
-  VELOX_CHECK(
-      outputColumns.has_value(), "Union DT outputColumns not set: {}", cname);
-  VELOX_CHECK_EQ(
-      outputColumns->size(),
-      columns.size(),
-      "Union DT outputColumns must match columns: {}",
-      cname);
-
-  // Each child's columns must contain the parent's columns (shared Column
-  // objects) and have 1:1 exprs. Exprs must reference only the child's own
-  // tables or the child itself.
-  for (const auto* child : unionInputs) {
-    VELOX_CHECK_GE(
-        child->columns.size(),
-        columns.size(),
-        "Union child has fewer columns than parent: {}, child {}",
-        cname,
-        child->cname);
-    auto childColumnSet = PlanObjectSet::fromObjects(child->columns);
-    for (const auto* column : columns) {
-      VELOX_CHECK(
-          childColumnSet.contains(column),
-          "Union child missing parent column: {}, child {}, {}",
-          cname,
-          child->cname,
-          column->toString());
-    }
-    VELOX_CHECK_EQ(
-        child->exprs.size(),
-        child->columns.size(),
-        "Union child exprs/columns size mismatch: {}, child {}",
-        cname,
-        child->cname);
-    for (auto* expr : child->exprs) {
-      expr->allTables().forEach([&](PlanObjectCP table) {
-        VELOX_CHECK(
-            child->tableSet.contains(table) || table == child,
-            "Union child expr references table not in child's tableSet: "
-            "{}, child {}, {}",
-            cname,
-            child->cname,
-            expr->toString());
-      });
-    }
-  }
-}
-
 void DerivedTable::checkConsistency() const {
   VELOX_CHECK_NOT_NULL(cname);
-
-  if (isUnion()) {
-    checkUnionConsistency();
-    return;
-  }
 
   // Verifies that all tables referenced by expressions in 'exprs' are in
   // tableSet or 'this'.
@@ -327,11 +358,6 @@ void DerivedTable::checkConsistency() const {
     }
   }
 
-  VELOX_CHECK_EQ(
-      unionInputs.size(),
-      0,
-      "unionInputs must be empty for non-set-operation: {}",
-      cname);
   VELOX_CHECK_GT(
       tables.size(),
       0,
@@ -573,47 +599,23 @@ void DerivedTable::initializePlans() {
 void DerivedTable::distributeAllConjuncts() {
   distributeConjuncts();
 
-  if (!isUnion()) {
-    for (auto* table : tables) {
-      if (table->is(PlanType::kDerivedTableNode)) {
-        const_cast<PlanObject*>(table)
-            ->as<DerivedTable>()
-            ->distributeAllConjuncts();
-      }
-    }
-  } else {
-    for (auto* child : unionInputs) {
-      child->distributeAllConjuncts();
+  for (auto* table : tables) {
+    if (table->is(PlanType::kDerivedTableNode)) {
+      const_cast<PlanObject*>(table)
+          ->as<DerivedTable>()
+          ->distributeAllConjuncts();
     }
   }
 }
 
 void DerivedTable::finalizeJoinsAndMakePlans() {
-  if (!isUnion()) {
-    VELOX_CHECK(!tables.empty());
-    VELOX_CHECK(unionInputs.empty());
+  VELOX_CHECK(!tables.empty());
 
-    for (auto* table : tables) {
-      if (table->is(PlanType::kDerivedTableNode)) {
-        const_cast<PlanObject*>(table)
-            ->as<DerivedTable>()
-            ->finalizeJoinsAndMakePlans();
-      }
-    }
-  } else {
-    VELOX_CHECK(tables.empty());
-    VELOX_CHECK(!unionInputs.empty());
-
-    for (auto* child : unionInputs) {
-      child->finalizeJoinsAndMakePlans();
-    }
-
-    // Set initial cardinality as the sum of unionInputs's cardinalities so that
-    // makeInitialPlan can use it when estimating groups for makeDistinct.
-    // The sum is unknown if any child's cardinality is unknown.
-    cardinality_ = 0;
-    for (const auto* child : unionInputs) {
-      cardinality_ = add(cardinality_, child->cardinality());
+  for (auto* table : tables) {
+    if (table->is(PlanType::kDerivedTableNode)) {
+      const_cast<PlanObject*>(table)
+          ->as<DerivedTable>()
+          ->finalizeJoinsAndMakePlans();
     }
   }
 
@@ -1218,7 +1220,7 @@ void DerivedTable::import(
   VELOX_DCHECK(joins.empty());
   VELOX_DCHECK(!superTables.empty());
   VELOX_DCHECK(superTables.contains(primaryTable));
-  VELOX_DCHECK(!super.isUnion(), "Cannot import from a union DT");
+  VELOX_DCHECK(super.asUnion() == nullptr, "Cannot import from a union DT");
 
   copySubset(super, superTables);
 
@@ -1785,11 +1787,11 @@ findJoin(DerivedTableP dt, std::vector<PlanObjectP>& tables, bool create) {
   return nullptr;
 }
 
-// Check if a non-UNION DT has a limit or one of the unionInputs of a UNION DT
+// Check if a non-UNION DT has a limit or one of the legs of a UNION DT
 // has a limit.
 bool dtHasLimit(const DerivedTable& dt) {
-  if (dt.isUnion()) {
-    for (const auto& child : dt.unionInputs) {
+  if (auto* setDt = dt.asUnion()) {
+    for (const auto& child : setDt->inputs) {
       if (child->is(PlanType::kDerivedTableNode) &&
           child->as<DerivedTable>()->hasLimit()) {
         return true;
@@ -2254,7 +2256,6 @@ void DerivedTable::clearState() {
   having.clear();
   aggregation = nullptr;
   windowPlan = nullptr;
-  unionInputs.clear();
   orderKeys.clear();
   orderTypes.clear();
   limit = -1;
@@ -2296,67 +2297,10 @@ void DerivedTable::makeEmpty() {
   addTable(valuesTable);
 }
 
-DerivedTable* DerivedTable::wrapChildWithFilter(
-    DerivedTable* child,
-    ExprCP conjunct) {
-  auto* wrapper = make<DerivedTable>();
-  wrapper->cname = queryCtx()->optimization()->newCName("wdt");
-
-  // In a set operation, all unionInputs share Column objects whose relation_
-  // points to the parent set DT. Create new intermediate columns with relation_
-  // = child so that the wrapper's importExpr translates the conjunct into
-  // child-column space. Without this, the conjunct would reference the set DT
-  // (not in the wrapper's tables), causing an infinite pushdown loop between
-  // the wrapper and the set DT.
-  auto sharedColumns = child->columns;
-
-  ColumnVector childColumns;
-  childColumns.reserve(sharedColumns.size());
-  for (const auto* col : sharedColumns) {
-    childColumns.push_back(
-        make<Column>(col->name(), child, col->value(), col->alias()));
-  }
-
-  child->columns = childColumns;
-  child->outputColumns = childColumns;
-
-  wrapper->addTable(child);
-  wrapper->columns = sharedColumns;
-  wrapper->exprs.assign(childColumns.begin(), childColumns.end());
-  wrapper->outputColumns = std::move(sharedColumns);
-  wrapper->conjuncts.push_back(wrapper->importExpr(conjunct));
-  return wrapper;
-}
-
 bool DerivedTable::addFilter(ExprCP conjunct) {
   // TODO: Support pushing conjuncts below LIMIT by wrapping in a DT.
   if (dtHasLimit(*this)) {
     return false;
-  }
-
-  if (isUnion()) {
-    for (auto i = 0; i < unionInputs.size(); ++i) {
-      if (!unionInputs[i]->addFilter(conjunct)) {
-        // The child cannot accept the filter (e.g. it has a window or limit).
-        // Wrap the child in a new DT that holds the filter above it.
-        unionInputs[i] = wrapChildWithFilter(unionInputs[i], conjunct);
-      }
-    }
-
-    if (isUnionAll()) {
-      std::erase_if(
-          unionInputs, [](const auto* child) { return child->isZeroRows(); });
-
-      if (unionInputs.size() == 1) {
-        auto* only = unionInputs[0];
-        unionInputs.clear();
-        flattenDt(only);
-      } else if (unionInputs.empty()) {
-        makeEmpty();
-      }
-    }
-
-    return true;
   }
 
   auto imported = importExpr(conjunct);
@@ -2461,10 +2405,15 @@ void DerivedTable::distributeConjuncts() {
   // neutral border. This is either a single leaf table or a pure UNION
   // ALL of dts (no dedup aggregation — pushing below dedup would let each
   // duplicate row evaluate the predicate independently).
+  const SetDt* singleUnionAll = nullptr;
+  if (tables.size() == 1 && tables[0]->is(PlanType::kDerivedTableNode)) {
+    singleUnionAll = tables[0]->as<DerivedTable>()->asUnion();
+    if (singleUnionAll != nullptr && !singleUnionAll->isUnionAll()) {
+      singleUnionAll = nullptr;
+    }
+  }
   const bool allowNondeterministic = tables.size() == 1 &&
-      (tables[0]->is(PlanType::kTableNode) ||
-       (tables[0]->is(PlanType::kDerivedTableNode) &&
-        tables[0]->as<DerivedTable>()->isUnionAll()));
+      (tables[0]->is(PlanType::kTableNode) || singleUnionAll != nullptr);
 
   tryConvertOuterJoins(allowNondeterministic);
 
@@ -2636,6 +2585,91 @@ bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
 
 std::string DerivedTable::toString() const {
   return DerivedTablePrinter::toText(*this);
+}
+
+// ---------------------------------------------------------------------------
+// SetDt
+// ---------------------------------------------------------------------------
+
+// Each override guards on `inputs.empty()` first — see the class doc
+// for why identity and shape can diverge.
+void SetDt::checkConsistency() const {
+  VELOX_CHECK_NOT_NULL(cname);
+  if (inputs.empty()) {
+    DerivedTable::checkConsistency();
+    return;
+  }
+  checkUnionShape(*this);
+}
+
+void SetDt::distributeAllConjuncts() {
+  if (inputs.empty()) {
+    DerivedTable::distributeAllConjuncts();
+    return;
+  }
+  distributeConjuncts();
+  for (auto* child : inputs) {
+    child->distributeAllConjuncts();
+  }
+}
+
+void SetDt::finalizeJoinsAndMakePlans() {
+  if (inputs.empty()) {
+    DerivedTable::finalizeJoinsAndMakePlans();
+    return;
+  }
+  VELOX_CHECK(tables.empty());
+
+  for (auto* child : inputs) {
+    child->finalizeJoinsAndMakePlans();
+  }
+
+  // Set initial cardinality as the sum of inputs's cardinalities so that
+  // makeInitialPlan can use it when estimating groups for makeDistinct. The
+  // sum is unknown if any child's cardinality is unknown.
+  cardinality_ = 0;
+  for (const auto* child : inputs) {
+    cardinality_ = add(cardinality_, child->cardinality());
+  }
+
+  finalizeJoins();
+
+  checkConsistency();
+  auto plan = queryCtx()->optimization()->makeInitialPlan(*this);
+  updateConstraints(*plan);
+}
+
+bool SetDt::addFilter(ExprCP conjunct) {
+  if (inputs.empty()) {
+    return DerivedTable::addFilter(conjunct);
+  }
+  // TODO: Support pushing conjuncts below LIMIT by wrapping in a DT.
+  if (dtHasLimit(*this)) {
+    return false;
+  }
+
+  for (size_t i{0}; i < inputs.size(); ++i) {
+    if (!inputs[i]->addFilter(conjunct)) {
+      // The child cannot accept the filter (e.g. it has a window or limit).
+      // Wrap the child in a new DT that holds the filter above it.
+      inputs[i] = wrapChildWithFilter(inputs[i], conjunct);
+    }
+  }
+
+  if (isUnionAll()) {
+    std::erase_if(
+        inputs, [](const auto* child) { return child->isZeroRows(); });
+
+    if (inputs.size() == 1) {
+      auto* only = inputs[0];
+      inputs.clear();
+      flattenDt(only);
+    } else if (inputs.empty()) {
+      makeEmpty();
+    }
+  }
+
+  return true;
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -48,9 +48,11 @@ using WritePlanCP = const WritePlan*;
 class WindowPlan;
 using WindowPlanCP = const WindowPlan*;
 
-/// Represents a derived table, i.e. a SELECT in a FROM clause. This is the
-/// basic unit of planning. Derived tables can be merged and split apart from
-/// other ones. Join types and orders are decided within each derived table. A
+class SetDt;
+
+/// Represents a derived table, i.e. a SELECT in a FROM clause. Derived tables
+/// are the basic unit of planning and can be merged and split apart from other
+/// ones. Join types and orders are decided within each derived table. A
 /// derived table is likewise a reorderable unit inside its parent derived
 /// table. Joins can move between derived tables within limits, considering the
 /// semantics of e.g. group by.
@@ -71,27 +73,47 @@ using WindowPlanCP = const WindowPlan*;
 ///
 /// See docs/DerivedTableLayers.md for the layered column ownership model
 /// and dependency rules validated by checkConsistency.
+///
+/// Direct-instantiated `DerivedTable` is a regular SELECT (tables, joins,
+/// conjuncts, exprs, postprocessing). `SetDt` (below) is the UNION ALL
+/// variant. `asUnion()` distinguishes them at runtime.
 struct DerivedTable : public TableObject {
   DerivedTable() : TableObject{PlanType::kDerivedTableNode} {}
 
+ protected:
+  // Ctor for subclasses sharing the DerivedTable PlanType.
+  explicit DerivedTable(PlanType kind) : TableObject{kind} {}
+
+ public:
   /// True if this DT is guaranteed to produce exactly one row: a global
   /// aggregation (no grouping keys) with no HAVING clause and a non-zero
   /// limit.
   bool isSingleRow() const;
 
-  /// Estimated number of rows this DerivedTable produces. Set during planning
-  /// by `initializePlans()` / `makeInitialPlan()`: for non-union DTs the
-  /// `resultCardinality()` of the initial physical plan, for union DTs the sum
-  /// across children. `nullopt` until planning has run.
+  /// Estimated number of rows this DerivedTable produces. Set during
+  /// planning by `initializePlans()` / `makeInitialPlan()`. `nullopt`
+  /// until planning has run.
   std::optional<float> cardinality() const override {
     return cardinality_;
+  }
+
+  /// Returns `this` as a `SetDt` if the DT is in Set shape (SetDt with
+  /// non-empty inputs — today, a UNION ALL with or without a dedup
+  /// aggregation), or nullptr otherwise. A SetDt whose inputs have been
+  /// cleared by `SetDt::addFilter` is in regular-DT shape and does not
+  /// qualify.
+  virtual SetDt* asUnion() {
+    return nullptr;
+  }
+  virtual const SetDt* asUnion() const {
+    return nullptr;
   }
 
   /// Correlation name.
   Name cname{nullptr};
 
-  /// Exprs projected out. 1:1 to 'columns' or empty if 'this' is a UNION
-  /// ALL (isUnion is true).
+  /// Exprs projected out. 1:1 to 'columns' (or empty on `SetDt`, where
+  /// each leg carries its own exprs).
   ExprVector exprs;
 
   /// Ordered list of columns this DT produces as output. Subset of 'columns'.
@@ -115,47 +137,6 @@ struct DerivedTable : public TableObject {
   /// for a build side. In this case joins that refer to tables not in
   /// 'tableSet' are not considered.
   PlanObjectSet tableSet;
-
-  /// Per-leg DTs of a UNION ALL. Has at least 2 entries for a union DT and
-  /// is empty for a non-union DT. When non-empty, 'tables', 'joins', and
-  /// 'exprs' are empty; the per-leg DTs hold the per-leg expressions.
-  /// ToGraph translates INTERSECT and EXCEPT to joins, and lowers UNION
-  /// DISTINCT to UNION ALL + GROUP BY all columns (the dedup lives on this
-  /// DT's `aggregation`).
-  ///
-  /// A UNION ALL produces a single result set — each leg contributes rows
-  /// to the same output columns. The output schema is defined once on the
-  /// parent, and all legs feed into it. No leg "owns" the output columns;
-  /// the parent does. Each leg's 'exprs' describes how that leg populates
-  /// the shared output columns.
-  ///
-  /// Column structure:
-  ///
-  ///   setDt (parent):
-  ///     columns = [col_a, col_b, ...]  (relation_ == setDt)
-  ///     exprs = {}                     (empty — union DTs have no exprs)
-  ///     outputColumns = columns
-  ///
-  ///   leg DTs:
-  ///     columns contains setDt->columns (shared Column objects from parent,
-  ///             plus possibly the leg's own columns from makeQueryGraph)
-  ///     exprs = [expr_a, expr_b, ...]  (1:1 with columns, reference the
-  ///                                     leg's internal tables or its own
-  ///                                     aggregation/window output columns)
-  ///     outputColumns = setDt->columns
-  QGVector<DerivedTable*> unionInputs;
-
-  /// True if this DT is a UNION or UNION ALL.
-  bool isUnion() const {
-    return !unionInputs.empty();
-  }
-
-  /// True if this DT is a UNION ALL without a dedup aggregation. UNION
-  /// DISTINCT is lowered in ToGraph to UNION ALL + an aggregation grouping
-  /// on all output columns; isUnionAll() returns false in that case.
-  bool isUnionAll() const {
-    return isUnion() && aggregation == nullptr;
-  }
 
   /// Single-row DTs (see isSingleRow()) that have no join dependencies in
   /// this DT — not referenced by any join's keys, sides, or filter.
@@ -285,7 +266,7 @@ struct DerivedTable : public TableObject {
   /// Adds a filter conjunct to this DT. Handles LIMIT (returns false),
   /// aggregation (adds to 'having'), and set operations (adds to all children).
   /// Returns true if the conjunct was successfully added, false otherwise.
-  bool addFilter(ExprCP conjunct);
+  virtual bool addFilter(ExprCP conjunct);
 
   /// Returns a copy of 'expr', replacing references to this DT's 'exprs' with
   /// the corresponding 'columns'. If 'expr' references columns not present in
@@ -394,8 +375,7 @@ struct DerivedTable : public TableObject {
   }
 
   /// Returns true if this DT has no postprocessing — no filter,
-  /// aggregation, having, window, order by, limit, or offset. See
-  /// 'Optimization::addPostprocess' for the corresponding planning step.
+  /// aggregation, having, window, order by, limit, or offset.
   bool hasNoPostprocess() const;
 
   /// Returns true if this DT's postprocessing has no filter, HAVING,
@@ -419,7 +399,15 @@ struct DerivedTable : public TableObject {
   bool isWrapOnly() const;
 
   /// Asserts invariants about this DerivedTable.
-  void checkConsistency() const;
+  virtual void checkConsistency() const;
+
+  /// Recursively distributes conjuncts across the entire DT tree (top-down).
+  /// Called as Pass 1 of initializePlans().
+  virtual void distributeAllConjuncts();
+
+  /// Recursively finalizes joins and builds initial plans across the entire
+  /// DT tree (bottom-up). Called as Pass 3 of initializePlans().
+  virtual void finalizeJoinsAndMakePlans();
 
   /// Returns the memo key for this DT.
   MemoKey memoKey() const;
@@ -432,32 +420,8 @@ struct DerivedTable : public TableObject {
   void distributeConjuncts();
 
  private:
-  // Wraps a set operation child in a new DT that holds the given filter. Used
-  // when the child cannot accept the filter directly (e.g. due to a window
-  // function or limit). Creates intermediate columns so the wrapper can apply
-  // the filter above the child.
-  DerivedTable* wrapChildWithFilter(DerivedTable* child, ExprCP conjunct);
-
   // Resets all mutable state to empty defaults.
   void clearState();
-
-  // Replaces this DT's contents with an empty ValuesTable producing zero rows.
-  // Preserves 'outputColumns' (external interface referenced by parent DTs).
-  void makeEmpty();
-
-  // Recursively distributes conjuncts across the entire DT tree (top-down).
-  // Called as Pass 1 of initializePlans().
-  void distributeAllConjuncts();
-
-  // Recursively finalizes joins and builds initial plans across the entire DT
-  // tree (bottom-up). Called as Pass 3 of initializePlans().
-  void finalizeJoinsAndMakePlans();
-
-  // Asserts invariants specific to union / unionAll DerivedTables.
-  void checkUnionConsistency() const;
-
-  // Updates cardinality and column constraints from the plan.
-  void updateConstraints(const RelationOp& plan);
 
   // Adds same-table equality filters that hold on a single table because of
   // its column equivalences. Three paths:
@@ -474,8 +438,7 @@ struct DerivedTable : public TableObject {
 
   // Enforces 'expr' on 'target': existing scan filter, pushdown via
   // tryPushdownConjunct, or fallback to this DT's conjuncts above the
-  // refusing target. The always-attaches invariant lets JoinEdge::addEquality
-  // drop equivalence-class-redundant join keys unconditionally.
+  // refusing target.
   void attachPredicate(PlanObjectP target, ExprCP expr);
 
   // Completes 'joins' with edges implied by column equivalences.
@@ -488,10 +451,6 @@ struct DerivedTable : public TableObject {
   // Fills in 'startTables_' to 'tables_' that are not to the right of
   // non-commutative joins.
   void setStartTables();
-
-  // Completes 'joins' with edges implied by column equivalences, links tables
-  // to their joins, estimates fanout for each join, and computes start tables.
-  void finalizeJoins();
 
   // Pushes the other tables in 'this' into 'subquery' as existence semijoins
   // below its aggregation boundary. A table can be pushed when the join key
@@ -530,12 +489,6 @@ struct DerivedTable : public TableObject {
       const DerivedTable& super,
       const PlanObjectSet& superTables,
       PlanObjectCP primaryTable);
-
-  // Replaces 'this' with the contents of 'dt', effectively removing one
-  // level of DT nesting. Reconstructs columns that have relation_ == dt
-  // (aggregation, window, outer join outputs) so they reference 'this'
-  // instead, since 'dt' will no longer be in tableSet after flattening.
-  void flattenDt(const DerivedTable* dt);
 
   // Attempts to convert outer joins to less restrictive join types based on
   // filter predicates. A filter that eliminates NULLs on the optional side of
@@ -581,10 +534,84 @@ struct DerivedTable : public TableObject {
   bool isPartitionKeyFilter(ExprCP imported) const;
 
  protected:
+  // Replaces this DT's contents with an empty ValuesTable producing zero rows.
+  // Preserves 'outputColumns' (external interface referenced by parent DTs).
+  void makeEmpty();
+
+  // Replaces 'this' with the contents of 'dt', effectively removing one
+  // level of DT nesting. Reconstructs columns that have relation_ == dt
+  // (aggregation, window, outer join outputs) so they reference 'this'
+  // instead, since 'dt' will no longer be in tableSet after flattening.
+  void flattenDt(const DerivedTable* dt);
+
+  // Updates cardinality and column constraints from the plan.
+  void updateConstraints(const RelationOp& plan);
+
+  // Completes 'joins' with edges implied by column equivalences, links tables
+  // to their joins, estimates fanout for each join, and computes start tables.
+  void finalizeJoins();
+
   std::optional<float> cardinality_{};
 };
 
 using DerivedTableP = DerivedTable*;
 using DerivedTableCP = const DerivedTable*;
+
+/// UNION ALL DT. UNION DISTINCT arrives here as UNION ALL plus a
+/// GROUP-BY-all-columns `aggregation` (base field).
+///
+/// A UNION ALL produces a single result set — each leg contributes rows
+/// to the same output columns. The output schema is defined once on the
+/// parent, and all legs feed into it. No leg "owns" the output columns;
+/// the parent does. Each leg's `exprs` describes how that leg populates
+/// the shared output columns.
+///
+/// Column structure:
+///
+///   setDt (parent):
+///     columns = [col_a, col_b, ...]  (relation_ == setDt)
+///     exprs = {}
+///     outputColumns = columns
+///
+///   leg DTs:
+///     columns contains setDt->columns (shared Column objects from parent,
+///             plus possibly the leg's own columns from makeQueryGraph)
+///     exprs = [expr_a, expr_b, ...]  (1:1 with columns, reference the
+///                                     leg's internal tables or its own
+///                                     aggregation/window output columns)
+///     outputColumns = setDt->columns
+///
+/// TODO: `SetDt::addFilter` mutates `this` to regular shape when a
+/// UNION ALL collapses (via `makeEmpty` / `flattenDt`). Each override
+/// guards on `inputs.empty()` and delegates to the base; `asUnion()`
+/// similarly gates on `!inputs.empty()`. Cleaner fix (return a
+/// replacement, reparent columns) deferred.
+class SetDt final : public DerivedTable {
+ public:
+  SetDt() : DerivedTable{PlanType::kDerivedTableNode} {}
+
+  /// Per-leg DTs.
+  QGVector<DerivedTable*> inputs;
+
+  /// True if this DT is a UNION ALL without a dedup aggregation. UNION
+  /// DISTINCT is lowered in ToGraph to UNION ALL + an aggregation
+  /// grouping on all output columns; `isUnionAll()` returns false in
+  /// that case.
+  bool isUnionAll() const {
+    return !inputs.empty() && aggregation == nullptr;
+  }
+
+  void checkConsistency() const override;
+  bool addFilter(ExprCP conjunct) override;
+  void distributeAllConjuncts() override;
+  void finalizeJoinsAndMakePlans() override;
+
+  SetDt* asUnion() override {
+    return inputs.empty() ? nullptr : this;
+  }
+  const SetDt* asUnion() const override {
+    return inputs.empty() ? nullptr : this;
+  }
+};
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/DerivedTablePrinter.cpp
+++ b/axiom/optimizer/DerivedTablePrinter.cpp
@@ -184,23 +184,42 @@ std::string visitJoinEdge(const JoinEdge& edge) {
   return out.str();
 }
 
+std::string visitDt(const DerivedTable& dt);
+
+std::string visitSetDt(const SetDt& setDt) {
+  std::stringstream out;
+  out << headerLine(setDt.cname, setDt.cardinality(), setDt.columns);
+
+  const auto& inputs = setDt.inputs;
+  out << "  " << (setDt.isUnionAll() ? "UNION ALL" : "UNION DISTINCT") << ": ";
+  int32_t i = 0;
+  for (const auto* child : inputs) {
+    if (i > 0) {
+      out << ", ";
+    }
+    i++;
+    out << child->cname;
+  }
+  out << std::endl;
+
+  for (const auto* child : inputs) {
+    out << std::endl;
+    out << visitDt(*child);
+  }
+  return out.str();
+}
+
 std::string visitDerivedTable(const DerivedTable& dt) {
   std::stringstream out;
   out << headerLine(dt.cname, dt.cardinality(), dt.columns);
 
-  if (dt.isUnion()) {
-    VELOX_CHECK_EQ(0, dt.exprs.size());
-  } else {
-    VELOX_CHECK_EQ(dt.columns.size(), dt.exprs.size());
-  }
+  VELOX_CHECK_EQ(dt.columns.size(), dt.exprs.size());
 
-  if (!dt.isUnion()) {
-    out << "  output:" << std::endl;
-    for (auto i = 0; i < dt.columns.size(); ++i) {
-      out << "    " << dt.columns.at(i)->name()
-          << " := " << dt.exprs.at(i)->toString() << " "
-          << constraintString(dt.columns.at(i)->value()) << std::endl;
-    }
+  out << "  output:" << std::endl;
+  for (auto i = 0; i < dt.columns.size(); ++i) {
+    out << "    " << dt.columns.at(i)->name()
+        << " := " << dt.exprs.at(i)->toString() << " "
+        << constraintString(dt.columns.at(i)->value()) << std::endl;
   }
 
   if (dt.enforceSingleRow) {
@@ -295,38 +314,27 @@ std::string visitDerivedTable(const DerivedTable& dt) {
         out << visitUnnestTable(*table->as<UnnestTable>());
         break;
       case PlanType::kDerivedTableNode:
-        out << visitDerivedTable(*table->as<DerivedTable>());
+        out << visitDt(*table->as<DerivedTable>());
         break;
       default:
         VELOX_FAIL();
     }
   }
 
-  if (dt.isUnion()) {
-    out << "  UNION ALL: ";
-    int32_t i = 0;
-    for (const auto* child : dt.unionInputs) {
-      if (i > 0) {
-        out << ", ";
-      }
-      i++;
-      out << child->cname;
-    }
-    out << std::endl;
-
-    for (const auto* child : dt.unionInputs) {
-      out << std::endl;
-      out << visitDerivedTable(*child);
-    }
-  }
-
   return out.str();
+}
+
+std::string visitDt(const DerivedTable& dt) {
+  if (const auto* setDt = dt.asUnion()) {
+    return visitSetDt(*setDt);
+  }
+  return visitDerivedTable(dt);
 }
 } // namespace
 
 // static
 std::string DerivedTablePrinter::toText(const DerivedTable& root) {
-  return visitDerivedTable(root);
+  return visitDt(root);
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -110,8 +110,10 @@ void collectBaseTables(
       collectBaseTables(table->as<DerivedTable>(), baseTables);
     }
   }
-  for (auto* child : dt->unionInputs) {
-    collectBaseTables(child, baseTables);
+  if (auto* setDt = dt->asUnion()) {
+    for (auto* child : setDt->inputs) {
+      collectBaseTables(child, baseTables);
+    }
   }
 }
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -122,8 +122,8 @@ void Optimization::estimateLeafSelectivity(BaseTable& baseTable) {
 
 namespace {
 void collectBaseTables(DerivedTable* dt, std::vector<BaseTable*>& baseTables) {
-  if (dt->isUnion()) {
-    for (auto* child : dt->unionInputs) {
+  if (auto* setDt = dt->asUnion()) {
+    for (auto* child : setDt->inputs) {
       collectBaseTables(child, baseTables);
     }
   } else {
@@ -3513,10 +3513,10 @@ RelationOpPtr Optimization::makeInitialPlan(const DerivedTable& dt) {
   PlanState state(*this, &dt, options().syntacticJoinOrder);
   RelationOpPtr result;
 
-  if (dt.isUnion()) {
+  if (auto* setDt = dt.asUnion()) {
     // Union: assemble from already-planned children.
     RelationOpPtrVector childOps;
-    for (auto* childDt : dt.unionInputs) {
+    for (auto* childDt : setDt->inputs) {
       auto* plans = memo_.find(childDt->memoKey());
       VELOX_CHECK(
           plans != nullptr, "Expecting to find a plan for union branch");
@@ -3548,7 +3548,7 @@ PlanP Optimization::makePlan(
     bool& needsShuffle) {
   needsShuffle = false;
   if (key.firstTable->is(PlanType::kDerivedTableNode) &&
-      key.firstTable->as<DerivedTable>()->isUnion()) {
+      key.firstTable->as<DerivedTable>()->asUnion() != nullptr) {
     return makeUnionPlan(key, distribution);
   }
   return makeDtPlan(dt, key, distribution, existsFanout, needsShuffle);
@@ -3566,7 +3566,7 @@ PlanP Optimization::makePlan(
 PlanP Optimization::makeUnionPlan(
     const MemoKey& key,
     const std::optional<DesiredDistribution>& distribution) {
-  const auto* setDt = key.firstTable->as<DerivedTable>();
+  const auto* setDt = key.firstTable->as<SetDt>();
 
   RelationOpPtrVector inputs;
   std::vector<PlanP> inputPlans;
@@ -3584,7 +3584,7 @@ PlanP Optimization::makeUnionPlan(
     childColumns.unionObjects(setDt->columns);
   }
 
-  for (auto* inputDt : setDt->unionInputs) {
+  for (auto* inputDt : setDt->inputs) {
     // Only include the child DT in the input tables. Extra tables from
     // the parent key (e.g., reducing bushy join tables) reference joins
     // against the UNION ALL DT which don't exist for individual children.
@@ -3593,7 +3593,7 @@ PlanP Optimization::makeUnionPlan(
 
     PlanP inputPlan;
     bool inputShuffle = false;
-    if (inputDt->isUnion()) {
+    if (inputDt->asUnion() != nullptr) {
       // Nested union (e.g., UNION ALL of UNION ALL).
       // TODO: Flatten nested unions in ToGraph.
       inputPlan = makeUnionPlan(inputKey, distribution);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2410,6 +2410,12 @@ DerivedTableP ToGraph::newDt() {
   return dt;
 }
 
+SetDt* ToGraph::newSetDt() {
+  auto* dt = make<SetDt>();
+  dt->cname = newCName("dt");
+  return dt;
+}
+
 void ToGraph::wrapInDt(
     const lp::LogicalPlanNode& node,
     bool orderObservedAbove) {
@@ -4722,7 +4728,7 @@ void translateSetOperationInput(
 } // namespace
 
 void ToGraph::translateUnion(const lp::SetNode& set) {
-  auto* setDt = currentDt_;
+  auto* setDt = currentDt_->as<SetDt>();
   const auto parentOperation = set.operation();
 
   auto shouldFlatten = [&](const lp::LogicalPlanNode& input) {
@@ -4793,13 +4799,13 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
       newDt->columns = setDt->columns;
     }
 
-    setDt->unionInputs.push_back(newDt);
+    setDt->inputs.push_back(newDt);
   };
 
   translateSetOperationInput(set, shouldFlatten, translateUnionInput);
 
   setDt->outputColumns = setDt->columns;
-  for (auto* child : setDt->unionInputs) {
+  for (auto* child : setDt->inputs) {
     child->outputColumns = setDt->columns;
   }
 
@@ -5143,10 +5149,13 @@ void ToGraph::makeQueryGraph(
       }
     } break;
     case lp::NodeKind::kSet: {
-      auto* outerDt = std::exchange(currentDt_, newDt());
       const auto& set = *node.as<lp::SetNode>();
-      if (set.operation() == lp::SetOperation::kUnion ||
-          set.operation() == lp::SetOperation::kUnionAll) {
+      const bool isUnion = set.operation() == lp::SetOperation::kUnion ||
+          set.operation() == lp::SetOperation::kUnionAll;
+      DerivedTable* freshDt =
+          isUnion ? static_cast<DerivedTable*>(newSetDt()) : newDt();
+      auto* outerDt = std::exchange(currentDt_, freshDt);
+      if (isUnion) {
         translateUnion(set);
       } else {
         translateSetJoin(set);

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -637,6 +637,8 @@ class ToGraph {
 
   DerivedTableP newDt();
 
+  SetDt* newSetDt();
+
   // Removes duplicate ordering keys from the input vector of SortingField
   // objects, returning a pair of vectors containing the deduplicated keys and
   // their corresponding order types. It dedups by comparing the expressions of


### PR DESCRIPTION
Summary:
Introduces `SetDt`, a `DerivedTable` subclass for UNION ALL. Four dispatch methods (`checkConsistency`, `addFilter`, `distributeAllConjuncts`, `finalizeJoinsAndMakePlans`) become virtual, with the union path moved from `if (isUnion())` branches on the base to overrides on `SetDt`. ToGraph builds union DTs via a new `newSetDt()` factory returning `SetDt*`.

Union-shape state moves to `SetDt`: the per-leg vector (renamed `inputs`), `isUnionAll()`, and `checkUnionConsistency()`. Base `DerivedTable` no longer carries any union field or method; `isUnion()` becomes virtual returning `false` on the base. External readers cast via `dt->as<SetDt>()->inputs`, guarded by the existing `isUnion()` check.

When a UNION ALL collapses during filter push-down (single leg or zero rows), `SetDt::addFilter` still calls the mutating `flattenDt` / `makeEmpty` to rewrite `this` in place. That leaves a `SetDt` whose C++ type no longer matches its shape, so each override guards `if (inputs.empty())` and delegates to the base. Cleanly fixing this requires reparenting shared columns from the collapsing SetDt to a replacement DT — see. D110992133. The follow-on FixedPoint DT can avoid the same debt: per-iteration filter push-down to an FP anchor is not always semantics-preserving, so the FP subclass will refuse and defer to the outer DT rather than mutate, and will not inherit these guards.

Differential Revision: D110842742


