### PR TITLE
fix(optimizer): Preserve joins under greedy enumeration

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3308,6 +3308,10 @@ void Optimization::greedyJoinChainDescend(
     PlanState& state) {
   VELOX_CHECK_NOT_NULL(plan);
 
+  // Greedy descends in place, so restore 'state' on return to keep the
+  // invariant that makeJoins leaves it unchanged for the caller.
+  PlanStateSaver save(state);
+
   // An unknown-cost partial plan cannot be ranked, so greedy cannot pick a
   // meaningful chain. Bail so the syntactic fallback in
   // makeJoinsWithSyntacticFallback re-enumerates this DT.

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -158,3 +158,11 @@ JOIN t t17 ON t16.b = t17.b
 JOIN t t18 ON t17.b = t18.b
 JOIN t t19 ON t18.b = t19.b
 JOIN t t20 ON t19.b = t20.b
+----
+-- Greedy join enumeration (>= 5 tables) driven by a UNION ALL subquery.
+SELECT b.v, s.k
+FROM (SELECT k FROM (VALUES (1)) AS t (k) UNION ALL SELECT k FROM (VALUES (1)) AS t (k)) AS s
+JOIN (VALUES (1)) AS a (k) ON s.k = a.k
+JOIN (VALUES (1)) AS c (k) ON s.k = c.k
+JOIN (VALUES (1)) AS d (k) ON s.k = d.k
+JOIN (VALUES (1, 2)) AS b (k, v) ON s.k = b.k


### PR DESCRIPTION
Summary:
A query with five or more tables whose join is driven by a UNION ALL subquery failed to plan:

    Field not found: c1. Available fields are: k.

The optimizer built a Project that referenced a joined table's column over a plan from which every join had been dropped.

Greedy join enumeration (used once a DerivedTable reaches greedyJoinThreshold, default 5) descended in place without restoring the plan state it mutated. A later planning step reused that state, saw every table already marked placed, and finalized a plan that kept only the UNION ALL and dropped the joins — cheaper, so it won cost comparison. Greedy now restores the state on return, as the cost-based path already does.

Differential Revision: D111171888


